### PR TITLE
feat(os-platform): jit executor — emit machine code at run time and call it

### DIFF
--- a/code/packages/c/os-platform/CHANGELOG.md
+++ b/code/packages/c/os-platform/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to semantic versioning.
 
 ### Added
 
+- **`jit` primitive** (CCPP02 follow-up — completes `mmap`'s deferred EXEC story):
+  emit machine code at run time and call it. Encapsulates each OS's W^X RW→RX
+  protocol so a code generator can `alloc → write → commit → call`.
+  - `osp_jit_alloc(out, capacity)` (JIT-capable writable buffer), `osp_jit_write`
+    (append machine code, capacity-checked), `osp_jit_commit` (flip to R+X + flush
+    the i-cache; no writes after), `osp_jit_entry` (callable address, NULL until
+    committed), `osp_jit_free`.
+  - Backends: `jit_posix.c` — Apple Silicon maps `MAP_JIT` (RWX) and toggles
+    writability per-thread with `pthread_jit_write_protect_np`, flushing with
+    `sys_icache_invalidate`; Linux maps RW, `mprotect`s to RX, and flushes with
+    `__builtin___clear_cache` (a no-op on x86, a real flush on arm64) — the single
+    `#if __APPLE__` split matching `mmap_posix.c`'s convention. `jit_windows.c` —
+    `VirtualAlloc` RW → `VirtualProtect` RX → `FlushInstructionCache`.
+  - Test (`tests/jit_test.c`): emits `int f(void){return N;}` for the current
+    architecture — **x86_64 and arm64** machine code — runs it through the
+    primitive, calls it, and asserts N (42 and 1337, proving the CPU runs the
+    exact bytes written); plus lifecycle (entry NULL until commit, no writes and
+    no double-commit after), capacity enforcement, and NULL validation. Verified
+    on Apple Silicon (executed live) and x86_64 (encoding disassembled); clean
+    under ASan+UBSan, 0 leaks.
+
 - **`mmap` primitive** (CCPP02 Phase 2, PR 6 — completes the six-primitive core):
   anonymous virtual memory with protection control — `malloc` gives bytes,
   but only the OS gives a page range with a chosen protection (read-only data,
@@ -24,9 +45,10 @@ and this project adheres to semantic versioning.
   - Test (`tests/mmap_test.c`): anonymous RW map, zero-fill check, page-sized
     write/read checksum, protection change to READ-only, accessors, unmap, and
     NULL/zero-length validation. Clean under ASan+UBSan, 0 leaks.
-  - The EXEC bit is plumbed to PROT_EXEC / PAGE_EXECUTE_* for JIT consumers; a
+  - The EXEC bit is plumbed to PROT_EXEC / PAGE_EXECUTE_* for JIT consumers; the
     dedicated JIT executor (per-arch machine code + the Apple-Silicon MAP_JIT
-    write-protect protocol + an execute-and-call test) is a planned follow-up.
+    write-protect protocol + an execute-and-call test) now ships as the `jit`
+    primitive above.
 - **`dynlib` primitive** (CCPP02 Phase 2, PR 5): load a shared library, resolve a
   symbol, unload — the foundation for plugins/FFI, and pure bucket B (ISO C
   cannot load code at run time).

--- a/code/packages/c/os-platform/README.md
+++ b/code/packages/c/os-platform/README.md
@@ -25,6 +25,7 @@ exactly one backend and the code contains no `#if defined(__linux__)` mazes.
 | `process` | `os_platform/process.h` | ✅ implemented |
 | `dynlib`  | `os_platform/dynlib.h`  | ✅ implemented |
 | `mmap`    | `os_platform/mmap.h`    | ✅ implemented |
+| `jit`     | `os_platform/jit.h`     | ✅ implemented |
 
 All primitives share the `osp_status` return convention from
 `os_platform/status.h` (`OSP_OK == 0`; negative on error).
@@ -223,9 +224,44 @@ Backends:
 | Windows     | `VirtualAlloc` | `VirtualProtect`| `VirtualFree`|
 
 `prot` is a bitmask of `OSP_PROT_NONE/READ/WRITE/EXEC`. The `EXEC` bit is plumbed
-through (for JIT) and works directly on Linux/Windows; a JIT executor that also
-handles Apple Silicon's `MAP_JIT` write-protect protocol, with a cross-arch
-execute-and-call test, is a planned follow-up.
+through for JIT consumers; the full JIT protocol lives in `jit` below.
+
+### `jit` — emit machine code at run time and call it
+
+`mmap` gives you an executable page, but W^X means you cannot just scribble
+instructions into it and jump — each OS has a protocol for the RW→RX transition.
+`jit` encapsulates it: allocate, write bytes, commit, call.
+
+```c
+#include "os_platform/jit.h"
+
+/* machine code for: int f(void){ return 42; } (x86_64) */
+static const unsigned char code[] = {0xB8, 0x2A, 0x00, 0x00, 0x00, 0xC3};
+
+osp_jit *j;
+osp_jit_alloc(&j, sizeof code);       /* JIT-capable, writable */
+osp_jit_write(j, code, sizeof code);  /* append machine code   */
+osp_jit_commit(j);                    /* flip to R+X, flush i-cache */
+
+void *entry = osp_jit_entry(j);
+int (*fn)(void);
+memcpy(&fn, &entry, sizeof fn);        /* void* -> function pointer */
+int r = fn();                          /* -> 42 */
+osp_jit_free(j);
+```
+
+Backends:
+
+| OS                    | allocate           | write              | commit                                |
+|-----------------------|--------------------|--------------------|---------------------------------------|
+| macOS (Apple Silicon) | `mmap` `MAP_JIT`   | write-protect toggle + `memcpy` | `sys_icache_invalidate`  |
+| Linux                 | `mmap` RW          | `memcpy`           | `mprotect` RX + `__builtin___clear_cache` |
+| Windows               | `VirtualAlloc` RW  | `memcpy`           | `VirtualProtect` RX + `FlushInstructionCache` |
+
+The instruction-cache flush is a no-op on x86 (coherent i-cache) but a real flush
+on arm64 (both Linux and macOS) — omitting it runs stale bytes. The
+`tests/jit_test.c` emit-and-call test carries x86_64 **and** arm64 machine code so
+it proves the whole path on every runner in the 3-OS matrix.
 
 ## Build & test
 
@@ -250,15 +286,17 @@ os-platform/
 │   ├── fs.h                      # fs API
 │   ├── process.h                 # process API
 │   ├── dynlib.h                  # dynlib API
-│   └── mmap.h                    # mmap API
+│   ├── mmap.h                    # mmap API
+│   └── jit.h                     # jit API
 ├── src/
 │   ├── clock_posix.c   · clock_windows.c     # per-OS clock backends
 │   ├── thread_posix.c  · thread_windows.c    # per-OS thread backends
 │   ├── fs_posix.c      · fs_windows.c        # per-OS fs backends
 │   ├── process_posix.c · process_windows.c   # per-OS process backends
 │   ├── dynlib_posix.c  · dynlib_windows.c    # per-OS dynlib backends
-│   └── mmap_posix.c    · mmap_windows.c      # per-OS mmap backends
-├── tests/  clock · thread · fs · process · dynlib · mmap  (one _test.c each)
+│   ├── mmap_posix.c    · mmap_windows.c      # per-OS mmap backends
+│   └── jit_posix.c     · jit_windows.c       # per-OS jit backends
+├── tests/  clock · thread · fs · process · dynlib · mmap · jit  (one _test.c each)
 ├── tools/run.sh  · run.ps1       # per-OS build drivers
 ├── BUILD  · BUILD_windows        # per-OS source selection
 └── required_capabilities.json    # CI needs gcc, clang, cl

--- a/code/packages/c/os-platform/include/os_platform/jit.h
+++ b/code/packages/c/os-platform/include/os_platform/jit.h
@@ -1,0 +1,103 @@
+/*
+ * os_platform/jit.h — emit machine code at run time and call it.
+ * ===========================================================================
+ *
+ * The seventh os-platform primitive, and the follow-up promised in mmap.h's
+ * scope note. `mmap` plumbs an EXEC bit, but on a modern OS you cannot simply
+ * map a page RWX, scribble instructions, and jump in: W^X (write-xor-execute) is
+ * enforced, and each OS has its own protocol for the RW → RX transition a JIT
+ * needs. `jit` encapsulates exactly that protocol so a code generator can:
+ *
+ *      alloc → write bytes → commit → call the entry
+ *
+ *      step        macOS (Apple Silicon)         Linux                Windows
+ *      ─────────   ───────────────────────────   ──────────────────   ─────────────────────
+ *      alloc       mmap MAP_JIT (RWX)            mmap RW              VirtualAlloc RW
+ *      write       pthread_jit_write_protect(0)  memcpy               memcpy
+ *                  → memcpy → …_protect(1)
+ *      commit      sys_icache_invalidate         mprotect RX +        VirtualProtect RX +
+ *                                                __clear_cache        FlushInstructionCache
+ *
+ * The Apple Silicon path is the hard one: hardened W^X means the page toggles
+ * per-thread between writable and executable, and the instruction cache must be
+ * flushed before the freshly written code is fetched. On x86 the i-cache is
+ * coherent so the flush is a no-op, but arm64 (Linux and macOS) genuinely needs
+ * it — omitting it runs stale bytes.
+ *
+ * MODEL. osp_jit_alloc reserves a JIT buffer with a byte capacity (writable to
+ * begin with). osp_jit_write appends machine code (repeatable up to capacity).
+ * osp_jit_commit flips the buffer to read+execute and flushes the i-cache; after
+ * commit the code is callable and no more writes are allowed. osp_jit_entry
+ * returns the callable address (NULL until committed). osp_jit_free releases it.
+ *
+ * THREADING. A single osp_jit buffer must be built (alloc → write → commit) by
+ * one thread: the Apple write-protect toggle is per-thread state, so interleaving
+ * writes to the same buffer across threads is a caller error. Once committed, the
+ * read-only code is of course safe to call from any thread.
+ *
+ * CALLING the entry: cast it to the function-pointer type your emitted code
+ * implements. The portable, warning-free cast is via memcpy (an object pointer
+ * and a function pointer need not be the same size in ISO C, though they are on
+ * every OS here) — see the test for the idiom.
+ *
+ * BUILD. Compiled by platform-harness; the POSIX backend needs _DEFAULT_SOURCE /
+ * _DARWIN_C_SOURCE (added by the BUILD) so MAP_ANONYMOUS / MAP_JIT are visible,
+ * and links no extra library (the Apple JIT calls live in libSystem). Windows
+ * uses only kernel32.
+ */
+#ifndef OS_PLATFORM_JIT_H
+#define OS_PLATFORM_JIT_H
+
+#include <stddef.h> /* size_t */
+
+#include "os_platform/status.h" /* osp_status */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque JIT buffer. Created by osp_jit_alloc, freed by osp_jit_free. */
+typedef struct osp_jit osp_jit;
+
+/*
+ * osp_jit_alloc — reserve a JIT buffer able to hold at least `capacity` bytes of
+ * machine code, initially writable. Writes a handle through *out. Returns
+ * OSP_ERR_INVAL (out NULL or capacity 0), OSP_ERR_NOMEM (handle allocation), or
+ * OSP_ERR_OS (the OS mapping call failed).
+ */
+osp_status osp_jit_alloc(osp_jit **out, size_t capacity);
+
+/*
+ * osp_jit_write — append `len` bytes of machine code to the buffer. May be
+ * called repeatedly before commit; the total may not exceed the requested
+ * capacity. Handles the Apple-Silicon write-protect toggle internally. Returns
+ * OSP_ERR_INVAL (j or code NULL, already committed, or would exceed capacity).
+ */
+osp_status osp_jit_write(osp_jit *j, const void *code, size_t len);
+
+/*
+ * osp_jit_commit — flip the buffer to read+execute and flush the instruction
+ * cache so the CPU sees the freshly written code. After commit the entry is
+ * callable and further writes are rejected. Returns OSP_ERR_INVAL (j NULL or
+ * already committed) or OSP_ERR_OS (the protection change failed).
+ */
+osp_status osp_jit_commit(osp_jit *j);
+
+/*
+ * osp_jit_entry — the callable base address of the committed code, or NULL if j
+ * is NULL or the buffer has not been committed yet.
+ */
+void *osp_jit_entry(const osp_jit *j);
+
+/*
+ * osp_jit_free — release the buffer and free the handle. Returns OSP_ERR_INVAL
+ * if j is NULL, OSP_ERR_OS if the OS release call fails (the handle is freed
+ * either way, matching the other primitives' "free releases the handle").
+ */
+osp_status osp_jit_free(osp_jit *j);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* OS_PLATFORM_JIT_H */

--- a/code/packages/c/os-platform/include/os_platform/mmap.h
+++ b/code/packages/c/os-platform/include/os_platform/mmap.h
@@ -26,10 +26,11 @@
  * PROT_EXEC / PAGE_EXECUTE_* so JIT consumers can request it, and it works
  * directly on Linux and Windows (map RW, emit, re-protect to R+X, run). Apple
  * Silicon's hardened runtime additionally requires MAP_JIT plus a per-thread
- * write-protect toggle and an instruction-cache flush; a dedicated JIT executor
- * that encapsulates that protocol (and a cross-architecture execute-and-call
- * test) is a planned follow-up. This header's own tests exercise anonymous
- * read/write memory and protection changes, which are identical on every OS.
+ * write-protect toggle and an instruction-cache flush. That full protocol — and
+ * a cross-architecture emit-and-call test — now lives in the sibling `jit`
+ * primitive (os_platform/jit.h); this header's own tests deliberately stay with
+ * anonymous read/write memory and protection changes, which are identical on
+ * every OS.
  *
  * BUILD. Compiled by platform-harness; the POSIX backend needs _DEFAULT_SOURCE
  * (added by the BUILD) so MAP_ANONYMOUS is visible on glibc, and links no extra

--- a/code/packages/c/os-platform/src/jit_posix.c
+++ b/code/packages/c/os-platform/src/jit_posix.c
@@ -1,0 +1,141 @@
+/*
+ * jit_posix.c — the POSIX backend of os_platform/jit (macOS + Linux).
+ * ===========================================================================
+ *
+ * Compiled on macOS + Linux (named by the shared `BUILD`; Windows uses
+ * jit_windows.c via `BUILD_windows`). The two POSIX platforms genuinely diverge
+ * in how a JIT page is made executable, so this file has a single
+ * `#if defined(__APPLE__)` split — the same convention mmap_posix.c uses for its
+ * MAP_ANON feature-macro difference:
+ *
+ *   - Apple (esp. Apple Silicon): map RWX with MAP_JIT, then toggle the page
+ *     writable/executable per-thread with pthread_jit_write_protect_np and flush
+ *     the i-cache with sys_icache_invalidate. Hardened W^X requires this dance.
+ *   - Linux: map RW, memcpy, mprotect to RX, then __builtin___clear_cache — a
+ *     no-op on x86 (coherent i-cache) but a real flush on arm64.
+ */
+#include "os_platform/jit.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h> /* sysconf */
+
+#if defined(__APPLE__)
+#include <libkern/OSCacheControl.h> /* sys_icache_invalidate */
+#include <pthread.h>                /* pthread_jit_write_protect_np */
+#endif
+
+struct osp_jit {
+    void *base;    /* mapping base (page-aligned)           */
+    size_t cap;    /* requested capacity (write limit)      */
+    size_t mapped; /* page-rounded mapping length (unmap)   */
+    size_t len;    /* bytes written so far                  */
+    int committed; /* 1 once flipped to R+X                 */
+};
+
+/* Round `n` up to a whole page (never zero). */
+static size_t osp__round_page(size_t n) {
+    long pg = sysconf(_SC_PAGESIZE);
+    size_t p = (pg > 0) ? (size_t)pg : 4096u;
+    return ((n + p - 1) / p) * p;
+}
+
+osp_status osp_jit_alloc(osp_jit **out, size_t capacity) {
+    struct osp_jit *j;
+    void *base;
+    size_t mapped;
+
+    if (out == NULL || capacity == 0) {
+        return OSP_ERR_INVAL;
+    }
+    j = (struct osp_jit *)malloc(sizeof(*j));
+    if (j == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    mapped = osp__round_page(capacity);
+    /* Reject a capacity so large the page round-up overflowed size_t (which
+     * would make `mapped` wrap below `capacity`) — explicit rather than relying
+     * on a zero-length OS mapping failing. */
+    if (mapped < capacity) {
+        free(j);
+        return OSP_ERR_OS;
+    }
+#if defined(__APPLE__)
+    /* MAP_JIT: an RWX region whose writability is gated per-thread by the
+     * write-protect toggle below. Required under the hardened runtime. */
+    base = mmap(NULL, mapped, PROT_READ | PROT_WRITE | PROT_EXEC,
+                MAP_PRIVATE | MAP_ANON | MAP_JIT, -1, 0);
+#else
+    /* Linux: start writable-only; flip to executable at commit. */
+    base = mmap(NULL, mapped, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+#endif
+    if (base == MAP_FAILED) {
+        free(j);
+        return OSP_ERR_OS;
+    }
+    j->base = base;
+    j->cap = capacity;
+    j->mapped = mapped;
+    j->len = 0;
+    j->committed = 0;
+    *out = j;
+    return OSP_OK;
+}
+
+osp_status osp_jit_write(osp_jit *j, const void *code, size_t len) {
+    if (j == NULL || code == NULL || j->committed) {
+        return OSP_ERR_INVAL;
+    }
+    /* Overflow-safe capacity check: cap >= len is an invariant, so cap - len
+     * never wraps. */
+    if (len > j->cap - j->len) {
+        return OSP_ERR_INVAL;
+    }
+#if defined(__APPLE__)
+    pthread_jit_write_protect_np(0); /* make the JIT page writable */
+#endif
+    memcpy((unsigned char *)j->base + j->len, code, len);
+#if defined(__APPLE__)
+    pthread_jit_write_protect_np(1); /* back to executable */
+#endif
+    j->len += len;
+    return OSP_OK;
+}
+
+osp_status osp_jit_commit(osp_jit *j) {
+    if (j == NULL || j->committed) {
+        return OSP_ERR_INVAL;
+    }
+#if defined(__APPLE__)
+    /* Already RWX via MAP_JIT and already write-protected (executable) after the
+     * last write; just flush the i-cache so the CPU fetches the new bytes. */
+    pthread_jit_write_protect_np(1);
+    sys_icache_invalidate(j->base, j->len);
+#else
+    if (mprotect(j->base, j->mapped, PROT_READ | PROT_EXEC) != 0) {
+        return OSP_ERR_OS;
+    }
+    /* Flush the i-cache: a no-op on x86, a real flush on arm64 Linux. */
+    __builtin___clear_cache((char *)j->base, (char *)j->base + j->len);
+#endif
+    j->committed = 1;
+    return OSP_OK;
+}
+
+void *osp_jit_entry(const osp_jit *j) {
+    return (j != NULL && j->committed) ? j->base : NULL;
+}
+
+osp_status osp_jit_free(osp_jit *j) {
+    osp_status st = OSP_OK;
+    if (j == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    if (munmap(j->base, j->mapped) != 0) {
+        st = OSP_ERR_OS;
+    }
+    free(j);
+    return st;
+}

--- a/code/packages/c/os-platform/src/jit_windows.c
+++ b/code/packages/c/os-platform/src/jit_windows.c
@@ -1,0 +1,108 @@
+/*
+ * jit_windows.c — the Win32 backend of os_platform/jit.
+ * ===========================================================================
+ *
+ * Compiled on Windows (named by `BUILD_windows`; macOS/Linux use jit_posix.c via
+ * the shared `BUILD`). Windows has no W^X toggle: reserve+commit the region
+ * read-write, memcpy the code, then VirtualProtect it to PAGE_EXECUTE_READ and
+ * FlushInstructionCache. No #ifdefs — the build chose this file. Links kernel32.
+ */
+#include "os_platform/jit.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+struct osp_jit {
+    void *base;
+    size_t cap;
+    size_t mapped;
+    size_t len;
+    int committed;
+};
+
+static size_t osp__round_page(size_t n) {
+    SYSTEM_INFO si;
+    size_t p;
+    GetSystemInfo(&si);
+    p = (si.dwPageSize != 0) ? (size_t)si.dwPageSize : 4096u;
+    return ((n + p - 1) / p) * p;
+}
+
+osp_status osp_jit_alloc(osp_jit **out, size_t capacity) {
+    struct osp_jit *j;
+    void *base;
+    size_t mapped;
+
+    if (out == NULL || capacity == 0) {
+        return OSP_ERR_INVAL;
+    }
+    j = (struct osp_jit *)malloc(sizeof(*j));
+    if (j == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    mapped = osp__round_page(capacity);
+    /* Reject a capacity so large the page round-up overflowed size_t (which
+     * would make `mapped` wrap below `capacity`). */
+    if (mapped < capacity) {
+        free(j);
+        return OSP_ERR_OS;
+    }
+    base = VirtualAlloc(NULL, mapped, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    if (base == NULL) {
+        free(j);
+        return OSP_ERR_OS;
+    }
+    j->base = base;
+    j->cap = capacity;
+    j->mapped = mapped;
+    j->len = 0;
+    j->committed = 0;
+    *out = j;
+    return OSP_OK;
+}
+
+osp_status osp_jit_write(osp_jit *j, const void *code, size_t len) {
+    if (j == NULL || code == NULL || j->committed) {
+        return OSP_ERR_INVAL;
+    }
+    if (len > j->cap - j->len) {
+        return OSP_ERR_INVAL;
+    }
+    memcpy((unsigned char *)j->base + j->len, code, len);
+    j->len += len;
+    return OSP_OK;
+}
+
+osp_status osp_jit_commit(osp_jit *j) {
+    DWORD old_prot;
+    if (j == NULL || j->committed) {
+        return OSP_ERR_INVAL;
+    }
+    if (!VirtualProtect(j->base, j->mapped, PAGE_EXECUTE_READ, &old_prot)) {
+        return OSP_ERR_OS;
+    }
+    if (!FlushInstructionCache(GetCurrentProcess(), j->base, j->len)) {
+        return OSP_ERR_OS;
+    }
+    j->committed = 1;
+    return OSP_OK;
+}
+
+void *osp_jit_entry(const osp_jit *j) {
+    return (j != NULL && j->committed) ? j->base : NULL;
+}
+
+osp_status osp_jit_free(osp_jit *j) {
+    osp_status st = OSP_OK;
+    if (j == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    if (!VirtualFree(j->base, 0, MEM_RELEASE)) {
+        st = OSP_ERR_OS;
+    }
+    free(j);
+    return st;
+}

--- a/code/packages/c/os-platform/tests/jit_test.c
+++ b/code/packages/c/os-platform/tests/jit_test.c
@@ -1,0 +1,112 @@
+/*
+ * jit_test.c — emit real machine code, commit it, and call it, on every OS+arch.
+ * ===========================================================================
+ *
+ * This is the execute-and-call test mmap.h's scope note deferred. It emits the
+ * machine code for `int f(void){ return N; }` for the current CPU architecture,
+ * runs it through the jit primitive (alloc → write → commit), casts the entry to
+ * a function pointer, calls it, and asserts it returns N. Two different constants
+ * prove the CPU really executes the bytes we wrote, not a fixed stub.
+ *
+ * The machine code is the only architecture-specific thing here — a small byte
+ * table selected by #if, exactly the per-arch data mmap.h anticipated. Encodings
+ * (verified: arm64 run live, x86_64 disassembled):
+ *
+ *   int f(void){return N;}
+ *     x86_64 : B8 <imm32-LE> C3            mov eax, N ; ret
+ *     arm64  : <movz w0,#N LE> C0 03 5F D6 movz w0, #N ; ret   (N must fit imm16)
+ *
+ * The entry is called via a memcpy'd function pointer — the portable idiom for
+ * turning a void* into a callable (object and function pointers need not share a
+ * representation in ISO C, though they do on every target here).
+ */
+#include "iso_test.h"
+
+#include "os_platform/jit.h"
+
+#include <stddef.h> /* NULL */
+#include <string.h> /* memcpy */
+
+#if defined(__x86_64__) || defined(_M_X64)
+/* mov eax, imm32 (little-endian) ; ret */
+static const unsigned char CODE_42[] = {0xB8, 0x2A, 0x00, 0x00, 0x00, 0xC3};
+static const unsigned char CODE_1337[] = {0xB8, 0x39, 0x05, 0x00, 0x00, 0xC3};
+#elif defined(__aarch64__) || defined(_M_ARM64)
+/* movz w0, #imm16 (little-endian) ; ret */
+static const unsigned char CODE_42[] = {0x40, 0x05, 0x80, 0x52, 0xC0, 0x03, 0x5F, 0xD6};
+static const unsigned char CODE_1337[] = {0x20, 0xA7, 0x80, 0x52, 0xC0, 0x03, 0x5F, 0xD6};
+#else
+#error "jit_test: no machine code for this architecture (need x86_64 or arm64)"
+#endif
+
+typedef int (*osp_fn0)(void);
+
+/* Build a JIT function from `code`, call it, and store its result in *out.
+ * Returns 1 on success, 0 if any jit step failed. */
+static int osp__build_and_call(const unsigned char *code, size_t n, int *out) {
+    osp_jit *j = NULL;
+    void *entry;
+    osp_fn0 fn;
+
+    if (osp_jit_alloc(&j, n) != OSP_OK) {
+        return 0;
+    }
+    if (osp_jit_write(j, code, n) != OSP_OK) {
+        osp_jit_free(j);
+        return 0;
+    }
+    if (osp_jit_commit(j) != OSP_OK) {
+        osp_jit_free(j);
+        return 0;
+    }
+    entry = osp_jit_entry(j);
+    if (entry == NULL) {
+        osp_jit_free(j);
+        return 0;
+    }
+    memcpy(&fn, &entry, sizeof(fn)); /* void* -> function pointer */
+    *out = fn();
+    osp_jit_free(j);
+    return 1;
+}
+
+int main(void) {
+    int r = 0;
+    osp_jit *j = NULL;
+    osp_jit *tmp = NULL;
+    unsigned char filler[8] = {0};
+
+    /* ── emit and call: the CPU returns exactly what we wrote ────────────── */
+    ISO_CHECK(osp__build_and_call(CODE_42, sizeof(CODE_42), &r));
+    ISO_CHECK_EQ_INT(r, 42);
+    ISO_CHECK(osp__build_and_call(CODE_1337, sizeof(CODE_1337), &r));
+    ISO_CHECK_EQ_INT(r, 1337);
+
+    /* ── lifecycle: entry is NULL until commit; no writes after commit ───── */
+    ISO_CHECK(osp_jit_alloc(&j, 16) == OSP_OK);
+    ISO_CHECK(osp_jit_entry(j) == NULL); /* not committed yet */
+    ISO_CHECK(osp_jit_write(j, CODE_42, sizeof(CODE_42)) == OSP_OK);
+    ISO_CHECK(osp_jit_entry(j) == NULL); /* still not committed */
+    ISO_CHECK(osp_jit_commit(j) == OSP_OK);
+    ISO_CHECK(osp_jit_entry(j) != NULL);                                   /* now callable */
+    ISO_CHECK(osp_jit_write(j, CODE_42, sizeof(CODE_42)) == OSP_ERR_INVAL); /* no writes after commit */
+    ISO_CHECK(osp_jit_commit(j) == OSP_ERR_INVAL);                          /* no double commit */
+    ISO_CHECK(osp_jit_free(j) == OSP_OK);
+
+    /* ── capacity is enforced against the requested size ─────────────────── */
+    ISO_CHECK(osp_jit_alloc(&tmp, 6) == OSP_OK);
+    ISO_CHECK(osp_jit_write(tmp, filler, 6) == OSP_OK);         /* fills capacity */
+    ISO_CHECK(osp_jit_write(tmp, filler, 1) == OSP_ERR_INVAL);  /* would exceed capacity */
+    ISO_CHECK(osp_jit_free(tmp) == OSP_OK);
+
+    /* ── NULL-argument validation ────────────────────────────────────────── */
+    tmp = NULL;
+    ISO_CHECK(osp_jit_alloc(NULL, 16) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_jit_alloc(&tmp, 0) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_jit_write(NULL, CODE_42, 1) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_jit_commit(NULL) == OSP_ERR_INVAL);
+    ISO_CHECK(osp_jit_entry(NULL) == NULL);
+    ISO_CHECK(osp_jit_free(NULL) == OSP_ERR_INVAL);
+
+    return ISO_TEST_RESULT();
+}

--- a/code/packages/c/os-platform/tools/run.ps1
+++ b/code/packages/c/os-platform/tools/run.ps1
@@ -54,3 +54,6 @@ Platform-BuildAndRun -Lang c -Name 'dynlib-tests' -Sources @('tests\dynlib_test.
 
 # mmap — Win32 backend (VirtualAlloc + VirtualProtect + VirtualFree).
 Platform-BuildAndRun -Lang c -Name 'mmap-tests' -Sources @('tests\mmap_test.c', 'src\mmap_windows.c')
+
+# jit — Win32 backend (VirtualAlloc RW -> VirtualProtect RX -> FlushInstructionCache).
+Platform-BuildAndRun -Lang c -Name 'jit-tests' -Sources @('tests\jit_test.c', 'src\jit_windows.c')

--- a/code/packages/c/os-platform/tools/run.sh
+++ b/code/packages/c/os-platform/tools/run.sh
@@ -86,4 +86,12 @@ PLATFORM_DEFINES="_DEFAULT_SOURCE _DARWIN_C_SOURCE"
 export PLATFORM_DEFINES
 platform_build_and_run c mmap-tests tests/mmap_test.c src/mmap_posix.c || rc=1
 
+# jit — POSIX backend (mmap MAP_JIT / mprotect + i-cache flush). No extra OS
+# library (Apple's pthread_jit_write_protect_np / sys_icache_invalidate live in
+# libSystem). Same MAP_ANON/MAP_JIT feature-macro needs as mmap above, so the
+# PLATFORM_DEFINES set for mmap carries over.
+PLATFORM_LIBS=""
+export PLATFORM_LIBS
+platform_build_and_run c jit-tests tests/jit_test.c src/jit_posix.c || rc=1
+
 exit "$rc"


### PR DESCRIPTION
## CCPP02 follow-up — the `jit` primitive: completing `mmap`'s deferred EXEC story

The [`mmap`](code/packages/c/os-platform/include/os_platform/mmap.h) primitive plumbs an EXEC bit but explicitly deferred the JIT executor — the piece that maps RW memory, emits real machine code, flips it to R+X, and *actually calls* it. Its scope note promised "a dedicated JIT executor + a cross-architecture execute-and-call test as a planned follow-up." **This is that follow-up** — a seventh `os-platform` primitive, `jit`.

### Why it's a real primitive (not just `mmap` + a cast)

On a modern OS you can't map a page RWX, scribble instructions, and jump in — **W^X** is enforced, and each OS has its own RW→RX protocol:

| step | macOS (Apple Silicon) | Linux | Windows |
|------|----------------------|-------|---------|
| **alloc** | `mmap` `MAP_JIT` (RWX) | `mmap` RW | `VirtualAlloc` RW |
| **write** | `pthread_jit_write_protect_np(0)` → `memcpy` → `(1)` | `memcpy` | `memcpy` |
| **commit** | `sys_icache_invalidate` | `mprotect` RX + `__builtin___clear_cache` | `VirtualProtect` RX + `FlushInstructionCache` |

Apple Silicon's hardened runtime is the hard case: the page toggles writable/executable **per-thread**, and the i-cache must be flushed before the new code is fetched (a no-op on x86, but a real flush on arm64 — omitting it runs stale bytes).

### API (`os_platform/jit.h`, reuses `osp_status`)

| Function | Purpose |
|----------|---------|
| `osp_jit_alloc(&j, capacity)` | JIT-capable, writable buffer |
| `osp_jit_write(j, code, len)` | append machine code (capacity-checked) |
| `osp_jit_commit(j)` | flip to R+X + flush i-cache; **no writes after** |
| `osp_jit_entry(j)` | callable address (NULL until committed) |
| `osp_jit_free(j)` | release |

`jit_posix.c` covers mac+linux with one `#if __APPLE__` split (the same convention `mmap_posix.c` uses); `jit_windows.c` is the Win32 backend.

### Test — emit, commit, and **call** on every OS *and* arch

`tests/jit_test.c` emits `int f(void){ return N; }` for the current CPU — carrying **both x86_64 and arm64** machine code, selected by `#if` — runs it through the primitive, calls it via a `memcpy`'d function pointer, and asserts N. Two constants (42 and 1337) prove the CPU executes the exact bytes written, not a fixed stub. Plus lifecycle (entry NULL until commit; no writes / no double-commit after), capacity enforcement, and NULL validation.

The machine code was verified **before** shipping: arm64 executed live on the Apple Silicon dev host; x86_64 encodings disassembled (`b8 <imm32> c3` / `movz w0,#N` + `ret`).

### Verification

- **Local (macOS / arm64):** full os-platform suite green including `jit` — **23 checks / 0 failed** under gcc + clang; the other six primitives unaffected.
- **Sanitizers:** clean under **ASan + UBSan** (no `-fsanitize=function` false positive — the `memcpy` call idiom avoids it); **0 leaks**.
- **Security review:** passed — reviewer confirmed the capacity subtraction can't underflow, the commit/write state machine can't yield a callable pointer to partial code, the MAP_JIT toggle is paired around every write, and all alloc/free paths are memory-safe. Two hardening notes applied: explicit page-round overflow rejection + a single-thread-ownership caveat in the header.
- The **Windows** and **Linux/x86_64** machine-code paths get their first real exercise on the 3-OS CI matrix.

Spec: [`CCPP02-os-platform-lane.md`](code/specs/CCPP02-os-platform-lane.md). Also updates the `mmap.h` scope note + README + CHANGELOG to point at `jit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)