### PR TITLE
feat(adj-facts-stdlib): biology blood-cell-types — cell type → job (RBC→carry_oxygen, WBC→fight_infection, platelets→clotting)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_bloodcells_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_bloodcells_e2e.rs
@@ -1,0 +1,70 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/blood-cell-types.adj`) driven through the built
+//! CLI: a native `table` of blood-cell-type → main-function resolves a
+//! binding-query recall with the source's citation, runs the relation backward
+//! (function → cell type), and abstains on a cell that is not a blood cell —
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsbloodcells_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_blood_cells_recall_binds_function_with_citation() {
+    let dir = scratch("bloodcells");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/blood-cell-types.adj");
+    std::fs::copy(&src, dir.join("blood-cell-types.adj")).expect("copy shipped blood-cell-types.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"blood-cell-types.adj\"\n\
+         ? blood_cell_function(red_blood_cells, $F)\n\
+         ? blood_cell_function(platelets, $F)\n\
+         ? blood_cell_function($C, fight_infection)\n\
+         ? blood_cell_function(neuron, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Red blood cells carry oxygen; platelets do the clotting — the recalled
+    // main-function atoms.
+    assert!(out.contains("\"F\":\"carry_oxygen\""), "red_blood_cells → carry_oxygen: {out}");
+    assert!(out.contains("\"F\":\"clotting\""), "platelets → clotting: {out}");
+    // The relation runs backward: the job fight_infection recalls white_blood_cells.
+    assert!(
+        out.contains("\"C\":\"white_blood_cells\""),
+        "fight_infection → white_blood_cells (reverse recall): {out}"
+    );
+    // The answer carries the MedlinePlus (NIH, .gov) citation as its proof.
+    assert!(
+        out.contains("medlineplus.gov/blood.html")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A neuron is a nerve cell, not a blood cell — honest abstention, never a
+    // fabricated function.
+    assert!(out.contains("\"abstained\":true"), "non-blood-cell abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/blood-cell-types.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/blood-cell-types.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% blood-cell-types — each main type of blood cell and its main job
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A middle-school biology facts library in the ADJ standard library — the kind
+% a science or medicine agent `import`s when it needs the most basic grounded
+% hematology fact: "red blood cells carry oxygen; white blood cells fight
+% infection; platelets do the clotting." Blood is made of three main kinds of
+% cell, and each kind carries out one main job. This is a small but real RUNG a
+% medicine agent reasons UP from: knowing what each blood cell does is the
+% foundation under anemia (too few oxygen-carrying red cells), infection (the
+% white cells that fight it), and bleeding/clotting disorders (the platelets
+% that stop a cut from bleeding). Before a medicine agent can reason about any
+% of those, it must first know — the way a middle-school student does — which
+% cell does what. Recall is a binding query:
+%
+%     ? blood_cell_function(red_blood_cells, $F)   % carry_oxygen
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `blood_cell_function(cell_type, function)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the function atom WITH its source, on the CPU, with zero model calls,
+% and abstains on something that is not one of the three blood cell types. The
+% query also runs BACKWARD — bind the job and recall the cell:
+%
+%     ? blood_cell_function($C, fight_infection)   % white_blood_cells
+%
+% The `function` value of every row is a SINGLE lowercase atom, chosen to be a
+% faithful one-word (or short snake_case) paraphrase of the primary-function
+% text MedlinePlus states — never an interpretation the source does not support.
+% A recalled function atom therefore composes straight into downstream reasoning
+% (a medicine agent asking "which cell fights_infection?" gets the grounded
+% answer, not a guess) — the concrete bridge from biology RECALL to reasoning.
+%
+% Provenance: every cell-type name and its `function` atom is grounded in a
+% VERBATIM span from MedlinePlus (the U.S. National Library of Medicine / NIH,
+% a `.gov` primary reference). The `source` span below is the VERBATIM sentence
+% for the first data row (red_blood_cells), copied character-for-character from
+% the MedlinePlus "Blood" health-topic page (the `locator`). Each row's atom is
+% a faithful short paraphrase of that cell's own VERBATIM span, quoted here from
+% the same page so any reader can re-check it byte-for-byte:
+%
+%   red_blood_cells   → carry_oxygen      https://medlineplus.gov/blood.html
+%     "Red blood cells (RBC) deliver oxygen from your lungs to your tissues and
+%      organs."
+%   white_blood_cells → fight_infection   https://medlineplus.gov/blood.html
+%     "White blood cells (WBC) fight infection and are part of your immune
+%      system."
+%   platelets         → clotting          https://medlineplus.gov/blood.html
+%     "Platelets help blood to clot when you have a cut or wound."
+%
+% `trust authoritative` — MedlinePlus is a `.gov` service of the U.S. National
+% Library of Medicine (NIH), a primary/official reference (contrast the
+% `consensus` tier reserved for a secondary source such as an encyclopedia or
+% KidsHealth). Nothing here is asserted from memory; each pair was read out of
+% the fetched MedlinePlus page and any cell type whose function the page did not
+% state would have been dropped.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_adjudication_no_interpretive_gating.)
+% ============================================================================
+
+table blood_cell_function {
+    columns cell_type, function
+
+    row (red_blood_cells, carry_oxygen)
+    row (white_blood_cells, fight_infection)
+    row (platelets, clotting)
+
+    source "Red blood cells (RBC) deliver oxygen from your lungs to your tissues and organs."
+    locator "https://medlineplus.gov/blood.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/blood-cell-types.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/blood-cell-types.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% blood-cell-types.query.adj — a worked recall over the biology blood-cell library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what do red blood cells
+% do?": it states no biology fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `blood_cell_function` rows and returns the function atom + the table's
+% source/locator/trust. The third query runs the relation BACKWARD (bind the
+% job, recall the cell). Something that is not one of the three blood cell
+% types abstains honestly — the engine never invents a function.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli blood-cell-types.query.adj
+% ============================================================================
+
+import "blood-cell-types.adj"
+
+? blood_cell_function(red_blood_cells, $F)   % expect carry_oxygen
+? blood_cell_function(platelets, $F)         % expect clotting
+? blood_cell_function($C, fight_infection)   % expect white_blood_cells — the reverse recall
+? blood_cell_function(neuron, $F)            % expect abstain — a nerve cell, not a blood cell


### PR DESCRIPTION
## What

A grounded **middle-school biology (hematology)** facts library for the ADJ standard library: the three main blood cell types mapped to their main job.

| cell_type | function |
|---|---|
| red_blood_cells | carry_oxygen |
| white_blood_cells | fight_infection |
| platelets | clotting |

This is a foundation rung a medicine agent reasons **up** from — anemia (too few oxygen-carrying red cells), infection (the white cells that fight it), and clotting/bleeding disorders (platelets).

## Files
- `code/specs/data/adj-facts-stdlib/biology/blood-cell-types.adj` — native `table blood_cell_function (cell_type, function)`; literate comment quotes each row's VERBATIM span with its page.
- `code/specs/data/adj-facts-stdlib/biology/blood-cell-types.query.adj` — worked recall: two forward binds, one reverse bind (`fight_infection → white_blood_cells`), one abstain on a non-blood-cell (`neuron`).
- `code/packages/rust/adj-lang-cli/tests/facts_bloodcells_e2e.rs` — e2e asserting the two binds, the reverse bind, the locator + trust tier, and the abstention.

## Grounding
Every value atom is a faithful short paraphrase of a **VERBATIM** span from MedlinePlus (U.S. National Library of Medicine / NIH, `.gov`):
- red_blood_cells → carry_oxygen: "Red blood cells (RBC) deliver oxygen from your lungs to your tissues and organs."
- white_blood_cells → fight_infection: "White blood cells (WBC) fight infection and are part of your immune system."
- platelets → clotting: "Platelets help blood to clot when you have a cut or wound."

Source / locator: https://medlineplus.gov/blood.html — **trust `authoritative`** (`.gov` primary reference). Nothing asserted from memory; a cell type whose function the page did not state would have been dropped.

## Verification
- `cargo test -p adj-lang-cli --test facts_bloodcells_e2e` — passes
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean
- Security review (sub-agent): PASSED, no vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)