### PR TITLE
feat(adj-facts-stdlib): geography oceans — ocean → size rank (NOAA-grounded)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_oceans_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_oceans_e2e.rs
@@ -1,0 +1,60 @@
+//! End-to-end test for the geography oceans FACTS library
+//! (`adj-facts-stdlib/geography/oceans.adj`): a native `table` of
+//! ocean → size-rank resolves forward AND reverse binding queries with the NOAA
+//! citation, and abstains on something that is not an ocean — 0 answer-time
+//! model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn geography_oceans_recall_binds_rank_forward_and_reverse() {
+    let dir = scratch("oceans");
+    let src = facts_stdlib().join("geography/oceans.adj");
+    std::fs::copy(&src, dir.join("oceans.adj")).expect("copy shipped oceans.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"oceans.adj\"\n\
+         ? ocean_size_rank(pacific, $R)\n\
+         ? ocean_size_rank($Ocean, 2)\n\
+         ? ocean_size_rank(mediterranean, $R)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward: the Pacific is the largest ocean basin, so rank 1.
+    assert!(out.contains("\"R\":\"1\""), "pacific → 1: {out}");
+    // Reverse: the second largest basin is the Atlantic (binds the other column).
+    assert!(out.contains("\"Ocean\":\"atlantic\""), "rank 2 → atlantic: {out}");
+    // The answer carries the NOAA citation as its proof.
+    assert!(
+        out.contains("oceanservice.noaa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NOAA citation: {out}"
+    );
+    // The Mediterranean is a sea, not one of the five oceans — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "mediterranean abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/geography/oceans.adj
+++ b/code/specs/data/adj-facts-stdlib/geography/oceans.adj
@@ -1,0 +1,45 @@
+% ============================================================================
+% oceans — each ocean basin's size rank, largest = 1 (adj-facts-stdlib, GEOGRAPHY).
+% ============================================================================
+% A geography facts library — an early science fact: the world's five ocean
+% basins, put in order from biggest to smallest. It is the kind of thing a child
+% learns with a map: the Pacific is the widest blue on the globe, the Arctic the
+% little one at the top. Recall is a binding query:
+%
+%     ? ocean_size_rank(pacific, $R)     % 1  (the Pacific is the largest basin)
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `ocean_size_rank(ocean, rank)` carrying the NOAA citation, so the lookup above
+% is the ordinary SLD binding query — the engine returns the rank WITH its source,
+% on the CPU, with zero model calls, and abstains on something that is not one of
+% the five named oceans (e.g. mediterranean is a SEA, not an ocean, so it is
+% deliberately NOT a row here). The `rank` value is a NUMBER, so a recalled rank
+% composes into arithmetic (how many basins sit between the Pacific and the
+% Southern Ocean? 4 − 1 − 1 = 2).
+%
+% Provenance: NOAA's National Ocean Service states the full size ordering in
+% prose — "The Pacific Ocean is the largest and deepest of the world ocean
+% basins. The Atlantic basin is the second largest basin, followed by the Indian
+% Ocean basin, the Southern Ocean, and finally the Arctic Ocean basin." That one
+% span fixes all five ranks: pacific 1, atlantic 2, indian 3, southern 4,
+% arctic 5. The citable artifact is NOAA's "What is the largest ocean basin on
+% Earth?" page at the `locator`. `trust authoritative` — NOAA is the primary
+% U.S. federal ocean authority (a .gov source). Nothing here is asserted from
+% memory. The set of oceans is the five that the U.S. (NOAA) recognizes today,
+% including the Southern (Antarctic) Ocean. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table ocean_size_rank {
+    columns ocean, rank
+
+    row (pacific, 1)
+    row (atlantic, 2)
+    row (indian, 3)
+    row (southern, 4)
+    row (arctic, 5)
+
+    source "The Pacific Ocean is the largest and deepest of the world ocean basins. The Atlantic basin is the second largest basin, followed by the Indian Ocean basin, the Southern Ocean, and finally the Arctic Ocean basin."
+    locator "https://oceanservice.noaa.gov/facts/biggestocean.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/geography/oceans.query.adj
+++ b/code/specs/data/adj-facts-stdlib/geography/oceans.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% oceans.query.adj — a worked recall over the geography oceans library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which is the biggest
+% ocean?" — it states no geography fact, only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the ocean_size_rank
+% rows and returns the rank (or the ocean, on a reverse query) + the NOAA
+% source/locator/trust. A body of water that is not one of the five named oceans
+% abstains honestly — the engine never invents a rank.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli oceans.query.adj
+% ============================================================================
+
+import "oceans.adj"
+
+? ocean_size_rank(pacific, $R)         % expect 1  (the largest ocean basin)
+? ocean_size_rank(arctic, $R)          % expect 5  (the smallest of the five)
+? ocean_size_rank($Ocean, 2)           % expect atlantic (reverse: who is #2?)
+? ocean_size_rank(mediterranean, $R)   % expect abstain — a sea, not an ocean


### PR DESCRIPTION
## What

Adds the first **GEOGRAPHY** library to the ADJ facts standard library: the world's five ocean basins ranked by size, largest = 1.

| ocean | rank |
|---|---|
| pacific | 1 |
| atlantic | 2 |
| indian | 3 |
| southern | 4 |
| arctic | 5 |

## Shape

Shipped the **rank** shape (`table ocean_size_rank { columns ocean, rank }`) because the ranking is fully grounded — not the membership fallback.

## Grounding

NOAA's National Ocean Service states the full size ordering in prose on **"What is the largest ocean basin on Earth?"** — one verbatim span fixes all five ranks:

> "The Pacific Ocean is the largest and deepest of the world ocean basins. The Atlantic basin is the second largest basin, followed by the Indian Ocean basin, the Southern Ocean, and finally the Arctic Ocean basin."

- **Source URL / locator:** https://oceanservice.noaa.gov/facts/biggestocean.html
- **Trust tier:** `authoritative` (NOAA, a `.gov` primary federal ocean authority)
- Nothing asserted from memory. A non-ocean (mediterranean, a *sea*) abstains honestly.

## Files

- `geography/oceans.adj` — native `table` with beginner comment + NOAA source/locator/trust.
- `geography/oceans.query.adj` — worked recall (forward, reverse, abstain).
- `adj-lang-cli/tests/facts_oceans_e2e.rs` — e2e (copies `facts_planets` shape): two binds (pacific→1, rank 2→atlantic), NOAA locator + `authoritative` trust, mediterranean abstains.

## Verification

- `cargo test -p adj-lang-cli --test facts_oceans_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review — passed (round 1, no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)