### PR TITLE
feat(adj-facts-stdlib): biology food-chain-roles grounded facts library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_foodchain_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_foodchain_e2e.rs
@@ -1,0 +1,71 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/food-chain-roles.adj`) driven through the built
+//! CLI: a native `table` of food-chain role → one-word job resolves a
+//! binding-query recall with the source's citation, runs the relation backward
+//! (job → role), and abstains on a non-role — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsbio_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_food_chain_recall_binds_job_with_citation() {
+    let dir = scratch("foodchain");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/food-chain-roles.adj");
+    std::fs::copy(&src, dir.join("food-chain-roles.adj"))
+        .expect("copy shipped food-chain-roles.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"food-chain-roles.adj\"\n\
+         ? food_chain_role(producer, $D)\n\
+         ? food_chain_role(consumer, $D)\n\
+         ? food_chain_role($R, makes_food)\n\
+         ? food_chain_role(volcano, $D)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The producer makes its own food; the consumer eats other organisms — the
+    // recalled one-word job atoms (two forward binds).
+    assert!(out.contains("\"D\":\"makes_food\""), "producer → makes_food: {out}");
+    assert!(out.contains("\"D\":\"eats_others\""), "consumer → eats_others: {out}");
+    // The relation runs backward: the job makes_food recalls producer.
+    assert!(
+        out.contains("\"R\":\"producer\""),
+        "makes_food → producer (reverse recall): {out}"
+    );
+    // The answer carries the NOAA citation and the authoritative trust tier as
+    // its proof (locator + trust).
+    assert!(
+        out.contains("noaa.gov/education/resource-collections/marine-life/aquatic-food-webs")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // "volcano" is not a food-chain role — honest abstention, never a fabricated
+    // job.
+    assert!(out.contains("\"abstained\":true"), "non-role abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/food-chain-roles.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/food-chain-roles.adj
@@ -1,0 +1,67 @@
+% ============================================================================
+% food-chain-roles — each food-chain role and the one-word job it does
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A beginner biology facts library in the ADJ standard library — the kind an
+% ecology or science agent `import`s when it needs the grounded, child-level
+% answer to "what does a producer do?": a plant MAKES its own food, an animal
+% EATS other organisms, a mushroom BREAKS DOWN what has died. Every food chain
+% is built from three roles, and each role has one job. Recall is a binding
+% query:
+%
+%     ? food_chain_role(producer, $D)    % makes_food
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `food_chain_role(role, description)` carrying the table's citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% description atom WITH its source, on the CPU, with zero model calls, and
+% abstains on a word that is not one of the three roles. The query also runs
+% BACKWARD — bind the job and recall the role:
+%
+%     ? food_chain_role($R, makes_food)  % producer
+%
+% The `description` value of every row is a SINGLE lowercase atom, chosen to be a
+% faithful one-word paraphrase of the role's definition the source states — never
+% an interpretation the source does not support. A recalled description atom
+% therefore composes straight into downstream reasoning (an ecology agent asking
+% "which role makes_food?" gets the grounded answer, not a guess) — the concrete
+% bridge from biology RECALL to reasoning.
+%
+% Provenance: every role and its `description` atom is grounded in the NOAA
+% (National Oceanic and Atmospheric Administration) "Aquatic food webs" education
+% resource — a primary U.S. government science-education page (the citable
+% artifact at the `locator`). The `source` span is the VERBATIM glossary
+% definition of the first data row (producer), copied character-for-character
+% from that page. The remaining rows' atoms are each a faithful one-word
+% paraphrase of that same page's definition for their role:
+%
+%     producer    → "An organism that makes its own food through photosynthesis
+%                     or chemosynthesis."                                → makes_food
+%     consumer    → "An organism that gains energy by feeding on other
+%                     organisms." (and: "Consumers are animals that cannot make
+%                     their own food and need to eat other organisms for
+%                     energy.")                                          → eats_others
+%     decomposer  → "Organic matter is broken down to carbon dioxide and mineral
+%                     forms of nutrients by organisms such as bacteria and
+%                     fungi."                                            → breaks_down
+%
+% `trust authoritative` — NOAA is a primary U.S. government scientific agency
+% (noaa.gov), the honest tier for an official source (contrast `consensus`,
+% reserved for a secondary reference such as an encyclopedia). Nothing here is
+% asserted from memory; each pair was read out of the fetched page and any role
+% whose job the page did not state would have been dropped.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_adjudication_no_interpretive_gating.)
+% ============================================================================
+
+table food_chain_role {
+    columns role, description
+
+    row (producer, makes_food)
+    row (consumer, eats_others)
+    row (decomposer, breaks_down)
+
+    source "An organism that makes its own food through photosynthesis or chemosynthesis."
+    locator "https://www.noaa.gov/education/resource-collections/marine-life/aquatic-food-webs"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/food-chain-roles.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/food-chain-roles.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% food-chain-roles.query.adj — a worked recall over the biology food-chain library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does a producer do?":
+% it states no biology fact — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `food_chain_role`
+% rows and returns the description atom + the table's source/locator/trust. The
+% fourth query runs the relation BACKWARD (bind the job, recall the role). A word
+% that is not one of the three roles abstains honestly — the engine never invents
+% a job.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli food-chain-roles.query.adj
+% ============================================================================
+
+import "food-chain-roles.adj"
+
+? food_chain_role(producer, $D)     % expect makes_food
+? food_chain_role(consumer, $D)     % expect eats_others
+? food_chain_role(decomposer, $D)   % expect breaks_down
+? food_chain_role($R, makes_food)   % expect producer — the reverse recall
+? food_chain_role(volcano, $D)      % expect abstain — not a food-chain role


### PR DESCRIPTION
## What

Adds a beginner **biology** FACTS library to the ADJ standard library: each food-chain **role** mapped to the one-word job the source states.

| role | description |
|---|---|
| producer | makes_food |
| consumer | eats_others |
| decomposer | breaks_down |

## Grounding

Every role and its `description` atom is a faithful one-word paraphrase of a **verbatim** span from NOAA's ["Aquatic food webs"](https://www.noaa.gov/education/resource-collections/marine-life/aquatic-food-webs) education resource — a primary U.S. government science-education page.

- producer -> "An organism that makes its own food through photosynthesis or chemosynthesis." -> `makes_food`
- consumer -> "An organism that gains energy by feeding on other organisms." (also "…need to eat other organisms for energy.") -> `eats_others`
- decomposer -> "Organic matter is broken down to carbon dioxide and mineral forms of nutrients by organisms such as bacteria and fungi." -> `breaks_down`

The table's `source` carries the verbatim producer definition; `trust authoritative` reflects the official .gov source. Value atoms match the source wording; nothing is asserted from memory.

## Ships

- `code/specs/data/adj-facts-stdlib/biology/food-chain-roles.adj` — native `table food_chain_role`
- `code/specs/data/adj-facts-stdlib/biology/food-chain-roles.query.adj` — worked recall (forward + reverse + abstain on a non-role)
- `code/packages/rust/adj-lang-cli/tests/facts_foodchain_e2e.rs` — CLI e2e: 2 forward binds, 1 reverse recall (`makes_food` -> `producer`), locator + `authoritative` trust citation, and honest abstention on "volcano"

## Verification

- `cargo test -p adj-lang-cli --test facts_foodchain_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)