### PR TITLE
feat: port fenwick tree to Lua and Perl

### DIFF
--- a/code/packages/lua/fenwick-tree/BUILD
+++ b/code/packages/lua/fenwick-tree/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-fenwick-tree-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/fenwick-tree/BUILD_windows
+++ b/code/packages/lua/fenwick-tree/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-fenwick-tree-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/fenwick-tree/CHANGELOG.md
+++ b/code/packages/lua/fenwick-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add a pure-Lua Fenwick tree with linear-time construction, prefix/range/point
+  queries, point updates, order-statistic lookup, and validation.

--- a/code/packages/lua/fenwick-tree/README.md
+++ b/code/packages/lua/fenwick-tree/README.md
@@ -1,0 +1,20 @@
+# Lua Fenwick tree
+
+A dependency-free Binary Indexed Tree for `O(log n)` prefix sums, range sums,
+point updates, and order-statistic lookup over numeric values.
+
+```lua
+local FenwickTree = require("coding_adventures.fenwick_tree").FenwickTree
+local tree = FenwickTree.from_list({3, 2, 1, 7, 4})
+assert(tree:range_sum(2, 4) == 10)
+tree:update(3, 5)
+```
+
+Positions are 1-indexed. `find_kth` assumes non-negative values so prefix sums
+remain monotonic.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/lua/fenwick-tree/coding-adventures-fenwick-tree-0.1.0-1.rockspec
+++ b/code/packages/lua/fenwick-tree/coding-adventures-fenwick-tree-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-fenwick-tree"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Binary Indexed Tree with prefix sums and point updates",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.fenwick_tree"] = "src/coding_adventures/fenwick_tree/init.lua",
+    },
+}

--- a/code/packages/lua/fenwick-tree/required_capabilities.json
+++ b/code/packages/lua/fenwick-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/fenwick-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/fenwick-tree/src/coding_adventures/fenwick_tree/init.lua
+++ b/code/packages/lua/fenwick-tree/src/coding_adventures/fenwick_tree/init.lua
@@ -1,0 +1,162 @@
+local M = {VERSION = "0.1.0"}
+
+local FenwickTree = {}
+FenwickTree.__index = FenwickTree
+
+local function require_integer(value, name)
+    if type(value) ~= "number" or value % 1 ~= 0 then
+        error(name .. " must be an integer", 3)
+    end
+end
+
+local function lowbit(index)
+    return index & -index
+end
+
+local function check_index(self, index)
+    require_integer(index, "index")
+    if index < 1 or index > self._n then
+        error(string.format("index %d out of range [1, %d]", index, self._n), 3)
+    end
+end
+
+function FenwickTree.new(size)
+    require_integer(size, "size")
+    if size < 0 then
+        error("size must be non-negative", 2)
+    end
+
+    local bit = {}
+    for index = 0, size do
+        bit[index] = 0
+    end
+
+    return setmetatable({_n = size, _bit = bit}, FenwickTree)
+end
+
+function FenwickTree.from_list(values)
+    if type(values) ~= "table" then
+        error("values must be a table", 2)
+    end
+
+    local tree = FenwickTree.new(#values)
+    for index = 1, tree._n do
+        local value = values[index]
+        if type(value) ~= "number" then
+            error(string.format("value at index %d must be a number", index), 2)
+        end
+        tree._bit[index] = tree._bit[index] + value
+        local parent = index + lowbit(index)
+        if parent <= tree._n then
+            tree._bit[parent] = tree._bit[parent] + tree._bit[index]
+        end
+    end
+    return tree
+end
+
+function FenwickTree:update(index, delta)
+    check_index(self, index)
+    if type(delta) ~= "number" then
+        error("delta must be a number", 2)
+    end
+
+    local current = index
+    while current <= self._n do
+        self._bit[current] = self._bit[current] + delta
+        current = current + lowbit(current)
+    end
+    return self
+end
+
+function FenwickTree:prefix_sum(index)
+    require_integer(index, "index")
+    if index < 0 or index > self._n then
+        error(string.format("prefix index %d out of range [0, %d]", index, self._n), 2)
+    end
+
+    local total = 0
+    local current = index
+    while current > 0 do
+        total = total + self._bit[current]
+        current = current - lowbit(current)
+    end
+    return total
+end
+
+function FenwickTree:range_sum(left, right)
+    require_integer(left, "left")
+    require_integer(right, "right")
+    if left > right then
+        error("left must be <= right", 2)
+    end
+    check_index(self, left)
+    check_index(self, right)
+    return self:prefix_sum(right) - self:prefix_sum(left - 1)
+end
+
+function FenwickTree:point_query(index)
+    check_index(self, index)
+    return self:range_sum(index, index)
+end
+
+function FenwickTree:find_kth(target)
+    if self._n == 0 then
+        error("find_kth called on empty tree", 2)
+    end
+    if type(target) ~= "number" or target <= 0 then
+        error("target must be positive", 2)
+    end
+
+    local total = self:prefix_sum(self._n)
+    if target > total then
+        error("target exceeds total sum", 2)
+    end
+
+    local index = 0
+    local step = 1
+    while step * 2 <= self._n do
+        step = step * 2
+    end
+
+    while step > 0 do
+        local next_index = index + step
+        if next_index <= self._n and self._bit[next_index] < target then
+            index = next_index
+            target = target - self._bit[index]
+        end
+        step = math.floor(step / 2)
+    end
+    return index + 1
+end
+
+function FenwickTree:len()
+    return self._n
+end
+
+function FenwickTree:size()
+    return self._n
+end
+
+function FenwickTree:is_empty()
+    return self._n == 0
+end
+
+function FenwickTree:bit_array()
+    local result = {}
+    for index = 1, self._n do
+        result[index] = self._bit[index]
+    end
+    return result
+end
+
+function FenwickTree:__tostring()
+    local values = self:bit_array()
+    for index, value in ipairs(values) do
+        values[index] = tostring(value)
+    end
+    return string.format("FenwickTree(n=%d, bit={%s})", self._n, table.concat(values, ", "))
+end
+
+M.FenwickTree = FenwickTree
+
+return M

--- a/code/packages/lua/fenwick-tree/tests/test_fenwick_tree.lua
+++ b/code/packages/lua/fenwick-tree/tests/test_fenwick_tree.lua
@@ -1,0 +1,90 @@
+package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+
+local module = require("coding_adventures.fenwick_tree")
+local FenwickTree = module.FenwickTree
+
+describe("FenwickTree construction", function()
+    it("exposes the package version and empty-tree state", function()
+        assert.equals("0.1.0", module.VERSION)
+        local tree = FenwickTree.new(0)
+        assert.equals(0, tree:len())
+        assert.equals(0, tree:size())
+        assert.is_true(tree:is_empty())
+        assert.are.same({}, tree:bit_array())
+    end)
+
+    it("rejects invalid sizes and inputs", function()
+        assert.has_error(function() FenwickTree.new(-1) end, "size must be non-negative")
+        assert.has_error(function() FenwickTree.new(1.5) end, "size must be an integer")
+        assert.has_error(function() FenwickTree.from_list("nope") end, "values must be a table")
+        assert.has_error(function() FenwickTree.from_list({1, "x"}) end, "value at index 2 must be a number")
+    end)
+end)
+
+describe("FenwickTree queries and updates", function()
+    it("matches the reference prefix, range, and point vectors", function()
+        local tree = FenwickTree.from_list({3, 2, 1, 7, 4})
+        assert.equals(5, tree:len())
+        assert.is_false(tree:is_empty())
+        assert.are.same({3, 5, 6, 13, 17}, {
+            tree:prefix_sum(1),
+            tree:prefix_sum(2),
+            tree:prefix_sum(3),
+            tree:prefix_sum(4),
+            tree:prefix_sum(5),
+        })
+        assert.equals(0, tree:prefix_sum(0))
+        assert.equals(10, tree:range_sum(2, 4))
+        assert.equals(17, tree:range_sum(1, 5))
+        assert.equals(7, tree:point_query(4))
+    end)
+
+    it("supports integer, negative, and floating-point updates", function()
+        local tree = FenwickTree.from_list({5, -2, 7, 1.5, 4.5})
+        assert.equals(16, tree:prefix_sum(5))
+        assert.equals(6.5, tree:range_sum(2, 4))
+        assert.equals(tree, tree:update(2, 4.5))
+        assert.equals(2.5, tree:point_query(2))
+        assert.equals(20.5, tree:prefix_sum(5))
+    end)
+
+    it("returns a defensive BIT-array copy and renders itself", function()
+        local tree = FenwickTree.from_list({1, 2, 3})
+        local bit = tree:bit_array()
+        bit[1] = 99
+        assert.equals(1, tree:point_query(1))
+        assert.is_truthy(tostring(tree):match("FenwickTree"))
+    end)
+end)
+
+describe("FenwickTree order statistics", function()
+    it("finds the first prefix that reaches each target", function()
+        local tree = FenwickTree.from_list({1, 2, 3, 4, 5})
+        assert.equals(1, tree:find_kth(1))
+        assert.equals(2, tree:find_kth(2))
+        assert.equals(2, tree:find_kth(3))
+        assert.equals(3, tree:find_kth(4))
+        assert.equals(4, tree:find_kth(10))
+        assert.equals(5, tree:find_kth(15))
+    end)
+
+    it("rejects invalid targets", function()
+        assert.has_error(function() FenwickTree.new(0):find_kth(1) end, "find_kth called on empty tree")
+        local tree = FenwickTree.from_list({1, 2, 3})
+        assert.has_error(function() tree:find_kth(0) end, "target must be positive")
+        assert.has_error(function() tree:find_kth(7) end, "target exceeds total sum")
+    end)
+end)
+
+describe("FenwickTree validation", function()
+    it("rejects invalid indices and ranges", function()
+        local tree = FenwickTree.from_list({1, 2, 3})
+        assert.has_error(function() tree:prefix_sum(-1) end, "prefix index -1 out of range [0, 3]")
+        assert.has_error(function() tree:prefix_sum(4) end, "prefix index 4 out of range [0, 3]")
+        assert.has_error(function() tree:update(0, 1) end, "index 0 out of range [1, 3]")
+        assert.has_error(function() tree:update(1, "x") end, "delta must be a number")
+        assert.has_error(function() tree:range_sum(3, 1) end, "left must be <= right")
+        assert.has_error(function() tree:range_sum(0, 2) end, "index 0 out of range [1, 3]")
+        assert.has_error(function() tree:point_query(4) end, "index 4 out of range [1, 3]")
+    end)
+end)

--- a/code/packages/perl/fenwick-tree/BUILD
+++ b/code/packages/perl/fenwick-tree/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/fenwick-tree/BUILD_windows
+++ b/code/packages/perl/fenwick-tree/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-fenwick-tree.t

--- a/code/packages/perl/fenwick-tree/CHANGELOG.md
+++ b/code/packages/perl/fenwick-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add a pure-Perl Fenwick tree with linear-time construction, prefix/range/point
+  queries, point updates, order-statistic lookup, and validation.

--- a/code/packages/perl/fenwick-tree/Makefile.PL
+++ b/code/packages/perl/fenwick-tree/Makefile.PL
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::FenwickTree',
+    VERSION_FROM     => 'lib/CodingAdventures/FenwickTree.pm',
+    ABSTRACT         => 'Binary Indexed Tree with prefix sums and point updates',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {},
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/fenwick-tree/README.md
+++ b/code/packages/perl/fenwick-tree/README.md
@@ -1,0 +1,19 @@
+# Perl Fenwick tree
+
+A dependency-free Binary Indexed Tree for `O(log n)` prefix sums, range sums,
+point updates, and order-statistic lookup over numeric values.
+
+```perl
+my $tree = CodingAdventures::FenwickTree->from_list([3, 2, 1, 7, 4]);
+print $tree->range_sum(2, 4); # 10
+$tree->update(3, 5);
+```
+
+Positions are 1-indexed. `find_kth` assumes non-negative values so prefix sums
+remain monotonic.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/perl/fenwick-tree/cpanfile
+++ b/code/packages/perl/fenwick-tree/cpanfile
@@ -1,0 +1,1 @@
+# No non-core dependencies.

--- a/code/packages/perl/fenwick-tree/lib/CodingAdventures/FenwickTree.pm
+++ b/code/packages/perl/fenwick-tree/lib/CodingAdventures/FenwickTree.pm
@@ -1,0 +1,146 @@
+package CodingAdventures::FenwickTree;
+
+use strict;
+use warnings;
+use Scalar::Util qw(looks_like_number);
+use overload '""' => 'to_string', fallback => 1;
+
+our $VERSION = '0.1.0';
+
+sub _require_integer {
+    my ($value, $name) = @_;
+    die "$name must be an integer\n"
+        if !defined($value) || !looks_like_number($value) || int($value) != $value;
+}
+
+sub _lowbit {
+    my ($index) = @_;
+    return $index & -$index;
+}
+
+sub new {
+    my ($class, $size) = @_;
+    _require_integer($size, 'size');
+    die "size must be non-negative\n" if $size < 0;
+
+    return bless {
+        n   => $size,
+        bit => [(0) x ($size + 1)],
+    }, $class;
+}
+
+sub from_list {
+    my ($class, $values) = @_;
+    die "values must be an array reference\n" if ref($values) ne 'ARRAY';
+
+    my $tree = $class->new(scalar @$values);
+    for my $index (1 .. $tree->{n}) {
+        my $value = $values->[$index - 1];
+        die "value at index $index must be a number\n"
+            if !defined($value) || !looks_like_number($value);
+        $tree->{bit}[$index] += $value;
+        my $parent = $index + _lowbit($index);
+        $tree->{bit}[$parent] += $tree->{bit}[$index] if $parent <= $tree->{n};
+    }
+    return $tree;
+}
+
+sub _check_index {
+    my ($self, $index) = @_;
+    _require_integer($index, 'index');
+    die "index $index out of range [1, $self->{n}]\n"
+        if $index < 1 || $index > $self->{n};
+}
+
+sub update {
+    my ($self, $index, $delta) = @_;
+    $self->_check_index($index);
+    die "delta must be a number\n"
+        if !defined($delta) || !looks_like_number($delta);
+
+    for (my $current = $index; $current <= $self->{n}; $current += _lowbit($current)) {
+        $self->{bit}[$current] += $delta;
+    }
+    return $self;
+}
+
+sub prefix_sum {
+    my ($self, $index) = @_;
+    _require_integer($index, 'index');
+    die "prefix index $index out of range [0, $self->{n}]\n"
+        if $index < 0 || $index > $self->{n};
+
+    my $total = 0;
+    for (my $current = $index; $current > 0; $current -= _lowbit($current)) {
+        $total += $self->{bit}[$current];
+    }
+    return $total;
+}
+
+sub range_sum {
+    my ($self, $left, $right) = @_;
+    _require_integer($left, 'left');
+    _require_integer($right, 'right');
+    die "left must be <= right\n" if $left > $right;
+    $self->_check_index($left);
+    $self->_check_index($right);
+    return $self->prefix_sum($right) - $self->prefix_sum($left - 1);
+}
+
+sub point_query {
+    my ($self, $index) = @_;
+    $self->_check_index($index);
+    return $self->range_sum($index, $index);
+}
+
+sub find_kth {
+    my ($self, $target) = @_;
+    die "find_kth called on empty tree\n" if $self->{n} == 0;
+    die "target must be positive\n"
+        if !defined($target) || !looks_like_number($target) || $target <= 0;
+
+    my $total = $self->prefix_sum($self->{n});
+    die "target exceeds total sum\n" if $target > $total;
+
+    my $index = 0;
+    my $step = 1;
+    $step *= 2 while $step * 2 <= $self->{n};
+
+    while ($step > 0) {
+        my $next = $index + $step;
+        if ($next <= $self->{n} && $self->{bit}[$next] < $target) {
+            $index = $next;
+            $target -= $self->{bit}[$index];
+        }
+        $step = int($step / 2);
+    }
+    return $index + 1;
+}
+
+sub size {
+    my ($self) = @_;
+    return $self->{n};
+}
+
+sub len {
+    my ($self) = @_;
+    return $self->{n};
+}
+
+sub is_empty {
+    my ($self) = @_;
+    return $self->{n} == 0;
+}
+
+sub bit_array {
+    my ($self) = @_;
+    return [] if $self->{n} == 0;
+    return [@{ $self->{bit} }[1 .. $self->{n}]];
+}
+
+sub to_string {
+    my ($self) = @_;
+    return sprintf('FenwickTree(n=%d, bit=[%s])', $self->{n}, join(', ', @{ $self->bit_array }));
+}
+
+1;

--- a/code/packages/perl/fenwick-tree/required_capabilities.json
+++ b/code/packages/perl/fenwick-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/fenwick-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/fenwick-tree/t/00-load.t
+++ b/code/packages/perl/fenwick-tree/t/00-load.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::FenwickTree; 1 }, 'CodingAdventures::FenwickTree loads');
+ok(CodingAdventures::FenwickTree->VERSION, 'has a VERSION');
+
+done_testing;

--- a/code/packages/perl/fenwick-tree/t/01-fenwick-tree.t
+++ b/code/packages/perl/fenwick-tree/t/01-fenwick-tree.t
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::FenwickTree;
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'construction and state' => sub {
+    my $empty = CodingAdventures::FenwickTree->new(0);
+    is($empty->size, 0, 'empty size');
+    is($empty->len, 0, 'len alias');
+    ok($empty->is_empty, 'empty state');
+    is_deeply($empty->bit_array, [], 'empty BIT array');
+
+    dies_like(sub { CodingAdventures::FenwickTree->new(-1) }, qr/size must be non-negative/, 'negative size rejected');
+    dies_like(sub { CodingAdventures::FenwickTree->new(1.5) }, qr/size must be an integer/, 'fractional size rejected');
+    dies_like(sub { CodingAdventures::FenwickTree->from_list('nope') }, qr/array reference/, 'non-array input rejected');
+    dies_like(sub { CodingAdventures::FenwickTree->from_list([1, 'x']) }, qr/value at index 2 must be a number/, 'non-number value rejected');
+};
+
+subtest 'prefix, range, point, and update operations' => sub {
+    my $tree = CodingAdventures::FenwickTree->from_list([3, 2, 1, 7, 4]);
+    is($tree->size, 5, 'tree size');
+    ok(!$tree->is_empty, 'tree is populated');
+    is_deeply(
+        [map { $tree->prefix_sum($_) } 1 .. 5],
+        [3, 5, 6, 13, 17],
+        'reference prefix vector',
+    );
+    is($tree->prefix_sum(0), 0, 'zero prefix');
+    is($tree->range_sum(2, 4), 10, 'middle range');
+    is($tree->range_sum(1, 5), 17, 'full range');
+    is($tree->point_query(4), 7, 'point query');
+    is($tree->update(3, 5), $tree, 'update chains');
+    is($tree->point_query(3), 6, 'updated point');
+    is($tree->prefix_sum(3), 11, 'updated prefix');
+};
+
+subtest 'numeric values, defensive copy, and rendering' => sub {
+    my $tree = CodingAdventures::FenwickTree->from_list([5, -2, 7, 1.5, 4.5]);
+    is($tree->prefix_sum(5), 16, 'negative and floating values');
+    is($tree->range_sum(2, 4), 6.5, 'floating range');
+    $tree->update(2, 4.5);
+    is($tree->point_query(2), 2.5, 'floating update');
+
+    my $copy = $tree->bit_array;
+    $copy->[0] = 99;
+    is($tree->point_query(1), 5, 'BIT array is defensive copy');
+    like("$tree", qr/FenwickTree/, 'string identifies tree');
+};
+
+subtest 'order statistics' => sub {
+    my $tree = CodingAdventures::FenwickTree->from_list([1, 2, 3, 4, 5]);
+    is_deeply(
+        [map { $tree->find_kth($_) } (1, 2, 3, 4, 10, 15)],
+        [1, 2, 2, 3, 4, 5],
+        'find_kth reference vector',
+    );
+
+    dies_like(sub { CodingAdventures::FenwickTree->new(0)->find_kth(1) }, qr/empty tree/, 'empty lookup rejected');
+    dies_like(sub { $tree->find_kth(0) }, qr/target must be positive/, 'zero target rejected');
+    dies_like(sub { $tree->find_kth(16) }, qr/target exceeds total sum/, 'oversized target rejected');
+};
+
+subtest 'validation' => sub {
+    my $tree = CodingAdventures::FenwickTree->from_list([1, 2, 3]);
+    dies_like(sub { $tree->prefix_sum(-1) }, qr/prefix index -1 out of range/, 'negative prefix rejected');
+    dies_like(sub { $tree->prefix_sum(4) }, qr/prefix index 4 out of range/, 'large prefix rejected');
+    dies_like(sub { $tree->update(0, 1) }, qr/index 0 out of range/, 'zero update index rejected');
+    dies_like(sub { $tree->update(1, 'x') }, qr/delta must be a number/, 'non-number delta rejected');
+    dies_like(sub { $tree->range_sum(3, 1) }, qr/left must be <= right/, 'reversed range rejected');
+    dies_like(sub { $tree->range_sum(0, 2) }, qr/index 0 out of range/, 'invalid left rejected');
+    dies_like(sub { $tree->point_query(4) }, qr/index 4 out of range/, 'invalid point rejected');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,12 +105,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 14, 2026 after the Python `in-memory-data-store` and
-`in-memory-data-store-engine` ports:
+on July 14, 2026 after the paired Lua/Perl `fenwick-tree` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 371 |
+| Present in 10-15 languages | 171 | 369 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -156,15 +155,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 371
+The 171 packages present in at least ten implementation languages need 369
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 16 | Pair with Perl data-structure/storage wave |
-| Perl | 16 | Pair with Lua data-structure/storage wave |
+| Lua | 15 | Pair with Perl data-structure/storage wave |
+| Perl | 15 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -175,6 +174,10 @@ ports to reach all 15. After Priority 1, select work in this order:
 
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
+
+The first paired Lua/Perl data-structure slice is complete: `fenwick-tree` now
+has pure implementations, package-native tests, metadata, and capability
+declarations in both lanes.
 
 Recommended family order:
 


### PR DESCRIPTION
## What changed

- add pure Lua and Perl `fenwick-tree` packages with linear-time construction
- support prefix sums, inclusive range sums, point queries and updates, and `find_kth` order-statistic lookup
- add package-native tests, manifests, BUILD files, capability declarations, READMEs, and changelogs
- refresh the parity roadmap from the live reporter: high-consensus missing slots fall from 371 to 369, with Lua and Perl each falling from 16 gaps to 15

## Why this slice is next

After the Python data-store PR merged, the remaining high-consensus queue has an identical Lua/Perl data-structure wave. `fenwick-tree` is the smallest dependency-free leaf in that wave, so porting it in both lanes closes a coherent pair without introducing temporary package dependencies.

## Validation

- Lua 5.4 syntax checks for the implementation and test file
- Lua Busted: 8 successes, 0 failures
- LuaRocks package build/install with no package dependencies
- Perl syntax check plus 2 load assertions and 5 behavioral subtests
- `python code/scripts/tests/test_package_parity_report.py`: 6 tests pass
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- final report: 369 high-consensus gaps, 15 Lua gaps, 15 Perl gaps, 0 collisions, 0 unknown buckets
- `git diff --cached --check`

## Remaining gaps

- Python: 1 high-consensus gap (`python-parser`, requiring careful self-hosting classification)
- Lua: 15 high-consensus gaps
- Perl: 15 high-consensus gaps
- total high-consensus missing slots across all lanes: 369
