### PR TITLE
feat(closure-pass-constant-fold): fold array-literal index access [a,b,c][K] (CLOC12.196)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.91.0] - 2026-07-15
+
+### Added — fold array-literal index access `[a, b, c][K]` → element — CLOC12.196
+
+`fold_member`'s computed-access path (`arr[K]`) now folds a constant integer index
+into the selected element, the companion to the CLOC12.193 array-`.length` fold.
+`[1,2,3][1]` → `2`, `[a,b,c][1]` → `b`, nested `[[1,2],[3,4]][1][0]` → `3`. Guards
+keep it byte-identical to the reference Closure Compiler (verified against the real
+jar): no spread anywhere (`[1,...x][0]` declines — indices are runtime-unknown); the
+index is a non-negative integer literal in range (a NumericLiteral is never negative
+in the AST, and a fractional / out-of-range index is not a canonical array index, so
+`[1,2,3][1.5]` / `[1,2,3][5]` / `[1,2,3][-1]` are left intact); the element at `K` is
+present (a hole is left, pending the `void 0` follow-up); and every element EXCEPT
+the selected one is side-effect-free — the SELECTED element is preserved verbatim, so
+`[a, b()][1]` folds to `b()` (its call still runs) while `[a, b()][0]` declines (it
+would drop `b()`). CV provenance recorded per fold. Three unit tests (fold cases +
+selected-side-effect preservation + each decline). Out of scope for this PR (a tight
+follow-up needing `void 0` construction): out-of-bounds / selected-hole → `void 0`,
+and canonical string-index keys (`[1,2,3]["0"]` → `1`). Additive; MINOR 0.90.0 → 0.91.0.
+
 ## [0.90.0] - 2026-07-14
 
 ### Added — fold array-literal `.length` → element count — CLOC12.193

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.90.0"
+version = "0.91.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -3918,6 +3918,57 @@ fn fold_member(m: &MemberExpression, st: &mut FoldState) -> Expression {
                 }
             }
         }
+    } else {
+        // `[e0, e1, …][K]` → the K-th element (CLOC12.196). Computed index access
+        // with a constant integer index folds to the element at that index,
+        // mirroring the array-`.length` fold. Guards keep it byte-identical to
+        // Closure:
+        //   1. no spread element anywhere — a spread (`[...x]`) makes the runtime
+        //      indices statically unknown, so decline;
+        //   2. K is a non-negative integer literal in range (`0 ≤ K < len`). A
+        //      NumericLiteral is never negative in the AST (`-1` is a unary
+        //      expression), and a fractional or out-of-range index is not a
+        //      canonical array index, so both decline here — matching Closure,
+        //      which leaves `[1,2,3][1.5]` / `[1,2,3][5]` / `[1,2,3][-1]` intact
+        //      (the out-of-bounds / hole `void 0` result is a follow-up);
+        //   3. the element at K is PRESENT (a hole reads as `undefined`, a
+        //      `void 0` result left to the follow-up);
+        //   4. every element EXCEPT the selected one is side-effect-free. The
+        //      SELECTED element is preserved verbatim — its own side effect still
+        //      runs (`[a, b()][1]` → `b()`) — but dropping the *other* elements
+        //      must not drop a side effect, so `[a, b()][0]` declines.
+        if let (Expression::ArrayExpression(a), Expression::NumericLiteral(k)) =
+            (&object, &property)
+        {
+            let has_spread = a
+                .elements
+                .iter()
+                .any(|el| matches!(el, Some(Expression::SpreadElement(_))));
+            let in_range = k.value.is_finite()
+                && k.value >= 0.0
+                && k.value.fract() == 0.0
+                && (k.value as usize) < a.elements.len();
+            if !has_spread && in_range {
+                let idx = k.value as usize;
+                if let Some(selected) = &a.elements[idx] {
+                    let others_free = a
+                        .elements
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| *i != idx)
+                        .all(|(_, el)| el.as_ref().is_none_or(is_side_effect_free));
+                    if others_free {
+                        let parent = m.cv.clone();
+                        let before = format!("array-literal[{}][{}]", a.elements.len(), idx);
+                        let after = format!("element[{idx}]");
+                        // Records the fold (and sets `changed`); the selected
+                        // element keeps its own cv for span provenance.
+                        let _new_cv = st.fork_cv(&parent, &before, &after);
+                        return selected.clone();
+                    }
+                }
+            }
+        }
     }
 
     Expression::MemberExpression(MemberExpression {
@@ -6714,6 +6765,129 @@ mod tests {
         );
         let (_out, _, changed, _) = run_pass(program_with_expr(m_spread, true));
         assert!(!changed, "[1,2,...x].length must not fold — spread length is unknown");
+    }
+
+    /// Build a computed index access `object[k]` (an integer-literal index).
+    fn index(object: Expression, k: f64) -> Expression {
+        Expression::MemberExpression(MemberExpression {
+            cv: Some("m.cv".to_string()),
+            object: Box::new(object),
+            property: Box::new(num(k, None)),
+            computed: true,
+        })
+    }
+
+    /// CLOC12.196: `[e0, e1, …][K]` folds to the element at index `K` when `K` is
+    /// an in-bounds non-negative integer, the element is present, no spread
+    /// exists, and every *other* element is side-effect-free. Verified against
+    /// the reference Closure Compiler.
+    #[test]
+    fn fold_array_index_when_in_bounds_and_pure() {
+        // `[1, 2, 3][0]` → 1, `[1, 2, 3][1]` → 2, `[1, 2, 3][2]` → 3.
+        for (k, want) in [(0.0, 1.0), (1.0, 2.0), (2.0, 3.0)] {
+            let e = index(
+                array_opt(vec![
+                    Some(num(1.0, None)),
+                    Some(num(2.0, None)),
+                    Some(num(3.0, None)),
+                ]),
+                k,
+            );
+            let (out, _, changed, _) = run_pass(program_with_expr(e, true));
+            assert!(changed, "[1,2,3][{k}] should fold");
+            match extract_expr(&out) {
+                Expression::NumericLiteral(n) => assert_eq!(n.value, want, "[1,2,3][{k}]"),
+                other => panic!("expected {want}; got {other:?}"),
+            }
+        }
+
+        // `[a, b, c][1]` → `b` — identifier elements are side-effect-free.
+        let e = index(
+            array_opt(vec![Some(ident("a")), Some(ident("b")), Some(ident("c"))]),
+            1.0,
+        );
+        let (out, _, changed, _) = run_pass(program_with_expr(e, true));
+        assert!(changed);
+        match extract_expr(&out) {
+            Expression::Identifier(id) => assert_eq!(id.name, "b"),
+            other => panic!("expected ident b; got {other:?}"),
+        }
+
+        // `[1, , 3][0]` → 1 — a hole ELSEWHERE (index 1) doesn't block index 0.
+        let e = index(
+            array_opt(vec![Some(num(1.0, None)), None, Some(num(3.0, None))]),
+            0.0,
+        );
+        let (out, _, changed, _) = run_pass(program_with_expr(e, true));
+        assert!(changed);
+        match extract_expr(&out) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, 1.0),
+            other => panic!("expected 1; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fold_array_index_preserves_side_effect_in_selected_element() {
+        // `[a, g()][1]` → `g()` — the SELECTED element is preserved verbatim, so
+        // its call still runs; the other element `a` is pure and safely dropped.
+        let call = Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident("g")),
+            arguments: vec![],
+        });
+        let e = index(array_opt(vec![Some(ident("a")), Some(call)]), 1.0);
+        let (out, _, changed, _) = run_pass(program_with_expr(e, true));
+        assert!(changed, "[a,g()][1] should fold to the (preserved) call");
+        assert!(
+            matches!(extract_expr(&out), Expression::CallExpression(_)),
+            "expected the selected call to survive"
+        );
+    }
+
+    #[test]
+    fn array_index_declines_on_side_effect_hole_oob_or_spread() {
+        // `[a, g()][0]` — selecting `a` would DROP `g()`, a side effect → decline.
+        let call = Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident("g")),
+            arguments: vec![],
+        });
+        let e = index(array_opt(vec![Some(ident("a")), Some(call)]), 0.0);
+        let (_out, _, changed, _) = run_pass(program_with_expr(e, true));
+        assert!(!changed, "[a,g()][0] must not fold — would drop the call g()");
+
+        // `[1, , 3][1]` — the SELECTED slot is a hole → `undefined`; left to the
+        // `void 0` follow-up, so decline for now.
+        let e = index(
+            array_opt(vec![Some(num(1.0, None)), None, Some(num(3.0, None))]),
+            1.0,
+        );
+        let (_out, _, changed, _) = run_pass(program_with_expr(e, true));
+        assert!(!changed, "[1,,3][1] selects a hole — must not fold (yet)");
+
+        // `[1, 2, 3][5]` — out of bounds → `undefined`; decline (follow-up).
+        let e = index(
+            array_opt(vec![
+                Some(num(1.0, None)),
+                Some(num(2.0, None)),
+                Some(num(3.0, None)),
+            ]),
+            5.0,
+        );
+        let (_out, _, changed, _) = run_pass(program_with_expr(e, true));
+        assert!(!changed, "[1,2,3][5] is out of bounds — must not fold (yet)");
+
+        // `[1, 2, ...x][0]` — a spread makes runtime indices unknown → decline.
+        let spread = Expression::SpreadElement(SpreadElement {
+            cv: None,
+            argument: Box::new(ident("x")),
+        });
+        let e = index(
+            array_opt(vec![Some(num(1.0, None)), Some(num(2.0, None)), Some(spread)]),
+            0.0,
+        );
+        let (_out, _, changed, _) = run_pass(program_with_expr(e, true));
+        assert!(!changed, "[1,2,...x][0] must not fold — spread indices unknown");
     }
 
     #[test]


### PR DESCRIPTION
## CLOC12.196 — constant-fold array-literal index access `[a,b,c][K]`

`fold_member`'s computed-access path now folds `[e0..en][K]` to the element at a constant integer index — the companion to [#8336](https://github.com/adhithyan15/coding-adventures/pull/8336) (array-`.length`), reusing the same `is_side_effect_free` predicate. Found via a fresh differential over the local Closure jar.

### Byte-identity verified against the reference jar (10/12 corpus cases)
| input | closurec now | Closure | |
|---|---|---|---|
| `[1,2,3][0/1/2]` | `1`/`2`/`3` | same | ✓ |
| `[a,b,c][1]` | `b` | `b` | ✓ |
| `[1,,3][0]` | `1` | `1` | ✓ (hole elsewhere) |
| `[a,b()][1]` | `b()` | `b()` | ✓ (selected effect preserved) |
| `[[1,2],[3,4]][1][0]` | `3` | `3` | ✓ (nested) |
| `[a,b()][0]` | *(unchanged)* | *(unchanged)* | ✓ decline (would drop `b()`) |
| `[1,...x,3][0]` | *(unchanged)* | *(unchanged)* | ✓ decline (spread) |
| `[1,2,3][1.5]` | *(unchanged)* | *(unchanged)* | ✓ decline (non-integer) |

### Soundness (four guards)
1. **no spread** anywhere — a spread makes runtime indices statically unknown;
2. **K is a non-negative integer literal in range** — a `NumericLiteral` is never negative in the AST, and fractional / out-of-range indices are not canonical array indices, so `[1,2,3][1.5]` / `[5]` / `[-1]` stay intact (matching Closure);
3. **element at K is present** — a hole reads as `undefined` (`void 0` follow-up);
4. **every element except the selected one is side-effect-free** — the *selected* element is preserved verbatim (its effect still runs: `[a,b()][1]`→`b()`), but dropping the *others* must not drop a side effect.

The `f64 as usize` index cast is bounds-checked (`< len`) before the single array access and saturates on overflow, so an out-of-range value fails the guard rather than wrapping.

### Tests
- 3 unit tests (fold cases + selected-side-effect preservation + each decline); constant-fold suite 348 pass under `-D warnings`, clippy clean.
- Full closurec suite (926) passes; no fixture drift.

### Out of scope (follow-up)
Out-of-bounds / selected-hole → `void 0`, and canonical string-index keys (`[1,2,3]["0"]`→`1`) — both need `void 0` construction.

Additive; MINOR bump `0.90.0 → 0.91.0`. Follow-up PR2 = closurec `tests/diff/` fixture + closurec version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)