### PR TITLE
feat(adj-facts-stdlib): nutrition food-groups facts library (USDA MyPlate)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_foodgroups_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_foodgroups_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the nutrition FACTS library
+//! (`adj-facts-stdlib/nutrition/food-groups.adj`) driven through the built CLI:
+//! a native `table` of food → USDA MyPlate food group resolves binding-query
+//! recalls with the source's citation, and abstains on a non-food — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn nutrition_food_groups_recall_binds_group_with_citation() {
+    let dir = scratch("foodgroups");
+    // Copy the shipped nutrition table beside the entry program and import it.
+    let src = facts_stdlib().join("nutrition/food-groups.adj");
+    std::fs::copy(&src, dir.join("food-groups.adj")).expect("copy shipped food-groups.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"food-groups.adj\"\n\
+         ? food_group(apple, $Group)\n\
+         ? food_group(chicken, $Group)\n\
+         ? food_group(rock, $Group)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // An apple is a fruit; chicken is a protein food — the recalled groups.
+    assert!(out.contains("\"Group\":\"fruits\""), "apple → fruits: {out}");
+    assert!(out.contains("\"Group\":\"protein\""), "chicken → protein: {out}");
+    // The answer carries the USDA MyPlate citation as its proof.
+    assert!(
+        out.contains("myplate.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A rock is not a food — honest abstention, never a fabricated group.
+    assert!(out.contains("\"abstained\":true"), "rock abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -33,6 +33,7 @@ per rotation, in parallel):
 | `calendar/` | day / month → number | ISO 8601 |
 | `money/` | US coin → cents | US Mint |
 | `earth-science/` | water-cycle stage → step number | USGS Water Science School |
+| `nutrition/` | common food → MyPlate food group | USDA MyPlate |
 | … | *physics, biology, geography, anatomy, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/nutrition/food-groups.adj
+++ b/code/specs/data/adj-facts-stdlib/nutrition/food-groups.adj
@@ -1,0 +1,132 @@
+% ============================================================================
+% food-groups — which of USDA MyPlate's five food groups a common food belongs
+% to (adj-facts-stdlib, NUTRITION).
+% ============================================================================
+% A kindergarten-level nutrition facts library: sort an everyday food into one
+% of the FIVE food groups a child meets first on the USDA MyPlate — fruits,
+% vegetables, grains, protein, and dairy. "An apple is a fruit; a carrot is a
+% vegetable; bread is a grain; chicken is protein; milk is dairy." Recall is a
+% binding query:
+%
+%     ? food_group(apple, $Group)          % fruits
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `food_group(food, food_group)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the group
+% WITH its source, on the CPU, with zero model calls, and abstains on anything
+% not in the table (it never guesses a group). The query also runs BACKWARD —
+% bind a group and recall every food shipped under it:
+%
+%     ? food_group($Food, dairy)           % milk ; cheese ; yogurt
+%
+% The five MyPlate food groups, as a plate a kindergartner can read:
+%
+%     group        example foods (all copied from MyPlate — see Provenance)
+%     ----------   --------------------------------------------------------
+%     fruits       apple, banana, orange, strawberries, grapes
+%     vegetables   broccoli, carrots, spinach, corn, tomatoes
+%     grains       bread, rice, pasta, oatmeal, tortillas
+%     protein      chicken, eggs, beans, nuts, seafood
+%     dairy        milk, cheese, yogurt
+%
+% The VALUE atom for each group is MyPlate's five-group naming reduced to a
+% single lowercase word: `fruits`, `vegetables`, `grains`, `protein`, `dairy`
+% (MyPlate titles these the Fruit Group, Vegetable Group, Grains Group, Protein
+% Foods, and Dairy Group). Every food shipped below is one MyPlate EXPLICITLY
+% lists under that group — a food MyPlate does not list is deliberately absent so
+% the recall ABSTAINS rather than inventing a group (see the `.query.adj`, which
+% asks about `rock` and gets no answer).
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every food below was read
+% out of a fetched USDA MyPlate page, and any food that could not be verified
+% there would have been dropped). MyPlate reorganized its site under the new
+% Dietary Guidelines, so each per-group page was verified from its U.S. National
+% Archives / Internet Archive capture of the genuine `myplate.gov` page; the
+% citable artifact is the canonical USDA page at each `locator`, and the verbatim
+% span that defines each group is quoted here:
+%
+%   fruits → apple, banana, orange, strawberries, grapes
+%     https://www.myplate.gov/eat-healthy/fruits  (USDA MyPlate)
+%     "The Fruit Group includes all fruits and 100% fruit juice."
+%     (apple, banana, grapes, orange, strawberries all appear in the Fruit
+%      Group "What counts as a cup?" examples on that page.)
+%
+%   vegetables → broccoli, carrots, spinach, corn, tomatoes
+%     https://www.myplate.gov/eat-healthy/vegetables  (USDA MyPlate)
+%     "Any vegetable or 100% vegetable juice counts as part of the Vegetable
+%      Group."
+%     (broccoli and spinach are listed Dark-Green Vegetables; carrots and
+%      tomatoes are listed Red and Orange Vegetables; corn — "Corn, yellow or
+%      white" — is a listed Starchy Vegetable.)
+%
+%   grains → bread, rice, pasta, oatmeal, tortillas
+%     https://www.myplate.gov/eat-healthy/grains  (USDA MyPlate)
+%     "Foods made from wheat, rice, oats, cornmeal, barley, or another cereal
+%      grain is a grain product. Bread, pasta, breakfast cereals, grits, and
+%      tortillas are examples of grain products."
+%     (oatmeal is a listed whole-grain example; rice is named in the grain-
+%      product definition itself.)
+%
+%   protein → chicken, eggs, beans, nuts, seafood
+%     https://www.myplate.gov/eat-healthy/protein-foods  (USDA MyPlate)
+%     "Protein Foods include all foods made from seafood; meat, poultry, and
+%      eggs; beans, peas, and lentils; and nuts, seeds, and soy products."
+%     (chicken grounds the poultry example — MyPlate names "skinless chicken
+%      breasts" as a lean protein choice.)
+%
+%   dairy → milk, cheese, yogurt
+%     https://www.myplate.gov/eat-healthy/dairy  (USDA MyPlate)
+%     "The Dairy Group includes milk, yogurt, cheese, lactose-free milk and
+%      fortified soy milk and yogurt."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the explicit Fruit Group
+% definition that fixes the first rows (fruits). Every OTHER group's per-fact
+% source and verbatim span is listed above, so each row remains independently
+% checkable. All five sources are the primary USDA MyPlate (`.gov`) pages, so
+% `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table food_group {
+    columns food, food_group
+
+    % --- fruits ---
+    row (apple, fruits)
+    row (banana, fruits)
+    row (orange, fruits)
+    row (strawberries, fruits)
+    row (grapes, fruits)
+
+    % --- vegetables ---
+    row (broccoli, vegetables)
+    row (carrots, vegetables)
+    row (spinach, vegetables)
+    row (corn, vegetables)
+    row (tomatoes, vegetables)
+
+    % --- grains ---
+    row (bread, grains)
+    row (rice, grains)
+    row (pasta, grains)
+    row (oatmeal, grains)
+    row (tortillas, grains)
+
+    % --- protein ---
+    row (chicken, protein)
+    row (eggs, protein)
+    row (beans, protein)
+    row (nuts, protein)
+    row (seafood, protein)
+
+    % --- dairy ---
+    row (milk, dairy)
+    row (cheese, dairy)
+    row (yogurt, dairy)
+
+    source "The Fruit Group includes all fruits and 100% fruit juice."
+    locator "https://www.myplate.gov/eat-healthy/fruits"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/nutrition/food-groups.query.adj
+++ b/code/specs/data/adj-facts-stdlib/nutrition/food-groups.query.adj
@@ -1,0 +1,18 @@
+% ============================================================================
+% food-groups.query.adj — a worked recall over the food-groups library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what food group is an
+% apple in?": it states no nutrition fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the `food_group`
+% rows and returns the group + the table's source/locator/trust. A thing that is
+% not a MyPlate food abstains honestly — the engine never invents a group.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli food-groups.query.adj
+% ============================================================================
+
+import "food-groups.adj"
+
+? food_group(apple, $Group)        % expect fruits
+? food_group(chicken, $Group)      % expect protein
+? food_group(rock, $Group)         % expect abstain — a rock is not a food


### PR DESCRIPTION
## What

Adds a kindergarten-level **NUTRITION** facts library to the ADJ standard library: `code/specs/data/adj-facts-stdlib/nutrition/food-groups.adj`.

A native `table food_group(food, food_group)` sorts 23 everyday foods into USDA MyPlate's five food groups:

| group | foods |
|---|---|
| fruits | apple, banana, orange, strawberries, grapes |
| vegetables | broccoli, carrots, spinach, corn, tomatoes |
| grains | bread, rice, pasta, oatmeal, tortillas |
| protein | chicken, eggs, beans, nuts, seafood |
| dairy | milk, cheese, yogurt |

Recall is a binding query resolved on the CPU with **zero model calls**, carrying the source citation, abstaining honestly on a non-food:

```
? food_group(apple, $Group)     % fruits, cited to myplate.gov
? food_group(rock, $Group)      % abstain — not a food
```

## Grounding

Every food is one **USDA MyPlate (`.gov`)** explicitly lists under that group. The five per-group definitions are quoted **verbatim** in the literate header, each with its canonical `myplate.gov` locator. An ADJ `table` carries one provenance envelope, so the strongest span (the Fruit Group definition) sits in `source`/`locator` — mirroring the established `anatomy/body-counts.adj` multi-source pattern. Content was verified from the Internet Archive captures of the genuine `myplate.gov` pages (the live site was reorganized under the new Dietary Guidelines). `trust authoritative` (USDA / `.gov`). Nothing asserted from memory.

## Tests

`code/packages/rust/adj-lang-cli/tests/facts_foodgroups_e2e.rs` drives the shipped table through the built CLI: two binds with the `myplate.gov` locator + `authoritative` trust, one abstention. Passes; `cargo clippy -p adj-lang-cli --tests -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)