### PR TITLE
feat(fold-control-flow): DIV#2 coalesce adjacent same-kind var declarations

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -34,6 +34,11 @@ transform this pass does not perform, so it declines rather than diverge. (For
 Folded-away declaration statements have their CV ids tombstoned via
 `record_fold_deleting`, recording the surviving container declaration's CV.
 
+The repeated-name check uses a `HashSet`, keeping the pass linear in the number
+of declarators: a run of many strictly-adjacent single-declarator statements is
+trivially authorable in the input, so a linear per-declarator membership scan
+would be Θ(N²) — a linear-input → quadratic-work DoS on the hot pass path.
+
 ## [0.24.0] - 2026-07-14
 
 ### Added — CLOC12.194: flatten redundant `BlockStatement`s (oracle divergence #4)

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.25.0] - 2026-07-15
+
+### Added — DIV#2: coalesce adjacent same-kind variable declarations
+
+A new statement-list post-step merges a run of *strictly adjacent*
+`VariableDeclaration` statements of the *same kind* (`var`/`let`/`const`) into a
+single multi-declarator declaration: `var a=1;var b=2;` → `var a=1,b=2;`,
+`let a=1;let b=2;` → `let a=1,b=2;`, `var a;var b;` → `var a,b;`, and 3+-decl
+runs collapse in one pass. Verified byte-identical to the reference Closure
+Compiler at `SIMPLE`. It is a pure size win with identical semantics —
+declarators keep their order (so initializer evaluation order is unchanged:
+`var a=b++;var c=2;` → `var a=b++,c=2;`), and merging same-scope same-kind
+bindings changes nothing about hoisting or the temporal dead zone.
+
+Runs as a post-step after this crate's other statement-list rewrites, so decls a
+block-flatten made adjacent (`{var a=1}var b=2` → `var a=1,b=2`) also merge. It
+is applied at both list-assembly points — the program body (`fold_program`) and
+block bodies (`fold_block_statement`) — via a small `VarDeclCarrier` trait so one
+generic `coalesce_var_decls` serves both `ProgramItem` and `Statement` lists.
+
+Decline conditions (each preserves byte-identity with Closure): different kinds
+don't merge (`var a=1;let b=2;` stays split); a non-declaration statement between
+two decls breaks the run (only strictly-adjacent decls merge); and a run whose
+merged declarator list would **repeat** a binding name is left untouched —
+`var a=1;var a=2;` must NOT become `var a=1,a=2;`, because Closure rewrites the
+redeclaration's second half to a bare assignment (`var a=1;a=2;`), a separate
+transform this pass does not perform, so it declines rather than diverge. (For
+`let`/`const` a repeated name is a syntax error that never reaches the pass.)
+
+Folded-away declaration statements have their CV ids tombstoned via
+`record_fold_deleting`, recording the surviving container declaration's CV.
+
 ## [0.24.0] - 2026-07-14
 
 ### Added — CLOC12.194: flatten redundant `BlockStatement`s (oracle divergence #4)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -331,7 +331,9 @@ fn fold_program(prog: &Program, st: &mut FoldState) -> Program {
         cv: prog.cv.clone(),
         version: prog.version,
         source_type: prog.source_type,
-        body: new_body,
+        // DIV#2 — as a post-step, merge any runs of adjacent same-kind variable
+        // declarations this list now holds (see `coalesce_var_decls`).
+        body: coalesce_var_decls(new_body, st),
     }
 }
 
@@ -631,8 +633,166 @@ fn fold_block_statement(b: &BlockStatement, st: &mut FoldState) -> BlockStatemen
     }
     BlockStatement {
         cv: b.cv.clone(),
-        body: new_body,
+        // DIV#2 — merge adjacent same-kind variable declarations in the block
+        // body (including any the flatten/hoist above made adjacent).
+        body: coalesce_var_decls(new_body, st),
     }
+}
+
+// =====================================================================
+// DIV#2 — coalesce adjacent same-kind variable declarations
+// =====================================================================
+//
+//   var a=1;var b=2;   ──▶   var a=1,b=2;      (one keyword + one `;` saved)
+//   let a=1;let b=2;    ──▶   let a=1,b=2;
+//   var a;var b;        ──▶   var a,b;
+//
+// The reference Closure Compiler merges a run of *strictly adjacent*
+// `VariableDeclaration` statements of the *same kind* (`var`/`let`/`const`)
+// into a single multi-declarator declaration. It is a pure size win with
+// identical semantics: the declarators keep their original order — and so their
+// initializer evaluation order (`var a=b++;var c=2;` → `var a=b++,c=2;` still
+// runs `b++` first) — and merging same-scope same-kind bindings changes nothing
+// about hoisting or the temporal dead zone.
+//
+// DECLINE conditions (each preserves byte-identity with Closure):
+//   * different kinds don't merge — `var a=1;let b=2;` stays two statements;
+//   * a non-declaration statement (or a different-kind decl) between two decls
+//     breaks the run — only *strictly adjacent* decls merge; an EmptyStatement
+//     (`;`) also breaks it here, but the pipeline's separate empty-statement
+//     removal drops the `;` in an earlier fixed-point iteration so the decls
+//     become adjacent and merge on a later pass;
+//   * a run whose merged declarator list would REPEAT a binding name is left
+//     untouched: `var a=1;var a=2;` must NOT become `var a=1,a=2;` — Closure
+//     rewrites the redeclaration's second half to a bare assignment
+//     (`var a=1;a=2;`), a *different* transform this pass does not perform, so
+//     we decline rather than diverge. (For `let`/`const` a repeated name is a
+//     syntax error that never reaches us.)
+//
+// Runs as a POST-STEP after this crate's other statement-list rewrites
+// (block-flatten, else-hoist, dead-code drop) so decls a block-flatten made
+// adjacent (`{var a=1}var b=2` → `var a=1;var b=2` → `var a=1,b=2`) also merge.
+
+/// A statement-list element that *may* carry a bare variable declaration.
+///
+/// Implemented for both list-element types this pass assembles — [`ProgramItem`]
+/// (top level) and [`Statement`] (block body) — so one generic coalescer serves
+/// both. A top-level `var` is bridged as
+/// `ProgramItem::Statement(Statement::Declaration(…))` (the parser routes
+/// variable statements through `statement`), so the program-item view looks
+/// through that wrapper as well as the bare `ProgramItem::Declaration` form, and
+/// rebuilds into the wrapper form the bridge uses.
+trait VarDeclCarrier: Clone {
+    /// The variable declaration this element carries, if any.
+    fn as_var_decl(&self) -> Option<&VariableDeclaration>;
+    /// Wrap a (merged) variable declaration back into a list element.
+    fn from_var_decl(decl: VariableDeclaration) -> Self;
+}
+
+impl VarDeclCarrier for ProgramItem {
+    fn as_var_decl(&self) -> Option<&VariableDeclaration> {
+        match self {
+            ProgramItem::Statement(Statement::Declaration(Declaration::VariableDeclaration(vd)))
+            | ProgramItem::Declaration(Declaration::VariableDeclaration(vd)) => Some(vd),
+            _ => None,
+        }
+    }
+    fn from_var_decl(decl: VariableDeclaration) -> Self {
+        // Match the bridge's program-level shape (a variable *statement*).
+        ProgramItem::Statement(Statement::Declaration(Declaration::VariableDeclaration(decl)))
+    }
+}
+
+impl VarDeclCarrier for Statement {
+    fn as_var_decl(&self) -> Option<&VariableDeclaration> {
+        match self {
+            Statement::Declaration(Declaration::VariableDeclaration(vd)) => Some(vd),
+            _ => None,
+        }
+    }
+    fn from_var_decl(decl: VariableDeclaration) -> Self {
+        Statement::Declaration(Declaration::VariableDeclaration(decl))
+    }
+}
+
+/// Merge runs of strictly-adjacent same-kind variable declarations in one
+/// statement list into single multi-declarator declarations. See the module
+/// comment above for the exact rule and the decline conditions.
+fn coalesce_var_decls<T: VarDeclCarrier>(items: Vec<T>, st: &mut FoldState) -> Vec<T> {
+    let mut out: Vec<T> = Vec::with_capacity(items.len());
+    let mut i = 0;
+    while i < items.len() {
+        // A run can only start at a variable declaration; anything else passes
+        // through verbatim.
+        let kind = match items[i].as_var_decl() {
+            Some(vd) => vd.kind,
+            None => {
+                out.push(items[i].clone());
+                i += 1;
+                continue;
+            }
+        };
+        // Extend the run over every immediately-following same-kind decl.
+        let mut j = i + 1;
+        while j < items.len() && items[j].as_var_decl().map(|vd| vd.kind) == Some(kind) {
+            j += 1;
+        }
+        if j - i < 2 {
+            // A lone declaration — nothing adjacent to merge into it.
+            out.push(items[i].clone());
+            i += 1;
+            continue;
+        }
+
+        // Gather the run's declarators in order; a repeated binding name across
+        // the run declines the *whole* run (redeclaration → separate transform).
+        let mut declarations: Vec<VariableDeclarator> = Vec::new();
+        let mut names: Vec<String> = Vec::new();
+        let mut duplicate = false;
+        for item in &items[i..j] {
+            let vd = item.as_var_decl().expect("run member is a var declaration");
+            for d in &vd.declarations {
+                let BindingTarget::Identifier(id) = &d.id;
+                if names.iter().any(|n| n == &id.name) {
+                    duplicate = true;
+                } else {
+                    names.push(id.name.clone());
+                }
+                declarations.push(d.clone());
+            }
+        }
+
+        if duplicate {
+            // Leave the run untouched — declining is never wrong.
+            for item in &items[i..j] {
+                out.push(item.clone());
+            }
+            i = j;
+            continue;
+        }
+
+        // Merge: the first decl's CV becomes the container; the folded-away
+        // declarations' CVs are tombstoned (their statement wrappers vanish).
+        let container_cv = items[i].as_var_decl().unwrap().cv.clone();
+        let discarded: Vec<Option<String>> = items[i + 1..j]
+            .iter()
+            .map(|item| item.as_var_decl().unwrap().cv.clone())
+            .collect();
+        st.record_fold_deleting(
+            &container_cv,
+            &discarded,
+            "coalesce-var-declarations",
+            "adjacent same-kind var declarations",
+            "one multi-declarator declaration",
+        );
+        out.push(T::from_var_decl(VariableDeclaration {
+            cv: container_cv,
+            kind,
+            declarations,
+        }));
+        i = j;
+    }
+    out
 }
 
 /// A statement that unconditionally transfers control out of the
@@ -3222,6 +3382,206 @@ mod tests {
                 Statement::Tagged(TaggedStatement::ExpressionStatement(_))
             ),
             "the inner block should flatten inside the function body"
+        );
+    }
+
+    // ---------------- DIV#2: coalesce adjacent same-kind var decls --------
+
+    /// A program-level variable declaration item (a `var`/`let`/`const`
+    /// statement) with one declarator, optionally carrying a CV id.
+    fn prog_var(name: &str, init: Option<Expression>, kind: VarKind, cv: Option<&str>) -> ProgramItem {
+        ProgramItem::Statement(Statement::Declaration(Declaration::VariableDeclaration(
+            VariableDeclaration {
+                cv: cv.map(|s| s.to_string()),
+                kind,
+                declarations: vec![VariableDeclarator {
+                    cv: None,
+                    id: BindingTarget::Identifier(Identifier {
+                        cv: None,
+                        name: name.to_string(),
+                    }),
+                    init,
+                }],
+            },
+        )))
+    }
+
+    /// The variable declaration at program-body index `idx` (panics otherwise).
+    fn prog_decl_at(prog: &Program, idx: usize) -> &VariableDeclaration {
+        match &prog.body[idx] {
+            ProgramItem::Statement(Statement::Declaration(Declaration::VariableDeclaration(vd)))
+            | ProgramItem::Declaration(Declaration::VariableDeclaration(vd)) => vd,
+            other => panic!("expected a variable declaration at {idx}; got {other:?}"),
+        }
+    }
+
+    /// The bound names of a declaration, in order (`var a=1,b=2` → `["a","b"]`).
+    fn declarator_names(vd: &VariableDeclaration) -> Vec<String> {
+        vd.declarations
+            .iter()
+            .map(|d| {
+                let BindingTarget::Identifier(id) = &d.id;
+                id.name.clone()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn two_adjacent_var_decls_coalesce() {
+        // `var a=1;var b=2;` → `var a=1,b=2;`
+        let prog = program().with_body(vec![
+            prog_var("a", Some(num(1.0, None)), VarKind::Var, None),
+            prog_var("b", Some(num(2.0, None)), VarKind::Var, None),
+        ]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(changed, "coalescing should mark the program changed");
+        assert_eq!(out.body.len(), 1, "the two decls should merge into one");
+        let vd = prog_decl_at(&out, 0);
+        assert_eq!(vd.kind, VarKind::Var);
+        assert_eq!(declarator_names(vd), vec!["a", "b"]);
+        // Inits are preserved in order.
+        assert!(matches!(&vd.declarations[0].init, Some(Expression::NumericLiteral(n)) if n.value == 1.0));
+        assert!(matches!(&vd.declarations[1].init, Some(Expression::NumericLiteral(n)) if n.value == 2.0));
+    }
+
+    #[test]
+    fn three_adjacent_var_decls_coalesce_into_one() {
+        // `var a=1;var b=2;var c=3;` → `var a=1,b=2,c=3;`
+        let prog = program().with_body(vec![
+            prog_var("a", Some(num(1.0, None)), VarKind::Var, None),
+            prog_var("b", Some(num(2.0, None)), VarKind::Var, None),
+            prog_var("c", Some(num(3.0, None)), VarKind::Var, None),
+        ]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 1);
+        assert_eq!(declarator_names(prog_decl_at(&out, 0)), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn adjacent_let_decls_coalesce() {
+        // `let a=1;let b=2;` → `let a=1,b=2;` — same rule, `let` kind preserved.
+        let prog = program().with_body(vec![
+            prog_var("a", Some(num(1.0, None)), VarKind::Let, None),
+            prog_var("b", Some(num(2.0, None)), VarKind::Let, None),
+        ]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 1);
+        let vd = prog_decl_at(&out, 0);
+        assert_eq!(vd.kind, VarKind::Let);
+        assert_eq!(declarator_names(vd), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn declarations_without_initializers_coalesce() {
+        // `var a;var b;` → `var a,b;`
+        let prog = program().with_body(vec![
+            prog_var("a", None, VarKind::Var, None),
+            prog_var("b", None, VarKind::Var, None),
+        ]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 1);
+        let vd = prog_decl_at(&out, 0);
+        assert_eq!(declarator_names(vd), vec!["a", "b"]);
+        assert!(vd.declarations.iter().all(|d| d.init.is_none()));
+    }
+
+    #[test]
+    fn different_kind_decls_do_not_coalesce() {
+        // `var a=1;let b=2;` — different kinds stay two separate statements.
+        let prog = program().with_body(vec![
+            prog_var("a", Some(num(1.0, None)), VarKind::Var, None),
+            prog_var("b", Some(num(2.0, None)), VarKind::Let, None),
+        ]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(!changed, "different-kind decls must not merge");
+        assert_eq!(out.body.len(), 2);
+        assert_eq!(prog_decl_at(&out, 0).kind, VarKind::Var);
+        assert_eq!(prog_decl_at(&out, 1).kind, VarKind::Let);
+    }
+
+    #[test]
+    fn non_adjacent_decls_do_not_coalesce() {
+        // `var a=1;f();var b=2;` — the call between them breaks the run.
+        let prog = program().with_body(vec![
+            prog_var("a", Some(num(1.0, None)), VarKind::Var, None),
+            ProgramItem::Statement(expr_stmt(ident("f"), None)),
+            prog_var("b", Some(num(2.0, None)), VarKind::Var, None),
+        ]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(!changed, "a statement between the decls must break the run");
+        assert_eq!(out.body.len(), 3);
+    }
+
+    #[test]
+    fn redeclaration_declines_to_preserve_byte_identity() {
+        // `var a=1;var a=2;` must NOT become `var a=1,a=2;` — the repeated name
+        // is a redeclaration the reference compiler rewrites differently
+        // (`var a=1;a=2;`), so this pass leaves the run untouched.
+        let prog = program().with_body(vec![
+            prog_var("a", Some(num(1.0, None)), VarKind::Var, None),
+            prog_var("a", Some(num(2.0, None)), VarKind::Var, None),
+        ]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(!changed, "a repeated binding name must decline the merge");
+        assert_eq!(out.body.len(), 2, "the two decls stay separate");
+    }
+
+    #[test]
+    fn lone_declaration_is_left_alone() {
+        let prog =
+            program().with_body(vec![prog_var("a", Some(num(1.0, None)), VarKind::Var, None)]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(!changed);
+        assert_eq!(out.body.len(), 1);
+        assert_eq!(declarator_names(prog_decl_at(&out, 0)), vec!["a"]);
+    }
+
+    #[test]
+    fn flattened_block_decls_then_coalesce() {
+        // `{var a=1;var b=2;}` at program level: the scope-safe block flattens
+        // into the program body (CLOC12.194), and the now-adjacent decls then
+        // coalesce — the two rewrites compose to `var a=1,b=2;`.
+        let block = Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![
+                make_var_decl("a", Some(num(1.0, None))),
+                make_var_decl("b", Some(num(2.0, None))),
+            ],
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(block)]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 1, "flatten + coalesce compose to one decl");
+        assert_eq!(declarator_names(prog_decl_at(&out, 0)), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn coalesce_tombstones_the_folded_away_declaration_cv() {
+        // Merging `var a=1;var b=2;` deletes the second decl's statement
+        // wrapper; its CV id must be tombstoned with the container recorded.
+        let mut log = CVLog::new(true);
+        let second_id = log.create(None);
+        let prog = program().with_body(vec![
+            prog_var("a", Some(num(1.0, None)), VarKind::Var, Some("v.first")),
+            prog_var("b", Some(num(2.0, None)), VarKind::Var, Some(second_id.as_str())),
+        ]);
+        let out = run_capturing_cv(&prog, &mut log);
+        assert_eq!(out.body.len(), 1, "the decls should have merged");
+        let del = log
+            .get(&second_id)
+            .unwrap()
+            .deleted
+            .as_ref()
+            .expect("the folded-away declaration must be tombstoned");
+        assert_eq!(del.source, "fold-control-flow");
+        assert_eq!(del.reason, "coalesce-var-declarations");
+        assert_eq!(
+            del.meta.get("container_cv").and_then(|v| v.as_str()),
+            Some("v.first"),
+            "tombstone should record the surviving container decl's cv"
         );
     }
 }

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -68,7 +68,7 @@ use coding_adventures_javascript_ast::{
     DoWhileStatement, VariableDeclarator, WhileStatement, WithStatement,
 };
 use serde_json::json;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// `Pass::depends_on` value. CLOC06 canonical order pins
 /// constant-fold first so we see folded literals as branch
@@ -746,17 +746,23 @@ fn coalesce_var_decls<T: VarDeclCarrier>(items: Vec<T>, st: &mut FoldState) -> V
 
         // Gather the run's declarators in order; a repeated binding name across
         // the run declines the *whole* run (redeclaration → separate transform).
+        //
+        // The seen-names check uses a `HashSet` (not a linear `Vec` scan): a run
+        // of N strictly-adjacent single-declarator statements is trivially
+        // authorable in the input JS (`var a0=1;var a1=1;…`), and a per-declarator
+        // linear membership test would be Θ(N²) — a linear-input → quadratic-work
+        // DoS on this hot pass path. The `&str` borrows live in `items[i..j]`,
+        // which outlives this per-run gather, so no owned clone is needed.
         let mut declarations: Vec<VariableDeclarator> = Vec::new();
-        let mut names: Vec<String> = Vec::new();
+        let mut names: HashSet<&str> = HashSet::new();
         let mut duplicate = false;
         for item in &items[i..j] {
             let vd = item.as_var_decl().expect("run member is a var declaration");
             for d in &vd.declarations {
                 let BindingTarget::Identifier(id) = &d.id;
-                if names.iter().any(|n| n == &id.name) {
+                // `insert` returns false when the name was already present.
+                if !names.insert(id.name.as_str()) {
                     duplicate = true;
-                } else {
-                    names.push(id.name.clone());
                 }
                 declarations.push(d.clone());
             }

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.34"
+version = "0.234.35"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.34",
+  "version": "0.234.35",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.34
+Version: 0.234.35
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-arrow-function/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-arrow-function/expected.stdout
@@ -1,1 +1,1 @@
-var factory=n=>3;var scaled=(a,b)=>a+12;arr.map(x=>x+4);
+var factory=n=>3,scaled=(a,b)=>a+12;arr.map(x=>x+4);

--- a/code/programs/rust/closurec/tests/diff/simple-asi-newline/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-newline/README.md
@@ -11,7 +11,7 @@ End-to-end oracle for **CLOC26 Phase 2** — Automatic Semicolon Insertion at a
 | `expected.stdout` | The optimized output (see below) |
 
 ```text
-var w=4;var s=3;report(w * s);
+var w=4,s=3;report(w * s);
 ```
 
 What this proves:

--- a/code/programs/rust/closurec/tests/diff/simple-asi-newline/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-newline/expected.stdout
@@ -1,1 +1,1 @@
-var w=4;var s=3;report(w*s);
+var w=4,s=3;report(w*s);

--- a/code/programs/rust/closurec/tests/diff/simple-asi-string-newline/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-asi-string-newline/expected.stdout
@@ -1,1 +1,1 @@
-var label="total";var n=3;show(label,n);
+var label="total",n=3;show(label,n);

--- a/code/programs/rust/closurec/tests/diff/simple-constant-fold/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-constant-fold/README.md
@@ -6,7 +6,7 @@ End-to-end oracle for `--compilation_level SIMPLE` (CLOC12.155, PR-1).
 |------|------|
 | `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | Three `var` declarations with constant arithmetic initializers |
-| `expected.stdout` | The folded output: `var sum=3;var product=12;var nested=14;` |
+| `expected.stdout` | The folded output: `var sum=3,product=12,nested=14;` |
 
 The SIMPLE level runs the typed-AST optimization pipeline (currently
 just the `constant-fold` pass), so `1 + 2` ⇒ `3`, `3 * 4` ⇒ `12`, and

--- a/code/programs/rust/closurec/tests/diff/simple-constant-fold/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-constant-fold/expected.stdout
@@ -1,1 +1,1 @@
-var sum=3;var product=12;var nested=14;report(sum,product,nested);
+var sum=3,product=12,nested=14;report(sum,product,nested);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-from/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-from/expected.stdout
@@ -1,1 +1,1 @@
-var a=["a","b","c"];var b=[];var c=Array.from("xy",f);var d=Array.from(s);var e=q.from("z");report(a,b,c,d,e);
+var a=["a","b","c"],b=[],c=Array.from("xy",f),d=Array.from(s),e=q.from("z");report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-isarray/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-isarray/expected.stdout
@@ -1,1 +1,1 @@
-var a=!0;var b=!1;var c=!1;var d=!1;var e=!1;var f=Array.isArray([1,2]);report(a,b,c,d,e,f);
+var a=!0,b=!1,c=!1,d=!1,e=!1,f=Array.isArray([1,2]);report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-of/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-of/expected.stdout
@@ -1,1 +1,1 @@
-var a=[];var b=[7];var c=[1,2,3];var d=[x,y];var e=q.of(1);report(a,b,c,d,e);
+var a=[],b=[7],c=[1,2,3],d=[x,y],e=q.of(1);report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/README.md
@@ -7,7 +7,7 @@ End-to-end oracle for unary bitwise-NOT folding at
 |------|------|
 | `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | Four `var` declarations whose initializers are `~<numeric literal>` expressions |
-| `expected.stdout` | The folded output: `var a=-6;var b=0;var c=-6;var d=9;report(a,b,c,d);` |
+| `expected.stdout` | The folded output: `var a=-6,b=0,c=-6,d=9;report(a,b,c,d);` |
 
 The SIMPLE level runs the typed-AST optimization pipeline, whose
 `constant-fold` pass now folds the unary `~` operator on a numeric

--- a/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-bitnot/expected.stdout
@@ -1,1 +1,1 @@
-var a=-6;var b=0;var c=-6;var d=9;report(a,b,c,d);
+var a=-6,b=0,c=-6,d=9;report(a,b,c,d);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-boolean/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-boolean/expected.stdout
@@ -1,1 +1,1 @@
-var a=!1;var b=!0;var c=!0;var d=!1;var e=!0;var f=Boolean(z);report(a,b,c,d,e,f);
+var a=!1,b=!0,c=!0,d=!1,e=!0,f=Boolean(z);report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-codepointat/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-codepointat/README.md
@@ -7,7 +7,7 @@ End-to-end oracle for string-indexing folding (`codePointAt`) at
 |------|------|
 | `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | three `"…".codePointAt(i)` calls into `report(...)` |
-| `expected.stdout` | The folded output: `var a=97;var b=128169;var c=56489;report(a,b,c);` |
+| `expected.stdout` | The folded output: `var a=97,b=128169,c=56489;report(a,b,c);` |
 
 The SIMPLE level runs the typed-AST optimization pipeline, whose
 `constant-fold` pass evaluates `String#codePointAt` on a string-literal

--- a/code/programs/rust/closurec/tests/diff/simple-fold-codepointat/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-codepointat/expected.stdout
@@ -1,1 +1,1 @@
-var a=97;var b=128169;var c=56489;report(a,b,c);
+var a=97,b=128169,c=56489;report(a,b,c);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-escape/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-escape/expected.stdout
@@ -1,1 +1,1 @@
-var a="a%20b";var b="%7E/@";var c="%E9";var d="%uD83D%uDE00";var e="a b";var f="\u00e9";var g="/";var h=unescape("%uD83D");report(a,b,c,d,e,f,g,h);
+var a="a%20b",b="%7E/@",c="%E9",d="%uD83D%uDE00",e="a b",f="\u00e9",g="/",h=unescape("%uD83D");report(a,b,c,d,e,f,g,h);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/expected.stdout
@@ -1,1 +1,1 @@
-var a="HI";var b="\ud83d\udca9";var c="";report(a,b,c);
+var a="HI",b="\ud83d\udca9",c="";report(a,b,c);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/expected.stdout
@@ -1,1 +1,1 @@
-var a="HI";var b="\ud83d\udca9";var c="\ud83d\udca9A";report(a,b,c);
+var a="HI",b="\ud83d\udca9",c="\ud83d\udca9A";report(a,b,c);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-isnan/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-isnan/expected.stdout
@@ -1,1 +1,1 @@
-var a=!0;var b=!1;var c=!1;var d=!0;var e=!1;var f=!1;var g=!0;report(a,b,c,d,e,f,g);
+var a=!0,b=!1,c=!1,d=!0,e=!1,f=!1,g=!0;report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-json-stringify/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-json-stringify/expected.stdout
@@ -1,1 +1,1 @@
-var a="42";var b="-7";var c="true";var d="null";var e=JSON.stringify("x");var f=JSON.stringify(3.5);report(a,b,c,d,e,f);
+var a="42",b="-7",c="true",d="null",e=JSON.stringify("x"),f=JSON.stringify(3.5);report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-lastindexof/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-lastindexof/README.md
@@ -7,7 +7,7 @@ string-literal operands at `--compilation_level SIMPLE`.
 |------|------|
 | `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | `"abcabc".lastIndexOf("bc")`, `"abcabc".lastIndexOf("z")`, `"abc".lastIndexOf("")`, `"ab".lastIndexOf("b")` |
-| `expected.stdout` | The folded output: `var a=4;var b=-1;var c=3;var d=1;report(a,b,c,d);` |
+| `expected.stdout` | The folded output: `var a=4,b=-1,c=3,d=1;report(a,b,c,d);` |
 
 The SIMPLE level runs the typed-AST optimization pipeline, whose `constant-fold`
 pass folds a `"…".lastIndexOf("…")` call into the UTF-16 code-unit index of the

--- a/code/programs/rust/closurec/tests/diff/simple-fold-lastindexof/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-lastindexof/expected.stdout
@@ -1,1 +1,1 @@
-var a=4;var b=-1;var c=3;var d=1;report(a,b,c,d);
+var a=4,b=-1,c=3,d=1;report(a,b,c,d);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-max-min/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-max-min/README.md
@@ -22,7 +22,7 @@ compile time and the call collapses to that literal.
 Expected SIMPLE stdout:
 
 ```text
-var a=3;var b=1;var c=-1;var d=7;var e=Math.max(1,x);var f=Math.max();var g=m.max(1,2);report(a,b,c,d,e,f,g);
+var a=3,b=1,c=-1,d=7,e=Math.max(1,x),f=Math.max(),g=m.max(1,2);report(a,b,c,d,e,f,g);
 ```
 
 Each result flows into `report(...)` so it stays referenced past

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-max-min/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-max-min/expected.stdout
@@ -1,1 +1,1 @@
-var a=3;var b=1;var c=-1;var d=7;var e=Math.max(1,x);var f=Math.max();var g=m.max(1,2);report(a,b,c,d,e,f,g);
+var a=3,b=1,c=-1,d=7,e=Math.max(1,x),f=Math.max(),g=m.max(1,2);report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-issafeinteger/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-issafeinteger/expected.stdout
@@ -1,1 +1,1 @@
-var a=!0;var b=!1;var c=!0;var d=!1;var e=Number.isSafeInteger(x);report(a,b,c,d,e);
+var a=!0,b=!1,c=!0,d=!1,e=Number.isSafeInteger(x);report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-parse/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-parse/README.md
@@ -34,7 +34,7 @@ for either), and `parseInt` only folds with a missing or integer-literal radix.
 - `expected.stdout` — the byte-exact SIMPLE output:
 
   ```text
-  var a=12;var b=255;var c=31;var d=314;var e=Number.parseInt("");report(a,b,c,d,e);
+  var a=12,b=255,c=31,d=314,e=Number.parseInt("");report(a,b,c,d,e);
   ```
 
 The integration test `tests/diff_simple_fold_number_parse.rs` runs the binary

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-parse/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-parse/expected.stdout
@@ -1,1 +1,1 @@
-var a=12;var b=255;var c=31;var d=314;var e=Number.parseInt("");report(a,b,c,d,e);
+var a=12,b=255,c=31,d=314,e=Number.parseInt("");report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-static/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-static/expected.stdout
@@ -1,1 +1,1 @@
-var a=!0;var b=!1;var c=!0;var d=!0;var e=!1;var f=!1;var g=!1;report(a,b,c,d,e,f,g);
+var a=!0,b=!1,c=!0,d=!0,e=!1,f=!1,g=!1;report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number/README.md
@@ -28,7 +28,7 @@ be numeric or the result is `NaN`:
 So the folded `expected.stdout` is:
 
 ```js
-var a=42;var b=0;var c=3.5;var d=31;var e=5;var f=15;var g=Number("abc");report(a,b,c,d,e,f,g);
+var a=42,b=0,c=3.5,d=31,e=5,f=15,g=Number("abc");report(a,b,c,d,e,f,g);
 ```
 
 Only the **bare global identifier** folds — a member access like

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number/expected.stdout
@@ -1,1 +1,1 @@
-var a=42;var b=0;var c=3.5;var d=31;var e=5;var f=15;var g=Number("abc");report(a,b,c,d,e,f,g);
+var a=42,b=0,c=3.5,d=31,e=5,f=15,g=Number("abc");report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/expected.stdout
@@ -1,1 +1,1 @@
-var a=[["a",1],["b",2]];var b=[["x","hi"]];var c=[];var d=Object.entries({1:"x"});var e=Object.entries({__proto__:1});var f=o.entries({a:1});report(a,b,c,d,e,f);
+var a=[["a",1],["b",2]],b=[["x","hi"]],c=[],d=Object.entries({1:"x"}),e=Object.entries({__proto__:1}),f=o.entries({a:1});report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-fromentries/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-fromentries/expected.stdout
@@ -1,1 +1,1 @@
-var a={a:1,b:2};var b={"1":"x"};var c={a:2};var d={};var e=o.fromEntries([["a",1]]);var f=Object.fromEntries([["__proto__",1]]);report(a,b,c,d,e,f);
+var a={a:1,b:2},b={"1":"x"},c={a:2},d={},e=o.fromEntries([["a",1]]),f=Object.fromEntries([["__proto__",1]]);report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-is/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-is/expected.stdout
@@ -1,1 +1,1 @@
-var a=!0;var b=!1;var c=!0;var d=!1;var e=Object.is(NaN,NaN);report(a,b,c,d,e);
+var a=!0,b=!1,c=!0,d=!1,e=Object.is(NaN,NaN);report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/expected.stdout
@@ -1,1 +1,1 @@
-var a=[];var b=[];var c=[];var d=["a","b"];var e=Object.values({a:1});var f=Object.keys({1:"x"});var g=Object.keys([]);report(a,b,c,d,e,f,g);
+var a=[],b=[],c=[],d=["a","b"],e=Object.values({a:1}),f=Object.keys({1:"x"}),g=Object.keys([]);report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-parseint/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-parseint/README.md
@@ -7,7 +7,7 @@ literals at `--compilation_level SIMPLE`.
 |------|------|
 | `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | `parseInt("12px")`, `parseInt("FF", 16)`, `parseFloat("3.14abc")`, `parseInt("0x1F")` |
-| `expected.stdout` | The folded output: `var a=12;var b=255;var c=3.14;var d=31;report(a,b,c,d);` |
+| `expected.stdout` | The folded output: `var a=12,b=255,c=3.14,d=31;report(a,b,c,d);` |
 
 The SIMPLE level runs the typed-AST optimization pipeline, whose
 `constant-fold` pass folds global `parseInt`/`parseFloat` calls whose first

--- a/code/programs/rust/closurec/tests/diff/simple-fold-parseint/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-parseint/expected.stdout
@@ -1,1 +1,1 @@
-var a=12;var b=255;var c=3.14;var d=31;report(a,b,c,d);
+var a=12,b=255,c=3.14,d=31;report(a,b,c,d);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-replace/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-replace/expected.stdout
@@ -1,1 +1,1 @@
-var a="a_b_c";var b="a-bXc";report(a,b);
+var a="a_b_c",b="a-bXc";report(a,b);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-split/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-split/expected.stdout
@@ -1,1 +1,1 @@
-var a=["a","b","c"];var b=["a","b","c"];var c=["a","b"];var d=["abc"];report(a,b,c,d);
+var a=["a","b","c"],b=["a","b","c"],c=["a","b"],d=["abc"];report(a,b,c,d);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-string/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-string/expected.stdout
@@ -1,1 +1,1 @@
-var a="42";var b="x";var c="-3";var d="255";var e=String(0.5);report(a,b,c,d,e);
+var a="42",b="x",c="-3",d="255",e=String(0.5);report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strpred/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strpred/expected.stdout
@@ -1,1 +1,1 @@
-var a=!0;var b=!1;var c=!0;report(a,b,c);
+var a=!0,b=!1,c=!0;report(a,b,c);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-substr/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-substr/expected.stdout
@@ -1,1 +1,1 @@
-var a="bc";var b="bcde";var c="de";var d="";report(a,b,c,d);
+var a="bc",b="bcde",c="de",d="";report(a,b,c,d);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-substring/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-substring/expected.stdout
@@ -1,1 +1,1 @@
-var a="bc";var b="bc";var c="abcd";var d="";report(a,b,c,d);
+var a="bc",b="bc",c="abcd",d="";report(a,b,c,d);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-uri/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-uri/expected.stdout
@@ -1,1 +1,1 @@
-var a="a%20b";var b="a/b?c=d";var c="%C3%A9";var d="a b";var e="%2F";var f="\u00e9";var g=decodeURI("%E0");report(a,b,c,d,e,f,g);
+var a="a%20b",b="a/b?c=d",c="%C3%A9",d="a b",e="%2F",f="\u00e9",g=decodeURI("%E0");report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-uricomponent/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-uricomponent/expected.stdout
@@ -1,1 +1,1 @@
-var a="a%20b";var b="%C3%A9";var c="%2F";var d="a b";var e="\u00e9";var f=decodeURIComponent("%E0");report(a,b,c,d,e,f);
+var a="a%20b",b="%C3%A9",c="%2F",d="a b",e="\u00e9",f=decodeURIComponent("%E0");report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-function-expression/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-function-expression/expected.stdout
@@ -1,1 +1,1 @@
-var factory=function make(n){return 3};var obj={run:function(){return 6}};(function(){var y;y=7})();arr.map(function(x){return x+0});
+var factory=function make(n){return 3},obj={run:function(){return 6}};(function(){var y;y=7})();arr.map(function(x){return x+0});

--- a/code/programs/rust/closurec/tests/diff/simple-negation-fold/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-negation-fold/expected.stdout
@@ -1,1 +1,1 @@
-var a=first();var b=second();report(a!=b,a!==b,!(a<b));
+var a=first(),b=second();report(a!=b,a!==b,!(a<b));

--- a/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/README.md
@@ -7,7 +7,7 @@ End-to-end oracle for the `remove-unused-vars` pass in
 |------|------|
 | `flags.txt` | `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | Three top-level `var`s — one dead, one live, one impure |
-| `expected.stdout` | `var live=10;var impure=run();log(live);` |
+| `expected.stdout` | `var live=10,impure=run();log(live);` |
 
 The SIMPLE pipeline is now
 `constant-fold → fold-control-flow → dce → inline → remove-unused-vars`.

--- a/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/expected.stdout
@@ -1,2 +1,1 @@
-var live=10;var impure=run();log(live);
-
+var live=10,impure=run();log(live);

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/expected.stdout
@@ -1,1 +1,1 @@
-var a=first();var b=second();var c=third();report(!a,-b,~c,!(a<b));
+var a=first(),b=second(),c=third();report(!a,-b,~c,!(a<b));


### PR DESCRIPTION
## DIV#2 — coalesce adjacent same-kind variable declarations

Merges a run of **strictly-adjacent same-kind** `var`/`let`/`const` declaration statements into one multi-declarator declaration, matching the reference Closure Compiler at `SIMPLE`.

| input | output |
|-------|--------|
| `var a=1;var b=2;` | `var a=1,b=2;` |
| `let a=1;let b=2;` | `let a=1,b=2;` |
| `var a;var b;` | `var a,b;` |
| `var a=1;var b=2;var c=3;` | `var a=1,b=2,c=3;` |

Pure size win, identical semantics: declarators keep their order (initializer evaluation order unchanged — `var a=b++;var c=2;` → `var a=b++,c=2;`), and merging same-scope same-kind bindings changes nothing about hoisting or the TDZ.

### Where
Statement-list post-step at both assembly points — program body (`fold_program`) and block bodies (`fold_block_statement`) — via a small `VarDeclCarrier` trait so one generic `coalesce_var_decls` serves both `ProgramItem` and `Statement` lists. Runs after the crate's other list rewrites, so decls a block-flatten made adjacent (`{var a=1}var b=2` → `var a=1,b=2`) also merge.

### Declines (each preserves byte-identity with Closure)
- **different kinds** don't merge — `var a=1;let b=2;` stays split;
- a **non-declaration statement between** decls breaks the run (only strictly-adjacent merge);
- a run whose merged declarator list would **repeat a binding name** is left untouched — `var a=1;var a=2;` must NOT become `var a=1,a=2;`, because Closure rewrites the redeclaration's second half to a bare assignment (`var a=1;a=2;`), a separate transform. (For `let`/`const` a repeat is a syntax error that never reaches the pass.)

### closurec impact
Regenerated **38 drifted closurec fixtures** whose adjacent decls now coalesce — every delta is purely the coalescing, no other output changed. Notably **7 fixtures now match the real Closure Compiler byte-for-byte** (simple-asi-newline, simple-asi-string-newline, simple-constant-fold, simple-fold-array-of, simple-fold-lastindexof, simple-fold-number-issafeinteger, simple-fold-split), closing that many oracle divergences. Updated 10 fixture READMEs; bumped closurec 0.234.34 → 0.234.35 (Cargo + cli.spec.json + help-markdown).

### Verification
- 10 new pass unit tests (each fold, each decline, flatten+coalesce composition, CV tombstone); clippy clean under `-D warnings`.
- **Full closurec suite green** (134 test binaries, fresh build).
- CV-traced: folded-away declarations' CV ids tombstoned via `record_fold_deleting`.
- Inline security review: found + fixed one MEDIUM (quadratic redeclaration guard → `HashSet`, now O(N)); re-verified.

Version: `closure-pass-fold-control-flow` 0.24.0 → 0.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)