### PR TITLE
feat(adj-facts-stdlib): mathematics place-value facts library (name → value)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_placevalue_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_placevalue_e2e.rs
@@ -1,0 +1,61 @@
+//! End-to-end test for the mathematics FACTS library
+//! (`adj-facts-stdlib/mathematics/place-value.adj`) driven through the built CLI:
+//! a native `table` of place-name → the number it is worth resolves a
+//! binding-query recall with the source's citation, and abstains on a
+//! non-place-name — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factspv_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn mathematics_place_value_recall_binds_value_with_citation() {
+    let dir = scratch("placevalue");
+    // Copy the shipped mathematics table beside the entry program and import it.
+    let src = facts_stdlib().join("mathematics/place-value.adj");
+    std::fs::copy(&src, dir.join("place-value.adj")).expect("copy shipped place-value.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"place-value.adj\"\n\
+         ? place_value(hundreds, $V)\n\
+         ? place_value(tens, $V)\n\
+         ? place_value(dozen, $V)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The hundreds column is worth 100; the tens column is worth 10 — the recalled
+    // values that compose straight into number decomposition.
+    assert!(out.contains("\"V\":\"100\""), "hundreds -> 100: {out}");
+    assert!(out.contains("\"V\":\"10\""), "tens -> 10: {out}");
+    // The answer carries the Cuemath citation and its honest trust tier as proof.
+    assert!(
+        out.contains("cuemath.com/numbers/place-value") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation with locator and trust tier: {out}"
+    );
+    // "dozen" is not a place-value column — honest abstention, never a fabricated value.
+    assert!(out.contains("\"abstained\":true"), "dozen abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/mathematics/place-value.adj
+++ b/code/specs/data/adj-facts-stdlib/mathematics/place-value.adj
@@ -1,0 +1,67 @@
+% ============================================================================
+% place-value — each place-value name → the number it is worth (adj-facts-stdlib, MATHEMATICS).
+% ============================================================================
+% The very first arithmetic fact a child meets: in our base-ten number system a
+% digit's WORTH depends on the COLUMN it sits in. The rightmost column is the
+% ones (each digit there is worth 1); the next column left is the tens (worth 10);
+% then the hundreds (100); then the thousands (1000). Each column to the left is
+% ten times bigger than the one to its right. Recall is a binding query — you name
+% a place and get back its value, WITH its citation:
+%
+%     ? place_value(hundreds, $V)      % 100
+%     ? place_value(tens, $V)          % 10
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `place_value(place, value)` carrying the table's citation, so the
+% lookup is the ordinary SLD binding query — the engine returns the value WITH its
+% source, on the CPU, with zero model calls, and abstains on a word that is not a
+% place name (it never invents a value).
+%
+% Why the `value` is a plain NUMBER, and why that matters: because each place is a
+% whole number (1, 10, 100, 1000), a recalled place value COMPOSES straight into
+% arithmetic. That is the concrete bridge from RECALL to COMPUTE — and it is
+% exactly how you take a number APART or put it back together. The number 143 is
+%
+%     1 × place_value(hundreds) + 4 × place_value(tens) + 3 × place_value(ones)
+%       = 1 × 100 + 4 × 10 + 3 × 1
+%       = 143
+%
+% So a looked-up place value feeds NUMBER DECOMPOSITION: recall the column values,
+% multiply each by its digit, add them up. Recall (name the place) flows straight
+% into compute (build or break apart the number). That is why this tiny table is a
+% foundation stone the rest of arithmetic is built on.
+%
+% Why a `table` and NOT four prose sentences: this is exactly the shape the fact
+% ships in — a place-value chart, one column per row with the number it is worth.
+% A chart cell like `hundreds | 100` was never a prose sentence, so there is no
+% sentence to cite; the citable artifact IS the place-value lesson at the `locator`
+% below, and each place→value pair here is read straight off the expanded-form
+% examples on that page. One provenance envelope defends the whole table rather
+% than repeating source/locator/trust on every row.
+%
+% Provenance: the place names and their values are taken from Cuemath's "Place
+% Value" lesson. The `source` span below joins the page's own expanded-form
+% examples VERBATIM (delimiter ` | ` added here): "3 × 1 = 3 or 3 ones" gives
+% ones = 1, "4 × 10 = 40 or 4 tens" gives tens = 10, "5 × 100 = 500 or 5 hundreds"
+% gives hundreds = 100, and "4 thousands = 4,000" gives thousands = 1000. Only
+% places whose value is confirmable on that page are shipped — the page does not
+% state a value for ten-thousands in the same expanded form, so it is deliberately
+% omitted rather than asserted from memory. `trust consensus` — Cuemath is a
+% secondary math-education reference (not a primary standards body), re-fetchable at
+% the `locator`. Nothing here is asserted from memory: every place→value pair is a
+% cell read off the cited lesson. (See ../README.md; ADJ-TABLES.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table place_value {
+    columns place, value
+
+    row (ones, 1)
+    row (tens, 10)
+    row (hundreds, 100)
+    row (thousands, 1000)
+
+    source "3 × 1 = 3 or 3 ones | 4 × 10 = 40 or 4 tens | 5 × 100 = 500 or 5 hundreds | 4 thousands = 4,000"
+    locator "https://www.cuemath.com/numbers/place-value/"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/mathematics/place-value.query.adj
+++ b/code/specs/data/adj-facts-stdlib/mathematics/place-value.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% place-value.query.adj — a worked recall over the mathematics place-value library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the hundreds place
+% worth?": it states no fact of its own — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the `place_value`
+% rows and returns the value + the table's source/locator/trust. Note the reverse
+% query below: because `value` is an ordinary column, you can bind the PLACE from a
+% known value (which place is worth 1000? → thousands). A word that is not a place
+% name abstains honestly — the engine never invents a value.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli place-value.query.adj
+% ============================================================================
+
+import "place-value.adj"
+
+? place_value(hundreds, $V)        % expect 100  (a digit in the hundreds column is worth 100)
+? place_value(tens, $V)            % expect 10   (a digit in the tens column is worth 10)
+? place_value($Place, 1000)        % expect thousands (reverse: which place is worth 1000?)
+? place_value(dozen, $V)           % expect abstain — "dozen" is not a place-value column


### PR DESCRIPTION
## What

A grounded early-elementary FACTS library for the ADJ standard library: each base-ten place-value name → the number it is worth.

| place | value |
|---|---|
| ones | 1 |
| tens | 10 |
| hundreds | 100 |
| thousands | 1000 |

Recall is a binding query resolved on the CPU (zero model calls), returning the value **with its citation**, and abstaining honestly on a non-place-name. A looked-up place value composes straight into **number decomposition** (recall → compute): `143 = 1×100 + 4×10 + 3×1`.

## Files

- `code/specs/data/adj-facts-stdlib/mathematics/place-value.adj` — native `table place_value` (ADJ-TABLES), one provenance envelope for the whole table.
- `code/specs/data/adj-facts-stdlib/mathematics/place-value.query.adj` — worked recall: two forward binds, one reverse bind by value (which place is worth 1000? → thousands), one honest abstain.
- `code/packages/rust/adj-lang-cli/tests/facts_placevalue_e2e.rs` — e2e recall test (binds hundreds→100 and tens→10, asserts locator + trust tier, abstains on `dozen`).

## Grounding

Values read **verbatim** off Cuemath's "Place Value" lesson expanded-form examples: `"3 × 1 = 3 or 3 ones"`, `"4 × 10 = 40 or 4 tens"`, `"5 × 100 = 500 or 5 hundreds"`, `"4 thousands = 4,000"`.

- **Source URL / locator:** https://www.cuemath.com/numbers/place-value/
- **Trust tier:** `consensus` (secondary math-education reference, not a primary standards body)
- Only places whose value is confirmable on that page are shipped; ten-thousands is deliberately omitted rather than asserted from memory. Nothing asserted from memory.

## Verification

- `cargo test -p adj-lang-cli --test facts_placevalue_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review (sub-agent) — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)