### PR TITLE
feat(logic-core): NX-1 — Number::Exact(BigDecimal) core variant (no silent f64 truncation)

### DIFF
--- a/code/packages/rust/adjudication-pipeline/src/hierarchical.rs
+++ b/code/packages/rust/adjudication-pipeline/src/hierarchical.rs
@@ -1215,6 +1215,9 @@ fn term_to_json(t: &Term) -> serde_json::Value {
         Term::Num(n) => match n {
             logic_core::Number::Int(i) => serde_json::json!({ "num": *i }),
             logic_core::Number::Float(f) => serde_json::json!({ "num": *f }),
+            // Exact decimals carry unbounded digits: serialise the full-precision
+            // string so a consumer's JSON-number parse can't silently truncate it.
+            logic_core::Number::Exact(d) => serde_json::json!({ "num": d.to_string() }),
         },
         Term::Str(s) => serde_json::json!({ "str": s }),
         Term::Var(v) => serde_json::json!({ "var": v.to_string() }),

--- a/code/packages/rust/logic-core/CHANGELOG.md
+++ b/code/packages/rust/logic-core/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-07-14
+
+### Added
+
+- `Number::Exact(BigDecimal)` — a third numeric variant holding an unbounded exact
+  decimal, so a written decimal literal (`3.14159…`, `6.022e23`) keeps every digit
+  instead of being truncated to `f64` at parse time (see
+  `code/specs/ADJ-EXACT-NUMBERS.md`). This is NX-1 of the exact-numbers arc; nothing
+  *produces* `Exact` yet (literals still lower via `f64` until NX-2), so this release
+  is a pure, behavior-preserving type widening.
+- `Number::to_f64_lossy()` — the single, greppable, sanctioned way to drop a `Number`
+  to `f64` (the "labeled lossy export" boundary). `Exact` rounds via `BigDecimal::to_f64`.
+- New dependency on `bignum-core` (for `BigDecimal`).
+
+### Changed
+
+- **Breaking:** `Number` no longer derives `Copy` — `Exact` wraps a heap-backed
+  `BigDecimal`, so `Number` now moves/clones like `Term`. Callers that copied a
+  `Number` by value must move or `.clone()`.
+- `Number`'s `Display` prints an `Exact` value with all of its digits (no truncation).
+- Equality stays **variant-distinct** (Prolog tradition): `Int(1)`, `Float(1.0)`, and
+  `Exact(1.0)` are three different ground terms; numeric reconciliation remains a
+  compute-layer concern.
+
 ## [0.1.0] - 2026-05-10
 
 ### Added

--- a/code/packages/rust/logic-core/Cargo.toml
+++ b/code/packages/rust/logic-core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "logic-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Terms, logic variables, substitutions, and unification — the semantic core of a logic VM."
 
 [dependencies]
+bignum-core = { path = "../bignum-core" }

--- a/code/packages/rust/logic-core/src/lib.rs
+++ b/code/packages/rust/logic-core/src/lib.rs
@@ -49,15 +49,50 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A numeric logic term.
 ///
-/// Integers and floats are kept as separate variants so that equality on
-/// integers is exact and so that downstream arithmetic can dispatch on
-/// type without re-parsing. Mixing across variants in unification follows
-/// Prolog tradition: `1 = 1.0` does **not** unify, because they are
-/// distinct ground terms.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// Three variants, kept **distinct** so that a value keeps exactly the shape it
+/// was written or computed in:
+///
+/// | variant        | holds                        | when it appears                                   |
+/// |----------------|------------------------------|---------------------------------------------------|
+/// | `Int(i64)`     | a small machine integer      | integer literals that fit `i64`; integer results  |
+/// | `Exact(..)`    | an unbounded exact decimal   | any decimal literal — `3.14159…`, `6.022e23` — so no digit is lost at parse time |
+/// | `Float(f64)`   | a labeled **lossy** `f64`    | the inherently-approximate / explicitly-exported value (a float backend, an approximate mode) |
+///
+/// Why three and not two: before `Exact`, a decimal literal was parsed straight
+/// to `f64`, so `pi` written to 39 digits came back at ~16 — truncated at parse
+/// time, upstream of every big number (see `code/specs/ADJ-EXACT-NUMBERS.md`).
+/// `Exact` gives a written decimal somewhere lossless to live; `f64` is now only
+/// the *labeled lossy export*, never the silent default.
+///
+/// **Equality / unification stays variant-distinct**, following Prolog tradition:
+/// `1 = 1.0` does **not** unify because they are distinct ground terms, and
+/// `Exact` joins as a third distinct term (`Int(1)`, `Float(1.0)`, `Exact(1.0)`
+/// are three different terms). *Numeric* reconciliation (`2.50` == `2.5`) is a
+/// compute-layer concern (`ExactRational`), not ground-term unification.
+///
+/// Note `Number` is **no longer `Copy`**: `Exact` wraps a heap-backed
+/// [`BigDecimal`], so the enum moves or clones like `Term` itself.
+#[derive(Debug, Clone, PartialEq)]
 pub enum Number {
     Int(i64),
     Float(f64),
+    Exact(bignum_core::BigDecimal),
+}
+
+impl Number {
+    /// The **labeled lossy** `f64` export — the *only* sanctioned way to obtain
+    /// an `f64` from a `Number`. `Int` widens exactly (all `i64` in range are
+    /// representable up to 2^53 without loss and saturate predictably beyond),
+    /// `Float` is already an `f64`, and `Exact` rounds to the nearest `f64` via
+    /// [`BigDecimal::to_f64`]. The name is deliberately greppable so every place
+    /// that drops to `f64` is auditable.
+    pub fn to_f64_lossy(&self) -> f64 {
+        match self {
+            Number::Int(i) => *i as f64,
+            Number::Float(x) => *x,
+            Number::Exact(d) => d.to_f64(),
+        }
+    }
 }
 
 impl fmt::Display for Number {
@@ -65,6 +100,8 @@ impl fmt::Display for Number {
         match self {
             Number::Int(i) => write!(f, "{}", i),
             Number::Float(x) => write!(f, "{}", x),
+            // Prints every digit the exact decimal carries — no truncation.
+            Number::Exact(d) => write!(f, "{}", d),
         }
     }
 }


### PR DESCRIPTION
## What

NX-1 of the **exact-numbers** arc (spec [ADJ-EXACT-NUMBERS.md](code/specs/ADJ-EXACT-NUMBERS.md), merged in #8257). Adds the core `Number::Exact(BigDecimal)` variant so a written decimal literal keeps **every digit** instead of being truncated to `f64` at parse time — the reason a 39-digit π bound at ~16.

This PR is the **type widening only** — nothing *produces* `Exact` yet (literals still lower via `f64` until NX-2), so behavior is unchanged and it's a clean, reviewable step.

## Changes

- **logic-core** (`0.1.0 → 0.2.0`):
  - add `Number::Exact(bignum_core::BigDecimal)`
  - `Display` prints an `Exact` value with all its digits (no truncation)
  - add `Number::to_f64_lossy()` — the single, greppable, sanctioned `f64` boundary
  - **drop `Copy` from `Number`** (BigDecimal is heap-backed) — the one breaking change; `Number` now moves/clones like `Term`
  - depend on `bignum-core`; CHANGELOG updated
- Equality stays **variant-distinct** (Prolog tradition): `Int(1)` / `Float(1.0)` / `Exact(1.0)` are three distinct ground terms; numeric reconciliation stays a compute-layer concern.
- **adjudication-pipeline**: `term_to_json` handles the new arm by emitting the exact decimal as a **full-precision string** (a JSON number would truncate on parse).

## Blast radius

The `Copy` removal + new variant broke exactly **one** match site (not the ~30 estimated) — most `Number` matches already carry a wildcard or borrow. Verified:
- `cargo build --workspace` compiles (pre-existing unrelated `uefi` no_std `duplicate lang item panic_impl` error is not from this change — `uefi` has no dep on logic-core/bignum)
- tests green: **logic-core 170, logic-engine 169**, adj-lang, adjudication-pipeline
- `cargo clippy -D warnings` clean on both edited crates
- security review passed

## Next

NX-2 (parse NUMBER → `BigDecimal`, lower literals/table cells to `Exact`) → NX-3 (exact compute ingestion, no f64 hop) → NX-4 (render full digits + refresh `mathematics/constants` so its "exact expansion" comment becomes true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)