### PR TITLE
feat(adj-facts-stdlib): anatomy heart-chambers — each chamber → its function

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_heartchambers_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_heartchambers_e2e.rs
@@ -1,0 +1,74 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/heart-chambers.adj`) driven through the built CLI:
+//! a native `table` of heart-chamber → function resolves binding-query recalls
+//! (forward and backward) with the source's NIH citation, and abstains on a
+//! non-chamber (the aorta) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_heart_chambers_recall_binds_function_with_citation() {
+    let dir = scratch("heartchambers");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/heart-chambers.adj");
+    std::fs::copy(&src, dir.join("heart-chambers.adj")).expect("copy shipped heart-chambers.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"heart-chambers.adj\"\n\
+         ? heart_chamber_function(right_atrium, $Job)\n\
+         ? heart_chamber_function(right_ventricle, $Job)\n\
+         ? heart_chamber_function($C, pumps_blood_to_body)\n\
+         ? heart_chamber_function(aorta, $Job)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The right atrium receives blood from the body; the right ventricle pumps
+    // it on to the lungs — the recalled jobs (forward binds).
+    assert!(
+        out.contains("\"Job\":\"receives_blood_from_body\""),
+        "right_atrium → receives_blood_from_body: {out}"
+    );
+    assert!(
+        out.contains("\"Job\":\"pumps_blood_to_lungs\""),
+        "right_ventricle → pumps_blood_to_lungs: {out}"
+    );
+    // The relation runs BACKWARD: bind the job, recall the chamber.
+    assert!(
+        out.contains("\"C\":\"left_ventricle\""),
+        "pumps_blood_to_body → left_ventricle (reverse recall): {out}"
+    );
+    // The answer carries the NIH / NLM StatPearls citation as its proof.
+    assert!(
+        out.contains("ncbi.nlm.nih.gov/books/NBK470256")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The aorta is not a chamber — honest abstention, never a fabricated job.
+    assert!(out.contains("\"abstained\":true"), "aorta abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/heart-chambers.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/heart-chambers.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% heart-chambers — each of the four heart chambers and the job it does
+% (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A cardiac-anatomy fact on the way to medicine: the human heart has FOUR
+% chambers, and each one has one job in the loop that moves blood around the
+% body. Blood comes back from the body, gets sent to the lungs to pick up
+% oxygen, comes back from the lungs, and is pumped back out to the body — and
+% each step is one chamber's job. Recall is a binding query:
+%
+%     ? heart_chamber_function(right_atrium, $Job)   % receives_blood_from_body
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `heart_chamber_function(chamber, function)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the job WITH its source, on the CPU, with zero model calls, and
+% abstains on anything that is not one of the four chambers.
+%
+% The four chambers, as a little truth table (follow the blood around the loop):
+%
+%     chamber          job                        where the blood comes/goes
+%     --------------   ------------------------   ----------------------------
+%     right_atrium     receives_blood_from_body   deoxygenated, from the body
+%     right_ventricle  pumps_blood_to_lungs       out to the lungs for oxygen
+%     left_atrium      receives_blood_from_lungs  oxygenated, back from lungs
+%     left_ventricle   pumps_blood_to_body        out to the whole body
+%
+% The RIGHT side of the heart handles used (deoxygenated) blood on its way to
+% the lungs; the LEFT side handles fresh (oxygenated) blood on its way to the
+% body. This is the concrete cardiac rung a medicine agent reasons UP from:
+% before it can reason about a murmur, a failing valve, or a shunt, it must
+% first know which chamber receives from where and pumps to where, the way a
+% first-year student does. The query also runs BACKWARD — bind the job and
+% recall the chamber that does it:
+%
+%     ? heart_chamber_function($C, pumps_blood_to_body)   % left_ventricle
+%
+% Something that is not one of the four chambers — the aorta, a valve, the
+% septum — has no row, so a recall on it ABSTAINS rather than inventing a job.
+% That honest-abstention property is what makes the table safe to reason from.
+%
+% The `function` value of every row is a SINGLE lowercase atom, chosen to be a
+% faithful short snake_case paraphrase of what the source states that chamber
+% does — never an interpretation the source does not support.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every chamber→job pair was
+% read out of a fetched NIH / National Library of Medicine page, and any
+% chamber that could not be grounded there would have been dropped). All four
+% spans come from the SAME primary U.S. government reference, NIH / NLM
+% StatPearls "Anatomy, Thorax, Heart" (ncbi.nlm.nih.gov/books/NBK470256/), each
+% quoted here character-for-character so any reader can re-check it:
+%
+%   right_atrium → receives_blood_from_body
+%     "The right atrium receives deoxygenated blood from the entire body except
+%      for the lungs (the systemic circulation) via the superior and inferior
+%      vena cavae."
+%
+%   right_ventricle → pumps_blood_to_lungs
+%     "The right ventricle pumps blood through the right ventricular outflow
+%      tract, across the pulmonic valve, and into the pulmonary artery that
+%      distributes it to the lungs for oxygenation."
+%
+%   left_atrium → receives_blood_from_lungs
+%     "This oxygenated blood is collected by the four pulmonary veins, two from
+%      each lung. All four of these veins open into the left atrium that acts as
+%      a collection chamber for oxygenated blood."
+%
+%   left_ventricle → pumps_blood_to_body
+%     "The left ventricle is the main pumping chamber of the left heart, then
+%      pumps, sending freshly oxygenated blood to the systemic circulation
+%      through the aortic valve."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the StatPearls sentence that
+% fixes the first row (right_atrium → receives_blood_from_body). Every OTHER
+% row's per-fact source and verbatim span is listed above, so each job remains
+% independently checkable. The source is a primary U.S. government NIH /
+% National Library of Medicine reference (ncbi.nlm.nih.gov), so
+% `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table heart_chamber_function {
+    columns chamber, function
+
+    row (right_atrium, receives_blood_from_body)
+    row (right_ventricle, pumps_blood_to_lungs)
+    row (left_atrium, receives_blood_from_lungs)
+    row (left_ventricle, pumps_blood_to_body)
+
+    source "The right atrium receives deoxygenated blood from the entire body except for the lungs (the systemic circulation) via the superior and inferior vena cavae."
+    locator "https://www.ncbi.nlm.nih.gov/books/NBK470256/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/heart-chambers.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/heart-chambers.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% heart-chambers.query.adj — a worked recall over the anatomy heart-chambers library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the right atrium
+% do?": it states no anatomy fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `heart_chamber_function` rows and returns the job + the table's
+% source/locator/trust. The fourth query runs the relation BACKWARD (bind the
+% job `pumps_blood_to_body`, recall the chamber that does it — the left
+% ventricle). The aorta is not a chamber, so a recall on it abstains honestly —
+% the engine never invents a job.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli heart-chambers.query.adj
+% ============================================================================
+
+import "heart-chambers.adj"
+
+? heart_chamber_function(right_atrium, $Job)     % expect receives_blood_from_body
+? heart_chamber_function(right_ventricle, $Job)  % expect pumps_blood_to_lungs
+? heart_chamber_function(left_atrium, $Job)      % expect receives_blood_from_lungs
+? heart_chamber_function($C, pumps_blood_to_body) % expect left_ventricle — reverse recall
+? heart_chamber_function(aorta, $Job)            % expect abstain — the aorta is not a chamber


### PR DESCRIPTION
## What

A grounded middle-school **anatomy** FACTS library for the ADJ standard library: a native `table heart_chamber_function` mapping each of the four heart chambers to the one job it does in the blood loop.

| chamber | function |
|---|---|
| `right_atrium` | `receives_blood_from_body` |
| `right_ventricle` | `pumps_blood_to_lungs` |
| `left_atrium` | `receives_blood_from_lungs` |
| `left_ventricle` | `pumps_blood_to_body` |

Recall is the ordinary SLD binding query — forward (`? heart_chamber_function(right_atrium, $Job)`) and backward (`? heart_chamber_function($C, pumps_blood_to_body)`) — returns the job with the table's citation, runs on the CPU with zero model calls, and **abstains** honestly on a non-chamber (the aorta). This is the concrete cardiac rung a medicine agent reasons up from before any valve / shunt / murmur reasoning.

## Grounding

Every chamber→job pair is copied **character-for-character** from the NIH / U.S. National Library of Medicine StatPearls *"Anatomy, Thorax, Heart"* — <https://www.ncbi.nlm.nih.gov/books/NBK470256/> — a primary `.gov` reference, so `trust authoritative`. Each row's own verbatim span is quoted in the file's literate provenance comment so every job stays independently checkable; the table's single `source` envelope holds the first row's (`right_atrium`) span. The right side handles deoxygenated blood to the lungs; the left side handles oxygenated blood to the body — confirmed against the page.

## Ships (DATA + one test)

- `code/specs/data/adj-facts-stdlib/anatomy/heart-chambers.adj`
- `code/specs/data/adj-facts-stdlib/anatomy/heart-chambers.query.adj`
- `code/packages/rust/adj-lang-cli/tests/facts_heartchambers_e2e.rs` — asserts two forward binds, a reverse recall, the NIH locator + authoritative trust, and one abstain.

## Verification

- `cargo test -p adj-lang-cli --test facts_heartchambers_e2e` ✅ (1 passed)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` ✅ (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)