### PR TITLE
feat(sql): IS [NOT] DISTINCT FROM (standard-SQL null-safe compare)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.31 — `IS [NOT] DISTINCT FROM` (standard-SQL null-safe compare)
+
+`SELECT a IS DISTINCT FROM b`, `a IS NOT DISTINCT FROM b`, and the WHERE-predicate
+form now parse and run: `IS NOT DISTINCT FROM` is the null-safe equality (both-NULL
+is "not distinct" = equal, one-NULL distinct, values compared otherwise) and `IS
+DISTINCT FROM` is its negation — the SQL-standard spelling of the `IS`/`IS NOT`
+operator merged earlier. It is lowered entirely in the planner (sql-parser 0.1.15
+grammar; sql-planner 0.2.14 inverts the sense on DISTINCT) onto the existing
+`plan_is_distinct` null-safe-CASE machinery — no new codegen or VM. Two
+differential-oracle cases (the four-combination table + a WHERE predicate) diff
+against real bundled SQLite.
+
 ## 0.5.30 — Expr-level `COLLATE` in comparisons
 
 `x = y COLLATE NOCASE`, `a < b COLLATE RTRIM`, `WHERE name = 'foo' COLLATE NOCASE`

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.30"
+version = "0.5.31"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1090,6 +1090,28 @@ const CASES: &[Case] = &[
         setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
         query: "SELECT (5 = '5' COLLATE NOCASE) AS a, (5 = 5 COLLATE NOCASE) AS b FROM t",
     },
+    // ---- Lane 2: IS [NOT] DISTINCT FROM (standard-SQL null-safe compare) --
+    // `IS NOT DISTINCT FROM` = null-safe equality (like `IS`); `IS DISTINCT
+    // FROM` = its negation. Both-NULL is "not distinct" (equal). Aliased so
+    // the diff is on the value, not the column name.
+    Case {
+        id: "is_distinct_from",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, a INTEGER, b INTEGER)",
+            "INSERT INTO t VALUES (1,1,1),(2,1,2),(3,NULL,NULL),(4,1,NULL)",
+        ],
+        query: "SELECT id, (a IS DISTINCT FROM b) AS d, (a IS NOT DISTINCT FROM b) AS nd FROM t ORDER BY id",
+    },
+    // `IS NOT DISTINCT FROM` used as a WHERE predicate — the null-safe match
+    // includes the both-NULL row, which a plain `a = b` would exclude.
+    Case {
+        id: "is_not_distinct_from_where",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, a INTEGER, b INTEGER)",
+            "INSERT INTO t VALUES (1,1,1),(2,1,2),(3,NULL,NULL),(4,2,NULL)",
+        ],
+        query: "SELECT id FROM t WHERE a IS NOT DISTINCT FROM b ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.15] - Unreleased
+
+### Added
+
+- **`IS [NOT] DISTINCT FROM`** in comparisons — the standard-SQL spelling of the
+  null-safe compare. The grammar adds `IS DISTINCT FROM <expr>` and `IS NOT
+  DISTINCT FROM <expr>` sequences ahead of the plain `IS [NOT] <expr>` forms so
+  ordered choice matches the DISTINCT keyword first.
+
 ## [0.1.14] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -501,6 +501,25 @@ pub fn parser_grammar() -> ParserGrammar {
                             GrammarElement::Literal { value: r#"NOT"#.to_string() },
                             GrammarElement::Literal { value: r#"NULL"#.to_string() },
                         ] },
+                        // `x IS [NOT] DISTINCT FROM <expr>` — the standard-SQL
+                        // spelling of the null-safe compare. `IS NOT DISTINCT
+                        // FROM` is the null-safe *equality* (`x IS y`) and `IS
+                        // DISTINCT FROM` is its negation. Placed BEFORE the plain
+                        // `IS [NOT] <expr>` forms so ordered choice matches the
+                        // DISTINCT keyword first (the planner inverts the sense).
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"IS"#.to_string() },
+                            GrammarElement::Literal { value: r#"NOT"#.to_string() },
+                            GrammarElement::Literal { value: r#"DISTINCT"#.to_string() },
+                            GrammarElement::Literal { value: r#"FROM"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"IS"#.to_string() },
+                            GrammarElement::Literal { value: r#"DISTINCT"#.to_string() },
+                            GrammarElement::Literal { value: r#"FROM"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
+                        ] },
                         // `x IS NOT <expr>` / `x IS <expr>` — null-safe (in)equality.
                         // These come AFTER the IS NULL / IS NOT NULL sequences so
                         // ordered-choice matches the NULL forms first (NULL is

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -588,6 +588,21 @@ mod tests {
         }
     }
 
+    /// `IS [NOT] DISTINCT FROM` (the standard-SQL null-safe compare) parses as a
+    /// comparison — its DISTINCT sequences are matched ahead of the plain
+    /// `IS [NOT] <expr>` forms, and `IS NULL` still works unchanged.
+    #[test]
+    fn test_parse_is_distinct_from() {
+        for q in [
+            "SELECT x FROM t WHERE a IS DISTINCT FROM b",
+            "SELECT x FROM t WHERE a IS NOT DISTINCT FROM b",
+            "SELECT x FROM t WHERE a IS NULL",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "comparison"), "Expected comparison for {q:?}");
+        }
+    }
+
     /// The `GLOB` and `NOT GLOB` infix operators parse as comparison forms
     /// (the planner lowers them onto the `glob` builtin).
     #[test]

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.14] - Unreleased
+
+### Added
+
+- **`IS [NOT] DISTINCT FROM` lowered onto `plan_is_distinct`.** The IS handler now
+  inverts the sense when `DISTINCT` is present: `IS NOT DISTINCT FROM` is the
+  null-safe *equality* (`x IS y`) and `IS DISTINCT FROM` its negation (`x IS NOT
+  y`). No new codegen/VM — reuses the null-safe CASE machinery from the IS
+  slice.
+
 ## [0.2.13] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1957,12 +1957,20 @@ fn plan_comparison(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
     // operand node), whereas `IS <expr>` / `IS NOT <expr>` produce a second
     // expression node — that is how we tell the two apart.
     if direct_tok_uppers.contains(&"IS".to_string()) {
-        let negated = direct_tok_uppers.contains(&"NOT".to_string());
+        let has_not = direct_tok_uppers.contains(&"NOT".to_string());
         if let Some(right_node) = child_nodes_ordered.get(1) {
             let right = plan_expression(right_node)?;
+            // Two spellings share the null-safe compare `plan_is_distinct`:
+            //   `x IS [NOT] y`                 → negated = has_not
+            //   `x IS [NOT] DISTINCT FROM y`   → negated = !has_not
+            // because DISTINCT *inverts* the sense: `IS NOT DISTINCT FROM` is the
+            // null-safe equality (like `IS`), and `IS DISTINCT FROM` its negation
+            // (like `IS NOT`).
+            let has_distinct = direct_tok_uppers.contains(&"DISTINCT".to_string());
+            let negated = if has_distinct { !has_not } else { has_not };
             return Ok(plan_is_distinct(left, right, negated));
         }
-        return Ok(if negated {
+        return Ok(if has_not {
             SqlExpr::IsNotNull(Box::new(left))
         } else {
             SqlExpr::IsNull(Box::new(left))


### PR DESCRIPTION
## `IS [NOT] DISTINCT FROM` — standard-SQL null-safe compare

Adds the SQL-standard spelling of the null-safe comparison that shipped earlier as
`IS` / `IS NOT`. **Rotation lane 2 (operators).** A small, clean desugar — a
quick-win between the larger writer/subquery slices.

### Semantics (verified vs real SQLite)
| Expr | Result |
|---|---|
| `1 IS DISTINCT FROM 1` | 0 |
| `1 IS DISTINCT FROM 2` | 1 |
| `NULL IS DISTINCT FROM NULL` | 0 (both-NULL = *not* distinct) |
| `1 IS NOT DISTINCT FROM 1` | 1 |
| `NULL IS NOT DISTINCT FROM NULL` | 1 |
| `1 IS NOT DISTINCT FROM NULL` | 0 |

So `IS NOT DISTINCT FROM` is the null-safe **equality** and `IS DISTINCT FROM` its
negation.

### Grammar + planner only — no codegen/VM
- **sql-parser 0.1.15** — grammar adds `IS DISTINCT FROM <expr>` / `IS NOT
  DISTINCT FROM <expr>` sequences **before** the plain `IS [NOT] <expr>` forms so
  ordered choice matches the `DISTINCT` keyword first.
- **sql-planner 0.2.14** — the IS handler **inverts** the sense when `DISTINCT` is
  present (`IS NOT DISTINCT FROM` → equality, `IS DISTINCT FROM` → inequality),
  reusing the merged `plan_is_distinct` null-safe-`CASE` machinery. Plain `IS` /
  `IS NULL` unchanged.

### Tests
Parser test (both forms + `IS NULL` regression) + two differential-oracle cases
(the four-combination table + a WHERE predicate) diffed against real bundled
SQLite. Full affected set green; clippy clean.

### Security
Inline adversarial review **PASSED** — Option-safe token access, no
panic/OOB/overflow, grammar adds only bounded ordered-choice alternatives, and the
four spellings were logic-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
