### PR TITLE
feat: port AVL tree to Lua and Perl

### DIFF
--- a/code/packages/lua/avl-tree/BUILD
+++ b/code/packages/lua/avl-tree/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-avl-tree-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/avl-tree/BUILD_windows
+++ b/code/packages/lua/avl-tree/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-avl-tree-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/avl-tree/CHANGELOG.md
+++ b/code/packages/lua/avl-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add a pure-Lua persistent AVL tree with rotations, balanced deletion, lookup,
+  order statistics, custom comparison, and structural validation.

--- a/code/packages/lua/avl-tree/README.md
+++ b/code/packages/lua/avl-tree/README.md
@@ -1,0 +1,25 @@
+# Lua AVL tree
+
+A dependency-free persistent AVL tree with duplicate suppression, balanced
+insertion and deletion, lookup, predecessor/successor queries, rank and k-th
+order statistics, custom comparison, and metadata validation.
+
+```lua
+local AVLTree = require("coding_adventures.avl_tree").AVLTree
+
+local tree = AVLTree.from_values({5, 1, 8, 3})
+local updated = tree:delete(5)
+assert(tree:contains(5))
+assert(not updated:contains(5))
+assert(updated:is_valid_avl())
+```
+
+`insert` and `delete` return new trees and preserve the original. Supply a
+three-way comparison function to `empty` or `from_values` for values that do
+not use Lua's default `<` and `>` ordering.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/lua/avl-tree/coding-adventures-avl-tree-0.1.0-1.rockspec
+++ b/code/packages/lua/avl-tree/coding-adventures-avl-tree-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-avl-tree"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Persistent AVL tree with order statistics",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.avl_tree"] = "src/coding_adventures/avl_tree/init.lua",
+    },
+}

--- a/code/packages/lua/avl-tree/required_capabilities.json
+++ b/code/packages/lua/avl-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/avl-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/avl-tree/src/coding_adventures/avl_tree/init.lua
+++ b/code/packages/lua/avl-tree/src/coding_adventures/avl_tree/init.lua
@@ -1,0 +1,415 @@
+local M = {VERSION = "0.1.0"}
+
+local function default_compare(left, right)
+    if left < right then
+        return -1
+    end
+    if left > right then
+        return 1
+    end
+    return 0
+end
+
+local AVLNode = {}
+AVLNode.__index = AVLNode
+
+local function is_node(value)
+    return type(value) == "table" and getmetatable(value) == AVLNode
+end
+
+local function node_height(root)
+    return root == nil and -1 or root.height
+end
+
+local function node_size(root)
+    return root == nil and 0 or root.size
+end
+
+local function is_non_negative_integer(value)
+    return type(value) == "number" and value >= 0 and value % 1 == 0
+end
+
+function AVLNode.new(value, left, right, height, size)
+    if value == nil then
+        error("node value must not be nil", 2)
+    end
+    if left ~= nil and not is_node(left) then
+        error("left must be an AVLNode or nil", 2)
+    end
+    if right ~= nil and not is_node(right) then
+        error("right must be an AVLNode or nil", 2)
+    end
+
+    local actual_height = height
+    if actual_height == nil then
+        actual_height = 1 + math.max(node_height(left), node_height(right))
+    elseif not is_non_negative_integer(actual_height) then
+        error("height must be a non-negative integer", 2)
+    end
+
+    local actual_size = size
+    if actual_size == nil then
+        actual_size = 1 + node_size(left) + node_size(right)
+    elseif not is_non_negative_integer(actual_size) then
+        error("size must be a non-negative integer", 2)
+    end
+
+    return setmetatable({
+        value = value,
+        left = left,
+        right = right,
+        height = actual_height,
+        size = actual_size,
+    }, AVLNode)
+end
+
+local function node(value, left, right)
+    return AVLNode.new(value, left, right)
+end
+
+local function balance_factor(root)
+    return node_height(root.left) - node_height(root.right)
+end
+
+local function rotate_left(root)
+    local right = root.right
+    if right == nil then
+        return root
+    end
+    local new_left = node(root.value, root.left, right.left)
+    return node(right.value, new_left, right.right)
+end
+
+local function rotate_right(root)
+    local left = root.left
+    if left == nil then
+        return root
+    end
+    local new_right = node(root.value, left.right, root.right)
+    return node(left.value, left.left, new_right)
+end
+
+local function rebalance(root)
+    local factor = balance_factor(root)
+    if factor > 1 then
+        local left = root.left
+        if left ~= nil and balance_factor(left) < 0 then
+            left = rotate_left(left)
+        end
+        return rotate_right(node(root.value, left, root.right))
+    end
+    if factor < -1 then
+        local right = root.right
+        if right ~= nil and balance_factor(right) > 0 then
+            right = rotate_right(right)
+        end
+        return rotate_left(node(root.value, root.left, right))
+    end
+    return root
+end
+
+local function insert_node(root, value, compare)
+    if root == nil then
+        return AVLNode.new(value)
+    end
+    local order = compare(value, root.value)
+    if order < 0 then
+        return rebalance(node(root.value, insert_node(root.left, value, compare), root.right))
+    end
+    if order > 0 then
+        return rebalance(node(root.value, root.left, insert_node(root.right, value, compare)))
+    end
+    return root
+end
+
+local function extract_min(root)
+    if root.left == nil then
+        return root.right, root.value
+    end
+    local new_left, minimum = extract_min(root.left)
+    return rebalance(node(root.value, new_left, root.right)), minimum
+end
+
+local function delete_node(root, value, compare)
+    if root == nil then
+        return nil
+    end
+    local order = compare(value, root.value)
+    if order < 0 then
+        return rebalance(node(root.value, delete_node(root.left, value, compare), root.right))
+    end
+    if order > 0 then
+        return rebalance(node(root.value, root.left, delete_node(root.right, value, compare)))
+    end
+    if root.left == nil then
+        return root.right
+    end
+    if root.right == nil then
+        return root.left
+    end
+
+    local new_right, successor = extract_min(root.right)
+    return rebalance(node(successor, root.left, new_right))
+end
+
+local function kth_smallest(root, k)
+    if root == nil or type(k) ~= "number" or k <= 0 or k % 1 ~= 0 then
+        return nil
+    end
+    local left_size = node_size(root.left)
+    if k == left_size + 1 then
+        return root.value
+    end
+    if k <= left_size then
+        return kth_smallest(root.left, k)
+    end
+    return kth_smallest(root.right, k - left_size - 1)
+end
+
+local function rank(root, value, compare)
+    if root == nil then
+        return 0
+    end
+    local order = compare(value, root.value)
+    if order < 0 then
+        return rank(root.left, value, compare)
+    end
+    if order > 0 then
+        return node_size(root.left) + 1 + rank(root.right, value, compare)
+    end
+    return node_size(root.left)
+end
+
+local function append_inorder(root, out)
+    if root == nil then
+        return
+    end
+    append_inorder(root.left, out)
+    out[#out + 1] = root.value
+    append_inorder(root.right, out)
+end
+
+local function validate_bst(root, minimum, maximum, has_minimum, has_maximum, compare)
+    if root == nil then
+        return true
+    end
+    if has_minimum and compare(root.value, minimum) <= 0 then
+        return false
+    end
+    if has_maximum and compare(root.value, maximum) >= 0 then
+        return false
+    end
+    return validate_bst(root.left, minimum, root.value, has_minimum, true, compare)
+        and validate_bst(root.right, root.value, maximum, true, has_maximum, compare)
+end
+
+local function validate_avl(root, minimum, maximum, has_minimum, has_maximum, compare)
+    if root == nil then
+        return -1, 0
+    end
+    if has_minimum and compare(root.value, minimum) <= 0 then
+        return nil
+    end
+    if has_maximum and compare(root.value, maximum) >= 0 then
+        return nil
+    end
+
+    local left_height, left_size = validate_avl(
+        root.left,
+        minimum,
+        root.value,
+        has_minimum,
+        true,
+        compare
+    )
+    if left_height == nil then
+        return nil
+    end
+    local right_height, right_size = validate_avl(
+        root.right,
+        root.value,
+        maximum,
+        true,
+        has_maximum,
+        compare
+    )
+    if right_height == nil then
+        return nil
+    end
+
+    local actual_height = 1 + math.max(left_height, right_height)
+    local actual_size = 1 + left_size + right_size
+    if root.height ~= actual_height
+        or root.size ~= actual_size
+        or math.abs(left_height - right_height) > 1
+    then
+        return nil
+    end
+    return actual_height, actual_size
+end
+
+local AVLTree = {}
+AVLTree.__index = AVLTree
+
+function AVLTree.new(root, compare)
+    if root ~= nil and not is_node(root) then
+        error("root must be an AVLNode or nil", 2)
+    end
+    local comparator = compare or default_compare
+    if type(comparator) ~= "function" then
+        error("compare must be a function", 2)
+    end
+    return setmetatable({root = root, compare = comparator}, AVLTree)
+end
+
+function AVLTree.empty(compare)
+    return AVLTree.new(nil, compare)
+end
+
+function AVLTree.from_values(values, compare)
+    if type(values) ~= "table" then
+        error("values must be a table", 2)
+    end
+    local tree = AVLTree.empty(compare)
+    for index, value in ipairs(values) do
+        if value == nil then
+            error(string.format("value at index %d must not be nil", index), 2)
+        end
+        tree = tree:insert(value)
+    end
+    return tree
+end
+
+function AVLTree:insert(value)
+    if value == nil then
+        error("value must not be nil", 2)
+    end
+    return AVLTree.new(insert_node(self.root, value, self.compare), self.compare)
+end
+
+function AVLTree:delete(value)
+    if value == nil then
+        error("value must not be nil", 2)
+    end
+    return AVLTree.new(delete_node(self.root, value, self.compare), self.compare)
+end
+
+function AVLTree:search(value)
+    local current = self.root
+    while current ~= nil do
+        local order = self.compare(value, current.value)
+        if order < 0 then
+            current = current.left
+        elseif order > 0 then
+            current = current.right
+        else
+            return current
+        end
+    end
+    return nil
+end
+
+function AVLTree:contains(value)
+    return self:search(value) ~= nil
+end
+
+function AVLTree:min_value()
+    local current = self.root
+    while current ~= nil and current.left ~= nil do
+        current = current.left
+    end
+    if current == nil then
+        return nil
+    end
+    return current.value
+end
+
+function AVLTree:max_value()
+    local current = self.root
+    while current ~= nil and current.right ~= nil do
+        current = current.right
+    end
+    if current == nil then
+        return nil
+    end
+    return current.value
+end
+
+function AVLTree:predecessor(value)
+    local current = self.root
+    local best = nil
+    while current ~= nil do
+        if self.compare(value, current.value) <= 0 then
+            current = current.left
+        else
+            best = current.value
+            current = current.right
+        end
+    end
+    return best
+end
+
+function AVLTree:successor(value)
+    local current = self.root
+    local best = nil
+    while current ~= nil do
+        if self.compare(value, current.value) >= 0 then
+            current = current.right
+        else
+            best = current.value
+            current = current.left
+        end
+    end
+    return best
+end
+
+function AVLTree:kth_smallest(k)
+    return kth_smallest(self.root, k)
+end
+
+function AVLTree:rank(value)
+    return rank(self.root, value, self.compare)
+end
+
+function AVLTree:to_sorted_array()
+    local out = {}
+    append_inorder(self.root, out)
+    return out
+end
+
+function AVLTree:is_valid_bst()
+    return validate_bst(self.root, nil, nil, false, false, self.compare)
+end
+
+function AVLTree:is_valid_avl()
+    return validate_avl(self.root, nil, nil, false, false, self.compare) ~= nil
+end
+
+function AVLTree:balance_factor(root)
+    if root == nil then
+        return 0
+    end
+    if not is_node(root) then
+        error("node must be an AVLNode or nil", 2)
+    end
+    return balance_factor(root)
+end
+
+function AVLTree:height()
+    return node_height(self.root)
+end
+
+function AVLTree:size()
+    return node_size(self.root)
+end
+
+function AVLTree:__tostring()
+    local root_value = self.root == nil and "nil" or tostring(self.root.value)
+    return string.format("AVLTree(root=%s, height=%d, size=%d)", root_value, self:height(), self:size())
+end
+
+M.default_compare = default_compare
+M.AVLNode = AVLNode
+M.AVLTree = AVLTree
+
+return M

--- a/code/packages/lua/avl-tree/tests/test_avl_tree.lua
+++ b/code/packages/lua/avl-tree/tests/test_avl_tree.lua
@@ -1,0 +1,151 @@
+package.path = "../src/?.lua;../src/?/init.lua;" .. package.path
+
+local module = require("coding_adventures.avl_tree")
+local AVLNode = module.AVLNode
+local AVLTree = module.AVLTree
+
+describe("AVLTree balancing", function()
+    it("performs left and right rotations", function()
+        local right_heavy = AVLTree.from_values({10, 20, 30})
+        local left_heavy = AVLTree.from_values({30, 20, 10})
+
+        assert.equals(20, right_heavy.root.value)
+        assert.equals(20, left_heavy.root.value)
+        assert.are.same({10, 20, 30}, right_heavy:to_sorted_array())
+        assert.is_true(right_heavy:is_valid_bst())
+        assert.is_true(right_heavy:is_valid_avl())
+        assert.equals(1, right_heavy:height())
+        assert.equals(3, right_heavy:size())
+        assert.equals(0, right_heavy:balance_factor(right_heavy.root))
+    end)
+
+    it("performs both double rotations", function()
+        local left_right = AVLTree.from_values({30, 10, 20})
+        local right_left = AVLTree.from_values({10, 30, 20})
+
+        assert.equals(20, left_right.root.value)
+        assert.equals(20, right_left.root.value)
+        assert.is_true(left_right:is_valid_avl())
+        assert.is_true(right_left:is_valid_avl())
+    end)
+end)
+
+describe("AVLTree persistence and queries", function()
+    it("searches and computes order statistics", function()
+        local tree = AVLTree.from_values({40, 20, 60, 10, 30, 50, 70})
+
+        assert.equals(20, tree:search(20).value)
+        assert.is_true(tree:contains(50))
+        assert.equals(10, tree:min_value())
+        assert.equals(70, tree:max_value())
+        assert.equals(30, tree:predecessor(40))
+        assert.equals(50, tree:successor(40))
+        assert.equals(40, tree:kth_smallest(4))
+        assert.equals(3, tree:rank(35))
+
+        local deleted = tree:delete(20)
+        assert.is_false(deleted:contains(20))
+        assert.is_true(deleted:is_valid_avl())
+        assert.is_true(tree:contains(20))
+    end)
+
+    it("handles empty trees, duplicates, and absent values", function()
+        local empty = AVLTree.empty()
+        assert.is_nil(empty:search(1))
+        assert.is_nil(empty:min_value())
+        assert.is_nil(empty:max_value())
+        assert.is_nil(empty:predecessor(1))
+        assert.is_nil(empty:successor(1))
+        assert.is_nil(empty:kth_smallest(0))
+        assert.equals(0, empty:rank(1))
+        assert.equals(0, empty:balance_factor(nil))
+        assert.equals(-1, empty:height())
+        assert.equals(0, empty:size())
+        assert.is_true(empty:is_valid_avl())
+        assert.equals("AVLTree(root=nil, height=-1, size=0)", tostring(empty))
+
+        local tree = AVLTree.from_values({30, 20, 40, 10, 25, 35, 50})
+        assert.are.same(tree:to_sorted_array(), tree:insert(25):to_sorted_array())
+        assert.are.same(tree:to_sorted_array(), tree:delete(999):to_sorted_array())
+    end)
+
+    it("deletes a root with a nested successor", function()
+        local tree = AVLTree.from_values({5, 3, 8, 7, 9, 6})
+        local deleted = tree:delete(5)
+
+        assert.are.same({3, 6, 7, 8, 9}, deleted:to_sorted_array())
+        assert.is_true(deleted:is_valid_avl())
+        assert.equals(3, tree:kth_smallest(1))
+        assert.equals(9, tree:kth_smallest(6))
+        assert.equals(1, tree:rank(5))
+        assert.are.same({2}, AVLTree.from_values({1, 2}):delete(1):to_sorted_array())
+        assert.are.same({1}, AVLTree.from_values({2, 1}):delete(2):to_sorted_array())
+    end)
+
+    it("maintains invariants across a larger update sequence", function()
+        local tree = AVLTree.empty()
+        for index = 1, 100 do
+            tree = tree:insert((index * 37) % 101)
+            assert.is_true(tree:is_valid_avl())
+        end
+        assert.equals(100, tree:size())
+
+        local updated = tree
+        for value = 1, 99, 2 do
+            updated = updated:delete(value)
+            assert.is_true(updated:is_valid_avl())
+        end
+
+        local expected = {}
+        for value = 2, 100, 2 do
+            expected[#expected + 1] = value
+        end
+        assert.are.same(expected, updated:to_sorted_array())
+        assert.equals(100, tree:size())
+    end)
+end)
+
+describe("AVLTree validation and comparison", function()
+    it("detects ordering, metadata, and balance corruption", function()
+        local bad_order = AVLTree.new(AVLNode.new(5, AVLNode.new(6), nil, 1, 2))
+        local bad_right_order = AVLTree.new(AVLNode.new(5, nil, AVLNode.new(4), 1, 2))
+        local bad_height = AVLTree.new(AVLNode.new(5, AVLNode.new(3), nil, 99, 2))
+        local bad_size = AVLTree.new(AVLNode.new(5, AVLNode.new(3), nil, 1, 99))
+        local unbalanced_left = AVLNode.new(2, AVLNode.new(1), nil)
+        local unbalanced = AVLTree.new(AVLNode.new(3, unbalanced_left, nil))
+
+        assert.is_false(bad_order:is_valid_bst())
+        assert.is_false(bad_order:is_valid_avl())
+        assert.is_false(bad_right_order:is_valid_bst())
+        assert.is_false(bad_right_order:is_valid_avl())
+        assert.is_false(bad_height:is_valid_avl())
+        assert.is_false(bad_size:is_valid_avl())
+        assert.is_false(unbalanced:is_valid_avl())
+    end)
+
+    it("supports custom comparators", function()
+        local function by_length(left, right)
+            return #left - #right
+        end
+        local tree = AVLTree.from_values({"bbb", "a", "cc"}, by_length)
+
+        assert.are.same({"a", "cc", "bbb"}, tree:to_sorted_array())
+        assert.is_true(tree:contains("zz"))
+        assert.equals("a", tree:predecessor("zz"))
+        assert.equals("bbb", tree:successor("zz"))
+        assert.is_true(tree:is_valid_avl())
+    end)
+
+    it("validates construction inputs", function()
+        assert.has_error(function() AVLNode.new(nil) end, "node value must not be nil")
+        assert.has_error(function() AVLNode.new(1, "left") end, "left must be an AVLNode or nil")
+        assert.has_error(function() AVLNode.new(1, nil, nil, -1) end, "height must be a non-negative integer")
+        assert.has_error(function() AVLNode.new(1, nil, nil, nil, -1) end, "size must be a non-negative integer")
+        assert.has_error(function() AVLTree.new("root") end, "root must be an AVLNode or nil")
+        assert.has_error(function() AVLTree.new(nil, "compare") end, "compare must be a function")
+        assert.has_error(function() AVLTree.from_values("values") end, "values must be a table")
+        assert.has_error(function() AVLTree.empty():insert(nil) end, "value must not be nil")
+        assert.has_error(function() AVLTree.empty():delete(nil) end, "value must not be nil")
+        assert.has_error(function() AVLTree.empty():balance_factor("node") end, "node must be an AVLNode or nil")
+    end)
+end)

--- a/code/packages/perl/avl-tree/BUILD
+++ b/code/packages/perl/avl-tree/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/avl-tree/BUILD_windows
+++ b/code/packages/perl/avl-tree/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-avl-tree.t

--- a/code/packages/perl/avl-tree/CHANGELOG.md
+++ b/code/packages/perl/avl-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-14
+
+- Add a pure-Perl persistent AVL tree with rotations, balanced deletion,
+  lookup, order statistics, custom comparison, and structural validation.

--- a/code/packages/perl/avl-tree/Makefile.PL
+++ b/code/packages/perl/avl-tree/Makefile.PL
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::AVLTree',
+    VERSION_FROM     => 'lib/CodingAdventures/AVLTree.pm',
+    ABSTRACT         => 'Persistent AVL tree with order statistics',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {},
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/avl-tree/README.md
+++ b/code/packages/perl/avl-tree/README.md
@@ -1,0 +1,23 @@
+# Perl AVL tree
+
+A dependency-free persistent AVL tree with duplicate suppression, balanced
+insertion and deletion, lookup, predecessor/successor queries, rank and k-th
+order statistics, custom comparison, and metadata validation.
+
+```perl
+my $tree = CodingAdventures::AVLTree->from_values([5, 1, 8, 3]);
+my $updated = $tree->delete(5);
+print $tree->contains(5);        # true
+print $updated->contains(5);     # false
+print $updated->is_valid_avl;    # true
+```
+
+`insert` and `delete` return new trees and preserve the original. Supply a
+three-way comparison code reference to `empty` or `from_values` for custom
+value ordering. The default comparator handles numeric and string scalars.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/perl/avl-tree/cpanfile
+++ b/code/packages/perl/avl-tree/cpanfile
@@ -1,0 +1,1 @@
+# No non-core dependencies.

--- a/code/packages/perl/avl-tree/lib/CodingAdventures/AVLTree.pm
+++ b/code/packages/perl/avl-tree/lib/CodingAdventures/AVLTree.pm
@@ -1,0 +1,376 @@
+package CodingAdventures::AVLTree::Node;
+
+use strict;
+use warnings;
+
+sub _is_node {
+    my ($value) = @_;
+    return defined($value)
+        && ref($value)
+        && eval { $value->isa(__PACKAGE__) };
+}
+
+sub _height {
+    my ($root) = @_;
+    return defined($root) ? $root->{height} : -1;
+}
+
+sub _size {
+    my ($root) = @_;
+    return defined($root) ? $root->{size} : 0;
+}
+
+sub new {
+    my ($class, $value, $left, $right, $height, $size) = @_;
+    die "node value must be defined\n" if !defined $value;
+    die "left must be a CodingAdventures::AVLTree::Node or undef\n"
+        if defined($left) && !_is_node($left);
+    die "right must be a CodingAdventures::AVLTree::Node or undef\n"
+        if defined($right) && !_is_node($right);
+
+    my $actual_height = defined($height)
+        ? $height
+        : 1 + (_height($left) > _height($right) ? _height($left) : _height($right));
+    die "height must be a non-negative integer\n"
+        if $actual_height !~ /^\d+$/;
+
+    my $actual_size = defined($size)
+        ? $size
+        : 1 + _size($left) + _size($right);
+    die "size must be a non-negative integer\n"
+        if $actual_size !~ /^\d+$/;
+
+    return bless {
+        value  => $value,
+        left   => $left,
+        right  => $right,
+        height => 0 + $actual_height,
+        size   => 0 + $actual_size,
+    }, $class;
+}
+
+sub value  { return $_[0]->{value}; }
+sub left   { return $_[0]->{left}; }
+sub right  { return $_[0]->{right}; }
+sub height { return $_[0]->{height}; }
+sub size   { return $_[0]->{size}; }
+
+package CodingAdventures::AVLTree;
+
+use strict;
+use warnings;
+use Scalar::Util qw(looks_like_number);
+use overload '""' => 'to_string', fallback => 1;
+
+our $VERSION = '0.1.0';
+
+sub _is_node {
+    my ($value) = @_;
+    return defined($value)
+        && ref($value)
+        && eval { $value->isa('CodingAdventures::AVLTree::Node') };
+}
+
+sub _default_compare {
+    my ($left, $right) = @_;
+    return $left <=> $right if looks_like_number($left) && looks_like_number($right);
+    return "$left" cmp "$right";
+}
+
+sub _node_height {
+    my ($root) = @_;
+    return defined($root) ? $root->{height} : -1;
+}
+
+sub _node_size {
+    my ($root) = @_;
+    return defined($root) ? $root->{size} : 0;
+}
+
+sub _node {
+    my ($value, $left, $right) = @_;
+    return CodingAdventures::AVLTree::Node->new($value, $left, $right);
+}
+
+sub new {
+    my ($class, $root, $compare) = @_;
+    die "root must be a CodingAdventures::AVLTree::Node or undef\n"
+        if defined($root) && !_is_node($root);
+    $compare = \&_default_compare if !defined $compare;
+    die "compare must be a code reference\n" if ref($compare) ne 'CODE';
+    return bless {root => $root, compare => $compare}, $class;
+}
+
+sub empty {
+    my ($class, $compare) = @_;
+    return $class->new(undef, $compare);
+}
+
+sub from_values {
+    my ($class, $values, $compare) = @_;
+    die "values must be an array reference\n" if ref($values) ne 'ARRAY';
+    my $tree = $class->empty($compare);
+    for my $index (0 .. $#$values) {
+        die "value at index $index must be defined\n" if !defined $values->[$index];
+        $tree = $tree->insert($values->[$index]);
+    }
+    return $tree;
+}
+
+sub root    { return $_[0]->{root}; }
+sub compare { return $_[0]->{compare}; }
+
+sub _balance_factor {
+    my ($root) = @_;
+    return _node_height($root->{left}) - _node_height($root->{right});
+}
+
+sub _rotate_left {
+    my ($root) = @_;
+    my $right = $root->{right};
+    return $root if !defined $right;
+    my $new_left = _node($root->{value}, $root->{left}, $right->{left});
+    return _node($right->{value}, $new_left, $right->{right});
+}
+
+sub _rotate_right {
+    my ($root) = @_;
+    my $left = $root->{left};
+    return $root if !defined $left;
+    my $new_right = _node($root->{value}, $left->{right}, $root->{right});
+    return _node($left->{value}, $left->{left}, $new_right);
+}
+
+sub _rebalance {
+    my ($root) = @_;
+    my $factor = _balance_factor($root);
+    if ($factor > 1) {
+        my $left = $root->{left};
+        $left = _rotate_left($left) if defined($left) && _balance_factor($left) < 0;
+        return _rotate_right(_node($root->{value}, $left, $root->{right}));
+    }
+    if ($factor < -1) {
+        my $right = $root->{right};
+        $right = _rotate_right($right) if defined($right) && _balance_factor($right) > 0;
+        return _rotate_left(_node($root->{value}, $root->{left}, $right));
+    }
+    return $root;
+}
+
+sub insert {
+    my ($self, $value) = @_;
+    die "value must be defined\n" if !defined $value;
+    return __PACKAGE__->new(_insert_node($self->{root}, $value, $self->{compare}), $self->{compare});
+}
+
+sub _insert_node {
+    my ($root, $value, $compare) = @_;
+    return CodingAdventures::AVLTree::Node->new($value) if !defined $root;
+    my $order = $compare->($value, $root->{value});
+    return _rebalance(_node($root->{value}, _insert_node($root->{left}, $value, $compare), $root->{right}))
+        if $order < 0;
+    return _rebalance(_node($root->{value}, $root->{left}, _insert_node($root->{right}, $value, $compare)))
+        if $order > 0;
+    return $root;
+}
+
+sub delete {
+    my ($self, $value) = @_;
+    die "value must be defined\n" if !defined $value;
+    return __PACKAGE__->new(_delete_node($self->{root}, $value, $self->{compare}), $self->{compare});
+}
+
+sub _delete_node {
+    my ($root, $value, $compare) = @_;
+    return undef if !defined $root;
+    my $order = $compare->($value, $root->{value});
+    return _rebalance(_node($root->{value}, _delete_node($root->{left}, $value, $compare), $root->{right}))
+        if $order < 0;
+    return _rebalance(_node($root->{value}, $root->{left}, _delete_node($root->{right}, $value, $compare)))
+        if $order > 0;
+    return $root->{right} if !defined $root->{left};
+    return $root->{left} if !defined $root->{right};
+
+    my ($new_right, $successor) = _extract_min($root->{right});
+    return _rebalance(_node($successor, $root->{left}, $new_right));
+}
+
+sub _extract_min {
+    my ($root) = @_;
+    return ($root->{right}, $root->{value}) if !defined $root->{left};
+    my ($new_left, $minimum) = _extract_min($root->{left});
+    return (_rebalance(_node($root->{value}, $new_left, $root->{right})), $minimum);
+}
+
+sub search {
+    my ($self, $value) = @_;
+    my $current = $self->{root};
+    while (defined $current) {
+        my $order = $self->{compare}->($value, $current->{value});
+        if ($order < 0) {
+            $current = $current->{left};
+        } elsif ($order > 0) {
+            $current = $current->{right};
+        } else {
+            return $current;
+        }
+    }
+    return undef;
+}
+
+sub contains {
+    my ($self, $value) = @_;
+    return defined $self->search($value);
+}
+
+sub min_value {
+    my ($self) = @_;
+    my $current = $self->{root};
+    $current = $current->{left} while defined($current) && defined($current->{left});
+    return defined($current) ? $current->{value} : undef;
+}
+
+sub max_value {
+    my ($self) = @_;
+    my $current = $self->{root};
+    $current = $current->{right} while defined($current) && defined($current->{right});
+    return defined($current) ? $current->{value} : undef;
+}
+
+sub predecessor {
+    my ($self, $value) = @_;
+    my $current = $self->{root};
+    my $best;
+    while (defined $current) {
+        if ($self->{compare}->($value, $current->{value}) <= 0) {
+            $current = $current->{left};
+        } else {
+            $best = $current->{value};
+            $current = $current->{right};
+        }
+    }
+    return $best;
+}
+
+sub successor {
+    my ($self, $value) = @_;
+    my $current = $self->{root};
+    my $best;
+    while (defined $current) {
+        if ($self->{compare}->($value, $current->{value}) >= 0) {
+            $current = $current->{right};
+        } else {
+            $best = $current->{value};
+            $current = $current->{left};
+        }
+    }
+    return $best;
+}
+
+sub kth_smallest {
+    my ($self, $k) = @_;
+    return _kth_smallest($self->{root}, $k);
+}
+
+sub _kth_smallest {
+    my ($root, $k) = @_;
+    return undef
+        if !defined($root) || !defined($k) || !looks_like_number($k) || $k <= 0 || int($k) != $k;
+    my $left_size = _node_size($root->{left});
+    return $root->{value} if $k == $left_size + 1;
+    return _kth_smallest($root->{left}, $k) if $k <= $left_size;
+    return _kth_smallest($root->{right}, $k - $left_size - 1);
+}
+
+sub rank {
+    my ($self, $value) = @_;
+    return _rank($self->{root}, $value, $self->{compare});
+}
+
+sub _rank {
+    my ($root, $value, $compare) = @_;
+    return 0 if !defined $root;
+    my $order = $compare->($value, $root->{value});
+    return _rank($root->{left}, $value, $compare) if $order < 0;
+    return _node_size($root->{left}) + 1 + _rank($root->{right}, $value, $compare)
+        if $order > 0;
+    return _node_size($root->{left});
+}
+
+sub to_sorted_array {
+    my ($self) = @_;
+    my @out;
+    _append_inorder($self->{root}, \@out);
+    return \@out;
+}
+
+sub _append_inorder {
+    my ($root, $out) = @_;
+    return if !defined $root;
+    _append_inorder($root->{left}, $out);
+    push @$out, $root->{value};
+    _append_inorder($root->{right}, $out);
+}
+
+sub is_valid_bst {
+    my ($self) = @_;
+    return _validate_bst($self->{root}, undef, undef, 0, 0, $self->{compare});
+}
+
+sub _validate_bst {
+    my ($root, $minimum, $maximum, $has_minimum, $has_maximum, $compare) = @_;
+    return 1 if !defined $root;
+    return 0 if $has_minimum && $compare->($root->{value}, $minimum) <= 0;
+    return 0 if $has_maximum && $compare->($root->{value}, $maximum) >= 0;
+    return _validate_bst($root->{left}, $minimum, $root->{value}, $has_minimum, 1, $compare)
+        && _validate_bst($root->{right}, $root->{value}, $maximum, 1, $has_maximum, $compare);
+}
+
+sub is_valid_avl {
+    my ($self) = @_;
+    return defined _validate_avl($self->{root}, undef, undef, 0, 0, $self->{compare});
+}
+
+sub _validate_avl {
+    my ($root, $minimum, $maximum, $has_minimum, $has_maximum, $compare) = @_;
+    return [-1, 0] if !defined $root;
+    return undef if $has_minimum && $compare->($root->{value}, $minimum) <= 0;
+    return undef if $has_maximum && $compare->($root->{value}, $maximum) >= 0;
+
+    my $left = _validate_avl($root->{left}, $minimum, $root->{value}, $has_minimum, 1, $compare);
+    return undef if !defined $left;
+    my $right = _validate_avl($root->{right}, $root->{value}, $maximum, 1, $has_maximum, $compare);
+    return undef if !defined $right;
+
+    my $height = 1 + ($left->[0] > $right->[0] ? $left->[0] : $right->[0]);
+    my $size = 1 + $left->[1] + $right->[1];
+    return undef if $root->{height} != $height;
+    return undef if $root->{size} != $size;
+    return undef if abs($left->[0] - $right->[0]) > 1;
+    return [$height, $size];
+}
+
+sub balance_factor {
+    my ($self, $root) = @_;
+    return 0 if !defined $root;
+    die "node must be a CodingAdventures::AVLTree::Node or undef\n" if !_is_node($root);
+    return _balance_factor($root);
+}
+
+sub height {
+    my ($self) = @_;
+    return _node_height($self->{root});
+}
+
+sub size {
+    my ($self) = @_;
+    return _node_size($self->{root});
+}
+
+sub to_string {
+    my ($self) = @_;
+    my $root = defined($self->{root}) ? $self->{root}{value} : 'undef';
+    return sprintf('AVLTree(root=%s, height=%d, size=%d)', $root, $self->height, $self->size);
+}
+
+1;

--- a/code/packages/perl/avl-tree/required_capabilities.json
+++ b/code/packages/perl/avl-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/avl-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/avl-tree/t/00-load.t
+++ b/code/packages/perl/avl-tree/t/00-load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::AVLTree; 1 }, 'CodingAdventures::AVLTree loads');
+ok(CodingAdventures::AVLTree->VERSION, 'has a VERSION');
+ok(CodingAdventures::AVLTree::Node->can('new'), 'node class is available');
+
+done_testing;

--- a/code/packages/perl/avl-tree/t/01-avl-tree.t
+++ b/code/packages/perl/avl-tree/t/01-avl-tree.t
@@ -1,0 +1,159 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::AVLTree;
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'left and right rotations' => sub {
+    my $right_heavy = CodingAdventures::AVLTree->from_values([10, 20, 30]);
+    my $left_heavy = CodingAdventures::AVLTree->from_values([30, 20, 10]);
+
+    is($right_heavy->root->value, 20, 'left rotation root');
+    is($left_heavy->root->value, 20, 'right rotation root');
+    is_deeply($right_heavy->to_sorted_array, [10, 20, 30], 'sorted values');
+    ok($right_heavy->is_valid_bst, 'valid BST');
+    ok($right_heavy->is_valid_avl, 'valid AVL tree');
+    is($right_heavy->height, 1, 'height');
+    is($right_heavy->size, 3, 'size');
+    is($right_heavy->balance_factor($right_heavy->root), 0, 'root balance factor');
+};
+
+subtest 'double rotations' => sub {
+    my $left_right = CodingAdventures::AVLTree->from_values([30, 10, 20]);
+    my $right_left = CodingAdventures::AVLTree->from_values([10, 30, 20]);
+
+    is($left_right->root->value, 20, 'left-right rotation root');
+    is($right_left->root->value, 20, 'right-left rotation root');
+    ok($left_right->is_valid_avl, 'left-right result valid');
+    ok($right_left->is_valid_avl, 'right-left result valid');
+};
+
+subtest 'persistent queries and deletion' => sub {
+    my $tree = CodingAdventures::AVLTree->from_values([40, 20, 60, 10, 30, 50, 70]);
+
+    is($tree->search(20)->value, 20, 'search');
+    ok($tree->contains(50), 'contains');
+    is($tree->min_value, 10, 'minimum');
+    is($tree->max_value, 70, 'maximum');
+    is($tree->predecessor(40), 30, 'predecessor');
+    is($tree->successor(40), 50, 'successor');
+    is($tree->kth_smallest(4), 40, 'k-th smallest');
+    is($tree->rank(35), 3, 'rank');
+
+    my $deleted = $tree->delete(20);
+    ok(!$deleted->contains(20), 'delete removes value');
+    ok($deleted->is_valid_avl, 'deleted tree valid');
+    ok($tree->contains(20), 'original remains unchanged');
+};
+
+subtest 'empty, duplicate, and absent cases' => sub {
+    my $empty = CodingAdventures::AVLTree->empty;
+    ok(!defined $empty->search(1), 'empty search');
+    ok(!defined $empty->min_value, 'empty minimum');
+    ok(!defined $empty->max_value, 'empty maximum');
+    ok(!defined $empty->predecessor(1), 'empty predecessor');
+    ok(!defined $empty->successor(1), 'empty successor');
+    ok(!defined $empty->kth_smallest(0), 'zero k');
+    is($empty->rank(1), 0, 'empty rank');
+    is($empty->balance_factor(undef), 0, 'empty balance factor');
+    is($empty->height, -1, 'empty height');
+    is($empty->size, 0, 'empty size');
+    ok($empty->is_valid_avl, 'empty valid');
+    is("$empty", 'AVLTree(root=undef, height=-1, size=0)', 'empty rendering');
+
+    my $tree = CodingAdventures::AVLTree->from_values([30, 20, 40, 10, 25, 35, 50]);
+    is_deeply($tree->insert(25)->to_sorted_array, $tree->to_sorted_array, 'duplicate ignored');
+    is_deeply($tree->delete(999)->to_sorted_array, $tree->to_sorted_array, 'absent delete unchanged');
+};
+
+subtest 'nested successor deletion' => sub {
+    my $tree = CodingAdventures::AVLTree->from_values([5, 3, 8, 7, 9, 6]);
+    my $deleted = $tree->delete(5);
+
+    is_deeply($deleted->to_sorted_array, [3, 6, 7, 8, 9], 'nested successor chosen');
+    ok($deleted->is_valid_avl, 'nested successor result valid');
+    is($tree->kth_smallest(1), 3, 'first order statistic');
+    is($tree->kth_smallest(6), 9, 'last order statistic');
+    is($tree->rank(5), 1, 'absent rank');
+    is_deeply(CodingAdventures::AVLTree->from_values([1, 2])->delete(1)->to_sorted_array, [2], 'delete root with right child');
+    is_deeply(CodingAdventures::AVLTree->from_values([2, 1])->delete(2)->to_sorted_array, [1], 'delete root with left child');
+};
+
+subtest 'larger update sequence' => sub {
+    my $tree = CodingAdventures::AVLTree->empty;
+    for my $index (1 .. 100) {
+        $tree = $tree->insert(($index * 37) % 101);
+        ok($tree->is_valid_avl, "insert $index preserves invariants");
+    }
+    is($tree->size, 100, 'all values inserted');
+
+    my $updated = $tree;
+    for my $value (grep { $_ % 2 == 1 } 1 .. 99) {
+        $updated = $updated->delete($value);
+        ok($updated->is_valid_avl, "delete $value preserves invariants");
+    }
+    is_deeply($updated->to_sorted_array, [grep { $_ % 2 == 0 } 1 .. 100], 'even values remain');
+    is($tree->size, 100, 'original remains unchanged');
+};
+
+subtest 'validation catches corruption' => sub {
+    my $bad_order = CodingAdventures::AVLTree->new(
+        CodingAdventures::AVLTree::Node->new(5, CodingAdventures::AVLTree::Node->new(6), undef, 1, 2),
+    );
+    my $bad_right_order = CodingAdventures::AVLTree->new(
+        CodingAdventures::AVLTree::Node->new(5, undef, CodingAdventures::AVLTree::Node->new(4), 1, 2),
+    );
+    my $bad_height = CodingAdventures::AVLTree->new(
+        CodingAdventures::AVLTree::Node->new(5, CodingAdventures::AVLTree::Node->new(3), undef, 99, 2),
+    );
+    my $bad_size = CodingAdventures::AVLTree->new(
+        CodingAdventures::AVLTree::Node->new(5, CodingAdventures::AVLTree::Node->new(3), undef, 1, 99),
+    );
+    my $unbalanced_left = CodingAdventures::AVLTree::Node->new(
+        2,
+        CodingAdventures::AVLTree::Node->new(1),
+    );
+    my $unbalanced = CodingAdventures::AVLTree->new(
+        CodingAdventures::AVLTree::Node->new(3, $unbalanced_left),
+    );
+
+    ok(!$bad_order->is_valid_bst, 'left ordering corruption');
+    ok(!$bad_order->is_valid_avl, 'left ordering invalid AVL');
+    ok(!$bad_right_order->is_valid_bst, 'right ordering corruption');
+    ok(!$bad_right_order->is_valid_avl, 'right ordering invalid AVL');
+    ok(!$bad_height->is_valid_avl, 'height corruption');
+    ok(!$bad_size->is_valid_avl, 'size corruption');
+    ok(!$unbalanced->is_valid_avl, 'balance corruption');
+};
+
+subtest 'custom comparator' => sub {
+    my $by_length = sub { return length($_[0]) <=> length($_[1]); };
+    my $tree = CodingAdventures::AVLTree->from_values(['bbb', 'a', 'cc'], $by_length);
+
+    is_deeply($tree->to_sorted_array, ['a', 'cc', 'bbb'], 'length order');
+    ok($tree->contains('zz'), 'comparator equality');
+    is($tree->predecessor('zz'), 'a', 'custom predecessor');
+    is($tree->successor('zz'), 'bbb', 'custom successor');
+    ok($tree->is_valid_avl, 'custom tree valid');
+};
+
+subtest 'construction validation' => sub {
+    dies_like(sub { CodingAdventures::AVLTree::Node->new(undef) }, qr/node value must be defined/, 'undefined node value rejected');
+    dies_like(sub { CodingAdventures::AVLTree::Node->new(1, 'left') }, qr/left must be a CodingAdventures/, 'invalid child rejected');
+    dies_like(sub { CodingAdventures::AVLTree::Node->new(1, undef, undef, -1) }, qr/height must be a non-negative integer/, 'invalid height rejected');
+    dies_like(sub { CodingAdventures::AVLTree::Node->new(1, undef, undef, undef, -1) }, qr/size must be a non-negative integer/, 'invalid size rejected');
+    dies_like(sub { CodingAdventures::AVLTree->new('root') }, qr/root must be a CodingAdventures/, 'invalid root rejected');
+    dies_like(sub { CodingAdventures::AVLTree->new(undef, 'compare') }, qr/compare must be a code reference/, 'invalid comparator rejected');
+    dies_like(sub { CodingAdventures::AVLTree->from_values('values') }, qr/array reference/, 'invalid values rejected');
+    dies_like(sub { CodingAdventures::AVLTree->empty->insert(undef) }, qr/value must be defined/, 'undefined insert rejected');
+    dies_like(sub { CodingAdventures::AVLTree->empty->delete(undef) }, qr/value must be defined/, 'undefined delete rejected');
+    dies_like(sub { CodingAdventures::AVLTree->empty->balance_factor('node') }, qr/node must be a CodingAdventures/, 'invalid balance node rejected');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -106,11 +106,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
 on July 14, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
-`binary-search-tree`, and `in-memory-data-store-protocol` ports:
+`binary-search-tree`, `in-memory-data-store-protocol`, and `avl-tree` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 363 |
+| Present in 10-15 languages | 171 | 361 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -156,15 +156,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 363
+The 171 packages present in at least ten implementation languages need 361
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 12 | Pair with Perl data-structure/storage wave |
-| Perl | 12 | Pair with Lua data-structure/storage wave |
+| Lua | 11 | Pair with Perl data-structure/storage wave |
+| Perl | 11 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -176,11 +176,12 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first four paired Lua/Perl slices are complete: `fenwick-tree`,
-`binary-tree`, `binary-search-tree`, and `in-memory-data-store-protocol` now have
-pure implementations, package-native tests, metadata, and capability
-declarations in both lanes. The protocol slice establishes the dependency-free
-IR needed before the higher in-memory data store layers move.
+The first five paired Lua/Perl slices are complete: `fenwick-tree`,
+`binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`, and
+`avl-tree` now have pure implementations, package-native tests, metadata, and
+capability declarations in both lanes. The protocol slice establishes the
+dependency-free IR needed before the higher in-memory data store layers move;
+the AVL slice unlocks `tree-set`.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add dependency-free persistent AVL trees for Lua and Perl
- support balanced insertion/deletion, all four rotations, lookup, predecessor/successor queries, rank, k-th order statistics, custom comparators, and structural validation
- add package-native tests, packaging metadata, build entrypoints, documentation, changelogs, and capability declarations
- refresh the package-parity roadmap after reducing the paired Lua/Perl high-consensus gap from 12 to 11 each

## Why this slice is next

`avl-tree` was the smallest dependency-free data-structure gap remaining in the paired Lua/Perl wave. It was already established in 11 language lanes and now unlocks the dependent `tree-set` package. The larger in-memory data-store engine remains correctly ordered behind the protocol IR merged in #8334.

## Impact

The repository now has 4,195 established-language package directories. High-consensus missing slots fall from 363 to 361, with zero canonical collisions or unknown language buckets.

## Validation

- Lua syntax check with `luac -p`
- LuaRocks local package install
- Lua Busted suite: 9 successes, including larger persistent insert/delete invariant sequences
- Perl module and `Makefile.PL` syntax checks
- Perl MakeMaker package generation
- Perl load test and 9 functional subtests, including 153 assertions in the larger update sequence
- package parity reporter unit tests: 6 passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- `git diff --cached --check`

## Remaining parity gaps

Lua and Perl each retain 11 high-consensus gaps. This package is pure computation and needs no native, wrapper, web-only, or target-specific exception.