### PR TITLE
feat: port tree set to Lua and Perl

### DIFF
--- a/code/packages/lua/tree-set/BUILD
+++ b/code/packages/lua/tree-set/BUILD
@@ -1,0 +1,3 @@
+luarocks show coding-adventures-avl-tree >/dev/null 2>&1 || (cd ../avl-tree && luarocks make --local --deps-mode=none coding-adventures-avl-tree-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-tree-set-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../avl-tree/src/?.lua;../../avl-tree/src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/tree-set/BUILD_windows
+++ b/code/packages/lua/tree-set/BUILD_windows
@@ -1,0 +1,3 @@
+luarocks show coding-adventures-avl-tree 1>nul 2>nul || (cd ..\avl-tree && luarocks make --local --deps-mode=none coding-adventures-avl-tree-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-tree-set-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;..\..\avl-tree\src\?.lua;..\..\avl-tree\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/tree-set/CHANGELOG.md
+++ b/code/packages/lua/tree-set/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-15
+
+- Add a pure-Lua AVL-backed ordered set with mutation, rank, selection, ranges,
+  custom comparison, iteration, and set algebra.

--- a/code/packages/lua/tree-set/README.md
+++ b/code/packages/lua/tree-set/README.md
@@ -1,0 +1,26 @@
+# Lua tree set
+
+An AVL-backed mutable ordered set with duplicate suppression, sorted iteration,
+rank and selection helpers, range queries, custom comparison, and set algebra.
+The AVL backend keeps insertion, deletion, and lookup logarithmic while set
+operations return independent sets.
+
+```lua
+local TreeSet = require("coding_adventures.tree_set").TreeSet
+
+local set = TreeSet.from_values({5, 1, 3, 3, 9})
+set:add(7)
+assert(set:contains(7))
+assert(set:kth_smallest(3) == 5)
+assert(set:backend():is_valid_avl())
+```
+
+`add` returns the set for chaining. `delete`, `remove`, and `discard` mutate the
+set and report whether a value was present. Union, intersection, difference,
+and symmetric difference leave both inputs unchanged.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/lua/tree-set/coding-adventures-tree-set-0.1.0-1.rockspec
+++ b/code/packages/lua/tree-set/coding-adventures-tree-set-0.1.0-1.rockspec
@@ -1,0 +1,19 @@
+package = "coding-adventures-tree-set"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "AVL-backed ordered set with rank, range, and set algebra",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+    "coding-adventures-avl-tree >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.tree_set"] = "src/coding_adventures/tree_set/init.lua",
+    },
+}

--- a/code/packages/lua/tree-set/required_capabilities.json
+++ b/code/packages/lua/tree-set/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/tree-set",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/tree-set/src/coding_adventures/tree_set/init.lua
+++ b/code/packages/lua/tree-set/src/coding_adventures/tree_set/init.lua
@@ -1,0 +1,401 @@
+local avl = require("coding_adventures.avl_tree")
+
+local M = {VERSION = "0.1.0"}
+
+local function lower_bound(items, value, compare)
+    local low = 1
+    local high = #items + 1
+    while low < high do
+        local middle = math.floor((low + high) / 2)
+        if compare(items[middle], value) < 0 then
+            low = middle + 1
+        else
+            high = middle
+        end
+    end
+    return low
+end
+
+local function upper_bound(items, value, compare)
+    local low = 1
+    local high = #items + 1
+    while low < high do
+        local middle = math.floor((low + high) / 2)
+        if compare(items[middle], value) <= 0 then
+            low = middle + 1
+        else
+            high = middle
+        end
+    end
+    return low
+end
+
+local function merge_unique(left, right, compare)
+    local result = {}
+    local left_index = 1
+    local right_index = 1
+    while left_index <= #left and right_index <= #right do
+        local order = compare(left[left_index], right[right_index])
+        if order < 0 then
+            result[#result + 1] = left[left_index]
+            left_index = left_index + 1
+        elseif order > 0 then
+            result[#result + 1] = right[right_index]
+            right_index = right_index + 1
+        else
+            result[#result + 1] = left[left_index]
+            left_index = left_index + 1
+            right_index = right_index + 1
+        end
+    end
+    while left_index <= #left do
+        result[#result + 1] = left[left_index]
+        left_index = left_index + 1
+    end
+    while right_index <= #right do
+        result[#result + 1] = right[right_index]
+        right_index = right_index + 1
+    end
+    return result
+end
+
+local function intersection_sorted(left, right, compare)
+    local result = {}
+    local left_index = 1
+    local right_index = 1
+    while left_index <= #left and right_index <= #right do
+        local order = compare(left[left_index], right[right_index])
+        if order < 0 then
+            left_index = left_index + 1
+        elseif order > 0 then
+            right_index = right_index + 1
+        else
+            result[#result + 1] = left[left_index]
+            left_index = left_index + 1
+            right_index = right_index + 1
+        end
+    end
+    return result
+end
+
+local function difference_sorted(left, right, compare)
+    local result = {}
+    local left_index = 1
+    local right_index = 1
+    while left_index <= #left and right_index <= #right do
+        local order = compare(left[left_index], right[right_index])
+        if order < 0 then
+            result[#result + 1] = left[left_index]
+            left_index = left_index + 1
+        elseif order > 0 then
+            right_index = right_index + 1
+        else
+            left_index = left_index + 1
+            right_index = right_index + 1
+        end
+    end
+    while left_index <= #left do
+        result[#result + 1] = left[left_index]
+        left_index = left_index + 1
+    end
+    return result
+end
+
+local function symmetric_difference_sorted(left, right, compare)
+    local result = {}
+    local left_index = 1
+    local right_index = 1
+    while left_index <= #left and right_index <= #right do
+        local order = compare(left[left_index], right[right_index])
+        if order < 0 then
+            result[#result + 1] = left[left_index]
+            left_index = left_index + 1
+        elseif order > 0 then
+            result[#result + 1] = right[right_index]
+            right_index = right_index + 1
+        else
+            left_index = left_index + 1
+            right_index = right_index + 1
+        end
+    end
+    while left_index <= #left do
+        result[#result + 1] = left[left_index]
+        left_index = left_index + 1
+    end
+    while right_index <= #right do
+        result[#result + 1] = right[right_index]
+        right_index = right_index + 1
+    end
+    return result
+end
+
+local function is_subset_sorted(left, right, compare)
+    local left_index = 1
+    local right_index = 1
+    while left_index <= #left and right_index <= #right do
+        local order = compare(left[left_index], right[right_index])
+        if order < 0 then
+            return false
+        end
+        if order > 0 then
+            right_index = right_index + 1
+        else
+            left_index = left_index + 1
+            right_index = right_index + 1
+        end
+    end
+    return left_index > #left
+end
+
+local function is_disjoint_sorted(left, right, compare)
+    local left_index = 1
+    local right_index = 1
+    while left_index <= #left and right_index <= #right do
+        local order = compare(left[left_index], right[right_index])
+        if order < 0 then
+            left_index = left_index + 1
+        elseif order > 0 then
+            right_index = right_index + 1
+        else
+            return false
+        end
+    end
+    return true
+end
+
+local TreeSet = {}
+TreeSet.__index = TreeSet
+
+local function is_tree_set(value)
+    return type(value) == "table" and getmetatable(value) == TreeSet
+end
+
+local function require_tree_set(value)
+    if not is_tree_set(value) then
+        error("other must be a TreeSet", 3)
+    end
+end
+
+function TreeSet.new(values, compare)
+    local initial = values
+    if initial == nil then
+        initial = {}
+    elseif type(initial) ~= "table" then
+        error("values must be a table", 2)
+    end
+    local comparator = compare or avl.default_compare
+    if type(comparator) ~= "function" then
+        error("compare must be a function", 2)
+    end
+
+    local self = setmetatable({
+        _tree = avl.AVLTree.empty(comparator),
+        _compare = comparator,
+    }, TreeSet)
+    for _, value in ipairs(initial) do
+        self:add(value)
+    end
+    return self
+end
+
+function TreeSet.empty(compare)
+    return TreeSet.new({}, compare)
+end
+
+function TreeSet.from_values(values, compare)
+    return TreeSet.new(values, compare)
+end
+
+function TreeSet:backend()
+    return self._tree
+end
+
+function TreeSet:add(value)
+    if value == nil then
+        error("value must not be nil", 2)
+    end
+    self._tree = self._tree:insert(value)
+    return self
+end
+
+TreeSet.insert = TreeSet.add
+
+function TreeSet:delete(value)
+    if value == nil then
+        return false
+    end
+    if not self._tree:contains(value) then
+        return false
+    end
+    self._tree = self._tree:delete(value)
+    return true
+end
+
+TreeSet.remove = TreeSet.delete
+TreeSet.discard = TreeSet.delete
+
+function TreeSet:has(value)
+    if value == nil then
+        return false
+    end
+    return self._tree:contains(value)
+end
+
+TreeSet.contains = TreeSet.has
+
+function TreeSet:size()
+    return self._tree:size()
+end
+
+function TreeSet:length()
+    return self:size()
+end
+
+function TreeSet:is_empty()
+    return self:size() == 0
+end
+
+function TreeSet:min()
+    return self._tree:min_value()
+end
+
+function TreeSet:max()
+    return self._tree:max_value()
+end
+
+TreeSet.first = TreeSet.min
+TreeSet.last = TreeSet.max
+
+function TreeSet:predecessor(value)
+    return self._tree:predecessor(value)
+end
+
+function TreeSet:successor(value)
+    return self._tree:successor(value)
+end
+
+function TreeSet:rank(value)
+    return self._tree:rank(value)
+end
+
+function TreeSet:by_rank(rank)
+    if type(rank) ~= "number" or rank < 0 or rank % 1 ~= 0 then
+        return nil
+    end
+    return self._tree:kth_smallest(rank + 1)
+end
+
+function TreeSet:kth_smallest(k)
+    return self._tree:kth_smallest(k)
+end
+
+function TreeSet:to_list()
+    return self._tree:to_sorted_array()
+end
+
+TreeSet.to_sorted_array = TreeSet.to_list
+TreeSet.to_array = TreeSet.to_list
+
+function TreeSet:range(minimum, maximum, inclusive)
+    local include_bounds = inclusive
+    if include_bounds == nil then
+        include_bounds = true
+    elseif type(include_bounds) ~= "boolean" then
+        error("inclusive must be a boolean", 2)
+    end
+    if self._compare(minimum, maximum) > 0 then
+        return {}
+    end
+
+    local values = self:to_list()
+    local first = include_bounds
+        and lower_bound(values, minimum, self._compare)
+        or upper_bound(values, minimum, self._compare)
+    local last = include_bounds
+        and upper_bound(values, maximum, self._compare) - 1
+        or lower_bound(values, maximum, self._compare) - 1
+    local result = {}
+    for index = first, last do
+        result[#result + 1] = values[index]
+    end
+    return result
+end
+
+function TreeSet:union(other)
+    require_tree_set(other)
+    return TreeSet.from_values(merge_unique(self:to_list(), other:to_list(), self._compare), self._compare)
+end
+
+function TreeSet:intersection(other)
+    require_tree_set(other)
+    return TreeSet.from_values(intersection_sorted(self:to_list(), other:to_list(), self._compare), self._compare)
+end
+
+function TreeSet:difference(other)
+    require_tree_set(other)
+    return TreeSet.from_values(difference_sorted(self:to_list(), other:to_list(), self._compare), self._compare)
+end
+
+function TreeSet:symmetric_difference(other)
+    require_tree_set(other)
+    return TreeSet.from_values(
+        symmetric_difference_sorted(self:to_list(), other:to_list(), self._compare),
+        self._compare
+    )
+end
+
+function TreeSet:is_subset(other)
+    require_tree_set(other)
+    return is_subset_sorted(self:to_list(), other:to_list(), self._compare)
+end
+
+function TreeSet:is_superset(other)
+    require_tree_set(other)
+    return other:is_subset(self)
+end
+
+function TreeSet:is_disjoint(other)
+    require_tree_set(other)
+    return is_disjoint_sorted(self:to_list(), other:to_list(), self._compare)
+end
+
+function TreeSet:equals(other)
+    if not is_tree_set(other) or self:size() ~= other:size() then
+        return false
+    end
+    local left = self:to_list()
+    local right = other:to_list()
+    for index = 1, #left do
+        if self._compare(left[index], right[index]) ~= 0 then
+            return false
+        end
+    end
+    return true
+end
+
+function TreeSet:values()
+    local values = self:to_list()
+    local index = 0
+    return function()
+        index = index + 1
+        return values[index]
+    end
+end
+
+function TreeSet:__len()
+    return self:size()
+end
+
+function TreeSet:__tostring()
+    local rendered = {}
+    for index, value in ipairs(self:to_list()) do
+        rendered[index] = tostring(value)
+    end
+    return "TreeSet([" .. table.concat(rendered, ", ") .. "])"
+end
+
+M.TreeSet = TreeSet
+M.from_values = TreeSet.from_values
+M.default_compare = avl.default_compare
+
+return M

--- a/code/packages/lua/tree-set/tests/test_tree_set.lua
+++ b/code/packages/lua/tree-set/tests/test_tree_set.lua
@@ -1,0 +1,160 @@
+package.path = table.concat({
+    "../src/?.lua",
+    "../src/?/init.lua",
+    "../../avl-tree/src/?.lua",
+    "../../avl-tree/src/?/init.lua",
+    package.path,
+}, ";")
+
+local module = require("coding_adventures.tree_set")
+local TreeSet = module.TreeSet
+
+describe("TreeSet basics", function()
+    it("deduplicates, sorts, mutates, and iterates", function()
+        local set = TreeSet.new({5, 1, 3, 3, 9})
+        assert.equals(set, set:add(7))
+
+        assert.are.same({1, 3, 5, 7, 9}, set:to_sorted_array())
+        assert.are.same({1, 3, 5, 7, 9}, set:to_list())
+        assert.equals(5, set:size())
+        assert.equals(5, set:length())
+        assert.equals(5, #set)
+        assert.is_true(set:contains(7))
+        assert.is_true(set:has(3))
+        assert.is_false(set:has(2))
+
+        local iterated = {}
+        for value in set:values() do
+            iterated[#iterated + 1] = value
+        end
+        assert.are.same({1, 3, 5, 7, 9}, iterated)
+        assert.equals("TreeSet([1, 3, 5, 7, 9])", tostring(set))
+        assert.is_true(set:backend():is_valid_avl())
+    end)
+
+    it("supports deletion aliases and defensive arrays", function()
+        local set = TreeSet.from_values({1, 2, 3, 4})
+        assert.is_true(set:delete(2))
+        assert.is_true(set:remove(3))
+        assert.is_false(set:discard(99))
+        assert.is_false(set:delete(nil))
+        assert.are.same({1, 4}, set:to_array())
+
+        local snapshot = set:to_list()
+        snapshot[1] = 999
+        assert.are.same({1, 4}, set:to_list())
+        assert.is_true(set:backend():is_valid_avl())
+    end)
+end)
+
+describe("TreeSet order queries", function()
+    it("provides boundaries, rank, and selection", function()
+        local set = module.from_values({10, 20, 30, 40})
+
+        assert.equals(10, set:min())
+        assert.equals(40, set:max())
+        assert.equals(10, set:first())
+        assert.equals(40, set:last())
+        assert.equals(20, set:predecessor(30))
+        assert.equals(40, set:successor(30))
+        assert.equals(0, set:rank(5))
+        assert.equals(2, set:rank(25))
+        assert.equals(10, set:by_rank(0))
+        assert.equals(40, set:by_rank(3))
+        assert.is_nil(set:by_rank(-1))
+        assert.equals(30, set:kth_smallest(3))
+        assert.is_nil(set:kth_smallest(0))
+    end)
+
+    it("handles empty sets", function()
+        local set = TreeSet.empty()
+        assert.is_true(set:is_empty())
+        assert.is_nil(set:min())
+        assert.is_nil(set:max())
+        assert.is_nil(set:first())
+        assert.is_nil(set:last())
+        assert.is_nil(set:predecessor(1))
+        assert.is_nil(set:successor(1))
+        assert.is_nil(set:by_rank(0))
+        assert.equals(0, set:rank(1))
+        assert.equals("TreeSet([])", tostring(set))
+    end)
+
+    it("supports inclusive and exclusive ranges", function()
+        local set = TreeSet.from_values({1, 3, 5, 7, 9})
+        assert.are.same({3, 5, 7}, set:range(3, 7))
+        assert.are.same({5}, set:range(3, 7, false))
+        assert.are.same({}, set:range(10, 20))
+        assert.are.same({}, set:range(7, 3))
+    end)
+end)
+
+describe("TreeSet algebra", function()
+    it("combines sets without mutating inputs", function()
+        local left = TreeSet.from_values({1, 2, 3, 5})
+        local right = TreeSet.from_values({3, 4, 5, 6})
+
+        assert.are.same({1, 2, 3, 4, 5, 6}, left:union(right):to_list())
+        assert.are.same({3, 5}, left:intersection(right):to_list())
+        assert.are.same({1, 2}, left:difference(right):to_list())
+        assert.are.same({1, 2, 4, 6}, left:symmetric_difference(right):to_list())
+        assert.are.same({1, 2, 3, 5}, left:to_list())
+        assert.are.same({3, 4, 5, 6}, right:to_list())
+    end)
+
+    it("supports subset, superset, disjointness, and equality", function()
+        local small = TreeSet.from_values({2, 3})
+        local large = TreeSet.from_values({1, 2, 3, 4})
+        local disjoint = TreeSet.from_values({8, 9})
+
+        assert.is_true(small:is_subset(large))
+        assert.is_true(large:is_superset(small))
+        assert.is_true(small:is_disjoint(disjoint))
+        assert.is_false(small:is_disjoint(large))
+        assert.is_true(small:equals(TreeSet.from_values({3, 2})))
+        assert.is_false(small:equals(large))
+        assert.is_false(small:equals({2, 3}))
+    end)
+end)
+
+describe("TreeSet comparison and validation", function()
+    it("supports custom comparators", function()
+        local function by_length(left, right)
+            if #left ~= #right then
+                return #left - #right
+            end
+            return module.default_compare(left, right)
+        end
+        local set = TreeSet.new({}, by_length):add("banana"):add("fig"):add("apple")
+
+        assert.are.same({"fig", "apple", "banana"}, set:to_list())
+        assert.is_true(set:backend():is_valid_avl())
+        assert.equals("apple", set:by_rank(1))
+    end)
+
+    it("validates public inputs", function()
+        assert.has_error(function() TreeSet.new("values") end, "values must be a table")
+        assert.has_error(function() TreeSet.new({}, "compare") end, "compare must be a function")
+        assert.has_error(function() TreeSet.empty():add(nil) end, "value must not be nil")
+        assert.has_error(function() TreeSet.empty():range(1, 2, "yes") end, "inclusive must be a boolean")
+        assert.has_error(function() TreeSet.empty():union({}) end, "other must be a TreeSet")
+    end)
+
+    it("keeps AVL invariants through a larger mutation sequence", function()
+        local set = TreeSet.empty()
+        for index = 1, 100 do
+            set:add((index * 37) % 101)
+            assert.is_true(set:backend():is_valid_avl())
+        end
+        for value = 1, 99, 2 do
+            assert.is_true(set:delete(value))
+            assert.is_true(set:backend():is_valid_avl())
+        end
+
+        local expected = {}
+        for value = 2, 100, 2 do
+            expected[#expected + 1] = value
+        end
+        assert.are.same(expected, set:to_list())
+    end)
+end)

--- a/code/packages/perl/tree-set/BUILD
+++ b/code/packages/perl/tree-set/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=../avl-tree/lib prove -l -v t/

--- a/code/packages/perl/tree-set/BUILD_windows
+++ b/code/packages/perl/tree-set/BUILD_windows
@@ -1,0 +1,1 @@
+set PERL5LIB=..\avl-tree\lib && perl -Ilib t/00-load.t && perl -Ilib t/01-tree-set.t

--- a/code/packages/perl/tree-set/CHANGELOG.md
+++ b/code/packages/perl/tree-set/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-15
+
+- Add a pure-Perl AVL-backed ordered set with mutation, rank, selection,
+  ranges, custom comparison, and set algebra.

--- a/code/packages/perl/tree-set/Makefile.PL
+++ b/code/packages/perl/tree-set/Makefile.PL
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::TreeSet',
+    VERSION_FROM     => 'lib/CodingAdventures/TreeSet.pm',
+    ABSTRACT         => 'AVL-backed ordered set with rank, range, and set algebra',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::AVLTree' => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/tree-set/README.md
+++ b/code/packages/perl/tree-set/README.md
@@ -1,0 +1,24 @@
+# Perl tree set
+
+An AVL-backed mutable ordered set with duplicate suppression, rank and
+selection helpers, range queries, custom comparison, and set algebra. The AVL
+backend keeps insertion, deletion, and lookup logarithmic while set operations
+return independent sets.
+
+```perl
+my $set = CodingAdventures::TreeSet->from_values([5, 1, 3, 3, 9]);
+$set->add(7);
+print $set->contains(7);                # true
+print $set->kth_smallest(3);            # 5
+print $set->backend->is_valid_avl;      # true
+```
+
+`add` returns the set for chaining. `delete`, `remove`, and `discard` mutate the
+set and report whether a value was present. Union, intersection, difference,
+and symmetric difference leave both inputs unchanged.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/perl/tree-set/cpanfile
+++ b/code/packages/perl/tree-set/cpanfile
@@ -1,0 +1,1 @@
+requires 'CodingAdventures::AVLTree';

--- a/code/packages/perl/tree-set/lib/CodingAdventures/TreeSet.pm
+++ b/code/packages/perl/tree-set/lib/CodingAdventures/TreeSet.pm
@@ -1,0 +1,364 @@
+package CodingAdventures::TreeSet;
+
+use strict;
+use warnings;
+use Scalar::Util qw(looks_like_number);
+use CodingAdventures::AVLTree;
+use overload '""' => 'to_string', fallback => 1;
+
+our $VERSION = '0.1.0';
+
+sub _is_set {
+    my ($value) = @_;
+    return defined($value)
+        && ref($value)
+        && eval { $value->isa(__PACKAGE__) };
+}
+
+sub _require_set {
+    my ($value) = @_;
+    die "other must be a CodingAdventures::TreeSet\n" if !_is_set($value);
+}
+
+sub new {
+    my ($class, $values, $compare) = @_;
+    $values = [] if !defined $values;
+    die "values must be an array reference\n" if ref($values) ne 'ARRAY';
+
+    my $self = bless {
+        backend => CodingAdventures::AVLTree->empty($compare),
+    }, $class;
+    for my $index (0 .. $#$values) {
+        die "value at index $index must be defined\n" if !defined $values->[$index];
+        $self->add($values->[$index]);
+    }
+    return $self;
+}
+
+sub empty {
+    my ($class, $compare) = @_;
+    return $class->new([], $compare);
+}
+
+sub from_values {
+    my ($class, $values, $compare) = @_;
+    return $class->new($values, $compare);
+}
+
+sub backend { return $_[0]->{backend}; }
+
+sub add {
+    my ($self, $value) = @_;
+    die "value must be defined\n" if !defined $value;
+    $self->{backend} = $self->{backend}->insert($value);
+    return $self;
+}
+
+sub insert {
+    my ($self, @args) = @_;
+    return $self->add(@args);
+}
+
+sub delete {
+    my ($self, $value) = @_;
+    return 0 if !defined($value) || !$self->{backend}->contains($value);
+    $self->{backend} = $self->{backend}->delete($value);
+    return 1;
+}
+
+sub remove {
+    my ($self, @args) = @_;
+    return $self->delete(@args);
+}
+
+sub discard {
+    my ($self, @args) = @_;
+    return $self->delete(@args);
+}
+
+sub has {
+    my ($self, $value) = @_;
+    return defined($value) && $self->{backend}->contains($value);
+}
+
+sub contains {
+    my ($self, @args) = @_;
+    return $self->has(@args);
+}
+
+sub size   { return $_[0]->{backend}->size; }
+sub length { return $_[0]->size; }
+sub is_empty { return $_[0]->size == 0; }
+
+sub min { return $_[0]->{backend}->min_value; }
+sub max { return $_[0]->{backend}->max_value; }
+sub first { return $_[0]->min; }
+sub last { return $_[0]->max; }
+
+sub predecessor {
+    my ($self, $value) = @_;
+    return $self->{backend}->predecessor($value);
+}
+
+sub successor {
+    my ($self, $value) = @_;
+    return $self->{backend}->successor($value);
+}
+
+sub rank {
+    my ($self, $value) = @_;
+    return $self->{backend}->rank($value);
+}
+
+sub by_rank {
+    my ($self, $rank) = @_;
+    return undef
+        if !defined($rank) || !looks_like_number($rank) || $rank < 0 || int($rank) != $rank;
+    return $self->{backend}->kth_smallest($rank + 1);
+}
+
+sub kth_smallest {
+    my ($self, $k) = @_;
+    return $self->{backend}->kth_smallest($k);
+}
+
+sub to_list {
+    my ($self) = @_;
+    return $self->{backend}->to_sorted_array;
+}
+
+sub to_sorted_array { return $_[0]->to_list; }
+sub to_array { return $_[0]->to_list; }
+
+sub _lower_bound {
+    my ($items, $value, $compare) = @_;
+    my $low = 0;
+    my $high = scalar @$items;
+    while ($low < $high) {
+        my $middle = int(($low + $high) / 2);
+        if ($compare->($items->[$middle], $value) < 0) {
+            $low = $middle + 1;
+        } else {
+            $high = $middle;
+        }
+    }
+    return $low;
+}
+
+sub _upper_bound {
+    my ($items, $value, $compare) = @_;
+    my $low = 0;
+    my $high = scalar @$items;
+    while ($low < $high) {
+        my $middle = int(($low + $high) / 2);
+        if ($compare->($items->[$middle], $value) <= 0) {
+            $low = $middle + 1;
+        } else {
+            $high = $middle;
+        }
+    }
+    return $low;
+}
+
+sub range {
+    my ($self, $minimum, $maximum, $inclusive) = @_;
+    die "minimum must be defined\n" if !defined $minimum;
+    die "maximum must be defined\n" if !defined $maximum;
+    $inclusive = 1 if !defined $inclusive;
+    die "inclusive must be 0 or 1\n" if ref($inclusive) || $inclusive !~ /^(?:0|1)$/;
+
+    my $compare = $self->{backend}->compare;
+    return [] if $compare->($minimum, $maximum) > 0;
+    my $values = $self->to_list;
+    my $first = $inclusive
+        ? _lower_bound($values, $minimum, $compare)
+        : _upper_bound($values, $minimum, $compare);
+    my $last = $inclusive
+        ? _upper_bound($values, $maximum, $compare)
+        : _lower_bound($values, $maximum, $compare);
+    return [@$values[$first .. $last - 1]] if $first < $last;
+    return [];
+}
+
+sub _merge_unique {
+    my ($left, $right, $compare) = @_;
+    my @result;
+    my ($left_index, $right_index) = (0, 0);
+    while ($left_index < @$left && $right_index < @$right) {
+        my $order = $compare->($left->[$left_index], $right->[$right_index]);
+        if ($order < 0) {
+            push @result, $left->[$left_index++];
+        } elsif ($order > 0) {
+            push @result, $right->[$right_index++];
+        } else {
+            push @result, $left->[$left_index++];
+            $right_index++;
+        }
+    }
+    push @result, @$left[$left_index .. $#$left] if $left_index < @$left;
+    push @result, @$right[$right_index .. $#$right] if $right_index < @$right;
+    return \@result;
+}
+
+sub _intersection_sorted {
+    my ($left, $right, $compare) = @_;
+    my @result;
+    my ($left_index, $right_index) = (0, 0);
+    while ($left_index < @$left && $right_index < @$right) {
+        my $order = $compare->($left->[$left_index], $right->[$right_index]);
+        if ($order < 0) {
+            $left_index++;
+        } elsif ($order > 0) {
+            $right_index++;
+        } else {
+            push @result, $left->[$left_index++];
+            $right_index++;
+        }
+    }
+    return \@result;
+}
+
+sub _difference_sorted {
+    my ($left, $right, $compare) = @_;
+    my @result;
+    my ($left_index, $right_index) = (0, 0);
+    while ($left_index < @$left && $right_index < @$right) {
+        my $order = $compare->($left->[$left_index], $right->[$right_index]);
+        if ($order < 0) {
+            push @result, $left->[$left_index++];
+        } elsif ($order > 0) {
+            $right_index++;
+        } else {
+            $left_index++;
+            $right_index++;
+        }
+    }
+    push @result, @$left[$left_index .. $#$left] if $left_index < @$left;
+    return \@result;
+}
+
+sub _symmetric_difference_sorted {
+    my ($left, $right, $compare) = @_;
+    my @result;
+    my ($left_index, $right_index) = (0, 0);
+    while ($left_index < @$left && $right_index < @$right) {
+        my $order = $compare->($left->[$left_index], $right->[$right_index]);
+        if ($order < 0) {
+            push @result, $left->[$left_index++];
+        } elsif ($order > 0) {
+            push @result, $right->[$right_index++];
+        } else {
+            $left_index++;
+            $right_index++;
+        }
+    }
+    push @result, @$left[$left_index .. $#$left] if $left_index < @$left;
+    push @result, @$right[$right_index .. $#$right] if $right_index < @$right;
+    return \@result;
+}
+
+sub _is_subset_sorted {
+    my ($left, $right, $compare) = @_;
+    my ($left_index, $right_index) = (0, 0);
+    while ($left_index < @$left && $right_index < @$right) {
+        my $order = $compare->($left->[$left_index], $right->[$right_index]);
+        return 0 if $order < 0;
+        if ($order > 0) {
+            $right_index++;
+        } else {
+            $left_index++;
+            $right_index++;
+        }
+    }
+    return $left_index == @$left;
+}
+
+sub _is_disjoint_sorted {
+    my ($left, $right, $compare) = @_;
+    my ($left_index, $right_index) = (0, 0);
+    while ($left_index < @$left && $right_index < @$right) {
+        my $order = $compare->($left->[$left_index], $right->[$right_index]);
+        if ($order < 0) {
+            $left_index++;
+        } elsif ($order > 0) {
+            $right_index++;
+        } else {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+sub _from_sorted_operation {
+    my ($self, $values) = @_;
+    return __PACKAGE__->from_values($values, $self->{backend}->compare);
+}
+
+sub union {
+    my ($self, $other) = @_;
+    _require_set($other);
+    return $self->_from_sorted_operation(
+        _merge_unique($self->to_list, $other->to_list, $self->{backend}->compare),
+    );
+}
+
+sub intersection {
+    my ($self, $other) = @_;
+    _require_set($other);
+    return $self->_from_sorted_operation(
+        _intersection_sorted($self->to_list, $other->to_list, $self->{backend}->compare),
+    );
+}
+
+sub difference {
+    my ($self, $other) = @_;
+    _require_set($other);
+    return $self->_from_sorted_operation(
+        _difference_sorted($self->to_list, $other->to_list, $self->{backend}->compare),
+    );
+}
+
+sub symmetric_difference {
+    my ($self, $other) = @_;
+    _require_set($other);
+    return $self->_from_sorted_operation(
+        _symmetric_difference_sorted($self->to_list, $other->to_list, $self->{backend}->compare),
+    );
+}
+
+sub is_subset {
+    my ($self, $other) = @_;
+    _require_set($other);
+    return _is_subset_sorted($self->to_list, $other->to_list, $self->{backend}->compare);
+}
+
+sub is_superset {
+    my ($self, $other) = @_;
+    _require_set($other);
+    return $other->is_subset($self);
+}
+
+sub is_disjoint {
+    my ($self, $other) = @_;
+    _require_set($other);
+    return _is_disjoint_sorted($self->to_list, $other->to_list, $self->{backend}->compare);
+}
+
+sub equals {
+    my ($self, $other) = @_;
+    return 0 if !_is_set($other) || $self->size != $other->size;
+    my $left = $self->to_list;
+    my $right = $other->to_list;
+    my $compare = $self->{backend}->compare;
+    for my $index (0 .. $#$left) {
+        return 0 if $compare->($left->[$index], $right->[$index]) != 0;
+    }
+    return 1;
+}
+
+sub to_string {
+    my ($self) = @_;
+    return 'TreeSet([' . join(', ', @{$self->to_list}) . '])';
+}
+
+1;

--- a/code/packages/perl/tree-set/required_capabilities.json
+++ b/code/packages/perl/tree-set/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/tree-set",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/tree-set/t/00-load.t
+++ b/code/packages/perl/tree-set/t/00-load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::TreeSet; 1 }, 'CodingAdventures::TreeSet loads');
+ok(CodingAdventures::TreeSet->VERSION, 'has a VERSION');
+ok(CodingAdventures::TreeSet->can('from_values'), 'constructor is available');
+
+done_testing;

--- a/code/packages/perl/tree-set/t/01-tree-set.t
+++ b/code/packages/perl/tree-set/t/01-tree-set.t
@@ -1,0 +1,146 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::TreeSet;
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'deduplication, ordering, mutation, and backend' => sub {
+    my $set = CodingAdventures::TreeSet->new([5, 1, 3, 3, 9]);
+    is($set->add(7), $set, 'add chains');
+
+    is_deeply($set->to_sorted_array, [1, 3, 5, 7, 9], 'sorted unique values');
+    is_deeply($set->to_list, [1, 3, 5, 7, 9], 'list alias');
+    is($set->size, 5, 'size');
+    is($set->length, 5, 'length');
+    ok($set->contains(7), 'contains value');
+    ok($set->has(3), 'has alias');
+    ok(!$set->has(2), 'absent value');
+    is("$set", 'TreeSet([1, 3, 5, 7, 9])', 'string rendering');
+    ok($set->backend->is_valid_avl, 'AVL backend valid');
+
+    ok($set->delete(3), 'delete existing value');
+    ok($set->remove(5), 'remove alias');
+    ok(!$set->discard(99), 'discard absent value');
+    ok(!$set->delete(undef), 'undefined delete absent');
+    is_deeply($set->to_array, [1, 7, 9], 'delete results');
+    ok($set->backend->is_valid_avl, 'backend valid after deletes');
+};
+
+subtest 'boundaries, rank, and selection' => sub {
+    my $set = CodingAdventures::TreeSet->from_values([10, 20, 30, 40]);
+
+    is($set->min, 10, 'minimum');
+    is($set->max, 40, 'maximum');
+    is($set->first, 10, 'first');
+    is($set->last, 40, 'last');
+    is($set->predecessor(30), 20, 'predecessor');
+    is($set->successor(30), 40, 'successor');
+    is($set->rank(5), 0, 'rank before minimum');
+    is($set->rank(25), 2, 'rank between values');
+    is($set->by_rank(0), 10, 'zero-based selection');
+    is($set->by_rank(3), 40, 'last rank');
+    ok(!defined $set->by_rank(-1), 'negative rank');
+    is($set->kth_smallest(3), 30, 'one-based selection');
+    ok(!defined $set->kth_smallest(0), 'zero k');
+};
+
+subtest 'empty and defensive arrays' => sub {
+    my $set = CodingAdventures::TreeSet->empty;
+    ok($set->is_empty, 'empty set');
+    ok(!defined $set->min, 'empty minimum');
+    ok(!defined $set->max, 'empty maximum');
+    ok(!defined $set->first, 'empty first');
+    ok(!defined $set->last, 'empty last');
+    ok(!defined $set->predecessor(1), 'empty predecessor');
+    ok(!defined $set->successor(1), 'empty successor');
+    ok(!defined $set->by_rank(0), 'empty rank selection');
+    is($set->rank(1), 0, 'empty rank');
+    is("$set", 'TreeSet([])', 'empty rendering');
+
+    my $populated = CodingAdventures::TreeSet->from_values([1, 2]);
+    my $snapshot = $populated->to_list;
+    $snapshot->[0] = 999;
+    is_deeply($populated->to_list, [1, 2], 'returned arrays are defensive');
+};
+
+subtest 'inclusive and exclusive ranges' => sub {
+    my $set = CodingAdventures::TreeSet->from_values([1, 3, 5, 7, 9]);
+    is_deeply($set->range(3, 7), [3, 5, 7], 'inclusive range');
+    is_deeply($set->range(3, 7, 0), [5], 'exclusive range');
+    is_deeply($set->range(10, 20), [], 'range above maximum');
+    is_deeply($set->range(7, 3), [], 'reversed range');
+};
+
+subtest 'set algebra does not mutate inputs' => sub {
+    my $left = CodingAdventures::TreeSet->from_values([1, 2, 3, 5]);
+    my $right = CodingAdventures::TreeSet->from_values([3, 4, 5, 6]);
+
+    is_deeply($left->union($right)->to_list, [1, 2, 3, 4, 5, 6], 'union');
+    is_deeply($left->intersection($right)->to_list, [3, 5], 'intersection');
+    is_deeply($left->difference($right)->to_list, [1, 2], 'difference');
+    is_deeply($left->symmetric_difference($right)->to_list, [1, 2, 4, 6], 'symmetric difference');
+    is_deeply($left->to_list, [1, 2, 3, 5], 'left input unchanged');
+    is_deeply($right->to_list, [3, 4, 5, 6], 'right input unchanged');
+};
+
+subtest 'set predicates and equality' => sub {
+    my $small = CodingAdventures::TreeSet->from_values([2, 3]);
+    my $large = CodingAdventures::TreeSet->from_values([1, 2, 3, 4]);
+    my $disjoint = CodingAdventures::TreeSet->from_values([8, 9]);
+
+    ok($small->is_subset($large), 'subset');
+    ok($large->is_superset($small), 'superset');
+    ok($small->is_disjoint($disjoint), 'disjoint');
+    ok(!$small->is_disjoint($large), 'overlap detected');
+    ok($small->equals(CodingAdventures::TreeSet->from_values([3, 2])), 'content equality');
+    ok(!$small->equals($large), 'different sizes unequal');
+    ok(!$small->equals([2, 3]), 'different type unequal');
+};
+
+subtest 'custom comparator' => sub {
+    my $by_length = sub {
+        return length($_[0]) <=> length($_[1]) || $_[0] cmp $_[1];
+    };
+    my $set = CodingAdventures::TreeSet->new([], $by_length)
+        ->add('banana')->add('fig')->add('apple');
+
+    is_deeply($set->to_list, ['fig', 'apple', 'banana'], 'custom order');
+    ok($set->backend->is_valid_avl, 'custom backend valid');
+    is($set->by_rank(1), 'apple', 'custom rank selection');
+};
+
+subtest 'larger mutation sequence preserves AVL invariants' => sub {
+    my $set = CodingAdventures::TreeSet->empty;
+    my $valid = 1;
+    for my $index (1 .. 100) {
+        $set->add(($index * 37) % 101);
+        $valid &&= $set->backend->is_valid_avl;
+    }
+    ok($valid, 'all inserts preserve invariants');
+    is($set->size, 100, 'all values inserted');
+
+    for my $value (grep { $_ % 2 == 1 } 1 .. 99) {
+        $valid &&= $set->delete($value);
+        $valid &&= $set->backend->is_valid_avl;
+    }
+    ok($valid, 'all deletes preserve invariants');
+    is_deeply($set->to_list, [grep { $_ % 2 == 0 } 1 .. 100], 'even values remain');
+};
+
+subtest 'public input validation' => sub {
+    dies_like(sub { CodingAdventures::TreeSet->new('values') }, qr/values must be an array reference/, 'invalid values rejected');
+    dies_like(sub { CodingAdventures::TreeSet->new([], 'compare') }, qr/compare must be a code reference/, 'invalid comparator rejected');
+    dies_like(sub { CodingAdventures::TreeSet->empty->add(undef) }, qr/value must be defined/, 'undefined add rejected');
+    dies_like(sub { CodingAdventures::TreeSet->empty->range(undef, 2) }, qr/minimum must be defined/, 'undefined minimum rejected');
+    dies_like(sub { CodingAdventures::TreeSet->empty->range(1, undef) }, qr/maximum must be defined/, 'undefined maximum rejected');
+    dies_like(sub { CodingAdventures::TreeSet->empty->range(1, 2, 'yes') }, qr/inclusive must be 0 or 1/, 'invalid inclusive flag rejected');
+    dies_like(sub { CodingAdventures::TreeSet->empty->union([]) }, qr/other must be a CodingAdventures::TreeSet/, 'invalid other set rejected');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,12 +105,13 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 14, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
-`binary-search-tree`, `in-memory-data-store-protocol`, and `avl-tree` ports:
+on July 15, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
+`binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, and
+`tree-set` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 361 |
+| Present in 10-15 languages | 171 | 359 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -156,15 +157,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 361
+The 171 packages present in at least ten implementation languages need 359
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 11 | Pair with Perl data-structure/storage wave |
-| Perl | 11 | Pair with Lua data-structure/storage wave |
+| Lua | 10 | Pair with Perl data-structure/storage wave |
+| Perl | 10 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -176,12 +177,13 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first five paired Lua/Perl slices are complete: `fenwick-tree`,
-`binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`, and
-`avl-tree` now have pure implementations, package-native tests, metadata, and
-capability declarations in both lanes. The protocol slice establishes the
-dependency-free IR needed before the higher in-memory data store layers move;
-the AVL slice unlocks `tree-set`.
+The first six paired Lua/Perl slices are complete: `fenwick-tree`,
+`binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
+`avl-tree`, and `tree-set` now have pure implementations, package-native tests,
+metadata, and capability declarations in both lanes. The protocol slice
+establishes the dependency-free IR needed before the higher in-memory data
+store layers move; the AVL slice now supplies the ordered backend for
+`tree-set`.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure-Lua and pure-Perl `tree-set` packages backed by the existing persistent AVL-tree ports
- expose ordered-set mutation, rank/selection, range, algebra, comparison, iteration, and custom-comparator APIs
- add package metadata, build scripts, documentation, capability declarations, and comprehensive tests
- refresh the package-parity roadmap after closing both language slots

## Why this slice

PR #8338 made `tree-set` newly dependency-safe in both Lua and Perl. It was the smallest remaining paired data-structure port whose required ordered backend was now available in both languages.

## Parity impact

- implementation slots: 4,197
- high-consensus missing slots: 361 -> 359
- Lua high-consensus gaps: 11 -> 10
- Perl high-consensus gaps: 11 -> 10
- identity collisions: 0
- unknown roadmap buckets: 0

## Validation

- Lua source syntax checked with `luac -p`
- Lua package installed with LuaRocks and smoke-tested from the installed user tree
- Lua Busted suite: 10 successes, 0 failures, 0 errors
- Perl module syntax, load tests, and `Makefile.PL` generation verified
- Perl functional suite: 9 passing subtests
- build-tool resolver and validator Go tests passed
- touched-lane metadata validation passed for 247 Lua packages and 245 Perl packages
- package-parity reporter unit tests: 6 passed
- package-parity report passed with `--fail-on-collisions`
- `git diff --check` passed

The remaining paired Lua/Perl high-consensus gaps are bloom-filter, hash-map, hash-set, hyperloglog, in-memory-data-store, in-memory-data-store-engine, radix-tree, resp-protocol, skip-list, and trie.