### PR TITLE
fix(hl-french): beginner-audience pass — stop assuming prior Spanish

### DIFF
--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Beginner-audience pass — Spanish no longer assumed as prior knowledge
+
+Corrected a systemic violation of HL00's Audience rule: the book and practice
+lessons addressed a reader who was "also learning Spanish" and leaned on
+Spanish as knowledge already owned. The books are for a true beginner whose
+only shared language is English; Spanish comparisons are enrichment the text
+must supply in full, not a baseline it may assume.
+
+- Preface rewritten: drops "Because the reader is also learning Spanish…" and
+  "exactly as in the Spanish book"; states the true-beginner framing and that
+  every Spanish comparison is supplied by the text (a reader who knows Spanish
+  "simply nods along").
+- Chapter 1 (`book/chapters/ch01-greetings.tex`) and the matching practice
+  lessons: recast every "Spanish twin," "the *bueno/buena* machine from
+  Spanish," "One mercy over Spanish," and "you know this from Spanish" into
+  self-contained "Spanish, another daughter of Latin, does X" enrichment.
+  Section title "*bien* — and a Spanish twin" → "*bien* — 'well'."
+- Filled the two missing noun plurals the standard wants: *les soirs*,
+  *les nuits* (a new Grammar Lens on *soir*, extended on *nuit*).
+- Book still compiles clean with XeLaTeX (13 pages).
+
 ## Chapter 1 — Greetings (track bootstrapped)
 
 - New French track, built on the same HL00 framework as Spanish: one word per

--- a/code/learning/human-languages/french/README.md
+++ b/code/learning/human-languages/french/README.md
@@ -9,10 +9,10 @@ never front-loaded.
 
 ## What's different about the French track
 
-Because the learner is **already learning Spanish**, French grounds each word
-against **both English and Spanish** (per `HL00`'s "English First, Then the
-Deep Root" — Spanish is now a known language, fair to compare). The
-*differences* between the Romance twins are often the lesson:
+French grounds each word against **English and its closest Romance sibling,
+Spanish** — both worn-down Latin. Per `HL00`'s Audience rule, no prior Spanish
+is assumed: the text supplies every Spanish form in full, as enrichment, so the
+*differences* between the two Latin daughters can become the lesson:
 
 - *día* (Spanish) vs. *jour* (French) — same Latin *dies*, but French detoured
   through *diurnum* (→ English *journal*, *journey*).

--- a/code/learning/human-languages/french/book/book.tex
+++ b/code/learning/human-languages/french/book/book.tex
@@ -37,24 +37,27 @@
 \chapter*{Preface}
 \addcontentsline{toc}{chapter}{Preface}
 
-This is the French volume of the same project as the Spanish one, and it works
-the same way: French is taught one word at a time, and each word is taken
-apart --- traced to its root (usually Latin), then forward to the English
-cousins you already own, so nothing is a fresh thing to memorize. \emph{jour}
-("day") arrives next to \emph{journal} and \emph{journey}; \emph{salut} ("hi")
-turns out to wish you \emph{health}, like \emph{salute} and \emph{salubrious}.
+This is the French volume of a wider project, and it is written for someone
+starting from zero, whose only shared language is English. French is taught one
+word at a time, and each word is taken apart --- traced to its root (usually
+Latin), then forward to the English cousins you already own, so nothing is a
+fresh thing to memorize. \emph{jour} ("day") arrives next to \emph{journal} and
+\emph{journey}; \emph{salut} ("hi") turns out to wish you \emph{health}, like
+\emph{salute} and \emph{salubrious}.
 
-Because the reader is also learning Spanish, French gets a second set of
-handles: where a French word and a Spanish word are cousins --- and they very
-often are, both being worn-down Latin --- the book shows both, and the
-\emph{differences} between them (why Spanish says \emph{d\'{i}a} but French
-says \emph{jour}; why Spanish pluralizes \emph{buenos d\'{i}as} but French
-keeps \emph{bonjour} singular) are some of the most memorable moments.
+French has a close sibling in Spanish --- both are worn-down Latin --- so where
+a French word and its Spanish cousin descend from one Latin root, the book
+shows both and dwells on the \emph{difference} between them (why the same
+\emph{dies} became French \emph{jour} but Spanish \emph{d\'{i}a}; why French
+keeps \emph{bonjour} singular where Spanish pluralizes \emph{buenos d\'{i}as}).
+Every such comparison is supplied in full by the text --- no prior Spanish is
+assumed; it is offered as enrichment, and a reader who happens to know Spanish
+simply nods along.
 
-Three things shape every lesson, exactly as in the Spanish book: one word per
-lesson, gone deep; the widest \emph{honest} web of cousins; and the cultural
-or idiomatic reason a thing is said, not just the rule. Pronunciation is a
-short reference at the front, never a gate. Released under CC~BY-SA~4.0.
+Three things shape every lesson: one word per lesson, gone deep; the widest
+\emph{honest} web of cousins; and the cultural or idiomatic reason a thing is
+said, not just the rule. Pronunciation is a short reference at the front, never
+a gate. Released under CC~BY-SA~4.0.
 
 \tableofcontents
 

--- a/code/learning/human-languages/french/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/french/book/chapters/ch01-greetings.tex
@@ -3,8 +3,10 @@
 
 The French greetings, built from their pieces --- a word for ``good,'' words
 for ``day,'' ``evening,'' ``night,'' and the gender machine that decides their
-endings. Where a French word has a Spanish twin, both appear, because the
-\emph{difference} between them is often the lesson. \emph{Practice lessons:
+endings. French and Spanish are both daughters of Latin; where a French word
+and its Spanish cousin split from one Latin root, both appear here, because the
+\emph{difference} between them is often the lesson --- and the text supplies
+the Spanish word whether or not you have met it before. \emph{Practice lessons:
 \texttt{lessons/FR-C01-*.md}.}
 
 \section{\emph{salut} --- ``hi,'' a wish for your health}
@@ -25,18 +27,19 @@ old English ``hail.'' Cousins: \textbf{salut}e, \textbf{salut}ation,
 
 \begin{culture}
 Strictly \textbf{informal}, and doubles as ``bye.'' For respect or a first
-meeting you reach for \emph{bonjour} --- exactly as Spanish reaches past
-\emph{hola} for \emph{buenos d\'{i}as}.
+meeting you reach for \emph{bonjour} --- just as Spanish, the other Latin
+daughter, reaches past its own casual \emph{hola} for the fuller \emph{buenos
+d\'{i}as}.
 \end{culture}
 
-\section{\emph{bien} --- ``well,'' and a Spanish twin}
+\section{\emph{bien} --- ``well''}
 \label{lesson:bien}
 
 \begin{cousinweb}
 \textbf{bien} (``well'') $\leftarrow$ Latin \emph{bene} $\to$ \textbf{bene}fit,
-\textbf{bene}volent, \textbf{bene}diction. \emph{Spanish twin:} Spanish also
-has \emph{bien}, also from \emph{bene} --- the two Romance languages inherited
-the same adverb almost unchanged.
+\textbf{bene}volent, \textbf{bene}diction. Spanish, from the same \emph{bene},
+kept the very same spelling, \emph{bien} --- the two Romance languages
+inherited the adverb almost unchanged.
 \end{cousinweb}
 
 A complete one-word answer: \emph{Comment \c{c}a va?} $\to$ \emph{Bien.};
@@ -55,15 +58,17 @@ two \emph{sound} different despite looking alike.
 \begin{cousinweb}
 \textbf{bon / bonne} $\leftarrow$ Latin \emph{bonus / bona} $\to$
 \textbf{bon}us, \textbf{bon}anza, \textbf{boun}ty (via \emph{bont\'{e}}),
-\emph{bonbon}. \emph{Spanish twin:} \emph{bueno / buena} --- same root; French
-kept it short (\emph{bon}) where Spanish broke the \emph{o} into a diphthong.
+\emph{bonbon}. Spanish, from the same \emph{bonus / bona}, made \emph{bueno /
+buena} --- where French kept the \emph{o} short, Spanish broke it into a
+diphthong (\emph{o} $\to$ \emph{ue}).
 \end{cousinweb}
 
 \begin{grammarlens}
-\emph{bon} \textbf{agrees} with its noun (the \emph{bueno/buena} machine from
-Spanish): \emph{bon} (m.), \emph{bonne} (f.), \emph{bons} (m.pl.),
-\emph{bonnes} (f.pl.). You'll watch it: \emph{bon jour} (m.) but \emph{bonne
-nuit} (f.).
+\emph{bon} \textbf{agrees} with its noun in gender and number ---
+\emph{bon} (m.), \emph{bonne} (f.), \emph{bons} (m.pl.), \emph{bonnes} (f.pl.).
+This gender-agreement of adjectives is Latin's legacy across the Romance
+languages (Spanish runs the same machine on \emph{bueno / buena}). You'll
+watch it: \emph{bon jour} (m.) but \emph{bonne nuit} (f.).
 \end{grammarlens}
 
 \section{\emph{le} / \emph{la} / \emph{les} --- ``the,'' and the gender it carries}
@@ -72,15 +77,17 @@ nuit} (f.).
 \begin{cousinweb}
 \textbf{le} $\leftarrow$ \emph{ille}, \textbf{la} $\leftarrow$ \emph{illa},
 \textbf{les} $\leftarrow$ \emph{illos} --- Latin demonstratives (``that
-one/those'') worn into ``the.'' \emph{Spanish twin, exactly:} \emph{el / la /
-los}, same source; and the same twins gave French \textbf{il} / \textbf{elle}
-(``he/she''). (English ``the'' is Germanic --- unrelated.)
+one/those'') worn down into ``the.'' Spanish, from the very same
+\emph{ille / illa / illos}, has \emph{el / la / los}; and those same Latin
+demonstratives also gave French \textbf{il} / \textbf{elle} (``he/she'').
+(English ``the'' is Germanic --- unrelated.)
 \end{cousinweb}
 
 \begin{grammarlens}
-Every French noun is masculine or feminine --- Latin's three genders collapsed
-to two, as in Spanish. Learn each noun \emph{with} its article. One mercy over
-Spanish: plurals share a single article, \emph{les}, for both genders.
+Every French noun is masculine or feminine --- Latin's three genders (masculine,
+feminine, neuter) collapsed to two, the neuter folding mostly into the
+masculine. Learn each noun \emph{with} its article. French has one convenience:
+in the plural, both genders share a single article, \emph{les}.
 \end{grammarlens}
 
 \section{\emph{jour} --- ``day,'' and the road to English \emph{journey}}
@@ -127,10 +134,15 @@ opening a shop or a conversation \emph{without} one reads as rude.
 \begin{cousinweb}
 \textbf{le soir} (masc., \emph{swahr}) $\leftarrow$ Latin \emph{s\={e}rum}
 (``the \textbf{late} hour''), from \emph{s\={e}rus} (``late''). Cousin:
-\emph{soir\'{e}e}. \emph{Spanish parallel:} \emph{tarde} (``afternoon'')
-$\leftarrow$ \emph{tardus}, ``\textbf{late}.'' Two languages, two ``late''
-words, the same instinct --- name the later day after its lateness.
+\emph{soir\'{e}e}. Spanish, from the same instinct, named its ``afternoon''
+\emph{tarde} $\leftarrow$ \emph{tardus}, ``\textbf{late}'' --- two languages,
+two ``late'' words, the same idea of naming the later day after its lateness.
 \end{cousinweb}
+
+\begin{grammarlens}
+\emph{le soir} is \textbf{masculine}; plural \emph{les soirs} (the \emph{-s}
+silent, heard only in \emph{les}).
+\end{grammarlens}
 
 \section{\emph{bonsoir} --- good evening}
 \label{lesson:bonsoir}
@@ -164,6 +176,7 @@ Latin & Spanish & French & English \\
 \begin{grammarlens}
 \emph{nuit} is \textbf{feminine} (\emph{la nuit}, from feminine Latin
 \emph{nox}) --- which is why ``good night'' is \emph{bon\textbf{ne} nuit}.
+Plural \emph{les nuits}.
 \end{grammarlens}
 
 \section{\emph{bonne nuit} --- good night, and the feminine \emph{bon}}

--- a/code/learning/human-languages/french/lessons/FR-C01-bien.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-bien.md
@@ -12,7 +12,7 @@ est_minutes: 3
 reviews_of: [FR-C01-salut]
 ---
 
-# bien — "well," a whole answer (and a Spanish twin)
+# bien — "well," a whole answer
 
 ## Warm-up
 

--- a/code/learning/human-languages/french/lessons/FR-C01-bon.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-bon.md
@@ -36,16 +36,17 @@ Latin **bonus / bona** ("good"). Your English cousins:
 - **bon**us (borrowed straight from Latin *bonus*), **bon**anza, and — via
   Old French *bonté* — **boun**ty. Even *bonbon* ("good-good," a candy).
 
-> Spanish twin: Spanish *bueno / buena*, also from *bonus / bona*. Notice
-> French kept it shorter (*bon*) while Spanish broke the *o* into a diphthong
-> (*bue-*). Same Latin word, two accents of wear.
+> Spanish cousin: from the same *bonus / bona*, Spanish made *bueno / buena*.
+> Notice French kept it shorter (*bon*) while Spanish broke the *o* into a
+> diphthong (*bue-*). Same Latin word, two accents of wear.
 
-## Grammar Lens: agreement (you know this from Spanish)
+## Grammar Lens: adjectives agree with their noun
 
 Like every Romance adjective, *bon* **agrees** with its noun's gender and
 number — *bon* (masc.), *bonne* (fem.), *bons* (masc. pl.), *bonnes* (fem.
-pl.). Exactly the *bueno/buena* machine from Spanish, and you'll watch it run
-in the next few lessons: *bon jour* (masc.) but *bonne nuit* (fem.).
+pl.). This is Latin's legacy: adjectives change their ending to match the noun
+(Spanish runs the same machine on *bueno / buena*). You'll watch it in the next
+few lessons: *bon jour* (masc.) but *bonne nuit* (fem.).
 
 ## Guided Practice
 
@@ -56,5 +57,5 @@ in the next few lessons: *bon jour* (masc.) but *bonne nuit* (fem.).
 ## Wrap-up Recall
 
 [PAUSE 3s] Why do *bon* and *bonne* sound different? (The double *nn* in
-*bonne* cancels the nasal — *bõ* vs *bun*.) What Spanish adjective is *bon*'s
-twin? (*bueno*, same root *bonus*.)
+*bonne* cancels the nasal — *bõ* vs *bun*.) Which Spanish adjective shares
+*bon*'s Latin root? (*bueno*, from the same *bonus*.)

--- a/code/learning/human-languages/french/lessons/FR-C01-le-la.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-le-la.md
@@ -34,10 +34,10 @@ so this is half-learned already.
 - **le** ← *ille*, **la** ← *illa*, **les** ← *illos* — the pointing force
   ("that") faded into a plain "the," and the initial *il-* wore off.
 
-> Spanish twin, exactly: Spanish *el / la / los* come from the *same ille /
-> illa / illos*. French kept *le* where Spanish kept *el* — same parent, and
-> the same twin trick: these articles gave French **il** ("he") and **elle**
-> ("she") too (Spanish: *él / ella*). Article and pronoun, one Latin root.
+> Spanish cousin, exactly: from the *same ille / illa / illos*, Spanish made
+> *el / la / los*. French kept *le* where Spanish kept *el* — same parent. And
+> those same Latin demonstratives also gave French **il** ("he") and **elle**
+> ("she") (Spanish *él / ella*): article and pronoun, one Latin root.
 > (English "the" is Germanic — unrelated.)
 
 ## Grammar Lens: French gender, also from Latin

--- a/code/learning/human-languages/french/lessons/FR-C01-le-la.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-le-la.md
@@ -16,9 +16,9 @@ reviews_of: [FR-C01-bon]
 
 ## Warm-up
 
-[PAUSE 2s] Before your first noun: the words for "the." Like Spanish, French
-splits "the" by gender — and it's the *same* Latin source you met in Spanish,
-so this is half-learned already.
+[PAUSE 2s] Before your first noun: the words for "the." French splits "the" by
+gender — masculine *le*, feminine *la* — a habit it inherited from Latin (its
+sibling Spanish did the same, from the same source).
 
 ## Sounds you'll need
 
@@ -42,12 +42,12 @@ so this is half-learned already.
 
 ## Grammar Lens: French gender, also from Latin
 
-Every French noun is **masculine or feminine** — the same grammatical-gender
-system you met in Spanish, and from the same source: Latin's three genders
-(masculine, feminine, neuter) collapsed to two, the neuters folding into the
-masculine. You learn each noun **with its article** (*le* or *la*), because
-gender can't be guessed. French offers *one* small mercy Spanish doesn't:
-plurals share a single article, *les*, for both genders.
+Every French noun is **masculine or feminine** — a grammatical gender baked
+into the noun, inherited from Latin: its three genders (masculine, feminine,
+neuter) collapsed to two, the neuters folding into the masculine. (Spanish, the
+other Latin daughter, did the very same.) You learn each noun **with its
+article** (*le* or *la*), because the gender can't be guessed. French has one
+convenience here: in the plural, both genders share a single article, *les*.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/french/lessons/FR-C01-salut.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-salut.md
@@ -37,9 +37,9 @@ you already own in English:
 - **salut**ary, **salu**brious — health-giving.
 - and, from the close cousin *salvus* ("safe"), *save*, *salvation*, *safe*.
 
-> Spanish note: you met *hola* — an uncertain, rootless interjection. French
-> *salut* is the opposite: a transparent Latin word meaning "health." Two
-> Romance languages, two totally different casual "hi"s.
+> Spanish note: its casual "hi" is *hola* — an uncertain, rootless
+> interjection. French *salut* is the opposite: a transparent Latin word
+> meaning "health." Two Romance languages, two totally different casual "hi"s.
 
 ## Why it's said this way
 

--- a/code/learning/human-languages/french/lessons/FR-C01-soir.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-soir.md
@@ -38,8 +38,7 @@ the rare *serotine* (a bat that flies in the *late* evening).
 > Spanish parallel — this is the good part. Spanish *tarde* ("afternoon")
 > comes from Latin *tardus*, "**late**." French *soir* ("evening") comes from
 > *sērus*, "**late**." Two different Latin "late" words, two languages, the
-> same idea: name the later part of the day after its *lateness*. You saw the
-> move once in Spanish; here it is again in French.
+> same idea: name the later part of the day after its *lateness*.
 
 ## Grammar Lens
 


### PR DESCRIPTION
Part of the full pedagogy pass on the existing Human Languages books. This one fixes **French**.

## The problem (found by audit)

The French book's structure was already correct — one word per lesson, gender at the first noun traced to Latin, grammar inline. But it **violated [`HL00`](code/specs/HL00-human-language-curriculum-framework.md)'s Audience rule**: the books are for a true beginner whose only shared language is English, yet the French book addressed a reader who was *"also learning Spanish"* and leaned on Spanish as knowledge already owned:

- Preface: *"Because the reader is also learning Spanish…"*, *"exactly as in the Spanish book."*
- *"the **bueno/buena** machine from Spanish"* · *"One mercy over Spanish"* · Grammar Lens titled *"agreement (you know this from Spanish)"*
- Section title *"bien — 'well,' and a Spanish twin."*

## The fix

Recast every such framing as **self-contained enrichment the text supplies** — *"Spanish, another daughter of Latin, does X"* — so a reader who has never seen Spanish loses nothing and one who knows it simply nods along. Applied to the preface, `ch01-greetings.tex`, the `FR-C01-bien/bon/le-la` practice lessons, and the README.

Also filled the two missing noun **plurals** the standard wants (*les soirs*, *les nuits*).

No structural rebuild — the lesson anatomy was already right. Book compiles clean with XeLaTeX (13 pages); the **Human Languages Books** workflow will build `french-book` for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)