### PR TITLE
feat(swift): port cli-builder

### DIFF
--- a/code/packages/swift/cli-builder/.gitignore
+++ b/code/packages/swift/cli-builder/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/code/packages/swift/cli-builder/BUILD
+++ b/code/packages/swift/cli-builder/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test; else swift test; fi

--- a/code/packages/swift/cli-builder/BUILD_windows
+++ b/code/packages/swift/cli-builder/BUILD_windows
@@ -1,0 +1,1 @@
+swift test

--- a/code/packages/swift/cli-builder/CHANGELOG.md
+++ b/code/packages/swift/cli-builder/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-13
+
+- Added the pure Swift CLI-builder spec model, validator, token classifier, parser, and help generator.
+- Added graph-backed transitive flag dependency checks and DFA-backed scanner modes.
+- Added tests for routing, flags, positional arguments, constraints, built-ins, and parsing modes.

--- a/code/packages/swift/cli-builder/Package.swift
+++ b/code/packages/swift/cli-builder/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+  name: "cli-builder",
+  products: [
+    .library(name: "CliBuilder", targets: ["CliBuilder"])
+  ],
+  dependencies: [
+    .package(path: "../directed-graph"),
+    .package(path: "../state-machine"),
+  ],
+  targets: [
+    .target(
+      name: "CliBuilder",
+      dependencies: [
+        .product(name: "DirectedGraph", package: "directed-graph"),
+        .product(name: "StateMachine", package: "state-machine"),
+      ]
+    ),
+    .testTarget(name: "CliBuilderTests", dependencies: ["CliBuilder"]),
+  ]
+)

--- a/code/packages/swift/cli-builder/README.md
+++ b/code/packages/swift/cli-builder/README.md
@@ -1,0 +1,36 @@
+# swift/cli-builder
+
+A pure Swift implementation of the declarative CLI parser described by
+[`cli-builder-spec.md`](../../../specs/cli-builder-spec.md). A JSON document
+defines commands, aliases, flags, positional arguments, defaults, dependencies,
+and mutually exclusive groups; `Parser` turns an `argv` array into a typed
+`ParseOutcome`.
+
+The implementation uses the sibling `DirectedGraph` package for transitive
+`requires` validation and the sibling `StateMachine` package to drive scanner
+modes. It supports GNU, POSIX, subcommand-first, and traditional parsing,
+stacked short flags, `--flag=value`, single-dash-long flags, variadic arguments,
+help/version built-ins, enum defaults, repeatable flags, fuzzy suggestions, and
+aggregated parse errors.
+
+## Usage
+
+```swift
+import CliBuilder
+
+let parser = try Parser(specPath: "tool.json", argv: ["tool", "-vv", "input.txt"])
+switch try parser.parse() {
+case .parsed(let result):
+    print(result.flags["verbose"] ?? .null)
+case .help(let result):
+    print(result.text)
+case .version(let result):
+    print(result.version)
+}
+```
+
+## Development
+
+```sh
+swift test
+```

--- a/code/packages/swift/cli-builder/Sources/CliBuilder/Models.swift
+++ b/code/packages/swift/cli-builder/Sources/CliBuilder/Models.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+public enum ValueType: String, Sendable, CaseIterable {
+  case boolean
+  case count
+  case string
+  case integer
+  case float
+  case path
+  case file
+  case directory
+  case enumeration = "enum"
+
+  var takesValue: Bool { self != .boolean && self != .count }
+}
+
+public enum ParsingMode: String, Sendable {
+  case gnu
+  case posix
+  case subcommandFirst = "subcommand_first"
+  case traditional
+}
+
+public indirect enum CliValue: Equatable, Sendable, CustomStringConvertible {
+  case null
+  case bool(Bool)
+  case int(Int)
+  case double(Double)
+  case string(String)
+  case array([CliValue])
+
+  public var description: String {
+    switch self {
+    case .null: "null"
+    case .bool(let value): String(value)
+    case .int(let value): String(value)
+    case .double(let value): String(value)
+    case .string(let value): value
+    case .array(let values): "[\(values.map(\.description).joined(separator: ", "))]"
+    }
+  }
+
+  var isPresent: Bool {
+    switch self {
+    case .null: false
+    case .bool(let value): value
+    case .int(let value): value != 0
+    case .array(let values): !values.isEmpty
+    default: true
+    }
+  }
+
+  static func fromJSON(_ value: Any?) -> CliValue {
+    guard let value else { return .null }
+    if let value = value as? Bool { return .bool(value) }
+    if let value = value as? Int { return .int(value) }
+    if let value = value as? Double { return .double(value) }
+    if let value = value as? String { return .string(value) }
+    if let value = value as? [Any] { return .array(value.map(CliValue.fromJSON)) }
+    return .string(String(describing: value))
+  }
+}
+
+public struct BuiltinFlags: Equatable, Sendable {
+  public let help: Bool
+  public let version: Bool
+}
+
+public struct FlagDefinition: Equatable, Sendable {
+  public let id: String
+  public let shortName: String?
+  public let longName: String?
+  public let singleDashLong: String?
+  public let description: String
+  public let type: ValueType
+  public let required: Bool
+  public let defaultValue: CliValue
+  public let valueName: String?
+  public let enumValues: [String]
+  public let defaultWhenPresent: String?
+  public let conflictsWith: [String]
+  public let requires: [String]
+  public let requiredUnless: [String]
+  public let repeatable: Bool
+
+  public init(
+    id: String,
+    shortName: String? = nil,
+    longName: String? = nil,
+    singleDashLong: String? = nil,
+    description: String = "",
+    type: ValueType = .string,
+    required: Bool = false,
+    defaultValue: CliValue = .null,
+    valueName: String? = nil,
+    enumValues: [String] = [],
+    defaultWhenPresent: String? = nil,
+    conflictsWith: [String] = [],
+    requires: [String] = [],
+    requiredUnless: [String] = [],
+    repeatable: Bool = false
+  ) {
+    self.id = id
+    self.shortName = shortName
+    self.longName = longName
+    self.singleDashLong = singleDashLong
+    self.description = description
+    self.type = type
+    self.required = required
+    self.defaultValue = defaultValue
+    self.valueName = valueName
+    self.enumValues = enumValues
+    self.defaultWhenPresent = defaultWhenPresent
+    self.conflictsWith = conflictsWith
+    self.requires = requires
+    self.requiredUnless = requiredUnless
+    self.repeatable = repeatable
+  }
+}
+
+public struct ArgumentDefinition: Equatable, Sendable {
+  public let id: String
+  public let displayName: String
+  public let description: String
+  public let type: ValueType
+  public let required: Bool
+  public let variadic: Bool
+  public let variadicMin: Int
+  public let variadicMax: Int?
+  public let defaultValue: CliValue
+  public let enumValues: [String]
+  public let requiredUnlessFlag: [String]
+}
+
+public struct ExclusiveGroup: Equatable, Sendable {
+  public let id: String
+  public let flagIds: [String]
+  public let required: Bool
+}
+
+public struct CommandDefinition: Equatable, Sendable {
+  public let id: String
+  public let name: String
+  public let aliases: [String]
+  public let description: String
+  public let inheritGlobalFlags: Bool
+  public let flags: [FlagDefinition]
+  public let arguments: [ArgumentDefinition]
+  public let commands: [CommandDefinition]
+  public let mutuallyExclusiveGroups: [ExclusiveGroup]
+
+  func findCommand(_ token: String) -> CommandDefinition? {
+    commands.first { $0.name == token || $0.aliases.contains(token) }
+  }
+}
+
+public struct CliSpec: Equatable, Sendable {
+  public let specVersion: String
+  public let name: String
+  public let displayName: String?
+  public let description: String
+  public let version: String?
+  public let parsingMode: ParsingMode
+  public let builtinFlags: BuiltinFlags
+  public let globalFlags: [FlagDefinition]
+  public let flags: [FlagDefinition]
+  public let arguments: [ArgumentDefinition]
+  public let commands: [CommandDefinition]
+  public let mutuallyExclusiveGroups: [ExclusiveGroup]
+
+  func findCommand(path: [String]) -> CommandDefinition? {
+    var scope = commands
+    var current: CommandDefinition?
+    for token in path {
+      guard
+        let command = scope.first(where: {
+          $0.name == token || $0.aliases.contains(token)
+        })
+      else { return nil }
+      current = command
+      scope = command.commands
+    }
+    return current
+  }
+
+  func commandChain(path: [String]) -> [CommandDefinition] {
+    var scope = commands
+    var result: [CommandDefinition] = []
+    for token in path {
+      guard
+        let command = scope.first(where: {
+          $0.name == token || $0.aliases.contains(token)
+        })
+      else { break }
+      result.append(command)
+      scope = command.commands
+    }
+    return result
+  }
+
+  func flagsForPath(_ path: [String]) -> [FlagDefinition] {
+    guard !path.isEmpty else { return flags + globalFlags }
+    let chain = commandChain(path: path)
+    guard let leaf = chain.last else { return flags + globalFlags }
+    var result = chain.flatMap(\.flags)
+    if leaf.inheritGlobalFlags { result += globalFlags }
+    return deduplicatedFlags(result)
+  }
+
+  func argumentsForPath(_ path: [String]) -> [ArgumentDefinition] {
+    path.isEmpty ? arguments : findCommand(path: path)?.arguments ?? arguments
+  }
+
+  func groupsForPath(_ path: [String]) -> [ExclusiveGroup] {
+    path.isEmpty ? mutuallyExclusiveGroups : findCommand(path: path)?.mutuallyExclusiveGroups ?? []
+  }
+}
+
+private func deduplicatedFlags(_ flags: [FlagDefinition]) -> [FlagDefinition] {
+  var seen: Set<String> = []
+  return flags.filter { seen.insert($0.id).inserted }
+}
+
+public struct ParseResult: Equatable, Sendable {
+  public let program: String
+  public let commandPath: [String]
+  public let flags: [String: CliValue]
+  public let arguments: [String: CliValue]
+  public let explicitFlags: [String]
+}
+
+public struct HelpResult: Equatable, Sendable {
+  public let text: String
+  public let commandPath: [String]
+}
+
+public struct VersionResult: Equatable, Sendable {
+  public let version: String
+}
+
+public enum ParseOutcome: Equatable, Sendable {
+  case parsed(ParseResult)
+  case help(HelpResult)
+  case version(VersionResult)
+}
+
+public struct ValidationResult: Equatable, Sendable {
+  public let errors: [String]
+  public let warnings: [String]
+
+  public init(errors: [String], warnings: [String] = []) {
+    self.errors = errors
+    self.warnings = warnings
+  }
+
+  public var isValid: Bool { errors.isEmpty }
+}
+
+public struct SpecError: Error, Equatable, Sendable, CustomStringConvertible {
+  public let message: String
+  public init(_ message: String) { self.message = message }
+  public var description: String { message }
+}
+
+public struct ParseIssue: Error, Equatable, Sendable {
+  public let errorType: String
+  public let message: String
+  public let suggestion: String?
+  public let context: [String]
+
+  public init(
+    errorType: String,
+    message: String,
+    suggestion: String? = nil,
+    context: [String] = []
+  ) {
+    self.errorType = errorType
+    self.message = message
+    self.suggestion = suggestion
+    self.context = context
+  }
+}
+
+public struct ParseErrors: Error, Equatable, Sendable, CustomStringConvertible {
+  public let errors: [ParseIssue]
+  public init(_ errors: [ParseIssue]) { self.errors = errors }
+
+  public var description: String {
+    if errors.count == 1 { return "parse error: \(errors[0].message)" }
+    return "\(errors.count) parse errors:\n"
+      + errors.map { "  - \($0.message)" }.joined(separator: "\n")
+  }
+}

--- a/code/packages/swift/cli-builder/Sources/CliBuilder/Parser.swift
+++ b/code/packages/swift/cli-builder/Sources/CliBuilder/Parser.swift
@@ -1,0 +1,876 @@
+import DirectedGraph
+import Foundation
+import StateMachine
+
+public struct Parser: Sendable {
+  public let spec: CliSpec
+  public let argv: [String]
+
+  public init(spec: CliSpec, argv: [String]) {
+    self.spec = spec
+    self.argv = argv
+  }
+
+  public init(specPath: String, argv: [String]) throws {
+    self.init(spec: try SpecLoader().load(fromFile: specPath), argv: argv)
+  }
+
+  public func parse() throws -> ParseOutcome {
+    guard let program = argv.first else {
+      throw ParseErrors([
+        ParseIssue(
+          errorType: "missing_required_argument",
+          message: "argv is empty (no program name)"
+        )
+      ])
+    }
+
+    var tokens = Array(argv.dropFirst())
+    if spec.parsingMode == .traditional,
+      let first = tokens.first,
+      !first.hasPrefix("-"),
+      !knownRootCommandNames.contains(first)
+    {
+      tokens = first.map { "-\($0)" } + tokens.dropFirst()
+    }
+
+    let routed = route(tokens)
+    let activeFlags = deduplicate(spec.flagsForPath(routed.commandPath) + builtinFlags)
+    let scanned = try scan(
+      routed.remainingTokens,
+      commandPath: routed.commandPath,
+      activeFlags: activeFlags
+    )
+
+    if scanned.helpRequested {
+      return .help(
+        HelpResult(
+          text: generateHelp(commandPath: routed.commandPath),
+          commandPath: [program] + routed.commandPath
+        ))
+    }
+    if scanned.versionRequested {
+      return .version(VersionResult(version: spec.version ?? "(unknown)"))
+    }
+
+    var errors = routed.errors + scanned.errors
+    let arguments = resolvePositionals(
+      definitions: spec.argumentsForPath(routed.commandPath),
+      tokens: scanned.positionals,
+      parsedFlags: scanned.flags,
+      errors: &errors
+    )
+    validateFlags(
+      activeFlags,
+      groups: spec.groupsForPath(routed.commandPath),
+      parsedFlags: scanned.flags,
+      errors: &errors
+    )
+    guard errors.isEmpty else { throw ParseErrors(errors) }
+
+    return .parsed(
+      ParseResult(
+        program: program,
+        commandPath: [program] + routed.commandPath,
+        flags: applyDefaults(activeFlags, to: scanned.flags),
+        arguments: arguments,
+        explicitFlags: scanned.explicitFlags
+      ))
+  }
+
+  private func route(_ tokens: [String]) -> RoutingResult {
+    var commandPath: [String] = []
+    var consumedIndices: Set<Int> = []
+    var errors: [ParseIssue] = []
+    var scope = spec.commands
+    var index = 0
+
+    while index < tokens.count {
+      let token = tokens[index]
+      if token == "--" { break }
+      if token.hasPrefix("-") {
+        let routingFlags = deduplicate(spec.flagsForPath(commandPath) + builtinFlags)
+        index += flagConsumesNextValue(token, flags: routingFlags) ? 2 : 1
+        continue
+      }
+      guard
+        let command = scope.first(where: {
+          $0.name == token || $0.aliases.contains(token)
+        })
+      else {
+        if spec.parsingMode == .subcommandFirst && commandPath.isEmpty {
+          let suggestion = fuzzyMatch(token, candidates: Array(knownRootCommandNames))
+          errors.append(
+            ParseIssue(
+              errorType: "unknown_command",
+              message: "unknown command \"\(token)\"",
+              suggestion: suggestion.map { "Did you mean \"\($0)\"?" }
+            ))
+        }
+        break
+      }
+      commandPath.append(command.name)
+      consumedIndices.insert(index)
+      scope = command.commands
+      index += 1
+    }
+
+    return RoutingResult(
+      commandPath: commandPath,
+      remainingTokens: tokens.enumerated().compactMap {
+        consumedIndices.contains($0.offset) ? nil : $0.element
+      },
+      errors: errors
+    )
+  }
+
+  private func scan(
+    _ tokens: [String],
+    commandPath: [String],
+    activeFlags: [FlagDefinition]
+  ) throws -> ScanningResult {
+    var flags: [String: CliValue] = [:]
+    var positionals: [String] = []
+    var errors: [ParseIssue] = []
+    var explicitFlags: [String] = []
+    let classifier = TokenClassifier(activeFlags)
+    let machine = try scannerMachine()
+    var pendingFlag: FlagDefinition?
+    var index = 0
+
+    while index < tokens.count {
+      let token = tokens[index]
+      if machine.currentState == "END_OF_FLAGS" {
+        positionals.append(token)
+        try machine.process("token")
+        index += 1
+        continue
+      }
+      if machine.currentState == "FLAG_VALUE" {
+        if let flag = pendingFlag {
+          if flag.type == .enumeration,
+            let defaultValue = flag.defaultWhenPresent,
+            token.hasPrefix("-") || !flag.enumValues.contains(token)
+          {
+            setFlagValue(.string(defaultValue), for: flag, flags: &flags, errors: &errors)
+            explicitFlags.append(flag.id)
+            pendingFlag = nil
+            try machine.process("value_consumed")
+            continue
+          }
+          if let value = coerce(token, type: flag.type, enumValues: flag.enumValues) {
+            setFlagValue(value, for: flag, flags: &flags, errors: &errors)
+            explicitFlags.append(flag.id)
+          } else {
+            errors.append(invalidValueIssue(token, flag: flag))
+          }
+          pendingFlag = nil
+        }
+        try machine.process("value_consumed")
+        index += 1
+        continue
+      }
+
+      let event = classifier.classify(token)
+      switch event.kind {
+      case .endOfFlags:
+        try machine.process("end_flags")
+
+      case .longFlag:
+        guard let name = event.name, let flag = classifier.flag(long: name) else {
+          appendUnknownFlag(token, classifier: classifier, errors: &errors)
+          try machine.process("token")
+          break
+        }
+        let action = applyFlag(
+          flag,
+          inlineValue: nil,
+          flags: &flags,
+          errors: &errors,
+          explicitFlags: &explicitFlags
+        )
+        switch action {
+        case .help: return scanResult(flags, positionals, errors, explicitFlags, help: true)
+        case .version: return scanResult(flags, positionals, errors, explicitFlags, version: true)
+        case .awaitValue:
+          pendingFlag = flag
+          try machine.process("await_value")
+        case .done: try machine.process("token")
+        }
+
+      case .shortFlag:
+        guard let name = event.name, let flag = classifier.flag(short: name) else {
+          appendUnknownFlag(token, classifier: classifier, errors: &errors)
+          try machine.process("token")
+          break
+        }
+        let action = applyFlag(
+          flag,
+          inlineValue: nil,
+          flags: &flags,
+          errors: &errors,
+          explicitFlags: &explicitFlags
+        )
+        switch action {
+        case .help: return scanResult(flags, positionals, errors, explicitFlags, help: true)
+        case .version: return scanResult(flags, positionals, errors, explicitFlags, version: true)
+        case .awaitValue:
+          pendingFlag = flag
+          try machine.process("await_value")
+        case .done: try machine.process("token")
+        }
+
+      case .singleDashLong:
+        guard let name = event.name, let flag = classifier.flag(singleDashLong: name) else {
+          appendUnknownFlag(token, classifier: classifier, errors: &errors)
+          try machine.process("token")
+          break
+        }
+        let action = applyFlag(
+          flag,
+          inlineValue: nil,
+          flags: &flags,
+          errors: &errors,
+          explicitFlags: &explicitFlags
+        )
+        if action == .awaitValue {
+          pendingFlag = flag
+          try machine.process("await_value")
+        } else {
+          try machine.process("token")
+        }
+
+      case .longFlagWithValue, .shortFlagWithValue:
+        let flag: FlagDefinition?
+        if event.kind == .longFlagWithValue {
+          flag = event.name.flatMap(classifier.flag(long:))
+        } else {
+          flag = event.name.flatMap(classifier.flag(short:))
+        }
+        guard let flag, let value = event.value else {
+          appendUnknownFlag(token, classifier: classifier, errors: &errors)
+          try machine.process("token")
+          break
+        }
+        _ = applyFlag(
+          flag,
+          inlineValue: value,
+          flags: &flags,
+          errors: &errors,
+          explicitFlags: &explicitFlags
+        )
+        try machine.process("token")
+
+      case .stackedFlags:
+        var awaitsValue = false
+        for character in event.characters {
+          guard let flag = classifier.flag(short: character) else {
+            appendUnknownFlag("-\(character)", classifier: classifier, errors: &errors)
+            continue
+          }
+          let action = applyFlag(
+            flag,
+            inlineValue: nil,
+            flags: &flags,
+            errors: &errors,
+            explicitFlags: &explicitFlags
+          )
+          if action == .help {
+            return scanResult(flags, positionals, errors, explicitFlags, help: true)
+          }
+          if action == .version {
+            return scanResult(flags, positionals, errors, explicitFlags, version: true)
+          }
+          if action == .awaitValue {
+            pendingFlag = flag
+            awaitsValue = true
+          }
+        }
+        try machine.process(awaitsValue ? "await_value" : "token")
+
+      case .positional:
+        positionals.append(event.name ?? token)
+        try machine.process(spec.parsingMode == .posix ? "end_flags" : "token")
+
+      case .unknownFlag:
+        appendUnknownFlag(token, classifier: classifier, errors: &errors)
+        try machine.process("token")
+      }
+      index += 1
+    }
+
+    if let flag = pendingFlag {
+      if flag.type == .enumeration, let defaultValue = flag.defaultWhenPresent {
+        setFlagValue(.string(defaultValue), for: flag, flags: &flags, errors: &errors)
+        explicitFlags.append(flag.id)
+      } else {
+        errors.append(
+          ParseIssue(
+            errorType: "missing_required_argument",
+            message: "\(flagLabel(flag)) expects a value",
+            context: commandPath
+          ))
+      }
+    }
+    return scanResult(flags, positionals, errors, explicitFlags)
+  }
+
+  private func applyFlag(
+    _ flag: FlagDefinition,
+    inlineValue: String?,
+    flags: inout [String: CliValue],
+    errors: inout [ParseIssue],
+    explicitFlags: inout [String]
+  ) -> FlagAction {
+    if flag.id == "help" { return .help }
+    if flag.id == "version" { return .version }
+    if let inlineValue {
+      if let value = coerce(inlineValue, type: flag.type, enumValues: flag.enumValues) {
+        setFlagValue(value, for: flag, flags: &flags, errors: &errors)
+        explicitFlags.append(flag.id)
+      } else {
+        errors.append(invalidValueIssue(inlineValue, flag: flag))
+      }
+      return .done
+    }
+    switch flag.type {
+    case .boolean:
+      setFlagValue(.bool(true), for: flag, flags: &flags, errors: &errors)
+      explicitFlags.append(flag.id)
+      return .done
+    case .count:
+      incrementCount(flag.id, flags: &flags)
+      explicitFlags.append(flag.id)
+      return .done
+    default:
+      return .awaitValue
+    }
+  }
+
+  private func resolvePositionals(
+    definitions: [ArgumentDefinition],
+    tokens: [String],
+    parsedFlags: [String: CliValue],
+    errors: inout [ParseIssue]
+  ) -> [String: CliValue] {
+    guard !definitions.isEmpty else {
+      if !tokens.isEmpty {
+        errors.append(
+          ParseIssue(
+            errorType: "too_many_arguments",
+            message: "unexpected positional argument(s): \(tokens)"
+          ))
+      }
+      return [:]
+    }
+
+    guard let variadicIndex = definitions.firstIndex(where: \.variadic) else {
+      var result: [String: CliValue] = [:]
+      for (index, definition) in definitions.enumerated() {
+        assignArgument(
+          definition,
+          token: index < tokens.count ? tokens[index] : nil,
+          parsedFlags: parsedFlags,
+          result: &result,
+          errors: &errors
+        )
+      }
+      if tokens.count > definitions.count {
+        errors.append(
+          ParseIssue(
+            errorType: "too_many_arguments",
+            message: "unexpected argument(s): \(Array(tokens.dropFirst(definitions.count)))"
+          ))
+      }
+      return result
+    }
+
+    var result: [String: CliValue] = [:]
+    let leading = Array(definitions[..<variadicIndex])
+    let variadic = definitions[variadicIndex]
+    let trailing = Array(definitions[(variadicIndex + 1)...])
+
+    for (index, definition) in leading.enumerated() {
+      assignArgument(
+        definition,
+        token: index < tokens.count ? tokens[index] : nil,
+        parsedFlags: parsedFlags,
+        result: &result,
+        errors: &errors
+      )
+    }
+
+    let variadicStart = min(leading.count, tokens.count)
+    let trailingStart = max(tokens.count - trailing.count, variadicStart)
+    for (index, definition) in trailing.enumerated() {
+      let tokenIndex = trailingStart + index
+      assignArgument(
+        definition,
+        token: tokenIndex < tokens.count ? tokens[tokenIndex] : nil,
+        parsedFlags: parsedFlags,
+        result: &result,
+        errors: &errors
+      )
+    }
+
+    let variadicTokens = Array(tokens[variadicStart..<trailingStart])
+    if variadicTokens.count < variadic.variadicMin {
+      errors.append(
+        ParseIssue(
+          errorType: "too_few_arguments",
+          message:
+            "expected at least \(variadic.variadicMin) <\(variadic.displayName)>, got \(variadicTokens.count)"
+        ))
+    }
+    if let maximum = variadic.variadicMax, variadicTokens.count > maximum {
+      errors.append(
+        ParseIssue(
+          errorType: "too_many_arguments",
+          message:
+            "expected at most \(maximum) <\(variadic.displayName)>, got \(variadicTokens.count)"
+        ))
+    }
+    result[variadic.id] = .array(
+      variadicTokens.compactMap { token in
+        guard let value = coerce(token, type: variadic.type, enumValues: variadic.enumValues) else {
+          errors.append(invalidArgumentIssue(token, definition: variadic))
+          return nil
+        }
+        return value
+      })
+    return result
+  }
+
+  private func assignArgument(
+    _ definition: ArgumentDefinition,
+    token: String?,
+    parsedFlags: [String: CliValue],
+    result: inout [String: CliValue],
+    errors: inout [ParseIssue]
+  ) {
+    if let token {
+      if let value = coerce(token, type: definition.type, enumValues: definition.enumValues) {
+        result[definition.id] = value
+      } else {
+        errors.append(invalidArgumentIssue(token, definition: definition))
+      }
+      return
+    }
+    let exempt = definition.requiredUnlessFlag.contains {
+      parsedFlags[$0]?.isPresent == true
+    }
+    if definition.required && !exempt {
+      errors.append(
+        ParseIssue(
+          errorType: "missing_required_argument",
+          message: "missing required argument: <\(definition.displayName)>"
+        ))
+    } else {
+      result[definition.id] = definition.defaultValue
+    }
+  }
+
+  private func validateFlags(
+    _ activeFlags: [FlagDefinition],
+    groups: [ExclusiveGroup],
+    parsedFlags: [String: CliValue],
+    errors: inout [ParseIssue]
+  ) {
+    var graph = Graph()
+    let byID = Dictionary(activeFlags.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+    for flag in activeFlags { graph.addNode(flag.id) }
+    for flag in activeFlags {
+      for required in flag.requires where byID[required] != nil {
+        try? graph.addEdge(from: flag.id, to: required)
+      }
+    }
+
+    var emittedConflicts: Set<String> = []
+    for flag in activeFlags {
+      let present = parsedFlags[flag.id]?.isPresent == true
+      if !present {
+        let exempt = flag.requiredUnless.contains {
+          parsedFlags[$0]?.isPresent == true
+        }
+        if flag.required && !exempt {
+          errors.append(
+            ParseIssue(
+              errorType: "missing_required_flag",
+              message: "\(flagLabel(flag)) is required"
+            ))
+        }
+        continue
+      }
+      for otherID in flag.conflictsWith
+      where parsedFlags[otherID]?.isPresent == true {
+        guard let other = byID[otherID] else { continue }
+        let key = [flag.id, otherID].sorted().joined(separator: "\0")
+        if emittedConflicts.insert(key).inserted {
+          errors.append(
+            ParseIssue(
+              errorType: "conflicting_flags",
+              message: "\(flagLabel(flag)) and \(flagLabel(other)) cannot be used together"
+            ))
+        }
+      }
+      if let requiredIDs = try? graph.transitiveClosure(of: flag.id) {
+        for requiredID in requiredIDs.sorted()
+        where parsedFlags[requiredID]?.isPresent != true {
+          guard let required = byID[requiredID] else { continue }
+          errors.append(
+            ParseIssue(
+              errorType: "missing_dependency_flag",
+              message: "\(flagLabel(flag)) requires \(flagLabel(required))"
+            ))
+        }
+      }
+    }
+
+    for group in groups {
+      let present = group.flagIds.filter { parsedFlags[$0]?.isPresent == true }
+      if present.count > 1 {
+        errors.append(
+          ParseIssue(
+            errorType: "exclusive_group_violation",
+            message:
+              "only one of \(present.compactMap { byID[$0].map(flagLabel) }.joined(separator: ", ")) may be used"
+          ))
+      } else if group.required && present.isEmpty {
+        errors.append(
+          ParseIssue(
+            errorType: "missing_exclusive_group",
+            message:
+              "one of \(group.flagIds.compactMap { byID[$0].map(flagLabel) }.joined(separator: ", ")) is required"
+          ))
+      }
+    }
+  }
+
+  private func applyDefaults(
+    _ activeFlags: [FlagDefinition],
+    to parsedFlags: [String: CliValue]
+  ) -> [String: CliValue] {
+    var result = parsedFlags
+    for flag in activeFlags where result[flag.id] == nil {
+      switch flag.type {
+      case .boolean: result[flag.id] = .bool(false)
+      case .count: result[flag.id] = .int(0)
+      default: result[flag.id] = flag.defaultValue
+      }
+    }
+    return result
+  }
+
+  private func generateHelp(commandPath: [String]) -> String {
+    let command = spec.findCommand(path: commandPath)
+    let isRoot = commandPath.isEmpty
+    let description = isRoot ? spec.description : command?.description ?? spec.description
+    let commands = isRoot ? spec.commands : command?.commands ?? []
+    let localFlags = isRoot ? spec.flags : command?.flags ?? []
+    let arguments = isRoot ? spec.arguments : command?.arguments ?? []
+    let globalFlags = spec.globalFlags + builtinFlags
+    var lines = [
+      "USAGE",
+      "  \(usageLine(commandPath, flags: localFlags, commands: commands, arguments: arguments))",
+      "",
+      "DESCRIPTION",
+      "  \(description)",
+    ]
+    if !commands.isEmpty {
+      lines += ["", "COMMANDS"]
+      lines += commands.map {
+        "  \($0.name.padding(toLength: 16, withPad: " ", startingAt: 0))\($0.description)"
+      }
+    }
+    if !localFlags.isEmpty {
+      lines += ["", "OPTIONS"]
+      lines += localFlags.map {
+        "  \(flagSignature($0).padding(toLength: 28, withPad: " ", startingAt: 0))\(flagDescription($0))"
+      }
+    }
+    if !globalFlags.isEmpty {
+      lines += ["", "GLOBAL OPTIONS"]
+      lines += globalFlags.map {
+        "  \(flagSignature($0).padding(toLength: 28, withPad: " ", startingAt: 0))\(flagDescription($0))"
+      }
+    }
+    if !arguments.isEmpty {
+      lines += ["", "ARGUMENTS"]
+      lines += arguments.map {
+        "  \(argumentUsage($0).padding(toLength: 16, withPad: " ", startingAt: 0))\($0.description)\($0.required ? " Required." : "")"
+      }
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  private func usageLine(
+    _ commandPath: [String],
+    flags: [FlagDefinition],
+    commands: [CommandDefinition],
+    arguments: [ArgumentDefinition]
+  ) -> String {
+    var parts = [spec.name] + commandPath
+    if !flags.isEmpty || !spec.globalFlags.isEmpty { parts.append("[OPTIONS]") }
+    if !commands.isEmpty { parts.append("[COMMAND]") }
+    parts += arguments.map(argumentUsage)
+    return parts.joined(separator: " ")
+  }
+
+  private var builtinFlags: [FlagDefinition] {
+    var result: [FlagDefinition] = []
+    if spec.builtinFlags.help {
+      result.append(
+        FlagDefinition(
+          id: "help",
+          shortName: "h",
+          longName: "help",
+          description: "Show this help message and exit.",
+          type: .boolean,
+          defaultValue: .bool(false)
+        ))
+    }
+    if spec.builtinFlags.version {
+      result.append(
+        FlagDefinition(
+          id: "version",
+          longName: "version",
+          description: "Show version and exit.",
+          type: .boolean,
+          defaultValue: .bool(false)
+        ))
+    }
+    return result
+  }
+
+  private var knownRootCommandNames: Set<String> {
+    Set(spec.commands.flatMap { [$0.name] + $0.aliases })
+  }
+
+  private func flagConsumesNextValue(_ token: String, flags: [FlagDefinition]) -> Bool {
+    let classifier = TokenClassifier(flags)
+    let event = classifier.classify(token)
+    switch event.kind {
+    case .longFlag: return event.name.flatMap(classifier.flag(long:))?.type.takesValue == true
+    case .shortFlag: return event.name.flatMap(classifier.flag(short:))?.type.takesValue == true
+    case .singleDashLong:
+      return event.name.flatMap(classifier.flag(singleDashLong:))?.type.takesValue == true
+    default: return false
+    }
+  }
+}
+
+private enum FlagAction: Equatable {
+  case done
+  case awaitValue
+  case help
+  case version
+}
+
+private struct RoutingResult {
+  let commandPath: [String]
+  let remainingTokens: [String]
+  let errors: [ParseIssue]
+}
+
+private struct ScanningResult {
+  let flags: [String: CliValue]
+  let positionals: [String]
+  let errors: [ParseIssue]
+  let explicitFlags: [String]
+  let helpRequested: Bool
+  let versionRequested: Bool
+}
+
+private func scanResult(
+  _ flags: [String: CliValue],
+  _ positionals: [String],
+  _ errors: [ParseIssue],
+  _ explicitFlags: [String],
+  help: Bool = false,
+  version: Bool = false
+) -> ScanningResult {
+  ScanningResult(
+    flags: flags,
+    positionals: positionals,
+    errors: errors,
+    explicitFlags: explicitFlags,
+    helpRequested: help,
+    versionRequested: version
+  )
+}
+
+private func scannerMachine() throws -> DFA {
+  try DFA(
+    states: ["SCANNING", "FLAG_VALUE", "END_OF_FLAGS"],
+    alphabet: ["token", "await_value", "value_consumed", "end_flags"],
+    transitions: [
+      .init(from: "SCANNING", on: "token", to: "SCANNING"),
+      .init(from: "SCANNING", on: "await_value", to: "FLAG_VALUE"),
+      .init(from: "SCANNING", on: "end_flags", to: "END_OF_FLAGS"),
+      .init(from: "FLAG_VALUE", on: "value_consumed", to: "SCANNING"),
+      .init(from: "END_OF_FLAGS", on: "token", to: "END_OF_FLAGS"),
+    ],
+    initial: "SCANNING",
+    accepting: ["SCANNING", "END_OF_FLAGS"]
+  )
+}
+
+private func setFlagValue(
+  _ value: CliValue,
+  for flag: FlagDefinition,
+  flags: inout [String: CliValue],
+  errors: inout [ParseIssue]
+) {
+  if flag.repeatable {
+    switch flags[flag.id] {
+    case .array(let values): flags[flag.id] = .array(values + [value])
+    case .some(let existing): flags[flag.id] = .array([existing, value])
+    case .none: flags[flag.id] = .array([value])
+    }
+    return
+  }
+  if flags[flag.id] != nil {
+    errors.append(
+      ParseIssue(
+        errorType: "duplicate_flag",
+        message: "\(flagLabel(flag)) specified more than once"
+      ))
+    return
+  }
+  flags[flag.id] = value
+}
+
+private func incrementCount(_ id: String, flags: inout [String: CliValue]) {
+  if case .int(let current) = flags[id] {
+    flags[id] = .int(current + 1)
+  } else {
+    flags[id] = .int(1)
+  }
+}
+
+private func coerce(_ raw: String, type: ValueType, enumValues: [String]) -> CliValue? {
+  switch type {
+  case .boolean: return .bool(raw == "true")
+  case .count, .integer: return Int(raw).map(CliValue.int)
+  case .float: return Double(raw).map(CliValue.double)
+  case .string, .path: return .string(raw)
+  case .file:
+    var isDirectory: ObjCBool = false
+    return FileManager.default.fileExists(atPath: raw, isDirectory: &isDirectory)
+      && !isDirectory.boolValue
+      ? .string(raw) : nil
+  case .directory:
+    var isDirectory: ObjCBool = false
+    return FileManager.default.fileExists(atPath: raw, isDirectory: &isDirectory)
+      && isDirectory.boolValue
+      ? .string(raw) : nil
+  case .enumeration: return enumValues.contains(raw) ? .string(raw) : nil
+  }
+}
+
+private func invalidValueIssue(_ raw: String, flag: FlagDefinition) -> ParseIssue {
+  ParseIssue(
+    errorType: flag.type == .enumeration ? "invalid_enum_value" : "invalid_value",
+    message: "invalid \(flag.type.rawValue) for \(flagLabel(flag)): \"\(raw)\""
+  )
+}
+
+private func invalidArgumentIssue(
+  _ raw: String,
+  definition: ArgumentDefinition
+) -> ParseIssue {
+  ParseIssue(
+    errorType: definition.type == .enumeration ? "invalid_enum_value" : "invalid_value",
+    message:
+      "invalid \(definition.type.rawValue) for argument <\(definition.displayName)>: \"\(raw)\""
+  )
+}
+
+private func appendUnknownFlag(
+  _ token: String,
+  classifier: TokenClassifier,
+  errors: inout [ParseIssue]
+) {
+  let suggestion = fuzzyMatch(
+    token, candidates: classifier.knownLongNames + classifier.knownShortNames)
+  errors.append(
+    ParseIssue(
+      errorType: "unknown_flag",
+      message: "unknown flag \"\(token)\"",
+      suggestion: suggestion.map { "Did you mean \"\($0)\"?" }
+    ))
+}
+
+private func argumentUsage(_ argument: ArgumentDefinition) -> String {
+  if argument.required && argument.variadic { return "<\(argument.displayName)>..." }
+  if !argument.required && argument.variadic { return "[\(argument.displayName)...]" }
+  return argument.required ? "<\(argument.displayName)>" : "[\(argument.displayName)]"
+}
+
+private func flagSignature(_ flag: FlagDefinition) -> String {
+  var parts: [String] = []
+  if let short = flag.shortName { parts.append("-\(short)") }
+  if let long = flag.longName { parts.append("--\(long)") }
+  if let single = flag.singleDashLong { parts.append("-\(single)") }
+  var result = parts.joined(separator: ", ")
+  if flag.type.takesValue {
+    let valueName = flag.valueName ?? flag.type.rawValue.uppercased()
+    result +=
+      flag.type == .enumeration && flag.defaultWhenPresent != nil
+      ? "[=\(valueName)]" : " <\(valueName)>"
+  }
+  return result
+}
+
+private func flagDescription(_ flag: FlagDefinition) -> String {
+  if flag.required { return "\(flag.description) (required)" }
+  if flag.defaultValue != .null { return "\(flag.description) [default: \(flag.defaultValue)]" }
+  return flag.description
+}
+
+private func flagLabel(_ flag: FlagDefinition) -> String {
+  var parts: [String] = []
+  if let short = flag.shortName { parts.append("-\(short)") }
+  if let long = flag.longName { parts.append("--\(long)") }
+  if let single = flag.singleDashLong { parts.append("-\(single)") }
+  return parts.isEmpty ? flag.id : parts.joined(separator: "/")
+}
+
+private func deduplicate(_ flags: [FlagDefinition]) -> [FlagDefinition] {
+  var seen: Set<String> = []
+  return flags.filter { seen.insert($0.id).inserted }
+}
+
+private func fuzzyMatch(_ value: String, candidates: [String]) -> String? {
+  var best: String?
+  var bestDistance = 3
+  for candidate in candidates {
+    let distance = levenshtein(value, candidate)
+    if distance < bestDistance {
+      bestDistance = distance
+      best = candidate
+    }
+  }
+  return best
+}
+
+private func levenshtein(_ left: String, _ right: String) -> Int {
+  let a = Array(left)
+  let b = Array(right)
+  if a.isEmpty { return b.count }
+  if b.isEmpty { return a.count }
+  var previous = Array(0...b.count)
+  var current = Array(repeating: 0, count: b.count + 1)
+  for i in 1...a.count {
+    current[0] = i
+    for j in 1...b.count {
+      if a[i - 1] == b[j - 1] {
+        current[j] = previous[j - 1]
+      } else {
+        current[j] = min(current[j - 1], previous[j], previous[j - 1]) + 1
+      }
+    }
+    swap(&previous, &current)
+  }
+  return previous[b.count]
+}

--- a/code/packages/swift/cli-builder/Sources/CliBuilder/SpecLoader.swift
+++ b/code/packages/swift/cli-builder/Sources/CliBuilder/SpecLoader.swift
@@ -1,0 +1,347 @@
+import DirectedGraph
+import Foundation
+
+public struct SpecLoader: Sendable {
+  public init() {}
+
+  public func load(fromFile path: String) throws -> CliSpec {
+    guard let data = FileManager.default.contents(atPath: path) else {
+      throw SpecError("unable to read CLI spec: \(path)")
+    }
+    return try load(from: data)
+  }
+
+  public func load(from json: String) throws -> CliSpec {
+    guard let data = json.data(using: .utf8) else {
+      throw SpecError("CLI spec is not valid UTF-8")
+    }
+    return try load(from: data)
+  }
+
+  public func load(from data: Data) throws -> CliSpec {
+    let object = try jsonObject(data)
+    let validation = validateSpecObject(object)
+    guard validation.isValid else { throw SpecError(validation.errors.joined(separator: "\n")) }
+    return try decodeSpec(object)
+  }
+}
+
+public func validateSpec(_ json: String) throws -> ValidationResult {
+  guard let data = json.data(using: .utf8) else {
+    throw SpecError("CLI spec is not valid UTF-8")
+  }
+  return validateSpecObject(try jsonObject(data))
+}
+
+public func validateSpecFile(_ path: String) throws -> ValidationResult {
+  guard let data = FileManager.default.contents(atPath: path) else {
+    throw SpecError("unable to read CLI spec: \(path)")
+  }
+  return validateSpecObject(try jsonObject(data))
+}
+
+private func jsonObject(_ data: Data) throws -> [String: Any] {
+  do {
+    guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      throw SpecError("CLI spec root must be a JSON object")
+    }
+    return object
+  } catch let error as SpecError {
+    throw error
+  } catch {
+    throw SpecError("invalid CLI spec JSON: \(error.localizedDescription)")
+  }
+}
+
+private func validateSpecObject(_ object: [String: Any]) -> ValidationResult {
+  var errors: [String] = []
+  let version =
+    string(object, "cli_builder_spec_version")
+    ?? string(object, "spec_version")
+    ?? "1.0"
+  if version != "1.0" {
+    errors.append("unsupported cli_builder_spec_version \"\(version)\"")
+  }
+  if (string(object, "name") ?? "").isEmpty {
+    errors.append("required field \"name\" is missing or empty")
+  }
+  if (string(object, "description") ?? "").isEmpty {
+    errors.append("required field \"description\" is missing or empty")
+  }
+
+  do {
+    let spec = try decodeSpec(object)
+    let globalIDs = Set(spec.globalFlags.map(\.id))
+    validateScope(
+      name: "root",
+      flags: spec.flags + spec.globalFlags,
+      arguments: spec.arguments,
+      groups: spec.mutuallyExclusiveGroups,
+      visibleIDs: globalIDs,
+      errors: &errors
+    )
+    validateCommandNames(spec.commands, scope: "root", errors: &errors)
+    for command in spec.commands {
+      validateCommand(command, inheritedIDs: globalIDs, errors: &errors)
+    }
+  } catch let error as SpecError {
+    errors.append(error.message)
+  } catch {
+    errors.append(String(describing: error))
+  }
+  return ValidationResult(errors: errors)
+}
+
+private func validateCommand(
+  _ command: CommandDefinition,
+  inheritedIDs: Set<String>,
+  errors: inout [String]
+) {
+  validateScope(
+    name: "command \"\(command.id)\"",
+    flags: command.flags,
+    arguments: command.arguments,
+    groups: command.mutuallyExclusiveGroups,
+    visibleIDs: inheritedIDs,
+    errors: &errors
+  )
+  validateCommandNames(command.commands, scope: "command \"\(command.id)\"", errors: &errors)
+  let nextIDs = inheritedIDs.union(command.flags.map(\.id))
+  for nested in command.commands {
+    validateCommand(nested, inheritedIDs: nextIDs, errors: &errors)
+  }
+}
+
+private func validateCommandNames(
+  _ commands: [CommandDefinition],
+  scope: String,
+  errors: inout [String]
+) {
+  var names: Set<String> = []
+  for command in commands {
+    if !names.insert(command.name).inserted {
+      errors.append("in \(scope): duplicate command name \"\(command.name)\"")
+    }
+    for alias in command.aliases where !names.insert(alias).inserted {
+      errors.append("in \(scope): duplicate command alias \"\(alias)\"")
+    }
+  }
+}
+
+private func validateScope(
+  name: String,
+  flags: [FlagDefinition],
+  arguments: [ArgumentDefinition],
+  groups: [ExclusiveGroup],
+  visibleIDs inheritedIDs: Set<String>,
+  errors: inout [String]
+) {
+  var localIDs: Set<String> = []
+  var visibleIDs = inheritedIDs
+  var shortNames: Set<String> = []
+  var longNames: Set<String> = []
+  var singleDashLongs: Set<String> = []
+
+  for flag in flags {
+    if !localIDs.insert(flag.id).inserted {
+      errors.append("in \(name): duplicate flag id \"\(flag.id)\"")
+    }
+    visibleIDs.insert(flag.id)
+    if flag.shortName == nil && flag.longName == nil && flag.singleDashLong == nil {
+      errors.append("in \(name): flag \"\(flag.id)\" must declare short, long, or single_dash_long")
+    }
+    if let shortName = flag.shortName, !shortNames.insert(shortName).inserted {
+      errors.append("in \(name): duplicate short flag \"-\(shortName)\"")
+    }
+    if let longName = flag.longName, !longNames.insert(longName).inserted {
+      errors.append("in \(name): duplicate long flag \"--\(longName)\"")
+    }
+    if let single = flag.singleDashLong, !singleDashLongs.insert(single).inserted {
+      errors.append("in \(name): duplicate single-dash-long flag \"-\(single)\"")
+    }
+    if flag.type == .enumeration && flag.enumValues.isEmpty {
+      errors.append("in \(name): flag \"\(flag.id)\" has type enum but no enum_values")
+    }
+    if flag.defaultWhenPresent != nil && flag.type != .enumeration {
+      errors.append("in \(name): flag \"\(flag.id)\" has default_when_present but is not an enum")
+    }
+  }
+
+  for flag in flags {
+    for reference in flag.conflictsWith + flag.requires + flag.requiredUnless
+    where !visibleIDs.contains(reference) {
+      errors.append("in \(name): flag \"\(flag.id)\" references unknown flag id \"\(reference)\"")
+    }
+  }
+
+  var graph = Graph()
+  for id in visibleIDs { graph.addNode(id) }
+  var graphConstructionFailed = false
+  for flag in flags {
+    for required in flag.requires where visibleIDs.contains(required) {
+      do { try graph.addEdge(from: flag.id, to: required) } catch { graphConstructionFailed = true }
+    }
+  }
+  if graphConstructionFailed || graph.hasCycle() {
+    errors.append("in \(name): circular requires dependency detected")
+  }
+
+  var argumentIDs: Set<String> = []
+  var variadicCount = 0
+  for argument in arguments {
+    if !argumentIDs.insert(argument.id).inserted {
+      errors.append("in \(name): duplicate argument id \"\(argument.id)\"")
+    }
+    if argument.type == .enumeration && argument.enumValues.isEmpty {
+      errors.append("in \(name): argument \"\(argument.id)\" has type enum but no enum_values")
+    }
+    if argument.variadic { variadicCount += 1 }
+    if let maximum = argument.variadicMax, maximum < argument.variadicMin {
+      errors.append("in \(name): argument \"\(argument.id)\" has variadic_max below variadic_min")
+    }
+    for id in argument.requiredUnlessFlag where !visibleIDs.contains(id) {
+      errors.append("in \(name): argument \"\(argument.id)\" references unknown flag id \"\(id)\"")
+    }
+  }
+  if variadicCount > 1 {
+    errors.append("in \(name): at most one argument may be variadic")
+  }
+  for group in groups {
+    for id in group.flagIds where !visibleIDs.contains(id) {
+      errors.append(
+        "in \(name): mutually exclusive group \"\(group.id)\" references unknown flag id \"\(id)\"")
+    }
+  }
+}
+
+private func decodeSpec(_ object: [String: Any]) throws -> CliSpec {
+  let builtinObject = object["builtin_flags"] as? [String: Any] ?? [:]
+  let parsedVersion = string(object, "version")
+  return CliSpec(
+    specVersion: string(object, "cli_builder_spec_version")
+      ?? string(object, "spec_version")
+      ?? "1.0",
+    name: string(object, "name") ?? "",
+    displayName: string(object, "display_name"),
+    description: string(object, "description") ?? "",
+    version: parsedVersion,
+    parsingMode: ParsingMode(rawValue: string(object, "parsing_mode") ?? "gnu") ?? .gnu,
+    builtinFlags: BuiltinFlags(
+      help: boolean(builtinObject, "help") ?? true,
+      version: boolean(builtinObject, "version") ?? (parsedVersion != nil)
+    ),
+    globalFlags: try objectArray(object, "global_flags").map(decodeFlag),
+    flags: try objectArray(object, "flags").map(decodeFlag),
+    arguments: try objectArray(object, "arguments").map(decodeArgument),
+    commands: try objectArray(object, "commands").map(decodeCommand),
+    mutuallyExclusiveGroups: try objectArray(object, "mutually_exclusive_groups").map(decodeGroup)
+  )
+}
+
+private func decodeFlag(_ object: [String: Any]) throws -> FlagDefinition {
+  guard let id = string(object, "id"), !id.isEmpty else {
+    throw SpecError("flag is missing required field \"id\"")
+  }
+  let typeName = string(object, "type") ?? "string"
+  guard let type = ValueType(rawValue: typeName) else {
+    throw SpecError("flag \"\(id)\" has unknown type \"\(typeName)\"")
+  }
+  return FlagDefinition(
+    id: id,
+    shortName: string(object, "short"),
+    longName: string(object, "long"),
+    singleDashLong: string(object, "single_dash_long"),
+    description: string(object, "description") ?? "",
+    type: type,
+    required: boolean(object, "required") ?? false,
+    defaultValue: CliValue.fromJSON(object["default"]),
+    valueName: string(object, "value_name"),
+    enumValues: stringArray(object, "enum_values"),
+    defaultWhenPresent: string(object, "default_when_present"),
+    conflictsWith: stringArray(object, "conflicts_with"),
+    requires: stringArray(object, "requires"),
+    requiredUnless: stringArray(object, "required_unless"),
+    repeatable: boolean(object, "repeatable") ?? false
+  )
+}
+
+private func decodeArgument(_ object: [String: Any]) throws -> ArgumentDefinition {
+  guard let id = string(object, "id"), !id.isEmpty else {
+    throw SpecError("argument is missing required field \"id\"")
+  }
+  let required = boolean(object, "required") ?? true
+  let typeName = string(object, "type") ?? "string"
+  guard let type = ValueType(rawValue: typeName) else {
+    throw SpecError("argument \"\(id)\" has unknown type \"\(typeName)\"")
+  }
+  return ArgumentDefinition(
+    id: id,
+    displayName: string(object, "display_name") ?? string(object, "name") ?? "",
+    description: string(object, "description") ?? "",
+    type: type,
+    required: required,
+    variadic: boolean(object, "variadic") ?? false,
+    variadicMin: integer(object, "variadic_min") ?? (required ? 1 : 0),
+    variadicMax: integer(object, "variadic_max"),
+    defaultValue: CliValue.fromJSON(object["default"]),
+    enumValues: stringArray(object, "enum_values"),
+    requiredUnlessFlag: stringArray(object, "required_unless_flag")
+  )
+}
+
+private func decodeGroup(_ object: [String: Any]) throws -> ExclusiveGroup {
+  guard let id = string(object, "id"), !id.isEmpty else {
+    throw SpecError("mutually exclusive group is missing required field \"id\"")
+  }
+  return ExclusiveGroup(
+    id: id,
+    flagIds: stringArray(object, "flag_ids"),
+    required: boolean(object, "required") ?? false
+  )
+}
+
+private func decodeCommand(_ object: [String: Any]) throws -> CommandDefinition {
+  guard let name = string(object, "name"), !name.isEmpty else {
+    throw SpecError("command is missing required field \"name\"")
+  }
+  return CommandDefinition(
+    id: string(object, "id") ?? name,
+    name: name,
+    aliases: stringArray(object, "aliases"),
+    description: string(object, "description") ?? "",
+    inheritGlobalFlags: boolean(object, "inherit_global_flags") ?? true,
+    flags: try objectArray(object, "flags").map(decodeFlag),
+    arguments: try objectArray(object, "arguments").map(decodeArgument),
+    commands: try objectArray(object, "commands").map(decodeCommand),
+    mutuallyExclusiveGroups: try objectArray(object, "mutually_exclusive_groups").map(decodeGroup)
+  )
+}
+
+private func objectArray(_ object: [String: Any], _ key: String) throws -> [[String: Any]] {
+  guard let value = object[key] else { return [] }
+  guard let array = value as? [Any] else { throw SpecError("field \"\(key)\" must be an array") }
+  return try array.map { value in
+    guard let dictionary = value as? [String: Any] else {
+      throw SpecError("field \"\(key)\" must contain objects")
+    }
+    return dictionary
+  }
+}
+
+private func string(_ object: [String: Any], _ key: String) -> String? {
+  object[key] as? String
+}
+
+private func boolean(_ object: [String: Any], _ key: String) -> Bool? {
+  object[key] as? Bool
+}
+
+private func integer(_ object: [String: Any], _ key: String) -> Int? {
+  if let value = object[key] as? Int { return value }
+  if let value = object[key] as? NSNumber { return value.intValue }
+  return nil
+}
+
+private func stringArray(_ object: [String: Any], _ key: String) -> [String] {
+  (object[key] as? [Any] ?? []).compactMap { $0 as? String }
+}

--- a/code/packages/swift/cli-builder/Sources/CliBuilder/TokenClassifier.swift
+++ b/code/packages/swift/cli-builder/Sources/CliBuilder/TokenClassifier.swift
@@ -1,0 +1,120 @@
+public enum TokenKind: Equatable, Sendable {
+  case endOfFlags
+  case longFlag
+  case longFlagWithValue
+  case singleDashLong
+  case shortFlag
+  case shortFlagWithValue
+  case stackedFlags
+  case positional
+  case unknownFlag
+}
+
+public struct TokenEvent: Equatable, Sendable {
+  public let kind: TokenKind
+  public let name: String?
+  public let value: String?
+  public let characters: [String]
+  public let raw: String
+}
+
+public struct TokenClassifier: Sendable {
+  private let longFlags: [String: FlagDefinition]
+  private let shortFlags: [String: FlagDefinition]
+  private let singleDashLongs: [String: FlagDefinition]
+
+  public init(_ flags: [FlagDefinition]) {
+    self.longFlags = Dictionary(
+      flags.compactMap { flag in
+        flag.longName.map { ($0, flag) }
+      }, uniquingKeysWith: { first, _ in first })
+    self.shortFlags = Dictionary(
+      flags.compactMap { flag in
+        flag.shortName.map { ($0, flag) }
+      }, uniquingKeysWith: { first, _ in first })
+    self.singleDashLongs = Dictionary(
+      flags.compactMap { flag in
+        flag.singleDashLong.map { ($0, flag) }
+      }, uniquingKeysWith: { first, _ in first })
+  }
+
+  public func classify(_ token: String) -> TokenEvent {
+    if token == "-" { return event(.positional, name: token, raw: token) }
+    if token == "--" { return event(.endOfFlags, raw: token) }
+    if token.hasPrefix("--") {
+      let rest = String(token.dropFirst(2))
+      if let equals = rest.firstIndex(of: "=") {
+        return event(
+          .longFlagWithValue,
+          name: String(rest[..<equals]),
+          value: String(rest[rest.index(after: equals)...]),
+          raw: token
+        )
+      }
+      return longFlags[rest] == nil
+        ? event(.unknownFlag, name: rest, raw: token)
+        : event(.longFlag, name: rest, raw: token)
+    }
+    if token.hasPrefix("-") && token.count >= 2 {
+      let rest = String(token.dropFirst())
+      if singleDashLongs[rest] != nil {
+        return event(.singleDashLong, name: rest, raw: token)
+      }
+      let first = String(rest.prefix(1))
+      if let flag = shortFlags[first] {
+        if !flag.type.takesValue {
+          return rest.count == 1
+            ? event(.shortFlag, name: first, raw: token)
+            : classifyStack(rest, raw: token)
+        }
+        if rest.count == 1 { return event(.shortFlag, name: first, raw: token) }
+        let suffix = String(rest.dropFirst())
+        if suffix.allSatisfy({ shortFlags[String($0)] != nil }) {
+          return event(.unknownFlag, name: first, raw: token)
+        }
+        return event(.shortFlagWithValue, name: first, value: suffix, raw: token)
+      }
+      return rest.count > 1
+        ? classifyStack(rest, raw: token)
+        : event(.unknownFlag, name: rest, raw: token)
+    }
+    return event(.positional, name: token, raw: token)
+  }
+
+  public func classifyTraditional(_ token: String, knownSubcommands: Set<String>) -> TokenEvent {
+    if token.hasPrefix("-") || knownSubcommands.contains(token) { return classify(token) }
+    let stacked = classifyStack(token, raw: token)
+    return stacked.kind == .stackedFlags ? stacked : event(.positional, name: token, raw: token)
+  }
+
+  public func flag(long name: String) -> FlagDefinition? { longFlags[name] }
+  public func flag(short name: String) -> FlagDefinition? { shortFlags[name] }
+  public func flag(singleDashLong name: String) -> FlagDefinition? { singleDashLongs[name] }
+  public var knownLongNames: [String] { longFlags.keys.map { "--\($0)" }.sorted() }
+  public var knownShortNames: [String] { shortFlags.keys.map { "-\($0)" }.sorted() }
+
+  private func classifyStack(_ text: String, raw: String) -> TokenEvent {
+    var result: [String] = []
+    let characters = text.map(String.init)
+    for (index, character) in characters.enumerated() {
+      guard let flag = shortFlags[character] else {
+        return event(.unknownFlag, name: character, raw: raw)
+      }
+      if flag.type.takesValue && index < characters.count - 1 {
+        return event(.unknownFlag, name: character, raw: raw)
+      }
+      result.append(character)
+    }
+    return event(.stackedFlags, characters: result, raw: raw)
+  }
+}
+
+private func event(
+  _ kind: TokenKind,
+  name: String? = nil,
+  value: String? = nil,
+  characters: [String] = [],
+  raw: String
+) -> TokenEvent {
+  TokenEvent(kind: kind, name: name, value: value, characters: characters, raw: raw)
+}

--- a/code/packages/swift/cli-builder/Tests/CliBuilderTests/CliBuilderTests.swift
+++ b/code/packages/swift/cli-builder/Tests/CliBuilderTests/CliBuilderTests.swift
@@ -1,0 +1,258 @@
+import Foundation
+import XCTest
+
+@testable import CliBuilder
+
+final class CliBuilderTests: XCTestCase {
+  func testValidationRejectsDuplicateFlagIDsAndCycles() throws {
+    let duplicate = """
+      {
+        "cli_builder_spec_version": "1.0",
+        "name": "tool",
+        "description": "A tool",
+        "flags": [
+          {"id":"same", "long":"first", "type":"boolean"},
+          {"id":"same", "long":"second", "type":"boolean"}
+        ]
+      }
+      """
+    let result = try validateSpec(duplicate)
+    XCTAssertFalse(result.isValid)
+    XCTAssertTrue(result.errors.joined(separator: "\n").contains("duplicate flag id"))
+
+    let cycle = """
+      {
+        "cli_builder_spec_version": "1.0",
+        "name": "tool",
+        "description": "A tool",
+        "flags": [
+          {"id":"a", "long":"a", "type":"boolean", "requires":["b"]},
+          {"id":"b", "long":"b", "type":"boolean", "requires":["a"]}
+        ]
+      }
+      """
+    let cycleResult = try validateSpec(cycle)
+    XCTAssertFalse(cycleResult.isValid)
+    XCTAssertTrue(cycleResult.errors.contains { $0.contains("circular requires") })
+  }
+
+  func testTokenClassifierHandlesStacksInlineValuesAndSingleDashLong() {
+    let classifier = TokenClassifier([
+      FlagDefinition(id: "verbose", shortName: "v", longName: "verbose", type: .count),
+      FlagDefinition(id: "output", shortName: "o", longName: "output", type: .string),
+      FlagDefinition(id: "classpath", singleDashLong: "classpath", type: .string),
+    ])
+    XCTAssertEqual(classifier.classify("-vvv").kind, .stackedFlags)
+    XCTAssertEqual(classifier.classify("-classpath").kind, .singleDashLong)
+    XCTAssertEqual(classifier.classify("--output=file").kind, .longFlagWithValue)
+    XCTAssertEqual(classifier.classify("-ofile").kind, .shortFlagWithValue)
+    XCTAssertEqual(classifier.classify("--").kind, .endOfFlags)
+  }
+
+  func testParsesRootFlagsArgumentsAndCounts() throws {
+    let outcome = try parse(baseSpec, ["paint", "--output", "out.png", "-vv", "scene.cad"])
+    guard case .parsed(let result) = outcome else { return XCTFail("expected parsed result") }
+    XCTAssertEqual(result.commandPath, ["paint"])
+    XCTAssertEqual(result.flags["output"], .string("out.png"))
+    XCTAssertEqual(result.flags["verbose"], .int(2))
+    XCTAssertEqual(result.arguments["input"], .string("scene.cad"))
+    XCTAssertEqual(result.explicitFlags, ["output", "verbose", "verbose"])
+  }
+
+  func testEnumDefaultWhenPresentAndNestedCommandInheritance() throws {
+    let root = try parse(baseSpec, ["paint", "--color", "scene.cad"])
+    guard case .parsed(let rootResult) = root else { return XCTFail("expected parsed result") }
+    XCTAssertEqual(rootResult.flags["color"], .string("always"))
+    XCTAssertEqual(rootResult.arguments["input"], .string("scene.cad"))
+
+    let nested = try parse(baseSpec, ["paint", "serve", "status", "--port", "8080", "-v"])
+    guard case .parsed(let nestedResult) = nested else { return XCTFail("expected parsed result") }
+    XCTAssertEqual(nestedResult.commandPath, ["paint", "serve", "status"])
+    XCTAssertEqual(nestedResult.flags["port"], .int(8080))
+    XCTAssertEqual(nestedResult.flags["verbose"], .int(1))
+  }
+
+  func testHelpAndVersionBuiltins() throws {
+    let help = try parse(baseSpec, ["paint", "serve", "--help"])
+    guard case .help(let result) = help else { return XCTFail("expected help") }
+    XCTAssertTrue(result.text.contains("USAGE"))
+    XCTAssertTrue(result.text.contains("GLOBAL OPTIONS"))
+    XCTAssertEqual(result.commandPath, ["paint", "serve"])
+
+    let version = try parse(baseSpec, ["paint", "--version"])
+    XCTAssertEqual(version, .version(VersionResult(version: "1.2.3")))
+  }
+
+  func testDependencyConflictAndExclusiveGroupErrorsAreAggregated() throws {
+    XCTAssertThrowsError(try parse(baseSpec, ["paint", "--profile", "scene.cad"])) { error in
+      guard let parseErrors = error as? ParseErrors else { return XCTFail("expected ParseErrors") }
+      XCTAssertTrue(parseErrors.errors.contains { $0.errorType == "missing_dependency_flag" })
+    }
+
+    let spec = """
+      {
+        "cli_builder_spec_version":"1.0",
+        "name":"tool",
+        "description":"A tool",
+        "flags":[
+          {"id":"json", "long":"json", "type":"boolean", "conflicts_with":["yaml"]},
+          {"id":"yaml", "long":"yaml", "type":"boolean", "conflicts_with":["json"]}
+        ],
+        "mutually_exclusive_groups":[
+          {"id":"format", "flag_ids":["json","yaml"], "required":false}
+        ]
+      }
+      """
+    XCTAssertThrowsError(try parse(spec, ["tool", "--json", "--yaml"])) { error in
+      guard let parseErrors = error as? ParseErrors else { return XCTFail("expected ParseErrors") }
+      XCTAssertEqual(parseErrors.errors.filter { $0.errorType == "conflicting_flags" }.count, 1)
+      XCTAssertEqual(
+        parseErrors.errors.filter { $0.errorType == "exclusive_group_violation" }.count, 1)
+    }
+  }
+
+  func testVariadicArgumentsUseLastWinsPartitioning() throws {
+    let spec = """
+      {
+        "cli_builder_spec_version":"1.0",
+        "name":"cp",
+        "description":"Copy files",
+        "arguments":[
+          {"id":"sources", "name":"SOURCE", "type":"string", "variadic":true, "variadic_min":1},
+          {"id":"destination", "name":"DEST", "type":"string", "required":true}
+        ]
+      }
+      """
+    let outcome = try parse(spec, ["cp", "a.txt", "b.txt", "/dest"])
+    guard case .parsed(let result) = outcome else { return XCTFail("expected parsed result") }
+    XCTAssertEqual(result.arguments["sources"], .array([.string("a.txt"), .string("b.txt")]))
+    XCTAssertEqual(result.arguments["destination"], .string("/dest"))
+  }
+
+  func testRepeatableValuesCoercionEndOfFlagsAndSuggestions() throws {
+    let spec = """
+      {
+        "cli_builder_spec_version":"1.0",
+        "name":"tool",
+        "description":"A tool",
+        "flags":[
+          {"id":"define", "short":"D", "long":"define", "type":"string", "repeatable":true},
+          {"id":"jobs", "long":"jobs", "type":"integer"}
+        ],
+        "arguments":[
+          {"id":"values", "name":"VALUE", "type":"string", "required":false, "variadic":true, "variadic_min":0}
+        ]
+      }
+      """
+    let outcome = try parse(
+      spec, ["tool", "-Done", "--define=two", "--jobs", "4", "--", "--literal"])
+    guard case .parsed(let result) = outcome else { return XCTFail("expected parsed result") }
+    XCTAssertEqual(result.flags["define"], .array([.string("one"), .string("two")]))
+    XCTAssertEqual(result.flags["jobs"], .int(4))
+    XCTAssertEqual(result.arguments["values"], .array([.string("--literal")]))
+
+    XCTAssertThrowsError(try parse(spec, ["tool", "--jbos", "4"])) { error in
+      guard let parseErrors = error as? ParseErrors else { return XCTFail("expected ParseErrors") }
+      XCTAssertEqual(parseErrors.errors.first?.errorType, "unknown_flag")
+      XCTAssertEqual(parseErrors.errors.first?.suggestion, "Did you mean \"--jobs\"?")
+    }
+  }
+
+  func testPosixSubcommandFirstAndTraditionalModes() throws {
+    let posix = """
+      {
+        "cli_builder_spec_version":"1.0", "name":"tool", "description":"A tool", "parsing_mode":"posix",
+        "flags":[{"id":"verbose", "short":"v", "type":"boolean"}],
+        "arguments":[{"id":"rest", "name":"REST", "type":"string", "required":false, "variadic":true, "variadic_min":0}]
+      }
+      """
+    let posixOutcome = try parse(posix, ["tool", "input", "-v"])
+    guard case .parsed(let posixResult) = posixOutcome else {
+      return XCTFail("expected parsed result")
+    }
+    XCTAssertEqual(posixResult.flags["verbose"], .bool(false))
+    XCTAssertEqual(posixResult.arguments["rest"], .array([.string("input"), .string("-v")]))
+
+    let subcommandFirst = """
+      {
+        "cli_builder_spec_version":"1.0", "name":"tool", "description":"A tool", "parsing_mode":"subcommand_first",
+        "commands":[{"id":"run", "name":"run", "description":"Run", "arguments":[], "flags":[], "commands":[]}]
+      }
+      """
+    XCTAssertThrowsError(try parse(subcommandFirst, ["tool", "rum"])) { error in
+      guard let parseErrors = error as? ParseErrors else { return XCTFail("expected ParseErrors") }
+      XCTAssertEqual(parseErrors.errors.first?.errorType, "unknown_command")
+      XCTAssertEqual(parseErrors.errors.first?.suggestion, "Did you mean \"run\"?")
+    }
+
+    let traditional = """
+      {
+        "cli_builder_spec_version":"1.0", "name":"tar", "description":"Archive", "parsing_mode":"traditional",
+        "flags":[
+          {"id":"extract", "short":"x", "type":"boolean"},
+          {"id":"verbose", "short":"v", "type":"count"},
+          {"id":"file", "short":"f", "type":"string"}
+        ]
+      }
+      """
+    let traditionalOutcome = try parse(traditional, ["tar", "xvf", "archive.tar"])
+    guard case .parsed(let traditionalResult) = traditionalOutcome else {
+      return XCTFail("expected parsed result")
+    }
+    XCTAssertEqual(traditionalResult.flags["extract"], .bool(true))
+    XCTAssertEqual(traditionalResult.flags["verbose"], .int(1))
+    XCTAssertEqual(traditionalResult.flags["file"], .string("archive.tar"))
+  }
+
+  func testSpecLoaderReadsAFile() throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("swift-cli-builder-\(UUID().uuidString).json")
+    try baseSpec.write(to: url, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: url) }
+    let parser = try Parser(specPath: url.path, argv: ["paint", "scene.cad"])
+    guard case .parsed(let result) = try parser.parse() else {
+      return XCTFail("expected parsed result")
+    }
+    XCTAssertEqual(result.arguments["input"], .string("scene.cad"))
+  }
+
+  private func parse(_ json: String, _ argv: [String]) throws -> ParseOutcome {
+    let spec = try SpecLoader().load(from: json)
+    return try Parser(spec: spec, argv: argv).parse()
+  }
+
+  private var baseSpec: String {
+    """
+    {
+      "cli_builder_spec_version":"1.0",
+      "name":"paint",
+      "description":"Paint things",
+      "version":"1.2.3",
+      "parsing_mode":"gnu",
+      "builtin_flags":{"help":true,"version":true},
+      "global_flags":[
+        {"id":"verbose", "short":"v", "long":"verbose", "description":"Verbose output", "type":"count"}
+      ],
+      "flags":[
+        {"id":"output", "short":"o", "long":"output", "description":"Output path", "type":"string"},
+        {"id":"color", "long":"color", "description":"Color mode", "type":"enum", "enum_values":["always","never"], "default_when_present":"always"},
+        {"id":"profile", "long":"profile", "description":"Enable profiling", "type":"boolean", "requires":["config"]},
+        {"id":"config", "long":"config", "description":"Config file", "type":"string"}
+      ],
+      "arguments":[
+        {"id":"input", "display_name":"INPUT", "description":"Input source", "type":"string", "required":true}
+      ],
+      "commands":[
+        {
+          "id":"serve", "name":"serve", "aliases":["srv"], "description":"Serve content", "inherit_global_flags":true,
+          "flags":[{"id":"port", "long":"port", "description":"Port", "type":"integer"}],
+          "arguments":[],
+          "commands":[
+            {"id":"status", "name":"status", "description":"Show status", "flags":[], "arguments":[], "commands":[]}
+          ]
+        }
+      ]
+    }
+    """
+  }
+}

--- a/code/packages/swift/cli-builder/required_capabilities.json
+++ b/code/packages/swift/cli-builder/required_capabilities.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/cli-builder",
+  "capabilities": [
+    "fs_read"
+  ],
+  "justification": "Reads JSON CLI spec files and validates file or directory argument values against the filesystem."
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,11 +105,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 14, 2026 after the Dart DT11 B-tree and DT12 B+ tree ports:
+on July 14, 2026 after the Swift CLI-builder port:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 376 |
+| Present in 10-15 languages | 171 | 375 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 694 | 9,716 |
@@ -128,8 +128,8 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Two package/language slots remain to turn 2 nearly complete packages into
-fully covered packages.
+One package/language slot remains to turn the final nearly complete package
+into a fully covered package.
 
 ### Dart: complete
 
@@ -144,12 +144,11 @@ The dependency-shaped DT11/DT12 `b-tree`/`b-plus-tree` pair is complete.
 Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
 `huffman-tree`, `huffman-compression`, `lz77`, `lzss`, `lzw`.
 
-### Swift: 2 remaining ports
+### Swift: 1 remaining port
 
-- `cli-builder`
 - `sql-execution-engine`
 
-Completed in the Swift lane: `wasm-simulator`.
+Completed in the Swift lane: `wasm-simulator`, `cli-builder`.
 
 Port dependency families together when doing so avoids temporary broken package
 graphs. Grammar-generated lexer/parser pairs should be generated from the shared
@@ -157,7 +156,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 378
+The 171 packages present in at least ten implementation languages need 375
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -169,7 +168,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
-| Swift | 52 | Data structures and generated frontends before native app surfaces |
+| Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 57 | Move with Kotlin |
 | Kotlin | 57 | Move with Java |
 | Dart | 106 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |


### PR DESCRIPTION
## Summary

- add a pure Swift implementation of the declarative CLI-builder spec
- use the existing DirectedGraph package for transitive flag dependencies and StateMachine DFA for scanner modes
- cover routing, built-in help/version flags, GNU/POSIX/traditional modes, type coercion, variadics, repeatable flags, constraints, defaults, and aggregated errors
- update the parity roadmap: `cli-builder` is now 15/15, leaving only Swift `sql-execution-engine` in Priority 1

## Why

`cli-builder` was one of two remaining 14-of-15 packages. Its Swift dependency chain already existed, making it the smallest dependency-safe next item after the Dart B-tree family merged.

## Impact

Swift consumers can now load the shared JSON CLI-builder format and parse command lines with behavior matching the established language ports. The 10-15-language parity band drops from 376 to 375 missing slots, and Swift high-consensus gaps drop from 52 to 51.

## Validation

- `swift-format lint -r Sources Tests Package.swift`
- `swift test` (10 tests)
- `swift test -c release` (10 tests)
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py` (6 tests)
- JSON parity report with `--fail-on-collisions` (zero collisions, zero unknown buckets)
- Markdown and CSV parity report generation
- capability metadata JSON parse
- `git diff --check origin/main...HEAD`