### PR TITLE
feat: port hyperloglog to Lua and Perl

### DIFF
--- a/code/packages/lua/hyperloglog/BUILD
+++ b/code/packages/lua/hyperloglog/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-hyperloglog-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/hyperloglog/BUILD_windows
+++ b/code/packages/lua/hyperloglog/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-hyperloglog-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/hyperloglog/CHANGELOG.md
+++ b/code/packages/lua/hyperloglog/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-15
+
+- Add a pure Lua HyperLogLog cardinality estimator.
+- Support deterministic hashing, bounded precision, merging, clearing, and
+  estimator metadata.
+- Add Busted coverage, LuaRocks metadata, build scripts, and a capability
+  declaration.

--- a/code/packages/lua/hyperloglog/README.md
+++ b/code/packages/lua/hyperloglog/README.md
@@ -1,0 +1,31 @@
+# hyperloglog
+
+Pure Lua HyperLogLog sketch for approximate distinct counting with fixed
+memory. The implementation uses deterministic internal FNV-1a hashes and has
+no non-Lua runtime dependencies.
+
+## Usage
+
+~~~lua
+local HyperLogLog = require("coding_adventures.hyperloglog").HyperLogLog
+
+local sketch = HyperLogLog.new(10)
+for value = 1, 10000 do
+    sketch:add("user-" .. value)
+end
+print(sketch:count())
+~~~
+
+Precision may range from 4 to 16 and defaults to 10. The sketch supports
+add, count, non-mutating merge, merge_in_place, clear, is_empty, and accessors
+for precision, register count, theoretical error rate, packed memory size, and
+a defensive register snapshot.
+
+## Tests
+
+~~~sh
+cd code/packages/lua/hyperloglog
+luarocks make --local --deps-mode=none coding-adventures-hyperloglog-0.1.0-1.rockspec
+cd tests
+LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_
+~~~

--- a/code/packages/lua/hyperloglog/coding-adventures-hyperloglog-0.1.0-1.rockspec
+++ b/code/packages/lua/hyperloglog/coding-adventures-hyperloglog-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-hyperloglog"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Dependency-free approximate distinct counter",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.hyperloglog"] = "src/coding_adventures/hyperloglog/init.lua",
+    },
+}

--- a/code/packages/lua/hyperloglog/required_capabilities.json
+++ b/code/packages/lua/hyperloglog/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/hyperloglog",
+  "capabilities": [],
+  "justification": "Pure in-memory probabilistic data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/hyperloglog/src/coding_adventures/hyperloglog/init.lua
+++ b/code/packages/lua/hyperloglog/src/coding_adventures/hyperloglog/init.lua
@@ -1,0 +1,213 @@
+--- A dependency-free HyperLogLog cardinality estimator.
+---
+--- Values are converted to strings and hashed into two independently seeded
+--- 32-bit FNV-1a words. Keeping the words separate avoids depending on
+--- floating-point representations of unsigned 64-bit integers.
+
+local HyperLogLog = {}
+HyperLogLog.__index = HyperLogLog
+
+local UINT32_MASK = 0xffffffff
+local FNV_OFFSET = 2166136261
+local FNV_PRIME = 16777619
+local SECOND_SEED = (FNV_OFFSET ~ 0x9e3779b9) & UINT32_MASK
+
+local function validate_precision(precision)
+    if type(precision) ~= "number"
+        or precision ~= math.floor(precision)
+        or precision < 4
+        or precision > 16
+    then
+        error("precision must be an integer between 4 and 16", 3)
+    end
+end
+
+local function avalanche32(hash)
+    hash = (hash ~ (hash >> 16)) & UINT32_MASK
+    hash = (hash * 1597334677) & UINT32_MASK
+    hash = (hash ~ (hash >> 15)) & UINT32_MASK
+    hash = (hash * 1226822519) & UINT32_MASK
+    return (hash ~ (hash >> 16)) & UINT32_MASK
+end
+
+local function fnv1a32(payload, seed, reverse)
+    local hash = seed
+    if reverse then
+        for index = #payload, 1, -1 do
+            hash = ((hash ~ string.byte(payload, index)) * FNV_PRIME) & UINT32_MASK
+        end
+    else
+        for index = 1, #payload do
+            hash = ((hash ~ string.byte(payload, index)) * FNV_PRIME) & UINT32_MASK
+        end
+    end
+    hash = ((hash ~ (#payload & 0xff)) * FNV_PRIME) & UINT32_MASK
+    return avalanche32(hash)
+end
+
+local function hash64(value)
+    local payload = tostring(value)
+    return fnv1a32(payload, FNV_OFFSET, false), fnv1a32(payload, SECOND_SEED, true)
+end
+
+local function leading_zeros32(value)
+    if value == 0 then
+        return 32
+    end
+    local zeros = 0
+    local bit = 0x80000000
+    while (value & bit) == 0 do
+        zeros = zeros + 1
+        bit = bit >> 1
+    end
+    return zeros
+end
+
+local function alpha(register_count)
+    if register_count == 16 then
+        return 0.673
+    elseif register_count == 32 then
+        return 0.697
+    elseif register_count == 64 then
+        return 0.709
+    end
+    return 0.7213 / (1 + 1.079 / register_count)
+end
+
+function HyperLogLog.new(precision)
+    precision = precision == nil and 10 or precision
+    validate_precision(precision)
+
+    local register_count = 1 << precision
+    local registers = {}
+    for index = 1, register_count do
+        registers[index] = 0
+    end
+
+    return setmetatable({
+        _precision = precision,
+        _register_count = register_count,
+        _registers = registers,
+    }, HyperLogLog)
+end
+
+function HyperLogLog:add(value)
+    local high, low = hash64(value)
+    local bucket = (high & (self._register_count - 1)) + 1
+    local upper = high >> self._precision
+    local upper_width = 32 - self._precision
+    local zero_count
+
+    if upper ~= 0 then
+        zero_count = leading_zeros32(upper) - self._precision
+    else
+        zero_count = upper_width + leading_zeros32(low)
+    end
+
+    local rank = zero_count + 1
+    if rank > self._registers[bucket] then
+        self._registers[bucket] = rank
+    end
+    return self
+end
+
+function HyperLogLog:count()
+    local indicator = 0.0
+    local empty_registers = 0
+    for index = 1, self._register_count do
+        local register = self._registers[index]
+        indicator = indicator + (2.0 ^ (-register))
+        if register == 0 then
+            empty_registers = empty_registers + 1
+        end
+    end
+
+    local m = self._register_count
+    local estimate = alpha(m) * m * m / indicator
+    if estimate <= 2.5 * m and empty_registers > 0 then
+        estimate = m * math.log(m / empty_registers)
+    end
+    return math.floor(estimate + 0.5)
+end
+
+function HyperLogLog:merge(other)
+    local merged = HyperLogLog.new(self._precision)
+    for index = 1, self._register_count do
+        merged._registers[index] = self._registers[index]
+    end
+    return merged:merge_in_place(other)
+end
+
+function HyperLogLog:merge_in_place(other)
+    if getmetatable(other) ~= HyperLogLog then
+        error("other must be a HyperLogLog", 2)
+    end
+    if other._precision ~= self._precision then
+        error("cannot merge HyperLogLog sketches with different precisions", 2)
+    end
+    for index = 1, self._register_count do
+        local candidate = other._registers[index]
+        if candidate > self._registers[index] then
+            self._registers[index] = candidate
+        end
+    end
+    return self
+end
+
+function HyperLogLog:clear()
+    for index = 1, self._register_count do
+        self._registers[index] = 0
+    end
+    return self
+end
+
+function HyperLogLog:is_empty()
+    for index = 1, self._register_count do
+        if self._registers[index] ~= 0 then
+            return false
+        end
+    end
+    return true
+end
+
+function HyperLogLog:precision()
+    return self._precision
+end
+
+function HyperLogLog:num_registers()
+    return self._register_count
+end
+
+function HyperLogLog:error_rate()
+    return 1.04 / math.sqrt(self._register_count)
+end
+
+function HyperLogLog:memory_bytes()
+    return math.floor(self._register_count * 6 / 8)
+end
+
+function HyperLogLog:registers()
+    local snapshot = {}
+    for index = 1, self._register_count do
+        snapshot[index] = self._registers[index]
+    end
+    return snapshot
+end
+
+HyperLogLog.__len = function(self)
+    return self:count()
+end
+
+HyperLogLog.__tostring = function(self)
+    return string.format(
+        "HyperLogLog(precision=%d, registers=%d, estimate=%d)",
+        self._precision,
+        self._register_count,
+        self:count()
+    )
+end
+
+return {
+    HyperLogLog = HyperLogLog,
+    new = HyperLogLog.new,
+}

--- a/code/packages/lua/hyperloglog/tests/test_hyperloglog.lua
+++ b/code/packages/lua/hyperloglog/tests/test_hyperloglog.lua
@@ -1,0 +1,103 @@
+package.path = table.concat({
+    "../src/?.lua",
+    "../src/?/init.lua",
+    package.path,
+}, ";")
+
+local module = require("coding_adventures.hyperloglog")
+local HyperLogLog = module.HyperLogLog
+
+local function assert_within(actual, expected, tolerance)
+    assert.is_true(
+        math.abs(actual - expected) <= tolerance,
+        string.format("expected %d within %d of %d", actual, tolerance, expected)
+    )
+end
+
+describe("HyperLogLog", function()
+    it("counts an empty sketch and repeated values", function()
+        local sketch = HyperLogLog.new()
+        assert.equals(0, sketch:count())
+        assert.is_true(sketch:is_empty())
+
+        for _ = 1, 1000 do
+            sketch:add("same-value")
+        end
+        assert.equals(1, sketch:count())
+        assert.is_false(sketch:is_empty())
+    end)
+
+    it("estimates distinct cardinality with bounded error", function()
+        local sketch = HyperLogLog.new(10)
+        for value = 1, 10000 do
+            sketch:add("user-" .. value)
+        end
+        assert_within(sketch:count(), 10000, 1000)
+    end)
+
+    it("merges disjoint and overlapping sketches without mutating inputs", function()
+        local left = HyperLogLog.new(10)
+        local right = HyperLogLog.new(10)
+        for value = 1, 1000 do
+            left:add("left-" .. value)
+            right:add("right-" .. value)
+        end
+
+        local left_count = left:count()
+        local merged = left:merge(right)
+        assert.equals(left_count, left:count())
+        assert_within(merged:count(), 2000, 300)
+
+        local overlap = HyperLogLog.new(10)
+        for value = 1, 1000 do
+            overlap:add("left-" .. value)
+        end
+        assert_within(left:merge(overlap):count(), 1000, 150)
+    end)
+
+    it("reports precision, memory, error rate, and defensive registers", function()
+        local sketch = module.new(10)
+        assert.equals(10, sketch:precision())
+        assert.equals(1024, sketch:num_registers())
+        assert.equals(768, sketch:memory_bytes())
+        assert.is_true(math.abs(sketch:error_rate() - 0.0325) < 0.0001)
+
+        local registers = sketch:registers()
+        registers[1] = 99
+        assert.equals(0, sketch:registers()[1])
+        assert.is_truthy(tostring(sketch):match("precision=10"))
+    end)
+
+    it("clears state and validates public inputs", function()
+        local sketch = HyperLogLog.new(4)
+        sketch:add("value"):clear()
+        assert.is_true(sketch:is_empty())
+        assert.equals(0, #sketch)
+
+        assert.has_error(function()
+            HyperLogLog.new(3)
+        end, "precision must be an integer between 4 and 16")
+        assert.has_error(function()
+            HyperLogLog.new(17)
+        end, "precision must be an integer between 4 and 16")
+        assert.has_error(function()
+            HyperLogLog.new(4.5)
+        end, "precision must be an integer between 4 and 16")
+        assert.has_error(function()
+            sketch:merge(HyperLogLog.new(5))
+        end, "cannot merge HyperLogLog sketches with different precisions")
+        assert.has_error(function()
+            sketch:merge({})
+        end, "other must be a HyperLogLog")
+    end)
+
+    it("hashes the same input deterministically", function()
+        local left = HyperLogLog.new(8)
+        local right = HyperLogLog.new(8)
+        for value = 1, 100 do
+            left:add("item-" .. value)
+            right:add("item-" .. value)
+        end
+        assert.are.same(left:registers(), right:registers())
+    end)
+end)

--- a/code/packages/perl/hyperloglog/BUILD
+++ b/code/packages/perl/hyperloglog/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/hyperloglog/BUILD_windows
+++ b/code/packages/perl/hyperloglog/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-hyperloglog.t

--- a/code/packages/perl/hyperloglog/CHANGELOG.md
+++ b/code/packages/perl/hyperloglog/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-15
+
+- Add a pure Perl HyperLogLog cardinality estimator.
+- Support deterministic hashing, bounded precision, merging, clearing, and
+  estimator metadata.
+- Add core-only tests, CPAN metadata, build scripts, and a capability
+  declaration.

--- a/code/packages/perl/hyperloglog/Makefile.PL
+++ b/code/packages/perl/hyperloglog/Makefile.PL
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::HyperLogLog',
+    VERSION_FROM     => 'lib/CodingAdventures/HyperLogLog.pm',
+    ABSTRACT         => 'Dependency-free approximate distinct counter',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'Encode'       => 0,
+        'Scalar::Util' => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/hyperloglog/README.md
+++ b/code/packages/perl/hyperloglog/README.md
@@ -1,0 +1,27 @@
+# hyperloglog
+
+Pure Perl HyperLogLog sketch for approximate distinct counting with fixed
+memory. The implementation uses deterministic internal FNV-1a hashes and only
+core Perl modules.
+
+## Usage
+
+~~~perl
+use CodingAdventures::HyperLogLog;
+
+my $sketch = CodingAdventures::HyperLogLog->new(precision => 10);
+$sketch->add("user-$_") for 1 .. 10000;
+print $sketch->count;
+~~~
+
+Precision may range from 4 to 16 and defaults to 10. The sketch supports add,
+count, non-mutating merge, merge_in_place, clear, is_empty, and accessors for
+precision, register count, theoretical error rate, packed memory size, and a
+defensive register snapshot.
+
+## Tests
+
+~~~sh
+cd code/packages/perl/hyperloglog
+prove -l -v t/
+~~~

--- a/code/packages/perl/hyperloglog/cpanfile
+++ b/code/packages/perl/hyperloglog/cpanfile
@@ -1,0 +1,3 @@
+# Core Perl modules only.
+requires 'Encode', '0';
+requires 'Scalar::Util', '0';

--- a/code/packages/perl/hyperloglog/lib/CodingAdventures/HyperLogLog.pm
+++ b/code/packages/perl/hyperloglog/lib/CodingAdventures/HyperLogLog.pm
@@ -1,0 +1,215 @@
+package CodingAdventures::HyperLogLog;
+
+use strict;
+use warnings;
+use Encode qw(encode);
+use Scalar::Util qw(blessed);
+use overload '""' => 'as_string', fallback => 1;
+
+our $VERSION = '0.1.0';
+
+my $UINT32_MASK = 0xffffffff;
+my $FNV_OFFSET = 2166136261;
+my $FNV_PRIME = 16777619;
+my $SECOND_SEED = ($FNV_OFFSET ^ 0x9e3779b9) & $UINT32_MASK;
+
+sub new {
+    my ($class, @arguments) = @_;
+    die "constructor expects key/value options\n" if @arguments % 2;
+    my %options = @arguments;
+    my $precision = exists $options{precision} ? $options{precision} : 10;
+    _validate_precision($precision);
+
+    my $register_count = 1 << $precision;
+    return bless {
+        precision      => 0 + $precision,
+        register_count => $register_count,
+        registers      => [(0) x $register_count],
+    }, $class;
+}
+
+sub add {
+    my ($self, $value) = @_;
+    my ($high, $low) = _hash64($value);
+    my $bucket = $high & ($self->{register_count} - 1);
+    my $upper = $high >> $self->{precision};
+    my $upper_width = 32 - $self->{precision};
+    my $zero_count;
+
+    if ($upper != 0) {
+        $zero_count = _leading_zeros32($upper) - $self->{precision};
+    } else {
+        $zero_count = $upper_width + _leading_zeros32($low);
+    }
+
+    my $rank = $zero_count + 1;
+    $self->{registers}[$bucket] = $rank
+        if $rank > $self->{registers}[$bucket];
+    return $self;
+}
+
+sub count {
+    my ($self) = @_;
+    my $indicator = 0.0;
+    my $empty_registers = 0;
+
+    for my $register (@{$self->{registers}}) {
+        $indicator += 2.0 ** (-$register);
+        $empty_registers++ if $register == 0;
+    }
+
+    my $m = $self->{register_count};
+    my $estimate = _alpha($m) * $m * $m / $indicator;
+    if ($estimate <= 2.5 * $m && $empty_registers > 0) {
+        $estimate = $m * log($m / $empty_registers);
+    }
+    return int($estimate + 0.5);
+}
+
+sub merge {
+    my ($self, $other) = @_;
+    my $merged = ref($self)->new(precision => $self->{precision});
+    @{$merged->{registers}} = @{$self->{registers}};
+    return $merged->merge_in_place($other);
+}
+
+sub merge_in_place {
+    my ($self, $other) = @_;
+    die "other must be a CodingAdventures::HyperLogLog\n"
+        unless blessed($other) && $other->isa(__PACKAGE__);
+    die "cannot merge HyperLogLog sketches with different precisions\n"
+        unless $other->{precision} == $self->{precision};
+
+    for my $index (0 .. $self->{register_count} - 1) {
+        my $candidate = $other->{registers}[$index];
+        $self->{registers}[$index] = $candidate
+            if $candidate > $self->{registers}[$index];
+    }
+    return $self;
+}
+
+sub clear {
+    my ($self) = @_;
+    @{$self->{registers}} = (0) x $self->{register_count};
+    return $self;
+}
+
+sub is_empty {
+    my ($self) = @_;
+    for my $register (@{$self->{registers}}) {
+        return 0 if $register != 0;
+    }
+    return 1;
+}
+
+sub precision {
+    my ($self) = @_;
+    return $self->{precision};
+}
+
+sub num_registers {
+    my ($self) = @_;
+    return $self->{register_count};
+}
+
+sub error_rate {
+    my ($self) = @_;
+    return 1.04 / sqrt($self->{register_count});
+}
+
+sub memory_bytes {
+    my ($self) = @_;
+    return int($self->{register_count} * 6 / 8);
+}
+
+sub registers {
+    my ($self) = @_;
+    return [@{$self->{registers}}];
+}
+
+sub as_string {
+    my ($self) = @_;
+    return sprintf(
+        'HyperLogLog(precision=%d, registers=%d, estimate=%d)',
+        $self->{precision},
+        $self->{register_count},
+        $self->count,
+    );
+}
+
+sub _validate_precision {
+    my ($precision) = @_;
+    die "precision must be an integer between 4 and 16\n"
+        unless defined($precision)
+            && !ref($precision)
+            && $precision =~ /\A\d+\z/
+            && $precision >= 4
+            && $precision <= 16;
+}
+
+sub _alpha {
+    my ($register_count) = @_;
+    return 0.673 if $register_count == 16;
+    return 0.697 if $register_count == 32;
+    return 0.709 if $register_count == 64;
+    return 0.7213 / (1 + 1.079 / $register_count);
+}
+
+sub _hash64 {
+    my ($value) = @_;
+    my $payload = encode('UTF-8', defined($value) ? "$value" : 'undef');
+    return (
+        _fnv1a32($payload, $FNV_OFFSET, 0),
+        _fnv1a32($payload, $SECOND_SEED, 1),
+    );
+}
+
+sub _fnv1a32 {
+    my ($payload, $seed, $reverse) = @_;
+    my @bytes = unpack('C*', $payload);
+    @bytes = reverse @bytes if $reverse;
+    my $hash = $seed;
+
+    for my $byte (@bytes) {
+        $hash = (($hash ^ $byte) * $FNV_PRIME) & $UINT32_MASK;
+    }
+    $hash = (($hash ^ (scalar(@bytes) & 0xff)) * $FNV_PRIME) & $UINT32_MASK;
+    return _avalanche32($hash);
+}
+
+sub _avalanche32 {
+    my ($hash) = @_;
+    $hash = ($hash ^ ($hash >> 16)) & $UINT32_MASK;
+    $hash = ($hash * 1597334677) & $UINT32_MASK;
+    $hash = ($hash ^ ($hash >> 15)) & $UINT32_MASK;
+    $hash = ($hash * 1226822519) & $UINT32_MASK;
+    return ($hash ^ ($hash >> 16)) & $UINT32_MASK;
+}
+
+sub _leading_zeros32 {
+    my ($value) = @_;
+    return 32 if $value == 0;
+    my $zeros = 0;
+    my $bit = 0x80000000;
+    while (($value & $bit) == 0) {
+        $zeros++;
+        $bit >>= 1;
+    }
+    return $zeros;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::HyperLogLog - dependency-free approximate distinct counter
+
+=head1 SYNOPSIS
+
+  my $sketch = CodingAdventures::HyperLogLog->new(precision => 10);
+  $sketch->add($_) for @values;
+  print $sketch->count;
+
+=cut

--- a/code/packages/perl/hyperloglog/required_capabilities.json
+++ b/code/packages/perl/hyperloglog/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/hyperloglog",
+  "capabilities": [],
+  "justification": "Pure in-memory probabilistic data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/hyperloglog/t/00-load.t
+++ b/code/packages/perl/hyperloglog/t/00-load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::HyperLogLog; 1 }, 'CodingAdventures::HyperLogLog loads');
+ok(CodingAdventures::HyperLogLog->VERSION, 'has a VERSION');
+ok(CodingAdventures::HyperLogLog->can('new'), 'constructor is available');
+
+done_testing;

--- a/code/packages/perl/hyperloglog/t/01-hyperloglog.t
+++ b/code/packages/perl/hyperloglog/t/01-hyperloglog.t
@@ -1,0 +1,100 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::HyperLogLog;
+
+sub within {
+    my ($actual, $expected, $tolerance, $name) = @_;
+    ok(
+        abs($actual - $expected) <= $tolerance,
+        "$name: got $actual, expected $expected +/- $tolerance",
+    );
+}
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'empty and duplicate values' => sub {
+    my $sketch = CodingAdventures::HyperLogLog->new;
+    is($sketch->count, 0, 'empty count');
+    ok($sketch->is_empty, 'empty state');
+    $sketch->add('same-value') for 1 .. 1000;
+    is($sketch->count, 1, 'duplicates do not increase cardinality');
+    ok(!$sketch->is_empty, 'non-empty state');
+};
+
+subtest 'bounded cardinality estimate' => sub {
+    my $sketch = CodingAdventures::HyperLogLog->new(precision => 10);
+    $sketch->add("user-$_") for 1 .. 10000;
+    within($sketch->count, 10000, 1000, 'ten thousand distinct values');
+};
+
+subtest 'disjoint and overlapping merges' => sub {
+    my $left = CodingAdventures::HyperLogLog->new(precision => 10);
+    my $right = CodingAdventures::HyperLogLog->new(precision => 10);
+    for my $value (1 .. 1000) {
+        $left->add("left-$value");
+        $right->add("right-$value");
+    }
+
+    my $left_count = $left->count;
+    my $merged = $left->merge($right);
+    is($left->count, $left_count, 'merge does not mutate the receiver');
+    within($merged->count, 2000, 300, 'disjoint union');
+
+    my $overlap = CodingAdventures::HyperLogLog->new(precision => 10);
+    $overlap->add("left-$_") for 1 .. 1000;
+    within($left->merge($overlap)->count, 1000, 150, 'overlapping union');
+};
+
+subtest 'metadata and defensive register snapshots' => sub {
+    my $sketch = CodingAdventures::HyperLogLog->new(precision => 10);
+    is($sketch->precision, 10, 'precision');
+    is($sketch->num_registers, 1024, 'register count');
+    is($sketch->memory_bytes, 768, 'packed memory size');
+    ok(abs($sketch->error_rate - 0.0325) < 0.0001, 'theoretical error rate');
+
+    my $registers = $sketch->registers;
+    $registers->[0] = 99;
+    is($sketch->registers->[0], 0, 'register snapshot is defensive');
+    like("$sketch", qr/precision=10/, 'string rendering');
+};
+
+subtest 'clear, deterministic hashing, and validation' => sub {
+    my $left = CodingAdventures::HyperLogLog->new(precision => 8);
+    my $right = CodingAdventures::HyperLogLog->new(precision => 8);
+    for my $value (1 .. 100) {
+        $left->add("item-$value");
+        $right->add("item-$value");
+    }
+    is_deeply($left->registers, $right->registers, 'hashing is deterministic');
+    $left->clear;
+    ok($left->is_empty, 'clear resets registers');
+
+    dies_like(
+        sub { CodingAdventures::HyperLogLog->new(precision => 3) },
+        qr/precision must be an integer between 4 and 16/,
+        'low precision rejected',
+    );
+    dies_like(
+        sub { CodingAdventures::HyperLogLog->new(precision => 17) },
+        qr/precision must be an integer between 4 and 16/,
+        'high precision rejected',
+    );
+    dies_like(
+        sub { $left->merge(CodingAdventures::HyperLogLog->new(precision => 9)) },
+        qr/different precisions/,
+        'precision mismatch rejected',
+    );
+    dies_like(
+        sub { $left->merge({}) },
+        qr/other must be a CodingAdventures::HyperLogLog/,
+        'invalid merge operand rejected',
+    );
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -107,11 +107,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 The missing matrix is heavily concentrated in singleton packages. Regenerated
 on July 15, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
-and `skip-list` ports:
+`skip-list`, and `hyperloglog` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 357 |
+| Present in 10-15 languages | 171 | 355 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -157,15 +157,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 357
+The 171 packages present in at least ten implementation languages need 355
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 9 | Pair with Perl data-structure/storage wave |
-| Perl | 9 | Pair with Lua data-structure/storage wave |
+| Lua | 8 | Pair with Perl data-structure/storage wave |
+| Perl | 8 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -177,14 +177,16 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first seven paired Lua/Perl slices are complete: `fenwick-tree`,
+The first eight paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
-`avl-tree`, `tree-set`, and `skip-list` now have pure implementations,
-package-native tests, metadata, and capability declarations in both lanes.
+`avl-tree`, `tree-set`, `skip-list`, and `hyperloglog` now have pure
+implementations, package-native tests, metadata, and capability declarations in
+both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
 in-memory data store layers move; the AVL slice supplies the ordered backend
 for `tree-set`; and the dependency-free skip-list slice adds a span-augmented
-ordered map with logarithmic rank and selection.
+ordered map with logarithmic rank and selection. The HyperLogLog slice adds a
+fixed-memory approximate distinct counter with deterministic internal hashing.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure Lua and Perl HyperLogLog implementations with deterministic internal hashing, configurable precision, approximate counting, merging, clearing, and estimator metadata
- add package-native tests, build commands, manifests, documentation, changelogs, and zero-capability declarations
- refresh the package-parity roadmap from 9 to 8 Lua/Perl high-consensus gaps and from 357 to 355 missing slots in the 10-15-language band

## Why this slice is next

HyperLogLog is the smallest dependency-free gap remaining in the paired Lua/Perl high-consensus wave. The hash-map, hash-set, and bloom-filter slices still need their hashing prerequisites; trie, radix-tree, RESP, and the storage layers are larger follow-on units.

## Validation

- LuaRocks package installation with dependency isolation
- Lua Busted suite: 6 successes, 0 failures
- Perl core test files: all load, behavior, accuracy, merge, metadata, determinism, and validation subtests pass
- LuaRocks manifest lint
- Lua and Perl syntax checks
- package parity reporter with collision enforcement
- package parity reporter unit suite: 6 tests pass
- JSON parsing and git diff whitespace checks

## Remaining paired Lua/Perl high-consensus gaps

- bloom-filter
- hash-map
- hash-set
- in-memory-data-store
- in-memory-data-store-engine
- radix-tree
- resp-protocol
- trie
