### PR TITLE
feat(adj-facts-stdlib): biology basic-tastes library (five basic tastes, NIDCD-grounded)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_tastes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_tastes_e2e.rs
@@ -1,0 +1,64 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/basic-tastes.adj`) driven through the built CLI:
+//! a native `table` of taste → is-basic-taste membership resolves a binding-query
+//! recall with the source's citation, and abstains on a non-taste — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_basic_tastes_recall_binds_membership_with_citation() {
+    let dir = scratch("tastes");
+    // Copy the shipped basic-tastes table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/basic-tastes.adj");
+    std::fs::copy(&src, dir.join("basic-tastes.adj")).expect("copy shipped basic-tastes.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"basic-tastes.adj\"\n\
+         ? basic_taste(sweet, $Is)\n\
+         ? basic_taste(umami, $Is)\n\
+         ? basic_taste(spicy, $Is)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Sweet and umami are both among the five basic tastes — the recalled membership.
+    // Two binds, both `yes`; `.matches` counts occurrences of the bound value.
+    assert!(out.contains("\"Is\":\"yes\""), "sweet/umami → yes: {out}");
+    assert!(
+        out.matches("\"Is\":\"yes\"").count() >= 2,
+        "both sweet and umami bind to yes: {out}"
+    );
+    // The answer carries the NIDCD (.gov) citation as its proof, at authoritative trust.
+    assert!(
+        out.contains("nidcd.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Spicy is a heat/pain sensation, not one of the five basic tastes —
+    // honest abstention, never a fabricated `yes`.
+    assert!(out.contains("\"abstained\":true"), "spicy abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/basic-tastes.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/basic-tastes.adj
@@ -1,0 +1,64 @@
+% ============================================================================
+% basic-tastes — the five basic tastes your tongue can sense
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A very early fact about your own body: your tongue does not sense infinitely
+% many flavors — it senses a small, fixed set of BASIC tastes. There are FIVE of
+% them: sweet, sour, salty, bitter, and umami (a savory taste, said "oo-MOM-ee").
+% Recall is a binding query that asks "is this one of the five basic tastes?":
+%
+%     ? basic_taste(sweet, $Is)          % yes
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `basic_taste(taste, is_basic_taste)` carrying the table's citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% membership answer WITH its source, on the CPU, with zero model calls, and
+% abstains on anything that is not one of the five basic tastes.
+%
+% The five basic tastes, as a membership truth table (every listed taste IS a
+% basic taste, so the answer column is `yes` for all five):
+%
+%     taste    is_basic_taste
+%     -------  --------------
+%     sweet    yes
+%     sour     yes
+%     salty    yes
+%     bitter   yes
+%     umami    yes
+%
+% Why a MEMBERSHIP table (taste -> yes) and not a taste -> example-food table?
+% Because we ship ONLY what the source states verbatim. The cited NIDCD page
+% names the five basic tastes but does NOT give a canonical example food for
+% each of the five, so grounding a `taste -> example` pairing would be inventing
+% facts the source does not contain. Membership is exactly what the sentence
+% supports, so membership is what we encode. (See feedback_nothing_human_authored.)
+%
+% Note that a NON-taste — say `spicy` (spiciness is a heat/pain sensation, not
+% one of the five basic tastes) — is deliberately NOT a row, so a basic-tastes
+% recall ABSTAINS on it rather than inventing a `yes`. That honest-abstention
+% property is what makes the table safe to trust: it answers exactly the five it
+% can ground, and only those.
+%
+% Provenance: the five tastes are copied VERBATIM from the U.S. National
+% Institute on Deafness and Other Communication Disorders (NIDCD, part of the
+% NIH), "Taste Disorders" health page, which states (see `source`): "Taste cells
+% have receptors that respond to one of at least five basic taste qualities:
+% sweet, sour, bitter, salty, and umami." The citable artifact is that page at
+% the `locator`. `trust authoritative` — NIDCD is a primary/official U.S.
+% government (.gov) health authority. Nothing here is asserted from memory.
+% (See ../README.md; feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table basic_taste {
+    columns taste, is_basic_taste
+
+    row (sweet, yes)
+    row (sour, yes)
+    row (salty, yes)
+    row (bitter, yes)
+    row (umami, yes)
+
+    source "Taste cells have receptors that respond to one of at least five basic taste qualities: sweet, sour, bitter, salty, and umami [oo-MOM-ee]."
+    locator "https://www.nidcd.nih.gov/health/taste-disorders"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/basic-tastes.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/basic-tastes.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% basic-tastes.query.adj — a worked recall over the basic-tastes library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "is sweet a basic taste?":
+% it states no biology fact — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `basic_taste` rows
+% and returns the membership answer + the table's source/locator/trust. A key
+% that is not one of the five basic tastes abstains honestly — the engine never
+% invents a `yes`.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli basic-tastes.query.adj
+% ============================================================================
+
+import "basic-tastes.adj"
+
+? basic_taste(sweet, $Is)      % expect yes
+? basic_taste(umami, $Is)      % expect yes
+? basic_taste(spicy, $Is)      % expect abstain — spicy is a heat/pain sensation, not one of the five basic tastes


### PR DESCRIPTION
## What

Adds one grounded early-elementary FACTS library to the ADJ standard library: the **five basic tastes** — sweet, sour, salty, bitter, umami.

- `code/specs/data/adj-facts-stdlib/biology/basic-tastes.adj` — a native `table basic_taste` (columns `taste, is_basic_taste`) with a literate, beginner-friendly comment block and citation.
- `code/specs/data/adj-facts-stdlib/biology/basic-tastes.query.adj` — a worked recall: two binds (`sweet`, `umami`) and an honest abstention on `spicy`.
- `code/packages/rust/adj-lang-cli/tests/facts_tastes_e2e.rs` — e2e test (copies the shapes test): 2 binds, checks locator + `authoritative` trust, abstains on `spicy`.

## Shape decision: membership, not example-food

The cited source names the five basic tastes but gives **no canonical example food** for each. To ship only what the source states verbatim, this encodes the **membership** shape `taste -> is_basic_taste = yes` (all five `yes`) rather than inventing a `taste -> example` pairing.

## Grounding

- **Source (verbatim):** "Taste cells have receptors that respond to one of at least five basic taste qualities: sweet, sour, bitter, salty, and umami [oo-MOM-ee]."
- **Locator:** https://www.nidcd.nih.gov/health/taste-disorders
- **Trust:** `authoritative` (U.S. NIDCD / NIH, a primary official `.gov` health authority)

Nothing is asserted from memory.

## Verification

- `cargo test -p adj-lang-cli --test facts_tastes_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)