### PR TITLE
feat(adj-facts-stdlib): earth-science rock-types facts library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_rocktypes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_rocktypes_e2e.rs
@@ -1,0 +1,65 @@
+//! End-to-end test for the earth-science FACTS library
+//! (`adj-facts-stdlib/earth-science/rock-types.adj`) driven through the built
+//! CLI: a native `table` of rock type → how it forms resolves a binding-query
+//! recall with the NPS citation, and abstains on `magma` (the molten material
+//! rock forms FROM, not one of the three rock types) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsrt_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn rock_types_recall_binds_formation_with_citation() {
+    let dir = scratch("rocktypes");
+    // Copy the shipped earth-science table beside the entry program and import it.
+    let src = facts_stdlib().join("earth-science/rock-types.adj");
+    std::fs::copy(&src, dir.join("rock-types.adj")).expect("copy shipped rock-types.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"rock-types.adj\"\n\
+         ? rock_formation(igneous, $How)\n\
+         ? rock_formation(metamorphic, $How)\n\
+         ? rock_formation(magma, $How)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Igneous rock is cooled magma; metamorphic rock is made by heat and
+    // pressure — the recalled formations, straight from the grounded rows.
+    assert!(out.contains("\"How\":\"cooled_magma\""), "igneous → cooled_magma: {out}");
+    assert!(
+        out.contains("\"How\":\"heat_and_pressure\""),
+        "metamorphic → heat_and_pressure: {out}"
+    );
+    // The answer carries the NPS citation (authoritative, a .gov source) as proof.
+    assert!(
+        out.contains("nps.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NPS source citation: {out}"
+    );
+    // Magma is the molten material rock forms FROM, not a rock type — honest
+    // abstention, never a fabricated formation.
+    assert!(out.contains("\"abstained\":true"), "magma abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/earth-science/rock-types.adj
+++ b/code/specs/data/adj-facts-stdlib/earth-science/rock-types.adj
@@ -1,0 +1,57 @@
+% ============================================================================
+% rock-types — each of the three main rock types and how it forms
+% (adj-facts-stdlib, EARTH-SCIENCE).
+% ============================================================================
+% One of the first earth-science facts a young student meets: every rock on
+% Earth belongs to one of THREE families, and the family is decided by HOW the
+% rock was made. Igneous rock is once-molten rock that cooled and hardened;
+% sedimentary rock is loose bits of older rock that got pressed together;
+% metamorphic rock is older rock that heat and pressure changed into something
+% new. Recall is a binding query:
+%
+%     ? rock_formation(igneous, $How)   % cooled_magma (igneous = cooled magma)
+%
+% A native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground relation
+% `rock_formation(rock_type, forms_from)` carrying the NPS citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns HOW the
+% rock forms WITH its source, on the CPU, with zero model calls. It abstains on
+% anything the page does not name as one of the three rock types: `magma` is the
+% molten material rock forms FROM, not a rock type, so a query for `magma`
+% honestly binds nothing rather than inventing a formation.
+%
+% The three rock families, as a truth table:
+%
+%     rock_type     forms_from            how it is made (NPS)
+%     -----------   -------------------   ----------------------------------
+%     igneous       cooled_magma          molten magma cools and hardens
+%     sedimentary   compacted_sediment    sediment is pressed / compacted
+%     metamorphic   heat_and_pressure     older rock changed by heat+pressure
+%
+% Provenance: copied from the U.S. National Park Service (NPS) geology teacher
+% page "Olympic Geology pt 2: Rock Sorting", which names the three groups and
+% describes each one's formation verbatim on a single page (the `locator`).
+% Each row's `forms_from` atom is confirmed by its own sentence there:
+%   - igneous → cooled_magma:
+%       "Igneous Rocks: form when hot, liquid rock, or magma, cools."   (see `source`)
+%   - sedimentary → compacted_sediment:
+%       "With the help of time and external pressures, these sediments get
+%        compacted into sedimentary rock."
+%   - metamorphic → heat_and_pressure:
+%       "This normally happens deep underground where heat, pressure, and
+%        chemical activity can actually alter the minerals inside rocks."
+% `trust authoritative` — NPS/nps.gov is a U.S. government (.gov) primary
+% reference. Nothing here is asserted from memory. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table rock_formation {
+    columns rock_type, forms_from
+
+    row (igneous, cooled_magma)
+    row (sedimentary, compacted_sediment)
+    row (metamorphic, heat_and_pressure)
+
+    source "Igneous Rocks: form when hot, liquid rock, or magma, cools."
+    locator "https://www.nps.gov/teachers/classrooms/olympic-geology-pt-2-rock-sorting.htm"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/earth-science/rock-types.query.adj
+++ b/code/specs/data/adj-facts-stdlib/earth-science/rock-types.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% rock-types.query.adj — a worked recall over the earth-science rock-types
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how does an igneous rock
+% form?" — it states no earth-science fact, only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `rock_formation` rows and returns how the rock forms (or the rock type, on a
+% reverse query) + the NPS source/locator/trust. Something the page does not
+% name as one of the three rock types abstains honestly — the engine never
+% invents a formation.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli rock-types.query.adj
+% ============================================================================
+
+import "rock-types.adj"
+
+? rock_formation(igneous, $How)          % expect cooled_magma (once-molten, cooled)
+? rock_formation(metamorphic, $How)      % expect heat_and_pressure (changed rock)
+? rock_formation($Type, compacted_sediment)
+                                         % expect sedimentary (reverse: pressed bits?)
+? rock_formation(magma, $How)            % expect abstain — magma is the molten
+                                         %   material rock forms FROM, not a rock type


### PR DESCRIPTION
## What

A grounded early-elementary FACTS library for the ADJ standard library: each of the three main rock types mapped to how it forms.

- **`earth-science/rock-types.adj`** — native \`table rock_formation\` (ADJ-TABLES RS-5) with rows:
  - \`(igneous, cooled_magma)\`
  - \`(sedimentary, compacted_sediment)\`
  - \`(metamorphic, heat_and_pressure)\`
- **`earth-science/rock-types.query.adj`** — two forward binds, one reverse bind, and an honest abstain on \`magma\` (the molten material rock forms *from*, not a rock type).
- **`adj-lang-cli/tests/facts_rocktypes_e2e.rs`** — drives the shipped table through the built CLI: binds igneous/metamorphic, asserts the NPS locator + \`authoritative\` trust, asserts \`magma\` abstains. 0 model calls.

## Grounding

Source: U.S. National Park Service (nps.gov, `.gov`) — *Olympic Geology pt 2: Rock Sorting*, a single page that names the three rock groups and describes each one's formation. Each \`forms_from\` atom is confirmed verbatim by its own sentence on that page:

- igneous → cooled_magma: "Igneous Rocks: form when hot, liquid rock, or magma, cools."
- sedimentary → compacted_sediment: "With the help of time and external pressures, these sediments get compacted into sedimentary rock."
- metamorphic → heat_and_pressure: "This normally happens deep underground where heat, pressure, and chemical activity can actually alter the minerals inside rocks."

`trust authoritative`. Nothing asserted from memory.

## Verification

- \`cargo test -p adj-lang-cli --test facts_rocktypes_e2e\` — passes (1/1)
- \`cargo clippy -p adj-lang-cli --tests -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)