### PR TITLE
feat(os-platform): CCPP02 Phase 2 PR5 — dynlib primitive (dlopen/dlsym/dlclose, C)

### DIFF
--- a/code/packages/c/os-platform/CHANGELOG.md
+++ b/code/packages/c/os-platform/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to semantic versioning.
 
 ### Added
 
+- **`dynlib` primitive** (CCPP02 Phase 2, PR 5): load a shared library, resolve a
+  symbol, unload — the foundation for plugins/FFI, and pure bucket B (ISO C
+  cannot load code at run time).
+  - `osp_dynlib_open` / `osp_dynlib_symbol` (address into a `void *`) /
+    `osp_dynlib_close`.
+  - Backends: `dynlib_posix.c` (`dlopen(RTLD_NOW|RTLD_LOCAL)` / `dlsym` /
+    `dlclose`; the `dlerror()`-clear dance distinguishes a missing symbol from a
+    legitimately NULL-valued one) and `dynlib_windows.c` (`LoadLibraryA` /
+    `GetProcAddress` / `FreeLibrary`; FARPROC→`void*` via memcpy to avoid the
+    MSVC C4054 function/data-pointer cast).
+  - The POSIX BUILD links `-ldl` on **Linux only** (macOS has dlopen in libc and
+    ships no libdl). This is why dynlib lives on platform-harness: converting the
+    resolved address to a function pointer is not strict-ISO.
+  - Test (`tests/dynlib_test.c`): loads a per-OS system library (libc.so.6 /
+    libSystem.dylib / kernel32.dll), resolves and *calls* a known symbol
+    (getpid / GetCurrentProcessId) via a memcpy'd function pointer, and checks
+    missing-symbol + NULL-arg errors. Clean under ASan+UBSan, 0 leaks.
 - **`process` primitive** (CCPP02 Phase 2, PR 4): spawn a child program, wait,
   read its exit code — bucket B (ISO `system()` blocks, needs a shell, and can't
   reliably report the exit code).

--- a/code/packages/c/os-platform/README.md
+++ b/code/packages/c/os-platform/README.md
@@ -23,7 +23,7 @@ exactly one backend and the code contains no `#if defined(__linux__)` mazes.
 | `thread` | `os_platform/thread.h`  | ✅ implemented |
 | `fs`      | `os_platform/fs.h`      | ✅ implemented |
 | `process` | `os_platform/process.h` | ✅ implemented |
-| dynlib    | —                       | planned       |
+| `dynlib`  | `os_platform/dynlib.h`  | ✅ implemented |
 | mmap     | —                       | planned       |
 
 All primitives share the `osp_status` return convention from
@@ -166,6 +166,39 @@ directly, so there is no shell word-splitting, globbing, or injection surface.
 On Windows the backend re-quotes `argv` into a command line using the exact
 `CommandLineToArgvW` rules, so the child reconstructs the caller's `argv` intact.
 
+### `dynlib` — load a shared library, resolve a symbol, close
+
+Loading code at run time (plugins, FFI) is bucket B — ISO C has no notion of it.
+
+```c
+#include "os_platform/dynlib.h"
+#include <string.h>
+
+osp_dynlib *lib;
+osp_dynlib_open(&lib, "libm.so.6");     /* dlopen / LoadLibrary */
+
+void *addr;
+osp_dynlib_symbol(lib, "cos", &addr);   /* dlsym / GetProcAddress */
+
+double (*cosfn)(double);
+memcpy(&cosfn, &addr, sizeof cosfn);    /* void* -> fn ptr, warning-free */
+double c = cosfn(0.0);                   /* == 1.0 */
+
+osp_dynlib_close(lib);                   /* dlclose / FreeLibrary */
+```
+
+Backends:
+
+| OS          | load          | resolve          | unload        |
+|-------------|---------------|------------------|---------------|
+| macOS/Linux | `dlopen`      | `dlsym`          | `dlclose`     |
+| Windows     | `LoadLibrary` | `GetProcAddress` | `FreeLibrary` |
+
+The POSIX BUILD links `-ldl` on **Linux only** (macOS has `dlopen` in libc). A
+resolved symbol is a `void *`; convert it to a function pointer with `memcpy`
+(the direct object↔function cast is non-ISO — which is exactly why `dynlib` lives
+on `platform-harness`, not `iso-harness`).
+
 ## Build & test
 
 ```sh
@@ -187,13 +220,15 @@ os-platform/
 │   ├── clock.h                   # clock API
 │   ├── thread.h                  # thread API
 │   ├── fs.h                      # fs API
-│   └── process.h                 # process API
+│   ├── process.h                 # process API
+│   └── dynlib.h                  # dynlib API
 ├── src/
 │   ├── clock_posix.c   · clock_windows.c     # per-OS clock backends
 │   ├── thread_posix.c  · thread_windows.c    # per-OS thread backends
 │   ├── fs_posix.c      · fs_windows.c        # per-OS fs backends
-│   └── process_posix.c · process_windows.c   # per-OS process backends
-├── tests/clock_test.c · thread_test.c · fs_test.c · process_test.c
+│   ├── process_posix.c · process_windows.c   # per-OS process backends
+│   └── dynlib_posix.c  · dynlib_windows.c    # per-OS dynlib backends
+├── tests/clock_test.c · thread_test.c · fs_test.c · process_test.c · dynlib_test.c
 ├── tools/run.sh  · run.ps1       # per-OS build drivers
 ├── BUILD  · BUILD_windows        # per-OS source selection
 └── required_capabilities.json    # CI needs gcc, clang, cl

--- a/code/packages/c/os-platform/include/os_platform/dynlib.h
+++ b/code/packages/c/os-platform/include/os_platform/dynlib.h
@@ -1,0 +1,79 @@
+/*
+ * os_platform/dynlib.h — load a shared library, resolve a symbol, close it.
+ * ===========================================================================
+ *
+ * The fifth os-platform primitive, and the foundation for plugins and FFI. ISO C
+ * has no notion of loading code at run time; it is entirely the OS's domain:
+ *
+ *      step            macOS / Linux    Windows
+ *      ──────────────  ───────────────  ─────────────────
+ *      load a library  dlopen           LoadLibrary
+ *      resolve symbol  dlsym            GetProcAddress
+ *      unload          dlclose          FreeLibrary
+ *
+ * WHY THIS LIVES ON platform-harness, NOT iso-harness. Resolving a symbol yields
+ * an address that the caller will usually invoke as a FUNCTION, but dlsym returns
+ * `void *` (an object pointer). Converting between object and function pointers
+ * is not defined by strict ISO C — which is exactly the kind of thing
+ * platform-harness allows (it keeps -Wall -Wextra -Werror but drops
+ * -pedantic-errors). POSIX itself guarantees the round trip works.
+ *
+ * CALLING A RESOLVED SYMBOL. `osp_dynlib_symbol` writes the address into a
+ * `void *`. To call it, convert that to the right function-pointer type. The
+ * portable, warning-free way (clean even under MSVC /W4 /WX, which rejects a
+ * direct object<->function pointer cast) is to copy the bits:
+ *
+ *      void *addr;
+ *      osp_dynlib_symbol(lib, "some_func", &addr);
+ *      int (*fn)(int);
+ *      memcpy(&fn, &addr, sizeof fn);   // object* -> function*, bit-for-bit
+ *      int r = fn(7);
+ *
+ * MODEL. An opaque handle from osp_dynlib_open is used with osp_dynlib_symbol and
+ * released by osp_dynlib_close (which frees the handle and drops the library's
+ * reference count). No OS handle leaks.
+ *
+ * BUILD. Compiled by platform-harness. On Linux the POSIX backend links `-ldl`
+ * (the BUILD adds it on Linux only — macOS has dlopen in libc and no libdl);
+ * Windows uses only kernel32.
+ */
+#ifndef OS_PLATFORM_DYNLIB_H
+#define OS_PLATFORM_DYNLIB_H
+
+#include "os_platform/status.h" /* osp_status */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque loaded-library handle. Created by osp_dynlib_open, freed by
+ * osp_dynlib_close. Do not copy or free it yourself. */
+typedef struct osp_dynlib osp_dynlib;
+
+/*
+ * osp_dynlib_open — load the shared library at `path`.
+ * Writes a handle through *out on success. Returns OSP_ERR_INVAL if out or path
+ * is NULL, OSP_ERR_NOMEM on an allocation failure, OSP_ERR_OS if the library
+ * cannot be loaded.
+ */
+osp_status osp_dynlib_open(osp_dynlib **out, const char *path);
+
+/*
+ * osp_dynlib_symbol — resolve `name` in `lib`, writing its address to *out_sym.
+ * See the header comment for how to invoke a function symbol. Returns
+ * OSP_ERR_INVAL if any argument is NULL, OSP_ERR_OS if the symbol is not found.
+ */
+osp_status osp_dynlib_symbol(osp_dynlib *lib, const char *name, void **out_sym);
+
+/*
+ * osp_dynlib_close — unload `lib` and free the handle. Returns OSP_ERR_INVAL if
+ * lib is NULL, OSP_ERR_OS if the OS unload call fails. Any symbol addresses
+ * previously resolved from `lib` are invalid after this returns.
+ */
+osp_status osp_dynlib_close(osp_dynlib *lib);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* OS_PLATFORM_DYNLIB_H */

--- a/code/packages/c/os-platform/src/dynlib_posix.c
+++ b/code/packages/c/os-platform/src/dynlib_posix.c
@@ -1,0 +1,79 @@
+/*
+ * dynlib_posix.c — the POSIX backend of os_platform/dynlib (macOS + Linux).
+ * ===========================================================================
+ *
+ * Compiled on macOS + Linux (named by the shared `BUILD`; Windows uses
+ * dynlib_windows.c via `BUILD_windows`). No OS #ifdefs — the build chose this
+ * file. Links `-ldl` on Linux (the BUILD adds it there only; macOS has dlopen in
+ * libc and ships no libdl).
+ *
+ * The one subtlety is in symbol lookup: dlsym returns NULL both when a symbol is
+ * missing AND when a symbol legitimately has the value NULL. POSIX's way to tell
+ * them apart is to clear dlerror() first, then, if dlsym returned NULL, check
+ * whether dlerror() now reports a message. We honour that so a real (but
+ * NULL-valued) symbol is not misreported as missing.
+ */
+#include "os_platform/dynlib.h"
+
+#include <dlfcn.h>
+#include <stdlib.h>
+
+struct osp_dynlib {
+    void *handle;
+};
+
+osp_status osp_dynlib_open(osp_dynlib **out, const char *path) {
+    struct osp_dynlib *lib;
+    void *h;
+
+    if (out == NULL || path == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* RTLD_NOW: resolve every symbol immediately, so a broken library fails here
+     * rather than at first use. RTLD_LOCAL: do not leak its symbols into the
+     * global namespace. */
+    h = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    if (h == NULL) {
+        return OSP_ERR_OS;
+    }
+    lib = (struct osp_dynlib *)malloc(sizeof(*lib));
+    if (lib == NULL) {
+        dlclose(h);
+        return OSP_ERR_NOMEM;
+    }
+    lib->handle = h;
+    *out = lib;
+    return OSP_OK;
+}
+
+osp_status osp_dynlib_symbol(osp_dynlib *lib, const char *name, void **out_sym) {
+    void *sym;
+
+    if (lib == NULL || name == NULL || out_sym == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    dlerror(); /* clear any stale error before the lookup */
+    sym = dlsym(lib->handle, name);
+    if (sym == NULL && dlerror() != NULL) {
+        /* NULL AND an error message => genuinely not found. (NULL with no error
+         * means the symbol exists and its value is NULL — still a success.) */
+        return OSP_ERR_OS;
+    }
+    *out_sym = sym;
+    return OSP_OK;
+}
+
+osp_status osp_dynlib_close(osp_dynlib *lib) {
+    osp_status st = OSP_OK;
+    if (lib == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* Free the wrapper unconditionally: the contract says close frees the
+     * handle, so a caller will not retry after a failure — keeping the struct
+     * would leak it. We still report an unload failure via the status. */
+    if (dlclose(lib->handle) != 0) {
+        st = OSP_ERR_OS;
+    }
+    free(lib);
+    return st;
+}

--- a/code/packages/c/os-platform/src/dynlib_windows.c
+++ b/code/packages/c/os-platform/src/dynlib_windows.c
@@ -1,0 +1,78 @@
+/*
+ * dynlib_windows.c — the Win32 backend of os_platform/dynlib.
+ * ===========================================================================
+ *
+ * Compiled on Windows (named by `BUILD_windows`; macOS/Linux use dynlib_posix.c
+ * via the shared `BUILD`). No OS #ifdefs — the build chose this file. Uses only
+ * kernel32.
+ *
+ * GetProcAddress returns a FARPROC (a function pointer), but our API hands the
+ * caller a `void *`. A direct function-pointer -> object-pointer cast is exactly
+ * what MSVC flags as C4054 (and it would become an error under /WX), so we copy
+ * the bits with memcpy instead — well-defined here because a code address and a
+ * data pointer are the same width on every Windows ABI, and warning-free on every
+ * compiler.
+ */
+#include "os_platform/dynlib.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <stdlib.h>
+#include <string.h> /* memcpy */
+
+struct osp_dynlib {
+    HMODULE handle;
+};
+
+osp_status osp_dynlib_open(osp_dynlib **out, const char *path) {
+    struct osp_dynlib *lib;
+    HMODULE h;
+
+    if (out == NULL || path == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    h = LoadLibraryA(path);
+    if (h == NULL) {
+        return OSP_ERR_OS;
+    }
+    lib = (struct osp_dynlib *)malloc(sizeof(*lib));
+    if (lib == NULL) {
+        FreeLibrary(h);
+        return OSP_ERR_NOMEM;
+    }
+    lib->handle = h;
+    *out = lib;
+    return OSP_OK;
+}
+
+osp_status osp_dynlib_symbol(osp_dynlib *lib, const char *name, void **out_sym) {
+    FARPROC sym;
+
+    if (lib == NULL || name == NULL || out_sym == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    sym = GetProcAddress(lib->handle, name);
+    if (sym == NULL) {
+        return OSP_ERR_OS;
+    }
+    /* FARPROC (function pointer) -> void *, bit-for-bit, to avoid the C4054
+     * function-to-data pointer cast diagnostic. Same width on every Win32 ABI. */
+    memcpy(out_sym, &sym, sizeof(sym));
+    return OSP_OK;
+}
+
+osp_status osp_dynlib_close(osp_dynlib *lib) {
+    osp_status st = OSP_OK;
+    if (lib == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* Free the wrapper unconditionally: the contract says close frees the
+     * handle, so a caller will not retry after a failure — keeping the struct
+     * would leak it. We still report an unload failure via the status. */
+    if (!FreeLibrary(lib->handle)) {
+        st = OSP_ERR_OS;
+    }
+    free(lib);
+    return st;
+}

--- a/code/packages/c/os-platform/tests/dynlib_test.c
+++ b/code/packages/c/os-platform/tests/dynlib_test.c
@@ -1,0 +1,75 @@
+/*
+ * dynlib_test.c — load/resolve/close tests for os_platform/dynlib, per OS.
+ * ===========================================================================
+ *
+ * We load a library guaranteed to be present on the platform, resolve a
+ * well-known no-argument function from it, call that function through the
+ * resolved address, and check the result is sane. This proves the whole chain:
+ * open -> symbol -> a usable code address -> close. Which library and symbol
+ * exist is inherently OS-specific, so (only in this test — never in the library
+ * backends) a #ifdef selects them:
+ *
+ *      OS       library            symbol (returns a positive id)
+ *      ───────  ─────────────────  ──────────────────────────────
+ *      Linux    libc.so.6          getpid
+ *      macOS    libSystem.dylib    getpid
+ *      Windows  kernel32.dll       GetCurrentProcessId
+ *
+ * The resolved void* is turned into a callable function pointer with memcpy —
+ * the portable, warning-free idiom (a direct cast trips MSVC /W4 /WX). Error and
+ * NULL-argument paths are checked too, and they are the same on every OS.
+ */
+#include "iso_test.h"
+
+#include "os_platform/dynlib.h"
+
+#include <stddef.h> /* NULL */
+#include <string.h> /* memcpy */
+
+#ifdef _WIN32
+#define OSP_TEST_LIB "kernel32.dll"
+#define OSP_TEST_SYM "GetCurrentProcessId"
+typedef unsigned long (*osp_id_fn)(void); /* DWORD GetCurrentProcessId(void) */
+#elif defined(__APPLE__)
+#define OSP_TEST_LIB "libSystem.dylib"
+#define OSP_TEST_SYM "getpid"
+typedef int (*osp_id_fn)(void); /* pid_t getpid(void) */
+#else
+#define OSP_TEST_LIB "libc.so.6"
+#define OSP_TEST_SYM "getpid"
+typedef int (*osp_id_fn)(void);
+#endif
+
+int main(void) {
+    osp_dynlib *lib = NULL;
+    osp_dynlib *bad = NULL;
+    void *sym = NULL;
+    osp_id_fn fn;
+
+    /* ── open → symbol → call → close ───────────────────────────────────── */
+    ISO_CHECK(osp_dynlib_open(&lib, OSP_TEST_LIB) == OSP_OK);
+    if (lib != NULL) {
+        ISO_CHECK(osp_dynlib_symbol(lib, OSP_TEST_SYM, &sym) == OSP_OK);
+        ISO_CHECK_MSG(sym != NULL, "resolved symbol address must be non-NULL");
+
+        /* void* -> function pointer, bit-for-bit (warning-free everywhere). */
+        memcpy(&fn, &sym, sizeof(fn));
+        ISO_CHECK_MSG(fn() > 0, "calling the resolved function should yield a positive id");
+
+        /* a missing symbol must fail cleanly */
+        ISO_CHECK(osp_dynlib_symbol(lib, "osp_no_such_symbol_zzz", &sym) == OSP_ERR_OS);
+
+        ISO_CHECK(osp_dynlib_close(lib) == OSP_OK);
+    } else {
+        ISO_CHECK_MSG(0, "osp_dynlib_open returned OK but a NULL handle");
+    }
+
+    /* ── error + NULL-argument paths (identical on every OS) ─────────────── */
+    ISO_CHECK(osp_dynlib_open(&bad, "osp_no_such_library_zzz.xyz") == OSP_ERR_OS);
+    ISO_CHECK(osp_dynlib_open(NULL, OSP_TEST_LIB) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_dynlib_open(&lib, NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_dynlib_symbol(NULL, OSP_TEST_SYM, &sym) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_dynlib_close(NULL) == OSP_ERR_INVAL);
+
+    return ISO_TEST_RESULT();
+}

--- a/code/packages/c/os-platform/tools/run.ps1
+++ b/code/packages/c/os-platform/tools/run.ps1
@@ -48,3 +48,6 @@ Platform-BuildAndRun -Lang c -Name 'fs-tests' -Sources @('tests\fs_test.c', 'src
 
 # process — Win32 backend (CreateProcess + WaitForSingleObject + GetExitCodeProcess).
 Platform-BuildAndRun -Lang c -Name 'process-tests' -Sources @('tests\process_test.c', 'src\process_windows.c')
+
+# dynlib — Win32 backend (LoadLibrary + GetProcAddress + FreeLibrary).
+Platform-BuildAndRun -Lang c -Name 'dynlib-tests' -Sources @('tests\dynlib_test.c', 'src\dynlib_windows.c')

--- a/code/packages/c/os-platform/tools/run.sh
+++ b/code/packages/c/os-platform/tools/run.sh
@@ -66,4 +66,14 @@ PLATFORM_LIBS=""
 export PLATFORM_LIBS
 platform_build_and_run c process-tests tests/process_test.c src/process_posix.c || rc=1
 
+# dynlib — POSIX backend (dlopen/dlsym/dlclose). Links -ldl on Linux only
+# (macOS has dlopen in libc and ships no libdl, so -ldl would fail to link).
+if [ "$(platform_os)" = "linux" ]; then
+    PLATFORM_LIBS="-ldl"
+else
+    PLATFORM_LIBS=""
+fi
+export PLATFORM_LIBS
+platform_build_and_run c dynlib-tests tests/dynlib_test.c src/dynlib_posix.c || rc=1
+
 exit "$rc"


### PR DESCRIPTION
## CCPP02 Phase 2 — `os-platform` fifth primitive: `dynlib`

Builds on merged `clock` (#8319), `thread` (#8321), `fs` (#8323), `process`
(#8329). Loading code at run time — the foundation for plugins and FFI (the
~77-crate FFI/dlopen category) — is pure **bucket B**: ISO C has no notion of it.

### API (`os_platform/dynlib.h`)

| Function | Purpose |
|----------|---------|
| `osp_dynlib_open(out, path)` | load a shared library |
| `osp_dynlib_symbol(lib, name, &addr)` | resolve a symbol into a `void *` |
| `osp_dynlib_close(lib)` | unload + free |

### Backends — per-OS source selection via BUILD, no `#ifdef` mazes

| | load | resolve | unload |
|--|------|---------|--------|
| **macOS/Linux** (`dynlib_posix.c`) | `dlopen(RTLD_NOW\|RTLD_LOCAL)` | `dlsym` | `dlclose` |
| **Windows** (`dynlib_windows.c`) | `LoadLibraryA` | `GetProcAddress` | `FreeLibrary` |

- POSIX uses the `dlerror()`-clear dance so a genuinely-NULL-valued symbol isn't misreported as missing.
- The BUILD links **`-ldl` on Linux only** (macOS has `dlopen` in libc and ships no libdl — `-ldl` would fail to link), gated by `platform_os` in `run.sh`.
- Windows converts `FARPROC → void*` via **memcpy** (a direct function→data pointer cast is MSVC **C4054**, an error under `/WX`).

### Why this lives on `platform-harness`, not `iso-harness`

A resolved symbol is usually **called**, but converting an object pointer to a
function pointer is not strict-ISO. The header documents the portable, warning-free
`memcpy` idiom for turning the `void*` into a function pointer.

### Test (`tests/dynlib_test.c`, run on each OS)

Loads a per-OS system library (`libc.so.6` / `libSystem.dylib` / `kernel32.dll`),
resolves **and calls** a known symbol (`getpid` / `GetCurrentProcessId`) through a
memcpy'd function pointer and checks the result is a positive id, plus
missing-symbol and NULL-arg errors. `#ifdef` picks the per-OS lib+symbol (test
only; the backends have no `#ifdef`).

### Verification

- **Local (macOS):** clock 13/0 + thread 28/0 + fs 24/0 + process 7/0 + dynlib 11/0 under gcc + clang.
- **Sanitizers:** dynlib test clean under **ASan + UBSan**; **0 leaks**.
- **Security review:** passed — reviewer verified the malloc-fail-after-load path releases the library, the `FARPROC→void*` memcpy width, the `dlerror()` NULL-vs-missing logic, and `RTLD_NOW|RTLD_LOCAL` as a non-weakening choice. Applied its one LOW finding: `osp_dynlib_close` now frees the wrapper unconditionally (still reporting an unload failure) so it can't leak the struct when the contract says the handle is freed.
- CI proves `dynlib_windows.c` on the windows runner.

Spec: [`CCPP02-os-platform-lane.md`](code/specs/CCPP02-os-platform-lane.md) · final primitive next: `mmap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)