### PR TITLE
feat(adj-facts-stdlib): anatomy tooth-types facts library (tooth type -> job)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_toothtypes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_toothtypes_e2e.rs
@@ -1,0 +1,66 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/tooth-types.adj`) driven through the built CLI:
+//! a native `table` of tooth type → its job resolves a binding-query recall
+//! with the source's citation, runs the relation backward (job → tooth types),
+//! and abstains on something that is not a tooth — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factstooth_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_tooth_types_recall_binds_function_with_citation() {
+    let dir = scratch("toothtypes");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/tooth-types.adj");
+    std::fs::copy(&src, dir.join("tooth-types.adj")).expect("copy shipped tooth-types.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"tooth-types.adj\"\n\
+         ? tooth_function(incisors, $Job)\n\
+         ? tooth_function(canines, $Job)\n\
+         ? tooth_function($T, grinding)\n\
+         ? tooth_function(gums, $Job)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Incisors cut food into pieces; canines tear — the recalled jobs, each a
+    // plain lowercase atom copied from the source's own wording.
+    assert!(out.contains("\"Job\":\"cutting\""), "incisors → cutting: {out}");
+    assert!(out.contains("\"Job\":\"tearing\""), "canines → tearing: {out}");
+    // The relation runs backward: the job `grinding` recalls the wide back
+    // teeth — both premolars and molars do the grinding.
+    assert!(out.contains("\"T\":\"premolars\""), "grinding → premolars (reverse recall): {out}");
+    assert!(out.contains("\"T\":\"molars\""), "grinding → molars (reverse recall): {out}");
+    // The answer carries the NIH/NLM (ncbi.nlm.nih.gov) citation as its proof.
+    assert!(
+        out.contains("ncbi.nlm.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // "gums" are not a tooth type — honest abstention, never a fabricated job.
+    assert!(out.contains("\"abstained\":true"), "unknown tooth abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/tooth-types.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/tooth-types.adj
@@ -1,0 +1,87 @@
+% ============================================================================
+% tooth-types — each kind of human tooth and the job it does when we eat
+% (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A first anatomy fact on the way to the mouth: an adult has four SHAPES of
+% tooth, and each shape does a different job while we chew. The sharp front
+% teeth CUT, the pointed corner teeth TEAR, and the wide back teeth GRIND —
+% shape follows job. Recall is a binding query:
+%
+%     ? tooth_function(incisors, $Job)      % cutting
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `tooth_function(tooth, function)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% job WITH its source, on the CPU, with zero model calls, and abstains on
+% anything that is not one of the four tooth types.
+%
+% The four tooth types, as a little truth table:
+%
+%     tooth       job         where it sits           what it does to food
+%     ---------   --------    --------------------    --------------------
+%     incisors    cutting     front and center        cuts / bites off pieces
+%     canines     tearing     the sharp corners       tears and punctures
+%     premolars   grinding    behind the canines      crushes / grinds
+%     molars      grinding    the wide back teeth      grinds when we chew
+%
+% The query also runs BACKWARD — bind a job and recall the tooth type(s) that
+% do it (both `premolars` and `molars` do the grinding, so both are recalled):
+%
+%     ? tooth_function($T, grinding)        % premolars ; molars
+%
+% Something that is not one of the four tooth types — the tongue, the gums —
+% has no row, so a recall on it ABSTAINS rather than inventing a job. That
+% honest-abstention property is what makes the table safe to reason from.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every tooth→job pair was
+% read out of a fetched NIH/NLM page, and any tooth that could not be grounded
+% there would have been dropped). Each row, with the NIH source it was copied
+% from and the verbatim span that states its job:
+%
+%   incisors → cutting
+%     https://www.ncbi.nlm.nih.gov/books/NBK538475/  (NIH / NLM, StatPearls:
+%     "Physiology, Tooth")
+%     "The anterior teeth are called incisors, directly reflecting their role
+%      in cutting food into smaller pieces without performing any grinding
+%      function."
+%
+%   canines → tearing
+%     https://www.ncbi.nlm.nih.gov/books/NBK538475/  (NIH / NLM, StatPearls:
+%     "Physiology, Tooth")
+%     "Canine teeth function to tear and puncture holes."
+%
+%   premolars → grinding
+%     https://www.ncbi.nlm.nih.gov/books/NBK538475/  (NIH / NLM, StatPearls:
+%     "Physiology, Tooth")
+%     "The 8 premolars (bicuspids), 4 in each arch, which assist in crushing,
+%      grinding, and mixing food."
+%
+%   molars → grinding
+%     https://www.ncbi.nlm.nih.gov/books/NBK553376/  (NIH / NLM,
+%     InformedHealth.org: "In brief: How our teeth and jaws work together")
+%     "When we bite down, the cusps of the upper molars fit into the grooves of
+%      the lower teeth. That way, they can grind food when we chew."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the StatPearls sentence that
+% fixes the first row (incisors → cutting). Every OTHER row's per-fact source
+% and verbatim span is listed above, so each job remains independently
+% checkable. All sources are primary U.S. government NIH / National Library of
+% Medicine references (ncbi.nlm.nih.gov), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table tooth_function {
+    columns tooth, function
+
+    row (incisors, cutting)
+    row (canines, tearing)
+    row (premolars, grinding)
+    row (molars, grinding)
+
+    source "The anterior teeth are called incisors, directly reflecting their role in cutting food into smaller pieces without performing any grinding function."
+    locator "https://www.ncbi.nlm.nih.gov/books/NBK538475/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/tooth-types.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/tooth-types.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% tooth-types.query.adj — a worked recall over the anatomy tooth-types library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what job does an incisor
+% do?": it states no anatomy fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `tooth_function` rows and returns the job + the table's source/locator/trust.
+% The fourth query runs the relation BACKWARD (bind the job `grinding`, recall
+% every tooth that does it — both premolars and molars). The gums are not a
+% tooth type, so a recall on them abstains honestly — the engine never invents
+% a job.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli tooth-types.query.adj
+% ============================================================================
+
+import "tooth-types.adj"
+
+? tooth_function(incisors, $Job)       % expect cutting
+? tooth_function(canines, $Job)        % expect tearing
+? tooth_function(molars, $Job)         % expect grinding
+? tooth_function($T, grinding)         % expect premolars ; molars — reverse recall
+? tooth_function(gums, $Job)           % expect abstain — gums are not a tooth


### PR DESCRIPTION
## What

A grounded early-elementary ANATOMY facts library for the ADJ standard library mapping each human tooth type to the job it does when we eat — a step toward the anatomy the MEDICINE agents reason from.

| tooth | job |
|-----------|----------|
| incisors | cutting |
| canines | tearing |
| premolars | grinding |
| molars | grinding |

Shipped as a native ADJ `table tooth_function(tooth, function)`, so recall is an ordinary SLD binding query resolved on the CPU with **zero model calls**:

- forward — `? tooth_function(incisors, $Job)` -> `cutting`
- backward — `? tooth_function($T, grinding)` -> `premolars ; molars`
- honest abstention — `? tooth_function(gums, $Job)` -> abstains (never invents a job)

## Grounding

Nothing from memory. Every row was copied **verbatim** from a fetched NIH / National Library of Medicine page:

- **incisors / canines / premolars** — StatPearls "Physiology, Tooth", https://www.ncbi.nlm.nih.gov/books/NBK538475/
- **molars** — InformedHealth.org "In brief: How our teeth and jaws work together", https://www.ncbi.nlm.nih.gov/books/NBK553376/

All sources are primary U.S. government references (`ncbi.nlm.nih.gov`), so `trust authoritative`. Per-row verbatim spans are recorded in the file's provenance comment; the table's single envelope holds the StatPearls incisors span.

## Files

- `code/specs/data/adj-facts-stdlib/anatomy/tooth-types.adj` — literate, beginner comment + truth table + citation
- `code/specs/data/adj-facts-stdlib/anatomy/tooth-types.query.adj` — worked recall (forward, reverse, abstain)
- `code/packages/rust/adj-lang-cli/tests/facts_toothtypes_e2e.rs` — 2 binds, locator + trust, reverse recall, one abstain

## Verification

- `cargo test -p adj-lang-cli --test facts_toothtypes_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review — passed (round 1, no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)