### PR TITLE
feat(adj-facts-stdlib): agriculture farm-animal → product recall table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_farmanimals_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_farmanimals_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the agriculture FACTS library
+//! (`adj-facts-stdlib/agriculture/farm-animals.adj`) driven through the built CLI:
+//! a native `table` of farm animal → product resolves a binding-query recall
+//! with the source's citation, and abstains on a non-farm-animal — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn agriculture_farm_animals_recall_binds_product_with_citation() {
+    let dir = scratch("farmanimals");
+    // Copy the shipped agriculture table beside the entry program and import it.
+    let src = facts_stdlib().join("agriculture/farm-animals.adj");
+    std::fs::copy(&src, dir.join("farm-animals.adj")).expect("copy shipped farm-animals.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animals.adj\"\n\
+         ? farm_animal_product(chicken, $Product)\n\
+         ? farm_animal_product(sheep, $Product)\n\
+         ? farm_animal_product(tiger, $Product)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A chicken gives eggs; a sheep gives wool — the recalled products.
+    assert!(out.contains("\"Product\":\"eggs\""), "chicken → eggs: {out}");
+    assert!(out.contains("\"Product\":\"wool\""), "sheep → wool: {out}");
+    // The answer carries the Iowa State CFSPH citation (locator + trust) as its proof.
+    assert!(
+        out.contains("cfsph.iastate.edu") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A tiger is not a farm animal — honest abstention, never a fabricated product.
+    assert!(out.contains("\"abstained\":true"), "tiger abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -34,6 +34,7 @@ per rotation, in parallel):
 | `money/` | US coin → cents | US Mint |
 | `earth-science/` | water-cycle stage → step number | USGS Water Science School |
 | `nutrition/` | common food → MyPlate food group | USDA MyPlate |
+| `agriculture/` | farm animal → product it gives | Iowa State University (CFSPH) |
 | … | *physics, biology, geography, anatomy, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/agriculture/farm-animals.adj
+++ b/code/specs/data/adj-facts-stdlib/agriculture/farm-animals.adj
@@ -1,0 +1,84 @@
+% ============================================================================
+% farm-animals — a familiar farm animal and the PRODUCT it gives us
+% (adj-facts-stdlib, AGRICULTURE).
+% ============================================================================
+% One of the very first "where does it come from?" facts a child learns: the
+% animals on a farm each give us something useful. A hen gives us EGGS, a sheep
+% gives us WOOL, a goat gives us MILK. This tiny library records, for a handful
+% of familiar farm animals, the product each one is raised to give. Recall is a
+% binding query:
+%
+%     ? farm_animal_product(chicken, $Product)     % eggs
+%     ? farm_animal_product(sheep, $Product)        % wool
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `farm_animal_product(animal, product)` carrying the table's citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% product WITH its source, on the CPU, with zero model calls, and abstains on any
+% animal that is not one of the recorded ones (ask it about a `tiger` and it stays
+% honestly silent rather than inventing a product).
+%
+% The farm-animal → product pairs shipped here, as a truth table:
+%
+%     animal     product   a beginner's cue
+%     ---------  --------   ------------------------------------------------
+%     chicken    eggs       a flock of hens lays eggs for the family
+%     duck       eggs       ducks lay eggs too, a little bigger than a hen's
+%     sheep      wool       a sheep's fleece is sheared and spun into wool
+%     rabbit     wool       some rabbit breeds grow a very soft wool (fibre)
+%     goat       milk       a goat is milked, like a cow
+%
+% Three distinct products appear — eggs, wool and milk — so a learner sees that
+% different animals give different things, and that TWO animals can give the SAME
+% product (a chicken and a duck both give eggs; a sheep and a rabbit both give
+% wool). Each animal here was chosen to have ONE clear, source-stated product.
+%
+% Honest abstention is the safety property. A word that is not one of these
+% animals — `tiger`, `rock`, `oak` — is deliberately NOT a row, so a product
+% recall ABSTAINS on it rather than fabricating an answer.
+%
+% Note which pairs are deliberately ABSENT. The everyday "cow → milk" and
+% "bee → honey" facts are NOT rows here, even though a child would expect them:
+% the single source this library is grounded on (below) does not state either one
+% verbatim — its honeybee entry says only that bees "provide versatile products,"
+% without naming honey, and it has no cattle entry at all. Rather than assert a
+% product from memory, the library omits those animals. That is the same
+% honest-sourcing discipline as leaving `uracil` out of the DNA base-pair table:
+% a fact enters ONLY when a citable source states it (feedback_nothing_human_authored).
+%
+% ----------------------------------------------------------------------------
+% Provenance (byte-quotable, per the ADJ-facts standard).
+% ----------------------------------------------------------------------------
+% Every row is copied from IOWA STATE UNIVERSITY's Center for Food Security and
+% Public Health (CFSPH), "The Livestock Project — Animals for Beginning Small
+% Farmers." CFSPH is a center of Iowa State University's College of Veterinary
+% Medicine, a primary university educational source — hence `trust authoritative`.
+% Nothing here is asserted from memory. Because ADJ tables carry ONE shared
+% provenance envelope (per-row provenance is a documented future extension — see
+% ADJ-TABLES §6), the envelope below cites that page at its `locator`, and the
+% `source` quotes the SHEEP entry verbatim. For full auditability, here is the
+% exact CFSPH span (all on the one page at the `locator`) that grounds EACH row:
+%
+%   chicken → eggs — "A small flock can keep a family in eggs or meat."
+%   duck    → eggs — "Like chickens, Ducks produce meat and eggs."
+%   sheep   → wool — "depending on the breed, they can produce wool, meat, and milk."
+%   rabbit  → wool — "Some rabbit breeds produce a very soft wool that can be
+%                     harvested regularly and used for fiber arts."
+%   goat    → milk — "Goat milk may be pasteurized for human consumption."
+%
+% (See ../README.md; feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table farm_animal_product {
+    columns animal, product
+
+    row (chicken, eggs)
+    row (duck, eggs)
+    row (sheep, wool)
+    row (rabbit, wool)
+    row (goat, milk)
+
+    source "Sheep are low maintenance and versatile – depending on the breed, they can produce wool, meat, and milk"
+    locator "https://www.cfsph.iastate.edu/thelivestockproject/animals-for-beginning-small-farmers/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/agriculture/farm-animals.query.adj
+++ b/code/specs/data/adj-facts-stdlib/agriculture/farm-animals.query.adj
@@ -1,0 +1,18 @@
+% ============================================================================
+% farm-animals.query.adj — a worked recall over the farm-animals FACTS library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does a chicken give
+% us?": it states no farm fact — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `farm_animal_product`
+% rows and returns the product + the table's source/locator/trust. An animal not
+% in the table abstains honestly — the engine never invents a product.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli farm-animals.query.adj
+% ============================================================================
+
+import "farm-animals.adj"
+
+? farm_animal_product(chicken, $Product)     % expect eggs
+? farm_animal_product(sheep, $Product)        % expect wool
+? farm_animal_product(tiger, $Product)        % expect abstain — a tiger is not a farm animal


### PR DESCRIPTION
## What

Adds a grounded ELEMENTARY facts library to the ADJ standard library: a new `agriculture/` subject with `farm-animals.adj` — a native `table farm_animal_product` mapping a familiar farm animal to the product it gives us. Recall is a zero-model-call binding query that returns the product **with its citation** and **abstains honestly** on an animal not in the table.

## Rows shipped (5, all verbatim-grounded)

All copied from ONE authoritative `.edu` page — Iowa State University's Center for Food Security and Public Health (CFSPH), *Animals for Beginning Small Farmers*:

| animal | product | verbatim span |
|---|---|---|
| chicken | eggs | "A small flock can keep a family in eggs or meat." |
| duck | eggs | "Like chickens, Ducks produce meat and eggs." |
| sheep | wool | "...they can produce wool, meat, and milk." |
| rabbit | wool | "Some rabbit breeds produce a very soft wool that can be harvested regularly and used for fiber arts." |
| goat | milk | "Goat milk may be pasteurized for human consumption." |

**Source:** https://www.cfsph.iastate.edu/thelivestockproject/animals-for-beginning-small-farmers/
**Trust:** `authoritative` (Iowa State University / CFSPH, a primary university educational source)

## Honest sourcing

The everyday **cow → milk** and **bee → honey** pairs are deliberately **omitted**: this source has no cattle entry, and its honeybee entry names only "versatile products," not honey. Per `feedback_nothing_human_authored`, a fact enters only when a citable source states it verbatim — nothing is asserted from memory.

## Also included

- `farm-animals.query.adj` — worked recall (two binds + a `tiger` abstain).
- `code/packages/rust/adj-lang-cli/tests/facts_farmanimals_e2e.rs` — e2e test: chicken→eggs, sheep→wool, carries the CFSPH locator + `authoritative` trust, and `tiger` abstains.
- README index row for the new `agriculture/` subject.

## Verification

- `cargo test -p adj-lang-cli --test facts_farmanimals_e2e` — passes.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)