### PR TITLE
feat(sql): scalar subquery ( SELECT ... ) parses (evaluation is a follow-up)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.33 — Scalar subquery `( SELECT … )` parses (evaluation is a follow-up)
+
+`SELECT (SELECT count(*) FROM t2)` and `WHERE x > (SELECT max(y) FROM t2)` now
+PARSE — the grammar's `primary` accepts a parenthesised `SELECT` (sql-parser
+0.1.17), tried before the plain `( expr )` form. Evaluation is not yet wired: the
+planner rejects a scalar subquery with a clear
+`scalar subqueries are not yet supported` error (sql-planner 0.2.15) rather than
+panicking or mis-planning — an integration test confirms the parse→plan→clean-error
+path end to end. This is the first, parse-only slice of scalar-subquery support;
+a follow-up adds `SqlExpr::ScalarSubquery` + the VM sub-plan evaluation (run the
+inner SELECT once, take row 0 / column 0, NULL if empty). The plain
+`( 1 + 2 )` parenthesised-expression form is unaffected (regression-tested).
+
 ## 0.5.32 — `COLLATE` on the left comparison operand
 
 `x COLLATE NOCASE = y` now folds the comparison just like `x = y COLLATE C`

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.32"
+version = "0.5.33"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/mini_sqlite_tests.rs
+++ b/code/packages/rust/mini-sqlite/tests/mini_sqlite_tests.rs
@@ -192,3 +192,19 @@ fn opening_a_missing_file_is_an_operational_error() {
     let err = connect("this/file/does/not/exist.sqlite").unwrap_err();
     assert!(matches!(err, MiniSqliteError::OperationalError(_)));
 }
+
+#[test]
+fn scalar_subquery_parses_but_errors_not_yet_supported() {
+    // A `( SELECT … )` scalar subquery now PARSES (grammar wired), but the
+    // evaluation path is not implemented — it must fail with a clear error
+    // rather than panicking or mis-planning.
+    let conn = must_connect();
+    must_execute(&conn, "CREATE TABLE t (x INTEGER)", &[]);
+    let err = conn
+        .execute("SELECT (SELECT 1) FROM t", &[])
+        .expect_err("scalar subquery should be rejected as not-yet-supported");
+    assert!(
+        format!("{err}").to_lowercase().contains("subquer"),
+        "expected a subquery-not-supported error, got: {err}"
+    );
+}

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.17] - Unreleased
+
+### Added
+
+- **Scalar subquery `( SELECT … )` parses as a `primary`.** The generated
+  `primary` rule gains `"(" select_stmt ")"` before the plain `"(" expr ")"` form
+  (matching the grammar source), so a subquery is matched when the token after `(`
+  is `SELECT` and a non-SELECT `(` backtracks to the expression form. Parsing is
+  wired; evaluation is a follow-up (the planner errors NYI).
+
 ## [0.1.16] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -685,6 +685,17 @@ pub fn parser_grammar() -> ParserGrammar {
                 ] },
                 GrammarElement::RuleReference { name: r#"function_call"#.to_string() },
                 GrammarElement::RuleReference { name: r#"column_ref"#.to_string() },
+                // Scalar subquery `( SELECT … )`. Placed BEFORE the plain
+                // `( expr )` form so ordered choice matches the subquery when the
+                // token after `(` is the `SELECT` keyword (which cannot start an
+                // `expr`); a non-SELECT `(` backtracks to `( expr )`. Parsing is
+                // wired here; the planner rejects it with a clear "not yet
+                // supported" error until the evaluation path lands.
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"("#.to_string() },
+                    GrammarElement::RuleReference { name: r#"select_stmt"#.to_string() },
+                    GrammarElement::Literal { value: r#")"#.to_string() },
+                ] },
                 GrammarElement::Sequence { elements: vec![
                     GrammarElement::Literal { value: r#"("#.to_string() },
                     GrammarElement::RuleReference { name: r#"expr"#.to_string() },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -705,6 +705,24 @@ mod tests {
         assert!(find_rule(&ast, "order_item"), "Expected order_item to keep COLLATE");
     }
 
+    /// A scalar subquery `( SELECT … )` parses as a `primary` containing a
+    /// nested `select_stmt` — in the SELECT list and in a WHERE comparison — and
+    /// does NOT disturb the plain parenthesised-expression form `( 1 + 2 )`.
+    #[test]
+    fn test_parse_scalar_subquery() {
+        for q in [
+            "SELECT (SELECT count(*) FROM t2) FROM t",
+            "SELECT x FROM t WHERE x > (SELECT max(y) FROM t2)",
+        ] {
+            let ast = assert_program_root(q);
+            // Two select_stmt nodes: the outer query and the nested subquery.
+            assert!(find_rule(&ast, "select_stmt"), "Expected select_stmt for {q:?}");
+        }
+        // Regression: a plain parenthesised expression still parses.
+        let ast = assert_program_root("SELECT (1 + 2) FROM t");
+        assert!(find_rule(&ast, "primary"), "Expected primary for parenthesised expr");
+    }
+
     // -----------------------------------------------------------------------
     // Test 20: BETWEEN expression
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.15] - Unreleased
+
+### Added
+
+- **Scalar subqueries rejected with a clear error (not yet evaluated).** A
+  `select_stmt` node inside a `primary` (a `( SELECT … )`) returns
+  `PlanError::UnsupportedStatement("scalar subqueries are not yet supported")`
+  rather than mis-planning it. Wiring `SqlExpr::ScalarSubquery` + the VM sub-plan
+  evaluation is the follow-up.
+
 ## [0.2.14] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -2281,6 +2281,16 @@ fn plan_primary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
                 "column_ref" => return plan_column_ref(n),
                 "function_call" => return plan_function_call(n),
                 "expr" => return plan_expression(n),
+                // A `( SELECT … )` scalar subquery parses to a nested `select_stmt`
+                // node in a primary. Parsing is wired but evaluation is not yet:
+                // reject it with a clear error rather than mis-planning it as an
+                // expression. Wiring `SqlExpr::ScalarSubquery` + the VM sub-plan
+                // eval is the follow-up.
+                "select_stmt" => {
+                    return Err(PlanError::UnsupportedStatement(
+                        "scalar subqueries are not yet supported".to_string(),
+                    ))
+                }
                 "or_expr" | "and_expr" | "not_expr" | "comparison" | "bitwise"
                 | "additive" | "multiplicative" | "unary" | "primary" => return plan_expression(n),
                 _ => return plan_expression(n),


### PR DESCRIPTION
## Scalar subquery `( SELECT … )` parses (evaluation is a follow-up)

The first, **parse-only** slice of scalar-subquery support — the last big untouched
lane-1 item. **Rotation lane 1 (CAST/CASE/subqueries).** Probed real SQLite first
(a scalar subquery returns row 0 / column 0, NULL if no rows — that evaluation
lands in the follow-up).

### What lands here
- **sql-parser 0.1.17** — the generated `primary` rule gains `"(" select_stmt ")"`
  **before** the plain `"(" expr ")"` form (matching the grammar *source*, which
  already listed it but the generated parser was stale). A subquery matches when
  the token after `(` is `SELECT` (which can't start an expr); a non-SELECT `(`
  backtracks to the expression form.
- **sql-planner 0.2.15** — a `select_stmt` node inside a `primary` returns a clear
  `PlanError::UnsupportedStatement("scalar subqueries are not yet supported")`
  rather than mis-planning or panicking.

### Why parse-only
This is a legit clean increment that **unblocks** the big feature: the grammar
accepts `(SELECT ...)`, the planner errors NYI, and the parse path is verified. The
**follow-up** wires `SqlExpr::ScalarSubquery` + plan the inner SELECT + codegen +
VM sub-plan eval (uncorrelated → run once, take row 0 / col 0, NULL if empty).

### Tests
Parser test: the subquery parses (nested `select_stmt`) in both a SELECT-list and a
WHERE comparison, plus a regression that plain `( 1 + 2 )` still parses. Integration
test: `SELECT (SELECT 1)` errors **cleanly** (not a panic) end to end. Parse-only
can't be oracle-tested (it errors), so these unit/integration tests are the
verification. Full affected set green (oracle unbroken); clippy clean.

### Security
Inline adversarial review **PASSED** — the new `( select_stmt )` alternative is not
left-recursive (consumes `(` first), `select_stmt` fails in O(1) on a non-SELECT
`(`, and the memoized packrat PEG stays linear-time; the planner error arm cannot
panic or be skipped. (The reviewer noted a **pre-existing**, not-introduced-here
DoS ceiling — the parser has no recursion-depth cap — which I've spun off as a
separate task; it's reachable more cheaply via the existing `( expr )` path and is
not amplified by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
