### PR TITLE
feat(adj-facts-stdlib): geography continents → size rank (NatGeo)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_continents_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_continents_e2e.rs
@@ -1,0 +1,63 @@
+//! End-to-end test for the geography continents FACTS library
+//! (`adj-facts-stdlib/geography/continents.adj`): a native `table` of
+//! continent → size-rank resolves forward AND reverse binding queries with the
+//! National Geographic citation, and abstains on something that is not a
+//! continent — 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn geography_continents_recall_binds_rank_forward_and_reverse() {
+    let dir = scratch("continents");
+    let src = facts_stdlib().join("geography/continents.adj");
+    std::fs::copy(&src, dir.join("continents.adj")).expect("copy shipped continents.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"continents.adj\"\n\
+         ? continent_size_rank(asia, $R)\n\
+         ? continent_size_rank($Continent, 3)\n\
+         ? continent_size_rank(greenland, $R)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward: Asia is the largest continent, so rank 1.
+    assert!(out.contains("\"R\":\"1\""), "asia → 1: {out}");
+    // Reverse: the third largest continent is North America (binds the other column).
+    assert!(
+        out.contains("\"Continent\":\"north_america\""),
+        "rank 3 → north_america: {out}"
+    );
+    // The answer carries the National Geographic citation as its proof.
+    assert!(
+        out.contains("education.nationalgeographic.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the National Geographic citation: {out}"
+    );
+    // Greenland is the world's largest island, not a continent — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "greenland abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/geography/continents.adj
+++ b/code/specs/data/adj-facts-stdlib/geography/continents.adj
@@ -1,0 +1,53 @@
+% ============================================================================
+% continents — each continent's size rank, largest = 1 (adj-facts-stdlib, GEOGRAPHY).
+% ============================================================================
+% A geography facts library — one of the very first things a child learns from a
+% globe or a classroom map: the seven great landmasses of the world, put in order
+% from biggest to smallest. Asia is the huge one that fills most of the map;
+% Australia is the small one down in the corner. Recall is a binding query:
+%
+%     ? continent_size_rank(asia, $R)     % 1  (Asia is the largest continent)
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `continent_size_rank(continent, rank)` carrying the National Geographic
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the rank WITH its source, on the CPU, with zero model calls, and
+% abstains on anything that is not one of the seven named continents (e.g.
+% greenland is the world's largest ISLAND, not a continent, so it is deliberately
+% NOT a row here). The `rank` value is a NUMBER, so a recalled rank composes into
+% arithmetic (how many continents sit between Asia and Europe? 6 − 1 − 1 = 4).
+%
+% Two-word continent names are written as lowercase atoms with an underscore:
+% `north_america`, `south_america`.
+%
+% Provenance: National Geographic Education states the full size ordering in a
+% single sentence — "The continents are, from largest to smallest: Asia, Africa,
+% North America, South America, Antarctica, Europe, and Australia." That one span
+% fixes all seven ranks in order: asia 1, africa 2, north_america 3,
+% south_america 4, antarctica 5, europe 6, australia 7. The citable artifact is
+% National Geographic Education's "Continent" resource at the `locator`.
+% `trust consensus` — National Geographic is an authoritative secondary reference
+% (an educational encyclopedia), not a primary/official standards body, so the
+% honest tier is `consensus`. (This same ordering is independently corroborated by
+% Encyclopaedia Britannica and by Wikipedia's "Continent" article, which lists the
+% seven "from largest to smallest in area" in exactly this order.) Nothing here is
+% asserted from memory. The set of continents is the seven-continent model taught
+% in the United States. (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table continent_size_rank {
+    columns continent, rank
+
+    row (asia, 1)
+    row (africa, 2)
+    row (north_america, 3)
+    row (south_america, 4)
+    row (antarctica, 5)
+    row (europe, 6)
+    row (australia, 7)
+
+    source "The continents are, from largest to smallest: Asia, Africa, North America, South America, Antarctica, Europe, and Australia."
+    locator "https://education.nationalgeographic.org/resource/Continent/"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/geography/continents.query.adj
+++ b/code/specs/data/adj-facts-stdlib/geography/continents.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% continents.query.adj — a worked recall over the geography continents library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which is the biggest
+% continent?" — it states no geography fact, only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% continent_size_rank rows and returns the rank (or the continent, on a reverse
+% query) + the National Geographic source/locator/trust. A landmass that is not
+% one of the seven named continents abstains honestly — the engine never invents
+% a rank.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli continents.query.adj
+% ============================================================================
+
+import "continents.adj"
+
+? continent_size_rank(asia, $R)          % expect 1  (the largest continent)
+? continent_size_rank(australia, $R)     % expect 7  (the smallest of the seven)
+? continent_size_rank($Continent, 3)     % expect north_america (reverse: who is #3?)
+? continent_size_rank(greenland, $R)     % expect abstain — an island, not a continent


### PR DESCRIPTION
## What

A grounded elementary FACTS library for the ADJ standard library: the **seven continents ranked by area** (largest = 1).

- `code/specs/data/adj-facts-stdlib/geography/continents.adj` — native `table continent_size_rank` (RS-5): asia 1, africa 2, north_america 3, south_america 4, antarctica 5, europe 6, australia 7. Each row lowers to a ground relation carrying the National Geographic citation; recall is an ordinary SLD binding query resolved on the CPU with **zero answer-time model calls**, and abstains on non-continents (e.g. `greenland`, an island). Two-word names use lowercase underscore atoms (`north_america`, `south_america`).
- `.../geography/continents.query.adj` — worked recall (forward, reverse, and an abstain).
- `code/packages/rust/adj-lang-cli/tests/facts_continents_e2e.rs` — e2e test: 2 binds (forward `asia → 1`, reverse `3 → north_america`), NatGeo locator + `consensus` trust, one abstain (`greenland`).

## Grounding

The full ordering is fixed by a single verbatim National Geographic Education span:

> "The continents are, from largest to smallest: Asia, Africa, North America, South America, Antarctica, Europe, and Australia."

Source: https://education.nationalgeographic.org/resource/Continent/ — independently corroborated by Encyclopaedia Britannica and by Wikipedia's "Continent" article ("from largest to smallest in area"). Nothing asserted from memory. Trust tier **`consensus`** — NatGeo is an authoritative secondary reference, not a primary standards body.

## Verification

- `cargo test -p adj-lang-cli --test facts_continents_e2e` — 1 passed
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)