### PR TITLE
feat(sql): expr-level COLLATE in comparisons (x = y COLLATE NOCASE)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.30 — Expr-level `COLLATE` in comparisons
+
+`x = y COLLATE NOCASE`, `a < b COLLATE RTRIM`, `WHERE name = 'foo' COLLATE NOCASE`
+now parse and run with SQLite's semantics: the collation applies to the whole
+comparison (equality and ordering), NOCASE folds ASCII case, RTRIM ignores
+trailing spaces, and a numeric operand is unaffected (`5 = '5' COLLATE NOCASE` is
+0). It is lowered entirely in the planner (sql-parser 0.1.14 grammar; sql-planner
+0.2.13) onto a new internal `__collate` builtin (sql-vm 0.4.16) that canonicalises
+each operand — no new comparison opcode, mirroring `GLOB → glob()`. The trick:
+NOCASE/RTRIM are canonicalising transforms, so `x <op> y COLLATE C` equals
+`canon_C(x) <op> canon_C(y)` under byte comparison, exactly. Five differential-
+oracle cases (=, <, WHERE, RTRIM, numeric-operand) diff against real bundled
+SQLite. (COLLATE on the LEFT operand — `col COLLATE NOCASE = 'x'` — is a follow-up.)
+
 ## 0.5.29 — Bitwise operators `& | ~ << >>`
 
 `SELECT 5 & 3`, `5 | 2`, `~0`, `1 << 4`, `256 >> 2` now parse and run with

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.29"
+version = "0.5.30"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1052,6 +1052,44 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id, (x & 6) AS m, (x | 1) AS o FROM t ORDER BY id",
     },
+    // ---- Lane 3: expr-level COLLATE in comparisons -----------------------
+    // `= … COLLATE NOCASE` folds case in the equality; aliased to isolate the
+    // value from the (orthogonal) unaliased-expression column name.
+    Case {
+        id: "collate_nocase_equality",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT ('A' = 'a' COLLATE NOCASE) AS a, ('A' = 'a') AS b FROM t",
+    },
+    // `= … COLLATE RTRIM` ignores trailing spaces in the equality.
+    Case {
+        id: "collate_rtrim_equality",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT ('a ' = 'a' COLLATE RTRIM) AS a FROM t",
+    },
+    // Ordering comparison honours the collation: `'B' < 'a' COLLATE NOCASE` is
+    // 0 (b > a case-folded) vs 1 under default binary ('B'=66 < 'a'=97).
+    Case {
+        id: "collate_nocase_ordering",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT ('B' < 'a' COLLATE NOCASE) AS c, ('B' < 'a') AS d FROM t",
+    },
+    // COLLATE on a WHERE predicate matches case-insensitively across rows.
+    Case {
+        id: "collate_nocase_where",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'BANANA')",
+        ],
+        query: "SELECT id FROM t WHERE name = 'apple' COLLATE NOCASE ORDER BY id",
+    },
+    // Collation is ignored for a numeric operand: `5 = '5' COLLATE NOCASE` is 0
+    // (5 stays integer, '5' stays text) — the canonicaliser passes non-text
+    // through unchanged, matching SQLite.
+    Case {
+        id: "collate_numeric_operand_unaffected",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (5 = '5' COLLATE NOCASE) AS a, (5 = 5 COLLATE NOCASE) AS b FROM t",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.14] - Unreleased
+
+### Added
+
+- **`COLLATE name` on a comparison's right operand.** The `comparison` grammar
+  accepts an optional `[COLLATE NAME]` after the right-hand `bitwise` operand
+  (`col = 'x' COLLATE NOCASE`, `a < b COLLATE RTRIM`). The planner applies the
+  collation to both sides.
+
 ## [0.1.13] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -436,6 +436,13 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::RuleReference { name: r#"cmp_op"#.to_string() },
                             GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
+                            // Optional `COLLATE name` on the right operand of a
+                            // comparison (`col = 'x' COLLATE NOCASE`). The planner
+                            // applies the collation to BOTH sides of the compare.
+                            GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                    GrammarElement::Literal { value: r#"COLLATE"#.to_string() },
+                                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                                ] }) },
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"BETWEEN"#.to_string() },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -659,6 +659,20 @@ mod tests {
         }
     }
 
+    /// `COLLATE name` parses on the right operand of a comparison — with `=` and
+    /// the ordering operators, in a bare expression and in a WHERE clause.
+    #[test]
+    fn test_parse_expr_collate() {
+        for q in [
+            "SELECT 'A' = 'a' COLLATE NOCASE FROM t",
+            "SELECT a < b COLLATE RTRIM FROM t",
+            "SELECT x FROM t WHERE name = 'foo' COLLATE NOCASE",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "comparison"), "Expected comparison for {q:?}");
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Test 20: BETWEEN expression
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.13] - Unreleased
+
+### Added
+
+- **Expr-level COLLATE lowered onto the `__collate` builtin.** A comparison with
+  `COLLATE NOCASE`/`RTRIM` wraps BOTH operands in `__collate(operand, 'NAME')`,
+  because those collations are *canonicalising* — `x <op> y COLLATE C` equals
+  `canon_C(x) <op> canon_C(y)` under byte comparison, including non-text and NULL
+  operands (`5 = '5' COLLATE NOCASE` stays 0). No new comparison opcode — mirrors
+  the `GLOB → glob()` lowering. `COLLATE BINARY` is a no-op; unknown names error
+  (`no such collating sequence`). New helpers `collate_name_after`/`wrap_collate`.
+
 ## [0.2.12] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -2093,16 +2093,63 @@ fn plan_comparison(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         let right_node = child_nodes_ordered
             .get(2)
             .ok_or_else(|| PlanError::UnsupportedStatement("comparison missing right operand".to_string()))?;
+        let right = plan_expression(right_node)?;
+
+        // Optional `COLLATE name` on the comparison (grammar allows it after the
+        // right operand). NOCASE (ASCII case-fold) and RTRIM (trim trailing
+        // spaces) are *canonicalising* transforms, so `x <op> y COLLATE C` is
+        // exactly `canon_C(x) <op> canon_C(y)` under the default byte comparison
+        // — including the non-text and NULL cases (`5 = '5' COLLATE NOCASE` is 0
+        // because 5 stays 5 while '5' stays '5'; a NULL operand stays NULL). We
+        // therefore lower the collation onto the internal `__collate` builtin
+        // wrapping BOTH operands, reusing the VM's existing collation helper —
+        // no new comparison opcode, mirroring the `GLOB → glob()` lowering.
+        // `COLLATE BINARY` is the default, so it is a no-op.
+        let (left, right) = match collate_name_after(&direct_tok_uppers)? {
+            Some(name) => (wrap_collate(left, &name), wrap_collate(right, &name)),
+            None => (left, right),
+        };
 
         return Ok(SqlExpr::BinaryOp {
             op,
             left: Box::new(left),
-            right: Box::new(plan_expression(right_node)?),
+            right: Box::new(right),
         });
     }
 
     // Passthrough — single operand, no recognised operator.
     Ok(left)
+}
+
+/// Find the collation name in a comparison's direct tokens, if it carries a
+/// `COLLATE name` clause. Returns `None` when absent or `COLLATE BINARY` (the
+/// default, a no-op); `Some(NAME)` for `NOCASE`/`RTRIM`; and an error for an
+/// unknown collation, matching SQLite's "no such collating sequence".
+fn collate_name_after(direct_tok_uppers: &[String]) -> Result<Option<String>, PlanError> {
+    let Some(pos) = direct_tok_uppers.iter().position(|t| t == "COLLATE") else {
+        return Ok(None);
+    };
+    let name = direct_tok_uppers.get(pos + 1).ok_or_else(|| {
+        PlanError::UnsupportedStatement("COLLATE clause missing collation name".to_string())
+    })?;
+    match name.as_str() {
+        "BINARY" => Ok(None),
+        "NOCASE" | "RTRIM" => Ok(Some(name.clone())),
+        other => Err(PlanError::UnsupportedStatement(format!(
+            "no such collating sequence: {other}"
+        ))),
+    }
+}
+
+/// Wrap an expression in the internal `__collate(value, 'NAME')` builtin, which
+/// canonicalises a text value for the given collation (and passes non-text and
+/// NULL through unchanged) so a following byte comparison honours the collation.
+fn wrap_collate(expr: SqlExpr, name: &str) -> SqlExpr {
+    SqlExpr::FunctionCall {
+        name: "__collate".to_string(),
+        args: vec![expr, SqlExpr::Literal(SqlValue::Text(name.to_string()))],
+        star: false,
+    }
 }
 
 /// Plan an `additive` node.

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.16] - Unreleased
+
+### Added
+
+- **Internal `__collate(value, name)` builtin.** Canonicalises a text value for
+  the given collation (NOCASE → ASCII-lowercase, RTRIM → strip trailing spaces),
+  passing NULL and every non-text value through unchanged, so a following byte
+  comparison honours the collation without changing numeric semantics. Reuses the
+  existing `collate_text` helper (from the ORDER BY COLLATE slice). Emitted by the
+  planner for expr-level COLLATE; not user-facing SQL.
+
 ## [0.4.15] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1283,6 +1283,33 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             }
         }
 
+        // Internal collation canonicaliser (not user-facing SQL — the planner
+        // emits it to lower `x <op> y COLLATE C` onto `canon_C(x) <op> canon_C(y)`).
+        // A text value is transformed by the collation (NOCASE → ASCII-lowercase,
+        // RTRIM → strip trailing spaces); NULL and every non-text value pass
+        // through UNCHANGED, so a numeric comparison keeps its own semantics
+        // (`5 = '5' COLLATE NOCASE` stays 0). Reuses `collate_text`.
+        "__COLLATE" => {
+            if args.len() != 2 {
+                return Err(VmError::TypeMismatch(format!(
+                    "__collate expects 2 args, got {}",
+                    args.len()
+                )));
+            }
+            let collation = match &args[1] {
+                SqlValue::Text(s) => s.clone(),
+                other => {
+                    return Err(VmError::TypeMismatch(format!(
+                        "__collate expects a text collation name, got {other:?}"
+                    )))
+                }
+            };
+            match &args[0] {
+                SqlValue::Text(s) => Ok(SqlValue::Text(collate_text(s, &collation))),
+                other => Ok(other.clone()),
+            }
+        }
+
         "TRIM" => trim_builtin("TRIM", &args, true, true),
 
         "LTRIM" => trim_builtin("LTRIM", &args, true, false),


### PR DESCRIPTION
## Expr-level `COLLATE` in comparisons

Adds SQLite's `COLLATE` on the right operand of a comparison — `col = 'x' COLLATE
NOCASE`, `a < b COLLATE RTRIM`, `WHERE name = 'foo' COLLATE NOCASE`. **Rotation
lane 3 (NULLS/COLLATE)** — the target I deferred last cycle as "fiddly," now
solved cleanly.

### The elegant lowering — no new opcode, no new `SqlExpr` variant
`NOCASE` (ASCII case-fold) and `RTRIM` (trim trailing spaces) are
**canonicalising** transforms, so `x <op> y COLLATE C` is **exactly**
`canon_C(x) <op> canon_C(y)` under the default byte comparison — for equality
**and** ordering, and including the non-text and NULL cases. So the planner lowers
COLLATE onto a new internal `__collate(value, 'NAME')` builtin wrapping **both**
operands, reusing the VM's existing `collate_text` helper — exactly the shape of
the merged `GLOB → glob()` lowering.

| Expr | Result | Note |
|---|---|---|
| `'A' = 'a' COLLATE NOCASE` | 1 | case-folded equality |
| `'a ' = 'a' COLLATE RTRIM` | 1 | trailing spaces ignored |
| `'B' < 'a' COLLATE NOCASE` | 0 | ordering honours collation (binary → 1) |
| `5 = '5' COLLATE NOCASE` | 0 | numeric operand unaffected — canonicaliser passes non-text through |

That last row is why the naive `lower()`/`rtrim()` desugar would have been **wrong**
(mini's `lower()` is Unicode, not ASCII like NOCASE, and errors on non-text); a
dedicated canonicaliser mirroring `collate_text` is exact.

### Layers (grammar + planner + one VM builtin)
- **sql-parser 0.1.14** — `comparison` grammar gains optional `[COLLATE NAME]`
  after the right operand.
- **sql-planner 0.2.13** — `plan_comparison` detects it, validates
  `NOCASE`/`RTRIM` (BINARY = no-op; unknown → `no such collating sequence`), wraps
  both operands. New `collate_name_after`/`wrap_collate`.
- **sql-vm 0.4.16** — internal `__COLLATE` builtin canonicalises text via
  `collate_text`, passing NULL and non-text through unchanged.

### Tests
Parser test (`=`, `<`, WHERE) + five differential-oracle cases (= NOCASE, RTRIM,
`<` ordering, WHERE predicate, numeric-operand-unaffected) diffed against real
bundled SQLite. Full affected set green; clippy clean. (COLLATE on the **left**
operand — `col COLLATE NOCASE = 'x'` — is a follow-up.)

### Security
Inline adversarial review **PASSED** — `get(pos+1)` bounds-safe, `__collate`
guards arg count before indexing, `collate_text` is O(len) with no ReDoS/unbounded
allocation, grammar adds no recursion. No panic path on attacker SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
