### PR TITLE
feat(logic-engine): NX-3 — exact compute ingestion of Number::Exact (no f64 hop)

### DIFF
--- a/code/packages/rust/bignum-core/CHANGELOG.md
+++ b/code/packages/rust/bignum-core/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the `bignum-core` package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-14
+
+### Added
+
+- **`BigDecimal::to_rational(&self) -> BigRational`** — the **exact** counterpart of the lossy
+  `to_f64()`. A `BigDecimal` is `mantissa × 10^(-scale)`, always a ratio of two integers, so this
+  converts with **zero loss and no `f64` hop**: `scale > 0` yields `mantissa / 10^scale`
+  (`2.54 → 127/50`, `0.3048 → 381/1250`), and `scale ≤ 0` yields the whole number
+  `mantissa × 10^|scale|` (`100 → 100/1`). The result is reduced to lowest terms by
+  `BigRational::new`, and a 39-digit π converts to `3141592653589793238462643383279502884197 / 10^39`
+  exactly. Introduced for ADJ exact-numbers NX-3 (exact compute ingestion): the logic engine now
+  ingests a stored `Number::Exact` decimal into its `ExactRational` sidecar through this method, so
+  arithmetic on a high-precision constant stays exact. Unit-tested across fractional, integer,
+  zero, negative, and 39-digit-π inputs.
+
 ## [0.5.0] - 2026-07-14
 
 ### Added

--- a/code/packages/rust/bignum-core/Cargo.toml
+++ b/code/packages/rust/bignum-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignum-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A zero-dependency arbitrary-precision numeric core: a signed integer (BigInteger), an exact rational (BigRational), an exact base-10 decimal (BigDecimal), and a correctly-rounded binary float of arbitrary precision (BigDouble) — all built from scratch with no third-party deps and no unsafe."
 license = "MIT"

--- a/code/packages/rust/bignum-core/README.md
+++ b/code/packages/rust/bignum-core/README.md
@@ -214,7 +214,8 @@ Every value is canonical — trailing zeros stripped, zero pinned to `(0, 0)` �
 | Construct | `zero`, `one`, `from_parts`, `from_integer`, `from_i64`, `From<BigInteger/i64/u64/i128/u128>` |
 | Exact arithmetic | `add`/`+`, `sub`/`-`, `mul`/`*`, unary `-`, `abs`, `pow(u32)` |
 | Rounding | `RoundingMode` (`Down`/`Up`/`Floor`/`Ceiling`/`HalfUp`/`HalfDown`/`HalfEven`), `div_round`/`checked_div_round`, `round_to_scale` |
-| Query | `is_zero`, `is_negative`, `is_positive`, `signum`, `mantissa`, `scale`, `Ord`/`Eq`/`Hash` |
+| Query | `is_zero`, `is_negative`, `is_positive`, `signum`, `mantissa`, `scale`, `significant_digits`, `Ord`/`Eq`/`Hash` |
+| Convert | `to_rational` (**exact** `BigRational`, no `f64` hop — `2.54 → 127/50`), `to_f64` (lossy, correctly rounded) |
 | I/O | `FromStr` (plain + scientific) with typed `ParseDecimalError`; plain-decimal `Display`/`Debug` |
 
 ## BigDouble — correctly-rounded binary float, any precision (NUM-4)

--- a/code/packages/rust/bignum-core/src/decimal.rs
+++ b/code/packages/rust/bignum-core/src/decimal.rs
@@ -46,7 +46,7 @@
 //! assert_eq!(third.to_string(), "3.3333");
 //! ```
 
-use crate::BigInteger;
+use crate::{BigInteger, BigRational};
 use std::cmp::Ordering;
 use std::fmt;
 use std::str::FromStr;
@@ -365,6 +365,45 @@ impl BigDecimal {
     /// and out-of-range magnitudes saturate to `±∞` / `0` exactly as the parser does.
     pub fn to_f64(&self) -> f64 {
         self.to_string().parse::<f64>().unwrap_or(f64::NAN)
+    }
+}
+
+// ===========================================================================
+//  Exact export to BigRational
+// ===========================================================================
+
+impl BigDecimal {
+    /// The **exact** value as a [`BigRational`] — no rounding, no `f64` hop.
+    ///
+    /// A [`BigDecimal`] is `mantissa × 10^(-scale)`, so it is *always* a ratio of two integers
+    /// and converts to a fraction with **zero loss**. This is the exact counterpart of the
+    /// lossy [`to_f64`](Self::to_f64): where `to_f64` narrows to the nearest binary float,
+    /// `to_rational` hands back the true value that a rational engine can keep computing on
+    /// exactly (see ADJ-EXACT-NUMBERS NX-3 — exact compute ingestion).
+    ///
+    /// The scale sign picks the shape of the fraction:
+    ///
+    /// | value | mantissa | scale | `to_rational()` |
+    /// |---|---|---|---|
+    /// | `2.54`   | `254`  | `2`  | `254 / 100` → `127/50`  (scale > 0 ⇒ denominator `10^scale`) |
+    /// | `0.3048` | `3048` | `4`  | `3048 / 10000` → `381/1250` |
+    /// | `100`    | `1`    | `-2` | `1 × 10^2` → `100/1`  (scale ≤ 0 ⇒ whole number `mant · 10^|scale|`) |
+    /// | `0`      | `0`    | `0`  | `0/1` |
+    ///
+    /// [`BigRational::new`] reduces to lowest terms and moves the sign onto the numerator, so the
+    /// result is canonical. The mantissa already carries the sign, so no separate sign handling
+    /// is needed here.
+    pub fn to_rational(&self) -> BigRational {
+        if self.scale > 0 {
+            // Fractional digits: the value is `mantissa / 10^scale`.
+            let denom = ten_pow(scale_diff_to_u32(self.scale as i128));
+            BigRational::new(self.mant.clone(), denom)
+        } else {
+            // scale <= 0: the value is a whole number `mantissa × 10^(-scale)`.
+            // (`scale == 0` folds in here too, since `10^0 == 1`.)
+            let factor = ten_pow(scale_diff_to_u32(-(self.scale as i128)));
+            BigRational::from_integer(&self.mant * &factor)
+        }
     }
 }
 
@@ -761,6 +800,56 @@ mod tests {
         // Out-of-range magnitudes saturate exactly as the parser does.
         let huge = "1".to_string() + &"0".repeat(400); // 10^400
         assert_eq!(d(&huge).to_f64(), f64::INFINITY);
+    }
+
+    // ---- exact BigRational export --------------------------------------
+
+    #[test]
+    fn to_rational_is_exact_for_fractional_decimals() {
+        // 2.54 = 254/100 = 127/50 in lowest terms.
+        let r = d("2.54").to_rational();
+        assert_eq!(r.numerator().to_string(), "127");
+        assert_eq!(r.denominator().to_string(), "50");
+        // 0.3048 = 3048/10000 = 381/1250.
+        let r = d("0.3048").to_rational();
+        assert_eq!(r.numerator().to_string(), "381");
+        assert_eq!(r.denominator().to_string(), "1250");
+    }
+
+    #[test]
+    fn to_rational_handles_integers_and_zero_and_signs() {
+        // Whole numbers land on denominator 1 (scale <= 0 branch).
+        assert_eq!(d("100").to_rational(), BigRational::from_ints(100, 1));
+        assert_eq!(d("7").to_rational(), BigRational::from_ints(7, 1));
+        // 12300 canonicalizes to mantissa 123, scale -2, then rehydrates exactly.
+        assert_eq!(d("12300").to_rational(), BigRational::from_ints(12300, 1));
+        // Zero is the canonical 0/1.
+        assert_eq!(d("0").to_rational(), BigRational::zero());
+        // Sign rides on the mantissa; new() keeps the denominator positive.
+        let r = d("-2.5").to_rational();
+        assert_eq!(r.numerator().to_string(), "-5");
+        assert_eq!(r.denominator().to_string(), "2");
+        assert!(r.is_negative());
+    }
+
+    #[test]
+    fn to_rational_is_exact_for_39_digit_pi() {
+        // The stdlib ships pi to 39 digits. Its exact rational value is
+        // 3141592653589793238462643383279502884197 / 10^39 (already coprime, so it
+        // does not reduce). No f64 hop, so all 39 digits survive.
+        let pi = d("3.141592653589793238462643383279502884197");
+        let r = pi.to_rational();
+        assert_eq!(
+            r.numerator().to_string(),
+            "3141592653589793238462643383279502884197"
+        );
+        assert_eq!(
+            r.denominator().to_string(),
+            "1000000000000000000000000000000000000000" // 10^39
+        );
+        // Round-trip sanity: numerator has 40 digits, denominator has 40 (1 + 39 zeros).
+        assert_eq!(r.numerator().to_string().len(), 40);
+        assert_eq!(r.denominator().to_string().len(), 40);
     }
 
     // ---- canonical form & display --------------------------------------

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.39.0] — 2026-07-14 — exact compute ingestion of `Number::Exact` (ADJ-EXACT-NUMBERS NX-3)
+
+### Changed
+
+- **`numeric_exact_magnitude` now ingests a `Number::Exact(BigDecimal)` leaf at full precision**,
+  replacing the NX-2 stopgap that folded the decimal through `to_f64()` (losing everything past the
+  ~16th significant digit). A `BigDecimal` is `mantissa × 10^(-scale)`, an exact ratio, so the
+  exact-rational sidecar is now populated via the new `BigDecimal::to_rational()` →
+  `ExactRational::from_ratio(...)` — **no `f64` hop**. `Int` was already exact; `Float` remains the
+  single documented inexact ingress. Net effect: `pi + pi` on the stdlib's stored 39-digit π stays
+  exact to all digits (`6.283185307179586476925286766559005768394`) instead of collapsing to the
+  f64-rounded `6.283185307179586`, and further arithmetic stays exact (NUM-5). Both the bare and
+  typed-wrapper (`Compound`) arms were migrated. No result changes for `Int`/`Float` inputs.
+- Added a compute-layer regression test proving the doubled-π sidecar equals the exact 40-digit
+  value and reduces to `3141592653589793238462643383279502884197 / (5 × 10^38)` in lowest terms.
+
 ## [0.38.1] — 2026-07-14 — read `Number::Exact` valued facts (ADJ-EXACT-NUMBERS NX-2)
 
 ### Changed

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.38.1"
+version = "0.39.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -1917,6 +1917,75 @@ mod tests {
     }
 
     #[test]
+    fn stored_exact_decimal_pi_doubles_exactly_with_no_f64_hop() {
+        // The proof of NX-3: a high-precision constant stored EXACTLY survives arithmetic.
+        // The stdlib ships pi to 39 digits. If the compute engine ingested it through an
+        // `f64` hop, `pi + pi` would collapse to the ~16-digit `6.283185307179586`. NX-3
+        // ingests the `BigDecimal` as its true `mantissa / 10^scale` rational, so all 39
+        // fractional digits survive doubling.
+        use logic_core::{Number, Term};
+        use std::str::FromStr;
+
+        let pi_str = "3.141592653589793238462643383279502884197";
+        let pi_decimal = bignum_core::BigDecimal::from_str(pi_str).unwrap();
+
+        // Store pi as an EXACT valued fact `pi(3.14159…197)` — a `Number::Exact`, not an f64.
+        let kb = kb_with(vec![crate::Fact::certain(compound(
+            "pi",
+            vec![Term::Num(Number::Exact(pi_decimal.clone()))],
+        ))]);
+
+        // Double it through the deterministic compute engine: pi + pi.
+        let d = compute(
+            "two_pi",
+            &bin(ComputeOp::Add, refexpr("pi"), refexpr("pi")),
+            &kb,
+        )
+        .unwrap();
+
+        // The human-readable exact expectation: 2·pi rendered to its full 40-digit decimal
+        // via BigDecimal's own exact addition — no rounding anywhere.
+        let doubled_decimal = &pi_decimal + &pi_decimal;
+        assert_eq!(
+            doubled_decimal.to_string(),
+            "6.283185307179586476925286766559005768394",
+            "BigDecimal exact doubling must keep every digit"
+        );
+
+        // The engine's exact sidecar must equal that exact value — NOT the f64-rounded one.
+        let exact = d
+            .exact
+            .expect("a stored Number::Exact fact must populate the exact sidecar");
+        assert_eq!(
+            exact,
+            ExactRational::from_ratio(doubled_decimal.to_rational()),
+            "compute must ingest the stored decimal exactly (no f64 hop)"
+        );
+
+        // And in lowest terms: 2·(N/10^39) = N / (5·10^38), so the numerator is pi's exact
+        // 40-digit mantissa and the denominator is 5·10^38 (39 digits). This pins the precise
+        // ratio the engine now holds.
+        assert_eq!(
+            exact.numerator().to_string(),
+            "3141592653589793238462643383279502884197"
+        );
+        assert_eq!(
+            exact.denominator().to_string(),
+            "500000000000000000000000000000000000000" // 5 × 10^38 (39 digits)
+        );
+
+        // Guard the regression this PR fixes: the exact value is strictly better than the
+        // f64 hop. The old NX-2 path folded through `to_f64()`, losing everything past the
+        // 16th significant digit; the exact denominator here has 39 digits.
+        assert_ne!(
+            exact,
+            ExactRational::from_integer_f64((pi_decimal.to_f64() * 2.0).trunc())
+                .unwrap_or_else(|| ExactRational::from_i128(0)),
+            "the exact sidecar must not degrade to the truncated f64 value"
+        );
+    }
+
+    #[test]
     fn integer_fraction_arithmetic_carries_exact_rational_sidecar() {
         let kb = KnowledgeBase::new();
         let expr = ComputeExpr::Bin(

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -1106,20 +1106,24 @@ pub fn numeric_magnitude(value: &Term) -> Option<f64> {
     }
 }
 
-/// Exact counterpart to [`numeric_magnitude`]. It intentionally returns `None`
-/// for non-integral floats; exact decimal parsing belongs at the language
-/// adapter layer, while this engine helper only trusts values that arrived as
-/// integer terms or integer-valued floats.
+/// Exact counterpart to [`numeric_magnitude`]. `Int` and `Exact(BigDecimal)` values ingest
+/// **exactly** — the decimal is `mantissa × 10^(-scale)`, converted to its true `BigRational`
+/// with no `f64` hop (NX-3). A `Float` term is the one inexact ingress: it captures only
+/// *integer-valued* floats (via [`from_integer_f64`](crate::compute::ExactRational::from_integer_f64))
+/// and returns `None` for a fractional binary float, whose intended exact form belongs to the
+/// base-10 literal string handled by the language adapter, not to the rounded `f64`.
 pub fn numeric_exact_magnitude(value: &Term) -> Option<crate::compute::ExactRational> {
     match value {
         Term::Num(Number::Int(i)) => Some(crate::compute::ExactRational::from_i128(*i as i128)),
         Term::Num(Number::Float(x)) => crate::compute::ExactRational::from_integer_f64(*x),
-        // NX-2 reads an exactly-stored decimal through the *same* integer-valued gate the `Float`
-        // path uses (`to_f64` then `from_integer_f64`), so the exact-rational sidecar is populated
-        // for integer-valued facts and `None` for fractional ones — byte-for-byte the old
-        // behavior. Ingesting the decimal's full precision into `ExactRational` without an `f64`
-        // hop is deliberately deferred to NX-3, so no compute result changes in this PR.
-        Term::Num(Number::Exact(d)) => crate::compute::ExactRational::from_integer_f64(d.to_f64()),
+        // NX-3 ingests an exactly-stored decimal at *full precision* — `BigDecimal` is
+        // `mantissa × 10^(-scale)`, an exact ratio, so `to_rational()` hands the compute layer the
+        // true value with **no `f64` hop**. A stored 39-digit pi therefore stays exact through
+        // arithmetic (`pi * 2`), instead of collapsing to the ~16-digit nearest float the NX-2
+        // stopgap produced. `Int` above is already exact; `Float` remains the one inexact ingress.
+        Term::Num(Number::Exact(d)) => {
+            Some(crate::compute::ExactRational::from_ratio(d.to_rational()))
+        }
         Term::Compound { args, .. } => match args.first() {
             Some(Term::Num(Number::Int(i))) => {
                 Some(crate::compute::ExactRational::from_i128(*i as i128))
@@ -1128,7 +1132,7 @@ pub fn numeric_exact_magnitude(value: &Term) -> Option<crate::compute::ExactRati
                 crate::compute::ExactRational::from_integer_f64(*x)
             }
             Some(Term::Num(Number::Exact(d))) => {
-                crate::compute::ExactRational::from_integer_f64(d.to_f64())
+                Some(crate::compute::ExactRational::from_ratio(d.to_rational()))
             }
             _ => None,
         },


### PR DESCRIPTION
## ADJ-EXACT-NUMBERS NX-3 — exact compute ingestion

The compute engine evaluates arithmetic over an exact `ExactRational` (a `bignum_core::BigRational`). When it read a ground `Number::Exact(BigDecimal)` leaf it went through the NX-2 stopgap that folded the decimal to `f64` (`to_f64` → `from_integer_f64`), losing everything past the ~16th significant digit. **NX-3 ingests the stored decimal at full precision — no `f64` hop.**

### Changes
- **bignum-core** (`0.5.0` → `0.6.0`): add `BigDecimal::to_rational(&self) -> BigRational`. A `BigDecimal` is `mantissa × 10^(-scale)`, an exact ratio, so this converts with **zero loss**: `scale > 0` → `mantissa / 10^scale` (`2.54 → 127/50`, `0.3048 → 381/1250`), `scale ≤ 0` → the whole number `mantissa × 10^|scale|`. Reduced to lowest terms; a 39-digit π → `3141…4197 / 10^39` exactly. Unit-tested.
- **logic-engine** (`0.38.1` → `0.39.0`): `numeric_exact_magnitude` now ingests `Number::Exact` via `ExactRational::from_ratio(d.to_rational())` on both the bare and typed-wrapper (`Compound`) arms. `Int` stays exact; `Float` remains the one documented inexact ingress. **No result changes for `Int`/`Float` inputs.**

### Proof of the win
New compute test stores the stdlib's 39-digit π as a `Number::Exact` fact and doubles it (`pi + pi`) through the engine. The exact sidecar equals the full 40-digit `6.283185307179586476925286766559005768394` (reduced `N / (5×10^38)`) — **not** the f64-rounded `6.283185307179586`.

### Gate
- `cargo test -p bignum-core -p logic-core -p logic-engine -p adj-lang -p adj-lang-cli` — all green, **zero regressions**, zero existing tests changed.
- `cargo clippy --all-targets -D warnings` clean on `bignum-core` + `logic-engine`.
- Security self-review: `10^scale` materialization is bounded by the same `INTERNAL_SCALE_LIMIT`/`MAX_SCALE` budgets already gating `from_parts`/`div_round`/`Display`; NX-2 caps parsed scale, so no new untrusted-input surface. No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)