### PR TITLE
feat(os-platform): CCPP02 Phase 2 PR2 — thread primitive (threads/mutex/cond, C)

### DIFF
--- a/code/packages/c/os-platform/BUILD
+++ b/code/packages/c/os-platform/BUILD
@@ -1,5 +1,5 @@
 # build-tool: deps=c/iso-harness c/platform-harness
-# os-platform (Unix backend: macOS + Linux). Compiles the POSIX clock backend
-# (clock_gettime / nanosleep) under every present C compiler via platform-harness.
-# Windows uses BUILD_windows, which names the Win32 backend instead.
+# os-platform (Unix backend: macOS + Linux). Compiles each primitive's POSIX
+# backend (clock, thread, …) under every present C compiler via platform-harness.
+# Windows uses BUILD_windows, which names the Win32 backends instead.
 sh tools/run.sh

--- a/code/packages/c/os-platform/CHANGELOG.md
+++ b/code/packages/c/os-platform/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to semantic versioning.
 
 ### Added
 
+- **`thread` primitive** (CCPP02 Phase 2, PR 2): threads, mutexes, and condition
+  variables — concurrency is bucket B (C11 `<threads.h>` is optional and
+  MSVC-absent). Opaque heap handles keep OS types out of the shared header; each
+  `_init`/`_spawn` allocates and each `_destroy`/`_join` frees, so nothing leaks.
+  - `osp_thread_spawn` / `osp_thread_join` (worker is `void *(*)(void *)`; join
+    delivers the worker's result and frees the handle).
+  - `osp_mutex_init` / `_lock` / `_unlock` / `_destroy` (non-recursive).
+  - `osp_cond_init` / `_wait` / `_signal` / `_broadcast` / `_destroy`.
+  - Backends: `thread_posix.c` (pthreads; links `-pthread` via PLATFORM_LIBS) and
+    `thread_windows.c` (`_beginthreadex` + `CRITICAL_SECTION` +
+    `CONDITION_VARIABLE`; CRT + kernel32, no extra lib).
+  - Integration tests (`tests/thread_test.c`): four-thread locked-counter mutual
+    exclusion (deterministic, not flaky), condition-variable handoff + return
+    value, and NULL-argument rejection. Verified under ASan+UBSan **and
+    ThreadSanitizer** (no data races) with 0 leaks.
+- **`os_platform/status.h`**: the shared `osp_status` enum, extracted so multiple
+  primitive headers can be included together without a duplicate `enum`
+  definition; adds `OSP_ERR_NOMEM`. `clock.h` now includes it (no API change).
+
+### Added — PR 1
+
 - **Initial package + `clock` primitive** (CCPP02 Phase 2, PR 1). The first
   bucket-B library: OS-provided capabilities that pure-ISO C cannot compute.
   Built by `platform-harness` (warnings-as-errors, but not `-pedantic-errors`).

--- a/code/packages/c/os-platform/README.md
+++ b/code/packages/c/os-platform/README.md
@@ -17,14 +17,17 @@ exactly one backend and the code contains no `#if defined(__linux__)` mazes.
 
 ## Primitives
 
-| Module  | Header                     | Status        |
-|---------|----------------------------|---------------|
-| `clock` | `os_platform/clock.h`      | ✅ implemented |
-| thread  | —                          | planned       |
-| fs      | —                          | planned       |
-| process | —                          | planned       |
-| dynlib  | —                          | planned       |
-| mmap    | —                          | planned       |
+| Module   | Header                  | Status        |
+|----------|-------------------------|---------------|
+| `clock`  | `os_platform/clock.h`   | ✅ implemented |
+| `thread` | `os_platform/thread.h`  | ✅ implemented |
+| fs       | —                       | planned       |
+| process  | —                       | planned       |
+| dynlib   | —                       | planned       |
+| mmap     | —                       | planned       |
+
+All primitives share the `osp_status` return convention from
+`os_platform/status.h` (`OSP_OK == 0`; negative on error).
 
 See [`CCPP02-os-platform-lane.md`](../../../specs/CCPP02-os-platform-lane.md) for
 the full plan.
@@ -67,6 +70,42 @@ links no extra library (both calls live in libc on modern glibc/macOS). The
 Windows backend uses only kernel32, linked by MSVC by default. On Windows,
 `osp_sleep_ns` has millisecond granularity (`Sleep` rounds up to whole ms).
 
+### `thread` — threads, mutexes, condition variables
+
+Concurrency is bucket B (C11 `<threads.h>` is optional and MSVC-absent). Opaque
+handles hide the OS types; create with `_init`/`_spawn`, release with
+`_destroy`/`_join`:
+
+```c
+#include "os_platform/thread.h"
+
+static void *worker(void *arg) { /* … */ return arg; }
+
+osp_thread *t;
+osp_thread_spawn(&t, worker, ctx);
+void *result;
+osp_thread_join(t, &result);        /* waits, delivers worker's return, frees t */
+
+osp_mutex *m; osp_mutex_init(&m);
+osp_mutex_lock(m); /* … */ osp_mutex_unlock(m);
+
+osp_cond *c; osp_cond_init(&c);
+osp_mutex_lock(m);
+while (!ready) osp_cond_wait(c, m); /* loop guards spurious wake-ups */
+osp_mutex_unlock(m);
+```
+
+Backends:
+
+| OS          | thread                             | mutex              | cond                 |
+|-------------|------------------------------------|--------------------|----------------------|
+| macOS/Linux | `pthread_create` / `_join`         | `pthread_mutex_t`  | `pthread_cond_t`     |
+| Windows     | `_beginthreadex` / `WaitForSingleObject` | `CRITICAL_SECTION` | `CONDITION_VARIABLE` |
+
+The POSIX backend links the OS thread library (`-pthread`); the Windows backend
+uses only the CRT + kernel32. Mutexes are non-recursive; a condition variable is
+always waited on while holding its paired mutex.
+
 ## Build & test
 
 ```sh
@@ -74,19 +113,23 @@ cd code/packages/c/os-platform
 sh tools/run.sh        # macOS / Linux (Windows: tools\run.ps1 via BUILD_windows)
 ```
 
-This compiles `tests/clock_test.c` with the OS's clock backend under every
-present compiler and runs it, printing `N checks, 0 failed`. Output goes to
-`_build/` (never `build/`, which collides with the `BUILD` file on
-case-insensitive filesystems). Remove it with `rm -rf _build`.
+This compiles each primitive's test with the OS's backend under every present
+compiler and runs it, printing `N checks, 0 failed`. Output goes to `_build/`
+(never `build/`, which collides with the `BUILD` file on case-insensitive
+filesystems). Remove it with `rm -rf _build`.
 
 ## Layout
 
 ```
 os-platform/
-├── include/os_platform/clock.h   # shared public API (one header per primitive)
-├── src/clock_posix.c             # macOS + Linux backend
-├── src/clock_windows.c           # Windows backend
-├── tests/clock_test.c            # property tests, run on each OS
+├── include/os_platform/
+│   ├── status.h                  # shared osp_status enum (all primitives)
+│   ├── clock.h                   # clock API
+│   └── thread.h                  # thread API
+├── src/
+│   ├── clock_posix.c   · clock_windows.c    # per-OS clock backends
+│   └── thread_posix.c  · thread_windows.c   # per-OS thread backends
+├── tests/clock_test.c  · thread_test.c      # per-primitive tests, run on each OS
 ├── tools/run.sh  · run.ps1       # per-OS build drivers
 ├── BUILD  · BUILD_windows        # per-OS source selection
 └── required_capabilities.json    # CI needs gcc, clang, cl

--- a/code/packages/c/os-platform/include/os_platform/clock.h
+++ b/code/packages/c/os-platform/include/os_platform/clock.h
@@ -64,18 +64,11 @@
 
 #include <stdint.h>
 
+#include "os_platform/status.h" /* osp_status: OSP_OK / OSP_ERR_* */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/* Status codes. 0 is success (so `if (osp_...())` reads as "if it failed"); all
- * errors are negative, leaving room to grow the vocabulary without colliding
- * with OSP_OK. */
-typedef enum {
-    OSP_OK = 0,          /* the call succeeded; the out-parameter is valid    */
-    OSP_ERR_OS = -1,     /* the underlying OS call reported a failure          */
-    OSP_ERR_INVAL = -2   /* a caller argument was invalid (e.g. NULL out-ptr) */
-} osp_status;
 
 /*
  * osp_monotonic_ns — elapsed-time clock, in nanoseconds.

--- a/code/packages/c/os-platform/include/os_platform/status.h
+++ b/code/packages/c/os-platform/include/os_platform/status.h
@@ -1,0 +1,40 @@
+/*
+ * os_platform/status.h — the shared status/error vocabulary for os-platform.
+ * ===========================================================================
+ *
+ * Every os-platform primitive (clock, thread, fs, …) reports success or failure
+ * through this one small enum, so a caller learns a single convention and every
+ * header agrees on the values. It lives in its own header (rather than inside any
+ * one primitive's header) so that including two primitives at once — e.g. both
+ * clock.h and thread.h — cannot produce a duplicate `enum osp_status` definition.
+ *
+ * CONVENTION
+ * ----------
+ * OSP_OK is 0, so the idiomatic check reads naturally:
+ *
+ *     if (osp_thread_spawn(&t, worker, arg)) {   // non-zero == it failed
+ *         // handle error
+ *     }
+ *
+ * All error codes are negative, leaving the entire positive range free should a
+ * primitive ever want to return a small count through the same type.
+ */
+#ifndef OS_PLATFORM_STATUS_H
+#define OS_PLATFORM_STATUS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    OSP_OK = 0,          /* the call succeeded; any out-parameter is valid     */
+    OSP_ERR_OS = -1,     /* an underlying OS call reported a failure            */
+    OSP_ERR_INVAL = -2,  /* a caller argument was invalid (e.g. a NULL pointer) */
+    OSP_ERR_NOMEM = -3   /* an allocation for an OS-object wrapper failed        */
+} osp_status;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* OS_PLATFORM_STATUS_H */

--- a/code/packages/c/os-platform/include/os_platform/thread.h
+++ b/code/packages/c/os-platform/include/os_platform/thread.h
@@ -1,0 +1,117 @@
+/*
+ * os_platform/thread.h — threads, mutexes, and condition variables, portably.
+ * ===========================================================================
+ *
+ * The second os-platform primitive. Concurrency is squarely *bucket B*: there is
+ * no portable pure-ISO way to start a thread. C11's <threads.h> is an OPTIONAL
+ * feature and MSVC does not ship it, so C code must call the OS directly —
+ * POSIX threads (pthreads) on macOS/Linux, the Win32 thread API on Windows. This
+ * header hides that split behind three small object types:
+ *
+ *      concept   macOS / Linux (pthreads)     Windows (Win32)
+ *      ────────  ───────────────────────────  ─────────────────────────────────
+ *      thread    pthread_create / _join        _beginthreadex / WaitForSingleObject
+ *      mutex     pthread_mutex_t               CRITICAL_SECTION
+ *      cond      pthread_cond_t                CONDITION_VARIABLE
+ *
+ * OPAQUE HANDLES. The three types below are forward-declared and always used
+ * through a pointer; the real struct (which embeds the pthread_t / HANDLE /
+ * CRITICAL_SECTION) lives in the per-OS .c file. That keeps OS types out of this
+ * shared header — the whole point of the os-platform design — and means a caller
+ * never needs <pthread.h> or <windows.h> to use threads. Each object is created
+ * on the heap by its `_init`/`_spawn` and released by its `_destroy`/`_join`, so
+ * no OS handle is ever leaked.
+ *
+ * THREADING MODEL. A worker is an `osp_thread_fn`: it takes a `void *` argument
+ * and returns a `void *` result (the pthreads shape, mirrored on Windows by a
+ * trampoline). `osp_thread_join` hands that result back and frees the handle.
+ * Mutexes are non-recursive; a condition variable is always waited on while
+ * holding its paired mutex, exactly as with pthreads.
+ *
+ * BUILD. Compiled by platform-harness. The POSIX backend links the OS thread
+ * library (`-pthread`, via PLATFORM_LIBS) and needs _POSIX_C_SOURCE; the Windows
+ * backend uses only the CRT + kernel32 (linked by default). Per-OS source
+ * selection is done by the BUILD file, so there are no OS #ifdefs in the code.
+ */
+#ifndef OS_PLATFORM_THREAD_H
+#define OS_PLATFORM_THREAD_H
+
+#include "os_platform/status.h" /* osp_status: OSP_OK / OSP_ERR_* */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Threads ────────────────────────────────────────────────────────────── */
+
+/* Opaque thread handle. Created by osp_thread_spawn, consumed by
+ * osp_thread_join (which frees it). Do not copy or free it yourself. */
+typedef struct osp_thread osp_thread;
+
+/* A thread body: receives its argument, returns a result pointer. The result is
+ * delivered to whoever joins the thread. */
+typedef void *(*osp_thread_fn)(void *arg);
+
+/*
+ * osp_thread_spawn — start `fn(arg)` on a new OS thread.
+ *
+ * On success writes a handle through *out and returns OSP_OK. The new thread
+ * runs concurrently until it returns from `fn`. Returns OSP_ERR_INVAL if `out`
+ * or `fn` is NULL, OSP_ERR_NOMEM if the handle allocation fails, OSP_ERR_OS if
+ * the OS refuses to create the thread.
+ */
+osp_status osp_thread_spawn(osp_thread **out, osp_thread_fn fn, void *arg);
+
+/*
+ * osp_thread_join — wait for `t` to finish, then free it.
+ *
+ * Blocks until the thread's `fn` returns. If `retval_out` is non-NULL, the
+ * thread's result pointer is written there. The handle `t` is freed and must not
+ * be used again. Returns OSP_ERR_INVAL if `t` is NULL, OSP_ERR_OS on a join
+ * failure.
+ */
+osp_status osp_thread_join(osp_thread *t, void **retval_out);
+
+/* ── Mutexes (non-recursive mutual exclusion) ───────────────────────────── */
+
+typedef struct osp_mutex osp_mutex;
+
+/* Create a mutex (initially unlocked). OSP_ERR_INVAL if out is NULL,
+ * OSP_ERR_NOMEM / OSP_ERR_OS on failure. */
+osp_status osp_mutex_init(osp_mutex **out);
+/* Lock the mutex, blocking until it is available. */
+osp_status osp_mutex_lock(osp_mutex *m);
+/* Unlock a mutex the caller holds. */
+osp_status osp_mutex_unlock(osp_mutex *m);
+/* Destroy a mutex and free it. It must be unlocked and unused. */
+osp_status osp_mutex_destroy(osp_mutex *m);
+
+/* ── Condition variables (wait/notify, paired with a mutex) ─────────────── */
+
+typedef struct osp_cond osp_cond;
+
+/* Create a condition variable. OSP_ERR_INVAL if out is NULL,
+ * OSP_ERR_NOMEM / OSP_ERR_OS on failure. */
+osp_status osp_cond_init(osp_cond **out);
+/*
+ * osp_cond_wait — atomically release `m` and sleep until signalled, then
+ * re-acquire `m` before returning. The caller MUST hold `m` on entry. Guard
+ * against spurious wake-ups by re-checking your predicate in a loop:
+ *
+ *     osp_mutex_lock(m);
+ *     while (!ready) osp_cond_wait(c, m);
+ *     osp_mutex_unlock(m);
+ */
+osp_status osp_cond_wait(osp_cond *c, osp_mutex *m);
+/* Wake at least one waiter (if any). */
+osp_status osp_cond_signal(osp_cond *c);
+/* Wake all current waiters. */
+osp_status osp_cond_broadcast(osp_cond *c);
+/* Destroy a condition variable and free it. It must have no waiters. */
+osp_status osp_cond_destroy(osp_cond *c);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* OS_PLATFORM_THREAD_H */

--- a/code/packages/c/os-platform/src/thread_posix.c
+++ b/code/packages/c/os-platform/src/thread_posix.c
@@ -1,0 +1,182 @@
+/*
+ * thread_posix.c — the POSIX (pthreads) backend of os_platform/thread.
+ * ===========================================================================
+ *
+ * Compiled on macOS + Linux (named by the shared `BUILD`; Windows uses
+ * clock_windows.c's sibling thread_windows.c via `BUILD_windows`). No OS #ifdefs
+ * here — the build already chose this file.
+ *
+ * Each opaque handle from thread.h is a small heap struct wrapping the real
+ * pthreads object. The `_init`/`_spawn` allocate it; the `_destroy`/`_join` free
+ * it — so no pthread object and no allocation is ever leaked.
+ *
+ * Links the OS thread library: the BUILD passes `-pthread` via PLATFORM_LIBS,
+ * and _POSIX_C_SOURCE (also from the BUILD) exposes the pthreads declarations.
+ */
+#include "os_platform/thread.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+
+/* ── Threads ────────────────────────────────────────────────────────────── */
+
+/*
+ * The handle carries the OS thread id plus the user's function, argument, and
+ * (once the thread finishes) its result. pthreads already speaks our
+ * `void *(*)(void *)` shape, so the trampoline exists only to stash the result
+ * where join() can find it — pthread_join's own out-parameter would also work,
+ * but routing it through the struct keeps the Windows backend (whose thread
+ * proc returns `unsigned`, not `void *`) structurally identical.
+ */
+struct osp_thread {
+    pthread_t tid;
+    osp_thread_fn fn;
+    void *arg;
+    void *result;
+};
+
+static void *osp__thread_trampoline(void *p) {
+    struct osp_thread *t = (struct osp_thread *)p;
+    t->result = t->fn(t->arg);
+    return NULL;
+}
+
+osp_status osp_thread_spawn(osp_thread **out, osp_thread_fn fn, void *arg) {
+    struct osp_thread *t;
+    if (out == NULL || fn == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    t = (struct osp_thread *)malloc(sizeof(*t));
+    if (t == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    t->fn = fn;
+    t->arg = arg;
+    t->result = NULL;
+    if (pthread_create(&t->tid, NULL, osp__thread_trampoline, t) != 0) {
+        free(t);
+        return OSP_ERR_OS;
+    }
+    *out = t;
+    return OSP_OK;
+}
+
+osp_status osp_thread_join(osp_thread *t, void **retval_out) {
+    if (t == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* On failure we deliberately keep the handle: the thread may still be
+     * running, so freeing it (and its pthread_t) would be unsafe. */
+    if (pthread_join(t->tid, NULL) != 0) {
+        return OSP_ERR_OS;
+    }
+    if (retval_out != NULL) {
+        *retval_out = t->result;
+    }
+    free(t);
+    return OSP_OK;
+}
+
+/* ── Mutexes ────────────────────────────────────────────────────────────── */
+
+struct osp_mutex {
+    pthread_mutex_t m;
+};
+
+osp_status osp_mutex_init(osp_mutex **out) {
+    struct osp_mutex *mu;
+    if (out == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    mu = (struct osp_mutex *)malloc(sizeof(*mu));
+    if (mu == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    if (pthread_mutex_init(&mu->m, NULL) != 0) {
+        free(mu);
+        return OSP_ERR_OS;
+    }
+    *out = mu;
+    return OSP_OK;
+}
+
+osp_status osp_mutex_lock(osp_mutex *m) {
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    return (pthread_mutex_lock(&m->m) == 0) ? OSP_OK : OSP_ERR_OS;
+}
+
+osp_status osp_mutex_unlock(osp_mutex *m) {
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    return (pthread_mutex_unlock(&m->m) == 0) ? OSP_OK : OSP_ERR_OS;
+}
+
+osp_status osp_mutex_destroy(osp_mutex *m) {
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    if (pthread_mutex_destroy(&m->m) != 0) {
+        return OSP_ERR_OS;
+    }
+    free(m);
+    return OSP_OK;
+}
+
+/* ── Condition variables ────────────────────────────────────────────────── */
+
+struct osp_cond {
+    pthread_cond_t c;
+};
+
+osp_status osp_cond_init(osp_cond **out) {
+    struct osp_cond *cv;
+    if (out == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    cv = (struct osp_cond *)malloc(sizeof(*cv));
+    if (cv == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    if (pthread_cond_init(&cv->c, NULL) != 0) {
+        free(cv);
+        return OSP_ERR_OS;
+    }
+    *out = cv;
+    return OSP_OK;
+}
+
+osp_status osp_cond_wait(osp_cond *c, osp_mutex *m) {
+    if (c == NULL || m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* pthread_cond_wait atomically unlocks m, sleeps, and re-locks m on wake. */
+    return (pthread_cond_wait(&c->c, &m->m) == 0) ? OSP_OK : OSP_ERR_OS;
+}
+
+osp_status osp_cond_signal(osp_cond *c) {
+    if (c == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    return (pthread_cond_signal(&c->c) == 0) ? OSP_OK : OSP_ERR_OS;
+}
+
+osp_status osp_cond_broadcast(osp_cond *c) {
+    if (c == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    return (pthread_cond_broadcast(&c->c) == 0) ? OSP_OK : OSP_ERR_OS;
+}
+
+osp_status osp_cond_destroy(osp_cond *c) {
+    if (c == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    if (pthread_cond_destroy(&c->c) != 0) {
+        return OSP_ERR_OS;
+    }
+    free(c);
+    return OSP_OK;
+}

--- a/code/packages/c/os-platform/src/thread_windows.c
+++ b/code/packages/c/os-platform/src/thread_windows.c
@@ -1,0 +1,186 @@
+/*
+ * thread_windows.c — the Win32 backend of os_platform/thread.
+ * ===========================================================================
+ *
+ * Compiled on Windows (named by `BUILD_windows`; macOS/Linux use thread_posix.c
+ * via the shared `BUILD`). No OS #ifdefs — the build already chose this file.
+ *
+ * The three opaque handles map onto Win32 primitives:
+ *   thread  →  _beginthreadex + HANDLE   (WaitForSingleObject to join)
+ *   mutex   →  CRITICAL_SECTION
+ *   cond    →  CONDITION_VARIABLE        (paired with the CRITICAL_SECTION)
+ *
+ * We use _beginthreadex rather than raw CreateThread because the worker runs
+ * arbitrary caller code that may touch the C runtime; _beginthreadex sets up (and
+ * tears down) the per-thread CRT state, avoiding a small resource leak. All of
+ * these live in the CRT + kernel32, linked by default, so no PLATFORM_LIBS entry
+ * is needed. Note: CONDITION_VARIABLE has no OS destroy call — you simply stop
+ * using it — so osp_cond_destroy only frees the wrapper.
+ */
+#include "os_platform/thread.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <process.h> /* _beginthreadex */
+#include <stdlib.h>
+
+/* ── Threads ────────────────────────────────────────────────────────────── */
+
+struct osp_thread {
+    HANDLE handle;
+    osp_thread_fn fn;
+    void *arg;
+    void *result;
+};
+
+/* Win32/CRT thread procs return `unsigned`, not `void *`, so the trampoline
+ * bridges to our osp_thread_fn shape and stashes the result for join(). */
+static unsigned __stdcall osp__thread_trampoline(void *p) {
+    struct osp_thread *t = (struct osp_thread *)p;
+    t->result = t->fn(t->arg);
+    return 0;
+}
+
+osp_status osp_thread_spawn(osp_thread **out, osp_thread_fn fn, void *arg) {
+    struct osp_thread *t;
+    uintptr_t h;
+    if (out == NULL || fn == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    t = (struct osp_thread *)malloc(sizeof(*t));
+    if (t == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    t->fn = fn;
+    t->arg = arg;
+    t->result = NULL;
+    h = _beginthreadex(NULL, 0, osp__thread_trampoline, t, 0, NULL);
+    if (h == 0) {
+        free(t);
+        return OSP_ERR_OS;
+    }
+    t->handle = (HANDLE)h;
+    *out = t;
+    return OSP_OK;
+}
+
+osp_status osp_thread_join(osp_thread *t, void **retval_out) {
+    if (t == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* On failure keep the handle: the thread may still be running. */
+    if (WaitForSingleObject(t->handle, INFINITE) != WAIT_OBJECT_0) {
+        return OSP_ERR_OS;
+    }
+    CloseHandle(t->handle);
+    if (retval_out != NULL) {
+        *retval_out = t->result;
+    }
+    free(t);
+    return OSP_OK;
+}
+
+/* ── Mutexes ────────────────────────────────────────────────────────────── */
+
+struct osp_mutex {
+    CRITICAL_SECTION cs;
+};
+
+osp_status osp_mutex_init(osp_mutex **out) {
+    struct osp_mutex *mu;
+    if (out == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    mu = (struct osp_mutex *)malloc(sizeof(*mu));
+    if (mu == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    /* InitializeCriticalSection returns void and does not fail on supported
+     * Windows versions. */
+    InitializeCriticalSection(&mu->cs);
+    *out = mu;
+    return OSP_OK;
+}
+
+osp_status osp_mutex_lock(osp_mutex *m) {
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    EnterCriticalSection(&m->cs);
+    return OSP_OK;
+}
+
+osp_status osp_mutex_unlock(osp_mutex *m) {
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    LeaveCriticalSection(&m->cs);
+    return OSP_OK;
+}
+
+osp_status osp_mutex_destroy(osp_mutex *m) {
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    DeleteCriticalSection(&m->cs);
+    free(m);
+    return OSP_OK;
+}
+
+/* ── Condition variables ────────────────────────────────────────────────── */
+
+struct osp_cond {
+    CONDITION_VARIABLE cv;
+};
+
+osp_status osp_cond_init(osp_cond **out) {
+    struct osp_cond *cv;
+    if (out == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    cv = (struct osp_cond *)malloc(sizeof(*cv));
+    if (cv == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    InitializeConditionVariable(&cv->cv);
+    *out = cv;
+    return OSP_OK;
+}
+
+osp_status osp_cond_wait(osp_cond *c, osp_mutex *m) {
+    if (c == NULL || m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* Atomically releases the CRITICAL_SECTION, sleeps, and re-acquires it on
+     * wake. With INFINITE, a FALSE return signals a real error, not a timeout. */
+    if (!SleepConditionVariableCS(&c->cv, &m->cs, INFINITE)) {
+        return OSP_ERR_OS;
+    }
+    return OSP_OK;
+}
+
+osp_status osp_cond_signal(osp_cond *c) {
+    if (c == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    WakeConditionVariable(&c->cv);
+    return OSP_OK;
+}
+
+osp_status osp_cond_broadcast(osp_cond *c) {
+    if (c == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    WakeAllConditionVariable(&c->cv);
+    return OSP_OK;
+}
+
+osp_status osp_cond_destroy(osp_cond *c) {
+    if (c == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* CONDITION_VARIABLE needs no OS teardown; just free the wrapper. */
+    free(c);
+    return OSP_OK;
+}

--- a/code/packages/c/os-platform/tests/thread_test.c
+++ b/code/packages/c/os-platform/tests/thread_test.c
@@ -1,0 +1,122 @@
+/*
+ * thread_test.c — integration tests for os_platform/thread, run on each OS.
+ * ===========================================================================
+ *
+ * Concurrency can't be checked by a golden vector, so we assert on observable
+ * outcomes that only hold when the primitives actually work:
+ *
+ *   1. MUTUAL EXCLUSION — four threads each do 100 000 locked increments of a
+ *      shared counter. If the mutex truly serialises them the total is exactly
+ *      400 000; a broken lock loses updates and the count comes up short. This
+ *      is a deterministic pass/fail (not timing-dependent, so not flaky).
+ *
+ *   2. CONDITION-VARIABLE HANDOFF + RETURN VALUE — the main thread waits on a
+ *      condition variable until a worker sets a flag and signals it, proving
+ *      wait/signal wake-up and the mutex/cond pairing. The worker returns a
+ *      pointer that join() must deliver back unchanged.
+ *
+ *   3. ARGUMENT VALIDATION — NULL arguments are rejected with OSP_ERR_INVAL.
+ *
+ * Only the main thread calls the ISO_CHECK macros (their counters are not
+ * thread-safe); workers touch only the os-platform primitives.
+ */
+#include "iso_test.h"
+
+#include "os_platform/thread.h"
+
+#include <stddef.h> /* NULL */
+
+#define NUM_THREADS 4
+#define ITERS 100000
+
+/* ── Test 1: mutual exclusion ───────────────────────────────────────────── */
+
+typedef struct {
+    osp_mutex *mu;
+    long counter;
+} counter_ctx;
+
+static void *bump_counter(void *arg) {
+    counter_ctx *ctx = (counter_ctx *)arg;
+    int i;
+    for (i = 0; i < ITERS; i++) {
+        osp_mutex_lock(ctx->mu);
+        ctx->counter++;
+        osp_mutex_unlock(ctx->mu);
+    }
+    return NULL;
+}
+
+/* ── Test 2: condition-variable handoff ─────────────────────────────────── */
+
+typedef struct {
+    osp_mutex *mu;
+    osp_cond *cv;
+    int ready;
+} handoff_ctx;
+
+/* A distinct object whose address is the worker's return value — comparing
+ * pointers avoids any integer-to-pointer casting in the test. */
+static int producer_token = 7;
+
+static void *producer(void *arg) {
+    handoff_ctx *h = (handoff_ctx *)arg;
+    osp_mutex_lock(h->mu);
+    h->ready = 1;
+    osp_cond_signal(h->cv);
+    osp_mutex_unlock(h->mu);
+    return &producer_token;
+}
+
+int main(void) {
+    counter_ctx cctx;
+    osp_thread *threads[NUM_THREADS];
+    handoff_ctx h;
+    osp_thread *pt = NULL;
+    osp_thread *dummy = NULL;
+    void *ret = NULL;
+    int i;
+
+    /* ── Test 1: mutual exclusion ───────────────────────────────────────── */
+    ISO_CHECK(osp_mutex_init(&cctx.mu) == OSP_OK);
+    cctx.counter = 0;
+    for (i = 0; i < NUM_THREADS; i++) {
+        ISO_CHECK(osp_thread_spawn(&threads[i], bump_counter, &cctx) == OSP_OK);
+    }
+    for (i = 0; i < NUM_THREADS; i++) {
+        ISO_CHECK(osp_thread_join(threads[i], NULL) == OSP_OK);
+    }
+    ISO_CHECK_MSG(cctx.counter == (long)NUM_THREADS * ITERS,
+                  "mutex must serialise increments (no lost updates)");
+    ISO_CHECK(osp_mutex_destroy(cctx.mu) == OSP_OK);
+
+    /* ── Test 2: condition-variable handoff + return value ──────────────── */
+    ISO_CHECK(osp_mutex_init(&h.mu) == OSP_OK);
+    ISO_CHECK(osp_cond_init(&h.cv) == OSP_OK);
+    h.ready = 0;
+    ISO_CHECK(osp_thread_spawn(&pt, producer, &h) == OSP_OK);
+
+    osp_mutex_lock(h.mu);
+    while (!h.ready) {                 /* loop guards against spurious wake-ups */
+        ISO_CHECK(osp_cond_wait(h.cv, h.mu) == OSP_OK);
+    }
+    osp_mutex_unlock(h.mu);
+
+    ISO_CHECK(osp_thread_join(pt, &ret) == OSP_OK);
+    ISO_CHECK_MSG(h.ready == 1, "worker must have set the ready flag");
+    ISO_CHECK_MSG(ret == &producer_token, "join must return the worker's result");
+    ISO_CHECK(osp_cond_destroy(h.cv) == OSP_OK);
+    ISO_CHECK(osp_mutex_destroy(h.mu) == OSP_OK);
+
+    /* ── Test 3: argument validation ────────────────────────────────────── */
+    ISO_CHECK(osp_thread_spawn(NULL, producer, NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_thread_spawn(&dummy, NULL, NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_thread_join(NULL, NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_mutex_lock(NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_mutex_unlock(NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_cond_signal(NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_cond_broadcast(NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_cond_wait(NULL, NULL) == OSP_ERR_INVAL);
+
+    return ISO_TEST_RESULT();
+}

--- a/code/packages/c/os-platform/tools/run.ps1
+++ b/code/packages/c/os-platform/tools/run.ps1
@@ -39,3 +39,6 @@ Write-Host "os-platform (windows): C compilers: $((Platform-Compilers -Lang c) -
 
 # clock — Win32 backend (QueryPerformanceCounter + FILETIME + Sleep).
 Platform-BuildAndRun -Lang c -Name 'clock-tests' -Sources @('tests\clock_test.c', 'src\clock_windows.c')
+
+# thread — Win32 backend (_beginthreadex + CRITICAL_SECTION + CONDITION_VARIABLE).
+Platform-BuildAndRun -Lang c -Name 'thread-tests' -Sources @('tests\thread_test.c', 'src\thread_windows.c')

--- a/code/packages/c/os-platform/tools/run.sh
+++ b/code/packages/c/os-platform/tools/run.sh
@@ -46,7 +46,14 @@ echo "os-platform ($(platform_os)): C compilers: $(platform_compilers c)"
 
 rc=0
 
-# clock — POSIX backend (clock_gettime + nanosleep).
+# clock — POSIX backend (clock_gettime + nanosleep). No extra OS library.
+PLATFORM_LIBS=""
+export PLATFORM_LIBS
 platform_build_and_run c clock-tests tests/clock_test.c src/clock_posix.c || rc=1
+
+# thread — POSIX backend (pthreads). Links the OS thread library.
+PLATFORM_LIBS="-pthread"
+export PLATFORM_LIBS
+platform_build_and_run c thread-tests tests/thread_test.c src/thread_posix.c || rc=1
 
 exit "$rc"


### PR DESCRIPTION
## CCPP02 Phase 2 — `os-platform` second primitive: `thread`

Builds on the merged `clock` primitive (#8319). Concurrency is squarely
**bucket B** — C11 `<threads.h>` is an *optional* feature MSVC doesn't ship, so
this calls the OS directly (pthreads on macOS/Linux, Win32 on Windows) behind
**opaque heap handles** that keep OS types out of the shared header. Each
`_init`/`_spawn` allocates; each `_destroy`/`_join` frees — nothing leaks.

### API (`os_platform/thread.h`)

| Group | Functions |
|-------|-----------|
| threads | `osp_thread_spawn` / `osp_thread_join` (worker is `void *(*)(void *)`; join delivers the result and frees the handle) |
| mutex | `osp_mutex_init` / `_lock` / `_unlock` / `_destroy` (non-recursive) |
| cond | `osp_cond_init` / `_wait` / `_signal` / `_broadcast` / `_destroy` |

### Backends — per-OS source selection via BUILD, no `#ifdef` mazes

| | thread | mutex | cond |
|--|--------|-------|------|
| **macOS/Linux** (`thread_posix.c`) | `pthread_create`/`_join` | `pthread_mutex_t` | `pthread_cond_t` |
| **Windows** (`thread_windows.c`) | `_beginthreadex` + trampoline | `CRITICAL_SECTION` | `CONDITION_VARIABLE` |

POSIX links `-pthread` (via `PLATFORM_LIBS`); Windows uses CRT + kernel32 only.
`_beginthreadex` (not raw `CreateThread`) is used so the worker's CRT state is
set up/torn down cleanly. The Win32 trampoline bridges the `unsigned __stdcall`
proc to our `void *` shape and stashes the result for `join()`.

### Shared `osp_status` → `os_platform/status.h`

Extracted the enum into its own header so a program can include `clock.h` +
`thread.h` together without a duplicate `enum` definition (adds `OSP_ERR_NOMEM`).
`clock.h` now includes it — **no API change**.

### Tests (`tests/thread_test.c`, run on each OS in the 3-OS matrix)

- **Mutual exclusion** — 4 threads × 100 000 locked increments must total exactly
  400 000 (deterministic; a broken lock loses updates — not timing-flaky).
- **Condition-variable handoff** — main waits on the cond until a worker sets a
  flag & signals; worker's return pointer must come back through `join`.
- **Argument validation** — NULL args rejected with `OSP_ERR_INVAL`.

### Verification

- **Local (macOS):** clock 13/0 + thread 28/0 under gcc + clang.
- **Sanitizers:** thread test clean under **ASan + UBSan** *and* **ThreadSanitizer** (no data races — the mutex genuinely serializes; the cond handoff has proper happens-before). **0 leaks** (`leaks --atExit`).
- **Security review:** passed round 1 (happens-before, no UAF/double-free, correct error paths, no `uintptr_t→HANDLE` truncation).
- CI proves `thread_windows.c` on the windows runner.

Spec: [`CCPP02-os-platform-lane.md`](code/specs/CCPP02-os-platform-lane.md) · next primitives: `fs`, `process`, `dynlib`, `mmap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)