### PR TITLE
feat(sql): COLLATE on the left comparison operand (col COLLATE NOCASE = 'x')

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.32 — `COLLATE` on the left comparison operand
+
+`x COLLATE NOCASE = y` now folds the comparison just like `x = y COLLATE C`
+(and `WHERE name COLLATE NOCASE = 'foo'` matches per row). Grammar-only
+(sql-parser 0.1.16): the left-side COLLATE binds inside the `cmp_op` alternative,
+so it never steals an `ORDER BY … COLLATE …` clause's collation (that regression
+was caught by the differential oracle and fixed via ordered-choice backtracking).
+The planner reuses the merged `collate_name_after`/`wrap_collate` unchanged — the
+first COLLATE token wins, so a left collation takes precedence over a right one,
+matching SQLite. Two differential-oracle cases (`=` and a WHERE predicate) plus a
+parser regression test for ORDER BY COLLATE.
+
 ## 0.5.31 — `IS [NOT] DISTINCT FROM` (standard-SQL null-safe compare)
 
 `SELECT a IS DISTINCT FROM b`, `a IS NOT DISTINCT FROM b`, and the WHERE-predicate

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.31"
+version = "0.5.32"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1112,6 +1112,22 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id FROM t WHERE a IS NOT DISTINCT FROM b ORDER BY id",
     },
+    // ---- Lane 3: COLLATE on the LEFT comparison operand ------------------
+    // `x COLLATE C = y` folds the comparison just like `x = y COLLATE C`.
+    Case {
+        id: "collate_left_operand_nocase",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT ('A' COLLATE NOCASE = 'a') AS a, ('a ' COLLATE RTRIM = 'a') AS b FROM t",
+    },
+    // COLLATE on the LEFT operand of a WHERE predicate matches per row.
+    Case {
+        id: "collate_left_operand_where",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'BANANA')",
+        ],
+        query: "SELECT id FROM t WHERE name COLLATE NOCASE = 'apple' ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.16] - Unreleased
+
+### Added
+
+- **`COLLATE name` on the LEFT comparison operand** (`col COLLATE NOCASE = 'x'`),
+  mirroring the right-operand COLLATE. Placed at the START of the `cmp_op`
+  alternative so a trailing `COLLATE` with no following operator (an
+  `ORDER BY … COLLATE …` clause, whose `order_item` owns the collation)
+  backtracks and is left for that caller — no regression to sort collation. The
+  planner already takes the first COLLATE token, so a left collation wins over a
+  right one, matching SQLite.
 ## [0.1.15] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -434,6 +434,20 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::Sequence { elements: vec![
+                            // Optional `COLLATE name` on the LEFT operand
+                            // (`col COLLATE NOCASE = 'x'`). It lives at the START
+                            // of THIS cmp_op alternative — not before the whole
+                            // alternation — so that a trailing `COLLATE` with no
+                            // following `cmp_op` (e.g. `ORDER BY name COLLATE
+                            // NOCASE`, where the order_item owns the COLLATE)
+                            // fails this alternative and backtracks, leaving the
+                            // COLLATE for the caller. The planner takes the FIRST
+                            // COLLATE token, so a left collation wins over a right
+                            // one — matching SQLite — and applies it to both sides.
+                            GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                    GrammarElement::Literal { value: r#"COLLATE"#.to_string() },
+                                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                                ] }) },
                             GrammarElement::RuleReference { name: r#"cmp_op"#.to_string() },
                             GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                             // Optional `COLLATE name` on the right operand of a

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -688,6 +688,23 @@ mod tests {
         }
     }
 
+    /// `COLLATE name` on the LEFT operand of a comparison parses — and crucially
+    /// does NOT steal an `ORDER BY … COLLATE …` clause's collation (the left-side
+    /// COLLATE only binds when a comparison operator follows, else it backtracks).
+    #[test]
+    fn test_parse_left_operand_collate() {
+        for q in [
+            "SELECT 'A' COLLATE NOCASE = 'a' FROM t",
+            "SELECT x FROM t WHERE name COLLATE NOCASE = 'foo'",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "comparison"), "Expected comparison for {q:?}");
+        }
+        // Regression: ORDER BY COLLATE still routes the collation to order_item.
+        let ast = assert_program_root("SELECT name FROM t ORDER BY name COLLATE NOCASE");
+        assert!(find_rule(&ast, "order_item"), "Expected order_item to keep COLLATE");
+    }
+
     // -----------------------------------------------------------------------
     // Test 20: BETWEEN expression
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## `COLLATE` on the left comparison operand

Extends expr-level COLLATE to the **left** operand — `col COLLATE NOCASE = 'x'`,
`WHERE name COLLATE NOCASE = 'foo'` — mirroring the merged right-operand COLLATE.
**Rotation lane 3 (NULLS/COLLATE).** A small, clean win.

### Grammar-only — planner/VM unchanged
The merged `collate_name_after` already takes the **first** COLLATE token, so a
left-side collation naturally **wins** over a right-side one (matching SQLite),
and `wrap_collate` already applies it to both operands. So this is purely a
grammar addition.

### The subtlety (caught by the differential oracle)
A naive placement of the left-COLLATE *between the leading operand and the
comparison* **swallows** the collation that an `ORDER BY name COLLATE NOCASE`
clause needs (the `order_item` owns it), silently breaking sort collation — the
oracle flagged exactly this on the existing ORDER-BY-COLLATE cases. **Fix:** put
the left-COLLATE at the **start of the `cmp_op` alternative**, so a trailing
`COLLATE` with no following operator fails that alternative and **backtracks**,
leaving the collation for `order_item`. Ordered-choice backtracking does the
disambiguation for free.

### Tests
Two differential-oracle cases (`=` and a WHERE predicate) diffed against real
SQLite + a parser **regression** test asserting `ORDER BY … COLLATE …` still
routes the collation to `order_item`. Full affected set green; clippy clean.

### Security
Inline adversarial review **PASSED** — the addition is a single bounded, optional,
non-recursive keyword prefix; the memoized packrat PEG stays linear-time (no
ReDoS/backtracking blowup). Planner/VM untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
