### PR TITLE
feat(adj-facts-stdlib): mathematics ordinal-numbers KINDERGARTEN facts library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_ordinals_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_ordinals_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the mathematics ordinal-numbers FACTS library
+//! (`adj-facts-stdlib/mathematics/ordinal-numbers.adj`): a native `table` of
+//! counting-number → ordinal-word resolves forward AND reverse binding queries
+//! with the EF citation, and abstains on an unlisted number — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn mathematics_ordinals_recall_binds_word_forward_and_reverse() {
+    let dir = scratch("ordinals");
+    let src = facts_stdlib().join("mathematics/ordinal-numbers.adj");
+    std::fs::copy(&src, dir.join("ordinal-numbers.adj")).expect("copy shipped ordinal-numbers.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ordinal-numbers.adj\"\n\
+         ? ordinal_number(1, $Word)\n\
+         ? ordinal_number($N, third)\n\
+         ? ordinal_number(11, $Word)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward: the ordinal word for 1 is "first".
+    assert!(out.contains("\"Word\":\"first\""), "1 -> first: {out}");
+    // Reverse: the number whose ordinal is "third" is 3 (binds the other column).
+    assert!(out.contains("\"N\":\"3\""), "third -> 3: {out}");
+    // The answer carries the EF citation (locator + trust) as its proof.
+    assert!(
+        out.contains("ef.edu") && out.contains("\"trust\":\"consensus\""),
+        "carries the EF citation: {out}"
+    );
+    // 11 is not a listed row — honest abstention, no fabricated ordinal.
+    assert!(out.contains("\"abstained\":true"), "11 abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/mathematics/ordinal-numbers.adj
+++ b/code/specs/data/adj-facts-stdlib/mathematics/ordinal-numbers.adj
@@ -1,0 +1,54 @@
+% ============================================================================
+% ordinal-numbers — each counting number's ordinal word (adj-facts-stdlib, MATHEMATICS).
+% ============================================================================
+% One of the very first ordering facts a kindergartner learns: after you can
+% COUNT (one, two, three...) you learn to say WHICH ONE comes where in a line —
+% the FIRST in line, the SECOND, the THIRD, and so on. Counting tells you HOW
+% MANY; the ordinal word tells you the POSITION. This little library maps each
+% cardinal number to the word for its place in order:
+%
+%     ? ordinal_number(1, $Word)          % first
+%     ? ordinal_number(3, $Word)          % third
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `ordinal_number(number, ordinal)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% ordinal word WITH its source, on the CPU, with zero model calls. It abstains
+% on any number the source does not list (e.g. 0, which has no ordinal here, or
+% 11): the engine never invents a word, it just says "I don't have that."
+%
+% Because the `number` column is a NUMBER, this composes with counting: count a
+% row of blocks to get how many (say 5), and the ordinal of the last one is the
+% recalled word for 5 — `fifth`. That is the bridge from COUNTING to ORDERING.
+%
+% Provenance: the number→ordinal pairs are copied from the cardinal/ordinal
+% number table quoted in `source`, taken verbatim from EF Education First's
+% "Numbers in English" grammar reference at the `locator`, which lists the
+% ordinals `first` through `tenth`. `trust consensus` — EF is an educational
+% reference (a secondary source), not a primary/official standards body; the
+% `authoritative` tier is reserved for primary authorities (a standards body, a
+% .gov/NIST publication). Ordinal-number words are an ordinary convention of
+% English with no single governing standards body, so a consensus educational
+% reference is the honest tier for this fact. Nothing here is asserted from
+% memory; every word traces to that table.
+% (See ../README.md; feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table ordinal_number {
+    columns number, ordinal
+
+    row (1, first)
+    row (2, second)
+    row (3, third)
+    row (4, fourth)
+    row (5, fifth)
+    row (6, sixth)
+    row (7, seventh)
+    row (8, eighth)
+    row (9, ninth)
+    row (10, tenth)
+
+    source "1 one first, 2 two second, 3 three third, 4 four fourth, 5 five fifth"
+    locator "https://www.ef.edu/english-resources/english-grammar/numbers-english/"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/mathematics/ordinal-numbers.query.adj
+++ b/code/specs/data/adj-facts-stdlib/mathematics/ordinal-numbers.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% ordinal-numbers.query.adj — a worked recall over the ordinal-numbers library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the ordinal word
+% for 4?" — it states no fact itself, only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `ordinal_number`
+% rows and returns the ordinal word (or the number, on a reverse query) + the
+% EF source/locator/trust. A number the table does not list abstains honestly —
+% the engine never invents an ordinal.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ordinal-numbers.query.adj
+% ============================================================================
+
+import "ordinal-numbers.adj"
+
+? ordinal_number(1, $Word)         % expect first   (who is at the front of the line?)
+? ordinal_number(4, $Word)         % expect fourth
+? ordinal_number($N, third)        % expect 3       (reverse: which number is "third"?)
+? ordinal_number(11, $Word)        % expect abstain — the table lists only 1..10


### PR DESCRIPTION
## What

A grounded **kindergarten** ordering-foundation facts library for the ADJ standard library: each counting number (1..10) mapped to its **ordinal word** (first..tenth). This is the natural next step after counting — *how many* (cardinal) vs *which position* (ordinal).

## Files (DATA + one test)

- `code/specs/data/adj-facts-stdlib/mathematics/ordinal-numbers.adj` — native `table ordinal_number { number, ordinal }`, integer keys, lowercase ordinal atoms, misses abstain. Beginner literate comment explains counting -> ordering and the recall-to-compute bridge.
- `code/specs/data/adj-facts-stdlib/mathematics/ordinal-numbers.query.adj` — worked recall (forward, reverse, abstain).
- `code/packages/rust/adj-lang-cli/tests/facts_ordinals_e2e.rs` — e2e over the shipped table: 2 binds (forward `1 -> first`, reverse `third -> 3`), locator (`ef.edu`) + trust (`consensus`), one abstain (`11` not listed).

## Grounding

Rows copied **verbatim** from EF Education First's "Numbers in English" grammar reference, which lists ordinals `first` through `tenth`. Nothing from memory.

- **Source span:** `1 one first, 2 two second, 3 three third, 4 four fourth, 5 five fifth`
- **Locator:** https://www.ef.edu/english-resources/english-grammar/numbers-english/
- **Trust:** `consensus` — an educational secondary reference, not a primary/official standards body.

## Verification

- `cargo test -p adj-lang-cli --test facts_ordinals_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)