### PR TITLE
feat(adj-facts-stdlib): money/us-bills — US bill denomination → front portrait

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_usbills_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_usbills_e2e.rs
@@ -1,0 +1,64 @@
+//! End-to-end test for the US-bills FACTS library
+//! (`adj-facts-stdlib/money/us-bills.adj`) driven through the built CLI:
+//! a native `table` of bill-denomination -> front-portrait resolves a
+//! binding-query recall with the U.S. Currency Education Program's citation,
+//! runs the relation backwards (portrait -> denomination), and abstains on an
+//! amount that is not a printed bill -- 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_facts_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn usbills_recall_binds_portrait_with_citation() {
+    let dir = scratch("usbills");
+    // Copy the shipped money table beside the entry program and import it.
+    let src = facts_stdlib().join("money/us-bills.adj");
+    std::fs::copy(&src, dir.join("us-bills.adj")).expect("copy shipped us-bills.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"us-bills.adj\"\n\
+         ? bill_portrait(1, $Who)\n\
+         ? bill_portrait(100, $Who)\n\
+         ? bill_portrait($Dollars, lincoln)\n\
+         ? bill_portrait(3, $Who)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Washington is on the $1 note; Franklin is on the $100 -- the recalled portraits.
+    assert!(out.contains("\"Who\":\"washington\""), "$1 -> washington: {out}");
+    assert!(out.contains("\"Who\":\"franklin\""), "$100 -> franklin: {out}");
+    // The relation runs backwards: the bill Lincoln is on is the five.
+    assert!(out.contains("\"Dollars\":\"5\""), "lincoln -> $5: {out}");
+    // The answer carries the U.S. Currency Education Program citation as its proof.
+    assert!(
+        out.contains("uscurrency.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the uscurrency.gov citation: {out}"
+    );
+    // There is no $3 bill -- honest abstention, never a fabricated portrait.
+    assert!(out.contains("\"abstained\":true"), "$3 abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/money/us-bills.adj
+++ b/code/specs/data/adj-facts-stdlib/money/us-bills.adj
@@ -1,0 +1,86 @@
+% ============================================================================
+% us-bills — who is on the FRONT of each US paper bill (adj-facts-stdlib, MONEY).
+% ============================================================================
+% The sibling of `us-coins.adj`. That file answers "how many CENTS is this coin
+% worth?"; this one answers the other everyday money question a young learner
+% asks: "WHOSE FACE is on this bill?" Recall is a binding query:
+%
+%     ? bill_portrait(1,   $Who)      % washington
+%     ? bill_portrait(20,  $Who)      % jackson
+%
+% This is a native `table` (ADJ-TABLES): each `row` lowers to a ground relation
+% `bill_portrait(dollars, portrait)` carrying the table's citation, so the lookup
+% above is the ordinary SLD binding query — the engine returns the answer WITH its
+% source, on the CPU, with zero model calls, and abstains honestly on an amount
+% that is NOT a printed denomination (it never invents a name). The relation runs
+% both ways: `? bill_portrait($Dollars, lincoln)` recalls the bill Lincoln is on —
+% the five.
+%
+% The KEY is the integer number of dollars (1, 2, 5, 10, 20, 50, 100) and the
+% VALUE is the person's SURNAME as a lowercase atom (washington, jefferson, …),
+% mirroring the coin table's integer-key / lowercase-atom shape so the two money
+% libraries read and compose the same way.
+%
+% ----------------------------------------------------------------------------
+% PROVENANCE — every portrait is byte-quoted from the U.S. Currency Education
+% Program (uscurrency.gov); nothing is asserted from memory.
+% ----------------------------------------------------------------------------
+% Each row's portrait is copied VERBATIM from that note's "Portrait and Vignette"
+% description in the U.S. Currency Education Program's per-note feature sheet
+% (uscurrency.gov — the public education program run jointly by the Federal
+% Reserve Board and the Bureau of Engraving and Printing). `trust authoritative`
+% — this is the U.S. government's own currency-education authority. The per-row
+% byte-quote and its exact URL:
+%
+%   1   → washington  "The $1 note features a portrait of George Washington on the
+%                       front of the note and an image of the Great Seal of the
+%                       United States on the back of the note."
+%       https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/1-1963-present-features-en.pdf
+%   2   → jefferson   "The $2 note features a portrait of Thomas Jefferson on the
+%                       front of the note and a vignette depicting the signing of
+%                       the Declaration of Independence on the back of the note."
+%       https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/2-1976-present-features-en.pdf
+%   5   → lincoln     "The $5 note features a portrait of President Abraham Lincoln
+%                       on the front of the note."
+%       https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/5-1914-1993-features-en.pdf
+%   10  → hamilton    "The $10 note features a portrait of Secretary Hamilton on
+%                       the front of the note and a vignette of the United States
+%                       Treasury Building on the back of the note."
+%       https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/10-2006-present-features-en.pdf
+%   20  → jackson     "The $20 note features a portrait of President Jackson on the
+%                       front of the note and a vignette of the White House on the
+%                       back of the note."
+%       https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/20-2003-present-features-en.pdf
+%   50  → grant       "The $50 note features a portrait of President Grant on the
+%                       front of the note and a vignette of the United States
+%                       Capitol on the back of the note."
+%       https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/50-2004-present-features-en.pdf
+%   100 → franklin    "The $100 note features a portrait of Benjamin Franklin on
+%                       the front of the note and a vignette of Independence Hall
+%                       on the back of the note."
+%       https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/100-2013-present-features-en.pdf
+%
+% ADJ `table` carries ONE provenance envelope per table (per-row provenance is a
+% documented future extension — ADJ-TABLES §6), so the `source`/`locator` below
+% pin the SET of denominations to the Currency Education Program's "Dollars in
+% Detail" guide, which enumerates exactly these seven banknotes; the per-row
+% byte-quotes above pin each individual portrait to its own note's feature sheet.
+% (See ../README.md; ADJ-TABLES.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table bill_portrait {
+    columns dollars, portrait
+
+    row (1, washington)
+    row (2, jefferson)
+    row (5, lincoln)
+    row (10, hamilton)
+    row (20, jackson)
+    row (50, grant)
+    row (100, franklin)
+
+    source "The Federal Reserve Board issues $1, $2, $5, $10, $20, $50, and $100 banknotes."
+    locator "https://www.uscurrency.gov/sites/default/files/downloadable-materials/files/en/dollars-in-detail-guide-en-2022.pdf"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/money/us-bills.query.adj
+++ b/code/specs/data/adj-facts-stdlib/money/us-bills.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% us-bills.query.adj — a worked recall over the US-bills money library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "whose face is on the twenty?":
+% it states no money fact — it only `import`s the grounded table and asks binding
+% queries. The engine resolves each `?` against the `bill_portrait` rows and returns
+% the surname + the table's source/locator/trust. An amount that is NOT a printed
+% US denomination abstains honestly — the engine never invents a name. The third
+% query runs the relation BACKWARDS: given the surname, recall the denomination.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli us-bills.query.adj
+% ============================================================================
+
+import "us-bills.adj"
+
+? bill_portrait(1, $Who)          % expect washington
+? bill_portrait(100, $Who)        % expect franklin
+? bill_portrait($Dollars, lincoln) % expect 5 — reverse lookup by portrait
+? bill_portrait(3, $Who)          % expect abstain — there is no $3 bill


### PR DESCRIPTION
## What

Adds a grounded **elementary** facts library `money/us-bills.adj` — the sibling of the existing `money/us-coins.adj`. Where the coin table answers *"how many cents is this coin worth?"*, this one answers the other everyday money question a young learner asks: **"whose face is on this bill?"**

Native ADJ `table` mapping the integer dollar denomination to the front-portrait surname (lowercase atom), mirroring the coin table's integer-key / lowercase-atom shape:

| dollars | portrait |
|---|---|
| 1 | washington |
| 2 | jefferson |
| 5 | lincoln |
| 10 | hamilton |
| 20 | jackson |
| 50 | grant |
| 100 | franklin |

Each `row` lowers to a ground relation `bill_portrait(dollars, portrait)` carrying the citation, so recall is the ordinary SLD binding query (**0 model calls**), runs both ways (`? bill_portrait($Dollars, lincoln)` → 5), and **abstains honestly** on a non-denomination (there is no $3 bill — it never invents a name).

## Grounding

Every portrait is byte-quoted **VERBATIM** from that note's *"Portrait and Vignette"* feature sheet on **uscurrency.gov** — the U.S. Currency Education Program, run jointly by the Federal Reserve Board and the Bureau of Engraving and Printing. **`trust authoritative`** (`.gov`). Nothing from memory. Per-row verbatim quotes and their exact per-note PDF URLs live in the file comment; the table envelope cites the "Dollars in Detail" guide's seven-denomination enumeration.

Example verbatim span (the $1 note):
> "The $1 note features a portrait of George Washington on the front of the note and an image of the Great Seal of the United States on the back of the note."

## Ships (data + one test only)

- `code/specs/data/adj-facts-stdlib/money/us-bills.adj` — data + literate provenance
- `code/specs/data/adj-facts-stdlib/money/us-bills.query.adj` — worked recall (2 binds, reverse lookup, abstain on $3)
- `code/packages/rust/adj-lang-cli/tests/facts_usbills_e2e.rs` — e2e test (2 binds, reverse lookup, `authoritative`-trust + locator assertion, one abstain)

## Verification

- `cargo test -p adj-lang-cli --test facts_usbills_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review (sub-agent): passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)