### PR TITLE
feat(adj-facts-stdlib): biology/skeleton-bones — human bone → body region table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_skeletonbones_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_skeletonbones_e2e.rs
@@ -1,0 +1,74 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/skeleton-bones.adj`) driven through the built CLI:
+//! a native `table` of common human bone → body region resolves binding-query
+//! recalls (forward AND backward) with the source's NIH / MedlinePlus citation,
+//! and abstains on a word that is not one of these bones (the spleen) — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_skeleton_bones_recall_binds_region_with_citation() {
+    let dir = scratch("skeletonbones");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/skeleton-bones.adj");
+    std::fs::copy(&src, dir.join("skeleton-bones.adj")).expect("copy shipped skeleton-bones.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"skeleton-bones.adj\"\n\
+         ? bone_region(femur, $Region)\n\
+         ? bone_region(patella, $Region)\n\
+         ? bone_region(sternum, $Region)\n\
+         ? bone_region($Bone, arm)\n\
+         ? bone_region(spleen, $Region)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The femur is a leg bone, the patella is at the knee, the sternum is in the
+    // chest — the recalled regions (forward binds).
+    assert!(out.contains("\"Region\":\"leg\""), "femur → leg: {out}");
+    assert!(out.contains("\"Region\":\"knee\""), "patella → knee: {out}");
+    assert!(out.contains("\"Region\":\"chest\""), "sternum → chest: {out}");
+    // The relation runs BACKWARD: bind the region `arm`, recall the arm bones.
+    assert!(
+        out.contains("\"Bone\":\"humerus\"")
+            && out.contains("\"Bone\":\"radius\"")
+            && out.contains("\"Bone\":\"ulna\""),
+        "arm → humerus ; radius ; ulna (reverse recall): {out}"
+    );
+    // The answer carries the NIH / NLM MedlinePlus citation as its proof, at the
+    // `authoritative` trust tier for a primary U.S. government source.
+    assert!(
+        out.contains("medlineplus.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The spleen is an organ, not a bone — honest abstention, never a fabricated
+    // region.
+    assert!(out.contains("\"abstained\":true"), "spleen abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -35,7 +35,8 @@ per rotation, in parallel):
 | `earth-science/` | water-cycle stage → step number | USGS Water Science School |
 | `nutrition/` | common food → MyPlate food group | USDA MyPlate |
 | `agriculture/` | farm animal → product it gives | Iowa State University (CFSPH) |
-| … | *physics, biology, geography, anatomy, physical constants, …* | *(expanding)* |
+| `biology/` | common bone → body region | NIH / MedlinePlus |
+| … | *physics, geography, anatomy, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown
 in `adj-formula-stdlib/<subject>/` using the `formula` construct — simple ones first, growing

--- a/code/specs/data/adj-facts-stdlib/biology/skeleton-bones.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/skeleton-bones.adj
@@ -1,0 +1,136 @@
+% ============================================================================
+% skeleton-bones — common human bones and the body region each one is in
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the very first maps a child draws of their own skeleton, and a rung a
+% MEDICINE agent reasons UP from: the body's bony framework is a set of named
+% bones, and each bone lives in one region of the body. "The femur is in the
+% leg; the humerus is in the arm; the sternum is in the chest." Before you can
+% reason about a fracture, a joint, or an X-ray you must first know WHERE each
+% bone is — a broken femur is a leg injury, a cracked sternum is a chest injury.
+% Recall is a binding query:
+%
+%     ? bone_region(femur, $Region)      % leg
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `bone_region(bone, region)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the region
+% WITH its source, on the CPU, with zero model calls, and abstains on a word
+% that is not one of these bones (it never invents a region).
+%
+% Each bone and the region it is in, as a little truth table:
+%
+%     bone (common name)     region    a beginner's cue
+%     --------------------   -------   --------------------------------------
+%     femur (thigh bone)     leg       the femur is the big upper-leg bone
+%     tibia (shin bone)      leg       the tibia is a lower-leg bone
+%     fibula                 leg       the fibula is the smaller lower-leg bone
+%     patella (kneecap)      knee      the patella is the kneecap, at the knee
+%     humerus (upper arm)    arm       the humerus is the upper-arm bone
+%     radius                 arm       the radius is a forearm bone
+%     ulna                   arm       the ulna is the other forearm bone
+%     clavicle (collarbone)  shoulder  the clavicle is a shoulder-joint bone
+%     scapula (shoulder blade) shoulder the scapula is the shoulder blade
+%     sternum (breast bone)  chest     the sternum is the flat bone of the chest
+%     ribs                   chest     the ribs make the cage of the chest
+%     frontal                skull     the frontal bone is a bone of the skull
+%     parietal               skull     the parietal bones are bones of the skull
+%     temporal               skull     the temporal bones are bones of the skull
+%     occipital              skull     the occipital bone is a bone of the skull
+%
+% The query also runs BACKWARD — bind a region and recall the bones in it:
+%
+%     ? bone_region($Bone, arm)   % humerus ; radius ; ulna
+%
+% A word that is NOT one of these bones — `spleen`, `muscle`, `rock` — is
+% deliberately NOT a row, so a bone-region recall ABSTAINS on it rather than
+% inventing a region. That honest-abstention property is what makes the table
+% safe to build a reasoner on: it answers exactly the bone→region pairs it can
+% ground, and only those.
+%
+% The `region` value of every row is a SINGLE lowercase atom (leg, knee, arm,
+% shoulder, chest, skull), chosen to be the everyday body region the source
+% states that bone belongs to — never a region the source does not support.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every bone→region pair
+% below was read out of a fetched U.S. government / NIH page, and any bone whose
+% region could not be verified there would have been dropped). Each pair, with
+% the primary source it was copied from and the verbatim span that states it:
+%
+%   femur → leg
+%     https://medlineplus.gov/ency/imagepages/8844.htm  (NIH / NLM, MedlinePlus)
+%     "The thigh bone, or femur, is the large upper leg bone that connects the
+%      lower leg bones (knee joint) to the pelvic bone (hip joint)."
+%
+%   tibia → leg, fibula → leg
+%     https://medlineplus.gov/ency/imagepages/8844.htm  (NIH / NLM, MedlinePlus)
+%     "The lower leg is comprised of two bones, the tibia and the smaller
+%      fibula."
+%
+%   patella → knee
+%     https://medlineplus.gov/ency/article/002974.htm  (NIH / NLM, MedlinePlus)
+%     "Your kneecap is called the patella."  (the kneecap, at the front of the
+%      knee joint)
+%
+%   humerus → arm, radius → arm, ulna → arm
+%     https://medlineplus.gov/arminjuriesanddisorders.html  (NIH / NLM, MedlinePlus)
+%     "Of the 206 bones in your body, three of them are in your arm: the
+%      humerus, radius, and ulna."
+%
+%   clavicle → shoulder, scapula → shoulder
+%     https://medlineplus.gov/shoulderinjuriesanddisorders.html  (NIH / NLM, MedlinePlus)
+%     "Your shoulder joint is composed of three bones: the clavicle
+%      (collarbone), the scapula (shoulder blade), and the humerus (upper arm
+%      bone)."
+%
+%   sternum → chest, ribs → chest
+%     https://medlineplus.gov/ency/imagepages/8787.htm  (NIH / NLM, MedlinePlus)
+%     "The ribs connect on the front of the chest with the long flat sternum, or
+%      breast bone, and on the back with the vertebral column, creating a cage
+%      of protection for the lungs and heart."
+%
+%   frontal → skull, parietal → skull, temporal → skull, occipital → skull
+%     https://medlineplus.gov/ency/article/002320.htm  (NIH / NLM, MedlinePlus)
+%     "An infant's skull is made up of 6 separate cranial (skull) bones:
+%      Frontal bone, Occipital bone, Two parietal bones, Two temporal bones."
+%
+% (The same regional grouping is corroborated by the NCI SEER Training Modules
+% Skeletal System pages — the axial skeleton's Skull and Thoracic Cage and the
+% appendicular skeleton's Upper Extremity, Lower Extremity, and Pectoral Girdle,
+% https://training.seer.cancer.gov/anatomy/skeletal/divisions/ — another primary
+% U.S. government teaching resource.)
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the MedlinePlus statement that
+% fixes the first row (femur → leg). Every OTHER row's per-fact source and
+% verbatim span is listed above, so each region remains independently checkable.
+% All sources are primary U.S. government / NIH (NLM MedlinePlus) references, so
+% `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table bone_region {
+    columns bone, region
+
+    row (femur, leg)
+    row (tibia, leg)
+    row (fibula, leg)
+    row (patella, knee)
+    row (humerus, arm)
+    row (radius, arm)
+    row (ulna, arm)
+    row (clavicle, shoulder)
+    row (scapula, shoulder)
+    row (sternum, chest)
+    row (ribs, chest)
+    row (frontal, skull)
+    row (parietal, skull)
+    row (temporal, skull)
+    row (occipital, skull)
+
+    source "The thigh bone, or femur, is the large upper leg bone that connects the lower leg bones (knee joint) to the pelvic bone (hip joint)."
+    locator "https://medlineplus.gov/ency/imagepages/8844.htm"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/skeleton-bones.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/skeleton-bones.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% skeleton-bones.query.adj — a worked recall over the biology skeleton-bones library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "where is the femur?": it
+% states no anatomy fact of its own — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the `bone_region`
+% rows and returns the region + the table's source/locator/trust. The fourth
+% query runs the relation BACKWARD (bind the region `arm`, recall the bones in
+% it — humerus, radius, ulna). A word that is not one of these bones abstains
+% honestly — the engine never invents a region.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli skeleton-bones.query.adj
+% ============================================================================
+
+import "skeleton-bones.adj"
+
+? bone_region(femur, $Region)      % expect leg
+? bone_region(patella, $Region)    % expect knee
+? bone_region(sternum, $Region)    % expect chest
+? bone_region($Bone, arm)          % reverse bind — expect humerus ; radius ; ulna
+? bone_region(spleen, $Region)     % expect abstain — the spleen is an organ, not a bone


### PR DESCRIPTION
Add a grounded biology facts library mapping 15 common human bones to the
everyday body region each one is in, as a native ADJ `table`
(`bone_region(bone, region)`). Recall is a zero-model-call binding query that
returns the region WITH its source and abstains on any word that is not one of
these bones.

Rows (bone → region), each byte-provenanced from a fetched NIH / NLM
MedlinePlus page this session (nothing from memory):

  femur, tibia, fibula → leg
    medlineplus.gov/ency/imagepages/8844.htm  (Leg skeletal anatomy)
  patella → knee
    medlineplus.gov/ency/article/002974.htm   (Knee joint replacement)
  humerus, radius, ulna → arm
    medlineplus.gov/arminjuriesanddisorders.html
  clavicle, scapula → shoulder
    medlineplus.gov/shoulderinjuriesanddisorders.html
  sternum, ribs → chest
    medlineplus.gov/ency/imagepages/8787.htm   (Ribcage)
  frontal, parietal, temporal, occipital → skull
    medlineplus.gov/ency/article/002320.htm    (Cranial sutures)

Trust tiers: all sources are primary U.S. government NIH / NLM MedlinePlus
references, so every row is `trust authoritative`. The same regional grouping
is corroborated by the NCI SEER Training Modules Skeletal System pages (axial +
appendicular divisions), another primary .gov teaching resource, noted in the
header. The ADJ `table` carries ONE provenance envelope holding the cleanest
span (femur → leg); each other row's per-fact source + verbatim span is quoted
in the literate header for independent checking.

Data-only change mirroring the merged anatomy/heart-chambers library:
- biology/skeleton-bones.adj + biology/skeleton-bones.query.adj
- adj-lang-cli e2e test facts_skeletonbones_e2e.rs (forward + reverse recall,
  citation assertion, honest abstention on `spleen`)
- README subject-index row for biology/

No engine, grammar, or adapter code touched. cargo test -p adj-lang
-p adj-lang-cli and cargo clippy --all-targets -D warnings both green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
