### PR TITLE
feat(os-platform): CCPP02 Phase 2 PR6 — mmap primitive (anon memory + protection, C)

### DIFF
--- a/code/packages/c/os-platform/CHANGELOG.md
+++ b/code/packages/c/os-platform/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to semantic versioning.
 
 ### Added
 
+- **`mmap` primitive** (CCPP02 Phase 2, PR 6 — completes the six-primitive core):
+  anonymous virtual memory with protection control — `malloc` gives bytes,
+  but only the OS gives a page range with a chosen protection (read-only data,
+  guard pages, or executable JIT memory).
+  - `osp_map_anon(out, len, prot)` (zero-filled anonymous pages),
+    `osp_map_protect`, `osp_map_base` / `osp_map_size`, `osp_map_unmap`. `prot`
+    is an OSP_PROT_* bitmask (NONE/READ/WRITE/EXEC).
+  - Backends: `mmap_posix.c` (`mmap(MAP_PRIVATE|MAP_ANONYMOUS)` / `mprotect` /
+    `munmap`; the BUILD adds `_DEFAULT_SOURCE` + `_DARWIN_C_SOURCE` so
+    MAP_ANONYMOUS is visible on both glibc and Darwin) and `mmap_windows.c`
+    (`VirtualAlloc(MEM_RESERVE|MEM_COMMIT)` / `VirtualProtect` /
+    `VirtualFree(MEM_RELEASE)`; OSP_PROT_* mapped onto the PAGE_* matrix).
+  - Test (`tests/mmap_test.c`): anonymous RW map, zero-fill check, page-sized
+    write/read checksum, protection change to READ-only, accessors, unmap, and
+    NULL/zero-length validation. Clean under ASan+UBSan, 0 leaks.
+  - The EXEC bit is plumbed to PROT_EXEC / PAGE_EXECUTE_* for JIT consumers; a
+    dedicated JIT executor (per-arch machine code + the Apple-Silicon MAP_JIT
+    write-protect protocol + an execute-and-call test) is a planned follow-up.
 - **`dynlib` primitive** (CCPP02 Phase 2, PR 5): load a shared library, resolve a
   symbol, unload — the foundation for plugins/FFI, and pure bucket B (ISO C
   cannot load code at run time).

--- a/code/packages/c/os-platform/README.md
+++ b/code/packages/c/os-platform/README.md
@@ -24,7 +24,7 @@ exactly one backend and the code contains no `#if defined(__linux__)` mazes.
 | `fs`      | `os_platform/fs.h`      | ✅ implemented |
 | `process` | `os_platform/process.h` | ✅ implemented |
 | `dynlib`  | `os_platform/dynlib.h`  | ✅ implemented |
-| mmap     | —                       | planned       |
+| `mmap`    | `os_platform/mmap.h`    | ✅ implemented |
 
 All primitives share the `osp_status` return convention from
 `os_platform/status.h` (`OSP_OK == 0`; negative on error).
@@ -199,6 +199,34 @@ resolved symbol is a `void *`; convert it to a function pointer with `memcpy`
 (the direct object↔function cast is non-ISO — which is exactly why `dynlib` lives
 on `platform-harness`, not `iso-harness`).
 
+### `mmap` — anonymous memory with protection control
+
+`malloc` gives bytes; only the OS gives a page range with a chosen protection
+(read-only data, guard pages, or executable JIT memory).
+
+```c
+#include "os_platform/mmap.h"
+
+osp_mapping *m;
+osp_map_anon(&m, 4096, OSP_PROT_READ | OSP_PROT_WRITE);  /* zero-filled pages */
+unsigned char *p = osp_map_base(m);
+p[0] = 0x42;                                             /* real, committed memory */
+osp_map_protect(m, OSP_PROT_READ);                      /* now read-only */
+osp_map_unmap(m);
+```
+
+Backends:
+
+| OS          | reserve+commit | protect         | release      |
+|-------------|----------------|-----------------|--------------|
+| macOS/Linux | `mmap`         | `mprotect`      | `munmap`     |
+| Windows     | `VirtualAlloc` | `VirtualProtect`| `VirtualFree`|
+
+`prot` is a bitmask of `OSP_PROT_NONE/READ/WRITE/EXEC`. The `EXEC` bit is plumbed
+through (for JIT) and works directly on Linux/Windows; a JIT executor that also
+handles Apple Silicon's `MAP_JIT` write-protect protocol, with a cross-arch
+execute-and-call test, is a planned follow-up.
+
 ## Build & test
 
 ```sh
@@ -221,14 +249,16 @@ os-platform/
 │   ├── thread.h                  # thread API
 │   ├── fs.h                      # fs API
 │   ├── process.h                 # process API
-│   └── dynlib.h                  # dynlib API
+│   ├── dynlib.h                  # dynlib API
+│   └── mmap.h                    # mmap API
 ├── src/
 │   ├── clock_posix.c   · clock_windows.c     # per-OS clock backends
 │   ├── thread_posix.c  · thread_windows.c    # per-OS thread backends
 │   ├── fs_posix.c      · fs_windows.c        # per-OS fs backends
 │   ├── process_posix.c · process_windows.c   # per-OS process backends
-│   └── dynlib_posix.c  · dynlib_windows.c    # per-OS dynlib backends
-├── tests/clock_test.c · thread_test.c · fs_test.c · process_test.c · dynlib_test.c
+│   ├── dynlib_posix.c  · dynlib_windows.c    # per-OS dynlib backends
+│   └── mmap_posix.c    · mmap_windows.c      # per-OS mmap backends
+├── tests/  clock · thread · fs · process · dynlib · mmap  (one _test.c each)
 ├── tools/run.sh  · run.ps1       # per-OS build drivers
 ├── BUILD  · BUILD_windows        # per-OS source selection
 └── required_capabilities.json    # CI needs gcc, clang, cl

--- a/code/packages/c/os-platform/include/os_platform/mmap.h
+++ b/code/packages/c/os-platform/include/os_platform/mmap.h
@@ -1,0 +1,92 @@
+/*
+ * os_platform/mmap.h — anonymous virtual memory with protection control.
+ * ===========================================================================
+ *
+ * The sixth os-platform primitive. `malloc` gives you bytes, but it cannot give
+ * you a *whole page range with a chosen protection* — read-only data, guard
+ * pages, or (with EXEC) memory you can execute, the substrate a JIT emits into.
+ * That is the OS's job:
+ *
+ *      operation           macOS / Linux    Windows
+ *      ──────────────────  ───────────────  ─────────────────────
+ *      reserve+commit      mmap             VirtualAlloc
+ *      change protection   mprotect         VirtualProtect
+ *      release             munmap           VirtualFree
+ *
+ * MODEL. osp_map_anon reserves and commits `len` bytes of fresh, zero-filled,
+ * page-aligned anonymous memory with an initial protection, returning an opaque
+ * handle. osp_map_protect changes the protection later (e.g. write code as RW,
+ * then flip to R+X). osp_map_base / osp_map_size expose the region;
+ * osp_map_unmap releases it and frees the handle. No mapping leaks.
+ *
+ * PROTECTION is a bitmask of OSP_PROT_* below. A classic W^X sequence maps RW,
+ * writes, then re-protects to READ|EXEC.
+ *
+ * EXECUTABLE MEMORY — SCOPE NOTE. The EXEC bit is plumbed through to
+ * PROT_EXEC / PAGE_EXECUTE_* so JIT consumers can request it, and it works
+ * directly on Linux and Windows (map RW, emit, re-protect to R+X, run). Apple
+ * Silicon's hardened runtime additionally requires MAP_JIT plus a per-thread
+ * write-protect toggle and an instruction-cache flush; a dedicated JIT executor
+ * that encapsulates that protocol (and a cross-architecture execute-and-call
+ * test) is a planned follow-up. This header's own tests exercise anonymous
+ * read/write memory and protection changes, which are identical on every OS.
+ *
+ * BUILD. Compiled by platform-harness; the POSIX backend needs _DEFAULT_SOURCE
+ * (added by the BUILD) so MAP_ANONYMOUS is visible on glibc, and links no extra
+ * library. Windows uses only kernel32.
+ */
+#ifndef OS_PLATFORM_MMAP_H
+#define OS_PLATFORM_MMAP_H
+
+#include <stddef.h> /* size_t */
+
+#include "os_platform/status.h" /* osp_status */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Protection bits — combine with bitwise OR. */
+enum {
+    OSP_PROT_NONE = 0,  /* no access                    */
+    OSP_PROT_READ = 1,  /* readable                     */
+    OSP_PROT_WRITE = 2, /* writable                     */
+    OSP_PROT_EXEC = 4   /* executable (for JIT/codegen) */
+};
+
+/* Opaque mapping handle. Created by osp_map_anon, freed by osp_map_unmap. */
+typedef struct osp_mapping osp_mapping;
+
+/*
+ * osp_map_anon — reserve+commit `len` bytes of anonymous, zero-filled memory
+ * with protection `prot` (a bitmask of OSP_PROT_*). `len` is rounded up to a
+ * page by the OS; the usable region is at least `len` bytes. Writes a handle
+ * through *out. Returns OSP_ERR_INVAL (out NULL or len 0), OSP_ERR_NOMEM on
+ * handle allocation failure, OSP_ERR_OS if the OS mapping call fails.
+ */
+osp_status osp_map_anon(osp_mapping **out, size_t len, int prot);
+
+/*
+ * osp_map_protect — change the protection of the whole mapping to `prot`.
+ * Returns OSP_ERR_INVAL if m is NULL, OSP_ERR_OS on failure.
+ */
+osp_status osp_map_protect(osp_mapping *m, int prot);
+
+/* Base address of the mapping (page-aligned), or NULL if m is NULL. */
+void *osp_map_base(const osp_mapping *m);
+
+/* The requested length in bytes, or 0 if m is NULL. */
+size_t osp_map_size(const osp_mapping *m);
+
+/*
+ * osp_map_unmap — release the mapping and free the handle. Returns OSP_ERR_INVAL
+ * if m is NULL, OSP_ERR_OS if the OS release call fails (the handle is freed
+ * either way, matching the "unmap frees the handle" contract).
+ */
+osp_status osp_map_unmap(osp_mapping *m);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* OS_PLATFORM_MMAP_H */

--- a/code/packages/c/os-platform/src/mmap_posix.c
+++ b/code/packages/c/os-platform/src/mmap_posix.c
@@ -1,0 +1,93 @@
+/*
+ * mmap_posix.c — the POSIX backend of os_platform/mmap (macOS + Linux).
+ * ===========================================================================
+ *
+ * Compiled on macOS + Linux (named by the shared `BUILD`; Windows uses
+ * mmap_windows.c via `BUILD_windows`). No OS #ifdefs — the build chose this
+ * file. Uses only libc (mmap/mprotect/munmap).
+ *
+ * MAP_ANONYMOUS is not strict POSIX, so on glibc it is gated behind
+ * _DEFAULT_SOURCE, which the BUILD defines for this primitive (harmless on
+ * macOS, whose headers expose it unconditionally).
+ */
+#include "os_platform/mmap.h"
+
+#include <stdlib.h>
+#include <sys/mman.h>
+
+struct osp_mapping {
+    void *base;
+    size_t len;
+};
+
+/* Translate our OSP_PROT_* bitmask into the OS's PROT_* bitmask. */
+static int osp__prot_to_posix(int prot) {
+    int p = 0;
+    if (prot & OSP_PROT_READ) {
+        p |= PROT_READ;
+    }
+    if (prot & OSP_PROT_WRITE) {
+        p |= PROT_WRITE;
+    }
+    if (prot & OSP_PROT_EXEC) {
+        p |= PROT_EXEC;
+    }
+    return (p == 0) ? PROT_NONE : p;
+}
+
+osp_status osp_map_anon(osp_mapping **out, size_t len, int prot) {
+    struct osp_mapping *m;
+    void *base;
+
+    if (out == NULL || len == 0) {
+        return OSP_ERR_INVAL;
+    }
+    m = (struct osp_mapping *)malloc(sizeof(*m));
+    if (m == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    /* MAP_PRIVATE | MAP_ANONYMOUS with fd -1: fresh, zero-filled, copy-on-write
+     * pages backed by no file. */
+    base = mmap(NULL, len, osp__prot_to_posix(prot),
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (base == MAP_FAILED) {
+        free(m);
+        return OSP_ERR_OS;
+    }
+    m->base = base;
+    m->len = len;
+    *out = m;
+    return OSP_OK;
+}
+
+osp_status osp_map_protect(osp_mapping *m, int prot) {
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    if (mprotect(m->base, m->len, osp__prot_to_posix(prot)) != 0) {
+        return OSP_ERR_OS;
+    }
+    return OSP_OK;
+}
+
+void *osp_map_base(const osp_mapping *m) {
+    return (m != NULL) ? m->base : NULL;
+}
+
+size_t osp_map_size(const osp_mapping *m) {
+    return (m != NULL) ? m->len : 0;
+}
+
+osp_status osp_map_unmap(osp_mapping *m) {
+    osp_status st = OSP_OK;
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* Free the wrapper unconditionally (the contract says unmap frees it, so a
+     * caller will not retry); report an OS failure via the status. */
+    if (munmap(m->base, m->len) != 0) {
+        st = OSP_ERR_OS;
+    }
+    free(m);
+    return st;
+}

--- a/code/packages/c/os-platform/src/mmap_windows.c
+++ b/code/packages/c/os-platform/src/mmap_windows.c
@@ -1,0 +1,103 @@
+/*
+ * mmap_windows.c — the Win32 backend of os_platform/mmap.
+ * ===========================================================================
+ *
+ * Compiled on Windows (named by `BUILD_windows`; macOS/Linux use mmap_posix.c
+ * via the shared `BUILD`). No OS #ifdefs — the build chose this file. Uses only
+ * kernel32.
+ *
+ * VirtualAlloc reserves and commits pages in one call; the protection is one of
+ * the PAGE_* constants (which, unlike POSIX's orthogonal PROT_ bits, are a fixed
+ * matrix — so we map our bitmask onto the right constant explicitly).
+ */
+#include "os_platform/mmap.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <stdlib.h>
+
+struct osp_mapping {
+    void *base;
+    size_t len;
+};
+
+/* Map our OSP_PROT_* bitmask onto the Win32 PAGE_* matrix. */
+static DWORD osp__prot_to_win(int prot) {
+    int w = prot & OSP_PROT_WRITE;
+    int r = prot & OSP_PROT_READ;
+    if (prot & OSP_PROT_EXEC) {
+        if (w) {
+            return PAGE_EXECUTE_READWRITE;
+        }
+        if (r) {
+            return PAGE_EXECUTE_READ;
+        }
+        return PAGE_EXECUTE;
+    }
+    if (w) {
+        return PAGE_READWRITE;
+    }
+    if (r) {
+        return PAGE_READONLY;
+    }
+    return PAGE_NOACCESS;
+}
+
+osp_status osp_map_anon(osp_mapping **out, size_t len, int prot) {
+    struct osp_mapping *m;
+    void *base;
+
+    if (out == NULL || len == 0) {
+        return OSP_ERR_INVAL;
+    }
+    m = (struct osp_mapping *)malloc(sizeof(*m));
+    if (m == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    base = VirtualAlloc(NULL, len, MEM_RESERVE | MEM_COMMIT,
+                        osp__prot_to_win(prot));
+    if (base == NULL) {
+        free(m);
+        return OSP_ERR_OS;
+    }
+    m->base = base;
+    m->len = len;
+    *out = m;
+    return OSP_OK;
+}
+
+osp_status osp_map_protect(osp_mapping *m, int prot) {
+    DWORD old_prot;
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* VirtualProtect requires a non-NULL out-parameter for the old protection,
+     * even when we do not need the value. */
+    if (!VirtualProtect(m->base, m->len, osp__prot_to_win(prot), &old_prot)) {
+        return OSP_ERR_OS;
+    }
+    return OSP_OK;
+}
+
+void *osp_map_base(const osp_mapping *m) {
+    return (m != NULL) ? m->base : NULL;
+}
+
+size_t osp_map_size(const osp_mapping *m) {
+    return (m != NULL) ? m->len : 0;
+}
+
+osp_status osp_map_unmap(osp_mapping *m) {
+    osp_status st = OSP_OK;
+    if (m == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* MEM_RELEASE frees the whole reservation; its dwSize argument must be 0.
+     * Free the wrapper unconditionally (see the POSIX backend for why). */
+    if (!VirtualFree(m->base, 0, MEM_RELEASE)) {
+        st = OSP_ERR_OS;
+    }
+    free(m);
+    return st;
+}

--- a/code/packages/c/os-platform/tests/mmap_test.c
+++ b/code/packages/c/os-platform/tests/mmap_test.c
@@ -1,0 +1,72 @@
+/*
+ * mmap_test.c — anonymous-memory + protection tests for os_platform/mmap.
+ * ===========================================================================
+ *
+ * Fully portable (no architecture-specific or JIT code): it exercises the parts
+ * of the primitive that behave identically on every OS.
+ *
+ *   - map anonymous READ|WRITE memory; confirm base != NULL and size == request;
+ *   - the fresh mapping is zero-filled (mmap / VirtualAlloc guarantee this);
+ *   - write a byte pattern across a full page and read it back via a checksum
+ *     (proves the pages are real, committed, writable memory);
+ *   - re-protect to READ-only; reading still works (we do NOT test that writing
+ *     now faults — that would crash the process by design);
+ *   - unmap; then NULL / zero-length argument validation.
+ *
+ * The executable (EXEC) protection is plumbed through the API but a JIT
+ * execute-and-call test is a separate follow-up (it needs per-architecture
+ * machine code and, on Apple Silicon, the MAP_JIT write-protect protocol).
+ */
+#include "iso_test.h"
+
+#include "os_platform/mmap.h"
+
+#include <stddef.h> /* NULL */
+
+#define PAGE_LEN 4096
+
+int main(void) {
+    osp_mapping *m = NULL;
+    unsigned char *p;
+    size_t i;
+    unsigned long sum;
+
+    /* ── anonymous READ|WRITE mapping ───────────────────────────────────── */
+    ISO_CHECK(osp_map_anon(&m, PAGE_LEN, OSP_PROT_READ | OSP_PROT_WRITE) == OSP_OK);
+    ISO_CHECK_MSG(osp_map_base(m) != NULL, "mapping base must be non-NULL");
+    ISO_CHECK_EQ_UINT(osp_map_size(m), (unsigned long)PAGE_LEN);
+
+    p = (unsigned char *)osp_map_base(m);
+
+    /* fresh anonymous memory is zero-filled */
+    ISO_CHECK_MSG(p[0] == 0 && p[PAGE_LEN - 1] == 0, "new mapping must be zeroed");
+
+    /* write a pattern, then read it back through a checksum. Sum of (i & 0xFF)
+     * over one page = 16 full 0..255 runs = 16 * 32640 = 522240. */
+    for (i = 0; i < PAGE_LEN; i++) {
+        p[i] = (unsigned char)(i & 0xFF);
+    }
+    sum = 0;
+    for (i = 0; i < PAGE_LEN; i++) {
+        sum += p[i];
+    }
+    ISO_CHECK_EQ_UINT(sum, 522240UL);
+
+    /* ── re-protect to READ-only; reads still succeed ───────────────────── */
+    ISO_CHECK(osp_map_protect(m, OSP_PROT_READ) == OSP_OK);
+    ISO_CHECK_EQ_INT(p[0], 0);
+    ISO_CHECK_EQ_INT(p[255], 255);
+
+    /* ── unmap ──────────────────────────────────────────────────────────── */
+    ISO_CHECK(osp_map_unmap(m) == OSP_OK);
+
+    /* ── argument validation ────────────────────────────────────────────── */
+    ISO_CHECK(osp_map_anon(NULL, PAGE_LEN, OSP_PROT_READ) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_map_anon(&m, 0, OSP_PROT_READ) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_map_protect(NULL, OSP_PROT_READ) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_map_base(NULL) == NULL);
+    ISO_CHECK_EQ_UINT(osp_map_size(NULL), 0UL);
+    ISO_CHECK(osp_map_unmap(NULL) == OSP_ERR_INVAL);
+
+    return ISO_TEST_RESULT();
+}

--- a/code/packages/c/os-platform/tools/run.ps1
+++ b/code/packages/c/os-platform/tools/run.ps1
@@ -51,3 +51,6 @@ Platform-BuildAndRun -Lang c -Name 'process-tests' -Sources @('tests\process_tes
 
 # dynlib — Win32 backend (LoadLibrary + GetProcAddress + FreeLibrary).
 Platform-BuildAndRun -Lang c -Name 'dynlib-tests' -Sources @('tests\dynlib_test.c', 'src\dynlib_windows.c')
+
+# mmap — Win32 backend (VirtualAlloc + VirtualProtect + VirtualFree).
+Platform-BuildAndRun -Lang c -Name 'mmap-tests' -Sources @('tests\mmap_test.c', 'src\mmap_windows.c')

--- a/code/packages/c/os-platform/tools/run.sh
+++ b/code/packages/c/os-platform/tools/run.sh
@@ -76,4 +76,14 @@ fi
 export PLATFORM_LIBS
 platform_build_and_run c dynlib-tests tests/dynlib_test.c src/dynlib_posix.c || rc=1
 
+# mmap — POSIX backend (mmap/mprotect/munmap). No extra OS library. MAP_ANONYMOUS
+# is a non-POSIX extension gated differently per OS: glibc needs _DEFAULT_SOURCE,
+# Darwin needs _DARWIN_C_SOURCE (each harmless on the other). These expose the
+# mmap/mprotect declarations too, so _POSIX_C_SOURCE is not needed here.
+PLATFORM_LIBS=""
+export PLATFORM_LIBS
+PLATFORM_DEFINES="_DEFAULT_SOURCE _DARWIN_C_SOURCE"
+export PLATFORM_DEFINES
+platform_build_and_run c mmap-tests tests/mmap_test.c src/mmap_posix.c || rc=1
+
 exit "$rc"


### PR DESCRIPTION
## CCPP02 Phase 2 — `os-platform` sixth primitive: `mmap` (completes the core)

Builds on merged `clock` (#8319), `thread` (#8321), `fs` (#8323), `process`
(#8329), `dynlib` (#8331). This is the **final core primitive** — `malloc` gives
bytes, but only the OS gives a page range with a chosen protection (read-only
data, guard pages, or the executable memory a JIT emits into). **Bucket B.**

### API (`os_platform/mmap.h`)

| Function | Purpose |
|----------|---------|
| `osp_map_anon(out, len, prot)` | reserve+commit zero-filled anonymous pages |
| `osp_map_protect(m, prot)` | change protection of the whole region |
| `osp_map_base` / `osp_map_size` | expose the mapping |
| `osp_map_unmap(m)` | release + free the handle |

`prot` is an `OSP_PROT_*` bitmask (`NONE`/`READ`/`WRITE`/`EXEC`). Classic W^X:
map `RW`, write, re-protect to `READ|EXEC`.

### Backends — per-OS source selection via BUILD, no `#ifdef` mazes

| | reserve+commit | protect | release |
|--|----------------|---------|---------|
| **macOS/Linux** (`mmap_posix.c`) | `mmap(MAP_PRIVATE\|MAP_ANONYMOUS)` | `mprotect` | `munmap` |
| **Windows** (`mmap_windows.c`) | `VirtualAlloc(MEM_RESERVE\|MEM_COMMIT)` | `VirtualProtect` | `VirtualFree(MEM_RELEASE)` |

`MAP_ANONYMOUS` is a non-POSIX extension gated differently per OS, so the BUILD
adds **`_DEFAULT_SOURCE` (glibc) + `_DARWIN_C_SOURCE` (Darwin)** for this
primitive (each harmless on the other). Windows maps `OSP_PROT_*` onto the fixed
`PAGE_*` matrix.

### Test (`tests/mmap_test.c`, portable — no arch/JIT code)

Anonymous `RW` map, **zero-fill check**, page-sized write/read **checksum**
(proves real committed memory), re-protect to `READ`-only (reads still work; we
don't test that writing faults — that would crash by design), accessors, unmap,
and NULL/zero-length validation.

### Executable memory — scope note

The `EXEC` bit is plumbed to `PROT_EXEC` / `PAGE_EXECUTE_*` for JIT consumers and
works directly on Linux/Windows. A JIT executor that also handles **Apple
Silicon's `MAP_JIT` write-protect protocol**, with a per-architecture
execute-and-call test, is a **planned follow-up** — deliberately kept out of this
core-primitive PR to avoid a cross-arch + hardened-runtime rabbit hole.

### Verification

- **Local (macOS):** all six primitives green — clock 13/0 + thread 28/0 + fs 24/0 + process 7/0 + dynlib 11/0 + **mmap 15/0** under gcc + clang.
- **Sanitizers:** mmap test clean under **ASan + UBSan**; **0 leaks**.
- **Security review:** passed — reviewer verified the protection mapping never over-grants (no accidental W+X), the `MAP_FAILED` sentinel (`(void*)-1`, not NULL) is checked, all return values checked, memory-safe on every path, RWX never the default.
- CI proves `mmap_windows.c` on the windows runner.

### 🎉 With this, the six-primitive `os-platform` core is complete

`clock · thread · fs · process · dynlib · mmap` — the bucket-B substrate that
unblocks the ~400 deferred Rust crates (time, threads, filesystem, process, FFI,
executable memory). Next: **Phase 3** (`net` + `reactor`) built on top.

Spec: [`CCPP02-os-platform-lane.md`](code/specs/CCPP02-os-platform-lane.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)