### PR TITLE
feat: port data store protocol to Lua and Perl

### DIFF
--- a/code/packages/lua/in-memory-data-store-protocol/BUILD
+++ b/code/packages/lua/in-memory-data-store-protocol/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-protocol-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/in-memory-data-store-protocol/BUILD_windows
+++ b/code/packages/lua/in-memory-data-store-protocol/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-protocol-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/in-memory-data-store-protocol/CHANGELOG.md
+++ b/code/packages/lua/in-memory-data-store-protocol/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add pure-Lua command frames, ASCII command normalization, typed engine
+  responses, defensive array copies, and convenience response constructors.

--- a/code/packages/lua/in-memory-data-store-protocol/README.md
+++ b/code/packages/lua/in-memory-data-store-protocol/README.md
@@ -1,0 +1,28 @@
+# Lua in-memory data store protocol
+
+A dependency-free protocol intermediate representation shared by in-memory data
+store engines and transport adapters. It provides normalized command frames over
+Lua byte strings and typed engine responses for strings, errors, integers, bulk
+strings, and nested arrays.
+
+```lua
+local protocol = require("coding_adventures.in_memory_data_store_protocol")
+
+local frame = protocol.CommandFrame.from_parts({"set", "key", "value"})
+assert(frame.command == "SET")
+
+local response = protocol.EngineResponse.array({
+    protocol.EngineResponse.ok(),
+    protocol.EngineResponse.integer(1),
+})
+```
+
+Lua strings are immutable byte strings, so frame arguments and bulk-string
+payloads preserve the reference protocol's byte-oriented semantics. This package
+models the engine boundary only; RESP parsing and encoding remain separate.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/lua/in-memory-data-store-protocol/coding-adventures-in-memory-data-store-protocol-0.1.0-1.rockspec
+++ b/code/packages/lua/in-memory-data-store-protocol/coding-adventures-in-memory-data-store-protocol-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-in-memory-data-store-protocol"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Protocol IR for the in-memory data store",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.in_memory_data_store_protocol"] = "src/coding_adventures/in_memory_data_store_protocol/init.lua",
+    },
+}

--- a/code/packages/lua/in-memory-data-store-protocol/required_capabilities.json
+++ b/code/packages/lua/in-memory-data-store-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/in-memory-data-store-protocol",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/in-memory-data-store-protocol/src/coding_adventures/in_memory_data_store_protocol/init.lua
+++ b/code/packages/lua/in-memory-data-store-protocol/src/coding_adventures/in_memory_data_store_protocol/init.lua
@@ -1,0 +1,166 @@
+local M = {VERSION = "0.1.0"}
+
+local function ascii_upper(data)
+    if type(data) ~= "string" then
+        error("data must be a string", 2)
+    end
+
+    local bytes = {}
+    for index = 1, #data do
+        local byte = string.byte(data, index)
+        if byte > 127 then
+            error("data must contain only ASCII bytes", 2)
+        end
+        if byte >= string.byte("a") and byte <= string.byte("z") then
+            byte = byte - 32
+        end
+        bytes[index] = string.char(byte)
+    end
+    return table.concat(bytes)
+end
+
+local function copy_string_array(values, name)
+    if values == nil then
+        return {}
+    end
+    if type(values) ~= "table" then
+        error(name .. " must be a table", 3)
+    end
+    local copy = {}
+    for index, value in ipairs(values) do
+        if type(value) ~= "string" then
+            error(string.format("%s[%d] must be a string", name, index), 3)
+        end
+        copy[index] = value
+    end
+    return copy
+end
+
+local CommandFrame = {}
+CommandFrame.__index = CommandFrame
+
+function CommandFrame.new(command, args)
+    if type(command) ~= "string" then
+        error("command must be a string", 2)
+    end
+    return setmetatable({command = command, args = copy_string_array(args, "args")}, CommandFrame)
+end
+
+function CommandFrame.from_parts(parts)
+    if type(parts) ~= "table" then
+        error("parts must be a table", 2)
+    end
+    if #parts == 0 then
+        return nil
+    end
+    local args = {}
+    for index = 2, #parts do
+        local value = parts[index]
+        if type(value) ~= "string" then
+            error(string.format("parts[%d] must be a string", index), 2)
+        end
+        args[#args + 1] = value
+    end
+    return CommandFrame.new(ascii_upper(parts[1]), args)
+end
+
+function CommandFrame:to_parts()
+    local parts = {self.command}
+    for _, arg in ipairs(self.args) do
+        parts[#parts + 1] = arg
+    end
+    return parts
+end
+
+local EngineResponse = {}
+EngineResponse.__index = EngineResponse
+
+local valid_kinds = {
+    simple_string = true,
+    error = true,
+    integer = true,
+    bulk_string = true,
+    array = true,
+}
+
+local function is_response(value)
+    return type(value) == "table" and getmetatable(value) == EngineResponse
+end
+
+local function copy_response_array(values)
+    if values == nil then
+        return nil
+    end
+    if type(values) ~= "table" then
+        error("array response value must be a table or nil", 3)
+    end
+    local copy = {}
+    for index, value in ipairs(values) do
+        if not is_response(value) then
+            error(string.format("array response value[%d] must be an EngineResponse", index), 3)
+        end
+        copy[index] = value
+    end
+    return copy
+end
+
+function EngineResponse.new(kind, value)
+    if not valid_kinds[kind] then
+        error("invalid response kind: " .. tostring(kind), 2)
+    end
+    if (kind == "simple_string" or kind == "error") and type(value) ~= "string" then
+        error(kind .. " value must be a string", 2)
+    end
+    if kind == "integer" and (type(value) ~= "number" or value % 1 ~= 0) then
+        error("integer value must be an integer", 2)
+    end
+    if kind == "bulk_string" and value ~= nil and type(value) ~= "string" then
+        error("bulk_string value must be a string or nil", 2)
+    end
+    if kind == "array" then
+        value = copy_response_array(value)
+    end
+    return setmetatable({kind = kind, value = value}, EngineResponse)
+end
+
+function EngineResponse.simple_string(value)
+    return EngineResponse.new("simple_string", value)
+end
+
+function EngineResponse.error(value)
+    return EngineResponse.new("error", value)
+end
+
+function EngineResponse.integer(value)
+    return EngineResponse.new("integer", value)
+end
+
+function EngineResponse.bulk_string(value)
+    return EngineResponse.new("bulk_string", value)
+end
+
+function EngineResponse.array(value)
+    return EngineResponse.new("array", value)
+end
+
+function EngineResponse.ok()
+    return EngineResponse.simple_string("OK")
+end
+
+function EngineResponse.null()
+    return EngineResponse.bulk_string(nil)
+end
+
+function EngineResponse.zero()
+    return EngineResponse.integer(0)
+end
+
+function EngineResponse.one()
+    return EngineResponse.integer(1)
+end
+
+M.ascii_upper = ascii_upper
+M.CommandFrame = CommandFrame
+M.EngineResponse = EngineResponse
+
+return M

--- a/code/packages/lua/in-memory-data-store-protocol/tests/test_protocol.lua
+++ b/code/packages/lua/in-memory-data-store-protocol/tests/test_protocol.lua
@@ -1,0 +1,80 @@
+package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+
+local protocol = require("coding_adventures.in_memory_data_store_protocol")
+local CommandFrame = protocol.CommandFrame
+local EngineResponse = protocol.EngineResponse
+
+describe("ASCII command normalization", function()
+    it("uppercases ASCII bytes without changing punctuation", function()
+        assert.equals("GET", protocol.ascii_upper("get"))
+        assert.equals("MSET", protocol.ascii_upper("mSeT"))
+        assert.equals("PING-2", protocol.ascii_upper("ping-2"))
+    end)
+
+    it("rejects non-string and non-ASCII input", function()
+        assert.has_error(function() protocol.ascii_upper(1) end, "data must be a string")
+        assert.has_error(function() protocol.ascii_upper("\255") end, "data must contain only ASCII bytes")
+    end)
+end)
+
+describe("CommandFrame", function()
+    it("builds normalized frames from byte-string parts", function()
+        local frame = CommandFrame.from_parts({"set", "key", "value"})
+        assert.equals("SET", frame.command)
+        assert.are.same({"key", "value"}, frame.args)
+        assert.are.same({"SET", "key", "value"}, frame:to_parts())
+        assert.is_nil(CommandFrame.from_parts({}))
+    end)
+
+    it("defensively copies argument and part arrays", function()
+        local args = {"key"}
+        local frame = CommandFrame.new("GET", args)
+        args[1] = "changed"
+        assert.are.same({"key"}, frame.args)
+
+        local parts = frame:to_parts()
+        parts[2] = "changed"
+        assert.are.same({"GET", "key"}, frame:to_parts())
+    end)
+
+    it("validates commands, args, and parts", function()
+        assert.has_error(function() CommandFrame.new(1) end, "command must be a string")
+        assert.has_error(function() CommandFrame.new("GET", "key") end, "args must be a table")
+        assert.has_error(function() CommandFrame.new("GET", {1}) end, "args[1] must be a string")
+        assert.has_error(function() CommandFrame.from_parts("GET") end, "parts must be a table")
+        assert.has_error(function() CommandFrame.from_parts({"GET", 1}) end, "parts[2] must be a string")
+    end)
+end)
+
+describe("EngineResponse", function()
+    it("constructs scalar and convenience responses", function()
+        assert.are.same({kind = "simple_string", value = "PONG"}, EngineResponse.simple_string("PONG"))
+        assert.are.same({kind = "error", value = "ERR"}, EngineResponse.error("ERR"))
+        assert.are.same({kind = "integer", value = 42}, EngineResponse.integer(42))
+        assert.are.same({kind = "bulk_string", value = "value"}, EngineResponse.bulk_string("value"))
+        assert.are.same({kind = "simple_string", value = "OK"}, EngineResponse.ok())
+        assert.equals("bulk_string", EngineResponse.null().kind)
+        assert.is_nil(EngineResponse.null().value)
+        assert.are.same({kind = "integer", value = 0}, EngineResponse.zero())
+        assert.are.same({kind = "integer", value = 1}, EngineResponse.one())
+    end)
+
+    it("constructs defensive response arrays and null arrays", function()
+        local values = {EngineResponse.ok(), EngineResponse.integer(3)}
+        local response = EngineResponse.array(values)
+        values[1] = EngineResponse.error("changed")
+        assert.equals("array", response.kind)
+        assert.equals("simple_string", response.value[1].kind)
+        assert.equals(3, response.value[2].value)
+        assert.equals("array", EngineResponse.array(nil).kind)
+        assert.is_nil(EngineResponse.array(nil).value)
+    end)
+
+    it("validates response kinds and payloads", function()
+        assert.has_error(function() EngineResponse.new("unknown", nil) end, "invalid response kind: unknown")
+        assert.has_error(function() EngineResponse.simple_string(1) end, "simple_string value must be a string")
+        assert.has_error(function() EngineResponse.integer(1.5) end, "integer value must be an integer")
+        assert.has_error(function() EngineResponse.bulk_string(1) end, "bulk_string value must be a string or nil")
+        assert.has_error(function() EngineResponse.array({"not a response"}) end, "array response value[1] must be an EngineResponse")
+    end)
+end)

--- a/code/packages/perl/in-memory-data-store-protocol/BUILD
+++ b/code/packages/perl/in-memory-data-store-protocol/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/in-memory-data-store-protocol/BUILD_windows
+++ b/code/packages/perl/in-memory-data-store-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-protocol.t

--- a/code/packages/perl/in-memory-data-store-protocol/CHANGELOG.md
+++ b/code/packages/perl/in-memory-data-store-protocol/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add pure-Perl command frames, ASCII command normalization, typed engine
+  responses, defensive array copies, and convenience response constructors.

--- a/code/packages/perl/in-memory-data-store-protocol/Makefile.PL
+++ b/code/packages/perl/in-memory-data-store-protocol/Makefile.PL
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::InMemoryDataStoreProtocol',
+    VERSION_FROM     => 'lib/CodingAdventures/InMemoryDataStoreProtocol.pm',
+    ABSTRACT         => 'Protocol IR for the in-memory data store',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {},
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/in-memory-data-store-protocol/README.md
+++ b/code/packages/perl/in-memory-data-store-protocol/README.md
@@ -1,0 +1,27 @@
+# Perl in-memory data store protocol
+
+A dependency-free protocol intermediate representation shared by in-memory data
+store engines and transport adapters. It provides normalized command frames over
+Perl byte strings and typed engine responses for strings, errors, integers, bulk
+strings, and nested arrays.
+
+```perl
+my $frame = CodingAdventures::InMemoryDataStoreProtocol::CommandFrame
+    ->from_parts(['set', 'key', 'value']);
+print $frame->command; # SET
+
+my $response = CodingAdventures::InMemoryDataStoreProtocol::EngineResponse
+    ->array([
+        CodingAdventures::InMemoryDataStoreProtocol::EngineResponse->ok,
+        CodingAdventures::InMemoryDataStoreProtocol::EngineResponse->integer(1),
+    ]);
+```
+
+Frame arrays and response arrays are defensively copied. This package models the
+engine boundary only; RESP parsing and encoding remain separate.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/perl/in-memory-data-store-protocol/cpanfile
+++ b/code/packages/perl/in-memory-data-store-protocol/cpanfile
@@ -1,0 +1,1 @@
+# No non-core dependencies.

--- a/code/packages/perl/in-memory-data-store-protocol/lib/CodingAdventures/InMemoryDataStoreProtocol.pm
+++ b/code/packages/perl/in-memory-data-store-protocol/lib/CodingAdventures/InMemoryDataStoreProtocol.pm
@@ -1,0 +1,120 @@
+package CodingAdventures::InMemoryDataStoreProtocol;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.1.0';
+
+sub ascii_upper {
+    my ($data) = @_;
+    die "data must be a string\n" if !defined($data) || ref($data);
+
+    my @bytes = unpack('C*', $data);
+    for my $byte (@bytes) {
+        die "data must contain only ASCII bytes\n" if $byte > 127;
+        $byte -= 32 if $byte >= ord('a') && $byte <= ord('z');
+    }
+    return pack('C*', @bytes);
+}
+
+package CodingAdventures::InMemoryDataStoreProtocol::CommandFrame;
+
+use strict;
+use warnings;
+
+sub _copy_strings {
+    my ($values, $name) = @_;
+    return [] if !defined $values;
+    die "$name must be an array reference\n" if ref($values) ne 'ARRAY';
+
+    my @copy;
+    for my $index (0 .. $#$values) {
+        my $value = $values->[$index];
+        die "$name\[$index] must be a string\n" if !defined($value) || ref($value);
+        push @copy, "$value";
+    }
+    return \@copy;
+}
+
+sub new {
+    my ($class, $command, $args) = @_;
+    die "command must be a string\n" if !defined($command) || ref($command);
+    return bless {command => "$command", args => _copy_strings($args, 'args')}, $class;
+}
+
+sub from_parts {
+    my ($class, $parts) = @_;
+    die "parts must be an array reference\n" if ref($parts) ne 'ARRAY';
+    return undef if !@$parts;
+
+    my $copy = _copy_strings($parts, 'parts');
+    my $command = shift @$copy;
+    return $class->new(CodingAdventures::InMemoryDataStoreProtocol::ascii_upper($command), $copy);
+}
+
+sub command { return $_[0]->{command}; }
+
+sub args {
+    my ($self) = @_;
+    return [@{ $self->{args} }];
+}
+
+sub to_parts {
+    my ($self) = @_;
+    return [$self->{command}, @{ $self->{args} }];
+}
+
+package CodingAdventures::InMemoryDataStoreProtocol::EngineResponse;
+
+use strict;
+use warnings;
+use Scalar::Util qw(blessed looks_like_number);
+
+my %VALID_KINDS = map { $_ => 1 } qw(simple_string error integer bulk_string array);
+
+sub _copy_response_array {
+    my ($values) = @_;
+    return undef if !defined $values;
+    die "array response value must be an array reference or undef\n"
+        if ref($values) ne 'ARRAY';
+
+    my @copy;
+    for my $index (0 .. $#$values) {
+        my $value = $values->[$index];
+        die "array response value\[$index] must be an EngineResponse\n"
+            if !blessed($value) || !$value->isa(__PACKAGE__);
+        push @copy, $value;
+    }
+    return \@copy;
+}
+
+sub new {
+    my ($class, $kind, $value) = @_;
+    die "invalid response kind: " . (defined($kind) ? $kind : 'undef') . "\n"
+        if !defined($kind) || !$VALID_KINDS{$kind};
+    die "$kind value must be a string\n"
+        if ($kind eq 'simple_string' || $kind eq 'error')
+            && (!defined($value) || ref($value));
+    die "integer value must be an integer\n"
+        if $kind eq 'integer'
+            && (!defined($value) || !looks_like_number($value) || int($value) != $value);
+    die "bulk_string value must be a string or undef\n"
+        if $kind eq 'bulk_string' && defined($value) && ref($value);
+    $value = _copy_response_array($value) if $kind eq 'array';
+    return bless {kind => $kind, value => $value}, $class;
+}
+
+sub kind  { return $_[0]->{kind}; }
+sub value { return $_[0]->{value}; }
+
+sub simple_string { return $_[0]->new('simple_string', $_[1]); }
+sub error         { return $_[0]->new('error', $_[1]); }
+sub integer       { return $_[0]->new('integer', $_[1]); }
+sub bulk_string   { return $_[0]->new('bulk_string', $_[1]); }
+sub array         { return $_[0]->new('array', $_[1]); }
+sub ok            { return $_[0]->simple_string('OK'); }
+sub null          { return $_[0]->bulk_string(undef); }
+sub zero          { return $_[0]->integer(0); }
+sub one           { return $_[0]->integer(1); }
+
+1;

--- a/code/packages/perl/in-memory-data-store-protocol/required_capabilities.json
+++ b/code/packages/perl/in-memory-data-store-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/in-memory-data-store-protocol",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/in-memory-data-store-protocol/t/00-load.t
+++ b/code/packages/perl/in-memory-data-store-protocol/t/00-load.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::InMemoryDataStoreProtocol; 1 }, 'protocol module loads');
+ok(CodingAdventures::InMemoryDataStoreProtocol->VERSION, 'has a VERSION');
+ok(CodingAdventures::InMemoryDataStoreProtocol::CommandFrame->can('new'), 'command frame is available');
+ok(CodingAdventures::InMemoryDataStoreProtocol::EngineResponse->can('new'), 'engine response is available');
+
+done_testing;

--- a/code/packages/perl/in-memory-data-store-protocol/t/01-protocol.t
+++ b/code/packages/perl/in-memory-data-store-protocol/t/01-protocol.t
@@ -1,0 +1,77 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::InMemoryDataStoreProtocol;
+
+my $CommandFrame = 'CodingAdventures::InMemoryDataStoreProtocol::CommandFrame';
+my $EngineResponse = 'CodingAdventures::InMemoryDataStoreProtocol::EngineResponse';
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'ASCII command normalization' => sub {
+    is(CodingAdventures::InMemoryDataStoreProtocol::ascii_upper('get'), 'GET', 'lowercase');
+    is(CodingAdventures::InMemoryDataStoreProtocol::ascii_upper('mSeT'), 'MSET', 'mixed case');
+    is(CodingAdventures::InMemoryDataStoreProtocol::ascii_upper('ping-2'), 'PING-2', 'punctuation');
+    dies_like(sub { CodingAdventures::InMemoryDataStoreProtocol::ascii_upper(undef) }, qr/data must be a string/, 'undefined rejected');
+    dies_like(sub { CodingAdventures::InMemoryDataStoreProtocol::ascii_upper("\xFF") }, qr/only ASCII bytes/, 'non-ASCII rejected');
+};
+
+subtest 'command frames' => sub {
+    my $frame = $CommandFrame->from_parts(['set', 'key', 'value']);
+    is($frame->command, 'SET', 'command normalized');
+    is_deeply($frame->args, ['key', 'value'], 'args');
+    is_deeply($frame->to_parts, ['SET', 'key', 'value'], 'parts');
+    ok(!defined $CommandFrame->from_parts([]), 'empty parts return undef');
+
+    my $args = ['key'];
+    my $get = $CommandFrame->new('GET', $args);
+    $args->[0] = 'changed';
+    is_deeply($get->args, ['key'], 'constructor copies args');
+    my $parts = $get->to_parts;
+    $parts->[1] = 'changed';
+    is_deeply($get->to_parts, ['GET', 'key'], 'to_parts is defensive');
+};
+
+subtest 'command validation' => sub {
+    dies_like(sub { $CommandFrame->new(undef) }, qr/command must be a string/, 'undefined command');
+    dies_like(sub { $CommandFrame->new('GET', 'key') }, qr/args must be an array reference/, 'invalid args');
+    dies_like(sub { $CommandFrame->new('GET', [undef]) }, qr/args\[0\] must be a string/, 'invalid arg');
+    dies_like(sub { $CommandFrame->from_parts('GET') }, qr/parts must be an array reference/, 'invalid parts');
+    dies_like(sub { $CommandFrame->from_parts(['GET', undef]) }, qr/parts\[1\] must be a string/, 'invalid part');
+};
+
+subtest 'scalar and convenience responses' => sub {
+    is_deeply($EngineResponse->simple_string('PONG'), $EngineResponse->new('simple_string', 'PONG'), 'simple string');
+    is_deeply($EngineResponse->error('ERR'), $EngineResponse->new('error', 'ERR'), 'error');
+    is_deeply($EngineResponse->integer(42), $EngineResponse->new('integer', 42), 'integer');
+    is_deeply($EngineResponse->bulk_string('value'), $EngineResponse->new('bulk_string', 'value'), 'bulk string');
+    is_deeply($EngineResponse->ok, $EngineResponse->new('simple_string', 'OK'), 'OK');
+    is_deeply($EngineResponse->null, $EngineResponse->new('bulk_string', undef), 'null');
+    is_deeply($EngineResponse->zero, $EngineResponse->new('integer', 0), 'zero');
+    is_deeply($EngineResponse->one, $EngineResponse->new('integer', 1), 'one');
+};
+
+subtest 'array responses' => sub {
+    my $values = [$EngineResponse->ok, $EngineResponse->integer(3)];
+    my $response = $EngineResponse->array($values);
+    $values->[0] = $EngineResponse->error('changed');
+    is($response->kind, 'array', 'array kind');
+    is($response->value->[0]->kind, 'simple_string', 'input array copied');
+    is($response->value->[1]->value, 3, 'nested value');
+    is_deeply($EngineResponse->array(undef), $EngineResponse->new('array', undef), 'null array');
+};
+
+subtest 'response validation' => sub {
+    dies_like(sub { $EngineResponse->new('unknown', undef) }, qr/invalid response kind: unknown/, 'invalid kind');
+    dies_like(sub { $EngineResponse->simple_string(undef) }, qr/simple_string value must be a string/, 'invalid string');
+    dies_like(sub { $EngineResponse->integer(1.5) }, qr/integer value must be an integer/, 'invalid integer');
+    dies_like(sub { $EngineResponse->bulk_string([]) }, qr/bulk_string value must be a string or undef/, 'invalid bulk string');
+    dies_like(sub { $EngineResponse->array(['not a response']) }, qr/value\[0\] must be an EngineResponse/, 'invalid array item');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,12 +105,12 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 14, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`, and
-`binary-search-tree` ports:
+on July 14, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
+`binary-search-tree`, and `in-memory-data-store-protocol` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 365 |
+| Present in 10-15 languages | 171 | 363 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -156,15 +156,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 365
+The 171 packages present in at least ten implementation languages need 363
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 13 | Pair with Perl data-structure/storage wave |
-| Perl | 13 | Pair with Lua data-structure/storage wave |
+| Lua | 12 | Pair with Perl data-structure/storage wave |
+| Perl | 12 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -176,10 +176,11 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first three paired Lua/Perl data-structure slices are complete:
-`fenwick-tree`, `binary-tree`, and `binary-search-tree` now have pure
-implementations, package-native tests, metadata, and capability declarations in
-both lanes.
+The first four paired Lua/Perl slices are complete: `fenwick-tree`,
+`binary-tree`, `binary-search-tree`, and `in-memory-data-store-protocol` now have
+pure implementations, package-native tests, metadata, and capability
+declarations in both lanes. The protocol slice establishes the dependency-free
+IR needed before the higher in-memory data store layers move.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add dependency-free in-memory-data-store-protocol packages for Lua and Perl
- model normalized byte-string command frames and typed engine responses with defensive array copies
- refresh the parity roadmap to 363 high-consensus gaps (12 each for Lua and Perl)

## Why
This is the smallest remaining dependency-free paired gap and establishes the protocol IR required by the higher datastore engine and facade layers.

## Validation
- Lua 5.4 syntax check and Busted: 8 successes
- LuaRocks package installation with `--deps-mode=none`
- Perl 5.38 syntax/load checks and six protocol subtests
- Perl `Makefile.PL` syntax with user-local ExtUtils::MakeMaker 7.78
- `python code/scripts/tests/test_package_parity_report.py`
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- `git diff --cached --check`