### PR TITLE
feat(adj-facts-stdlib): biology animal-homes recall library (bee→hive, …)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_animalhomes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_animalhomes_e2e.rs
@@ -1,0 +1,61 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/animal-homes.adj`) driven through the built CLI:
+//! a native `table` of animal → the name of its home resolves a binding-query
+//! recall with the source's citation, and abstains on a non-animal — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_animal_homes_recall_binds_home_with_citation() {
+    let dir = scratch("animalhomes");
+    // Copy the shipped animal-homes table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/animal-homes.adj");
+    std::fs::copy(&src, dir.join("animal-homes.adj")).expect("copy shipped animal-homes.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"animal-homes.adj\"\n\
+         ? animal_home(bee, $Home)\n\
+         ? animal_home(spider, $Home)\n\
+         ? animal_home(rock, $Home)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A bee lives in a hive; a spider lives in a web — the recalled home names.
+    assert!(out.contains("\"Home\":\"hive\""), "bee → hive: {out}");
+    assert!(out.contains("\"Home\":\"web\""), "spider → web: {out}");
+    // The answer carries the Wikipedia citation as its proof, at the honest
+    // `consensus` trust tier for a collaboratively edited encyclopedia.
+    assert!(
+        out.contains("en.wikipedia.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation: {out}"
+    );
+    // A rock is not an animal — honest abstention, never a fabricated home.
+    assert!(out.contains("\"abstained\":true"), "rock abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/animal-homes.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/animal-homes.adj
@@ -1,0 +1,88 @@
+% ============================================================================
+% animal-homes — each animal and the name of the home it lives in
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A first vocabulary fact a child learns about the living world: animals build
+% or live in homes, and each kind of home has its own NAME. "A bee lives in a
+% hive; a bird lives in a nest." Recall is a binding query:
+%
+%     ? animal_home(bee, $Home)      % hive
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `animal_home(animal, home)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the home's
+% name WITH its source, on the CPU, with zero model calls, and abstains on an
+% animal (or a non-animal like a `rock`) that is not in the table.
+%
+% Each animal and the name of its home, as a truth table:
+%
+%     animal    home     a beginner's cue
+%     -------   ------   ----------------------------------------------
+%     bee       hive     bees build a wax hive and live together in it
+%     bird      nest     a bird builds a nest to lay its eggs
+%     spider    web      a spider spins a silk web to live in and catch food
+%     rabbit    burrow   a rabbit digs a burrow (a tunnel) in the ground
+%     beaver    lodge    a beaver builds a lodge of sticks in the water
+%
+% The query also runs BACKWARD — bind the home and recall which animal:
+%
+%     ? animal_home($Animal, hive)   % bee
+%
+% Note that a word that is NOT one of these animals — `rock`, `car`, `dog` —
+% is deliberately NOT a row, so an animal-home recall ABSTAINS on it rather
+% than inventing a home. That honest-abstention property is what makes the
+% table safe to build a reasoner on: it answers exactly the pairs it can
+% ground, and only those.
+%
+% ----------------------------------------------------------------------------
+% Provenance (byte-quotable, per the ADJ-facts standard).
+% ----------------------------------------------------------------------------
+% Every row is copied from WIKIPEDIA (en.wikipedia.org), the collaboratively
+% edited encyclopedia — hence `trust consensus` (NOT `authoritative`, which is
+% reserved for a primary/official .gov/.edu or standards source). Nothing here
+% is asserted from memory. Because ADJ tables carry ONE shared provenance
+% envelope (per-row provenance is a documented future extension — see
+% ADJ-TABLES §6), the envelope below cites the "Beehive" article at its
+% `locator`, and the `source` quotes that article's opening definition verbatim.
+% For full auditability, here is the exact Wikipedia span that grounds EACH row,
+% copied character-for-character, with the article it was read from:
+%
+%   bee → hive     — "A beehive is an enclosed structure in which honey bees
+%                     raise their young and produce honey as part of their
+%                     seasonal cycle."
+%                     https://en.wikipedia.org/wiki/Beehive
+%
+%   bird → nest    — "A bird nest is the spot in which a bird lays and incubates
+%                     its eggs and raises its young."
+%                     https://en.wikipedia.org/wiki/Bird_nest
+%
+%   spider → web   — "A spider web ... is a structure created by a spider out of
+%                     proteinaceous spider silk extruded from its spinnerets,
+%                     generally meant to catch its prey."
+%                     https://en.wikipedia.org/wiki/Spider_web
+%
+%   rabbit → burrow — "The European rabbit notably lives in extensive burrow
+%                     networks called warrens."
+%                     https://en.wikipedia.org/wiki/Rabbit
+%
+%   beaver → lodge — "Beavers make two types of lodges: bank lodges and
+%                     open-water lodges."
+%                     https://en.wikipedia.org/wiki/Beaver
+%
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table animal_home {
+    columns animal, home
+
+    row (bee, hive)
+    row (bird, nest)
+    row (spider, web)
+    row (rabbit, burrow)
+    row (beaver, lodge)
+
+    source "A beehive is an enclosed structure in which honey bees raise their young and produce honey as part of their seasonal cycle."
+    locator "https://en.wikipedia.org/wiki/Beehive"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/biology/animal-homes.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/animal-homes.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% animal-homes.query.adj — a worked recall over the animal-homes library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what home does a bee live
+% in?": it states no fact of its own — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the `animal_home`
+% rows and returns the home + the table's source/locator/trust. An animal (or a
+% non-animal) not in the table abstains honestly — the engine never invents a
+% home.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli animal-homes.query.adj
+% ============================================================================
+
+import "animal-homes.adj"
+
+? animal_home(bee, $Home)         % expect hive
+? animal_home(spider, $Home)      % expect web
+? animal_home(rock, $Home)        % expect abstain — a rock is not an animal


### PR DESCRIPTION
## What

Adds a grounded **kindergarten vocabulary** facts library to the ADJ standard library: `animal_home(animal, home)`, mapping each animal to the name of the home it lives in.

| animal | home |
|---|---|
| bee | hive |
| bird | nest |
| spider | web |
| rabbit | burrow |
| beaver | lodge |

Like every `adj-facts-stdlib` table, it lowers to a ground relation (ADJ-TABLES RS-5) carrying its citation, so recall is an ordinary SLD binding query resolved on the CPU with **zero model calls**, and it **abstains honestly** on any animal (or non-animal like `rock`) not in the table. The query runs backward too (`? animal_home($Animal, hive)` → `bee`).

## Grounding

Every row is copied **verbatim from Wikipedia** (`en.wikipedia.org`), the collaboratively edited encyclopedia → `trust consensus` (not `authoritative`, which is reserved for a primary/official source). Each row's exact source span and article URL are quoted character-for-character in the file comment for full auditability; the table envelope cites the "Beehive" article in `source`/`locator` (per-row provenance is a documented future ADJ-TABLES extension). Nothing is asserted from memory.

The classic fox→den example was **dropped** because the word "den" could not be verbatim-grounded to foxes from any fetchable source (Merriam-Webster / Britannica / A-Z Animals all 403'd; the Wikipedia Red fox denning section was truncated). The well-grounded **beaver→lodge** pair was shipped in its place.

## Files

- `biology/animal-homes.adj` — the grounded `table animal_home`
- `biology/animal-homes.query.adj` — a worked recall (2 binds + 1 abstain)
- `adj-lang-cli/tests/facts_animalhomes_e2e.rs` — E2E: binds hive/web with the Wikipedia citation at `consensus` trust, and abstains on a non-animal

## Verification

- `cargo test -p adj-lang-cli --test facts_animalhomes_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review — passed (round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)