### PR TITLE
feat: port trie to Lua and Perl

### DIFF
--- a/code/packages/lua/trie/BUILD
+++ b/code/packages/lua/trie/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-trie-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/trie/BUILD_windows
+++ b/code/packages/lua/trie/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-trie-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/trie/CHANGELOG.md
+++ b/code/packages/lua/trie/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Lua trie package with insertion, exact lookup, deletion, prefix scans,
+  longest-prefix matching, sorted enumeration, and validation helpers.

--- a/code/packages/lua/trie/README.md
+++ b/code/packages/lua/trie/README.md
@@ -1,0 +1,16 @@
+# coding-adventures-trie
+
+A dependency-free Lua 5.4 prefix trie for UTF-8 string keys and arbitrary
+values. It supports exact lookup, deletion with pruning, lexicographically
+sorted enumeration, prefix scans, and longest-prefix matching.
+
+```lua
+local Trie = require("coding_adventures.trie").Trie
+
+local trie = Trie.new()
+trie:insert("app", 1)
+trie:insert("apple", 2)
+
+assert(trie:search("app") == 1)
+assert(trie:longest_prefix_match("apples")[1] == "apple")
+```

--- a/code/packages/lua/trie/coding-adventures-trie-0.1.0-1.rockspec
+++ b/code/packages/lua/trie/coding-adventures-trie-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-trie"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Prefix trie with sorted enumeration and longest-prefix matching",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.trie"] = "src/coding_adventures/trie/init.lua",
+    },
+}

--- a/code/packages/lua/trie/required_capabilities.json
+++ b/code/packages/lua/trie/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/trie",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/trie/src/coding_adventures/trie/init.lua
+++ b/code/packages/lua/trie/src/coding_adventures/trie/init.lua
@@ -1,0 +1,236 @@
+--- A prefix trie for UTF-8 string keys and arbitrary values.
+
+local Trie = {}
+Trie.__index = Trie
+
+local function new_node()
+    return {
+        children = {},
+        terminal = false,
+        value = nil,
+    }
+end
+
+local function assert_string(value, name, level)
+    if type(value) ~= "string" then
+        error(name .. " must be a string", level or 3)
+    end
+end
+
+local function characters(value)
+    local result = {}
+    for _, codepoint in utf8.codes(value) do
+        result[#result + 1] = utf8.char(codepoint)
+    end
+    return result
+end
+
+local function find_node(self, key)
+    local node = self._root
+    for _, codepoint in utf8.codes(key) do
+        node = node.children[utf8.char(codepoint)]
+        if node == nil then
+            return nil
+        end
+    end
+    return node
+end
+
+local function collect(node, current, results)
+    if node.terminal then
+        results[#results + 1] = { current, node.value }
+    end
+
+    local child_keys = {}
+    for character in pairs(node.children) do
+        child_keys[#child_keys + 1] = character
+    end
+    table.sort(child_keys)
+
+    for _, character in ipairs(child_keys) do
+        collect(node.children[character], current .. character, results)
+    end
+end
+
+local function delete_recursive(node, chars, depth)
+    if depth > #chars then
+        node.terminal = false
+        node.value = nil
+        return next(node.children) == nil
+    end
+
+    local character = chars[depth]
+    local child = node.children[character]
+    if child ~= nil and delete_recursive(child, chars, depth + 1) then
+        node.children[character] = nil
+    end
+
+    return next(node.children) == nil and not node.terminal
+end
+
+local function count_endpoints(node)
+    local count = node.terminal and 1 or 0
+    for _, child in pairs(node.children) do
+        count = count + count_endpoints(child)
+    end
+    return count
+end
+
+function Trie.new(entries)
+    entries = entries == nil and {} or entries
+    if type(entries) ~= "table" then
+        error("entries must be a table", 2)
+    end
+
+    local self = setmetatable({
+        _root = new_node(),
+        _size = 0,
+    }, Trie)
+
+    for index, entry in ipairs(entries) do
+        if type(entry) ~= "table" or entry[1] == nil then
+            error("entry at index " .. index .. " must contain a key", 2)
+        end
+        self:insert(entry[1], entry[2])
+    end
+    return self
+end
+
+function Trie:insert(key, value)
+    assert_string(key, "key", 2)
+    if value == nil then
+        value = true
+    end
+
+    local node = self._root
+    for _, codepoint in utf8.codes(key) do
+        local character = utf8.char(codepoint)
+        local child = node.children[character]
+        if child == nil then
+            child = new_node()
+            node.children[character] = child
+        end
+        node = child
+    end
+
+    if not node.terminal then
+        self._size = self._size + 1
+    end
+    node.terminal = true
+    node.value = value
+    return self
+end
+
+function Trie:search(key)
+    assert_string(key, "key", 2)
+    local node = find_node(self, key)
+    if node ~= nil and node.terminal then
+        return node.value
+    end
+    return nil
+end
+
+function Trie:contains_key(key)
+    assert_string(key, "key", 2)
+    local node = find_node(self, key)
+    return node ~= nil and node.terminal
+end
+
+Trie.key_exists = Trie.contains_key
+Trie.contains = Trie.contains_key
+
+function Trie:delete(key)
+    assert_string(key, "key", 2)
+    if not self:contains_key(key) then
+        return false
+    end
+
+    delete_recursive(self._root, characters(key), 1)
+    self._size = self._size - 1
+    return true
+end
+
+function Trie:starts_with(prefix)
+    assert_string(prefix, "prefix", 2)
+    if prefix == "" then
+        return self._size > 0
+    end
+    return find_node(self, prefix) ~= nil
+end
+
+function Trie:words_with_prefix(prefix)
+    assert_string(prefix, "prefix", 2)
+    local node = find_node(self, prefix)
+    if node == nil then
+        return {}
+    end
+
+    local results = {}
+    collect(node, prefix, results)
+    return results
+end
+
+function Trie:all_words()
+    local results = {}
+    collect(self._root, "", results)
+    return results
+end
+
+Trie.entries = Trie.all_words
+Trie.to_array = Trie.all_words
+
+function Trie:keys()
+    local result = {}
+    for _, entry in ipairs(self:all_words()) do
+        result[#result + 1] = entry[1]
+    end
+    return result
+end
+
+function Trie:longest_prefix_match(input)
+    assert_string(input, "input", 2)
+    local node = self._root
+    local current = ""
+    local best = node.terminal and { "", node.value } or nil
+
+    for _, codepoint in utf8.codes(input) do
+        local character = utf8.char(codepoint)
+        local child = node.children[character]
+        if child == nil then
+            break
+        end
+        current = current .. character
+        node = child
+        if node.terminal then
+            best = { current, node.value }
+        end
+    end
+    return best
+end
+
+function Trie:size()
+    return self._size
+end
+
+Trie.length = Trie.size
+
+function Trie:is_empty()
+    return self._size == 0
+end
+
+function Trie:is_valid()
+    return count_endpoints(self._root) == self._size
+end
+
+Trie.__len = function(self)
+    return self._size
+end
+
+Trie.__tostring = function(self)
+    return string.format("Trie(%d keys)", self._size)
+end
+
+return {
+    Trie = Trie,
+    new = Trie.new,
+}

--- a/code/packages/lua/trie/tests/test_trie.lua
+++ b/code/packages/lua/trie/tests/test_trie.lua
@@ -1,0 +1,123 @@
+package.path = table.concat({
+    "../src/?.lua",
+    "../src/?/init.lua",
+    package.path,
+}, ";")
+
+local module = require("coding_adventures.trie")
+local Trie = module.Trie
+
+local function make_trie(...)
+    local trie = Trie.new()
+    for _, word in ipairs({ ... }) do
+        trie:insert(word)
+    end
+    return trie
+end
+
+describe("Trie", function()
+    it("represents an empty trie", function()
+        local trie = Trie.new()
+        assert.equals(0, trie:size())
+        assert.equals(0, #trie)
+        assert.is_true(trie:is_empty())
+        assert.is_nil(trie:search("anything"))
+        assert.is_false(trie:starts_with("a"))
+        assert.is_true(trie:is_valid())
+    end)
+
+    it("inserts, searches, and updates exact keys", function()
+        local trie = Trie.new()
+        trie:insert("hello", 42)
+        assert.equals(42, trie:search("hello"))
+        assert.is_nil(trie:search("hell"))
+        assert.is_nil(trie:search("hellos"))
+
+        trie:insert("hello", 99)
+        assert.equals(99, trie:search("hello"))
+        assert.equals(1, trie:length())
+        assert.is_true(trie:contains_key("hello"))
+        assert.is_true(trie:key_exists("hello"))
+
+        trie:insert("false", false)
+        assert.is_false(trie:search("false"))
+        assert.is_true(trie:contains("false"))
+    end)
+
+    it("enumerates prefixes and all keys in sorted order", function()
+        local trie = make_trie("banana", "app", "apple", "apply", "apt")
+        assert.are.same({
+            { "app", true },
+            { "apple", true },
+            { "apply", true },
+        }, trie:words_with_prefix("app"))
+        assert.are.same({}, trie:words_with_prefix("xyz"))
+        assert.are.same({ "app", "apple", "apply", "apt", "banana" }, trie:keys())
+        assert.are.same(trie:all_words(), trie:entries())
+    end)
+
+    it("deletes leaves and shared prefixes with pruning", function()
+        local trie = make_trie("app", "apple", "apt")
+        assert.is_true(trie:delete("app"))
+        assert.is_false(trie:contains_key("app"))
+        assert.is_true(trie:contains_key("apple"))
+        assert.is_true(trie:contains_key("apt"))
+        assert.equals(2, trie:size())
+        assert.is_false(trie:delete("missing"))
+        assert.is_false(trie:delete("ap"))
+        assert.is_true(trie:delete("apple"))
+        assert.is_true(trie:delete("apt"))
+        assert.is_true(trie:is_empty())
+        assert.is_true(trie:is_valid())
+    end)
+
+    it("constructs from entries and finds the longest prefix", function()
+        local trie = module.new({
+            { "a", 1 },
+            { "ab", 2 },
+            { "abc", 3 },
+            { "abcd", 4 },
+        })
+        assert.are.same({ "abcd", 4 }, trie:longest_prefix_match("abcde"))
+        assert.is_nil(trie:longest_prefix_match("xyz"))
+        assert.are.same({ "a", 1 }, trie:longest_prefix_match("a"))
+    end)
+
+    it("supports Unicode and empty-string keys", function()
+        local trie = Trie.new()
+        trie:insert("", "root")
+        trie:insert("cafe", "plain")
+        trie:insert("cafe\u{0301}", "accent-combining")
+        trie:insert("caf\u{00e9}", "accent-single")
+
+        assert.equals("root", trie:search(""))
+        assert.is_true(trie:starts_with(""))
+        assert.is_true(trie:starts_with("caf"))
+        assert.equals("accent-single", trie:search("caf\u{00e9}"))
+        assert.are.same(
+            { "cafe\u{0301}", "accent-combining" },
+            trie:longest_prefix_match("cafe\u{0301}-au-lait")
+        )
+        assert.is_true(trie:delete(""))
+        assert.is_nil(trie:search(""))
+        assert.is_truthy(tostring(trie):match("3 keys"))
+    end)
+
+    it("validates constructor entries and public string inputs", function()
+        assert.has_error(function()
+            Trie.new("not-a-table")
+        end, "entries must be a table")
+        assert.has_error(function()
+            Trie.new({ {} })
+        end, "entry at index 1 must contain a key")
+        assert.has_error(function()
+            Trie.new():insert({})
+        end, "key must be a string")
+        assert.has_error(function()
+            Trie.new():starts_with({})
+        end, "prefix must be a string")
+        assert.has_error(function()
+            Trie.new():longest_prefix_match({})
+        end, "input must be a string")
+    end)
+end)

--- a/code/packages/perl/trie/BUILD
+++ b/code/packages/perl/trie/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/trie/BUILD_windows
+++ b/code/packages/perl/trie/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-trie.t

--- a/code/packages/perl/trie/CHANGELOG.md
+++ b/code/packages/perl/trie/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Perl trie package with insertion, exact lookup, deletion, prefix
+  scans, longest-prefix matching, sorted enumeration, and validation helpers.

--- a/code/packages/perl/trie/Makefile.PL
+++ b/code/packages/perl/trie/Makefile.PL
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::Trie',
+    VERSION_FROM     => 'lib/CodingAdventures/Trie.pm',
+    ABSTRACT         => 'Prefix trie with sorted enumeration and longest-prefix matching',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {},
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/trie/README.md
+++ b/code/packages/perl/trie/README.md
@@ -1,0 +1,15 @@
+# CodingAdventures::Trie
+
+A dependency-free Perl prefix trie for string keys and arbitrary values. It
+supports exact lookup, deletion with pruning, lexicographically sorted
+enumeration, prefix scans, and longest-prefix matching.
+
+```perl
+use CodingAdventures::Trie;
+
+my $trie = CodingAdventures::Trie->new;
+$trie->insert('app', 1)->insert('apple', 2);
+
+my $match = $trie->longest_prefix_match('apples');
+print $match->[0]; # apple
+```

--- a/code/packages/perl/trie/cpanfile
+++ b/code/packages/perl/trie/cpanfile
@@ -1,0 +1,1 @@
+# No non-core dependencies.

--- a/code/packages/perl/trie/lib/CodingAdventures/Trie.pm
+++ b/code/packages/perl/trie/lib/CodingAdventures/Trie.pm
@@ -1,0 +1,217 @@
+package CodingAdventures::Trie;
+
+use strict;
+use warnings;
+use utf8;
+use overload '""' => 'as_string', fallback => 1;
+
+our $VERSION = '0.1.0';
+
+sub _new_node {
+    return {
+        children => {},
+        terminal => 0,
+        value    => undef,
+    };
+}
+
+sub _assert_string {
+    my ($value, $name) = @_;
+    die "$name must be a string\n" if !defined($value) || ref($value);
+}
+
+sub new {
+    my ($class, $entries) = @_;
+    $entries = [] if !defined $entries;
+    die "entries must be an array reference\n" if ref($entries) ne 'ARRAY';
+
+    my $self = bless {
+        root => _new_node(),
+        size => 0,
+    }, $class;
+
+    for my $index (0 .. $#$entries) {
+        my $entry = $entries->[$index];
+        die "entry at index $index must contain a key\n"
+            if ref($entry) ne 'ARRAY' || !@$entry;
+        my $value = @$entry >= 2 ? $entry->[1] : 1;
+        $self->insert($entry->[0], $value);
+    }
+    return $self;
+}
+
+sub insert {
+    my ($self, $key) = @_;
+    my $value = @_ >= 3 ? $_[2] : 1;
+    _assert_string($key, 'key');
+
+    my $node = $self->{root};
+    for my $character (split //u, $key) {
+        $node->{children}{$character} //= _new_node();
+        $node = $node->{children}{$character};
+    }
+
+    $self->{size}++ if !$node->{terminal};
+    $node->{terminal} = 1;
+    $node->{value} = $value;
+    return $self;
+}
+
+sub _find_node {
+    my ($self, $key) = @_;
+    my $node = $self->{root};
+    for my $character (split //u, $key) {
+        return undef if !exists $node->{children}{$character};
+        $node = $node->{children}{$character};
+    }
+    return $node;
+}
+
+sub search {
+    my ($self, $key) = @_;
+    _assert_string($key, 'key');
+    my $node = $self->_find_node($key);
+    return defined($node) && $node->{terminal} ? $node->{value} : undef;
+}
+
+sub contains_key {
+    my ($self, $key) = @_;
+    _assert_string($key, 'key');
+    my $node = $self->_find_node($key);
+    return defined($node) && $node->{terminal} ? 1 : 0;
+}
+
+sub key_exists { return shift->contains_key(@_); }
+sub contains   { return shift->contains_key(@_); }
+
+sub _delete_recursive {
+    my ($node, $characters, $depth) = @_;
+    if ($depth >= @$characters) {
+        $node->{terminal} = 0;
+        $node->{value} = undef;
+        return !keys %{$node->{children}};
+    }
+
+    my $character = $characters->[$depth];
+    my $child = $node->{children}{$character};
+    if (defined($child) && _delete_recursive($child, $characters, $depth + 1)) {
+        delete $node->{children}{$character};
+    }
+    return !keys(%{$node->{children}}) && !$node->{terminal};
+}
+
+sub delete {
+    my ($self, $key) = @_;
+    _assert_string($key, 'key');
+    return 0 if !$self->contains_key($key);
+
+    my @characters = split //u, $key;
+    _delete_recursive($self->{root}, \@characters, 0);
+    $self->{size}--;
+    return 1;
+}
+
+sub starts_with {
+    my ($self, $prefix) = @_;
+    _assert_string($prefix, 'prefix');
+    return $self->{size} > 0 ? 1 : 0 if $prefix eq '';
+    return defined($self->_find_node($prefix)) ? 1 : 0;
+}
+
+sub _collect {
+    my ($node, $current, $results) = @_;
+    push @$results, [$current, $node->{value}] if $node->{terminal};
+    for my $character (sort keys %{$node->{children}}) {
+        _collect($node->{children}{$character}, $current . $character, $results);
+    }
+}
+
+sub words_with_prefix {
+    my ($self, $prefix) = @_;
+    _assert_string($prefix, 'prefix');
+    my $node = $self->_find_node($prefix);
+    return [] if !defined $node;
+
+    my $results = [];
+    _collect($node, $prefix, $results);
+    return $results;
+}
+
+sub all_words {
+    my ($self) = @_;
+    my $results = [];
+    _collect($self->{root}, '', $results);
+    return $results;
+}
+
+sub entries  { return shift->all_words(@_); }
+sub to_array { return shift->all_words(@_); }
+
+sub keys {
+    my ($self) = @_;
+    return [map { $_->[0] } @{$self->all_words}];
+}
+
+sub longest_prefix_match {
+    my ($self, $input) = @_;
+    _assert_string($input, 'input');
+    my $node = $self->{root};
+    my $current = '';
+    my $best = $node->{terminal} ? ['', $node->{value}] : undef;
+
+    for my $character (split //u, $input) {
+        last if !exists $node->{children}{$character};
+        $current .= $character;
+        $node = $node->{children}{$character};
+        $best = [$current, $node->{value}] if $node->{terminal};
+    }
+    return $best;
+}
+
+sub each {
+    my ($self, $callback) = @_;
+    die "callback must be a code reference\n" if ref($callback) ne 'CODE';
+    $callback->(@$_) for @{$self->all_words};
+    return $self;
+}
+
+sub size   { return $_[0]->{size}; }
+sub length { return $_[0]->{size}; }
+
+sub is_empty {
+    my ($self) = @_;
+    return $self->{size} == 0 ? 1 : 0;
+}
+
+sub _count_endpoints {
+    my ($node) = @_;
+    my $count = $node->{terminal} ? 1 : 0;
+    $count += _count_endpoints($_) for values %{$node->{children}};
+    return $count;
+}
+
+sub is_valid {
+    my ($self) = @_;
+    return _count_endpoints($self->{root}) == $self->{size} ? 1 : 0;
+}
+
+sub as_string {
+    my ($self) = @_;
+    return sprintf('Trie(%d keys)', $self->{size});
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::Trie - prefix trie with sorted enumeration
+
+=head1 SYNOPSIS
+
+  my $trie = CodingAdventures::Trie->new;
+  $trie->insert('app', 1)->insert('apple', 2);
+  my $match = $trie->longest_prefix_match('apples');
+
+=cut

--- a/code/packages/perl/trie/required_capabilities.json
+++ b/code/packages/perl/trie/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/trie",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/trie/t/00-load.t
+++ b/code/packages/perl/trie/t/00-load.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::Trie; 1 }, 'CodingAdventures::Trie loads');
+ok(CodingAdventures::Trie->VERSION, 'has a VERSION');
+
+done_testing;

--- a/code/packages/perl/trie/t/01-trie.t
+++ b/code/packages/perl/trie/t/01-trie.t
@@ -1,0 +1,143 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use CodingAdventures::Trie;
+
+sub make_trie {
+    my $trie = CodingAdventures::Trie->new;
+    $trie->insert($_) for @_;
+    return $trie;
+}
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'empty trie' => sub {
+    my $trie = CodingAdventures::Trie->new;
+    is($trie->size, 0, 'size');
+    is($trie->length, 0, 'length');
+    ok($trie->is_empty, 'empty');
+    is($trie->search('anything'), undef, 'missing search');
+    ok(!$trie->starts_with('a'), 'missing prefix');
+    ok($trie->is_valid, 'valid');
+};
+
+subtest 'insert, search, and update' => sub {
+    my $trie = CodingAdventures::Trie->new;
+    $trie->insert('hello', 42);
+    is($trie->search('hello'), 42, 'exact key');
+    is($trie->search('hell'), undef, 'prefix is not a key');
+    is($trie->search('hellos'), undef, 'extension is not a key');
+    $trie->insert('hello', 99);
+    is($trie->search('hello'), 99, 'value updated');
+    is($trie->size, 1, 'size unchanged');
+    ok($trie->contains_key('hello'), 'contains key');
+    ok($trie->key_exists('hello'), 'key_exists alias');
+    $trie->insert('undefined', undef);
+    ok($trie->contains('undefined'), 'terminal key can contain undef');
+};
+
+subtest 'prefix words and sorted keys' => sub {
+    my $trie = make_trie(qw(banana app apple apply apt));
+    is_deeply(
+        $trie->words_with_prefix('app'),
+        [['app', 1], ['apple', 1], ['apply', 1]],
+        'prefix results are sorted',
+    );
+    is_deeply($trie->words_with_prefix('xyz'), [], 'missing prefix');
+    is_deeply(
+        $trie->keys,
+        [qw(app apple apply apt banana)],
+        'all keys sorted',
+    );
+    is_deeply($trie->entries, $trie->all_words, 'entries alias');
+};
+
+subtest 'delete leaves and shared prefixes' => sub {
+    my $trie = make_trie(qw(app apple apt));
+    ok($trie->delete('app'), 'delete shared prefix');
+    ok(!$trie->contains_key('app'), 'deleted key absent');
+    ok($trie->contains_key('apple'), 'longer key preserved');
+    ok($trie->contains_key('apt'), 'sibling key preserved');
+    is($trie->size, 2, 'size decremented');
+    ok(!$trie->delete('missing'), 'missing key not deleted');
+    ok(!$trie->delete('ap'), 'non-terminal prefix not deleted');
+    ok($trie->delete('apple'), 'delete leaf');
+    ok($trie->delete('apt'), 'delete final leaf');
+    ok($trie->is_empty, 'empty after deletes');
+    ok($trie->is_valid, 'valid after pruning');
+};
+
+subtest 'constructor and longest-prefix match' => sub {
+    my $trie = CodingAdventures::Trie->new([
+        ['a', 1], ['ab', 2], ['abc', 3], ['abcd', 4],
+    ]);
+    is_deeply($trie->longest_prefix_match('abcde'), ['abcd', 4], 'longest match');
+    is($trie->longest_prefix_match('xyz'), undef, 'no match');
+    is_deeply($trie->longest_prefix_match('a'), ['a', 1], 'exact match');
+};
+
+subtest 'Unicode and empty-string keys' => sub {
+    my $trie = CodingAdventures::Trie->new;
+    $trie->insert('', 'root');
+    $trie->insert('cafe', 'plain');
+    $trie->insert("cafe\x{0301}", 'accent-combining');
+    $trie->insert("caf\x{00e9}", 'accent-single');
+    is($trie->search(''), 'root', 'empty key');
+    ok($trie->starts_with(''), 'empty prefix');
+    ok($trie->starts_with('caf'), 'shared prefix');
+    is($trie->search("caf\x{00e9}"), 'accent-single', 'Unicode key');
+    is_deeply(
+        $trie->longest_prefix_match("cafe\x{0301}-au-lait"),
+        ["cafe\x{0301}", 'accent-combining'],
+        'Unicode longest prefix',
+    );
+    ok($trie->delete(''), 'delete empty key');
+    is($trie->search(''), undef, 'empty key absent');
+    like("$trie", qr/3 keys/, 'string rendering');
+};
+
+subtest 'iteration and validation' => sub {
+    my $trie = make_trie(qw(b a));
+    my @seen;
+    $trie->each(sub { push @seen, [@_] });
+    is_deeply(\@seen, [['a', 1], ['b', 1]], 'sorted callback iteration');
+
+    dies_like(
+        sub { CodingAdventures::Trie->new('not-an-array') },
+        qr/entries must be an array reference/,
+        'constructor validation',
+    );
+    dies_like(
+        sub { CodingAdventures::Trie->new([[]]) },
+        qr/entry at index 0 must contain a key/,
+        'entry validation',
+    );
+    dies_like(
+        sub { $trie->insert([]) },
+        qr/key must be a string/,
+        'key validation',
+    );
+    dies_like(
+        sub { $trie->starts_with({}) },
+        qr/prefix must be a string/,
+        'prefix validation',
+    );
+    dies_like(
+        sub { $trie->longest_prefix_match([]) },
+        qr/input must be a string/,
+        'input validation',
+    );
+    dies_like(
+        sub { $trie->each('not-code') },
+        qr/callback must be a code reference/,
+        'callback validation',
+    );
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,13 +105,13 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 15, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
+on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
-`skip-list`, and `hyperloglog` ports:
+`skip-list`, `hyperloglog`, and `trie` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 355 |
+| Present in 10-15 languages | 171 | 353 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -164,8 +164,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 8 | Pair with Perl data-structure/storage wave |
-| Perl | 8 | Pair with Lua data-structure/storage wave |
+| Lua | 7 | Pair with Perl data-structure/storage wave |
+| Perl | 7 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -177,9 +177,9 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first eight paired Lua/Perl slices are complete: `fenwick-tree`,
+The first nine paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
-`avl-tree`, `tree-set`, `skip-list`, and `hyperloglog` now have pure
+`avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, and `trie` now have pure
 implementations, package-native tests, metadata, and capability declarations in
 both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
@@ -187,6 +187,8 @@ in-memory data store layers move; the AVL slice supplies the ordered backend
 for `tree-set`; and the dependency-free skip-list slice adds a span-augmented
 ordered map with logarithmic rank and selection. The HyperLogLog slice adds a
 fixed-memory approximate distinct counter with deterministic internal hashing.
+The trie slice adds Unicode-aware prefix storage with sorted scans, pruning
+deletion, and longest-prefix matching without introducing new dependencies.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a dependency-free Lua 5.4 trie with UTF-8 keys, sorted prefix scans, pruning deletion, longest-prefix matching, and package-native tests
- add the equivalent dependency-free Perl trie with the same behavior and native tests
- refresh the parity roadmap from 355 to 353 high-consensus missing slots and reduce the Lua/Perl lanes from 8 gaps to 7

## Validation

- `luarocks lint coding-adventures-trie-0.1.0-1.rockspec`
- `luarocks make --local --deps-mode=none coding-adventures-trie-0.1.0-1.rockspec`
- Lua Busted suite: 7 successes
- `perl -Ilib -c lib/CodingAdventures/Trie.pm`
- `perl -Ilib t/00-load.t`
- `perl -Ilib t/01-trie.t` (7 passing subtests)
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'` (6 tests)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- `git diff --check`
