### PR TITLE
feat(closure-pass-constant-fold): fold template literal → string (CLOC12.197)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.92.0] - 2026-07-15
+
+### Added — fold template literal → string when every substitution is constant — CLOC12.197
+
+`fold_expression` now collapses a `TemplateLiteral` to a `StringLiteral` when
+every `${…}` substitution is a stringifiable constant (number / string / boolean
+/ null / undefined) and every quasi carries a cooked value: `` `a${1}b` `` →
+`"a1b"`, `` `${1}-${2}-${3}` `` → `"1-2-3"`, `` `hello` `` → `"hello"`, `` `` `` →
+`""`. Recursion handles nested templates (`` `a${`b${1}c`}d` `` → `"ab1cd"`) and
+constant sub-expressions (`` `a${1+2}b` `` → `"a3b"`, the `1+2` folds first).
+Verified byte-identical to the reference Closure Compiler; no emitter work is
+needed because closurec's string emitter already matches its quote choice
+(single-quote when the value contains a `"`) and escaping (`\n`, `\t`, `\\`). A
+non-constant substitution (`` `a${x}b` ``, `` `a${f()}b` ``) or an illegal-escape
+(tagged-only) quasi declines.
+
+The fold body lives in an `#[inline(never)]` `fold_template_literal` helper so its
+`Vec`/`String` locals don't inflate the shared recursive `fold_expression` frame
+(that frame is walked once per AST depth level; bloating it lowers the nesting
+depth the pass survives — the `deeply_nested_*` stack-safety tests pin this).
+
+Adds a `stringify_const_operand` predicate + four unit tests. NOTE: end-to-end at
+SIMPLE this currently only fires on **no-substitution** templates (`` `hello` `` →
+`"hello"`) — *substituted* templates (`` `a${x}b` ``) do not yet parse in
+closurec's grammar, so the fold, though correct and unit-tested, can't receive one
+until that separate grammar/bridge arc lands. Additive; MINOR 0.91.0 → 0.92.0.
+
 ## [0.91.0] - 2026-07-15
 
 ### Added — fold array-literal index access `[a, b, c][K]` → element — CLOC12.196

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.91.0"
+version = "0.92.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -842,11 +842,82 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         // `quasis` are fixed string segments with no sub-expressions to
         // fold. (Folding the *whole* template to a string literal when all
         // parts are constant is a future optimisation; here we only recurse.)
-        Expression::TemplateLiteral(t) => Expression::TemplateLiteral(TemplateLiteral {
-            cv: t.cv.clone(),
-            quasis: t.quasis.clone(),
-            expressions: t.expressions.iter().map(|e| fold_expression(e, st)).collect(),
-        }),
+        Expression::TemplateLiteral(t) => fold_template_literal(t, st),
+    }
+}
+
+/// Fold a template literal — recurse into its substitutions, then collapse the
+/// whole node to a string literal when every substitution is a stringifiable
+/// constant (CLOC12.197). Kept `#[inline(never)]` and out of the big
+/// `fold_expression` match so its several `Vec`/`String` locals do NOT inflate
+/// the shared recursive frame — that frame is walked once per AST depth level,
+/// so bloating it lowers the input-nesting depth the pass survives (the
+/// `deeply_nested_*` stack-safety tests pin this). See the DCE crate's identical
+/// `#[inline(never)]` helper convention.
+#[inline(never)]
+fn fold_template_literal(t: &TemplateLiteral, st: &mut FoldState) -> Expression {
+    // Recurse first so a substitution like `${1 + 2}` folds to `${3}`, and a
+    // nested template `${`b${1}c`}` folds to `${"b1c"}` — by the time we test
+    // the substitutions below they are already constants.
+    let expressions: Vec<Expression> =
+        t.expressions.iter().map(|e| fold_expression(e, st)).collect();
+
+    // When EVERY substitution is a stringifiable constant literal AND every
+    // quasi carries a cooked value, the whole template is a compile-time-known
+    // string: interleave the quasis' cooked text with each substitution's
+    // `ToString` form (`cooked₀ str(e₀) cooked₁ … cookedₙ`).
+    //
+    // Emitted as a plain string literal; no emitter work is needed because
+    // closurec's string emitter already matches the reference compiler's quote
+    // choice (single-quote when the value contains a `"`) and escaping (`\n`,
+    // `\t`, `\\`) byte-for-byte.
+    //
+    // A `cooked` of `None` (an escape legal only in a *tagged* template) or a
+    // non-const / BigInt / RegExp substitution makes the string not statically
+    // known, so we decline and keep the template.
+    let sub_strings: Option<Vec<String>> =
+        expressions.iter().map(stringify_const_operand).collect();
+    let cooked: Option<Vec<&str>> = t.quasis.iter().map(|q| q.cooked.as_deref()).collect();
+    if let (Some(subs), Some(cooked)) = (sub_strings, cooked) {
+        let mut result = String::new();
+        for (i, quasi) in cooked.iter().enumerate() {
+            result.push_str(quasi);
+            if let Some(s) = subs.get(i) {
+                result.push_str(s);
+            }
+        }
+        let parent = t.cv.clone();
+        let before = format!("template-literal[{} subs]", subs.len());
+        let after = format!("\"{result}\"");
+        let new_cv = st.fork_cv(&parent, &before, &after);
+        return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
+    }
+
+    Expression::TemplateLiteral(TemplateLiteral {
+        cv: t.cv.clone(),
+        quasis: t.quasis.clone(),
+        expressions,
+    })
+}
+
+/// The `ToString` form of a constant-literal template substitution, or `None`
+/// if the operand is not a constant we can stringify at compile time.
+///
+/// Matches JavaScript `String(x)` for the primitives that appear as folded
+/// constants: a number takes its shortest round-trip form (`3`, not `3.0`), a
+/// string is itself, `true`/`false`/`null`/`undefined` take their keyword text.
+/// A `BigInt` (its text would drop the `n`), a `RegExp`, or any non-literal
+/// (identifier, call, …) returns `None`, so the enclosing template declines to
+/// fold — exactly matching the reference compiler, which leaves
+/// `` `a${x}b` `` / `` `a${f()}b` `` intact.
+fn stringify_const_operand(e: &Expression) -> Option<String> {
+    match e {
+        Expression::NumericLiteral(n) => Some(format_js_number(n.value)),
+        Expression::StringLiteral(s) => Some(s.value.clone()),
+        Expression::BooleanLiteral(b) => Some(if b.value { "true" } else { "false" }.to_string()),
+        Expression::NullLiteral(_) => Some("null".to_string()),
+        Expression::UndefinedLiteral(_) => Some("undefined".to_string()),
+        _ => None,
     }
 }
 
@@ -6888,6 +6959,115 @@ mod tests {
         );
         let (_out, _, changed, _) = run_pass(program_with_expr(e, true));
         assert!(!changed, "[1,2,...x][0] must not fold — spread indices unknown");
+    }
+
+    /// Build a template literal from quasi cooked strings + substitution
+    /// expressions (`quasis.len() == exprs.len() + 1`). CLOC12.197 test helper.
+    fn template(quasis: &[&str], exprs: Vec<Expression>) -> Expression {
+        use coding_adventures_javascript_ast::{TemplateElement, TemplateLiteral};
+        let n = exprs.len();
+        let quasi_elems = quasis
+            .iter()
+            .enumerate()
+            .map(|(i, q)| TemplateElement {
+                cv: None,
+                raw: q.to_string(),
+                cooked: Some(q.to_string()),
+                tail: i == n,
+            })
+            .collect();
+        Expression::TemplateLiteral(TemplateLiteral {
+            cv: Some("tpl.cv".to_string()),
+            quasis: quasi_elems,
+            expressions: exprs,
+        })
+    }
+
+    /// CLOC12.197: `` `a${1}b` `` → `"a1b"` when every substitution is a
+    /// stringifiable constant literal. Truth table verified against the
+    /// reference Closure Compiler.
+    #[test]
+    fn fold_template_all_const_subs() {
+        // `\`a${1}b\`` → "a1b".
+        let t = template(&["a", "b"], vec![num(1.0, None)]);
+        let (out, _, changed, _) = run_pass(program_with_expr(t, true));
+        assert!(changed, "template with a const sub should fold");
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "a1b"),
+            other => panic!("expected \"a1b\"; got {other:?}"),
+        }
+
+        // `\`${1}-${2}-${3}\`` → "1-2-3".
+        let t = template(
+            &["", "-", "-", ""],
+            vec![num(1.0, None), num(2.0, None), num(3.0, None)],
+        );
+        let (out, _, _, _) = run_pass(program_with_expr(t, true));
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "1-2-3"),
+            other => panic!("expected \"1-2-3\"; got {other:?}"),
+        }
+
+        // string / bool / null substitutions stringify via `ToString`.
+        let t = template(
+            &["", "-", "-", ""],
+            vec![string("x", None), boolean(true, None), null(None)],
+        );
+        let (out, _, _, _) = run_pass(program_with_expr(t, true));
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "x-true-null"),
+            other => panic!("expected \"x-true-null\"; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fold_template_no_substitutions() {
+        // `\`hello\`` → "hello".
+        let t = template(&["hello"], vec![]);
+        let (out, _, changed, _) = run_pass(program_with_expr(t, true));
+        assert!(changed);
+        assert!(matches!(extract_expr(&out), Expression::StringLiteral(s) if s.value == "hello"));
+
+        // `\`\`` → "".
+        let t = template(&[""], vec![]);
+        let (out, _, _, _) = run_pass(program_with_expr(t, true));
+        assert!(matches!(extract_expr(&out), Expression::StringLiteral(s) if s.value.is_empty()));
+    }
+
+    #[test]
+    fn fold_template_const_expr_sub_folds_first() {
+        // `\`a${1+2}b\`` — `1+2` folds to `3` first (recursion), then the
+        // template collapses → "a3b".
+        let sum = Expression::BinaryExpression(BinaryExpression {
+            cv: None,
+            operator: BinaryOperator::Add,
+            left: Box::new(num(1.0, None)),
+            right: Box::new(num(2.0, None)),
+        });
+        let t = template(&["a", "b"], vec![sum]);
+        let (out, _, changed, _) = run_pass(program_with_expr(t, true));
+        assert!(changed);
+        assert!(matches!(extract_expr(&out), Expression::StringLiteral(s) if s.value == "a3b"));
+    }
+
+    #[test]
+    fn template_declines_on_nonconst_substitution() {
+        // `\`a${x}b\`` — an identifier is not a compile-time constant → keep.
+        let t = template(&["a", "b"], vec![ident("x")]);
+        let (out, _, changed, _) = run_pass(program_with_expr(t, true));
+        assert!(!changed, "template with a non-const sub must not fold");
+        assert!(matches!(extract_expr(&out), Expression::TemplateLiteral(_)));
+
+        // `\`a${f()}b\`` — a call is not constant → keep.
+        let call = Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident("f")),
+            arguments: vec![],
+        });
+        let t = template(&["a", "b"], vec![call]);
+        let (out, _, changed, _) = run_pass(program_with_expr(t, true));
+        assert!(!changed);
+        assert!(matches!(extract_expr(&out), Expression::TemplateLiteral(_)));
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/simple-template-literal/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-template-literal/expected.stdout
@@ -1,1 +1,1 @@
-log(`hello`,3);
+log("hello",3);

--- a/code/programs/rust/closurec/tests/diff/simple-template-literal/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-template-literal/input/a.js
@@ -1,7 +1,9 @@
-// A no-substitution template literal (CLOC12.155) now flows through the full
-// SIMPLE pipeline (parser → typed-AST bridge → passes → emitter) instead of
-// declining at the bridge and dragging the whole file to WHITESPACE_ONLY.
-// Both facts are observable below: the template round-trips as a backtick
-// literal, and the adjacent `1 + 2` folds to `3` — a WHITESPACE_ONLY fallback
-// (which a bridge decline would force) would leave `1+2` intact and unfolded.
+// A no-substitution template literal (CLOC12.155) flows through the full SIMPLE
+// pipeline (parser → typed-AST bridge → passes → emitter) instead of declining
+// at the bridge and dragging the whole file to WHITESPACE_ONLY. As of CLOC12.197
+// constant-fold also collapses it to a plain string literal (`"hello"`),
+// matching the reference Closure Compiler. Both facts are observable below: the
+// template folds to `"hello"`, and the adjacent `1 + 2` folds to `3` — a
+// WHITESPACE_ONLY fallback (which a bridge decline would force) would leave both
+// `` `hello` `` and `1+2` intact and unfolded.
 log(`hello`, 1 + 2);

--- a/code/programs/rust/closurec/tests/diff_simple_template_literal.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_template_literal.rs
@@ -1,18 +1,20 @@
 //! Integration test for the `tests/diff/simple-template-literal/` fixture.
 //!
-//! Exercises CLOC12.155 — a **no-substitution template literal** (`` `hello` ``)
-//! now flows through the full SIMPLE pipeline (parser → typed-AST bridge →
-//! passes → emitter) instead of declining at the bridge and dragging the whole
-//! file to WHITESPACE_ONLY.
+//! Exercises CLOC12.155 (a **no-substitution template literal** `` `hello` ``
+//! flows through the full SIMPLE pipeline: parser → typed-AST bridge → passes →
+//! emitter) *and* CLOC12.197 (constant-fold collapses a no-sub template to a
+//! plain string literal, matching the reference Closure Compiler which folds
+//! `` `hello` `` → `"hello"`).
 //!
 //! The fixture puts the template in a call argument next to a foldable `1 + 2`.
 //! Two facts prove the pipeline ran end-to-end:
-//!   1. the template round-trips as a backtick literal (`` `hello` ``), and
+//!   1. the no-sub template **folds** to a string literal (`"hello"`), and
 //!   2. `1 + 2` folds to `3`.
 //! A WHITESPACE_ONLY fallback — which a bridge decline would force — would
-//! instead re-emit the source verbatim, leaving `1 + 2` unfolded.
+//! instead re-emit the source verbatim, leaving `` `hello` `` and `1 + 2` intact.
 //!
-//! *Substitution* templates (`` `a${x}b` ``) still don't parse in the grammar,
+//! *Substitution* templates (`` `a${x}b` ``) still don't parse in the grammar
+//! (so the CLOC12.197 fold, though correct, can't fire on them end-to-end yet),
 //! and *tagged* templates remain Phase 3 — neither appears here (see the
 //! CLOC12-gaps §CLOC12.155 note).
 
@@ -58,11 +60,12 @@ fn simple_template_literal_fixture_matches_expected_stdout() {
         "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
     );
 
-    // Guard the *point* of the fixture: the template survived as a backtick
-    // literal AND the adjacent `1 + 2` folded — proving the SIMPLE pipeline ran
-    // rather than falling back to WHITESPACE_ONLY.
+    // Guard the *point* of the fixture: the no-sub template FOLDED to a string
+    // literal (CLOC12.197) AND the adjacent `1 + 2` folded — proving the SIMPLE
+    // pipeline ran rather than falling back to WHITESPACE_ONLY.
     let a = actual.replace(' ', "");
-    assert!(a.contains("`hello`"), "template did not round-trip: {actual}");
+    assert!(a.contains("\"hello\""), "no-sub template did not fold to a string literal: {actual}");
+    assert!(!a.contains("`hello`"), "template survived as a backtick — CLOC12.197 fold did not fire: {actual}");
     assert!(a.contains(",3)"), "1+2 not folded — did it fall back to WHITESPACE_ONLY? {actual}");
     assert!(!a.contains("1+2"), "a pre-fold expression survived: {actual}");
 }


### PR DESCRIPTION
## CLOC12.197 — constant-fold template literal → string

`fold_expression` now collapses a `TemplateLiteral` to a `StringLiteral` when every `${…}` substitution is a stringifiable constant and every quasi has a cooked value. Found via a fresh differential over the local Closure jar.

### Byte-identity verified against the reference jar
`` `a${1}b` ``→`"a1b"`, `` `${1}-${2}-${3}` ``→`"1-2-3"`, `` `a${true}b` ``→`"atrueb"`, `` `a${null}b` ``→`"anullb"`, `` `hello` ``→`"hello"`, `` `` ``→`""`, nested `` `a${`b${1}c`}d` ``→`"ab1cd"`, const-expr `` `a${1+2}b` ``→`"a3b"`. Declines non-const subs (`` `a${x}b` ``, `` `a${f()}b` `` stay).

**No emitter work needed** — verified closurec's string emitter already matches Closure's quote choice (single-quote when the value contains a `"`) and escaping (`\n`/`\t`/`\\`) byte-for-byte, so quote/newline template results emit identically.

### Frame-size safety
The fold body is an `#[inline(never)]` `fold_template_literal` helper — its `Vec`/`String` locals must stay out of the shared recursive `fold_expression` frame, which is walked once per AST depth level (inlining them overflowed the `deeply_nested_binary_chain` stack-safety test). This mirrors the DCE crate's `#[inline(never)]` convention.

### Scope note (grammar gap)
End-to-end at SIMPLE this currently fires only on **no-substitution** templates (`` `hello` ``→`"hello"`). *Substituted* templates (`` `a${x}b` ``) do not yet parse in closurec's grammar (they decline to WHITESPACE_ONLY), so the fold — though correct and unit-tested — can't receive one until a separate grammar/bridge arc lands. The fold logic is ready for it.

### Tests
- 4 unit tests (all-const subs, no-sub, const-expr sub folds first, non-const declines); constant-fold suite 352 pass under `-D warnings`, clippy clean, deep-nesting guard holds.
- Updates the existing `simple-template-literal` fixture: output shifts `log(\`hello\`,3)` → `log("hello",3)` (the no-sub fold, now byte-identical to Closure); full closurec suite (926) passes.

Additive; MINOR bump `0.91.0 → 0.92.0`. Follow-up PR2 = closurec version bump + dedicated no-sub template-fold fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)