### PR TITLE
feat(hl-french): Chapter 2 — Introducing Yourself

### DIFF
--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 2 — Introducing Yourself
+
+- New chapter built around the introduction dialogue (*Je m'appelle Susanne. /
+  Comment vous appelez-vous? / Je m'appelle David. / Enchanté.*), atom-first,
+  one word per lesson (`lessons/FR-C02-*`, `book/chapters/ch02-introductions.tex`):
+  - **je** ("I" ← *ego*; English *ego*)
+  - **(s')appeler** ("to call [oneself]" ← *appellāre*; *appeal*, *appellation*)
+    — introduces **reflexive verbs**.
+  - **je m'appelle…** — assembled: **"my name is…"** ("I call myself"), with the
+    literal *mon nom est* (← *nōmen*, English *noun*) as the stiffer alternative.
+  - **tu / vous** (familiar / formal "you" ← *tū / vōs*) — politeness by using
+    the plural on one person; contrasted with Spanish *usted*.
+  - **comment** ("how" ← *quo modo*; same source as Spanish *cómo*).
+  - **comment vous appelez-vous?** — **"what's your name?"** by inversion; the
+    informal *comment tu t'appelles?*.
+  - **enchanté(e)** ("pleased to meet you" ← *in-cantāre*; *enchant*,
+    *incantation*, *chant*) — gender agreement with the speaker.
+  - **practice** — the whole dialogue.
+- Also fixed two leftover beginner-audience slips the earlier pass missed
+  (`roadmap.md` "the learner's in-progress language"; `session-map.md` "the
+  Spanish twin"). Book compiles clean with XeLaTeX.
+
 ## Beginner-audience pass — Spanish no longer assumed as prior knowledge
 
 Corrected a systemic violation of HL00's Audience rule: the book and practice

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -6,6 +6,9 @@
   Comment vous appelez-vous? / Je m'appelle David. / Enchanté.*), atom-first,
   one word per lesson (`lessons/FR-C02-*`, `book/chapters/ch02-introductions.tex`):
   - **je** ("I" ← *ego*; English *ego*)
+  - **me** ("myself" ← Latin *mē*; English *me*, *my*, *mine*) — its own lesson,
+    with the reflexive set *me / te / se* traced. (Every atom of *je m'appelle*
+    is taught and rooted, not just glossed.)
   - **(s')appeler** ("to call [oneself]" ← *appellāre*; *appeal*, *appellation*)
     — introduces **reflexive verbs**.
   - **je m'appelle…** — assembled: **"my name is…"** ("I call myself"), with the

--- a/code/learning/human-languages/french/README.md
+++ b/code/learning/human-languages/french/README.md
@@ -27,9 +27,10 @@ is assumed: the text supplies every Spanish form in full, as enrichment, so the
   salut, bien, bon/bonne, le/la/les (gender), jour, bonjour, soir, bonsoir,
   nuit, bonne nuit, practice. In the book.
 - **Chapter 2 — Introducing Yourself**: authored ([`lessons/FR-C02-*`](./lessons/))
-  — je, (s')appeler, **je m'appelle** ("my name is"), **tu / vous**, comment,
-  **comment vous appelez-vous?** ("what's your name?"), enchanté(e), practice.
-  In the book.
+  — je, me, (s')appeler, **je m'appelle** ("my name is"), **tu / vous**,
+  comment, **comment vous appelez-vous?** ("what's your name?"), enchanté(e),
+  practice. In the book. (Every atom — *je*, *me*, *appelle* — traced to its
+  root.)
 - Later chapters mirror the Spanish roadmap's themes.
 
 ## Files

--- a/code/learning/human-languages/french/README.md
+++ b/code/learning/human-languages/french/README.md
@@ -26,8 +26,10 @@ is assumed: the text supplies every Spanish form in full, as enrichment, so the
 - **Chapter 1 — Greetings**: authored ([`lessons/FR-C01-*`](./lessons/)) —
   salut, bien, bon/bonne, le/la/les (gender), jour, bonjour, soir, bonsoir,
   nuit, bonne nuit, practice. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): je m'appelle, **tu / vous**
-  (informal vs formal "you"), comment, enchanté.
+- **Chapter 2 — Introducing Yourself**: authored ([`lessons/FR-C02-*`](./lessons/))
+  — je, (s')appeler, **je m'appelle** ("my name is"), **tu / vous**, comment,
+  **comment vous appelez-vous?** ("what's your name?"), enchanté(e), practice.
+  In the book.
 - Later chapters mirror the Spanish roadmap's themes.
 
 ## Files

--- a/code/learning/human-languages/french/book/book.tex
+++ b/code/learning/human-languages/french/book/book.tex
@@ -67,4 +67,6 @@ a gate. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
 \end{document}

--- a/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
@@ -1,0 +1,173 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you're glad to meet them:
+
+\begin{center}\itshape
+--- Je m'appelle Susanne.\\
+--- Comment vous appelez-vous?\\
+--- Je m'appelle David.\\
+--- Enchant\'{e}.
+\end{center}
+
+We build it the same way as the greetings: each piece taken apart first, then
+assembled. \emph{Practice lessons: \texttt{lessons/FR-C02-*.md}.}
+
+\section{\emph{je} --- ``I,'' the smallest word you own}
+\label{lesson:je}
+
+\begin{sounds}
+\emph{zhuh} --- soft \emph{j} (as in \emph{measure}), a light \emph{uh}. Before
+a vowel it elides to \emph{j'}: \emph{je ai} $\to$ \emph{j'ai}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{je} (``I'') $\leftarrow$ Latin \emph{ego}. The Latin form survives raw
+in English \textbf{ego}, \textbf{ego}ist, \textbf{ego}tism --- so the word for
+``I'' and the psychologist's ``ego'' are the \emph{same} ancient word, one worn
+down to a whisper (\emph{je}), one kept whole. (Spanish took \emph{ego} to
+\emph{yo}; French wore it further, to \emph{je}.)
+\end{cousinweb}
+
+\section{\emph{(s')appeler} --- ``to call,'' and ``to call \emph{oneself}''}
+\label{lesson:appeler}
+
+\begin{sounds}
+\emph{a-play}; the \emph{-er} ending of the infinitive is a plain ``ay.'' In
+\emph{m'appelle} the doubled \emph{ll} keeps a crisp ``l.''
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{appeler} (``to call'') $\leftarrow$ Latin \emph{appell\=are} (``to
+address, call by name''). A rich English family: \textbf{appeal} (call to a
+higher authority), \textbf{appell}ation (a name), \textbf{appell}ate (a court
+that hears appeals), \textbf{appell}ant. To name someone is, at root, to
+\emph{call} them.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Reflexive verbs --- doing something to yourself.} French makes ``to be
+called'' out of ``to call'' plus a little word that bounces the action back:
+\emph{s'appeler}, ``to call \emph{oneself}.'' That \emph{se} (``oneself'')
+changes for each person --- \emph{me} (myself), \emph{te} (yourself),
+\emph{se} (himself/herself). So ``I call myself'' needs \emph{me}: \emph{je
+\textbf{me} appelle} --- and, next lesson, \emph{me} elides to \emph{m'}.
+(English has this too, hidden: ``I call \emph{myself}.'')
+\end{grammarlens}
+
+\section{\emph{je m'appelle\ldots} --- ``my name is\ldots,'' literally ``I call myself''}
+\label{lesson:je-mappelle}
+
+\emph{je} (I) $+$ \emph{me} (myself, elided to \emph{m'} before the vowel) $+$
+\emph{appelle} (call) $=$ \textbf{je m'appelle\ldots} --- word for word ``I call
+myself\ldots,'' and the everyday way to say \textbf{``my name is\ldots''}
+\emph{Je m'appelle David.} = ``My name is David.''
+
+\begin{culture}
+French \emph{prefers} this verb-based ``I call myself'' to a literal ``my name
+is.'' The literal version, \emph{mon nom est\ldots} (``my name is\ldots,'' with
+\emph{nom} $\leftarrow$ Latin \emph{n\=omen} $\to$ English \textbf{noun},
+\textbf{nom}inate, \textbf{nom}inal), exists and is understood, but it sounds
+stiff or officious --- a form for a passport desk, not a introduction. Reach for
+\emph{je m'appelle}.
+\end{culture}
+
+\section{\emph{tu} / \emph{vous} --- ``you,'' familiar and formal}
+\label{lesson:tu-vous}
+
+\begin{cousinweb}
+\textbf{tu} (familiar ``you'') $\leftarrow$ Latin \emph{t\=u}; \textbf{vous}
+(formal/plural ``you'') $\leftarrow$ Latin \emph{v\=os} (``you all''). English
+lost the distinction --- old \emph{thou} was the \emph{tu}, now vanished, leaving
+one flat \emph{you} for everyone.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Two ``you''s, chosen by \emph{register}.} \emph{tu} is for friends,
+family, children, peers; \emph{vous} is for strangers, elders, anyone you'd
+show respect --- \emph{and} it doubles as the plural ``you all.'' French makes
+politeness by using the \emph{plural} on one person (the verb has its own name
+for this: \emph{vouvoyer}). This is the same politeness Spanish builds with
+\emph{usted}, but by a different mechanism: Spanish invented a new pronoun
+(from ``your grace''); French just uses ``you all'' for one respected person.
+Using \emph{tu} too soon can read as over-familiar --- when unsure, \emph{vous}.
+\end{grammarlens}
+
+\section{\emph{comment} --- ``how,'' the same \emph{quomodo} behind Spanish \emph{c\'{o}mo}}
+\label{lesson:comment}
+
+\begin{cousinweb}
+\textbf{comment} (``how'') $\leftarrow$ Latin \emph{quo modo} (``in what
+manner''), the two words fused and worn down. That exact phrase \emph{quomodo}
+also became Spanish \emph{c\'{o}mo} --- two Romance languages, one Latin
+``in-what-way,'' reshaped differently. The piece \emph{modo} (``manner, measure'')
+is itself alive in English \textbf{mode}, \textbf{mod}el, \textbf{mod}erate.
+\end{cousinweb}
+
+\begin{grammarlens}
+French uses \emph{comment} (``how'') where English uses ``what'' for names ---
+literally ``\emph{how} are you called?'', not ``\emph{what} is your name?''. The
+question is about the \emph{manner} of your calling. Keep the French logic:
+\emph{comment} $=$ ``how,'' and the name-question is built on it.
+\end{grammarlens}
+
+\section{\emph{comment vous appelez-vous?} --- ``what's your name?''}
+\label{lesson:comment-vous-appelez-vous}
+
+\emph{comment} (how) $+$ \emph{vous appelez-vous} (``do you call yourself,''
+with the verb and \emph{vous} swapped for a question) $=$ literally ``\textbf{how
+do you call yourself?}'' --- the polite ``what's your name?''
+
+\begin{grammarlens}
+\textbf{Asking by inversion.} A statement, \emph{vous vous appelez} (``you call
+yourself''), becomes a question by flipping verb and pronoun: \emph{vous
+appelez-\textbf{vous}?} (with a hyphen). The informal version simply swaps in
+\emph{tu}: \emph{comment tu t'appelles?} --- note \emph{te} elides to \emph{t'},
+exactly as \emph{me} became \emph{m'}.
+\end{grammarlens}
+
+\section{\emph{enchant\'{e}} --- ``delighted,'' i.e. ``pleased to meet you''}
+\label{lesson:enchante}
+
+\begin{sounds}
+\emph{ahn-shahn-TAY}: two nasal vowels (\emph{en}, \emph{an}), then a clean
+``tay.'' \emph{ch} $=$ English \emph{sh}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{enchant\'{e}} (``delighted'') $\leftarrow$ Latin \emph{in-} (``upon'')
+$+$ \emph{cant\=are} (``to sing, chant''): to \emph{enchant} was literally to
+\emph{sing a spell upon} someone. English kept the magic in \textbf{enchant},
+\textbf{incant}ation, and the plain \textbf{chant}. To say \emph{enchant\'{e}}
+on meeting someone is to say, gallantly, ``I'm \emph{enchanted}.''
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{It agrees with \emph{you}.} \emph{enchant\'{e}} follows the gender rule
+from \S\ref{lesson:le-la}: a man says \emph{enchant\'{e}}, a woman
+\emph{enchant\'{e}\textbf{e}} (an extra \emph{-e}, same sound). The adjective
+reports the speaker's own gender.
+\end{grammarlens}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+French & English \\
+\midrule
+\emph{Je m'appelle Susanne.} & My name is Susanne. \\
+\emph{Comment vous appelez-vous?} & What's your name? \\
+\emph{Je m'appelle David.} & My name is David. \\
+\emph{Enchant\'{e}.} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every piece was built from a root: \emph{je} from \emph{ego}, \emph{appeler}
+from \emph{appell\=are} (appeal/appellation), \emph{comment} from \emph{quo
+modo}, \emph{enchant\'{e}} from \emph{in-cant\=are}. Next chapter: \emph{Comment
+\c{c}a va?} (``how's it going?'') and answering with \emph{bien} again --- the
+recursive responding cycle.

--- a/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
@@ -5,9 +5,9 @@ Now a first real exchange --- giving your name, asking for someone else's, and
 saying you're glad to meet them:
 
 \begin{center}\itshape
---- Je m'appelle Susanne.\\
+--- Je m'appelle Mira.\\
 --- Comment vous appelez-vous?\\
---- Je m'appelle David.\\
+--- Je m'appelle Arun.\\
 --- Enchant\'{e}.
 \end{center}
 
@@ -41,7 +41,7 @@ down to a whisper (\emph{je}), one kept whole. (Spanish took \emph{ego} to
 \begin{cousinweb}
 \textbf{me} (``me, myself'') $\leftarrow$ Latin \emph{m\=e} (the accusative
 ``me'') --- literally the \emph{same} word as English \textbf{me}. The whole
-family grows from one Proto-Indo-European root \emph{\*me-}: English
+family grows from one Proto-Indo-European root \emph{*me-}: English
 \textbf{me}, \textbf{my}, \textbf{mine}; Latin \emph{m\=e} and \emph{meus}
 (``my,'' which became French \emph{mon} / \emph{ma} / \emph{mes}). So the little
 \emph{m'} in \emph{je m'appelle} is a first-person marker you have owned in
@@ -89,7 +89,7 @@ That is how French says a name --- not ``my name is'' but ``I call myself.''
 elided to \emph{m'} before the vowel) $+$ \emph{appelle} (call,
 \S\ref{lesson:appeler}) $=$ \textbf{je m'appelle\ldots} --- word for word ``I
 call myself\ldots,'' and the everyday way to say \textbf{``my name is\ldots''}
-\emph{Je m'appelle David.} = ``My name is David.'' Three atoms, each traced;
+\emph{Je m'appelle Arun.} = ``My name is Arun.'' Three atoms, each traced;
 now they click together.
 
 \begin{culture}
@@ -186,9 +186,9 @@ reports the speaker's own gender.
 \toprule
 French & English \\
 \midrule
-\emph{Je m'appelle Susanne.} & My name is Susanne. \\
+\emph{Je m'appelle Mira.} & My name is Mira. \\
 \emph{Comment vous appelez-vous?} & What's your name? \\
-\emph{Je m'appelle David.} & My name is David. \\
+\emph{Je m'appelle Arun.} & My name is Arun. \\
 \emph{Enchant\'{e}.} & Pleased to meet you. \\
 \bottomrule
 \end{tabular}

--- a/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
@@ -30,6 +30,34 @@ down to a whisper (\emph{je}), one kept whole. (Spanish took \emph{ego} to
 \emph{yo}; French wore it further, to \emph{je}.)
 \end{cousinweb}
 
+\section{\emph{me} --- ``myself,'' the same word as English \emph{me}}
+\label{lesson:me}
+
+\begin{sounds}
+\emph{muh} --- a light \emph{uh}, like \emph{je}. Before a vowel it elides to
+\emph{m'}: \emph{me appelle} $\to$ \emph{m'appelle}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{me} (``me, myself'') $\leftarrow$ Latin \emph{m\=e} (the accusative
+``me'') --- literally the \emph{same} word as English \textbf{me}. The whole
+family grows from one Proto-Indo-European root \emph{\*me-}: English
+\textbf{me}, \textbf{my}, \textbf{mine}; Latin \emph{m\=e} and \emph{meus}
+(``my,'' which became French \emph{mon} / \emph{ma} / \emph{mes}). So the little
+\emph{m'} in \emph{je m'appelle} is a first-person marker you have owned in
+English all your life.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{The reflexive set.} \emph{me} is one of three pronouns that bounce a
+verb back on its doer: \emph{me} (myself), \emph{te} (yourself), \emph{se}
+(himself/herself). Their roots run in parallel: \emph{te} $\leftarrow$ Latin
+\emph{t\=e} (cousin of archaic English \textbf{thee}), \emph{se} $\leftarrow$
+Latin \emph{s\=e} (the ``self'' root behind \textbf{se}parate and, distantly,
+\textbf{su}icide, \emph{su\={\i}} ``of oneself''). You'll use \emph{me} to say
+your name and \emph{te} in the informal ``what's your name?''
+\end{grammarlens}
+
 \section{\emph{(s')appeler} --- ``to call,'' and ``to call \emph{oneself}''}
 \label{lesson:appeler}
 
@@ -47,22 +75,22 @@ that hears appeals), \textbf{appell}ant. To name someone is, at root, to
 \end{cousinweb}
 
 \begin{grammarlens}
-\textbf{Reflexive verbs --- doing something to yourself.} French makes ``to be
-called'' out of ``to call'' plus a little word that bounces the action back:
-\emph{s'appeler}, ``to call \emph{oneself}.'' That \emph{se} (``oneself'')
-changes for each person --- \emph{me} (myself), \emph{te} (yourself),
-\emph{se} (himself/herself). So ``I call myself'' needs \emph{me}: \emph{je
-\textbf{me} appelle} --- and, next lesson, \emph{me} elides to \emph{m'}.
-(English has this too, hidden: ``I call \emph{myself}.'')
+\textbf{Reflexive verbs --- doing something to yourself.} Pair this verb with
+the \emph{me} you just met (\S\ref{lesson:me}) and you get \emph{s'appeler},
+``to call \emph{oneself}'': \emph{je \textbf{me} appelle}, ``I call myself.''
+That is how French says a name --- not ``my name is'' but ``I call myself.''
+(English has the same move, hidden in ``I call \emph{myself}.'')
 \end{grammarlens}
 
 \section{\emph{je m'appelle\ldots} --- ``my name is\ldots,'' literally ``I call myself''}
 \label{lesson:je-mappelle}
 
-\emph{je} (I) $+$ \emph{me} (myself, elided to \emph{m'} before the vowel) $+$
-\emph{appelle} (call) $=$ \textbf{je m'appelle\ldots} --- word for word ``I call
-myself\ldots,'' and the everyday way to say \textbf{``my name is\ldots''}
-\emph{Je m'appelle David.} = ``My name is David.''
+\emph{je} (I, \S\ref{lesson:je}) $+$ \emph{me} (myself, \S\ref{lesson:me},
+elided to \emph{m'} before the vowel) $+$ \emph{appelle} (call,
+\S\ref{lesson:appeler}) $=$ \textbf{je m'appelle\ldots} --- word for word ``I
+call myself\ldots,'' and the everyday way to say \textbf{``my name is\ldots''}
+\emph{Je m'appelle David.} = ``My name is David.'' Three atoms, each traced;
+now they click together.
 
 \begin{culture}
 French \emph{prefers} this verb-based ``I call myself'' to a literal ``my name

--- a/code/learning/human-languages/french/lessons/FR-C02-appeler.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-appeler.md
@@ -1,0 +1,63 @@
+---
+id: FR-C02-appeler
+chapter: 2
+type: word
+headword: (s')appeler
+gloss: to call / to call oneself
+concept_tag: VERB-CALL
+prerequisites: [FR-C02-je]
+sounds: [er-ending]
+roots: [appellare]
+est_minutes: 4
+reviews_of: [FR-C02-je]
+---
+
+# (s')appeler — "to call," and "to call *oneself*"
+
+## Warm-up
+
+[PAUSE 2s] French says "my name is" by saying "I call myself." Here's the verb
+that does it — and a fat English family riding on it.
+
+## Sounds you'll need
+
+- **appeler** = *a-play* — the *-er* infinitive ending is a plain "ay."
+- In **m'appelle** the doubled *ll* keeps a crisp "l": *ma-PELL*.
+
+## The word, taken apart
+
+**appeler** — "to call." Root: Latin **appellāre** ("to address, call by
+name"). The English cousins are everywhere in formal language:
+
+- **appeal** — to *call* to a higher authority.
+- **appell**ation — a name or title (an *appellation* of wine is its official
+  name).
+- **appell**ate, **appell**ant — the court that hears appeals, and the one who
+  brings it.
+
+To **name** someone is, at root, to **call** them.
+
+## Grammar Lens: reflexive verbs — doing something to yourself
+
+French builds "to be called" from "to call" plus a little word that bounces the
+action back onto the doer: **s'appeler**, "to call *oneself*." That bounce-back
+word changes for each person:
+
+- **me** = myself · **te** = yourself · **se** = himself/herself.
+
+So "I call myself" needs **me**: *je **me** appelle* → (elided) *je m'appelle*.
+English hides the same move in "I call **myself**" — French just uses it as the
+normal way to give a name.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "appeler" (*a-play*)]
+- [YOU SAY: the English cousins — *appeal*, *appellation*]
+- [YOU SAY: "call oneself" with *me* — *je me appelle*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is **appeler** from, and two English cousins? (*appellāre*
+— *appeal*, *appellation*.) What does a *reflexive* verb do, and which little
+word means "myself"? (Bounces the action back on the doer; *me*.)

--- a/code/learning/human-languages/french/lessons/FR-C02-comment-vous-appelez-vous.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-comment-vous-appelez-vous.md
@@ -1,0 +1,56 @@
+---
+id: FR-C02-comment-vous-appelez-vous
+chapter: 2
+type: phrase
+headword: comment vous appelez-vous?
+gloss: what's your name? (literally "how do you call yourself?")
+concept_tag: WHATS-YOUR-NAME
+prerequisites: [FR-C02-comment, FR-C02-tu-vous, FR-C02-appeler]
+sounds: [liaison]
+roots: [quo-modo, appellare, vos]
+est_minutes: 4
+reviews_of: [FR-C02-comment, FR-C02-tu-vous, FR-C02-je-mappelle]
+---
+
+# comment vous appelez-vous? — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Assemble it: "how" + "do you call yourself" = the polite question
+that gets the introduction going.
+
+## The phrase, assembled
+
+- **comment** (how) + **vous appelez-vous** ("do you call yourself").
+
+> **comment vous appelez-vous?** = literally "**how do you call yourself?**" =
+> the polite **"what's your name?"**
+
+## Grammar Lens: asking by inversion
+
+A statement — *vous vous appelez* ("you call yourself") — becomes a **question**
+by flipping the verb and the pronoun, joined with a hyphen:
+
+> *vous appelez-**vous**?*
+
+That flip is French's formal way to ask anything. The **informal** version
+simply swaps in *tu*:
+
+> *comment **tu t'appelles**?* — note *te* elides to **t'**, exactly as *me*
+> became *m'* in *je m'appelle*.
+
+So the same verb, *s'appeler*, runs the whole exchange: *je m'appelle* to give
+your name, *comment vous appelez-vous?* to ask for theirs.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "comment vous appelez-vous?" (formal)]
+- [YOU SAY: the informal — "comment tu t'appelles?"]
+- [YOU SAY: the pair — ask, then answer: "…vous appelez-vous?" / "je m'appelle…"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **comment vous appelez-vous?** literally say? ("How do you
+call yourself?") How do you turn the statement into a question, and what's the
+*tu* version? (Invert verb + pronoun with a hyphen; *comment tu t'appelles?*)

--- a/code/learning/human-languages/french/lessons/FR-C02-comment.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-comment.md
@@ -1,0 +1,55 @@
+---
+id: FR-C02-comment
+chapter: 2
+type: word
+headword: comment
+gloss: how
+concept_tag: HOW
+prerequisites: [FR-C02-tu-vous]
+sounds: [nasal-on]
+roots: [quo-modo]
+est_minutes: 3
+reviews_of: [FR-C02-tu-vous, FR-C02-je-mappelle]
+---
+
+# comment — "how," from the same *quomodo* as Spanish *cómo*
+
+## Warm-up
+
+[PAUSE 2s] French asks "what's your name?" as "**how** are you called?" — so
+first, the word for "how."
+
+## Sounds you'll need
+
+- **comment** = *ko-MAHN* — the final *-ent* is a **nasal** vowel; the *t* is
+  silent.
+
+## The word, taken apart
+
+**comment** — "how." Root: Latin **quo modo**, "in what manner" — two words
+fused and worn into one.
+
+- That same **quomodo** also became Spanish **cómo** — two Romance languages,
+  one Latin "in-what-way," reshaped differently.
+- The piece **modo** ("manner, measure") is alive in English **mode**,
+  **mod**el, **mod**erate, **mod**ify — all about the *way* a thing is done.
+
+## Grammar Lens: French counts names as a matter of "how"
+
+Where English asks "**what** is your name?", French asks "**how** are you
+called?" — *comment* (how), not *what*. The question is about the *manner* of
+your calling, not a thing to be named. Don't translate word for word; learn the
+French logic: the name-question runs on **comment**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "comment" (*ko-MAHN*, nasal ending)]
+- [YOU SAY: the Latin *quo modo* → French *comment*, Spanish *cómo*]
+- [YOU SAY: English *mode/model* share the *modo* piece]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two Latin words fused into **comment**, and what Spanish word
+shares them? (*quo modo* — Spanish *cómo*.) English asks "what is your name?" —
+what does French literally ask? ("*How* are you called?")

--- a/code/learning/human-languages/french/lessons/FR-C02-enchante.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-enchante.md
@@ -1,0 +1,57 @@
+---
+id: FR-C02-enchante
+chapter: 2
+type: word
+headword: enchanté(e)
+gloss: pleased to meet you (literally "enchanted")
+concept_tag: PLEASED-TO-MEET
+prerequisites: [FR-C02-je-mappelle]
+sounds: [nasal-on, nasal-an, ch-sh]
+roots: [in-cantare]
+est_minutes: 3
+reviews_of: [FR-C02-je-mappelle, FR-C01-le-la]
+---
+
+# enchanté(e) — "delighted," i.e. "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The graceful close to an introduction — and it literally says you've
+been put under a spell.
+
+## Sounds you'll need
+
+- **enchanté** = *ahn-shahn-TAY* — two **nasal** vowels (*en*, *an*), then a
+  clean "tay." **ch** = English *sh*.
+
+## The word, taken apart
+
+**enchanté** — "delighted." Root: Latin **in-** ("upon") + **cantāre** ("to
+sing, chant"). To *enchant* was literally to **sing a spell upon** someone. The
+magic survives in the English family:
+
+- **enchant**, **incant**ation, and the plain **chant**.
+
+So saying *enchanté* on meeting someone means, gallantly, "I'm **enchanted**
+[to meet you]."
+
+## Grammar Lens: it agrees with *you*
+
+*enchanté* follows the gender-agreement rule of *bon/bonne* from Chapter 1: it
+reports the **speaker's own gender**.
+
+- A man says **enchanté**.
+- A woman says **enchantée** — an extra *-e* (same sound, silent).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "enchanté" (*ahn-shahn-TAY*)]
+- [YOU SAY: the English cousins — *enchant*, *incantation*, *chant*]
+- [YOU SAY: both forms — *enchanté* (m.) / *enchantée* (f.)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **enchanté** literally mean, and from what Latin pieces?
+("Enchanted" — *in-* + *cantāre*, "to sing upon.") How does a woman say it, and
+why? (*enchantée* — it agrees with the speaker's gender.)

--- a/code/learning/human-languages/french/lessons/FR-C02-je-mappelle.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-je-mappelle.md
@@ -5,11 +5,11 @@ type: phrase
 headword: je m'appelle…
 gloss: my name is… (literally "I call myself…")
 concept_tag: MY-NAME-IS
-prerequisites: [FR-C02-je, FR-C02-appeler]
+prerequisites: [FR-C02-je, FR-C02-me, FR-C02-appeler]
 sounds: [elision]
-roots: [ego, appellare, nomen]
+roots: [ego, me-latin, appellare, nomen]
 est_minutes: 4
-reviews_of: [FR-C02-je, FR-C02-appeler]
+reviews_of: [FR-C02-je, FR-C02-me, FR-C02-appeler]
 ---
 
 # je m'appelle… — "my name is…," literally "I call myself"
@@ -20,6 +20,10 @@ reviews_of: [FR-C02-je, FR-C02-appeler]
 the single most useful sentence for meeting anyone.
 
 ## The phrase, assembled
+
+Three atoms, each already taken apart on its own — [je](FR-C02-je.md) (I, ←
+*ego*), [me](FR-C02-me.md) (myself, ← *mē*), [appelle](FR-C02-appeler.md)
+(call, ← *appellāre*):
 
 - **je** (I) + **me** (myself) + **appelle** (call).
 - *me* elides before the vowel of *appelle* → **m'**.

--- a/code/learning/human-languages/french/lessons/FR-C02-je-mappelle.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-je-mappelle.md
@@ -30,8 +30,8 @@ Three atoms, each already taken apart on its own — [je](FR-C02-je.md) (I, ←
 
 > **je m'appelle…** = word for word "I call myself…" = **"my name is…"**
 
-*Je m'appelle David.* → "My name is David." *Je m'appelle Susanne.* → "My name
-is Susanne."
+*Je m'appelle Arun.* → "My name is Arun." *Je m'appelle Mira.* → "My name
+is Mira."
 
 ## Why it's said this way
 

--- a/code/learning/human-languages/french/lessons/FR-C02-je-mappelle.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-je-mappelle.md
@@ -1,0 +1,56 @@
+---
+id: FR-C02-je-mappelle
+chapter: 2
+type: phrase
+headword: je m'appelle…
+gloss: my name is… (literally "I call myself…")
+concept_tag: MY-NAME-IS
+prerequisites: [FR-C02-je, FR-C02-appeler]
+sounds: [elision]
+roots: [ego, appellare, nomen]
+est_minutes: 4
+reviews_of: [FR-C02-je, FR-C02-appeler]
+---
+
+# je m'appelle… — "my name is…," literally "I call myself"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the two pieces you just met — *je* and *(s')appeler* — into
+the single most useful sentence for meeting anyone.
+
+## The phrase, assembled
+
+- **je** (I) + **me** (myself) + **appelle** (call).
+- *me* elides before the vowel of *appelle* → **m'**.
+
+> **je m'appelle…** = word for word "I call myself…" = **"my name is…"**
+
+*Je m'appelle David.* → "My name is David." *Je m'appelle Susanne.* → "My name
+is Susanne."
+
+## Why it's said this way
+
+French *prefers* this verb-based "I call myself" to a literal "my name is." The
+literal form does exist:
+
+- **mon nom est…** ("my name is…"), with **nom** ("name") ← Latin **nōmen** →
+  English **noun**, **nom**inate, **nom**inal, **nom**enclature.
+
+But *mon nom est* sounds stiff and official — a passport-desk phrase. For a
+real introduction, reach for **je m'appelle**. (You now also see why "noun" is
+literally "a naming word.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "je m'appelle…" then your own name]
+- [YOU SAY: what it *literally* says ("I call myself")]
+- [YOU SAY: the stiff literal alternative — "mon nom est…"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **je m'appelle** literally mean, and why does *me* become
+*m'*? ("I call myself"; elision before the vowel of *appelle*.) What's the more
+literal but stiffer "my name is," and what English word is *nom* cousin to?
+(*mon nom est*; *noun*.)

--- a/code/learning/human-languages/french/lessons/FR-C02-je.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-je.md
@@ -1,0 +1,50 @@
+---
+id: FR-C02-je
+chapter: 2
+type: word
+headword: je
+gloss: I
+concept_tag: PRONOUN-I
+prerequisites: []
+sounds: [soft-j, elision]
+roots: [ego]
+est_minutes: 3
+reviews_of: [FR-C01-bonjour]
+---
+
+# je — "I," the smallest word you own
+
+## Warm-up
+
+[PAUSE 2s] To introduce yourself you need "I." French's is tiny — but it comes
+from a word you already own whole in English.
+
+## Sounds you'll need
+
+- **je** = *zhuh* — a soft *j* (as in *measure*) plus a light *uh*.
+- Before a vowel it **elides**: *je ai* → **j'ai** ("I have"). You'll see the
+  same squeeze in *je m'appelle*.
+
+## The word, taken apart
+
+**je** — "I." Root: Latin **ego**. That Latin form survives *raw* in English:
+
+- **ego**, **ego**ist, **ego**tism, **ego**centric — the "I" at the center of
+  the self.
+
+So the word for "I" and the psychologist's *ego* are the **same** ancient word
+— one worn down to a whisper (*je*), one kept whole (*ego*). (Spanish wore
+*ego* down to *yo*; French wore it further, to *je*.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "je" (*zhuh*)]
+- [YOU SAY: the elision — "je ai" → "j'ai"]
+- [YOU SAY: the English cousin that kept the Latin whole — *ego*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word is **je** worn down from, and what English word kept
+it whole? (*ego* — English *ego*.) What happens to *je* before a vowel?
+(It elides to *j'*.)

--- a/code/learning/human-languages/french/lessons/FR-C02-me.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-me.md
@@ -1,0 +1,66 @@
+---
+id: FR-C02-me
+chapter: 2
+type: word
+headword: me
+gloss: me / myself (reflexive & object pronoun)
+concept_tag: PRONOUN-ME
+prerequisites: [FR-C02-je]
+sounds: [soft-e, elision]
+roots: [me-latin]
+est_minutes: 3
+reviews_of: [FR-C02-je]
+---
+
+# me — "myself," the same word as English *me*
+
+## Warm-up
+
+[PAUSE 2s] The middle piece of *je m'appelle*. It's a real word with a real
+history — not just a bit of glue — and you've owned it in English all your life.
+
+## Sounds you'll need
+
+- **me** = *muh* — a light *uh*, like *je*.
+- Before a vowel it **elides**: *me appelle* → **m'appelle** (the *e* drops,
+  the words fuse).
+
+## The word, taken apart
+
+**me** — "me / myself." Root: Latin **mē** (the accusative "me") — literally the
+**same** word as English **me**. The whole family grows from one
+Proto-Indo-European root **\*me-**:
+
+- English **me**, **my**, **mine**;
+- Latin **mē** and **meus** ("my"), which became French *mon / ma / mes*.
+
+So the tiny *m'* in *je m'appelle* is a first-person marker you've carried in
+English since childhood — *me*, *my*, *mine* are its cousins.
+
+## Grammar Lens: the reflexive set (me / te / se)
+
+*me* is one of three little pronouns that **bounce a verb back onto its doer**:
+
+| French | means | root | English cousin |
+|---|---|---|---|
+| **me** | myself | Latin *mē* | **me**, **my**, **mine** |
+| **te** | yourself | Latin *tē* | archaic **thee** |
+| **se** | himself/herself | Latin *sē* | the "self" root in **se**parate |
+
+You'll use **me** to give your own name (*je m'appelle*) and **te** in the
+informal "what's your name?" (*comment tu t'appelles?*). Same machine, different
+person.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "me" (*muh*), then its elision — "m'appelle"]
+- [YOU SAY: the English cousins from the same root — *me*, *my*, *mine*]
+- [YOU SAY: the set — *me* (myself), *te* (yourself), *se* (oneself)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word is **me** from, and what three English words share
+its root? (*mē* — *me*, *my*, *mine*.) What are its two siblings, and what does
+*me* do to a verb? (*te*, *se*; it bounces the action back onto the doer —
+reflexive.)

--- a/code/learning/human-languages/french/lessons/FR-C02-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-practice.md
@@ -1,0 +1,56 @@
+---
+id: FR-C02-practice
+chapter: 2
+type: practice
+headword: (dialogue)
+gloss: Chapter 2 recap — the introduction exchange
+concept_tag: REVIEW
+prerequisites: [FR-C02-je-mappelle, FR-C02-comment-vous-appelez-vous, FR-C02-enchante]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [FR-C02-je, FR-C02-appeler, FR-C02-je-mappelle, FR-C02-tu-vous, FR-C02-comment, FR-C02-comment-vous-appelez-vous, FR-C02-enchante]
+---
+
+# Chapter 2 — the introduction, whole
+
+## Warm-up
+
+[PAUSE 2s] Every piece is built. Here's the exchange it was all for.
+
+## The dialogue
+
+| French | English |
+|---|---|
+| *Je m'appelle Susanne.* | My name is Susanne. |
+| *Comment vous appelez-vous?* | What's your name? |
+| *Je m'appelle David.* | My name is David. |
+| *Enchanté.* | Pleased to meet you. |
+
+Every piece traced to a root:
+
+- **je** ← *ego* (English *ego*)
+- **(s')appeler** ← *appellāre* (English *appeal*, *appellation*)
+- **comment** ← *quo modo* (Spanish *cómo*, English *mode*)
+- **enchanté** ← *in-cantāre* (English *enchant*, *incantation*, *chant*)
+
+And two habits of French to keep: it gives a name with a **reflexive verb**
+("I call *myself*") and asks for one with **"how"** ("*how* are you called?"),
+and it makes politeness by using the **plural** *vous* on one person.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the whole exchange, both voices]
+- [YOU SAY: your own introduction — "je m'appelle …, enchanté(e)"]
+- [YOU SAY: ask it back — "comment vous appelez-vous?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in French, ask someone else's, and say you're pleased
+to meet them. (*Je m'appelle… / Comment vous appelez-vous? / Enchanté(e).*)
+Which two French habits does this exchange show? (Naming with a reflexive verb;
+asking with "how," not "what.")
+
+Next chapter: *Comment ça va?* ("how's it going?") and answering with *bien*
+again — the responding cycle.

--- a/code/learning/human-languages/french/lessons/FR-C02-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-practice.md
@@ -22,9 +22,9 @@ reviews_of: [FR-C02-je, FR-C02-me, FR-C02-appeler, FR-C02-je-mappelle, FR-C02-tu
 
 | French | English |
 |---|---|
-| *Je m'appelle Susanne.* | My name is Susanne. |
+| *Je m'appelle Mira.* | My name is Mira. |
 | *Comment vous appelez-vous?* | What's your name? |
-| *Je m'appelle David.* | My name is David. |
+| *Je m'appelle Arun.* | My name is Arun. |
 | *Enchanté.* | Pleased to meet you. |
 
 Every piece traced to a root:

--- a/code/learning/human-languages/french/lessons/FR-C02-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-practice.md
@@ -9,7 +9,7 @@ prerequisites: [FR-C02-je-mappelle, FR-C02-comment-vous-appelez-vous, FR-C02-enc
 sounds: []
 roots: []
 est_minutes: 5
-reviews_of: [FR-C02-je, FR-C02-appeler, FR-C02-je-mappelle, FR-C02-tu-vous, FR-C02-comment, FR-C02-comment-vous-appelez-vous, FR-C02-enchante]
+reviews_of: [FR-C02-je, FR-C02-me, FR-C02-appeler, FR-C02-je-mappelle, FR-C02-tu-vous, FR-C02-comment, FR-C02-comment-vous-appelez-vous, FR-C02-enchante]
 ---
 
 # Chapter 2 — the introduction, whole
@@ -30,6 +30,7 @@ reviews_of: [FR-C02-je, FR-C02-appeler, FR-C02-je-mappelle, FR-C02-tu-vous, FR-C
 Every piece traced to a root:
 
 - **je** ← *ego* (English *ego*)
+- **me** ← *mē* (English *me*, *my*, *mine*)
 - **(s')appeler** ← *appellāre* (English *appeal*, *appellation*)
 - **comment** ← *quo modo* (Spanish *cómo*, English *mode*)
 - **enchanté** ← *in-cantāre* (English *enchant*, *incantation*, *chant*)

--- a/code/learning/human-languages/french/lessons/FR-C02-tu-vous.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-tu-vous.md
@@ -1,0 +1,59 @@
+---
+id: FR-C02-tu-vous
+chapter: 2
+type: word
+headword: tu / vous
+gloss: you (familiar / formal)
+concept_tag: PRONOUN-YOU
+prerequisites: [FR-C02-je]
+sounds: [front-rounded-u]
+roots: [tu, vos]
+est_minutes: 4
+reviews_of: [FR-C02-je, FR-C02-appeler]
+---
+
+# tu / vous — "you," familiar and formal
+
+## Warm-up
+
+[PAUSE 2s] To *ask* someone their name, you need "you." French has two, and
+choosing between them is a small act of social judgment.
+
+## Sounds you'll need
+
+- **tu** = *too*, but with the front-rounded French *u* (lips rounded, tongue
+  forward). **vous** = *voo* (silent *s*).
+
+## The word, taken apart
+
+- **tu** (familiar "you") ← Latin **tū**.
+- **vous** (formal / plural "you") ← Latin **vōs**, "you all."
+
+English once had the same split — old **thou** was the *tu* — but *thou* died
+out, leaving one flat **you** for everyone.
+
+## Grammar Lens: two "you"s, chosen by register
+
+- **tu** — for friends, family, children, peers. Intimate, equal.
+- **vous** — for strangers, elders, anyone you'd show respect — **and** it's the
+  plural "you all."
+
+The trick: French makes politeness by using the **plural** on a single person.
+Addressing one respected person as "you all" is the polite move (French even has
+a verb for it, *vouvoyer*). This is the same politeness Spanish builds with
+*usted*, but by a different route: Spanish coined a whole new pronoun (from
+"your grace"); French just borrows its plural. Using *tu* too early can feel
+over-familiar — **when in doubt, *vous***.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tu" (front-rounded *u*), "vous" (*voo*)]
+- [YOU SAY: who gets *tu* (friends), who gets *vous* (strangers, elders)]
+- [YOU SAY: the rule of thumb — "when in doubt, *vous*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What decides *tu* vs *vous* — and what does French do to be polite to
+one person? (Register — familiar vs respect; it uses the *plural* (*vous*) on
+one person.) What old English word was the lost *tu*? (*thou*.)

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -14,9 +14,10 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
 
 - **Ch. 1 — Greetings**: salut → bien → bon/bonne → **le/la/les** (gender) →
   jour → **bonjour** → soir → bonsoir → nuit → **bonne nuit** → practice.
-- **Ch. 2 — Introducing Yourself**: je → (s')appeler → **je m'appelle** ("my
-  name is") → **tu / vous** → comment → **comment vous appelez-vous?** →
-  enchanté(e) → practice.
+- **Ch. 2 — Introducing Yourself**: je → **me** → (s')appeler → **je
+  m'appelle** ("my name is") → **tu / vous** → comment → **comment vous
+  appelez-vous?** → enchanté(e) → practice. (Every atom traced, *me* ← *mē*
+  included.)
 
 ## Planned (mirrors the Spanish theme sequence)
 

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -6,23 +6,25 @@ French. Lessons are slug-identified; order lives in the book (LaTeX
 auto-numbers) and [`session-map.md`](./session-map.md). See
 [`HL00`](../../../specs/HL00-human-language-curriculum-framework.md).
 
-Grounding (per `HL00`): English + Latin roots, **plus Spanish** — the
-learner's in-progress language — so the Romance twins can be compared and
-contrasted directly.
+Grounding (per `HL00`): English + Latin roots, **plus its closest Romance
+sibling, Spanish** — both worn-down Latin — so the two daughters can be
+compared, every Spanish form supplied in full (no prior Spanish assumed).
 
 ## Authored
 
 - **Ch. 1 — Greetings**: salut → bien → bon/bonne → **le/la/les** (gender) →
   jour → **bonjour** → soir → bonsoir → nuit → **bonne nuit** → practice.
+- **Ch. 2 — Introducing Yourself**: je → (s')appeler → **je m'appelle** ("my
+  name is") → **tu / vous** → comment → **comment vous appelez-vous?** →
+  enchanté(e) → practice.
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: je m'appelle, **tu / vous** (informal vs formal "you"), comment, enchanté, comment ça va |
 | 3 | Responding: ça va, très bien, merci, et vous/et toi |
 | 4 | Farewells: au revoir, à bientôt, à demain |
-| 5+ | Numbers, time, days & months, family, food — following the Spanish theme order, always with the Spanish twin in view |
+| 5+ | Numbers, time, days & months, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
 
 The *tu/vous* lesson (Ch. 2) is the French counterpart to Spanish *tú/usted*:
 same formal/informal split, but French makes the formal from the **plural**

--- a/code/learning/human-languages/french/session-map.md
+++ b/code/learning/human-languages/french/session-map.md
@@ -25,13 +25,14 @@ authoritative order.
 | Session | New lesson(s) | Introduces |
 |---|---|---|
 | 10 | je | "I" (← *ego*; English *ego*) |
-| 11 | (s')appeler | "to call [oneself]" (← *appellāre*); **reflexive verbs** |
-| 12 | je m'appelle… | **"my name is…"** assembled (+ literal *mon nom est*) |
-| 13 | tu / vous | familiar / formal **"you"** (← *tū / vōs*); politeness by plural |
-| 14 | comment | "how" (← *quo modo*; Spanish *cómo*) |
-| 15 | comment vous appelez-vous? | **"what's your name?"** by inversion |
-| 16 | enchanté(e) | "pleased to meet you" (← *in-cantāre*); gender agreement |
-| 17 | practice | the whole introduction dialogue |
+| 11 | me | "myself" (← *mē*; English *me/my/mine*); the reflexive set me/te/se |
+| 12 | (s')appeler | "to call [oneself]" (← *appellāre*); **reflexive verbs** |
+| 13 | je m'appelle… | **"my name is…"** assembled from je + me + appelle |
+| 14 | tu / vous | familiar / formal **"you"** (← *tū / vōs*); politeness by plural |
+| 15 | comment | "how" (← *quo modo*; Spanish *cómo*) |
+| 16 | comment vous appelez-vous? | **"what's your name?"** by inversion |
+| 17 | enchanté(e) | "pleased to meet you" (← *in-cantāre*); gender agreement |
+| 18 | practice | the whole introduction dialogue |
 
 Reviews of earlier words fold into each session per the interval schedule.
 

--- a/code/learning/human-languages/french/session-map.md
+++ b/code/learning/human-languages/french/session-map.md
@@ -1,17 +1,17 @@
-# Session Map — French Chapter 1 (Greetings)
+# Session Map — French Chapters 1–2
 
-How Chapter 1's lessons compose into commute sessions. Mechanics in
+How the lessons compose into commute sessions. Mechanics in
 [`HL00`](../../../specs/HL00-human-language-curriculum-framework.md); same
-spaced-repetition schedule as Spanish (a word from session *N* resurfaces at
-*N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the authoritative
-order.
+spaced-repetition schedule as the other tracks (a word from session *N*
+resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
+authoritative order.
 
-## Session-by-session
+## Chapter 1 — Greetings
 
 | Session | New lesson(s) | Introduces |
 |---|---|---|
 | 1 | salut | informal "hi" (← *salus*, health) |
-| 2 | bien | "well"; the Spanish twin |
+| 2 | bien | "well" (← *bene*); Spanish, another Latin daughter, kept the same word |
 | 3 | bon / bonne | "good" (adjective) + its four forms |
 | 4 | le / la / les | grammatical **gender** (← *ille/illa*) |
 | 5 | jour | first noun (masculine); *diurnum* → journal/journey |
@@ -20,9 +20,22 @@ order.
 | 8 | nuit · bonne nuit | night (fem.); *-ct-→-it-* vs Spanish *-ch-*; feminine agreement |
 | 9 | practice | all the greetings together |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | New lesson(s) | Introduces |
+|---|---|---|
+| 10 | je | "I" (← *ego*; English *ego*) |
+| 11 | (s')appeler | "to call [oneself]" (← *appellāre*); **reflexive verbs** |
+| 12 | je m'appelle… | **"my name is…"** assembled (+ literal *mon nom est*) |
+| 13 | tu / vous | familiar / formal **"you"** (← *tū / vōs*); politeness by plural |
+| 14 | comment | "how" (← *quo modo*; Spanish *cómo*) |
+| 15 | comment vous appelez-vous? | **"what's your name?"** by inversion |
+| 16 | enchanté(e) | "pleased to meet you" (← *in-cantāre*); gender agreement |
+| 17 | practice | the whole introduction dialogue |
+
 Reviews of earlier words fold into each session per the interval schedule.
 
 ## Next
 
-Chapter 2 — introducing yourself, and **tu / vous** (French's formal/informal
-"you," the counterpart to Spanish *tú / usted*).
+Chapter 3 — *Comment ça va?* ("how's it going?") and answering with *bien*
+again — the responding cycle.


### PR DESCRIPTION
Chapter 2 for French — the introduction dialogue you specified, built the same atom-first way as the greetings.

## The dialogue it teaches

> — *Je m'appelle Susanne.* (My name is Susanne.)
> — *Comment vous appelez-vous?* (What's your name?)
> — *Je m'appelle David.* (My name is David.)
> — *Enchanté.* (Pleased to meet you.)

| Lesson | Piece | Root / hook |
|---|---|---|
| je | "I" | ← *ego* (English *ego*) |
| (s')appeler | "to call [oneself]" | ← *appellāre* (*appeal*, *appellation*); **reflexive verbs** |
| **je m'appelle…** | **"my name is…"** | "I call myself"; + literal *mon nom est* (← *nōmen* → *noun*) |
| tu / vous | familiar / formal "you" | ← *tū / vōs*; politeness by plural (vs Spanish *usted*) |
| comment | "how" | ← *quo modo* (same source as Spanish *cómo*) |
| comment vous appelez-vous? | "what's your name?" | by inversion; informal *comment tu t'appelles?* |
| enchanté(e) | "pleased to meet you" | ← *in-cantāre* (*enchant*, *incantation*, *chant*); gender agreement |
| practice | the whole exchange | — |

You specifically wanted **"my name is"** — it's the centerpiece (`je m'appelle`, with the literal `mon nom est` explained and gently discouraged as stiff).

Also swept up two leftover beginner-audience slips the earlier French pass missed (`roadmap.md`, `session-map.md`). Compiles clean with XeLaTeX (19 pages); the Ch1→Ch2 `\ref` resolves under latexmk.

This is the first of the Chapter-2 rollout across the eight non-Spanish tracks (Spanish already has this as its Chapter 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)