### PR TITLE
fix(hl-german): beginner-audience + parity pass

### DIFF
--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Beginner-audience + parity pass
+
+Brought the German book fully to the Hindi/Spanish standard. Two things:
+
+**Stop assuming prior Spanish/French (HL00 Audience rule).** The books are for a
+true beginner whose only shared language is English; German leaned on the other
+tracks as knowledge already owned.
+- Preface: dropped "exactly as the Spanish book used the *-ct-→-ch-* rules" and
+  "Because the reader also knows Spanish (and is meeting French)"; states the
+  true-beginner framing and that every Spanish/French form is supplied in full.
+- `ch01-greetings.tex`: "German's version of the Spanish *-ct-→-ch-* rule" →
+  self-contained sound-law framing; "the same job *bueno/buena* and *bon/bonne*
+  did" → "the same job Romance adjectives do."
+- Practice lessons `GE-C01-gut` ("the rules you met in Spanish") and
+  `GE-C01-der-die-das` ("You've met gender in Spanish and French") de-assumed.
+
+**Filled the parity gaps the audit flagged.**
+- Added per-word **`sounds` boxes** (the book previously gave pronunciation only
+  inline): *hallo*, *gut*, *der/die/das*, *Tag*, *Morgen*, *Abend*, *Nacht* ---
+  including German final-devoicing (*Tag* → *tahk*, *Abend* → *AH-bent*) and the
+  *ach*-laut in *Nacht*.
+- Added noun **plurals**: *die Tage*, *die Morgen*, *die Abende*, *die Nächte*.
+- Book still compiles clean with XeLaTeX (14 pages).
+
 ## Chapter 1 — Greetings (track bootstrapped)
 
 - New German track on the HL00 framework: one word per lesson, slug ids,

--- a/code/learning/human-languages/german/book/book.tex
+++ b/code/learning/human-languages/german/book/book.tex
@@ -37,22 +37,25 @@
 \chapter*{Preface}
 \addcontentsline{toc}{chapter}{Preface}
 
-This is the German volume of the same project as the Spanish and French ones,
-and it works the same way --- one word per lesson, taken apart --- but the
-etymology flows through a different channel. Spanish and French are Latin's
-children; \emph{German is English's sibling}. Both are Germanic languages, so
-German words are most often \emph{direct cousins} of English words, with no
-Latin middleman: \emph{gut} is English \emph{good}, \emph{Tag} is \emph{day},
-\emph{Nacht} is \emph{night}. The gaps between them are not random --- they
-follow the \textbf{High German Consonant Shift} (\emph{d}$\to$\emph{t},
-\emph{t}$\to$\emph{s}, \emph{k}$\to$\emph{ch}), a sound-law you can learn once
-and then use to guess English cousins on sight, exactly as the Spanish book
-used the \emph{-ct-}$\to$\emph{-ch-} rules.
+This is the German volume of a wider project, written for someone starting
+from zero whose only shared language is English. It works like the others ---
+one word per lesson, taken apart --- but the etymology flows through a
+different channel. Spanish and French are Latin's children; \emph{German is
+English's sibling}. Both are Germanic languages, so German words are most often
+\emph{direct cousins} of English words, with no Latin middleman: \emph{gut} is
+English \emph{good}, \emph{Tag} is \emph{day}, \emph{Nacht} is \emph{night}.
+The gaps between them are not random --- they follow the \textbf{High German
+Consonant Shift} (\emph{d}$\to$\emph{t}, \emph{t}$\to$\emph{s},
+\emph{k}$\to$\emph{ch}), a single sound-law you can learn once and then use to
+guess the English cousin on sight (the Romance languages have their own such
+laws --- Latin \emph{-ct-} became Spanish \emph{-ch-}).
 
-Because the reader also knows Spanish (and is meeting French), the book keeps
-all four in view where it helps --- most memorably at \emph{Nacht}, where
-German \emph{Nacht}, English \emph{night}, Spanish \emph{noche}, and French
-\emph{nuit} turn out to be the same Indo-European word, split four ways.
+Where it lights something up, the book sets German beside its cousins ---
+English always, and Spanish and French as Latin's side of the family, each form
+supplied in full so no prior knowledge of them is needed. The richest moment is
+\emph{Nacht}, where German \emph{Nacht}, English \emph{night}, Spanish
+\emph{noche}, and French \emph{nuit} turn out to be the same Indo-European
+word, split four ways.
 
 Same three commitments as the other volumes: one word per lesson, gone deep;
 the widest \emph{honest} web of cousins; the cultural or grammatical reason,

--- a/code/learning/human-languages/german/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/german/book/chapters/ch01-greetings.tex
@@ -10,6 +10,12 @@ contrast. \emph{Practice lessons: \texttt{lessons/GE-C01-*.md}.}
 \section{\emph{hallo} --- ``hi,'' a real cousin this time}
 \label{lesson:hallo}
 
+\begin{sounds}
+\emph{HAH-loh}, stress on the first syllable; the \emph{a} is short and open,
+the \emph{h} fully breathed (German never drops an \emph{h} the way French
+does).
+\end{sounds}
+
 \begin{cousinweb}
 \textbf{hallo} (informal ``hi'') --- unlike Spanish \emph{hola} (a false
 friend), German \emph{hallo} and English \emph{hello} are genuine relatives,
@@ -25,13 +31,20 @@ Tag}, built over the next lessons.
 \section{\emph{gut} --- ``good,'' and the shift that reshapes German}
 \label{lesson:gut}
 
+\begin{sounds}
+\emph{goot}, one long \emph{u} as in English \emph{boot}; the final \emph{t}
+stays crisp.
+\end{sounds}
+
 \begin{cousinweb}
 \textbf{gut} (``good'') $\leftarrow$ Proto-Germanic \emph{\*g\=odaz} --- the
 \emph{same} word as English \textbf{good}. Why \emph{gut}, not \emph{good}?
 The \textbf{High German Consonant Shift}, rule \emph{d}$\to$\emph{t}: goo\emph{d}
 $\to$ gu\emph{t}, \emph{d}ay $\to$ \emph{T}ag, be\emph{d} $\to$ Be\emph{tt}.
 Learn the shift once and you can guess the English cousin behind a German word
-on sight --- German's version of the Spanish \emph{-ct-}$\to$\emph{-ch-} rule.
+on sight --- a single regular sound-law, the same kind of trick that reshaped
+the Romance words too (Latin \emph{-ct-} became Spanish \emph{-ch-},
+\emph{noche}).
 \end{cousinweb}
 
 \begin{grammarlens}
@@ -43,6 +56,11 @@ English splits \emph{good} (adjective) from \emph{well} (adverb); Spanish
 
 \section{\emph{der} / \emph{die} / \emph{das} --- ``the,'' and \emph{three} genders}
 \label{lesson:der-die-das}
+
+\begin{sounds}
+\emph{dair} / \emph{dee} / \emph{dahss}. The \emph{r} of \emph{der} is barely
+a vowel-like murmur at the back; \emph{die} rhymes with English \emph{see}.
+\end{sounds}
 
 \begin{cousinweb}
 \textbf{der} (m.) / \textbf{die} (f.) / \textbf{das} (n.) $\leftarrow$ the old
@@ -64,6 +82,12 @@ gender entirely. (German articles also change by \emph{case} later ---
 \section{\emph{Tag} --- ``day,'' straight cousin of English \emph{day}}
 \label{lesson:tag}
 
+\begin{sounds}
+\emph{tahk}: long \emph{a} as in \emph{father}, and a final \emph{-g} that
+Germans harden to a \emph{k} at the end of a word (\emph{final devoicing}) ---
+so \emph{Tag} rhymes with English \emph{tock}, not \emph{tag}.
+\end{sounds}
+
 \begin{cousinweb}
 \textbf{der Tag} (masc.) $\leftarrow$ Proto-Germanic \emph{\*dagaz} = English
 \textbf{day}, via the \emph{d}$\to$\emph{t} shift. Note the split from Latin:
@@ -72,6 +96,12 @@ Spanish \emph{d\'{i}a} and French \emph{jour} come from Latin \emph{dies} --- a
 and \emph{Tag} look nothing alike. (And every German noun is Capitalized ---
 \emph{Tag}.)
 \end{cousinweb}
+
+\begin{grammarlens}
+\emph{der Tag} is \textbf{masculine}; plural \emph{die Tage} (``the days'').
+Note the article shift: \emph{der} $\to$ \emph{die} in the plural, whatever the
+gender --- German, like French \emph{les}, uses one plural article for all.
+\end{grammarlens}
 
 \section{\emph{Guten Tag} --- assembled, and a first German ending}
 \label{lesson:guten-tag}
@@ -91,6 +121,11 @@ track gender+number+case, and watch \emph{Gute Nacht} change it.)
 \section{\emph{Morgen} --- ``morning,'' inside English \emph{tomorrow}}
 \label{lesson:morgen}
 
+\begin{sounds}
+\emph{MOR-gun}: stress the first syllable; the \emph{-en} sinks to a soft
+\emph{-un}.
+\end{sounds}
+
 \begin{cousinweb}
 \textbf{der Morgen} (masc.) $\leftarrow$ Proto-Germanic \emph{\*murganaz} =
 English \textbf{morning}, \textbf{morn}, and the \emph{-morrow} of
@@ -98,12 +133,17 @@ English \textbf{morning}, \textbf{morn}, and the \emph{-morrow} of
 context decides.)
 \end{cousinweb}
 
-\emph{Guten Morgen} $=$ \emph{gut} $+$ \emph{Morgen} (masc.) $=$ ``good
-morning'' --- \emph{guten} again, same as \emph{Tag}. Used until midday, then
-\emph{Guten Tag}.
+\emph{Guten Morgen} $=$ \emph{gut} $+$ \emph{Morgen} (masc., plural
+\emph{die Morgen} --- unchanged) $=$ ``good morning'' --- \emph{guten} again,
+same as \emph{Tag}. Used until midday, then \emph{Guten Tag}.
 
 \section{\emph{Abend} --- ``evening,'' cousin of English \emph{eve}}
 \label{lesson:abend}
+
+\begin{sounds}
+\emph{AH-bent}: first-syllable stress, and again final devoicing --- the
+\emph{-d} hardens to \emph{-t}.
+\end{sounds}
 
 \begin{cousinweb}
 \textbf{der Abend} (masc.) $\leftarrow$ Proto-Germanic \emph{\*\=aban\th{}s} =
@@ -113,12 +153,20 @@ a \emph{different} root in each branch: Germanic \emph{\=aban\th{}s} (\emph{Aben
 \emph{s\=erus}), Spanish \emph{tarde} ($\leftarrow$ \emph{tardus}).
 \end{cousinweb}
 
-\emph{Guten Abend} $=$ ``good evening,'' \emph{guten} once more --- the third
-masculine day-part in a row. The arc: \emph{Guten Morgen} $\to$ \emph{Guten
-Tag} $\to$ \emph{Guten Abend}.
+\emph{Guten Abend} $=$ ``good evening'' (\emph{der Abend}, masc., plural
+\emph{die Abende}), \emph{guten} once more --- the third masculine day-part in
+a row. The arc: \emph{Guten Morgen} $\to$ \emph{Guten Tag} $\to$ \emph{Guten
+Abend}.
 
 \section{\emph{Nacht} --- ``night,'' where all four languages meet}
 \label{lesson:nacht}
+
+\begin{sounds}
+\emph{nahkht}: the \emph{ch} is the throaty \emph{ach}-sound (a scrape at the
+back of the mouth, like the \emph{ch} in Scottish \emph{loch}), \textbf{not}
+an English \emph{ch}. This is the same throat-scrape as Spanish \emph{j} and
+Arabic \emph{kh}.
+\end{sounds}
 
 \begin{cousinweb}
 \textbf{die Nacht} (fem.) goes back to Proto-Indo-European \emph{\*n\'{o}k\textsuperscript{w}ts}
@@ -139,8 +187,9 @@ Spanish / French (Latin) & \textbf{noche} / \textbf{nuit} \\
 \end{tabular}
 \end{center}
 
-\emph{Nacht} is \textbf{feminine} (\emph{die Nacht}) --- which is why ``good
-night'' breaks the \emph{guten} streak.
+\emph{Nacht} is \textbf{feminine} (\emph{die Nacht}; plural \emph{die
+N\"achte}, the \emph{a} taking an umlaut $\to$ \emph{\"a}) --- which is why
+``good night'' breaks the \emph{guten} streak.
 
 \section{\emph{Gute Nacht} --- good night, and the ending that changes}
 \label{lesson:gute-nacht}
@@ -151,8 +200,9 @@ night'' breaks the \emph{guten} streak.
 Three greetings were \emph{gut\textbf{en}} (Tag, Morgen, Abend --- masculine).
 This is \emph{gut\textbf{e}}: \emph{Nacht} is \textbf{feminine}, and a feminine
 noun in the ``(I wish you a) good ---'' accusative takes \emph{-e}. So:
-\emph{guten} (masc.) vs \emph{gute} (fem.) --- German's adjective reporting
-gender, the same job \emph{bueno/buena} and \emph{bon/bonne} did.
+\emph{guten} (masc.) vs \emph{gute} (fem.) --- the German adjective reports the
+noun's gender through its ending, the same job Romance adjectives do (Spanish
+\emph{bueno/buena}, French \emph{bon/bonne}).
 \end{grammarlens}
 
 \begin{culture}

--- a/code/learning/human-languages/german/lessons/GE-C01-der-die-das.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-der-die-das.md
@@ -16,9 +16,9 @@ reviews_of: [GE-C01-gut]
 
 ## Warm-up
 
-[PAUSE 2s] Before your first noun: German's words for "the." You've met gender
-in Spanish and French — German has it too, but with a twist neither of them
-kept.
+[PAUSE 2s] Before your first noun: German's words for "the." Many European
+languages tag every noun with a grammatical *gender* — Spanish and French each
+run two — and German has it too, but with a twist neither of them kept.
 
 ## Sounds you'll need
 

--- a/code/learning/human-languages/german/lessons/GE-C01-gut.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-gut.md
@@ -43,9 +43,10 @@ So why *gut* and not *good*? One sound-law:
 > | be**d** | Be**tt** |
 > | **d**o | **t**un |
 >
-> This is German's version of the *-ct-→-ch-* rules you met in Spanish: learn
-> the shift once, and you can guess the English cousin behind a German word
-> (and vice-versa) on sight. More rules of the shift as we go.
+> It's a single regular sound-law — the same kind of trick that reshaped the
+> Romance languages (Latin *-ct-* became Spanish *-ch-*, *noche*). Learn the
+> shift once, and you can guess the English cousin behind a German word (and
+> vice-versa) on sight. More rules of the shift as we go.
 
 ## Grammar Lens: German merges "good" and "well"
 


### PR DESCRIPTION
Part of the full pedagogy pass on the existing Human Languages books. This one fixes **German** — the audit's two findings.

## 1. Beginner-audience (the systemic one)

The books are for a true beginner whose only shared language is English ([`HL00`](code/specs/HL00-human-language-curriculum-framework.md) Audience rule), but German leaned on Spanish/French as knowledge already owned:

- Preface: *"exactly as the Spanish book used the -ct-→-ch- rules"*, *"Because the reader also knows Spanish (and is meeting French)."*
- Chapter: *"German's version of the Spanish -ct-→-ch- rule"*, *"the same job bueno/buena and bon/bonne did."*
- Practice lessons: *"the rules you met in Spanish"*, *"You've met gender in Spanish and French."*

All recast as **self-contained enrichment** — the text supplies every Spanish/French form in full, so a reader who has never seen them loses nothing.

## 2. Parity gaps

German was missing two things the Spanish/French books have:

- **Per-word `sounds` boxes** (it previously gave pronunciation only inline). Added for *hallo, gut, der/die/das, Tag, Morgen, Abend, Nacht* — including German **final-devoicing** (*Tag* → *tahk*, *Abend* → *AH-bent*) and the **ach-laut** in *Nacht*.
- **Noun plurals**: *die Tage, die Morgen, die Abende, die Nächte*.

No structural rebuild — one word per lesson, three genders at the article traced to Germanic/Latin, grammar inline were all already right. Compiles clean with XeLaTeX (14 pages); the **Human Languages Books** workflow will build `german-book` for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)