### PR TITLE
feat(adj-facts-stdlib): chemistry states-of-matter facts library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_statesofmatter_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_statesofmatter_e2e.rs
@@ -1,0 +1,60 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/states-of-matter.adj`) driven through the built
+//! CLI: a native `table` of state-of-matter -> defining property resolves a
+//! binding-query recall with the source's citation, and abstains on a state not
+//! in the table — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factssom_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_states_of_matter_recall_binds_property_with_citation() {
+    let dir = scratch("statesofmatter");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/states-of-matter.adj");
+    std::fs::copy(&src, dir.join("states-of-matter.adj")).expect("copy shipped states-of-matter.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"states-of-matter.adj\"\n\
+         ? matter_state(solid, $Property)\n\
+         ? matter_state(gas, $Property)\n\
+         ? matter_state(plasma, $Property)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A solid holds its own shape; a gas fills its container — the recalled props.
+    assert!(out.contains("\"Property\":\"fixed_shape\""), "solid -> fixed_shape: {out}");
+    assert!(out.contains("\"Property\":\"fills_container\""), "gas -> fills_container: {out}");
+    // The answer carries the NASA citation as its proof.
+    assert!(
+        out.contains("grc.nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // plasma is the 4th state and is not shipped here — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "plasma abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/states-of-matter.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/states-of-matter.adj
@@ -1,0 +1,62 @@
+% ============================================================================
+% states-of-matter — each everyday state of matter and its defining property
+% (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% An early-elementary science fact: matter around us comes in three everyday
+% STATES, and each one behaves differently when you put it in a container. A
+% solid keeps its own shape; a liquid flows to take the shape of whatever holds
+% it (but keeps the same amount); a gas spreads out to fill the whole container.
+% Recall is a binding query:
+%
+%     ? matter_state(solid, $Property)      % fixed_shape
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `matter_state(state, property)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the
+% property WITH its source, on the CPU, with zero model calls, and abstains on a
+% state not in the table.
+%
+% The three everyday states, as a truth table:
+%
+%     state    property                    what it means
+%     ------   -------------------------   ---------------------------------
+%     solid    fixed_shape                 keeps its own shape and volume
+%     liquid   takes_shape_of_container    flows to fit its container,
+%                                          but has a FIXED volume
+%     gas      fills_container             spreads to fill the whole container
+%
+% The property atoms are chosen to match the source's own wording: a solid
+% "holds its shape" (fixed_shape); a liquid "will take the shape of its
+% container" (takes_shape_of_container); a gas "fills its container"
+% (fills_container).
+%
+% Note that `plasma` — the "fourth state of matter" — is deliberately NOT a row:
+% this beginner library covers only the three everyday states a young learner
+% sees (ice, water, steam), so a recall must ABSTAIN on plasma rather than
+% invent a property for it. That honest-abstention property is what makes the
+% table safe to trust.
+%
+% Provenance: the properties are copied from NASA's Glenn Research Center K-12
+% "State of Matter" educational page. The `source` span below is the VERBATIM
+% solid-phase sentence from that page; the liquid and gas properties are the
+% page's own words too — it states verbatim that "A liquid will take the shape
+% of its container ... a liquid has a fixed volume" and that "A gas fills its
+% container, taking both the shape and the volume of the container." The citable
+% artifact is that page at the `locator`, and each state->property row was
+% confirmed against it. `trust authoritative` — grc.nasa.gov is a primary U.S.
+% government (.gov) science-education source. Nothing here is asserted from
+% memory. (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table matter_state {
+    columns state, property
+
+    row (solid, fixed_shape)
+    row (liquid, takes_shape_of_container)
+    row (gas, fills_container)
+
+    source "A solid holds its shape and the volume of a solid is fixed by the shape of the solid."
+    locator "https://www.grc.nasa.gov/www/k-12/airplane/state.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/states-of-matter.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/states-of-matter.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% states-of-matter.query.adj — a worked recall over the states-of-matter library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does a solid do in a
+% container?": it states no science fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `matter_state` rows and returns the property + the table's source/locator/
+% trust. A state not in the table abstains honestly — the engine never invents a
+% property.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli states-of-matter.query.adj
+% ============================================================================
+
+import "states-of-matter.adj"
+
+? matter_state(solid, $Property)       % expect fixed_shape
+? matter_state(gas, $Property)         % expect fills_container
+? matter_state(plasma, $Property)      % expect abstain — plasma is the 4th state, not shipped here


### PR DESCRIPTION
## Summary

Adds an early-elementary **CHEMISTRY** facts library to `adj-facts-stdlib`: the three everyday **states of matter** mapped to their defining property, as a native ADJ `table`.

| state | property |
|---|---|
| solid | `fixed_shape` |
| liquid | `takes_shape_of_container` (fixed volume) |
| gas | `fills_container` |

Recall is an ordinary SLD binding query — `? matter_state(solid, $P)` — that returns the property **with its citation** on the CPU, zero model calls, and **abstains** honestly on states not shipped here (e.g. `plasma`, the fourth state).

## Grounding / provenance

Every property atom is copied from **NASA Glenn Research Center's** K-12 "State of Matter" education page (`grc.nasa.gov`, a `.gov` primary science-education source → **`trust authoritative`**). The `source` span is the verbatim solid-phase sentence; the liquid and gas properties are the page's own words ("A liquid will take the shape of its container ... a liquid has a fixed volume"; "A gas fills its container, taking both the shape and the volume of the container"). Nothing asserted from memory.

- Source: https://www.grc.nasa.gov/www/k-12/airplane/state.html

## What ships

- `code/specs/data/adj-facts-stdlib/chemistry/states-of-matter.adj` — the grounded `table` (literate comment + citation)
- `code/specs/data/adj-facts-stdlib/chemistry/states-of-matter.query.adj` — a worked recall (two binds + one abstain)
- `code/packages/rust/adj-lang-cli/tests/facts_statesofmatter_e2e.rs` — one e2e test (copied from `facts_shapes`): two binds, locator + trust citation, one honest abstention

## Verification

- `cargo test -p adj-lang-cli --test facts_statesofmatter_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review — passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>