### PR TITLE
feat(adj-facts-stdlib): geometry solid → number of faces (Platonic solids)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_solids_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_solids_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the geometry FACTS library
+//! (`adj-facts-stdlib/geometry/solid-shapes.adj`) driven through the built CLI:
+//! a native `table` of solid → number-of-faces resolves a binding-query recall
+//! with the source's citation, and abstains on a non-solid — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn geometry_solids_recall_binds_face_count_with_citation() {
+    let dir = scratch("solids");
+    // Copy the shipped geometry table beside the entry program and import it.
+    let src = facts_stdlib().join("geometry/solid-shapes.adj");
+    std::fs::copy(&src, dir.join("solid-shapes.adj")).expect("copy shipped solid-shapes.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"solid-shapes.adj\"\n\
+         ? solid_faces(cube, $Faces)\n\
+         ? solid_faces(icosahedron, $Faces)\n\
+         ? solid_faces(sphere, $Faces)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A cube has six faces; an icosahedron has twenty — the recalled counts.
+    assert!(out.contains("\"Faces\":\"6\""), "cube → 6: {out}");
+    assert!(out.contains("\"Faces\":\"20\""), "icosahedron → 20: {out}");
+    // The answer carries the MathWorld citation as its proof.
+    assert!(
+        out.contains("mathworld.wolfram.com") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A sphere has no flat faces — honest abstention, never a fabricated count.
+    assert!(out.contains("\"abstained\":true"), "sphere abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/geometry/solid-shapes.adj
+++ b/code/specs/data/adj-facts-stdlib/geometry/solid-shapes.adj
@@ -1,0 +1,40 @@
+% ============================================================================
+% solid-shapes — how many faces each common solid has (adj-facts-stdlib, GEOMETRY).
+% ============================================================================
+% A geometry facts library, the 3-D sibling of shapes.adj (polygon -> sides):
+% how many flat faces each Platonic solid has — "a cube has six faces, a
+% tetrahedron (a triangular pyramid) has four." Recall is a binding query:
+%
+%     ? solid_faces(cube, $Faces)      % 6
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `solid_faces(solid, faces)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the count
+% WITH its source, on the CPU, with zero model calls, and abstains on a solid not
+% in the table. Because the `faces` value is a NUMBER, a recalled count composes
+% straight into a formula (Euler's V - E + F = 2 for convex polyhedra): the same
+% concrete bridge from RECALL to COMPUTE as its 2-D sibling.
+%
+% Provenance: the five solid names and their face counts are copied from the one
+% Wolfram MathWorld "Platonic Solid" sentence that lists them together —
+% "The ordered number of faces for the Platonic solids are 4, 6, 8, 12, 20 ... in
+% the order tetrahedron, cube, octahedron, dodecahedron, icosahedron" — so each
+% name->count pair below is read straight off that ordered list (tetrahedron=4,
+% cube=6, octahedron=8, dodecahedron=12, icosahedron=20). `trust authoritative`
+% — a primary mathematics reference. Nothing here is asserted from memory. (See
+% ../README.md; feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table solid_faces {
+    columns solid, faces
+
+    row (tetrahedron, 4)
+    row (cube, 6)
+    row (octahedron, 8)
+    row (dodecahedron, 12)
+    row (icosahedron, 20)
+
+    source "The ordered number of faces for the Platonic solids are 4, 6, 8, 12, 20 (OEIS A053016; in the order tetrahedron, cube, octahedron, dodecahedron, icosahedron)"
+    locator "https://mathworld.wolfram.com/PlatonicSolid.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/geometry/solid-shapes.query.adj
+++ b/code/specs/data/adj-facts-stdlib/geometry/solid-shapes.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% solid-shapes.query.adj — a worked recall over the geometry solid-shapes library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how many faces does a
+% cube have?": it states no geometry fact — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `solid_faces` rows and returns the count + the table's source/locator/trust.
+% A solid (or non-solid) not in the table abstains honestly — the engine never
+% invents a count.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli solid-shapes.query.adj
+% ============================================================================
+
+import "solid-shapes.adj"
+
+? solid_faces(cube, $Faces)            % expect 6
+? solid_faces(icosahedron, $Faces)     % expect 20
+? solid_faces(sphere, $Faces)          % expect abstain — a sphere has no flat faces


### PR DESCRIPTION
## What

Add a grounded elementary FACTS library to the ADJ standard library: **`geometry/solid-shapes.adj`**, the 3-D sibling of `geometry/shapes.adj` (polygon → sides). A native ADJ `table solid_faces { solid, faces }` maps each common (Platonic) solid to its number of faces:

| solid | faces |
|---|---|
| tetrahedron | 4 |
| cube | 6 |
| octahedron | 8 |
| dodecahedron | 12 |
| icosahedron | 20 |

Recall is an ordinary SLD binding query — `? solid_faces(cube, $Faces)` returns `6` **with its citation**, on the CPU, zero model calls, and abstains on a solid not in the table.

## Grounding

Every name→count pair is read off the single Wolfram MathWorld **Platonic Solid** sentence that lists the ordered face counts against the ordered solid names:

> "The ordered number of faces for the Platonic solids are 4, 6, 8, 12, 20 (OEIS A053016; in the order tetrahedron, cube, octahedron, dodecahedron, icosahedron)"

- **source** (verbatim span): the sentence above, copied into the table.
- **locator**: https://mathworld.wolfram.com/PlatonicSolid.html
- **trust**: `authoritative` (primary mathematics reference)

Nothing asserted from memory.

## Also included

- `solid-shapes.query.adj` — worked recall: two binds (cube, icosahedron) + a `sphere` abstain.
- `facts_solids_e2e.rs` — copied from `facts_shapes_e2e`; drives the shipped table through the built CLI and asserts cube→6, icosahedron→20, the MathWorld/`authoritative` citation, and honest abstention on `sphere`.

## Verification

- `cargo test -p adj-lang-cli --test facts_solids_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review — passed (no vulnerabilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)