### PR TITLE
feat(sqlite-file): sqlite_schema row builder + full single-table file (Phase F rung 4)

### DIFF
--- a/code/packages/rust/sqlite-file/CHANGELOG.md
+++ b/code/packages/rust/sqlite-file/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — sqlite-file
 
+## 0.11.0 - Unreleased
+
+**Phase F (writer), rung 4 — the `sqlite_schema` row + a full single-table file.**
+`SchemaEntry::to_record_columns()` is the inverse of the reader's schema-row
+decode: it serialises an entry into the five `sqlite_schema` columns
+(`type`, `name`, `tbl_name`, `rootpage`, `sql`), and the convenience
+`table_schema_row(name, root_page, sql)` builds the row for an ordinary rowid
+table. Combined with the earlier rungs — `record::encode` (row payload, 0.8.0),
+`page_writer::encode_table_leaf_page` (leaf page, 0.9.0), and `Header::encode`
+(100-byte DB header, 0.10.0) — the writer can now emit a **complete, re-readable
+single-table database**: a test assembles a two-page file by hand (page 1 = DB
+header + a `sqlite_schema` leaf at offset 100 describing table `t` at root page 2;
+page 2 = the data leaf) and reads the rows back through the real reader
+(`schema::read_table` by table name) plus confirms the schema round-trips. This
+completes the byte-level toolkit that makes dropping the `rusqlite` dev-dependency
+viable. (A one-call whole-file assembler that handles page 1's 100-byte b-tree
+offset is a natural follow-up.)
+
 ## 0.10.0 - Unreleased
 
 **Phase F (writer), rung 3: the 100-byte DB-header encoder.** New

--- a/code/packages/rust/sqlite-file/Cargo.toml
+++ b/code/packages/rust/sqlite-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite-file"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "A small, zero-dependency reader for the SQLite on-disk file format — the read subset the Engram Anki-package importer needs — reimplemented from scratch to keep the Engram stack free of the bundled-C `rusqlite` crate."
 license = "MIT"

--- a/code/packages/rust/sqlite-file/src/schema.rs
+++ b/code/packages/rust/sqlite-file/src/schema.rs
@@ -28,6 +28,50 @@ pub struct SchemaEntry {
     pub sql: Option<String>,
 }
 
+impl SchemaEntry {
+    /// Serialise this entry into the five `sqlite_schema` columns, in order —
+    /// the exact inverse of the private `decode_schema_row`, so that decoding the
+    /// [`record::encode`] of these columns reconstructs the entry. The columns
+    /// are `type TEXT`, `name TEXT`, `tbl_name TEXT`, `rootpage INTEGER`,
+    /// `sql TEXT`; a `None` root page or SQL is written as `NULL`.
+    ///
+    /// This is a *write*-path helper: paired with [`record::encode`],
+    /// [`crate::page_writer`], and [`Header::encode`], a caller can lay down the
+    /// `sqlite_schema` b-tree on page 1 that describes a user table — the last
+    /// piece needed to emit a file our own reader resolves by table name.
+    pub fn to_record_columns(&self) -> Vec<SqlValue> {
+        vec![
+            SqlValue::Text(self.object_type.clone()),
+            SqlValue::Text(self.name.clone()),
+            SqlValue::Text(self.table_name.clone()),
+            match self.root_page {
+                Some(page) => SqlValue::Int(i64::from(page)),
+                None => SqlValue::Null,
+            },
+            match &self.sql {
+                Some(sql) => SqlValue::Text(sql.clone()),
+                None => SqlValue::Null,
+            },
+        ]
+    }
+}
+
+/// Build the `sqlite_schema` row describing an ordinary rowid `table` — the
+/// common case for emitting a single-table database. Returns the five schema
+/// columns for `type='table'`, `name = tbl_name = name`, the given root page, and
+/// the `CREATE TABLE` SQL. Feed the result to [`record::encode`] to get the cell
+/// payload for the schema b-tree.
+pub fn table_schema_row(name: &str, root_page: u32, sql: &str) -> Vec<SqlValue> {
+    SchemaEntry {
+        object_type: "table".to_string(),
+        name: name.to_string(),
+        table_name: name.to_string(),
+        root_page: Some(root_page),
+        sql: Some(sql.to_string()),
+    }
+    .to_record_columns()
+}
+
 /// Decode every row from `sqlite_schema`.
 pub fn read_schema(data: &[u8]) -> Result<Vec<SchemaEntry>, SqliteError> {
     let (header, pager) = Pager::open(data)?;
@@ -134,5 +178,109 @@ fn expect_text(value: &SqlValue, what: &'static str) -> Result<String, SqliteErr
     match value {
         SqlValue::Text(s) => Ok(s.clone()),
         _ => Err(SqliteError::Corrupt(what)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::header::{Header, TextEncoding, MAGIC};
+    use crate::page_writer::encode_table_leaf_page;
+    use crate::{record, varint};
+
+    /// `to_record_columns` is the inverse of `decode_schema_row`: a schema row
+    /// encoded and decoded through the record codec reconstructs the entry.
+    #[test]
+    fn schema_row_round_trips_through_the_record_codec() {
+        let entry = SchemaEntry {
+            object_type: "table".to_string(),
+            name: "widgets".to_string(),
+            table_name: "widgets".to_string(),
+            root_page: Some(4),
+            sql: Some("CREATE TABLE widgets(id, label)".to_string()),
+        };
+        let bytes = record::encode(&entry.to_record_columns());
+        let decoded = decode_schema_row(&bytes).unwrap();
+        assert_eq!(decoded, entry);
+
+        // The convenience builder produces the same five columns for a table.
+        assert_eq!(
+            table_schema_row("widgets", 4, "CREATE TABLE widgets(id, label)"),
+            entry.to_record_columns()
+        );
+    }
+
+    /// The milestone: assemble a full two-page single-table database entirely
+    /// from the writer helpers — page 1 = the 100-byte DB header followed by a
+    /// `sqlite_schema` leaf (at offset 100) describing table `t` rooted on page
+    /// 2, and page 2 = a data leaf holding `t`'s rows — then read it back through
+    /// the real reader (`schema::read_table`) by table name.
+    #[test]
+    fn writes_a_readable_single_table_database() {
+        let ps = 512usize;
+
+        // --- Page 2: the user table's data leaf, via the page writer. ---------
+        let rows: Vec<(i64, Vec<u8>)> = [
+            (1i64, vec![SqlValue::Int(1), SqlValue::Text("a".into())]),
+            (2, vec![SqlValue::Int(2), SqlValue::Text("b".into())]),
+        ]
+        .iter()
+        .map(|(rowid, cols)| (*rowid, record::encode(cols)))
+        .collect();
+        let data_leaf = encode_table_leaf_page(ps, 0, &rows).unwrap();
+
+        // --- Page 1: DB header (100 bytes) + sqlite_schema leaf at offset 100. -
+        // The schema b-tree has one cell: rowid 1, the record describing table
+        // `t` at root page 2. Page 1 is the only page whose b-tree header is
+        // offset by the 100-byte database header, so we lay the leaf out by hand.
+        let header = Header {
+            page_size: ps as u32,
+            reserved_space: 0,
+            page_count: 2,
+            change_counter: 1,
+            freelist_trunk: 0,
+            freelist_count: 0,
+            schema_cookie: 1,
+            schema_format: 1,
+            text_encoding: TextEncoding::Utf8,
+        };
+        let mut page1 = vec![0u8; ps];
+        page1[0..100].copy_from_slice(&header.encode());
+        assert_eq!(&page1[0..16], MAGIC);
+
+        let schema_record =
+            record::encode(&table_schema_row("t", 2, "CREATE TABLE t(id, v)"));
+        let mut cell = Vec::new();
+        varint::write(schema_record.len() as i64, &mut cell); // payload length
+        varint::write(1, &mut cell); // rowid
+        cell.extend_from_slice(&schema_record);
+
+        let h = 100; // page-1 b-tree header offset
+        page1[h] = 0x0D; // leaf table page
+        page1[h + 3..h + 5].copy_from_slice(&1u16.to_be_bytes()); // one cell
+        let content_top = ps - cell.len();
+        page1[content_top..ps].copy_from_slice(&cell);
+        page1[h + 5..h + 7].copy_from_slice(&(content_top as u16).to_be_bytes()); // content start
+        page1[h + 8..h + 10].copy_from_slice(&(content_top as u16).to_be_bytes()); // cell ptr[0]
+
+        // --- Assemble the file and read table `t` back by name. ---------------
+        let mut file = page1;
+        file.extend_from_slice(&data_leaf);
+
+        let read = read_table(&file, "t").unwrap();
+        assert_eq!(
+            read,
+            vec![
+                (1, vec![SqlValue::Int(1), SqlValue::Text("a".into())]),
+                (2, vec![SqlValue::Int(2), SqlValue::Text("b".into())]),
+            ]
+        );
+
+        // The schema itself reads back as one table entry rooted on page 2.
+        let schema = read_schema(&file).unwrap();
+        assert_eq!(schema.len(), 1);
+        assert_eq!(schema[0].object_type, "table");
+        assert_eq!(schema[0].name, "t");
+        assert_eq!(schema[0].root_page, Some(2));
     }
 }


### PR DESCRIPTION
## `sqlite_schema` row builder + a full re-readable single-table file

**The writer capstone.** Adds `SchemaEntry::to_record_columns()` — the inverse of
the reader's schema-row decode — and the convenience `table_schema_row(name,
root_page, sql)`. **Rotation lane 4 (sqlite-file writer).**

### The milestone
Combined with the earlier rungs, the writer now emits a **complete, re-readable
single-table database**:
```
record::encode (0.8.0)                       → a row's record bytes
page_writer::encode_table_leaf_page (0.9.0)  → a table-leaf page
Header::encode (0.10.0)                       → page 1's 100-byte DB header
schema table_schema_row (THIS, 0.11.0)        → the sqlite_schema row
```
A test **assembles a two-page file by hand** — page 1 = the DB header + a
`sqlite_schema` leaf (at offset 100) describing table `t` at root page 2; page 2 =
the data leaf — then reads the rows back through the **real reader**
(`schema::read_table` by table name) and confirms the schema round-trips. This
completes the byte-level toolkit that makes dropping the `rusqlite` dev-dependency
viable.

### The schema row
The five `sqlite_schema` columns in order — `type='table'`, `name`, `tbl_name =
name`, `rootpage`, `sql` — matching exactly what `decode_schema_row` reads; a
`None` root page / SQL is written as `NULL`.

### Tests
Record-codec round-trip of a schema row, and the full single-table-file assembly
read back by table name. Full `sqlite-file` suite green (55 tests); consumers
(`storage-sqlite`, `mini-sqlite`) build clean; clippy clean. (A one-call
whole-file assembler that handles page 1's 100-byte b-tree offset is a natural
follow-up.)

### Security
Inline adversarial review **PASSED** — pure struct→columns serializer, no
panic/overflow (`i64::from(u32)` is lossless), no unbounded allocation, correct
inverse of the decoder. No untrusted-byte parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
