### PR TITLE
feat(sql): column-defined COLLATE flows into ORDER BY

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.34 — Column-defined COLLATE honoured in ORDER BY
+
+A column declared with `COLLATE NOCASE` / `RTRIM` now drives ordering when a
+query sorts by that column without an explicit COLLATE:
+`CREATE TABLE t(id INTEGER, name TEXT COLLATE NOCASE); SELECT name FROM t ORDER
+BY name` folds case exactly like real SQLite (previously the column collation
+was parsed and discarded, so the sort fell back to BINARY). An explicit COLLATE
+on the ORDER BY key still wins, and an unknown collation on the column is
+rejected at CREATE time. Adds seven differential-oracle cases (sql-parser 0.1.18,
+sql-planner 0.2.16, sql-backend 0.1.1). Comparison / GROUP BY / DISTINCT
+collation and multi-table resolution remain follow-ups.
+
 ## 0.5.33 — Scalar subquery `( SELECT … )` parses (evaluation is a follow-up)
 
 `SELECT (SELECT count(*) FROM t2)` and `WHERE x > (SELECT max(y) FROM t2)` now

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.33"
+version = "0.5.34"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -966,6 +966,80 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT name FROM t ORDER BY name COLLATE BINARY",
     },
+    // ---- Lane 3: column-DEFINED COLLATE flows into ORDER BY --------------
+    // A `COLLATE NOCASE` on the column definition itself makes a bare
+    // `ORDER BY name` (no explicit COLLATE in the query) fold case, exactly as
+    // if the query said `ORDER BY name COLLATE NOCASE`. Before this feature the
+    // column collation was parsed and discarded, so the sort fell back to
+    // BINARY and diverged from SQLite.
+    Case {
+        id: "order_by_column_collate_nocase",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'cherry'),(4,'BANANA'),(5,'apple')",
+        ],
+        query: "SELECT name FROM t ORDER BY name, id",
+    },
+    // Column-defined RTRIM: 'a  ' and 'a' compare equal (id breaks the tie),
+    // where BINARY would order 'a' before 'a  '.
+    Case {
+        id: "order_by_column_collate_rtrim",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE RTRIM)",
+            "INSERT INTO t VALUES (1,'b'),(2,'a  '),(3,'a'),(4,'b '),(5,'c')",
+        ],
+        query: "SELECT name FROM t ORDER BY name, id",
+    },
+    // The column collation also flows through a qualified reference (`t.name`)
+    // and through a table alias (`u.name` where `u` aliases `t`).
+    Case {
+        id: "order_by_column_collate_qualified",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'apple')",
+        ],
+        query: "SELECT name FROM t ORDER BY t.name, t.id",
+    },
+    // The ORDER BY qualifier may be a table alias (`u` aliases `t`). The select
+    // list is qualified too (`u.name`) to sidestep an unrelated pre-existing bug
+    // where an *unqualified* projection under a table alias yields NULL.
+    Case {
+        id: "order_by_column_collate_alias",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'apple')",
+        ],
+        query: "SELECT u.name FROM t AS u ORDER BY u.name, u.id",
+    },
+    // An explicit `COLLATE` in the query overrides the column's declared
+    // sequence: the column is NOCASE, but `COLLATE BINARY` forces byte order
+    // ('A'=65 sorts before 'a'=97).
+    Case {
+        id: "order_by_column_collate_explicit_override",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'apple')",
+        ],
+        query: "SELECT name FROM t ORDER BY name COLLATE BINARY, id",
+    },
+    // DESC honours the column collation just like ASC — case still folds, only
+    // the key order reverses.
+    Case {
+        id: "order_by_column_collate_nocase_desc",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'cherry'),(4,'BANANA'),(5,'apple')",
+        ],
+        query: "SELECT name FROM t ORDER BY name DESC, id",
+    },
+    // An unknown collation on the column definition is rejected at CREATE time
+    // ("no such collating sequence"), matching SQLite's prepare-time error.
+    // The oracle compares error-vs-success, so both engines erroring is a pass.
+    Case {
+        id: "create_table_unknown_column_collation",
+        setup: &[],
+        query: "CREATE TABLE t (x TEXT COLLATE BOGUS)",
+    },
     // ---- Lane 1: simple (operand) CASE ----------------------------------
     // `CASE x WHEN v THEN r … ELSE d END` compares the operand to each value
     // for equality; a NULL operand matches nothing (x = NULL is never true)

--- a/code/packages/rust/sql-backend/CHANGELOG.md
+++ b/code/packages/rust/sql-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.1 — Column-level COLLATE on `ColumnDef` + `SchemaProvider::column_collation`
+
+- `ColumnDef` gains a `collation: Option<String>` field and a `.collation(name)`
+  builder (BINARY normalises to `None`; NOCASE/RTRIM stored uppercased) so a
+  `CREATE TABLE t(x TEXT COLLATE NOCASE)` sequence is persisted in the schema
+  instead of being parsed and discarded.
+- `SchemaProvider` gains `column_collation(table, column)` (default `None`),
+  implemented by `BackendSchemaProvider` over `Backend::columns`. Lookups are
+  case-insensitive; unknown table/column collapse to `Ok(None)` rather than an
+  error. Consumed by sql-planner to let a bare `ORDER BY col` inherit the
+  column's declared collation.
+
 ## 0.1.0
 
 - Add the Rust sql-backend package with the portable backend contract and in-memory reference implementation.

--- a/code/packages/rust/sql-backend/Cargo.toml
+++ b/code/packages/rust/sql-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-backend"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Pluggable SQL backend abstractions and in-memory reference backend"
 

--- a/code/packages/rust/sql-backend/src/lib.rs
+++ b/code/packages/rust/sql-backend/src/lib.rs
@@ -187,6 +187,14 @@ pub struct ColumnDef {
     pub has_default: bool,
     pub check_expression: Option<String>,
     pub foreign_key: Option<String>,
+    /// Column-level collating sequence from a `COLLATE name` clause in the
+    /// column definition (`CREATE TABLE t(x TEXT COLLATE NOCASE)`). Uppercased.
+    /// `None` means the default `BINARY` (byte-order) collation. When a query
+    /// sorts or compares this column *without* an explicit `COLLATE`, SQLite
+    /// falls back to this column-defined sequence — so it must be persisted in
+    /// the schema, not just parsed and discarded. Recognised names: `NOCASE`
+    /// (ASCII case-fold) and `RTRIM` (ignore trailing spaces).
+    pub collation: Option<String>,
 }
 
 impl ColumnDef {
@@ -202,7 +210,17 @@ impl ColumnDef {
             has_default: false,
             check_expression: None,
             foreign_key: None,
+            collation: None,
         }
+    }
+
+    /// Builder: attach a column-level collating sequence. `BINARY` (the
+    /// default) is normalised to `None` so downstream comparison/sort code can
+    /// treat "no collation" and "explicit BINARY" identically.
+    pub fn collation(mut self, name: impl Into<String>) -> Self {
+        let upper = name.into().to_uppercase();
+        self.collation = if upper == "BINARY" { None } else { Some(upper) };
+        self
     }
 
     pub fn not_null(mut self) -> Self {
@@ -383,6 +401,32 @@ pub trait Backend {
 
 pub trait SchemaProvider {
     fn column_names(&self, table: &str) -> Result<Vec<String>, BackendError>;
+
+    /// The column-level collating sequence declared for `table.column`, if any
+    /// (`CREATE TABLE t(x TEXT COLLATE NOCASE)` → `Some("NOCASE")`). Returns
+    /// `Ok(None)` when the column has no explicit collation (the default
+    /// `BINARY`) *or* when the table/column is unknown — callers treat a
+    /// missing collation and an unknown column identically (both fall back to
+    /// byte-order comparison), so this never surfaces a lookup error. The
+    /// default implementation returns `None`, letting schema providers that do
+    /// not track collation opt out without extra code.
+    fn column_collation(
+        &self,
+        _table: &str,
+        _column: &str,
+    ) -> Result<Option<String>, BackendError> {
+        Ok(None)
+    }
+
+    /// Every column of `table` that carries a non-default collation, as
+    /// `(column_name, COLLATE_NAME)` pairs. Lets a caller resolve many column
+    /// references against one table without re-fetching (and re-cloning) the
+    /// schema per lookup — the planner uses this to avoid O(keys × columns)
+    /// work when an ORDER BY names many columns. Default returns empty (no
+    /// collations); unknown table collapses to empty, never an error.
+    fn table_collations(&self, _table: &str) -> Result<Vec<(String, String)>, BackendError> {
+        Ok(Vec::new())
+    }
 }
 
 pub struct BackendSchemaProvider<'a> {
@@ -400,6 +444,37 @@ impl SchemaProvider for BackendSchemaProvider<'_> {
             .columns(table)?
             .into_iter()
             .map(|c| c.name)
+            .collect())
+    }
+
+    fn column_collation(
+        &self,
+        table: &str,
+        column: &str,
+    ) -> Result<Option<String>, BackendError> {
+        // Unknown table → no collation (see trait doc: lookup failures collapse
+        // to "default collation" rather than propagating as errors). Column
+        // names compare case-insensitively, matching SQLite identifier rules.
+        let cols = match self.backend.columns(table) {
+            Ok(cols) => cols,
+            Err(_) => return Ok(None),
+        };
+        Ok(cols
+            .into_iter()
+            .find(|c| c.name.eq_ignore_ascii_case(column))
+            .and_then(|c| c.collation))
+    }
+
+    fn table_collations(&self, table: &str) -> Result<Vec<(String, String)>, BackendError> {
+        // One `columns()` fetch, then keep only the columns that declare a
+        // collation. Unknown table → empty (see trait doc), never an error.
+        let cols = match self.backend.columns(table) {
+            Ok(cols) => cols,
+            Err(_) => return Ok(Vec::new()),
+        };
+        Ok(cols
+            .into_iter()
+            .filter_map(|c| c.collation.map(|coll| (c.name, coll)))
             .collect())
     }
 }

--- a/code/packages/rust/sql-backend/tests/backend_tests.rs
+++ b/code/packages/rust/sql-backend/tests/backend_tests.rs
@@ -559,3 +559,69 @@ fn contains_id(backend: &InMemoryBackend, id: i64) -> bool {
         .into_iter()
         .any(|row| row["id"] == SqlValue::Int(id))
 }
+
+#[test]
+fn column_def_collation_builder_normalises_binary() {
+    // NOCASE/RTRIM are stored uppercased; BINARY (the default) collapses to
+    // None so "no collation" and "explicit BINARY" are indistinguishable.
+    assert_eq!(
+        ColumnDef::new("x", "TEXT").collation("nocase").collation,
+        Some("NOCASE".to_string())
+    );
+    assert_eq!(
+        ColumnDef::new("x", "TEXT").collation("RtRiM").collation,
+        Some("RTRIM".to_string())
+    );
+    assert_eq!(ColumnDef::new("x", "TEXT").collation("binary").collation, None);
+    assert_eq!(ColumnDef::new("x", "TEXT").collation, None, "default is None");
+}
+
+#[test]
+fn schema_provider_reports_column_collation() {
+    // A column declared with COLLATE NOCASE round-trips through create_table and
+    // is surfaced by the BackendSchemaProvider; lookups are case-insensitive on
+    // both the table and column name, and unknown names collapse to Ok(None).
+    let mut backend = InMemoryBackend::new();
+    backend
+        .create_table(
+            "docs",
+            vec![
+                ColumnDef::new("id", "INTEGER"),
+                ColumnDef::new("title", "TEXT").collation("NOCASE"),
+            ],
+            false,
+        )
+        .unwrap();
+
+    let schema = backend_as_schema_provider(&backend);
+    assert_eq!(
+        schema.column_collation("docs", "title").unwrap().as_deref(),
+        Some("NOCASE")
+    );
+    assert_eq!(
+        schema.column_collation("DOCS", "TITLE").unwrap().as_deref(),
+        Some("NOCASE"),
+        "table and column names compare case-insensitively"
+    );
+    assert_eq!(schema.column_collation("docs", "id").unwrap(), None);
+    assert_eq!(
+        schema.column_collation("docs", "missing").unwrap(),
+        None,
+        "unknown column → None, not an error"
+    );
+    assert_eq!(
+        schema.column_collation("nope", "title").unwrap(),
+        None,
+        "unknown table → None, not an error"
+    );
+
+    // The batch form returns only collation-bearing columns, in one fetch.
+    assert_eq!(
+        schema.table_collations("docs").unwrap(),
+        vec![("title".to_string(), "NOCASE".to_string())]
+    );
+    assert!(
+        schema.table_collations("nope").unwrap().is_empty(),
+        "unknown table → empty, not an error"
+    );
+}

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.18] - Unreleased
+
+### Added
+
+- **Column-level `COLLATE name` in `CREATE TABLE`.** `col_constraint` now accepts
+  a `COLLATE NAME` alternative (`x TEXT COLLATE NOCASE`), mirroring the existing
+  `order_item` COLLATE clause. `COLLATE` arrives as a NAME token matched
+  case-insensitively; the collation name that follows is a generic NAME the
+  planner validates. Enables sql-planner to persist and honour column-defined
+  collations.
+
 ## [0.1.17] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -374,6 +374,18 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"DEFAULT"#.to_string() },
                         GrammarElement::RuleReference { name: r#"primary"#.to_string() },
                     ] }) },
+                // Column-level `COLLATE name` (e.g. `x TEXT COLLATE NOCASE`).
+                // `COLLATE` arrives as a NAME token — it is not a lexer keyword,
+                // so the literal matcher accepts it case-insensitively — and the
+                // following collation name (BINARY / NOCASE / RTRIM) is a generic
+                // NAME the planner validates. This mirrors the `order_item`
+                // COLLATE clause; the sequence is persisted on the column so a
+                // later bare `ORDER BY col` inherits it (see sql-planner
+                // `apply_col_constraint` / `resolve_column_collation`).
+                GrammarElement::Group { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"COLLATE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
             ] },
             line_number: 57,
         },

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.16] - Unreleased
+
+### Added
+
+- **Column-defined `COLLATE` flows into `ORDER BY`.** `apply_col_constraint`
+  now parses a column's `COLLATE NAME` (validating NOCASE/RTRIM/BINARY; an
+  unknown sequence errors with "no such collating sequence", matching SQLite's
+  prepare-time rejection) and stores it on `ColumnDef`. A bare `ORDER BY col`
+  (single-table query, no JOINs) inherits that sequence — `CREATE TABLE
+  t(x TEXT COLLATE NOCASE); SELECT x FROM t ORDER BY x` now folds case like
+  real SQLite. An explicit `COLLATE` on the key (including `COLLATE BINARY`)
+  still overrides the column default. Qualified (`t.x`) and aliased (`u.x`)
+  references resolve too. Comparison / GROUP BY / DISTINCT collation
+  propagation and multi-table resolution remain follow-ups.
+
 ## [0.2.15] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -630,6 +630,12 @@ fn plan_select(
     // single-row, no-column virtual table (the "dual" table).  We model
     // this as a `Scan` of a special `__dual__` table that the backend and
     // codegen handle as yielding one empty row.
+    // Records the single base table (real name + optional alias) so ORDER BY can
+    // resolve a bare column's schema-defined COLLATE. Left `None` for the dual
+    // table and (below) for any query with JOINs, where column→table resolution
+    // is ambiguous and out of scope for this pass.
+    let mut base_table_ref: Option<(String, Option<String>)> = None;
+
     let mut plan: LogicalPlan = if let Some(table_ref) = find_node(stmt, "table_ref") {
         // Extract table name and optional alias from `table_ref = table_name [ "AS" NAME ]`.
         let (table_name, table_alias) = extract_table_ref(table_ref);
@@ -638,6 +644,8 @@ fn plan_select(
         schema
             .column_names(&table_name)
             .map_err(|_| PlanError::UnknownTable(table_name.clone()))?;
+
+        base_table_ref = Some((table_name.clone(), table_alias.clone()));
 
         LogicalPlan::Scan {
             table: table_name,
@@ -752,7 +760,16 @@ fn plan_select(
     // Step 7: ORDER BY.
     // -----------------------------------------------------------------------
     if let Some(order_clause) = find_node(stmt, "order_clause") {
-        let keys = plan_order_by(order_clause)?;
+        // Column-defined COLLATE only propagates into ORDER BY for a single
+        // base table (no JOINs) — see `base_table_ref`. With JOINs present we
+        // pass `None`, so every sort key keeps whatever explicit collation it
+        // carried and otherwise falls back to BINARY.
+        let collate_ctx = if find_nodes(stmt, "join_clause").is_empty() {
+            base_table_ref.as_ref().map(|(t, a)| (t.as_str(), a.as_deref()))
+        } else {
+            None
+        };
+        let keys = plan_order_by(order_clause, schema, collate_ctx)?;
         plan = LogicalPlan::Sort {
             input: Box::new(plan),
             keys,
@@ -955,15 +972,76 @@ fn plan_group_by_exprs(group_clause: &GrammarASTNode) -> Result<Vec<SqlExpr>, Pl
 ///
 /// Grammar: `order_clause = ORDER BY order_item { "," order_item }`
 /// Grammar: `order_item = expr [ ASC | DESC ]`
-fn plan_order_by(order_clause: &GrammarASTNode) -> Result<Vec<SortKey>, PlanError> {
+fn plan_order_by(
+    order_clause: &GrammarASTNode,
+    schema: &dyn SchemaProvider,
+    collate_ctx: Option<(&str, Option<&str>)>,
+) -> Result<Vec<SortKey>, PlanError> {
+    // Fetch the base table's declared collations exactly ONCE (not per sort
+    // key). A bare `ORDER BY c0, c0, …` over a very wide table would otherwise
+    // clone the whole schema for every key — O(keys × columns) deep copies,
+    // both dimensions attacker-controlled. Building a name→collation map up
+    // front keeps planning linear in the number of keys.
+    let order_ctx = collate_ctx.map(|(table, alias)| {
+        let collations = schema
+            .table_collations(table)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(name, coll)| (name.to_ascii_lowercase(), coll))
+            .collect::<std::collections::HashMap<String, String>>();
+        OrderCollateCtx {
+            table,
+            alias,
+            collations,
+        }
+    });
     find_nodes(order_clause, "order_item")
         .iter()
-        .map(|item| plan_order_item(item))
+        .map(|item| plan_order_item(item, order_ctx.as_ref()))
         .collect()
 }
 
+/// Single base table (name + alias) plus its precomputed `column → COLLATE`
+/// map, used to resolve a bare ORDER BY column's inherited collation without
+/// re-querying the schema per key.
+struct OrderCollateCtx<'a> {
+    table: &'a str,
+    alias: Option<&'a str>,
+    /// Lowercased column name → declared collation, for columns that have one.
+    collations: std::collections::HashMap<String, String>,
+}
+
+/// Resolve the collation a bare-column ORDER BY key inherits from its column
+/// definition. Returns `Some(name)` only when the sort expression is a plain
+/// column reference (optionally qualified by the table's name or alias) whose
+/// column was declared with a non-default `COLLATE`. Anything else — a computed
+/// expression, an alias to an output column, a qualifier that doesn't match the
+/// base table — yields `None`, and the key keeps the default BINARY ordering.
+fn resolve_column_collation(expr: &SqlExpr, ctx: &OrderCollateCtx) -> Option<String> {
+    let SqlExpr::Column { table, name } = expr else {
+        return None;
+    };
+    // A qualifier, if present, must name the base table or its alias; otherwise
+    // it refers to something not in scope for single-table collation resolution.
+    if let Some(qual) = table {
+        let matches_table = qual.eq_ignore_ascii_case(ctx.table);
+        let matches_alias = ctx.alias.is_some_and(|a| qual.eq_ignore_ascii_case(a));
+        if !matches_table && !matches_alias {
+            return None;
+        }
+    }
+    ctx.collations.get(&name.to_ascii_lowercase()).cloned()
+}
+
 /// Plan a single `order_item` node.
-fn plan_order_item(item: &GrammarASTNode) -> Result<SortKey, PlanError> {
+///
+/// `collate_ctx` carries the single base table (name + alias + collation map)
+/// when the query has exactly one table, enabling column-defined COLLATE to
+/// flow into the sort key; it is `None` for multi-table or table-less queries.
+fn plan_order_item(
+    item: &GrammarASTNode,
+    collate_ctx: Option<&OrderCollateCtx>,
+) -> Result<SortKey, PlanError> {
     // The first child Node is the expression; check for ASC/DESC tokens.
     let expr_node = item
         .children
@@ -1041,6 +1119,22 @@ fn plan_order_item(item: &GrammarASTNode) -> Result<SortKey, PlanError> {
             }
         }
         coll.transpose()?.flatten()
+    };
+
+    // An explicit `COLLATE` on the ORDER BY item always wins — including
+    // `COLLATE BINARY`, which forces byte order even when the column is declared
+    // NOCASE/RTRIM. Because BINARY parses to `None` (same as "no collation"), we
+    // must detect the *presence* of the clause separately: only a key with no
+    // explicit COLLATE at all inherits the column's schema-defined sequence
+    // (`CREATE TABLE t(x TEXT COLLATE NOCASE); ... ORDER BY x`).
+    let has_explicit_collate = item
+        .children
+        .iter()
+        .any(|c| is_keyword_token(c, "COLLATE"));
+    let collation = if has_explicit_collate {
+        collation
+    } else {
+        collate_ctx.and_then(|ctx| resolve_column_collation(&expr, ctx))
     };
 
     Ok(SortKey {
@@ -1633,7 +1727,7 @@ fn plan_col_def(col_def: &GrammarASTNode) -> Result<ColumnDef, PlanError> {
     for child in &col_def.children {
         if let ASTNodeOrToken::Node(constraint) = child {
             if constraint.rule_name == "col_constraint" {
-                apply_col_constraint(&mut col, constraint);
+                apply_col_constraint(&mut col, constraint)?;
             }
         }
     }
@@ -1643,8 +1737,19 @@ fn plan_col_def(col_def: &GrammarASTNode) -> Result<ColumnDef, PlanError> {
 
 /// Apply a `col_constraint` to a mutable `ColumnDef`.
 ///
-/// Grammar: `col_constraint = NOT NULL | NULL | PRIMARY KEY | UNIQUE | DEFAULT primary`
-fn apply_col_constraint(col: &mut ColumnDef, constraint: &GrammarASTNode) {
+/// Grammar: `col_constraint = ( "NOT" "NULL" … ) | "NULL" | ( "PRIMARY" "KEY" … )
+///                          | ( "UNIQUE" … ) | ( "DEFAULT" primary )
+///                          | ( "CHECK" "(" expr ")" ) | ( "COLLATE" NAME )
+///                          | ( "REFERENCES" NAME … ) ;`
+///
+/// Returns an error only for an unrecognised `COLLATE` sequence — SQLite
+/// rejects `CREATE TABLE t(x COLLATE BOGUS)` at prepare time with "no such
+/// collating sequence", so we surface that here rather than silently storing a
+/// collation the VM cannot honour.
+fn apply_col_constraint(
+    col: &mut ColumnDef,
+    constraint: &GrammarASTNode,
+) -> Result<(), PlanError> {
     // Check which constraint keyword tokens are present.
     if has_token(constraint, "PRIMARY") {
         col.primary_key = true;
@@ -1665,6 +1770,43 @@ fn apply_col_constraint(col: &mut ColumnDef, constraint: &GrammarASTNode) {
             }
         }
     }
+    // COLLATE handling: the collation name is the token immediately after the
+    // COLLATE keyword. `BINARY` is the default and collapses to `None` (see
+    // `ColumnDef::collation`); `NOCASE`/`RTRIM` are stored uppercased; anything
+    // else is a "no such collating sequence" error, matching SQLite. Only the
+    // three built-in sequences exist in mini-sqlite (no user-registered ones).
+    if has_token(constraint, "COLLATE") {
+        let name = token_after_keyword(constraint, "COLLATE").ok_or_else(|| {
+            PlanError::UnsupportedStatement("COLLATE clause missing collation name".to_string())
+        })?;
+        let upper = name.to_uppercase();
+        match upper.as_str() {
+            "BINARY" => col.collation = None,
+            "NOCASE" | "RTRIM" => col.collation = Some(upper),
+            other => {
+                return Err(PlanError::UnsupportedStatement(format!(
+                    "no such collating sequence: {other}"
+                )))
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Return the text of the token immediately following the first occurrence of
+/// keyword `kw` among a node's direct token children. Used to read the operand
+/// of a single-keyword clause such as `COLLATE NOCASE`.
+fn token_after_keyword(node: &GrammarASTNode, kw: &str) -> Option<String> {
+    let toks: Vec<&str> = node
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Token(t) => Some(t.value.as_str()),
+            _ => None,
+        })
+        .collect();
+    let pos = toks.iter().position(|t| t.eq_ignore_ascii_case(kw))?;
+    toks.get(pos + 1).map(|s| s.to_string())
 }
 
 /// Plan a `drop_table_stmt` node.
@@ -3278,6 +3420,103 @@ mod tests {
         } else {
             panic!("Expected CreateTable");
         }
+    }
+
+    #[test]
+    fn test_create_table_stores_column_collation() {
+        // NOCASE / RTRIM are stored uppercased; an explicit BINARY collapses to
+        // None (the default), so `has-collation` is unambiguous downstream.
+        let plan = plan_ok(
+            "CREATE TABLE t2 (a TEXT COLLATE NOCASE, b TEXT COLLATE RTRIM, \
+             c TEXT COLLATE BINARY, d TEXT)",
+        );
+        if let LogicalPlan::CreateTable { columns, .. } = &plan {
+            assert_eq!(columns[0].collation.as_deref(), Some("NOCASE"));
+            assert_eq!(columns[1].collation.as_deref(), Some("RTRIM"));
+            assert_eq!(columns[2].collation, None, "explicit BINARY → None");
+            assert_eq!(columns[3].collation, None, "no COLLATE → None");
+        } else {
+            panic!("Expected CreateTable");
+        }
+    }
+
+    #[test]
+    fn test_create_table_unknown_collation_errors() {
+        // Matches SQLite's prepare-time "no such collating sequence" rejection.
+        let err = plan_err("CREATE TABLE t2 (x TEXT COLLATE BOGUS)");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("no such collating sequence"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// A schema whose single table `tc` declares `name` with a `NOCASE`
+    /// collation, used to prove a bare ORDER BY key inherits it.
+    struct CollSchema;
+    impl SchemaProvider for CollSchema {
+        fn column_names(&self, table: &str) -> Result<Vec<String>, BackendError> {
+            if table.eq_ignore_ascii_case("tc") {
+                Ok(vec!["id".to_string(), "name".to_string()])
+            } else {
+                Err(BackendError::TableNotFound {
+                    table: table.to_string(),
+                })
+            }
+        }
+        fn table_collations(&self, table: &str) -> Result<Vec<(String, String)>, BackendError> {
+            if table.eq_ignore_ascii_case("tc") {
+                Ok(vec![("name".to_string(), "NOCASE".to_string())])
+            } else {
+                Ok(Vec::new())
+            }
+        }
+    }
+
+    /// Pull the first Sort node's keys out of a planned SELECT (Sort sits below
+    /// the outermost Project).
+    fn sort_keys(plan: &LogicalPlan) -> Vec<SortKey> {
+        fn walk(p: &LogicalPlan) -> Option<Vec<SortKey>> {
+            match p {
+                LogicalPlan::Sort { keys, .. } => Some(keys.clone()),
+                LogicalPlan::Project { input, .. }
+                | LogicalPlan::Filter { input, .. }
+                | LogicalPlan::Distinct(input)
+                | LogicalPlan::Limit { input, .. } => walk(input),
+                _ => None,
+            }
+        }
+        walk(plan).unwrap_or_default()
+    }
+
+    #[test]
+    fn test_order_by_inherits_column_collation() {
+        // Bare `ORDER BY name` inherits the column's declared NOCASE sequence…
+        let plan = plan_sql("SELECT name FROM tc ORDER BY name", &CollSchema).unwrap();
+        assert_eq!(sort_keys(&plan)[0].collation.as_deref(), Some("NOCASE"));
+
+        // …a qualified reference (`tc.name`) resolves the same way…
+        let plan = plan_sql("SELECT name FROM tc ORDER BY tc.name", &CollSchema).unwrap();
+        assert_eq!(sort_keys(&plan)[0].collation.as_deref(), Some("NOCASE"));
+
+        // …and through a table alias (`u.name`).
+        let plan = plan_sql("SELECT u.name FROM tc AS u ORDER BY u.name", &CollSchema).unwrap();
+        assert_eq!(sort_keys(&plan)[0].collation.as_deref(), Some("NOCASE"));
+    }
+
+    #[test]
+    fn test_explicit_collate_overrides_column_collation() {
+        // An explicit COLLATE BINARY on the key wins over the column's NOCASE.
+        let plan =
+            plan_sql("SELECT name FROM tc ORDER BY name COLLATE BINARY", &CollSchema).unwrap();
+        assert_eq!(sort_keys(&plan)[0].collation, None, "BINARY → no collation");
+    }
+
+    #[test]
+    fn test_order_by_column_without_collation_stays_binary() {
+        // `id` has no declared collation, so its sort key stays BINARY (None).
+        let plan = plan_sql("SELECT id FROM tc ORDER BY id", &CollSchema).unwrap();
+        assert_eq!(sort_keys(&plan)[0].collation, None);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Lane 3 (NULLS/COLLATE ordering): column-defined COLLATE flows into ORDER BY

A column declared with `COLLATE NOCASE` / `RTRIM` now drives ordering when a query sorts by that column **without** an explicit COLLATE:

```sql
CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE);
INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'cherry'),(4,'BANANA'),(5,'apple');
SELECT name FROM t ORDER BY name;   -- Apple, apple, banana, BANANA, cherry  (case-folded, like real SQLite)
```

Previously the column-level COLLATE was parsed and silently discarded, so the sort fell back to BINARY and diverged from SQLite.

### What changed
- **sql-parser** (`_grammar.rs`): add the `( "COLLATE" NAME )` alternative to `col_constraint` so `CREATE TABLE t(x TEXT COLLATE NOCASE)` parses (mirrors the existing `order_item` COLLATE encoding). Hand-edited to match how the merged feature PRs maintain the generated grammar — the source `.grammar` has diverged and a wholesale regenerate would revert shipped grammar work (scalar-subquery, bitwise, IS DISTINCT, …).
- **sql-backend**: `ColumnDef` gains `collation: Option<String>` + a `.collation()` builder (BINARY → None). `SchemaProvider` gains `column_collation` and a batch `table_collations` (default empty), implemented by `BackendSchemaProvider` over `Backend::columns`.
- **sql-planner**: `apply_col_constraint` parses + validates the column COLLATE (unknown → `"no such collating sequence"`, matching SQLite's prepare-time rejection). ORDER BY on a bare column (single-table, no JOINs) inherits the column's declared sequence. An explicit COLLATE on the key — **including `COLLATE BINARY`** — still overrides. Qualified (`t.x`) and aliased (`u.x`) references resolve too.

### Performance / safety
Security review flagged an O(keys × columns) quadratic: resolving each ORDER BY key independently cloned the whole schema. Fixed — the base table's collations are fetched **once per query** into a `name → collation` map (`table_collations`), so N sort keys cost N map lookups, not N full-schema clones. Re-reviewed clean.

### Tests
Seven differential-oracle cases against real bundled SQLite (NOCASE/RTRIM inherit, qualified, aliased, explicit-BINARY override, DESC, unknown-collation CREATE error) plus planner and sql-backend unit tests. All green; downstream SQL consumers (vm/codegen/optimizer/storage-sqlite) tested for regressions.

### Follow-ups (out of scope)
- Column-collation in comparisons / `GROUP BY` / `DISTINCT`, and multi-table (JOIN) resolution.
- Pre-existing bug spun off separately: an **unqualified** projection under a table alias (`SELECT name FROM t AS u`) returns NULL.
- Minor known laxity (non-blocking): a qualifier is accepted if it matches the table name *or* its alias, whereas SQLite forbids the real name once an alias is bound.

Versions: sql-parser 0.1.18, sql-planner 0.2.16, sql-backend 0.1.1, mini-sqlite 0.5.34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
