### PR TITLE
feat(adj-facts-stdlib): word → opposite (antonym) LANGUAGE facts library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_opposites_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_opposites_e2e.rs
@@ -1,0 +1,60 @@
+//! End-to-end test for the LANGUAGE FACTS library
+//! (`adj-facts-stdlib/language/opposites.adj`) driven through the built CLI:
+//! a native `table` of word → its opposite (antonym) resolves a binding-query
+//! recall with the dictionary's citation, and abstains on a word with no
+//! shipped opposite — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn language_opposites_recall_binds_antonym_with_citation() {
+    let dir = scratch("opposites");
+    // Copy the shipped opposites table beside the entry program and import it.
+    let src = facts_stdlib().join("language/opposites.adj");
+    std::fs::copy(&src, dir.join("opposites.adj")).expect("copy shipped opposites.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"opposites.adj\"\n\
+         ? opposite(hot, $Word)\n\
+         ? opposite(happy, $Word)\n\
+         ? opposite(purple, $Word)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The opposite of hot is cold; the opposite of happy is sad — recalled.
+    assert!(out.contains("\"Word\":\"cold\""), "hot → cold: {out}");
+    assert!(out.contains("\"Word\":\"sad\""), "happy → sad: {out}");
+    // The answer carries the Wiktionary citation as its proof, at consensus trust.
+    assert!(
+        out.contains("en.wiktionary.org/wiki/hot") && out.contains("\"trust\":\"consensus\""),
+        "carries the dictionary citation: {out}"
+    );
+    // No opposite is shipped for `purple` — honest abstention, never invented.
+    assert!(out.contains("\"abstained\":true"), "purple abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/language/opposites.adj
+++ b/code/specs/data/adj-facts-stdlib/language/opposites.adj
@@ -1,0 +1,70 @@
+% ============================================================================
+% opposites — a common word and its opposite (antonym)
+% (adj-facts-stdlib, LANGUAGE).
+% ============================================================================
+% One of the very first things a child learns about words: many of them come in
+% pairs that mean the reverse of each other. HOT is the opposite of COLD, BIG is
+% the opposite of SMALL. The word for "the opposite of" is an ANTONYM. This tiny
+% library records a handful of clean word→opposite pairs so an ADJ program can
+% recall them, each one cited to a dictionary. Recall is a binding query:
+%
+%     ? opposite(hot, $Word)      % cold
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `opposite(word, opposite)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the
+% opposite WITH its source, on the CPU, with zero model calls, and ABSTAINS on
+% any word not in the table (it never invents an opposite it cannot cite).
+%
+% The pairs, as a truth table:
+%
+%     word    opposite    read as…
+%     ------  --------    ----------------------
+%     hot     cold        "the opposite of hot is cold"
+%     big     small       "the opposite of big is small"
+%     fast    slow        "the opposite of fast is slow"
+%     wet     dry         "the opposite of wet is dry"
+%     happy   sad         "the opposite of happy is sad"
+%     open    closed      "the opposite of open is closed"
+%     hard    soft        "the opposite of hard is soft"
+%
+% Only ONE direction is shipped per pair (word → its opposite). A query like
+% `? opposite(cold, $W)` therefore ABSTAINS: the honest-abstention property is
+% deliberate — the table answers only what its source explicitly lists, and a
+% word with no shipped opposite (e.g. `purple`) returns no invented answer.
+%
+% Provenance — nothing here is from memory. Each pair is copied from the English
+% Wiktionary entry for the FIRST word, whose "Antonyms" line lists the opposite
+% verbatim. The per-pair citable spans (quoted exactly as printed) are:
+%
+%     hot    → en.wiktionary.org/wiki/hot     "Antonyms: cold, chilled"
+%     big    → en.wiktionary.org/wiki/big     "little, small, tiny, minuscule, …"
+%     fast   → en.wiktionary.org/wiki/fast    "Antonyms: slow"  (sense: quick/rapid)
+%     wet    → en.wiktionary.org/wiki/wet     "Antonym: dry"
+%     happy  → en.wiktionary.org/wiki/happy   "blue, depressed, down, miserable, moody, morose, sad, unhappy"
+%     open   → en.wiktionary.org/wiki/open    "closed, shut"
+%     hard   → en.wiktionary.org/wiki/hard    "Antonym: soft"  (sense: resistant to pressure)
+%
+% The single `source` span below is the clearest one (the `hot` entry); the
+% `locator` points at that entry, and each remaining pair's own page + verbatim
+% span is quoted above so every row is independently checkable. `trust
+% consensus` — a dictionary is a secondary reference, not a primary authority.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table opposite {
+    columns word, opposite
+
+    row (hot, cold)
+    row (big, small)
+    row (fast, slow)
+    row (wet, dry)
+    row (happy, sad)
+    row (open, closed)
+    row (hard, soft)
+
+    source "Antonyms: cold, chilled"
+    locator "https://en.wiktionary.org/wiki/hot"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/language/opposites.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/opposites.query.adj
@@ -1,0 +1,18 @@
+% ============================================================================
+% opposites.query.adj — a worked recall over the word-opposites library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the opposite of
+% hot?": it states no fact of its own — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the `opposite` rows
+% and returns the opposite + the table's source/locator/trust. A word the table
+% does not carry abstains honestly — the engine never invents an opposite.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli opposites.query.adj
+% ============================================================================
+
+import "opposites.adj"
+
+? opposite(hot, $Word)         % expect cold
+? opposite(happy, $Word)       % expect sad
+? opposite(purple, $Word)      % expect abstain — no opposite is shipped for purple


### PR DESCRIPTION
## What

Adds a new grounded ELEMENTARY facts library to the ADJ standard library under a new `language/` subject: **word → its opposite (antonym)**.

- `code/specs/data/adj-facts-stdlib/language/opposites.adj` — a native `table opposite { columns word, opposite … }` with 7 child-level pairs: hot→cold, big→small, fast→slow, wet→dry, happy→sad, open→closed, hard→soft. Beginner-friendly literate comment with a truth table.
- `code/specs/data/adj-facts-stdlib/language/opposites.query.adj` — worked recall: two binds (hot, happy) + one abstain (purple).
- `code/packages/rust/adj-lang-cli/tests/facts_opposites_e2e.rs` — e2e test (patterned on `facts_shapes_e2e`): asserts hot→cold, happy→sad, the citation + `consensus` trust, and honest abstention on `purple`.

## Grounding

Nothing from memory. Each pair copied **verbatim** from the English Wiktionary "Antonyms" line of the first word (per-pair page + span quoted in the file comment). Merriam-Webster's thesaurus hard-blocks automated fetches (HTTP 403), so a dictionary alternative (Wiktionary) was used, which supplies explicit "Antonyms" lists. Representative `source` span: `"Antonyms: cold, chilled"`; `locator`: `https://en.wiktionary.org/wiki/hot`. **trust: consensus** (a dictionary is a secondary reference).

## Verification

- `cargo test -p adj-lang-cli --test facts_opposites_e2e` — pass
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)