### PR TITLE
feat(adj-facts-stdlib): English vowel letters (LANGUAGE)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_vowels_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_vowels_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the LANGUAGE FACTS library
+//! (`adj-facts-stdlib/language/vowels.adj`) driven through the built CLI:
+//! a native `table` of the five English vowel letters resolves a binding-query
+//! recall with the encyclopedia's citation, and abstains on a consonant letter
+//! that has no shipped row — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn language_vowels_recall_binds_membership_with_citation() {
+    let dir = scratch("vowels");
+    // Copy the shipped vowels table beside the entry program and import it.
+    let src = facts_stdlib().join("language/vowels.adj");
+    std::fs::copy(&src, dir.join("vowels.adj")).expect("copy shipped vowels.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"vowels.adj\"\n\
+         ? vowel_letter(a, $V)\n\
+         ? vowel_letter(u, $V)\n\
+         ? vowel_letter(b, $V)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // a and u are both vowel letters — each binds `yes` from the table.
+    assert!(out.contains("\"V\":\"yes\""), "vowel letters bind yes: {out}");
+    // The answer carries the Simple-Wikipedia citation as its proof, at consensus trust.
+    assert!(
+        out.contains("simple.wikipedia.org/wiki/Vowel") && out.contains("\"trust\":\"consensus\""),
+        "carries the encyclopedia citation: {out}"
+    );
+    // `b` is a consonant with no shipped row — honest abstention, never invented.
+    assert!(out.contains("\"abstained\":true"), "consonant b abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/language/vowels.adj
+++ b/code/specs/data/adj-facts-stdlib/language/vowels.adj
@@ -1,0 +1,59 @@
+% ============================================================================
+% vowels — which letters of the English alphabet are vowels
+% (adj-facts-stdlib, LANGUAGE).
+% ============================================================================
+% One of the very first things a child learns about the alphabet: most letters
+% are CONSONANTS, but a special handful are VOWELS. In English there are five
+% vowel letters — a, e, i, o, u — and every other letter (b, c, d, f, …) is a
+% consonant. This tiny library records that membership so an ADJ program can
+% ASK whether a letter is a vowel, and get a cited answer. Recall is a binding
+% query:
+%
+%     ? vowel_letter(a, $V)      % yes
+%     ? vowel_letter(b, $V)      % abstains — b is not in the table
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `vowel_letter(letter, is_vowel)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% membership WITH its source, on the CPU, with zero model calls, and ABSTAINS
+% on any letter not in the table (it never guesses).
+%
+% The five vowels, as a truth table:
+%
+%     letter   is_vowel    read as…
+%     ------   --------    -------------------------------
+%     a        yes         "a is a vowel"
+%     e        yes         "e is a vowel"
+%     i        yes         "i is a vowel"
+%     o        yes         "o is a vowel"
+%     u        yes         "u is a vowel"
+%
+% Only the FIVE vowel rows are shipped — nothing else. A consonant such as `b`
+% has NO row, so a query like `? vowel_letter(b, $V)` ABSTAINS rather than
+% answering "no": the table's honest-abstention property means it only ever
+% asserts the membership it can cite, and stays silent on everything else. (The
+% letter `y` is deliberately NOT shipped: the source names it only as a
+% "sometimes" vowel, so an unqualified vowel-letter table must leave it out.)
+%
+% Provenance — nothing here is from memory. The five vowels are copied from the
+% Simple English Wikipedia "Vowel" article, which states verbatim (see
+% `source`) that the vowel letters in English are A, E, I, O and U. The citable
+% artifact is that article at the `locator`. `trust consensus` — an encyclopedia
+% is a secondary reference, not a .gov/.edu-primary literacy standard.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table vowel_letter {
+    columns letter, is_vowel
+
+    row (a, yes)
+    row (e, yes)
+    row (i, yes)
+    row (o, yes)
+    row (u, yes)
+
+    source "These letters are vowels in English: A, E, I, O and U (and sometimes Y)"
+    locator "https://simple.wikipedia.org/wiki/Vowel"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/language/vowels.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/vowels.query.adj
@@ -1,0 +1,18 @@
+% ============================================================================
+% vowels.query.adj — a worked recall over the English-vowels library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "is this letter a vowel?":
+% it states no fact of its own — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `vowel_letter` rows
+% and returns `yes` + the table's source/locator/trust. A consonant that has no
+% row abstains honestly — the engine never guesses a membership it cannot cite.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli vowels.query.adj
+% ============================================================================
+
+import "vowels.adj"
+
+? vowel_letter(a, $V)       % expect yes
+? vowel_letter(u, $V)       % expect yes
+? vowel_letter(b, $V)       % expect abstain — b is a consonant, not in the table


### PR DESCRIPTION
## What

A grounded elementary FACTS library for the ADJ standard library encoding **which letters of the English alphabet are vowels: a, e, i, o, u**.

- `code/specs/data/adj-facts-stdlib/language/vowels.adj` — native `vowel_letter(letter, is_vowel)` table with five `yes` rows.
- `code/specs/data/adj-facts-stdlib/language/vowels.query.adj` — worked recall: `? vowel_letter(a, $V)` → yes, `? vowel_letter(u, $V)` → yes, `? vowel_letter(b, $V)` → abstains (consonant, no row).
- `code/packages/rust/adj-lang-cli/tests/facts_vowels_e2e.rs` — one e2e test (mirrors `facts_opposites_e2e`).

Each `row` lowers to a ground relation carrying the table's citation, so recall is an ordinary SLD binding query on the CPU with **zero model calls**, and any letter not shipped (every consonant) **abstains honestly**.

## Grounding

Nothing from memory. The five vowels are copied verbatim from the Simple English Wikipedia "Vowel" article:

> These letters are vowels in English: A, E, I, O and U (and sometimes Y)

- **Source URL:** https://simple.wikipedia.org/wiki/Vowel
- **Trust:** `consensus` (an encyclopedia is a secondary reference, not a .gov/.edu-primary literacy standard)
- **Rows shipped:** a, e, i, o, u (5). `y` deliberately omitted — the source names it only as a "sometimes" vowel.

## Verification

- `cargo test -p adj-lang-cli --test facts_vowels_e2e` — passes (1 test).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)