### PR TITLE
feat(adj-facts-stdlib): chemistry/ph-scale — common substance → approximate pH table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_phscale_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_phscale_e2e.rs
@@ -1,0 +1,69 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/ph-scale.adj`) driven through the built CLI:
+//! a native `table` of common substance → approximate pH resolves binding-query
+//! recalls (forward and backward) with the source's LibreTexts citation, and
+//! abstains on a substance not in the table (dish soap) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsph_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_substance_ph_recall_binds_ph_with_citation() {
+    let dir = scratch("phscale");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/ph-scale.adj");
+    std::fs::copy(&src, dir.join("ph-scale.adj")).expect("copy shipped ph-scale.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ph-scale.adj\"\n\
+         ? substance_ph(lemon_juice, $P)\n\
+         ? substance_ph(ammonia, $P)\n\
+         ? substance_ph($S, 7.0)\n\
+         ? substance_ph(dish_soap, $P)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Lemon juice is strongly acidic (pH 2.2); ammonia is strongly basic (12.5) —
+    // the recalled pH values (forward binds).
+    assert!(out.contains("\"P\":\"2.2\""), "lemon_juice -> 2.2: {out}");
+    assert!(out.contains("\"P\":\"12.5\""), "ammonia -> 12.5: {out}");
+    // The relation runs BACKWARD: bind the neutral pH 7.0, recall the substance —
+    // pure water, the middle of the scale.
+    assert!(
+        out.contains("\"S\":\"pure_water\""),
+        "7.0 -> pure_water (reverse recall to the neutral point): {out}"
+    );
+    // The answer carries the LibreTexts citation as its proof, at consensus trust
+    // (a secondary teaching reference, honestly tiered).
+    assert!(
+        out.contains("chem.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation at consensus trust: {out}"
+    );
+    // "dish_soap" is not in the table — honest abstention, never a fabricated pH.
+    assert!(out.contains("\"abstained\":true"), "dish_soap abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -28,6 +28,7 @@ per rotation, in parallel):
 | `geometry/` | polygon → number of sides | Wolfram MathWorld |
 | `astronomy/` | planet → order from the Sun | NASA |
 | `chemistry/` | element → atomic number | PubChem / NIH |
+| `chemistry/` | common substance → approximate pH | LibreTexts (consensus) |
 | `metrology/` | SI prefix → power of ten | NIST |
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |

--- a/code/specs/data/adj-facts-stdlib/chemistry/ph-scale.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/ph-scale.adj
@@ -1,0 +1,106 @@
+% ============================================================================
+% substance_ph — the approximate pH of common everyday substances
+% (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% An elementary/middle-school science fact set: where does each familiar liquid
+% sit on the pH scale? The pH scale runs from 0 to 14. A value BELOW 7 is acidic
+% (lemon juice, vinegar, soda), exactly 7 is NEUTRAL (pure water), and ABOVE 7 is
+% basic / alkaline (milk of magnesia, ammonia). Recall is a binding query:
+%
+%     ? substance_ph(lemon_juice, $P)      % 2.2
+%
+% Like every FACTS library this is a native `table` (ADJ-TABLES RS-5): each
+% `row` lowers to a ground relation `substance_ph(substance, ph)` carrying the
+% table's citation, so the lookup above is the ordinary SLD binding query — the
+% engine returns the pH WITH its source, on the CPU, with zero model calls, and
+% abstains on a substance that is not in the table. It also runs BACKWARD (bind a
+% pH, recall the substance that has it):
+%
+%     ? substance_ph($S, 7.0)              % pure_water — the neutral point
+%
+% WHY a number and not just a label — recall feeding COMPUTE. Because each `ph`
+% cell is a NUMBER (not an atom), a recalled pH composes straight into
+% arithmetic. pH is a LOGARITHMIC scale: each whole step is a ten-fold change in
+% acidity, so lemon juice (2.2) is roughly 100000 times more acidic than pure
+% water (7.0) — that "100000" is 10 raised to (7.0 - 2.2), a subtraction and a
+% power that a recalled pH flows straight into. That is the concrete bridge from
+% chemistry RECALL to acidity COMPUTE, the reason a facts library and a formula
+% library belong in one standard library.
+%
+% The thirteen substances, ordered up the scale from most acidic to most basic
+% (a little truth table — follow the value from 0 toward 14):
+%
+%     substance          pH     where it sits
+%     ----------------   ----   -------------------------
+%     stomach_acid       1.7    strongly acidic
+%     lemon_juice        2.2    acidic
+%     vinegar            2.9    acidic
+%     soda               3.0    acidic (a fizzy soft drink)
+%     wine               3.5    acidic
+%     black_coffee       5.0    weakly acidic
+%     milk               6.9    just below neutral
+%     pure_water         7.0    NEUTRAL — the middle of the scale
+%     blood              7.4    just above neutral
+%     seawater           8.5    weakly basic
+%     milk_of_magnesia   10.5   basic
+%     ammonia            12.5   strongly basic
+%     sodium_hydroxide   14.0   strongly basic (1.0 M NaOH — the top)
+%
+% A substance that is not one of these thirteen — dish soap, tomato juice, a rock
+% — has no row, so a recall on it ABSTAINS rather than inventing a pH. That
+% honest-abstention property is what makes the table safe to reason from.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every substance→pH pair was
+% read out of a fetched teaching-reference page, and any substance whose value
+% could not be copied verbatim would have been dropped). All thirteen values come
+% from the SAME source: the LibreTexts Chemistry table "Typical pH Values of
+% Various Substances" (chem.libretexts.org, South Puget Sound Community College
+% "Chem 121: Introduction to Chemistry", §9.2 "The pH Scale"), each pH copied
+% character-for-character from that table:
+%
+%   stomach acid → 1.7        milk → 6.9              milk of magnesia → 10.5
+%   lemon juice → 2.2         pure water → 7.0        ammonia solution → 12.5
+%   vinegar → 2.9             blood → 7.4             1.0 M NaOH → 14.0
+%   soda → 3.0                seawater → 8.5
+%   wine → 3.5                coffee, black → 5.0
+%
+% The table carries the footnote "*Actual values may vary depending on
+% conditions", so each pH is an APPROXIMATE representative value (the single
+% number the source states), which is exactly what an elementary/middle-school
+% pH fact set wants. The neutral point pure_water → 7.0 is independently
+% corroborated by primary U.S. government sources (USGS Water Science School and
+% EPA both state pure water has "a pH of 7.0"), but this table's ONE provenance
+% envelope holds the LibreTexts source that fixes ALL thirteen rows in text.
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold that single source's caption and two representative verbatim
+% rows; every other row's verbatim value is listed above, so each pH remains
+% independently checkable. LibreTexts is a SECONDARY teaching reference (a
+% college course text, not a primary standards body), so `trust consensus` — the
+% honest tier for a teaching summary, per the standard-library trust convention.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table substance_ph {
+    columns substance, ph
+
+    row (stomach_acid, 1.7)
+    row (lemon_juice, 2.2)
+    row (vinegar, 2.9)
+    row (soda, 3.0)
+    row (wine, 3.5)
+    row (black_coffee, 5.0)
+    row (milk, 6.9)
+    row (pure_water, 7.0)
+    row (blood, 7.4)
+    row (seawater, 8.5)
+    row (milk_of_magnesia, 10.5)
+    row (ammonia, 12.5)
+    row (sodium_hydroxide, 14.0)
+
+    source "Typical pH Values of Various Substances* — lemon juice 2.2 … pure water 7.0 … ammonia solution 12.5 (*Actual values may vary depending on conditions)"
+    locator "https://chem.libretexts.org/Courses/South_Puget_Sound_Community_College/Chem_121:_Introduction_to_Chemistry/09:_Chapter_8A_-_Acids_bases_and_pH/9.02:_The_pH_Scale_(Acidic_Basic_Neutral_solutions)"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/ph-scale.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/ph-scale.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% ph-scale.query.adj — a worked recall over the chemistry ph-scale library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how acidic is lemon
+% juice?": it states no chemistry fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the `substance_ph`
+% rows and returns the pH + the table's source/locator/trust. The fourth query
+% runs the relation BACKWARD (bind the pH 7.0, recall the substance that has it —
+% pure water, the neutral point). Dish soap is not in the table, so a recall on
+% it abstains honestly — the engine never invents a pH.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ph-scale.query.adj
+% ============================================================================
+
+import "ph-scale.adj"
+
+? substance_ph(lemon_juice, $P)   % expect 2.2   — acidic
+? substance_ph(milk, $P)          % expect 6.9   — just below neutral
+? substance_ph(ammonia, $P)       % expect 12.5  — strongly basic
+? substance_ph($S, 7.0)           % expect pure_water — reverse recall to the neutral point
+? substance_ph(dish_soap, $P)     % expect abstain — dish soap is not in the table


### PR DESCRIPTION
Add a chemistry FACTS library mapping thirteen common everyday substances to
their approximate pH, as an elementary/middle-school science fact set. Like every
FACTS library it is a native `table` (ADJ-TABLES): each row lowers to a ground
relation `substance_ph(substance, ph)` carrying the table's citation, so recall is
an ordinary SLD binding query resolved on the CPU with zero model calls, running
forward (substance → pH) and backward (pH → substance), and abstaining honestly on
any substance not in the table.

Because each `ph` cell is a NUMBER, a recalled pH composes straight into arithmetic
(pH is logarithmic: each whole step is a ten-fold change in acidity) — the recall →
compute bridge that the standard library is built around.

Files (data-only diff):
  - code/specs/data/adj-facts-stdlib/chemistry/ph-scale.adj        (the table)
  - code/specs/data/adj-facts-stdlib/chemistry/ph-scale.query.adj  (worked lookup)
  - code/packages/rust/adj-lang-cli/tests/facts_phscale_e2e.rs     (e2e: bind + abstain)
  - README.md subject-index row

Provenance (nothing from memory — every value read out of a source fetched this
session; any value not copyable verbatim would have been dropped):
  - All thirteen substance → pH values come from ONE source, the LibreTexts
    Chemistry table "Typical pH Values of Various Substances" (South Puget Sound
    Community College, Chem 121, §9.2 "The pH Scale"):
    stomach_acid 1.7, lemon_juice 2.2, vinegar 2.9, soda 3.0, wine 3.5,
    black_coffee 5.0, milk 6.9, pure_water 7.0, blood 7.4, seawater 8.5,
    milk_of_magnesia 10.5, ammonia 12.5, sodium_hydroxide 14.0.
  - Trust tier: `consensus` — LibreTexts is a secondary teaching reference (a
    college course text), not a primary standards body, so it is tiered honestly.
  - The neutral point pure_water → 7.0 is independently corroborated by primary
    U.S. government sources fetched this session (USGS Water Science School and
    EPA both state pure water has a pH of 7.0), but the table's single provenance
    envelope holds the LibreTexts source that fixes all thirteen rows in text.

Note: the USGS/EPA pH pages present their common-substance values only inside a
scale IMAGE (no fetchable text), so per the no-byte-arithmetic / verbatim-only
rule they could not seed rows; the LibreTexts text table was used instead at the
honest consensus tier.

Verified: `cargo test -p adj-lang -p adj-lang-cli` green (incl. facts_phscale_e2e);
`cargo clippy -p adj-lang -p adj-lang-cli --all-targets -- -D warnings` clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
