### PR TITLE
feat(adj-facts-stdlib): biology animal → vertebrate-class recall table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_animalclasses_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_animalclasses_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/animal-classes.adj`) driven through the built CLI:
+//! a native `table` of animal → vertebrate class resolves a binding-query recall
+//! with the source's citation, and abstains on a non-animal — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_animal_classes_recall_binds_class_with_citation() {
+    let dir = scratch("animalclasses");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/animal-classes.adj");
+    std::fs::copy(&src, dir.join("animal-classes.adj")).expect("copy shipped animal-classes.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"animal-classes.adj\"\n\
+         ? animal_class(cat, $Class)\n\
+         ? animal_class(snake, $Class)\n\
+         ? animal_class(rock, $Class)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A cat is a mammal; a snake is a reptile — the recalled classes.
+    assert!(out.contains("\"Class\":\"mammal\""), "cat → mammal: {out}");
+    assert!(out.contains("\"Class\":\"reptile\""), "snake → reptile: {out}");
+    // The answer carries the Australian Museum citation (locator + trust) as its proof.
+    assert!(
+        out.contains("australian.museum") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A rock is not an animal — honest abstention, never a fabricated class.
+    assert!(out.contains("\"abstained\":true"), "rock abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/animal-classes.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/animal-classes.adj
@@ -1,0 +1,95 @@
+% ============================================================================
+% animal-classes — a familiar animal and the vertebrate CLASS it belongs to
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the first classifications a child (and a biology student) learns: the
+% backboned animals — the vertebrates — fall into five big groups, called
+% CLASSES: mammals, birds, reptiles, amphibians and fishes. This tiny library
+% records, for a handful of familiar animals, which class each one belongs to.
+% Recall is a binding query:
+%
+%     ? animal_class(cat, $Class)          % mammal
+%     ? animal_class(snake, $Class)        % reptile
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `animal_class(animal, class)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the class
+% WITH its source, on the CPU, with zero model calls, and abstains on anything
+% that is not one of the recorded animals (ask it about a `rock` and it stays
+% honestly silent rather than inventing a class).
+%
+% The five vertebrate classes, as a truth table over the animals shipped here:
+%
+%     animal     class        why (a beginner's cue)
+%     ---------  ----------   --------------------------------------------
+%     cat        mammal       has fur, feeds its young milk
+%     kangaroo   mammal       a marsupial mammal (a pouched mammal)
+%     emu        bird         has feathers, lays hard-shelled eggs
+%     ostrich    bird         a huge flightless bird
+%     frog       amphibian    lives part in water, part on land
+%     snake      reptile      cold-blooded, has scales
+%     turtle     reptile      a shelled reptile
+%     shark      fish         cold-blooded, has gills and fins
+%
+% All five classes appear, so a learner sees the whole family: two mammals, two
+% birds, one amphibian, two reptiles and one fish. The animals were chosen to be
+% FAMILIAR and to have ONE clear class each — no tricky borderline cases (a whale
+% is a mammal and a bat is a mammal, but those surprise beginners, so they are
+% left out of this first library). A word that is not one of these animals —
+% `rock`, `banana`, `oak` — is deliberately NOT a row, so a class recall ABSTAINS
+% on it rather than fabricating an answer. That honest-abstention property is what
+% makes a recall table safe to build a reasoner on.
+%
+% ----------------------------------------------------------------------------
+% Provenance (byte-quotable, per the ADJ-facts standard).
+% ----------------------------------------------------------------------------
+% Every row is copied from the AUSTRALIAN MUSEUM's animal library
+% (australian.museum/learn/animals), a natural-history museum and a primary
+% reference — hence `trust authoritative`. Nothing here is asserted from memory.
+% Because ADJ tables carry ONE shared provenance envelope (per-row provenance is
+% a documented future extension — see ADJ-TABLES §6), the envelope below cites the
+% museum's animal library at its `locator`, and the `source` quotes the museum's
+% REPTILE grouping verbatim. For full auditability, here is the exact museum span
+% that grounds EACH row, with the page it was read from:
+%
+%   mammals  — "introduced mammals such as cats, foxes and rabbits" and
+%              "marsupials like kangaroos, bandicoots, quolls and the Koala"
+%              → cat, kangaroo are mammals.
+%              https://australian.museum/learn/animals/mammals/
+%
+%   birds    — "Australia is home to two of the largest flightless birds- the
+%              Emu and Southern Cassowary" and "ranging from tiny hummingbirds up
+%              to huge ostriches" → emu, ostrich are birds.
+%              https://australian.museum/learn/animals/birds/
+%
+%   amphibs  — "Frogs are the only remaining amphibians in Australia."
+%              → frog is an amphibian.
+%              https://australian.museum/learn/animals/frogs/
+%
+%   reptiles — "A diverse group of animals including turtles, lizards, snakes
+%              and crocodiles." → snake, turtle are reptiles.
+%              https://australian.museum/learn/animals/reptiles/
+%
+%   fishes   — "Cartilaginous fish are characterised by their bones made of
+%              cartilage, this include sharks and rays." → shark is a fish.
+%              https://australian.museum/learn/animals/fishes/
+%
+% (See ../README.md; feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table animal_class {
+    columns animal, class
+
+    row (cat, mammal)
+    row (kangaroo, mammal)
+    row (emu, bird)
+    row (ostrich, bird)
+    row (frog, amphibian)
+    row (snake, reptile)
+    row (turtle, reptile)
+    row (shark, fish)
+
+    source "turtles, lizards, snakes and crocodiles, including the largest living reptile in the world: the Australian Crocodile"
+    locator "https://australian.museum/learn/animals/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/animal-classes.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/animal-classes.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% animal-classes.query.adj — a worked recall over the animal-class library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what class does a cat
+% belong to?": it states no biology fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `animal_class` rows and returns the class + the table's source/locator/trust.
+% A word that is not a recorded animal abstains honestly — the engine never
+% invents a class.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli animal-classes.query.adj
+% ============================================================================
+
+import "animal-classes.adj"
+
+? animal_class(cat, $Class)        % expect mammal
+? animal_class(snake, $Class)      % expect reptile
+? animal_class(shark, $Class)      % expect fish
+? animal_class(rock, $Class)       % expect abstain — a rock is not an animal


### PR DESCRIPTION
## What

Adds a grounded early-elementary FACTS library to `adj-facts-stdlib/biology/`: **animal → vertebrate class**.

| animal | class |
|---|---|
| cat, kangaroo | mammal |
| emu, ostrich | bird |
| frog | amphibian |
| snake, turtle | reptile |
| shark | fish |

Ships as a native ADJ `table` (`animal-classes.adj`) whose rows lower to `animal_class(animal, class)` ground relations. Recall is an ordinary SLD binding query resolved on the CPU with **zero model calls**, carrying the source citation and **abstaining honestly** on a non-animal (e.g. `rock`).

Also adds `animal-classes.query.adj` (a worked recall) and `facts_animalclasses_e2e.rs` (CLI e2e: two binds + citation assertion + one abstain), mirroring `facts_shapes_e2e`.

## Grounding

Every row is byte-provenanced verbatim to the **Australian Museum** animal library (`australian.museum`, a natural-history museum → `trust authoritative`). Nothing is asserted from memory. Because ADJ tables carry one shared provenance envelope (per-row provenance is a documented future extension), the envelope cites the museum's animal library at its locator and quotes the reptile grouping; the file's literate comment quotes the exact museum span **and page URL for every row**:

- mammals — "introduced mammals such as cats, foxes and rabbits" / "marsupials like kangaroos, bandicoots, quolls and the Koala" — /learn/animals/mammals/
- birds — "the Emu and Southern Cassowary" / "from tiny hummingbirds up to huge ostriches" — /learn/animals/birds/
- amphibians — "Frogs are the only remaining amphibians in Australia." — /learn/animals/frogs/
- reptiles — "A diverse group of animals including turtles, lizards, snakes and crocodiles." — /learn/animals/reptiles/
- fishes — "Cartilaginous fish ... this include sharks and rays." — /learn/animals/fishes/

## Verification

- `cargo test -p adj-lang-cli --test facts_animalclasses_e2e` — pass
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)