### PR TITLE
feat(adj-facts-stdlib): traffic-signal color → driver meaning (FHWA MUTCD)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_trafficlights_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_trafficlights_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the transportation FACTS library
+//! (`adj-facts-stdlib/transportation/traffic-lights.adj`) driven through the built CLI:
+//! a native `table` of steady-signal color → meaning resolves a binding-query recall
+//! with the source's citation, and abstains on a non-signal color — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn transportation_traffic_lights_recall_binds_meaning_with_citation() {
+    let dir = scratch("trafficlights");
+    // Copy the shipped transportation table beside the entry program and import it.
+    let src = facts_stdlib().join("transportation/traffic-lights.adj");
+    std::fs::copy(&src, dir.join("traffic-lights.adj")).expect("copy shipped traffic-lights.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"traffic-lights.adj\"\n\
+         ? traffic_light_meaning(red, $Meaning)\n\
+         ? traffic_light_meaning(green, $Meaning)\n\
+         ? traffic_light_meaning(blue, $Meaning)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Red means stop; green means proceed — the recalled meanings.
+    assert!(out.contains("\"Meaning\":\"stop\""), "red → stop: {out}");
+    assert!(out.contains("\"Meaning\":\"proceed\""), "green → proceed: {out}");
+    // The answer carries the FHWA MUTCD citation (locator + trust) as its proof.
+    assert!(
+        out.contains("mutcd.fhwa.dot.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Blue is not a steady signal color — honest abstention, never a fabricated meaning.
+    assert!(out.contains("\"abstained\":true"), "blue abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/transportation/traffic-lights.adj
+++ b/code/specs/data/adj-facts-stdlib/transportation/traffic-lights.adj
@@ -1,0 +1,77 @@
+% ============================================================================
+% traffic-lights — each steady traffic-signal COLOR and what it means to a
+% driver (adj-facts-stdlib, TRANSPORTATION).
+% ============================================================================
+% One of the very first rules a child learns about the road, and the first
+% thing a new driver studies: a steady traffic light shows one of three
+% colors, and each color tells the driver what to do. Red means stop, yellow
+% is a warning that red is coming, and green means you may go. Recall is a
+% binding query:
+%
+%     ? traffic_light_meaning(red, $Meaning)      % stop
+%     ? traffic_light_meaning(green, $Meaning)    % proceed
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `traffic_light_meaning(color, meaning)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the meaning WITH its source, on the CPU, with zero model calls, and
+% abstains on anything that is not one of the three steady signal colors.
+%
+% The three STEADY (not flashing) circular signal indications, as a truth
+% table over the colors shipped here:
+%
+%     color     meaning     what the driver does (a beginner's cue)
+%     --------  ---------   -------------------------------------------------
+%     red       stop        stop at the stop line / before the crosswalk
+%     yellow    warned      warned that the green is ending and red is next
+%     green     proceed     permitted to proceed (go straight / turn)
+%
+% Only these three colors are steady vehicular indications. A color that is
+% NOT a traffic-signal color — `blue`, `purple`, `orange` — is deliberately
+% NOT a row, so a meaning recall ABSTAINS on it rather than inventing a rule.
+% That honest-abstention property is what makes a recall table safe to build a
+% reasoner on. (Note: this library covers the STEADY circular indications; a
+% flashing yellow or a red/green ARROW carries a different, separate meaning
+% in the manual and is intentionally out of scope for this first table.)
+%
+% ----------------------------------------------------------------------------
+% Provenance (byte-quotable, per the ADJ-facts standard).
+% ----------------------------------------------------------------------------
+% Every row is copied from the FHWA MANUAL ON UNIFORM TRAFFIC CONTROL DEVICES
+% (MUTCD), 2009 Edition, Section 4D.04 "Meaning of Vehicular Signal
+% Indications" — the federal standard for U.S. traffic control devices, hence
+% `trust authoritative` (mutcd.fhwa.dot.gov is a `.gov` primary source).
+% Nothing here is asserted from memory. Because ADJ tables carry ONE shared
+% provenance envelope (per-row provenance is a documented future extension —
+% see ADJ-TABLES §6), the envelope below cites Section 4D.04 at its `locator`,
+% and the `source` quotes the RED indication verbatim. For full auditability,
+% here is the exact MUTCD span that grounds EACH row:
+%
+%   red    — "Vehicular traffic facing a steady CIRCULAR RED signal
+%             indication, unless entering the intersection to make another
+%             movement permitted by another signal indication, shall stop at a
+%             clearly marked stop line" → red means STOP.
+%
+%   yellow — "Vehicular traffic facing a steady CIRCULAR YELLOW signal
+%             indication is thereby warned that the related green movement ...
+%             is being terminated or that a steady red signal indication will
+%             be displayed immediately thereafter" → yellow means WARNED.
+%
+%   green  — "Vehicular traffic facing a CIRCULAR GREEN signal indication is
+%             permitted to proceed straight through or turn right or left or
+%             make a U-turn movement" → green means PROCEED.
+%
+% (See ../README.md; feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table traffic_light_meaning {
+    columns color, meaning
+
+    row (red, stop)
+    row (yellow, warned)
+    row (green, proceed)
+
+    source "Vehicular traffic facing a steady CIRCULAR RED signal indication, unless entering the intersection to make another movement permitted by another signal indication, shall stop at a clearly marked stop line"
+    locator "https://mutcd.fhwa.dot.gov/htm/2009/part4/part4d.htm"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/transportation/traffic-lights.query.adj
+++ b/code/specs/data/adj-facts-stdlib/transportation/traffic-lights.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% traffic-lights.query.adj — a worked recall over the traffic-light library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does a red light
+% mean to a driver?": it states no rule of the road — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?`
+% against the `traffic_light_meaning` rows and returns the meaning + the
+% table's source/locator/trust. A color that is not a steady signal color
+% abstains honestly — the engine never invents a meaning.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli traffic-lights.query.adj
+% ============================================================================
+
+import "traffic-lights.adj"
+
+? traffic_light_meaning(red, $Meaning)      % expect stop
+? traffic_light_meaning(green, $Meaning)    % expect proceed
+? traffic_light_meaning(blue, $Meaning)     % expect abstain — not a signal color


### PR DESCRIPTION
## What

Adds one grounded elementary FACTS library to the ADJ standard library: **`transportation/traffic-lights.adj`** — a native ADJ `table` mapping each **steady circular traffic-signal color → what it means to a driver**.

| color | meaning |
|---|---|
| red | stop |
| yellow | warned |
| green | proceed |

## Grounding

Every value atom is copied verbatim from the **FHWA Manual on Uniform Traffic Control Devices (MUTCD), 2009 Edition, Section 4D.04 "Meaning of Vehicular Signal Indications"** — a `.gov` federal standard, so `trust authoritative`.

- **locator:** https://mutcd.fhwa.dot.gov/htm/2009/part4/part4d.htm
- red — "shall stop at a clearly marked stop line" → **stop**
- yellow — "is thereby warned that the related green movement ... is being terminated" → **warned**
- green — "is permitted to proceed straight through or turn right or left" → **proceed**

A non-signal color (`blue`) is not a row, so a meaning recall **abstains** honestly rather than fabricating.

## Ships

- `transportation/traffic-lights.adj` — the grounded `table` with a beginner-facing literate comment and per-row provenance spans.
- `transportation/traffic-lights.query.adj` — a worked recall (2 binds + 1 abstain).
- `code/packages/rust/adj-lang-cli/tests/facts_trafficlights_e2e.rs` — end-to-end test (modeled on `facts_shapes_e2e`): red→stop and green→proceed bind with the MUTCD locator + `authoritative` trust; blue abstains. 0 model calls.

## Verification

- `cargo test -p adj-lang-cli --test facts_trafficlights_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

Data + one test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)