### PR TITLE
feat(adj-lang): NX-2 — parse literals to Number::Exact (no silent f64 truncation)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.11.1] — 2026-07-14 — exact-number bindings render every digit (ADJ-EXACT-NUMBERS NX-2)
+
+### Added
+
+- E2E test: a native `table` whose cell is π to 39 decimal places binds through `? t(key, $V)`
+  and renders **all 39 digits**, proving the exact-numbers path survives parse → store → query →
+  render end-to-end (previously it came back as the f64-truncated `3.141592653589793`).
+
+### Changed
+
+- Behavior: a numeric literal whose magnitude overflows `f64` (`1e400`) now compiles and is stored
+  exactly, instead of being reported as a malformed-literal error. The `malformed_numeric_clauses`
+  golden was updated to probe a scale-amplification payload (`1e-2000000000`), which `BigDecimal`'s
+  `MAX_SCALE` budget still rejects cleanly — so the "un-representable literal → `{"error":…}`, never
+  a panic" invariant is unchanged.
+
 ## [Unreleased] — render applied-formula provenance in the `derived` section
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -276,12 +276,18 @@ fn compile_error_is_reported_as_json() {
 
 #[test]
 fn malformed_numeric_clauses_do_not_panic_the_cli() {
-    // Regression: a non-positive LR / out-of-range prior / overflowing
+    // Regression: a non-positive LR / out-of-range prior / un-representable
     // literal must be a clean `{"error":...}` (exit 1), never a panic.
+    //
+    // Note the numeric-literal case changed with ADJ-EXACT-NUMBERS NX-2: `1e400` is no longer
+    // malformed — it is a perfectly good exact decimal (`10^400`) now stored with full precision
+    // instead of saturating to `f64` infinity. The remaining un-representable literal is a
+    // scale-amplification payload (`1e-2000000000`), which `BigDecimal`'s `MAX_SCALE` budget
+    // rejects at parse — a few bytes that would otherwise force a multi-gigabyte materialization.
     for src in [
         "contributes -5 from x to y\n? y\n",
         "prior 2 for x\n? x\n",
-        "observe gross_income(1e400)\n? required_to_file\n",
+        "observe gross_income(1e-2000000000)\n? required_to_file\n",
     ] {
         let (ok, s) = run("adjcli_malformed.adj", src);
         assert!(!ok, "expected non-zero exit for {src:?}: {s}");

--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -84,6 +84,37 @@ fn table_exact_lookup_binds_value_with_citation() {
 }
 
 #[test]
+fn table_high_precision_pi_binds_all_39_digits() {
+    // The exact-numbers win (ADJ-EXACT-NUMBERS NX-2): a table cell written to 39 decimal places
+    // binds and RENDERS with every digit, instead of being truncated to the ~16 an `f64` carries
+    // the moment it is parsed. This drives the full parse → store → query → render path through
+    // the built CLI, proving the digits survive end-to-end.
+    let dir = scratch("pi39");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "table math_constant {\n\
+         \x20   columns name, value\n\
+         \x20   row (pi, 3.141592653589793238462643383279502884197)\n\
+         \x20   source \"Wolfram MathWorld — Pi\"\n\
+         \x20   locator \"https://mathworld.wolfram.com/Pi.html\"\n\
+         \x20   trust authoritative\n\
+         }\n\
+         ? math_constant(pi, $V)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Every one of the 39 fractional digits is present in the binding — not the f64-truncated
+    // prefix. Before NX-2 this came back as `3.141592653589793`.
+    assert!(
+        out.contains("\"V\":\"3.141592653589793238462643383279502884197\""),
+        "pi binds ALL 39 decimal places exactly, not the f64-truncated ~16: {out}"
+    );
+    assert!(out.contains("\"abstained\":false"), "not an abstention: {out}");
+}
+
+#[test]
 fn table_absent_key_abstains() {
     let dir = scratch("absent");
     write(

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.53.0] — 2026-07-14
+
+### Added — NX-2: parse numeric literals to exact values (no silent f64 truncation)
+
+A written decimal literal is now stored **exactly as written** instead of being narrowed to `f64`
+at parse time (spec: `code/specs/ADJ-EXACT-NUMBERS.md`). Before this change a table cell or valued
+fact like π to 39 places bound at only ~16 significant digits; now every digit survives parse →
+store → query.
+
+- New AST node **`NumLit { Int(i64), Exact(BigDecimal) }`** with `to_f64_lossy()`. `Term::Num` and
+  `TableCell::Number` now carry a `NumLit` instead of an `f64`.
+- The adapter's two **ground-term** sites (a table cell and a valued-fact argument) parse the
+  NUMBER token via new `parse_numlit`: a whole number that fits `i64` becomes `Int` (keeping the
+  engine's small-integer fast paths), everything else is parsed with `BigDecimal::from_str` into
+  `Exact`. The two **compute-leaf** sites (`ExprAst::Lit`, inherently `f64`) keep their
+  `parse_finite` → `f64` path — the labeled-lossy boundary.
+- `lower_*` emit `Number::Int` / `Number::Exact` directly, never through `f64`.
+- Behavior note: a magnitude that overflows `f64` (`1e400`) is no longer rejected at parse — it is
+  a valid exact decimal now stored with full precision. A scale-amplification payload
+  (`1e-2000000000`) is still rejected by `BigDecimal`'s `MAX_SCALE` budget.
+- Depends on `bignum-core` ≥ 0.5.0 and `logic-core` ≥ 0.2.1.
+
 ## [0.52.0] — 2026-07-13
 
 ### Fixed — recursion-depth guard against native stack overflow (DoS)

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -20,6 +20,13 @@ store → query.
 - Behavior note: a magnitude that overflows `f64` (`1e400`) is no longer rejected at parse — it is
   a valid exact decimal now stored with full precision. A scale-amplification payload
   (`1e-2000000000`) is still rejected by `BigDecimal`'s `MAX_SCALE` budget.
+- **DoS guard.** Because `.adj` source is untrusted and `BigDecimal` base-10 conversion is
+  `O(digits²)`, `parse_numlit` caps an exact literal's **byte length** (`MAX_NUMBER_TOKEN_LEN =
+  4096`, checked before the quadratic parse) and its **scale magnitude** (`MAX_NUMBER_TOKEN_SCALE =
+  4096`, so a tiny token like `1e-1000000` cannot force a ~1 MB render/`to_f64` string). Both sit
+  ~100× above any legitimate constant (π to 39 places is 41 bytes), so only hostile payloads are
+  rejected — restoring the implicit bound the old `f64` parse provided. Adversarial tests cover
+  both shapes.
 - Depends on `bignum-core` ≥ 0.5.0 and `logic-core` ≥ 0.2.1.
 
 ## [0.52.0] — 2026-07-13

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "adj-lang"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 
 [dependencies]
 asciimath = { path = "../asciimath" }
+bignum-core = { path = "../bignum-core" }
 grammar-tools = { path = "../grammar-tools" }
 latex = { path = "../latex" }
 lexer = { path = "../lexer" }

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -2606,6 +2606,29 @@ fn parse_finite(raw: &str, kind: TokenType, rule: &str) -> Result<f64, AdapterEr
     }
 }
 
+/// The maximum **length in bytes** of an exact decimal NUMBER token accepted from `.adj` source.
+///
+/// This is a **DoS budget** at the untrusted-input boundary, not a precision limit. Base-10
+/// `BigDecimal` conversion is schoolbook-quadratic in the mantissa's digit count — `from_str`
+/// (parse), [`BigDecimal::significant_digits`], `Display`, and `to_f64` are each `O(L²)` for an
+/// `L`-digit literal. The old `parse_finite` path scanned a token in `O(L)` and saturated an
+/// out-of-range magnitude to `±∞`; routing tokens through `BigDecimal` instead removes that
+/// implicit bound, so a hostile `.adj` file could pack multi-megabyte number literals to force
+/// quadratic work. Capping the token length bounds every such materialization to a few million
+/// ops — trivial and one-time. `4096` bytes is ~100× the longest literal any real rulebook needs
+/// (π to 39 places is 41 bytes; Planck's constant is 15), so no legitimate high-precision constant
+/// is rejected.
+const MAX_NUMBER_TOKEN_LEN: usize = 4096;
+
+/// The maximum **scale magnitude** (`|scale|`, i.e. decimal places on either side of the point) of
+/// an accepted exact literal. `BigDecimal`'s own `MAX_SCALE` budget already caps this at
+/// `1_000_000`, but that still permits a *tiny* token — `1e-1000000` is 11 bytes — to force a
+/// ~1 MB decimal string every time the value is rendered or narrowed to `f64` (which happens
+/// several times per term during lowering/evaluation, uncached). A `.adj` literal never needs a
+/// scale past a few thousand, so this tighter cap keeps every render/`to_f64` string small while
+/// still accepting every real scientific-notation constant (Avogadro's scale is 15, Planck's 42).
+const MAX_NUMBER_TOKEN_SCALE: i64 = 4096;
+
 /// Parse a NUMBER token into a [`NumLit`] that loses no digit (ADJ-EXACT-NUMBERS NX-2).
 ///
 /// The precedence is chosen so small whole numbers keep the engine's `Int` fast paths while
@@ -2614,18 +2637,46 @@ fn parse_finite(raw: &str, kind: TokenType, rule: &str) -> Result<f64, AdapterEr
 /// 1. If the literal is a whole number that fits `i64` (`18000`), it becomes [`NumLit::Int`].
 /// 2. Otherwise — a fractional or out-of-`i64` decimal, scientific or not (`2.54`, `6.022e23`,
 ///    π to 39 places) — it is parsed with [`BigDecimal::from_str`] into [`NumLit::Exact`], keeping
-///    every written digit. `BigDecimal`'s own `MAX_SCALE` budget rejects scale-amplification
-///    payloads (`1e-2000000000`), so this is also the safe boundary for untrusted input.
+///    every written digit.
 /// 3. If neither parse succeeds, it is a malformed token — an [`AdapterError::BadToken`].
+///
+/// **DoS boundary.** Because `.adj` source is untrusted and `BigDecimal` base-10 conversion is
+/// `O(digits²)`, this is where the exact-number path is throttled: a token longer than
+/// [`MAX_NUMBER_TOKEN_LEN`] is rejected *before* the quadratic parse runs, and a parsed value whose
+/// scale magnitude exceeds [`MAX_NUMBER_TOKEN_SCALE`] is rejected *after* (bounding the
+/// render/`to_f64` string). Both budgets sit ~100× above any legitimate literal, so they only ever
+/// reject a hostile payload, never a real constant. (`BigDecimal::from_str` also enforces its own
+/// `MAX_SCALE`; these caps are the tighter, adj-lang-specific layer.)
 ///
 /// This replaces the old `f64` parse at the two **ground-term** sites (a table cell and a
 /// valued-fact argument). Compute leaves (`ExprAst::Lit`) still take an `f64` via `parse_finite`,
 /// because the compute layer is inherently `f64`.
 fn parse_numlit(raw: &str, kind: TokenType, rule: &str) -> Result<NumLit, AdapterError> {
+    // Reject an over-long token FIRST — before either the `i64` scan or the O(digits²) BigDecimal
+    // parse — so no oversized mantissa can force superlinear work on any path. (A legitimate small
+    // integer is far under the cap, so its `Int` fast path below is unaffected.)
+    if raw.len() > MAX_NUMBER_TOKEN_LEN {
+        return Err(AdapterError::BadToken {
+            rule: rule.to_string(),
+            kind,
+            value: format!("<{}-byte numeric literal>", raw.len()),
+            reason: "numeric literal exceeds the exact-decimal length budget",
+        });
+    }
     if let Ok(i) = raw.parse::<i64>() {
         return Ok(NumLit::Int(i));
     }
     match BigDecimal::from_str(raw) {
+        // A tiny token can still name a huge scale (`1e-1000000`); reject it so a later render /
+        // `to_f64` cannot be forced to materialize a megabyte-long decimal string.
+        Ok(d) if d.scale().unsigned_abs() > MAX_NUMBER_TOKEN_SCALE as u64 => {
+            Err(AdapterError::BadToken {
+                rule: rule.to_string(),
+                kind,
+                value: raw.to_string(),
+                reason: "numeric literal exceeds the exact-decimal scale budget",
+            })
+        }
         Ok(d) => Ok(NumLit::Exact(d)),
         Err(_) => Err(AdapterError::BadToken {
             rule: rule.to_string(),
@@ -2836,6 +2887,14 @@ mod tests {
             .expect("at least one statement")
     }
 
+    /// Parse `src` expecting it to fail in the ADAPTER stage, returning that [`AdapterError`].
+    fn adapt_one(src: &str) -> AdapterError {
+        match parse(src) {
+            Err(crate::CompileError::Adapt(e)) => e,
+            other => panic!("expected an adapter error, got {other:?}"),
+        }
+    }
+
     #[test]
     fn round_trips_prior() {
         match parse_one("prior 0.10 for acs") {
@@ -2963,6 +3022,49 @@ mod tests {
             },
             other => panic!("expected Observe, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn exact_high_precision_literal_parses_to_numlit_exact() {
+        // A >17-digit fractional literal (π to 39 places) is preserved exactly as a NumLit::Exact
+        // — the NX-2 win — while staying comfortably within the size budgets.
+        let pi = "3.141592653589793238462643383279502884197";
+        match parse_one(&format!("observe c({pi})")) {
+            Statement::Observe { term } => match term {
+                Term::Compound { args, .. } => match &args[0] {
+                    Term::Num(NumLit::Exact(d)) => assert_eq!(d.to_string(), pi),
+                    other => panic!("expected NumLit::Exact, got {other:?}"),
+                },
+                other => panic!("expected compound, got {other:?}"),
+            },
+            other => panic!("expected Observe, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oversized_numeric_literal_is_rejected_before_quadratic_parse() {
+        // DoS guard (security review, NX-2): a multi-kilobyte number literal — which would force
+        // O(digits²) BigDecimal work — is rejected at the untrusted `.adj` boundary, cleanly, not
+        // parsed. This is the length budget the old f64 parse gave implicitly (it saturated).
+        let giant = "9".repeat(super::MAX_NUMBER_TOKEN_LEN + 1);
+        let err = adapt_one(&format!("observe c({giant})"));
+        assert!(
+            matches!(err, AdapterError::BadToken { reason, .. } if reason.contains("length budget")),
+            "an over-long literal is a clean BadToken, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn huge_scale_literal_is_rejected_to_bound_render_materialization() {
+        // DoS guard (security review, NX-2): a *tiny* token can still name an enormous scale
+        // (`1e-1000000`, 11 bytes) that a later render / `to_f64` would blow up into a ~1 MB decimal
+        // string. It is rejected by the scale budget even though it is short and within
+        // BigDecimal's own MAX_SCALE.
+        let err = adapt_one("observe c(1e-1000000)");
+        assert!(
+            matches!(err, AdapterError::BadToken { reason, .. } if reason.contains("scale budget")),
+            "a huge-scale literal is a clean BadToken, got {err:?}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -33,8 +33,10 @@ use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 
 use crate::ast::{
     AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, FormulaDef,
-    NamedFn, OptDir, Program, RelOp, RuleLiteral, Statement, Term, TrustTierName,
+    NamedFn, NumLit, OptDir, Program, RelOp, RuleLiteral, Statement, Term, TrustTierName,
 };
+use bignum_core::BigDecimal;
+use std::str::FromStr;
 
 /// Errors raised while adapting a generic AST to the typed AST.
 ///
@@ -999,7 +1001,7 @@ fn adapt_row_item(node: &GrammarASTNode) -> Result<crate::ast::TableCell, Adapte
         if let ASTNodeOrToken::Token(t) = c {
             match t.type_ {
                 TokenType::Number => {
-                    return Ok(crate::ast::TableCell::Number(parse_finite(
+                    return Ok(crate::ast::TableCell::Number(parse_numlit(
                         &t.value, t.type_, "row_item",
                     )?));
                 }
@@ -2472,7 +2474,7 @@ fn adapt_term(node: &GrammarASTNode) -> Result<Term, AdapterError> {
         match c {
             ASTNodeOrToken::Node(n) if n.rule_name == "term" => args.push(adapt_term(n)?),
             ASTNodeOrToken::Token(t) if t.type_ == TokenType::Number => {
-                args.push(Term::Num(parse_finite(&t.value, t.type_, "term")?));
+                args.push(Term::Num(parse_numlit(&t.value, t.type_, "term")?));
             }
             // A `$Enzyme` VAR surfaces as a Name token whose value begins with
             // `$` (unknown token names fall back to TokenType::Name). The functor
@@ -2600,6 +2602,36 @@ fn parse_finite(raw: &str, kind: TokenType, rule: &str) -> Result<f64, AdapterEr
             kind,
             value: raw.to_string(),
             reason: "not a finite f64",
+        }),
+    }
+}
+
+/// Parse a NUMBER token into a [`NumLit`] that loses no digit (ADJ-EXACT-NUMBERS NX-2).
+///
+/// The precedence is chosen so small whole numbers keep the engine's `Int` fast paths while
+/// everything else is preserved exactly:
+///
+/// 1. If the literal is a whole number that fits `i64` (`18000`), it becomes [`NumLit::Int`].
+/// 2. Otherwise — a fractional or out-of-`i64` decimal, scientific or not (`2.54`, `6.022e23`,
+///    π to 39 places) — it is parsed with [`BigDecimal::from_str`] into [`NumLit::Exact`], keeping
+///    every written digit. `BigDecimal`'s own `MAX_SCALE` budget rejects scale-amplification
+///    payloads (`1e-2000000000`), so this is also the safe boundary for untrusted input.
+/// 3. If neither parse succeeds, it is a malformed token — an [`AdapterError::BadToken`].
+///
+/// This replaces the old `f64` parse at the two **ground-term** sites (a table cell and a
+/// valued-fact argument). Compute leaves (`ExprAst::Lit`) still take an `f64` via `parse_finite`,
+/// because the compute layer is inherently `f64`.
+fn parse_numlit(raw: &str, kind: TokenType, rule: &str) -> Result<NumLit, AdapterError> {
+    if let Ok(i) = raw.parse::<i64>() {
+        return Ok(NumLit::Int(i));
+    }
+    match BigDecimal::from_str(raw) {
+        Ok(d) => Ok(NumLit::Exact(d)),
+        Err(_) => Err(AdapterError::BadToken {
+            rule: rule.to_string(),
+            kind,
+            value: raw.to_string(),
+            reason: "not an integer or exact decimal literal",
         }),
     }
 }
@@ -2923,7 +2955,9 @@ mod tests {
                 Term::Compound { functor, args } => {
                     assert_eq!(functor, "gross_income");
                     assert_eq!(args.len(), 1);
-                    assert!(matches!(args[0], Term::Num(x) if x == 18000.0));
+                    // A whole number that fits `i64` parses to `NumLit::Int` (NX-2), keeping the
+                    // engine's small-integer fast path — not a lossy `f64`.
+                    assert!(matches!(args[0], Term::Num(NumLit::Int(18000))));
                 }
                 other => panic!("expected compound, got {other:?}"),
             },

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -8,6 +8,43 @@
 //! (one annotation = one rule) while still letting the lowerer
 //! enforce ordering / multiplicity invariants.
 
+/// A **numeric literal** as written in the source, kept in the shape that loses no digit
+/// (ADJ-EXACT-NUMBERS NX-2). Before NX-2 every number went straight to `f64` at parse time, so a
+/// 39-digit π literal came back at ~16 digits. `NumLit` fixes that at the AST level:
+///
+/// - **`Int(i64)`** — a whole number that fits `i64` (`18000`). It lowers to
+///   `logic_core::Number::Int`, keeping the engine's small-integer fast paths and exact-integer
+///   ergonomics.
+/// - **`Exact(BigDecimal)`** — anything else: a fractional or out-of-`i64` decimal, in scientific
+///   notation or not (`2.54`, `6.022e23`, π to 39 places). It lowers to
+///   `logic_core::Number::Exact`, so every written digit survives to the stored ground value.
+///
+/// The lossy `f64` still exists, but only where a value is *asked for* as an `f64` — a compute
+/// leaf (`ExprAst::Lit`) or an inherently-approximate backend — via [`NumLit::to_f64_lossy`],
+/// never as the silent default at parse time.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NumLit {
+    /// A whole number that fits `i64` — lowers to `logic_core::Number::Int`.
+    Int(i64),
+    /// An exactly-written decimal (fractional, scientific, or beyond `i64`) — lowers to
+    /// `logic_core::Number::Exact`, preserving every digit.
+    Exact(bignum_core::BigDecimal),
+}
+
+impl NumLit {
+    /// The **labeled lossy** `f64` view of this literal — the single sanctioned way to obtain an
+    /// `f64` from a `NumLit`. `Int` widens with `as f64`; `Exact` narrows to the nearest `f64` via
+    /// [`bignum_core::BigDecimal::to_f64`]. Used only where an `f64` is genuinely required (a
+    /// compute leaf or an approximate backend), never at parse time. The name is deliberately
+    /// greppable so every lossy boundary is auditable, mirroring `logic_core::Number::to_f64_lossy`.
+    pub fn to_f64_lossy(&self) -> f64 {
+        match self {
+            NumLit::Int(i) => *i as f64,
+            NumLit::Exact(d) => d.to_f64(),
+        }
+    }
+}
+
 /// A Term in the surface language: either an atom or a compound
 /// term. The lowerer converts these to `logic_core::Term`s.
 ///
@@ -19,10 +56,11 @@
 pub enum Term {
     Atom(String),
     /// A numeric literal — appears as a compound argument in a *valued*
-    /// fact, e.g. `gross_income(18000)`. Carried as `f64`; the lowerer
-    /// converts it to `logic_core::Term::Num`. Valued facts are what
+    /// fact, e.g. `gross_income(18000)`. Carried as a [`NumLit`] so no digit is
+    /// lost at parse time; the lowerer converts it to `logic_core::Term::Num`
+    /// (`Int` → `Number::Int`, `Exact` → `Number::Exact`). Valued facts are what
     /// predicate-gated contributions read on the CPU.
-    Num(f64),
+    Num(NumLit),
     /// A logic VARIABLE — the `$Enzyme` surface form (MYCIN-2026 REL-2). Appears
     /// only as a *compound argument* in a binding query goal
     /// (`? deficient_in(tay_sachs, $Enzyme)`); the lowerer maps it to a
@@ -505,9 +543,12 @@ pub struct TableRow {
 /// variable or a compound: a table holds ground data, not open goals.)
 #[derive(Debug, Clone, PartialEq)]
 pub enum TableCell {
-    /// A numeric literal (`2.54`) — lowers to `logic_core::Term::Num`. This is
-    /// the cell kind a looked-up value flows from into a `let`/`formula`.
-    Number(f64),
+    /// A numeric literal (`2.54`) — lowers to `logic_core::Term::Num`. Carried as a
+    /// [`NumLit`] so a high-precision table cell (π to 39 places) keeps every digit
+    /// through parse → store → query; the lowerer maps `Int` → `Number::Int` and
+    /// `Exact` → `Number::Exact`. This is the cell kind a looked-up value flows from
+    /// into a `let`/`formula`.
+    Number(NumLit),
     /// A bare identifier (`inch`) — lowers to `logic_core::Term::Atom`. Typically
     /// the key column of a key→value table.
     Atom(String),

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -20,7 +20,8 @@
 //!   `source` annotations are a [`LowerError::DuplicateAnnotation`].
 
 use logic_core::{
-    atom as core_atom, compound, float as core_float, var as core_var, LogicVar, Term as CoreTerm,
+    atom as core_atom, compound, int as core_int, var as core_var, LogicVar, Number as CoreNumber,
+    Term as CoreTerm,
 };
 use logic_engine::{
     compute, BodyLiteral, Citation, CmpOp as EngineCmpOp, ComputeExpr, ComputeOp,
@@ -33,7 +34,7 @@ use std::collections::HashMap;
 
 use crate::ast::{
     AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, FormulaDef,
-    NamedFn, OptDir, Program, RelOp, Statement, Term as AstTerm, TrustTierName,
+    NamedFn, NumLit, OptDir, Program, RelOp, Statement, Term as AstTerm, TrustTierName,
 };
 
 /// One lowered constraint: `lhs <op> rhs`, with both sides kept as
@@ -962,12 +963,22 @@ fn check_lr(lr: f64) -> Result<(), LowerError> {
     }
 }
 
+/// Lower a surface [`NumLit`] to the engine's ground [`CoreNumber`] **without an `f64` hop**
+/// (ADJ-EXACT-NUMBERS NX-2): `Int` becomes `Number::Int` (keeping the small-integer fast path),
+/// and `Exact` becomes `Number::Exact`, carrying every written digit into the stored value.
+fn lower_numlit(n: &NumLit) -> CoreTerm {
+    match n {
+        NumLit::Int(i) => core_int(*i),
+        NumLit::Exact(d) => CoreTerm::Num(CoreNumber::Exact(d.clone())),
+    }
+}
+
 /// Lower one [`crate::ast::TableCell`] (ADJ-TABLES RS-5) to a ground engine term.
 /// The three cell kinds map 1:1 onto the engine's three ground term kinds; a cell
 /// is never a variable or compound, so this is total and never fails.
 fn lower_cell(cell: &crate::ast::TableCell) -> CoreTerm {
     match cell {
-        crate::ast::TableCell::Number(x) => core_float(*x),
+        crate::ast::TableCell::Number(x) => lower_numlit(x),
         crate::ast::TableCell::Atom(name) => core_atom(name),
         crate::ast::TableCell::Text(s) => CoreTerm::Str(s.clone()),
     }
@@ -976,7 +987,7 @@ fn lower_cell(cell: &crate::ast::TableCell) -> CoreTerm {
 fn lower_term(t: &AstTerm) -> CoreTerm {
     match t {
         AstTerm::Atom(name) => core_atom(name),
-        AstTerm::Num(x) => core_float(*x),
+        AstTerm::Num(x) => lower_numlit(x),
         // A bare `Var` outside a query goal (e.g. inside a `relate` ground edge)
         // is unusual — ground edges have no variables — but lower it to a fresh
         // logic variable rather than panicking, so the engine treats it as an
@@ -996,7 +1007,7 @@ fn lower_term(t: &AstTerm) -> CoreTerm {
 fn lower_term_scoped(t: &AstTerm, vars: &mut HashMap<String, LogicVar>) -> CoreTerm {
     match t {
         AstTerm::Atom(name) => core_atom(name),
-        AstTerm::Num(x) => core_float(*x),
+        AstTerm::Num(x) => lower_numlit(x),
         AstTerm::Var(name) => {
             let lv = vars
                 .entry(name.clone())
@@ -1611,7 +1622,10 @@ fn apply_formula(fd: &FormulaDef, goal: &AstTerm) -> Result<ExprAst, LowerError>
     for (param, arg) in fd.params.iter().zip(args.iter()) {
         let bound = match arg {
             AstTerm::Atom(name) => ExprAst::Ref(name.clone()),
-            AstTerm::Num(x) => ExprAst::Lit(*x),
+            // A numeric formula argument feeds the (inherently `f64`) compute layer, so it
+            // takes the labeled-lossy export here — the exact literal is preserved on the
+            // ground-term paths (`lower_numlit`), not on this compute leaf.
+            AstTerm::Num(x) => ExprAst::Lit(x.to_f64_lossy()),
             _ => {
                 return Err(LowerError::FormulaBadArgument {
                     formula: fd.name.clone(),
@@ -1737,6 +1751,7 @@ mod tests {
     use super::*;
     use crate::compile;
     use logic_engine::{enumerate_all, search, SearchMode, SearchResult};
+    use std::str::FromStr;
 
     // ---- ADJ-FORMULA-LIBRARIES rung-0: formulabook / formula ----
 
@@ -2088,7 +2103,15 @@ mod tests {
         let v = query_var(query);
         let dag = enumerate_all(query, &lowered.kb);
         assert_eq!(dag.proofs.len(), 1, "exactly one row matches the key `foot`");
-        assert_eq!(dag.proofs[0].bindings.walk_var(&v), core_float(0.3048));
+        // NX-2: a fractional cell binds as an EXACT decimal, not a lossy `f64` (a distinct
+        // `Number` variant). Preserving the exact value is the whole intent — `0.3048` is stored
+        // with every digit, and only the *rendering* falls back to the f64 form when it fits.
+        assert_eq!(
+            dag.proofs[0].bindings.walk_var(&v),
+            CoreTerm::Num(CoreNumber::Exact(
+                bignum_core::BigDecimal::from_str("0.3048").unwrap()
+            ))
+        );
         // The answer's proof is a table row whose Fact carries the citation.
         let fid = dag.proofs[0].via_facts[0];
         let prov = &lowered.kb.fact(fid).expect("row fact exists").provenance;
@@ -2524,12 +2547,26 @@ mod tests {
     }
 
     #[test]
-    fn non_finite_number_literal_is_rejected_at_parse() {
-        // 1e400 overflows f64 to +inf; reject it rather than flow inf on.
-        let err = compile("observe gross_income(1e400)").unwrap_err();
-        assert!(
-            matches!(err, crate::CompileError::Adapt(_)),
-            "expected an adapter BadToken error, got {err:?}"
+    fn large_magnitude_literal_is_stored_exactly_not_rejected() {
+        // Before NX-2, `1e400` overflowed `f64` to +inf and was rejected at parse. Now it is a
+        // perfectly good exact decimal (`10^400`) preserved with every digit — the whole point of
+        // the exact-numbers arc is that a written magnitude is stored as written, not truncated
+        // (or, here, saturated to inf) the instant it is parsed. The lossy `f64` view appears only
+        // if something later asks for one.
+        let src = r#"
+            observe gross_income(1e400)
+            ? gross_income($V)
+        "#;
+        let lowered = compile(src).unwrap();
+        let query = &lowered.queries[0];
+        let v = query_var(query);
+        let dag = enumerate_all(query, &lowered.kb);
+        assert_eq!(dag.proofs.len(), 1);
+        assert_eq!(
+            dag.proofs[0].bindings.walk_var(&v),
+            CoreTerm::Num(CoreNumber::Exact(
+                bignum_core::BigDecimal::from_str("1e400").unwrap()
+            ))
         );
     }
 

--- a/code/packages/rust/bignum-core/CHANGELOG.md
+++ b/code/packages/rust/bignum-core/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the `bignum-core` package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-07-14
+
+### Added
+
+- **`BigDecimal::significant_digits(&self) -> usize`** — counts the meaningful digits a value
+  carries (the mantissa's digit count once trailing zeros are removed; `0` for zero). Because a
+  `BigDecimal` is always canonical (no trailing-zero mantissa), this is simply the digit length of
+  the mantissa's magnitude — `20.180 → 4`, `100 → 1`, `0 → 0`, π-to-39 → `39`. Introduced for the
+  ADJ exact-numbers renderer (NX-2): it decides whether an exact value still fits an `f64`'s
+  ~17-digit budget (render the `f64` canonical form, preserving existing output byte-for-byte) or
+  exceeds it (render every exact digit). Tested across zero, trailing/leading zeros, the 17-vs-18
+  digit f64 boundary, negatives, and scientific-notation inputs.
+
 ## [0.4.1] - 2026-07-11
 
 ### Added

--- a/code/packages/rust/bignum-core/Cargo.toml
+++ b/code/packages/rust/bignum-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignum-core"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "A zero-dependency arbitrary-precision numeric core: a signed integer (BigInteger), an exact rational (BigRational), an exact base-10 decimal (BigDecimal), and a correctly-rounded binary float of arbitrary precision (BigDouble) — all built from scratch with no third-party deps and no unsafe."
 license = "MIT"

--- a/code/packages/rust/bignum-core/src/decimal.rs
+++ b/code/packages/rust/bignum-core/src/decimal.rs
@@ -295,6 +295,34 @@ impl BigDecimal {
         self.mant.signum()
     }
 
+    /// How many **significant digits** the value carries — the count of digits in the mantissa
+    /// once trailing zeros are removed. Because a `BigDecimal` is always kept in canonical form
+    /// (the [module documentation](crate::decimal) explains: the mantissa never ends in a `0`
+    /// unless the value *is* zero), this is simply the number of base-10 digits in the mantissa,
+    /// and `0` for the value zero. The scale (where the decimal point sits) is irrelevant — only
+    /// the run of meaningful digits counts.
+    ///
+    /// | value    | canonical `(mant, scale)` | significant digits |
+    /// |----------|---------------------------|--------------------|
+    /// | `0`      | `(0, 0)`                  | `0`                |
+    /// | `100`    | `(1, -2)`                 | `1`                |
+    /// | `20.180` | `(2018, 2)`               | `4`                |
+    /// | `-3.14`  | `(-314, 2)`               | `3`                |
+    /// | π (39dp) | `(3141…197, 39)`          | `40`               |
+    ///
+    /// This is the measure the exact-numbers renderer (ADJ NX-2) uses to decide whether a value
+    /// still fits an `f64`'s ~17-digit budget (render the `f64` canonical form, preserving
+    /// existing output byte-for-byte) or exceeds it (render every exact digit instead).
+    pub fn significant_digits(&self) -> usize {
+        if self.mant.is_zero() {
+            return 0;
+        }
+        // The mantissa carries no trailing zero in canonical form, so its digit count *is* the
+        // significant-digit count. `abs()` drops a leading `-` so the sign never inflates the
+        // length.
+        self.mant.abs().to_string().len()
+    }
+
     /// The absolute value `|self|`.
     pub fn abs(&self) -> BigDecimal {
         BigDecimal {
@@ -747,6 +775,35 @@ mod tests {
         assert_eq!(hundred.scale(), -2);
         assert_eq!(hundred.to_string(), "100");
         assert_eq!(d("12300").to_string(), "12300");
+    }
+
+    #[test]
+    fn significant_digits_counts_meaningful_mantissa_digits() {
+        // Zero has no significant digits.
+        assert_eq!(d("0").significant_digits(), 0);
+        assert_eq!(d("0.000").significant_digits(), 0);
+        // Trailing zeros are not significant (canonical form already strips them).
+        assert_eq!(d("20.180").significant_digits(), 4); // 2018
+        assert_eq!(d("100").significant_digits(), 1); // mantissa 1
+        assert_eq!(d("1000").significant_digits(), 1);
+        assert_eq!(d("12300").significant_digits(), 3); // 123
+        // Leading zeros before the first non-zero digit are not significant either.
+        assert_eq!(d("0.001").significant_digits(), 1);
+        assert_eq!(d("0.0123").significant_digits(), 3);
+        // Ordinary values.
+        assert_eq!(d("1.23").significant_digits(), 3);
+        assert_eq!(d("-3.14").significant_digits(), 3); // sign does not count
+        assert_eq!(d("42").significant_digits(), 2);
+        // The f64 fit/overflow boundary the renderer keys on: 17 digits vs 18.
+        assert_eq!(d("1.2345678901234567").significant_digits(), 17);
+        assert_eq!(d("1.23456789012345678").significant_digits(), 18);
+        // π to 39 decimal places — the motivating case (every digit counts). The literal has one
+        // integer digit plus 39 fractional digits, so 40 significant digits in all.
+        let pi = "3.141592653589793238462643383279502884197";
+        assert_eq!(d(pi).significant_digits(), 40);
+        // Scientific notation is normalized first, so only real digits count.
+        assert_eq!(d("6.02214076e23").significant_digits(), 9);
+        assert_eq!(d("1e3").significant_digits(), 1); // 1000 -> mantissa 1
     }
 
     #[test]

--- a/code/packages/rust/logic-core/CHANGELOG.md
+++ b/code/packages/rust/logic-core/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2026-07-14
+
+### Changed
+
+- **`Number::Exact` `Display` now follows the NX-2 rendering policy.** An exact value with
+  **≤ 17 significant digits** (everything an `f64` can represent) renders through its `f64`
+  canonical form, so its printed string is byte-for-byte identical to the value's old `Float`
+  rendering — trailing-zero normalization (`20.180` → `20.18`), extreme-magnitude formatting, and
+  so on all match. A value with **more than 17 significant digits** (π to 39 places) prints every
+  exact digit it carries. This makes exactness a strict *superset* of the old output: nothing that
+  already fit an `f64` changes how it looks, and only genuinely higher-precision values gain digits.
+  Depends on `bignum-core` ≥ 0.5.0 for `BigDecimal::significant_digits`. (Nothing produced `Exact`
+  before NX-2, so this only affects values created by the exact-literal lowering that lands with it.)
+
 ## [0.2.0] - 2026-07-14
 
 ### Added

--- a/code/packages/rust/logic-core/Cargo.toml
+++ b/code/packages/rust/logic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Terms, logic variables, substitutions, and unification — the semantic core of a logic VM."
 

--- a/code/packages/rust/logic-core/src/lib.rs
+++ b/code/packages/rust/logic-core/src/lib.rs
@@ -64,6 +64,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// `Exact` gives a written decimal somewhere lossless to live; `f64` is now only
 /// the *labeled lossy export*, never the silent default.
 ///
+/// **Display of `Exact` is a superset of the old `f64` output.** An `Exact` with
+/// ≤ 17 significant digits (everything an `f64` can represent) renders through its
+/// `f64` canonical form, so its printed string is byte-for-byte what the value
+/// showed before literals were stored exactly (scientific notation for extreme
+/// magnitudes, trailing-zero normalization, and so on). Only a value that exceeds
+/// the `f64` budget — π to 39 places — prints its full exact digit string. Nothing
+/// that already fit an `f64` changes how it looks.
+///
 /// **Equality / unification stays variant-distinct**, following Prolog tradition:
 /// `1 = 1.0` does **not** unify because they are distinct ground terms, and
 /// `Exact` joins as a third distinct term (`Int(1)`, `Float(1.0)`, `Exact(1.0)`
@@ -100,8 +108,26 @@ impl fmt::Display for Number {
         match self {
             Number::Int(i) => write!(f, "{}", i),
             Number::Float(x) => write!(f, "{}", x),
-            // Prints every digit the exact decimal carries — no truncation.
-            Number::Exact(d) => write!(f, "{}", d),
+            // The rendering policy that keeps exactness a *superset* of the old f64 behavior
+            // (ADJ-EXACT-NUMBERS NX-2). An `f64` carries ~15–17 significant decimal digits, so:
+            //
+            //   * If the exact value has **≤ 17 significant digits**, it still round-trips
+            //     through `f64` losslessly, and we render its `f64` canonical form. This is
+            //     byte-for-byte what the value displayed *before* NX-2 lowered literals to
+            //     `Exact` — including scientific notation for tiny/huge magnitudes
+            //     (`6.62607015e-34`) and trailing-zero normalization (`20.180` → `20.18`) —
+            //     so none of the existing rendered-string tests regress.
+            //   * Otherwise (e.g. π to 39 places), the value cannot fit an `f64`, so we print
+            //     every exact digit the `BigDecimal` carries. This is the whole point of the
+            //     exact-numbers arc: the extra precision becomes visible in the binding, not
+            //     silently truncated at 17 digits.
+            Number::Exact(d) => {
+                if d.significant_digits() <= 17 {
+                    write!(f, "{}", d.to_f64())
+                } else {
+                    write!(f, "{}", d)
+                }
+            }
         }
     }
 }
@@ -419,6 +445,27 @@ mod tests {
     #[test]
     fn strings_display_with_quotes() {
         assert_eq!(string("hello world").to_string(), "\"hello world\"");
+    }
+
+    #[test]
+    fn exact_display_is_a_superset_of_f64_output() {
+        use bignum_core::BigDecimal;
+        use std::str::FromStr;
+        let exact = |s: &str| Number::Exact(BigDecimal::from_str(s).unwrap());
+        // ≤ 17 significant digits: render the f64 canonical form, byte-for-byte what the value
+        // showed before literals were stored exactly — trailing zeros normalize away, extreme
+        // magnitudes use scientific notation.
+        assert_eq!(exact("20.180").to_string(), "20.18");
+        assert_eq!(exact("2.54").to_string(), "2.54");
+        assert_eq!(exact("0.3048").to_string(), "0.3048");
+        assert_eq!(exact("100").to_string(), "100");
+        // Extreme magnitudes render exactly as the corresponding `f64` would (the whole point of
+        // the ≤17-digit branch: `Exact` and `Float` print the same string for any f64-sized value).
+        assert_eq!(exact("6.62607015e-34").to_string(), format!("{}", 6.62607015e-34_f64));
+        assert_eq!(exact("6.02214076e23").to_string(), format!("{}", 6.02214076e23_f64));
+        // > 17 significant digits: every exact digit prints (this is the NX-2 win).
+        let pi = "3.141592653589793238462643383279502884197";
+        assert_eq!(exact(pi).to_string(), pi);
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.38.1] — 2026-07-14 — read `Number::Exact` valued facts (ADJ-EXACT-NUMBERS NX-2)
+
+### Changed
+
+- The compute-layer valued-fact readers now recognize the `Number::Exact` variant that `adj-lang`
+  begins producing in NX-2. `numeric_magnitude`, `numeric_exact_magnitude`, `dimensioned_value`,
+  and the `datetime` integral reader each gained an `Exact` arm that **folds into the existing
+  `Float` handling via the labeled-lossy `to_f64` boundary** — so a valued fact stored exactly is
+  visible to a formula/predicate exactly as it was when it stored an `f64`, and no compute result
+  changes. (Before this, an `Exact`-valued slot was invisible and surfaced as `UnknownSlot`.)
+  Ingesting an exact decimal's full precision into `ExactRational` **without** an `f64` hop is
+  deliberately deferred to NX-3; this release only restores parity.
+
 ## [0.38.0] — exact arithmetic by default: `ExactRational` is now a `BigRational` (NUM-5)
 
 ### Changed

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.38.0"
+version = "0.38.1"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/datetime.rs
+++ b/code/packages/rust/logic-engine/src/datetime.rs
@@ -180,6 +180,16 @@ fn read_int(t: &Term) -> Option<i64> {
         Term::Num(Number::Int(i)) => Some(*i),
         // A whole-valued float is accepted (the decomposer may emit 2025.0).
         Term::Num(Number::Float(x)) if x.fract() == 0.0 && x.is_finite() => Some(*x as i64),
+        // A whole-valued exact decimal (NX-2) is accepted on the same integral gate — a date field
+        // written as `2025` lowers to `Int`, but one written `2025.0` lowers to `Exact`.
+        Term::Num(Number::Exact(d)) => {
+            let x = d.to_f64();
+            if x.fract() == 0.0 && x.is_finite() {
+                Some(x as i64)
+            } else {
+                None
+            }
+        }
         _ => None,
     }
 }

--- a/code/packages/rust/logic-engine/src/dimension.rs
+++ b/code/packages/rust/logic-engine/src/dimension.rs
@@ -278,6 +278,9 @@ pub fn dimensioned_value(value: &Term) -> Option<Dimensioned> {
     match value {
         Term::Num(Number::Int(i)) => Some(Dimensioned::scalar(*i as f64)),
         Term::Num(Number::Float(x)) => Some(Dimensioned::scalar(*x)),
+        // An exactly-stored decimal (NX-2) is a scalar magnitude read as its labeled-lossy `f64`,
+        // matching the old `Float` path (the dimension layer is inherently `f64`).
+        Term::Num(Number::Exact(d)) => Some(Dimensioned::scalar(d.to_f64())),
         Term::Compound { functor, args } => {
             // Dates/times are multi-field points in time, not scalar-magnitude
             // wrappers — `date(2025, 1, 15)`'s leading `2025` is a year, not a
@@ -288,6 +291,7 @@ pub fn dimensioned_value(value: &Term) -> Option<Dimensioned> {
             let magnitude = match args.first()? {
                 Term::Num(Number::Int(i)) => *i as f64,
                 Term::Num(Number::Float(x)) => *x,
+                Term::Num(Number::Exact(d)) => d.to_f64(),
                 _ => return None,
             };
             let unit_tag = || match args.get(1) {

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -1090,10 +1090,16 @@ pub fn numeric_magnitude(value: &Term) -> Option<f64> {
     match value {
         Term::Num(Number::Int(i)) => Some(*i as f64),
         Term::Num(Number::Float(x)) => Some(*x),
+        // An exactly-stored decimal (ADJ-EXACT-NUMBERS NX-2) reads out as its labeled-lossy `f64`
+        // magnitude here — the same value the old `Float(f64)` path yielded, since a valued fact's
+        // magnitude flows into the inherently-`f64` compute layer. (Exact-rational ingestion of the
+        // decimal, with no `f64` hop, is NX-3.)
+        Term::Num(Number::Exact(d)) => Some(d.to_f64()),
         // Typed wrapper: the magnitude is the leading numeric argument.
         Term::Compound { args, .. } => match args.first() {
             Some(Term::Num(Number::Int(i))) => Some(*i as f64),
             Some(Term::Num(Number::Float(x))) => Some(*x),
+            Some(Term::Num(Number::Exact(d))) => Some(d.to_f64()),
             _ => None,
         },
         _ => None,
@@ -1108,12 +1114,21 @@ pub fn numeric_exact_magnitude(value: &Term) -> Option<crate::compute::ExactRati
     match value {
         Term::Num(Number::Int(i)) => Some(crate::compute::ExactRational::from_i128(*i as i128)),
         Term::Num(Number::Float(x)) => crate::compute::ExactRational::from_integer_f64(*x),
+        // NX-2 reads an exactly-stored decimal through the *same* integer-valued gate the `Float`
+        // path uses (`to_f64` then `from_integer_f64`), so the exact-rational sidecar is populated
+        // for integer-valued facts and `None` for fractional ones — byte-for-byte the old
+        // behavior. Ingesting the decimal's full precision into `ExactRational` without an `f64`
+        // hop is deliberately deferred to NX-3, so no compute result changes in this PR.
+        Term::Num(Number::Exact(d)) => crate::compute::ExactRational::from_integer_f64(d.to_f64()),
         Term::Compound { args, .. } => match args.first() {
             Some(Term::Num(Number::Int(i))) => {
                 Some(crate::compute::ExactRational::from_i128(*i as i128))
             }
             Some(Term::Num(Number::Float(x))) => {
                 crate::compute::ExactRational::from_integer_f64(*x)
+            }
+            Some(Term::Num(Number::Exact(d))) => {
+                crate::compute::ExactRational::from_integer_f64(d.to_f64())
             }
             _ => None,
         },


### PR DESCRIPTION
## What & why

NX-2 of the ADJ exact-numbers arc (spec: `code/specs/ADJ-EXACT-NUMBERS.md`). Before this, a written decimal literal was parsed straight to `f64` at parse time, so a 39-digit π table cell bound at ~16 significant digits. This PR makes literals **lower to `logic_core::Number::Exact`**, preserving every digit through parse → store → query → render — **without changing the rendered output of any value that already fit an `f64`** (so the ~50 merged `facts_*_e2e` tests stay green).

## The rendering policy (what keeps merged tests green)

`Number::Exact` Displays as:
- **≤ 17 significant digits** → the `f64` canonical form (`d.to_f64()`). Byte-for-byte the pre-NX-2 output — trailing-zero normalization (`20.180`→`20.18`), extreme-magnitude formatting, etc.
- **> 17 significant digits** (π to 39) → the full exact decimal.

So exactness is a strict **superset** of the old output: nothing that fit an `f64` looks different; only higher-precision values gain digits.

## Changes

- **bignum-core** (0.4.1→0.5.0): `BigDecimal::significant_digits()` — mantissa digit count, trailing zeros stripped (`20.180`→4, `100`→1, `0`→0, π-39→40). Unit tests across the 17/18-digit f64 boundary.
- **logic-core** (0.2.0→0.2.1): `Number::Exact` Display applies the ≤17-sig policy above; doc + unit test.
- **adj-lang** (0.52.0→0.53.0): new AST `NumLit { Int(i64), Exact(BigDecimal) }` with `to_f64_lossy()`; `Term::Num` / `TableCell::Number` carry `NumLit`. Adapter `parse_numlit` at the two **ground-term** sites (i64 fast path, else `BigDecimal::from_str`); the two compute-leaf `ExprAst::Lit` sites keep `parse_finite`→f64. `lower_*` emit `Number::Int`/`Number::Exact` directly, never via f64.
- **logic-engine** (0.38.0→0.38.1) — *divergence from the 3-crate plan*: its compute valued-fact readers (`numeric_magnitude`, `numeric_exact_magnitude`, `dimensioned_value`, datetime `read_int`) matched only `Int`/`Float`, so an `Exact`-valued slot became invisible and surfaced as `UnknownSlot`, breaking formula/predicate tests. Added `Exact` arms that **fold into the existing `Float` handling via the labeled-lossy `to_f64` boundary** — behavior-preserving parity restore, **no compute result changes**. Exact-rational ingestion without an f64 hop stays NX-3.

## Security / DoS guard

Routing untrusted `.adj` NUMBER tokens through `BigDecimal::from_str` introduces `O(digits²)` base-10 conversion that the old `O(L)` f64 parse didn't have. A 2-round `/security-review` flagged this MEDIUM; fixed at the `parse_numlit` boundary:
- reject a token longer than `MAX_NUMBER_TOKEN_LEN = 4096` **before** the quadratic parse;
- reject a parsed scale magnitude over `MAX_NUMBER_TOKEN_SCALE = 4096` (catches the tiny-token/huge-scale `1e-1000000` shape that would blow up render/`to_f64`).

Both caps sit ~100× above any legitimate literal (π-39 = 41 bytes). Clean `BadToken`, never a panic; adversarial tests for both shapes. **Security review round 2: PASSED.** (A pre-existing, unrelated exposure at the two `parse_finite`→f64 compute-leaf sites was noted as a separate follow-up.)

## Regression gate — zero regressions

`cargo test -p bignum-core -p logic-core -p adj-lang -p adj-lang-cli`:

| crate | result |
|---|---|
| bignum-core | **105 passed, 0 failed** |
| logic-core | **23 passed, 0 failed** |
| adj-lang | **173 passed, 0 failed** |
| adj-lang-cli | **153 passed, 0 failed** (whole facts suite) |

Also green: logic-engine 169, adjudication-pipeline 62. `cargo clippy -- -D warnings` clean on all five crates. The pre-existing, unrelated `uefi` no_std duplicate-lang-item build error (documented in NX-1, no dep on these crates, zero diff on this branch) is not from this change.

**Existing tests updated: 3** (all because preserving exactness is the intended new behavior, not to hide a problem):
1. `adj-lang` adapter `round_trips_valued_observation` — `18000` now matches `NumLit::Int(18000)` (was `Term::Num(x) if x == 18000.0`).
2. `adj-lang` lower `0.3048` table-cell binding now expects `Number::Exact(BigDecimal "0.3048")` (a distinct variant from the old `Float`).
3. `adj-lang`/`adj-lang-cli` `non_finite`/`malformed` literal tests — `1e400` is no longer rejected (it's a valid exact `10^400` now stored with full precision); repointed to a scale-amplification payload (`1e-2000000000`) that `BigDecimal`'s `MAX_SCALE` still rejects cleanly.

## Proof of the win

New e2e (`adj-lang-cli` `rs5_table_e2e::table_high_precision_pi_binds_all_39_digits`) drives a table with a 39-decimal-place π cell through the built CLI. The query binds:

```
"V":"3.141592653589793238462643383279502884197"
```

— all 39 digits, where before NX-2 it was `3.141592653589793`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
