### PR TITLE
feat(adj-facts-stdlib): metrology time-units — unit → length in seconds (NIST)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_timeunits_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_timeunits_e2e.rs
@@ -1,0 +1,63 @@
+//! End-to-end test for the metrology TIME-UNITS facts library
+//! (`adj-facts-stdlib/metrology/time-units.adj`) driven through the built CLI:
+//! a native `table` of time-unit → length-in-seconds resolves a binding-query
+//! recall with the NIST citation, and abstains on a non-listed unit — 0 model
+//! calls. A recalled length (e.g. hour → 3600 s) is the number that flows into
+//! duration arithmetic.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factstu_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn metrology_time_units_recall_binds_seconds_with_citation() {
+    let dir = scratch("timeunits");
+    // Copy the shipped metrology table beside the entry program and import it.
+    let src = facts_stdlib().join("metrology/time-units.adj");
+    std::fs::copy(&src, dir.join("time-units.adj")).expect("copy shipped time-units.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"time-units.adj\"\n\
+         ? time_unit_seconds(hour, $S)\n\
+         ? time_unit_seconds(day, $S)\n\
+         ? time_unit_seconds(fortnight, $S)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // An hour is 3600 seconds; a day is 86400 — the recalled lengths that feed
+    // duration arithmetic.
+    assert!(out.contains("\"S\":\"3600\""), "hour -> 3600 s: {out}");
+    assert!(out.contains("\"S\":\"86400\""), "day -> 86400 s: {out}");
+    // The answer carries the NIST citation (locator + trust) as its proof.
+    assert!(
+        out.contains("nist.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NIST source citation: {out}"
+    );
+    // A "fortnight" is not in this table — honest abstention, never a fabricated
+    // length.
+    assert!(out.contains("\"abstained\":true"), "fortnight abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/metrology/time-units.adj
+++ b/code/specs/data/adj-facts-stdlib/metrology/time-units.adj
@@ -1,0 +1,58 @@
+% ============================================================================
+% time-units — each time unit → its length in SECONDS (adj-facts-stdlib, METROLOGY).
+% ============================================================================
+% The everyday metrology fact that turns a clock into arithmetic: a named time
+% unit stands for a fixed number of seconds. A minute is 60 seconds; an hour is
+% 3600 seconds; a day is 86400 seconds. Recall is a binding query — you name a
+% unit and get back its length in seconds, WITH its citation:
+%
+%     ? time_unit_seconds(minute, $S)     % 60
+%     ? time_unit_seconds(hour, $S)       % 3600
+%     ? time_unit_seconds(day, $S)        % 86400
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `time_unit_seconds(unit, seconds)` carrying the table's citation, so
+% the lookup is the ordinary SLD binding query — the engine returns the length in
+% seconds WITH its source, on the CPU, with zero model calls, and abstains on a
+% word that is not one of these time units (it never invents a length).
+%
+% Why the `seconds` value is a NUMBER (and why the unit is SECONDS): because the
+% length is a plain integer count of seconds, a looked-up unit length flows
+% straight into DURATION ARITHMETIC. To turn "how many seconds in 3 hours?" into a
+% number you recall hour → 3600 and multiply: 3 × 3600 = 10800 s. To convert a
+% span of seconds back into hours you divide by the same recalled 3600. Seconds is
+% the SI base unit of time, so every unit here reduces to the SAME base and the
+% factors compose cleanly (a day is 24 hours because 86400 = 24 × 3600). That is
+% the concrete metrology bridge from RECALL (name the unit) to COMPUTE (scale by
+% its seconds).
+%
+% Why a `table` and NOT three prose sentences: this is exactly the shape reference
+% data ships in — a published units table, one unit per row with its conversion to
+% the base unit. The citable artifact IS the NIST table at the `locator` below, and
+% each unit→seconds pair here is read straight off it. The whole table is defended
+% by one provenance envelope rather than repeating source/locator/trust per row.
+%
+% Provenance: the units and their lengths are taken VERBATIM from NIST Special
+% Publication 811, "Units outside the SI" (Table 6, units accepted for use with the
+% SI). The `source` span below reproduces the three conversion cells of that table
+% that state 1 min = 60 s, 1 h = 3600 s, and 1 d = 86400 s. `trust authoritative`
+% — a primary U.S. standards reference (NIST, a .gov), re-fetchable at the
+% `locator`. Nothing here is asserted from memory: every unit→seconds pair is a
+% cell of the cited table. WEEK is deliberately OMITTED — NIST Table 6 does not
+% state a "7 days per week" relation, so 604800 s cannot be grounded on this page
+% and is not shipped (only units whose length is confirmable on the cited page are
+% included). (See ../README.md; ADJ-TABLES.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table time_unit_seconds {
+    columns unit, seconds
+
+    row (minute, 60)      % 1 min = 60 s
+    row (hour, 3600)      % 1 h = 60 min = 3600 s
+    row (day, 86400)      % 1 d = 24 h = 86400 s
+
+    source "1 min = 60 s | 1 h = 60 min = 3600 s | 1 d = 24 h = 86 400 s"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-5-units-outside-si"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/metrology/time-units.query.adj
+++ b/code/specs/data/adj-facts-stdlib/metrology/time-units.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% time-units.query.adj — a worked recall over the metrology time-units library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how many seconds in an
+% hour?": it states no fact of its own — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `time_unit_seconds` rows and returns the length in seconds + the table's
+% source/locator/trust. Note the reverse query below: because `seconds` is an
+% ordinary column, you can bind the UNIT from a known length (which unit is 86400
+% seconds long? → day). A word that is not one of these units abstains honestly —
+% the engine never invents a length.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli time-units.query.adj
+% ============================================================================
+
+import "time-units.adj"
+
+? time_unit_seconds(hour, $S)          % expect 3600  (1 h = 3600 s)
+? time_unit_seconds(day, $S)           % expect 86400 (1 d = 86400 s)
+? time_unit_seconds($Unit, 86400)      % expect day   (reverse: which unit is 86400 s?)
+? time_unit_seconds(fortnight, $S)     % expect abstain — "fortnight" is not in this table


### PR DESCRIPTION
## What

Adds one grounded **ELEMENTARY** facts library to the ADJ standard library: **metrology / time-units**. Each time unit recalls its length in **seconds** as a native `table` (`time_unit_seconds(unit, seconds)`), so a looked-up length flows straight into **duration arithmetic** — the recall → compute bridge (e.g. `? time_unit_seconds(hour, $S)` binds `3600`, which multiplies into "3 hours = 10800 s").

## Rows shipped

| unit | seconds |
|---|---|
| minute | 60 |
| hour | 3600 |
| day | 86400 |

**`week` is deliberately omitted** — NIST Table 6 states no "7 days per week" relation, so `604800 s` cannot be grounded on the cited page. Nothing from memory.

## Grounding

Values taken **verbatim** from **NIST Special Publication 811**, "Units outside the SI" (Table 6):
- `1 min = 60 s`
- `1 h = 60 min = 3600 s`
- `1 d = 24 h = 86 400 s`

- **source URL / locator:** https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-5-units-outside-si
- **trust tier:** `authoritative` (NIST, a `.gov` primary U.S. standards reference; re-fetchable at the locator)

## Files

- `code/specs/data/adj-facts-stdlib/metrology/time-units.adj` — grounded table + literate provenance envelope
- `code/specs/data/adj-facts-stdlib/metrology/time-units.query.adj` — worked recall (forward, reverse bind-by-seconds, honest abstain on `fortnight`)
- `code/packages/rust/adj-lang-cli/tests/facts_timeunits_e2e.rs` — e2e (mirrors `facts_shapes_e2e`): 2 binds (`hour → 3600`, `day → 86400`) with NIST locator + `trust=authoritative`, one abstain

## Verification

- `cargo test -p adj-lang-cli --test facts_timeunits_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review sub-agent: PASSED (no vulnerabilities; data files carry no executable/injection surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>