### PR TITLE
feat(closure-pass-dce): strip stray top-level empty statements (CLOC12.195)

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.24.0] - 2026-07-15
+
+### Added — CLOC12.195: strip stray top-level `EmptyStatement`s
+
+`dce_program` now sweeps bare `EmptyStatement`s (`;`) out of the **program body**,
+mirroring the sweep `dce_block_statement` already performs on block bodies. An
+empty statement at statement-list position is a pure no-op, so removing it is
+byte-safe. These arise from a hand-written `;`, from `constant-fold` /
+`fold-control-flow` folding `if (false) …` / `while (false) …` to an
+`EmptyStatement`, and — new in this cycle — from the trailing `;` a flattened
+block leaves behind (`g(0);{g(1)};g(2)` → `g(0);g(1);;g(2)` → `g(0);g(1);g(2)`),
+closing the CLOC12.194 residual. Verified byte-identical to the reference Closure
+Compiler: `;`→removed, `;;;`→removed, `g(0);;g(1)`→`g(0);g(1)`, `;g(1)`→`g(1)`,
+`if(false){g(1)}`→removed. A `for (…) ;` / `if (c) ;` empty *substatement* is a
+loop/if body, NOT a statement-list member, so it never reaches this sweep and
+stays intact — exactly as Closure keeps it. Adds an `is_empty_program_item`
+predicate and records a `removed-empty-statement` deletion (tombstoning each
+swept span for `--correlation_vector`). Additive; MINOR bump 0.23.0 → 0.24.0.
+
 ## [0.23.0] - 2026-07-12
 
 ### Added — CLOC12.189 PR1: export declaration rebuild clones the export; the removability predicate treats an export as live

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -293,6 +293,37 @@ fn dce_program(prog: &Program, st: &mut DceState) -> Program {
         );
     }
 
+    // Strip stray top-level `EmptyStatement`s (`;`) — CLOC12.195.
+    //
+    // Like `debugger`, an empty statement at statement-list position is a pure
+    // no-op, so the program body needs its own sweep separate from
+    // `dce_block_statement`'s (which already does this for block bodies). These
+    // arise from a hand-written `;`, from `constant-fold`/`fold-control-flow`
+    // folding `if (false) …;` / `while (false) …;` to an `EmptyStatement`, and
+    // from the trailing `;` a flattened block leaves behind
+    // (`g(0);{g(1)};g(2)` → `g(0);g(1);;g(2)` → `g(0);g(1);g(2)`). Upstream
+    // Closure removes them all; matching it here removes the last stray `;`.
+    // A `for (…) ;` / `if (c) ;` empty *substatement* is a loop/if body, NOT a
+    // statement-list member, so it never reaches this sweep — it stays intact,
+    // exactly as Closure keeps it.
+    let before_empty_drop = new_body.len();
+    let removed_empty_cvs: Vec<Option<String>> = new_body
+        .iter()
+        .filter(|item| is_empty_program_item(item))
+        .map(program_item_cv)
+        .collect();
+    new_body.retain(|item| !is_empty_program_item(item));
+    let dropped_empties = before_empty_drop - new_body.len();
+    if dropped_empties > 0 {
+        st.record_deletion(
+            &removed_empty_cvs,
+            &prog.cv,
+            "removed-empty-statement",
+            &format!("program with {} top-level items", before_empty_drop),
+            &format!("dropped {} top-level empty statements", dropped_empties),
+        );
+    }
+
     Program {
         cv: prog.cv.clone(),
         version: prog.version,
@@ -1076,6 +1107,15 @@ fn is_debugger_program_item(item: &ProgramItem) -> bool {
     matches!(item, ProgramItem::Statement(s) if is_debugger_statement(s))
 }
 
+/// Is this top-level item a bare `EmptyStatement` (`;`)? Mirrors
+/// [`is_empty_statement`] for the `ProgramItem` list, so [`dce_program`] can
+/// sweep stray semicolons out of the program body the same way
+/// [`dce_block_statement`] sweeps them out of a block body. An `EmptyStatement`
+/// only ever appears as a `ProgramItem::Statement`, never a `Declaration`.
+fn is_empty_program_item(item: &ProgramItem) -> bool {
+    matches!(item, ProgramItem::Statement(s) if is_empty_statement(s))
+}
+
 /// Fetch a statement's own correlation-vector id, if it carries one.
 ///
 /// DCE's deletion sites need the *removed* node's CV id — not just the
@@ -1801,6 +1841,65 @@ mod tests {
             .as_ref()
             .expect("a stripped top-level debugger must be tombstoned");
         assert_eq!(del.reason, "removed-debugger");
+    }
+
+    #[test]
+    fn top_level_empty_statement_is_removed() {
+        // `keep(); ;` at PROGRAM level → `keep();` — CLOC12.195. Before this the
+        // program-body sweep only stripped `debugger`, leaving stray top-level
+        // `;` behind (block bodies were already cleaned by `dce_block_statement`).
+        let prog = program().with_body(vec![
+            ProgramItem::Statement(expr_stmt(ident("keep"))),
+            ProgramItem::Statement(empty_stmt()),
+        ]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed, "a stray top-level `;` should be removed");
+        assert_eq!(out.body.len(), 1, "only the kept statement survives");
+        assert!(matches!(
+            &out.body[0],
+            ProgramItem::Statement(Statement::Tagged(TaggedStatement::ExpressionStatement(_)))
+        ));
+    }
+
+    #[test]
+    fn multiple_top_level_empty_statements_all_removed() {
+        // `; ; keep(); ;` → `keep();` — leading, interior, and trailing empties.
+        let prog = program().with_body(vec![
+            ProgramItem::Statement(empty_stmt()),
+            ProgramItem::Statement(empty_stmt()),
+            ProgramItem::Statement(expr_stmt(ident("keep"))),
+            ProgramItem::Statement(empty_stmt()),
+        ]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 1, "all three empties swept, `keep` remains");
+    }
+
+    #[test]
+    fn top_level_empty_statement_removal_tombstones_the_statement() {
+        // The program-body empty sweep is a separate code path from the
+        // block-body sweep, so it gets its own tombstone test (mirrors the
+        // top-level debugger tombstone test).
+        let mut log = CVLog::new(true);
+        let empty_id = log.create(None);
+        let empty = Statement::empty_statement(EmptyStatement {
+            cv: Some(empty_id.clone()),
+        });
+        let prog = program().with_body(vec![
+            ProgramItem::Statement(expr_stmt(ident("keep"))),
+            ProgramItem::Statement(empty),
+        ]);
+
+        let _out = run_pass_capturing_cv(&prog, &mut log);
+
+        let del = log
+            .get(&empty_id)
+            .unwrap()
+            .deleted
+            .as_ref()
+            .expect("a stripped top-level empty statement must be tombstoned");
+        assert_eq!(del.source, "dce");
+        assert_eq!(del.reason, "removed-empty-statement");
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/README.md
@@ -7,7 +7,7 @@ SIMPLE` (CLOC12.156, PR-2).
 |------|------|
 | `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | Three `if` statements with statically-decidable conditions |
-| `expected.stdout` | `takeThis();alsoKept();;` |
+| `expected.stdout` | `takeThis();alsoKept();` |
 
 The SIMPLE pipeline is now `constant-fold → fold-control-flow`. Each `if`'s
 condition is decided at compile time and the dead branch is pruned; the
@@ -19,7 +19,7 @@ statement runs directly in the enclosing list):
 |--------|--------|
 | `if (2 > 3) { keepElse(); } else { takeThis(); }` | `takeThis();` |
 | `if (true) { alsoKept(); } else { dropped(); }` | `alsoKept();` |
-| `if (4 > 5) { vanishes(); }` | `;` (empty statement) |
+| `if (4 > 5) { vanishes(); }` | *(removed — empty statement)* |
 
 The `if (2 > 3)` row is the key one: `constant-fold` turns `2 > 3` into
 `false`, and only *then* can `fold-control-flow` keep the `else` branch —
@@ -28,12 +28,11 @@ bare blocks (`{takeThis()}{alsoKept()}`); now they flatten to `takeThis();` and
 `alsoKept();`, matching the reference Closure Compiler. The same input under
 `WHITESPACE_ONLY` keeps every `if` verbatim.
 
-The trailing `;;` is the residual empty statement from the third `if (4 > 5)`
-(which folds to a bare `;`) plus the `alsoKept();` terminator. Removing that
-stray empty statement is a **pending DCE follow-up** — `fold-control-flow`
-deliberately folds a dead `if` to an `EmptyStatement` and leaves statement-list
-cleanup to a later pass — so the reference-Closure `takeThis();alsoKept();`
-(no double `;`) is not yet reached here.
+The third `if (4 > 5)` folds to a bare `EmptyStatement` (`;`); as of CLOC12.195
+DCE sweeps that stray top-level `;` out, so the output is exactly
+`takeThis();alsoKept();` — byte-identical to the reference Closure Compiler
+(before CLOC12.195 a residual `;;` remained). `fold-control-flow` still
+deliberately produces the `EmptyStatement`; DCE removes it afterward.
 
 Regenerate the expected file after an intentional behavior change:
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-control-flow/expected.stdout
@@ -1,1 +1,1 @@
-takeThis();alsoKept();;
+takeThis();alsoKept();


### PR DESCRIPTION
## CLOC12.195 — strip stray top-level `EmptyStatement`s (DCE)

`dce_program` now sweeps bare `;` out of the **program body**, mirroring the sweep `dce_block_statement` already performs on block bodies. An empty statement at statement-list position is a pure no-op, so removing it is byte-safe. This also closes the `;;` residual the CLOC12.194 block-flatten left behind.

### Byte-identity verified against the reference jar (0/7 divergences)
| input | closurec now | Closure | |
|---|---|---|---|
| `;` | *(removed)* | *(removed)* | ✓ |
| `;;;` | *(removed)* | *(removed)* | ✓ |
| `g(0);;g(1)` | `g(0);g(1);` | `g(0);g(1);` | ✓ |
| `;g(1)` | `g(1);` | `g(1);` | ✓ |
| `if(false){g(1)}` | *(removed)* | *(removed)* | ✓ |
| `g(0);{g(1)};g(2)` | `g(0);g(1);g(2);` | same | ✓ (block-flatten `;;` residual gone) |
| `for(var i=0;i<9;i++);` | *(unchanged)* | *(unchanged)* | ✓ (substatement preserved) |

### Soundness
A `for (…) ;` / `if (c) ;` empty **substatement** is a loop/if body, **not** a statement-list member, so it never reaches this program-body sweep and stays intact — exactly as Closure keeps it. `fold-control-flow` still deliberately folds a dead `if`/`while` to an `EmptyStatement` (pinned by its own tests); DCE removes it afterward.

Adds `is_empty_program_item`, records a `removed-empty-statement` deletion (tombstoning each swept span for `--correlation_vector`). Three unit tests (single / multiple / tombstone).

### Tests
- DCE crate: 59 lib tests pass (3 new) under `-D warnings`; clippy clean.
- Updates the closurec `simple-fold-control-flow` fixture: output tightens `takeThis();alsoKept();;` → `takeThis();alsoKept();`. Full closurec suite (926) passes.

Additive; MINOR bump `0.23.0 → 0.24.0`. Follow-up PR2 will add a dedicated closurec `tests/diff/` fixture + closurec version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)