### PR TITLE
feat(adj-facts-stdlib): kindergarten number-words facts library (counting foundation)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_numberwords_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_numberwords_e2e.rs
@@ -1,0 +1,66 @@
+//! End-to-end test for the mathematics (early numeracy) FACTS library
+//! (`adj-facts-stdlib/mathematics/number-words.adj`) driven through the built
+//! CLI: a native `table` of counting number → English word resolves a
+//! binding-query recall with the source's citation, binds both directions, and
+//! abstains on a number the source does not spell out — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn mathematics_number_words_recall_binds_word_with_citation() {
+    let dir = scratch("numberwords");
+    // Copy the shipped mathematics table beside the entry program and import it.
+    let src = facts_stdlib().join("mathematics/number-words.adj");
+    std::fs::copy(&src, dir.join("number-words.adj")).expect("copy shipped number-words.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"number-words.adj\"\n\
+         ? number_word(5, $W)\n\
+         ? number_word(10, $W)\n\
+         ? number_word($N, five)\n\
+         ? number_word(99, $W)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // 5 is said "five"; 10 is said "ten" — the recalled words.
+    assert!(out.contains("\"W\":\"five\""), "5 → five: {out}");
+    assert!(out.contains("\"W\":\"ten\""), "10 → ten: {out}");
+    // The relation binds in reverse too: the word "five" recovers the number 5.
+    assert!(out.contains("\"N\":\"5\""), "five → 5: {out}");
+    // The answer carries the Cuemath citation as its proof. Cuemath is a secondary
+    // math-education reference, so the trust tier is `consensus`, not `authoritative`.
+    assert!(
+        out.contains("cuemath.com/numbers/number-names-1-to-10")
+            && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation: {out}"
+    );
+    // 99 is beyond the ten numbers this table ships — honest abstention, never a
+    // fabricated word.
+    assert!(out.contains("\"abstained\":true"), "99 abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/mathematics/number-words.adj
+++ b/code/specs/data/adj-facts-stdlib/mathematics/number-words.adj
@@ -1,0 +1,64 @@
+% ============================================================================
+% number-words — each counting number's English word (adj-facts-stdlib, MATHEMATICS).
+% ============================================================================
+% The very first fact of arithmetic: the number you can hold up on your fingers,
+% and the WORD you say for it. One, two, three, four, five, six, seven, eight,
+% nine, ten — the count a kindergartener chants before they can read or add. This
+% library lives under the MATHEMATICS subject (early numeracy); the facts stdlib
+% is organized by SUBJECT, not by grade level. Recall is a binding query:
+%
+%     ? number_word(5, $W)         % five  (what do we SAY for 5?)
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `number_word(number, word)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the word
+% WITH its source, on the CPU, with zero model calls, and abstains on any number
+% the source does not name (e.g. 99 — this table only ships 1 through 10, the
+% numbers the source spells out).
+%
+% WHY THIS IS THE FOUNDATION. A number-word looked up here underlies BOTH the
+% things a child builds next:
+%   * READING — to read the numeral "5" aloud you recall its word, "five".
+%   * ARITHMETIC — "two plus three" is spoken in words; each spoken number is a
+%     recalled word standing in for a `number` key that then composes into a sum
+%     (2 + 3 = 5, whose answer is in turn read back as "five"). Because the
+%     `number` column is a NUMBER, a recalled row drops straight into arithmetic.
+% The relation also binds in REVERSE — `? number_word($N, five)` recovers 5 — so
+% the same table answers "which number is this word?" as well as "which word is
+% this number?".
+%
+% A NOTE ON CASE: ADJ atoms are lowercase, so each `word` key is written with the
+% lowercase spelling (`one`, `two`, …). The source (below) writes the words with
+% an initial capital (One, Two, …); the word each denotes is identical — only the
+% atom spelling is lowercased so it parses as a bare identifier.
+%
+% Provenance: the ten number→word pairs are copied from the sentence quoted in
+% `source`, taken verbatim from Cuemath's "Number Names 1 to 10" FAQ ("What are
+% One to Ten Spellings in English?") at the `locator`. The quoted span reads
+% "2 - two" in lowercase — a spelling quirk of the source, reproduced faithfully;
+% the atom here is `two` regardless. `trust consensus` — Cuemath is a SECONDARY
+% math-education reference, not a primary standards body: the `authoritative` tier
+% is reserved for a primary/official source (a standards body, a .gov/NIST
+% publication). Nothing here is asserted from memory; every word traces to that
+% sentence. (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table number_word {
+    columns number, word
+
+    row (1, one)
+    row (2, two)
+    row (3, three)
+    row (4, four)
+    row (5, five)
+    row (6, six)
+    row (7, seven)
+    row (8, eight)
+    row (9, nine)
+    row (10, ten)
+
+    source "1 - One, 2 - two, 3 - Three, 4 - Four, 5 - Five, 6 - Six, 7 - Seven, 8 - Eight, 9 - Nine, 10 - Ten."
+    locator "https://www.cuemath.com/numbers/number-names-1-to-10/"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/mathematics/number-words.query.adj
+++ b/code/specs/data/adj-facts-stdlib/mathematics/number-words.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% number-words.query.adj — a worked recall over the mathematics number-words library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what word do we say for 5?"
+% — it states no fact of its own, only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `number_word` rows and
+% returns the word (or, on a reverse query, the number) + the Cuemath
+% source/locator/trust. A number the source does not spell out abstains honestly —
+% the engine never invents a word.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli number-words.query.adj
+% ============================================================================
+
+import "number-words.adj"
+
+? number_word(1, $W)          % expect one   (the first counting number)
+? number_word(5, $W)          % expect five  (how we SAY 5)
+? number_word(10, $W)         % expect ten   (the last number this table ships)
+? number_word($N, five)       % expect 5     (reverse: which number is "five"?)
+? number_word(99, $W)         % expect abstain — beyond 1..10, not a shipped row


### PR DESCRIPTION
## What

Ship one grounded ADJ facts library mapping each counting number **1..10 to its English word** (1→one … 10→ten), under the `mathematics/` subject of the ADJ facts stdlib. This is the counting foundation of early numeracy: a looked-up number-word underlies both reading a numeral aloud and speaking arithmetic, and because the `number` column is a NUMBER, a recalled row composes straight into a sum.

## Files (data + one test)

- `code/specs/data/adj-facts-stdlib/mathematics/number-words.adj` — native `table number_word { number, word }`, ten grounded rows, literate beginner comment (counting foundation + recall→compose bridge, reverse-binding note, case note).
- `code/specs/data/adj-facts-stdlib/mathematics/number-words.query.adj` — worked recall: forward lookups, a reverse query `? number_word($N, five)` → 5, and an abstain on 99.
- `code/packages/rust/adj-lang-cli/tests/facts_numberwords_e2e.rs` — drives the shipped table through the CLI: binds 5→five and 10→ten, binds reverse five→5, asserts the Cuemath citation + `consensus` trust, and asserts honest abstention on 99.

## Grounding

Every word is copied **verbatim** from Cuemath's "Number Names 1 to 10" FAQ ("What are One to Ten Spellings in English?"):

> `1 - One, 2 - two, 3 - Three, 4 - Four, 5 - Five, 6 - Six, 7 - Seven, 8 - Eight, 9 - Nine, 10 - Ten.`

- **Source URL / locator:** https://www.cuemath.com/numbers/number-names-1-to-10/
- **Trust tier:** `consensus` — Cuemath is a secondary math-education reference, not a primary standards body.
- The `source` reproduces the span faithfully, including the source's lowercase "2 - two" quirk (noted inline). Nothing asserted from memory.

## Verification

- `cargo test -p adj-lang-cli --test facts_numberwords_e2e` — passes (1 test).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Security review: passed (no vulnerabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)