### PR TITLE
feat(adj-facts-stdlib): biology animal → baby-name recall table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_animalbabies_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_animalbabies_e2e.rs
@@ -1,0 +1,61 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/animal-babies.adj`) driven through the built CLI:
+//! a native `table` of animal → the name of its baby resolves a binding-query
+//! recall with the source's citation, and abstains on a non-animal — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_animal_babies_recall_binds_baby_name_with_citation() {
+    let dir = scratch("animalbabies");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/animal-babies.adj");
+    std::fs::copy(&src, dir.join("animal-babies.adj")).expect("copy shipped animal-babies.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"animal-babies.adj\"\n\
+         ? animal_baby(dog, $Baby)\n\
+         ? animal_baby(kangaroo, $Baby)\n\
+         ? animal_baby(rock, $Baby)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A baby dog is a puppy; a baby kangaroo is a joey — the recalled names.
+    assert!(out.contains("\"Baby\":\"puppy\""), "dog → puppy: {out}");
+    assert!(out.contains("\"Baby\":\"joey\""), "kangaroo → joey: {out}");
+    // The answer carries the Wikipedia citation (locator + trust) as its proof.
+    // Wikipedia is an encyclopedia — a secondary reference — so `consensus`.
+    assert!(
+        out.contains("List_of_animal_names") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation: {out}"
+    );
+    // A rock is not an animal — honest abstention, never a fabricated name.
+    assert!(out.contains("\"abstained\":true"), "rock abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/animal-babies.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/animal-babies.adj
@@ -1,0 +1,83 @@
+% ============================================================================
+% animal-babies — a familiar animal and the NAME OF ITS BABY (its young)
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the very first vocabulary lessons a small child learns: baby animals
+% have SPECIAL NAMES. A baby dog is not a "baby dog" — it is a PUPPY. A baby cat
+% is a KITTEN, a baby cow (cattle) is a CALF, a baby horse is a FOAL, a baby
+% sheep is a LAMB, a baby kangaroo is a JOEY, and a baby goat is a KID. This tiny
+% library records, for a handful of familiar animals, what its young is called.
+% Recall is a binding query:
+%
+%     ? animal_baby(dog, $Baby)            % puppy
+%     ? animal_baby(kangaroo, $Baby)       % joey
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `animal_baby(animal, baby)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the baby's
+% name WITH its source, on the CPU, with zero model calls, and abstains on
+% anything that is not one of the recorded animals (ask it about a `rock` and it
+% stays honestly silent rather than inventing a name).
+%
+% The baby names, as a truth table over the animals shipped here:
+%
+%     animal    baby      a beginner's cue
+%     --------  --------  -------------------------------------------------
+%     dog       puppy     a young dog; "pup" is the short form
+%     cat       kitten    a young cat
+%     cattle    calf      a young cow or bull (cattle) — also called a calf
+%     horse     foal      a young horse (a colt if male, a filly if female)
+%     sheep     lamb      a young sheep
+%     kangaroo  joey      a young kangaroo, carried in its mother's pouch
+%     goat      kid       a young goat — yes, the word "kid" comes from this!
+%
+% The animals were chosen to be FAMILIAR and to have ONE clear, well-known baby
+% name each. Note "cattle": the general word for cows and bulls is *cattle*, and
+% that is the exact word the source uses, so we keep it as the animal here (a
+% baby cow is still a calf). A word that is NOT one of these animals — `rock`,
+% `banana`, `oak` — is deliberately NOT a row, so a baby-name recall ABSTAINS on
+% it rather than fabricating a name. That honest-abstention property is what
+% makes a recall table safe to build a reasoner on.
+%
+% ----------------------------------------------------------------------------
+% Provenance (byte-quotable, per the ADJ-facts standard).
+% ----------------------------------------------------------------------------
+% Every row is copied from Wikipedia's "List of animal names" — the big table of
+% animals with their male, female, YOUNG, and collective terms. Wikipedia is a
+% general ENCYCLOPEDIA (a secondary reference), so the honest trust tier is
+% `trust consensus` (not `authoritative`, which we reserve for a primary source
+% like a museum, .gov or .edu). Nothing here is asserted from memory. Because ADJ
+% tables carry ONE shared provenance envelope (per-row provenance is a documented
+% future extension — see ADJ-TABLES §6), the envelope below cites the article at
+% its `locator`, and the `source` quotes the HORSE row's "Young" cell verbatim
+% (it contains "foal"). For full auditability, here is the exact "Young"-cell
+% span that grounds EACH row, copied from that table:
+%
+%   dog       — "pup, puppy, whelp"                                  → puppy
+%   cat       — "kit, kitten"                                        → kitten
+%   cattle    — "calf"                                               → calf
+%   horse     — "colt (male), filly (female), foal, weanling, ..."   → foal
+%   sheep     — "cosset, lamb, lambkin"                              → lamb
+%   kangaroo  — "joey"                                               → joey
+%   goat      — "kid"                                                → kid
+%
+%   https://en.wikipedia.org/wiki/List_of_animal_names
+%
+% (See ../README.md; feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table animal_baby {
+    columns animal, baby
+
+    row (dog, puppy)
+    row (cat, kitten)
+    row (cattle, calf)
+    row (horse, foal)
+    row (sheep, lamb)
+    row (kangaroo, joey)
+    row (goat, kid)
+
+    source "colt (male), filly (female), foal, weanling, yearling"
+    locator "https://en.wikipedia.org/wiki/List_of_animal_names"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/biology/animal-babies.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/animal-babies.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% animal-babies.query.adj — a worked recall over the animal-baby library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is a baby dog
+% called?": it states no fact — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `animal_baby` rows
+% and returns the baby's name + the table's source/locator/trust. A word that is
+% not a recorded animal abstains honestly — the engine never invents a name.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli animal-babies.query.adj
+% ============================================================================
+
+import "animal-babies.adj"
+
+? animal_baby(dog, $Baby)          % expect puppy
+? animal_baby(kangaroo, $Baby)     % expect joey
+? animal_baby(horse, $Baby)        % expect foal
+? animal_baby(rock, $Baby)         % expect abstain — a rock is not an animal


### PR DESCRIPTION
## What

A grounded **kindergarten vocabulary** FACTS library for the ADJ standard library: a familiar animal → **the name of its baby**.

| animal | baby |
|---|---|
| dog | puppy |
| cat | kitten |
| cattle | calf |
| horse | foal |
| sheep | lamb |
| kangaroo | joey |
| goat | kid |

## Files
- `code/specs/data/adj-facts-stdlib/biology/animal-babies.adj` — the native `table animal_baby { columns animal, baby … }` with a beginner-facing literate header and per-row provenance.
- `code/specs/data/adj-facts-stdlib/biology/animal-babies.query.adj` — a worked recall: binds dog/kangaroo/horse and **abstains** on `rock`.
- `code/packages/rust/adj-lang-cli/tests/facts_animalbabies_e2e.rs` — e2e test through the built CLI: 2 binds (dog→puppy, kangaroo→joey), citation (locator + trust), one abstain.

## Grounding
Every row is copied **verbatim** from the "Young" cells of Wikipedia's [List of animal names](https://en.wikipedia.org/wiki/List_of_animal_names) table (e.g. horse → `"colt (male), filly (female), foal, weanling, yearling"`). Wikipedia is a general encyclopedia (a secondary reference), so the honest trust tier is **`consensus`**. Nothing is asserted from memory; the per-row source spans are quoted in the file header.

## Verification
- `cargo test -p adj-lang-cli --test facts_animalbabies_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)