### PR TITLE
feat(adj-facts-stdlib): earth-science water-cycle stage → step number

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_watercycle_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_watercycle_e2e.rs
@@ -1,0 +1,62 @@
+//! End-to-end test for the earth-science FACTS library
+//! (`adj-facts-stdlib/earth-science/water-cycle.adj`) driven through the built
+//! CLI: a native `table` of water-cycle stage → step number resolves a
+//! binding-query recall with the USGS citation, and abstains on the Sun (which
+//! DRIVES the cycle but is not one of its stages) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factswc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn water_cycle_recall_binds_step_number_with_citation() {
+    let dir = scratch("watercycle");
+    // Copy the shipped earth-science table beside the entry program and import it.
+    let src = facts_stdlib().join("earth-science/water-cycle.adj");
+    std::fs::copy(&src, dir.join("water-cycle.adj")).expect("copy shipped water-cycle.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"water-cycle.adj\"\n\
+         ? water_cycle_stage(evaporation, $N)\n\
+         ? water_cycle_stage(precipitation, $N)\n\
+         ? water_cycle_stage(sun, $N)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Evaporation is the first step of the cycle; precipitation is the third —
+    // the recalled step numbers, straight from the grounded rows.
+    assert!(out.contains("\"N\":\"1\""), "evaporation → 1: {out}");
+    assert!(out.contains("\"N\":\"3\""), "precipitation → 3: {out}");
+    // The answer carries the USGS citation (authoritative, a .gov source) as proof.
+    assert!(
+        out.contains("water.usgs.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the USGS source citation: {out}"
+    );
+    // The Sun drives the cycle but is not a stage — honest abstention, never a
+    // fabricated step number.
+    assert!(out.contains("\"abstained\":true"), "sun abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -32,6 +32,7 @@ per rotation, in parallel):
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |
 | `money/` | US coin → cents | US Mint |
+| `earth-science/` | water-cycle stage → step number | USGS Water Science School |
 | … | *physics, biology, geography, anatomy, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/earth-science/water-cycle.adj
+++ b/code/specs/data/adj-facts-stdlib/earth-science/water-cycle.adj
@@ -1,0 +1,47 @@
+% ============================================================================
+% water-cycle — each water-cycle stage's step number (adj-facts-stdlib,
+% EARTH-SCIENCE).
+% ============================================================================
+% An early earth-science fact every young student meets: water is always on the
+% move, and the trip repeats in the same order. The Sun warms water so it rises
+% as invisible vapor, the vapor cools into clouds, the clouds rain or snow it
+% back down, that water runs downhill, and some soaks underground — then the Sun
+% lifts it up again. Recall is a binding query:
+%
+%     ? water_cycle_stage(precipitation, $N)   % 3  (rain/snow is the 3rd step)
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `water_cycle_stage(stage, step_number)` carrying the USGS citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the step
+% WITH its source, on the CPU, with zero model calls. It abstains on anything the
+% page does not name as a moving-water stage: the Sun is deliberately NOT a row
+% (USGS calls it "the real boss of the water cycle" — the ENERGY that drives the
+% cycle, not a stage the water passes through), just as a driver is not a step.
+% The `step_number` value is a NUMBER, so a recalled step composes into arithmetic
+% (how many steps from evaporation to precipitation? 3 − 1 = 2).
+%
+% Provenance: the USGS Water Science School beginner diagram for kids names these
+% stages and describes them in this process order — each stage's text hands off to
+% the next (evaporation lifts vapor; "This is condensation, the opposite of
+% evaporation"; the cloud droplets "fall to Earth as precipitation"; when rain/snow
+% melts "it flows downhill ... This is called runoff"; "Some precipitation and
+% runoff soaks into the ground to become groundwater"). The citable artifact is that
+% USGS page at the `locator`, and every stage below is confirmed by its own section
+% there. `trust authoritative` — a U.S. Geological Survey (.gov) primary reference.
+% Nothing here is asserted from memory. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table water_cycle_stage {
+    columns stage, step_number
+
+    row (evaporation, 1)
+    row (condensation, 2)
+    row (precipitation, 3)
+    row (runoff, 4)
+    row (groundwater, 5)
+
+    source "The sun causes liquid water to evaporate, or turn from a liquid to a gas (water vapor)."
+    locator "https://water.usgs.gov/edu/watercycle-kids-beg.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/earth-science/water-cycle.query.adj
+++ b/code/specs/data/adj-facts-stdlib/earth-science/water-cycle.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% water-cycle.query.adj — a worked recall over the earth-science water-cycle
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which step of the water
+% cycle is precipitation?" — it states no earth-science fact, only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `water_cycle_stage` rows and returns the step number (or the stage, on a
+% reverse query) + the USGS source/locator/trust. Something the page does not name
+% as a moving-water stage abstains honestly — the engine never invents a step.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli water-cycle.query.adj
+% ============================================================================
+
+import "water-cycle.adj"
+
+? water_cycle_stage(evaporation, $N)      % expect 1  (the cycle starts here)
+? water_cycle_stage(precipitation, $N)    % expect 3  (rain / snow falls to Earth)
+? water_cycle_stage($Stage, 2)            % expect condensation (reverse: 2nd step?)
+? water_cycle_stage(sun, $N)              % expect abstain — the Sun DRIVES the
+                                          %   cycle; it is not a stage, not a row


### PR DESCRIPTION
## What

Adds a grounded early-elementary FACTS library to `adj-facts-stdlib`: each water-cycle stage → its step number, as a native ADJ `table`.

| stage | step_number |
|---|---|
| evaporation | 1 |
| condensation | 2 |
| precipitation | 3 |
| runoff | 4 |
| groundwater | 5 |

## Grounding

Every row is provenanced to the **USGS Water Science School** beginner "Interactive Water Cycle Diagram for Kids":
- **source** (verbatim): `The sun causes liquid water to evaporate, or turn from a liquid to a gas (water vapor).`
- **locator**: https://water.usgs.gov/edu/watercycle-kids-beg.html
- **trust**: `authoritative` — a U.S. Geological Survey (`.gov`) primary reference.

The page names exactly these five moving-water stages and its section text chains them in this process order (evaporation lifts vapor → "This is condensation, the opposite of evaporation" → droplets "fall to Earth as precipitation" → rain/snowmelt "flows downhill ... This is called runoff" → "Some precipitation and runoff soaks into the ground to become groundwater"). Nothing is asserted from memory. The Sun is deliberately **not** a row — USGS calls it the cycle's driver/energy, not a stage — so a query on `sun` abstains honestly (the pluto pattern from `astronomy/planets.adj`).

## Files
- `earth-science/water-cycle.adj` — the grounded table with beginner-level literate comment
- `earth-science/water-cycle.query.adj` — worked recall (forward + reverse binds, one abstain)
- `adj-lang-cli/tests/facts_watercycle_e2e.rs` — e2e test (2 binds, locator + trust assertion, one abstain), modeled on `facts_shapes_e2e.rs`
- `README.md` — adds the `earth-science/` subject row (spec kept in sync)

## Verification
- `cargo test -p adj-lang-cli --test facts_watercycle_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review (Rust + data): PASSED, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)