### PR TITLE
feat(closure-pass-fold-control-flow): empty-then if with a multi-statement else → x||(seq)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.27.0] - 2026-07-16
+
+### Added — empty-then `if` with a MULTI-statement else → `x || (seq)`
+
+Generalises the 0.26.0 empty-then→logical-OR fold from a *single* expression
+statement to a **run** of them, sequenced with the comma operator — verified
+byte-identical against the reference Closure Compiler (`SIMPLE`):
+
+- `if (x) {} else { a(); b(); }` → `x || (a(), b());`
+- `if (x) {} else { a(); b(); c(); }` → `x || (a(), b(), c());`
+- `if (x) {} else { a(); b; c(); }` → `x || (a(), b, c());` (a pure member such
+  as the bare `b` is **kept** — dropping it is a separate DCE transform)
+
+**Soundness.** The comma operator evaluates its operands left-to-right and yields
+the last, so `(s1, s2, …)` runs the else block's statements in the original order
+with the same side effects; the wrapping `x || (…)` discards the value, so only
+that ordering matters, and — as in 0.26.0 — the effects fire exactly when `x` is
+falsy.
+
+**Scope.** Every else-block member must be a plain expression statement. A block
+containing a `var`/`let`/`const` declaration, a `return`/`break`, an `if`/loop,
+or a nested block **declines** (the `if` is kept), because those can't join a
+comma-sequence — Closure reaches for a different rewrite there (e.g. the De
+Morgan `if (!x) { … }`). Non-empty then-branches (`if (x) a(); else { b(); c() }`
+→ `x ? a() : (b(), c())`) are the ternary-sequence generalisation, a separate
+follow-up.
+
+A new `stmts_as_sequence_expr` helper backs this: a strict superset of
+`single_expr_stmt` that returns the bare expression for a one-statement block and
+a `SequenceExpression` for a ≥2-statement all-expression block.
+
 ## [0.26.0] - 2026-07-15
 
 ### Added — empty-then `if` → logical-OR (`if (x) {} else S;` → `x || S;`)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -1224,10 +1224,13 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
             //                                                   the lower-
             //                                                   precedence assign)
             //   if (a && b) {} else c();     → a && b || c();  (compound test)
-            //   if (x) {} else { a(); b(); } → unchanged (multi-statement else
-            //                                  needs a sequence — separate arc)
+            //   if (x) {} else { a(); b(); } → x || (a(), b());  (multi-statement
+            //                                  else — sequenced; the `,` groups
+            //                                  the effects under one `||` right
+            //                                  operand, preserving order)
             //   if (x) {} else return E;     → unchanged (return isn't an
-            //                                  expression statement)
+            //                                  expression statement, so it can't
+            //                                  join a comma-sequence)
             //
             // Why this is safe (the dual of the `&&` case):
             //
@@ -1235,6 +1238,8 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
             //   * If `x` is truthy: `||` short-circuits and does NOT evaluate
             //     `S`, matching the empty then-branch running nothing.
             //   * If `x` is falsy: `||` evaluates `S`, matching the else branch.
+            //     When the else is several statements, `S` is `(s1, s2, …)` — the
+            //     comma operator runs them left-to-right, same order as the block.
             //   * The wrapper ExpressionStatement discards the result, so the
             //     value `||` yields is irrelevant — only `S`'s side effects
             //     matter, and they fire exactly when `x` is falsy in both forms.
@@ -1245,12 +1250,12 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
             // with that normalisation.
             if let Some(alt) = &alternate {
                 if statement_is_empty(&consequent) {
-                    if let Some(a_expr) = single_expr_stmt(alt) {
+                    if let Some(a_expr) = stmts_as_sequence_expr(alt) {
                         st.record_fold(
                             &s.cv,
                             "if-empty-then-to-logical-or",
-                            "if (<test>) {} else <expr>;",
-                            "<test> || <expr>;",
+                            "if (<test>) {} else <stmts>;",
+                            "<test> || (<stmts>);",
                         );
                         let or = Expression::LogicalExpression(LogicalExpression {
                             cv: None,
@@ -1296,6 +1301,57 @@ fn single_expr_stmt(stmt: &Statement) -> Option<Expression> {
         }
         _ => None,
     }
+}
+
+/// Collapse a statement into a *single expression* by comma-sequencing, when
+/// possible. Generalises [`single_expr_stmt`] from one expression statement to a
+/// **run** of them:
+///
+///   { a(); }            → a()               (1-element: bare, no `,` wrapper)
+///   { a(); b(); }       → (a(), b())         (2+ → SequenceExpression)
+///   { a(); b; c(); }    → (a(), b, c())      (pure members kept — dropping them
+///                                             is a *separate* DCE transform)
+///
+/// It is a strict superset of `single_expr_stmt`, so callers that used that
+/// helper keep byte-identical output on the single-statement case and now also
+/// fold a multi-statement block. It **declines** (returns `None`) whenever a
+/// member isn't a plain expression statement — a `var`/`let`/`const`
+/// declaration, a `return`/`break`/`if`/loop, or a nested block — because those
+/// can't be expressed as one comma-sequence (Closure reaches for a different
+/// rewrite there, e.g. the De Morgan `if (!x) { … }`).
+///
+/// The comma operator evaluates its operands left-to-right and yields the last,
+/// so `(s1, s2, …)` runs the block's statements in the original order with the
+/// same set of side effects — the wrapping context (`x || (…)`) discards the
+/// value, so only that ordering matters.
+fn stmts_as_sequence_expr(stmt: &Statement) -> Option<Expression> {
+    // The 1-element case (a bare expression statement, or single-statement block
+    // layers) is exactly `single_expr_stmt`; reuse it so behaviour is identical.
+    if let Some(e) = single_expr_stmt(stmt) {
+        return Some(e);
+    }
+    // Otherwise only a block of ≥2 statements can sequence, and only when EVERY
+    // member is a plain expression statement.
+    if let Statement::Tagged(TaggedStatement::BlockStatement(b)) = stmt {
+        if b.body.len() >= 2 {
+            let mut expressions = Vec::with_capacity(b.body.len());
+            for member in &b.body {
+                match member {
+                    Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => {
+                        expressions.push(es.expression.clone());
+                    }
+                    // A declaration / return / nested block / etc. can't join a
+                    // comma-sequence — bail so the `if` is left intact.
+                    _ => return None,
+                }
+            }
+            return Some(Expression::SequenceExpression(SequenceExpression {
+                cv: None,
+                expressions,
+            }));
+        }
+    }
+    None
 }
 
 /// True when `stmt` does nothing observable — an `EmptyStatement` (`;`) or a
@@ -2581,11 +2637,9 @@ mod tests {
     }
 
     #[test]
-    fn if_empty_then_with_multi_statement_else_passes_through() {
-        // `if (x) {} else { a; b; }` — a two-statement else would need a
-        // sequence expression, which this fold doesn't build (a
-        // LogicalExpression takes exactly one right operand), so the
-        // IfStatement is kept intact (that's a separate arc).
+    fn if_empty_then_with_multi_statement_else_folds_to_or_of_sequence() {
+        // `if (x) {} else { a; b; }` — the multi-statement else now collapses to
+        // a comma-sequence under the `||` right operand: `x || (a, b)`.
         let if_stmt = Statement::if_statement(IfStatement {
             cv: Some("if.or2".to_string()),
             test: ident("x"),
@@ -2599,14 +2653,62 @@ mod tests {
             }))),
         });
         let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
-        let (out, _contribs, _changed, _) = run_pass(prog);
-        match first_stmt(&out) {
-            Statement::Tagged(TaggedStatement::IfStatement(_)) => {}
-            other => panic!(
-                "expected IfStatement intact (multi-statement else); got {:?}",
-                other
+        let (out, _contribs, changed, _) = run_pass(prog);
+        assert!(changed, "multi-statement else should fold to || of a sequence");
+        let Statement::Tagged(TaggedStatement::ExpressionStatement(es)) = first_stmt(&out) else {
+            panic!("expected an ExpressionStatement; got {:?}", first_stmt(&out))
+        };
+        let Expression::LogicalExpression(l) = &es.expression else {
+            panic!("expected a LogicalExpression(Or); got {:?}", es.expression)
+        };
+        assert_eq!(l.operator, LogicalOperator::Or, "operator must be ||");
+        let Expression::SequenceExpression(seq) = &*l.right else {
+            panic!("|| right operand must be a SequenceExpression; got {:?}", l.right)
+        };
+        assert_eq!(seq.expressions.len(), 2, "the two else statements sequence");
+    }
+
+    #[test]
+    fn if_empty_then_with_declaration_else_passes_through() {
+        // `if (x) {} else { var y; a(); }` — a `var` declaration can't join a
+        // comma-sequence, so the fold declines and the `if` is kept intact
+        // (Closure reaches for a De Morgan `if (!x) { … }` there — a separate arc).
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: Some("if.or3".to_string()),
+            test: ident("x"),
+            consequent: Box::new(Statement::block_statement(BlockStatement {
+                cv: None,
+                body: vec![],
+            })),
+            alternate: Some(Box::new(Statement::block_statement(BlockStatement {
+                cv: None,
+                body: vec![
+                    Statement::Declaration(Declaration::VariableDeclaration(VariableDeclaration {
+                        cv: None,
+                        kind: VarKind::Var,
+                        declarations: vec![VariableDeclarator {
+                            cv: None,
+                            id: BindingTarget::Identifier(Identifier {
+                                cv: None,
+                                name: "y".to_string(),
+                            }),
+                            init: None,
+                        }],
+                    })),
+                    expr_stmt(ident("a"), None),
+                ],
+            }))),
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
+        let (out, _c, _changed, _) = run_pass(prog);
+        assert!(
+            matches!(
+                first_stmt(&out),
+                Statement::Tagged(TaggedStatement::IfStatement(_))
             ),
-        }
+            "declaration in the else must keep the if intact; got {:?}",
+            first_stmt(&out)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Generalizes #8364's empty-then→logical-OR fold from a **single** else expression statement to a **run** of them, comma-sequenced. Verified **byte-identical against the reference Closure Compiler** (local oracle jar `v20260712`, `SIMPLE`):

| input | closurec | oracle |
|-------|----------|--------|
| `if(x){}else{a();b()}` | `x||(a(),b());` | `x||(a(),b());` |
| `if(x){}else{a();b();c()}` | `x||(a(),b(),c());` | `x||(a(),b(),c());` |
| `if(x){}else{a();b;c()}` | `x||(a(),b,c());` | `x||(a(),b,c());` |
| `if(x){}else{a()}` | `x||a();` | `x||a();` |

A pure member (the bare `b` in `{a();b;c()}`) is **kept** in the sequence — dropping it is a separate DCE transform.

## Soundness

The comma operator evaluates its operands left-to-right and yields the last, so `(s1, s2, …)` runs the else block's statements in original order with the same side effects. `x || (…)` short-circuits when `x` is truthy (the sequence isn't run — matching the empty then-branch) and evaluates it when `x` is falsy (matching the else). The wrapping expression statement discards the `||` value, so only that ordering matters.

## Scope

Every else-block member must be a plain expression statement. A block containing a `var`/`let`/`const` declaration, a `return`/`break`, an `if`/loop, or a nested block **declines** (the `if` is kept intact) — those can't join a comma-sequence, and Closure reaches for a different rewrite there (`if(x){}else{var y=1;a()}` → De Morgan `if(!x){var y=1;a()}`, a separate arc). Non-empty then-branches (`if(x)a();else{b();c()}` → `x?a():(b(),c())`) are the ternary-sequence generalization, also a follow-up.

A new `stmts_as_sequence_expr` helper backs this — a strict superset of `single_expr_stmt` returning the bare expression for a 1-statement block and a `SequenceExpression` for a ≥2-statement all-expression block, so #8364's single-statement cases stay byte-identical.

## Verification

- `cargo test -p coding-adventures-closure-pass-fold-control-flow` — 60 pass (replaced the #8364 "multi-statement else is kept" test with a `x||(seq)` assertion; added a `var`-declaration-else decline test).
- `cargo clippy` clean.
- Full `closurec` suite green — **no fixture drift**.
- End-to-end closurec-vs-oracle: all in-scope cases byte-identical; the `var`-decl else correctly declines (unchanged from before this PR).
- Inline security review: **PASSED** (soundness confirmed, no drop/reorder, `var` correctly declines, no panic/recursion issues).

Version `0.26.0` → `0.27.0`. fold-control-flow-pass-only; no `closurec` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)