### PR TITLE
feat(adj-facts-stdlib): biology major-organs — human organ → its main job

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_majororgans_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_majororgans_e2e.rs
@@ -1,0 +1,64 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/major-organs.adj`) driven through the built CLI:
+//! a native `table` of major human organ → its main job resolves a binding-query
+//! recall with the source's citation (forward AND reverse), and abstains on a
+//! word that is not one of these organs — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_major_organs_recall_binds_function_with_citation() {
+    let dir = scratch("majororgans");
+    // Copy the shipped major-organs table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/major-organs.adj");
+    std::fs::copy(&src, dir.join("major-organs.adj")).expect("copy shipped major-organs.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"major-organs.adj\"\n\
+         ? organ_function(heart, $Job)\n\
+         ? organ_function(kidneys, $Job)\n\
+         ? organ_function($Organ, gas_exchange)\n\
+         ? organ_function(bone, $Job)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The heart pumps blood; the kidneys filter blood — the recalled jobs.
+    assert!(out.contains("\"Job\":\"pumps_blood\""), "heart → pumps_blood: {out}");
+    assert!(out.contains("\"Job\":\"filter_blood\""), "kidneys → filter_blood: {out}");
+    // The query also runs BACKWARD: bind the job, recall the organ that does it.
+    assert!(out.contains("\"Organ\":\"lungs\""), "gas_exchange → lungs: {out}");
+    // The answer carries the NIH / NHLBI citation as its proof, at the
+    // `authoritative` trust tier for a primary U.S. government source.
+    assert!(
+        out.contains("nhlbi.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A bone is not one of these organs — honest abstention, never a fabricated job.
+    assert!(out.contains("\"abstained\":true"), "bone abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/major-organs.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/major-organs.adj
@@ -1,0 +1,102 @@
+% ============================================================================
+% major-organs — each major human organ and its main job in the body
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the very first facts a child learns about their own body, and the
+% rung a MEDICINE agent reasons UP from: the body is built of organs, and each
+% organ has one main job. "The heart pumps blood; the lungs do gas exchange;
+% the kidneys filter blood." Before you can reason about disease you must know
+% what each organ is FOR — chest pain matters because the heart pumps blood to
+% the whole body; kidney failure matters because the kidneys filter the blood.
+% Recall is a binding query:
+%
+%     ? organ_function(heart, $Job)      % pumps_blood
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `organ_function(organ, function)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% job WITH its source, on the CPU, with zero model calls, and abstains on a
+% word that is not one of these organs (it never invents a job).
+%
+% Each organ and its main job, as a truth table:
+%
+%     organ     function         a beginner's cue
+%     -------   --------------   ---------------------------------------------
+%     heart     pumps_blood      the heart pumps blood all through your body
+%     lungs     gas_exchange     the lungs swap oxygen in for carbon dioxide out
+%     liver     removes_poisons  the liver helps remove poisons from the body
+%     kidneys   filter_blood     the kidneys filter your blood into urine
+%     brain     controls_body    the brain is the control center of the body
+%     stomach   digests_food     the stomach mixes and starts digesting food
+%
+% The query also runs BACKWARD — bind the job and recall which organ does it:
+%
+%     ? organ_function($Organ, pumps_blood)   % heart
+%
+% A word that is NOT one of these organs — `bone`, `skin`, `rock` — is
+% deliberately NOT a row, so an organ-function recall ABSTAINS on it rather
+% than inventing a job. That honest-abstention property is what makes the table
+% safe to build a reasoner on: it answers exactly the organ→job pairs it can
+% ground, and only those.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every organ's job below was
+% read out of a fetched U.S. government / NIH page, and any organ whose job could
+% not be verified there would have been dropped). Each organ→function pair, with
+% the primary source it was copied from and the verbatim span that states it:
+%
+%   heart → pumps_blood
+%     https://www.nhlbi.nih.gov/health/heart  (NIH / NHLBI)
+%     "The heart is an organ about the size of your fist that pumps blood
+%      through your body."
+%
+%   lungs → gas_exchange
+%     https://www.nhlbi.nih.gov/health/lungs  (NIH / NHLBI)
+%     "This process, called gas exchange, is essential to life."
+%     (the process by which oxygen moves into the blood and carbon dioxide
+%      moves out to be exhaled)
+%
+%   liver → removes_poisons
+%     https://medlineplus.gov/liverdiseases.html  (NIH / NLM, MedlinePlus)
+%     "Your liver is the largest organ inside your body. It helps your body
+%      digest food, store energy, and remove poisons."
+%
+%   kidneys → filter_blood
+%     https://medlineplus.gov/kidneydiseases.html  (NIH / NLM, MedlinePlus)
+%     "They filter your blood. They remove wastes and extra water, which
+%      become urine."
+%
+%   brain → controls_body
+%     https://medlineplus.gov/braindiseases.html  (NIH / NLM, MedlinePlus)
+%     "Your brain is the control center of your body."
+%
+%   stomach → digests_food
+%     https://medlineplus.gov/stomachdisorders.html  (NIH / NLM, MedlinePlus)
+%     "It stores swallowed food. It mixes the food with stomach acids. Then it
+%      sends the mixture on to the small intestine." — "It is where digestion
+%      of protein begins."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the NHLBI statement that fixes
+% the first row (heart → pumps_blood). Every OTHER row's per-fact source and
+% verbatim span is listed above, so each job remains independently checkable.
+% All six sources are primary U.S. government / NIH references, so
+% `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table organ_function {
+    columns organ, function
+
+    row (heart, pumps_blood)
+    row (lungs, gas_exchange)
+    row (liver, removes_poisons)
+    row (kidneys, filter_blood)
+    row (brain, controls_body)
+    row (stomach, digests_food)
+
+    source "The heart is an organ about the size of your fist that pumps blood through your body."
+    locator "https://www.nhlbi.nih.gov/health/heart"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/major-organs.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/major-organs.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% major-organs.query.adj — a worked recall over the major-organs library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the heart do?":
+% it states no fact of its own — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `organ_function`
+% rows and returns the job + the table's source/locator/trust. A word that is
+% not one of these organs abstains honestly — the engine never invents a job.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli major-organs.query.adj
+% ============================================================================
+
+import "major-organs.adj"
+
+? organ_function(heart, $Job)         % expect pumps_blood
+? organ_function(kidneys, $Job)       % expect filter_blood
+? organ_function($Organ, gas_exchange) % reverse bind — expect lungs
+? organ_function(bone, $Job)          % expect abstain — a bone is not one of these organs


### PR DESCRIPTION
Add a grounded later-elementary FACTS library mapping each **major human organ → its main function** — the organ→function rung a medicine agent reasons up from — plus a worked query file and a CLI e2e test.

## Rows (each grounded verbatim in a primary NIH / .gov source; nothing from memory)

| organ | function | source | span |
|---|---|---|---|
| heart | pumps_blood | NHLBI `nhlbi.nih.gov/health/heart` | "The heart is an organ about the size of your fist that pumps blood through your body." |
| lungs | gas_exchange | NHLBI `nhlbi.nih.gov/health/lungs` | "This process, called gas exchange, is essential to life." |
| liver | removes_poisons | MedlinePlus `medlineplus.gov/liverdiseases.html` | "…It helps your body digest food, store energy, and remove poisons." |
| kidneys | filter_blood | MedlinePlus `medlineplus.gov/kidneydiseases.html` | "They filter your blood. They remove wastes and extra water, which become urine." |
| brain | controls_body | MedlinePlus `medlineplus.gov/braindiseases.html` | "Your brain is the control center of your body." |
| stomach | digests_food | MedlinePlus `medlineplus.gov/stomachdisorders.html` | "…It is where digestion of protein begins." |

All six sources are primary U.S. government / NIH references, so the table's provenance envelope carries **`trust authoritative`**. Each value atom matches its source's wording (e.g. `removes_poisons` follows "remove poisons", not the generic "filters blood"). A word that is not one of these organs abstains honestly.

## Files
- `code/specs/data/adj-facts-stdlib/biology/major-organs.adj` — the `table organ_function` (columns organ, function) with a beginner literate comment: truth table, forward/backward recall, and per-row verbatim provenance.
- `code/specs/data/adj-facts-stdlib/biology/major-organs.query.adj` — worked recall: two `?` binds, a reverse bind (`gas_exchange → lungs`), and an abstain on a non-organ (`bone`).
- `code/packages/rust/adj-lang-cli/tests/facts_majororgans_e2e.rs` — copies the shipped table beside an entry program; asserts 2 forward binds, 1 reverse bind, the NHLBI locator + `authoritative` trust, and honest abstention on `bone`.

## Verification
- `cargo test -p adj-lang-cli --test facts_majororgans_e2e` — passes (1 test).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Security review (Rust + data): passed, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)