### PR TITLE
feat(sir-runtime-array): N-D array/matrix runtime for Semantic-IR JS/TS (HML01 Stream A item 6)

### DIFF
--- a/code/packages/typescript/sir-runtime-array/BUILD
+++ b/code/packages/typescript/sir-runtime-array/BUILD
@@ -1,0 +1,13 @@
+load("code/packages/starlark/library-rules/typescript_library.star", "ts_library")
+
+_targets = [
+    ts_library(
+        name = "sir-runtime-array",
+        srcs = ["src/**/*.ts", "tests/**/*.ts"],
+        # No in-repo `file:` deps — this package is a self-contained numeric
+        # wrapper over Float64Array, unlike sir-runtime-symbolic/-core which
+        # build on sibling term-tree/pairs packages.
+        deps = [],
+        test_runner = "vitest",
+    ),
+]

--- a/code/packages/typescript/sir-runtime-array/BUILD_windows
+++ b/code/packages/typescript/sir-runtime-array/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx tsc --noEmit
+npx vitest run --coverage

--- a/code/packages/typescript/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-array/CHANGELOG.md
@@ -56,7 +56,7 @@ All notable changes to this project will be documented in this file.
   `array_runtime::ops`'s existing `reduce`/`scan`/`outer` Rust
   implementations now would be speculative. A natural follow-up once
   `apl-to-semantic-ir`'s own JS-backend consumption needs them.
-- 53 tests, 100% line/branch/function coverage, including an adversarial
+- 54 tests, 100% line/branch/function coverage, including an adversarial
   regression test confirming `range`'s `MAX_ELEMENTS` cap actually trips
   (not just trusting the code that it would) on a runtime-computed bound
   that would otherwise materialize an unbounded array.
@@ -91,3 +91,17 @@ All notable changes to this project will be documented in this file.
   can't police at runtime) fell through to `undefined` and surfaced as a
   confusing `TypeError` several calls downstream instead of a clean
   `Error` at the point of the actual mistake.
+- **The same allocate-before-validate gap in `indexGet`/`indexSet`'s
+  2-index sub-array path** — found on the *second* `/security-review`
+  round, after the first three fixes above. `rows.length`/`cols.length`
+  (from `resolvePositions` on each index argument) are each individually
+  bounded — by `a`'s own dimensions for a `whole` selection, or by a
+  `range` NDArray's own `MAX_ELEMENTS` cap for a `range` selection — but
+  nothing bounded their *product*, so a `range`-selected row list and a
+  `range`-selected column list, each independently legitimate (up to
+  `MAX_ELEMENTS` positions), could still multiply to an absurd output size
+  before `indexGet`'s `new Float64Array(rows.length * cols.length)` or
+  `indexSet`'s `broadcastValues(value, rows.length * cols.length)` ever
+  allocated it — the exact outer-product-shaped gap the `matmul` fix
+  above closed, reopened one function over. Fixed the same way:
+  `checkedShapeSize([rows.length, cols.length])` before either allocation.

--- a/code/packages/typescript/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-array/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-07-14
+
+### Added
+
+- Initial release — the SIR22 N-D array/matrix runtime (HML01 Stream A,
+  item 6), meant to be imported by Semantic-IR-emitted TypeScript/
+  JavaScript as `__SirArray` for the MATLAB/Octave array domain, once a
+  follow-up backend PR wires up the codegen call sites (currently both
+  `semantic-ir-to-javascript` and `semantic-ir-to-typescript` hard-reject
+  `Feature::NDArrays`/`Feature::MatrixOps` and hit a deferred `panic!` at
+  every SIR22 `Expr` match arm — this package builds the runtime primitives
+  that follow-up PR will call, mirroring exactly how `sir-runtime-symbolic`
+  landed before SIR23's own Stream-B codegen).
+- **`NDArray`** (`ndarray`, `scalar`, `fromVec`, `fromRows`, `zeros`,
+  `ndims`, `isScalar`, `nrows`, `ncols`, `get`, `set`) — the dense,
+  column-major `f64` value model, mirroring `array_runtime::value::Array`
+  (`code/packages/rust/array-runtime/src/value.rs`) field-for-field,
+  including its exact column-major indexing formula (`(r, c)` lives at flat
+  offset `c * nrows + r`) and its "a vector `[n]` is `n×1`" row/column
+  convention. Bounded by `MAX_ELEMENTS` (2²⁶, matching `matlab-runtime`'s
+  own `MAX_RANGE`) so a compiled program's runtime-computed shape can't
+  exhaust memory.
+- **`elementwise(op, a, b)`** — all 13 `ElementwiseOpKind`s the SIR22 spec
+  defines (`array_runtime::ops::BinOp`'s 12 — `Add`/`Sub`/`Mul`/`Div`/`Max`/
+  `Min`/`Eq`/`Ne`/`Lt`/`Le`/`Ge`/`Gt` — plus `Pow`, which is in the SIR spec's
+  "original cut" but hasn't been ported to Rust's `array-runtime` crate
+  yet). Same scalar-broadcast rule as the Rust reference: either operand
+  may be a scalar, otherwise shapes must match exactly. Comparisons produce
+  APL-style `1`/`0`, never a native `boolean`.
+- **`matmul(a, b)`** / **`transpose(a, conjugate?)`** — mirror
+  `array_runtime::ops::matmul`/`transpose` exactly, including their
+  column-major indexing arithmetic. `conjugate` (MATLAB `'` vs `.'`) is
+  accepted for API-shape parity with the SIR22 spec's `Transpose` field but
+  is currently a no-op — there is no `Complex` value type yet, matching
+  `array-runtime`'s own real-only scope.
+- **`range(start, stop, step?)`** — MATLAB-style `start:step:stop`
+  materialization as a `1×n` row vector, with the same inclusive-stop
+  tolerance (`1e-9`) and length cap (`MAX_ELEMENTS`) `matlab-runtime`'s own
+  `eval_colon` (`code/packages/rust/matlab-runtime/src/eval.rs`) uses.
+- **`indexGet(a, indices)`** / **`indexSet(a, indices, value)`** — `A(i)`/
+  `A(i, j)` read and in-place write, covering the SIR22 spec's `IndexArg`
+  shapes (`scalar`/`whole`/`range`). Scoped to 1 (linear, column-major) or 2
+  (row/col) index arguments, matching this whole package's rank-≤-2 scope.
+  `indexSet` mutates `a.data` in place — the SIR22 spec makes `IndexSet` a
+  *statement*, not a pure expression, for exactly the reason MATLAB
+  assignment (`A(i,j) = v`) rebinds one element of the existing array
+  rather than producing a new one.
+- Deliberately **not** implemented: the SIR22 spec's "APL addendum" `Expr`
+  variants (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+  `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) — no frontend crate emits
+  these nine variants yet (per that spec's own note), so porting
+  `array_runtime::ops`'s existing `reduce`/`scan`/`outer` Rust
+  implementations now would be speculative. A natural follow-up once
+  `apl-to-semantic-ir`'s own JS-backend consumption needs them.
+- 49 tests, 100% line/branch/function coverage, including an adversarial
+  regression test confirming `range`'s `MAX_ELEMENTS` cap actually trips
+  (not just trusting the code that it would) on a runtime-computed bound
+  that would otherwise materialize an unbounded array.

--- a/code/packages/typescript/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-array/CHANGELOG.md
@@ -56,7 +56,7 @@ All notable changes to this project will be documented in this file.
   `array_runtime::ops`'s existing `reduce`/`scan`/`outer` Rust
   implementations now would be speculative. A natural follow-up once
   `apl-to-semantic-ir`'s own JS-backend consumption needs them.
-- 56 tests, 100% line/branch/function coverage, including an adversarial
+- 57 tests, 100% line/branch/function coverage, including an adversarial
   regression test confirming `range`'s `MAX_ELEMENTS` cap actually trips
   (not just trusting the code that it would) on a runtime-computed bound
   that would otherwise materialize an unbounded array.
@@ -123,3 +123,15 @@ All notable changes to this project will be documented in this file.
     `NaN`, corrupting data instead of failing loudly (the same missing-
     `default` class `resolvePositions` was fixed for above). Now throws
     a clean `Error` for an unrecognised `op`.
+- **`ndarray()` never checked that `data` was really a `Float64Array`** —
+  found by a fourth, final confirmation sweep. `NDArray` is a plain
+  structural interface, not a class, and every other function in this
+  package sizes its own allocations from an existing `NDArray`'s
+  `data.length`, trusting it was already validated by `ndarray()` — an
+  unenforced invariant a compiled-JS caller could violate by handing back
+  an `NDArray`-shaped object whose `data` is a plain array or other
+  array-like instead of a real `Float64Array`. `ndarray()` now asserts
+  `data instanceof Float64Array` before anything else. 57 tests (up from
+  56), 100% coverage maintained — this closed the review; four rounds of
+  `/security-review`, converging from 5 findings down to 1 defense-in-depth
+  item with no demonstrated live exploit path.

--- a/code/packages/typescript/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-array/CHANGELOG.md
@@ -56,7 +56,38 @@ All notable changes to this project will be documented in this file.
   `array_runtime::ops`'s existing `reduce`/`scan`/`outer` Rust
   implementations now would be speculative. A natural follow-up once
   `apl-to-semantic-ir`'s own JS-backend consumption needs them.
-- 49 tests, 100% line/branch/function coverage, including an adversarial
+- 53 tests, 100% line/branch/function coverage, including an adversarial
   regression test confirming `range`'s `MAX_ELEMENTS` cap actually trips
   (not just trusting the code that it would) on a runtime-computed bound
   that would otherwise materialize an unbounded array.
+
+### Fixed
+
+- **Allocate-before-validate ordering in `zeros`/`fromRows`/`matmul`** —
+  found by this package's own `/security-review` before its first push.
+  `zeros(rows, cols)` and `fromRows` computed `new Float64Array(rows *
+  cols)` (or `nrows * ncols`) *before* the shared `ndarray()` constructor
+  ever checked `MAX_ELEMENTS` — so an absurd `rows`/`cols` attempted the
+  allocation first, either stalling on a huge request or throwing an
+  uncaught `RangeError` instead of this package's own clean `Error`.
+  `matmul` had the same gap one level up: `m`/`n` come from two
+  *independent* operands, each individually under `MAX_ELEMENTS`, but nothing
+  bounded their *product* — an outer-product-shaped call (e.g. `[2²⁶, 1] ·
+  [1, 2²⁶]`) could still request a `2⁵²`-element output before any check
+  ran. Fixed by extracting `checkedShapeSize(shape)` — validates
+  negative/non-integer dimensions and the `MAX_ELEMENTS` cap *before*
+  returning a safe element count — and calling it in all three places
+  before the corresponding `new Float64Array(...)`, not after.
+- **Negative/non-integer shape dimensions were not rejected** — `ndarray`
+  only checked `n === data.length` and `n <= MAX_ELEMENTS`; a shape like
+  `[-2, -50]` against a 100-element buffer computes `n = 100` (two
+  negatives multiply positive), passing both checks and producing an
+  `NDArray` with negative dimensions that `matmul`/`transpose` would later
+  compute a negative allocation size from. `checkedShapeSize` (see above)
+  closes this the same way it closes the allocation-ordering gap.
+- **`resolvePositions`'s `IndexArg` dispatch had no `default` case** — a
+  malformed `kind` (only reachable from a compiled-JS call site that
+  crosses the TypeScript/JavaScript boundary this package's exported types
+  can't police at runtime) fell through to `undefined` and surfaced as a
+  confusing `TypeError` several calls downstream instead of a clean
+  `Error` at the point of the actual mistake.

--- a/code/packages/typescript/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-array/CHANGELOG.md
@@ -56,7 +56,7 @@ All notable changes to this project will be documented in this file.
   `array_runtime::ops`'s existing `reduce`/`scan`/`outer` Rust
   implementations now would be speculative. A natural follow-up once
   `apl-to-semantic-ir`'s own JS-backend consumption needs them.
-- 54 tests, 100% line/branch/function coverage, including an adversarial
+- 56 tests, 100% line/branch/function coverage, including an adversarial
   regression test confirming `range`'s `MAX_ELEMENTS` cap actually trips
   (not just trusting the code that it would) on a runtime-computed bound
   that would otherwise materialize an unbounded array.
@@ -105,3 +105,21 @@ All notable changes to this project will be documented in this file.
   allocated it — the exact outer-product-shaped gap the `matmul` fix
   above closed, reopened one function over. Fixed the same way:
   `checkedShapeSize([rows.length, cols.length])` before either allocation.
+- **`fromVec` and `applyOp` were missing the same two guard classes,
+  found by a third, systematic sweep of every `Float64Array` call site
+  in the package** (checking each one's size argument back to its
+  source, not just spot-checking what earlier rounds had already
+  touched):
+  - `fromVec(values)` called `Float64Array.from(values)` before
+    validating `values.length` — `Float64Array.from` accepts any bare
+    `{ length: N }` array-like, not just a real `number[]`, so a caller
+    could request an `N`-sized allocation while paying for none of the
+    `N` elements themselves (the same allocate-before-validate class
+    fixed three times above, one level lower). Now calls
+    `checkedShapeSize([values.length])` first.
+  - `applyOp` (in `elementwise.ts`) had no `default` case in its
+    `ElementwiseOpKind` switch — an unrecognised `op` fell through to an
+    implicit `undefined`, which array assignment silently coerces to
+    `NaN`, corrupting data instead of failing loudly (the same missing-
+    `default` class `resolvePositions` was fixed for above). Now throws
+    a clean `Error` for an unrecognised `op`.

--- a/code/packages/typescript/sir-runtime-array/README.md
+++ b/code/packages/typescript/sir-runtime-array/README.md
@@ -100,11 +100,19 @@ out of scope for the same reason.
 
 ## Security: bounded allocation
 
-`ndarray`/`range` both enforce `MAX_ELEMENTS` (2²⁶, matching
+`checkedShapeSize` enforces `MAX_ELEMENTS` (2²⁶, matching
 `matlab-runtime`'s own `MAX_RANGE`) — a compiled program's array shapes and
 range bounds are runtime values, potentially attacker-influenced, not fixed
 at compile time, so an absurd shape or range fails with a clean `Error`
-rather than exhausting memory.
+rather than exhausting memory. Every function that allocates a buffer sized
+from caller-supplied numbers (`zeros`, `fromRows`, `matmul`'s `m * n`,
+`range`'s incremental loop) validates *before* calling `new Float64Array`,
+not after — validating only inside `ndarray`'s constructor would be too
+late, since the allocation attempt itself can throw an uncaught
+`RangeError` or stall on a huge request before a cap ever gets a chance to
+reject anything cleanly. `checkedShapeSize` also rejects negative and
+non-integer dimensions, closing a variant where two negative dimensions
+multiply to a small, cap-passing positive product.
 
 ## Where it fits
 

--- a/code/packages/typescript/sir-runtime-array/README.md
+++ b/code/packages/typescript/sir-runtime-array/README.md
@@ -1,0 +1,122 @@
+# @coding-adventures/sir-runtime-array
+
+The **N-D array/matrix runtime** imported by Semantic-IR-emitted
+TypeScript/JavaScript for the array-language domain (MATLAB/Octave), per
+[`code/specs/SIR22-array-matrix-semantic-ir.md`](../../../specs/SIR22-array-matrix-semantic-ir.md).
+
+## What it is
+
+SIR22 adds array/matrix `Expr`/`Stmt` variants to Semantic IR — `ArrayLit`,
+`Range`, `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet`, `IndexSet` — so
+a compiled MATLAB/Octave program can build, index, and operate on arrays
+**at runtime**. This package is what those nodes compile down to: it's
+meant to be bound as `__SirArray` at the emitted call sites
+(`__SirArray.matmul(...)`, `.elementwise(...)`, `.range(...)`,
+`.indexGet(...)`/`.indexSet(...)`).
+
+It mirrors [`array_runtime`](../../rust/array-runtime) — the Rust crate the
+MATLAB/Octave *runtimes* (not the compiled-to-JS path) already use —
+field-for-field and algorithm-for-algorithm, so a program run through
+`matlab-runtime` and the same program compiled to JS via this package agree
+on every result.
+
+| Concern | This package | Rust equivalent |
+|---|---|---|
+| Value model | `NDArray` (`shape`, `data: Float64Array`) | `array_runtime::value::Array` |
+| Elementwise ops | `elementwise(op, a, b)`, 13 `ElementwiseOpKind`s | `array_runtime::ops::{BinOp, elementwise}` (12 — no `Pow` yet) |
+| Matrix product | `matmul(a, b)` | `array_runtime::ops::matmul` |
+| Transpose | `transpose(a, conjugate?)` | `array_runtime::ops::transpose` |
+| Range | `range(start, stop, step?)` | `matlab-runtime`'s `eval_colon` |
+| Indexing | `indexGet`/`indexSet` | (SIR-level only — no Rust runtime equivalent yet) |
+
+## Why this package exists before any backend consumes it
+
+This mirrors exactly how `sir-runtime-symbolic` (SIR23's runtime) landed
+*before* the Stream-B codegen that calls it. `semantic-ir-to-javascript` and
+`semantic-ir-to-typescript` currently hard-reject `Feature::NDArrays`/
+`Feature::MatrixOps` and hit a deferred `panic!` at every SIR22 `Expr` match
+arm (see those crates' `emit.rs`) — real codegen is a first-wave-JS
+follow-up PR, not part of this package. Building the runtime primitives
+first means that follow-up PR only has to wire up calls, not design an
+array representation from scratch.
+
+## How emitted code will use it (once the backend PR lands)
+
+```ts
+import * as __SirArray from "@coding-adventures/sir-runtime-array";
+
+// A = [1, 2; 3, 4]
+const A = __SirArray.fromRows([
+  [1, 2],
+  [3, 4],
+]);
+
+// A * A  (MatMul)
+const A2 = __SirArray.matmul(A, A);
+
+// A .+ 1  (ElementwiseOp, scalar broadcast)
+const A_plus_1 = __SirArray.elementwise("Add", A, __SirArray.scalar(1));
+
+// A(1, :)  (MATLAB 1-based -> already-resolved 0-based IndexGet)
+const row0 = __SirArray.indexGet(A, [{ kind: "scalar", value: 0 }, { kind: "whole" }]);
+```
+
+## Scope: what this package covers today
+
+- **`NDArray`** — the dense, column-major `f64` value model (`ndarray.ts`),
+  plus `scalar`/`fromVec`/`fromRows`/`zeros` constructors and `get`/`set`
+  element accessors.
+- **`elementwise`** — all 13 `ElementwiseOpKind`s the SIR22 spec defines
+  (`array_runtime::ops::BinOp`'s 12, plus `Pow`, which Rust's crate hasn't
+  ported yet), with the same scalar-broadcast rule (either operand may be a
+  scalar; otherwise shapes must match exactly — full NumPy/MATLAB
+  broadcasting is out of scope, matching the Rust reference).
+- **`matmul`** / **`transpose`** — mirror the Rust reference exactly,
+  including column-major indexing arithmetic. `transpose`'s `conjugate`
+  flag (MATLAB `'` vs `.'`) is accepted for API-shape parity with the spec
+  but is a no-op today — there is no `Complex` value type yet.
+- **`range`** — MATLAB-style `start:step:stop` materialization, with the
+  same inclusive-stop tolerance and length cap `matlab-runtime`'s own
+  `eval_colon` uses.
+- **`indexGet`/`indexSet`** — `A(i)`/`A(i,j)` read and in-place write,
+  covering the SIR22 spec's `Scalar`/`Whole`/`Range` `IndexArg` shapes.
+  `IndexSet` mutates in place rather than returning a new array, matching
+  MATLAB assignment semantics and the spec's own "statement, not
+  expression" treatment of it.
+
+## Deliberately out of scope
+
+The SIR22 spec's "APL addendum" `Expr` variants (`Reduce`/`Scan`/
+`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
+`Catenate`) are **not** implemented here, even though `array_runtime::ops`
+already has Rust reference implementations for `reduce`/`scan`/`outer` — no
+frontend crate emits these nine `Expr` variants yet, so porting them now
+would be speculative rather than filling a real gap. They are a natural,
+cleanly-scoped follow-up once `apl-to-semantic-ir`'s own JS-backend
+consumption needs them.
+
+`Complex`/`Rational` scalar support (shared `SirType`s with SIR23) is also
+out of scope for the same reason.
+
+## Security: bounded allocation
+
+`ndarray`/`range` both enforce `MAX_ELEMENTS` (2²⁶, matching
+`matlab-runtime`'s own `MAX_RANGE`) — a compiled program's array shapes and
+range bounds are runtime values, potentially attacker-influenced, not fixed
+at compile time, so an absurd shape or range fails with a clean `Error`
+rather than exhausting memory.
+
+## Where it fits
+
+`matlab-to-semantic-ir` / `octave-to-semantic-ir` → `semantic-ir` (SIR22
+`Expr` variants) → *(follow-up)* `semantic-ir-to-typescript` /
+`semantic-ir-to-javascript` → emitted code that imports this package. See
+[`code/specs/HML01-math-to-semantic-ir.md`](../../../specs/HML01-math-to-semantic-ir.md).
+
+## Development
+
+```sh
+npm install
+npx tsc --noEmit
+npx vitest run --coverage
+```

--- a/code/packages/typescript/sir-runtime-array/package-lock.json
+++ b/code/packages/typescript/sir-runtime-array/package-lock.json
@@ -1,0 +1,1552 @@
+{
+  "name": "@coding-adventures/sir-runtime-array",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/sir-runtime-array",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/sir-runtime-array/package.json
+++ b/code/packages/typescript/sir-runtime-array/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@coding-adventures/sir-runtime-array",
+  "version": "0.1.0",
+  "description": "N-D array/matrix runtime for Semantic-IR-emitted TypeScript/JavaScript (SIR22)",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "sir",
+    "semantic-ir",
+    "runtime",
+    "matrix",
+    "ndarray",
+    "matlab",
+    "compiler"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/sir-runtime-array/required_capabilities.json
+++ b/code/packages/typescript/sir-runtime-array/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/sir-runtime-array",
+  "capabilities": [],
+  "justification": "Pure in-process N-D array/matrix arithmetic over a Float64Array. No filesystem, network, process, or environment access."
+}

--- a/code/packages/typescript/sir-runtime-array/src/elementwise.ts
+++ b/code/packages/typescript/sir-runtime-array/src/elementwise.ts
@@ -56,6 +56,13 @@ function applyOp(op: ElementwiseOpKind, a: number, b: number): number {
       return b2f(a >= b);
     case "Gt":
       return b2f(a > b);
+    default:
+      // Same "crosses a JS runtime boundary TypeScript can't enforce"
+      // reasoning as `resolvePositions` in `indexing.ts`: an unrecognised
+      // `op` must fail loudly here, not fall through to `undefined` —
+      // which `Float64Array.from`/direct assignment would otherwise
+      // silently coerce to `NaN`, corrupting data instead of erroring.
+      throw new Error(`applyOp: unrecognised ElementwiseOpKind ${JSON.stringify(op)}`);
   }
 }
 

--- a/code/packages/typescript/sir-runtime-array/src/elementwise.ts
+++ b/code/packages/typescript/sir-runtime-array/src/elementwise.ts
@@ -1,0 +1,95 @@
+/**
+ * Elementwise binary operators — mirrors `array_runtime::ops::BinOp`
+ * (`code/packages/rust/array-runtime/src/ops.rs`) plus `Pow`, which the
+ * SIR22 spec's `ElementwiseOpKind` includes in its "original cut" but
+ * `array-runtime`'s own `BinOp` does not yet — this runtime implements the
+ * full SIR-level operator set, not just the subset Rust's array-runtime
+ * crate happens to have ported to its GPU-dispatch pipeline so far.
+ *
+ * Comparisons follow the same APL-style boolean convention Rust's `BinOp`
+ * uses: `1` for true, `0` for false (never a native `boolean`), since the
+ * result must stay a plain array element like every other value here.
+ */
+import { ndarray, isScalar, type NDArray } from "./ndarray.js";
+
+export type ElementwiseOpKind =
+  | "Add"
+  | "Sub"
+  | "Mul"
+  | "Div"
+  | "Pow"
+  | "Max"
+  | "Min"
+  | "Eq"
+  | "Ne"
+  | "Lt"
+  | "Le"
+  | "Ge"
+  | "Gt";
+
+function applyOp(op: ElementwiseOpKind, a: number, b: number): number {
+  const b2f = (cond: boolean): number => (cond ? 1 : 0);
+  switch (op) {
+    case "Add":
+      return a + b;
+    case "Sub":
+      return a - b;
+    case "Mul":
+      return a * b;
+    case "Div":
+      return a / b;
+    case "Pow":
+      return Math.pow(a, b);
+    case "Max":
+      return Math.max(a, b);
+    case "Min":
+      return Math.min(a, b);
+    case "Eq":
+      return b2f(a === b);
+    case "Ne":
+      return b2f(a !== b);
+    case "Lt":
+      return b2f(a < b);
+    case "Le":
+      return b2f(a <= b);
+    case "Ge":
+      return b2f(a >= b);
+    case "Gt":
+      return b2f(a > b);
+  }
+}
+
+function sameShape(a: readonly number[], b: readonly number[]): boolean {
+  return a.length === b.length && a.every((d, i) => d === b[i]);
+}
+
+/**
+ * Elementwise binary op with scalar broadcasting — mirrors
+ * `array_runtime::ops::elementwise` exactly, including its branch order and
+ * "result takes the non-scalar operand's shape" rule. Either operand may be
+ * a scalar; otherwise the shapes must match exactly (full NumPy/MATLAB
+ * broadcasting is out of scope here, same as the Rust reference).
+ */
+export function elementwise(op: ElementwiseOpKind, a: NDArray, b: NDArray): NDArray {
+  const { data: ad } = a;
+  const { data: bd } = b;
+  let data: Float64Array;
+  if (isScalar(a)) {
+    data = Float64Array.from(bd, (y) => applyOp(op, ad[0], y));
+  } else if (isScalar(b)) {
+    data = Float64Array.from(ad, (x) => applyOp(op, x, bd[0]));
+  } else {
+    if (!sameShape(a.shape, b.shape)) {
+      throw new Error(
+        `elementwise: non-conformable arrays: ${JSON.stringify(a.shape)} vs ${JSON.stringify(b.shape)}`,
+      );
+    }
+    data = new Float64Array(ad.length);
+    for (let i = 0; i < data.length; i++) {
+      data[i] = applyOp(op, ad[i], bd[i]);
+    }
+  }
+  // Result takes the non-scalar operand's shape (or the scalar's if both are).
+  const shape = isScalar(a) ? b.shape : a.shape;
+  return ndarray(shape, data);
+}

--- a/code/packages/typescript/sir-runtime-array/src/index.ts
+++ b/code/packages/typescript/sir-runtime-array/src/index.ts
@@ -56,7 +56,7 @@
  * real-only scope.
  */
 
-export { ndarray, scalar, fromVec, fromRows, zeros, ndims, isScalar, nrows, ncols, get, set, MAX_ELEMENTS, type NDArray } from "./ndarray.js";
+export { ndarray, checkedShapeSize, scalar, fromVec, fromRows, zeros, ndims, isScalar, nrows, ncols, get, set, MAX_ELEMENTS, type NDArray } from "./ndarray.js";
 export { elementwise, type ElementwiseOpKind } from "./elementwise.js";
 export { matmul } from "./matmul.js";
 export { transpose } from "./transpose.js";

--- a/code/packages/typescript/sir-runtime-array/src/index.ts
+++ b/code/packages/typescript/sir-runtime-array/src/index.ts
@@ -1,0 +1,64 @@
+/**
+ * sir-runtime-array — the SIR22 N-D array/matrix runtime imported by
+ * Semantic-IR-emitted TypeScript/JavaScript, bound as `__SirArray` at call
+ * sites (see `code/specs/SIR22-array-matrix-semantic-ir.md` and this
+ * package's README for the exact call shapes a future backend PR wires
+ * up). A compiled MATLAB/Octave program's `ArrayLit`, `Range`, `MatMul`,
+ * `ElementwiseOp`, `Transpose`, `IndexGet`, and `IndexSet` IR nodes all
+ * become calls into this package at runtime.
+ *
+ * ## Why this package exists before any backend consumes it
+ *
+ * This mirrors exactly how `sir-runtime-symbolic` (SIR23's runtime) landed
+ * *before* the Stream-B JS/TS codegen that calls it: `semantic-ir-to-javascript`
+ * and `semantic-ir-to-typescript` currently hard-reject `Feature::NDArrays`/
+ * `Feature::MatrixOps` and hit a deferred `panic!` at every SIR22 `Expr`
+ * match arm (see those crates' `emit.rs`) — real codegen (`__SirArray.matmul(...)`,
+ * `.elementwise(...)`, `.range(...)`, `.indexGet(...)`/`.indexSet(...)`) is a
+ * first-wave-JS follow-up PR, not part of this package. Building the runtime
+ * primitives first means that follow-up PR only has to *wire up calls*, not
+ * design an array representation from scratch.
+ *
+ * ## Scope: what this package covers today
+ *
+ * - **`NDArray`** (`./ndarray`) — the dense, column-major `f64` value model,
+ *   plus `scalar`/`fromVec`/`fromRows`/`zeros` constructors and `get`/`set`
+ *   element accessors. Mirrors `array_runtime::value::Array`
+ *   (`code/packages/rust/array-runtime/src/value.rs`) field-for-field.
+ * - **`elementwise`** (`./elementwise`) — the 13 `ElementwiseOpKind`s the
+ *   SIR22 spec defines (`array_runtime::ops::BinOp`'s 12, plus `Pow`, which
+ *   Rust's crate hasn't ported yet), with the same scalar-broadcast rule.
+ * - **`matmul`** / **`transpose`** (`./matmul`, `./transpose`) — mirror
+ *   `array_runtime::ops::matmul` / `transpose` exactly, including their
+ *   column-major indexing arithmetic.
+ * - **`range`** (`./range`) — MATLAB-style `start:step:stop` materialization,
+ *   with the same inclusive-stop tolerance and length cap `matlab-runtime`'s
+ *   own `eval_colon` uses.
+ * - **`indexGet`/`indexSet`** (`./indexing`) — `A(i)`/`A(i,j)` read and
+ *   in-place write, covering the SIR22 spec's `Scalar`/`Whole`/`Range`
+ *   `IndexArg` shapes.
+ *
+ * ## Deliberately out of scope
+ *
+ * The SIR22 spec's "APL addendum" `Expr` variants (`Reduce`/`Scan`/
+ * `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
+ * `Catenate`) are **not** implemented here, even though `array_runtime::ops`
+ * already has Rust reference implementations for `reduce`/`scan`/`outer` —
+ * no frontend crate emits these nine `Expr` variants yet (per that spec's
+ * own "No frontend crate consumes any of these nine variants yet" note), so
+ * porting them now would be speculative rather than filling a real gap.
+ * They are a natural, cleanly-scoped follow-up once `apl-to-semantic-ir`'s
+ * own JS-backend consumption needs them.
+ *
+ * `Complex`/`Rational` scalar support (shared `SirType`s with SIR23) is also
+ * out of scope — `transpose`'s `conjugate` flag is accepted for API-shape
+ * parity with the spec but is a no-op today, matching `array-runtime`'s own
+ * real-only scope.
+ */
+
+export { ndarray, scalar, fromVec, fromRows, zeros, ndims, isScalar, nrows, ncols, get, set, MAX_ELEMENTS, type NDArray } from "./ndarray.js";
+export { elementwise, type ElementwiseOpKind } from "./elementwise.js";
+export { matmul } from "./matmul.js";
+export { transpose } from "./transpose.js";
+export { range } from "./range.js";
+export { indexGet, indexSet, type IndexArg } from "./indexing.js";

--- a/code/packages/typescript/sir-runtime-array/src/indexing.ts
+++ b/code/packages/typescript/sir-runtime-array/src/indexing.ts
@@ -1,4 +1,4 @@
-import { get, set, ndarray, nrows, ncols, type NDArray } from "./ndarray.js";
+import { get, set, ndarray, checkedShapeSize, nrows, ncols, type NDArray } from "./ndarray.js";
 
 /**
  * One MATLAB-style index-position argument — mirrors the SIR22 spec's
@@ -74,7 +74,15 @@ export function indexGet(a: NDArray, indices: readonly IndexArg[]): NDArray | nu
     if (rowArg.kind === "scalar" && colArg.kind === "scalar") {
       return read(rows[0], cols[0]);
     }
-    const data = new Float64Array(rows.length * cols.length);
+    // `rows.length`/`cols.length` are each individually bounded by
+    // `a`'s own dimensions (`whole`) or by a `range` NDArray's own
+    // `MAX_ELEMENTS` cap — but nothing bounds their *product* on its own
+    // (a `range`-selected row list and a `range`-selected column list can
+    // each independently approach `MAX_ELEMENTS`), so this is the exact
+    // outer-product-shaped allocation `matmul` guards against, one level
+    // up. Validate before allocating, not after.
+    const outLen = checkedShapeSize([rows.length, cols.length]);
+    const data = new Float64Array(outLen);
     for (let c = 0; c < cols.length; c++) {
       for (let r = 0; r < rows.length; r++) {
         data[c * rows.length + r] = read(rows[r], cols[c]);
@@ -124,7 +132,10 @@ export function indexSet(a: NDArray, indices: readonly IndexArg[], value: number
     const [rowArg, colArg] = indices;
     const rows = resolvePositions(rowArg, nrows(a));
     const cols = resolvePositions(colArg, ncols(a));
-    const values = broadcastValues(value, rows.length * cols.length);
+    // Same product-of-two-independent-selections gap `indexGet` closes
+    // above — validate before `broadcastValues` allocates.
+    const count = checkedShapeSize([rows.length, cols.length]);
+    const values = broadcastValues(value, count);
     let k = 0;
     for (let c = 0; c < cols.length; c++) {
       for (let r = 0; r < rows.length; r++) {

--- a/code/packages/typescript/sir-runtime-array/src/indexing.ts
+++ b/code/packages/typescript/sir-runtime-array/src/indexing.ts
@@ -27,6 +27,12 @@ function resolvePositions(arg: IndexArg, dimSize: number): number[] {
       return Array.from({ length: dimSize }, (_, i) => i);
     case "range":
       return Array.from(arg.indices.data, (x) => Math.trunc(x));
+    default:
+      // Emitted code crosses a JS runtime boundary that TypeScript can't
+      // enforce at the actual call site — a malformed `kind` must fail
+      // cleanly here, not fall through to `undefined` and surface as a
+      // confusing `TypeError` several calls further down.
+      throw new Error(`resolvePositions: unrecognised IndexArg ${JSON.stringify(arg)}`);
   }
 }
 

--- a/code/packages/typescript/sir-runtime-array/src/indexing.ts
+++ b/code/packages/typescript/sir-runtime-array/src/indexing.ts
@@ -1,0 +1,132 @@
+import { get, set, ndarray, nrows, ncols, type NDArray } from "./ndarray.js";
+
+/**
+ * One MATLAB-style index-position argument — mirrors the SIR22 spec's
+ * `IndexArg` exactly:
+ *
+ * ```text
+ * IndexArg = Scalar(Box<Expr>) | Whole | Range(Box<Expr>)
+ * ```
+ *
+ * `end`-relative indices (`A(end)`, `A(end-1)`) are never seen here — per
+ * SIR10 discipline, the frontend resolves `end` to a concrete 0-based
+ * `Scalar` index before emitting `IndexGet`/`IndexSet`, so this module only
+ * ever deals in already-resolved, already-0-based positions.
+ */
+export type IndexArg =
+  | { kind: "scalar"; value: number }
+  | { kind: "whole" }
+  | { kind: "range"; indices: NDArray };
+
+/** Resolve one `IndexArg` against a dimension of size `dimSize` into a flat list of 0-based positions along that dimension. */
+function resolvePositions(arg: IndexArg, dimSize: number): number[] {
+  switch (arg.kind) {
+    case "scalar":
+      return [arg.value];
+    case "whole":
+      return Array.from({ length: dimSize }, (_, i) => i);
+    case "range":
+      return Array.from(arg.indices.data, (x) => Math.trunc(x));
+  }
+}
+
+/**
+ * `A(i)` / `A(i, j)` — read one element or a sub-array. Scoped to 1 or 2
+ * index arguments (rank ≤ 2, matching this whole package's scope): a single
+ * argument indexes `a`'s underlying column-major data linearly (MATLAB's own
+ * single-subscript convention, which is column-major too — the *same*
+ * order this package already stores data in, so no reordering is needed);
+ * two arguments index `(row, col)`. Returns a bare `number` when every
+ * argument is `scalar` (a single element), otherwise an `NDArray`.
+ */
+export function indexGet(a: NDArray, indices: readonly IndexArg[]): NDArray | number {
+  if (indices.length === 1) {
+    const [arg] = indices;
+    const positions = resolvePositions(arg, a.data.length);
+    const read = (i: number): number => {
+      if (i < 0 || i >= a.data.length) {
+        throw new Error(`indexGet: linear index ${i} out of bounds`);
+      }
+      return a.data[i];
+    };
+    if (arg.kind === "scalar") {
+      return read(positions[0]);
+    }
+    return ndarray([1, positions.length], Float64Array.from(positions, read));
+  }
+  if (indices.length === 2) {
+    const [rowArg, colArg] = indices;
+    const rows = resolvePositions(rowArg, nrows(a));
+    const cols = resolvePositions(colArg, ncols(a));
+    const read = (r: number, c: number): number => {
+      const v = get(a, r, c);
+      if (v === undefined) {
+        throw new Error(`indexGet: (${r}, ${c}) out of bounds for shape ${JSON.stringify(a.shape)}`);
+      }
+      return v;
+    };
+    if (rowArg.kind === "scalar" && colArg.kind === "scalar") {
+      return read(rows[0], cols[0]);
+    }
+    const data = new Float64Array(rows.length * cols.length);
+    for (let c = 0; c < cols.length; c++) {
+      for (let r = 0; r < rows.length; r++) {
+        data[c * rows.length + r] = read(rows[r], cols[c]);
+      }
+    }
+    return ndarray([rows.length, cols.length], data);
+  }
+  throw new Error(`indexGet: only 1 or 2 index arguments are supported (rank ≤ 2 scope), got ${indices.length}`);
+}
+
+/** Broadcast a scalar-or-`NDArray` right-hand side to exactly `count` values (mirrors [`elementwise`](./elementwise.js)'s scalar-broadcast rule). */
+function broadcastValues(value: number | NDArray, count: number): Float64Array {
+  if (typeof value === "number") {
+    return new Float64Array(count).fill(value);
+  }
+  if (value.data.length === 1) {
+    return new Float64Array(count).fill(value.data[0]);
+  }
+  if (value.data.length !== count) {
+    throw new Error(`indexSet: value has ${value.data.length} elements, expected ${count}`);
+  }
+  return value.data;
+}
+
+/**
+ * `A(i) = v` / `A(i, j) = v` — write one element or a sub-array, **in
+ * place** (see [`set`](./ndarray.js)'s doc comment for why this mutates
+ * rather than returns a new array — the SIR22 spec makes `IndexSet` a
+ * statement, not a pure expression, for the same reason). `value` may be a
+ * scalar (broadcast to every selected position) or an `NDArray` with
+ * exactly as many elements as positions are selected.
+ */
+export function indexSet(a: NDArray, indices: readonly IndexArg[], value: number | NDArray): void {
+  if (indices.length === 1) {
+    const [arg] = indices;
+    const positions = resolvePositions(arg, a.data.length);
+    const values = broadcastValues(value, positions.length);
+    positions.forEach((i, k) => {
+      if (i < 0 || i >= a.data.length) {
+        throw new Error(`indexSet: linear index ${i} out of bounds`);
+      }
+      a.data[i] = values[k];
+    });
+    return;
+  }
+  if (indices.length === 2) {
+    const [rowArg, colArg] = indices;
+    const rows = resolvePositions(rowArg, nrows(a));
+    const cols = resolvePositions(colArg, ncols(a));
+    const values = broadcastValues(value, rows.length * cols.length);
+    let k = 0;
+    for (let c = 0; c < cols.length; c++) {
+      for (let r = 0; r < rows.length; r++) {
+        set(a, rows[r], cols[c], values[k]);
+        k++;
+      }
+    }
+    return;
+  }
+  throw new Error(`indexSet: only 1 or 2 index arguments are supported (rank ≤ 2 scope), got ${indices.length}`);
+}

--- a/code/packages/typescript/sir-runtime-array/src/matmul.ts
+++ b/code/packages/typescript/sir-runtime-array/src/matmul.ts
@@ -1,0 +1,32 @@
+import { ndarray, nrows, ncols, type NDArray } from "./ndarray.js";
+
+/**
+ * Matrix product `[m, k] · [k, n] → [m, n]` (column-major throughout) —
+ * mirrors `array_runtime::ops::matmul` exactly, including its indexing
+ * arithmetic. `ndarray`'s own `MAX_ELEMENTS` cap on the constructed result
+ * guards against an absurd `m × n` (e.g. an outer-product-shaped call)
+ * exhausting memory, the same class of guard the Rust reference closes with
+ * a checked multiply.
+ */
+export function matmul(a: NDArray, b: NDArray): NDArray {
+  const m = nrows(a);
+  const ka = ncols(a);
+  const kb = nrows(b);
+  const n = ncols(b);
+  if (ka !== kb) {
+    throw new Error(`matmul: inner dimensions disagree (${m}x${ka} · ${kb}x${n})`);
+  }
+  const ad = a.data;
+  const bd = b.data;
+  const out = new Float64Array(m * n);
+  for (let j = 0; j < n; j++) {
+    for (let i = 0; i < m; i++) {
+      let acc = 0;
+      for (let p = 0; p < ka; p++) {
+        acc += ad[p * m + i] * bd[j * kb + p]; // column-major indexing
+      }
+      out[j * m + i] = acc;
+    }
+  }
+  return ndarray([m, n], out);
+}

--- a/code/packages/typescript/sir-runtime-array/src/matmul.ts
+++ b/code/packages/typescript/sir-runtime-array/src/matmul.ts
@@ -1,12 +1,15 @@
-import { ndarray, nrows, ncols, type NDArray } from "./ndarray.js";
+import { ndarray, checkedShapeSize, nrows, ncols, type NDArray } from "./ndarray.js";
 
 /**
  * Matrix product `[m, k] · [k, n] → [m, n]` (column-major throughout) —
  * mirrors `array_runtime::ops::matmul` exactly, including its indexing
- * arithmetic. `ndarray`'s own `MAX_ELEMENTS` cap on the constructed result
- * guards against an absurd `m × n` (e.g. an outer-product-shaped call)
- * exhausting memory, the same class of guard the Rust reference closes with
- * a checked multiply.
+ * arithmetic. `m` and `n` come from two *independent* operands (each
+ * individually under `MAX_ELEMENTS`, but their product isn't bounded by
+ * that alone — an outer-product-shaped call, e.g. `[2²⁶, 1] · [1, 2²⁶]`,
+ * could still ask for a `2⁵²`-element output), so `checkedShapeSize`
+ * validates `[m, n]` *before* allocating `out`, not after — the same
+ * allocate-after-validate ordering `zeros`/`fromRows` use, and the same
+ * class of guard the Rust reference closes with a checked multiply.
  */
 export function matmul(a: NDArray, b: NDArray): NDArray {
   const m = nrows(a);
@@ -16,9 +19,10 @@ export function matmul(a: NDArray, b: NDArray): NDArray {
   if (ka !== kb) {
     throw new Error(`matmul: inner dimensions disagree (${m}x${ka} · ${kb}x${n})`);
   }
+  const outLen = checkedShapeSize([m, n]);
   const ad = a.data;
   const bd = b.data;
-  const out = new Float64Array(m * n);
+  const out = new Float64Array(outLen);
   for (let j = 0; j < n; j++) {
     for (let i = 0; i < m; i++) {
       let acc = 0;

--- a/code/packages/typescript/sir-runtime-array/src/ndarray.ts
+++ b/code/packages/typescript/sir-runtime-array/src/ndarray.ts
@@ -34,8 +34,27 @@ export interface NDArray {
  */
 export const MAX_ELEMENTS = 1 << 26; // 67,108,864
 
-function shapeSize(shape: readonly number[]): number {
-  return shape.reduce((acc, d) => acc * d, 1);
+/**
+ * Validate a shape *before* any caller allocates a buffer sized from it —
+ * every function that computes an output size from caller-supplied numbers
+ * (`zeros`, `fromRows`, `matmul`'s `m * n`, …) must call this first, not
+ * after, so a negative, non-integer, or absurdly large shape is rejected
+ * with a clean `Error` before `new Float64Array(...)` ever runs. Calling
+ * the cap check *after* allocating (as `ndarray`'s own validation alone
+ * would, if factories didn't also call this) is too late: the allocation
+ * attempt itself can throw an uncaught `RangeError` or stall on a huge
+ * request before the cap gets a chance to reject anything cleanly.
+ * Returns the validated element count.
+ */
+export function checkedShapeSize(shape: readonly number[]): number {
+  if (!shape.every((d) => Number.isInteger(d) && d >= 0)) {
+    throw new Error(`checkedShapeSize: shape ${JSON.stringify(shape)} has a negative or non-integer dimension`);
+  }
+  const n = shape.reduce((acc, d) => acc * d, 1);
+  if (!Number.isFinite(n) || n > MAX_ELEMENTS) {
+    throw new Error(`checkedShapeSize: shape ${JSON.stringify(shape)} (${n} elements) exceeds the ${MAX_ELEMENTS}-element cap`);
+  }
+  return n;
 }
 
 /**
@@ -45,14 +64,11 @@ function shapeSize(shape: readonly number[]): number {
  * mismatch and a shape whose element count exceeds `MAX_ELEMENTS`.
  */
 export function ndarray(shape: readonly number[], data: Float64Array): NDArray {
-  const n = shapeSize(shape);
-  if (!Number.isFinite(n) || n !== data.length) {
+  const n = checkedShapeSize(shape);
+  if (n !== data.length) {
     throw new Error(
       `ndarray: shape ${JSON.stringify(shape)} implies ${n} elements, got ${data.length}`,
     );
-  }
-  if (n > MAX_ELEMENTS) {
-    throw new Error(`ndarray: ${n} elements exceeds the ${MAX_ELEMENTS}-element cap`);
   }
   return { shape, data };
 }
@@ -81,7 +97,8 @@ export function fromRows(rows: readonly (readonly number[])[]): NDArray {
   if (rows.some((r) => r.length !== ncols)) {
     throw new Error("fromRows: ragged rows");
   }
-  const data = new Float64Array(nrows * ncols);
+  const n = checkedShapeSize([nrows, ncols]);
+  const data = new Float64Array(n);
   for (let r = 0; r < nrows; r++) {
     for (let c = 0; c < ncols; c++) {
       data[c * nrows + r] = rows[r][c]; // column-major store
@@ -92,7 +109,8 @@ export function fromRows(rows: readonly (readonly number[])[]): NDArray {
 
 /** An `[rows, cols]` array of zeros. */
 export function zeros(rows: number, cols: number): NDArray {
-  return ndarray([rows, cols], new Float64Array(rows * cols));
+  const n = checkedShapeSize([rows, cols]);
+  return ndarray([rows, cols], new Float64Array(n));
 }
 
 export function ndims(a: NDArray): number {

--- a/code/packages/typescript/sir-runtime-array/src/ndarray.ts
+++ b/code/packages/typescript/sir-runtime-array/src/ndarray.ts
@@ -1,0 +1,147 @@
+/**
+ * The N-D array value model — dense, rectangular, **column-major** `f64`
+ * (stored here as a `Float64Array`), mirroring `array_runtime::value::Array`
+ * (`code/packages/rust/array-runtime/src/value.rs`) exactly. Column-major
+ * (Fortran/MATLAB) storage is deliberate, not incidental: MATLAB's `reshape`,
+ * linear indexing, and `[a; b]` literal semantics all assume it, and the
+ * SIR22 spec's `Feature::ArrayColumnMajor` manifest flag exists precisely so
+ * a JS/TS backend states this convention explicitly (see that spec's
+ * "Storage convention" section) rather than leaving it implicit the way the
+ * Rust struct's memory layout does.
+ *
+ * `shape == []` is a scalar, `[n]` a vector (treated as `n×1`, a column, for
+ * row/column purposes — matching the Rust convention exactly), `[r, c]` a
+ * matrix. Higher ranks are representable but no operation in this package
+ * defines them yet (same "rank ≤ 2 today" scope `array-runtime` itself
+ * documents).
+ */
+
+/** A dense N-D `f64` array — column-major storage, shape-validated. */
+export interface NDArray {
+  readonly shape: readonly number[];
+  readonly data: Float64Array;
+}
+
+/**
+ * Upper bound on total elements for any array this package constructs
+ * (`ndarray`, `range`, `matmul`'s output, …) — a compiled program's array
+ * construction is driven by potentially attacker-influenced input (sizes
+ * computed at runtime, not fixed at compile time), so an unbounded shape or
+ * range must fail cleanly rather than exhaust memory. Matches
+ * `matlab-runtime`'s own `MAX_RANGE` bound
+ * (`code/packages/rust/matlab-runtime/src/eval.rs`) for consistency across
+ * the MATLAB-family stack.
+ */
+export const MAX_ELEMENTS = 1 << 26; // 67,108,864
+
+function shapeSize(shape: readonly number[]): number {
+  return shape.reduce((acc, d) => acc * d, 1);
+}
+
+/**
+ * Build an `NDArray` from an explicit column-major `data` buffer and
+ * `shape` — the shared validating constructor every factory below funnels
+ * through (mirrors `Array::from_shape`). Rejects a shape/data-length
+ * mismatch and a shape whose element count exceeds `MAX_ELEMENTS`.
+ */
+export function ndarray(shape: readonly number[], data: Float64Array): NDArray {
+  const n = shapeSize(shape);
+  if (!Number.isFinite(n) || n !== data.length) {
+    throw new Error(
+      `ndarray: shape ${JSON.stringify(shape)} implies ${n} elements, got ${data.length}`,
+    );
+  }
+  if (n > MAX_ELEMENTS) {
+    throw new Error(`ndarray: ${n} elements exceeds the ${MAX_ELEMENTS}-element cap`);
+  }
+  return { shape, data };
+}
+
+/** A length-1 (scalar) array. */
+export function scalar(value: number): NDArray {
+  return ndarray([], Float64Array.of(value));
+}
+
+/** A 1-D array (a column vector's worth of values, shape `[n]`). */
+export function fromVec(values: readonly number[]): NDArray {
+  return ndarray([values.length], Float64Array.from(values));
+}
+
+/**
+ * Build a matrix from rows (mirrors `Array::from_rows`). All rows must be
+ * the same length; the data is transposed into column-major order on the
+ * way in.
+ */
+export function fromRows(rows: readonly (readonly number[])[]): NDArray {
+  const nrows = rows.length;
+  if (nrows === 0) {
+    return ndarray([0, 0], new Float64Array(0));
+  }
+  const ncols = rows[0].length;
+  if (rows.some((r) => r.length !== ncols)) {
+    throw new Error("fromRows: ragged rows");
+  }
+  const data = new Float64Array(nrows * ncols);
+  for (let r = 0; r < nrows; r++) {
+    for (let c = 0; c < ncols; c++) {
+      data[c * nrows + r] = rows[r][c]; // column-major store
+    }
+  }
+  return ndarray([nrows, ncols], data);
+}
+
+/** An `[rows, cols]` array of zeros. */
+export function zeros(rows: number, cols: number): NDArray {
+  return ndarray([rows, cols], new Float64Array(rows * cols));
+}
+
+export function ndims(a: NDArray): number {
+  return a.shape.length;
+}
+
+export function isScalar(a: NDArray): boolean {
+  return a.data.length === 1;
+}
+
+/** Rows, treating a scalar as `1×1` and a vector `[n]` as `n×1`. */
+export function nrows(a: NDArray): number {
+  switch (a.shape.length) {
+    case 0:
+      return 1;
+    default:
+      return a.shape[0];
+  }
+}
+
+/** Columns, treating a scalar as `1×1` and a vector `[n]` as `n×1`. */
+export function ncols(a: NDArray): number {
+  switch (a.shape.length) {
+    case 0:
+    case 1:
+      return 1;
+    default:
+      return a.shape[1];
+  }
+}
+
+/** Element `(r, c)` (column-major), or `undefined` if out of bounds. */
+export function get(a: NDArray, r: number, c: number): number | undefined {
+  if (r >= 0 && c >= 0 && r < nrows(a) && c < ncols(a)) {
+    return a.data[c * nrows(a) + r];
+  }
+  return undefined;
+}
+
+/**
+ * Set element `(r, c)` in place (column-major). Mutates `a.data` directly —
+ * matches MATLAB assignment semantics (`A(i,j) = v` rebinds one element of
+ * the existing array, it does not produce a new one), and the SIR22 spec's
+ * `IndexSet` is a *statement*, not a pure expression, for exactly this
+ * reason.
+ */
+export function set(a: NDArray, r: number, c: number, value: number): void {
+  if (r < 0 || c < 0 || r >= nrows(a) || c >= ncols(a)) {
+    throw new Error(`set: index (${r}, ${c}) out of bounds for shape ${JSON.stringify(a.shape)}`);
+  }
+  a.data[c * nrows(a) + r] = value;
+}

--- a/code/packages/typescript/sir-runtime-array/src/ndarray.ts
+++ b/code/packages/typescript/sir-runtime-array/src/ndarray.ts
@@ -62,8 +62,18 @@ export function checkedShapeSize(shape: readonly number[]): number {
  * `shape` — the shared validating constructor every factory below funnels
  * through (mirrors `Array::from_shape`). Rejects a shape/data-length
  * mismatch and a shape whose element count exceeds `MAX_ELEMENTS`.
+ *
+ * `NDArray` is a plain structural interface, not a class, so nothing stops
+ * a compiled-JS caller from handing back an object shaped like one whose
+ * `data` isn't really a `Float64Array` — every other function in this
+ * package sizes its own allocations from an existing `NDArray`'s
+ * `data.length`, trusting it was already validated here, so this check is
+ * where that trust actually has to be earned.
  */
 export function ndarray(shape: readonly number[], data: Float64Array): NDArray {
+  if (!(data instanceof Float64Array)) {
+    throw new Error("ndarray: data must be a Float64Array");
+  }
   const n = checkedShapeSize(shape);
   if (n !== data.length) {
     throw new Error(

--- a/code/packages/typescript/sir-runtime-array/src/ndarray.ts
+++ b/code/packages/typescript/sir-runtime-array/src/ndarray.ts
@@ -78,8 +78,18 @@ export function scalar(value: number): NDArray {
   return ndarray([], Float64Array.of(value));
 }
 
-/** A 1-D array (a column vector's worth of values, shape `[n]`). */
+/**
+ * A 1-D array (a column vector's worth of values, shape `[n]`). Validates
+ * `values.length` with `checkedShapeSize` *before* `Float64Array.from`
+ * allocates — a genuine TypeScript-typed `number[]` costs its caller
+ * memory proportional to its own length already, but `values` crosses the
+ * same unenforced JS-runtime boundary every other factory in this module
+ * does, and `Float64Array.from` also accepts a bare `{ length: N }`
+ * array-like with no real backing elements, which would otherwise drive an
+ * `N`-sized allocation from a caller who paid for none of it.
+ */
 export function fromVec(values: readonly number[]): NDArray {
+  checkedShapeSize([values.length]);
   return ndarray([values.length], Float64Array.from(values));
 }
 

--- a/code/packages/typescript/sir-runtime-array/src/range.ts
+++ b/code/packages/typescript/sir-runtime-array/src/range.ts
@@ -1,0 +1,40 @@
+import { ndarray, MAX_ELEMENTS, type NDArray } from "./ndarray.js";
+
+/**
+ * Tolerance for the inclusive-stop boundary check, matching
+ * `matlab-runtime`'s own `eval_colon` exactly (`code/packages/rust/matlab-runtime/src/eval.rs`)
+ * — a floating step (e.g. `1:0.1:2`) can drift a few ULPs short of `stop` by
+ * the final iteration, and MATLAB's `a:step:b` is inclusive of `b`.
+ */
+const RANGE_EPSILON = 1e-9;
+
+/**
+ * Materialize a MATLAB-style range `start:step:stop` (default `step = 1`,
+ * per the SIR22 spec's `Range { step: Option<...> }` field) as a `1×n` row
+ * vector — MATLAB's `:` always produces a row, never a column, which is why
+ * this returns shape `[1, n]` rather than the "bare vector" shape `[n]`
+ * `fromVec` uses.
+ *
+ * Bounded by `MAX_ELEMENTS` (shared with `ndarray`'s own cap, and matching
+ * `matlab-runtime`'s `MAX_RANGE`) so a compiled program's `1:1e18`-style
+ * range can't exhaust memory before this function ever gets to materialize
+ * anything.
+ */
+export function range(start: number, stop: number, step = 1): NDArray {
+  if (step === 0) {
+    throw new Error("range: step cannot be zero");
+  }
+  const values: number[] = [];
+  let x = start;
+  while ((step > 0 && x <= stop + RANGE_EPSILON) || (step < 0 && x >= stop - RANGE_EPSILON)) {
+    if (values.length >= MAX_ELEMENTS) {
+      throw new Error(`range: produces more than ${MAX_ELEMENTS} elements`);
+    }
+    values.push(x);
+    x += step;
+  }
+  return ndarray(
+    values.length === 0 ? [1, 0] : [1, values.length],
+    Float64Array.from(values),
+  );
+}

--- a/code/packages/typescript/sir-runtime-array/src/transpose.ts
+++ b/code/packages/typescript/sir-runtime-array/src/transpose.ts
@@ -1,0 +1,25 @@
+import { ndarray, nrows, ncols, type NDArray } from "./ndarray.js";
+
+/**
+ * Matrix transpose — mirrors `array_runtime::ops::transpose`. `conjugate`
+ * distinguishes MATLAB `'` (`true`) from `.'` (`false`), per the SIR22
+ * spec's `Transpose { conjugate }` field. This runtime has no `Complex`
+ * value type yet (matching `array-runtime`'s own real-only scope today), so
+ * a conjugate transpose of real data is identical to a plain transpose —
+ * `conjugate` is accepted for API-shape parity with the SIR spec and
+ * documented here so a future `Complex` extension knows exactly where the
+ * actual conjugation step belongs.
+ */
+export function transpose(a: NDArray, conjugate = false): NDArray {
+  void conjugate;
+  const m = nrows(a);
+  const n = ncols(a);
+  const ad = a.data;
+  const out = new Float64Array(ad.length);
+  for (let j = 0; j < n; j++) {
+    for (let i = 0; i < m; i++) {
+      out[i * n + j] = ad[j * m + i];
+    }
+  }
+  return ndarray([n, m], out);
+}

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -315,6 +315,24 @@ describe("indexGet / indexSet", () => {
     expect(Array.from((sub as arr.NDArray).data)).toEqual([2, 5, 3, 6]);
   });
 
+  it("a 2-index sub-array selection whose row x col product would exceed MAX_ELEMENTS is a clean error, not an OOM", () => {
+    // Each of `rows`/`cols` is individually a perfectly legitimate
+    // range-selection size (100,000 positions) — only their PRODUCT is
+    // absurd, exactly the outer-product-shaped gap `matmul` guards
+    // against, one level up in `indexGet`/`indexSet`.
+    const a = arr.zeros(1, 1);
+    const bigSelection: arr.NDArray = {
+      shape: [1, 100000],
+      data: Float64Array.from({ length: 100000 }, (_, i) => i),
+    };
+    const twoBigRanges = [
+      { kind: "range" as const, indices: bigSelection },
+      { kind: "range" as const, indices: bigSelection },
+    ];
+    expect(() => arr.indexGet(a, twoBigRanges)).toThrow(/exceeds/);
+    expect(() => arr.indexSet(a, twoBigRanges, 0)).toThrow(/exceeds/);
+  });
+
   it("single-argument linear indexing", () => {
     const a = arr.fromRows([
       [1, 2],

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -80,6 +80,18 @@ describe("ndarray construction and accessors", () => {
       /exceeds/,
     );
   });
+
+  it("checkedShapeSize rejects negative and non-integer dimensions before any allocation", () => {
+    expect(() => arr.checkedShapeSize([-2, 5])).toThrow(/negative or non-integer/);
+    expect(() => arr.checkedShapeSize([2.5, 5])).toThrow(/negative or non-integer/);
+  });
+
+  it("zeros/fromRows validate the shape before allocating, not after", () => {
+    // Two negative dims multiply to a small positive product — a naive
+    // `rows * cols` check alone would miss this; `checkedShapeSize`
+    // rejects the negative dimension directly instead.
+    expect(() => arr.zeros(-100, -100)).toThrow(/negative or non-integer/);
+  });
 });
 
 describe("elementwise", () => {
@@ -191,6 +203,16 @@ describe("matmul", () => {
     const a = arr.fromRows([[1, 2]]); // 1x2
     const b = arr.fromRows([[1, 2]]); // 1x2
     expect(() => arr.matmul(a, b)).toThrow(/inner dimensions disagree/);
+  });
+
+  it("an outer-product-shaped call whose output would exceed MAX_ELEMENTS is a clean error, not an OOM", () => {
+    // Each operand is individually tiny; only their PRODUCT (m * n) is
+    // absurd. This proves the output shape is validated before `matmul`
+    // ever allocates `out`, not after — an allocate-then-validate ordering
+    // would attempt the huge allocation first.
+    const col: arr.NDArray = { shape: [100000, 1], data: new Float64Array(1) };
+    const row: arr.NDArray = { shape: [1, 100000], data: new Float64Array(1) };
+    expect(() => arr.matmul(col, row)).toThrow(/exceeds/);
   });
 });
 
@@ -383,5 +405,13 @@ describe("indexGet / indexSet", () => {
     ];
     expect(() => arr.indexGet(a, tooMany)).toThrow(/rank ≤ 2/);
     expect(() => arr.indexSet(a, tooMany, 1)).toThrow(/rank ≤ 2/);
+  });
+
+  it("a malformed IndexArg (only reachable from untyped emitted JS, not real TypeScript callers) is a clean error", () => {
+    const a = arr.zeros(1, 1);
+    // `as unknown as arr.IndexArg` simulates a compiled-JS call site that
+    // TypeScript's own type-checking can't police at runtime.
+    const malformed = { kind: "bogus" } as unknown as arr.IndexArg;
+    expect(() => arr.indexGet(a, [malformed])).toThrow(/unrecognised IndexArg/);
   });
 });

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -1,0 +1,387 @@
+/** Tests for @coding-adventures/sir-runtime-array. */
+
+import { describe, it, expect } from "vitest";
+import * as arr from "../src/index.js";
+
+describe("ndarray construction and accessors", () => {
+  it("scalar is rank-0, length-1", () => {
+    const s = arr.scalar(42);
+    expect(arr.isScalar(s)).toBe(true);
+    expect(arr.ndims(s)).toBe(0);
+    expect(s.shape).toEqual([]);
+    expect(arr.nrows(s)).toBe(1);
+    expect(arr.ncols(s)).toBe(1);
+    expect(arr.get(s, 0, 0)).toBe(42);
+  });
+
+  it("fromVec is a column vector (n x 1)", () => {
+    const v = arr.fromVec([1, 2, 3]);
+    expect(v.shape).toEqual([3]);
+    expect(arr.ndims(v)).toBe(1);
+    expect(arr.nrows(v)).toBe(3);
+    expect(arr.ncols(v)).toBe(1);
+    expect(arr.isScalar(v)).toBe(false);
+  });
+
+  it("fromRows stores column-major", () => {
+    // Row-major input [[1,2,3],[4,5,6]] becomes column-major [1,4,2,5,3,6].
+    const a = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    expect(a.shape).toEqual([2, 3]);
+    expect(Array.from(a.data)).toEqual([1, 4, 2, 5, 3, 6]);
+    expect(arr.get(a, 0, 0)).toBe(1);
+    expect(arr.get(a, 1, 2)).toBe(6);
+    expect(arr.get(a, 0, 2)).toBe(3);
+  });
+
+  it("fromRows rejects ragged rows", () => {
+    expect(() => arr.fromRows([[1, 2], [3]])).toThrow(/ragged/);
+  });
+
+  it("fromRows of zero rows is a 0x0 array", () => {
+    const empty = arr.fromRows([]);
+    expect(empty.shape).toEqual([0, 0]);
+    expect(empty.data.length).toBe(0);
+  });
+
+  it("zeros builds an all-zero matrix of the given shape", () => {
+    const z = arr.zeros(2, 3);
+    expect(z.shape).toEqual([2, 3]);
+    expect(Array.from(z.data)).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+
+  it("get is out-of-bounds-safe", () => {
+    const a = arr.fromRows([[1, 2]]); // 1x2
+    expect(arr.get(a, 0, 1)).toBe(2);
+    expect(arr.get(a, 1, 0)).toBeUndefined(); // row OOB
+    expect(arr.get(a, 0, 2)).toBeUndefined(); // col OOB
+  });
+
+  it("set mutates in place", () => {
+    const a = arr.zeros(2, 2);
+    arr.set(a, 1, 0, 9);
+    expect(arr.get(a, 1, 0)).toBe(9);
+    expect(arr.get(a, 0, 0)).toBe(0);
+  });
+
+  it("set rejects an out-of-bounds index", () => {
+    const a = arr.zeros(1, 1);
+    expect(() => arr.set(a, 1, 0, 1)).toThrow(/out of bounds/);
+  });
+
+  it("ndarray rejects a shape/data-length mismatch", () => {
+    expect(() => arr.ndarray([2, 2], Float64Array.of(1, 2, 3))).toThrow(/implies/);
+  });
+
+  it("ndarray rejects a shape exceeding MAX_ELEMENTS", () => {
+    expect(() => arr.ndarray([arr.MAX_ELEMENTS + 1], new Float64Array(arr.MAX_ELEMENTS + 1))).toThrow(
+      /exceeds/,
+    );
+  });
+});
+
+describe("elementwise", () => {
+  it("elementwise arithmetic on equal shapes", () => {
+    const a = arr.fromVec([1, 2, 3]);
+    const b = arr.fromVec([10, 20, 30]);
+    expect(Array.from(arr.elementwise("Add", a, b).data)).toEqual([11, 22, 33]);
+    expect(Array.from(arr.elementwise("Sub", b, a).data)).toEqual([9, 18, 27]);
+    expect(Array.from(arr.elementwise("Mul", a, b).data)).toEqual([10, 40, 90]);
+    expect(Array.from(arr.elementwise("Div", b, a).data)).toEqual([10, 10, 10]);
+  });
+
+  it("Pow raises elementwise (the one op array-runtime's BinOp lacks)", () => {
+    const a = arr.fromVec([2, 3, 4]);
+    const b = arr.fromVec([3, 2, 1]);
+    expect(Array.from(arr.elementwise("Pow", a, b).data)).toEqual([8, 9, 4]);
+  });
+
+  it("scalar broadcasts on either side, result keeps the array operand's shape", () => {
+    const v = arr.fromVec([1, 2, 3]);
+    const s = arr.scalar(2);
+    expect(Array.from(arr.elementwise("Mul", s, v).data)).toEqual([2, 4, 6]);
+    const r = arr.elementwise("Add", v, s);
+    expect(Array.from(r.data)).toEqual([3, 4, 5]);
+    expect(r.shape).toEqual([3]);
+  });
+
+  it("two scalars stay a scalar", () => {
+    const r = arr.elementwise("Add", arr.scalar(2), arr.scalar(40));
+    expect(arr.isScalar(r)).toBe(true);
+    expect(Array.from(r.data)).toEqual([42]);
+  });
+
+  it("non-conformable shapes are an error", () => {
+    const a = arr.fromVec([1, 2]);
+    const b = arr.fromVec([1, 2, 3]);
+    expect(() => arr.elementwise("Add", a, b)).toThrow(/non-conformable/);
+  });
+
+  it("comparisons produce APL-style 1/0, never a native boolean", () => {
+    const a = arr.fromVec([1, 2, 3]);
+    const b = arr.fromVec([3, 2, 1]);
+    expect(Array.from(arr.elementwise("Eq", a, b).data)).toEqual([0, 1, 0]);
+    expect(Array.from(arr.elementwise("Ne", a, b).data)).toEqual([1, 0, 1]);
+    expect(Array.from(arr.elementwise("Lt", a, b).data)).toEqual([1, 0, 0]);
+    expect(Array.from(arr.elementwise("Le", a, b).data)).toEqual([1, 1, 0]);
+    expect(Array.from(arr.elementwise("Ge", a, b).data)).toEqual([0, 1, 1]);
+    expect(Array.from(arr.elementwise("Gt", a, b).data)).toEqual([0, 0, 1]);
+  });
+
+  it("Max/Min are elementwise", () => {
+    const a = arr.fromVec([1, 5, 3]);
+    const b = arr.fromVec([4, 2, 3]);
+    expect(Array.from(arr.elementwise("Max", a, b).data)).toEqual([4, 5, 3]);
+    expect(Array.from(arr.elementwise("Min", a, b).data)).toEqual([1, 2, 3]);
+  });
+
+  it("NaN/Infinity propagate through Div", () => {
+    const a = arr.fromVec([1, 0]);
+    const b = arr.fromVec([0, 0]);
+    const q = arr.elementwise("Div", a, b);
+    expect(q.data[0]).toBe(Infinity);
+    expect(Number.isNaN(q.data[1])).toBe(true);
+  });
+});
+
+describe("matmul", () => {
+  it("identity leaves a matrix unchanged", () => {
+    const a = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]);
+    const identity = arr.fromRows([
+      [1, 0],
+      [0, 1],
+    ]);
+    expect(Array.from(arr.matmul(a, identity).data)).toEqual(Array.from(a.data));
+  });
+
+  it("2x2 · 2x2 product", () => {
+    const a = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]);
+    const b = arr.fromRows([
+      [5, 6],
+      [7, 8],
+    ]);
+    const c = arr.matmul(a, b);
+    expect(c.shape).toEqual([2, 2]);
+    expect(arr.get(c, 0, 0)).toBe(19);
+    expect(arr.get(c, 0, 1)).toBe(22);
+    expect(arr.get(c, 1, 0)).toBe(43);
+    expect(arr.get(c, 1, 1)).toBe(50);
+  });
+
+  it("non-square (2x3 · 3x1 -> 2x1)", () => {
+    const a = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    const x = arr.fromRows([[1], [0], [-1]]);
+    const y = arr.matmul(a, x);
+    expect(y.shape).toEqual([2, 1]);
+    expect(Array.from(y.data)).toEqual([-2, -2]);
+  });
+
+  it("dimension mismatch is an error", () => {
+    const a = arr.fromRows([[1, 2]]); // 1x2
+    const b = arr.fromRows([[1, 2]]); // 1x2
+    expect(() => arr.matmul(a, b)).toThrow(/inner dimensions disagree/);
+  });
+});
+
+describe("transpose", () => {
+  it("swaps rows and columns", () => {
+    const a = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    const t = arr.transpose(a);
+    expect(t.shape).toEqual([3, 2]);
+    expect(arr.get(t, 0, 0)).toBe(1);
+    expect(arr.get(t, 2, 1)).toBe(6);
+  });
+
+  it("is an involution", () => {
+    const a = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    expect(Array.from(arr.transpose(arr.transpose(a)).data)).toEqual(Array.from(a.data));
+  });
+
+  it("conjugate flag is a no-op on real data (no Complex type yet)", () => {
+    const a = arr.fromRows([[1, 2]]);
+    expect(Array.from(arr.transpose(a, true).data)).toEqual(Array.from(arr.transpose(a, false).data));
+  });
+});
+
+describe("range", () => {
+  it("unit-step range is a 1xn row vector", () => {
+    const r = arr.range(1, 5);
+    expect(r.shape).toEqual([1, 5]);
+    expect(Array.from(r.data)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("stepped range", () => {
+    const r = arr.range(1, 10, 2);
+    expect(Array.from(r.data)).toEqual([1, 3, 5, 7, 9]);
+  });
+
+  it("negative step counts down", () => {
+    const r = arr.range(5, 1, -1);
+    expect(Array.from(r.data)).toEqual([5, 4, 3, 2, 1]);
+  });
+
+  it("floating step is inclusive of stop within tolerance", () => {
+    const r = arr.range(0, 1, 0.25);
+    expect(Array.from(r.data)).toEqual([0, 0.25, 0.5, 0.75, 1]);
+  });
+
+  it("an empty range (start already past stop) is a 1x0 array", () => {
+    const r = arr.range(5, 1);
+    expect(r.shape).toEqual([1, 0]);
+    expect(r.data.length).toBe(0);
+  });
+
+  it("zero step is an error", () => {
+    expect(() => arr.range(1, 5, 0)).toThrow(/step cannot be zero/);
+  });
+
+  it("a range that would produce more than MAX_ELEMENTS is a clean error, not an OOM", () => {
+    // A compiled program's range bounds can be attacker-influenced (runtime
+    // values, not fixed at compile time) — this proves the cap actually
+    // trips rather than trusting the code that it would.
+    expect(() => arr.range(1, Number.MAX_SAFE_INTEGER)).toThrow(/produces more than/);
+  });
+});
+
+describe("indexGet / indexSet", () => {
+  it("2-index scalar read", () => {
+    const a = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(arr.indexGet(a, [{ kind: "scalar", value: 1 }, { kind: "scalar", value: 0 }])).toBe(3);
+  });
+
+  it("whole-row / whole-column selection", () => {
+    const a = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    const row0 = arr.indexGet(a, [{ kind: "scalar", value: 0 }, { kind: "whole" }]);
+    expect(row0).not.toBeTypeOf("number");
+    expect(Array.from((row0 as arr.NDArray).data)).toEqual([1, 2, 3]);
+
+    const col1 = arr.indexGet(a, [{ kind: "whole" }, { kind: "scalar", value: 1 }]);
+    expect(Array.from((col1 as arr.NDArray).data)).toEqual([2, 5]);
+  });
+
+  it("range-selected sub-array", () => {
+    const a = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    const cols = arr.range(1, 2); // 0-based columns 1..2, already resolved by the frontend
+    const sub = arr.indexGet(a, [{ kind: "whole" }, { kind: "range", indices: cols }]);
+    expect((sub as arr.NDArray).shape).toEqual([2, 2]);
+    expect(Array.from((sub as arr.NDArray).data)).toEqual([2, 5, 3, 6]);
+  });
+
+  it("single-argument linear indexing", () => {
+    const a = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]); // column-major data: [1, 3, 2, 4]
+    expect(arr.indexGet(a, [{ kind: "scalar", value: 2 }])).toBe(2);
+  });
+
+  it("single-argument whole-array linear read returns every element as a row vector", () => {
+    const a = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]); // column-major data: [1, 3, 2, 4]
+    const all = arr.indexGet(a, [{ kind: "whole" }]);
+    expect((all as arr.NDArray).shape).toEqual([1, 4]);
+    expect(Array.from((all as arr.NDArray).data)).toEqual([1, 3, 2, 4]);
+  });
+
+  it("single-argument linear read out of bounds is a clean error", () => {
+    const a = arr.fromVec([1, 2]);
+    expect(() => arr.indexGet(a, [{ kind: "scalar", value: 9 }])).toThrow(/out of bounds/);
+  });
+
+  it("indexGet out of bounds is a clean error", () => {
+    const a = arr.fromRows([[1, 2]]);
+    expect(() => arr.indexGet(a, [{ kind: "scalar", value: 5 }, { kind: "scalar", value: 0 }])).toThrow(
+      /out of bounds/,
+    );
+  });
+
+  it("indexSet writes a scalar in place", () => {
+    const a = arr.zeros(2, 2);
+    arr.indexSet(a, [{ kind: "scalar", value: 0 }, { kind: "scalar", value: 1 }], 9);
+    expect(arr.get(a, 0, 1)).toBe(9);
+  });
+
+  it("indexSet with a single (linear) index writes into the underlying data", () => {
+    const a = arr.zeros(2, 2); // column-major data [0, 0, 0, 0]
+    arr.indexSet(a, [{ kind: "scalar", value: 2 }], 5);
+    expect(arr.get(a, 0, 1)).toBe(5); // linear position 2 is (row 0, col 1)
+  });
+
+  it("indexSet with a single whole-array index broadcasts a scalar to every element", () => {
+    const a = arr.zeros(1, 3);
+    arr.indexSet(a, [{ kind: "whole" }], 4);
+    expect(Array.from(a.data)).toEqual([4, 4, 4]);
+  });
+
+  it("indexSet with a single out-of-bounds linear index is an error", () => {
+    const a = arr.zeros(1, 2);
+    expect(() => arr.indexSet(a, [{ kind: "scalar", value: 5 }], 1)).toThrow(/out of bounds/);
+  });
+
+  it("indexSet value can be an NDArray matching the selection count exactly", () => {
+    const a = arr.zeros(1, 3);
+    arr.indexSet(a, [{ kind: "scalar", value: 0 }, { kind: "whole" }], arr.fromVec([1, 2, 3]));
+    expect(Array.from(a.data)).toEqual([1, 2, 3]);
+  });
+
+  it("indexSet value can be a length-1 NDArray, broadcast like a scalar", () => {
+    const a = arr.zeros(1, 3);
+    arr.indexSet(a, [{ kind: "scalar", value: 0 }, { kind: "whole" }], arr.scalar(6));
+    expect(Array.from(a.data)).toEqual([6, 6, 6]);
+  });
+
+  it("indexSet broadcasts a scalar across a whole-row selection", () => {
+    const a = arr.zeros(2, 3);
+    arr.indexSet(a, [{ kind: "scalar", value: 0 }, { kind: "whole" }], 7);
+    expect(arr.get(a, 0, 0)).toBe(7);
+    expect(arr.get(a, 0, 1)).toBe(7);
+    expect(arr.get(a, 0, 2)).toBe(7);
+    expect(arr.get(a, 1, 0)).toBe(0);
+  });
+
+  it("indexSet with a mismatched value length is an error", () => {
+    const a = arr.zeros(1, 3);
+    expect(() =>
+      arr.indexSet(a, [{ kind: "scalar", value: 0 }, { kind: "whole" }], arr.fromVec([1, 2])),
+    ).toThrow(/expected 3/);
+  });
+
+  it("indexGet/indexSet reject more than 2 index arguments", () => {
+    const a = arr.zeros(1, 1);
+    const tooMany = [
+      { kind: "scalar" as const, value: 0 },
+      { kind: "scalar" as const, value: 0 },
+      { kind: "scalar" as const, value: 0 },
+    ];
+    expect(() => arr.indexGet(a, tooMany)).toThrow(/rank ≤ 2/);
+    expect(() => arr.indexSet(a, tooMany, 1)).toThrow(/rank ≤ 2/);
+  });
+});

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -23,6 +23,14 @@ describe("ndarray construction and accessors", () => {
     expect(arr.isScalar(v)).toBe(false);
   });
 
+  it("fromVec validates length before allocating, even for a bare array-like with no real elements", () => {
+    // `Float64Array.from` accepts any `{ length: N }` array-like, not just a
+    // real `number[]` — a caller could pass one with no backing elements at
+    // all, costing them nothing while requesting an N-sized allocation.
+    const arrayLike = { length: 1e10 } as unknown as readonly number[];
+    expect(() => arr.fromVec(arrayLike)).toThrow(/exceeds/);
+  });
+
   it("fromRows stores column-major", () => {
     // Row-major input [[1,2,3],[4,5,6]] becomes column-major [1,4,2,5,3,6].
     const a = arr.fromRows([
@@ -108,6 +116,13 @@ describe("elementwise", () => {
     const a = arr.fromVec([2, 3, 4]);
     const b = arr.fromVec([3, 2, 1]);
     expect(Array.from(arr.elementwise("Pow", a, b).data)).toEqual([8, 9, 4]);
+  });
+
+  it("a malformed op (only reachable from untyped emitted JS) is a clean error, not silent NaN corruption", () => {
+    const a = arr.fromVec([1, 2]);
+    const b = arr.fromVec([3, 4]);
+    const bogus = "Bogus" as unknown as arr.ElementwiseOpKind;
+    expect(() => arr.elementwise(bogus, a, b)).toThrow(/unrecognised ElementwiseOpKind/);
   });
 
   it("scalar broadcasts on either side, result keeps the array operand's shape", () => {

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -83,6 +83,14 @@ describe("ndarray construction and accessors", () => {
     expect(() => arr.ndarray([2, 2], Float64Array.of(1, 2, 3))).toThrow(/implies/);
   });
 
+  it("ndarray rejects a data buffer that isn't really a Float64Array", () => {
+    // NDArray is a plain structural interface, not a class — a compiled-JS
+    // caller could hand back an object shaped like one whose `data` is a
+    // plain array or array-like instead of a real Float64Array.
+    const notReallyFloat64 = [1, 2, 3, 4] as unknown as Float64Array;
+    expect(() => arr.ndarray([2, 2], notReallyFloat64)).toThrow(/must be a Float64Array/);
+  });
+
   it("ndarray rejects a shape exceeding MAX_ELEMENTS", () => {
     expect(() => arr.ndarray([arr.MAX_ELEMENTS + 1], new Float64Array(arr.MAX_ELEMENTS + 1))).toThrow(
       /exceeds/,

--- a/code/packages/typescript/sir-runtime-array/tsconfig.json
+++ b/code/packages/typescript/sir-runtime-array/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/sir-runtime-array/vitest.config.ts
+++ b/code/packages/typescript/sir-runtime-array/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Front3 (Semantic-IR/HML01 math-language work). Stream A (array/matrix domain) items 1-5 are already done (HML01 spec, SIR22 spec+core, `matlab-to-semantic-ir`, `octave-to-semantic-ir`). This PR is item 6: a new `@coding-adventures/sir-runtime-array` npm package, following the exact precedent `sir-runtime-symbolic` set for SIR23's Stream B — the runtime primitives land *before* any backend consumes them, so the follow-up codegen PR (item 7, currently deferred — both `semantic-ir-to-javascript` and `semantic-ir-to-typescript` hard-reject `Feature::NDArrays`/`Feature::MatrixOps` and hit a deferred `panic!` at every SIR22 `Expr` match arm) only has to wire up calls, not design an array representation from scratch.

### What's in this package

Mirrors [`array_runtime`](code/packages/rust/array-runtime) (the Rust crate the MATLAB/Octave *runtimes* already use) field-for-field and algorithm-for-algorithm:

- **`NDArray`** — dense, column-major `f64` value model (`ndarray`, `scalar`, `fromVec`, `fromRows`, `zeros`, `get`, `set`, …), matching `array_runtime::value::Array`'s exact indexing formula and row/column conventions.
- **`elementwise(op, a, b)`** — all 13 `ElementwiseOpKind`s the SIR22 spec defines (`array_runtime::ops::BinOp`'s 12, plus `Pow`, which Rust's crate hasn't ported yet), same scalar-broadcast rule.
- **`matmul`** / **`transpose`** — mirror the Rust reference exactly. `transpose`'s `conjugate` flag is accepted for API-shape parity with the SIR22 spec but is a no-op today (no `Complex` type yet).
- **`range(start, stop, step?)`** — MATLAB-style materialization, same inclusive-stop tolerance and length cap as `matlab-runtime`'s `eval_colon`.
- **`indexGet`/`indexSet`** — `A(i)`/`A(i,j)` read and in-place write, covering the SIR22 spec's `Scalar`/`Whole`/`Range` `IndexArg` shapes.

Deliberately **not** implemented: the SIR22 spec's "APL addendum" `Expr` variants (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) — no frontend crate emits them yet, so porting `array_runtime::ops`'s existing Rust reference implementations now would be speculative rather than filling a real gap.

### Security hardening (4 rounds of `/security-review`)

Since this runtime will eventually execute compiled, potentially attacker-influenced numeric bounds (array shapes, range bounds computed at runtime), the review focused on allocate-before-validate ordering and JS/TS trust-boundary gaps. Converged from 5 findings down to one defense-in-depth item across 4 rounds:

1. `zeros`/`fromRows`/`matmul` allocated `new Float64Array(size)` from caller-supplied numbers *before* validating against the `MAX_ELEMENTS` cap (2²⁶) — an outer-product-shaped `matmul` call with two individually-tiny operands could still request an absurd output size.
2. Same gap in `indexGet`/`indexSet`'s 2-index sub-array path (`rows.length * cols.length`).
3. Same gap in `fromVec` (a bare `{length: N}` array-like costs nothing to construct); plus a missing `default` case in `elementwise.ts`'s op-dispatch switch (silent `NaN` corruption instead of a clean error).
4. `ndarray()` never asserted its `data` argument was really a `Float64Array` (defense-in-depth — no demonstrated live exploit path today).

Fixed with a shared `checkedShapeSize(shape)` helper (validates negative/non-integer dimensions and the cap *before* any allocation) called everywhere a buffer is sized from caller-supplied numbers, plus `default: throw` cases on every switch dispatching on an externally-suppliable tag.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run --coverage` — 57 tests, 100% line/branch/function coverage
- [x] `/security-review` — 4 rounds, converged (see above)
- [x] Merged latest `origin/main` — no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)