### PR TITLE
feat(adj-facts-stdlib): optics rainbow-color → visible-spectrum order (grounded, NASA)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_rainbow_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_rainbow_e2e.rs
@@ -1,0 +1,60 @@
+//! End-to-end test for the optics FACTS library
+//! (`adj-facts-stdlib/optics/rainbow-colors.adj`) driven through the built CLI:
+//! a native `table` of rainbow-color → order-in-the-visible-spectrum resolves a
+//! binding-query recall with the NASA citation, and abstains on a non-spectral
+//! color — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsr_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn optics_rainbow_recall_binds_color_order_with_citation() {
+    let dir = scratch("rainbow");
+    // Copy the shipped optics table beside the entry program and import it.
+    let src = facts_stdlib().join("optics/rainbow-colors.adj");
+    std::fs::copy(&src, dir.join("rainbow-colors.adj")).expect("copy shipped rainbow-colors.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"rainbow-colors.adj\"\n\
+         ? rainbow_color_order(green, $N)\n\
+         ? rainbow_color_order(violet, $N)\n\
+         ? rainbow_color_order(brown, $N)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Green is the fourth color; violet is the seventh — the recalled orders.
+    assert!(out.contains("\"N\":\"4\""), "green → 4: {out}");
+    assert!(out.contains("\"N\":\"7\""), "violet → 7: {out}");
+    // The answer carries the NASA locator + trust tier as its proof.
+    assert!(
+        out.contains("imagine.gsfc.nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Brown is not a spectral color — honest abstention, never a fabricated order.
+    assert!(out.contains("\"abstained\":true"), "brown abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/optics/rainbow-colors.adj
+++ b/code/specs/data/adj-facts-stdlib/optics/rainbow-colors.adj
@@ -1,0 +1,41 @@
+% ============================================================================
+% rainbow-colors — the visible-spectrum colors in order (adj-facts-stdlib, OPTICS).
+% ============================================================================
+% An optics facts library — an early science fact: the colors of the rainbow
+% (the visible spectrum), counting from red, the thing a child remembers with
+% the name "Roy G. Biv". Recall is a binding query:
+%
+%     ? rainbow_color_order(green, $N)   % 4  (green is the fourth color)
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `rainbow_color_order(color, order)` carrying the NASA citation, so the lookup
+% above is the ordinary SLD binding query — the engine returns the position WITH
+% its source, on the CPU, with zero model calls, and abstains on a non-color
+% (e.g. brown, which is not a spectral color, is deliberately NOT a row here).
+% The `order` value is a NUMBER, so a recalled position composes into arithmetic
+% (how many colors lie between red and green? 4 − 1 − 1 = 2).
+%
+% Provenance: NASA's Goddard "Imagine the Universe" education lesson names the
+% seven colors of visible sunlight in order in one sentence (see `source` below);
+% the citable artifact is that lesson page at the `locator`. `trust authoritative`
+% — a NASA (.gov) primary education reference. Nothing here is asserted from
+% memory. Order is red (longest wavelength) → violet (shortest), exactly as the
+% cited sentence lists them. (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table rainbow_color_order {
+    columns color, order
+
+    row (red, 1)
+    row (orange, 2)
+    row (yellow, 3)
+    row (green, 4)
+    row (blue, 5)
+    row (indigo, 6)
+    row (violet, 7)
+
+    source "the colors red, orange, yellow, green, blue, indigo, and violet"
+    locator "https://imagine.gsfc.nasa.gov/educators/lessons/roygbiv/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/optics/rainbow-colors.query.adj
+++ b/code/specs/data/adj-facts-stdlib/optics/rainbow-colors.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% rainbow-colors.query.adj — a worked recall over the optics rainbow library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which color is fourth in
+% the rainbow?" — it states no optics fact, only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `rainbow_color_order` rows and returns the position (or the color, on a reverse
+% query) + the NASA source/locator/trust. A hue that is not one of the seven
+% spectral colors abstains honestly — the engine never invents an order.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli rainbow-colors.query.adj
+% ============================================================================
+
+import "rainbow-colors.adj"
+
+? rainbow_color_order(green, $N)       % expect 4  (which position is green?)
+? rainbow_color_order(violet, $N)      % expect 7  (the last/shortest-wavelength)
+? rainbow_color_order($Color, 1)       % expect red (reverse: which is first?)
+? rainbow_color_order(brown, $N)       % expect abstain — not a spectral color


### PR DESCRIPTION
## Summary

Adds a grounded ELEMENTARY facts library under a new `optics/` subject of the ADJ facts standard library: the seven colors of the visible spectrum (rainbow) in order.

- `rainbow_color_order(color, order)` native ADJ `table`: red→1, orange→2, yellow→3, green→4, blue→5, indigo→6, violet→7.
- Recall is an ordinary SLD binding query — returns the position WITH its citation on the CPU, zero model calls, and abstains honestly on a non-spectral color (brown is deliberately not a row).
- Mirrors the sibling `astronomy/planets.adj` name→order shape.

## Grounding

- **Source:** NASA Goddard "Imagine the Universe" ROY G. BIV education lesson, which lists the colors in order in one sentence.
- **Verbatim span** (in `source`): `the colors red, orange, yellow, green, blue, indigo, and violet`
- **Locator:** https://imagine.gsfc.nasa.gov/educators/lessons/roygbiv/
- **Trust:** `authoritative` (NASA `.gov` primary reference). Nothing asserted from memory.

## Files (data + one test only)

- `code/specs/data/adj-facts-stdlib/optics/rainbow-colors.adj`
- `code/specs/data/adj-facts-stdlib/optics/rainbow-colors.query.adj`
- `code/packages/rust/adj-lang-cli/tests/facts_rainbow_e2e.rs` — 2 binds (green→4, violet→7), asserts locator + trust, one abstain on brown.

## Verification

- `cargo test -p adj-lang-cli --test facts_rainbow_e2e` — passing
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review (Rust sub-agent) — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)