### PR TITLE
feat: NX-4 — full-digit exact rendering proof + honest constants comments (exact-numbers arc complete)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.12.0] — 2026-07-14 — exact-number arc COMPLETE: computed results render every digit (ADJ-EXACT-NUMBERS NX-4)
+
+### Changed
+
+- **`derived.value` now renders exact-first.** When a `let`/`formula` computation stayed inside
+  exact rational arithmetic (NX-3) and its result has a finite base-10 expansion, the CLI prints
+  **all** of its digits (via the new `ExactRational::to_exact_decimal_string`), mirroring NX-2's
+  exact recall-binding rendering. So a stored 39-digit π fed through the shipped `product` formula
+  and doubled now renders `6.283185307179586476925286766559005768394`, not the f64-truncated
+  `6.283185307179586`. The `f64` (`jnum`) remains the labeled-lossy fallback, used only when there
+  is no exact sidecar or when the value **repeats** (e.g. `1/3`), which no finite decimal can hold.
+  The field stays a JSON number literal — its type is unchanged; only its precision grows for values
+  that were previously truncated. Non-terminating results (e.g. the ideal-gas pressure, a division
+  whose denominator carries a prime other than 2/5) are byte-for-byte unchanged.
+
+### Added
+
+- E2E proofs closing the arc: the shipped `mathematics/constants.adj` binds π, e, and
+  golden_ratio to their **full** published digit strings through the CLI (updated from the previous
+  ~16-digit leading-substring assertion, which hedged that "the runtime binds a double-precision
+  float" — no longer true); and a computed-result test doubles a stored 39-digit π through the
+  shipped `product` formula and asserts the rendered `value` shows all 39 exact digits.
+
 ## [0.11.1] — 2026-07-14 — exact-number bindings render every digit (ADJ-EXACT-NUMBERS NX-2)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -78,6 +78,26 @@ fn jnum(x: f64) -> String {
     }
 }
 
+/// Render a derived value's `"value"` field, **exact-first** (ADJ-EXACT-NUMBERS NX-4).
+///
+/// When a computation stayed inside exact rational arithmetic (NX-3) *and* the result has a
+/// finite base-10 expansion, we print ALL of its digits — the same policy NX-2 gave a stored
+/// `Number::Exact` recall binding. So a stored 39-digit π fed through a shipped `formula` renders
+/// its doubled value to all 39 fractional digits here, instead of the ~16 an `f64` carries.
+///
+/// The `f64` (`jnum`) is the labeled-lossy fallback, used only when there is no exact sidecar or
+/// when the value *repeats* (e.g. `1/3`), which no finite decimal can hold. The emitted digits
+/// remain a JSON number literal, so the field's type is unchanged for every existing consumer;
+/// only its precision grows for values that were previously truncated.
+fn value_json(d: &logic_engine::compute::Derived) -> String {
+    if let Some(exact) = &d.exact {
+        if let Some(s) = exact.to_exact_decimal_string() {
+            return s;
+        }
+    }
+    jnum(d.value)
+}
+
 /// Render the `let`-bound derived values as a JSON array, one object per
 /// distinct binding name, each carrying the engine-computed magnitude plus the
 /// [`Dimension`](logic_engine::dimension::Dimension) tag the engine *inferred*
@@ -131,7 +151,7 @@ fn derived_json(kb: &KnowledgeBase) -> String {
             format!(
                 "{{\"name\":\"{}\",\"value\":{},\"dim\":\"{}\"{}{}}}",
                 esc(&d.name),
-                jnum(d.value),
+                value_json(d),
                 esc(&d.dim.tag()),
                 exact,
                 provenance

--- a/code/packages/rust/adj-lang-cli/tests/facts_mathconstants_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_mathconstants_e2e.rs
@@ -41,6 +41,7 @@ fn mathematics_constants_recall_binds_values_with_citation() {
         "import \"constants.adj\"\n\
          ? math_constant(pi, $V)\n\
          ? math_constant(e, $V)\n\
+         ? math_constant(golden_ratio, $V)\n\
          ? math_constant(unicorn_constant, $V)\n",
     )
     .unwrap();
@@ -49,16 +50,24 @@ fn mathematics_constants_recall_binds_values_with_citation() {
     assert!(ok, "cli should succeed: {out}");
     assert!(out.contains("\"recall\""), "has a recall section: {out}");
 
-    // pi and e bind their MathWorld decimal values. The runtime binds a
-    // double-precision float, so we assert on the leading-digit substring (robust
-    // to how many low-order digits the float prints) rather than all 39 digits.
+    // pi and e bind their MathWorld decimal values to EVERY published digit — the
+    // exact-numbers arc (ADJ-EXACT-NUMBERS NX-1..4) is now complete, so a recall
+    // binding is stored exactly as the `.adj` literal writes it and renders in full,
+    // NOT truncated to the ~16 significant digits an f64 carries. Before this arc the
+    // binding came back as `3.141592653589793`; now the whole 39-digit string does.
     assert!(
-        out.contains("\"V\":\"3.14159265358979"),
-        "pi binds its decimal value: {out}"
+        out.contains("\"V\":\"3.141592653589793238462643383279502884197\""),
+        "pi binds ALL 39 published decimal places, not the f64-truncated ~16: {out}"
     );
     assert!(
-        out.contains("\"V\":\"2.71828182845904"),
-        "e binds its decimal value: {out}"
+        out.contains("\"V\":\"2.718281828459045235360287471352662497757\""),
+        "e binds ALL 39 published decimal places exactly: {out}"
+    );
+    // golden_ratio's literal ends in a trailing zero (…117720), which the canonical
+    // decimal form drops — every SIGNIFICANT digit is still bound exactly.
+    assert!(
+        out.contains("\"V\":\"1.61803398874989484820458683436563811772\""),
+        "golden_ratio binds its full exact decimal: {out}"
     );
 
     // The answer carries the Wolfram MathWorld citation, at the authoritative
@@ -79,5 +88,59 @@ fn mathematics_constants_recall_binds_values_with_citation() {
     assert!(
         out.contains("\"abstained\":true"),
         "unknown constant abstains: {out}"
+    );
+}
+
+/// Path to the shipped elementary-arithmetic formula library (a sibling stdlib).
+fn shipped_arithmetic_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/arithmetic/arithmetic.adj")
+        .canonicalize()
+        .expect("shipped arithmetic.adj must exist")
+}
+
+#[test]
+fn high_precision_constant_computes_exactly_through_shipped_formula() {
+    // The CLOSING proof of the exact-numbers arc (ADJ-EXACT-NUMBERS NX-4): a stored
+    // high-precision constant does not just BIND exactly (test above) — it COMPUTES
+    // exactly and RENDERS the computed result to every digit. We take pi's stored
+    // 39-digit value (copied verbatim from `mathematics/constants.adj`), feed it as an
+    // operand into the shipped `product` formula, and double it. Before the arc this
+    // came back as the f64-truncated `6.283185307179586`; now the CLI's `derived.value`
+    // field carries all 39 fractional digits, because NX-3 ingests the literal into an
+    // exact rational (no f64 hop) and NX-4 renders the exact terminating decimal.
+    let dir = scratch("compute_exact");
+    let lib = std::fs::read_to_string(shipped_arithmetic_lib()).unwrap();
+    std::fs::write(dir.join("arithmetic.adj"), lib).unwrap();
+    // pi to 39 places — the exact value the stdlib ships and stores.
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"arithmetic.adj\"\n\
+         observe factor_one(3.141592653589793238462643383279502884197)\n\
+         observe factor_two(2)\n\
+         ? product(factor_one, factor_two)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"derived\":["), "has a derived section: {out}");
+
+    // 2 · pi = 6.283185307179586476925286766559005768394 — a terminating decimal, so
+    // the exact result renders in FULL, not the ~16-significant-digit f64 export.
+    assert!(
+        out.contains("\"value\":6.283185307179586476925286766559005768394"),
+        "computed 2*pi renders ALL 39 exact digits, not the f64-truncated value: {out}"
+    );
+    // The exact rational sidecar corroborates it: pi's exact 40-digit mantissa over 5·10^38.
+    assert!(
+        out.contains("\"num\":\"3141592653589793238462643383279502884197\""),
+        "the exact-rational sidecar carries pi's full mantissa: {out}"
+    );
+    // The applied primitive still carries its cited provenance — an auditable answer.
+    assert!(
+        out.contains("mathworld.wolfram.com/Product.html")
+            && out.contains("\"trust\":\"authoritative\""),
+        "the computed answer carries the formula's cited provenance: {out}"
     );
 }

--- a/code/packages/rust/bignum-core/CHANGELOG.md
+++ b/code/packages/rust/bignum-core/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the `bignum-core` package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-07-14
+
+### Added
+
+- **`BigDecimal::from_rational_exact(r: &BigRational) -> Option<BigDecimal>`** — the inverse of
+  `to_rational`, and the rendering half of the ADJ exact-numbers arc (NX-4). A reduced fraction
+  `p/q` has a **finite** decimal expansion iff `q`'s only prime factors are `2` and `5` (the primes
+  of base 10); the method strips those factors, and if anything else remains (`3`, `7`, `11`, …) the
+  expansion repeats and it returns `None` (so the caller falls back to a labeled-lossy `f64`). When
+  it terminates, it rebalances to `mantissa / 10^scale` and hands the parts to `from_parts`, so
+  `1/4 → 0.25`, `7/20 → 0.35`, and a doubled 39-digit π
+  (`6283185307179586476925286766559005768394 / 10^39`) renders to all 39 fractional digits, while
+  `1/3` and `2/7` return `None`. Sign rides on the mantissa; zero and integers are the scale-0 case.
+  Round-trips exactly against `to_rational`. Introduced so the logic engine / CLI can print an exact
+  **computed** result with every digit instead of the ~16-significant-digit f64 export.
+
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/code/packages/rust/bignum-core/Cargo.toml
+++ b/code/packages/rust/bignum-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bignum-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A zero-dependency arbitrary-precision numeric core: a signed integer (BigInteger), an exact rational (BigRational), an exact base-10 decimal (BigDecimal), and a correctly-rounded binary float of arbitrary precision (BigDouble) — all built from scratch with no third-party deps and no unsafe."
 license = "MIT"

--- a/code/packages/rust/bignum-core/README.md
+++ b/code/packages/rust/bignum-core/README.md
@@ -215,7 +215,7 @@ Every value is canonical — trailing zeros stripped, zero pinned to `(0, 0)` �
 | Exact arithmetic | `add`/`+`, `sub`/`-`, `mul`/`*`, unary `-`, `abs`, `pow(u32)` |
 | Rounding | `RoundingMode` (`Down`/`Up`/`Floor`/`Ceiling`/`HalfUp`/`HalfDown`/`HalfEven`), `div_round`/`checked_div_round`, `round_to_scale` |
 | Query | `is_zero`, `is_negative`, `is_positive`, `signum`, `mantissa`, `scale`, `significant_digits`, `Ord`/`Eq`/`Hash` |
-| Convert | `to_rational` (**exact** `BigRational`, no `f64` hop — `2.54 → 127/50`), `to_f64` (lossy, correctly rounded) |
+| Convert | `to_rational` (**exact** `BigRational`, no `f64` hop — `2.54 → 127/50`), `from_rational_exact` (its inverse — `Some(decimal)` when the fraction terminates, `None` when it repeats: `1/4 → 0.25`, `1/3 → None`), `to_f64` (lossy, correctly rounded) |
 | I/O | `FromStr` (plain + scientific) with typed `ParseDecimalError`; plain-decimal `Display`/`Debug` |
 
 ## BigDouble — correctly-rounded binary float, any precision (NUM-4)

--- a/code/packages/rust/bignum-core/src/decimal.rs
+++ b/code/packages/rust/bignum-core/src/decimal.rs
@@ -405,6 +405,91 @@ impl BigDecimal {
             BigRational::from_integer(&self.mant * &factor)
         }
     }
+
+    /// The **exact** base-10 expansion of a rational, when a finite one exists — the inverse
+    /// direction of [`to_rational`](Self::to_rational), and the rendering half of the
+    /// ADJ-EXACT-NUMBERS arc (NX-4).
+    ///
+    /// ## When does a fraction have a *finite* decimal?
+    ///
+    /// Write the rational in lowest terms as `p / q` (a [`BigRational`] is always kept reduced
+    /// with a positive denominator). Its base-10 expansion terminates **iff** `q`'s only prime
+    /// factors are the primes of the base, `2` and `5`:
+    ///
+    /// | fraction | reduced `q` | factors of `q` | expansion |
+    /// |---|---|---|---|
+    /// | `1/4`   | `4`    | `2²`      | `0.25`  — terminates |
+    /// | `3/8`   | `8`    | `2³`      | `0.375` — terminates |
+    /// | `7/20`  | `20`   | `2²·5`    | `0.35`  — terminates |
+    /// | `1/3`   | `3`    | `3`       | `0.333…` — **repeats**, no finite decimal |
+    /// | `2/7`   | `7`    | `7`       | `0.285714…` — **repeats** |
+    ///
+    /// So we strip every factor of `2` and `5` out of `q`, counting how many of each; if anything
+    /// but `1` is left over, the expansion repeats and we return `None` (the caller then falls
+    /// back to a labeled-lossy `f64` — a repeating value simply has no exact `BigDecimal`).
+    ///
+    /// ## Building the mantissa when it *does* terminate
+    ///
+    /// After stripping we know `q = 2^a · 5^b`. We want a scale `s` and mantissa `m` with
+    /// `p / q = m / 10^s`. Choosing `s = max(a, b)` makes `10^s / q = 2^(s−a) · 5^(s−b)` a whole
+    /// number, so `m = p · 2^(s−a) · 5^(s−b)` is exact — we scale numerator and denominator by the
+    /// same factor, which cannot change the value. Handing `(m, s)` to [`from_parts`](Self::from_parts)
+    /// (which strips trailing zeros into canonical form) gives the terminating decimal, sign and all.
+    ///
+    /// ```
+    /// # use bignum_core::{BigDecimal, BigRational, BigInteger};
+    /// let quarter = BigRational::from_ints(1, 4);
+    /// assert_eq!(BigDecimal::from_rational_exact(&quarter).unwrap().to_string(), "0.25");
+    /// let third = BigRational::from_ints(1, 3);
+    /// assert!(BigDecimal::from_rational_exact(&third).is_none()); // repeats — no finite decimal
+    /// ```
+    pub fn from_rational_exact(r: &BigRational) -> Option<BigDecimal> {
+        let two = BigInteger::from_i64(2);
+        let five = BigInteger::from_i64(5);
+
+        // Strip factors of 2, then of 5, from the (positive) denominator, tallying each.
+        let mut den = r.denominator().clone();
+        let mut twos: i64 = 0;
+        let mut fives: i64 = 0;
+        loop {
+            let (q, rem) = den.div_rem(&two);
+            if rem.is_zero() {
+                den = q;
+                twos += 1;
+            } else {
+                break;
+            }
+        }
+        loop {
+            let (q, rem) = den.div_rem(&five);
+            if rem.is_zero() {
+                den = q;
+                fives += 1;
+            } else {
+                break;
+            }
+        }
+        // Any leftover prime factor (3, 7, 11, …) ⇒ the expansion repeats ⇒ no finite decimal.
+        if den != BigInteger::one() {
+            return None;
+        }
+
+        // Rebalance so the denominator is exactly 10^scale, scaling the numerator to match.
+        let scale = twos.max(fives);
+        let mut mant = r.numerator().clone();
+        if scale > twos {
+            mant = &mant * &two.pow((scale - twos) as u32);
+        }
+        if scale > fives {
+            mant = &mant * &five.pow((scale - fives) as u32);
+        }
+        // `checked_from_parts` keeps this a **total** function: a value whose exact scale would
+        // exceed `BigDecimal`'s internal scale budget (an astronomically fine fraction like
+        // `1 / 2^8_000_001`) yields `None` — the same "no representable exact decimal" signal a
+        // repeating expansion gives — rather than panicking. In every real caller the rational is
+        // already size-bounded well under the budget, so this branch is defence-in-depth.
+        BigDecimal::checked_from_parts(mant, scale)
+    }
 }
 
 // ===========================================================================
@@ -1254,6 +1339,70 @@ mod tests {
                 .div_round(&BigDecimal::from_i64(dd as i64), target, mode);
             let want = oracle(expect_r, target);
             assert_eq!(got, want, "{n}/{dd} @s{target} {mode:?}");
+        }
+    }
+
+    // ---- from_rational_exact: terminating vs repeating expansions ---------
+
+    #[test]
+    fn from_rational_exact_renders_terminating_decimals() {
+        // Powers-of-2-and-5 denominators all terminate; the string is fully exact.
+        let cases = [
+            (1i64, 4i64, "0.25"),
+            (3, 8, "0.375"),
+            (7, 20, "0.35"),
+            (1, 2, "0.5"),
+            (1, 1, "1"),      // an integer is the scale-0 case
+            (0, 1, "0"),      // zero
+            (5463, 20, "273.15"), // the temperature-conversion offset
+            (1013248623, 10000, "101324.8623"),
+            (-3, 8, "-0.375"), // sign rides on the mantissa
+        ];
+        for (n, d, want) in cases {
+            let r = BigRational::from_ints(n, d);
+            let got = BigDecimal::from_rational_exact(&r)
+                .unwrap_or_else(|| panic!("{n}/{d} should terminate"));
+            assert_eq!(got.to_string(), want, "{n}/{d}");
+        }
+    }
+
+    #[test]
+    fn from_rational_exact_rejects_repeating_decimals() {
+        // Any leftover prime factor (3, 7, 11, …) means the expansion repeats forever,
+        // so no finite BigDecimal can hold it — the caller must fall back to a lossy f64.
+        for (n, d) in [(1i64, 3i64), (2, 7), (5, 6), (1, 11), (22, 7)] {
+            let r = BigRational::from_ints(n, d);
+            assert!(
+                BigDecimal::from_rational_exact(&r).is_none(),
+                "{n}/{d} repeats and must return None"
+            );
+        }
+    }
+
+    #[test]
+    fn from_rational_exact_round_trips_high_precision_pi_times_two() {
+        // The exact-numbers headline: pi to 39 digits, doubled, stays exact end to end.
+        // pi*2 = 6283185307179586476925286766559005768394 / 10^39 — a terminating decimal.
+        let pi2 = BigRational::new(
+            BigInteger::parse_radix("6283185307179586476925286766559005768394", 10).unwrap(),
+            ten_pow(39),
+        );
+        let got = BigDecimal::from_rational_exact(&pi2).expect("pi*2 terminates");
+        assert_eq!(
+            got.to_string(),
+            "6.283185307179586476925286766559005768394",
+            "all 39 fractional digits survive, not the ~16 an f64 carries"
+        );
+    }
+
+    #[test]
+    fn from_rational_exact_inverts_to_rational() {
+        // Round-trip: a terminating BigDecimal → rational → back is byte-identical.
+        for s in ["0.25", "273.15", "101324.8623", "-0.375", "1000", "0"] {
+            let d = BigDecimal::from_str(s).unwrap();
+            let back = BigDecimal::from_rational_exact(&d.to_rational())
+                .expect("a decimal's rational always terminates");
+            assert_eq!(back, d, "round-trip {s}");
         }
     }
 

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.40.0] — 2026-07-14 — exact rendering of a computed result (ADJ-EXACT-NUMBERS NX-4)
+
+### Added
+
+- **`ExactRational::to_exact_decimal_string(&self) -> Option<String>`** — the rendering side of the
+  exact-numbers arc. When the exact-rational result of a computation has a finite base-10 expansion
+  it returns all its digits (`3/4 → "0.75"`; a stored 39-digit π doubled →
+  `"6.283185307179586476925286766559005768394"`); for a repeating expansion (`1/3`) it returns
+  `None`, leaving the caller to fall back to the labeled-lossy `f64` from `to_f64()`. Delegates to
+  the new `BigDecimal::from_rational_exact`. This is the compute-result analogue of NX-2's
+  `Number::Exact` recall rendering: exact by default, `f64` only as a labeled fallback.
+- Compute-layer tests: the doubled-π sidecar renders every digit and is strictly richer than its
+  `f64` form; a repeating quotient (`1/3`) renders `None` while a terminating one (`3/4`) renders
+  `"0.75"`.
+
 ## [0.39.0] — 2026-07-14 — exact compute ingestion of `Number::Exact` (ADJ-EXACT-NUMBERS NX-3)
 
 ### Changed

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -157,6 +157,18 @@ impl ExactRational {
         self.0.to_f64()
     }
 
+    /// The **exact** base-10 expansion as a string, when the value terminates — the rendering
+    /// side of ADJ-EXACT-NUMBERS NX-4. `1/4 → "0.25"`; a stored 39-digit π doubled → all 39
+    /// fractional digits; `1/3 → None` (a repeating expansion no finite decimal can hold).
+    ///
+    /// This is the compute-result analogue of NX-2's `Number::Exact` recall rendering: an exact
+    /// value is shown *exactly* by default, and the `f64` from [`to_f64`](Self::to_f64) is used
+    /// only as the labeled-lossy fallback for the repeating case. See
+    /// [`BigDecimal::from_rational_exact`] for the terminating-vs-repeating test.
+    pub fn to_exact_decimal_string(&self) -> Option<String> {
+        bignum_core::BigDecimal::from_rational_exact(&self.0).map(|d| d.to_string())
+    }
+
     /// Raise to a **non-negative integer** power, exactly (`x^0 = 1`). A rational to a whole
     /// power is itself rational, so `(3/2)^2 = 9/4` stays exact rather than collapsing to the
     /// `f64` `2.25`.
@@ -1982,6 +1994,34 @@ mod tests {
             ExactRational::from_integer_f64((pi_decimal.to_f64() * 2.0).trunc())
                 .unwrap_or_else(|| ExactRational::from_i128(0)),
             "the exact sidecar must not degrade to the truncated f64 value"
+        );
+
+        // NX-4 — the RENDERING half: the exact sidecar prints all 39 fractional digits, where
+        // `to_f64` would collapse to the ~16 a binary float carries. This is the string the CLI
+        // now emits for a computed exact result.
+        assert_eq!(
+            exact.to_exact_decimal_string().as_deref(),
+            Some("6.283185307179586476925286766559005768394"),
+            "a computed exact result renders with every digit, not the f64 export"
+        );
+        assert_ne!(
+            exact.to_exact_decimal_string().as_deref(),
+            Some(format!("{}", exact.to_f64()).as_str()),
+            "the exact rendering is strictly richer than the lossy f64 rendering"
+        );
+    }
+
+    #[test]
+    fn exact_decimal_string_is_none_for_repeating_expansions() {
+        // A quotient like 1/3 has no finite decimal; the render path must fall back to the
+        // labeled-lossy f64 rather than loop forever or fabricate a truncation.
+        let third = ExactRational::new(1, 3).unwrap();
+        assert_eq!(third.to_exact_decimal_string(), None);
+        // But a terminating quotient (3/4) renders exactly.
+        let three_quarters = ExactRational::new(3, 4).unwrap();
+        assert_eq!(
+            three_quarters.to_exact_decimal_string().as_deref(),
+            Some("0.75")
         );
     }
 

--- a/code/specs/data/adj-facts-stdlib/mathematics/constants.adj
+++ b/code/specs/data/adj-facts-stdlib/mathematics/constants.adj
@@ -25,13 +25,16 @@
 % ON DIGITS AND PRECISION. ADJ number literals accept many decimal digits, so each
 % `value` below is written to EXACTLY the digits the source span prints — 39
 % fractional digits, ending where MathWorld's "..." begins; no digit is appended
-% from memory. The full-precision digits therefore live in the LITERAL and in the
-% quoted `source` span, which is where the provenance lives. Note, however, that
-% the runtime binds the value as a double-precision float: `? math_constant(pi,
-% $V)` returns pi rounded to ~15-16 significant digits (3.141592653589793), not
-% all 39. That is a property of the numeric runtime, not of the stored fact — the
-% grounded, full-precision value is the literal, and a consumer needing every digit
-% reads it from there. Keys are lowercase atoms.
+% from memory. The full-precision digits live in the LITERAL and in the quoted
+% `source` span, which is where the provenance lives. Since the exact-numbers arc
+% (ADJ-EXACT-NUMBERS NX-1..4) the value now BINDS and RENDERS exactly to all its
+% digits: `? math_constant(pi, $V)` returns the whole
+% `3.141592653589793238462643383279502884197`, not the ~16 an f64 once carried, and
+% a computed result that consumes it (e.g. `2*pi` through a shipped formula) prints
+% every exact digit too. The literal is stored as a `Number::Exact` big-decimal, the
+% compute engine ingests it as an exact rational with no f64 hop, and the CLI renders
+% the exact value — so the grounded fact and the queryable value are now the SAME
+% full-precision number. Keys are lowercase atoms.
 %
 % PROVENANCE. Every value is copied verbatim from Wolfram MathWorld — the
 % authoritative online mathematics reference (Weisstein, Eric W.). The `source`

--- a/code/specs/data/adj-facts-stdlib/mathematics/constants.query.adj
+++ b/code/specs/data/adj-facts-stdlib/mathematics/constants.query.adj
@@ -18,8 +18,8 @@
 
 import "constants.adj"
 
-? math_constant(pi, $V)             % expect pi's value (runtime rounds to f64: 3.141592653589793)
-? math_constant(e, $V)              % expect e's value  (runtime rounds to f64: 2.718281828459045)
-? math_constant(golden_ratio, $V)   % expect phi        (runtime rounds to f64: 1.618033988749895)
+? math_constant(pi, $V)             % expect pi EXACT: 3.141592653589793238462643383279502884197
+? math_constant(e, $V)              % expect e  EXACT: 2.718281828459045235360287471352662497757
+? math_constant(golden_ratio, $V)   % expect phi EXACT: 1.61803398874989484820458683436563811772
 ? math_constant($C, 3.141592653589793238462643383279502884197) % reverse recall — expect C = pi
 ? math_constant(tau, $V)            % expect abstain — tau is not a row in this table

--- a/code/specs/data/adj-facts-stdlib/physics/physical-constants.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/physical-constants.adj
@@ -32,8 +32,11 @@
 % metrology authority — is the citable artifact; hence `trust authoritative`.
 % Nothing here is asserted from memory. Note how ADJ stores each value: a literal
 % written in scientific notation (`6.62607015e-34`) is kept as its EXACT decimal
-% expansion, so no precision is lost — `? physical_constant(planck_constant, $V)`
-% binds the full exact decimal, not a rounded float. Keys are lowercase atoms.
+% expansion, so no precision is lost. Since the exact-numbers arc (ADJ-EXACT-NUMBERS
+% NX-1..4) this exactness is end-to-end: `? physical_constant(planck_constant, $V)`
+% BINDS and RENDERS the full exact decimal (a `Number::Exact` big-decimal, never a
+% rounded f64), and a formula that consumes the constant computes and prints its
+% result exactly too. Keys are lowercase atoms.
 % (See ../README.md; feedback_nothing_human_authored,
 % feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
 % ============================================================================


### PR DESCRIPTION
## NX-4 — closes the ADJ-EXACT-NUMBERS arc (NX-1..4)

Spec: `code/specs/ADJ-EXACT-NUMBERS.md`. NX-1 (`Number::Exact`), NX-2 (literals lower to `Exact` + full-digit recall rendering), NX-3 (exact compute ingestion, no f64 hop) are merged. NX-4 makes the exactness win **visible and honest** across the shipped constant libraries and extends full-digit rendering to **computed** results.

### What NX-4 proves / refreshes

**Render fix (the one truncation site that remained).** A stored high-precision constant already bound its full digits (NX-2) and computed exactly (NX-3), but the CLI's `derived.value` field still emitted the **f64 export** — `2*pi` rendered `6.283185307179586` even though the exact-rational sidecar (`num/den`) was correct. `derived.value` now renders **exact-first**: a terminating exact result prints every digit; f64 (`jnum`) stays the labeled-lossy fallback, used only when there is no exact sidecar or the value **repeats** (e.g. `1/3`). Non-terminating results (ideal-gas pressure, any division whose denominator carries a prime other than 2/5) are byte-for-byte unchanged.

**New API.** `BigDecimal::from_rational_exact(&BigRational) -> Option<BigDecimal>` — a reduced fraction terminates in base 10 iff its denominator is `2^a·5^b`; returns `None` for a repeating expansion. Total function (`checked_from_parts`, never panics). `ExactRational::to_exact_decimal_string` delegates to it; the CLI calls that.

**Honest comments** (no numeric values changed): refreshed the hedging prose in `mathematics/constants.adj` (dropped "the runtime binds the value as a double-precision float… not all 39"), `mathematics/constants.query.adj`, and `physics/physical-constants.adj` to state truthfully that values now **bind and render exactly to all digits** post exact-numbers arc.

### Test output the new e2e proofs assert

Constant **bind** (shipped `mathematics/constants.adj`, through the CLI):
- pi   → `3.141592653589793238462643383279502884197`
- e    → `2.718281828459045235360287471352662497757`
- golden_ratio → `1.61803398874989484820458683436563811772` (literal's trailing zero drops; every significant digit exact)

Computed **result** (stored 39-digit pi doubled through the shipped `product` formula):
- `derived.value` → `6.283185307179586476925286766559005768394` (all 39 digits, not the f64 `6.283185307179586`)
- exact sidecar `num` → `3141592653589793238462643383279502884197`, carrying the cited `mathworld.wolfram.com/Product.html` provenance

One existing e2e assertion updated: `facts_mathconstants_e2e.rs` previously asserted a ~16-digit **leading substring** (`"V":"3.14159265358979`) and its comment hedged that "the runtime binds a double-precision float" — replaced with full-digit equality for pi/e/golden_ratio. That is the intended improvement (the hedge is no longer true).

### Gate (green, zero regressions)

`cargo test` — bignum-core **113**, logic-core **23**, logic-engine **205**, adj-lang **173**, adj-lang-cli **156** (all `0 failed`). `cargo clippy -D warnings` clean on every touched crate. Security review passed — one INFO-level hardening applied (made `from_rational_exact` a total function via `checked_from_parts`).

**The ADJ exact-numbers arc (NX-1 → NX-4) is now COMPLETE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)