### PR TITLE
feat(elixir): port python-parser

### DIFF
--- a/code/packages/elixir/python_parser/BUILD
+++ b/code/packages/elixir/python_parser/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/python_parser/CHANGELOG.md
+++ b/code/packages/elixir/python_parser/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Added the Elixir Python parser wrapper over the shared grammar-driven parser.
+- Added version-aware lexing for Python 2.7, 3.0, 3.6, 3.8, 3.10, and 3.12 before parsing with the shared Python subset grammar.
+- Added tests for assignments, arithmetic precedence, version selection, parser caching, lexer errors, and malformed syntax.

--- a/code/packages/elixir/python_parser/README.md
+++ b/code/packages/elixir/python_parser/README.md
@@ -1,0 +1,12 @@
+# Python Parser (Elixir)
+
+Grammar-driven Python parser for Elixir.
+
+This package tokenizes source with `CodingAdventures.PythonLexer`, loads the shared parser grammar from `code/grammars/python/python.grammar`, and delegates AST construction to `CodingAdventures.Parser.GrammarParser`. The optional version selects the matching lexer grammar; the parser grammar covers the common Python expression and assignment subset used by the other thin-wrapper ports.
+
+```elixir
+{:ok, ast} = CodingAdventures.PythonParser.parse("x = 1 + 2\n")
+{:ok, ast_27} = CodingAdventures.PythonParser.parse("x = 42\n", "2.7")
+```
+
+Python 3.12 is the default. Supported versions are 2.7, 3.0, 3.6, 3.8, 3.10, and 3.12.

--- a/code/packages/elixir/python_parser/lib/python_parser.ex
+++ b/code/packages/elixir/python_parser/lib/python_parser.ex
@@ -1,0 +1,77 @@
+defmodule CodingAdventures.PythonParser do
+  @moduledoc """
+  Python parser backed by the shared grammar-driven parser engine.
+
+  The parser selects a versioned lexer grammar, tokenizes source with
+  `CodingAdventures.PythonLexer`, and delegates AST construction to
+  `CodingAdventures.Parser.GrammarParser` using the shared Python subset
+  grammar.
+
+  Python 3.12 is used by default. Supported versions are 2.7, 3.0, 3.6, 3.8,
+  3.10, and 3.12.
+  """
+
+  alias CodingAdventures.GrammarTools.ParserGrammar
+  alias CodingAdventures.Parser.{ASTNode, GrammarParser}
+  alias CodingAdventures.PythonLexer
+
+  @grammars_dir Path.join([__DIR__, "..", "..", "..", "..", "grammars"])
+                |> Path.expand()
+
+  @default_version "3.12"
+  @supported_versions ["2.7", "3.0", "3.6", "3.8", "3.10", "3.12"]
+
+  @doc """
+  The default Python version used when no version is specified.
+  """
+  @spec default_version() :: String.t()
+  def default_version, do: @default_version
+
+  @doc """
+  The Python versions with matching lexer grammars.
+  """
+  @spec supported_versions() :: [String.t()]
+  def supported_versions, do: @supported_versions
+
+  @doc """
+  Parse Python source code with the grammar for `version`.
+
+  A `nil` or empty version selects Python 3.12.
+  """
+  @spec parse(String.t(), String.t() | nil) :: {:ok, ASTNode.t()} | {:error, String.t()}
+  def parse(source, version \\ nil) when is_binary(source) do
+    resolved = resolve_version!(version)
+
+    with {:ok, tokens} <- PythonLexer.tokenize(source, resolved) do
+      GrammarParser.parse(tokens, create_parser())
+    end
+  end
+
+  @doc """
+  Return the cached shared Python `ParserGrammar`.
+  """
+  @spec create_parser() :: ParserGrammar.t()
+  def create_parser do
+    case :persistent_term.get({__MODULE__, :grammar}, nil) do
+      nil ->
+        grammar_path = Path.join([@grammars_dir, "python", "python.grammar"])
+        {:ok, grammar} = ParserGrammar.parse(File.read!(grammar_path))
+        :persistent_term.put({__MODULE__, :grammar}, grammar)
+        grammar
+
+      grammar ->
+        grammar
+    end
+  end
+
+  defp resolve_version!(nil), do: @default_version
+  defp resolve_version!(""), do: @default_version
+
+  defp resolve_version!(version) when version in @supported_versions, do: version
+
+  defp resolve_version!(version) do
+    raise ArgumentError,
+          "Unknown Python version #{inspect(version)}. " <>
+            "Valid values: #{Enum.join(@supported_versions, ", ")}"
+  end
+end

--- a/code/packages/elixir/python_parser/mix.exs
+++ b/code/packages/elixir/python_parser/mix.exs
@@ -1,0 +1,29 @@
+defmodule CodingAdventures.PythonParser.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_python_parser,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80]
+      ]
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:coding_adventures_parser, path: "../parser"},
+      {:coding_adventures_python_lexer, path: "../python_lexer"}
+    ]
+  end
+end

--- a/code/packages/elixir/python_parser/required_capabilities.json
+++ b/code/packages/elixir/python_parser/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "elixir/python_parser",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads the shared Python parser grammar file from code/grammars/ to configure the parser."
+    }
+  ],
+  "justification": "Reads the shared Python parser grammar file once at runtime and caches the parsed grammar."
+}

--- a/code/packages/elixir/python_parser/test/python_parser_test.exs
+++ b/code/packages/elixir/python_parser/test/python_parser_test.exs
@@ -1,0 +1,75 @@
+defmodule CodingAdventures.PythonParserTest do
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.Parser.ASTNode
+  alias CodingAdventures.PythonParser
+
+  defp find_nodes(%ASTNode{} = node, rule_name) do
+    current = if node.rule_name == rule_name, do: [node], else: []
+
+    Enum.reduce(node.children, current, fn
+      %ASTNode{} = child, acc -> acc ++ find_nodes(child, rule_name)
+      _child, acc -> acc
+    end)
+  end
+
+  test "defaults to Python 3.12 and lists every supported grammar version" do
+    assert PythonParser.default_version() == "3.12"
+
+    assert PythonParser.supported_versions() == [
+             "2.7",
+             "3.0",
+             "3.6",
+             "3.8",
+             "3.10",
+             "3.12"
+           ]
+  end
+
+  test "parses assignment statements with the default grammar" do
+    {:ok, ast} = PythonParser.parse("x = 1 + 2\n")
+    assert ast.rule_name == "program"
+    assert length(find_nodes(ast, "assignment")) == 1
+    assert length(find_nodes(ast, "expression")) >= 1
+  end
+
+  test "preserves arithmetic precedence through term nesting" do
+    {:ok, ast} = PythonParser.parse("x = 1 + 2 * 3\n")
+    assert ast.rule_name == "program"
+    assert length(find_nodes(ast, "term")) >= 2
+  end
+
+  test "parses source with an explicit historical lexer grammar" do
+    {:ok, ast} = PythonParser.parse("x = 1\n", "2.7")
+    assert ast.rule_name == "program"
+    assert length(find_nodes(ast, "assignment")) == 1
+  end
+
+  test "nil and empty versions select the default grammar" do
+    assert {:ok, %ASTNode{rule_name: "program"}} = PythonParser.parse("x = 1\n", nil)
+    assert {:ok, %ASTNode{rule_name: "program"}} = PythonParser.parse("x = 1\n", "")
+  end
+
+  test "create_parser returns and caches the shared parsed grammar" do
+    grammar = PythonParser.create_parser()
+    assert is_map(grammar)
+    assert hd(grammar.rules).name == "program"
+    assert PythonParser.create_parser() === grammar
+  end
+
+  test "unknown versions raise a useful error" do
+    assert_raise ArgumentError, ~r/Unknown Python version "3.11"/, fn ->
+      PythonParser.parse("x = 1\n", "3.11")
+    end
+  end
+
+  test "lexer errors are returned" do
+    assert {:error, message} = PythonParser.parse("x = \u00A7\n")
+    assert message =~ "Unexpected character"
+  end
+
+  test "malformed Python returns a parser error" do
+    assert {:error, message} = PythonParser.parse("x = (1 + 2\n")
+    assert message =~ "Expected"
+  end
+end

--- a/code/packages/elixir/python_parser/test/test_helper.exs
+++ b/code/packages/elixir/python_parser/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,16 +105,16 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 14, 2026 after the Swift CLI-builder port:
+on July 14, 2026 after the Elixir `python-parser` port:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 375 |
+| Present in 10-15 languages | 171 | 373 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 694 | 9,716 |
+| Present in one language | 695 | 9,730 |
 
-The loop must not start by attempting 9,716 singleton ports. It should finish
+The loop must not start by attempting 9,730 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -155,13 +155,13 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 374
+The 171 packages present in at least ten implementation languages need 373
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 3 | Pair `in-memory-data-store` packages; classify self-hosted `python-parser` carefully |
-| Elixir | 1 | Complete alongside the Python parser/frontend decision |
+| Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 16 | Pair with Perl data-structure/storage wave |
 | Perl | 16 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |


### PR DESCRIPTION
## What changed

- add a pure-Elixir `python-parser` package over the existing grammar-driven lexer and parser engines
- support the same Python lexer versions as `python_lexer`, defaulting to 3.12, while using the shared cross-language Python subset parser grammar
- add package metadata, documentation, BUILD coverage, and focused AST/error/cache tests
- refresh the parity roadmap from the live report: high-consensus gaps fall from 374 to 373 and Elixir reaches zero

## Why

Elixir was the smallest remaining Priority 2 high-consensus lane with one missing package. This dependency-safe port closes that lane without adding runtime dependencies or handwritten parsing logic.

## Validation

- `mix format --check-formatted mix.exs 'lib/**/*.ex' 'test/**/*.exs'`
- `mix test --cover` (9 tests, 100% package coverage)
- `python code/scripts/tests/test_package_parity_report.py` (6 tests)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions, 0 unknown buckets, 373 high-consensus gaps, Elixir 0)
- `git diff --cached --check`