### PR TITLE
feat(js-parser): bridge async arrow functions async () => expr — CLOC12.192

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.57.0] - 2026-07-14
+
+### Added — bridge async arrow functions (`async () => expr`) — CLOC12.192
+
+The grammar rule `async_arrow_function = "async" arrow_parameters ARROW concise_body` is the plain
+`arrow_function` shape plus a leading `async` literal, so `convert_arrow_function` (now taking an
+`is_async` flag) handles its children unchanged and just sets the flag. `async_arrow_function` is
+dispatched to it instead of declining. The AST (`ArrowFunctionExpression.is_async`) and emitter (prints
+`async`) already modelled async arrows, so this is a bridge-only enable — an async arrow file no longer
+declines to WHITESPACE_ONLY. A body needing `await` still declines separately (that grammar is not
+parseable yet). Additive; MINOR.
+
 ## [0.56.0] - 2026-07-14
 
 ### Added — bridge default parameters (`function f(a = expr){}`) — CLOC12.191 PR2

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -2023,7 +2023,10 @@ fn convert_yield_expression(node: &GrammarASTNode) -> Result<Expression, BridgeE
 /// Async arrows (`async x => x`) parse under the separate
 /// `async_arrow_function` rule and remain declined for now — a follow-up
 /// once the async evaluation model lands.
-fn convert_arrow_function(node: &GrammarASTNode) -> Result<ArrowFunctionExpression, BridgeError> {
+fn convert_arrow_function(
+    node: &GrammarASTNode,
+    is_async: bool,
+) -> Result<ArrowFunctionExpression, BridgeError> {
     let children = node_children(node);
 
     let mut params = Vec::new();
@@ -2077,7 +2080,7 @@ fn convert_arrow_function(node: &GrammarASTNode) -> Result<ArrowFunctionExpressi
         cv: None,
         params,
         body,
-        is_async: false,
+        is_async,
     })
 }
 
@@ -2401,7 +2404,18 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
         // itself declines the ambiguous `() => {}` / object-body case and
         // (until the grammar parses them) never sees a block body.
         "arrow_function" => {
-            convert_arrow_function(node).map(Expression::ArrowFunctionExpression)
+            convert_arrow_function(node, false).map(Expression::ArrowFunctionExpression)
+        }
+
+        // Async arrow function (CLOC12.192). The grammar rule
+        // `async_arrow_function = "async" arrow_parameters ARROW concise_body`
+        // is the plain `arrow_function` shape plus a leading `async` literal, so
+        // `convert_arrow_function` handles its children unchanged (the `async`
+        // token is not a node) — we just set `is_async`. The AST and emitter
+        // already model async arrows; a body that requires `await` still
+        // declines separately (that grammar is not parseable yet).
+        "async_arrow_function" => {
+            convert_arrow_function(node, true).map(Expression::ArrowFunctionExpression)
         }
 
         // No-substitution template literal (CLOC12.155). `convert_template_literal`
@@ -2431,8 +2445,7 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
             convert_class_expression(node).map(Expression::ClassExpression)
         }
 
-        "async_arrow_function"
-        | "await_expression"
+        "await_expression"
         | "async_function_expression"
         | "async_generator_expression"
         | "tagged_template_expression"
@@ -6294,17 +6307,30 @@ mod tests {
     }
 
     #[test]
-    fn async_arrow_is_still_declined() {
-        // Async arrows parse under `async_arrow_function` and remain declined
-        // (safe whitespace-only passthrough) until the async model lands.
-        assert!(
-            grammar_to_program(
-                &crate::parse_javascript("var f=async x=>x;", "es2025").expect("parse"),
-                DEFAULT_ES_VERSION,
-            )
-            .is_err(),
-            "async arrow should still decline"
-        );
+    fn async_arrow_single_param_bridges() {
+        // `async x => x` — CLOC12.192. Async arrows parse under
+        // `async_arrow_function` (the plain arrow shape plus a leading `async`
+        // literal) and now bridge to an `ArrowFunctionExpression` with `is_async`
+        // set, instead of declining to WHITESPACE_ONLY.
+        let f = arrow_of("x = async x => x;");
+        assert!(f.is_async, "async arrow must set is_async");
+        assert_eq!(f.params.len(), 1);
+    }
+
+    #[test]
+    fn async_arrow_paren_params_bridges() {
+        // `async (a, b) => a` — parenthesised params carry the same async flag.
+        let f = arrow_of("x = async (a, b) => a;");
+        assert!(f.is_async);
+        assert_eq!(f.params.len(), 2);
+    }
+
+    #[test]
+    fn plain_arrow_is_not_async() {
+        // Regression: the plain-arrow dispatch still bridges with is_async=false
+        // after the shared converter gained the `is_async` parameter.
+        let f = arrow_of("x = y => y;");
+        assert!(!f.is_async, "plain arrow must not be async");
     }
 
     /// Pull the single `ForOfStatement` out of a one-statement program.


### PR DESCRIPTION
## CLOC12.192 async arrow functions — bridge-only enable

Enables bridging of async arrow functions. The grammar rule `async_arrow_function = "async" arrow_parameters ARROW concise_body` is the plain `arrow_function` shape plus a leading `async` literal token, so `convert_arrow_function` (now taking an `is_async: bool`) handles its children unchanged — the `async` token is filtered out by `node_children`, never misread as a param or body — and just sets the flag. `async_arrow_function` is dispatched to that converter instead of sitting in the decline list.

Because the AST (`ArrowFunctionExpression.is_async`) and emitter (prints `async`) already modelled async arrows, this is a **bridge-only enable** — no new AST or emitter.

### End-to-end proof (SIMPLE)
```
var f = async () => 1 + 2; g(f);   →   var f=async()=>3;g(f);
```
The async arrow body folds `1 + 2` → `3` — the file optimizes instead of declining to WHITESPACE_ONLY. A body that needs `await` still declines separately (that grammar isn't parseable yet): `await_expression` remains in the decline list, so `async x => await y` recurses into it and cleanly declines the whole file.

### Tests
The `async_arrow_is_still_declined` test becomes three: async single-param bridges, async paren-params bridges, and a plain-arrow-is-not-async regression. All 254 parser tests + the full closurec suite pass under `-D warnings` + clippy.

### Security review
Inline review passed clean: child dispatch is correct (leading `async` is a token, not a node), `is_async=true` is semantically faithful (emitter reprints `async`), await-bodies still decline safely, and no shape now bridges that would mis-emit rather than decline. No panic/DoS surface.

Bumps javascript-parser 0.56.0 → 0.57.0. Next: PR2 = closurec e2e fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)