### PR TITLE
feat(adj-facts-stdlib): five senses → body organ (biology)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_senses_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_senses_e2e.rs
@@ -1,0 +1,60 @@
+//! End-to-end test for the biology FIVE-SENSES facts library
+//! (`adj-facts-stdlib/biology/five-senses.adj`) driven through the built CLI:
+//! a native `table` of sense → body organ resolves a binding-query recall with
+//! the source's citation, and abstains on a non-sense — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_senses_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_five_senses_recall_binds_organ_with_citation() {
+    let dir = scratch("fivesenses");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/five-senses.adj");
+    std::fs::copy(&src, dir.join("five-senses.adj")).expect("copy shipped five-senses.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"five-senses.adj\"\n\
+         ? sense_organ(sight, $Organ)\n\
+         ? sense_organ(taste, $Organ)\n\
+         ? sense_organ(balance, $Organ)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // You see with your eyes and taste with your tongue — the recalled organs.
+    assert!(out.contains("\"Organ\":\"eyes\""), "sight → eyes: {out}");
+    assert!(out.contains("\"Organ\":\"tongue\""), "taste → tongue: {out}");
+    // The answer carries the KidsHealth citation as its proof, at consensus trust.
+    assert!(
+        out.contains("kidshealth.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation: {out}"
+    );
+    // "balance" is not one of the five senses — honest abstention, never a
+    // fabricated organ.
+    assert!(out.contains("\"abstained\":true"), "balance abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/five-senses.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/five-senses.adj
@@ -1,0 +1,57 @@
+% ============================================================================
+% five-senses — each of the five senses and the body part you sense it with
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the very first facts a young child learns about their own body: you
+% have five senses, and each one has a body part that does the sensing. You SEE
+% with your eyes, HEAR with your ears, SMELL with your nose, TASTE with your
+% tongue, and FEEL (touch) with your skin. Recall is a binding query:
+%
+%     ? sense_organ(sight, $Organ)          % eyes
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `sense_organ(sense, organ)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the body
+% part WITH its source, on the CPU, with zero model calls, and abstains on
+% anything that is not one of the five senses.
+%
+% The five senses, as a truth table:
+%
+%     sense    organ    what it does
+%     -------  -------  --------------------------------
+%     sight    eyes     you use your eyes to SEE
+%     hearing  ears     you use your ears to HEAR
+%     smell    nose     you use your nose to SMELL
+%     taste    tongue   you use your tongue to TASTE
+%     touch    skin     you use your skin to FEEL (touch)
+%
+% Note that a NON-sense — say `balance`, or a body part like `hand` used as a
+% key — is deliberately NOT a row, so a five-senses recall ABSTAINS on it
+% rather than inventing an organ. That honest-abstention property is what makes
+% the table safe to trust: it answers exactly the five it can ground, and only
+% those.
+%
+% Provenance: the pairing is copied VERBATIM from the Nemours KidsHealth "The
+% Five Senses" classroom guide (K to Grade 2, Human Body Series), whose
+% "Activities for Students" page states (see `source`): "You use your eyes to
+% see, your ears to hear, your nose to smell, your tongue to taste, and your
+% skin to feel." The citable artifact is that guide at the `locator`.
+% `trust consensus` — KidsHealth / the Nemours Foundation is a well-established
+% secondary health-education reference (not a primary/official .gov source, so
+% not `authoritative`). Nothing here is asserted from memory. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table sense_organ {
+    columns sense, organ
+
+    row (sight, eyes)
+    row (hearing, ears)
+    row (smell, nose)
+    row (taste, tongue)
+    row (touch, skin)
+
+    source "You use your eyes to see, your ears to hear, your nose to smell, your tongue to taste, and your skin to feel."
+    locator "https://kidshealth.org/classroom/prekto2/body/functions/senses.pdf"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/biology/five-senses.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/five-senses.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% five-senses.query.adj — a worked recall over the five-senses library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what body part do you
+% see with?": it states no biology fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `sense_organ` rows and returns the organ + the table's source/locator/trust.
+% A key that is not one of the five senses abstains honestly — the engine never
+% invents an organ.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli five-senses.query.adj
+% ============================================================================
+
+import "five-senses.adj"
+
+? sense_organ(sight, $Organ)       % expect eyes
+? sense_organ(taste, $Organ)       % expect tongue
+? sense_organ(balance, $Organ)     % expect abstain — balance is not one of the five senses


### PR DESCRIPTION
## What

Adds a kindergarten-level grounded facts library to the ADJ standard library pairing each of the **five senses** with the body part that senses it:

| sense | organ |
|---|---|
| sight | eyes |
| hearing | ears |
| smell | nose |
| taste | tongue |
| touch | skin |

Encoded as a native ADJ `table` (`sense_organ`) so recall is a **zero-model-call binding query** that returns the organ **with its citation** and **abstains honestly** on a non-sense (e.g. `balance`).

## Grounding

The pairing is copied **verbatim** from the Nemours KidsHealth "The Five Senses" classroom guide (K to Grade 2, Human Body Series):

> "You use your eyes to see, your ears to hear, your nose to smell, your tongue to taste, and your skin to feel."

- **Source URL / locator:** https://kidshealth.org/classroom/prekto2/body/functions/senses.pdf
- **Trust tier:** `consensus` (a well-established secondary health-education reference, not a primary/official `.gov` source, so not `authoritative`).

Nothing is asserted from memory.

## Files

- `code/specs/data/adj-facts-stdlib/biology/five-senses.adj` — the grounded table + literate explanation for a beginner
- `code/specs/data/adj-facts-stdlib/biology/five-senses.query.adj` — a worked recall (2 binds + 1 abstain)
- `code/packages/rust/adj-lang-cli/tests/facts_senses_e2e.rs` — asserts 2 binds, locator substring + `consensus` trust, and one abstain (0 model calls)

## Verification

- `cargo test -p adj-lang-cli --test facts_senses_e2e` — passes (1 test)
- `cargo clippy -p adj-lang-cli --test facts_senses_e2e -- -D warnings` — clean
- Security review: passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)