### PR TITLE
test(closurec): default-parameters e2e fixture — CLOC12.191 PR3

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.30] - 2026-07-14
+
+### Added — CLOC12.191 PR3: ES default parameters end-to-end
+
+Picks up javascript-parser 0.56.0 (the `convert_formal_parameter` EQUALS-branch bridge flip, PR2) on top
+of the PR1 `FunctionParam::AssignmentPattern` node + emitter + pass threading. A file with a default
+parameter no longer declines to WHITESPACE_ONLY — it flows through the full optimization pipeline, and the
+default expression itself folds as live code. New `tests/diff/default-params/` fixture +
+`diff_default_params.rs`: `function f(a=1+2){return a} g(f());` at SIMPLE emits
+`function f(a=3){return a};g(f());` — the default `a = 1 + 2` folds to `a = 3`, proving the pipeline ran
+(a WHITESPACE_ONLY fallback would leave `a=1+2` intact). PATCH bump; regen `--help_markdown` fixture +
+`cli.spec.json` version sync.
+
 ## [0.234.29] - 2026-07-14
 
 ### Added — CLOC12.190 PR3: ES rest parameters end-to-end

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.29"
+version = "0.234.30"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.29",
+  "version": "0.234.30",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/default-params/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/default-params/expected.stdout
@@ -1,0 +1,1 @@
+function f(a=3){return a};g(f());

--- a/code/programs/rust/closurec/tests/diff/default-params/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/default-params/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/default-params/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/default-params/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/default-params/input/a.js
@@ -1,0 +1,1 @@
+function f(a=1+2){return a} g(f());

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.29
+Version: 0.234.30
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_default_params.rs
+++ b/code/programs/rust/closurec/tests/diff_default_params.rs
@@ -1,0 +1,81 @@
+//! Integration test for the `tests/diff/default-params/` fixture.
+//!
+//! Exercises ES default parameters (`function f(a = expr){}`) end-to-end — the
+//! CLOC12.191 arc. Before it, a default parameter landed in the parser bridge's
+//! *unsupported* bucket (`convert_formal_parameter` declined the `EQUALS`
+//! branch), so any file with a default parameter DECLINED to WHITESPACE_ONLY
+//! (no optimization at all). The arc landed in three PRs:
+//!   - PR1 (#8284): the `FunctionParam::AssignmentPattern` AST variant + emitter
+//!     arm (`name=expr`) + the pass-traversal threading — the default's `right`
+//!     is *live code* that constant-fold folds, the renamers rewrite, and inline
+//!     declines around (atomic; the variant was unreachable);
+//!   - PR2 (#8295): the parser-bridge flip (`convert_formal_parameter` maps a
+//!     `NAME = assignment_expression` parameter to an `AssignmentPattern`, while
+//!     a destructuring default `{x} = {}` still declines);
+//!   - PR3 (this test): the closurec end-to-end proof.
+//!
+//! ## Fact — SIMPLE: the default folds and the pipeline optimizes
+//!
+//! `function f(a=1+2){return a} g(f());` at SIMPLE emits
+//! `function f(a=3){return a};g(f());`. The proof that the whole pipeline ran —
+//! and did NOT fall back to WHITESPACE_ONLY — is that the DEFAULT expression
+//! itself folds: `a = 1 + 2` → `a = 3`. A WHITESPACE_ONLY fallback would emit
+//! the source verbatim (only stripping whitespace), leaving `a=1+2` intact. This
+//! is the CLOC12.191 headline: unlike a rest parameter (which binds only a
+//! name), a default parameter carries a live expression that the optimizer walks
+//! and folds exactly as it would a function body.
+//!
+//! The single-use function `f` is *retained* (an unknown `g` consumes its
+//! result via `g(f())`), keeping the `a=3` default parameter visible in the
+//! output rather than being inlined away.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw =
+        std::fs::read_to_string("tests/diff/default-params/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn default_params_fold_and_optimize() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/default-params/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    let flat = actual.replace([' ', '\n'], "");
+    // The default expression folded: `a = 1 + 2` → `a = 3`. This is the proof
+    // the file OPTIMIZED (not a WHITESPACE_ONLY fallback, which would keep
+    // `a=1+2`). Checked on space-stripped output.
+    assert!(
+        flat.contains("f(a=3)"),
+        "default did not fold to `a=3` — pipeline may have fallen back to WHITESPACE_ONLY: {actual}"
+    );
+    assert!(
+        !flat.contains("1+2"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+}


### PR DESCRIPTION
## CLOC12.191 default parameters — PR3 (closurec e2e fixture) — closes the arc

Picks up javascript-parser 0.56.0 (PR2 #8295 bridge flip) on top of the PR1 (#8284) AST/emitter/pass substrate. A file with a default parameter now flows through the full optimization pipeline instead of declining to WHITESPACE_ONLY — and the default expression itself folds as live code.

### The proof
New `tests/diff/default-params/` fixture + `diff_default_params.rs`:
```
function f(a=1+2){return a} g(f());   →   function f(a=3){return a};g(f());
```
The default `a = 1 + 2` folds to `a = 3` (asserted on space-stripped output: contains `f(a=3)`, not `1+2`). That fold is the proof the pipeline ran — a WHITESPACE_ONLY fallback would emit the source verbatim, leaving `a=1+2` intact. `g(f())` retains the single-use function so the default parameter stays visible in the output rather than being inlined away.

### Housekeeping
- closurec PATCH bump 0.234.29 → 0.234.30
- `cli.spec.json` version synced
- `tests/diff/help-markdown/expected.stdout` regenerated via `closurec --help_markdown`
- CHANGELOG updated

Test-only + version metadata: `cargo test` passes under `-D warnings` (new fixture, `version_string_matches_crate_version`, `help_markdown_fixture_matches_expected_dump` all green). No executable-logic change.

With this the **CLOC12.191 default-parameters arc is complete** across its three PRs (AST/passes → bridge → e2e), the same shape as the CLOC12.190 rest-parameters arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)