### PR TITLE
feat(swift): port sql-execution-engine

### DIFF
--- a/code/packages/swift/sql-execution-engine/.gitignore
+++ b/code/packages/swift/sql-execution-engine/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/code/packages/swift/sql-execution-engine/BUILD
+++ b/code/packages/swift/sql-execution-engine/BUILD
@@ -1,0 +1,1 @@
+swift test

--- a/code/packages/swift/sql-execution-engine/BUILD_windows
+++ b/code/packages/swift/sql-execution-engine/BUILD_windows
@@ -1,0 +1,1 @@
+swift test

--- a/code/packages/swift/sql-execution-engine/CHANGELOG.md
+++ b/code/packages/swift/sql-execution-engine/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add a pure Swift, SELECT-only SQL execution engine.
+- Support pluggable and in-memory data sources.
+- Support filtering, joins, grouping, aggregates, ordering, distinct, limit,
+  and offset.

--- a/code/packages/swift/sql-execution-engine/Package.swift
+++ b/code/packages/swift/sql-execution-engine/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+  name: "sql-execution-engine",
+  products: [
+    .library(name: "SqlExecutionEngine", targets: ["SqlExecutionEngine"])
+  ],
+  targets: [
+    .target(name: "SqlExecutionEngine"),
+    .testTarget(
+      name: "SqlExecutionEngineTests",
+      dependencies: ["SqlExecutionEngine"]
+    ),
+  ]
+)

--- a/code/packages/swift/sql-execution-engine/README.md
+++ b/code/packages/swift/sql-execution-engine/README.md
@@ -1,0 +1,30 @@
+# sql-execution-engine (Swift)
+
+A dependency-free, SELECT-only SQL execution engine for the coding-adventures
+SQL stack. It evaluates SQL against any data source that implements
+`SqlDataSource`.
+
+```swift
+import SqlExecutionEngine
+
+let source = InMemoryDataSource()
+    .addTable(
+        "users",
+        schema: ["id", "name", "age"],
+        rows: [
+            ["id": 1, "name": "Alice", "age": 30],
+            ["id": 2, "name": "Bob", "age": 25],
+        ]
+    )
+
+let result = try SqlEngine.execute(
+    "SELECT name FROM users WHERE age > 27",
+    dataSource: source
+)
+```
+
+The engine supports projection, expressions, SQL NULL logic, INNER/LEFT/RIGHT/
+FULL/CROSS joins, GROUP BY, HAVING, COUNT/SUM/AVG/MIN/MAX, ORDER BY, DISTINCT,
+LIMIT, and OFFSET. Parsing is intentionally local to this package so the port
+does not create a broken dependency edge while Swift's reusable grammar-driven
+SQL lexer/parser pair remains a separate Priority 2 item.

--- a/code/packages/swift/sql-execution-engine/Sources/SqlExecutionEngine/Engine.swift
+++ b/code/packages/swift/sql-execution-engine/Sources/SqlExecutionEngine/Engine.swift
@@ -1,0 +1,534 @@
+private struct RowContext {
+  var values: [String: SqlValue]
+  var ambiguous: Set<String>
+
+  func value(table: String?, name: String) throws -> SqlValue {
+    if let table {
+      let key = "\(table).\(name)"
+      guard let value = values[key] else { throw SqlExecutionError.columnNotFound(key) }
+      return value
+    }
+    if ambiguous.contains(name) { throw SqlExecutionError.ambiguousColumn(name) }
+    guard let value = values[name] else { throw SqlExecutionError.columnNotFound(name) }
+    return value
+  }
+
+  func merged(with other: RowContext) -> RowContext {
+    var merged = self
+    for (key, value) in other.values where key.contains(".") {
+      merged.values[key] = value
+    }
+    let bareNames = Set(values.keys.filter { !$0.contains(".") })
+      .union(other.values.keys.filter { !$0.contains(".") })
+      .union(ambiguous)
+      .union(other.ambiguous)
+    for name in bareNames {
+      let leftHas = values[name] != nil || ambiguous.contains(name)
+      let rightHas = other.values[name] != nil || other.ambiguous.contains(name)
+      if leftHas, rightHas {
+        merged.values.removeValue(forKey: name)
+        merged.ambiguous.insert(name)
+      } else if let value = other.values[name] {
+        merged.values[name] = value
+      }
+    }
+    return merged
+  }
+}
+
+private struct TableRows {
+  let rows: [RowContext]
+  let nullRow: RowContext
+}
+
+private struct RowFrame {
+  let row: RowContext
+  let groupRows: [RowContext]?
+}
+
+/// Entry points for executing SELECT statements.
+public enum SqlEngine {
+  public static func execute(_ sql: String, dataSource: SqlDataSource) throws -> QueryResult {
+    var parser = try SelectParser(sql)
+    return try execute(parser.parse(), dataSource: dataSource)
+  }
+
+  public static func tryExecute(_ sql: String, dataSource: SqlDataSource) -> ExecutionResult {
+    do {
+      return ExecutionResult(result: try execute(sql, dataSource: dataSource), error: nil)
+    } catch let error as SqlExecutionError {
+      return ExecutionResult(result: nil, error: error.description)
+    } catch {
+      return ExecutionResult(result: nil, error: String(describing: error))
+    }
+  }
+
+  private static func execute(
+    _ statement: SelectStatement,
+    dataSource: SqlDataSource
+  ) throws -> QueryResult {
+    var current = try scan(statement.from, from: dataSource)
+    var rows = current.rows
+
+    for join in statement.joins {
+      let right = try scan(join.table, from: dataSource)
+      rows = try applyJoin(
+        leftRows: rows,
+        leftNullRow: current.nullRow,
+        rightRows: right,
+        clause: join
+      )
+      current = TableRows(
+        rows: rows,
+        nullRow: current.nullRow.merged(with: right.nullRow)
+      )
+    }
+
+    if let whereExpression = statement.whereExpression {
+      rows = try rows.filter {
+        try truth(evaluate(whereExpression, row: $0, groupRows: nil)) == true
+      }
+    }
+
+    var frames = try makeFrames(rows, statement: statement)
+    if let having = statement.having {
+      frames = try frames.filter {
+        try truth(evaluate(having, row: $0.row, groupRows: $0.groupRows)) == true
+      }
+    }
+    if !statement.orderBy.isEmpty {
+      try stableSort(&frames, orderBy: statement.orderBy)
+    }
+
+    let projection = try project(frames, statement: statement)
+    var resultRows = projection.rows
+    if statement.distinct {
+      var seen: Set<[SqlValue]> = []
+      resultRows = resultRows.filter { seen.insert($0).inserted }
+    }
+
+    let offset = max(0, statement.offset ?? 0)
+    guard offset < resultRows.count else {
+      return QueryResult(columns: projection.columns, rows: [])
+    }
+    let end: Int
+    if let limit = statement.limit {
+      end = min(resultRows.count, offset + max(0, limit))
+    } else {
+      end = resultRows.count
+    }
+    return QueryResult(
+      columns: projection.columns,
+      rows: Array(resultRows[offset..<end])
+    )
+  }
+
+  private static func scan(
+    _ table: TableReference,
+    from dataSource: SqlDataSource
+  ) throws -> TableRows {
+    let schema = try dataSource.schema(table.name)
+    let rows = try dataSource.scan(table.name).map { raw -> RowContext in
+      var values: [String: SqlValue] = [:]
+      for column in schema {
+        let value = raw[column] ?? .null
+        values[column] = value
+        values["\(table.name).\(column)"] = value
+        values["\(table.alias).\(column)"] = value
+      }
+      return RowContext(values: values, ambiguous: [])
+    }
+    var nullValues: [String: SqlValue] = [:]
+    for column in schema {
+      nullValues[column] = .null
+      nullValues["\(table.name).\(column)"] = .null
+      nullValues["\(table.alias).\(column)"] = .null
+    }
+    return TableRows(
+      rows: rows,
+      nullRow: RowContext(values: nullValues, ambiguous: [])
+    )
+  }
+
+  private static func applyJoin(
+    leftRows: [RowContext],
+    leftNullRow: RowContext,
+    rightRows: TableRows,
+    clause: JoinClause
+  ) throws -> [RowContext] {
+    if clause.type == .cross {
+      return leftRows.flatMap { left in rightRows.rows.map { left.merged(with: $0) } }
+    }
+
+    var result: [RowContext] = []
+    var matchedRight: Set<Int> = []
+    for left in leftRows {
+      var matched = false
+      for (index, right) in rightRows.rows.enumerated() {
+        let merged = left.merged(with: right)
+        let matches =
+          if let condition = clause.condition {
+            try truth(evaluate(condition, row: merged, groupRows: nil)) == true
+          } else {
+            true
+          }
+        if matches {
+          result.append(merged)
+          matched = true
+          matchedRight.insert(index)
+        }
+      }
+      if !matched, clause.type == .left || clause.type == .full {
+        result.append(left.merged(with: rightRows.nullRow))
+      }
+    }
+    if clause.type == .right || clause.type == .full {
+      for (index, right) in rightRows.rows.enumerated() where !matchedRight.contains(index) {
+        result.append(leftNullRow.merged(with: right))
+      }
+    }
+    return result
+  }
+
+  private static func makeFrames(
+    _ rows: [RowContext],
+    statement: SelectStatement
+  ) throws -> [RowFrame] {
+    let grouped = !statement.groupBy.isEmpty
+    let aggregated =
+      statement.selectItems.contains { hasAggregate($0.expression) }
+      || statement.having.map(hasAggregate) == true
+    if !grouped, !aggregated {
+      return rows.map { RowFrame(row: $0, groupRows: nil) }
+    }
+    if !grouped {
+      return [
+        RowFrame(
+          row: rows.first ?? RowContext(values: [:], ambiguous: []),
+          groupRows: rows
+        )
+      ]
+    }
+
+    var groups: [[SqlValue]: [RowContext]] = [:]
+    var order: [[SqlValue]] = []
+    for row in rows {
+      let key = try statement.groupBy.map { try evaluate($0, row: row, groupRows: nil) }
+      if groups[key] == nil { order.append(key) }
+      groups[key, default: []].append(row)
+    }
+    return order.compactMap { key in
+      guard let group = groups[key], let first = group.first else { return nil }
+      return RowFrame(row: first, groupRows: group)
+    }
+  }
+
+  private static func project(
+    _ frames: [RowFrame],
+    statement: SelectStatement
+  ) throws -> (columns: [String], rows: [[SqlValue]]) {
+    if statement.selectItems.count == 1, case .star = statement.selectItems[0].expression {
+      let columns =
+        frames.first?.row.values.keys
+        .filter { !$0.contains(".") }
+        .sorted() ?? []
+      let rows = frames.map { frame in columns.map { frame.row.values[$0] ?? .null } }
+      return (columns, rows)
+    }
+    let columns = statement.selectItems.map { item in
+      item.alias ?? expressionLabel(item.expression)
+    }
+    let rows = try frames.map { frame in
+      try statement.selectItems.map {
+        try evaluate($0.expression, row: frame.row, groupRows: frame.groupRows)
+      }
+    }
+    return (columns, rows)
+  }
+
+  private static func evaluate(
+    _ expression: Expression,
+    row: RowContext,
+    groupRows: [RowContext]?
+  ) throws -> SqlValue {
+    switch expression {
+    case .literal(let value):
+      return value
+    case .column(let table, let name):
+      return try row.value(table: table, name: name)
+    case .star:
+      throw SqlExecutionError.typeMismatch("STAR is only valid in projection or COUNT")
+    case .unary(let operation, let operand):
+      let value = try evaluate(operand, row: row, groupRows: groupRows)
+      if operation == "NOT" {
+        return truth(value).map { .boolean(!$0) } ?? .null
+      }
+      guard operation == "-" else {
+        throw SqlExecutionError.typeMismatch("unknown unary \(operation)")
+      }
+      guard value != .null else { return .null }
+      return .real(-(try number(value)))
+    case .binary(let operation, let leftExpression, let rightExpression):
+      return try evaluateBinary(
+        operation,
+        left: leftExpression,
+        right: rightExpression,
+        row: row,
+        groupRows: groupRows
+      )
+    case .isNull(let operand, let negated):
+      let isNull = try evaluate(operand, row: row, groupRows: groupRows) == .null
+      return .boolean(negated ? !isNull : isNull)
+    case .between(let operand, let lowerExpression, let upperExpression, let negated):
+      let value = try evaluate(operand, row: row, groupRows: groupRows)
+      let lower = try evaluate(lowerExpression, row: row, groupRows: groupRows)
+      let upper = try evaluate(upperExpression, row: row, groupRows: groupRows)
+      guard value != .null, lower != .null, upper != .null else { return .null }
+      let match = try compare(value, lower) >= 0 && compare(value, upper) <= 0
+      return .boolean(negated ? !match : match)
+    case .inList(let operand, let expressions, let negated):
+      let value = try evaluate(operand, row: row, groupRows: groupRows)
+      guard value != .null else { return .null }
+      var found = false
+      for candidate in expressions {
+        let candidateValue = try evaluate(candidate, row: row, groupRows: groupRows)
+        if candidateValue != .null, try sqlEquals(value, candidateValue) {
+          found = true
+          break
+        }
+      }
+      return .boolean(negated ? !found : found)
+    case .like(let operand, let patternExpression, let negated):
+      let value = try evaluate(operand, row: row, groupRows: groupRows)
+      let pattern = try evaluate(patternExpression, row: row, groupRows: groupRows)
+      guard value != .null, pattern != .null else { return .null }
+      guard case .text(let text) = value, case .text(let patternText) = pattern else {
+        throw SqlExecutionError.typeMismatch("LIKE requires text operands")
+      }
+      let match = like(text, pattern: patternText)
+      return .boolean(negated ? !match : match)
+    case .function(let name, let arguments):
+      return try evaluateFunction(name, arguments: arguments, row: row, groupRows: groupRows)
+    }
+  }
+
+  private static func evaluateBinary(
+    _ operation: String,
+    left leftExpression: Expression,
+    right rightExpression: Expression,
+    row: RowContext,
+    groupRows: [RowContext]?
+  ) throws -> SqlValue {
+    let left = try evaluate(leftExpression, row: row, groupRows: groupRows)
+    if operation == "AND" {
+      if truth(left) == false { return .boolean(false) }
+      let right = try evaluate(rightExpression, row: row, groupRows: groupRows)
+      if truth(right) == false { return .boolean(false) }
+      return truth(left) == nil || truth(right) == nil ? .null : .boolean(true)
+    }
+    if operation == "OR" {
+      if truth(left) == true { return .boolean(true) }
+      let right = try evaluate(rightExpression, row: row, groupRows: groupRows)
+      if truth(right) == true { return .boolean(true) }
+      return truth(left) == nil || truth(right) == nil ? .null : .boolean(false)
+    }
+
+    let right = try evaluate(rightExpression, row: row, groupRows: groupRows)
+    guard left != .null, right != .null else { return .null }
+    switch operation {
+    case "+": return .real(try number(left) + number(right))
+    case "-": return .real(try number(left) - number(right))
+    case "*": return .real(try number(left) * number(right))
+    case "/":
+      let divisor = try number(right)
+      guard divisor != 0 else { throw SqlExecutionError.divisionByZero }
+      return .real(try number(left) / divisor)
+    case "%":
+      let divisor = try number(right)
+      guard divisor != 0 else { throw SqlExecutionError.divisionByZero }
+      return .real(try number(left).truncatingRemainder(dividingBy: divisor))
+    case "=": return .boolean(try sqlEquals(left, right))
+    case "!=", "<>": return .boolean(try !sqlEquals(left, right))
+    case "<": return .boolean(try compare(left, right) < 0)
+    case ">": return .boolean(try compare(left, right) > 0)
+    case "<=": return .boolean(try compare(left, right) <= 0)
+    case ">=": return .boolean(try compare(left, right) >= 0)
+    default: throw SqlExecutionError.typeMismatch("unknown operator \(operation)")
+    }
+  }
+
+  private static func evaluateFunction(
+    _ rawName: String,
+    arguments: [Expression],
+    row: RowContext,
+    groupRows: [RowContext]?
+  ) throws -> SqlValue {
+    let name = rawName.uppercased()
+    if ["COUNT", "SUM", "AVG", "MIN", "MAX"].contains(name) {
+      guard let groupRows else {
+        throw SqlExecutionError.typeMismatch("aggregate \(name) used outside grouped context")
+      }
+      if name == "COUNT", arguments.count == 1, case .star = arguments[0] {
+        return .integer(groupRows.count)
+      }
+      guard arguments.count == 1 else {
+        throw SqlExecutionError.typeMismatch("\(name) expects one argument")
+      }
+      let values = try groupRows.map {
+        try evaluate(arguments[0], row: $0, groupRows: nil)
+      }.filter { $0 != .null }
+      if name == "COUNT" { return .integer(values.count) }
+      guard let first = values.first else { return .null }
+      switch name {
+      case "SUM": return .real(try values.reduce(0) { try $0 + number($1) })
+      case "AVG": return .real(try values.reduce(0) { try $0 + number($1) } / Double(values.count))
+      case "MIN":
+        return try values.dropFirst().reduce(first) { try compare($1, $0) < 0 ? $1 : $0 }
+      case "MAX":
+        return try values.dropFirst().reduce(first) { try compare($1, $0) > 0 ? $1 : $0 }
+      default: fatalError("unreachable aggregate")
+      }
+    }
+
+    guard arguments.count == 1 else {
+      throw SqlExecutionError.typeMismatch("\(name) expects one argument")
+    }
+    let value = try evaluate(arguments[0], row: row, groupRows: groupRows)
+    guard value != .null else { return .null }
+    guard case .text(let text) = value else {
+      throw SqlExecutionError.typeMismatch("\(name) expects text")
+    }
+    switch name {
+    case "UPPER": return .text(text.uppercased())
+    case "LOWER": return .text(text.lowercased())
+    case "LENGTH": return .integer(text.count)
+    default: throw SqlExecutionError.unknownFunction(name)
+    }
+  }
+
+  private static func truth(_ value: SqlValue) -> Bool? {
+    switch value {
+    case .null: nil
+    case .boolean(let value): value
+    default: nil
+    }
+  }
+
+  private static func number(_ value: SqlValue) throws -> Double {
+    switch value {
+    case .integer(let value): Double(value)
+    case .real(let value): value
+    default: throw SqlExecutionError.typeMismatch("expected number, got \(value)")
+    }
+  }
+
+  private static func sqlEquals(_ left: SqlValue, _ right: SqlValue) throws -> Bool {
+    if isNumber(left), isNumber(right) { return try number(left) == number(right) }
+    switch (left, right) {
+    case (.text(let lhs), .text(let rhs)): return lhs == rhs
+    case (.boolean(let lhs), .boolean(let rhs)): return lhs == rhs
+    default: throw SqlExecutionError.typeMismatch("cannot compare \(left) and \(right)")
+    }
+  }
+
+  private static func compare(_ left: SqlValue, _ right: SqlValue) throws -> Int {
+    if left == .null { return right == .null ? 0 : 1 }
+    if right == .null { return -1 }
+    if isNumber(left), isNumber(right) {
+      let lhs = try number(left)
+      let rhs = try number(right)
+      return lhs == rhs ? 0 : (lhs < rhs ? -1 : 1)
+    }
+    switch (left, right) {
+    case (.text(let lhs), .text(let rhs)): return lhs == rhs ? 0 : (lhs < rhs ? -1 : 1)
+    case (.boolean(let lhs), .boolean(let rhs)): return lhs == rhs ? 0 : (lhs ? 1 : -1)
+    default: throw SqlExecutionError.typeMismatch("cannot order \(left) and \(right)")
+    }
+  }
+
+  private static func isNumber(_ value: SqlValue) -> Bool {
+    if case .integer = value { return true }
+    if case .real = value { return true }
+    return false
+  }
+
+  private static func like(_ text: String, pattern: String) -> Bool {
+    let input = Array(text)
+    let wildcard = Array(pattern)
+    var table = Array(
+      repeating: Array(repeating: false, count: wildcard.count + 1),
+      count: input.count + 1
+    )
+    table[0][0] = true
+    if !wildcard.isEmpty {
+      for j in 1...wildcard.count where wildcard[j - 1] == "%" {
+        table[0][j] = table[0][j - 1]
+      }
+    }
+    guard !input.isEmpty, !wildcard.isEmpty else { return table[input.count][wildcard.count] }
+    for i in 1...input.count {
+      for j in 1...wildcard.count {
+        if wildcard[j - 1] == "%" {
+          table[i][j] = table[i][j - 1] || table[i - 1][j]
+        } else if wildcard[j - 1] == "_" || wildcard[j - 1] == input[i - 1] {
+          table[i][j] = table[i - 1][j - 1]
+        }
+      }
+    }
+    return table[input.count][wildcard.count]
+  }
+
+  private static func hasAggregate(_ expression: Expression) -> Bool {
+    switch expression {
+    case .function(let name, let arguments):
+      ["COUNT", "SUM", "AVG", "MIN", "MAX"].contains(name.uppercased())
+        || arguments.contains(where: hasAggregate)
+    case .unary(_, let operand), .isNull(let operand, _):
+      hasAggregate(operand)
+    case .binary(_, let left, let right):
+      hasAggregate(left) || hasAggregate(right)
+    case .between(let operand, let lower, let upper, _):
+      hasAggregate(operand) || hasAggregate(lower) || hasAggregate(upper)
+    case .inList(let operand, let values, _):
+      hasAggregate(operand) || values.contains(where: hasAggregate)
+    case .like(let operand, let pattern, _):
+      hasAggregate(operand) || hasAggregate(pattern)
+    default:
+      false
+    }
+  }
+
+  private static func expressionLabel(_ expression: Expression) -> String {
+    switch expression {
+    case .column(_, let name): name
+    case .function(let name, _): name.uppercased()
+    case .star: "*"
+    default: "expression"
+    }
+  }
+
+  private static func stableSort(_ frames: inout [RowFrame], orderBy: [OrderItem]) throws {
+    guard frames.count > 1 else { return }
+    for index in 1..<frames.count {
+      var cursor = index
+      while cursor > 0, try ordered(frames[cursor], before: frames[cursor - 1], orderBy: orderBy) {
+        frames.swapAt(cursor, cursor - 1)
+        cursor -= 1
+      }
+    }
+  }
+
+  private static func ordered(
+    _ left: RowFrame,
+    before right: RowFrame,
+    orderBy: [OrderItem]
+  ) throws -> Bool {
+    for item in orderBy {
+      let lhs = try evaluate(item.expression, row: left.row, groupRows: left.groupRows)
+      let rhs = try evaluate(item.expression, row: right.row, groupRows: right.groupRows)
+      let result = try compare(lhs, rhs)
+      if result != 0 { return item.descending ? result > 0 : result < 0 }
+    }
+    return false
+  }
+}

--- a/code/packages/swift/sql-execution-engine/Sources/SqlExecutionEngine/Models.swift
+++ b/code/packages/swift/sql-execution-engine/Sources/SqlExecutionEngine/Models.swift
@@ -1,0 +1,119 @@
+/// A value that can participate in SQL expression evaluation.
+public enum SqlValue: Hashable, CustomStringConvertible {
+  case null
+  case integer(Int)
+  case real(Double)
+  case text(String)
+  case boolean(Bool)
+
+  public var description: String {
+    switch self {
+    case .null: "NULL"
+    case .integer(let value): String(value)
+    case .real(let value): String(value)
+    case .text(let value): value
+    case .boolean(let value): value ? "TRUE" : "FALSE"
+    }
+  }
+}
+
+extension SqlValue: ExpressibleByNilLiteral {
+  public init(nilLiteral: ()) { self = .null }
+}
+
+extension SqlValue: ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Int) { self = .integer(value) }
+}
+
+extension SqlValue: ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Double) { self = .real(value) }
+}
+
+extension SqlValue: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) { self = .text(value) }
+}
+
+extension SqlValue: ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Bool) { self = .boolean(value) }
+}
+
+public typealias SqlRow = [String: SqlValue]
+
+/// Storage boundary consumed by the execution engine.
+public protocol SqlDataSource {
+  func schema(_ tableName: String) throws -> [String]
+  func scan(_ tableName: String) throws -> [SqlRow]
+}
+
+/// A small data source useful for tests and embedded use.
+public final class InMemoryDataSource: SqlDataSource {
+  private var schemas: [String: [String]] = [:]
+  private var tables: [String: [SqlRow]] = [:]
+
+  public init() {}
+
+  @discardableResult
+  public func addTable(_ name: String, schema: [String], rows: [SqlRow]) -> Self {
+    schemas[name] = schema
+    tables[name] = rows
+    return self
+  }
+
+  public func schema(_ tableName: String) throws -> [String] {
+    guard let schema = schemas[tableName] else {
+      throw SqlExecutionError.tableNotFound(tableName)
+    }
+    return schema
+  }
+
+  public func scan(_ tableName: String) throws -> [SqlRow] {
+    guard let rows = tables[tableName] else {
+      throw SqlExecutionError.tableNotFound(tableName)
+    }
+    return rows
+  }
+}
+
+public struct QueryResult: Equatable {
+  public let columns: [String]
+  public let rows: [[SqlValue]]
+
+  public init(columns: [String], rows: [[SqlValue]]) {
+    self.columns = columns
+    self.rows = rows
+  }
+}
+
+public struct ExecutionResult: Equatable {
+  public let result: QueryResult?
+  public let error: String?
+
+  public var isSuccess: Bool { result != nil }
+
+  public init(result: QueryResult?, error: String?) {
+    self.result = result
+    self.error = error
+  }
+}
+
+public enum SqlExecutionError: Error, Equatable, CustomStringConvertible {
+  case parse(String)
+  case tableNotFound(String)
+  case columnNotFound(String)
+  case ambiguousColumn(String)
+  case typeMismatch(String)
+  case divisionByZero
+  case unknownFunction(String)
+
+  public var description: String {
+    switch self {
+    case .parse(let message): "parse error: \(message)"
+    case .tableNotFound(let name): "table not found: \(name)"
+    case .columnNotFound(let name): "column not found: \(name)"
+    case .ambiguousColumn(let name): "ambiguous column: \(name)"
+    case .typeMismatch(let message): "type mismatch: \(message)"
+    case .divisionByZero: "division by zero"
+    case .unknownFunction(let name): "unknown function: \(name)"
+    }
+  }
+}

--- a/code/packages/swift/sql-execution-engine/Sources/SqlExecutionEngine/Parser.swift
+++ b/code/packages/swift/sql-execution-engine/Sources/SqlExecutionEngine/Parser.swift
@@ -1,0 +1,538 @@
+private enum TokenKind: Equatable {
+  case identifier
+  case keyword
+  case number
+  case string
+  case symbol
+  case end
+}
+
+private struct Token: Equatable {
+  let kind: TokenKind
+  let value: String
+  let offset: Int
+}
+
+private let sqlKeywords: Set<String> = [
+  "SELECT", "FROM", "WHERE", "GROUP", "BY", "HAVING", "ORDER", "LIMIT", "OFFSET",
+  "DISTINCT", "ALL", "JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "CROSS",
+  "ON", "AS", "AND", "OR", "NOT", "IS", "NULL", "IN", "BETWEEN", "LIKE", "TRUE",
+  "FALSE", "ASC", "DESC",
+]
+
+private struct Lexer {
+  private let characters: [Character]
+  private var position = 0
+
+  init(_ source: String) {
+    characters = Array(source)
+  }
+
+  mutating func tokenize() throws -> [Token] {
+    var tokens: [Token] = []
+    while position < characters.count {
+      try skipTrivia()
+      guard position < characters.count else { break }
+      let start = position
+      let character = characters[position]
+
+      if character.isLetter || character == "_" {
+        let value = readIdentifier()
+        let upper = value.uppercased()
+        tokens.append(
+          Token(
+            kind: sqlKeywords.contains(upper) ? .keyword : .identifier,
+            value: sqlKeywords.contains(upper) ? upper : value,
+            offset: start
+          ))
+      } else if character.isNumber {
+        tokens.append(Token(kind: .number, value: readNumber(), offset: start))
+      } else if character == "'" {
+        tokens.append(Token(kind: .string, value: try readString(), offset: start))
+      } else if character == "`" || character == "\"" {
+        tokens.append(Token(kind: .identifier, value: try readQuotedIdentifier(), offset: start))
+      } else {
+        let pair =
+          position + 1 < characters.count
+          ? String([characters[position], characters[position + 1]])
+          : ""
+        if ["!=", "<>", "<=", ">="].contains(pair) {
+          tokens.append(Token(kind: .symbol, value: pair, offset: start))
+          position += 2
+        } else if "=<>+-*/%(),.;".contains(character) {
+          tokens.append(Token(kind: .symbol, value: String(character), offset: start))
+          position += 1
+        } else {
+          throw SqlExecutionError.parse("unexpected character '\(character)' at offset \(start)")
+        }
+      }
+    }
+    tokens.append(Token(kind: .end, value: "", offset: position))
+    return tokens
+  }
+
+  private mutating func skipTrivia() throws {
+    while position < characters.count {
+      if characters[position].isWhitespace {
+        position += 1
+      } else if hasPrefix("--") {
+        position += 2
+        while position < characters.count, characters[position] != "\n" { position += 1 }
+      } else if hasPrefix("/*") {
+        position += 2
+        while position + 1 < characters.count, !hasPrefix("*/") { position += 1 }
+        guard position + 1 < characters.count else {
+          throw SqlExecutionError.parse("unterminated block comment")
+        }
+        position += 2
+      } else {
+        return
+      }
+    }
+  }
+
+  private func hasPrefix(_ prefix: String) -> Bool {
+    let expected = Array(prefix)
+    guard position + expected.count <= characters.count else { return false }
+    return Array(characters[position..<position + expected.count]) == expected
+  }
+
+  private mutating func readIdentifier() -> String {
+    let start = position
+    while position < characters.count,
+      characters[position].isLetter || characters[position].isNumber || characters[position] == "_"
+    {
+      position += 1
+    }
+    return String(characters[start..<position])
+  }
+
+  private mutating func readNumber() -> String {
+    let start = position
+    while position < characters.count, characters[position].isNumber { position += 1 }
+    if position + 1 < characters.count,
+      characters[position] == ".", characters[position + 1].isNumber
+    {
+      position += 1
+      while position < characters.count, characters[position].isNumber { position += 1 }
+    }
+    return String(characters[start..<position])
+  }
+
+  private mutating func readString() throws -> String {
+    position += 1
+    var value = ""
+    while position < characters.count {
+      let character = characters[position]
+      if character == "'" {
+        if position + 1 < characters.count, characters[position + 1] == "'" {
+          value.append("'")
+          position += 2
+        } else {
+          position += 1
+          return value
+        }
+      } else if character == "\\", position + 1 < characters.count {
+        position += 1
+        value.append(characters[position])
+        position += 1
+      } else {
+        value.append(character)
+        position += 1
+      }
+    }
+    throw SqlExecutionError.parse("unterminated string literal")
+  }
+
+  private mutating func readQuotedIdentifier() throws -> String {
+    let quote = characters[position]
+    position += 1
+    let start = position
+    while position < characters.count, characters[position] != quote { position += 1 }
+    guard position < characters.count else {
+      throw SqlExecutionError.parse("unterminated quoted identifier")
+    }
+    let value = String(characters[start..<position])
+    position += 1
+    return value
+  }
+}
+
+indirect enum Expression {
+  case literal(SqlValue)
+  case column(table: String?, name: String)
+  case star
+  case unary(String, Expression)
+  case binary(String, Expression, Expression)
+  case isNull(Expression, negated: Bool)
+  case between(Expression, lower: Expression, upper: Expression, negated: Bool)
+  case inList(Expression, values: [Expression], negated: Bool)
+  case like(Expression, pattern: Expression, negated: Bool)
+  case function(String, [Expression])
+}
+
+struct SelectItem {
+  let expression: Expression
+  let alias: String?
+}
+
+struct TableReference {
+  let name: String
+  let alias: String
+}
+
+enum JoinType {
+  case inner
+  case left
+  case right
+  case full
+  case cross
+}
+
+struct JoinClause {
+  let type: JoinType
+  let table: TableReference
+  let condition: Expression?
+}
+
+struct OrderItem {
+  let expression: Expression
+  let descending: Bool
+}
+
+struct SelectStatement {
+  let distinct: Bool
+  let selectItems: [SelectItem]
+  let from: TableReference
+  let joins: [JoinClause]
+  let whereExpression: Expression?
+  let groupBy: [Expression]
+  let having: Expression?
+  let orderBy: [OrderItem]
+  let limit: Int?
+  let offset: Int?
+}
+
+struct SelectParser {
+  private let tokens: [Token]
+  private var position = 0
+
+  init(_ source: String) throws {
+    var lexer = Lexer(source)
+    tokens = try lexer.tokenize()
+  }
+
+  mutating func parse() throws -> SelectStatement {
+    try expectKeyword("SELECT")
+    let distinct = matchKeyword("DISTINCT")
+    _ = matchKeyword("ALL")
+    let selectItems = try parseSelectList()
+    try expectKeyword("FROM")
+    let from = try parseTableReference()
+    let joins = try parseJoins()
+    let whereExpression = matchKeyword("WHERE") ? try parseExpression() : nil
+
+    var groupBy: [Expression] = []
+    if matchKeyword("GROUP") {
+      try expectKeyword("BY")
+      groupBy = try parseExpressionList()
+    }
+    let having = matchKeyword("HAVING") ? try parseExpression() : nil
+
+    var orderBy: [OrderItem] = []
+    if matchKeyword("ORDER") {
+      try expectKeyword("BY")
+      orderBy = try parseOrderList()
+    }
+    let limit = matchKeyword("LIMIT") ? try expectInteger() : nil
+    let offset = matchKeyword("OFFSET") ? try expectInteger() : nil
+    _ = matchSymbol(";")
+    guard peek().kind == .end else { throw error("unexpected trailing token '\(peek().value)'") }
+
+    return SelectStatement(
+      distinct: distinct,
+      selectItems: selectItems,
+      from: from,
+      joins: joins,
+      whereExpression: whereExpression,
+      groupBy: groupBy,
+      having: having,
+      orderBy: orderBy,
+      limit: limit,
+      offset: offset
+    )
+  }
+
+  private mutating func parseSelectList() throws -> [SelectItem] {
+    var result: [SelectItem] = []
+    repeat {
+      if matchSymbol("*") {
+        result.append(SelectItem(expression: .star, alias: nil))
+      } else {
+        let expression = try parseExpression()
+        let alias: String?
+        if matchKeyword("AS") {
+          alias = try expectIdentifier()
+        } else if peek().kind == .identifier {
+          alias = advance().value
+        } else {
+          alias = nil
+        }
+        result.append(SelectItem(expression: expression, alias: alias))
+      }
+    } while matchSymbol(",")
+    return result
+  }
+
+  private mutating func parseTableReference() throws -> TableReference {
+    let name = try expectIdentifier()
+    let alias: String
+    if matchKeyword("AS") {
+      alias = try expectIdentifier()
+    } else if peek().kind == .identifier {
+      alias = advance().value
+    } else {
+      alias = name
+    }
+    return TableReference(name: name, alias: alias)
+  }
+
+  private mutating func parseJoins() throws -> [JoinClause] {
+    var result: [JoinClause] = []
+    while true {
+      let type: JoinType?
+      if matchKeyword("INNER") {
+        try expectKeyword("JOIN")
+        type = .inner
+      } else if matchKeyword("LEFT") {
+        _ = matchKeyword("OUTER")
+        try expectKeyword("JOIN")
+        type = .left
+      } else if matchKeyword("RIGHT") {
+        _ = matchKeyword("OUTER")
+        try expectKeyword("JOIN")
+        type = .right
+      } else if matchKeyword("FULL") {
+        _ = matchKeyword("OUTER")
+        try expectKeyword("JOIN")
+        type = .full
+      } else if matchKeyword("CROSS") {
+        try expectKeyword("JOIN")
+        type = .cross
+      } else if matchKeyword("JOIN") {
+        type = .inner
+      } else {
+        type = nil
+      }
+      guard let type else { break }
+      let table = try parseTableReference()
+      let condition: Expression?
+      if type == .cross {
+        condition = nil
+      } else {
+        try expectKeyword("ON")
+        condition = try parseExpression()
+      }
+      result.append(JoinClause(type: type, table: table, condition: condition))
+    }
+    return result
+  }
+
+  private mutating func parseExpressionList() throws -> [Expression] {
+    var result = [try parseExpression()]
+    while matchSymbol(",") { result.append(try parseExpression()) }
+    return result
+  }
+
+  private mutating func parseOrderList() throws -> [OrderItem] {
+    var result: [OrderItem] = []
+    repeat {
+      let expression = try parseExpression()
+      let descending = matchKeyword("DESC")
+      if !descending { _ = matchKeyword("ASC") }
+      result.append(OrderItem(expression: expression, descending: descending))
+    } while matchSymbol(",")
+    return result
+  }
+
+  private mutating func parseExpression() throws -> Expression { try parseOr() }
+
+  private mutating func parseOr() throws -> Expression {
+    var left = try parseAnd()
+    while matchKeyword("OR") { left = .binary("OR", left, try parseAnd()) }
+    return left
+  }
+
+  private mutating func parseAnd() throws -> Expression {
+    var left = try parseNot()
+    while matchKeyword("AND") { left = .binary("AND", left, try parseNot()) }
+    return left
+  }
+
+  private mutating func parseNot() throws -> Expression {
+    matchKeyword("NOT") ? .unary("NOT", try parseNot()) : try parseComparison()
+  }
+
+  private mutating func parseComparison() throws -> Expression {
+    let left = try parseAdditive()
+    if matchKeyword("IS") {
+      let negated = matchKeyword("NOT")
+      try expectKeyword("NULL")
+      return .isNull(left, negated: negated)
+    }
+    if matchKeyword("NOT") {
+      if matchKeyword("BETWEEN") {
+        let lower = try parseAdditive()
+        try expectKeyword("AND")
+        return .between(left, lower: lower, upper: try parseAdditive(), negated: true)
+      }
+      if matchKeyword("IN") {
+        return .inList(left, values: try parseParenthesizedList(), negated: true)
+      }
+      if matchKeyword("LIKE") {
+        return .like(left, pattern: try parseAdditive(), negated: true)
+      }
+      throw error("expected BETWEEN, IN, or LIKE after NOT")
+    }
+    if matchKeyword("BETWEEN") {
+      let lower = try parseAdditive()
+      try expectKeyword("AND")
+      return .between(left, lower: lower, upper: try parseAdditive(), negated: false)
+    }
+    if matchKeyword("IN") {
+      return .inList(left, values: try parseParenthesizedList(), negated: false)
+    }
+    if matchKeyword("LIKE") {
+      return .like(left, pattern: try parseAdditive(), negated: false)
+    }
+    if peek().kind == .symbol, ["=", "!=", "<>", "<", ">", "<=", ">="].contains(peek().value) {
+      let operation = advance().value
+      return .binary(operation, left, try parseAdditive())
+    }
+    return left
+  }
+
+  private mutating func parseParenthesizedList() throws -> [Expression] {
+    try expectSymbol("(")
+    let values = try parseExpressionList()
+    try expectSymbol(")")
+    return values
+  }
+
+  private mutating func parseAdditive() throws -> Expression {
+    var left = try parseMultiplicative()
+    while peek().kind == .symbol, ["+", "-"].contains(peek().value) {
+      let operation = advance().value
+      left = .binary(operation, left, try parseMultiplicative())
+    }
+    return left
+  }
+
+  private mutating func parseMultiplicative() throws -> Expression {
+    var left = try parseUnary()
+    while peek().kind == .symbol, ["*", "/", "%"].contains(peek().value) {
+      let operation = advance().value
+      left = .binary(operation, left, try parseUnary())
+    }
+    return left
+  }
+
+  private mutating func parseUnary() throws -> Expression {
+    matchSymbol("-") ? .unary("-", try parseUnary()) : try parsePrimary()
+  }
+
+  private mutating func parsePrimary() throws -> Expression {
+    let token = peek()
+    if matchSymbol("(") {
+      let expression = try parseExpression()
+      try expectSymbol(")")
+      return expression
+    }
+    if token.kind == .number {
+      _ = advance()
+      if token.value.contains("."), let value = Double(token.value) {
+        return .literal(.real(value))
+      }
+      guard let value = Int(token.value) else { throw error("invalid number '\(token.value)'") }
+      return .literal(.integer(value))
+    }
+    if token.kind == .string {
+      _ = advance()
+      return .literal(.text(token.value))
+    }
+    if matchKeyword("NULL") { return .literal(.null) }
+    if matchKeyword("TRUE") { return .literal(.boolean(true)) }
+    if matchKeyword("FALSE") { return .literal(.boolean(false)) }
+    if matchSymbol("*") { return .star }
+    if token.kind == .identifier || token.kind == .keyword {
+      let name = advance().value
+      if matchSymbol("(") {
+        var arguments: [Expression] = []
+        if !matchSymbol(")") {
+          if matchSymbol("*") {
+            arguments.append(.star)
+          } else {
+            arguments.append(try parseExpression())
+            while matchSymbol(",") { arguments.append(try parseExpression()) }
+          }
+          try expectSymbol(")")
+        }
+        return .function(name, arguments)
+      }
+      if matchSymbol(".") {
+        return .column(table: name, name: try expectIdentifier())
+      }
+      return .column(table: nil, name: name)
+    }
+    throw error("unexpected token '\(token.value)'")
+  }
+
+  private func peek() -> Token { tokens[position] }
+
+  @discardableResult
+  private mutating func advance() -> Token {
+    let token = tokens[position]
+    if token.kind != .end { position += 1 }
+    return token
+  }
+
+  private mutating func expectIdentifier() throws -> String {
+    let token = advance()
+    guard token.kind == .identifier || token.kind == .keyword else {
+      throw error("expected identifier")
+    }
+    return token.value
+  }
+
+  private mutating func expectInteger() throws -> Int {
+    let token = advance()
+    guard token.kind == .number, !token.value.contains("."), let value = Int(token.value) else {
+      throw error("expected integer")
+    }
+    return value
+  }
+
+  private mutating func expectKeyword(_ value: String) throws {
+    guard matchKeyword(value) else { throw error("expected \(value)") }
+  }
+
+  private mutating func matchKeyword(_ value: String) -> Bool {
+    guard peek().kind == .keyword, peek().value == value else { return false }
+    _ = advance()
+    return true
+  }
+
+  private mutating func expectSymbol(_ value: String) throws {
+    guard matchSymbol(value) else { throw error("expected '\(value)'") }
+  }
+
+  private mutating func matchSymbol(_ value: String) -> Bool {
+    guard peek().kind == .symbol, peek().value == value else { return false }
+    _ = advance()
+    return true
+  }
+
+  private func error(_ message: String) -> SqlExecutionError {
+    .parse("\(message) at offset \(peek().offset)")
+  }
+}

--- a/code/packages/swift/sql-execution-engine/Tests/SqlExecutionEngineTests/SqlExecutionEngineTests.swift
+++ b/code/packages/swift/sql-execution-engine/Tests/SqlExecutionEngineTests/SqlExecutionEngineTests.swift
@@ -1,0 +1,178 @@
+import SqlExecutionEngine
+import XCTest
+
+final class SqlExecutionEngineTests: XCTestCase {
+  func testInMemoryDataSourceCopiesSchemaAndReportsMissingTables() throws {
+    let source = makeSource()
+    XCTAssertEqual(try source.schema("employees"), ["id", "name", "dept", "salary", "active"])
+    XCTAssertEqual(try source.scan("employees").count, 5)
+    XCTAssertThrowsError(try source.schema("missing")) { error in
+      XCTAssertEqual(error as? SqlExecutionError, .tableNotFound("missing"))
+    }
+  }
+
+  func testSelectFilterArithmeticAndOrder() throws {
+    let result = try SqlEngine.execute(
+      "SELECT name, salary * 1.5 AS adjusted FROM employees "
+        + "WHERE active = true AND salary >= 70000 ORDER BY salary DESC",
+      dataSource: makeSource()
+    )
+    XCTAssertEqual(result.columns, ["name", "adjusted"])
+    XCTAssertEqual(
+      result.rows,
+      [
+        [.text("Alice"), .real(142_500)],
+        [.text("Bob"), .real(108_000)],
+      ])
+  }
+
+  func testNullBetweenInAndLikePredicates() throws {
+    let source = makeSource()
+    XCTAssertEqual(
+      try SqlEngine.execute("SELECT name FROM employees WHERE dept IS NULL", dataSource: source)
+        .rows,
+      [[.text("Dave")]]
+    )
+    XCTAssertEqual(
+      try SqlEngine.execute(
+        "SELECT name FROM employees WHERE salary BETWEEN 70000 AND 90000 "
+          + "AND dept IN ('Engineering', 'Marketing') AND name LIKE '_o%'",
+        dataSource: source
+      ).rows,
+      [[.text("Bob")]]
+    )
+  }
+
+  func testInnerAndOuterJoins() throws {
+    let source = makeSource()
+    let inner = try SqlEngine.execute(
+      "SELECT e.name, d.budget FROM employees AS e "
+        + "INNER JOIN departments AS d ON e.dept = d.dept ORDER BY e.id",
+      dataSource: source
+    )
+    XCTAssertEqual(inner.rows.count, 4)
+    XCTAssertEqual(inner.rows.first, [.text("Alice"), .integer(500_000)])
+
+    let left = try SqlEngine.execute(
+      "SELECT e.name, d.budget FROM employees e LEFT JOIN departments d "
+        + "ON e.dept = d.dept ORDER BY e.id",
+      dataSource: source
+    )
+    XCTAssertEqual(left.rows[3], [.text("Dave"), .null])
+
+    let full = try SqlEngine.execute(
+      "SELECT e.name, d.dept FROM employees e FULL JOIN departments d "
+        + "ON e.dept = d.dept WHERE e.name IS NULL OR d.dept IS NULL",
+      dataSource: source
+    )
+    XCTAssertEqual(full.rows, [[.text("Dave"), .null], [.null, .text("Sales")]])
+
+    let right = try SqlEngine.execute(
+      "SELECT e.name, d.dept FROM employees e RIGHT JOIN departments d "
+        + "ON e.dept = d.dept WHERE e.name IS NULL",
+      dataSource: source
+    )
+    XCTAssertEqual(right.rows, [[.null, .text("Sales")]])
+
+    let cross = try SqlEngine.execute(
+      "SELECT e.id, d.dept FROM employees e CROSS JOIN departments d",
+      dataSource: source
+    )
+    XCTAssertEqual(cross.rows.count, 20)
+
+    XCTAssertThrowsError(
+      try SqlEngine.execute(
+        "SELECT dept FROM employees e JOIN departments d ON e.dept = d.dept",
+        dataSource: source
+      )
+    ) { error in
+      XCTAssertEqual(error as? SqlExecutionError, .ambiguousColumn("dept"))
+    }
+  }
+
+  func testGroupingAggregatesAndHaving() throws {
+    let result = try SqlEngine.execute(
+      "SELECT dept, COUNT(*) AS cnt, SUM(salary) AS total, AVG(salary) AS average "
+        + "FROM employees WHERE dept IS NOT NULL GROUP BY dept "
+        + "HAVING COUNT(*) >= 1 ORDER BY dept",
+      dataSource: makeSource()
+    )
+    XCTAssertEqual(result.columns, ["dept", "cnt", "total", "average"])
+    XCTAssertEqual(
+      result.rows,
+      [
+        [.text("Engineering"), .integer(2), .real(183_000), .real(91_500)],
+        [.text("HR"), .integer(1), .real(70_000), .real(70_000)],
+        [.text("Marketing"), .integer(1), .real(72_000), .real(72_000)],
+      ])
+  }
+
+  func testDistinctLimitOffsetAndScalarFunctions() throws {
+    let result = try SqlEngine.execute(
+      "SELECT DISTINCT UPPER(dept) AS department FROM employees "
+        + "WHERE dept IS NOT NULL ORDER BY dept LIMIT 2 OFFSET 1",
+      dataSource: makeSource()
+    )
+    XCTAssertEqual(result.rows, [[.text("HR")], [.text("MARKETING")]])
+  }
+
+  func testSelectStarReturnsBareColumns() throws {
+    let result = try SqlEngine.execute(
+      "SELECT * FROM employees WHERE id = 1",
+      dataSource: makeSource()
+    )
+    XCTAssertEqual(result.columns, ["active", "dept", "id", "name", "salary"])
+    XCTAssertEqual(
+      result.rows,
+      [
+        [
+          .boolean(true), .text("Engineering"), .integer(1), .text("Alice"), .integer(95_000),
+        ]
+      ])
+  }
+
+  func testCommentsCaseInsensitivityAndQuotedIdentifiers() throws {
+    let result = try SqlEngine.execute(
+      "/* lead */ select `name` from employees -- tail\nwhere id = 2;",
+      dataSource: makeSource()
+    )
+    XCTAssertEqual(result.rows, [[.text("Bob")]])
+  }
+
+  func testTryExecuteAndSpecificErrors() throws {
+    let failed = SqlEngine.tryExecute("SELECT * FROM ghosts", dataSource: makeSource())
+    XCTAssertFalse(failed.isSuccess)
+    XCTAssertEqual(failed.error, "table not found: ghosts")
+
+    XCTAssertThrowsError(
+      try SqlEngine.execute("SELECT salary / 0 FROM employees", dataSource: makeSource())
+    ) { error in
+      XCTAssertEqual(error as? SqlExecutionError, .divisionByZero)
+    }
+  }
+
+  private func makeSource() -> InMemoryDataSource {
+    InMemoryDataSource()
+      .addTable(
+        "employees",
+        schema: ["id", "name", "dept", "salary", "active"],
+        rows: [
+          ["id": 1, "name": "Alice", "dept": "Engineering", "salary": 95_000, "active": true],
+          ["id": 2, "name": "Bob", "dept": "Marketing", "salary": 72_000, "active": true],
+          ["id": 3, "name": "Carol", "dept": "Engineering", "salary": 88_000, "active": false],
+          ["id": 4, "name": "Dave", "dept": nil, "salary": 60_000, "active": true],
+          ["id": 5, "name": "Eve", "dept": "HR", "salary": 70_000, "active": false],
+        ]
+      )
+      .addTable(
+        "departments",
+        schema: ["dept", "budget"],
+        rows: [
+          ["dept": "Engineering", "budget": 500_000],
+          ["dept": "Marketing", "budget": 200_000],
+          ["dept": "HR", "budget": 150_000],
+          ["dept": "Sales", "budget": 100_000],
+        ]
+      )
+  }
+}

--- a/code/packages/swift/sql-execution-engine/required_capabilities.json
+++ b/code/packages/swift/sql-execution-engine/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../../schemas/required-capabilities.schema.json",
+  "version": 1,
+  "package": "swift/sql-execution-engine",
+  "capabilities": [],
+  "justification": "Pure Swift in-memory SQL evaluation; callers provide data through the SqlDataSource protocol."
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -128,8 +128,8 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-One package/language slot remains to turn the final nearly complete package
-into a fully covered package.
+Priority 1 is complete. Every package that entered this wave at 14-of-15 now
+has an implementation in all 15 language lanes.
 
 ### Dart: complete
 
@@ -144,11 +144,10 @@ The dependency-shaped DT11/DT12 `b-tree`/`b-plus-tree` pair is complete.
 Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
 `huffman-tree`, `huffman-compression`, `lz77`, `lzss`, `lzw`.
 
-### Swift: 1 remaining port
+### Swift: complete
 
-- `sql-execution-engine`
-
-Completed in the Swift lane: `wasm-simulator`, `cli-builder`.
+Completed in the Swift lane: `wasm-simulator`, `cli-builder`,
+`sql-execution-engine`.
 
 Port dependency families together when doing so avoids temporary broken package
 graphs. Grammar-generated lexer/parser pairs should be generated from the shared
@@ -156,7 +155,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 375
+The 171 packages present in at least ten implementation languages need 374
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -168,7 +167,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
-| Swift | 51 | Data structures and generated frontends before native app surfaces |
+| Swift | 50 | Data structures and generated frontends before native app surfaces |
 | Java | 57 | Move with Kotlin |
 | Kotlin | 57 | Move with Java |
 | Dart | 106 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |


### PR DESCRIPTION
## Summary

- add a dependency-free Swift SELECT execution engine with typed SQL values and a pluggable data-source protocol
- support expressions, SQL NULL logic, INNER/LEFT/RIGHT/FULL/CROSS joins, grouping, aggregates, HAVING, ordering, DISTINCT, LIMIT, and OFFSET
- add nine native tests covering the execution pipeline, errors, comments, quoted identifiers, and all join modes
- mark Priority 1 complete and refresh the measured high-consensus backlog to 374 slots, including 50 in Swift

## Why this is next

`sql-execution-engine` was the final 14-of-15 package in Priority 1. The native Swift port keeps its SELECT parser local, matching existing language ports and avoiding a broken dependency graph while the reusable grammar-driven Swift SQL lexer/parser pair remains a separate Priority 2 wave.

## Validation

- `swift-format lint -r Sources Tests Package.swift`
- `swift test` (9 passed)
- `swift test -c release` (9 passed)
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py` (6 passed)
- collision-gated JSON parity report (0 collisions, 0 unknown language buckets)
- Markdown and CSV parity report generation
- required-capabilities JSON parse
- `git diff HEAD^ --check`