### PR TITLE
feat(closure-pass-fold-control-flow): flatten redundant block statements (CLOC12.194)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.24.0] - 2026-07-14
+
+### Added — CLOC12.194: flatten redundant `BlockStatement`s (oracle divergence #4)
+
+A bare `{ … }` block at statement-list position creates a lexical scope, but if
+nothing inside is block-scoped that scope is unobservable — the braces can be
+removed and the inner statements run directly in the enclosing list with
+identical semantics. `fold_program` and `fold_block_statement` now splice such a
+block's body in place; the empty block `{}` flattens to nothing (removed). This
+mirrors Closure's `PeepholeRemoveDeadCode` block normalization and closes
+**oracle divergence #3-adjacent #4**: it fires both on a hand-written `{ … }`
+and — importantly — on the block left behind when `if (true) { … }` collapses to
+its consequent, so `if (true) { a(); } else { b(); }` at SIMPLE now emits `a();`
+instead of `{ a(); }`.
+
+The soundness gate is the existing `block_is_scope_safe_to_hoist` predicate that
+already backs the CLOC25 `else`-hoist: a block declaring `let`/`const`/`class`/a
+`function` is **kept** (flattening would leak or collide its binding), while a
+plain `var` is function-scoped and hoists harmlessly. A spliced block that ends
+in a terminator re-arms the dead-code-after-terminator drop, exactly as the
+`else`-hoist does. Verified byte-identical to the reference Closure Compiler
+across the case set (`{a}`→`a;`, `{a;b}`→`a;b;`, `{var x=1;a}`→`var x=1;a;`,
+`{}`→removed, `if(true){…}`/`if(false){…}` unwrap; `let`/`const`/`class`/
+`function` blocks unchanged). Additive; MINOR bump 0.23.0 → 0.24.0.
+
 ## [0.23.0] - 2026-07-12
 
 ### Added — CLOC12.189 PR1: export declaration the control-flow predicate reports no foldable flow; the rebuild clones each export

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -306,11 +306,27 @@ fn expression_cv(expr: &Expression) -> Option<String> {
 
 fn fold_program(prog: &Program, st: &mut FoldState) -> Program {
     st.visit();
-    let new_body = prog
-        .body
-        .iter()
-        .map(|item| fold_program_item(item, st))
-        .collect();
+    // Fold each top-level item, then flatten any redundant block it produced
+    // (CLOC12.194). We build the list imperatively rather than `map`ping because
+    // flattening turns one block item into *many* items (its body spliced in) —
+    // or zero, for an empty block.
+    let mut new_body: Vec<ProgramItem> = Vec::with_capacity(prog.body.len());
+    for item in &prog.body {
+        let folded = fold_program_item(item, st);
+        if let ProgramItem::Statement(s) = &folded {
+            if let Some((block_cv, body)) = redundant_block(s) {
+                st.record_fold(
+                    block_cv,
+                    "flatten-redundant-block",
+                    "{ <stmts> }",
+                    "<stmts>",
+                );
+                new_body.extend(body.iter().cloned().map(ProgramItem::Statement));
+                continue;
+            }
+        }
+        new_body.push(folded);
+    }
     Program {
         cv: prog.cv.clone(),
         version: prog.version,
@@ -571,6 +587,29 @@ fn fold_block_statement(b: &BlockStatement, st: &mut FoldState) -> BlockStatemen
             }
         }
 
+        // CLOC12.194 — flatten a redundant nested block into this block's
+        // statement list. A bare `{ … }` with nothing block-scoped inside is
+        // identical to its body run in place (e.g. the block left behind when
+        // `if (true) { … }` folds to its consequent). Splicing may expose a
+        // terminator as the new last statement, so re-check `hit_terminator`
+        // for the dead-code-after-terminator drop, exactly as the `else`-hoist
+        // above does.
+        if let Some((block_cv, body)) = redundant_block(&folded) {
+            st.record_fold(
+                block_cv,
+                "flatten-redundant-block",
+                "{ <stmts> }",
+                "<stmts>",
+            );
+            for inner in body {
+                new_body.push(inner.clone());
+            }
+            if new_body.last().map(is_terminator).unwrap_or(false) {
+                hit_terminator = true;
+            }
+            continue;
+        }
+
         let terminates = is_terminator(&folded);
         new_body.push(folded);
         if terminates {
@@ -664,6 +703,34 @@ fn block_is_scope_safe_to_hoist(b: &BlockStatement) -> bool {
         // Tagged statements introduce no lexical binding of their own.
         Statement::Tagged(_) => true,
     })
+}
+
+/// CLOC12.194 — is `folded`, sitting at statement-list position, a **redundant
+/// block** that should be replaced by its own statements spliced in place?
+///
+/// A bare `{ … }` block introduces a fresh lexical scope, but if nothing inside
+/// is block-scoped (`let`/`const`/`class`/`function`) that scope is
+/// unobservable: the braces can be removed and the inner statements run
+/// directly in the enclosing list with identical semantics. `var` is
+/// function-scoped, so it hoists out harmlessly; the empty block `{}` flattens
+/// to *nothing* (removed). This mirrors Closure's `PeepholeRemoveDeadCode`
+/// block normalization and fires on a hand-written `{ … }` as well as on the
+/// block left behind when `if (true) { … }` collapses to its consequent.
+///
+/// Returns `Some((block_cv, body))` when safe to flatten — the caller splices
+/// `body` into the statement list and records a fold against `block_cv` — or
+/// `None` to keep the statement as-is (any non-block, or a block that declares
+/// a block-scoped binding: reuses the [`block_is_scope_safe_to_hoist`] gate that
+/// backs the CLOC25 `else`-hoist, so the soundness boundary is shared).
+fn redundant_block(folded: &Statement) -> Option<(&Option<String>, &[Statement])> {
+    match folded {
+        Statement::Tagged(TaggedStatement::BlockStatement(b))
+            if block_is_scope_safe_to_hoist(b) =>
+        {
+            Some((&b.cv, &b.body))
+        }
+        _ => None,
+    }
 }
 
 /// Is this `else` branch safe to hoist into the enclosing block (CLOC25)?
@@ -2953,5 +3020,208 @@ mod tests {
                 ));
             }
         }
+    }
+
+    // =====================================================================
+    // CLOC12.194 — redundant BlockStatement flattening (oracle divergence #4)
+    //
+    // A bare `{ … }` at statement-list position is a lexical scope with no
+    // observable effect UNLESS it declares a block-scoped binding. Closure
+    // removes such braces (`PeepholeRemoveDeadCode`); these tests pin the fold
+    // and its soundness boundary — verified byte-identical to the real Closure
+    // jar (`{a}`→`a;`, `{a;b}`→`a;b;`, `{var x=1;a}`→`var x=1;a;`, `{}`→removed;
+    // `{let…}`/`{const…}`/`{function…}` kept).
+    // =====================================================================
+
+    /// Wrap statements in a `{ … }` block statement (test helper).
+    fn block(cv: Option<&str>, body: Vec<Statement>) -> Statement {
+        Statement::block_statement(BlockStatement {
+            cv: cv.map(|s| s.to_string()),
+            body,
+        })
+    }
+
+    #[test]
+    fn flatten_bare_block_at_program_level() {
+        // `{ a; }` → `a;`
+        let prog = program().with_body(vec![ProgramItem::Statement(block(
+            Some("blk.1"),
+            vec![expr_stmt(ident("a"), None)],
+        ))]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed, "bare block should flatten");
+        assert_eq!(out.body.len(), 1, "block braces gone, one statement left");
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => assert!(
+                matches!(&es.expression, Expression::Identifier(i) if i.name == "a")
+            ),
+            other => panic!("expected `a;`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flatten_multi_statement_block() {
+        // `{ a; b; }` → `a; b;`
+        let prog = program().with_body(vec![ProgramItem::Statement(block(
+            None,
+            vec![expr_stmt(ident("a"), None), expr_stmt(ident("b"), None)],
+        ))]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 2, "both inner statements spliced in");
+    }
+
+    #[test]
+    fn flatten_empty_block_removes_it() {
+        // `a; {}` → `a;` — the empty block flattens to nothing.
+        let prog = program().with_body(vec![
+            ProgramItem::Statement(expr_stmt(ident("a"), None)),
+            ProgramItem::Statement(block(None, vec![])),
+        ]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 1, "empty block removed entirely");
+    }
+
+    #[test]
+    fn flatten_block_with_only_var_is_safe() {
+        // `{ var x = 1; a; }` → `var x = 1; a;` — `var` is function-scoped and
+        // hoists, so the block boundary is unobservable.
+        let prog = program().with_body(vec![ProgramItem::Statement(block(
+            None,
+            vec![
+                make_var_decl("x", Some(num(1.0, None))),
+                expr_stmt(ident("a"), None),
+            ],
+        ))]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 2);
+        assert!(
+            matches!(
+                &out.body[0],
+                ProgramItem::Statement(Statement::Declaration(
+                    Declaration::VariableDeclaration(_)
+                ))
+            ),
+            "the `var` declaration hoisted out of the block"
+        );
+    }
+
+    #[test]
+    fn block_with_let_is_not_flattened() {
+        // `{ let x = 1; a; }` — `let` is block-scoped; flattening would leak the
+        // binding into the enclosing scope. Must be kept.
+        let prog = program().with_body(vec![ProgramItem::Statement(block(
+            None,
+            vec![
+                make_let_decl("x", Some(num(1.0, None))),
+                expr_stmt(ident("a"), None),
+            ],
+        ))]);
+        let (out, _c, _changed, _n) = run_pass(prog);
+        assert_eq!(out.body.len(), 1);
+        assert!(
+            matches!(
+                first_stmt(&out),
+                Statement::Tagged(TaggedStatement::BlockStatement(_))
+            ),
+            "a `let` block must NOT be flattened"
+        );
+    }
+
+    #[test]
+    fn block_with_const_is_not_flattened() {
+        // `{ const x = 1; }` — `const` is block-scoped: keep the block.
+        let const_decl =
+            Statement::Declaration(Declaration::VariableDeclaration(VariableDeclaration {
+                cv: None,
+                kind: VarKind::Const,
+                declarations: vec![VariableDeclarator {
+                    cv: None,
+                    id: BindingTarget::Identifier(Identifier {
+                        cv: None,
+                        name: "x".to_string(),
+                    }),
+                    init: Some(num(1.0, None)),
+                }],
+            }));
+        let prog = program().with_body(vec![ProgramItem::Statement(block(None, vec![const_decl]))]);
+        let (out, _c, _changed, _n) = run_pass(prog);
+        assert_eq!(out.body.len(), 1);
+        assert!(matches!(
+            first_stmt(&out),
+            Statement::Tagged(TaggedStatement::BlockStatement(_))
+        ));
+    }
+
+    #[test]
+    fn block_with_function_declaration_is_not_flattened() {
+        // `{ function f(){} }` — a nested function declaration is block-scoped
+        // (strict mode) / Annex-B special; hoisting it out could change scope or
+        // collide. Keep the block.
+        let fdecl = Statement::Declaration(Declaration::FunctionDeclaration(FunctionDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "f".to_string(),
+            },
+            params: vec![],
+            body: BlockStatement {
+                cv: None,
+                body: vec![],
+            },
+            generator: false,
+            is_async: false,
+        }));
+        let prog = program().with_body(vec![ProgramItem::Statement(block(None, vec![fdecl]))]);
+        let (out, _c, _changed, _n) = run_pass(prog);
+        assert_eq!(out.body.len(), 1);
+        assert!(matches!(
+            first_stmt(&out),
+            Statement::Tagged(TaggedStatement::BlockStatement(_))
+        ));
+    }
+
+    #[test]
+    fn if_true_block_consequent_flattens_to_statements() {
+        // `if (true) { a; } else { b; }` → `a;` — the branch folds to its
+        // consequent block, then that redundant block flattens. This is the
+        // exact divergence #4 case (closurec previously emitted `{a}`).
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: Some("if.1".to_string()),
+            test: boolean(true, None),
+            consequent: Box::new(block(None, vec![expr_stmt(ident("a"), None)])),
+            alternate: Some(Box::new(block(None, vec![expr_stmt(ident("b"), None)]))),
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 1);
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => assert!(
+                matches!(&es.expression, Expression::Identifier(i) if i.name == "a"),
+                "expected the consequent `a;` un-blocked"
+            ),
+            other => panic!("expected `a;` after if-fold + flatten, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flatten_block_inside_function_body() {
+        // `function f(){ { a; } }` → `function f(){ a; }` — exercises the
+        // nested (`fold_block_statement`) flatten path, not just program level.
+        let prog = fdecl_with_body(vec![block(None, vec![expr_stmt(ident("a"), None)])]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed);
+        let body = extract_fn_body(&out);
+        assert_eq!(body.body.len(), 1);
+        assert!(
+            matches!(
+                &body.body[0],
+                Statement::Tagged(TaggedStatement::ExpressionStatement(_))
+            ),
+            "the inner block should flatten inside the function body"
+        );
     }
 }

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -5915,6 +5915,11 @@ mod tests {
         // the load-bearing case: constant-fold turns `2 > 3` into
         // `false`, and only then can fold-control-flow decide the
         // branch — so this exercises the two passes composing.
+        //
+        // CLOC12.194: the selected `else` branch is a bare `{ b(); }` block
+        // with no block-scoped binding, so fold-control-flow now *flattens*
+        // it — the redundant braces are removed and `b()` runs directly,
+        // matching the reference Closure Compiler (which emits `b();`).
         let cfg = CompilerConfig {
             compilation: crate::config::CompilationConfig {
                 level: crate::config::CompilationLevel::Simple,
@@ -5923,7 +5928,10 @@ mod tests {
             ..Default::default()
         };
         let out = transform_source("if (2 > 3) { a(); } else { b(); }", &cfg).expect("ok");
-        assert_eq!(out, "{b()}", "fold-control-flow must keep only the else branch");
+        assert_eq!(
+            out, "b();",
+            "fold-control-flow keeps the else branch AND flattens its redundant block"
+        );
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/README.md
@@ -7,21 +7,33 @@ SIMPLE` (CLOC12.156, PR-2).
 |------|------|
 | `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | Three `if` statements with statically-decidable conditions |
-| `expected.stdout` | `{takeThis()}{alsoKept()};` |
+| `expected.stdout` | `takeThis();alsoKept();;` |
 
 The SIMPLE pipeline is now `constant-fold → fold-control-flow`. Each `if`'s
-condition is decided at compile time and the dead branch is pruned:
+condition is decided at compile time and the dead branch is pruned; the
+surviving branch's block is then **flattened** (CLOC12.194 — a bare `{ … }`
+with no block-scoped binding is redundant, so its braces are removed and the
+statement runs directly in the enclosing list):
 
 | Source | Result |
 |--------|--------|
-| `if (2 > 3) { keepElse(); } else { takeThis(); }` | `{takeThis()}` |
-| `if (true) { alsoKept(); } else { dropped(); }` | `{alsoKept()}` |
+| `if (2 > 3) { keepElse(); } else { takeThis(); }` | `takeThis();` |
+| `if (true) { alsoKept(); } else { dropped(); }` | `alsoKept();` |
 | `if (4 > 5) { vanishes(); }` | `;` (empty statement) |
 
 The `if (2 > 3)` row is the key one: `constant-fold` turns `2 > 3` into
 `false`, and only *then* can `fold-control-flow` keep the `else` branch —
-proving the two passes compose. The same input under `WHITESPACE_ONLY` keeps
-every `if` verbatim.
+proving the two passes compose. Before CLOC12.194 the kept branches emitted as
+bare blocks (`{takeThis()}{alsoKept()}`); now they flatten to `takeThis();` and
+`alsoKept();`, matching the reference Closure Compiler. The same input under
+`WHITESPACE_ONLY` keeps every `if` verbatim.
+
+The trailing `;;` is the residual empty statement from the third `if (4 > 5)`
+(which folds to a bare `;`) plus the `alsoKept();` terminator. Removing that
+stray empty statement is a **pending DCE follow-up** — `fold-control-flow`
+deliberately folds a dead `if` to an `EmptyStatement` and leaves statement-list
+cleanup to a later pass — so the reference-Closure `takeThis();alsoKept();`
+(no double `;`) is not yet reached here.
 
 Regenerate the expected file after an intentional behavior change:
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/expected.stdout
@@ -1,2 +1,1 @@
-{takeThis()}{alsoKept()};
-
+takeThis();alsoKept();;


### PR DESCRIPTION
## CLOC12.194 — redundant `BlockStatement` flattening (oracle divergence #4)

`fold_program` and `fold_block_statement` now flatten a redundant `{ … }` block at statement-list position into its constituent statements. This closes **oracle divergence #4** found by the local Closure differential: closurec previously left a bare block (`{ b(); }`) where the reference Closure Compiler emits `b();`.

### Byte-identity verified against the reference jar
9/11 divergence-#4 probe cases now match exactly (the 2 residuals are a *different* transform — see below):

| input | closurec now | Closure | |
|---|---|---|---|
| `if(true){g(1)}else{g(2)}` | `g(1);` | `g(1);` | ✓ |
| `if(false){g(1)}else{g(2)}` | `g(2);` | `g(2);` | ✓ |
| `if(true){g(1)}` | `g(1);` | `g(1);` | ✓ |
| `if(true){g(1);g(2)}else{…}` | `g(1);g(2);` | `g(1);g(2);` | ✓ |
| `if(true){var x=1;g(x)}else{…}` | `var x=1;g(x);` | `var x=1;g(x);` | ✓ (var hoists) |
| `if(true){}else{g(2)}` | *(empty)* | *(empty)* | ✓ |
| `{g(1)}` | `g(1);` | `g(1);` | ✓ |
| `{g(1);g(2)}` | `g(1);g(2);` | `g(1);g(2);` | ✓ |
| `g(0);{var x=1;g(x)}` | `g(0);var x=1;g(x);` | same | ✓ |

### Soundness
Reuses the existing `block_is_scope_safe_to_hoist` predicate (backs the CLOC25 else-hoist): a block declaring `let`/`const`/`class`/a `function` is **kept** — flattening would leak or collide the binding. A plain `var` is function-scoped and hoists harmlessly. A spliced block ending in a terminator re-arms the dead-code-after-terminator drop.

Fires generically — on a hand-written `{ … }` **and** on the block left behind when `if (true) { … }` collapses to its consequent, so no special-casing in the branch-selection path.

### Tests
- 9 pass-crate unit tests (flatten cases + `let`/`const`/`function` declines; program-level, nested, and if-fold integration).
- Updates one closurec pipeline test: expected output shifts `{b()}` → `b();` (now byte-identical to Closure).
- Full closurec suite (685 tests) + pipeline + dce consumer suites pass under `-D warnings`; clippy clean.

### Out of scope (follow-up)
Empty-statement removal (`if(false){g(1)}` → stray `;`, and the `;;` after a flattened block) is intentionally **not** here: fold-control-flow deliberately folds `if(false)`/`while(false)` to `EmptyStatement` (two tests pin this contract). That cleanup belongs in a separate DCE arc.

Additive; MINOR bump `0.23.0 → 0.24.0`. Follow-up PR2 will add a closurec `tests/diff/` end-to-end fixture + closurec version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)