### PR TITLE
feat(adj-facts-stdlib): language/alphabet — letter → alphabet position (a→1 … z→26)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_alphabet_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_alphabet_e2e.rs
@@ -1,0 +1,65 @@
+//! End-to-end test for the LANGUAGE FACTS library
+//! (`adj-facts-stdlib/language/alphabet.adj`) driven through the built CLI:
+//! a native `table` of the 26 English letters → their 1-based position in the
+//! alphabet resolves forward AND reverse binding-query recalls with the
+//! encyclopedia's citation, and abstains on a digit that has no shipped row —
+//! 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn language_alphabet_recall_binds_position_forward_and_reverse() {
+    let dir = scratch("alphabet");
+    // Copy the shipped alphabet table beside the entry program and import it.
+    let src = facts_stdlib().join("language/alphabet.adj");
+    std::fs::copy(&src, dir.join("alphabet.adj")).expect("copy shipped alphabet.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alphabet.adj\"\n\
+         ? alphabet_position(a, $N)\n\
+         ? alphabet_position(z, $N)\n\
+         ? alphabet_position($L, 3)\n\
+         ? alphabet_position(3, $N)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward: a is the first letter, z is the twenty-sixth (and last).
+    assert!(out.contains("\"N\":\"1\""), "a → 1: {out}");
+    assert!(out.contains("\"N\":\"26\""), "z → 26: {out}");
+    // Reverse: the third letter of the alphabet is c (binds the other column).
+    assert!(out.contains("\"L\":\"c\""), "position 3 → c: {out}");
+    // The answer carries the Simple-Wikipedia citation as its proof, at consensus trust.
+    assert!(
+        out.contains("simple.wikipedia.org/wiki/English_alphabet")
+            && out.contains("\"trust\":\"consensus\""),
+        "carries the encyclopedia citation: {out}"
+    );
+    // `3` is a digit, not one of the 26 letter rows — honest abstention, never invented.
+    assert!(out.contains("\"abstained\":true"), "digit 3 abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/language/alphabet.adj
+++ b/code/specs/data/adj-facts-stdlib/language/alphabet.adj
@@ -1,0 +1,94 @@
+% ============================================================================
+% alphabet — each English letter's position in the alphabet
+% (adj-facts-stdlib, LANGUAGE).
+% ============================================================================
+% One of the very first ordering facts a child learns: the alphabet is not just
+% a SET of letters, it is a SEQUENCE — a comes first (1), b comes next (2), … all
+% the way to z, the twenty-sixth and last (26). Knowing a letter's NUMBER is the
+% seed of three bigger skills: SPELLING (letters in order), SORTING (which word
+% comes first in a list — compare letter positions), and simple CIPHERS (shift
+% every letter by a number: the Caesar cipher is just "add 3 to each position").
+% This tiny library records that letter → position mapping so an ADJ program can
+% ASK where a letter sits, and get a cited answer. Recall is a binding query:
+%
+%     ? alphabet_position(a, $N)     % 1  (a is the first letter)
+%     ? alphabet_position(z, $N)     % 26 (z is the last letter)
+%
+% Because the value is a NUMBER, the answer composes into arithmetic — how many
+% letters lie between c and g? 7 − 3 − 1 = 3 (d, e, f). A reverse query binds the
+% other column, turning a number back into its letter:
+%
+%     ? alphabet_position($L, 3)     % c  (which letter is third?)
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `alphabet_position(letter, position)` carrying the table's citation, so
+% every lookup above is the ordinary SLD binding query — the engine returns the
+% position (or the letter, on a reverse query) WITH its source, on the CPU, with
+% zero model calls, and ABSTAINS on anything that is not one of the 26 letters
+% (a digit, a symbol) rather than guessing.
+%
+% The 26 letters, as an ordered truth table:
+%
+%     letter   position    letter   position    letter   position
+%     ------   --------    ------   --------    ------   --------
+%     a        1           j        10          s        19
+%     b        2           k        11          t        20
+%     c        3           l        12          u        21
+%     d        4           m        13          v        22
+%     e        5           n        14          w        23
+%     f        6           o        15          x        24
+%     g        7           p        16          y        25
+%     h        8           q        17          z        26
+%     i        9           r        18
+%
+% Only the 26 letter rows are shipped — nothing else. A digit such as `3` has NO
+% row (it is a number, not a letter), so a query like `? alphabet_position(3, $N)`
+% ABSTAINS rather than inventing a position: the table's honest-abstention
+% property means it only ever asserts the ordering it can cite, and stays silent
+% on everything else.
+%
+% Provenance — nothing here is from memory. The 26-letter A–Z ordering is copied
+% from the Simple English Wikipedia "English alphabet" article, which states
+% verbatim (see `source`) that the English alphabet now has 26 letters and lists
+% them A B C D E F G H I J K L M N O P Q R S T U V W X Y Z — in that order. Each
+% row below assigns a letter its 1-based position IN that stated A–Z sequence. The
+% citable artifact is that article at the `locator`. `trust consensus` — an
+% encyclopedia is a secondary reference, not a .gov/.edu-primary literacy standard.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table alphabet_position {
+    columns letter, position
+
+    row (a, 1)
+    row (b, 2)
+    row (c, 3)
+    row (d, 4)
+    row (e, 5)
+    row (f, 6)
+    row (g, 7)
+    row (h, 8)
+    row (i, 9)
+    row (j, 10)
+    row (k, 11)
+    row (l, 12)
+    row (m, 13)
+    row (n, 14)
+    row (o, 15)
+    row (p, 16)
+    row (q, 17)
+    row (r, 18)
+    row (s, 19)
+    row (t, 20)
+    row (u, 21)
+    row (v, 22)
+    row (w, 23)
+    row (x, 24)
+    row (y, 25)
+    row (z, 26)
+
+    source "With these changes, the English alphabet now has 26 letters: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z"
+    locator "https://simple.wikipedia.org/wiki/English_alphabet"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/language/alphabet.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/alphabet.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% alphabet.query.adj — a worked recall over the English-alphabet library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "where does this letter sit
+% in the alphabet?" — it states no fact of its own — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `alphabet_position` rows and returns the position (or the letter, on a
+% reverse query) + the encyclopedia's source/locator/trust. Anything that is not
+% one of the 26 letters — a digit, a symbol — abstains honestly: the engine never
+% invents a position it cannot cite.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli alphabet.query.adj
+% ============================================================================
+
+import "alphabet.adj"
+
+? alphabet_position(a, $N)         % expect 1   (which position is a? the first)
+? alphabet_position(z, $N)         % expect 26  (z is the last letter)
+? alphabet_position($L, 3)         % expect c   (reverse: which letter is third?)
+? alphabet_position(3, $N)         % expect abstain — 3 is a digit, not a letter row


### PR DESCRIPTION
## What

Adds one grounded **kindergarten FACTS library** to the ADJ standard library: each English letter → its position in the alphabet (**a→1, b→2, … z→26**, all 26). This is the ordering foundation under spelling, sorting, and simple ciphers (Caesar = "add N to each position").

## Files (DATA + one test)

- `code/specs/data/adj-facts-stdlib/language/alphabet.adj` — native `table alphabet_position { letter, position }` with all 26 rows, a beginner-oriented literate comment (ordered truth table, worked arithmetic, abstention note), and the citation.
- `code/specs/data/adj-facts-stdlib/language/alphabet.query.adj` — worked recall: `a→1`, `z→26`, reverse `? alphabet_position($L, 3)` → `c`, and a digit `3` abstains.
- `code/packages/rust/adj-lang-cli/tests/facts_alphabet_e2e.rs` — e2e test (modeled on `facts_planets_e2e`): forward + reverse bind, locator + `consensus` trust, honest abstention on a non-letter.

## Grounding

Nothing from memory. The 26-letter A–Z ordering is copied **verbatim** from the Simple English Wikipedia "English alphabet" article:

> With these changes, the English alphabet now has 26 letters: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z

- **locator:** https://simple.wikipedia.org/wiki/English_alphabet
- **trust:** `consensus` (an encyclopedia is a secondary reference, not a .gov/.edu-primary literacy standard)

Each row assigns a letter its 1-based position in that stated A–Z sequence.

## Verification

- `cargo test -p adj-lang-cli --test facts_alphabet_e2e` — passes (forward a→1 / z→26, reverse pos 3→c, digit abstains).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)