### PR TITLE
feat(adj-facts-stdlib): biology body-systems facts library (system → main job)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_bodysystems_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_bodysystems_e2e.rs
@@ -1,0 +1,70 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/body-systems.adj`) driven through the built CLI:
+//! a native `table` of body-system → main-function resolves a binding-query
+//! recall with the source's citation, runs the relation backward
+//! (function → system), and abstains on a body part that is not a system —
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsbodysys_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_body_systems_recall_binds_function_with_citation() {
+    let dir = scratch("bodysystems");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/body-systems.adj");
+    std::fs::copy(&src, dir.join("body-systems.adj")).expect("copy shipped body-systems.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"body-systems.adj\"\n\
+         ? body_system_function(digestive, $F)\n\
+         ? body_system_function(respiratory, $F)\n\
+         ? body_system_function($S, moves_blood)\n\
+         ? body_system_function(elbow, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The digestive system breaks down food; the respiratory system does
+    // breathing — the recalled main-function atoms.
+    assert!(out.contains("\"F\":\"breaks_down_food\""), "digestive → breaks_down_food: {out}");
+    assert!(out.contains("\"F\":\"breathing\""), "respiratory → breathing: {out}");
+    // The relation runs backward: the job moves_blood recalls the circulatory system.
+    assert!(
+        out.contains("\"S\":\"circulatory\""),
+        "moves_blood → circulatory (reverse recall): {out}"
+    );
+    // The answer carries the MedlinePlus (NIH, .gov) citation as its proof.
+    assert!(
+        out.contains("medlineplus.gov/ency/imagepages/1090.htm")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // "elbow" is a body part, not a body system — honest abstention, never a
+    // fabricated function.
+    assert!(out.contains("\"abstained\":true"), "non-system abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/body-systems.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/body-systems.adj
@@ -1,0 +1,85 @@
+% ============================================================================
+% body-systems — each major human body system and its main job
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% An early-elementary biology facts library in the ADJ standard library — the
+% kind a science or medicine agent `import`s when it needs the most basic
+% grounded physiology fact: "the digestive system breaks down food; the
+% respiratory system does breathing; the circulatory system moves blood." The
+% human body is organized into systems, and each system carries out one main
+% job. This is a small but real STEP toward how a medicine agent reasons about
+% physiology: before diagnosing anything it must first know which system does
+% what, the way a first-year student does. Recall is a binding query:
+%
+%     ? body_system_function(digestive, $F)   % breaks_down_food
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `body_system_function(system, function)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the function atom WITH its source, on the CPU, with zero model calls,
+% and abstains on a body part (or non-system) not in the table. The query also
+% runs BACKWARD — bind the job and recall the system:
+%
+%     ? body_system_function($S, moves_blood)  % circulatory
+%
+% The `function` value of every row is a SINGLE lowercase atom, chosen to be a
+% faithful one-word (or short snake_case) paraphrase of the primary-function
+% text MedlinePlus states — never an interpretation the source does not support.
+% A recalled function atom therefore composes straight into downstream reasoning
+% (a medicine agent asking "which system moves_blood?" gets the grounded answer,
+% not a guess) — the concrete bridge from biology RECALL to reasoning.
+%
+% Provenance: every system name and its `function` atom is grounded in a
+% VERBATIM span from MedlinePlus (the U.S. National Library of Medicine / NIH,
+% a `.gov` primary reference). The `source` span below is the VERBATIM overview
+% text for the first data row (digestive), copied character-for-character from
+% its MedlinePlus page (the `locator`). Each remaining row's atom is a faithful
+% short paraphrase of that system's own MedlinePlus span, quoted here with its
+% own page so any reader can re-check it byte-for-byte:
+%
+%   digestive    → breaks_down_food  https://medlineplus.gov/ency/imagepages/1090.htm
+%     "The esophagus, stomach, large and small intestine, aided by the liver,
+%      gallbladder and pancreas convert the nutritive components of food into
+%      energy and break down the non-nutritive components into waste to be
+%      excreted through the large intestine."
+%   respiratory  → breathing         https://medlineplus.gov/ency/imagepages/9828.htm
+%     "Air is breathed in through the nasal passageways, travels through the
+%      trachea and bronchi to the lungs."
+%   circulatory  → moves_blood       https://medlineplus.gov/ency/imagepages/8747.htm
+%     "Blood used by the body is brought back to the heart and lungs by the
+%      veins of the body. Once the blood has gathered more oxygen from the lungs,
+%      it is pumped back out to the body through the arteries."
+%   nervous      → controls_body     https://medlineplus.gov/ency/article/007456.htm
+%     "Together, your brain and spinal cord serve as the main \"processing
+%      center\" for the entire nervous system, and control all the functions of
+%      your body."
+%   skeletal     → supports_body     https://medlineplus.gov/ency/imagepages/9065.htm
+%     "The bones of the skeleton provide support for the soft tissues."
+%   muscular     → movement          https://medlineplus.gov/ency/imagepages/9676.htm
+%     "Muscle tissue is composed primarily of contractile cells. Contractile
+%      cells have the ability to produce movement."
+%
+% `trust authoritative` — MedlinePlus is a `.gov` service of the U.S. National
+% Library of Medicine (NIH), a primary/official reference (contrast the
+% `consensus` tier reserved for a secondary source such as an encyclopedia or
+% KidsHealth). Nothing here is asserted from memory; each pair was read out of
+% the fetched MedlinePlus page and any system whose function the pages did not
+% state would have been dropped.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_adjudication_no_interpretive_gating.)
+% ============================================================================
+
+table body_system_function {
+    columns system, function
+
+    row (digestive, breaks_down_food)
+    row (respiratory, breathing)
+    row (circulatory, moves_blood)
+    row (nervous, controls_body)
+    row (skeletal, supports_body)
+    row (muscular, movement)
+
+    source "The esophagus, stomach, large and small intestine, aided by the liver, gallbladder and pancreas convert the nutritive components of food into energy and break down the non-nutritive components into waste to be excreted through the large intestine."
+    locator "https://medlineplus.gov/ency/imagepages/1090.htm"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/body-systems.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/body-systems.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% body-systems.query.adj — a worked recall over the biology body-systems library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the digestive
+% system do?": it states no biology fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `body_system_function` rows and returns the function atom + the table's
+% source/locator/trust. The third query runs the relation BACKWARD (bind the
+% job, recall the system). A body part (or non-system) not in the table abstains
+% honestly — the engine never invents a function.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli body-systems.query.adj
+% ============================================================================
+
+import "body-systems.adj"
+
+? body_system_function(digestive, $F)    % expect breaks_down_food
+? body_system_function(respiratory, $F)  % expect breathing
+? body_system_function($S, moves_blood)  % expect circulatory — the reverse recall
+? body_system_function(elbow, $F)        % expect abstain — a body part, not a system


### PR DESCRIPTION
## What

Adds an early-elementary **biology** facts library to the ADJ standard library: a native `table body_system_function` mapping each major human body system to its main job.

| system | function |
|---|---|
| digestive | breaks_down_food |
| respiratory | breathing |
| circulatory | moves_blood |
| nervous | controls_body |
| skeletal | supports_body |
| muscular | movement |

A step toward how a medicine agent reasons about physiology — know which system does what before diagnosing anything. Recall composes: `? body_system_function(digestive, $F)` → `breaks_down_food`, with citation, on the CPU, 0 model calls; runs backward (`$S, moves_blood → circulatory`); abstains on a body part that is not a system.

## Grounding

Every system + atom is grounded in a **VERBATIM** span from **MedlinePlus** (U.S. National Library of Medicine / NIH, `.gov`) → `trust authoritative`. Each row's own span + page URL is quoted in the file's literate comment; `source`/`locator` carry the strong span for the first row (digestive → https://medlineplus.gov/ency/imagepages/1090.htm). Nothing asserted from memory.

## Files
- `code/specs/data/adj-facts-stdlib/biology/body-systems.adj` — the grounded table + literate comment
- `code/specs/data/adj-facts-stdlib/biology/body-systems.query.adj` — worked recall (forward + reverse + abstain)
- `code/packages/rust/adj-lang-cli/tests/facts_bodysystems_e2e.rs` — e2e test (2 forward binds, reverse recall, locator + trust assertion, one abstain)

## Verification
- `cargo test -p adj-lang-cli --test facts_bodysystems_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review — CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)