### PR TITLE
feat(adj-facts-stdlib): art primary-colors (traditional RYB) facts library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_primarycolors_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_primarycolors_e2e.rs
@@ -1,0 +1,67 @@
+//! End-to-end test for the art FACTS library
+//! (`adj-facts-stdlib/art/primary-colors.adj`) driven through the built CLI:
+//! a native `table` of color → is-a-traditional-(RYB)-primary resolves a binding
+//! query recall with the Tate citation, and abstains on a non-primary
+//! (secondary) color — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factspc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn art_primary_colors_recall_binds_membership_with_citation() {
+    let dir = scratch("primarycolors");
+    // Copy the shipped art table beside the entry program and import it.
+    let src = facts_stdlib().join("art/primary-colors.adj");
+    std::fs::copy(&src, dir.join("primary-colors.adj")).expect("copy shipped primary-colors.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"primary-colors.adj\"\n\
+         ? primary_color(red, $Is)\n\
+         ? primary_color(blue, $Is)\n\
+         ? primary_color(green, $Is)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Red and blue are traditional RYB primaries — each binds to `yes`.
+    assert!(out.contains("\"Is\":\"yes\""), "a primary binds to yes: {out}");
+    assert!(
+        out.contains("primary_color(red, yes)"),
+        "red is governing-bound to yes: {out}"
+    );
+    assert!(
+        out.contains("primary_color(blue, yes)"),
+        "blue is governing-bound to yes: {out}"
+    );
+    // The answer carries the Tate locator + trust tier as its proof.
+    assert!(
+        out.contains("tate.org.uk") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Green is a SECONDARY color — honest abstention, never a fabricated "yes".
+    assert!(out.contains("\"abstained\":true"), "green abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/art/primary-colors.adj
+++ b/code/specs/data/adj-facts-stdlib/art/primary-colors.adj
@@ -1,0 +1,53 @@
+% ============================================================================
+% primary-colors — the three traditional (RYB) primary colors of paint
+% (adj-facts-stdlib, ART).
+% ============================================================================
+% One of the first art facts a child learns: with just three "primary" paints
+% you can mix every other color, but you cannot mix the three primaries
+% themselves from anything else. In the traditional artists' color wheel — the
+% RYB (red–yellow–blue) model — those three primaries are RED, YELLOW, and BLUE.
+% Recall is a membership binding query: is this color a primary?
+%
+%     ? primary_color(red, $Is)      % yes  (red is a primary)
+%     ? primary_color(green, $Is)    % abstain — green is a SECONDARY color
+%
+% WHICH color model (this matters — do not conflate two different "primaries"):
+%
+%     model                       primaries        used for
+%     --------------------------  ---------------  -----------------------------
+%     RYB (subtractive, paint)    red yellow blue  mixing PAINTS/PIGMENTS  <-- THIS TABLE
+%     RGB (additive, light)       red green blue   screens, colored LIGHT
+%     CMY (subtractive, print)    cyan magenta yel color PRINTING / inks
+%
+% This library encodes ONLY the traditional RYB paint primaries — the ones an
+% art class teaches. It is NOT the RGB primaries of light (which swap in green
+% for yellow and blue) and NOT the CMY primaries of printing. Green, orange, and
+% purple are SECONDARY colors (each mixed from two primaries), so a query for
+% them deliberately has no row and ABSTAINS — the engine never invents a "yes".
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `primary_color(color, is_primary)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% membership WITH its source, on the CPU, with zero model calls, and abstains on
+% any color not shipped as a row.
+%
+% Provenance: the Tate (the UK national art museum) Art Terms glossary entry for
+% "complementary colours" states verbatim (see `source`) that the "primaries are
+% red, yellow and blue." The citable artifact is that glossary page at the
+% `locator`. `trust authoritative` — Tate is a primary art-education museum
+% reference. Nothing here is asserted from memory; only the three colors the
+% cited span names as primary are shipped. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table primary_color {
+    columns color, is_primary
+
+    row (red, yes)
+    row (yellow, yes)
+    row (blue, yes)
+
+    source "primaries are red, yellow and blue"
+    locator "https://www.tate.org.uk/art/art-terms/c/complementary-colours"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/art/primary-colors.query.adj
+++ b/code/specs/data/adj-facts-stdlib/art/primary-colors.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% primary-colors.query.adj — a worked recall over the ART primary-colors library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "is red a primary color?"
+% in the traditional artists' (RYB) color model: it states no art fact — it only
+% `import`s the grounded table and asks membership binding queries. The engine
+% resolves each `?` against the `primary_color` rows and returns yes + the Tate
+% source/locator/trust. A color that is NOT a traditional RYB primary — a
+% secondary color such as green — abstains honestly; the engine never invents a
+% membership.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli primary-colors.query.adj
+% ============================================================================
+
+import "primary-colors.adj"
+
+? primary_color(red, $Is)      % expect yes  (red is a traditional RYB primary)
+? primary_color(blue, $Is)     % expect yes  (blue is a traditional RYB primary)
+? primary_color(green, $Is)    % expect abstain — green is a SECONDARY color


### PR DESCRIPTION
## What

Adds a grounded **ART** facts library to the ADJ standard library: the three traditional artists' **RYB (subtractive / paint)** primary colors — **red, yellow, blue** — encoded as a native ADJ `table` mapping `color -> is_primary` membership.

Files:
- `code/specs/data/adj-facts-stdlib/art/primary-colors.adj` — the grounded table (`row (red, yes) row (yellow, yes) row (blue, yes)`), with a beginner comment that names the RYB model and explicitly contrasts it with RGB (light) and CMY (print) so the two different "primaries" are never conflated.
- `code/specs/data/adj-facts-stdlib/art/primary-colors.query.adj` — worked recall: red->yes, blue->yes, abstain on green.
- `code/packages/rust/adj-lang-cli/tests/facts_primarycolors_e2e.rs` — E2E through the built CLI: two membership binds, Tate locator + `authoritative` trust, honest abstention on the secondary color green.

## Grounding + trust

Source: **Tate** (UK national art museum) Art Terms glossary, "complementary colours". Verbatim span shipped in `source`: **"primaries are red, yellow and blue"**. Locator: https://www.tate.org.uk/art/art-terms/c/complementary-colours

- **Color model:** traditional RYB (subtractive, paint) primaries — NOT RGB light, NOT CMY print.
- **Trust tier:** `authoritative` (Tate is a primary art-education museum reference).
- Only the three colors the cited span names as primary are shipped; secondary colors (green/orange/purple) have no row and abstain. Nothing asserted from memory.

## Verification

- `cargo test -p adj-lang-cli --test facts_primarycolors_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review: passed (round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)