### PR TITLE
feat(hl): Chapter 2 (Introducing Yourself) for Hindi, Tamil, Kannada, Telugu, Malayalam, Arabic

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Chapter 2 — Introducing Yourself
+
+- New chapter around the introduction dialogue (*ismī … / mā ismuka?*),
+  atom-first, Arabic inline, RTL (`lessons/AR-C02-*`,
+  `book/chapters/ch02-introductions.tex`). Built from Ch. 1's letters/roots:
+  - **اسم** ism ("name") ← Semitic root *s–m–w*; cousin of Hebrew *shem*, **not**
+    the Indo-European *name/nōmen*.
+  - **ي** *-ī* ("my") — a glued possessive suffix (like *al-*).
+  - **اسمي …** — **"my name is…"**; the **zero copula** (no "is") — shared with
+    the Dravidian languages, a meeting of two unrelated families.
+  - **أنت** anta/anti — "you," split by **gender** (not register, unlike the
+    European/Dravidian tracks); introduces ت (tāʾ) and أ (alif-hamza).
+  - **ما** mā ("what").
+  - **ما اسمك؟** — **"what's your name?"**; the *-ka/-ki* "your" suffix, gendered.
+  - **تشرفنا** tasharrafnā — "pleased to meet you" ("we are honoured," root
+    *sh–r–f* → *sharīf*, English *sheriff*).
+  - **practice** — the whole dialogue.
+- Example names are invented (Mira / Arun). Book compiles clean with XeLaTeX.
+
 ## Reworked to inline-letters: one Chapter 1, script taught within the words
 
 Replaced the standalone reading-course structure (Ch1 reading course + Ch2

--- a/code/learning/human-languages/arabic/README.md
+++ b/code/learning/human-languages/arabic/README.md
@@ -35,8 +35,11 @@ Two more things:
   shukran → practice. The Arabic script is taught inline (RTL, connecting
   letters, dots-on-a-skeleton, the emphatic consonants, ʿayn/hamza), and the
   root engine + attached *al-* are shown as the words are built. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): ismī, the gendered "you"
-  (*anta* / *anti*).
+- **Chapter 2 — Introducing Yourself** ([`lessons/AR-C02-*`](./lessons/)): ism,
+  -ī ("my"), **ismī** ("my name is," zero copula), anta/anti (gendered "you"),
+  mā, **mā ismuka/ismuki?** ("what's your name?"), tasharrafnā, practice. The
+  zero copula (shared with Dravidian) and "you" split by **gender**. In the
+  book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/arabic/book/book.tex
+++ b/code/learning/human-languages/arabic/book/book.tex
@@ -68,4 +68,6 @@ just the rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
 \end{document}

--- a/code/learning/human-languages/arabic/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch02-introductions.tex
@@ -1,0 +1,157 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you're glad to meet them:
+
+\begin{center}
+\ar{اسمي أرون.} \quad(\emph{ism\=\i\ Arun} --- ``My name is Arun.'')\\
+\ar{ما اسمك؟} \quad(\emph{m\=a ismuka} --- ``What is your name?'')
+\end{center}
+
+Built from Chapter~1's letters and roots, each piece taken apart, then
+assembled. \emph{Practice lessons: \texttt{lessons/AR-C02-*.md}.}
+
+\section{\ar{اسم} \emph{(ism)} --- ``name''}
+\label{lesson:ism}
+
+\begin{sounds}
+No new letters --- \ar{ا} (\emph{alif}), \ar{س} (\emph{s\=\i n}), \ar{م}
+(\emph{m\=\i m}) are all from Chapter~1. Read \ar{اسم} right to left $\to$
+\emph{ism}.
+\end{sounds}
+
+\begin{cousinweb}
+\ar{اسم} (\emph{ism}, ``name''), root \textbf{s--m--w}. It is a \textbf{Semitic}
+word, the cousin of Hebrew \emph{shem} (``name'') --- the same pairing you saw
+with \emph{sal\=am} / \emph{shalom}. It has \emph{no} tie to the Indo-European
+\emph{name} / Latin \emph{n\=omen}: Arabic belongs to a different family
+entirely, and its word for ``name'' is its own.
+\end{cousinweb}
+
+\section{\ar{ي} \emph{(-\=\i)} --- ``my,'' a letter stuck on the end}
+\label{lesson:ii-my}
+
+\begin{sounds}
+\ar{ي} (\emph{y\=aʾ}), met in \emph{`alaykum}, here does a new job: attached to
+the end of a noun it means ``my.''
+\end{sounds}
+
+\begin{cousinweb}
+Arabic doesn't use a separate word for ``my'' --- it \textbf{glues a suffix} onto
+the noun: \ar{اسم} (\emph{ism}, ``name'') $+$ \ar{ي} (\emph{-\=\i}, ``my'') $=$
+\ar{اسمي} (\emph{ism\=\i}, ``my name''). This is the same trick as the attached
+\emph{al-} from Chapter~1: Arabic loves to build meaning by fastening little
+pieces onto a word, not by stringing separate words together.
+\end{cousinweb}
+
+\section{\ar{اسمي \ldots} \emph{(ism\=\i\ \ldots)} --- ``my name is\ldots,'' with no ``is''}
+\label{lesson:ismii}
+
+\ar{اسمي} (my name) $+$ name $=$ \textbf{ism\=\i\ \ldots} \emph{Ism\=\i\ Arun.}
+$=$ ``My name is Arun.''
+
+\begin{grammarlens}
+\textbf{No word for ``is'' --- again.} Recall from \emph{as-sal\=amu `alaykum}
+(Ch.~1) that Arabic sets two words side by side and lets ``is'' be understood.
+So \emph{ism\=\i\ Arun} is literally ``my-name Arun.'' Arabic shares this
+\textbf{zero copula} with the Dravidian languages (Tamil \emph{eṉ peyar
+Arun}) --- a striking meeting of two unrelated families on the same habit.
+\end{grammarlens}
+
+\section{\ar{أنت} \emph{(anta / anti)} --- ``you,'' marked by \emph{gender}}
+\label{lesson:anta-anti}
+
+\begin{sounds}
+Two new letters: \ar{أ} (\emph{alif} with a \emph{hamza} seat, a glottal
+``a''-start) and \ar{ت} (\emph{t\=aʾ}, ``t'' --- the \ar{ب}/\ar{ت}/\ar{ث}
+skeleton from Ch.~1, two dots above). The final vowel is written only with a
+mark: \ar{أنتَ} \emph{anta}, \ar{أنتِ} \emph{anti}.
+\end{sounds}
+
+\begin{cousinweb}
+\ar{أنت} is ``you'' --- but Arabic splits it by the listener's \textbf{gender}:
+\emph{anta} to a man, \emph{anti} to a woman. (Root of the pronoun aside, note
+the shared Semitic \emph{-ta}/\emph{-ti} ending, the same \emph{t} that marks
+``you'' in Hebrew \emph{atta}/\emph{att}.)
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{A different axis of ``you.''} The European and Dravidian tracks split
+``you'' by \emph{register} (familiar vs.\ respectful --- \emph{t\=u/vous},
+\emph{n\=\i/n\=\i\d{n}gaḷ}). Arabic splits it by \emph{gender}: \emph{anta}
+(to a man) vs.\ \emph{anti} (to a woman). Same pronoun, a wholly different
+distinction --- you choose by \emph{who you're talking to}, not how formal you
+are.
+\end{grammarlens}
+
+\section{\ar{ما} \emph{(m\=a)} --- ``what''}
+\label{lesson:maa}
+
+\begin{sounds}
+No new letters: \ar{م} (\emph{m}) $+$ \ar{ا} (\emph{alif}, long \=a) $\to$
+\ar{ما} \emph{m\=a} --- the little word you already read as a warm-up in
+Chapter~1.
+\end{sounds}
+
+\begin{cousinweb}
+\ar{ما} (\emph{m\=a}, ``what'') is the everyday question-word for things. (Arabic
+has a second, \emph{m\=adh\=a}, for ``what'' before verbs; \emph{m\=a} is the one
+you want before a noun, as in ``what [is] your name?'')
+\end{cousinweb}
+
+\section{\ar{ما اسمك؟} \emph{(m\=a ismuka / ismuki)} --- ``what's your name?''}
+\label{lesson:maa-ismuka}
+
+\ar{اسمك} $=$ \ar{اسم} (\emph{ism}, name) $+$ \ar{ك} (\emph{k\=af}, the ``your''
+suffix) --- and \emph{it too is gendered}: \emph{ismuka} (a man's name),
+\emph{ismuki} (a woman's). So \ar{ما اسمك؟} is literally ``\textbf{what
+[is] your-name?}'' --- no ``is,'' the possessive glued on, the gender in the
+suffix.
+
+\begin{grammarlens}
+Notice the matched pair: ``my name'' takes \ar{ي} (\emph{-\=\i}), ``your name''
+takes \ar{ك} (\emph{-ka/-ki}). Answer with \emph{ism\=\i\ Arun}. The suffixes
+are the whole grammar of the exchange.
+\end{grammarlens}
+
+\section{\ar{تشرفنا} \emph{(tasharrafn\=a)} --- ``pleased to meet you''}
+\label{lesson:tasharrafna}
+
+\begin{sounds}
+Uses \ar{ت} (\emph{t\=aʾ}, just met), \ar{ش} (\emph{sh\=\i n}) and \ar{ر}
+(\emph{r\=aʾ}) from Ch.~1, plus \ar{ف} (\emph{f\=aʾ}, ``f'').
+\end{sounds}
+
+\begin{cousinweb}
+\ar{تشرفنا} (\emph{tasharrafn\=a}), root \textbf{sh--r--f} (\emph{honour,
+nobility}): \emph{sharaf} (honour), \emph{shar\=\i f} (noble --- the English
+borrowing \emph{sherif} of Mecca, and, distantly, the title behind
+\emph{sheriff}). \emph{tasharrafn\=a} means literally ``\textbf{we have been
+honoured}'' --- to meet you is presented as an honour received. A more literal
+option is \ar{فرصة سعيدة} (\emph{fur\d{s}a sa`\=\i da}, ``a happy occasion'').
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Arabic & English \\
+\midrule
+\ar{اسمي ميرا.} & My name is Mira. \\
+\ar{ما اسمك؟} & What's your name? \\
+\ar{اسمي أرون.} & My name is Arun. \\
+\ar{تشرفنا.} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every piece from the root-and-suffix engine: \emph{ism} (root s-m-w, Hebrew
+\emph{shem}), the glued \emph{-\=\i} (``my'') and \emph{-ka/-ki} (``your''),
+\emph{tasharrafn\=a} (root sh-r-f, ``honour''). And two Arabic habits: it drops
+``is'' entirely (the \textbf{zero copula}, shared with the Dravidian
+languages), and it marks ``you'' by \textbf{gender} (\emph{anta}/\emph{anti}),
+not register. Next chapter: \emph{kayfa \d{h}\=aluka?} (``how are you?'') and
+\emph{al-\d{h}amdu lill\=ah} --- the responding cycle.

--- a/code/learning/human-languages/arabic/book/preamble.tex
+++ b/code/learning/human-languages/arabic/book/preamble.tex
@@ -7,6 +7,14 @@
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}
 
+% A few transliteration letters (used when citing Tamil etc.) are absent from
+% Latin Modern; map them to accents so romanizations don't drop characters.
+\usepackage{newunicodechar}
+\newunicodechar{ṉ}{\b{n}}
+\newunicodechar{ṟ}{\b{r}}
+\newunicodechar{ṁ}{\.{m}}
+\newunicodechar{ḻ}{\b{l}}
+
 % IMPORTANT: xcolor, hyperref, tcolorbox, etc. must be loaded BEFORE
 % polyglossia, because polyglossia loads `bidi` for the Arabic (RTL) language,
 % and bidi errors out ("you have loaded package xcolor after bidi package") if

--- a/code/learning/human-languages/arabic/lessons/AR-C02-anta-anti.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-anta-anti.md
@@ -1,0 +1,50 @@
+---
+id: AR-C02-anta-anti
+chapter: 2
+type: word
+headword: أنت
+gloss: you (anta m. / anti f.)
+concept_tag: PRONOUN-YOU
+prerequisites: [AR-C02-ism]
+sounds: [alif-hamza, taa]
+roots: []
+est_minutes: 4
+reviews_of: [AR-C02-ismii]
+---
+
+# أنت (anta / anti) — "you," marked by *gender*
+
+## Warm-up
+
+[PAUSE 2s] To ask a name you need "you" — and Arabic's is unlike any you've met:
+it changes with the *listener's* gender.
+
+## The letters in this word
+
+*(Skim if you read Arabic.)* Two new letters: **أ** (*alif* with a *hamza* seat,
+a glottal "a"-start) and **ت** (*tāʾ*, "t" — the ب/ت/ث skeleton from Ch. 1, two
+dots above). The final vowel is a mark: **أنتَ** *anta*, **أنتِ** *anti*.
+
+## The word, taken apart
+
+**أنت** is "you" — but Arabic splits it by the listener's **gender**: **anta** to
+a man, **anti** to a woman. (Note the Semitic *-ta*/*-ti* ending — the same *t*
+that marks "you" in Hebrew *atta*/*att*.)
+
+## Grammar Lens: a different axis of "you"
+
+The European and Dravidian tracks split "you" by **register** (familiar vs.
+respectful — *tū/vous*, *nī/nīṅgaḷ*). Arabic splits it by **gender**: *anta* (to
+a man) vs. *anti* (to a woman). Same pronoun, a wholly different distinction —
+you choose by *who you're talking to*, not how formal you are.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "anta" (to a man), "anti" (to a woman)]
+- [YOU SAY: the contrast — European/Dravidian split by register, Arabic by gender]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Arabic split "you," and how is that different from French or
+Tamil? (By **gender** — *anta* (m.) / *anti* (f.); the others split by register.)

--- a/code/learning/human-languages/arabic/lessons/AR-C02-ii-my.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-ii-my.md
@@ -1,0 +1,43 @@
+---
+id: AR-C02-ii-my
+chapter: 2
+type: word
+headword: ي
+gloss: my (possessive suffix -ī)
+concept_tag: MY
+prerequisites: [AR-C02-ism]
+sounds: [yaa-suffix]
+roots: []
+est_minutes: 3
+reviews_of: [AR-C02-ism]
+---
+
+# ي (-ī) — "my," a letter stuck on the end
+
+## Warm-up
+
+[PAUSE 2s] Arabic has no separate word for "my" — it glues one letter onto the
+noun.
+
+## The letters in this word
+
+*(Skim if you read Arabic.)* **ي** (*yāʾ*), met in *ʿalaykum* — here it does a
+new job: attached to the end of a noun, it means "my."
+
+## The word, taken apart
+
+Arabic builds "my" by **suffix**, not a separate word: **اسم** (*ism*, "name") +
+**ي** (*-ī*, "my") = **اسمي** (*ismī*, "my name"). This is the same trick as the
+attached **al-** ("the") from Chapter 1 — Arabic loves to fasten little pieces
+onto a word rather than string separate words together.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ism" + "-ī" → "ismī" ("my name")]
+- [YOU SAY: the pattern — Arabic glues "my" on, like it glued "the" (*al-*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Arabic say "my," and what is "my name"? (A suffix **ي** (-ī)
+glued on; *ismī*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C02-ism.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-ism.md
@@ -1,0 +1,42 @@
+---
+id: AR-C02-ism
+chapter: 2
+type: word
+headword: اسم
+gloss: name
+concept_tag: NAME
+prerequisites: []
+sounds: [rtl-known-letters]
+roots: [s-m-w]
+est_minutes: 3
+reviews_of: [AR-C01-salam]
+---
+
+# اسم (ism) — "name"
+
+## Warm-up
+
+[PAUSE 2s] To introduce yourself you need "name" — and it needs no new letters.
+
+## The letters in this word
+
+*(Skim if you read Arabic.)* All three are from Chapter 1: **ا** (*alif*), **س**
+(*sīn*), **م** (*mīm*). Read **اسم** right to left → **ism**.
+
+## The word, taken apart
+
+**اسم** (*ism*, "name"), root **s–m–w**. It is a **Semitic** word, cousin of
+Hebrew *shem* ("name") — the same pairing you saw with *salām* / *shalom*. It
+has *no* tie to the Indo-European *name* / Latin *nōmen*: Arabic is a different
+family entirely, and its word for "name" is its own.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: read right to left — "ism"]
+- [YOU SAY: its Hebrew cousin — *shem*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What family does **اسم** belong to, and what Hebrew word is its
+cousin? (Semitic; *shem*. Not related to English *name*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C02-ismii.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-ismii.md
@@ -1,0 +1,46 @@
+---
+id: AR-C02-ismii
+chapter: 2
+type: phrase
+headword: اسمي …
+gloss: my name is… (with no "is")
+concept_tag: MY-NAME-IS
+prerequisites: [AR-C02-ism, AR-C02-ii-my]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [AR-C02-ism, AR-C02-ii-my]
+---
+
+# اسمي … (ismī …) — "my name is…," with no "is"
+
+## Warm-up
+
+[PAUSE 2s] Assemble it — and notice the missing word.
+
+## The phrase, assembled
+
+- [ism](AR-C02-ism.md) (name) + [-ī](AR-C02-ii-my.md) (my) + your name.
+
+> **اسمي …** = "my-name …" → **"my name is…"**
+
+*Ismī Arun.* → "My name is Arun."
+
+## Grammar Lens: no word for "is" — again
+
+Recall from *as-salāmu ʿalaykum* (Ch. 1) that Arabic sets two words side by side
+and lets "is" be understood. So *ismī Arun* is literally "my-name Arun." Arabic
+shares this **zero copula** with the Dravidian languages (Tamil *eṉ peyar
+Arun*) — two unrelated families meeting on the same habit.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ismī …" with your name]
+- [YOU SAY: notice — no word for "is"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in Arabic. (*Ismī ….*) What does Arabic leave out, and
+which other family does the same? (The verb "is" — the zero copula, shared with
+the Dravidian languages.)

--- a/code/learning/human-languages/arabic/lessons/AR-C02-maa-ismuka.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-maa-ismuka.md
@@ -1,0 +1,45 @@
+---
+id: AR-C02-maa-ismuka
+chapter: 2
+type: phrase
+headword: ما اسمك؟
+gloss: what's your name?
+concept_tag: WHATS-YOUR-NAME
+prerequisites: [AR-C02-maa, AR-C02-ism, AR-C02-anta-anti]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [AR-C02-maa, AR-C02-ism, AR-C02-ismii]
+---
+
+# ما اسمك؟ (mā ismuka / ismuki) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the question — what + your-name — no "is," gender in the
+suffix.
+
+## The phrase, assembled
+
+- **اسمك** = **اسم** (*ism*, name) + **ك** (*kāf*, the "your" suffix) — and it
+  too is **gendered**: *ismuka* (a man's name), *ismuki* (a woman's).
+
+> **ما اسمك؟** = literally "**what [is] your-name?**"
+
+No "is," the possessive glued on, the gender carried in the suffix.
+
+## Grammar Lens: the matched suffixes
+
+"My name" takes **ي** (*-ī*), "your name" takes **ك** (*-ka/-ki*). The suffixes
+*are* the grammar of the exchange. Answer with *ismī Arun*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mā ismuka?" (to a man), "mā ismuki?" (to a woman)]
+- [YOU SAY: ask, then answer — "mā ismuka?" / "ismī …"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ما اسمك؟** literally say, and where is the gender marked?
+("What your-name?"; in the suffix — *-ka* (m.) / *-ki* (f.).)

--- a/code/learning/human-languages/arabic/lessons/AR-C02-maa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-maa.md
@@ -1,0 +1,41 @@
+---
+id: AR-C02-maa
+chapter: 2
+type: word
+headword: ما
+gloss: what
+concept_tag: WHAT
+prerequisites: [AR-C02-anta-anti]
+sounds: [known-letters]
+roots: []
+est_minutes: 2
+reviews_of: [AR-C02-anta-anti, AR-C02-ismii]
+---
+
+# ما (mā) — "what"
+
+## Warm-up
+
+[PAUSE 2s] The question-word — and you already read it as a warm-up in Chapter
+1.
+
+## The letters in this word
+
+*(Skim if you read Arabic.)* No new letters: **م** (*m*) + **ا** (*alif*, long
+*ā*) → **ما** *mā*.
+
+## The word, taken apart
+
+**ما** (*mā*, "what") is the everyday question-word for things. (Arabic has a
+second, *māḏā*, for "what" before verbs; *mā* is the one you want before a noun,
+as in "what [is] your name?")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mā" ("what")]
+- [YOU SAY: "mā ismuka?" — "what [is] your name?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ما** mean, and when is it used? ("What," before a noun.)

--- a/code/learning/human-languages/arabic/lessons/AR-C02-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-practice.md
@@ -1,0 +1,53 @@
+---
+id: AR-C02-practice
+chapter: 2
+type: practice
+headword: (dialogue)
+gloss: Chapter 2 recap — the introduction exchange
+concept_tag: REVIEW
+prerequisites: [AR-C02-ismii, AR-C02-maa-ismuka, AR-C02-tasharrafna]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [AR-C02-ism, AR-C02-ii-my, AR-C02-ismii, AR-C02-anta-anti, AR-C02-maa, AR-C02-maa-ismuka, AR-C02-tasharrafna]
+---
+
+# Chapter 2 — the introduction, whole
+
+## The dialogue
+
+Read right to left:
+
+| Arabic | English |
+|---|---|
+| اسمي ميرا. (*ismī Mira*) | My name is Mira. |
+| ما اسمك؟ (*mā ismuka*) | What's your name? |
+| اسمي أرون. (*ismī Arun*) | My name is Arun. |
+| تشرفنا. (*tasharrafnā*) | Pleased to meet you. |
+
+Every piece from the root-and-suffix engine:
+
+- **ism** ← root *s–m–w* (Hebrew *shem*, *not* English *name*)
+- the glued **-ī** ("my") and **-ka/-ki** ("your")
+- **tasharrafnā** ← root *sh–r–f* ("honour"; *sharīf*, *sheriff*)
+
+Two Arabic habits: it drops "is" entirely (the **zero copula**, shared with the
+Dravidian languages), and it marks "you" by **gender** (*anta*/*anti*), not
+register.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the whole exchange, right to left]
+- [YOU SAY: your own introduction — "ismī …, tasharrafnā"]
+- [YOU SAY: ask it back — "mā ismuka?" (to a man) / "mā ismuki?" (to a woman)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name, ask someone else's, say you're pleased. (*Ismī …. /
+Mā ismuka? / Tasharrafnā.*) Two things Arabic does differently from the European
+tracks? (No word for "is" — zero copula; and "you" split by *gender*, not
+register.)
+
+Next chapter: *kayfa ḥāluka?* ("how are you?") and *al-ḥamdu lillāh* — the
+responding cycle.

--- a/code/learning/human-languages/arabic/lessons/AR-C02-tasharrafna.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-tasharrafna.md
@@ -1,0 +1,43 @@
+---
+id: AR-C02-tasharrafna
+chapter: 2
+type: phrase
+headword: تشرفنا
+gloss: pleased to meet you (literally "we have been honoured")
+concept_tag: PLEASED-TO-MEET
+prerequisites: [AR-C02-ismii]
+sounds: [taa, faa]
+roots: [sh-r-f]
+est_minutes: 3
+reviews_of: [AR-C02-ismii, AR-C02-maa-ismuka]
+---
+
+# تشرفنا (tasharrafnā) — "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The warm close — and it presents the meeting as an honour.
+
+## The letters in this word
+
+*(Skim if you read Arabic.)* Uses **ت** (*tāʾ*, just met), **ش** (*shīn*) and
+**ر** (*rāʾ*) from Ch. 1, plus **ف** (*fāʾ*, "f").
+
+## The word, taken apart
+
+**تشرفنا** (*tasharrafnā*), root **sh–r–f** (*honour, nobility*): *sharaf*
+("honour"), *sharīf* ("noble" — the *Sharif* of Mecca, and distantly the title
+behind English *sheriff*). *tasharrafnā* means literally "**we have been
+honoured**" — to meet you is presented as an honour received. A more literal
+option is **فرصة سعيدة** (*furṣa saʿīda*, "a happy occasion").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tasharrafnā"]
+- [YOU SAY: the root family — *sharaf* (honour), *sharīf* (noble)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **تشرفنا** literally mean, and from what root? ("We have
+been honoured"; *sh–r–f*, "honour.")

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -18,11 +18,15 @@ word lessons — never as a gated reading course.
   the emphatic consonants, ʿayn/hamza), and the root engine + attached *al-*
   (with sun/moon assimilation) are shown as the words are built.
 
+- **Ch. 2 — Introducing Yourself**: ism → -ī ("my" suffix) → **ismī** ("my name
+  is," zero copula) → anta/anti (gendered "you") → mā → **mā ismuka/ismuki?** →
+  tasharrafnā → practice. Root-and-suffix engine; the **zero copula** (shared
+  with the Dravidian tracks); "you" split by **gender**, not register.
+
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *ismī…* ("my name is"), the **gendered "you"** (*anta* m. / *anti* f.), the root system deepened |
 | 3 | Responding: *kayfa ḥāluk* ("how are you"), *bi-khayr* ("well"), *al-ḥamdu lillāh* |
 | 4 | Farewells: *maʿa s-salāma* ("with safety"), *ilā l-liqāʾ* |
 | 5+ | Numbers, the pattern system (verb forms I–X), family, food — always with the root engine and the Spanish-loanword thread |

--- a/code/learning/human-languages/arabic/session-map.md
+++ b/code/learning/human-languages/arabic/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Arabic Chapter 1
+# Session Map — Arabic Chapters 1–2
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -23,7 +23,20 @@ greetings, plus the root engine and the attached *al-*.
 | 7 | shukran | شكرا | ش (= س + 3 dots), ك | root *sh-k-r*; the *kātib/maktūb* patterns |
 | 8 | practice | (recap) | read all six, RTL | the day of greetings + replies |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 9 | ism | اسم | "name" ← Semitic s-m-w (Hebrew *shem*, not *name*) |
+| 10 | ii-my | ي | "my" — a glued suffix *-ī* (like *al-*) |
+| 11 | ismii | اسمي … | **"my name is…"** — the **zero copula** (shared with Dravidian) |
+| 12 | anta-anti | أنت | **"you"**, split by **gender** (*anta* m. / *anti* f.), not register |
+| 13 | maa | ما | "what" |
+| 14 | maa-ismuka | ما اسمك؟ | **"what's your name?"**; the *-ka/-ki* "your" suffix, gendered |
+| 15 | tasharrafna | تشرفنا | "pleased to meet you" ("we are honoured"; root sh-r-f → *sharīf/sheriff*) |
+| 16 | practice | (dialogue) | the whole exchange |
+
 ## Next
 
-Chapter 2 — introducing yourself (*ismī…*) and Arabic's **gendered** "you"
-(*anta* to a man / *anti* to a woman).
+Chapter 3 — *kayfa ḥāluka?* ("how are you?") and *al-ḥamdu lillāh* — the
+responding cycle.

--- a/code/learning/human-languages/hindi/CHANGELOG.md
+++ b/code/learning/human-languages/hindi/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 2 — Introducing Yourself
+
+- New chapter around the introduction dialogue (*merā nām … hai / āpkā nām kyā
+  hai? / …khushī huī*), atom-first, one word per lesson (`lessons/HI-C02-*`,
+  `book/chapters/ch02-introductions.tex`), Devanagari taught inline. Every atom
+  traced with its cross-family cousins (no glossing):
+  - **नाम** nām ("name") ← Sanskrit *nāman* → English **name**, Latin *nōmen* →
+    **noun**.
+  - **मेरा** merā ("my") ← root *ma-* → English **me/my/mine**; agrees with the
+    noun.
+  - **है** hai ("is") ← Sanskrit *asti* → English **is**, German *ist*, Latin
+    *est*, Spanish *es*.
+  - **मेरा नाम … है** — **"my name is…"**; subject–object–verb order.
+  - **आप / तुम** āp/tum — the three-level "you" (āp/tum/tū); *tum* ← *tū* →
+    archaic **thou**.
+  - **क्या** kyā ("what") ← stem *ka-* → English **what/who**.
+  - **आपका नाम क्या है?** — **"what's your name?"** (verb still last).
+  - **ख़ुशी** khushī — "pleased to meet you"; *khushī* ← **Persian**, Hindi's
+    second vocabulary.
+  - **practice** — the whole dialogue.
+- Book compiles clean with XeLaTeX.
+
 ## Chapter 1 — Greetings (Devanagari taught inline)
 
 - New Hindi track on the HL00 framework: one word per lesson, slug ids,

--- a/code/learning/human-languages/hindi/README.md
+++ b/code/learning/human-languages/hindi/README.md
@@ -31,8 +31,11 @@ Two things shape this track.
   inline (inherent *a*, mātrā vowel signs, halant + conjuncts, independent
   vowels) and the Sanskrit vs. Perso-Arabic heritage introduced through the
   words themselves. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): *āp* vs. *tum* (formal /
-  informal "you"), *merā nām*, gender in Hindi nouns.
+- **Chapter 2 — Introducing Yourself** ([`lessons/HI-C02-*`](./lessons/)): nām,
+  merā, hai, **merā nām … hai** ("my name is"), āp/tum, kyā, **āpkā nām kyā
+  hai?** ("what's your name?"), khushī, practice. Every atom traced (nām ←
+  *nāman* → *name*; hai ← *asti* → *is*); SOV order; the three-level "you". In
+  the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/hindi/book/book.tex
+++ b/code/learning/human-languages/hindi/book/book.tex
@@ -65,4 +65,6 @@ Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
 \end{document}

--- a/code/learning/human-languages/hindi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch02-introductions.tex
@@ -1,0 +1,177 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you're glad to meet them:
+
+\begin{center}
+\hi{मेरा नाम सुज़ाना है।} \quad(\emph{mer\=a n\=am Suz\=an\=a hai} --- ``My name is Susana.'')\\
+\hi{आपका नाम क्या है?} \quad(\emph{\=apk\=a n\=am ky\=a hai} --- ``What is your name?'')
+\end{center}
+
+Built the same way as the greetings --- each piece taken apart, its letters and
+its root, then assembled. \emph{Practice lessons: \texttt{lessons/HI-C02-*.md}.}
+
+\section{\hi{नाम} \emph{(n\=am)} --- ``name,'' a word older than Europe}
+\label{lesson:naam}
+
+\begin{sounds}
+Three letters, left to right: \hi{न} (\emph{na}), \hi{ा} the long-\=a
+\emph{m\=atr\=a} (\hi{ना} $=$ n\=a), \hi{म} (\emph{ma}). Read \hi{ना·म} $\to$
+\emph{n\=am}.
+\end{sounds}
+
+\begin{cousinweb}
+\hi{नाम} (\emph{n\=am}) $\leftarrow$ Sanskrit \hi{नामन्} (\emph{n\=aman}), from
+Proto-Indo-European *h\textsubscript{3}n\'{o}mn\d{} --- the \emph{same} ancient
+root as English \textbf{name}, Latin \emph{n\=omen} (English \textbf{noun},
+\textbf{nom}inate), and Greek \emph{onoma}. So Hindi \emph{n\=am} and English
+\emph{name} are cousins from before either language existed --- one of the
+clearest bridges between the Indian and European branches of the same family.
+\end{cousinweb}
+
+\section{\hi{मेरा} \emph{(mer\=a)} --- ``my''}
+\label{lesson:meraa}
+
+\begin{sounds}
+\hi{म} (\emph{ma}) $+$ \hi{े} (the \emph{e}-m\=atr\=a) $\to$ \hi{मे} (me);
+then \hi{र} (\emph{ra}) $+$ \hi{ा} (long \=a) $\to$ \hi{रा} (r\=a). Read
+\hi{मे·रा} $\to$ \emph{mer\=a}.
+\end{sounds}
+
+\begin{cousinweb}
+\hi{मेरा} (\emph{mer\=a}, ``my'') descends from Sanskrit \emph{mad-\=\i ya}
+(``of me''), on the first-person root \emph{ma-} --- the same \emph{ma-}/\emph{me-}
+behind English \textbf{me}, \textbf{my}, \textbf{mine} and Latin \emph{me\-us}.
+The Hindi ``my'' and the English ``my'' are, at the root, the same word.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``My'' agrees with the noun.} Hindi possessives change to match what is
+owned: \emph{mer\=a} (masculine), \emph{mer\=\i} (feminine), \emph{mere}
+(plural). \emph{n\=am} is masculine, so it takes \emph{mer\=a}: \emph{mer\=a
+n\=am}. (You will meet \emph{mer\=\i} the first time you own a feminine noun.)
+\end{grammarlens}
+
+\section{\hi{है} \emph{(hai)} --- ``is,'' cousin of English \emph{is}}
+\label{lesson:hai}
+
+\begin{sounds}
+\hi{ह} (\emph{ha}) $+$ \hi{ै} (the \emph{ai}-m\=atr\=a) $\to$ \hi{है}
+(\emph{hai}). One syllable.
+\end{sounds}
+
+\begin{cousinweb}
+\hi{है} (\emph{hai}, ``is'') $\leftarrow$ Sanskrit \hi{अस्ति} (\emph{asti}, ``is''),
+from Proto-Indo-European *h\textsubscript{1}es- --- the root of ``to be'' across
+the whole family: English \textbf{is}, German \emph{ist}, Latin \emph{est},
+Spanish \emph{es}, French \emph{est}. Hindi \emph{hai} is the Indian cousin of
+the same little verb --- ``is'' really is one word from Ireland to India.
+\end{cousinweb}
+
+\section{\hi{मेरा नाम \ldots है} \emph{(mer\=a n\=am \ldots hai)} --- ``my name is\ldots''}
+\label{lesson:mera-naam-hai}
+
+\hi{मेरा} (my) $+$ \hi{नाम} (name) $+$ name $+$ \hi{है} (is) $=$ \textbf{mer\=a
+n\=am \ldots hai}, ``my name is\ldots'' \emph{Mer\=a n\=am David hai.} $=$ ``My
+name is David.''
+
+\begin{grammarlens}
+\textbf{Word order: the verb goes last.} Hindi is a \emph{subject--object--verb}
+language --- literally ``my name David \emph{is}.'' The \emph{hai} sits at the
+end, where English puts ``is'' in the middle. Bank this shape: in Hindi, the
+verb waits until the end of the sentence.
+\end{grammarlens}
+
+\section{\hi{आप} / \hi{तुम} \emph{(\=ap / tum)} --- ``you,'' respectful and familiar}
+\label{lesson:aap-tum}
+
+\begin{sounds}
+\hi{आप}: the independent vowel \hi{आ} (\=a, word-initial) $+$ \hi{प} (\emph{pa})
+$\to$ \emph{\=ap}. \hi{तुम}: \hi{त} (\emph{ta}) $+$ \hi{ु} (the \emph{u}-sign)
+$+$ \hi{म} (\emph{ma}) $\to$ \emph{tum}.
+\end{sounds}
+
+\begin{cousinweb}
+\hi{तुम} (\emph{tum}, familiar ``you'') $\leftarrow$ Sanskrit \emph{tvam}, from
+PIE *t\=u --- the same root as English archaic \textbf{thou}, Latin \emph{t\=u},
+French \emph{tu}. \hi{आप} (\emph{\=ap}, respectful ``you'') is a different,
+honorific word (originally ``oneself'').
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Three levels of ``you.''} Hindi grades respect in three: \emph{\=ap}
+(respectful --- strangers, elders, politeness), \emph{tum} (familiar ---
+friends, peers), \emph{t\=u} (intimate or to a child, and can insult if
+misused). Each of the earlier tracks had two levels; Hindi has three. For a
+first meeting, always \emph{\=ap}.
+\end{grammarlens}
+
+\section{\hi{क्या} \emph{(ky\=a)} --- ``what''}
+\label{lesson:kya}
+
+\begin{sounds}
+A \textbf{conjunct}: \hi{क} (\emph{ka}) loses its vowel (\emph{halant}) and
+joins \hi{य} (\emph{ya}) $\to$ \hi{क्य} (\emph{kya}); add the long-\=a m\=atr\=a
+$\to$ \hi{क्या} (\emph{ky\=a}).
+\end{sounds}
+
+\begin{cousinweb}
+\hi{क्या} (\emph{ky\=a}, ``what'') $\leftarrow$ Sanskrit \emph{kim} / the
+interrogative stem \emph{ka-}, from PIE *k\ensuremath{^w}o- --- the same
+question-root behind English \textbf{wh-} words (\textbf{what}, \textbf{who},
+\textbf{which}) and Latin \emph{qu-}. Hindi's question-words nearly all start
+with this \emph{k-}: \emph{ky\=a} (what), \emph{kaun} (who), \emph{kab} (when),
+\emph{ky\=un} (why) --- the Indian branch of the same family of question-words.
+\end{cousinweb}
+
+\section{\hi{आपका नाम क्या है?} \emph{(\=apk\=a n\=am ky\=a hai)} --- ``what's your name?''}
+\label{lesson:aapka-naam-kya-hai}
+
+\hi{आपका} (\emph{\=apk\=a}, ``your'') $=$ \hi{आप} (you) $+$ \hi{का} (\emph{k\=a},
+the possessive ``of,'' the same agreeing \emph{k\=a/k\=\i/ke} that matches the
+noun). So \hi{आपका नाम क्या है?} is literally ``\textbf{your name what is?}'' ---
+Hindi keeps the verb last again, and simply drops the question-word \emph{ky\=a}
+into the object slot.
+
+\begin{grammarlens}
+Answer it with the sentence you built: \emph{Mer\=a n\=am David hai.} The
+informal version swaps \emph{\=apk\=a} for \emph{tumh\=ar\=a}: \emph{tumh\=ar\=a
+n\=am ky\=a hai?}
+\end{grammarlens}
+
+\section{\hi{ख़ुशी} \emph{(khush\=\i)} --- ``happiness,'' and ``pleased to meet you''}
+\label{lesson:khushi}
+
+\begin{cousinweb}
+The Hindi ``pleased to meet you'' is \hi{आपसे मिलकर ख़ुशी हुई} (\emph{\=ap-se
+milkar khush\=\i\ hu\=\i}) --- literally ``\textbf{having met you, happiness
+happened}.'' The key word \hi{ख़ुशी} (\emph{khush\=\i}, ``happiness'') is
+\textbf{not} Sanskrit --- it is \textbf{Persian} (\emph{khush}, ``happy,
+pleasant''), one of the thousands of Persian words in everyday Hindi. So even
+introducing yourself draws on Hindi's \emph{two} vocabularies: Sanskrit
+(\emph{n\=am}, \emph{hai}) and Perso-Arabic (\emph{khush\=\i}).
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Hindi & English \\
+\midrule
+\hi{मेरा नाम सुज़ाना है।} & My name is Susana. \\
+\hi{आपका नाम क्या है?} & What's your name? \\
+\hi{मेरा नाम डेविड है।} & My name is David. \\
+\hi{आपसे मिलकर ख़ुशी हुई।} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{n\=am} (Sanskrit \emph{n\=aman}, English \emph{name}),
+\emph{mer\=a} (root \emph{ma-}, English \emph{my}), \emph{hai} (Sanskrit
+\emph{asti}, English \emph{is}), \emph{ky\=a} (root \emph{ka-}, English
+\emph{what}). And two Hindi habits: the \textbf{verb goes last}, and ``you'' has
+\textbf{three} respect-levels. Next chapter: \emph{\=ap kaise haiṁ?} (``how are
+you?'') and answering with \emph{\d{t}h\=\i k} --- the responding cycle.

--- a/code/learning/human-languages/hindi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch02-introductions.tex
@@ -5,7 +5,7 @@ Now a first real exchange --- giving your name, asking for someone else's, and
 saying you're glad to meet them:
 
 \begin{center}
-\hi{मेरा नाम सुज़ाना है।} \quad(\emph{mer\=a n\=am Suz\=an\=a hai} --- ``My name is Susana.'')\\
+\hi{मेरा नाम मीरा है।} \quad(\emph{mer\=a n\=am Mira hai} --- ``My name is Mira.'')\\
 \hi{आपका नाम क्या है?} \quad(\emph{\=apk\=a n\=am ky\=a hai} --- ``What is your name?'')
 \end{center}
 
@@ -73,12 +73,12 @@ the same little verb --- ``is'' really is one word from Ireland to India.
 \label{lesson:mera-naam-hai}
 
 \hi{मेरा} (my) $+$ \hi{नाम} (name) $+$ name $+$ \hi{है} (is) $=$ \textbf{mer\=a
-n\=am \ldots hai}, ``my name is\ldots'' \emph{Mer\=a n\=am David hai.} $=$ ``My
-name is David.''
+n\=am \ldots hai}, ``my name is\ldots'' \emph{Mer\=a n\=am Arun hai.} $=$ ``My
+name is Arun.''
 
 \begin{grammarlens}
 \textbf{Word order: the verb goes last.} Hindi is a \emph{subject--object--verb}
-language --- literally ``my name David \emph{is}.'' The \emph{hai} sits at the
+language --- literally ``my name Arun \emph{is}.'' The \emph{hai} sits at the
 end, where English puts ``is'' in the middle. Bank this shape: in Hindi, the
 verb waits until the end of the sentence.
 \end{grammarlens}
@@ -135,7 +135,7 @@ Hindi keeps the verb last again, and simply drops the question-word \emph{ky\=a}
 into the object slot.
 
 \begin{grammarlens}
-Answer it with the sentence you built: \emph{Mer\=a n\=am David hai.} The
+Answer it with the sentence you built: \emph{Mer\=a n\=am Arun hai.} The
 informal version swaps \emph{\=apk\=a} for \emph{tumh\=ar\=a}: \emph{tumh\=ar\=a
 n\=am ky\=a hai?}
 \end{grammarlens}
@@ -161,9 +161,9 @@ introducing yourself draws on Hindi's \emph{two} vocabularies: Sanskrit
 \toprule
 Hindi & English \\
 \midrule
-\hi{मेरा नाम सुज़ाना है।} & My name is Susana. \\
+\hi{मेरा नाम मीरा है।} & My name is Mira. \\
 \hi{आपका नाम क्या है?} & What's your name? \\
-\hi{मेरा नाम डेविड है।} & My name is David. \\
+\hi{मेरा नाम अरुण है।} & My name is Arun. \\
 \hi{आपसे मिलकर ख़ुशी हुई।} & Pleased to meet you. \\
 \bottomrule
 \end{tabular}

--- a/code/learning/human-languages/hindi/book/preamble.tex
+++ b/code/learning/human-languages/hindi/book/preamble.tex
@@ -9,6 +9,13 @@
 \setsansfont{Latin Modern Sans}
 \setmonofont{Latin Modern Mono}
 
+% Transliteration letters absent from Latin Modern, mapped to accents so the
+% romanizations don't drop characters (ṁ = anusvāra, in haiṁ etc.).
+\usepackage{newunicodechar}
+\newunicodechar{ṁ}{\.{m}}
+\newunicodechar{ṉ}{\b{n}}
+\newunicodechar{ṟ}{\b{r}}
+
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins,breakable}

--- a/code/learning/human-languages/hindi/lessons/HI-C02-aap-tum.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-aap-tum.md
@@ -1,0 +1,53 @@
+---
+id: HI-C02-aap-tum
+chapter: 2
+type: word
+headword: आप / तुम
+gloss: you (respectful / familiar)
+concept_tag: PRONOUN-YOU
+prerequisites: [HI-C02-naam]
+sounds: [independent-aa, matra-u]
+roots: [tvam]
+est_minutes: 4
+reviews_of: [HI-C02-mera-naam-hai]
+---
+
+# आप / तुम (āp / tum) — "you," respectful and familiar
+
+## Warm-up
+
+[PAUSE 2s] To ask someone's name, you need "you" — and Hindi grades it in
+*three* levels of respect.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **आप**: independent vowel **आ** (ā,
+word-initial) + **प** (pa) → *āp*. **तुम**: **त** (ta) + **ु** (the *u*-sign) +
+**म** (ma) → *tum*.
+
+## The word, taken apart
+
+- **तुम** (*tum*, familiar "you") ← Sanskrit *tvam*, from PIE **\*tū** — the
+  same root as English archaic **thou**, Latin *tū*, French *tu*.
+- **आप** (*āp*, respectful "you") is a separate honorific word (originally
+  "oneself").
+
+## Grammar Lens: three levels of "you"
+
+Hindi grades respect three ways: **āp** (respectful — strangers, elders),
+**tum** (familiar — friends, peers), **tū** (intimate or to a child; can insult
+if misused). The European tracks had two levels each; Hindi has three. For a
+first meeting, always **āp**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āp" (respectful), "tum" (familiar)]
+- [YOU SAY: the cousin of *tum* — archaic English *thou*]
+- [YOU SAY: which to use with a stranger (*āp*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name Hindi's three "you"s and when *āp* is used. (*āp* / *tum* /
+*tū*; *āp* for respect, strangers, first meetings.) What English word is *tum*'s
+cousin? (*thou*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C02-aapka-naam-kya-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-aapka-naam-kya-hai.md
@@ -1,0 +1,48 @@
+---
+id: HI-C02-aapka-naam-kya-hai
+chapter: 2
+type: phrase
+headword: आपका नाम क्या है?
+gloss: what's your name?
+concept_tag: WHATS-YOUR-NAME
+prerequisites: [HI-C02-kya, HI-C02-aap-tum, HI-C02-hai]
+sounds: []
+roots: [kim, asti]
+est_minutes: 3
+reviews_of: [HI-C02-kya, HI-C02-aap-tum, HI-C02-mera-naam-hai]
+---
+
+# आपका नाम क्या है? (āpkā nām kyā hai?) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the question: your + name + what + is.
+
+## The phrase, assembled
+
+- **आपका** (*āpkā*, "your") = **आप** (you) + **का** (*kā*, the possessive "of,"
+  the same agreeing *kā/kī/ke* that matches the noun).
+
+> **आपका नाम क्या है?** = literally "**your name what is?**" = "what's your
+> name?"
+
+Hindi keeps the verb **last** again, and simply drops the question-word *kyā*
+into the object slot — no reordering, no inversion.
+
+## Grammar Lens: answer, and the informal version
+
+Answer with the sentence you built: **Merā nām David hai.** The informal "your"
+swaps *āpkā* for **tumhārā**: *tumhārā nām kyā hai?*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āpkā nām kyā hai?"]
+- [YOU SAY: ask, then answer — "āpkā nām kyā hai?" / "merā nām … hai"]
+- [YOU SAY: the informal — "tumhārā nām kyā hai?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **आपका नाम क्या है?** literally say, and where's the verb?
+("Your name what is?"; the verb *hai* is last.) What's *āpkā* made of? (*āp* +
+*kā*, "you" + possessive.)

--- a/code/learning/human-languages/hindi/lessons/HI-C02-aapka-naam-kya-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-aapka-naam-kya-hai.md
@@ -31,7 +31,7 @@ into the object slot — no reordering, no inversion.
 
 ## Grammar Lens: answer, and the informal version
 
-Answer with the sentence you built: **Merā nām David hai.** The informal "your"
+Answer with the sentence you built: **Merā nām Arun hai.** The informal "your"
 swaps *āpkā* for **tumhārā**: *tumhārā nām kyā hai?*
 
 ## Guided Practice

--- a/code/learning/human-languages/hindi/lessons/HI-C02-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-hai.md
@@ -1,0 +1,54 @@
+---
+id: HI-C02-hai
+chapter: 2
+type: word
+headword: है
+gloss: is
+concept_tag: IS
+prerequisites: [HI-C02-naam]
+sounds: [matra-ai]
+roots: [asti]
+est_minutes: 3
+reviews_of: [HI-C02-naam, HI-C02-meraa]
+---
+
+# है (hai) — "is," cousin of English *is*
+
+## Warm-up
+
+[PAUSE 2s] The little verb "is" — and it's the same "is" spoken from Ireland to
+India.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **ह** (ha) + **ै** (the *ai*-mātrā) → **है**
+(*hai*). One syllable.
+
+## The word, taken apart
+
+**है** (*hai*, "is") ← Sanskrit **अस्ति** (*asti*, "is"), from Proto-Indo-European
+**\*h₁es-** — the root of "to be" across the whole family:
+
+- English **is**, German **ist**, Latin **est**, Spanish **es**, French **est**.
+
+Hindi *hai* is the Indian cousin of the same tiny verb. "Is" really is *one*
+word, stretched across a continent.
+
+## Grammar Lens: the verb comes last
+
+Hindi is **subject–object–verb**: "my name David **is**." *hai* sits at the
+*end* of the sentence, where English puts "is" in the middle. Bank the shape —
+in Hindi the verb waits until the end.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hai"]
+- [YOU SAY: the family — *hai* / *is* / *ist* / *est* / *es*]
+- [YOU SAY: "merā nām David hai" — note *hai* at the end]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Sanskrit/PIE root is **है** from, and its cousins? (*asti* /
+*\*h₁es-* — *is*, *ist*, *est*, *es*.) Where does the verb sit in a Hindi
+sentence? (At the end.)

--- a/code/learning/human-languages/hindi/lessons/HI-C02-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-hai.md
@@ -36,7 +36,7 @@ word, stretched across a continent.
 
 ## Grammar Lens: the verb comes last
 
-Hindi is **subject–object–verb**: "my name David **is**." *hai* sits at the
+Hindi is **subject–object–verb**: "my name Arun **is**." *hai* sits at the
 *end* of the sentence, where English puts "is" in the middle. Bank the shape —
 in Hindi the verb waits until the end.
 
@@ -45,7 +45,7 @@ in Hindi the verb waits until the end.
 [PAUSE 1s]
 - [YOU SAY: "hai"]
 - [YOU SAY: the family — *hai* / *is* / *ist* / *est* / *es*]
-- [YOU SAY: "merā nām David hai" — note *hai* at the end]
+- [YOU SAY: "merā nām Arun hai" — note *hai* at the end]
 
 ## Wrap-up Recall
 

--- a/code/learning/human-languages/hindi/lessons/HI-C02-khushi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-khushi.md
@@ -1,0 +1,47 @@
+---
+id: HI-C02-khushi
+chapter: 2
+type: phrase
+headword: ख़ुशी
+gloss: happiness / pleased to meet you
+concept_tag: PLEASED-TO-MEET
+prerequisites: [HI-C02-mera-naam-hai]
+sounds: [nukta-kh, matra-u, matra-i]
+roots: [khush-persian]
+est_minutes: 3
+reviews_of: [HI-C02-mera-naam-hai, HI-C02-aapka-naam-kya-hai]
+---
+
+# ख़ुशी (khushī) — "happiness," and "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The close to an introduction — and a word from Hindi's *other*
+vocabulary.
+
+## The phrase
+
+The Hindi "pleased to meet you" is **आपसे मिलकर ख़ुशी हुई** (*āp-se milkar
+khushī huī*) — literally "**having met you, happiness happened**."
+
+## The word, taken apart
+
+The key word **ख़ुशी** (*khushī*, "happiness") is **not** Sanskrit — it's
+**Persian** (*khush*, "happy, pleasant"), one of the thousands of Persian words
+in everyday Hindi. (The dot under **ख़** — a *nukta* — marks the Persian *kh*
+sound.) So even introducing yourself draws on Hindi's **two** vocabularies:
+Sanskrit (*nām*, *hai*) and Perso-Arabic (*khushī*) — the same double heritage
+you met with *shukriyā* and *alvidā* in Chapter 1.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āpse milkar khushī huī"]
+- [YOU SAY: the key word — *khushī* ("happiness"), a Persian word]
+- [YOU SAY: the two heritages — Sanskrit *nām*, Persian *khushī*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the Hindi "pleased to meet you" literally mean, and where
+is *khushī* from? ("Having met you, happiness happened"; Persian.) What does the
+*nukta* dot under ख़ mark? (A Persian/Arabic sound.)

--- a/code/learning/human-languages/hindi/lessons/HI-C02-kya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-kya.md
@@ -1,0 +1,45 @@
+---
+id: HI-C02-kya
+chapter: 2
+type: word
+headword: क्या
+gloss: what
+concept_tag: WHAT
+prerequisites: [HI-C02-aap-tum]
+sounds: [conjunct-kya, matra-aa]
+roots: [kim]
+est_minutes: 3
+reviews_of: [HI-C02-aap-tum, HI-C02-hai]
+---
+
+# क्या (kyā) — "what"
+
+## Warm-up
+
+[PAUSE 2s] German asks a name with "how"; Hindi uses "what" — so here's *kyā*.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* A **conjunct**: **क** (ka) loses its vowel (a
+*halant*) and joins **य** (ya) → **क्य** (kya); add the long-*ā* mātrā → **क्या**
+(*kyā*).
+
+## The word, taken apart
+
+**क्या** (*kyā*, "what") ← Sanskrit *kim* / the interrogative stem **ka-**, from
+PIE **\*kʷo-** — the same question-root behind English **wh-** words (**what**,
+**who**, **which**) and Latin **qu-**. Hindi's question-words nearly all start
+with this **k-**: *kyā* (what), *kaun* (who), *kab* (when), *kyūn* (why).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kyā"]
+- [YOU SAY: the English *wh-* cousins — what, who, which]
+- [YOU SAY: the Hindi *k-* question family — kyā, kaun, kab]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root is **क्या** from, and its English cousins? (*ka-* / *\*kʷo-*
+— *what*, *who*, *which*.) What sound do most Hindi question-words start with?
+(*k-*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C02-mera-naam-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-mera-naam-hai.md
@@ -26,13 +26,13 @@ Three atoms, each already rooted — [merā](HI-C02-meraa.md) (my, ← *ma-*),
 
 > **मेरा नाम … है** = "my name … is" = **"my name is…"**
 
-*Merā nām David hai.* → "My name is David." Slot your name into the gap; *hai*
+*Merā nām Arun hai.* → "My name is Arun." Slot your name into the gap; *hai*
 stays at the end.
 
 ## Grammar Lens: subject–object–verb
 
-Literally the Hindi is "my name David **is**" — the verb last. English puts "is"
-in the middle ("my name **is** David"); Hindi holds it to the end. Every Hindi
+Literally the Hindi is "my name Arun **is**" — the verb last. English puts "is"
+in the middle ("my name **is** Arun"); Hindi holds it to the end. Every Hindi
 sentence you build will end on its verb.
 
 ## Guided Practice

--- a/code/learning/human-languages/hindi/lessons/HI-C02-mera-naam-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-mera-naam-hai.md
@@ -1,0 +1,47 @@
+---
+id: HI-C02-mera-naam-hai
+chapter: 2
+type: phrase
+headword: मेरा नाम … है
+gloss: my name is…
+concept_tag: MY-NAME-IS
+prerequisites: [HI-C02-meraa, HI-C02-naam, HI-C02-hai]
+sounds: []
+roots: [ma, naaman, asti]
+est_minutes: 3
+reviews_of: [HI-C02-meraa, HI-C02-naam, HI-C02-hai]
+---
+
+# मेरा नाम … है (merā nām … hai) — "my name is…"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the three atoms you just traced — *merā*, *nām*, *hai* —
+into the sentence for meeting anyone.
+
+## The phrase, assembled
+
+Three atoms, each already rooted — [merā](HI-C02-meraa.md) (my, ← *ma-*),
+[nām](HI-C02-naam.md) (name, ← *nāman*), [hai](HI-C02-hai.md) (is, ← *asti*):
+
+> **मेरा नाम … है** = "my name … is" = **"my name is…"**
+
+*Merā nām David hai.* → "My name is David." Slot your name into the gap; *hai*
+stays at the end.
+
+## Grammar Lens: subject–object–verb
+
+Literally the Hindi is "my name David **is**" — the verb last. English puts "is"
+in the middle ("my name **is** David"); Hindi holds it to the end. Every Hindi
+sentence you build will end on its verb.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "merā nām … hai" with your own name]
+- [YOU SAY: notice the order — my / name / [name] / is]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in Hindi. (*Merā nām … hai.*) What's different about
+where "is" sits, versus English? (Hindi puts the verb *last*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C02-meraa.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-meraa.md
@@ -1,0 +1,49 @@
+---
+id: HI-C02-meraa
+chapter: 2
+type: word
+headword: मेरा
+gloss: my
+concept_tag: MY
+prerequisites: [HI-C02-naam]
+sounds: [matra-e, matra-aa]
+roots: [ma]
+est_minutes: 4
+reviews_of: [HI-C02-naam]
+---
+
+# मेरा (merā) — "my"
+
+## Warm-up
+
+[PAUSE 2s] The word for "my" — and, like *name*, a first-person word English
+shares to the root.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **म** (ma) + **े** (the *e*-mātrā) → **मे**
+(me); **र** (ra) + **ा** (long *ā*) → **रा** (rā). Read **मे·रा** → **merā**.
+
+## The word, taken apart
+
+**मेरा** (*merā*, "my") descends from Sanskrit *madīya* ("of me"), on the
+first-person root **ma-** — the *same* *ma-/me-* behind English **me**, **my**,
+**mine** and Latin *meus*. Hindi "my" and English "my" are, at root, one word.
+
+## Grammar Lens: "my" agrees with the noun
+
+Hindi possessives change to match what's owned: **merā** (masculine), **merī**
+(feminine), **mere** (plural). *nām* is masculine → **merā nām**. (You'll meet
+*merī* at your first feminine noun.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "merā"]
+- [YOU SAY: the cousins — *merā* / English *my*, *mine*]
+- [YOU SAY: the three forms — merā (m.) / merī (f.) / mere (pl.)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root is **मेरा** built on, and its English cousins? (*ma-* —
+*me*, *my*, *mine*.) Why *merā nām* and not *merī*? (*nām* is masculine.)

--- a/code/learning/human-languages/hindi/lessons/HI-C02-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-naam.md
@@ -1,0 +1,48 @@
+---
+id: HI-C02-naam
+chapter: 2
+type: word
+headword: नाम
+gloss: name
+concept_tag: NAME
+prerequisites: []
+sounds: [matra-aa]
+roots: [naaman]
+est_minutes: 4
+reviews_of: [HI-C01-namaste]
+---
+
+# नाम (nām) — "name," a word older than Europe
+
+## Warm-up
+
+[PAUSE 2s] To introduce yourself you need "name." Hindi's is one you already
+own in English — from before either language was born.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* Left to right: **न** (na) + **ा** (the long-*ā*
+mātrā) → **ना** (nā), then **म** (ma). Read **ना·म** → **nām**.
+
+## The word, taken apart
+
+**नाम** (*nām*) ← Sanskrit **नामन्** (*nāman*), from Proto-Indo-European
+**\*h₃nómn̥** — the *same* ancient root as:
+
+- English **name**, Latin **nōmen** (→ English **noun**, **nom**inate), Greek
+  *onoma*.
+
+So Hindi *nām* and English *name* are cousins from before either language
+existed — one of the clearest bridges between the Indian and European branches
+of one family.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nām"]
+- [YOU SAY: the cousins — Hindi *nām*, English *name*, Latin *nōmen* → *noun*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Sanskrit and PIE root is **नाम** from, and what English words
+share it? (*nāman* / *\*h₃nómn̥* — *name*, *noun*, *nominate*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C02-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-practice.md
@@ -1,0 +1,56 @@
+---
+id: HI-C02-practice
+chapter: 2
+type: practice
+headword: (dialogue)
+gloss: Chapter 2 recap — the introduction exchange
+concept_tag: REVIEW
+prerequisites: [HI-C02-mera-naam-hai, HI-C02-aapka-naam-kya-hai, HI-C02-khushi]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [HI-C02-naam, HI-C02-meraa, HI-C02-hai, HI-C02-mera-naam-hai, HI-C02-aap-tum, HI-C02-kya, HI-C02-aapka-naam-kya-hai, HI-C02-khushi]
+---
+
+# Chapter 2 — the introduction, whole
+
+## Warm-up
+
+[PAUSE 2s] Every atom is built and rooted. Here's the exchange it was for.
+
+## The dialogue
+
+| Hindi | English |
+|---|---|
+| मेरा नाम सुज़ाना है। (*merā nām Suzānā hai*) | My name is Susana. |
+| आपका नाम क्या है? (*āpkā nām kyā hai*) | What's your name? |
+| मेरा नाम डेविड है। (*merā nām David hai*) | My name is David. |
+| आपसे मिलकर ख़ुशी हुई। (*āpse milkar khushī huī*) | Pleased to meet you. |
+
+Every atom traced:
+
+- **nām** ← Sanskrit *nāman* (English **name**, **noun**)
+- **merā** ← root *ma-* (English **me**, **my**, **mine**)
+- **hai** ← Sanskrit *asti* (English **is**, German *ist*, Latin *est*)
+- **kyā** ← stem *ka-* (English **what**, **who**)
+- **khushī** ← Persian *khush* (Hindi's second, Perso-Arabic vocabulary)
+
+Two Hindi habits: the **verb goes last** (subject–object–verb), and "you" has
+**three** respect-levels (*āp / tum / tū*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the whole exchange, both voices]
+- [YOU SAY: your own introduction — "merā nām … hai"]
+- [YOU SAY: ask it back — "āpkā nām kyā hai?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name, ask someone else's, say you're pleased to meet them.
+(*Merā nām … hai. / Āpkā nām kyā hai? / …khushī huī.*) Which two words here come
+from Hindi's Persian vocabulary rather than Sanskrit? (*khushī* — and you'll
+recall *shukriyā*, *alvidā* from Ch1.)
+
+Next chapter: *āp kaise haiṁ?* ("how are you?") and answering with *ṭhīk* — the
+responding cycle.

--- a/code/learning/human-languages/hindi/lessons/HI-C02-practice.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-practice.md
@@ -22,9 +22,9 @@ reviews_of: [HI-C02-naam, HI-C02-meraa, HI-C02-hai, HI-C02-mera-naam-hai, HI-C02
 
 | Hindi | English |
 |---|---|
-| मेरा नाम सुज़ाना है। (*merā nām Suzānā hai*) | My name is Susana. |
+| मेरा नाम मीरा है। (*merā nām Mira hai*) | My name is Mira. |
 | आपका नाम क्या है? (*āpkā nām kyā hai*) | What's your name? |
-| मेरा नाम डेविड है। (*merā nām David hai*) | My name is David. |
+| मेरा नाम अरुण है। (*merā nām Arun hai*) | My name is Arun. |
 | आपसे मिलकर ख़ुशी हुई। (*āpse milkar khushī huī*) | Pleased to meet you. |
 
 Every atom traced:

--- a/code/learning/human-languages/hindi/roadmap.md
+++ b/code/learning/human-languages/hindi/roadmap.md
@@ -16,12 +16,16 @@ reading course.
   practice. Devanagari introduced through the words (inherent *a*, mātrā vowel
   signs, halant + conjuncts, independent vowels), and the Sanskrit /
   Perso-Arabic split introduced through the greetings themselves.
+- **Ch. 2 — Introducing Yourself**: nām → merā → hai → **merā nām … hai** ("my
+  name is") → āp/tum → kyā → **āpkā nām kyā hai?** → khushī (pleased to meet) →
+  practice. Every atom traced (nām ← *nāman* → *name*; hai ← *asti* → *is*;
+  merā ← *ma-* → *my*; kyā ← *ka-* → *what*); SOV word order; the three-level
+  "you."
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *merā nām* ("my name"), the formal/informal "you" (*āp* / *tum*), grammatical gender at the first noun (traced to Sanskrit) |
 | 3 | Responding: *āp kaise haiṅ* ("how are you"), *ṭhīk hūṅ* ("I'm fine"), the verb *honā* ("to be") |
 | 4 | Farewells deepened, *phir milenge* ("we'll meet again"); numbers 1–10 |
 | 5+ | Postpositions (Hindi's "back-placed" prepositions), the ergative *ne*, family, food — always with the two-vocabularies thread |

--- a/code/learning/human-languages/hindi/session-map.md
+++ b/code/learning/human-languages/hindi/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Hindi Chapter 1
+# Session Map — Hindi Chapters 1–2
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -21,7 +21,21 @@ in the service of real greetings.
 | 5 | alvida | अलविदा | independent अ, ल | Perso-Arabic (*al-widāʿ*) |
 | 6 | practice | (recap) | decode all five; the two vocabularies | both |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 7 | naam | नाम | "name" ← Sanskrit *nāman* → English *name*, *noun* |
+| 8 | meraa | मेरा | "my" ← *ma-* → English *my/mine*; agrees with the noun |
+| 9 | hai | है | "is" ← Sanskrit *asti* → English *is*, German *ist*, Latin *est* |
+| 10 | mera-naam-hai | मेरा नाम … है | **"my name is…"**; subject–object–verb |
+| 11 | aap-tum | आप / तुम | **"you"** — three levels (āp / tum / tū); *tum* ← *tū* → *thou* |
+| 12 | kya | क्या | "what" ← *ka-* → English *what/who*; क्य conjunct |
+| 13 | aapka-naam-kya-hai | आपका नाम क्या है? | **"what's your name?"**; verb still last |
+| 14 | khushi | ख़ुशी | "pleased to meet you"; *khushī* ← Persian (the second vocabulary) |
+| 15 | practice | (dialogue) | the whole exchange |
+
 ## Next
 
-Chapter 2 — introducing yourself: *merā nām* ("my name"), and Hindi's formal /
-informal "you" (*āp* / *tum*), with grammatical gender at the first noun.
+Chapter 3 — *āp kaise haiṁ?* ("how are you?") and answering with *ṭhīk* — the
+responding cycle.

--- a/code/learning/human-languages/kannada/CHANGELOG.md
+++ b/code/learning/human-languages/kannada/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Chapter 2 — Introducing Yourself
+
+- New chapter around the introduction dialogue (*nanna hesaru … / nimma hesaru
+  ēnu?*), atom-first, Kannada inline (`lessons/KA-C02-*`,
+  `book/chapters/ch02-introductions.tex`). Every atom traced:
+  - **ಹೆಸರು** hesaru ("name") ← Proto-Dravidian *\*pesar*, via Kannada's **p→h**
+    shift — cousin of Tamil *peyar*, **not** the Indo-European *name/nām*.
+  - **ನನ್ನ** nanna ("my") ← *nānu* ("I").
+  - **ನನ್ನ ಹೆಸರು …** — **"my name is…"**; the **zero copula** (no "is").
+  - **ನೀನು / ನೀವು** nīnu/nīvu — "you," familiar/respectful; respect by plural.
+  - **ಏನು** ēnu ("what") ← Dravidian question-stem *\*yā-/\*e-*.
+  - **ನಿಮ್ಮ ಹೆಸರು ಏನು?** — **"what's your name?"**
+  - **ಸಂತೋಷ** santōṣa — "pleased to meet you," a **Sanskrit** loan (vs. Tamil's
+    native *magiḻcci*) — the Kannada-borrows-Sanskrit thread continued.
+  - **practice** — the whole dialogue.
+- Book compiles clean with XeLaTeX.
+
 ## Chapter 1 — Greetings (Kannada script taught inline)
 
 - New Kannada track on the HL00 framework — the second of the four Dravidian

--- a/code/learning/human-languages/kannada/README.md
+++ b/code/learning/human-languages/kannada/README.md
@@ -30,8 +30,11 @@ book.
   dhanyavāda → haudu → illa → sari → practice (with the *hōgi baruttēne*
   farewell). Kannada script taught inline; Dravidian cognates traced. In the
   book.
-- **Chapter 2 — Introducing Yourself** (planned): *nanna hesaru…* ("my name"),
-  and *nīnu* / *nīvu* (familiar / respectful "you").
+- **Chapter 2 — Introducing Yourself** ([`lessons/KA-C02-*`](./lessons/)):
+  hesaru, nanna, **nanna hesaru** ("my name is," zero copula), nīnu/nīvu, ēnu,
+  **nimma hesaru ēnu?** ("what's your name?"), santōṣa, practice. Every atom
+  traced (*hesaru* ← *\*pesar*, p→h; *santōṣa* Sanskrit vs. Tamil *magiḻcci*).
+  In the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/kannada/book/book.tex
+++ b/code/learning/human-languages/kannada/book/book.tex
@@ -67,4 +67,6 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
 \end{document}

--- a/code/learning/human-languages/kannada/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch02-introductions.tex
@@ -1,0 +1,163 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you're glad to meet them:
+
+\begin{center}
+\kn{ನನ್ನ ಹೆಸರು ಅರುಣ್.} \quad(\emph{nanna hesaru Arun} --- ``My name is Arun.'')\\
+\kn{ನಿಮ್ಮ ಹೆಸರು ಏನು?} \quad(\emph{nimma hesaru \=enu} --- ``What is your name?'')
+\end{center}
+
+Built the same way as the greetings --- each piece taken apart, its letters and
+its root, then assembled. \emph{Practice lessons: \texttt{lessons/KA-C02-*.md}.}
+
+\section{\kn{ಹೆಸರು} \emph{(hesaru)} --- ``name,'' and the \emph{p}$\to$\emph{h} shift}
+\label{lesson:hesaru}
+
+\begin{sounds}
+\kn{ಹ} (\emph{ha}) $+$ \kn{ೆ} (the \emph{e}-sign) $\to$ \kn{ಹೆ} (he); \kn{ಸ}
+(\emph{sa}); \kn{ರು} (\emph{ru}). Read \kn{ಹೆ·ಸ·ರು} $\to$ \emph{hesaru}.
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ಹೆಸರು} (\emph{hesaru}, ``name'') is \textbf{native Dravidian}, from
+Proto-Dravidian *pesar --- and it hides a famous Kannada sound-law: an old
+initial \emph{p} became \emph{h}. So *pesar $\to$ *hesar $\to$ \emph{hesaru}.
+That makes it a \emph{cousin} of Tamil \emph{peyar} (same root; Tamil kept the
+\emph{p}, Kannada softened it to \emph{h}) --- and, like \emph{peyar}, \emph{not}
+related
+to the Sanskrit \emph{n\=ama} (Hindi \emph{n\=am}, English \emph{name}). The
+Dravidian south kept its own word for ``name.''
+\end{cousinweb}
+
+\begin{cognates}
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Language & ``Name'' & Source \\
+\midrule
+\textbf{Kannada} & \kn{ಹೆಸರು} \emph{hesaru} & Dravidian *pesar (p$\to$h) \\
+Tamil & \emph{peyar} & the \emph{same} Dravidian root (kept \emph{p}) \\
+Telugu & \emph{p\=eru} & the \emph{same} Dravidian root \\
+Malayalam & \emph{p\=er} & the \emph{same} Dravidian root \\
+Hindi & \emph{n\=am} & Sanskrit (Indo-European) \\
+English & \emph{name} & Indo-European \\
+\bottomrule
+\end{tabular}
+\end{center}
+The \emph{p}$\to$\emph{h} shift is why \emph{hesaru} looks unlike its sisters
+--- but it is the same word.
+\end{cognates}
+
+\section{\kn{ನನ್ನ} \emph{(nanna)} --- ``my''}
+\label{lesson:nanna}
+
+\begin{sounds}
+\kn{ನ} (\emph{na}) $+$ the conjunct \kn{ನ್ನ} (\emph{nna}) $\to$ \emph{nanna} ---
+a doubled, held \emph{nn}.
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ನನ್ನ} (\emph{nanna}, ``my'') is the possessive of \kn{ನಾನು} (\emph{n\=anu},
+``I'') --- native Dravidian, on the pronoun stem *n\=an, the same one behind
+Tamil \emph{n\=aṉ} / \emph{eṉ}. It has no Indo-European cousin: the Dravidian
+``I/my'' is a different word from the European \emph{I/my}.
+\end{cousinweb}
+
+\section{\kn{ನನ್ನ ಹೆಸರು \ldots} \emph{(nanna hesaru \ldots)} --- ``my name is\ldots''}
+\label{lesson:nanna-hesaru}
+
+\kn{ನನ್ನ} (my) $+$ \kn{ಹೆಸರು} (name) $+$ name $=$ \textbf{nanna hesaru \ldots}
+\emph{Nanna hesaru Arun.} $=$ ``My name is Arun.''
+
+\begin{grammarlens}
+\textbf{No word for ``is.''} As in Tamil, notice there is \emph{no} verb:
+Kannada sets ``my name'' beside ``Arun'' and lets the ``is'' be understood ---
+the \textbf{zero copula} of the Dravidian family. \emph{Nanna hesaru Arun} $=$
+literally ``my name Arun.''
+\end{grammarlens}
+
+\section{\kn{ನೀನು} / \kn{ನೀವು} \emph{(n\=\i nu / n\=\i vu)} --- ``you,'' familiar and respectful}
+\label{lesson:niinu-niivu}
+
+\begin{sounds}
+\kn{ನೀ} (\emph{n\=\i}) $+$ \kn{ನು} (\emph{nu}) $\to$ \emph{n\=\i nu}; \kn{ನೀ} $+$
+\kn{ವು} (\emph{vu}) $\to$ \emph{n\=\i vu}.
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ನೀನು} (\emph{n\=\i nu}, familiar ``you'') $\leftarrow$ Proto-Dravidian *n\=\i n
+--- the same native root as Tamil \emph{n\=\i}. \kn{ನೀವು} (\emph{n\=\i vu}) is
+the respectful/plural ``you.''
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Respect by the plural, once more.} \emph{n\=\i nu} (familiar) vs.\
+\emph{n\=\i vu} (respectful, and literally plural) --- the same
+politeness-by-plural as Tamil \emph{n\=\i\d{n}gaḷ} and French \emph{vous}. For a
+first meeting, \emph{n\=\i vu}.
+\end{grammarlens}
+
+\section{\kn{ಏನು} \emph{(\=enu)} --- ``what''}
+\label{lesson:enu}
+
+\begin{sounds}
+\kn{ಏ} (independent long \=e, word-initial) $+$ \kn{ನು} (\emph{nu}) $\to$
+\emph{\=enu}.
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ಏನು} (\emph{\=enu}, ``what'') is native Dravidian, on the interrogative stem
+*y\=a- / *e- --- the same Dravidian question-root as Tamil \emph{eṉṉa}, heading
+Kannada's question family: \emph{\=enu} (what), \emph{y\=aru} (who),
+\emph{elli} (where), \emph{y\=ake} (why).
+\end{cousinweb}
+
+\section{\kn{ನಿಮ್ಮ ಹೆಸರು ಏನು?} \emph{(nimma hesaru \=enu)} --- ``what's your name?''}
+\label{lesson:nimma-hesaru-enu}
+
+\kn{ನಿಮ್ಮ} (\emph{nimma}, ``your'') is the possessive of \emph{n\=\i vu}
+(``you,'' respectful). So \kn{ನಿಮ್ಮ ಹೆಸರು ಏನು?} is literally ``\textbf{your name
+what?}'' --- and again \emph{no ``is.''} Three words, no verb.
+
+\begin{grammarlens}
+Answer with the sentence you built: \emph{Nanna hesaru Arun.} The familiar
+``your'' is \emph{ninna} (from \emph{n\=\i nu}): \emph{ninna hesaru \=enu?}
+\end{grammarlens}
+
+\section{\kn{ಸಂತೋಷ} \emph{(santōṣa)} --- ``joy,'' and ``pleased to meet you''}
+\label{lesson:santosha}
+
+\begin{cousinweb}
+The warm close is \kn{ನಿಮ್ಮನ್ನು ಭೇಟಿಯಾಗಿ ಸಂತೋಷ} (\emph{nimmannu bh\=e\d{t}iy\=agi
+sant\=oṣa}) --- ``\textbf{having met you, joy}.'' But note the key word:
+\kn{ಸಂತೋಷ} (\emph{sant\=oṣa}, ``joy, contentment'') is \textbf{Sanskrit}
+(\emph{sam-} ``fully'' $+$ \emph{toṣa} ``satisfaction''), not native. Where
+Tamil reaches for its home-grown \emph{magiḻcci}, Kannada --- true to form ---
+uses a Sanskrit word even for ``pleased.'' The same split you saw over
+``hello'' and ``thanks'' runs right through the introductions.
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Kannada & & English \\
+\midrule
+\kn{ನನ್ನ ಹೆಸರು ಮೀರಾ.} & \emph{nanna hesaru Mira} & My name is Mira. \\
+\kn{ನಿಮ್ಮ ಹೆಸರು ಏನು?} & \emph{nimma hesaru \=enu} & What's your name? \\
+\kn{ನನ್ನ ಹೆಸರು ಅರುಣ್.} & \emph{nanna hesaru Arun} & My name is Arun. \\
+\kn{ಸಂತೋಷ.} & \emph{sant\=oṣa} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{hesaru} (Dravidian *pesar, p$\to$h; \emph{not}
+\emph{name}), \emph{nanna} (from \emph{n\=anu}, ``I''), \emph{\=enu} (Dravidian
+question-stem) --- and \emph{sant\=oṣa}, a Sanskrit loan for ``pleased,'' the
+family thread again. The Kannada habit to keep: the \textbf{zero copula} (no
+``is''). Next chapter: \emph{h\=egiddīra?} (``how are you?'') and answering with
+\emph{chenn\=agiddēne} --- the responding cycle.

--- a/code/learning/human-languages/kannada/book/preamble.tex
+++ b/code/learning/human-languages/kannada/book/preamble.tex
@@ -18,6 +18,7 @@
 \newunicodechar{ṉ}{\b{n}}
 \newunicodechar{ṟ}{\b{r}}
 \newunicodechar{ṁ}{\.{m}}
+\newunicodechar{ḻ}{\b{l}}
 
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}

--- a/code/learning/human-languages/kannada/lessons/KA-C02-enu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-enu.md
@@ -1,0 +1,41 @@
+---
+id: KA-C02-enu
+chapter: 2
+type: word
+headword: ಏನು
+gloss: what
+concept_tag: WHAT
+prerequisites: [KA-C02-niinu-niivu]
+sounds: [independent-ee]
+roots: [yaa-dravidian]
+est_minutes: 3
+reviews_of: [KA-C02-niinu-niivu, KA-C02-nanna-hesaru]
+---
+
+# ಏನು (ēnu) — "what"
+
+## Warm-up
+
+[PAUSE 2s] The last piece of the question: "what."
+
+## The letters in this word
+
+*(Skim if you read Kannada.)* **ಏ** (independent long *ē*, word-initial) + **ನು**
+(nu) → **ēnu**.
+
+## The word, taken apart
+
+**ಏನು** (*ēnu*, "what") is native Dravidian, on the interrogative stem **\*yā- /
+\*e-** — the same Dravidian question-root as Tamil *eṉṉa*, heading Kannada's
+question family: *ēnu* (what), *yāru* (who), *elli* (where), *yāke* (why).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ēnu"]
+- [YOU SAY: the question family — ēnu, yāru, elli]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Dravidian stem heads **ಏನು** and Kannada's other question-words?
+(*\*yā-/\*e-*, the same as Tamil *eṉṉa*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C02-hesaru.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-hesaru.md
@@ -1,0 +1,48 @@
+---
+id: KA-C02-hesaru
+chapter: 2
+type: word
+headword: ಹೆಸರು
+gloss: name
+concept_tag: NAME
+prerequisites: []
+sounds: [e-sign]
+roots: [pesar-dravidian]
+est_minutes: 4
+reviews_of: [KA-C01-namaskara]
+---
+
+# ಹೆಸರು (hesaru) — "name," and the *p*→*h* shift
+
+## Warm-up
+
+[PAUSE 2s] "Name" — and a word that shows off a famous Kannada sound-law.
+
+## The letters in this word
+
+*(Skim if you read Kannada.)* **ಹ** (ha) + **ೆ** (the *e*-sign) → **ಹೆ** (he);
+**ಸ** (sa); **ರು** (ru). Read **ಹೆ·ಸ·ರು** → **hesaru**.
+
+## The word, taken apart
+
+**ಹೆಸರು** (*hesaru*, "name") is **native Dravidian**, from Proto-Dravidian
+**\*pesar** — and it hides a famous Kannada sound-law: an old initial *p* became
+*h*. So **\*pesar → \*hesar → hesaru**. That makes it a **cousin of Tamil
+*peyar*** (same root; Tamil kept the *p*, Kannada softened it to *h*) — and,
+like *peyar*, *not* related to Sanskrit *nāma* (Hindi *nām*, English *name*).
+
+Across the family: Kannada *hesaru*, Tamil *peyar*, Telugu *pēru*, Malayalam
+*pēr* — one Dravidian word; only Hindi *nām* / English *name* are Indo-European.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hesaru"]
+- [YOU SAY: the shift — *\*pesar* → *hesaru* (p → h)]
+- [YOU SAY: its Tamil cousin — *peyar*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What sound-law turned *\*pesar* into *hesaru*, and what Tamil word is
+its cousin? (*p* → *h*; Tamil *peyar*.) Is it related to English *name*? (No —
+native Dravidian.)

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nanna-hesaru.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nanna-hesaru.md
@@ -1,0 +1,44 @@
+---
+id: KA-C02-nanna-hesaru
+chapter: 2
+type: phrase
+headword: ನನ್ನ ಹೆಸರು …
+gloss: my name is… (with no "is")
+concept_tag: MY-NAME-IS
+prerequisites: [KA-C02-nanna, KA-C02-hesaru]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [KA-C02-nanna, KA-C02-hesaru]
+---
+
+# ನನ್ನ ಹೆಸರು … (nanna hesaru …) — "my name is…," with no "is"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the two atoms — and notice, as in Tamil, no word for "is."
+
+## The phrase, assembled
+
+- [nanna](KA-C02-nanna.md) (my) + [hesaru](KA-C02-hesaru.md) (name) + your name.
+
+> **ನನ್ನ ಹೆಸರು …** = "my name …" → **"my name is…"**
+
+*Nanna hesaru Arun.* → "My name is Arun."
+
+## Grammar Lens: the zero copula
+
+There is **no verb**. Kannada sets "my name" beside "Arun" and lets the "is" be
+understood — the **zero copula** of the Dravidian family (just like Tamil).
+*Nanna hesaru Arun* = literally "my name Arun."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nanna hesaru …" with your name]
+- [YOU SAY: notice — no word for "is"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in Kannada. (*Nanna hesaru ….*) What does Kannada
+leave out that English needs? (The verb "is" — zero copula.)

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nanna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nanna.md
@@ -1,0 +1,42 @@
+---
+id: KA-C02-nanna
+chapter: 2
+type: word
+headword: ನನ್ನ
+gloss: my
+concept_tag: MY
+prerequisites: [KA-C02-hesaru]
+sounds: [nna-conjunct]
+roots: [naanu-dravidian]
+est_minutes: 3
+reviews_of: [KA-C02-hesaru]
+---
+
+# ನನ್ನ (nanna) — "my"
+
+## Warm-up
+
+[PAUSE 2s] "My" — native Dravidian, with no European cousin.
+
+## The letters in this word
+
+*(Skim if you read Kannada.)* **ನ** (na) + the conjunct **ನ್ನ** (nna) → **nanna**
+— a doubled, held *nn*.
+
+## The word, taken apart
+
+**ನನ್ನ** (*nanna*, "my") is the possessive of **ನಾನು** (*nānu*, "I") — native
+Dravidian, on the pronoun stem **\*nān**, the same one behind Tamil *nāṉ / eṉ*.
+It has no Indo-European cousin: the Dravidian "I/my" is a different word from
+the European *I/my*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nanna"]
+- [YOU SAY: its source — *nānu* ("I") → *nanna* ("my")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What word is **ನನ್ನ** the possessive of? (*nānu*, "I".) Which Tamil
+pronoun shares its root? (*nāṉ*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C02-niinu-niivu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-niinu-niivu.md
@@ -1,0 +1,45 @@
+---
+id: KA-C02-niinu-niivu
+chapter: 2
+type: word
+headword: ನೀನು / ನೀವು
+gloss: you (familiar / respectful)
+concept_tag: PRONOUN-YOU
+prerequisites: [KA-C02-hesaru]
+sounds: [long-ii]
+roots: [niin-dravidian]
+est_minutes: 3
+reviews_of: [KA-C02-nanna-hesaru]
+---
+
+# ನೀನು / ನೀವು (nīnu / nīvu) — "you," familiar and respectful
+
+## Warm-up
+
+[PAUSE 2s] "You" — and Kannada makes respect the same way Tamil and French do.
+
+## The letters in this word
+
+*(Skim if you read Kannada.)* **ನೀ** (nī) + **ನು** (nu) → *nīnu*; **ನೀ** + **ವು**
+(vu) → *nīvu*.
+
+## The word, taken apart
+
+**ನೀನು** (*nīnu*, familiar "you") ← Proto-Dravidian **\*nīn** — the same native
+root as Tamil *nī*. **ನೀವು** (*nīvu*) is the respectful/plural "you."
+
+## Grammar Lens: respect by the plural
+
+*nīnu* (familiar) vs. *nīvu* (respectful, and literally plural) — the same
+politeness-by-plural as Tamil *nīṅgaḷ* and French *vous*: one respected person
+addressed as "you all." For a first meeting, **nīvu**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nīnu" (familiar), "nīvu" (respectful)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Kannada make "you" respectful, and which languages use the
+same trick? (By the plural — *nīvu*; Tamil *nīṅgaḷ*, French *vous*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nimma-hesaru-enu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nimma-hesaru-enu.md
@@ -1,0 +1,43 @@
+---
+id: KA-C02-nimma-hesaru-enu
+chapter: 2
+type: phrase
+headword: ನಿಮ್ಮ ಹೆಸರು ಏನು?
+gloss: what's your name?
+concept_tag: WHATS-YOUR-NAME
+prerequisites: [KA-C02-enu, KA-C02-niinu-niivu, KA-C02-hesaru]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [KA-C02-enu, KA-C02-niinu-niivu, KA-C02-nanna-hesaru]
+---
+
+# ನಿಮ್ಮ ಹೆಸರು ಏನು? (nimma hesaru ēnu?) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the question — your + name + what — still no "is."
+
+## The phrase, assembled
+
+- **ನಿಮ್ಮ** (*nimma*, "your") = the possessive of *nīvu* ("you," respectful).
+
+> **ನಿಮ್ಮ ಹೆಸರು ಏನು?** = literally "**your name what?**" = "what's your name?"
+
+Three words, **no verb** — the zero copula holds for questions too.
+
+## Grammar Lens: answer, and the familiar version
+
+Answer with the sentence you built: **Nanna hesaru Arun.** The familiar "your"
+is *ninna* (from *nīnu*): *ninna hesaru ēnu?*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nimma hesaru ēnu?"]
+- [YOU SAY: ask, then answer — "nimma hesaru ēnu?" / "nanna hesaru …"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **ನಿಮ್ಮ ಹೆಸರು ಏನು?** literally say, and what's missing vs.
+English? ("Your name what?"; no "is" — zero copula.)

--- a/code/learning/human-languages/kannada/lessons/KA-C02-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-practice.md
@@ -1,0 +1,55 @@
+---
+id: KA-C02-practice
+chapter: 2
+type: practice
+headword: (dialogue)
+gloss: Chapter 2 recap — the introduction exchange
+concept_tag: REVIEW
+prerequisites: [KA-C02-nanna-hesaru, KA-C02-nimma-hesaru-enu, KA-C02-santosha]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [KA-C02-hesaru, KA-C02-nanna, KA-C02-nanna-hesaru, KA-C02-niinu-niivu, KA-C02-enu, KA-C02-nimma-hesaru-enu, KA-C02-santosha]
+---
+
+# Chapter 2 — the introduction, whole
+
+## Warm-up
+
+[PAUSE 2s] Every atom built. Here's the exchange.
+
+## The dialogue
+
+| Kannada | English |
+|---|---|
+| ನನ್ನ ಹೆಸರು ಮೀರಾ. (*nanna hesaru Mira*) | My name is Mira. |
+| ನಿಮ್ಮ ಹೆಸರು ಏನು? (*nimma hesaru ēnu*) | What's your name? |
+| ನನ್ನ ಹೆಸರು ಅರುಣ್. (*nanna hesaru Arun*) | My name is Arun. |
+| ಸಂತೋಷ. (*santōṣa*) | Pleased to meet you. |
+
+Every atom traced:
+
+- **hesaru** ← Dravidian *\*pesar* (p→h; cousin of Tamil *peyar*, *not* *name*)
+- **nanna** ← *nānu* ("I")
+- **ēnu** ← Dravidian question-stem *\*yā-/\*e-*
+- **santōṣa** ← **Sanskrit** (Kannada borrows even for "pleased"; Tamil keeps
+  native *magiḻcci*)
+
+The Kannada habit: the **zero copula** (no "is"). And the family thread —
+native Dravidian grammar words, a Sanskrit word for "pleased."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the whole exchange, both voices]
+- [YOU SAY: your own introduction — "nanna hesaru …"]
+- [YOU SAY: ask it back — "nimma hesaru ēnu?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name, ask someone else's, say you're pleased. (*Nanna
+hesaru …. / Nimma hesaru ēnu? / Santōṣa.*) Which word here is Sanskrit, not
+native? (*santōṣa* — "pleased.")
+
+Next chapter: *hēgiddīra?* ("how are you?") and answering with *chennāgiddēne* —
+the responding cycle.

--- a/code/learning/human-languages/kannada/lessons/KA-C02-santosha.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-santosha.md
@@ -1,0 +1,45 @@
+---
+id: KA-C02-santosha
+chapter: 2
+type: phrase
+headword: ಸಂತೋಷ
+gloss: joy / pleased to meet you
+concept_tag: PLEASED-TO-MEET
+prerequisites: [KA-C02-nanna-hesaru]
+sounds: [anusvara]
+roots: [santosha-sanskrit]
+est_minutes: 3
+reviews_of: [KA-C02-nanna-hesaru, KA-C02-nimma-hesaru-enu]
+---
+
+# ಸಂತೋಷ (santōṣa) — "joy," and "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The warm close — and, true to Kannada, a Sanskrit word where Tamil
+used a native one.
+
+## The phrase
+
+The full form is **ನಿಮ್ಮನ್ನು ಭೇಟಿಯಾಗಿ ಸಂತೋಷ** (*nimmannu bhēṭiyāgi santōṣa*) —
+"having met you, joy."
+
+## The word, taken apart
+
+**ಸಂತೋಷ** (*santōṣa*, "joy, contentment") is **Sanskrit** — *sam-* ("fully") +
+*toṣa* ("satisfaction") — not native. Where Tamil reaches for its home-grown
+*magiḻcci*, Kannada uses a Sanskrit word even for "pleased." The same split you
+saw over "hello" (*namaskāra*) and "thanks" (*dhanyavāda*) runs right through
+the introductions: Kannada borrows, Tamil keeps its own.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "santōṣa"]
+- [YOU SAY: the split — Kannada *santōṣa* (Sanskrit) vs. Tamil *magiḻcci* (native)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **ಸಂತೋಷ** native or borrowed, and what does the contrast with
+Tamil show? (Sanskrit; Kannada borrows Sanskrit — here for "pleased" — where
+Tamil keeps native *magiḻcci*.)

--- a/code/learning/human-languages/kannada/roadmap.md
+++ b/code/learning/human-languages/kannada/roadmap.md
@@ -18,12 +18,16 @@ needs it.
   practice. Kannada script introduced through the words (inherent *a*, vowel
   signs, virama + *ottakṣara* stacked conjuncts, independent vowels), and the
   Sanskrit-loan vs. native-Dravidian split shown through the words themselves.
+- **Ch. 2 — Introducing Yourself**: hesaru → nanna → **nanna hesaru** ("my name
+  is," zero copula) → nīnu/nīvu → ēnu → **nimma hesaru ēnu?** → santōṣa →
+  practice. Every atom traced (*hesaru* ← *\*pesar*, p→h, cousin of Tamil
+  *peyar*; *santōṣa* a Sanskrit loan for "pleased" vs. Tamil's native
+  *magiḻcci*); the zero copula.
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *nanna hesaru…* ("my name"), *nīnu* / *nīvu* (familiar / respectful "you"), native/Sanskrit doublets |
 | 3 | Responding: *hēgiddīra?* ("how are you"), *chennāgiddēne* ("I'm well"), the verb *iru* ("to be") |
 | 4 | The case-endings (Kannada's agglutinative suffixes), numbers 1–10 |
 | 5+ | Postpositions, tense on the verb, family, food — always with the Dravidian-cognate thread |

--- a/code/learning/human-languages/kannada/session-map.md
+++ b/code/learning/human-languages/kannada/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Kannada Chapter 1
+# Session Map — Kannada Chapters 1–2
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -21,7 +21,20 @@ independent vowels — all in the service of real greetings.
 | 5 | sari | ಸರಿ | ಸ, ರಿ (i-sign) | native; the *same word* as Tamil *sari* |
 | 6 | practice | (recap) | read all five | the *hōgi baruttēne* farewell (= Tamil *pōy varugiṟēṉ*) |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 7 | hesaru | ಹೆಸರು | "name" ← Dravidian *\*pesar* (p→h; cousin of Tamil *peyar*, not *name*) |
+| 8 | nanna | ನನ್ನ | "my" ← *nānu* ("I") |
+| 9 | nanna-hesaru | ನನ್ನ ಹೆಸರು … | **"my name is…"** — the **zero copula** (no "is") |
+| 10 | niinu-niivu | ನೀನು / ನೀವು | **"you"** familiar/respectful; respect by plural |
+| 11 | enu | ಏನು | "what" ← Dravidian question-stem *\*yā-/\*e-* |
+| 12 | nimma-hesaru-enu | ನಿಮ್ಮ ಹೆಸರು ಏನು? | **"what's your name?"** (still no "is") |
+| 13 | santosha | ಸಂತೋಷ | "pleased to meet you" — **Sanskrit** (vs. Tamil's native *magiḻcci*) |
+| 14 | practice | (dialogue) | the whole exchange |
+
 ## Next
 
-Chapter 2 — introducing yourself: *nanna hesaru…* ("my name"), *nīnu* / *nīvu*
-(familiar / respectful "you"), and the first native/Sanskrit doublets.
+Chapter 3 — *hēgiddīra?* ("how are you?") and answering with *chennāgiddēne* —
+the responding cycle.

--- a/code/learning/human-languages/malayalam/CHANGELOG.md
+++ b/code/learning/human-languages/malayalam/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter 2 — Introducing Yourself
+
+- New chapter around the introduction dialogue (*enṟe pēru … āṇŭ / ninṟe pēru
+  entāṇŭ?*), atom-first, Malayalam inline (`lessons/ML-C02-*`,
+  `book/chapters/ch02-introductions.tex`). Every atom traced:
+  - **പേര്** pēru ("name") ← Proto-Dravidian *\*pēr* — twin of Tamil *peyar*,
+    **not** the Indo-European *name/nām*.
+  - **എന്റെ** enṟe ("my") ← *ñāṉ* ("I").
+  - **ആണ്** āṇŭ ("is") — Malayalam's **copula**, from the verb *āka*. The
+    standout: Tamil/Kannada/Telugu use the **zero copula**, but Malayalam,
+    Tamil's closest sister, grammaticalised a "to be" verb.
+  - **എന്റെ പേര് … ആണ്** — **"my name is…"**; verb last (unlike Tamil).
+  - **നീ / നിങ്ങൾ** nī/niṅṅaḷ — "you," familiar/respectful; respect by plural.
+  - **എന്ത്** entŭ ("what") ← Dravidian question-stem *\*yā-/\*e-*.
+  - **നിന്റെ പേര് എന്താണ്?** — **"what's your name?"** (*entŭ* + *āṇŭ* fused).
+  - **സന്തോഷം** santōṣam — "pleased to meet you," a **Sanskrit** loan (Malayalam
+    borrows selectively: native *nandi* for thanks, Sanskrit here).
+  - **practice** — the whole dialogue.
+- Example names are invented (Mira / Arun). Book compiles clean with XeLaTeX.
+
 ## Chapter 1 — Greetings (Malayalam script taught inline)
 
 - New Malayalam track on the HL00 framework — the last of the four Dravidian

--- a/code/learning/human-languages/malayalam/README.md
+++ b/code/learning/human-languages/malayalam/README.md
@@ -31,8 +31,11 @@ book.
 - **Chapter 1 — Greetings** ([`lessons/ML-C01-*`](./lessons/)): namaskāram →
   nandi → athe → illa → śari → practice (with the *pōyi varām* farewell).
   Malayalam script taught inline; Dravidian cognates traced. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): *enṟe pēru…* ("my name"), and
-  *nī* / *niṅṅaḷ* (familiar / respectful "you").
+- **Chapter 2 — Introducing Yourself** ([`lessons/ML-C02-*`](./lessons/)):
+  peru, enṟe, **āṇŭ** ("is" — the copula), **enṟe pēru … āṇŭ** ("my name is"),
+  nī/niṅṅaḷ, entŭ, **ninṟe pēru entāṇŭ?** ("what's your name?"), santōṣam,
+  practice. The Malayalam standout: it *has* a copula *āṇŭ*, unlike its
+  zero-copula Dravidian sisters. In the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/malayalam/book/book.tex
+++ b/code/learning/human-languages/malayalam/book/book.tex
@@ -69,4 +69,6 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
 \end{document}

--- a/code/learning/human-languages/malayalam/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch02-introductions.tex
@@ -1,0 +1,157 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you're glad to meet them:
+
+\begin{center}
+\ml{എന്റെ പേര് അരുൺ ആണ്.} \quad(\emph{enṟe p\=eru Arun \=aṇŭ} --- ``My name is Arun.'')\\
+\ml{നിന്റെ പേര് എന്താണ്?} \quad(\emph{ninṟe p\=eru ent\=aṇŭ} --- ``What is your name?'')
+\end{center}
+
+Built the same way as the greetings --- each piece taken apart, its letters and
+its root, then assembled. \emph{Practice lessons: \texttt{lessons/ML-C02-*.md}.}
+
+\section{\ml{പേര്} \emph{(p\=eru)} --- ``name,'' the native Dravidian word}
+\label{lesson:peru}
+
+\begin{sounds}
+\ml{പ} (\emph{pa}) $+$ \ml{േ} (the \emph{\=e}-sign) $\to$ \ml{പേ} (p\=e); \ml{ര്}
+(bare \emph{r}, with the chandrakkala). Read \ml{പേ·ര്} $\to$ \emph{p\=eru}.
+\end{sounds}
+
+\begin{cousinweb}
+\ml{പേര്} (\emph{p\=eru}, ``name'') is \textbf{native Dravidian}, from
+Proto-Dravidian *p\=er --- the \emph{same} word as Tamil \emph{peyar} and Telugu
+\emph{p\=eru}, a cousin of Kannada \emph{hesaru} (\emph{p}$\to$\emph{h}). Being
+Tamil's closest sister, Malayalam naturally keeps the native word, \emph{not} the
+Sanskrit \emph{n\=ama} (Hindi \emph{n\=am}, English \emph{name}).
+\end{cousinweb}
+
+\section{\ml{എന്റെ} \emph{(enṟe)} --- ``my''}
+\label{lesson:enre}
+
+\begin{sounds}
+\ml{എ} (independent \emph{e}) $+$ the conjunct \ml{ന്റെ} (\emph{nṟe}) $\to$
+\emph{enṟe}.
+\end{sounds}
+
+\begin{cousinweb}
+\ml{എന്റെ} (\emph{enṟe}, ``my'') is the possessive of \ml{ഞാൻ} (\emph{ñ\=aṉ},
+``I'') --- native Dravidian, the same pronoun stem behind Tamil \emph{n\=aṉ} /
+\emph{eṉ}. No Indo-European cousin.
+\end{cousinweb}
+
+\section{\ml{ആണ്} \emph{(\=aṇŭ)} --- ``is,'' where Malayalam breaks with its sisters}
+\label{lesson:aanu}
+
+\begin{sounds}
+\ml{ആ} (independent long \=a) $+$ \ml{ണ്} (bare retroflex \emph{ṇ}) $\to$
+\emph{\=aṇŭ}.
+\end{sounds}
+
+\begin{cousinweb}
+\ml{ആണ്} (\emph{\=aṇŭ}, ``is'') is Malayalam's \textbf{copula} --- a real word
+for ``is,'' grown from the verb \ml{ആക} (\emph{\=aka}, ``to be, to become'').
+Here is the surprise: Tamil, Kannada, and Telugu all use the \textbf{zero
+copula} --- no word for ``is'' at all --- yet Malayalam, though it is Tamil's
+\emph{closest} sister, went its own way and grammaticalised a ``to be'' verb.
+So where Tamil says only \emph{eṉ peyar David}, Malayalam adds \emph{\=aṇŭ}:
+\emph{enṟe p\=eru David \=aṇŭ}.
+\end{cousinweb}
+
+\section{\ml{എന്റെ പേര് \ldots ആണ്} \emph{(enṟe p\=eru \ldots \=aṇŭ)} --- ``my name is\ldots''}
+\label{lesson:enre-peru-aanu}
+
+\ml{എന്റെ} (my) $+$ \ml{പേര്} (name) $+$ name $+$ \ml{ആണ്} (is) $=$ \textbf{enṟe
+p\=eru \ldots \=aṇŭ}. \emph{Enṟe p\=eru Arun \=aṇŭ.} $=$ ``My name is Arun.''
+
+\begin{grammarlens}
+\textbf{The verb comes last} --- as in Hindi (\emph{hai}) and unlike Tamil's
+verbless sentence. Malayalam is subject--object--\emph{verb}, and the copula
+\emph{\=aṇŭ} closes the sentence: ``my name Arun \emph{is}.'' (In fast speech
+Malayalis sometimes drop \emph{\=aṇŭ}, but the full, correct form keeps it.)
+\end{grammarlens}
+
+\section{\ml{നീ} / \ml{നിങ്ങൾ} \emph{(n\=\i\ / niṅṅaḷ)} --- ``you,'' familiar and respectful}
+\label{lesson:nii-ningal}
+
+\begin{sounds}
+\ml{നീ} (\emph{n\=\i}); \ml{നിങ്ങൾ} (\emph{niṅṅaḷ}).
+\end{sounds}
+
+\begin{cousinweb}
+\ml{നീ} (\emph{n\=\i}, familiar ``you'') $\leftarrow$ Proto-Dravidian *n\=\i n ---
+the same native root as Tamil \emph{n\=\i}, Kannada \emph{n\=\i nu}, Telugu
+\emph{nuvvu}. \ml{നിങ്ങൾ} (\emph{niṅṅaḷ}) is the respectful/plural ``you'' ---
+\emph{n\=\i} $+$ a plural ending, the exact cousin of Tamil \emph{n\=\i\d{n}gaḷ}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Respect by the plural, once more.} \emph{n\=\i} (familiar) vs.\
+\emph{niṅṅaḷ} (respectful, literally plural) --- the family's shared
+politeness-by-plural, and the same idea as French \emph{vous}. For a first
+meeting, \emph{niṅṅaḷ}.
+\end{grammarlens}
+
+\section{\ml{എന്ത്} \emph{(entŭ)} --- ``what''}
+\label{lesson:entu}
+
+\begin{sounds}
+\ml{എ} (\emph{e}) $+$ the conjunct \ml{ന്ത്} (\emph{ntŭ}) $\to$ \emph{entŭ}.
+\end{sounds}
+
+\begin{cousinweb}
+\ml{എന്ത്} (\emph{entŭ}, ``what'') is native Dravidian, on the interrogative stem
+*y\=a-/*e- --- the same Dravidian question-root as Tamil \emph{eṉṉa} and Telugu
+\emph{\=emiṭi}, heading Malayalam's question family: \emph{entŭ} (what),
+\emph{\=ar} (who), \emph{eviṭe} (where), \emph{ent\=\i naṇŭ} (why).
+\end{cousinweb}
+
+\section{\ml{നിന്റെ പേര് എന്താണ്?} \emph{(ninṟe p\=eru ent\=aṇŭ)} --- ``what's your name?''}
+\label{lesson:ninre-peru-entaanu}
+
+\ml{നിന്റെ} (\emph{ninṟe}, ``your'') is the possessive of \emph{n\=\i} (``you'').
+And watch the last word: \emph{ent\=aṇŭ} is \emph{entŭ} (what) $+$ \emph{\=aṇŭ}
+(is), fused --- so \ml{നിന്റെ പേര് എന്താണ്?} is literally ``\textbf{your name what
+is?}'' Unlike the Tamil question (which had \emph{no} verb), Malayalam's carries
+its copula \emph{\=aṇŭ} right inside the question-word.
+
+\begin{grammarlens}
+Answer with the sentence you built: \emph{Enṟe p\=eru Arun \=aṇŭ.} The
+respectful ``your'' is \emph{niṅṅaḷuṭe}: \emph{niṅṅaḷuṭe p\=eru ent\=aṇŭ?}
+\end{grammarlens}
+
+\section{\ml{സന്തോഷം} \emph{(sant\=oṣam)} --- ``joy,'' and ``pleased to meet you''}
+\label{lesson:santosham}
+
+\begin{cousinweb}
+The warm close is \ml{നിങ്ങളെ കണ്ടതിൽ സന്തോഷം} (\emph{niṅṅaḷe kaṇḍatil
+sant\=oṣam}) --- ``\textbf{joy at having seen you}.'' The word \ml{സന്തോഷം}
+(\emph{sant\=oṣam}, ``joy'') is \textbf{Sanskrit} --- the same loan Kannada and
+Telugu use. So even Malayalam, the great keeper of native words (recall
+\emph{nandi} for ``thanks''), reaches for Sanskrit here: the loan words spread
+\emph{selectively}, word by word, which is exactly what these lessons trace.
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Malayalam & & English \\
+\midrule
+\ml{എന്റെ പേര് മീരാ ആണ്.} & \emph{enṟe p\=eru Mira \=aṇŭ} & My name is Mira. \\
+\ml{നിന്റെ പേര് എന്താണ്?} & \emph{ninṟe p\=eru ent\=aṇŭ} & What's your name? \\
+\ml{എന്റെ പേര് അരുൺ ആണ്.} & \emph{enṟe p\=eru Arun \=aṇŭ} & My name is Arun. \\
+\ml{സന്തോഷം.} & \emph{sant\=oṣam} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{p\=eru} (Dravidian *p\=er, \emph{not} \emph{name}),
+\emph{enṟe} (from \emph{ñ\=aṉ}, ``I''), \emph{entŭ} (Dravidian question-stem),
+\emph{sant\=oṣam} (Sanskrit). And the Malayalam standout: it \emph{has} a copula
+\emph{\=aṇŭ} (``is''), where its Dravidian sisters use none. Next chapter:
+\emph{sukham\=aṇ\=o?} (``are you well?'') --- the responding cycle.

--- a/code/learning/human-languages/malayalam/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch02-introductions.tex
@@ -56,8 +56,8 @@ for ``is,'' grown from the verb \ml{ആക} (\emph{\=aka}, ``to be, to become'')
 Here is the surprise: Tamil, Kannada, and Telugu all use the \textbf{zero
 copula} --- no word for ``is'' at all --- yet Malayalam, though it is Tamil's
 \emph{closest} sister, went its own way and grammaticalised a ``to be'' verb.
-So where Tamil says only \emph{eṉ peyar David}, Malayalam adds \emph{\=aṇŭ}:
-\emph{enṟe p\=eru David \=aṇŭ}.
+So where Tamil says only \emph{eṉ peyar Arun}, Malayalam adds \emph{\=aṇŭ}:
+\emph{enṟe p\=eru Arun \=aṇŭ}.
 \end{cousinweb}
 
 \section{\ml{എന്റെ പേര് \ldots ആണ്} \emph{(enṟe p\=eru \ldots \=aṇŭ)} --- ``my name is\ldots''}

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-aanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-aanu.md
@@ -1,0 +1,54 @@
+---
+id: ML-C02-aanu
+chapter: 2
+type: word
+headword: ആണ്
+gloss: is (the copula)
+concept_tag: IS
+prerequisites: [ML-C02-peru]
+sounds: [independent-aa, retroflex-nu]
+roots: [aaka-dravidian]
+est_minutes: 3
+reviews_of: [ML-C02-peru, ML-C02-enre]
+---
+
+# ആണ് (āṇŭ) — "is," where Malayalam breaks with its sisters
+
+## Warm-up
+
+[PAUSE 2s] A small surprise: Malayalam has a real word for "is," where its
+Dravidian sisters have none.
+
+## The letters in this word
+
+*(Skim if you read Malayalam.)* **ആ** (independent long *ā*) + **ണ്** (bare
+retroflex *ṇ*) → **āṇŭ**.
+
+## The word, taken apart
+
+**ആണ്** (*āṇŭ*, "is") is Malayalam's **copula** — a real "to be" word, grown
+from the verb **ആക** (*āka*, "to be, to become").
+
+Here's the point: Tamil, Kannada, and Telugu all use the **zero copula** — *no*
+word for "is." Yet Malayalam, though it is Tamil's *closest* sister,
+grammaticalised a "to be" verb. So where Tamil says only *eṉ peyar Arun*,
+Malayalam adds *āṇŭ*: *enṟe pēru Arun āṇŭ*.
+
+## Grammar Lens: the verb comes last
+
+Like Hindi's *hai* (and unlike Tamil), *āṇŭ* closes the sentence — Malayalam is
+subject–object–**verb**: "my name Arun **is**." (Malayalis sometimes drop *āṇŭ*
+in fast speech, but the full form keeps it.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āṇŭ"]
+- [YOU SAY: the contrast — Tamil *eṉ peyar Arun* (no verb) vs. Malayalam *enṟe
+  pēru Arun āṇŭ*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is **ആണ്**, and how does Malayalam differ from Tamil here?
+(The copula "is," from *āka*; Malayalam *has* a word for "is" where Tamil uses
+none.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-enre-peru-aanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-enre-peru-aanu.md
@@ -1,0 +1,45 @@
+---
+id: ML-C02-enre-peru-aanu
+chapter: 2
+type: phrase
+headword: എന്റെ പേര് … ആണ്
+gloss: my name is…
+concept_tag: MY-NAME-IS
+prerequisites: [ML-C02-enre, ML-C02-peru, ML-C02-aanu]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [ML-C02-enre, ML-C02-peru, ML-C02-aanu]
+---
+
+# എന്റെ പേര് … ആണ് (enṟe pēru … āṇŭ) — "my name is…"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the three atoms — including the copula *āṇŭ* that Tamil
+lacks.
+
+## The phrase, assembled
+
+- [enṟe](ML-C02-enre.md) (my) + [pēru](ML-C02-peru.md) (name) + your name +
+  [āṇŭ](ML-C02-aanu.md) (is).
+
+> **എന്റെ പേര് … ആണ്** = "my name … is" = **"my name is…"**
+
+*Enṟe pēru Arun āṇŭ.* → "My name is Arun."
+
+## Grammar Lens: verb last
+
+Malayalam is subject–object–**verb**, so *āṇŭ* ("is") sits at the end — "my name
+Arun **is**," like Hindi *hai* and unlike Tamil's verbless *eṉ peyar Arun*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "enṟe pēru … āṇŭ" with your name]
+- [YOU SAY: note the copula at the end — *āṇŭ*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in Malayalam. (*Enṟe pēru … āṇŭ.*) What word does
+Malayalam add that Tamil omits? (The copula *āṇŭ*, "is.")

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-enre.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-enre.md
@@ -1,0 +1,40 @@
+---
+id: ML-C02-enre
+chapter: 2
+type: word
+headword: എന്റെ
+gloss: my
+concept_tag: MY
+prerequisites: [ML-C02-peru]
+sounds: [nre-conjunct]
+roots: [njaan-dravidian]
+est_minutes: 3
+reviews_of: [ML-C02-peru]
+---
+
+# എന്റെ (enṟe) — "my"
+
+## Warm-up
+
+[PAUSE 2s] "My" — native Dravidian.
+
+## The letters in this word
+
+*(Skim if you read Malayalam.)* **എ** (independent *e*) + the conjunct **ന്റെ**
+(*nṟe*) → **enṟe**.
+
+## The word, taken apart
+
+**എന്റെ** (*enṟe*, "my") is the possessive of **ഞാൻ** (*ñāṉ*, "I") — native
+Dravidian, the same pronoun stem behind Tamil *nāṉ / eṉ*. No Indo-European
+cousin: the Dravidian "I/my" is a different word from the European *I/my*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "enṟe"]
+- [YOU SAY: its source — *ñāṉ* ("I") → *enṟe* ("my")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What word is **എന്റെ** the possessive of? (*ñāṉ*, "I".)

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-entu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-entu.md
@@ -1,0 +1,42 @@
+---
+id: ML-C02-entu
+chapter: 2
+type: word
+headword: എന്ത്
+gloss: what
+concept_tag: WHAT
+prerequisites: [ML-C02-nii-ningal]
+sounds: [ntu-conjunct]
+roots: [yaa-dravidian]
+est_minutes: 3
+reviews_of: [ML-C02-nii-ningal, ML-C02-enre-peru-aanu]
+---
+
+# എന്ത് (entŭ) — "what"
+
+## Warm-up
+
+[PAUSE 2s] The last piece of the question: "what."
+
+## The letters in this word
+
+*(Skim if you read Malayalam.)* **എ** (*e*) + the conjunct **ന്ത്** (*ntŭ*) →
+**entŭ**.
+
+## The word, taken apart
+
+**എന്ത്** (*entŭ*, "what") is native Dravidian, on the interrogative stem
+**\*yā-/\*e-** — the same Dravidian question-root as Tamil *eṉṉa* and Telugu
+*ēmiṭi*, heading Malayalam's question family: *entŭ* (what), *ār* (who), *eviṭe*
+(where).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "entŭ"]
+- [YOU SAY: the question family — entŭ, ār, eviṭe]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Dravidian stem heads **എന്ത്**? (*\*yā-/\*e-*, same as Tamil
+*eṉṉa*, Telugu *ēmiṭi*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-nii-ningal.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-nii-ningal.md
@@ -1,0 +1,46 @@
+---
+id: ML-C02-nii-ningal
+chapter: 2
+type: word
+headword: നീ / നിങ്ങൾ
+gloss: you (familiar / respectful)
+concept_tag: PRONOUN-YOU
+prerequisites: [ML-C02-peru]
+sounds: [long-ii]
+roots: [niin-dravidian]
+est_minutes: 3
+reviews_of: [ML-C02-enre-peru-aanu]
+---
+
+# നീ / നിങ്ങൾ (nī / niṅṅaḷ) — "you," familiar and respectful
+
+## Warm-up
+
+[PAUSE 2s] "You" — respect made by the plural, the family's shared trick.
+
+## The letters in this word
+
+*(Skim if you read Malayalam.)* **നീ** (*nī*); **നിങ്ങൾ** (*niṅṅaḷ*).
+
+## The word, taken apart
+
+**നീ** (*nī*, familiar "you") ← Proto-Dravidian **\*nīn** — the same native root
+as Tamil *nī*, Kannada *nīnu*, Telugu *nuvvu*. **നിങ്ങൾ** (*niṅṅaḷ*) is the
+respectful/plural "you" — *nī* + a plural ending, the exact cousin of Tamil
+*nīṅgaḷ*.
+
+## Grammar Lens: respect by the plural
+
+*nī* (familiar) vs. *niṅṅaḷ* (respectful, literally plural) — the family's
+shared politeness-by-plural, same idea as French *vous*. For a first meeting,
+**niṅṅaḷ**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nī" (familiar), "niṅṅaḷ" (respectful)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Malayalam make "you" respectful, and which Tamil word is
+*niṅṅaḷ*'s twin? (By the plural; Tamil *nīṅgaḷ*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-ninre-peru-entaanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-ninre-peru-entaanu.md
@@ -1,0 +1,47 @@
+---
+id: ML-C02-ninre-peru-entaanu
+chapter: 2
+type: phrase
+headword: നിന്റെ പേര് എന്താണ്?
+gloss: what's your name?
+concept_tag: WHATS-YOUR-NAME
+prerequisites: [ML-C02-entu, ML-C02-nii-ningal, ML-C02-peru, ML-C02-aanu]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [ML-C02-entu, ML-C02-nii-ningal, ML-C02-enre-peru-aanu]
+---
+
+# നിന്റെ പേര് എന്താണ്? (ninṟe pēru entāṇŭ?) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the question — your + name + what-is. And notice the copula
+hiding in the last word.
+
+## The phrase, assembled
+
+- **നിന്റെ** (*ninṟe*, "your") = the possessive of *nī* ("you").
+- **എന്താണ്** (*entāṇŭ*) = **entŭ** (what) + **āṇŭ** (is), fused into one.
+
+> **നിന്റെ പേര് എന്താണ്?** = literally "**your name what is?**"
+
+Unlike the Tamil question (which had **no** verb), Malayalam carries its copula
+*āṇŭ* right inside the question-word *entāṇŭ*.
+
+## Grammar Lens: answer, and the respectful version
+
+Answer with the sentence you built: **Enṟe pēru Arun āṇŭ.** The respectful
+"your" is *niṅṅaḷuṭe*: *niṅṅaḷuṭe pēru entāṇŭ?*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ninṟe pēru entāṇŭ?"]
+- [YOU SAY: hear the copula inside — *entŭ* + *āṇŭ* → *entāṇŭ*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two words fuse into **എന്താണ്**, and how does this differ from
+the Tamil question? (*entŭ* "what" + *āṇŭ* "is"; Tamil's question has no verb,
+Malayalam's carries the copula.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-peru.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-peru.md
@@ -1,0 +1,42 @@
+---
+id: ML-C02-peru
+chapter: 2
+type: word
+headword: പേര്
+gloss: name
+concept_tag: NAME
+prerequisites: []
+sounds: [ee-sign, chandrakkala]
+roots: [peer-dravidian]
+est_minutes: 3
+reviews_of: [ML-C01-namaskaram]
+---
+
+# പേര് (pēru) — "name," the native Dravidian word
+
+## Warm-up
+
+[PAUSE 2s] "Name" — native, as you'd expect from Tamil's closest sister.
+
+## The letters in this word
+
+*(Skim if you read Malayalam.)* **പ** (pa) + **േ** (the *ē*-sign) → **പേ** (pē);
+**ര്** (bare *r*, chandrakkala). Read **പേ·ര്** → **pēru**.
+
+## The word, taken apart
+
+**പേര്** (*pēru*, "name") is **native Dravidian**, from Proto-Dravidian **\*pēr**
+— the same word as Tamil *peyar* and Telugu *pēru*, a cousin of Kannada *hesaru*
+(*p*→*h*). Being Tamil's closest sister, Malayalam keeps the native word, *not*
+Sanskrit *nāma* (Hindi *nām*, English *name*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pēru"]
+- [YOU SAY: its cousins — *pēru* / *peyar* / *pēr* / *hesaru*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **പേര്** native or borrowed, and what Tamil word is its twin?
+(Native Dravidian, *\*pēr*; Tamil *peyar*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-practice.md
@@ -1,0 +1,51 @@
+---
+id: ML-C02-practice
+chapter: 2
+type: practice
+headword: (dialogue)
+gloss: Chapter 2 recap — the introduction exchange
+concept_tag: REVIEW
+prerequisites: [ML-C02-enre-peru-aanu, ML-C02-ninre-peru-entaanu, ML-C02-santosham]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ML-C02-peru, ML-C02-enre, ML-C02-aanu, ML-C02-enre-peru-aanu, ML-C02-nii-ningal, ML-C02-entu, ML-C02-ninre-peru-entaanu, ML-C02-santosham]
+---
+
+# Chapter 2 — the introduction, whole
+
+## The dialogue
+
+| Malayalam | English |
+|---|---|
+| എന്റെ പേര് മീരാ ആണ്. (*enṟe pēru Mira āṇŭ*) | My name is Mira. |
+| നിന്റെ പേര് എന്താണ്? (*ninṟe pēru entāṇŭ*) | What's your name? |
+| എന്റെ പേര് അരുൺ ആണ്. (*enṟe pēru Arun āṇŭ*) | My name is Arun. |
+| സന്തോഷം. (*santōṣam*) | Pleased to meet you. |
+
+Every atom traced:
+
+- **pēru** ← Dravidian *\*pēr* (*not* *name*; twin of Tamil *peyar*)
+- **enṟe** ← *ñāṉ* ("I")
+- **āṇŭ** ← the verb *āka* ("to be") — Malayalam's **copula**
+- **entŭ** ← Dravidian question-stem *\*yā-/\*e-*
+- **santōṣam** ← **Sanskrit** (borrowed even in native-loving Malayalam)
+
+The Malayalam standout: unlike its Dravidian sisters' **zero copula**, Malayalam
+**has a word for "is"** (*āṇŭ*) — a real grammatical difference between the
+closest of sisters.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the whole exchange, both voices]
+- [YOU SAY: your own introduction — "enṟe pēru … āṇŭ"]
+- [YOU SAY: ask it back — "ninṟe pēru entāṇŭ?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name, ask someone else's, say you're pleased. (*Enṟe pēru
+… āṇŭ. / Ninṟe pēru entāṇŭ? / Santōṣam.*) What grammatical word does Malayalam
+have that Tamil, Kannada, and Telugu lack? (A copula — *āṇŭ*, "is.")
+
+Next chapter: *sukhamāṇō?* ("are you well?") — the responding cycle.

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-santosham.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-santosham.md
@@ -1,0 +1,45 @@
+---
+id: ML-C02-santosham
+chapter: 2
+type: phrase
+headword: സന്തോഷം
+gloss: joy / pleased to meet you
+concept_tag: PLEASED-TO-MEET
+prerequisites: [ML-C02-enre-peru-aanu]
+sounds: [anusvara]
+roots: [santosha-sanskrit]
+est_minutes: 3
+reviews_of: [ML-C02-enre-peru-aanu, ML-C02-ninre-peru-entaanu]
+---
+
+# സന്തോഷം (santōṣam) — "joy," and "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The warm close — a Sanskrit word even in native-loving Malayalam.
+
+## The phrase
+
+The full form is **നിങ്ങളെ കണ്ടതിൽ സന്തോഷം** (*niṅṅaḷe kaṇḍatil santōṣam*) —
+"joy at having seen you."
+
+## The word, taken apart
+
+**സന്തോഷം** (*santōṣam*, "joy") is **Sanskrit** — the same loan Kannada and
+Telugu use. So even Malayalam, the great keeper of native words (recall *nandi*
+for "thanks" in Chapter 1), reaches for Sanskrit here. The loanwords spread
+**selectively**, word by word — which is exactly what these cognate notes
+trace: native for "name" and "thanks," Sanskrit for "pleased."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "santōṣam"]
+- [YOU SAY: the pattern — Malayalam keeps native *nandi* (thanks) but borrows
+  Sanskrit *santōṣam* (pleased)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **സന്തോഷം** native or Sanskrit, and what does that show about how
+Malayalam borrows? (Sanskrit; it borrows *selectively* — native for some words,
+Sanskrit for others.)

--- a/code/learning/human-languages/malayalam/roadmap.md
+++ b/code/learning/human-languages/malayalam/roadmap.md
@@ -17,12 +17,15 @@ by piece, on the first word that needs it.
   Malayalam script introduced through the words (inherent *a*, vowel signs, the
   chandrakkala + conjuncts, anusvāram, independent vowels), and the native
   (Tamil-shared) vs. Sanskrit split shown through the words themselves.
+- **Ch. 2 — Introducing Yourself**: peru → enṟe → **āṇŭ** (the copula) → **enṟe
+  pēru … āṇŭ** ("my name is") → nī/niṅṅaḷ → entŭ → **ninṟe pēru entāṇŭ?** →
+  santōṣam → practice. Every atom traced (*pēru* ← *\*pēr*, twin of Tamil
+  *peyar*); the standout **copula *āṇŭ*** where the Dravidian sisters use none.
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *enṟe pēru…* ("my name"), *nī* / *niṅṅaḷ* (familiar / respectful "you"), native/Sanskrit doublets |
 | 3 | Responding: *sukhamāṇō?* ("are you well"), *sukhamāṇŭ* ("I'm well"), the verb *uṇṭŭ* ("to be") |
 | 4 | The case-endings (Malayalam's agglutinative suffixes), numbers 1–10 |
 | 5+ | Postpositions, tense on the verb, family, food — always with the Dravidian-cognate thread |

--- a/code/learning/human-languages/malayalam/session-map.md
+++ b/code/learning/human-languages/malayalam/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Malayalam Chapter 1
+# Session Map — Malayalam Chapters 1–2
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -21,7 +21,20 @@ independent vowels — all in the service of real greetings.
 | 5 | sari | ശരി | ശ (śa), ri-sign | native; the family word *sari* (Sanskrit ശ) |
 | 6 | practice | (recap) | read all five | the *pōyi varām* farewell (≈ Tamil *pōy varugiṟēṉ*) |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 7 | peru | പേര് | "name" ← Dravidian *\*pēr* (twin of Tamil *peyar*, not *name*) |
+| 8 | enre | എന്റെ | "my" ← *ñāṉ* ("I") |
+| 9 | aanu | ആണ് | **"is"** — Malayalam's copula (← *āka*); its sisters use **none** |
+| 10 | enre-peru-aanu | എന്റെ പേര് … ആണ് | **"my name is…"**; verb last (unlike Tamil) |
+| 11 | nii-ningal | നീ / നിങ്ങൾ | **"you"** familiar/respectful; respect by plural |
+| 12 | entu | എന്ത് | "what" ← Dravidian question-stem *\*yā-/\*e-* |
+| 13 | ninre-peru-entaanu | നിന്റെ പേര് എന്താണ്? | **"what's your name?"** (*entŭ* + *āṇŭ* fused) |
+| 14 | santosham | സന്തോഷം | "pleased to meet you" — **Sanskrit** (vs. native *nandi* for thanks) |
+| 15 | practice | (dialogue) | the whole exchange |
+
 ## Next
 
-Chapter 2 — introducing yourself: *enṟe pēru…* ("my name"), *nī* / *niṅṅaḷ*
-(familiar / respectful "you"), and the first native/Sanskrit doublets.
+Chapter 3 — *sukhamāṇō?* ("are you well?") — the responding cycle.

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter 2 — Introducing Yourself
+
+- New chapter around the introduction dialogue (*eṉ peyar … / uṅgaḷ peyar
+  eṉṉa?*), atom-first, Tamil script inline (`lessons/TA-C02-*`,
+  `book/chapters/ch02-introductions.tex`). Every atom is **native Dravidian**
+  and traced:
+  - **பெயர்** peyar ("name") ← Proto-Dravidian *\*peyar* — pointedly **not** the
+    Indo-European *name/nām*; the family fault-line made visible (cognate box
+    across all four Dravidian tongues vs. Hindi/English).
+  - **என்** eṉ ("my") ← *nāṉ* ("I"); no European cousin.
+  - **என் பெயர் …** — **"my name is…"**; introduces the **zero copula** (Tamil
+    has no word for "is" in an equational sentence).
+  - **நீ / நீங்கள்** nī/nīṅgaḷ — "you," familiar/respectful; respect by the
+    plural (the same mechanism as French *vous*).
+  - **என்ன** eṉṉa ("what") ← Dravidian question-stem *\*yā-/\*e-*.
+  - **உங்கள் பெயர் என்ன?** — **"what's your name?"** (still no "is").
+  - **மகிழ்ச்சி** magiḻcci — "pleased to meet you" ("joy"); the rare ழ (*ḻ*).
+  - **practice** — the whole dialogue.
+- Book compiles clean with XeLaTeX.
+
 ## Chapter 1 — Greetings (Tamil script taught inline)
 
 - New Tamil track on the HL00 framework — the **anchor** of the four Dravidian

--- a/code/learning/human-languages/tamil/README.md
+++ b/code/learning/human-languages/tamil/README.md
@@ -30,8 +30,11 @@ shown, LaTeX book.
 - **Chapter 1 — Greetings** ([`lessons/TA-C01-*`](./lessons/)): vaṇakkam →
   naṉṟi → ām → illai → sari → practice (with the *pōy varugiṟēṉ* farewell).
   Tamil script taught inline; Dravidian cognates traced. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): *eṉ peyar…* ("my name"), and
-  *nī* / *nīṅgaḷ* (familiar / respectful "you").
+- **Chapter 2 — Introducing Yourself** ([`lessons/TA-C02-*`](./lessons/)):
+  peyar, eṉ, **eṉ peyar** ("my name is," zero copula), nī/nīṅgaḷ, eṉṉa,
+  **uṅgaḷ peyar eṉṉa?** ("what's your name?"), magiḻcci, practice. Every atom
+  native Dravidian and traced (*peyar* ≠ Indo-European *name*); the **zero
+  copula** (no word for "is"). In the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/tamil/book/book.tex
+++ b/code/learning/human-languages/tamil/book/book.tex
@@ -66,4 +66,6 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
 \end{document}

--- a/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
@@ -5,7 +5,7 @@ Now a first real exchange --- giving your name, asking for someone else's, and
 saying you're glad to meet them:
 
 \begin{center}
-\ta{என் பெயர் டேவிட்.} \quad(\emph{eṉ peyar David} --- ``My name is David.'')\\
+\ta{என் பெயர் அருண்.} \quad(\emph{eṉ peyar Arun} --- ``My name is Arun.'')\\
 \ta{உங்கள் பெயர் என்ன?} \quad(\emph{uṅgaḷ peyar eṉṉa} --- ``What is your name?'')
 \end{center}
 
@@ -70,15 +70,15 @@ two entirely separate words for the self.
 \label{lesson:en-peyar}
 
 \ta{என்} (my) $+$ \ta{பெயர்} (name) $+$ name $=$ \textbf{eṉ peyar \ldots}
-\emph{Eṉ peyar David.} $=$ ``My name is David.''
+\emph{Eṉ peyar Arun.} $=$ ``My name is Arun.''
 
 \begin{grammarlens}
 \textbf{Tamil has no word for ``is'' here.} Notice what's missing: there is
-\emph{no} verb. Tamil simply places ``my name'' beside ``David'' --- \emph{eṉ
-peyar David} --- and the ``is'' is understood. This is the \textbf{zero
+\emph{no} verb. Tamil simply places ``my name'' beside ``Arun'' --- \emph{eṉ
+peyar Arun} --- and the ``is'' is understood. This is the \textbf{zero
 copula}: for equational sentences (X is Y), Dravidian needs no ``to be'' at all,
 where English needs \emph{is}, Hindi needs \emph{hai}, and Arabic (you'll see)
-also drops it. Tamil says only ``my name David.''
+also drops it. Tamil says only ``my name Arun.''
 \end{grammarlens}
 
 \section{\ta{நீ} / \ta{நீங்கள்} \emph{(n\=\i\ / n\=\i\d{n}gaḷ)} --- ``you,'' familiar and respectful}
@@ -130,7 +130,7 @@ name what?}'' --- and again \emph{no ``is''}: the zero copula holds for question
 too. Just three words, no verb.
 
 \begin{grammarlens}
-Answer with the sentence you built: \emph{Eṉ peyar David.} The familiar version
+Answer with the sentence you built: \emph{Eṉ peyar Arun.} The familiar version
 swaps \emph{uṅgaḷ} for \emph{uṉ} (``your,'' from \emph{n\=\i}): \emph{uṉ peyar
 eṉṉa?}
 \end{grammarlens}
@@ -155,9 +155,9 @@ casual speech Tamils often just smile, or say the English ``nice to meet you.'')
 \toprule
 Tamil & & English \\
 \midrule
-\ta{என் பெயர் சுசன்.} & \emph{eṉ peyar Susan} & My name is Susan. \\
+\ta{என் பெயர் மீரா.} & \emph{eṉ peyar Mira} & My name is Mira. \\
 \ta{உங்கள் பெயர் என்ன?} & \emph{uṅgaḷ peyar eṉṉa} & What's your name? \\
-\ta{என் பெயர் டேவிட்.} & \emph{eṉ peyar David} & My name is David. \\
+\ta{என் பெயர் அருண்.} & \emph{eṉ peyar Arun} & My name is Arun. \\
 \ta{மகிழ்ச்சி.} & \emph{magiḻcci} & Pleased to meet you. \\
 \bottomrule
 \end{tabular}

--- a/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
@@ -1,0 +1,171 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you're glad to meet them:
+
+\begin{center}
+\ta{என் பெயர் டேவிட்.} \quad(\emph{eṉ peyar David} --- ``My name is David.'')\\
+\ta{உங்கள் பெயர் என்ன?} \quad(\emph{uṅgaḷ peyar eṉṉa} --- ``What is your name?'')
+\end{center}
+
+Built the same way as the greetings --- each piece taken apart, its letters and
+its root, then assembled. And here the roots run \emph{native}: this is where
+Tamil is most itself. \emph{Practice lessons: \texttt{lessons/TA-C02-*.md}.}
+
+\section{\ta{பெயர்} \emph{(peyar)} --- ``name,'' and where the family is \emph{not} Indo-European}
+\label{lesson:peyar}
+
+\begin{sounds}
+\ta{ப} (\emph{pa}) $+$ \ta{ெ} (the \emph{e}-sign, written before, read after) $\to$
+\ta{பெ} (pe); \ta{ய} (\emph{ya}); \ta{ர்} (bare \emph{r}, with the puḷḷi). Read
+\ta{பெ·ய·ர்} $\to$ \emph{peyar}.
+\end{sounds}
+
+\begin{cousinweb}
+\ta{பெயர்} (\emph{peyar}, ``name'') is \textbf{native Dravidian}, from
+Proto-Dravidian *peyar / *p\=er --- and it is \emph{not} related to the Sanskrit
+\emph{n\=ama} (Hindi \emph{n\=am}, English \emph{name}). Here the two great
+families part: where Indo-European shares one word for ``name'' from Ireland to
+North India, the Dravidian south kept its own. That is the whole reason to
+learn Tamil deeply --- it preserves a word-stock older than the Sanskrit layer.
+\end{cousinweb}
+
+\begin{cognates}
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Language & ``Name'' & Source \\
+\midrule
+\textbf{Tamil} & \ta{பெயர்} \emph{peyar} & \textbf{native Dravidian} (*peyar) \\
+Malayalam & \emph{p\=er} & the \emph{same} Dravidian root \\
+Telugu & \emph{p\=eru} & the \emph{same} Dravidian root \\
+Kannada & \emph{hesaru} & Dravidian (*pesar, with p$\to$h) \\
+Hindi & \emph{n\=am} & Sanskrit \emph{n\=aman} (Indo-European) \\
+English & \emph{name} & Indo-European \\
+\bottomrule
+\end{tabular}
+\end{center}
+Four Dravidian tongues share \emph{peyar/pēru}; only the Indo-European languages
+have \emph{name/nām}.
+\end{cognates}
+
+\section{\ta{என்} \emph{(eṉ)} --- ``my''}
+\label{lesson:en}
+
+\begin{sounds}
+\ta{எ} (independent vowel \emph{e}, word-initial) $+$ \ta{ன்} (bare alveolar
+\emph{ṉ}, puḷḷi) $\to$ \emph{eṉ}.
+\end{sounds}
+
+\begin{cousinweb}
+\ta{என்} (\emph{eṉ}, ``my'') is the possessive of \ta{நான்} (\emph{n\=aṉ}, ``I'')
+--- native Dravidian, from the pronoun stem *y\=an / *n\=an. It has \emph{no}
+Indo-European cousin: the Tamil ``I/my'' is built on a different root from the
+English \emph{I} / \emph{my} (which go back to *e\'{g} and *me-). Two families,
+two entirely separate words for the self.
+\end{cousinweb}
+
+\section{\ta{என் பெயர் \ldots} \emph{(eṉ peyar \ldots)} --- ``my name is\ldots,'' with no ``is''}
+\label{lesson:en-peyar}
+
+\ta{என்} (my) $+$ \ta{பெயர்} (name) $+$ name $=$ \textbf{eṉ peyar \ldots}
+\emph{Eṉ peyar David.} $=$ ``My name is David.''
+
+\begin{grammarlens}
+\textbf{Tamil has no word for ``is'' here.} Notice what's missing: there is
+\emph{no} verb. Tamil simply places ``my name'' beside ``David'' --- \emph{eṉ
+peyar David} --- and the ``is'' is understood. This is the \textbf{zero
+copula}: for equational sentences (X is Y), Dravidian needs no ``to be'' at all,
+where English needs \emph{is}, Hindi needs \emph{hai}, and Arabic (you'll see)
+also drops it. Tamil says only ``my name David.''
+\end{grammarlens}
+
+\section{\ta{நீ} / \ta{நீங்கள்} \emph{(n\=\i\ / n\=\i\d{n}gaḷ)} --- ``you,'' familiar and respectful}
+\label{lesson:nii-niingal}
+
+\begin{sounds}
+\ta{நீ}: \ta{ந} (dental \emph{na}) $+$ \ta{ீ} (the long-\=\i\ sign) $\to$
+\emph{n\=\i}. \ta{நீங்கள்} adds \ta{ங்கள்} (\emph{ṅgaḷ}).
+\end{sounds}
+
+\begin{cousinweb}
+\ta{நீ} (\emph{n\=\i}, familiar ``you'') $\leftarrow$ Proto-Dravidian *n\=\i n
+--- native, unrelated to the European ``you'' words (which come from *t\=u).
+\ta{நீங்கள்} (\emph{n\=\i\d{n}gaḷ}) is \emph{n\=\i} $+$ the plural ending
+\emph{-kaḷ}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Respect by the plural --- again.} Tamil grades ``you'' in two:
+\emph{n\=\i} (familiar --- friends, children) and \emph{n\=\i\d{n}gaḷ}
+(respectful --- and literally the \emph{plural}, ``you-all''). This is the
+\emph{same} politeness-by-plural you would find in French \emph{vous} --- address
+one respected person as ``you all.'' For a first meeting, always
+\emph{n\=\i\d{n}gaḷ}.
+\end{grammarlens}
+
+\section{\ta{என்ன} \emph{(eṉṉa)} --- ``what''}
+\label{lesson:enna}
+
+\begin{sounds}
+\ta{எ} (\emph{e}) $+$ \ta{ன்} (bare \emph{ṉ}) $+$ \ta{ன} (\emph{ṉa}) $\to$
+\emph{eṉṉa} --- a doubled, held \emph{ṉṉ}.
+\end{sounds}
+
+\begin{cousinweb}
+\ta{என்ன} (\emph{eṉṉa}, ``what'') is native Dravidian, on the interrogative stem
+*y\=a- / *e- that heads Tamil's whole question family: \emph{eṉṉa} (what),
+\emph{y\=ar} (who), \emph{eppo} (when), \emph{enge} (where), \emph{\=en} (why).
+Like Hindi's \emph{k-} words and English's \emph{wh-} words --- but from a
+\emph{different} root, the Dravidian one.
+\end{cousinweb}
+
+\section{\ta{உங்கள் பெயர் என்ன?} \emph{(uṅgaḷ peyar eṉṉa)} --- ``what's your name?''}
+\label{lesson:ungal-peyar-enna}
+
+\ta{உங்கள்} (\emph{uṅgaḷ}, ``your'') is the possessive of \emph{n\=\i\d{n}gaḷ}
+(``you,'' respectful). So \ta{உங்கள் பெயர் என்ன?} is literally ``\textbf{your
+name what?}'' --- and again \emph{no ``is''}: the zero copula holds for questions
+too. Just three words, no verb.
+
+\begin{grammarlens}
+Answer with the sentence you built: \emph{Eṉ peyar David.} The familiar version
+swaps \emph{uṅgaḷ} for \emph{uṉ} (``your,'' from \emph{n\=\i}): \emph{uṉ peyar
+eṉṉa?}
+\end{grammarlens}
+
+\section{\ta{மகிழ்ச்சி} \emph{(magiḻcci)} --- ``joy,'' and ``pleased to meet you''}
+\label{lesson:magizhcci}
+
+\begin{cousinweb}
+The warm close is \ta{உங்களை சந்தித்ததில் மகிழ்ச்சி} (\emph{uṅgaḷai
+sandittatil magiḻcci}) --- ``\textbf{in having met you, joy}.'' The key word
+\ta{மகிழ்ச்சி} (\emph{magiḻcci}, ``joy, gladness'') is native Dravidian, from
+\emph{magiḻ} (``to rejoice''). It carries the \ta{ழ} (\emph{ḻ}) --- a sound
+almost unique to Tamil, a retroflex glide with no English equivalent. (In
+casual speech Tamils often just smile, or say the English ``nice to meet you.'')
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Tamil & & English \\
+\midrule
+\ta{என் பெயர் சுசன்.} & \emph{eṉ peyar Susan} & My name is Susan. \\
+\ta{உங்கள் பெயர் என்ன?} & \emph{uṅgaḷ peyar eṉṉa} & What's your name? \\
+\ta{என் பெயர் டேவிட்.} & \emph{eṉ peyar David} & My name is David. \\
+\ta{மகிழ்ச்சி.} & \emph{magiḻcci} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom native and traced: \emph{peyar} (Dravidian *peyar, \emph{not}
+\emph{name}), \emph{eṉ} (from \emph{n\=aṉ}, ``I''), \emph{eṉṉa} (Dravidian
+question-stem). And the Tamil habit to keep: the \textbf{zero copula} --- an
+equational sentence needs no ``is'' at all. Next chapter: \emph{eppaḍi
+irukk\=\i\d{n}gaḷ?} (``how are you?'') and answering with \emph{nall\=a}
+--- the responding cycle.

--- a/code/learning/human-languages/tamil/book/preamble.tex
+++ b/code/learning/human-languages/tamil/book/preamble.tex
@@ -14,6 +14,8 @@
 \usepackage{newunicodechar}
 \newunicodechar{ṉ}{\b{n}}
 \newunicodechar{ṟ}{\b{r}}
+\newunicodechar{ḻ}{\b{l}}
+\newunicodechar{ṁ}{\.{m}}
 
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}

--- a/code/learning/human-languages/tamil/lessons/TA-C02-en-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-en-peyar.md
@@ -1,0 +1,47 @@
+---
+id: TA-C02-en-peyar
+chapter: 2
+type: phrase
+headword: என் பெயர் …
+gloss: my name is… (with no "is")
+concept_tag: MY-NAME-IS
+prerequisites: [TA-C02-en, TA-C02-peyar]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [TA-C02-en, TA-C02-peyar]
+---
+
+# என் பெயர் … (eṉ peyar …) — "my name is…," with no "is"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the two atoms — *eṉ* and *peyar* — and notice a whole word
+English needs that Tamil doesn't.
+
+## The phrase, assembled
+
+- [eṉ](TA-C02-en.md) (my) + [peyar](TA-C02-peyar.md) (name) + your name.
+
+> **என் பெயர் …** = "my name …" → **"my name is…"**
+
+*Eṉ peyar David.* → "My name is David."
+
+## Grammar Lens: Tamil has no word for "is" here
+
+Look at what's missing: there is **no verb**. Tamil sets "my name" beside
+"David" — *eṉ peyar David* — and the "is" is simply understood. This is the
+**zero copula**: for equational sentences (X is Y), Dravidian needs no "to be"
+at all — where English needs *is*, Hindi needs *hai*, Arabic (you'll see) also
+drops it. Tamil says only "my name David."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "eṉ peyar …" with your name]
+- [YOU SAY: notice — no word for "is"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in Tamil. (*Eṉ peyar ….*) What does Tamil leave out
+that English requires? (The verb "is" — the zero copula.)

--- a/code/learning/human-languages/tamil/lessons/TA-C02-en-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-en-peyar.md
@@ -25,15 +25,15 @@ English needs that Tamil doesn't.
 
 > **என் பெயர் …** = "my name …" → **"my name is…"**
 
-*Eṉ peyar David.* → "My name is David."
+*Eṉ peyar Arun.* → "My name is Arun."
 
 ## Grammar Lens: Tamil has no word for "is" here
 
 Look at what's missing: there is **no verb**. Tamil sets "my name" beside
-"David" — *eṉ peyar David* — and the "is" is simply understood. This is the
+"Arun" — *eṉ peyar Arun* — and the "is" is simply understood. This is the
 **zero copula**: for equational sentences (X is Y), Dravidian needs no "to be"
 at all — where English needs *is*, Hindi needs *hai*, Arabic (you'll see) also
-drops it. Tamil says only "my name David."
+drops it. Tamil says only "my name Arun."
 
 ## Guided Practice
 

--- a/code/learning/human-languages/tamil/lessons/TA-C02-en.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-en.md
@@ -1,0 +1,43 @@
+---
+id: TA-C02-en
+chapter: 2
+type: word
+headword: என்
+gloss: my
+concept_tag: MY
+prerequisites: [TA-C02-peyar]
+sounds: [independent-e, pulli]
+roots: [naan-dravidian]
+est_minutes: 3
+reviews_of: [TA-C02-peyar]
+---
+
+# என் (eṉ) — "my"
+
+## Warm-up
+
+[PAUSE 2s] "My" — and, like *peyar*, a word with no European cousin at all.
+
+## The letters in this word
+
+*(Skim if you read Tamil.)* **எ** (independent vowel *e*, word-initial) + **ன்**
+(bare alveolar *ṉ*, puḷḷi) → **eṉ**.
+
+## The word, taken apart
+
+**என்** (*eṉ*, "my") is the possessive of **நான்** (*nāṉ*, "I") — native
+Dravidian, from the pronoun stem **\*yān / \*nān**. It has *no* Indo-European
+cousin: the Tamil "I/my" is built on a different root from English *I/my* (which
+go back to *\*eǵ* and *\*me-*). Two families, two entirely separate words for
+the self.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "eṉ"]
+- [YOU SAY: its source — *nāṉ* ("I") → *eṉ* ("my")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What word is **என்** the possessive of, and does it share a root with
+English *my*? (*nāṉ*, "I"; no — different family entirely.)

--- a/code/learning/human-languages/tamil/lessons/TA-C02-enna.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-enna.md
@@ -1,0 +1,42 @@
+---
+id: TA-C02-enna
+chapter: 2
+type: word
+headword: என்ன
+gloss: what
+concept_tag: WHAT
+prerequisites: [TA-C02-nii-niingal]
+sounds: [independent-e, doubled-nn]
+roots: [yaa-dravidian]
+est_minutes: 3
+reviews_of: [TA-C02-nii-niingal, TA-C02-en-peyar]
+---
+
+# என்ன (eṉṉa) — "what"
+
+## Warm-up
+
+[PAUSE 2s] The last piece of the question: "what."
+
+## The letters in this word
+
+*(Skim if you read Tamil.)* **எ** (*e*) + **ன்** (bare *ṉ*) + **ன** (*ṉa*) →
+**eṉṉa** — a doubled, held *ṉṉ*.
+
+## The word, taken apart
+
+**என்ன** (*eṉṉa*, "what") is native Dravidian, on the interrogative stem
+**\*yā- / \*e-** that heads Tamil's whole question family: *eṉṉa* (what), *yār*
+(who), *eppo* (when), *enge* (where), *ēṉ* (why). Like Hindi's *k-* words and
+English's *wh-* words — but from a *different*, Dravidian root.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "eṉṉa"]
+- [YOU SAY: the Tamil question family — eṉṉa, yār, enge]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What stem heads Tamil's question-words, and is it the same as
+English's *wh-*? (*\*yā-/\*e-*; same *idea*, different — Dravidian — root.)

--- a/code/learning/human-languages/tamil/lessons/TA-C02-magizhcci.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-magizhcci.md
@@ -1,0 +1,44 @@
+---
+id: TA-C02-magizhcci
+chapter: 2
+type: phrase
+headword: மகிழ்ச்சி
+gloss: joy / pleased to meet you
+concept_tag: PLEASED-TO-MEET
+prerequisites: [TA-C02-en-peyar]
+sounds: [zha-retroflex-glide]
+roots: [magizh-dravidian]
+est_minutes: 3
+reviews_of: [TA-C02-en-peyar, TA-C02-ungal-peyar-enna]
+---
+
+# மகிழ்ச்சி (magiḻcci) — "joy," and "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The warm close — and a sound almost unique to Tamil.
+
+## The phrase
+
+The full form is **உங்களை சந்தித்ததில் மகிழ்ச்சி** (*uṅgaḷai sandittatil
+magiḻcci*) — "**in having met you, joy**."
+
+## The word, taken apart
+
+**மகிழ்ச்சி** (*magiḻcci*, "joy, gladness") is native Dravidian, from **magiḻ**
+("to rejoice"). It carries the letter **ழ** (*ḻ*) — a retroflex glide almost
+unique to Tamil, with no English equivalent (the same sound in the name *Tamiḻ*
+itself). In casual speech, a smile or the English "nice to meet you" also does
+the job.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "magiḻcci" — feel the ழ (*ḻ*) glide]
+- [YOU SAY: the fuller form — "uṅgaḷai sandittatil magiḻcci"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **மகிழ்ச்சி** mean and from what verb? ("Joy," from
+*magiḻ*, "to rejoice.") What rare Tamil sound does it contain? (**ழ**, *ḻ* —
+also in *Tamiḻ*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C02-nii-niingal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-nii-niingal.md
@@ -1,0 +1,49 @@
+---
+id: TA-C02-nii-niingal
+chapter: 2
+type: word
+headword: நீ / நீங்கள்
+gloss: you (familiar / respectful)
+concept_tag: PRONOUN-YOU
+prerequisites: [TA-C02-peyar]
+sounds: [long-ii, ngal]
+roots: [nii-dravidian]
+est_minutes: 3
+reviews_of: [TA-C02-en-peyar]
+---
+
+# நீ / நீங்கள் (nī / nīṅgaḷ) — "you," familiar and respectful
+
+## Warm-up
+
+[PAUSE 2s] To ask a name you need "you" — and Tamil makes respect the same way
+French does.
+
+## The letters in this word
+
+*(Skim if you read Tamil.)* **நீ**: **ந** (dental *na*) + **ீ** (the long-*ī*
+sign) → *nī*. **நீங்கள்** adds **ங்கள்** (*ṅgaḷ*).
+
+## The word, taken apart
+
+**நீ** (*nī*, familiar "you") ← Proto-Dravidian **\*nīn** — native, unrelated to
+the European "you" words (from *\*tū*). **நீங்கள்** (*nīṅgaḷ*) is *nī* + the
+plural ending **-kaḷ**.
+
+## Grammar Lens: respect by the plural — again
+
+Tamil grades "you" in two: **nī** (familiar — friends, children) and **nīṅgaḷ**
+(respectful — and literally the **plural**, "you-all"). This is the *same*
+politeness-by-plural as French *vous*: address one respected person as "you
+all." For a first meeting, always **nīṅgaḷ**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nī" (familiar), "nīṅgaḷ" (respectful)]
+- [YOU SAY: nīṅgaḷ = nī + plural -kaḷ]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Tamil make "you" respectful, and which European language
+uses the same trick? (By the plural — *nīṅgaḷ*; French *vous*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C02-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-peyar.md
@@ -1,0 +1,49 @@
+---
+id: TA-C02-peyar
+chapter: 2
+type: word
+headword: பெயர்
+gloss: name
+concept_tag: NAME
+prerequisites: []
+sounds: [e-sign, pulli]
+roots: [peyar-dravidian]
+est_minutes: 4
+reviews_of: [TA-C01-vanakkam]
+---
+
+# பெயர் (peyar) — "name," where the family is *not* Indo-European
+
+## Warm-up
+
+[PAUSE 2s] "Name" — and a word that shows Tamil at its most itself.
+
+## The letters in this word
+
+*(Skim if you read Tamil.)* **ப** (pa) + **ெ** (the *e*-sign, written before,
+read after) → **பெ** (pe); **ய** (ya); **ர்** (bare *r*, with the puḷḷi). Read
+**பெ·ய·ர்** → **peyar**.
+
+## The word, taken apart
+
+**பெயர்** (*peyar*, "name") is **native Dravidian**, from Proto-Dravidian
+**\*peyar / \*pēr** — and it is *not* related to Sanskrit *nāma* (Hindi *nām*,
+English *name*). Here the two great families part: Indo-European shares one word
+for "name" from Ireland to North India, but the Dravidian south kept its own.
+
+Across the family: Tamil *peyar*, Malayalam *pēr*, Telugu *pēru* — the same
+Dravidian root; Kannada *hesaru* (also Dravidian, with *p* → *h*); only Hindi
+*nām* and English *name* are the Indo-European word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "peyar"]
+- [YOU SAY: the Dravidian cousins — *peyar* / *pēr* / *pēru*]
+- [YOU SAY: what it is *not* — not *nām*, not *name*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **பெயர்** related to English *name*? (No — it's native Dravidian,
+*\*peyar*; *name/nām* are Indo-European.) Which languages share *peyar/pēru*?
+(Tamil, Malayalam, Telugu — and Kannada's *hesaru*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C02-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-practice.md
@@ -22,9 +22,9 @@ reviews_of: [TA-C02-peyar, TA-C02-en, TA-C02-en-peyar, TA-C02-nii-niingal, TA-C0
 
 | Tamil | English |
 |---|---|
-| என் பெயர் சுசன். (*eṉ peyar Susan*) | My name is Susan. |
+| என் பெயர் மீரா. (*eṉ peyar Mira*) | My name is Mira. |
 | உங்கள் பெயர் என்ன? (*uṅgaḷ peyar eṉṉa*) | What's your name? |
-| என் பெயர் டேவிட். (*eṉ peyar David*) | My name is David. |
+| என் பெயர் அருண். (*eṉ peyar Arun*) | My name is Arun. |
 | மகிழ்ச்சி. (*magiḻcci*) | Pleased to meet you. |
 
 Every atom native and traced:
@@ -36,7 +36,7 @@ Every atom native and traced:
 
 And the Tamil habit to keep: the **zero copula** — an equational sentence ("X is
 Y") needs *no* word for "is" at all. Where Hindi added *hai* and English needs
-*is*, Tamil says only "my name David."
+*is*, Tamil says only "my name Arun."
 
 ## Guided Practice
 

--- a/code/learning/human-languages/tamil/lessons/TA-C02-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-practice.md
@@ -1,0 +1,55 @@
+---
+id: TA-C02-practice
+chapter: 2
+type: practice
+headword: (dialogue)
+gloss: Chapter 2 recap — the introduction exchange
+concept_tag: REVIEW
+prerequisites: [TA-C02-en-peyar, TA-C02-ungal-peyar-enna, TA-C02-magizhcci]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [TA-C02-peyar, TA-C02-en, TA-C02-en-peyar, TA-C02-nii-niingal, TA-C02-enna, TA-C02-ungal-peyar-enna, TA-C02-magizhcci]
+---
+
+# Chapter 2 — the introduction, whole
+
+## Warm-up
+
+[PAUSE 2s] Every atom built, and every one of them native Dravidian.
+
+## The dialogue
+
+| Tamil | English |
+|---|---|
+| என் பெயர் சுசன். (*eṉ peyar Susan*) | My name is Susan. |
+| உங்கள் பெயர் என்ன? (*uṅgaḷ peyar eṉṉa*) | What's your name? |
+| என் பெயர் டேவிட். (*eṉ peyar David*) | My name is David. |
+| மகிழ்ச்சி. (*magiḻcci*) | Pleased to meet you. |
+
+Every atom native and traced:
+
+- **peyar** ← Dravidian *\*peyar* (*not* English *name*)
+- **eṉ** ← *nāṉ* ("I")
+- **eṉṉa** ← Dravidian question-stem *\*yā-/\*e-*
+- **magiḻcci** ← *magiḻ* ("to rejoice")
+
+And the Tamil habit to keep: the **zero copula** — an equational sentence ("X is
+Y") needs *no* word for "is" at all. Where Hindi added *hai* and English needs
+*is*, Tamil says only "my name David."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the whole exchange, both voices]
+- [YOU SAY: your own introduction — "eṉ peyar …"]
+- [YOU SAY: ask it back — "uṅgaḷ peyar eṉṉa?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name, ask someone else's, say you're pleased. (*Eṉ peyar
+…. / Uṅgaḷ peyar eṉṉa? / Magiḻcci.*) What does Tamil leave out that English and
+Hindi require? (The verb "is" — zero copula.)
+
+Next chapter: *eppaḍi irukkīṅgaḷ?* ("how are you?") and answering with *nallā* —
+the responding cycle.

--- a/code/learning/human-languages/tamil/lessons/TA-C02-ungal-peyar-enna.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-ungal-peyar-enna.md
@@ -1,0 +1,45 @@
+---
+id: TA-C02-ungal-peyar-enna
+chapter: 2
+type: phrase
+headword: உங்கள் பெயர் என்ன?
+gloss: what's your name?
+concept_tag: WHATS-YOUR-NAME
+prerequisites: [TA-C02-enna, TA-C02-nii-niingal, TA-C02-peyar]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [TA-C02-enna, TA-C02-nii-niingal, TA-C02-en-peyar]
+---
+
+# உங்கள் பெயர் என்ன? (uṅgaḷ peyar eṉṉa?) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the question — your + name + what — and note, again, no
+"is."
+
+## The phrase, assembled
+
+- **உங்கள்** (*uṅgaḷ*, "your") = the possessive of *nīṅgaḷ* ("you," respectful).
+
+> **உங்கள் பெயர் என்ன?** = literally "**your name what?**" = "what's your name?"
+
+Three words, **no verb** — the zero copula holds for questions too. Tamil never
+adds an "is."
+
+## Grammar Lens: answer, and the familiar version
+
+Answer with the sentence you built: **Eṉ peyar David.** The familiar "your"
+swaps *uṅgaḷ* for **uṉ** (from *nī*): *uṉ peyar eṉṉa?*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "uṅgaḷ peyar eṉṉa?"]
+- [YOU SAY: ask, then answer — "uṅgaḷ peyar eṉṉa?" / "eṉ peyar …"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **உங்கள் பெயர் என்ன?** literally say, and what's missing
+versus English? ("Your name what?"; no "is" — zero copula.)

--- a/code/learning/human-languages/tamil/lessons/TA-C02-ungal-peyar-enna.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-ungal-peyar-enna.md
@@ -30,7 +30,7 @@ adds an "is."
 
 ## Grammar Lens: answer, and the familiar version
 
-Answer with the sentence you built: **Eṉ peyar David.** The familiar "your"
+Answer with the sentence you built: **Eṉ peyar Arun.** The familiar "your"
 swaps *uṅgaḷ* for **uṉ** (from *nī*): *uṉ peyar eṉṉa?*
 
 ## Guided Practice

--- a/code/learning/human-languages/tamil/roadmap.md
+++ b/code/learning/human-languages/tamil/roadmap.md
@@ -17,12 +17,15 @@ that needs it.
   Tamil script introduced through the words (inherent *a*, puḷḷi, vowel signs,
   independent vowels, the three-way *n*/*l*/*r* distinction), and the native
   vs. Sanskrit split shown through the greetings themselves.
+- **Ch. 2 — Introducing Yourself**: peyar → eṉ → **eṉ peyar** ("my name is,"
+  zero copula) → nī/nīṅgaḷ → eṉṉa → **uṅgaḷ peyar eṉṉa?** → magiḻcci → practice.
+  Every atom native Dravidian and traced (*peyar* ≠ *name*); the **zero copula**
+  (no word for "is"); respect-by-plural like French *vous*.
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *eṉ peyar…* ("my name"), *nī* / *nīṅgaḷ* (familiar / respectful "you"), the native/Sanskrit doublets (*arasaṉ* / *rāja*, "king") |
 | 3 | Responding: *eppaḍi irukkīṅgaḷ?* ("how are you"), *nallā irukkēṉ* ("I'm well"), the verb *iru* ("to be") |
 | 4 | The case-endings (Tamil's agglutinative suffixes), numbers 1–10 |
 | 5+ | Postpositions, tense on the verb, family, food — always with the Dravidian-cognate thread |

--- a/code/learning/human-languages/tamil/session-map.md
+++ b/code/learning/human-languages/tamil/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Tamil Chapter 1
+# Session Map — Tamil Chapters 1–2
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -21,7 +21,20 @@ puḷḷi, the common vowel signs, the independent vowels, and the three-way
 | 5 | sari | சரி | ச (one letter, many sounds) | voicing read from position |
 | 6 | practice | (recap) | read all five | the *pōy varugiṟēṉ* farewell |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 7 | peyar | பெயர் | "name" ← Dravidian *\*peyar* (**not** *name/nām*) |
+| 8 | en | என் | "my" ← *nāṉ* ("I"); no European cousin |
+| 9 | en-peyar | என் பெயர் … | **"my name is…"** — the **zero copula** (no "is") |
+| 10 | nii-niingal | நீ / நீங்கள் | **"you"** familiar/respectful; respect by plural (like French *vous*) |
+| 11 | enna | என்ன | "what" ← Dravidian question-stem *\*yā-/\*e-* |
+| 12 | ungal-peyar-enna | உங்கள் பெயர் என்ன? | **"what's your name?"** (still no "is") |
+| 13 | magizhcci | மகிழ்ச்சி | "pleased to meet you" ("joy"); the rare ழ (*ḻ*) |
+| 14 | practice | (dialogue) | the whole exchange |
+
 ## Next
 
-Chapter 2 — introducing yourself: *eṉ peyar…* ("my name"), *nī* / *nīṅgaḷ*
-(familiar / respectful "you"), and the first native/Sanskrit doublets.
+Chapter 3 — *eppaḍi irukkīṅgaḷ?* ("how are you?") and answering with *nallā* —
+the responding cycle.

--- a/code/learning/human-languages/telugu/CHANGELOG.md
+++ b/code/learning/human-languages/telugu/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Chapter 2 — Introducing Yourself
+
+- New chapter around the introduction dialogue (*nā pēru … / mī pēru ēmiṭi?*),
+  atom-first, Telugu inline (`lessons/TE-C02-*`,
+  `book/chapters/ch02-introductions.tex`). Every atom traced:
+  - **పేరు** pēru ("name") ← Proto-Dravidian *\*pēr* — twin of Tamil *peyar*,
+    **not** the Indo-European *name/nām* (even Sanskrit-heavy Telugu kept the
+    native word).
+  - **నా** nā ("my") ← *nēnu* ("I").
+  - **నా పేరు …** — **"my name is…"**; the **zero copula** (no "is").
+  - **నువ్వు / మీరు** nuvvu/mīru — "you," familiar/respectful; respect by plural.
+  - **ఏమిటి** ēmiṭi ("what") ← Dravidian question-stem *\*yā-/\*e-*.
+  - **మీ పేరు ఏమిటి?** — **"what's your name?"**
+  - **సంతోషం** santōṣam — "pleased to meet you," a **Sanskrit** loan (as in
+    Kannada; vs. Tamil's native *magiḻcci*).
+  - **practice** — the whole dialogue.
+- Example names are invented (Mira / Arun), not reused from any source text.
+  Book compiles clean with XeLaTeX.
+
 ## Chapter 1 — Greetings (Telugu script taught inline)
 
 - New Telugu track on the HL00 framework — the third of the four Dravidian

--- a/code/learning/human-languages/telugu/README.md
+++ b/code/learning/human-languages/telugu/README.md
@@ -31,8 +31,11 @@ book.
   dhanyavādamulu → avunu → lēdu → sarē → practice (with the *veḷḷi vastānu*
   farewell). Telugu script taught inline; Dravidian cognates traced. In the
   book.
-- **Chapter 2 — Introducing Yourself** (planned): *nā pēru…* ("my name"), and
-  *nuvvu* / *mīru* (familiar / respectful "you").
+- **Chapter 2 — Introducing Yourself** ([`lessons/TE-C02-*`](./lessons/)):
+  peru, naa, **nā pēru** ("my name is," zero copula), nuvvu/mīru, ēmiṭi,
+  **mī pēru ēmiṭi?** ("what's your name?"), santōṣam, practice. Every atom
+  traced (*pēru* ← *\*pēr*, twin of Tamil *peyar*; *santōṣam* Sanskrit). In the
+  book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/telugu/book/book.tex
+++ b/code/learning/human-languages/telugu/book/book.tex
@@ -68,4 +68,6 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
 \end{document}

--- a/code/learning/human-languages/telugu/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch02-introductions.tex
@@ -1,0 +1,156 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you're glad to meet them:
+
+\begin{center}
+\te{నా పేరు అరుణ్.} \quad(\emph{n\=a p\=eru Arun} --- ``My name is Arun.'')\\
+\te{మీ పేరు ఏమిటి?} \quad(\emph{m\=\i\ p\=eru \=emiṭi} --- ``What is your name?'')
+\end{center}
+
+Built the same way as the greetings --- each piece taken apart, its letters and
+its root, then assembled. \emph{Practice lessons: \texttt{lessons/TE-C02-*.md}.}
+
+\section{\te{పేరు} \emph{(p\=eru)} --- ``name,'' the native Dravidian word}
+\label{lesson:peru}
+
+\begin{sounds}
+\te{ప} (\emph{pa}) $+$ \te{ే} (the \emph{\=e}-sign) $\to$ \te{పే} (p\=e); \te{రు}
+(\emph{ru}). Read \te{పే·రు} $\to$ \emph{p\=eru}.
+\end{sounds}
+
+\begin{cousinweb}
+\te{పేరు} (\emph{p\=eru}, ``name'') is \textbf{native Dravidian}, from
+Proto-Dravidian *p\=er --- the \emph{same} word as Tamil \emph{peyar} and
+Malayalam \emph{p\=er}, and a cousin of Kannada \emph{hesaru} (which softened the
+old \emph{p} to \emph{h}). It is \emph{not} the Sanskrit \emph{n\=ama} (Hindi
+\emph{n\=am}, English \emph{name}). Even in Telugu --- the most Sanskritised of
+the Dravidian tongues --- the everyday word for ``name'' stayed home-grown.
+\end{cousinweb}
+
+\begin{cognates}
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Language & ``Name'' & Source \\
+\midrule
+\textbf{Telugu} & \te{పేరు} \emph{p\=eru} & \textbf{native Dravidian} (*p\=er) \\
+Tamil & \emph{peyar} & the \emph{same} Dravidian root \\
+Malayalam & \emph{p\=er} & the \emph{same} Dravidian root \\
+Kannada & \emph{hesaru} & Dravidian (*pesar, p$\to$h) \\
+Hindi & \emph{n\=am} & Sanskrit (Indo-European) \\
+English & \emph{name} & Indo-European \\
+\bottomrule
+\end{tabular}
+\end{center}
+\end{cognates}
+
+\section{\te{నా} \emph{(n\=a)} --- ``my''}
+\label{lesson:naa}
+
+\begin{sounds}
+\te{న} (\emph{na}) $+$ \te{ా} (long \=a) $\to$ \te{నా} (\emph{n\=a}).
+\end{sounds}
+
+\begin{cousinweb}
+\te{నా} (\emph{n\=a}, ``my'') is the possessive of \te{నేను} (\emph{n\=enu},
+``I'') --- native Dravidian, on the pronoun stem *n\=an/*y\=an behind Tamil
+\emph{n\=aṉ} and Kannada \emph{n\=anu}. No Indo-European cousin: the Dravidian
+``I/my'' is a wholly different word from the European \emph{I/my}.
+\end{cousinweb}
+
+\section{\te{నా పేరు \ldots} \emph{(n\=a p\=eru \ldots)} --- ``my name is\ldots''}
+\label{lesson:naa-peru}
+
+\te{నా} (my) $+$ \te{పేరు} (name) $+$ name $=$ \textbf{n\=a p\=eru \ldots}
+\emph{N\=a p\=eru Arun.} $=$ ``My name is Arun.''
+
+\begin{grammarlens}
+\textbf{No word for ``is.''} As in Tamil and Kannada, there is \emph{no} verb:
+Telugu sets ``my name'' beside ``Arun'' and lets the ``is'' be understood --- the
+\textbf{zero copula} of the Dravidian family. \emph{N\=a p\=eru Arun} $=$
+literally ``my name Arun.''
+\end{grammarlens}
+
+\section{\te{నువ్వు} / \te{మీరు} \emph{(nuvvu / m\=\i ru)} --- ``you,'' familiar and respectful}
+\label{lesson:nuvvu-miiru}
+
+\begin{sounds}
+\te{నువ్వు} (\emph{nuvvu}); \te{మీరు} (\emph{m\=\i ru}, \te{మీ} m\=\i\ $+$ \te{రు}
+ru).
+\end{sounds}
+
+\begin{cousinweb}
+\te{నువ్వు} (\emph{nuvvu}, familiar ``you'') traces to Proto-Dravidian *n\=\i n
+--- the same native root as Tamil \emph{n\=\i} and Kannada \emph{n\=\i nu}.
+\te{మీరు} (\emph{m\=\i ru}) is the respectful/plural ``you.''
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Respect by the plural, again.} \emph{nuvvu} (familiar) vs.\ \emph{m\=\i
+ru} (respectful, and literally plural) --- the same politeness-by-plural as Tamil
+\emph{n\=\i\d{n}gaḷ}, Kannada \emph{n\=\i vu}, and French \emph{vous}. For a first
+meeting, \emph{m\=\i ru}.
+\end{grammarlens}
+
+\section{\te{ఏమిటి} \emph{(\=emiṭi)} --- ``what''}
+\label{lesson:emiti}
+
+\begin{sounds}
+\te{ఏ} (independent long \=e) $+$ \te{మి} (\emph{mi}) $+$ \te{టి} (\emph{ṭi},
+retroflex) $\to$ \emph{\=emiṭi}.
+\end{sounds}
+
+\begin{cousinweb}
+\te{ఏమిటి} (\emph{\=emiṭi}, ``what'') is native Dravidian, on the interrogative
+stem *y\=a-/*e- --- the same Dravidian question-root as Tamil \emph{eṉṉa} and
+Kannada \emph{\=enu}, heading Telugu's question family: \emph{\=emiṭi} (what),
+\emph{evaru} (who), \emph{ekkaḍa} (where), \emph{enduku} (why).
+\end{cousinweb}
+
+\section{\te{మీ పేరు ఏమిటి?} \emph{(m\=\i\ p\=eru \=emiṭi)} --- ``what's your name?''}
+\label{lesson:mii-peru-emiti}
+
+\te{మీ} (\emph{m\=\i}, ``your'') is the possessive of \emph{m\=\i ru} (``you,''
+respectful). So \te{మీ పేరు ఏమిటి?} is literally ``\textbf{your name what?}'' ---
+and again \emph{no ``is.''} Three words, no verb.
+
+\begin{grammarlens}
+Answer with the sentence you built: \emph{N\=a p\=eru Arun.} The familiar
+``your'' is \emph{n\=\i} (from \emph{nuvvu}): \emph{n\=\i\ p\=eru \=emiṭi?}
+\end{grammarlens}
+
+\section{\te{సంతోషం} \emph{(sant\=oṣam)} --- ``joy,'' and ``pleased to meet you''}
+\label{lesson:santosham}
+
+\begin{cousinweb}
+The warm close is \te{మిమ్మల్ని కలిసినందుకు సంతోషం} (\emph{mimmalni kalisinanduku
+sant\=oṣam}) --- ``\textbf{joy at having met you}.'' The key word \te{సంతోషం}
+(\emph{sant\=oṣam}, ``joy, gladness'') is \textbf{Sanskrit} (\emph{sam-} $+$
+\emph{toṣa}, ``full satisfaction''), the \emph{same} loan Kannada uses --- both
+reach for Sanskrit where Tamil keeps its native \emph{magiḻcci}. Telugu, the
+most Sanskritised of the four, does so most readily of all.
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Telugu & & English \\
+\midrule
+\te{నా పేరు మీరా.} & \emph{n\=a p\=eru Mira} & My name is Mira. \\
+\te{మీ పేరు ఏమిటి?} & \emph{m\=\i\ p\=eru \=emiṭi} & What's your name? \\
+\te{నా పేరు అరుణ్.} & \emph{n\=a p\=eru Arun} & My name is Arun. \\
+\te{సంతోషం.} & \emph{sant\=oṣam} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{p\=eru} (Dravidian *p\=er, \emph{not} \emph{name}),
+\emph{n\=a} (from \emph{n\=enu}, ``I''), \emph{\=emiṭi} (Dravidian question-stem)
+--- and \emph{sant\=oṣam}, a Sanskrit loan for ``pleased.'' The Telugu habit: the
+\textbf{zero copula} (no ``is''). Next chapter: \emph{el\=a unn\=aru?} (``how are
+you?'') and answering with \emph{b\=agunn\=anu} --- the responding cycle.

--- a/code/learning/human-languages/telugu/book/preamble.tex
+++ b/code/learning/human-languages/telugu/book/preamble.tex
@@ -18,6 +18,7 @@
 \newunicodechar{ṉ}{\b{n}}
 \newunicodechar{ṟ}{\b{r}}
 \newunicodechar{ṁ}{\.{m}}
+\newunicodechar{ḻ}{\b{l}}
 
 \usepackage[table]{xcolor}
 \usepackage{tcolorbox}

--- a/code/learning/human-languages/telugu/lessons/TE-C02-emiti.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-emiti.md
@@ -1,0 +1,42 @@
+---
+id: TE-C02-emiti
+chapter: 2
+type: word
+headword: ఏమిటి
+gloss: what
+concept_tag: WHAT
+prerequisites: [TE-C02-nuvvu-miiru]
+sounds: [independent-ee, retroflex-ti]
+roots: [yaa-dravidian]
+est_minutes: 3
+reviews_of: [TE-C02-nuvvu-miiru, TE-C02-naa-peru]
+---
+
+# ఏమిటి (ēmiṭi) — "what"
+
+## Warm-up
+
+[PAUSE 2s] The last piece of the question: "what."
+
+## The letters in this word
+
+*(Skim if you read Telugu.)* **ఏ** (independent long *ē*) + **మి** (mi) + **టి**
+(*ṭi*, retroflex) → **ēmiṭi**.
+
+## The word, taken apart
+
+**ఏమిటి** (*ēmiṭi*, "what") is native Dravidian, on the interrogative stem
+**\*yā-/\*e-** — the same Dravidian question-root as Tamil *eṉṉa* and Kannada
+*ēnu*, heading Telugu's question family: *ēmiṭi* (what), *evaru* (who), *ekkaḍa*
+(where), *enduku* (why).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ēmiṭi"]
+- [YOU SAY: the question family — ēmiṭi, evaru, ekkaḍa]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Dravidian stem heads **ఏమిటి** and the other Telugu
+question-words? (*\*yā-/\*e-*, same as Tamil *eṉṉa*, Kannada *ēnu*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C02-mii-peru-emiti.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-mii-peru-emiti.md
@@ -1,0 +1,43 @@
+---
+id: TE-C02-mii-peru-emiti
+chapter: 2
+type: phrase
+headword: మీ పేరు ఏమిటి?
+gloss: what's your name?
+concept_tag: WHATS-YOUR-NAME
+prerequisites: [TE-C02-emiti, TE-C02-nuvvu-miiru, TE-C02-peru]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [TE-C02-emiti, TE-C02-nuvvu-miiru, TE-C02-naa-peru]
+---
+
+# మీ పేరు ఏమిటి? (mī pēru ēmiṭi?) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the question — your + name + what — still no "is."
+
+## The phrase, assembled
+
+- **మీ** (*mī*, "your") = the possessive of *mīru* ("you," respectful).
+
+> **మీ పేరు ఏమిటి?** = literally "**your name what?**" = "what's your name?"
+
+Three words, **no verb** — the zero copula holds for questions too.
+
+## Grammar Lens: answer, and the familiar version
+
+Answer with the sentence you built: **Nā pēru Arun.** The familiar "your" is
+*nī* (from *nuvvu*): *nī pēru ēmiṭi?*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mī pēru ēmiṭi?"]
+- [YOU SAY: ask, then answer — "mī pēru ēmiṭi?" / "nā pēru …"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **మీ పేరు ఏమిటి?** literally say, and what's missing vs.
+English? ("Your name what?"; no "is" — zero copula.)

--- a/code/learning/human-languages/telugu/lessons/TE-C02-naa-peru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-naa-peru.md
@@ -1,0 +1,45 @@
+---
+id: TE-C02-naa-peru
+chapter: 2
+type: phrase
+headword: నా పేరు …
+gloss: my name is… (with no "is")
+concept_tag: MY-NAME-IS
+prerequisites: [TE-C02-naa, TE-C02-peru]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [TE-C02-naa, TE-C02-peru]
+---
+
+# నా పేరు … (nā pēru …) — "my name is…," with no "is"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the two atoms — and note, as in Tamil and Kannada, no word
+for "is."
+
+## The phrase, assembled
+
+- [nā](TE-C02-naa.md) (my) + [pēru](TE-C02-peru.md) (name) + your name.
+
+> **నా పేరు …** = "my name …" → **"my name is…"**
+
+*Nā pēru Arun.* → "My name is Arun."
+
+## Grammar Lens: the zero copula
+
+There is **no verb**. Telugu sets "my name" beside "Arun" and lets the "is" be
+understood — the **zero copula** of the Dravidian family. *Nā pēru Arun* =
+literally "my name Arun."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nā pēru …" with your name]
+- [YOU SAY: notice — no word for "is"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in Telugu. (*Nā pēru ….*) What does Telugu leave out
+that English needs? (The verb "is" — zero copula.)

--- a/code/learning/human-languages/telugu/lessons/TE-C02-naa.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-naa.md
@@ -1,0 +1,41 @@
+---
+id: TE-C02-naa
+chapter: 2
+type: word
+headword: నా
+gloss: my
+concept_tag: MY
+prerequisites: [TE-C02-peru]
+sounds: [long-aa]
+roots: [neenu-dravidian]
+est_minutes: 3
+reviews_of: [TE-C02-peru]
+---
+
+# నా (nā) — "my"
+
+## Warm-up
+
+[PAUSE 2s] "My" — native Dravidian, no European cousin.
+
+## The letters in this word
+
+*(Skim if you read Telugu.)* **న** (na) + **ా** (long *ā*) → **నా** (*nā*).
+
+## The word, taken apart
+
+**నా** (*nā*, "my") is the possessive of **నేను** (*nēnu*, "I") — native
+Dravidian, on the pronoun stem **\*nān/\*yān** behind Tamil *nāṉ* and Kannada
+*nānu*. No Indo-European cousin: the Dravidian "I/my" is a wholly different word
+from the European *I/my*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nā"]
+- [YOU SAY: its source — *nēnu* ("I") → *nā* ("my")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What word is **నా** the possessive of, and which Tamil/Kannada
+pronouns share its root? (*nēnu*, "I"; Tamil *nāṉ*, Kannada *nānu*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C02-nuvvu-miiru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-nuvvu-miiru.md
@@ -1,0 +1,46 @@
+---
+id: TE-C02-nuvvu-miiru
+chapter: 2
+type: word
+headword: నువ్వు / మీరు
+gloss: you (familiar / respectful)
+concept_tag: PRONOUN-YOU
+prerequisites: [TE-C02-peru]
+sounds: [long-ii]
+roots: [niin-dravidian]
+est_minutes: 3
+reviews_of: [TE-C02-naa-peru]
+---
+
+# నువ్వు / మీరు (nuvvu / mīru) — "you," familiar and respectful
+
+## Warm-up
+
+[PAUSE 2s] "You" — respect made the same way as Tamil, Kannada, and French.
+
+## The letters in this word
+
+*(Skim if you read Telugu.)* **నువ్వు** (*nuvvu*); **మీరు** (*mīru*) = **మీ** (mī)
++ **రు** (ru).
+
+## The word, taken apart
+
+**నువ్వు** (*nuvvu*, familiar "you") traces to Proto-Dravidian **\*nīn** — the
+same native root as Tamil *nī* and Kannada *nīnu*. **మీరు** (*mīru*) is the
+respectful/plural "you."
+
+## Grammar Lens: respect by the plural
+
+*nuvvu* (familiar) vs. *mīru* (respectful, and literally plural) — the same
+politeness-by-plural as Tamil *nīṅgaḷ*, Kannada *nīvu*, and French *vous*. For a
+first meeting, **mīru**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nuvvu" (familiar), "mīru" (respectful)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Telugu make "you" respectful, and which languages share the
+trick? (By the plural — *mīru*; Tamil *nīṅgaḷ*, Kannada *nīvu*, French *vous*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C02-peru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-peru.md
@@ -1,0 +1,47 @@
+---
+id: TE-C02-peru
+chapter: 2
+type: word
+headword: పేరు
+gloss: name
+concept_tag: NAME
+prerequisites: []
+sounds: [ee-sign]
+roots: [peer-dravidian]
+est_minutes: 4
+reviews_of: [TE-C01-namaskaram]
+---
+
+# పేరు (pēru) — "name," the native Dravidian word
+
+## Warm-up
+
+[PAUSE 2s] "Name" — native Dravidian, even in Sanskrit-loving Telugu.
+
+## The letters in this word
+
+*(Skim if you read Telugu.)* **ప** (pa) + **ే** (the *ē*-sign) → **పే** (pē);
+**రు** (ru). Read **పే·రు** → **pēru**.
+
+## The word, taken apart
+
+**పేరు** (*pēru*, "name") is **native Dravidian**, from Proto-Dravidian **\*pēr**
+— the same word as Tamil *peyar* and Malayalam *pēr*, and a cousin of Kannada
+*hesaru* (which softened *p* → *h*). It is *not* Sanskrit *nāma* (Hindi *nām*,
+English *name*). Even Telugu — the most Sanskritised of the Dravidian tongues —
+kept its home-grown word for "name."
+
+Across the family: Telugu *pēru*, Tamil *peyar*, Malayalam *pēr*, Kannada
+*hesaru* — one Dravidian word; only Hindi *nām* / English *name* are
+Indo-European.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pēru"]
+- [YOU SAY: its Dravidian cousins — *pēru* / *peyar* / *pēr*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **పేరు** native or a Sanskrit loan, and what Tamil word is its
+twin? (Native Dravidian, *\*pēr*; Tamil *peyar*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C02-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-practice.md
@@ -1,0 +1,50 @@
+---
+id: TE-C02-practice
+chapter: 2
+type: practice
+headword: (dialogue)
+gloss: Chapter 2 recap — the introduction exchange
+concept_tag: REVIEW
+prerequisites: [TE-C02-naa-peru, TE-C02-mii-peru-emiti, TE-C02-santosham]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [TE-C02-peru, TE-C02-naa, TE-C02-naa-peru, TE-C02-nuvvu-miiru, TE-C02-emiti, TE-C02-mii-peru-emiti, TE-C02-santosham]
+---
+
+# Chapter 2 — the introduction, whole
+
+## The dialogue
+
+| Telugu | English |
+|---|---|
+| నా పేరు మీరా. (*nā pēru Mira*) | My name is Mira. |
+| మీ పేరు ఏమిటి? (*mī pēru ēmiṭi*) | What's your name? |
+| నా పేరు అరుణ్. (*nā pēru Arun*) | My name is Arun. |
+| సంతోషం. (*santōṣam*) | Pleased to meet you. |
+
+Every atom traced:
+
+- **pēru** ← Dravidian *\*pēr* (*not* *name*; twin of Tamil *peyar*)
+- **nā** ← *nēnu* ("I")
+- **ēmiṭi** ← Dravidian question-stem *\*yā-/\*e-*
+- **santōṣam** ← **Sanskrit** (Telugu borrows for "pleased"; Tamil keeps native
+  *magiḻcci*)
+
+The Telugu habit: the **zero copula** (no "is").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the whole exchange, both voices]
+- [YOU SAY: your own introduction — "nā pēru …"]
+- [YOU SAY: ask it back — "mī pēru ēmiṭi?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name, ask someone else's, say you're pleased. (*Nā pēru
+…. / Mī pēru ēmiṭi? / Santōṣam.*) Which word is Sanskrit, not native?
+(*santōṣam*.)
+
+Next chapter: *elā unnāru?* ("how are you?") and answering with *bāgunnānu* —
+the responding cycle.

--- a/code/learning/human-languages/telugu/lessons/TE-C02-santosham.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-santosham.md
@@ -1,0 +1,44 @@
+---
+id: TE-C02-santosham
+chapter: 2
+type: phrase
+headword: సంతోషం
+gloss: joy / pleased to meet you
+concept_tag: PLEASED-TO-MEET
+prerequisites: [TE-C02-naa-peru]
+sounds: [anusvara]
+roots: [santosha-sanskrit]
+est_minutes: 3
+reviews_of: [TE-C02-naa-peru, TE-C02-mii-peru-emiti]
+---
+
+# సంతోషం (santōṣam) — "joy," and "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The warm close — and, as in Kannada, a Sanskrit word.
+
+## The phrase
+
+The full form is **మిమ్మల్ని కలిసినందుకు సంతోషం** (*mimmalni kalisinanduku
+santōṣam*) — "joy at having met you."
+
+## The word, taken apart
+
+**సంతోషం** (*santōṣam*, "joy, gladness") is **Sanskrit** — *sam-* ("fully") +
+*toṣa* ("satisfaction") — the *same* loan Kannada uses (*santōṣa*). Both reach
+for Sanskrit where Tamil keeps its native *magiḻcci*. Telugu — the most
+Sanskritised of the four Dravidian tongues — does so most readily of all.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "santōṣam"]
+- [YOU SAY: the split — Telugu/Kannada *santōṣa(m)* (Sanskrit) vs. Tamil
+  *magiḻcci* (native)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is **సంతోషం** native or borrowed, and what does the contrast with
+Tamil show? (Sanskrit; Telugu borrows Sanskrit — here for "pleased" — where
+Tamil keeps native *magiḻcci*.)

--- a/code/learning/human-languages/telugu/roadmap.md
+++ b/code/learning/human-languages/telugu/roadmap.md
@@ -17,12 +17,15 @@ piece by piece, on the first word that needs it.
   practice. Telugu script introduced through the words (inherent *a*, vowel
   signs, virama + below-stacking conjuncts, anusvāra, independent vowels), the
   Sanskrit-loan vs. native split, and the first taste of agglutination.
+- **Ch. 2 — Introducing Yourself**: pēru → nā → **nā pēru** ("my name is," zero
+  copula) → nuvvu/mīru → ēmiṭi → **mī pēru ēmiṭi?** → santōṣam → practice.
+  Every atom traced (*pēru* ← *\*pēr*, twin of Tamil *peyar*; *santōṣam* a
+  Sanskrit loan for "pleased"); the zero copula; respect-by-plural.
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *nā pēru…* ("my name"), *nuvvu* / *mīru* (familiar / respectful "you"), native/Sanskrit doublets |
 | 3 | Responding: *elā unnāru?* ("how are you"), *bāgunnānu* ("I'm well"), the verb *uṇḍu* ("to be") |
 | 4 | The case-endings (Telugu's agglutinative suffixes), numbers 1–10 |
 | 5+ | Postpositions, tense on the verb, family, food — always with the Dravidian-cognate thread |

--- a/code/learning/human-languages/telugu/session-map.md
+++ b/code/learning/human-languages/telugu/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Telugu Chapter 1
+# Session Map — Telugu Chapters 1–2
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -21,7 +21,19 @@ the independent vowels — all in the service of real greetings.
 | 5 | sare | సరే | స, రే (ē-sign) | native; the family word *sari* in Telugu dress |
 | 6 | practice | (recap) | read all five | the *veḷḷi vastānu* farewell |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 7 | peru | పేరు | "name" ← Dravidian *\*pēr* (twin of Tamil *peyar*, not *name*) |
+| 8 | naa | నా | "my" ← *nēnu* ("I") |
+| 9 | naa-peru | నా పేరు … | **"my name is…"** — the **zero copula** (no "is") |
+| 10 | nuvvu-miiru | నువ్వు / మీరు | **"you"** familiar/respectful; respect by plural |
+| 11 | emiti | ఏమిటి | "what" ← Dravidian question-stem *\*yā-/\*e-* |
+| 12 | mii-peru-emiti | మీ పేరు ఏమిటి? | **"what's your name?"** (still no "is") |
+| 13 | santosham | సంతోషం | "pleased to meet you" — **Sanskrit** (vs. Tamil's native *magiḻcci*) |
+| 14 | practice | (dialogue) | the whole exchange |
+
 ## Next
 
-Chapter 2 — introducing yourself: *nā pēru…* ("my name"), *nuvvu* / *mīru*
-(familiar / respectful "you"), and the first native/Sanskrit doublets.
+Chapter 3 — *elā unnāru?* ("how are you?") — the responding cycle.


### PR DESCRIPTION
A single PR advancing **all six remaining languages** to **Chapter 2 — Introducing Yourself**, in one batch (as requested, since building these individually is slow). Same atom-first structure as the merged French/German Ch2, with the **every-atom-traced** rule applied throughout (each piece — the "my," the "name," the "is," the "you," the "what" — is its own lesson, rooted with cross-family cousins).

## The dialogue, in each language

*My name is Mira. / What's your name? / My name is Arun. / Pleased to meet you.*

| Track | "my name is" | "you" axis | Standout etymology |
|---|---|---|---|
| **Hindi** | *merā nām … hai* | register (āp/tum/tū) | *nām*←*nāman*→**name/noun**, *hai*←*asti*→**is** (PIE across the family) |
| **Tamil** | *eṉ peyar …* (zero copula) | plural = respect | *peyar*←*\*peyar* — the point where the family is **not** Indo-European |
| **Kannada** | *nanna hesaru …* (zero copula) | plural = respect | *hesaru*←*\*pesar* via the **p→h** shift (cousin of Tamil *peyar*) |
| **Telugu** | *nā pēru …* (zero copula) | plural = respect | *pēru* native even in Sanskrit-heavy Telugu; *santōṣam* (Sanskrit) for "pleased" |
| **Malayalam** | *enṟe pēru … āṇŭ* | plural = respect | the **copula *āṇŭ*** — Malayalam *has* a word for "is" where its sisters use none |
| **Arabic** | *ismī …* (zero copula) | **gender** (anta/anti) | *ism*←Semitic *s-m-w* (Hebrew *shem*); *-ī/-ka/-ki* glued suffixes |

Two lovely cross-cutting threads emerge: (1) the **zero copula** unites Tamil/Kannada/Telugu **and** Arabic — two unrelated families dropping "is" — while Hindi (*hai*) and Malayalam (*āṇŭ*) keep it; (2) three different **"you"** systems: register (Hindi), respect-by-plural (Dravidian, like French *vous*), and **gender** (Arabic).

## Notes
- **Example names are invented (Mira / Arun)** — not reused from any source textbook (copyright-safe).
- Non-Latin scripts taught **inline** per word (no reading course); every book compiles clean with XeLaTeX and its vendored Noto font. Reconstructed-root asterisks use a literal `*` (a prior `\*` rendered as ×; fixed here and noted for the French/German branches).
- Spanish already has this as its Chapter 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)