### PR TITLE
feat(js-ast,passes): default parameters function f(a = expr) — CLOC12.191 PR1

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.47.0] - 2026-07-14
+
+### Added — emit `name=expr` default parameters — CLOC12.191 PR1
+
+Picks up javascript-ast 0.42.0. New `FunctionParam::AssignmentPattern` emit arm writes the `left`
+identifier, `=` (tight in minified mode, spaced `a = 1` in pretty mode via `pretty_ws()`), then the
+`right` default expression at `PREC_ASSIGNMENT` — so a looser bare-sequence default parenthesises
+(`function f(a=(1,2)){}`) while an ordinary literal prints bare. The arrow single-param paren-elision
+guard already restricts to a plain identifier, so a lone default param `(a=1)=>` keeps its parens
+(`a=1=>` is invalid JS). Additive; MINOR.
+
 ## [0.46.0] - 2026-07-14
 
 ### Added — emit `...name` rest parameters — CLOC12.190 PR1

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -1079,6 +1079,19 @@ impl<'a> Emitter<'a> {
                     self.write_str("...");
                     self.emit_identifier(&re.argument);
                 }
+                FunctionParam::AssignmentPattern(ap) => {
+                    // `name=expr` — a default parameter. The default is emitted
+                    // at `PREC_ASSIGNMENT` (the RHS of `=`), so a looser bare
+                    // sequence default wraps (`a=(1,2)`) while everything tighter
+                    // prints bare — exactly as an assignment RHS or class-field
+                    // value does. `pretty_ws()` gives `a = 1` in pretty mode and
+                    // `a=1` minified.
+                    self.emit_identifier(&ap.left);
+                    self.pretty_ws();
+                    self.write_str("=");
+                    self.pretty_ws();
+                    self.emit_expression_inner(&ap.right, PREC_ASSIGNMENT);
+                }
             }
         }
         self.write_str(")");
@@ -1157,6 +1170,19 @@ impl<'a> Emitter<'a> {
                     // `...name` — the rest parameter, always last in the list.
                     self.write_str("...");
                     self.emit_identifier(&re.argument);
+                }
+                FunctionParam::AssignmentPattern(ap) => {
+                    // `name=expr` — a default parameter. The default is emitted
+                    // at `PREC_ASSIGNMENT` (the RHS of `=`), so a looser bare
+                    // sequence default wraps (`a=(1,2)`) while everything tighter
+                    // prints bare — exactly as an assignment RHS or class-field
+                    // value does. `pretty_ws()` gives `a = 1` in pretty mode and
+                    // `a=1` minified.
+                    self.emit_identifier(&ap.left);
+                    self.pretty_ws();
+                    self.write_str("=");
+                    self.pretty_ws();
+                    self.emit_expression_inner(&ap.right, PREC_ASSIGNMENT);
                 }
             }
         }
@@ -1421,6 +1447,15 @@ impl<'a> Emitter<'a> {
                     FunctionParam::RestElement(re) => {
                         self.write_str("...");
                         self.emit_identifier(&re.argument);
+                    }
+                    FunctionParam::AssignmentPattern(ap) => {
+                        // `name=expr` default param — same shape as a function's,
+                        // emitted at `PREC_ASSIGNMENT` so a sequence default wraps.
+                        self.emit_identifier(&ap.left);
+                        self.pretty_ws();
+                        self.write_str("=");
+                        self.pretty_ws();
+                        self.emit_expression_inner(&ap.right, PREC_ASSIGNMENT);
                     }
                 }
             }
@@ -3061,7 +3096,7 @@ mod tests {
     #![allow(clippy::neg_multiply)]
     use super::*;
     use coding_adventures_javascript_ast::{
-        CatchClause, PrivateName, Program, RestElement, SourceType,
+        AssignmentPattern, CatchClause, PrivateName, Program, RestElement, SourceType,
     };
     use coding_adventures_javascript_tokens::EsVersion;
 
@@ -4052,6 +4087,101 @@ mod tests {
         )]);
         let out = emit_default(prog);
         assert_eq!(out.code, "function g(...args){};");
+    }
+
+    // ---- default parameters (CLOC12.191 PR1) ----------------
+    //
+    // A default parameter prints `name=expr` (minified) — the `=` has no
+    // surrounding whitespace in compact mode. The default is a *live*
+    // expression, emitted at `PREC_ASSIGNMENT`: an ordinary literal prints
+    // bare, but a looser bare sequence default must parenthesise (`a=(1,2)`),
+    // and a plain identifier param mixed alongside a default still prints
+    // uniformly.
+
+    /// `function f(a,b=1){}` → `function f(a,b=1){}` — a fixed param followed
+    /// by a numeric-literal default. The `=` is tight in minified mode.
+    #[test]
+    fn default_parameter_minified() {
+        let f = FunctionDeclaration {
+            cv: None,
+            id: Identifier { cv: None, name: "f".to_string() },
+            params: vec![
+                FunctionParam::Identifier(Identifier { cv: None, name: "a".to_string() }),
+                FunctionParam::AssignmentPattern(AssignmentPattern {
+                    cv: None,
+                    left: Identifier { cv: None, name: "b".to_string() },
+                    right: num(1.0),
+                }),
+            ],
+            body: BlockStatement { cv: None, body: vec![] },
+            generator: false,
+            is_async: false,
+        };
+        let prog = program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(f),
+        )]);
+        assert_eq!(emit_default(prog).code, "function f(a,b=1){};");
+    }
+
+    /// A **sequence** default must parenthesise: `function f(a=(1,2)){}`. The
+    /// default is emitted at `PREC_ASSIGNMENT`, so a bare comma sequence — which
+    /// binds looser than `=` — is wrapped; without the parens `a=1,2` would parse
+    /// as two parameters `a=1` and `2` (the latter invalid).
+    #[test]
+    fn default_parameter_sequence_wraps() {
+        let seq = Expression::SequenceExpression(SequenceExpression {
+            cv: None,
+            expressions: vec![num(1.0), num(2.0)],
+        });
+        let f = FunctionDeclaration {
+            cv: None,
+            id: Identifier { cv: None, name: "f".to_string() },
+            params: vec![FunctionParam::AssignmentPattern(AssignmentPattern {
+                cv: None,
+                left: Identifier { cv: None, name: "a".to_string() },
+                right: seq,
+            })],
+            body: BlockStatement { cv: None, body: vec![] },
+            generator: false,
+            is_async: false,
+        };
+        let prog = program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(f),
+        )]);
+        assert_eq!(emit_default(prog).code, "function f(a=(1,2)){};");
+    }
+
+    /// Pretty mode spaces the `=`: `function f(a = 1){ }`-style. Confirms the
+    /// `pretty_ws()` bracketing around `=` mirrors a class-field initializer.
+    #[test]
+    fn default_parameter_pretty_spaces_equals() {
+        let f = FunctionDeclaration {
+            cv: None,
+            id: Identifier { cv: None, name: "f".to_string() },
+            params: vec![FunctionParam::AssignmentPattern(AssignmentPattern {
+                cv: None,
+                left: Identifier { cv: None, name: "a".to_string() },
+                right: num(1.0),
+            })],
+            body: BlockStatement { cv: None, body: vec![] },
+            generator: false,
+            is_async: false,
+        };
+        let prog = program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(f),
+        )]);
+        let out = emit_with(
+            prog,
+            EmitOptions {
+                pretty: true,
+                ..EmitOptions::default()
+            },
+        );
+        assert!(
+            out.code.contains("a = 1"),
+            "pretty mode should space the default `=`; got {}",
+            out.code
+        );
     }
 
     // ---- class declarations (CLOC12.174 PR1) ----------------

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.89.0] - 2026-07-14
+
+### Added — fold default-parameter expressions — CLOC12.191 PR1
+
+Picks up javascript-ast 0.42.0. New `fold_params` helper folds each `FunctionParam::AssignmentPattern`
+default `right` through the same `fold_expression` path a function body uses, so `function f(a = 1 + 2){}`
+shrinks to `function f(a = 3){}`. Applied at all four param-list sites (function declaration/expression,
+class method, arrow). Plain and rest params clone verbatim (no default expression).
+
 ## [0.88.0] - 2026-07-12
 
 ### Added — CLOC12.189 PR1: export declaration rebuild arms clone each export verbatim

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.88.0"
+version = "0.89.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -96,7 +96,7 @@ use coding_adventures_javascript_ast::{
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     ClassDeclaration, ClassExpression, ClassMember, MethodDefinition, PropertyDefinition,
-    FunctionDeclaration, FunctionExpression, Identifier,
+    AssignmentPattern, FunctionDeclaration, FunctionExpression, FunctionParam, Identifier,
     ChainExpression, IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral, OptionalCallExpression, OptionalMemberExpression,
     ObjectExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey, PropertyKind, ReturnStatement, Statement,
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, UpdateExpression, VariableDeclaration,
@@ -454,6 +454,29 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> TaggedSt
 // Declarations
 // =====================================================================
 
+/// Fold each parameter's default-value expression. A plain identifier and a
+/// rest element carry no sub-expression, so they clone verbatim; a default
+/// parameter (`a = 1 + 2`) holds live code — its `right` is folded (→ `a = 3`)
+/// through the same [`fold_expression`] path a function body uses. This is what
+/// makes `function f(a = 1 + 2){}` shrink to `function f(a = 3){}` instead of
+/// carrying the arithmetic to the output.
+fn fold_params(params: &[FunctionParam], st: &mut FoldState) -> Vec<FunctionParam> {
+    params
+        .iter()
+        .map(|p| match p {
+            FunctionParam::AssignmentPattern(ap) => {
+                FunctionParam::AssignmentPattern(AssignmentPattern {
+                    cv: ap.cv.clone(),
+                    left: ap.left.clone(),
+                    right: fold_expression(&ap.right, st),
+                })
+            }
+            // Plain identifier / rest element: no default expression to fold.
+            other => other.clone(),
+        })
+        .collect()
+}
+
 fn fold_declaration(decl: &Declaration, st: &mut FoldState) -> Declaration {
     st.visit();
     match decl {
@@ -464,7 +487,7 @@ fn fold_declaration(decl: &Declaration, st: &mut FoldState) -> Declaration {
             Declaration::FunctionDeclaration(FunctionDeclaration {
                 cv: f.cv.clone(),
                 id: f.id.clone(),
-                params: f.params.clone(),
+                params: fold_params(&f.params, st),
                 body: BlockStatement {
                     cv: f.body.cv.clone(),
                     body: f.body.body.iter().map(|s| fold_statement(s, st)).collect(),
@@ -554,7 +577,7 @@ fn fold_class_body(
                 value: FunctionExpression {
                     cv: md.value.cv.clone(),
                     id: md.value.id.clone(),
-                    params: md.value.params.clone(),
+                    params: fold_params(&md.value.params, st),
                     body: BlockStatement {
                         cv: md.value.body.cv.clone(),
                         body: md
@@ -778,7 +801,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             Expression::FunctionExpression(FunctionExpression {
                 cv: f.cv.clone(),
                 id: f.id.clone(),
-                params: f.params.clone(),
+                params: fold_params(&f.params, st),
                 body: BlockStatement {
                     cv: f.body.cv.clone(),
                     body: f.body.body.iter().map(|s| fold_statement(s, st)).collect(),
@@ -802,7 +825,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         Expression::ArrowFunctionExpression(a) => {
             Expression::ArrowFunctionExpression(ArrowFunctionExpression {
                 cv: a.cv.clone(),
-                params: a.params.clone(),
+                params: fold_params(&a.params, st),
                 body: match &a.body {
                     ArrowBody::Block(b) => ArrowBody::Block(BlockStatement {
                         cv: b.cv.clone(),
@@ -5599,6 +5622,44 @@ mod tests {
                 expression: expr,
             }),
         )])
+    }
+
+    /// CLOC12.191 PR1: a default-parameter's `right` expression must fold. The
+    /// pass previously cloned parameter lists verbatim (rest-params carry only a
+    /// name); a default carries *live code*, so `function f(a = 2 + 3){}` has to
+    /// shrink to `function f(a = 5){}` — the same fold a function body gets.
+    #[test]
+    fn folds_default_parameter_expression() {
+        let default_expr = Expression::BinaryExpression(BinaryExpression {
+            cv: None,
+            operator: BinaryOperator::Add,
+            left: Box::new(num(2.0, None)),
+            right: Box::new(num(3.0, None)),
+        });
+        let fd = FunctionDeclaration {
+            cv: None,
+            id: Identifier { cv: None, name: "f".to_string() },
+            params: vec![FunctionParam::AssignmentPattern(AssignmentPattern {
+                cv: None,
+                left: Identifier { cv: None, name: "a".to_string() },
+                right: default_expr,
+            })],
+            body: BlockStatement { cv: None, body: vec![] },
+            generator: false,
+            is_async: false,
+        };
+        let prog = untraced_program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(fd),
+        )]);
+        let (out, _contribs, changed, _) = run_pass(prog);
+        assert!(changed, "folding a default expression should mark the program changed");
+        let ProgramItem::Declaration(Declaration::FunctionDeclaration(f)) = &out.body[0] else {
+            panic!("expected a function declaration back");
+        };
+        match f.params[0].default_value() {
+            Some(Expression::NumericLiteral(n)) => assert_eq!(n.value, 5.0),
+            other => panic!("expected the default to fold to 5; got {other:?}"),
+        }
     }
 
     /// Extract the (folded) expression from a Program whose body is a

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -12,6 +12,12 @@ binding can’t reproduce a default’s undefined-triggered semantics (`function
 yield `a = 5`, not `a = undefined`). The function is left intact for the other passes. A rest parameter
 remains inlinable — it binds a name with no default expression.
 
+Additionally, the two body-rewriters that descend into *nested* function/arrow/method values inside an
+inlined body — `substitute` (param→arg) and `rename_in_expr` (void-splice alpha-rename) — now rewrite those
+nested values' parameter defaults with the same shadow-stripped map as the body, and `collect_binding_idents_expr`
+collects a nested default's identifiers into the avoid-set. Without this a nested default that reads a
+substituted outer parameter or a renamed outer local was left dangling (a miscompile; found in security review).
+
 ## [0.29.0] - 2026-07-14
 
 ### Changed — handle `FunctionParam::RestElement` — CLOC12.190 PR1

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.30.0] - 2026-07-14
+
+### Changed — decline to inline functions with a default parameter — CLOC12.191 PR1
+
+Picks up javascript-ast 0.42.0. Both inline-candidate builders (return-expression and void-statement) now
+reject a function whose parameter list contains a `FunctionParam::AssignmentPattern`: positional argument
+binding can’t reproduce a default’s undefined-triggered semantics (`function f(a = 5); f(undefined)` must
+yield `a = 5`, not `a = undefined`). The function is left intact for the other passes. A rest parameter
+remains inlinable — it binds a name with no default expression.
+
 ## [0.29.0] - 2026-07-14
 
 ### Changed — handle `FunctionParam::RestElement` — CLOC12.190 PR1

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -584,6 +584,16 @@ fn candidate_from_function(
         return None;
     }
 
+    // A default parameter (`function f(a = expr)`) can't be inlined by simple
+    // positional argument binding: when a call omits the argument or passes
+    // `undefined`, the default value applies — semantics a plain `const a = arg`
+    // substitution does not reproduce. Decline the whole candidate; the function
+    // is left intact for the other passes. (A rest param is fine — it binds a
+    // name with no default expression.)
+    if fd.params.iter().any(|p| p.default_value().is_some()) {
+        return None;
+    }
+
     // Parameter names must be distinct, or the substitution map would
     // be ambiguous. (`function f(a, a)` is a syntax error in strict
     // mode anyway, but we never assume the parser rejected it.)
@@ -2645,6 +2655,13 @@ fn void_candidate_from_function(
     // (1) The name must be declared exactly once in the whole program, so
     // every use of the identifier resolves to this function.
     if decl_counts.get(&fd.id.name).copied().unwrap_or(0) != 1 {
+        return None;
+    }
+
+    // A default parameter can't be inlined by positional argument binding (an
+    // omitted/`undefined` argument triggers the default) — decline, exactly as
+    // the return-expression candidate builder does.
+    if fd.params.iter().any(|p| p.default_value().is_some()) {
         return None;
     }
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -961,8 +961,13 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 out.insert(id.name.clone());
             }
             for p in &fe.params {
-                let id = p.binding_identifier();
-                out.insert(id.name.clone());
+                out.insert(p.binding_identifier().name.clone());
+                // A default's `right` reads names too (`a = SOME_NAME`); over-
+                // collect them so a fresh name the void splice mints can never
+                // collide with a name a nested default reads.
+                if let Some(def) = p.default_value() {
+                    collect_binding_idents_expr(def, out);
+                }
             }
         }
         // A class *value* binds its own name (if named) and each method
@@ -988,8 +993,10 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                             out.insert(id.name.clone());
                         }
                         for p in &m.value.params {
-                            let id = p.binding_identifier();
-                            out.insert(id.name.clone());
+                            out.insert(p.binding_identifier().name.clone());
+                            if let Some(def) = p.default_value() {
+                                collect_binding_idents_expr(def, out);
+                            }
                         }
                     }
                     // A field's initializer is evaluated at construction; the
@@ -1022,8 +1029,10 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // record them so an inline never captures or collides with them.
         Expression::ArrowFunctionExpression(ae) => {
             for p in &ae.params {
-                let id = p.binding_identifier();
-                out.insert(id.name.clone());
+                out.insert(p.binding_identifier().name.clone());
+                if let Some(def) = p.default_value() {
+                    collect_binding_idents_expr(def, out);
+                }
             }
         }
         // A template literal introduces NO boundary bindings; its quasis are
@@ -2053,6 +2062,15 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
                 let id = p.binding_identifier();
                 inner.remove(&id.name);
             }
+            // A default parameter's `right` runs in the nested scope and can
+            // reference a substituted outer parameter (`return function(a = b){}`
+            // inside `f(a, b)`); substitute through it with the shadow-stripped
+            // `inner`, exactly like the body.
+            for p in &mut fe.params {
+                if let Some(def) = p.default_value_mut() {
+                    substitute(def, &inner);
+                }
+            }
             for s in &mut fe.body.body {
                 substitute_in_stmt(s, &inner);
             }
@@ -2083,6 +2101,13 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
                         for p in &m.value.params {
                             let id = p.binding_identifier();
                             inner.remove(&id.name);
+                        }
+                        // Default-param `right` expressions — see the
+                        // `FunctionExpression` arm.
+                        for p in &mut m.value.params {
+                            if let Some(def) = p.default_value_mut() {
+                                substitute(def, &inner);
+                            }
                         }
                         for s in &mut m.value.body.body {
                             substitute_in_stmt(s, &inner);
@@ -2119,6 +2144,12 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
             for p in &ae.params {
                 let id = p.binding_identifier();
                 inner.remove(&id.name);
+            }
+            // Default-param `right` expressions — see the `FunctionExpression` arm.
+            for p in &mut ae.params {
+                if let Some(def) = p.default_value_mut() {
+                    substitute(def, &inner);
+                }
             }
             match &mut ae.body {
                 ArrowBody::Block(b) => {
@@ -4177,6 +4208,14 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                 let id = p.binding_identifier();
                 inner.remove(&id.name);
             }
+            // A default's `right` can reference an outer name being alpha-renamed
+            // (`(x = loc) => …` spliced where `loc` is renamed); rename it with
+            // the shadow-stripped `inner`, exactly like the body.
+            for p in &mut fe.params {
+                if let Some(def) = p.default_value_mut() {
+                    rename_in_expr(def, &inner);
+                }
+            }
             for s in &mut fe.body.body {
                 rename_in_stmt(s, &inner);
             }
@@ -4206,6 +4245,13 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                         for p in &m.value.params {
                             let id = p.binding_identifier();
                             inner.remove(&id.name);
+                        }
+                        // Default-param `right` expressions — see the
+                        // `FunctionExpression` arm.
+                        for p in &mut m.value.params {
+                            if let Some(def) = p.default_value_mut() {
+                                rename_in_expr(def, &inner);
+                            }
                         }
                         for s in &mut m.value.body.body {
                             rename_in_stmt(s, &inner);
@@ -4242,6 +4288,12 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             for p in &ae.params {
                 let id = p.binding_identifier();
                 inner.remove(&id.name);
+            }
+            // Default-param `right` expressions — see the `FunctionExpression` arm.
+            for p in &mut ae.params {
+                if let Some(def) = p.default_value_mut() {
+                    rename_in_expr(def, &inner);
+                }
             }
             match &mut ae.body {
                 ArrowBody::Block(b) => {
@@ -5834,5 +5886,107 @@ mod tests {
             inline_source("var t = 9; function f(x) { var t = x; return t; } var g = f(5);"),
             "var t=9;function f(x){var t=x;return t};var b=5;const a=b;var g=a;"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // CLOC12.191 PR1 (security-review regression) — when the inliner splices a
+    // function body that contains a NESTED function/arrow value with a default
+    // parameter, the body-rewriters (`substitute` param→arg, `rename_in_expr`
+    // alpha-rename) must rewrite that nested default too — else a name it reads
+    // (an outer param being substituted, or an outer local being renamed) is
+    // left dangling. The bridge does not yet produce defaults (PR2), so these
+    // call the rewriters directly on hand-built AST.
+    // -------------------------------------------------------------------
+    #[test]
+    fn substitute_reaches_nested_default_parameter() {
+        use coding_adventures_javascript_ast::statement::ReturnStatement;
+        use coding_adventures_javascript_ast::{
+            AssignmentPattern, BlockStatement, Expression, FunctionExpression, FunctionParam,
+            Identifier, NumericLiteral, Statement,
+        };
+
+        let id = |n: &str| Identifier {
+            cv: None,
+            name: n.to_string(),
+        };
+        // `function(a = b){ return a; }` — the default reads `b`.
+        let mut expr = Expression::FunctionExpression(FunctionExpression {
+            cv: None,
+            id: None,
+            params: vec![FunctionParam::AssignmentPattern(AssignmentPattern {
+                cv: None,
+                left: id("a"),
+                right: Expression::Identifier(id("b")),
+            })],
+            body: BlockStatement {
+                cv: None,
+                body: vec![Statement::return_statement(ReturnStatement {
+                    cv: None,
+                    argument: Some(Expression::Identifier(id("a"))),
+                })],
+            },
+            generator: false,
+            is_async: false,
+        });
+
+        // Substituting `b -> 2` must reach the default `= b`.
+        let mut map = HashMap::new();
+        map.insert(
+            "b".to_string(),
+            Expression::NumericLiteral(NumericLiteral {
+                cv: None,
+                value: 2.0,
+                raw: "2".to_string(),
+            }),
+        );
+        substitute(&mut expr, &map);
+
+        let Expression::FunctionExpression(fe) = &expr else {
+            panic!("expected a function expression");
+        };
+        match fe.params[0].default_value() {
+            Some(Expression::NumericLiteral(n)) => assert_eq!(n.value, 2.0),
+            other => panic!("nested default `= b` was not substituted: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rename_in_expr_reaches_nested_arrow_default() {
+        use coding_adventures_javascript_ast::{
+            ArrowBody, ArrowFunctionExpression, AssignmentPattern, Expression, FunctionParam,
+            Identifier,
+        };
+
+        let id = |n: &str| Identifier {
+            cv: None,
+            name: n.to_string(),
+        };
+        // `(x = loc) => x` — the default reads the outer local `loc`.
+        let mut expr = Expression::ArrowFunctionExpression(ArrowFunctionExpression {
+            cv: None,
+            params: vec![FunctionParam::AssignmentPattern(AssignmentPattern {
+                cv: None,
+                left: id("x"),
+                right: Expression::Identifier(id("loc")),
+            })],
+            body: ArrowBody::Expression(Box::new(Expression::Identifier(id("x")))),
+            is_async: false,
+        });
+
+        // Alpha-renaming `loc -> _a` must reach the default `= loc`.
+        let mut map = HashMap::new();
+        map.insert("loc".to_string(), "_a".to_string());
+        rename_in_expr(&mut expr, &map);
+
+        let Expression::ArrowFunctionExpression(ae) = &expr else {
+            panic!("expected an arrow expression");
+        };
+        match ae.params[0].default_value() {
+            Some(Expression::Identifier(idref)) => assert_eq!(
+                idref.name, "_a",
+                "nested arrow default `= loc` was not alpha-renamed"
+            ),
+            other => panic!("expected an identifier default, got {other:?}"),
+        }
     }
 }

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -10,7 +10,9 @@ Picks up javascript-ast 0.42.0. The apply step now rewrites global references in
 `FunctionParam::AssignmentPattern` default `right` (using the same shadow-stripped map as the function body,
 so a global read is renamed while a reference to an earlier param is left alone), and the new
 `collect_param_idents` helper adds a default’s identifiers to the avoid set so a freshly-minted global name
-never collides with one.
+never collides with one. Covers both the nested-value apply path (`rename_apply_expr`) and the top-level
+declaration apply path (`rename_apply_decl`, for a global read in a top-level function/method default —
+added after security review).
 
 ## [0.17.0] - 2026-07-14
 

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.18.0] - 2026-07-14
+
+### Changed — rename globals referenced inside default-parameter expressions — CLOC12.191 PR1
+
+Picks up javascript-ast 0.42.0. The apply step now rewrites global references inside a
+`FunctionParam::AssignmentPattern` default `right` (using the same shadow-stripped map as the function body,
+so a global read is renamed while a reference to an earlier param is left alone), and the new
+`collect_param_idents` helper adds a default’s identifiers to the avoid set so a freshly-minted global name
+never collides with one.
+
 ## [0.17.0] - 2026-07-14
 
 ### Changed — handle `FunctionParam::RestElement` — CLOC12.190 PR1

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -1021,6 +1021,16 @@ fn rename_apply_decl(decl: &mut Declaration, map: &HashMap<String, String>) {
             if let Some(new) = map.get(&fd.id.name) {
                 fd.id.name = new.clone();
             }
+            // A default parameter's `right` runs in the function scope and can
+            // read a renamed global (`function f(x = SOME_GLOBAL){}`); rewrite it
+            // with the full `map`, exactly like the body. A param that shadowed a
+            // global would push that name's count past 1 (excluded from `map`), so
+            // a shadowed reference is never rewritten.
+            for p in &mut fd.params {
+                if let Some(def) = p.default_value_mut() {
+                    rename_apply_expr(def, map);
+                }
+            }
             // … and recurse into the body for uses of any renamed global.
             // Parameters are NOT renamed here — a parameter that shared a
             // top-level name would make that name declared-more-than-once,
@@ -1052,6 +1062,13 @@ fn rename_apply_decl(decl: &mut Declaration, map: &HashMap<String, String>) {
             for member in &mut cd.body {
                 match member {
                     ClassMember::Method(m) => {
+                        // Default-param `right` expressions — see the function
+                        // declaration arm above.
+                        for p in &mut m.value.params {
+                            if let Some(def) = p.default_value_mut() {
+                                rename_apply_expr(def, map);
+                            }
+                        }
                         for s in &mut m.value.body.body {
                             rename_apply_stmt(s, map);
                         }
@@ -1822,5 +1839,100 @@ mod tests {
         assert!(!out.changed, "must not rename globals when a `with` is present");
         assert_eq!(out.program, prog, "program must be returned unchanged");
         assert!(out.contributions.is_empty());
+    }
+
+    // -------------------------------------------------------------------
+    // CLOC12.191 PR1 (security-review regression) — a global referenced only
+    // inside a TOP-LEVEL function's default parameter must be renamed there
+    // too. The apply path for top-level declarations (`rename_apply_decl`)
+    // recurses into the body but originally skipped parameter defaults, so a
+    // renamed global left a dangling reference in the default. The bridge does
+    // not yet produce defaults (PR2), so the AST is hand-built.
+    // -------------------------------------------------------------------
+    #[test]
+    fn renames_global_referenced_in_top_level_default_parameter() {
+        use coding_adventures_javascript_ast::statement::ReturnStatement;
+        use coding_adventures_javascript_ast::{
+            AssignmentPattern, BindingTarget, BlockStatement, Declaration, Expression,
+            FunctionDeclaration, FunctionParam, Identifier, NumericLiteral, ProgramItem, Statement,
+            VarKind, VariableDeclaration, VariableDeclarator,
+        };
+
+        let id = |n: &str| Identifier {
+            cv: None,
+            name: n.to_string(),
+        };
+
+        // `var SOME_GLOBAL = 1;`
+        let var = Declaration::VariableDeclaration(VariableDeclaration {
+            cv: None,
+            kind: VarKind::Var,
+            declarations: vec![VariableDeclarator {
+                cv: None,
+                id: BindingTarget::Identifier(id("SOME_GLOBAL")),
+                init: Some(Expression::NumericLiteral(NumericLiteral {
+                    cv: None,
+                    value: 1.0,
+                    raw: "1".to_string(),
+                })),
+            }],
+        });
+        // `function longFn(x = SOME_GLOBAL) { return x; }`
+        let f = Declaration::FunctionDeclaration(FunctionDeclaration {
+            cv: None,
+            id: id("longFn"),
+            params: vec![FunctionParam::AssignmentPattern(AssignmentPattern {
+                cv: None,
+                left: id("x"),
+                right: Expression::Identifier(id("SOME_GLOBAL")),
+            })],
+            body: BlockStatement {
+                cv: None,
+                body: vec![Statement::return_statement(ReturnStatement {
+                    cv: None,
+                    argument: Some(Expression::Identifier(id("x"))),
+                })],
+            },
+            generator: false,
+            is_async: false,
+        });
+
+        let mut prog = program();
+        prog.body = vec![
+            ProgramItem::Declaration(var),
+            ProgramItem::Declaration(f),
+        ];
+
+        let pass = RenameGlobalsPass::with_no_externs();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("rename-globals");
+
+        assert!(out.changed, "the two long globals should have been renamed");
+        // The new name chosen for `SOME_GLOBAL` on its declaration …
+        let ProgramItem::Declaration(Declaration::VariableDeclaration(vd)) = &out.program.body[0]
+        else {
+            panic!("expected the var declaration back");
+        };
+        let BindingTarget::Identifier(decl_id) = &vd.declarations[0].id;
+        assert_ne!(decl_id.name, "SOME_GLOBAL", "the global should have been renamed");
+        // … must be the name the default reads, not the stale `SOME_GLOBAL`.
+        let ProgramItem::Declaration(Declaration::FunctionDeclaration(f)) = &out.program.body[1]
+        else {
+            panic!("expected the function declaration back");
+        };
+        match f.params[0].default_value() {
+            Some(Expression::Identifier(idref)) => assert_eq!(
+                idref.name, decl_id.name,
+                "top-level default `= SOME_GLOBAL` must track the renamed global"
+            ),
+            other => panic!("expected an identifier default, got {other:?}"),
+        }
     }
 }

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -77,7 +77,7 @@ use coding_adventures_javascript_ast::statement::TaggedStatement;
 use serde_json::json;
 use coding_adventures_javascript_ast::{
     ArrowBody, AssignmentTarget, BindingTarget, ClassMember, Declaration, Expression, ForInit,
-    ObjectMember, Program, ProgramItem, PropertyKey, Statement, VariableDeclaration,
+    FunctionParam, ObjectMember, Program, ProgramItem, PropertyKey, Statement, VariableDeclaration,
 };
 
 /// `Pass::depends_on` value — empty. Global renaming is correct on its
@@ -529,6 +529,21 @@ fn count_decl_names_stmt(
 
 // ---- avoid-set collection (every identifier, anywhere) -------------------
 
+/// Collect every identifier a parameter list introduces or references into
+/// `out`: each param's bound name, plus — for a default parameter (`a = expr`)
+/// — every identifier in its `right` default expression. The default is live
+/// code that can read a global (`function f(a = GLOBAL) {}`); over-collecting
+/// its idents keeps a freshly-minted short GLOBAL name from colliding with a
+/// name the default reads. Plain and rest params contribute only their name.
+fn collect_param_idents(params: &[FunctionParam], out: &mut HashSet<String>) {
+    for p in params {
+        out.insert(p.binding_identifier().name.clone());
+        if let Some(def) = p.default_value() {
+            collect_all_idents_expr(def, out);
+        }
+    }
+}
+
 fn collect_all_idents_program(program: &Program, out: &mut HashSet<String>) {
     for item in &program.body {
         match item {
@@ -572,10 +587,7 @@ fn collect_all_idents_decl(decl: &Declaration, out: &mut HashSet<String>) {
                         if let Some(id) = &m.value.id {
                             out.insert(id.name.clone());
                         }
-                        for p in &m.value.params {
-                            let id = p.binding_identifier();
-                            out.insert(id.name.clone());
-                        }
+                        collect_param_idents(&m.value.params, out);
                         for s in &m.value.body.body {
                             collect_all_idents_stmt(s, out);
                         }
@@ -607,10 +619,7 @@ fn collect_all_idents_decl(decl: &Declaration, out: &mut HashSet<String>) {
         }
         Declaration::FunctionDeclaration(fd) => {
             out.insert(fd.id.name.clone());
-            for p in &fd.params {
-                let id = p.binding_identifier();
-                out.insert(id.name.clone());
-            }
+            collect_param_idents(&fd.params, out);
             for s in &fd.body.body {
                 collect_all_idents_stmt(s, out);
             }
@@ -873,10 +882,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
             if let Some(id) = &fe.id {
                 out.insert(id.name.clone());
             }
-            for p in &fe.params {
-                let id = p.binding_identifier();
-                out.insert(id.name.clone());
-            }
+            collect_param_idents(&fe.params, out);
             for s in &fe.body.body {
                 collect_all_idents_stmt(s, out);
             }
@@ -905,10 +911,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                         if let Some(id) = &m.value.id {
                             out.insert(id.name.clone());
                         }
-                        for p in &m.value.params {
-                            let id = p.binding_identifier();
-                            out.insert(id.name.clone());
-                        }
+                        collect_param_idents(&m.value.params, out);
                         for s in &m.value.body.body {
                             collect_all_idents_stmt(s, out);
                         }
@@ -939,10 +942,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // An arrow value contributes its params and body identifiers (it
         // has no name), so a renamed global never collides with them.
         Expression::ArrowFunctionExpression(ae) => {
-            for p in &ae.params {
-                let id = p.binding_identifier();
-                out.insert(id.name.clone());
-            }
+            collect_param_idents(&ae.params, out);
             match &ae.body {
                 ArrowBody::Block(b) => {
                     for s in &b.body {
@@ -1347,6 +1347,14 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                 let id = p.binding_identifier();
                 inner.remove(&id.name);
             }
+            // A default parameter's `right` runs in the function scope: a global
+            // it reads is renamed, a reference to an earlier param is left alone
+            // (that name was just removed from `inner`). Same `inner` as the body.
+            for p in &mut fe.params {
+                if let Some(def) = p.default_value_mut() {
+                    rename_apply_expr(def, &inner);
+                }
+            }
             for s in &mut fe.body.body {
                 rename_apply_stmt(s, &inner);
             }
@@ -1380,6 +1388,13 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                         for p in &m.value.params {
                             let id = p.binding_identifier();
                             inner.remove(&id.name);
+                        }
+                        // Default-param `right` expressions — see the
+                        // `FunctionExpression` arm.
+                        for p in &mut m.value.params {
+                            if let Some(def) = p.default_value_mut() {
+                                rename_apply_expr(def, &inner);
+                            }
                         }
                         for s in &mut m.value.body.body {
                             rename_apply_stmt(s, &inner);
@@ -1419,6 +1434,12 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             for p in &ae.params {
                 let id = p.binding_identifier();
                 inner.remove(&id.name);
+            }
+            // Default-param `right` expressions — see the `FunctionExpression` arm.
+            for p in &mut ae.params {
+                if let Some(def) = p.default_value_mut() {
+                    rename_apply_expr(def, &inner);
+                }
             }
             match &mut ae.body {
                 ArrowBody::Block(b) => {

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.19.0] - 2026-07-14
+
+### Changed — classify and rewrite property accesses inside default-parameter expressions — CLOC12.191 PR1
+
+Picks up javascript-ast 0.42.0. New `classify_param_defaults` / `rewrite_param_defaults` helpers walk each
+`FunctionParam::AssignmentPattern` default `right` in both phases, kept in lockstep across the function
+declaration/expression, class-method, and arrow arms — so a quoted access in a default still disables
+renaming of that property, and a renamed property is rewritten where a default reads it.
+
 ## [0.18.0] - 2026-07-12
 
 ### Changed — CLOC12.189 PR2: bail on module `export`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -87,8 +87,8 @@ use coding_adventures_correlation_vector::Contribution;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use serde_json::json;
 use coding_adventures_javascript_ast::{
-    ArrowBody, AssignmentTarget, ClassMember, Declaration, Expression, ForInit, ObjectMember,
-    Program, ProgramItem, PropertyKey, Statement,
+    ArrowBody, AssignmentTarget, ClassMember, Declaration, Expression, ForInit, FunctionParam,
+    ObjectMember, Program, ProgramItem, PropertyKey, Statement,
 };
 
 /// `Pass::depends_on` value — empty. Property renaming is correct
@@ -1046,6 +1046,7 @@ fn classify_decl(decl: &Declaration, cls: &mut Classify, nodes_touched: &mut u32
             }
         }
         Declaration::FunctionDeclaration(fd) => {
+            classify_param_defaults(&fd.params, cls);
             for s in &fd.body.body {
                 classify_stmt(s, cls, nodes_touched);
             }
@@ -1102,6 +1103,7 @@ fn classify_class_members(
                     // inside the key expression.
                     classify_expr(e, cls);
                 }
+                classify_param_defaults(&m.value.params, cls);
                 let mut nested = 0u32;
                 for s in &m.value.body.body {
                     classify_stmt(s, cls, &mut nested);
@@ -1262,6 +1264,20 @@ fn classify_stmt(stmt: &Statement, cls: &mut Classify, nodes_touched: &mut u32) 
     }
 }
 
+/// Classify property accesses inside each parameter's default-value expression
+/// (`function f(a = o["x"]) {}`). A default is live code: a quoted access there
+/// must still DISABLE renaming of that property, exactly as one in a function
+/// body would — miss it and a later `rewrite` could rename `o.x` while the
+/// quoted default access keeps the old name (a miscompile). Plain and rest
+/// params have no default expression.
+fn classify_param_defaults(params: &[FunctionParam], cls: &mut Classify) {
+    for p in params {
+        if let Some(def) = p.default_value() {
+            classify_expr(def, cls);
+        }
+    }
+}
+
 fn classify_expr(expr: &Expression, cls: &mut Classify) {
     match expr {
         Expression::Identifier(_)
@@ -1380,6 +1396,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         // `classify_expr` isn't threaded it, so a throwaway counter is
         // used for the nested walk.
         Expression::FunctionExpression(fe) => {
+            classify_param_defaults(&fe.params, cls);
             let mut nested = 0u32;
             for s in &fe.body.body {
                 classify_stmt(s, cls, &mut nested);
@@ -1405,15 +1422,18 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         // a quoted `o["foo"]` written there must still disable renaming
         // of `foo`. Params are variable names, never property names, so
         // they don't touch the property namespace.
-        Expression::ArrowFunctionExpression(ae) => match &ae.body {
-            ArrowBody::Block(b) => {
-                let mut nested = 0u32;
-                for s in &b.body {
-                    classify_stmt(s, cls, &mut nested);
+        Expression::ArrowFunctionExpression(ae) => {
+            classify_param_defaults(&ae.params, cls);
+            match &ae.body {
+                ArrowBody::Block(b) => {
+                    let mut nested = 0u32;
+                    for s in &b.body {
+                        classify_stmt(s, cls, &mut nested);
+                    }
                 }
+                ArrowBody::Expression(e) => classify_expr(e, cls),
             }
-            ArrowBody::Expression(e) => classify_expr(e, cls),
-        },
+        }
         // Classify property accesses inside each `${…}` insert too. Quasis
         // are leaf strings — only the insert expressions can hold a member
         // access that touches the property namespace.
@@ -1474,6 +1494,7 @@ fn rewrite_decl(decl: &mut Declaration, map: &HashMap<String, String>) {
             }
         }
         Declaration::FunctionDeclaration(fd) => {
+            rewrite_param_defaults(&mut fd.params, map);
             for s in &mut fd.body.body {
                 rewrite_stmt(s, map);
             }
@@ -1525,6 +1546,7 @@ fn rewrite_class_members(
                         }
                     }
                 }
+                rewrite_param_defaults(&mut m.value.params, map);
                 for s in &mut m.value.body.body {
                     rewrite_stmt(s, map);
                 }
@@ -1679,6 +1701,18 @@ fn rewrite_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
     }
 }
 
+/// Rewrite renamed property accesses inside each parameter's default-value
+/// expression — the mirror of [`classify_param_defaults`], keeping the classify
+/// and rewrite walks over the same positions so a property renamed elsewhere is
+/// also renamed where a default reads it (`function f(a = o.x)` → `a = o.<new>`).
+fn rewrite_param_defaults(params: &mut [FunctionParam], map: &HashMap<String, String>) {
+    for p in params {
+        if let Some(def) = p.default_value_mut() {
+            rewrite_expr(def, map);
+        }
+    }
+}
+
 fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
     match expr {
         Expression::Identifier(_)
@@ -1785,6 +1819,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // Rewrite property accesses inside a function *value*'s body, the
         // mirror of classifying them above.
         Expression::FunctionExpression(fe) => {
+            rewrite_param_defaults(&mut fe.params, map);
             for s in &mut fe.body.body {
                 rewrite_stmt(s, map);
             }
@@ -1798,14 +1833,17 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::ClassExpression(ce) => rewrite_class_members(&mut ce.super_class, &mut ce.body, map),
         // Rewrite property accesses inside an arrow-value's body, the
         // mirror of classifying them above.
-        Expression::ArrowFunctionExpression(ae) => match &mut ae.body {
-            ArrowBody::Block(b) => {
-                for s in &mut b.body {
-                    rewrite_stmt(s, map);
+        Expression::ArrowFunctionExpression(ae) => {
+            rewrite_param_defaults(&mut ae.params, map);
+            match &mut ae.body {
+                ArrowBody::Block(b) => {
+                    for s in &mut b.body {
+                        rewrite_stmt(s, map);
+                    }
                 }
+                ArrowBody::Expression(e) => rewrite_expr(e, map),
             }
-            ArrowBody::Expression(e) => rewrite_expr(e, map),
-        },
+        }
         // Rewrite property accesses inside each `${…}` insert, the mirror of
         // classifying them above. Quasis are leaf strings — nothing to walk.
         Expression::TemplateLiteral(t) => {

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.22.0] - 2026-07-14
+
+### Changed — rename references inside default-parameter expressions — CLOC12.191 PR1
+
+Picks up javascript-ast 0.42.0. A default parameter’s `right` (`function f(x, y = x){}`) is live code: the
+apply step now rewrites its uses through the rename map so a reference tracks its renamed binding, and the
+new `collect_param_idents` helper adds a default’s identifiers to the collision-avoidance set so a fresh
+short name never shadows a name a default reads. Routed through every param-collection site (leaf function,
+nested function/arrow, class method).
+
 ## [0.21.0] - 2026-07-14
 
 ### Changed — handle `FunctionParam::RestElement` — CLOC12.190 PR1

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -10,7 +10,9 @@ Picks up javascript-ast 0.42.0. A default parameter’s `right` (`function f(x, 
 apply step now rewrites its uses through the rename map so a reference tracks its renamed binding, and the
 new `collect_param_idents` helper adds a default’s identifiers to the collision-avoidance set so a fresh
 short name never shadows a name a default reads. Routed through every param-collection site (leaf function,
-nested function/arrow, class method).
+nested function/arrow, class method). The apply-side rewrite covers both the leaf function's own defaults
+and — via `rewrite_uses_expr` — a default in a nested function/arrow/method value that closes over a
+renamed outer local (the closure-descent path, added after security review).
 
 ## [0.21.0] - 2026-07-14
 

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -96,7 +96,7 @@ use serde_json::json;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use coding_adventures_javascript_ast::{
     ArrowBody, AssignmentTarget, BindingTarget, BlockStatement, ClassMember, Declaration,
-    Expression, ForInit, FunctionDeclaration, ObjectMember, Program, ProgramItem,
+    Expression, ForInit, FunctionDeclaration, FunctionParam, ObjectMember, Program, ProgramItem,
     PropertyKey, Statement, VarKind, VariableDeclaration,
 };
 
@@ -589,10 +589,7 @@ fn rename_leaf_bindings(fd: &mut FunctionDeclaration, renames: &mut Vec<LocalRen
     // uses, and property names), so a rename can neither collide with a
     // local nor capture a free global.
     let mut avoid: HashSet<String> = HashSet::new();
-    for p in &fd.params {
-        let id = p.binding_identifier();
-        avoid.insert(id.name.clone());
-    }
+    collect_param_idents(&fd.params, &mut avoid);
     collect_all_idents_block(&fd.body, &mut avoid);
 
     // Decide the renames, in declaration order for deterministic output.
@@ -638,9 +635,18 @@ fn rename_leaf_bindings(fd: &mut FunctionDeclaration, renames: &mut Vec<LocalRen
 
     // Apply: rewrite the parameter declarations …
     for p in &mut fd.params {
-        let id = p.binding_identifier_mut();
-        if let Some(new) = map.get(&id.name) {
-            id.name = new.clone();
+        {
+            let id = p.binding_identifier_mut();
+            if let Some(new) = map.get(&id.name) {
+                id.name = new.clone();
+            }
+        }
+        // … including a default parameter's `right` expression: a reference in
+        // `function f(a, b = a)` must track `a`'s new name, so rewrite the
+        // default's uses through the same map. (Defaults are evaluated in the
+        // function scope, so the same renames apply.)
+        if let Some(def) = p.default_value_mut() {
+            rewrite_uses_expr(def, &map);
         }
     }
     // … and every declaration + use inside the body.
@@ -828,6 +834,23 @@ fn push_var_occurrences(vd: &VariableDeclaration, out: &mut Vec<(String, bool)>,
     }
 }
 
+/// Collect every identifier a parameter list introduces or references into
+/// `out`: each parameter's bound name plus — for a default parameter
+/// (`a = expr`) — every identifier in its `right` default expression. A
+/// default's `right` is live code that can read a free name (`function f(a =
+/// GLOBAL) {}`), so its identifiers must join the collision-avoidance set or a
+/// freshly-minted short name could shadow the very name the default reads. A
+/// plain or rest parameter has no such expression and contributes only its
+/// bound name.
+fn collect_param_idents(params: &[FunctionParam], out: &mut HashSet<String>) {
+    for p in params {
+        out.insert(p.binding_identifier().name.clone());
+        if let Some(def) = p.default_value() {
+            collect_all_idents_expr(def, out);
+        }
+    }
+}
+
 /// Collect EVERY identifier name appearing anywhere in `block`
 /// (declarations, uses, and property names) — used to pick collision-free
 /// fresh names. Over-inclusive on purpose: avoiding a name that only
@@ -852,10 +875,7 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
         }
         Statement::Declaration(Declaration::FunctionDeclaration(fd)) => {
             out.insert(fd.id.name.clone());
-            for p in &fd.params {
-                let id = p.binding_identifier();
-                out.insert(id.name.clone());
-            }
+            collect_param_idents(&fd.params, out);
             collect_all_idents_block(&fd.body, out);
         }
         // An import declaration's bound names link to a foreign module's
@@ -884,10 +904,7 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                         if let Some(id) = &m.value.id {
                             out.insert(id.name.clone());
                         }
-                        for p in &m.value.params {
-                            let id = p.binding_identifier();
-                            out.insert(id.name.clone());
-                        }
+                        collect_param_idents(&m.value.params, out);
                         for s in &m.value.body.body {
                             collect_all_idents_stmt(s, out);
                         }
@@ -1157,10 +1174,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
             if let Some(id) = &fe.id {
                 out.insert(id.name.clone());
             }
-            for p in &fe.params {
-                let id = p.binding_identifier();
-                out.insert(id.name.clone());
-            }
+            collect_param_idents(&fe.params, out);
             for s in &fe.body.body {
                 collect_all_idents_stmt(s, out);
             }
@@ -1189,10 +1203,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                         if let Some(id) = &m.value.id {
                             out.insert(id.name.clone());
                         }
-                        for p in &m.value.params {
-                            let id = p.binding_identifier();
-                            out.insert(id.name.clone());
-                        }
+                        collect_param_idents(&m.value.params, out);
                         for s in &m.value.body.body {
                             collect_all_idents_stmt(s, out);
                         }
@@ -1225,10 +1236,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // fresh short name for an OUTER local can never collide with a
         // name used inside the arrow.
         Expression::ArrowFunctionExpression(ae) => {
-            for p in &ae.params {
-                let id = p.binding_identifier();
-                out.insert(id.name.clone());
-            }
+            collect_param_idents(&ae.params, out);
             match &ae.body {
                 ArrowBody::Block(b) => {
                     for s in &b.body {
@@ -2312,5 +2320,86 @@ mod tests {
             out.contributions.is_empty(),
             "no rename contributions when bailing on `with`"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // CLOC12.191 PR1 — default-parameter reference rewriting.
+    //
+    // A default parameter's `right` expression can REFERENCE another param
+    // (`function f(x, y = x){…}`). When rename shortens `x`, the reference in
+    // the default must move with it, or the emitted code reads a name that no
+    // longer exists. The bridge does not yet produce defaults (that is PR2), so
+    // this hand-builds the AST to exercise the rewrite directly.
+    // -------------------------------------------------------------------
+    #[test]
+    fn rewrites_reference_inside_default_parameter() {
+        use coding_adventures_javascript_ast::statement::ReturnStatement;
+        use coding_adventures_javascript_ast::{
+            AssignmentPattern, BlockStatement, Declaration, Expression, FunctionDeclaration,
+            FunctionParam, Identifier, ProgramItem, Statement,
+        };
+
+        let id = |n: &str| Identifier {
+            cv: None,
+            name: n.to_string(),
+        };
+
+        // `function f(longX, longY = longX) { return longX; }` — two leaf params
+        // (both long enough to shorten); the second's default reads the first.
+        let f = FunctionDeclaration {
+            cv: None,
+            id: id("f"),
+            params: vec![
+                FunctionParam::Identifier(id("longX")),
+                FunctionParam::AssignmentPattern(AssignmentPattern {
+                    cv: None,
+                    left: id("longY"),
+                    right: Expression::Identifier(id("longX")),
+                }),
+            ],
+            body: BlockStatement {
+                cv: None,
+                body: vec![Statement::return_statement(ReturnStatement {
+                    cv: None,
+                    argument: Some(Expression::Identifier(id("longX"))),
+                })],
+            },
+            generator: false,
+            is_async: false,
+        };
+
+        let mut prog = program();
+        prog.body = vec![ProgramItem::Statement(Statement::Declaration(
+            Declaration::FunctionDeclaration(f),
+        ))];
+
+        let pass = RenamePass::new();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("rename");
+
+        assert!(out.changed, "the two long params should have been renamed");
+        let ProgramItem::Statement(Statement::Declaration(Declaration::FunctionDeclaration(f))) =
+            &out.program.body[0]
+        else {
+            panic!("expected the function declaration back");
+        };
+        // `longX` shortened on the binding …
+        let x_new = f.params[0].binding_identifier().name.clone();
+        assert_ne!(x_new, "longX", "first param should have been shortened");
+        // … and the default's reference to it must track the same new name.
+        match f.params[1].default_value() {
+            Some(Expression::Identifier(idref)) => assert_eq!(
+                idref.name, x_new,
+                "default `= longX` must be rewritten to the renamed `{x_new}`"
+            ),
+            other => panic!("expected an identifier default, got {other:?}"),
+        }
     }
 }

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -1344,6 +1344,13 @@ fn rewrite_uses_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
                             let id = p.binding_identifier();
                             inner.remove(&id.name);
                         }
+                        // Default-param `right` expressions — see the
+                        // `FunctionExpression` arm.
+                        for p in &mut m.value.params {
+                            if let Some(def) = p.default_value_mut() {
+                                rewrite_uses_expr(def, &inner);
+                            }
+                        }
                         for s in &mut m.value.body.body {
                             rewrite_uses_stmt(s, &inner);
                         }
@@ -1630,6 +1637,14 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                 let id = p.binding_identifier();
                 inner.remove(&id.name);
             }
+            // A default parameter's `right` closes over the enclosing locals
+            // (`function(a = outerLocal){}`); rewrite its uses with the same
+            // shadow-stripped `inner` as the body.
+            for p in &mut fe.params {
+                if let Some(def) = p.default_value_mut() {
+                    rewrite_uses_expr(def, &inner);
+                }
+            }
             for s in &mut fe.body.body {
                 rewrite_uses_stmt(s, &inner);
             }
@@ -1661,6 +1676,13 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                         for p in &m.value.params {
                             let id = p.binding_identifier();
                             inner.remove(&id.name);
+                        }
+                        // Default-param `right` expressions — see the
+                        // `FunctionExpression` arm.
+                        for p in &mut m.value.params {
+                            if let Some(def) = p.default_value_mut() {
+                                rewrite_uses_expr(def, &inner);
+                            }
                         }
                         for s in &mut m.value.body.body {
                             rewrite_uses_stmt(s, &inner);
@@ -1699,6 +1721,14 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             for p in &ae.params {
                 let id = p.binding_identifier();
                 inner.remove(&id.name);
+            }
+            // Default-param `right` expressions — see the `FunctionExpression`
+            // arm. An arrow default (`(a = outerLocal) => …`) closes over the
+            // enclosing locals just as the body does.
+            for p in &mut ae.params {
+                if let Some(def) = p.default_value_mut() {
+                    rewrite_uses_expr(def, &inner);
+                }
             }
             match &mut ae.body {
                 ArrowBody::Block(b) => {
@@ -2398,6 +2428,110 @@ mod tests {
             Some(Expression::Identifier(idref)) => assert_eq!(
                 idref.name, x_new,
                 "default `= longX` must be rewritten to the renamed `{x_new}`"
+            ),
+            other => panic!("expected an identifier default, got {other:?}"),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // CLOC12.191 PR1 (security-review regression) — a NESTED arrow's default
+    // that closes over a renamed outer local must be rewritten too. The leaf
+    // function's own defaults were handled, but `rewrite_uses_expr` (the walk
+    // that descends into nested function/arrow values to fix closure-over uses)
+    // originally skipped their param defaults, leaving a stale reference.
+    // -------------------------------------------------------------------
+    #[test]
+    fn rewrites_outer_local_referenced_in_nested_arrow_default() {
+        use coding_adventures_javascript_ast::statement::ReturnStatement;
+        use coding_adventures_javascript_ast::{
+            ArrowBody, ArrowFunctionExpression, AssignmentPattern, BindingTarget, BlockStatement,
+            Declaration, Expression, FunctionDeclaration, FunctionParam, Identifier, ProgramItem,
+            Statement, VarKind, VariableDeclaration, VariableDeclarator,
+        };
+
+        let id = |n: &str| Identifier {
+            cv: None,
+            name: n.to_string(),
+        };
+
+        // `var g = (a = longName) => a;` — the arrow default closes over the
+        // outer param `longName`.
+        let arrow = Expression::ArrowFunctionExpression(ArrowFunctionExpression {
+            cv: None,
+            params: vec![FunctionParam::AssignmentPattern(AssignmentPattern {
+                cv: None,
+                left: id("a"),
+                right: Expression::Identifier(id("longName")),
+            })],
+            body: ArrowBody::Expression(Box::new(Expression::Identifier(id("a")))),
+            is_async: false,
+        });
+        let var_g = Statement::Declaration(Declaration::VariableDeclaration(VariableDeclaration {
+            cv: None,
+            kind: VarKind::Var,
+            declarations: vec![VariableDeclarator {
+                cv: None,
+                id: BindingTarget::Identifier(id("g")),
+                init: Some(arrow),
+            }],
+        }));
+
+        // `function outer(longName) { var g = (a = longName) => a; return g; }`
+        // — a leaf (an arrow in a var initializer does NOT disqualify leaf
+        // status), so its param `longName` is renamed everywhere it is read.
+        let outer = FunctionDeclaration {
+            cv: None,
+            id: id("outer"),
+            params: vec![FunctionParam::Identifier(id("longName"))],
+            body: BlockStatement {
+                cv: None,
+                body: vec![
+                    var_g,
+                    Statement::return_statement(ReturnStatement {
+                        cv: None,
+                        argument: Some(Expression::Identifier(id("g"))),
+                    }),
+                ],
+            },
+            generator: false,
+            is_async: false,
+        };
+
+        let mut prog = program();
+        prog.body = vec![ProgramItem::Statement(Statement::Declaration(
+            Declaration::FunctionDeclaration(outer),
+        ))];
+
+        let pass = RenamePass::new();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("rename");
+
+        assert!(out.changed, "`longName` should have been shortened");
+        let ProgramItem::Statement(Statement::Declaration(Declaration::FunctionDeclaration(f))) =
+            &out.program.body[0]
+        else {
+            panic!("expected the outer function back");
+        };
+        let new_name = f.params[0].binding_identifier().name.clone();
+        assert_ne!(new_name, "longName", "outer param should have been shortened");
+        // Dig out the nested arrow's default and confirm it tracks the new name.
+        let Statement::Declaration(Declaration::VariableDeclaration(vd)) = &f.body.body[0] else {
+            panic!("expected the `var g` declaration");
+        };
+        let Some(Expression::ArrowFunctionExpression(ae)) = &vd.declarations[0].init else {
+            panic!("expected the arrow initializer");
+        };
+        match ae.params[0].default_value() {
+            Some(Expression::Identifier(idref)) => assert_eq!(
+                idref.name, new_name,
+                "nested arrow default `= longName` must track the renamed outer local"
             ),
             other => panic!("expected an identifier default, got {other:?}"),
         }

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.20.0] - 2026-07-14
+
+### Changed — collect references inside default-parameter expressions — CLOC12.191 PR1
+
+Picks up javascript-ast 0.42.0. `walk_function_declaration` / `walk_function_expression` /
+`walk_arrow_function_expression` now walk each `FunctionParam::AssignmentPattern` default (`a = expr`) in
+the function scope, recording the identifiers it references. Every downstream pass that consumes
+`ScopeAnalysis` — `remove-unused-vars`, `treeshake` — therefore counts a variable read in a default,
+so it is never wrongly deleted. The param-binding loops now use the AST `binding_identifier()` accessor
+(handling all three variants uniformly).
+
 ## [0.19.0] - 2026-07-14
 
 ### Changed — handle `FunctionParam::RestElement` — CLOC12.190 PR1

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -69,7 +69,7 @@ use coding_adventures_javascript_ast::statement::TaggedStatement;
 use coding_adventures_javascript_ast::{
     ArrowBody, ArrowFunctionExpression,
     AssignmentTarget, BindingTarget, BlockStatement, ClassDeclaration, ClassMember, CvId, Declaration, Expression, ForInit,
-    FunctionDeclaration, FunctionExpression, FunctionParam, ObjectMember, Program, ProgramItem, Property, PropertyKey, Statement,
+    FunctionDeclaration, FunctionExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey, Statement,
     VarKind, VariableDeclaration,
 };
 use serde::{Deserialize, Serialize};
@@ -718,12 +718,12 @@ fn walk_function_declaration(
 
     // Params become Param-kind bindings in the function scope.
     for param in &fd.params {
-        // Both a plain identifier param and a rest param (`...name`) bind a
-        // single name in the function scope — extract it from either variant.
-        let id = match param {
-            FunctionParam::Identifier(id) => id,
-            FunctionParam::RestElement(re) => &re.argument,
-        };
+        // Every parameter shape binds a single name in the function scope —
+        // a plain identifier's name, a rest param's gathered-array name, or a
+        // default param's LEFT name. The AST accessor yields it uniformly. A
+        // default param's RIGHT expression is walked separately below for its
+        // references.
+        let id = param.binding_identifier();
         emit_binding(
             id.name.clone(),
             BindingKind::Param,
@@ -742,6 +742,15 @@ fn walk_function_declaration(
         current: function_scope,
         enclosing_function: function_scope,
     };
+    // A default parameter's `right` (`function f(a, b = a + 1) {}`) is live code
+    // evaluated in the function scope — its references resolve against the
+    // params and enclosing scopes, so collect them under `inner_ctx` for rename
+    // soundness. Plain and rest params carry no such expression.
+    for param in &fd.params {
+        if let Some(def) = param.default_value() {
+            walk_expression(def, inner_ctx, analysis, pending);
+        }
+    }
     for stmt in &fd.body.body {
         walk_statement(stmt, inner_ctx, analysis, pending);
     }
@@ -782,12 +791,12 @@ fn walk_function_expression(
     }
 
     for param in &fe.params {
-        // Both a plain identifier param and a rest param (`...name`) bind a
-        // single name in the function scope — extract it from either variant.
-        let id = match param {
-            FunctionParam::Identifier(id) => id,
-            FunctionParam::RestElement(re) => &re.argument,
-        };
+        // Every parameter shape binds a single name in the function scope —
+        // a plain identifier's name, a rest param's gathered-array name, or a
+        // default param's LEFT name. The AST accessor yields it uniformly. A
+        // default param's RIGHT expression is walked separately below for its
+        // references.
+        let id = param.binding_identifier();
         emit_binding(
             id.name.clone(),
             BindingKind::Param,
@@ -801,6 +810,12 @@ fn walk_function_expression(
         current: function_scope,
         enclosing_function: function_scope,
     };
+    // Default-param `right` expressions — see `walk_function_declaration`.
+    for param in &fe.params {
+        if let Some(def) = param.default_value() {
+            walk_expression(def, inner_ctx, analysis, pending);
+        }
+    }
     for stmt in &fe.body.body {
         walk_statement(stmt, inner_ctx, analysis, pending);
     }
@@ -828,12 +843,12 @@ fn walk_arrow_function_expression(
     let function_scope = emit_scope(ScopeKind::Function, ctx.current, analysis);
 
     for param in &ae.params {
-        // Both a plain identifier param and a rest param (`...name`) bind a
-        // single name in the function scope — extract it from either variant.
-        let id = match param {
-            FunctionParam::Identifier(id) => id,
-            FunctionParam::RestElement(re) => &re.argument,
-        };
+        // Every parameter shape binds a single name in the function scope —
+        // a plain identifier's name, a rest param's gathered-array name, or a
+        // default param's LEFT name. The AST accessor yields it uniformly. A
+        // default param's RIGHT expression is walked separately below for its
+        // references.
+        let id = param.binding_identifier();
         emit_binding(
             id.name.clone(),
             BindingKind::Param,
@@ -847,6 +862,12 @@ fn walk_arrow_function_expression(
         current: function_scope,
         enclosing_function: function_scope,
     };
+    // Default-param `right` expressions — see `walk_function_declaration`.
+    for param in &ae.params {
+        if let Some(def) = param.default_value() {
+            walk_expression(def, inner_ctx, analysis, pending);
+        }
+    }
     match &ae.body {
         ArrowBody::Block(b) => {
             for stmt in &b.body {
@@ -1261,7 +1282,7 @@ fn walk_property(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coding_adventures_javascript_ast::SourceType;
+    use coding_adventures_javascript_ast::{FunctionParam, SourceType};
     use coding_adventures_javascript_tokens::EsVersion;
 
     fn empty_program() -> Program {

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.42.0] - 2026-07-14
+
+### Added — `FunctionParam::AssignmentPattern` (`name = expr` default parameter) — CLOC12.191 PR1
+
+New `AssignmentPattern` struct (`left: Identifier`, `right: Expression`) + a `FunctionParam::AssignmentPattern`
+variant so a default-valued parameter (`function f(a = 1){}`) is representable. The `#[serde(untagged)]`
+`FunctionParam` tells it apart from a plain identifier (`name`) and a rest element (`argument`) by its
+`left`/`right` shape — no `type` tag. `binding_identifier()`/`binding_identifier_mut()` return the `left`
+name for this variant; two new accessors — `default_value()`/`default_value_mut()` — expose the `right`
+expression so the folding, renaming, and inlining passes can walk and rewrite the default as live code
+(`function f(a = 1 + 2)` → `function f(a = 3)`), unlike a rest element whose only payload is a bound name.
+Additive; MINOR.
+
 ## [0.41.0] - 2026-07-14
 
 ### Added — `FunctionParam::RestElement` (`...name` rest parameter) — CLOC12.190 PR1

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/declaration.rs
+++ b/code/packages/rust/javascript-ast/src/declaration.rs
@@ -139,14 +139,55 @@ pub struct RestElement {
     pub argument: Identifier,
 }
 
-/// One parameter of a [`FunctionDeclaration`]. A plain [`Identifier`] or a
-/// trailing [`RestElement`] (`...name`) in this slice; `AssignmentPattern`
-/// (default value) and destructuring patterns are Phase 3.
+/// A **default parameter** — `name = expr` in a parameter list. When the
+/// caller omits the argument (or passes `undefined`), the binding takes the
+/// value of the default expression instead:
+///
+/// ```text
+///   function f(a = 1) {}        // f()    → a=1 ;  f(5) → a=5
+///   function g(a, b = a + 1) {} // g(2)   → a=2, b=3
+/// ```
+///
+/// ESTree `AssignmentPattern`: `{ left, right }`. `left` is the bound name and
+/// `right` is the default-value [`Expression`]. Only a **simple identifier**
+/// target is modelled here — a destructuring target with a default
+/// (`{x} = {}`, `[a] = []`) reuses the Phase-3 pattern machinery and is
+/// declined by the bridge for now.
+///
+/// The distinctive `left` + `right` field shape is what lets the
+/// `#[serde(untagged)]` [`FunctionParam`] tell a default parameter apart from a
+/// plain [`Identifier`] (`name`) or a [`RestElement`] (`argument`) — no `type`
+/// tag needed.
+///
+/// **Why `right` must be a full [`Expression`], not just a literal:** the
+/// default is live code that the optimizer walks. `function f(a = 1 + 2)` folds
+/// to `function f(a = 3)`; a name referenced in the default (`b = SOME_GLOBAL`)
+/// participates in renaming and inlining exactly as any other expression does.
+/// Every pass that visits a parameter list therefore recurses into `right`
+/// through the same expression-visit path it uses for a function body — unlike
+/// [`RestElement`], whose only payload is a bound name.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssignmentPattern {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    /// The bound name (`a` in `a = 1`). A simple identifier in this slice.
+    pub left: Identifier,
+    /// The default-value expression (`1` in `a = 1`). Full live code: folded,
+    /// renamed, and inlined by the passes like any other expression.
+    pub right: Expression,
+}
+
+/// One parameter of a [`FunctionDeclaration`]. A plain [`Identifier`], a
+/// trailing [`RestElement`] (`...name`), or a default-valued
+/// [`AssignmentPattern`] (`name = expr`) in this slice; destructuring patterns
+/// are Phase 3.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum FunctionParam {
     Identifier(Identifier),
     RestElement(RestElement),
+    AssignmentPattern(AssignmentPattern),
 }
 
 impl FunctionParam {
@@ -159,6 +200,7 @@ impl FunctionParam {
         match self {
             FunctionParam::Identifier(id) => id,
             FunctionParam::RestElement(re) => &re.argument,
+            FunctionParam::AssignmentPattern(ap) => &ap.left,
         }
     }
 
@@ -170,6 +212,29 @@ impl FunctionParam {
         match self {
             FunctionParam::Identifier(id) => id,
             FunctionParam::RestElement(re) => &mut re.argument,
+            FunctionParam::AssignmentPattern(ap) => &mut ap.left,
+        }
+    }
+
+    /// The default-value expression when this parameter is an
+    /// [`AssignmentPattern`] (`name = expr`), else `None`. Passes that walk
+    /// parameter defaults — constant-fold, the renamers, the inliners — reach
+    /// the live `right` expression through this accessor, then visit it with the
+    /// same machinery they use for a function body.
+    pub fn default_value(&self) -> Option<&Expression> {
+        match self {
+            FunctionParam::AssignmentPattern(ap) => Some(&ap.right),
+            _ => None,
+        }
+    }
+
+    /// Mutable twin of [`default_value`](Self::default_value) — the folding and
+    /// renaming passes rewrite the default expression in place (`a = 1 + 2` →
+    /// `a = 3`), so they need `&mut` access to `right`.
+    pub fn default_value_mut(&mut self) -> Option<&mut Expression> {
+        match self {
+            FunctionParam::AssignmentPattern(ap) => Some(&mut ap.right),
+            _ => None,
         }
     }
 }
@@ -822,6 +887,110 @@ mod tests {
                 assert_eq!(e.source.value, "y");
             }
             other => panic!("expected ExportAllDeclaration, got {other:?}"),
+        }
+    }
+
+    // ---- CLOC12.191: default parameters (AssignmentPattern) ----
+
+    /// Build the numeric-literal default `= n` used by the default-param tests.
+    fn num_default(value: f64, raw: &str) -> Expression {
+        Expression::NumericLiteral(NumericLiteral {
+            cv: None,
+            value,
+            raw: raw.to_string(),
+        })
+    }
+
+    #[test]
+    fn default_param_roundtrips_and_untagged_discriminates() {
+        // `function f(a, b = 1) {}` — a fixed parameter followed by a default.
+        // The untagged `FunctionParam` must tell the three shapes apart:
+        // Identifier (`name`), RestElement (`argument`), AssignmentPattern
+        // (`left`+`right`). Serialize then deserialize and confirm each param
+        // deserializes back to the *same* variant — the whole point of the
+        // shape-based discrimination.
+        let d = FunctionDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "f".to_string(),
+            },
+            params: vec![
+                FunctionParam::Identifier(Identifier {
+                    cv: None,
+                    name: "a".to_string(),
+                }),
+                FunctionParam::AssignmentPattern(AssignmentPattern {
+                    cv: None,
+                    left: Identifier {
+                        cv: None,
+                        name: "b".to_string(),
+                    },
+                    right: num_default(1.0, "1"),
+                }),
+            ],
+            body: BlockStatement {
+                cv: None,
+                body: vec![],
+            },
+            generator: false,
+            is_async: false,
+        };
+
+        let json = serde_json::to_string(&d).expect("serialize");
+        // The default carries ESTree's `left`/`right`, not a `type` tag.
+        assert!(json.contains("\"left\""), "expected `left` field; got {json}");
+        assert!(
+            json.contains("\"right\""),
+            "expected `right` field; got {json}"
+        );
+
+        let back: FunctionDeclaration = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, d, "default param did not round-trip");
+        assert!(
+            matches!(back.params[0], FunctionParam::Identifier(_)),
+            "first param should stay a plain Identifier"
+        );
+        assert!(
+            matches!(back.params[1], FunctionParam::AssignmentPattern(_)),
+            "second param should stay an AssignmentPattern (not mis-read as Identifier)"
+        );
+    }
+
+    #[test]
+    fn default_param_accessors_reach_name_and_expr() {
+        // The `binding_identifier*` accessors return the LEFT name; the
+        // `default_value*` accessors expose the RIGHT expression that the
+        // folding/renaming passes rewrite in place.
+        let mut p = FunctionParam::AssignmentPattern(AssignmentPattern {
+            cv: None,
+            left: Identifier {
+                cv: None,
+                name: "a".to_string(),
+            },
+            right: num_default(2.0, "2"),
+        });
+
+        assert_eq!(p.binding_identifier().name, "a");
+        assert!(
+            p.default_value().is_some(),
+            "a default param must expose its default expression"
+        );
+
+        // A plain identifier has no default.
+        let plain = FunctionParam::Identifier(Identifier {
+            cv: None,
+            name: "x".to_string(),
+        });
+        assert!(plain.default_value().is_none());
+
+        // Mutating through the accessors reaches both sides.
+        p.binding_identifier_mut().name = "renamed".to_string();
+        *p.default_value_mut().expect("default expr") = num_default(3.0, "3");
+        assert_eq!(p.binding_identifier().name, "renamed");
+        match p.default_value().expect("default expr") {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 3.0),
+            other => panic!("expected numeric default, got {other:?}"),
         }
     }
 }

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -128,10 +128,10 @@ mod es_version_serde {
 // `use coding_adventures_javascript_ast::{Program, IfStatement,
 // BinaryOperator}` without learning the module layout.
 pub use declaration::{
-    BindingTarget, ClassDeclaration, Declaration, ExportAllDeclaration, ExportDefaultDeclaration,
-    ExportDefaultKind, ExportNamedDeclaration, ExportSpecifier, FunctionDeclaration, FunctionParam,
-    ImportDeclaration, ImportSpecifier, RestElement, VarKind, VariableDeclaration,
-    VariableDeclarator,
+    AssignmentPattern, BindingTarget, ClassDeclaration, Declaration, ExportAllDeclaration,
+    ExportDefaultDeclaration, ExportDefaultKind, ExportNamedDeclaration, ExportSpecifier,
+    FunctionDeclaration, FunctionParam, ImportDeclaration, ImportSpecifier, RestElement, VarKind,
+    VariableDeclaration, VariableDeclarator,
 };
 pub use expression::{
     ArrayExpression, ArrowBody, ArrowFunctionExpression, AssignmentExpression,


### PR DESCRIPTION
## CLOC12.191 default parameters — PR1 (atomic AST + emitter + pass traversal)

Adds the ESTree `AssignmentPattern` default-parameter representation (`function f(a = expr)`) and threads its default `right` expression through every optimization pass that walks a parameter list, so a default-param file will **optimize instead of falling back to WHITESPACE_ONLY** once the bridge produces the node (PR2). The variant is unreachable until then — this is the atomic substrate.

### Front end
- **javascript-ast** (0.42.0): new `AssignmentPattern { left, right }` struct + `FunctionParam::AssignmentPattern` variant (`#[serde(untagged)]`, distinguished by `left`/`right` shape). `binding_identifier()`/`_mut()` return `left`; new `default_value()`/`_mut()` expose `right`.
- **closure-emitter** (0.47.0): emits `<left>=<right>` at all param sites; the default at `PREC_ASSIGNMENT` so a bare-sequence default parenthesizes (`f(a=(1,2))`); `=` tight when minified, spaced when pretty.

### Passes — the default `right` is live code, walked everywhere
- **constant-fold** (0.89.0): `fold_params` folds each default (`a = 1+2` → `a = 3`).
- **scope-analyzer** (0.20.0): walks each default in the function scope, recording its references → `remove-unused-vars` / `treeshake` inherit default-awareness (they're scope-analysis-driven).
- **rename** (0.22.0) / **rename-globals** (0.18.0): rewrite references inside defaults through the rename map (leaf, nested closure-descent, and top-level declaration apply paths) + add default idents to the collision-avoidance set.
- **rename-properties** (0.19.0): classify + rewrite property accesses inside defaults, kept in lockstep.
- **inline** (0.30.0): declines to inline a function with a default parameter (positional binding can't reproduce undefined-triggered default semantics); its nested-value body-rewriters (`substitute`, `rename_in_expr`) rewrite nested defaults too.

### Verification
- `RUSTFLAGS="-D warnings"` build + `cargo test` + `cargo clippy --tests -- -D warnings` across all 8 edited crates and downstream consumers (javascript-parser + all pass crates + the separate closurec workspace) — all green.
- New behavior + regression tests: AST roundtrip/accessors; emitter minified/sequence-wrap/pretty; constant-fold default-fold; rename default-reference rewrite (leaf + nested-arrow-closure); rename-globals top-level-default global rename; inline `substitute`/`rename_in_expr` nested-default rewrite.

### Security review
Ran an inline multi-round security review before push. It caught **three real HIGH miscompiles** (all a default-parameter collect/apply asymmetry) which are **fixed in this PR** with regression tests:
1. rename-globals top-level declaration apply path skipped defaults;
2. rename closure-descent rewriter skipped nested defaults;
3. inline's `substitute` / `rename_in_expr` skipped nested-value defaults.
Round 3 passed clean with an exhaustive sweep.

Part of the CLOC12.191 arc: **PR1 (this)** = atomic node + emitter + passes; PR2 = bridge flip (`convert_formal_parameter` EQUALS branch); PR3 = closurec e2e fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)