### PR TITLE
feat(os-platform): CCPP02 Phase 2 PR3 — fs primitive (metadata/read/write/list, C)

### DIFF
--- a/code/packages/c/os-platform/CHANGELOG.md
+++ b/code/packages/c/os-platform/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to semantic versioning.
 
 ### Added
 
+- **`fs` primitive** (CCPP02 Phase 2, PR 3): filesystem metadata, whole-file
+  read/write, and directory listing — bucket B (ISO `<stdio.h>` opens files by
+  name but cannot list a directory or report type/size/mtime).
+  - `osp_fs_stat` → `osp_file_info` (is_dir / is_regular / size / mtime_unix_ns)
+    and `osp_fs_exists`.
+  - `osp_fs_read_file` (whole file into a malloc'd, NUL-terminated, binary-safe
+    buffer; caller frees) and `osp_fs_write_file` (create/truncate).
+  - `osp_fs_list_dir` (callback per entry, skipping "." / "..").
+  - Backends: `fs_posix.c` (`stat`/`open`/`fstat`/`read`/`write`/`opendir`; libc
+    only, EINTR-safe and partial-read/write loops; fstat on the open fd to avoid
+    a TOCTOU size gap) and `fs_windows.c` (`GetFileAttributesEx` /
+    `CreateFile`+`ReadFile`/`WriteFile` chunked to DWORD / `FindFirstFile`;
+    FILETIME→UNIX-ns like the clock backend; kernel32 only).
+  - Size→allocation guarded against 32-bit `size_t` truncation and `len+1`
+    wraparound. Round-trip test (binary payload with an embedded NUL) verified
+    under ASan+UBSan with 0 leaks; files created under gitignored `_build/`.
 - **`thread` primitive** (CCPP02 Phase 2, PR 2): threads, mutexes, and condition
   variables — concurrency is bucket B (C11 `<threads.h>` is optional and
   MSVC-absent). Opaque heap handles keep OS types out of the shared header; each

--- a/code/packages/c/os-platform/README.md
+++ b/code/packages/c/os-platform/README.md
@@ -21,7 +21,7 @@ exactly one backend and the code contains no `#if defined(__linux__)` mazes.
 |----------|-------------------------|---------------|
 | `clock`  | `os_platform/clock.h`   | ✅ implemented |
 | `thread` | `os_platform/thread.h`  | ✅ implemented |
-| fs       | —                       | planned       |
+| `fs`     | `os_platform/fs.h`      | ✅ implemented |
 | process  | —                       | planned       |
 | dynlib   | —                       | planned       |
 | mmap     | —                       | planned       |
@@ -106,6 +106,39 @@ The POSIX backend links the OS thread library (`-pthread`); the Windows backend
 uses only the CRT + kernel32. Mutexes are non-recursive; a condition variable is
 always waited on while holding its paired mutex.
 
+### `fs` — metadata, whole-file I/O, directory listing
+
+ISO `<stdio.h>` opens a file by name but cannot list a directory or report a
+file's type, size, or modification time — that needs the OS.
+
+```c
+#include "os_platform/fs.h"
+
+osp_fs_write_file("out.bin", bytes, n);   /* create/truncate, binary-safe */
+
+unsigned char *data; size_t len;
+osp_fs_read_file("out.bin", &data, &len); /* malloc'd, NUL-terminated; you free */
+free(data);
+
+osp_file_info info;
+osp_fs_stat("out.bin", &info);            /* is_dir / is_regular / size / mtime */
+if (osp_fs_exists("out.bin")) { /* … */ }
+
+static void on_entry(const char *name, void *user) { /* … */ }
+osp_fs_list_dir(".", on_entry, NULL);     /* callback per entry, skips . and .. */
+```
+
+Backends:
+
+| OS          | metadata              | read / write               | list                        |
+|-------------|-----------------------|----------------------------|-----------------------------|
+| macOS/Linux | `stat`                | `open`/`read` · `write`    | `opendir`/`readdir`         |
+| Windows     | `GetFileAttributesEx` | `CreateFile`+`ReadFile`/`WriteFile` | `FindFirstFile`/`FindNextFile` |
+
+`osp_fs_read_file` is binary-safe (length-based; embedded NULs preserved) and the
+allocation is guarded against `size_t` overflow. `mtime_unix_ns` is
+second-resolution on POSIX (portable `st_mtime`).
+
 ## Build & test
 
 ```sh
@@ -125,11 +158,13 @@ os-platform/
 ├── include/os_platform/
 │   ├── status.h                  # shared osp_status enum (all primitives)
 │   ├── clock.h                   # clock API
-│   └── thread.h                  # thread API
+│   ├── thread.h                  # thread API
+│   └── fs.h                      # fs API
 ├── src/
 │   ├── clock_posix.c   · clock_windows.c    # per-OS clock backends
-│   └── thread_posix.c  · thread_windows.c   # per-OS thread backends
-├── tests/clock_test.c  · thread_test.c      # per-primitive tests, run on each OS
+│   ├── thread_posix.c  · thread_windows.c   # per-OS thread backends
+│   └── fs_posix.c      · fs_windows.c       # per-OS fs backends
+├── tests/clock_test.c · thread_test.c · fs_test.c   # per-primitive tests
 ├── tools/run.sh  · run.ps1       # per-OS build drivers
 ├── BUILD  · BUILD_windows        # per-OS source selection
 └── required_capabilities.json    # CI needs gcc, clang, cl

--- a/code/packages/c/os-platform/include/os_platform/fs.h
+++ b/code/packages/c/os-platform/include/os_platform/fs.h
@@ -1,0 +1,100 @@
+/*
+ * os_platform/fs.h — filesystem metadata, whole-file I/O, and directory listing.
+ * ===========================================================================
+ *
+ * The third os-platform primitive. Enumerating a directory and reading file
+ * metadata are bucket B: ISO C's <stdio.h> can open a file *by name* but cannot
+ * list a directory, tell a file from a directory, or report a size or
+ * modification time. Those need the OS — dirent + stat on POSIX, the FindFirstFile
+ * / GetFileAttributesEx family on Windows:
+ *
+ *      operation          macOS / Linux            Windows
+ *      ─────────────────  ───────────────────────  ────────────────────────────
+ *      metadata           stat()                   GetFileAttributesEx
+ *      whole-file read     open/fstat/read          CreateFile/ReadFile
+ *      whole-file write    open/write               CreateFile/WriteFile
+ *      list a directory    opendir/readdir          FindFirstFile/FindNextFile
+ *
+ * Whole-file read/write are included here (rather than left to <stdio.h>) so a
+ * caller gets one convenient, size-exact, binary-safe call per direction with
+ * uniform os_platform error handling — the shape the deferred Rust crates want.
+ *
+ * PATHS are NUL-terminated C strings in the OS's native encoding (UTF-8 on
+ * macOS/Linux; the ANSI code page on Windows — adequate for the ASCII paths the
+ * tests and downstream ports use). No path is ever constructed from untrusted
+ * concatenation inside this library.
+ *
+ * BUILD. Compiled by platform-harness. The POSIX backend needs _POSIX_C_SOURCE
+ * (from the BUILD) and links no extra library; the Windows backend uses only
+ * kernel32. Per-OS source selection is done by the BUILD file.
+ */
+#ifndef OS_PLATFORM_FS_H
+#define OS_PLATFORM_FS_H
+
+#include <stddef.h> /* size_t */
+#include <stdint.h> /* uint64_t, int64_t */
+
+#include "os_platform/status.h" /* osp_status */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Metadata about one filesystem entry. */
+typedef struct {
+    int is_dir;             /* 1 if a directory                              */
+    int is_regular;         /* 1 if a regular file (not a directory)         */
+    uint64_t size;          /* size in bytes (meaningful for regular files)  */
+    int64_t mtime_unix_ns;  /* last-modified time, ns since the UNIX epoch
+                             * (second-resolution on POSIX — see fs_posix.c)  */
+} osp_file_info;
+
+/*
+ * osp_fs_stat — fill *out with metadata for the entry at `path`.
+ * Returns OSP_ERR_INVAL if path or out is NULL, OSP_ERR_OS if the entry does not
+ * exist or cannot be queried.
+ */
+osp_status osp_fs_stat(const char *path, osp_file_info *out);
+
+/*
+ * osp_fs_exists — 1 if something exists at `path`, else 0 (also 0 if path is
+ * NULL). A convenience predicate over osp_fs_stat.
+ */
+int osp_fs_exists(const char *path);
+
+/*
+ * osp_fs_read_file — read the entire file into a freshly malloc'd buffer.
+ *
+ * On success *out_data points to `*out_len` bytes plus a trailing '\0' (so text
+ * files can be used as C strings; the terminator is NOT counted in *out_len).
+ * The read is binary-safe — embedded NULs are preserved. The caller must free()
+ * *out_data. Returns OSP_ERR_INVAL (NULL args), OSP_ERR_NOMEM (allocation or a
+ * file too large for size_t), OSP_ERR_OS (open/read failure or not a regular
+ * file).
+ */
+osp_status osp_fs_read_file(const char *path, unsigned char **out_data,
+                            size_t *out_len);
+
+/*
+ * osp_fs_write_file — write `len` bytes from `data` to `path`, creating the file
+ * or truncating an existing one. `data` may be NULL only if `len` is 0.
+ * Returns OSP_ERR_INVAL (NULL path, or NULL data with len > 0), OSP_ERR_OS.
+ */
+osp_status osp_fs_write_file(const char *path, const unsigned char *data,
+                             size_t len);
+
+/*
+ * osp_fs_list_dir — call `cb(name, user)` once per entry in directory `path`,
+ * skipping "." and "..". `name` is the bare entry name (not a full path) and is
+ * valid only for the duration of the callback. Enumeration order is unspecified.
+ * Returns OSP_ERR_INVAL (NULL path or cb), OSP_ERR_OS (not a directory / cannot
+ * open).
+ */
+typedef void (*osp_dir_cb)(const char *name, void *user);
+osp_status osp_fs_list_dir(const char *path, osp_dir_cb cb, void *user);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* OS_PLATFORM_FS_H */

--- a/code/packages/c/os-platform/src/fs_posix.c
+++ b/code/packages/c/os-platform/src/fs_posix.c
@@ -1,0 +1,159 @@
+/*
+ * fs_posix.c — the POSIX backend of os_platform/fs (macOS + Linux).
+ * ===========================================================================
+ *
+ * Compiled on macOS + Linux (named by the shared `BUILD`; Windows uses
+ * fs_windows.c via `BUILD_windows`). No OS #ifdefs — the build chose this file.
+ * Uses only libc (stat/open/read/write/opendir), so no extra library is linked;
+ * _POSIX_C_SOURCE (from the BUILD) exposes the declarations.
+ *
+ * The two subtleties worth calling out:
+ *   - mtime is reported in SECONDS scaled to nanoseconds. The sub-second field
+ *     spells differently across systems (st_mtim on Linux, st_mtimespec on
+ *     macOS), and this file must compile on both, so it uses the portable
+ *     st_mtime (whole seconds) rather than an #ifdef per OS.
+ *   - read()/write() can transfer fewer bytes than asked and can be interrupted
+ *     by a signal (EINTR); both are looped to completion.
+ */
+#include "os_platform/fs.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define OSP_NS_PER_SEC 1000000000LL
+
+osp_status osp_fs_stat(const char *path, osp_file_info *out) {
+    struct stat st;
+    if (path == NULL || out == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    if (stat(path, &st) != 0) {
+        return OSP_ERR_OS;
+    }
+    out->is_dir = S_ISDIR(st.st_mode) ? 1 : 0;
+    out->is_regular = S_ISREG(st.st_mode) ? 1 : 0;
+    out->size = (st.st_size > 0) ? (uint64_t)st.st_size : 0;
+    out->mtime_unix_ns = (int64_t)st.st_mtime * OSP_NS_PER_SEC;
+    return OSP_OK;
+}
+
+int osp_fs_exists(const char *path) {
+    struct stat st;
+    if (path == NULL) {
+        return 0;
+    }
+    return (stat(path, &st) == 0) ? 1 : 0;
+}
+
+osp_status osp_fs_read_file(const char *path, unsigned char **out_data,
+                            size_t *out_len) {
+    int fd;
+    struct stat st;
+    size_t len;
+    size_t off;
+    unsigned char *buf;
+
+    if (path == NULL || out_data == NULL || out_len == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return OSP_ERR_OS;
+    }
+    /* fstat the OPEN descriptor (not the path) so the size we allocate matches
+     * the file we will actually read — no TOCTOU gap between two path lookups. */
+    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size < 0) {
+        close(fd);
+        return OSP_ERR_OS;
+    }
+    len = (size_t)st.st_size;
+    /* On a 32-bit size_t a large file would truncate; reject rather than
+     * under-allocate. Also guard the len+1 terminator against wraparound. */
+    if ((off_t)len != st.st_size || len + 1 == 0) {
+        close(fd);
+        return OSP_ERR_NOMEM;
+    }
+    buf = (unsigned char *)malloc(len + 1);
+    if (buf == NULL) {
+        close(fd);
+        return OSP_ERR_NOMEM;
+    }
+    off = 0;
+    while (off < len) {
+        ssize_t n = read(fd, buf + off, len - off);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue; /* interrupted before any byte — retry */
+            }
+            free(buf);
+            close(fd);
+            return OSP_ERR_OS;
+        }
+        if (n == 0) {
+            break; /* EOF: the file shrank since fstat; return what we read */
+        }
+        off += (size_t)n;
+    }
+    close(fd);
+    buf[off] = '\0';
+    *out_data = buf;
+    *out_len = off;
+    return OSP_OK;
+}
+
+osp_status osp_fs_write_file(const char *path, const unsigned char *data,
+                             size_t len) {
+    int fd;
+    size_t off;
+
+    if (path == NULL || (data == NULL && len > 0)) {
+        return OSP_ERR_INVAL;
+    }
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        return OSP_ERR_OS;
+    }
+    off = 0;
+    while (off < len) {
+        ssize_t n = write(fd, data + off, len - off);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            close(fd);
+            return OSP_ERR_OS;
+        }
+        off += (size_t)n;
+    }
+    /* close() can surface a deferred write error (e.g. ENOSPC), so check it. */
+    if (close(fd) != 0) {
+        return OSP_ERR_OS;
+    }
+    return OSP_OK;
+}
+
+osp_status osp_fs_list_dir(const char *path, osp_dir_cb cb, void *user) {
+    DIR *d;
+    struct dirent *ent;
+
+    if (path == NULL || cb == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    d = opendir(path);
+    if (d == NULL) {
+        return OSP_ERR_OS;
+    }
+    while ((ent = readdir(d)) != NULL) {
+        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
+            continue;
+        }
+        cb(ent->d_name, user);
+    }
+    closedir(d);
+    return OSP_OK;
+}

--- a/code/packages/c/os-platform/src/fs_windows.c
+++ b/code/packages/c/os-platform/src/fs_windows.c
@@ -1,0 +1,187 @@
+/*
+ * fs_windows.c — the Win32 backend of os_platform/fs.
+ * ===========================================================================
+ *
+ * Compiled on Windows (named by `BUILD_windows`; macOS/Linux use fs_posix.c via
+ * the shared `BUILD`). No OS #ifdefs — the build chose this file. Uses only
+ * kernel32 (linked by default).
+ *
+ * We call the ...A (ANSI) entry points explicitly (CreateFileA, FindFirstFileA,
+ * …) so the char* paths from the shared header map straight through without
+ * defining UNICODE. Reads and writes are chunked because ReadFile/WriteFile take
+ * a 32-bit DWORD count, while our sizes are size_t. The modification time is a
+ * FILETIME (100-ns ticks since 1601) converted to UNIX nanoseconds exactly as in
+ * the clock backend.
+ */
+#include "os_platform/fs.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+/* 100-ns ticks between the 1601 FILETIME epoch and the 1970 UNIX epoch. */
+#define OSP_FILETIME_UNIX_EPOCH_DELTA 116444736000000000ULL
+/* Per-call transfer cap: a comfortably-large chunk that fits a DWORD. */
+#define OSP_IO_CHUNK 0x10000000UL /* 256 MiB */
+
+static int64_t osp__filetime_to_unix_ns(FILETIME ft) {
+    uint64_t ticks = ((uint64_t)ft.dwHighDateTime << 32) |
+                     (uint64_t)ft.dwLowDateTime;
+    return (int64_t)(ticks - OSP_FILETIME_UNIX_EPOCH_DELTA) * 100;
+}
+
+osp_status osp_fs_stat(const char *path, osp_file_info *out) {
+    WIN32_FILE_ATTRIBUTE_DATA fad;
+    int is_dir;
+    if (path == NULL || out == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    if (!GetFileAttributesExA(path, GetFileExInfoStandard, &fad)) {
+        return OSP_ERR_OS;
+    }
+    is_dir = (fad.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? 1 : 0;
+    out->is_dir = is_dir;
+    out->is_regular = is_dir ? 0 : 1; /* anything that is not a directory */
+    out->size = ((uint64_t)fad.nFileSizeHigh << 32) | (uint64_t)fad.nFileSizeLow;
+    out->mtime_unix_ns = osp__filetime_to_unix_ns(fad.ftLastWriteTime);
+    return OSP_OK;
+}
+
+int osp_fs_exists(const char *path) {
+    if (path == NULL) {
+        return 0;
+    }
+    return (GetFileAttributesA(path) != INVALID_FILE_ATTRIBUTES) ? 1 : 0;
+}
+
+osp_status osp_fs_read_file(const char *path, unsigned char **out_data,
+                            size_t *out_len) {
+    HANDLE h;
+    LARGE_INTEGER sz;
+    uint64_t u;
+    size_t len;
+    size_t off;
+    unsigned char *buf;
+
+    if (path == NULL || out_data == NULL || out_len == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    h = CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL, NULL);
+    if (h == INVALID_HANDLE_VALUE) {
+        return OSP_ERR_OS;
+    }
+    if (!GetFileSizeEx(h, &sz) || sz.QuadPart < 0) {
+        CloseHandle(h);
+        return OSP_ERR_OS;
+    }
+    u = (uint64_t)sz.QuadPart;
+    len = (size_t)u;
+    /* Reject a file too large for size_t (32-bit builds), and guard the +1. */
+    if ((uint64_t)len != u || len + 1 == 0) {
+        CloseHandle(h);
+        return OSP_ERR_NOMEM;
+    }
+    buf = (unsigned char *)malloc(len + 1);
+    if (buf == NULL) {
+        CloseHandle(h);
+        return OSP_ERR_NOMEM;
+    }
+    off = 0;
+    while (off < len) {
+        size_t remain = len - off;
+        DWORD want = (remain > OSP_IO_CHUNK) ? (DWORD)OSP_IO_CHUNK
+                                             : (DWORD)remain;
+        DWORD got = 0;
+        if (!ReadFile(h, buf + off, want, &got, NULL)) {
+            free(buf);
+            CloseHandle(h);
+            return OSP_ERR_OS;
+        }
+        if (got == 0) {
+            break; /* EOF earlier than the reported size */
+        }
+        off += got;
+    }
+    CloseHandle(h);
+    buf[off] = '\0';
+    *out_data = buf;
+    *out_len = off;
+    return OSP_OK;
+}
+
+osp_status osp_fs_write_file(const char *path, const unsigned char *data,
+                             size_t len) {
+    HANDLE h;
+    size_t off;
+
+    if (path == NULL || (data == NULL && len > 0)) {
+        return OSP_ERR_INVAL;
+    }
+    h = CreateFileA(path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
+                    FILE_ATTRIBUTE_NORMAL, NULL);
+    if (h == INVALID_HANDLE_VALUE) {
+        return OSP_ERR_OS;
+    }
+    off = 0;
+    while (off < len) {
+        size_t remain = len - off;
+        DWORD want = (remain > OSP_IO_CHUNK) ? (DWORD)OSP_IO_CHUNK
+                                             : (DWORD)remain;
+        DWORD wrote = 0;
+        if (!WriteFile(h, data + off, want, &wrote, NULL)) {
+            CloseHandle(h);
+            return OSP_ERR_OS;
+        }
+        off += wrote;
+    }
+    if (!CloseHandle(h)) {
+        return OSP_ERR_OS;
+    }
+    return OSP_OK;
+}
+
+osp_status osp_fs_list_dir(const char *path, osp_dir_cb cb, void *user) {
+    size_t plen;
+    char *pattern;
+    size_t k;
+    WIN32_FIND_DATAA fd;
+    HANDLE hf;
+
+    if (path == NULL || cb == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* Build the search pattern "<path>\*" (FindFirstFile needs a wildcard),
+     * inserting a separator only if the path lacks a trailing one. Worst case
+     * adds '\' + '*' + '\0' = 3 bytes. */
+    plen = strlen(path);
+    pattern = (char *)malloc(plen + 3);
+    if (pattern == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    memcpy(pattern, path, plen);
+    k = plen;
+    if (plen > 0 && pattern[plen - 1] != '\\' && pattern[plen - 1] != '/') {
+        pattern[k++] = '\\';
+    }
+    pattern[k++] = '*';
+    pattern[k] = '\0';
+
+    hf = FindFirstFileA(pattern, &fd);
+    free(pattern);
+    if (hf == INVALID_HANDLE_VALUE) {
+        /* An empty match set is reported as ERROR_FILE_NOT_FOUND, which for a
+         * valid (but entry-less) directory is success, not an error. */
+        return (GetLastError() == ERROR_FILE_NOT_FOUND) ? OSP_OK : OSP_ERR_OS;
+    }
+    do {
+        if (strcmp(fd.cFileName, ".") == 0 || strcmp(fd.cFileName, "..") == 0) {
+            continue;
+        }
+        cb(fd.cFileName, user);
+    } while (FindNextFileA(hf, &fd));
+    FindClose(hf);
+    return OSP_OK;
+}

--- a/code/packages/c/os-platform/tests/fs_test.c
+++ b/code/packages/c/os-platform/tests/fs_test.c
@@ -1,0 +1,103 @@
+/*
+ * fs_test.c — round-trip tests for os_platform/fs, run on each OS.
+ * ===========================================================================
+ *
+ * The test drives a real file through the API and checks observable results:
+ *
+ *   - write then read returns the exact bytes (binary-safe: the payload holds an
+ *     embedded NUL, so a string-based reader would truncate — this proves ours
+ *     does not), with the right length and a '\0' terminator past the data;
+ *   - stat reports a regular file of the written size, and osp_fs_exists agrees;
+ *   - list_dir enumerates the directory and surfaces our file by name;
+ *   - NULL arguments are rejected.
+ *
+ * Files are created under `_build/` — the harness makes that directory and it is
+ * .gitignore'd, so nothing leaks into the working tree. Cleanup uses ISO C
+ * remove() (not part of the fs API under test). The working directory when the
+ * test binary runs is the package root (both run.sh and run.ps1 cd there), so
+ * the relative paths below resolve correctly on every OS.
+ */
+#include "iso_test.h"
+
+#include "os_platform/fs.h"
+
+#include <stdio.h>  /* remove */
+#include <stdlib.h> /* free */
+#include <stddef.h> /* NULL */
+#include <string.h> /* strcmp */
+
+/* A payload with an embedded NUL, to prove reads are length-based, not string
+ * based. */
+static const unsigned char PAYLOAD[] = {'h', 'i', 0x00, 'x', 'y'};
+#define PAYLOAD_LEN 5
+
+#define PROBE_DIR "_build"
+#define PROBE_NAME "osp_fs_probe.bin"
+#define PROBE_PATH PROBE_DIR "/" PROBE_NAME
+
+typedef struct {
+    const char *target;
+    int found;
+} list_ctx;
+
+static void list_cb(const char *name, void *user) {
+    list_ctx *c = (list_ctx *)user;
+    if (strcmp(name, c->target) == 0) {
+        c->found = 1;
+    }
+}
+
+int main(void) {
+    unsigned char *data = NULL;
+    size_t len = 0;
+    osp_file_info info;
+    list_ctx lc;
+
+    /* ── write → read round-trip (binary-safe) ──────────────────────────── */
+    ISO_CHECK(osp_fs_write_file(PROBE_PATH, PAYLOAD, PAYLOAD_LEN) == OSP_OK);
+    ISO_CHECK(osp_fs_read_file(PROBE_PATH, &data, &len) == OSP_OK);
+    ISO_CHECK_EQ_UINT(len, PAYLOAD_LEN);
+    if (data != NULL) {
+        ISO_CHECK_MEM_EQ(data, PAYLOAD, PAYLOAD_LEN);
+        ISO_CHECK_MSG(data[PAYLOAD_LEN] == '\0', "read buffer must be terminated");
+        free(data);
+    } else {
+        ISO_CHECK_MSG(0, "osp_fs_read_file returned OK but a NULL buffer");
+    }
+
+    /* ── stat + exists ──────────────────────────────────────────────────── */
+    ISO_CHECK(osp_fs_stat(PROBE_PATH, &info) == OSP_OK);
+    ISO_CHECK_MSG(info.is_regular == 1, "probe should be a regular file");
+    ISO_CHECK_MSG(info.is_dir == 0, "probe should not be a directory");
+    ISO_CHECK_EQ_UINT(info.size, PAYLOAD_LEN);
+    ISO_CHECK(osp_fs_exists(PROBE_PATH) == 1);
+    ISO_CHECK(osp_fs_exists(PROBE_DIR "/does_not_exist") == 0);
+
+    /* stat should also recognise a directory */
+    ISO_CHECK(osp_fs_stat(PROBE_DIR, &info) == OSP_OK);
+    ISO_CHECK_MSG(info.is_dir == 1, "_build should stat as a directory");
+
+    /* ── list_dir surfaces our file ─────────────────────────────────────── */
+    lc.target = PROBE_NAME;
+    lc.found = 0;
+    ISO_CHECK(osp_fs_list_dir(PROBE_DIR, list_cb, &lc) == OSP_OK);
+    ISO_CHECK_MSG(lc.found == 1, "list_dir must surface the probe file");
+
+    /* ── argument validation ────────────────────────────────────────────── */
+    ISO_CHECK(osp_fs_stat(NULL, &info) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_fs_stat(PROBE_PATH, NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_fs_read_file(NULL, &data, &len) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_fs_write_file(NULL, PAYLOAD, PAYLOAD_LEN) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_fs_write_file(PROBE_PATH, NULL, 1) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_fs_list_dir(NULL, list_cb, &lc) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_fs_list_dir(PROBE_DIR, NULL, &lc) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_fs_exists(NULL) == 0);
+
+    /* reading a non-existent file must fail cleanly */
+    ISO_CHECK(osp_fs_read_file(PROBE_DIR "/does_not_exist", &data, &len) == OSP_ERR_OS);
+
+    /* ── cleanup (ISO C remove, not part of the fs API) ─────────────────── */
+    remove(PROBE_PATH);
+
+    return ISO_TEST_RESULT();
+}

--- a/code/packages/c/os-platform/tools/run.ps1
+++ b/code/packages/c/os-platform/tools/run.ps1
@@ -42,3 +42,6 @@ Platform-BuildAndRun -Lang c -Name 'clock-tests' -Sources @('tests\clock_test.c'
 
 # thread — Win32 backend (_beginthreadex + CRITICAL_SECTION + CONDITION_VARIABLE).
 Platform-BuildAndRun -Lang c -Name 'thread-tests' -Sources @('tests\thread_test.c', 'src\thread_windows.c')
+
+# fs — Win32 backend (CreateFile/ReadFile/WriteFile + GetFileAttributesEx + FindFirstFile).
+Platform-BuildAndRun -Lang c -Name 'fs-tests' -Sources @('tests\fs_test.c', 'src\fs_windows.c')

--- a/code/packages/c/os-platform/tools/run.sh
+++ b/code/packages/c/os-platform/tools/run.sh
@@ -56,4 +56,9 @@ PLATFORM_LIBS="-pthread"
 export PLATFORM_LIBS
 platform_build_and_run c thread-tests tests/thread_test.c src/thread_posix.c || rc=1
 
+# fs — POSIX backend (stat/open/read/write/opendir). No extra OS library.
+PLATFORM_LIBS=""
+export PLATFORM_LIBS
+platform_build_and_run c fs-tests tests/fs_test.c src/fs_posix.c || rc=1
+
 exit "$rc"


### PR DESCRIPTION
## CCPP02 Phase 2 — `os-platform` third primitive: `fs`

Builds on merged `clock` (#8319) and `thread` (#8321). The filesystem beyond ISO
`<stdio.h>`: standard C opens a file *by name* but cannot list a directory or
report a file's type, size, or modification time — that's **bucket B** (dirent +
stat / FindFirstFile + GetFileAttributesEx).

### API (`os_platform/fs.h`)

| Function | Purpose |
|----------|---------|
| `osp_fs_stat` → `osp_file_info` | is_dir · is_regular · size · mtime_unix_ns |
| `osp_fs_exists` | 1/0 predicate |
| `osp_fs_read_file` | whole file → malloc'd, NUL-terminated, **binary-safe** buffer (caller frees) |
| `osp_fs_write_file` | create/truncate |
| `osp_fs_list_dir` | callback per entry, skipping `.` / `..` |

### Backends — per-OS source selection via BUILD, no `#ifdef` mazes

| | metadata | read / write | list |
|--|----------|--------------|------|
| **macOS/Linux** (`fs_posix.c`) | `stat` | `open`+`fstat`+`read` · `write` | `opendir`/`readdir` |
| **Windows** (`fs_windows.c`) | `GetFileAttributesExA` | `CreateFileA`+`ReadFile`/`WriteFile` (chunked to DWORD) | `FindFirstFileA`/`FindNextFileA` |

POSIX uses libc only (no extra lib); Windows uses kernel32 only.

**Robustness/security baked in:**
- Size→allocation guarded against **32-bit `size_t` truncation** *and* **`len+1` wraparound** on both backends → no under-allocation.
- POSIX `fstat`s the **open fd** (not the path) so the allocated size matches the bytes read — **no TOCTOU gap**; read/write **loop over partial transfers** and retry `EINTR`; `close()` checked to surface deferred write errors (ENOSPC).
- Windows search pattern built with `memcpy` + manual separator (no `strcpy`/`strcat`); `...A` entry points so `char*` paths pass through without `UNICODE`.
- `mtime` uses portable `st_mtime` (second-resolution) so one file compiles on both mac (`st_mtimespec`) and linux (`st_mtim`) with no `#ifdef`.

### Test (`tests/fs_test.c`, run on each OS)

Write→read round-trip with an **embedded NUL** (proves reads are length-based, not
string-based), stat/exists on a file *and* a directory, `list_dir` surfaces the
probe file, NULL-arg rejection, and read-of-missing-file fails cleanly. Files
live under gitignored `_build/`; cleanup via ISO `remove()`.

### Verification

- **Local (macOS):** clock 13/0 + thread 28/0 + fs 24/0 under gcc + clang.
- **Sanitizers:** fs test clean under **ASan + UBSan**; **0 leaks** (`leaks --atExit`).
- **Security review:** passed round 1 — reviewer explicitly verified the integer-overflow guards and the Windows pattern-buffer bound (exactly right, no off-by-one) plus every error path (handles closed once, buffers freed on failure, no leak/double-free/UAF/TOCTOU).
- CI proves `fs_windows.c` on the windows runner.

Spec: [`CCPP02-os-platform-lane.md`](code/specs/CCPP02-os-platform-lane.md) · next primitives: `process`, `dynlib`, `mmap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)