### PR TITLE
feat: port binary search tree to Lua and Perl

### DIFF
--- a/code/packages/lua/binary-search-tree/BUILD
+++ b/code/packages/lua/binary-search-tree/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-binary-search-tree-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/binary-search-tree/BUILD_windows
+++ b/code/packages/lua/binary-search-tree/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-binary-search-tree-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/binary-search-tree/CHANGELOG.md
+++ b/code/packages/lua/binary-search-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add a pure-Lua persistent binary search tree with balanced construction,
+  deletion, lookup, order statistics, custom comparison, and validation.

--- a/code/packages/lua/binary-search-tree/README.md
+++ b/code/packages/lua/binary-search-tree/README.md
@@ -1,0 +1,25 @@
+# Lua binary search tree
+
+A dependency-free persistent binary search tree with duplicate suppression,
+deletion, lookup, predecessor/successor queries, rank and k-th order statistics,
+balanced construction from sorted arrays, and metadata validation.
+
+```lua
+local BinarySearchTree = require("coding_adventures.binary_search_tree").BinarySearchTree
+
+local tree = BinarySearchTree.empty():insert(5):insert(1):insert(8):insert(3)
+local updated = tree:delete(5)
+assert(tree:contains(5))
+assert(not updated:contains(5))
+assert(updated:kth_smallest(2) == 3)
+```
+
+`insert` and `delete` return new trees and preserve the original. Supply a
+three-way comparison function to `empty` or `from_sorted_array` for values that
+do not use Lua's default `<` and `>` ordering.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/lua/binary-search-tree/coding-adventures-binary-search-tree-0.1.0-1.rockspec
+++ b/code/packages/lua/binary-search-tree/coding-adventures-binary-search-tree-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-binary-search-tree"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Persistent binary search tree with order statistics",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.binary_search_tree"] = "src/coding_adventures/binary_search_tree/init.lua",
+    },
+}

--- a/code/packages/lua/binary-search-tree/required_capabilities.json
+++ b/code/packages/lua/binary-search-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/binary-search-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/binary-search-tree/src/coding_adventures/binary_search_tree/init.lua
+++ b/code/packages/lua/binary-search-tree/src/coding_adventures/binary_search_tree/init.lua
@@ -1,0 +1,321 @@
+local M = {VERSION = "0.1.0"}
+
+local function default_compare(left, right)
+    if left < right then
+        return -1
+    end
+    if left > right then
+        return 1
+    end
+    return 0
+end
+
+local BSTNode = {}
+BSTNode.__index = BSTNode
+
+local function is_node(value)
+    return type(value) == "table" and getmetatable(value) == BSTNode
+end
+
+local function node_size(root)
+    return root == nil and 0 or root.size
+end
+
+function BSTNode.new(value, left, right, size)
+    if value == nil then
+        error("node value must not be nil", 2)
+    end
+    if left ~= nil and not is_node(left) then
+        error("left must be a BSTNode or nil", 2)
+    end
+    if right ~= nil and not is_node(right) then
+        error("right must be a BSTNode or nil", 2)
+    end
+    local actual_size = size
+    if actual_size == nil then
+        actual_size = 1 + node_size(left) + node_size(right)
+    elseif type(actual_size) ~= "number" or actual_size < 0 or actual_size % 1 ~= 0 then
+        error("size must be a non-negative integer", 2)
+    end
+    return setmetatable({value = value, left = left, right = right, size = actual_size}, BSTNode)
+end
+
+local function with_children(root, left, right)
+    return BSTNode.new(root.value, left, right)
+end
+
+local function insert_node(root, value, compare)
+    if root == nil then
+        return BSTNode.new(value)
+    end
+    local order = compare(value, root.value)
+    if order < 0 then
+        return with_children(root, insert_node(root.left, value, compare), root.right)
+    end
+    if order > 0 then
+        return with_children(root, root.left, insert_node(root.right, value, compare))
+    end
+    return root
+end
+
+local function extract_min(root)
+    if root.left == nil then
+        return root.right, root.value
+    end
+    local new_left, minimum = extract_min(root.left)
+    return with_children(root, new_left, root.right), minimum
+end
+
+local function delete_node(root, value, compare)
+    if root == nil then
+        return nil
+    end
+    local order = compare(value, root.value)
+    if order < 0 then
+        return with_children(root, delete_node(root.left, value, compare), root.right)
+    end
+    if order > 0 then
+        return with_children(root, root.left, delete_node(root.right, value, compare))
+    end
+    if root.left == nil then
+        return root.right
+    end
+    if root.right == nil then
+        return root.left
+    end
+
+    local new_right, successor = extract_min(root.right)
+    return BSTNode.new(successor, root.left, new_right)
+end
+
+local function kth_smallest(root, k)
+    if root == nil or type(k) ~= "number" or k <= 0 or k % 1 ~= 0 then
+        return nil
+    end
+    local left_size = node_size(root.left)
+    if k == left_size + 1 then
+        return root.value
+    end
+    if k <= left_size then
+        return kth_smallest(root.left, k)
+    end
+    return kth_smallest(root.right, k - left_size - 1)
+end
+
+local function rank(root, value, compare)
+    if root == nil then
+        return 0
+    end
+    local order = compare(value, root.value)
+    if order < 0 then
+        return rank(root.left, value, compare)
+    end
+    if order > 0 then
+        return node_size(root.left) + 1 + rank(root.right, value, compare)
+    end
+    return node_size(root.left)
+end
+
+local function append_inorder(root, out)
+    if root == nil then
+        return
+    end
+    append_inorder(root.left, out)
+    out[#out + 1] = root.value
+    append_inorder(root.right, out)
+end
+
+local function height(root)
+    if root == nil then
+        return -1
+    end
+    return 1 + math.max(height(root.left), height(root.right))
+end
+
+local function validate(root, minimum, maximum, has_minimum, has_maximum, compare)
+    if root == nil then
+        return -1, 0
+    end
+    if has_minimum and compare(root.value, minimum) <= 0 then
+        return nil
+    end
+    if has_maximum and compare(root.value, maximum) >= 0 then
+        return nil
+    end
+
+    local left_height, left_size = validate(root.left, minimum, root.value, has_minimum, true, compare)
+    if left_height == nil then
+        return nil
+    end
+    local right_height, right_size = validate(root.right, root.value, maximum, true, has_maximum, compare)
+    if right_height == nil then
+        return nil
+    end
+
+    local actual_size = 1 + left_size + right_size
+    if root.size ~= actual_size then
+        return nil
+    end
+    return 1 + math.max(left_height, right_height), actual_size
+end
+
+local function build_balanced(values, first, last)
+    if first > last then
+        return nil
+    end
+    local middle = math.floor((first + last + 1) / 2)
+    local value = values[middle]
+    if value == nil then
+        error(string.format("value at index %d must not be nil", middle), 3)
+    end
+    return BSTNode.new(
+        value,
+        build_balanced(values, first, middle - 1),
+        build_balanced(values, middle + 1, last)
+    )
+end
+
+local BinarySearchTree = {}
+BinarySearchTree.__index = BinarySearchTree
+
+function BinarySearchTree.new(root, compare)
+    if root ~= nil and not is_node(root) then
+        error("root must be a BSTNode or nil", 2)
+    end
+    local comparator = compare or default_compare
+    if type(comparator) ~= "function" then
+        error("compare must be a function", 2)
+    end
+    return setmetatable({root = root, compare = comparator}, BinarySearchTree)
+end
+
+function BinarySearchTree.empty(compare)
+    return BinarySearchTree.new(nil, compare)
+end
+
+function BinarySearchTree.from_sorted_array(values, compare)
+    if type(values) ~= "table" then
+        error("values must be a table", 2)
+    end
+    return BinarySearchTree.new(build_balanced(values, 1, #values), compare)
+end
+
+function BinarySearchTree:insert(value)
+    if value == nil then
+        error("value must not be nil", 2)
+    end
+    return BinarySearchTree.new(insert_node(self.root, value, self.compare), self.compare)
+end
+
+function BinarySearchTree:delete(value)
+    if value == nil then
+        error("value must not be nil", 2)
+    end
+    return BinarySearchTree.new(delete_node(self.root, value, self.compare), self.compare)
+end
+
+function BinarySearchTree:search(value)
+    local current = self.root
+    while current ~= nil do
+        local order = self.compare(value, current.value)
+        if order < 0 then
+            current = current.left
+        elseif order > 0 then
+            current = current.right
+        else
+            return current
+        end
+    end
+    return nil
+end
+
+function BinarySearchTree:contains(value)
+    return self:search(value) ~= nil
+end
+
+function BinarySearchTree:min_value()
+    local current = self.root
+    while current ~= nil and current.left ~= nil do
+        current = current.left
+    end
+    if current == nil then
+        return nil
+    end
+    return current.value
+end
+
+function BinarySearchTree:max_value()
+    local current = self.root
+    while current ~= nil and current.right ~= nil do
+        current = current.right
+    end
+    if current == nil then
+        return nil
+    end
+    return current.value
+end
+
+function BinarySearchTree:predecessor(value)
+    local current = self.root
+    local best = nil
+    while current ~= nil do
+        if self.compare(value, current.value) <= 0 then
+            current = current.left
+        else
+            best = current.value
+            current = current.right
+        end
+    end
+    return best
+end
+
+function BinarySearchTree:successor(value)
+    local current = self.root
+    local best = nil
+    while current ~= nil do
+        if self.compare(value, current.value) >= 0 then
+            current = current.right
+        else
+            best = current.value
+            current = current.left
+        end
+    end
+    return best
+end
+
+function BinarySearchTree:kth_smallest(k)
+    return kth_smallest(self.root, k)
+end
+
+function BinarySearchTree:rank(value)
+    return rank(self.root, value, self.compare)
+end
+
+function BinarySearchTree:to_sorted_array()
+    local out = {}
+    append_inorder(self.root, out)
+    return out
+end
+
+function BinarySearchTree:is_valid()
+    return validate(self.root, nil, nil, false, false, self.compare) ~= nil
+end
+
+function BinarySearchTree:height()
+    return height(self.root)
+end
+
+function BinarySearchTree:size()
+    return node_size(self.root)
+end
+
+function BinarySearchTree:__tostring()
+    local root_value = self.root == nil and "nil" or tostring(self.root.value)
+    return string.format("BinarySearchTree(root=%s, size=%d)", root_value, self:size())
+end
+
+M.default_compare = default_compare
+M.BSTNode = BSTNode
+M.BinarySearchTree = BinarySearchTree
+
+return M

--- a/code/packages/lua/binary-search-tree/tests/test_binary_search_tree.lua
+++ b/code/packages/lua/binary-search-tree/tests/test_binary_search_tree.lua
@@ -1,0 +1,112 @@
+package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+
+local module = require("coding_adventures.binary_search_tree")
+local BSTNode = module.BSTNode
+local BinarySearchTree = module.BinarySearchTree
+
+local function populated()
+    local tree = BinarySearchTree.empty()
+    for _, value in ipairs({5, 1, 8, 3, 7}) do
+        tree = tree:insert(value)
+    end
+    return tree
+end
+
+describe("BinarySearchTree persistence", function()
+    it("inserts, searches, ranks, and deletes", function()
+        local tree = populated()
+        assert.are.same({1, 3, 5, 7, 8}, tree:to_sorted_array())
+        assert.equals(5, tree:size())
+        assert.is_true(tree:contains(7))
+        assert.equals(7, tree:search(7).value)
+        assert.equals(1, tree:min_value())
+        assert.equals(8, tree:max_value())
+        assert.equals(3, tree:predecessor(5))
+        assert.equals(7, tree:successor(5))
+        assert.equals(2, tree:rank(4))
+        assert.equals(7, tree:kth_smallest(4))
+
+        local deleted = tree:delete(5)
+        assert.is_false(deleted:contains(5))
+        assert.is_true(deleted:is_valid())
+        assert.is_true(tree:contains(5))
+    end)
+
+    it("ignores duplicate comparator keys", function()
+        local tree = populated()
+        local duplicate = tree:insert(3)
+        assert.are.same(tree:to_sorted_array(), duplicate:to_sorted_array())
+        assert.equals(tree:search(3), duplicate:search(3))
+    end)
+end)
+
+describe("BinarySearchTree construction", function()
+    it("builds a balanced tree from a sorted array", function()
+        local values = {1, 2, 3, 4, 5, 6, 7}
+        local tree = BinarySearchTree.from_sorted_array(values)
+        assert.are.same(values, tree:to_sorted_array())
+        assert.equals(4, tree.root.value)
+        assert.equals(2, tree:height())
+        assert.equals(7, tree:size())
+        assert.is_true(tree:is_valid())
+    end)
+
+    it("handles empty trees and edge queries", function()
+        local tree = BinarySearchTree.empty()
+        assert.is_nil(tree:search(1))
+        assert.is_nil(tree:min_value())
+        assert.is_nil(tree:max_value())
+        assert.is_nil(tree:predecessor(1))
+        assert.is_nil(tree:successor(1))
+        assert.is_nil(tree:kth_smallest(0))
+        assert.is_nil(tree:kth_smallest(1))
+        assert.equals(0, tree:rank(1))
+        assert.equals(-1, tree:height())
+        assert.equals(0, tree:size())
+        assert.is_true(tree:is_valid())
+        assert.equals("BinarySearchTree(root=nil, size=0)", tostring(tree))
+    end)
+
+    it("validates constructor inputs", function()
+        assert.has_error(function() BSTNode.new(nil) end, "node value must not be nil")
+        assert.has_error(function() BSTNode.new(1, "left") end, "left must be a BSTNode or nil")
+        assert.has_error(function() BSTNode.new(1, nil, nil, -1) end, "size must be a non-negative integer")
+        assert.has_error(function() BinarySearchTree.new("root") end, "root must be a BSTNode or nil")
+        assert.has_error(function() BinarySearchTree.new(nil, "compare") end, "compare must be a function")
+        assert.has_error(function() BinarySearchTree.from_sorted_array("values") end, "values must be a table")
+        assert.has_error(function()
+            local tree = BinarySearchTree.empty()
+            tree:insert(nil)
+        end, "value must not be nil")
+    end)
+end)
+
+describe("BinarySearchTree deletion", function()
+    it("deletes leaves, one-child nodes, and absent values", function()
+        local tree = BinarySearchTree.from_sorted_array({2, 4, 6, 8})
+        assert.equals(6, tree.root.value)
+        assert.are.same({4, 6, 8}, tree:delete(2):to_sorted_array())
+        assert.are.same({2, 4, 6}, tree:delete(8):to_sorted_array())
+        assert.are.same({2, 4, 6, 8}, tree:delete(99):to_sorted_array())
+    end)
+end)
+
+describe("BinarySearchTree validation and comparison", function()
+    it("catches ordering and size corruption", function()
+        local bad_order = BinarySearchTree.new(BSTNode.new(5, BSTNode.new(6)))
+        local bad_size = BinarySearchTree.new(BSTNode.new(5, BSTNode.new(3), nil, 99))
+        assert.is_false(bad_order:is_valid())
+        assert.is_false(bad_size:is_valid())
+    end)
+
+    it("supports custom comparators", function()
+        local function by_length(left, right)
+            return #left - #right
+        end
+        local tree = BinarySearchTree.empty(by_length):insert("bbb"):insert("a"):insert("cc")
+        assert.are.same({"a", "cc", "bbb"}, tree:to_sorted_array())
+        assert.is_true(tree:contains("zz"))
+        assert.equals("a", tree:predecessor("zz"))
+        assert.equals("bbb", tree:successor("zz"))
+    end)
+end)

--- a/code/packages/perl/binary-search-tree/BUILD
+++ b/code/packages/perl/binary-search-tree/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/binary-search-tree/BUILD_windows
+++ b/code/packages/perl/binary-search-tree/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-binary-search-tree.t

--- a/code/packages/perl/binary-search-tree/CHANGELOG.md
+++ b/code/packages/perl/binary-search-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add a pure-Perl persistent binary search tree with balanced construction,
+  deletion, lookup, order statistics, custom comparison, and validation.

--- a/code/packages/perl/binary-search-tree/Makefile.PL
+++ b/code/packages/perl/binary-search-tree/Makefile.PL
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::BinarySearchTree',
+    VERSION_FROM     => 'lib/CodingAdventures/BinarySearchTree.pm',
+    ABSTRACT         => 'Persistent binary search tree with order statistics',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {},
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/binary-search-tree/README.md
+++ b/code/packages/perl/binary-search-tree/README.md
@@ -1,0 +1,24 @@
+# Perl binary search tree
+
+A dependency-free persistent binary search tree with duplicate suppression,
+deletion, lookup, predecessor/successor queries, rank and k-th order statistics,
+balanced construction from sorted arrays, and metadata validation.
+
+```perl
+my $tree = CodingAdventures::BinarySearchTree->empty
+    ->insert(5)->insert(1)->insert(8)->insert(3);
+my $updated = $tree->delete(5);
+print $tree->contains(5);       # true
+print $updated->contains(5);    # false
+print $updated->kth_smallest(2); # 3
+```
+
+`insert` and `delete` return new trees and preserve the original. Supply a
+three-way comparison code reference to `empty` or `from_sorted_array` for custom
+value ordering. The default comparator handles numeric and string scalars.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/perl/binary-search-tree/cpanfile
+++ b/code/packages/perl/binary-search-tree/cpanfile
@@ -1,0 +1,1 @@
+# No non-core dependencies.

--- a/code/packages/perl/binary-search-tree/lib/CodingAdventures/BinarySearchTree.pm
+++ b/code/packages/perl/binary-search-tree/lib/CodingAdventures/BinarySearchTree.pm
@@ -1,0 +1,308 @@
+package CodingAdventures::BinarySearchTree::Node;
+
+use strict;
+use warnings;
+
+sub _is_node {
+    my ($value) = @_;
+    return defined($value)
+        && ref($value)
+        && eval { $value->isa(__PACKAGE__) };
+}
+
+sub new {
+    my ($class, $value, $left, $right, $size) = @_;
+    die "node value must be defined\n" if !defined $value;
+    die "left must be a CodingAdventures::BinarySearchTree::Node or undef\n"
+        if defined($left) && !_is_node($left);
+    die "right must be a CodingAdventures::BinarySearchTree::Node or undef\n"
+        if defined($right) && !_is_node($right);
+
+    my $actual_size = defined($size)
+        ? $size
+        : 1 + (defined($left) ? $left->{size} : 0) + (defined($right) ? $right->{size} : 0);
+    die "size must be a non-negative integer\n"
+        if $actual_size !~ /^\d+$/;
+
+    return bless {
+        value => $value,
+        left  => $left,
+        right => $right,
+        size  => 0 + $actual_size,
+    }, $class;
+}
+
+sub value { return $_[0]->{value}; }
+sub left  { return $_[0]->{left}; }
+sub right { return $_[0]->{right}; }
+sub size  { return $_[0]->{size}; }
+
+package CodingAdventures::BinarySearchTree;
+
+use strict;
+use warnings;
+use Scalar::Util qw(looks_like_number);
+use overload '""' => 'to_string', fallback => 1;
+
+our $VERSION = '0.1.0';
+
+sub _is_node {
+    my ($value) = @_;
+    return defined($value)
+        && ref($value)
+        && eval { $value->isa('CodingAdventures::BinarySearchTree::Node') };
+}
+
+sub _default_compare {
+    my ($left, $right) = @_;
+    return $left <=> $right if looks_like_number($left) && looks_like_number($right);
+    return "$left" cmp "$right";
+}
+
+sub _node_size {
+    my ($root) = @_;
+    return defined($root) ? $root->{size} : 0;
+}
+
+sub new {
+    my ($class, $root, $compare) = @_;
+    die "root must be a CodingAdventures::BinarySearchTree::Node or undef\n"
+        if defined($root) && !_is_node($root);
+    $compare = \&_default_compare if !defined $compare;
+    die "compare must be a code reference\n" if ref($compare) ne 'CODE';
+    return bless {root => $root, compare => $compare}, $class;
+}
+
+sub empty {
+    my ($class, $compare) = @_;
+    return $class->new(undef, $compare);
+}
+
+sub from_sorted_array {
+    my ($class, $values, $compare) = @_;
+    die "values must be an array reference\n" if ref($values) ne 'ARRAY';
+    return $class->new(_build_balanced($values, 0, $#$values), $compare);
+}
+
+sub _build_balanced {
+    my ($values, $first, $last) = @_;
+    return undef if $first > $last;
+    my $middle = int(($first + $last + 1) / 2);
+    die "value at index $middle must be defined\n" if !defined $values->[$middle];
+    return CodingAdventures::BinarySearchTree::Node->new(
+        $values->[$middle],
+        _build_balanced($values, $first, $middle - 1),
+        _build_balanced($values, $middle + 1, $last),
+    );
+}
+
+sub root    { return $_[0]->{root}; }
+sub compare { return $_[0]->{compare}; }
+
+sub _with_children {
+    my ($root, $left, $right) = @_;
+    return CodingAdventures::BinarySearchTree::Node->new($root->{value}, $left, $right);
+}
+
+sub insert {
+    my ($self, $value) = @_;
+    die "value must be defined\n" if !defined $value;
+    return __PACKAGE__->new(_insert_node($self->{root}, $value, $self->{compare}), $self->{compare});
+}
+
+sub _insert_node {
+    my ($root, $value, $compare) = @_;
+    return CodingAdventures::BinarySearchTree::Node->new($value) if !defined $root;
+    my $order = $compare->($value, $root->{value});
+    return _with_children($root, _insert_node($root->{left}, $value, $compare), $root->{right})
+        if $order < 0;
+    return _with_children($root, $root->{left}, _insert_node($root->{right}, $value, $compare))
+        if $order > 0;
+    return $root;
+}
+
+sub delete {
+    my ($self, $value) = @_;
+    die "value must be defined\n" if !defined $value;
+    return __PACKAGE__->new(_delete_node($self->{root}, $value, $self->{compare}), $self->{compare});
+}
+
+sub _delete_node {
+    my ($root, $value, $compare) = @_;
+    return undef if !defined $root;
+    my $order = $compare->($value, $root->{value});
+    return _with_children($root, _delete_node($root->{left}, $value, $compare), $root->{right})
+        if $order < 0;
+    return _with_children($root, $root->{left}, _delete_node($root->{right}, $value, $compare))
+        if $order > 0;
+    return $root->{right} if !defined $root->{left};
+    return $root->{left} if !defined $root->{right};
+
+    my ($new_right, $successor) = _extract_min($root->{right});
+    return CodingAdventures::BinarySearchTree::Node->new($successor, $root->{left}, $new_right);
+}
+
+sub _extract_min {
+    my ($root) = @_;
+    return ($root->{right}, $root->{value}) if !defined $root->{left};
+    my ($new_left, $minimum) = _extract_min($root->{left});
+    return (_with_children($root, $new_left, $root->{right}), $minimum);
+}
+
+sub search {
+    my ($self, $value) = @_;
+    my $current = $self->{root};
+    while (defined $current) {
+        my $order = $self->{compare}->($value, $current->{value});
+        if ($order < 0) {
+            $current = $current->{left};
+        } elsif ($order > 0) {
+            $current = $current->{right};
+        } else {
+            return $current;
+        }
+    }
+    return undef;
+}
+
+sub contains {
+    my ($self, $value) = @_;
+    return defined $self->search($value);
+}
+
+sub min_value {
+    my ($self) = @_;
+    my $current = $self->{root};
+    $current = $current->{left} while defined($current) && defined($current->{left});
+    return defined($current) ? $current->{value} : undef;
+}
+
+sub max_value {
+    my ($self) = @_;
+    my $current = $self->{root};
+    $current = $current->{right} while defined($current) && defined($current->{right});
+    return defined($current) ? $current->{value} : undef;
+}
+
+sub predecessor {
+    my ($self, $value) = @_;
+    my $current = $self->{root};
+    my $best;
+    while (defined $current) {
+        if ($self->{compare}->($value, $current->{value}) <= 0) {
+            $current = $current->{left};
+        } else {
+            $best = $current->{value};
+            $current = $current->{right};
+        }
+    }
+    return $best;
+}
+
+sub successor {
+    my ($self, $value) = @_;
+    my $current = $self->{root};
+    my $best;
+    while (defined $current) {
+        if ($self->{compare}->($value, $current->{value}) >= 0) {
+            $current = $current->{right};
+        } else {
+            $best = $current->{value};
+            $current = $current->{left};
+        }
+    }
+    return $best;
+}
+
+sub kth_smallest {
+    my ($self, $k) = @_;
+    return _kth_smallest($self->{root}, $k);
+}
+
+sub _kth_smallest {
+    my ($root, $k) = @_;
+    return undef
+        if !defined($root) || !defined($k) || !looks_like_number($k) || $k <= 0 || int($k) != $k;
+    my $left_size = _node_size($root->{left});
+    return $root->{value} if $k == $left_size + 1;
+    return _kth_smallest($root->{left}, $k) if $k <= $left_size;
+    return _kth_smallest($root->{right}, $k - $left_size - 1);
+}
+
+sub rank {
+    my ($self, $value) = @_;
+    return _rank($self->{root}, $value, $self->{compare});
+}
+
+sub _rank {
+    my ($root, $value, $compare) = @_;
+    return 0 if !defined $root;
+    my $order = $compare->($value, $root->{value});
+    return _rank($root->{left}, $value, $compare) if $order < 0;
+    return _node_size($root->{left}) + 1 + _rank($root->{right}, $value, $compare)
+        if $order > 0;
+    return _node_size($root->{left});
+}
+
+sub to_sorted_array {
+    my ($self) = @_;
+    my @out;
+    _append_inorder($self->{root}, \@out);
+    return \@out;
+}
+
+sub _append_inorder {
+    my ($root, $out) = @_;
+    return if !defined $root;
+    _append_inorder($root->{left}, $out);
+    push @$out, $root->{value};
+    _append_inorder($root->{right}, $out);
+}
+
+sub is_valid {
+    my ($self) = @_;
+    return defined _validate($self->{root}, undef, undef, 0, 0, $self->{compare});
+}
+
+sub _validate {
+    my ($root, $minimum, $maximum, $has_minimum, $has_maximum, $compare) = @_;
+    return [-1, 0] if !defined $root;
+    return undef if $has_minimum && $compare->($root->{value}, $minimum) <= 0;
+    return undef if $has_maximum && $compare->($root->{value}, $maximum) >= 0;
+
+    my $left = _validate($root->{left}, $minimum, $root->{value}, $has_minimum, 1, $compare);
+    return undef if !defined $left;
+    my $right = _validate($root->{right}, $root->{value}, $maximum, 1, $has_maximum, $compare);
+    return undef if !defined $right;
+
+    my $actual_size = 1 + $left->[1] + $right->[1];
+    return undef if $root->{size} != $actual_size;
+    my $height = 1 + ($left->[0] > $right->[0] ? $left->[0] : $right->[0]);
+    return [$height, $actual_size];
+}
+
+sub height {
+    my ($self) = @_;
+    return _height($self->{root});
+}
+
+sub _height {
+    my ($root) = @_;
+    return -1 if !defined $root;
+    my $left = _height($root->{left});
+    my $right = _height($root->{right});
+    return 1 + ($left > $right ? $left : $right);
+}
+
+sub size {
+    my ($self) = @_;
+    return _node_size($self->{root});
+}
+
+sub to_string {
+    my ($self) = @_;
+    my $root = defined($self->{root}) ? $self->{root}{value} : 'undef';
+    return sprintf('BinarySearchTree(root=%s, size=%d)', $root, $self->size);
+}
+
+1;

--- a/code/packages/perl/binary-search-tree/required_capabilities.json
+++ b/code/packages/perl/binary-search-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/binary-search-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/binary-search-tree/t/00-load.t
+++ b/code/packages/perl/binary-search-tree/t/00-load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::BinarySearchTree; 1 }, 'CodingAdventures::BinarySearchTree loads');
+ok(CodingAdventures::BinarySearchTree->VERSION, 'has a VERSION');
+ok(CodingAdventures::BinarySearchTree::Node->can('new'), 'node class is available');
+
+done_testing;

--- a/code/packages/perl/binary-search-tree/t/01-binary-search-tree.t
+++ b/code/packages/perl/binary-search-tree/t/01-binary-search-tree.t
@@ -1,0 +1,105 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::BinarySearchTree;
+
+sub populated {
+    my $tree = CodingAdventures::BinarySearchTree->empty;
+    $tree = $tree->insert($_) for (5, 1, 8, 3, 7);
+    return $tree;
+}
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'persistent insert, search, rank, and delete' => sub {
+    my $tree = populated();
+    is_deeply($tree->to_sorted_array, [1, 3, 5, 7, 8], 'sorted values');
+    is($tree->size, 5, 'size');
+    ok($tree->contains(7), 'contains value');
+    is($tree->search(7)->value, 7, 'search value');
+    is($tree->min_value, 1, 'minimum');
+    is($tree->max_value, 8, 'maximum');
+    is($tree->predecessor(5), 3, 'predecessor');
+    is($tree->successor(5), 7, 'successor');
+    is($tree->rank(4), 2, 'rank');
+    is($tree->kth_smallest(4), 7, 'k-th smallest');
+
+    my $deleted = $tree->delete(5);
+    ok(!$deleted->contains(5), 'delete removes value');
+    ok($deleted->is_valid, 'deleted tree is valid');
+    ok($tree->contains(5), 'original remains unchanged');
+
+    my $duplicate = $tree->insert(3);
+    is_deeply($duplicate->to_sorted_array, $tree->to_sorted_array, 'duplicate ignored');
+    is($duplicate->search(3), $tree->search(3), 'duplicate node is shared');
+};
+
+subtest 'balanced and empty construction' => sub {
+    my $values = [1, 2, 3, 4, 5, 6, 7];
+    my $tree = CodingAdventures::BinarySearchTree->from_sorted_array($values);
+    is_deeply($tree->to_sorted_array, $values, 'sorted array round trip');
+    is($tree->root->value, 4, 'middle root');
+    is($tree->height, 2, 'balanced height');
+    is($tree->size, 7, 'balanced size');
+    ok($tree->is_valid, 'balanced tree valid');
+
+    my $empty = CodingAdventures::BinarySearchTree->empty;
+    ok(!defined $empty->search(1), 'empty search');
+    ok(!defined $empty->min_value, 'empty minimum');
+    ok(!defined $empty->max_value, 'empty maximum');
+    ok(!defined $empty->predecessor(1), 'empty predecessor');
+    ok(!defined $empty->successor(1), 'empty successor');
+    ok(!defined $empty->kth_smallest(0), 'zero k');
+    ok(!defined $empty->kth_smallest(1), 'empty k');
+    is($empty->rank(1), 0, 'empty rank');
+    is($empty->height, -1, 'empty height');
+    is($empty->size, 0, 'empty size');
+    ok($empty->is_valid, 'empty valid');
+    is("$empty", 'BinarySearchTree(root=undef, size=0)', 'empty rendering');
+};
+
+subtest 'construction validation' => sub {
+    dies_like(sub { CodingAdventures::BinarySearchTree::Node->new(undef) }, qr/node value must be defined/, 'undefined node value rejected');
+    dies_like(sub { CodingAdventures::BinarySearchTree::Node->new(1, 'left') }, qr/left must be a CodingAdventures/, 'invalid child rejected');
+    dies_like(sub { CodingAdventures::BinarySearchTree::Node->new(1, undef, undef, -1) }, qr/size must be a non-negative integer/, 'invalid size rejected');
+    dies_like(sub { CodingAdventures::BinarySearchTree->new('root') }, qr/root must be a CodingAdventures/, 'invalid root rejected');
+    dies_like(sub { CodingAdventures::BinarySearchTree->new(undef, 'compare') }, qr/compare must be a code reference/, 'invalid comparator rejected');
+    dies_like(sub { CodingAdventures::BinarySearchTree->from_sorted_array('values') }, qr/array reference/, 'invalid array rejected');
+    dies_like(sub { CodingAdventures::BinarySearchTree->empty->insert(undef) }, qr/value must be defined/, 'undefined insert rejected');
+};
+
+subtest 'deletion cases' => sub {
+    my $tree = CodingAdventures::BinarySearchTree->from_sorted_array([2, 4, 6, 8]);
+    is($tree->root->value, 6, 'upper middle root');
+    is_deeply($tree->delete(2)->to_sorted_array, [4, 6, 8], 'delete leaf');
+    is_deeply($tree->delete(8)->to_sorted_array, [2, 4, 6], 'delete one-child branch');
+    is_deeply($tree->delete(99)->to_sorted_array, [2, 4, 6, 8], 'delete absent value');
+};
+
+subtest 'validation catches corruption' => sub {
+    my $bad_order = CodingAdventures::BinarySearchTree->new(
+        CodingAdventures::BinarySearchTree::Node->new(5, CodingAdventures::BinarySearchTree::Node->new(6)),
+    );
+    my $bad_size = CodingAdventures::BinarySearchTree->new(
+        CodingAdventures::BinarySearchTree::Node->new(5, CodingAdventures::BinarySearchTree::Node->new(3), undef, 99),
+    );
+    ok(!$bad_order->is_valid, 'ordering corruption');
+    ok(!$bad_size->is_valid, 'size corruption');
+};
+
+subtest 'custom comparator' => sub {
+    my $by_length = sub { return length($_[0]) <=> length($_[1]); };
+    my $tree = CodingAdventures::BinarySearchTree->empty($by_length)
+        ->insert('bbb')->insert('a')->insert('cc');
+    is_deeply($tree->to_sorted_array, ['a', 'cc', 'bbb'], 'length order');
+    ok($tree->contains('zz'), 'comparator equality');
+    is($tree->predecessor('zz'), 'a', 'custom predecessor');
+    is($tree->successor('zz'), 'bbb', 'custom successor');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,12 +105,12 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 14, 2026 after the paired Lua/Perl `fenwick-tree` and `binary-tree`
-ports:
+on July 14, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`, and
+`binary-search-tree` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 367 |
+| Present in 10-15 languages | 171 | 365 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -156,15 +156,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 367
+The 171 packages present in at least ten implementation languages need 365
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 14 | Pair with Perl data-structure/storage wave |
-| Perl | 14 | Pair with Lua data-structure/storage wave |
+| Lua | 13 | Pair with Perl data-structure/storage wave |
+| Perl | 13 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -176,9 +176,10 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first two paired Lua/Perl data-structure slices are complete: `fenwick-tree`
-and `binary-tree` now have pure implementations, package-native tests, metadata,
-and capability declarations in both lanes.
+The first three paired Lua/Perl data-structure slices are complete:
+`fenwick-tree`, `binary-tree`, and `binary-search-tree` now have pure
+implementations, package-native tests, metadata, and capability declarations in
+both lanes.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add dependency-free persistent binary-search-tree packages for Lua and Perl
- cover balanced construction, insert/delete, lookup, rank, k-th selection, custom comparison, and metadata validation
- refresh the parity roadmap to 365 high-consensus gaps (13 each for Lua and Perl)

## Validation
- Lua 5.4 syntax check and Busted: 8 successes
- LuaRocks package installation with `--deps-mode=none`
- Perl 5.38 syntax/load checks and six behavioral subtests
- Perl `Makefile.PL` syntax with user-local ExtUtils::MakeMaker 7.78
- `python code/scripts/tests/test_package_parity_report.py`
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- rebased onto current `origin/main`; `git diff origin/main...HEAD --check`