### PR TITLE
feat(closure-pass-dce): eliminate empty if with side-effect-free test

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.25.0] - 2026-07-15
+
+### Added — empty-`if` elimination (test side-effect-free)
+
+`dce_statement` now drops an `if` statement whose consequent is empty AND whose
+alternate is absent-or-empty AND whose test is **side-effect-free**: `if(x){}`,
+`if(x.y){}`, `if(x[k]){}`, `if(a&&b){}`, `if(typeof x){}`, `if(!x){}`,
+`if(x){}else{}` all collapse to `;` (which the block/program empty-statement
+sweep then removes), matching the reference Closure Compiler. When either branch
+does real work, or the test may have side effects (`if(f()){}`, `if(x++){}`), the
+`if` is kept — the "keep the test as an expression statement" rewrite
+(`if(f()){}`→`f();`) is a deliberate follow-up, and switch elimination for a
+side-effect-free-but-non-leaf discriminant is a separate slice.
+
+A new `is_side_effect_free` predicate backs the decision: identifiers, `this`,
+literals, and property reads / unary (non-`delete`) / binary / logical /
+conditional expressions built from side-effect-free parts are pure; calls,
+`new`, assignment, `++`/`--`, `delete`, `yield`, `await`, tagged templates,
+dynamic `import()`, and (conservatively) the comma operator are not. Member
+access is pure only when its object (and computed key) are pure, so `f().y` is
+correctly excluded. Safe-by-construction: anything not positively known pure is
+never removed.
+
 ## [0.24.0] - 2026-07-15
 
 ### Added — CLOC12.195: strip stray top-level `EmptyStatement`s

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -79,7 +79,7 @@ use coding_adventures_javascript_ast::{
     ClassDeclaration, ClassExpression, ClassMember, MethodDefinition, PropertyDefinition,
     ChainExpression, FunctionDeclaration, FunctionExpression, IfStatement, LogicalExpression, MemberExpression, NullLiteral, OptionalCallExpression, OptionalMemberExpression,
     NumericLiteral, ObjectExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey,
-    ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, UpdateExpression, VarKind,
+    ReturnStatement, Statement, StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, UpdateExpression, VarKind,
     DoWhileStatement, VariableDeclaration, VariableDeclarator, WhileStatement, WithStatement,
 };
 use serde_json::json;
@@ -253,6 +253,81 @@ fn is_pure_leaf(expr: &Expression) -> bool {
     )
 }
 
+/// Is evaluating `expr` free of observable side effects? Used to decide whether
+/// a statement whose only job is to evaluate `expr` (e.g. the test of an
+/// otherwise-empty `if`) can be dropped entirely.
+///
+/// This is broader than [`is_pure_leaf`] (which is literals only): it mirrors
+/// the reference Closure Compiler's notion, under which reading a binding or a
+/// property, and combining pure sub-expressions with the pure operators, has no
+/// side effect. So `if (x) {}`, `if (x.y) {}`, `if (x[k]) {}`, `if (a && b) {}`,
+/// `if (typeof x) {}`, `if (!x) {}` all drop.
+///
+/// SAFE-BY-CONSTRUCTION: anything not positively known pure returns `false`
+/// (never removed). The impure set — calls, `new`, assignment, `++`/`--`,
+/// `delete`, `yield`, `await`, tagged templates, dynamic `import()`, and
+/// (conservatively) the comma operator — is therefore handled by the catch-all.
+///
+/// - **Member access** is pure only when its object *and* (for a computed key)
+///   its property are pure — `f().y` is NOT pure (the call runs).
+/// - **`delete`** is excluded from the pure unary operators: it mutates.
+/// - The comma operator (`SequenceExpression`) returns `false` even when both
+///   operands are pure, because the reference compiler rewrites
+///   `if (a, b) {}` to `a;` (a different transform), so declining here keeps us
+///   byte-identical rather than removing it outright.
+fn is_side_effect_free(expr: &Expression) -> bool {
+    match expr {
+        // Leaf values and bindings: no side effect to read.
+        Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::UndefinedLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::Identifier(_)
+        | Expression::ThisExpression(_) => true,
+        // Property read: pure iff the object (and computed key) are pure.
+        Expression::MemberExpression(m) => {
+            is_side_effect_free(&m.object)
+                && (!m.computed || is_side_effect_free(&m.property))
+        }
+        // Pure prefix operators over a pure operand. `delete` is NOT here — it
+        // removes a property (a side effect).
+        Expression::UnaryExpression(u) => {
+            u.operator != UnaryOperator::Delete && is_side_effect_free(&u.argument)
+        }
+        Expression::BinaryExpression(b) => {
+            is_side_effect_free(&b.left) && is_side_effect_free(&b.right)
+        }
+        Expression::LogicalExpression(l) => {
+            is_side_effect_free(&l.left) && is_side_effect_free(&l.right)
+        }
+        Expression::ConditionalExpression(c) => {
+            is_side_effect_free(&c.test)
+                && is_side_effect_free(&c.consequent)
+                && is_side_effect_free(&c.alternate)
+        }
+        // Anything else (Call / New / Assignment / Update / Sequence / Yield /
+        // Await / TaggedTemplate / ImportExpression / …) is treated as possibly
+        // side-effecting and is NOT removed.
+        _ => false,
+    }
+}
+
+/// Does this statement do nothing when executed — an `EmptyStatement` (`;`) or
+/// an empty `BlockStatement` (`{}`)? Used to test whether an `if`'s branch is
+/// empty. (An empty block IS observably a no-op: it declares no bindings.)
+fn statement_is_empty(stmt: &Statement) -> bool {
+    matches!(
+        stmt,
+        Statement::Tagged(TaggedStatement::EmptyStatement(_))
+    ) || matches!(
+        stmt,
+        Statement::Tagged(TaggedStatement::BlockStatement(b)) if b.body.is_empty()
+    )
+}
+
 // =====================================================================
 // Program / top-level
 // =====================================================================
@@ -362,12 +437,37 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
         TaggedStatement::BlockStatement(s) => {
             TaggedStatement::BlockStatement(dce_block_statement(s, st))
         }
-        TaggedStatement::IfStatement(s) => TaggedStatement::IfStatement(IfStatement {
-            cv: s.cv.clone(),
-            test: dce_expression(&s.test, st),
-            consequent: Box::new(dce_statement(&s.consequent, st)),
-            alternate: s.alternate.as_ref().map(|a| Box::new(dce_statement(a, st))),
-        }),
+        TaggedStatement::IfStatement(s) => {
+            let test = dce_expression(&s.test, st);
+            let consequent = Box::new(dce_statement(&s.consequent, st));
+            let alternate = s.alternate.as_ref().map(|a| Box::new(dce_statement(a, st)));
+
+            // Empty-`if` elimination. When both branches do nothing (consequent
+            // empty AND alternate absent-or-empty) the whole statement's only
+            // remaining effect is evaluating `test`; if `test` is side-effect-
+            // free the entire `if` is dead and collapses to `;` (which the
+            // block/program sweep then drops). `if(x){}`, `if(x.y){}else{}`, … →
+            // removed; a side-effecting test (`if(f()){}`) is left intact — the
+            // "keep the test as an expression statement" rewrite is a follow-up.
+            let cons_empty = statement_is_empty(&consequent);
+            let alt_empty = alternate.as_ref().is_none_or(|a| statement_is_empty(a));
+            if cons_empty && alt_empty && is_side_effect_free(&test) {
+                st.record(
+                    &s.cv,
+                    "if_eliminated",
+                    "IfStatement{ <empty>, test side-effect-free }",
+                    "EmptyStatement",
+                );
+                return TaggedStatement::EmptyStatement(EmptyStatement { cv: s.cv.clone() });
+            }
+
+            TaggedStatement::IfStatement(IfStatement {
+                cv: s.cv.clone(),
+                test,
+                consequent,
+                alternate,
+            })
+        }
         TaggedStatement::WhileStatement(s) => TaggedStatement::WhileStatement(WhileStatement {
             cv: s.cv.clone(),
             test: dce_expression(&s.test, st),
@@ -3165,5 +3265,105 @@ mod tests {
             "the statement after a try/finally must remain reachable; got {:?}",
             block.body,
         );
+    }
+
+    // ---------------- empty-`if` elimination ------------------------------
+
+    fn empty_block_stmt() -> Statement {
+        Statement::block_statement(BlockStatement { cv: None, body: vec![] })
+    }
+    fn if_full(test: Expression, consequent: Statement, alternate: Option<Statement>) -> Statement {
+        Statement::if_statement(IfStatement {
+            cv: None,
+            test,
+            consequent: Box::new(consequent),
+            alternate: alternate.map(Box::new),
+        })
+    }
+    fn member(obj: Expression, prop: &str) -> Expression {
+        Expression::MemberExpression(MemberExpression {
+            cv: None,
+            object: Box::new(obj),
+            property: Box::new(ident(prop)),
+            computed: false,
+        })
+    }
+    fn call0(name: &str) -> Expression {
+        Expression::CallExpression(coding_adventures_javascript_ast::CallExpression {
+            cv: None,
+            callee: Box::new(ident(name)),
+            arguments: vec![],
+        })
+    }
+    fn not(arg: Expression) -> Expression {
+        Expression::UnaryExpression(UnaryExpression {
+            cv: None,
+            operator: UnaryOperator::Not,
+            prefix: true,
+            argument: Box::new(arg),
+        })
+    }
+
+    #[test]
+    fn empty_if_with_side_effect_free_test_is_removed() {
+        // `if(x){}`, `if(x.y){}`, `if(true){}`, `if(!x){}` — the test is
+        // side-effect-free and both branches empty, so the whole `if` is dead
+        // and drops (collapses to `;`, then the program sweep removes it).
+        for test in [ident("x"), member(ident("x"), "y"), boolean(true), not(ident("x"))] {
+            let prog = program()
+                .with_body(vec![ProgramItem::Statement(if_full(test.clone(), empty_block_stmt(), None))]);
+            let (out, _c, changed, _) = run_pass(prog);
+            assert!(changed, "empty if with pure test should mark changed: {test:?}");
+            assert!(out.body.is_empty(), "the empty if should be removed; got {:?}", out.body);
+        }
+    }
+
+    #[test]
+    fn empty_if_else_both_empty_is_removed() {
+        // `if(x){}else{}` — both branches empty, pure test → removed.
+        let prog = program().with_body(vec![ProgramItem::Statement(if_full(
+            ident("x"),
+            empty_block_stmt(),
+            Some(empty_block_stmt()),
+        ))]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert!(out.body.is_empty(), "if/else with both branches empty should drop");
+    }
+
+    #[test]
+    fn empty_if_removed_but_neighbours_kept() {
+        // The removal must not disturb sibling statements.
+        let prog = program().with_body(vec![
+            ProgramItem::Statement(expr_stmt(call0("before"))),
+            ProgramItem::Statement(if_full(ident("x"), empty_block_stmt(), None)),
+            ProgramItem::Statement(expr_stmt(call0("after"))),
+        ]);
+        let (out, _c, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 2, "only the empty if should be removed; got {:?}", out.body);
+    }
+
+    #[test]
+    fn empty_if_with_side_effecting_test_is_kept() {
+        // `if(f()){}` — the call may have side effects, so the `if` stays
+        // (converting to `f();` is a deliberate follow-up).
+        let prog = program()
+            .with_body(vec![ProgramItem::Statement(if_full(call0("f"), empty_block_stmt(), None))]);
+        let (out, _c, _changed, _) = run_pass(prog);
+        assert_eq!(out.body.len(), 1, "impure-test empty if must be kept");
+        assert!(matches!(
+            &out.body[0],
+            ProgramItem::Statement(Statement::Tagged(TaggedStatement::IfStatement(_)))
+        ));
+    }
+
+    #[test]
+    fn if_with_non_empty_consequent_is_kept() {
+        // `if(x)g();` — the consequent does work, so nothing is removed.
+        let prog = program()
+            .with_body(vec![ProgramItem::Statement(if_full(ident("x"), expr_stmt(call0("g")), None))]);
+        let (out, _c, _changed, _) = run_pass(prog);
+        assert_eq!(out.body.len(), 1, "non-empty-consequent if must be kept");
     }
 }


### PR DESCRIPTION
## Empty-`if` elimination

`dce_statement` now drops an `if` statement whose consequent is empty, whose alternate is absent-or-empty, and whose test is **side-effect-free** — collapsing it to `;` (which the block/program empty-statement sweep then removes), matching the reference Closure Compiler:

| input | output |
|-------|--------|
| `if(x){}` | *(removed)* |
| `if(x.y){}` | *(removed)* |
| `if(x[k]){}` | *(removed)* |
| `if(a&&b){}` | *(removed)* |
| `if(typeof x){}` | *(removed)* |
| `if(!x){}` | *(removed)* |
| `if(x){}else{}` | *(removed)* |
| `if(x){}g()` | `g();` |

Verified byte-identical to the oracle (`java -jar closure-compiler … SIMPLE`) on all of the above.

### Declines (kept intact)
- A branch that does real work (`if(x)g();`) — untouched (the `if`→`&&` rewrite already handles it).
- A test that may have side effects (`if(f()){}`, `if(x++){}`) — kept. The "keep the test as an expression statement" rewrite (`if(f()){}`→`f();`) is a deliberate follow-up.
- Switch elimination for a side-effect-free-but-non-leaf discriminant (`switch(x){}`→removed) is a separate slice.

### `is_side_effect_free`
A new recursive purity predicate backs the decision, mirroring Closure's model: identifiers, `this`, literals, and property reads / unary (non-`delete`) / binary / logical / conditional expressions built from side-effect-free parts are pure; calls, `new`, assignment, `++`/`--`, `delete`, `yield`, `await`, tagged templates, dynamic `import()`, and (conservatively) the comma operator are not. Member access is pure only when its object **and** computed key are pure, so `f().y` / `x[g()]` are correctly excluded. **Safe-by-construction:** anything not positively known pure is never removed.

### Verification
- 5 new unit tests (each remove case, empty-else, sibling preservation, impure-test decline, non-empty-consequent decline); **64 total green**, clippy clean under `-D warnings`.
- **Full closurec suite green** — no fixture drift (pass-only change; no existing fixture contains an empty `if`/`switch`).
- Inline security review passed (soundness, termination, no new DoS surface, correct empty-statement classification).

Version: `closure-pass-dce` 0.24.0 → 0.25.0. Pass-only — no closurec change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)