### PR TITLE
feat(adj-facts-stdlib): meteorological season → start month (NOAA, earth-science)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_seasons_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_seasons_e2e.rs
@@ -1,0 +1,63 @@
+//! End-to-end test for the earth-science FACTS library
+//! (`adj-facts-stdlib/earth-science/seasons.adj`) driven through the built CLI:
+//! a native `table` of meteorological season → start month (Northern Hemisphere)
+//! resolves a binding-query recall with the NOAA citation, and abstains on an
+//! equinox (an astronomical instant, not a meteorological season) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsseason_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn seasons_recall_binds_start_month_with_citation() {
+    let dir = scratch("seasons");
+    // Copy the shipped earth-science table beside the entry program and import it.
+    let src = facts_stdlib().join("earth-science/seasons.adj");
+    std::fs::copy(&src, dir.join("seasons.adj")).expect("copy shipped seasons.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"seasons.adj\"\n\
+         ? season_start_month(spring, $Month)\n\
+         ? season_start_month(summer, $Month)\n\
+         ? season_start_month(equinox, $Month)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Meteorological spring begins in March; summer begins in June — the recalled
+    // start months, straight from the grounded rows.
+    assert!(out.contains("\"Month\":\"march\""), "spring → march: {out}");
+    assert!(out.contains("\"Month\":\"june\""), "summer → june: {out}");
+    // The answer carries the NOAA/NCEI citation (authoritative, a .gov source) as
+    // proof — both the locator URL and the honest trust tier.
+    assert!(
+        out.contains("ncei.noaa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NOAA source citation: {out}"
+    );
+    // An equinox is an astronomical instant, not a meteorological season — honest
+    // abstention, never a fabricated month.
+    assert!(out.contains("\"abstained\":true"), "equinox abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/earth-science/seasons.adj
+++ b/code/specs/data/adj-facts-stdlib/earth-science/seasons.adj
@@ -1,0 +1,57 @@
+% ============================================================================
+% seasons — each meteorological season's start month, Northern Hemisphere
+% (adj-facts-stdlib, EARTH-SCIENCE).
+% ============================================================================
+% A plain earth-science fact a young student meets with the calendar: forecasters
+% do not wait for the exact tilt of the Earth to call a season — they group the
+% year into four tidy three-month blocks that line up with the temperature cycle,
+% so each block starts on the first of a month. Spring is March–April–May, so it
+% STARTS in March; summer is June–July–August, so it starts in June; fall is
+% September–October–November, starting in September; and winter is
+% December–January–February, starting in December. Recall is a binding query:
+%
+%     ? season_start_month(spring, $Month)   % march  (spring begins in March)
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `season_start_month(season, start_month)` carrying the NOAA citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% start month WITH its source, on the CPU, with zero model calls. The relation
+% binds BOTH ways: forward `? season_start_month(summer, $M)` gives june, and
+% reverse `? season_start_month($S, december)` gives winter. It abstains on any
+% word the page does not name as a meteorological season — an equinox, a solstice,
+% or a made-up "monsoon" is not a row, so the engine stays silent rather than
+% invent a month. Both atoms — season and month — are lowercase, and the
+% `start_month` value is a month ATOM (a name, not a number): to turn it into a
+% number for arithmetic, compose it with the calendar library
+% (`? month_number(march, $N)` → 3), the concrete bridge from RECALL to COMPUTE.
+%
+% IMPORTANT — this is the METEOROLOGICAL definition, and Northern-Hemisphere only.
+% NOAA distinguishes meteorological seasons (fixed calendar months, used here)
+% from astronomical seasons (which begin at the equinoxes and solstices and shift
+% by a day or two each year). The Southern Hemisphere's seasons are offset by six
+% months. This table encodes exactly the one span quoted below and nothing more.
+%
+% Provenance: the four season → months groupings are copied from NOAA's National
+% Centers for Environmental Information (NCEI) explainer, whose single sentence at
+% the `locator` lists every meteorological season with its months in order:
+% "Meteorological spring in the Northern Hemisphere includes March, April, and
+% May; ... summer includes June, July, and August; ... fall includes September,
+% October, and November; and ... winter includes December, January, and
+% February." Each season's START month is the first month of its listed block.
+% `trust authoritative` — NOAA/NCEI is a U.S. government (.gov) primary source.
+% Nothing here is asserted from memory. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table season_start_month {
+    columns season, start_month
+
+    row (spring, march)
+    row (summer, june)
+    row (fall, september)
+    row (winter, december)
+
+    source "Meteorological spring in the Northern Hemisphere includes March, April, and May; meteorological summer includes June, July, and August; meteorological fall includes September, October, and November; and meteorological winter includes December, January, and February."
+    locator "https://www.ncei.noaa.gov/news/meteorological-versus-astronomical-seasons"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/earth-science/seasons.query.adj
+++ b/code/specs/data/adj-facts-stdlib/earth-science/seasons.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% seasons.query.adj — a worked recall over the earth-science seasons library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which month does spring
+% start in?" — it states no earth-science fact, only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `season_start_month` rows and returns the start month (or the season, on a
+% reverse query) + the NOAA source/locator/trust. A word the page does not name as
+% a meteorological season abstains honestly — the engine never invents a month.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli seasons.query.adj
+% ============================================================================
+
+import "seasons.adj"
+
+? season_start_month(spring, $Month)      % expect march   (spring begins in March)
+? season_start_month(summer, $Month)      % expect june    (summer begins in June)
+? season_start_month($Season, december)   % expect winter  (reverse: starts in Dec?)
+? season_start_month(equinox, $Month)     % expect abstain — an equinox is an
+                                          %   astronomical instant, not a season


### PR DESCRIPTION
## What

Adds one grounded ELEMENTARY facts library to the ADJ standard library: the meteorological season → start month mapping for the Northern Hemisphere.

- `code/specs/data/adj-facts-stdlib/earth-science/seasons.adj` — native `table season_start_month { columns season, start_month }` with four rows: spring→march, summer→june, fall→september, winter→december. Lowercase season + month atoms; beginner literate comment. The `start_month` is a month ATOM (compose with `calendar/months.adj` to get a number). Misses abstain (an equinox/solstice is not a row).
- `code/specs/data/adj-facts-stdlib/earth-science/seasons.query.adj` — worked recall: 2 forward binds, 1 reverse bind, 1 abstain on a non-season.
- `code/packages/rust/adj-lang-cli/tests/facts_seasons_e2e.rs` — e2e recall test (copies the shipped table beside an entry program, imports it), asserting 2 binds, the `ncei.noaa.gov` locator + `"trust":"authoritative"`, and one abstain.

## Grounding

Source: NOAA National Centers for Environmental Information (NCEI), *Meteorological Versus Astronomical Seasons*.
Locator: https://www.ncei.noaa.gov/news/meteorological-versus-astronomical-seasons

Verbatim span copied into `source`:
> "Meteorological spring in the Northern Hemisphere includes March, April, and May; meteorological summer includes June, July, and August; meteorological fall includes September, October, and November; and meteorological winter includes December, January, and February."

Each season's START month is the first month of its listed three-month block. TRUST tier `authoritative` (U.S. government .gov primary source). Nothing asserted from memory.

## Verification

- `cargo test -p adj-lang-cli --test facts_seasons_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review: passed (no findings)

DATA + one test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)