### PR TITLE
feat(adj-facts-stdlib): biology plant-parts → primary-function table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_plantparts_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_plantparts_e2e.rs
@@ -1,0 +1,68 @@
+//! End-to-end test for the biology PLANT-PARTS facts library
+//! (`adj-facts-stdlib/biology/plant-parts.adj`) driven through the built CLI:
+//! a native `table` of plant-part → primary-function resolves binding-query
+//! recalls (forward and backward) with the source's citation, and abstains on a
+//! non-plant-part — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_plant_parts_recall_binds_function_with_citation() {
+    let dir = scratch("plantparts");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/plant-parts.adj");
+    std::fs::copy(&src, dir.join("plant-parts.adj")).expect("copy shipped plant-parts.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"plant-parts.adj\"\n\
+         ? plant_part_function(roots, $Function)\n\
+         ? plant_part_function($Part, photosynthesis)\n\
+         ? plant_part_function(mushroom, $Function)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The roots absorb water — the recalled forward binding.
+    assert!(
+        out.contains("\"Function\":\"absorb_water\""),
+        "roots → absorb_water: {out}"
+    );
+    // The relation runs BACKWARD too: what does photosynthesis? — the leaves.
+    assert!(
+        out.contains("\"Part\":\"leaves\""),
+        "photosynthesis ← leaves (reverse recall): {out}"
+    );
+    // The answer carries the UF/IFAS Extension citation, at the authoritative tier.
+    assert!(
+        out.contains("blogs.ifas.ufl.edu") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation with its locator + trust: {out}"
+    );
+    // A mushroom is a fungus, not a plant part — honest abstention, never a
+    // fabricated function.
+    assert!(out.contains("\"abstained\":true"), "mushroom abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/plant-parts.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/plant-parts.adj
@@ -1,0 +1,64 @@
+% ============================================================================
+% plant-parts — each main plant part and its primary function
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the first biology facts a child learns, and a foundation a science or
+% medicine agent reasons up from: a plant is built from a few main PARTS, and
+% each part does one main JOB. The roots drink up water, the stem holds the
+% plant up, the leaves make food from sunlight, and the flower makes new plants.
+% Recall is a binding query:
+%
+%     ? plant_part_function(roots, $Function)   % absorb_water
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `plant_part_function(part, function)` carrying the table's citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% function atom WITH its source, on the CPU, with zero model calls, and abstains
+% on anything that is not one of these parts. The query also runs BACKWARD —
+% bind the function and recall the part:
+%
+%     ? plant_part_function($Part, photosynthesis)  % leaves
+%
+% Each row's `function` value is a SINGLE lowercase atom, chosen as a faithful
+% one-word paraphrase of the function the source states for that part — never an
+% interpretation the source does not support. A recalled function atom therefore
+% composes straight into downstream reasoning (an agent asking "which part does
+% photosynthesis?" gets the grounded answer, not a guess) — the concrete bridge
+% from biology RECALL to reasoning.
+%
+% Each plant part and its `function` atom, as a truth table, with the VERBATIM
+% sentence from the source that grounds it:
+%
+%     part     function        grounding sentence (copied character-for-character)
+%     ------   -------------   ------------------------------------------------------------
+%     roots    absorb_water    "Roots anchor a plant in the soil and absorb air, water, and nutrients."
+%     stem     support         "Stems provide structural support and transport water and nutrients between roots, leaves, and flowers."
+%     leaves   photosynthesis  "Leaves capture sunlight for photosynthesis."
+%     flower   reproduction    "Flowers are the reproductive structures of plants, classified as perfect (having both male and female parts) or imperfect (male or female)."
+%
+% Provenance: every part name and its `function` atom is grounded in the plant
+% "Organs" article on UF/IFAS Extension (University of Florida Institute of Food
+% and Agricultural Sciences) Pasco County — the citable artifact at the
+% `locator`. The `source` span below is the VERBATIM sentence for the FIRST data
+% row (roots), copied character-for-character from that page; the other three
+% rows' atoms are each grounded in the same page's verbatim sentence shown in the
+% table above. `trust authoritative` — a university-extension publication is a
+% primary educational reference (contrast the `consensus` tier reserved for a
+% collaboratively edited encyclopedia). Nothing here is asserted from memory;
+% any part whose function the article did not state would have been dropped.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_adjudication_no_interpretive_gating.)
+% ============================================================================
+
+table plant_part_function {
+    columns part, function
+
+    row (roots, absorb_water)
+    row (stem, support)
+    row (leaves, photosynthesis)
+    row (flower, reproduction)
+
+    source "Roots anchor a plant in the soil and absorb air, water, and nutrients."
+    locator "https://blogs.ifas.ufl.edu/pascoco/2025/01/23/plant-biology-organs/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/plant-parts.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/plant-parts.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% plant-parts.query.adj — a worked recall over the biology plant-parts library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the stem do?":
+% it states no biology fact — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `plant_part_function`
+% rows and returns the function atom + the table's source/locator/trust. The
+% fourth query runs the relation BACKWARD (bind the function, recall the part).
+% A part not in the table — here `mushroom`, which is a fungus, not a plant part —
+% abstains honestly: the engine never invents a function.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli plant-parts.query.adj
+% ============================================================================
+
+import "plant-parts.adj"
+
+? plant_part_function(roots, $Function)        % expect absorb_water
+? plant_part_function(leaves, $Function)       % expect photosynthesis
+? plant_part_function(flower, $Function)       % expect reproduction
+? plant_part_function($Part, photosynthesis)   % expect leaves — the reverse recall
+? plant_part_function(mushroom, $Function)     % expect abstain — not a plant part


### PR DESCRIPTION
## What

Adds a grounded elementary FACTS library to the ADJ standard library: each main plant part → its primary function.

| part | function |
|---|---|
| roots | absorb_water |
| stem | support |
| leaves | photosynthesis |
| flower | reproduction |

Native ADJ-TABLES `table` (part → function), lowercase atoms, honest abstention on a non-part. Resolves as an ordinary SLD binding query — forward and backward — with zero answer-time model calls, returning the answer WITH its citation.

## Grounding

Every part/function pair is byte-provenanced to a VERBATIM sentence from the UF/IFAS Extension "Plant Biology: Organs" article (University of Florida Institute of Food and Agricultural Sciences), Pasco County — a university-extension publication.

- **Source URL:** https://blogs.ifas.ufl.edu/pascoco/2025/01/23/plant-biology-organs/
- **Trust tier:** `authoritative` (university-extension primary educational reference)
- Verbatim spans (confirmed against the raw page):
  - roots — "Roots anchor a plant in the soil and absorb air, water, and nutrients."
  - stem — "Stems provide structural support and transport water and nutrients between roots, leaves, and flowers."
  - leaves — "Leaves capture sunlight for photosynthesis."
  - flower — "Flowers are the reproductive structures of plants, classified as perfect (having both male and female parts) or imperfect (male or female)."

Nothing asserted from memory.

## Ships

- `code/specs/data/adj-facts-stdlib/biology/plant-parts.adj` — 4-row table + beginner literate comment + citation
- `code/specs/data/adj-facts-stdlib/biology/plant-parts.query.adj` — forward + reverse recall, abstain on `mushroom`
- `code/packages/rust/adj-lang-cli/tests/facts_plantparts_e2e.rs` — 2 binds, locator + trust, one abstain

## Verification

- `cargo test -p adj-lang-cli --test facts_plantparts_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)