### PR TITLE
feat(adj-facts-stdlib): astronomy moon-phases table (phase → cycle position)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_moonphases_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_moonphases_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the astronomy FACTS library
+//! (`adj-facts-stdlib/astronomy/moon-phases.adj`) driven through the built CLI:
+//! a native `table` of Moon-phase → cycle-position resolves a binding-query
+//! recall with NASA's citation, and abstains on a non-phase — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn astronomy_moon_phases_recall_binds_cycle_position_with_citation() {
+    let dir = scratch("moonphases");
+    // Copy the shipped astronomy table beside the entry program and import it.
+    let src = facts_stdlib().join("astronomy/moon-phases.adj");
+    std::fs::copy(&src, dir.join("moon-phases.adj")).expect("copy shipped moon-phases.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"moon-phases.adj\"\n\
+         ? moon_phase_order(new_moon, $Pos)\n\
+         ? moon_phase_order(full_moon, $Pos)\n\
+         ? moon_phase_order(eclipse, $Pos)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // New Moon opens the cycle (1); full Moon is the fifth phase (5).
+    assert!(out.contains("\"Pos\":\"1\""), "new_moon → 1: {out}");
+    assert!(out.contains("\"Pos\":\"5\""), "full_moon → 5: {out}");
+    // The answer carries NASA's citation as its proof, at authoritative trust.
+    assert!(
+        out.contains("science.nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NASA source citation: {out}"
+    );
+    // An eclipse is not a lunar phase — honest abstention, never a fabricated order.
+    assert!(out.contains("\"abstained\":true"), "eclipse abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/astronomy/moon-phases.adj
+++ b/code/specs/data/adj-facts-stdlib/astronomy/moon-phases.adj
@@ -1,0 +1,46 @@
+% ============================================================================
+% moon-phases — each Moon phase's position in the lunar cycle
+% (adj-facts-stdlib, ASTRONOMY).
+% ============================================================================
+% An astronomy facts library — a child's first sky fact: the Moon does not
+% change shape, but the sunlit part we SEE changes night by night, and those
+% shapes come around in a fixed order that repeats about once a month. Recall
+% is a binding query:
+%
+%     ? moon_phase_order(full_moon, $N)     % 5  (full Moon is the 5th phase)
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `moon_phase_order(phase, order)` carrying the NASA citation, so the lookup
+% above is the ordinary SLD binding query — the engine returns the position
+% WITH its source, on the CPU, with zero model calls, and abstains on a
+% non-phase (e.g. `eclipse` is a different event, deliberately NOT a row here).
+% The `order` value is a NUMBER, so a recalled position composes into arithmetic
+% (how many phases separate new Moon and full Moon? 5 − 1 = 4 steps apart).
+%
+% Provenance: NASA lists the eight lunar phases in cycle order in one sentence;
+% the citable artifact is NASA's Moon Phases page at the `locator`, and the row
+% order below is exactly the order that sentence states — starting at new Moon
+% and running to waning crescent, after which the cycle repeats. `trust
+% authoritative` — the space agency's primary reference. Nothing here is
+% asserted from memory. The atoms use NASA's names (lowercased, spaces → `_`),
+% and `third_quarter` is NASA's name for the phase also called the last quarter.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table moon_phase_order {
+    columns phase, order
+
+    row (new_moon, 1)
+    row (waxing_crescent, 2)
+    row (first_quarter, 3)
+    row (waxing_gibbous, 4)
+    row (full_moon, 5)
+    row (waning_gibbous, 6)
+    row (third_quarter, 7)
+    row (waning_crescent, 8)
+
+    source "The eight lunar phases are, in order: new Moon, waxing crescent, first quarter, waxing gibbous, full Moon, waning gibbous, third quarter, and waning crescent."
+    locator "https://science.nasa.gov/moon/moon-phases/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/astronomy/moon-phases.query.adj
+++ b/code/specs/data/adj-facts-stdlib/astronomy/moon-phases.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% moon-phases.query.adj — a worked recall over the astronomy moon-phases library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which phase is fifth in
+% the cycle?" — it states no astronomy fact, only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `moon_phase_order` rows and returns the position (or the phase, on a reverse
+% query) + the NASA source/locator/trust. A body/event that is not one of the
+% eight named phases abstains honestly — the engine never invents an order.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli moon-phases.query.adj
+% ============================================================================
+
+import "moon-phases.adj"
+
+? moon_phase_order(new_moon, $N)       % expect 1  (the cycle starts here)
+? moon_phase_order(full_moon, $N)      % expect 5  (the fully lit phase)
+? moon_phase_order($Phase, 3)          % expect first_quarter (reverse: 3rd phase?)
+? moon_phase_order(eclipse, $N)        % expect abstain — an eclipse is not a phase


### PR DESCRIPTION
## What

Adds one grounded ELEMENTARY facts library to the ADJ standard library: the **eight Moon phases in NASA's stated cycle order**, as a native `table moon_phase_order(phase, order)`.

Recall is a zero-model-call SLD binding query that returns the position WITH its NASA citation and **abstains honestly** on a non-phase (`eclipse`).

| phase | order |
|---|---|
| new_moon | 1 |
| waxing_crescent | 2 |
| first_quarter | 3 |
| waxing_gibbous | 4 |
| full_moon | 5 |
| waning_gibbous | 6 |
| third_quarter | 7 |
| waning_crescent | 8 |

## Grounding

- **Source (verbatim):** "The eight lunar phases are, in order: new Moon, waxing crescent, first quarter, waxing gibbous, full Moon, waning gibbous, third quarter, and waning crescent."
- **Locator:** https://science.nasa.gov/moon/moon-phases/
- **Trust:** `authoritative` (NASA / .gov primary reference)

Nothing asserted from memory. `third_quarter` is NASA's name for the phase also called the last quarter.

## Files

- `code/specs/data/adj-facts-stdlib/astronomy/moon-phases.adj` — the grounded table (beginner literate comment, NASA citation)
- `code/specs/data/adj-facts-stdlib/astronomy/moon-phases.query.adj` — worked recall (`?` binds + a reverse query + an abstain)
- `code/packages/rust/adj-lang-cli/tests/facts_moonphases_e2e.rs` — one e2e test modeled on `facts_shapes`: two binds, locator + `authoritative` trust, one abstain

## Verification

- `cargo test -p adj-lang-cli --test facts_moonphases_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

Data + one test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)