### PR TITLE
feat(closure-pass-dce): empty-switch removal — broaden discriminant gate to any side-effect-free expr

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.27.0] - 2026-07-16
+
+### Changed — empty-switch removal: broaden the DISCRIMINANT gate to any side-effect-free expression
+
+The gap-014 step-2 empty-switch elimination previously required the discriminant
+to be a **leaf literal** (`is_pure_leaf`). The reference Closure Compiler removes
+an otherwise-empty switch for *any* side-effect-free discriminant, so this
+release broadens the discriminant gate to `is_side_effect_free` — closing a batch
+of oracle divergences where closurec kept a switch Closure dropped:
+
+- `switch (x) {}` → removed (bare identifier read)
+- `switch (a.b) {}` → removed (pure member read)
+- `switch (a && b) {}` → removed (pure logical)
+- `switch (!x) {}` → removed (pure unary)
+- `switch (typeof x) {}` → removed
+
+The two gates are deliberately **asymmetric**, mirroring Closure byte-for-byte:
+
+- The **discriminant** now only needs to be side-effect-free.
+- Each case **test**, however, still must be a literal (`is_pure_leaf`) or absent
+  (`default:`). Closure *keeps* a switch whose case test is a non-literal even
+  when that test is itself side-effect-free — `switch (x) { case y: }` and
+  `switch (x) { case a.b: case c: }` survive, while `switch (x) { case 1: case 2: }`
+  and `switch (x) { default: }` drop. We match that exactly rather than removing
+  more (which would diverge).
+
+Also generalised the "empty consequent" check: a consequent counts as empty when
+**every statement in it is itself empty** (via `statement_is_empty`), not only
+when the consequent list is literally empty. So `switch (x) { case 1: {} }` — a
+case whose only body is an empty block — now drops too (oracle: `→` removed).
+
+**Soundness.** The switch is removed only when evaluating the discriminant and
+every (literal) case test has no observable side effect *and* no case runs any
+statement — so the whole construct is a verified no-op. A side-EFFECTING
+discriminant such as `switch (f()) {}` is **not** side-effect-free, so this path
+declines and keeps the switch intact (Closure instead extracts the discriminant
+to `f();` via a separate transform we do not perform here — declining avoids
+dropping the call, so there is no unsound removal and no regression). Step-4
+constant-discriminant collapse is untouched: it still requires a literal
+discriminant (`is_pure_leaf`) to compile-time evaluate strict-equality.
+
+Additive behavior-narrowing to match the oracle; MINOR bump 0.26.0 → 0.27.0.
+
 ## [0.26.0] - 2026-07-15
 
 ### Added — empty-`if` with a side-effecting **call** test → expression statement

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -663,24 +663,55 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
 
             // gap-014 step 2 / CLOC12.34 — empty-switch elimination.
             //
-            // If every case's consequent is empty (or there are no
-            // cases at all) AND both the discriminant and every
-            // case-test are leaf literals (no side-effect risk),
-            // collapse the whole switch to `;`. The block-walker
-            // (`dce_block_statement`) will drop the EmptyStatement
-            // in its next sweep.
+            // If every case runs nothing (no cases at all, or every
+            // consequent is only empty statements / empty blocks) AND
+            // evaluating the discriminant and every case-test has no
+            // observable side effect, the whole switch is a no-op and
+            // collapses to `;`. The block-walker (`dce_block_statement`)
+            // drops the EmptyStatement in its next sweep.
             //
-            // Conservative bail: anything else (Identifier
-            // discriminant, computed test, non-empty consequent)
-            // keeps the switch intact. The "drop after pure
-            // discriminant with side-effecting tests" rule is a
-            // future slice that needs a proper effect analysis.
-            let all_consequents_empty = new_cases.iter().all(|c| c.consequent.is_empty());
+            // The two gates are deliberately ASYMMETRIC, mirroring the
+            // reference Closure Compiler (`PeepholeRemoveDeadCode`)
+            // byte-for-byte:
+            //
+            //   • The DISCRIMINANT gate is [`is_side_effect_free`] — a
+            //     bare read is enough. So `switch (x) {}`,
+            //     `switch (a.b) {}`, `switch (a && b) {}`,
+            //     `switch (!x) {}`, `switch (typeof x) {}` all drop,
+            //     not just literal discriminants.
+            //
+            //   • Each case TEST, however, must be [`is_pure_leaf`] (a
+            //     literal) or absent (`default:`). Closure KEEPS a
+            //     switch whose case test is a non-literal even when it
+            //     is side-effect-free: `switch (x) { case y: }` and
+            //     `switch (x) { case a.b: case c: }` survive, while
+            //     `switch (x) { case 1: case 2: }` and
+            //     `switch (x) { default: }` drop. We match that exactly
+            //     rather than removing more (which would diverge).
+            //
+            // A consequent counts as empty when every statement in it is
+            // itself empty (via [`statement_is_empty`]), so
+            // `switch (x) { case 1: {} }` — a case whose only body is an
+            // empty block — also drops.
+            //
+            // Still a conservative bail (keeps the switch, a KNOWN
+            // divergence handled by a separate future slice): a
+            // side-EFFECTING discriminant, e.g. `switch (f()) {}`, which
+            // Closure rewrites to `f();` — extracting the discriminant
+            // as an expression statement. That extract-discriminant
+            // transform needs its own effect-preserving lowering and is
+            // out of scope here; `is_side_effect_free(&new_disc)` is
+            // false for `f()`, so this path declines and we leave the
+            // switch untouched (no regression).
+            let all_consequents_empty = new_cases
+                .iter()
+                .all(|c| c.consequent.iter().all(statement_is_empty));
             let discriminant_pure = is_pure_leaf(&new_disc);
             let all_tests_pure_or_none = new_cases
                 .iter()
                 .all(|c| c.test.as_ref().is_none_or(is_pure_leaf));
-            if all_consequents_empty && discriminant_pure && all_tests_pure_or_none {
+            let discriminant_side_effect_free = is_side_effect_free(&new_disc);
+            if all_consequents_empty && discriminant_side_effect_free && all_tests_pure_or_none {
                 st.record(
                     &s.cv,
                     "switch_eliminated",
@@ -2662,20 +2693,82 @@ mod tests {
         assert!(contribs.iter().any(|c| c.tag == "switch_eliminated"));
     }
 
-    /// Conservative bail: Identifier discriminant might TDZ-throw
-    /// for an uninitialised `let` / `const`. Keep the switch.
+    /// A bare Identifier discriminant is side-effect-free, so an
+    /// otherwise-empty `switch (x) {}` DROPS — matching the reference
+    /// Closure Compiler byte-for-byte (verified: `switch(x){}` → ``).
+    /// The read of `x` has no observable effect, and with no cases
+    /// there is nothing to run.
     #[test]
-    fn empty_switch_with_identifier_discriminant_keeps_switch() {
+    fn empty_switch_with_identifier_discriminant_drops() {
         let body = vec![switch_stmt(ident("x"), vec![])];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, changed, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(block.body.is_empty(), "expected empty body; got {:?}", block.body);
+        assert!(changed);
+        assert!(contribs.iter().any(|c| c.tag == "switch_eliminated"));
+    }
+
+    /// A member-read discriminant (`switch (a.b) {}`) is also
+    /// side-effect-free — object and (non-computed) key are pure — so
+    /// the empty switch drops. Oracle: `switch(a.b){}` → ``.
+    #[test]
+    fn empty_switch_with_member_discriminant_drops() {
+        let body = vec![switch_stmt(member(ident("a"), "b"), vec![])];
         let prog = program_with_function(body, Some("fn.1"));
         let (out, contribs, _, _) = run_pass(prog);
         let block = extract_function_body(&out);
-        // SwitchStatement preserved.
+        assert!(block.body.is_empty(), "expected empty body; got {:?}", block.body);
+        assert!(contribs.iter().any(|c| c.tag == "switch_eliminated"));
+    }
+
+    /// A unary `!x` discriminant is side-effect-free (the operand is a
+    /// pure read and `!` has no effect), so `switch (!x) {}` drops.
+    /// Oracle: `switch(!x){}` → ``.
+    #[test]
+    fn empty_switch_with_unary_discriminant_drops() {
+        let body = vec![switch_stmt(not(ident("x")), vec![])];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, _, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(block.body.is_empty(), "expected empty body; got {:?}", block.body);
+    }
+
+    /// A side-EFFECTING discriminant keeps the switch. `switch (f()) {}`
+    /// is NOT side-effect-free (the call runs), so this path declines.
+    /// (The reference compiler instead extracts the discriminant to
+    /// `f();`, a separate transform we do not perform here — declining
+    /// keeps the switch intact rather than dropping the call, so no
+    /// unsound removal and no regression.)
+    #[test]
+    fn empty_switch_with_call_discriminant_keeps_switch() {
+        let body = vec![switch_stmt(call0("f"), vec![])];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
         assert!(matches!(
             &block.body[0],
             Statement::Tagged(TaggedStatement::SwitchStatement(_))
         ));
         assert!(!contribs.iter().any(|c| c.tag == "switch_eliminated"));
+    }
+
+    /// A case whose only consequent is an empty block (`case 1: {}`)
+    /// counts as empty via `statement_is_empty`, so the whole switch
+    /// drops. Oracle: `switch(x){case 1:{}}` → ``.
+    #[test]
+    fn empty_switch_with_empty_block_consequent_drops() {
+        let cases = vec![SwitchCase {
+            cv: None,
+            test: Some(num(1.0)),
+            consequent: vec![empty_block_stmt()],
+        }];
+        let body = vec![switch_stmt(ident("x"), cases)];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(block.body.is_empty(), "expected empty body; got {:?}", block.body);
+        assert!(contribs.iter().any(|c| c.tag == "switch_eliminated"));
     }
 
     /// Non-empty consequent keeps the switch even with a pure


### PR DESCRIPTION
## What

Broadens the gap-014 step-2 **empty-`switch` elimination** so the *discriminant* only needs to be **side-effect-free**, not a leaf literal. The reference Closure Compiler (`PeepholeRemoveDeadCode`, `SIMPLE`) removes an otherwise-empty switch for any side-effect-free discriminant; closurec previously kept it. This closes a batch of oracle divergences.

### Oracle-verified byte-identity (fresh binary vs `closure-compiler-v20260712.jar`)

| input | before | after / oracle |
|---|---|---|
| `switch(x){}` | kept | **removed** |
| `switch(a.b){}` | kept | **removed** |
| `switch(a&&b){}` | kept | **removed** |
| `switch(!x){}` | kept | **removed** |
| `switch(typeof x){}` | kept | **removed** |
| `switch(x){case 1:}` | kept | **removed** |
| `switch(x){case 1:case 2:}` | kept | **removed** |
| `switch(x){default:}` | kept | **removed** |
| `switch(x){case 1:{}}` | kept | **removed** |

### Deliberately asymmetric gates (matches Closure exactly)

- **Discriminant** → `is_side_effect_free` (identifier / member-read / logical / unary / typeof).
- **Case test** → stays `is_pure_leaf` (literal) or absent (`default:`). Closure *keeps* a switch whose case test is a non-literal even when side-effect-free, so `switch(x){case y:}` and `switch(x){case a.b:case c:}` correctly **survive**.

Also generalizes the empty-consequent check to "every statement is itself empty" (`statement_is_empty`), so `switch(x){case 1:{}}` (empty-block body) drops.

## Soundness

Removed only when the discriminant + every (literal) case test are side-effect-free **and** no case runs a statement — a verified no-op. A side-effecting discriminant (`switch(f()){}`) is **not** side-effect-free, so the path declines and keeps the switch (Closure instead extracts `f();` via a separate transform we don't perform — no unsound removal, no regression). Step-4 constant-discriminant collapse is untouched: it still requires a literal discriminant for compile-time strict-equality.

## Out of scope (pre-existing divergences, unchanged)

- Emitter trailing `;` after a *kept* switch (`switch(x){case y:}` → oracle `…};`) — separate emitter arc.
- Extract-discriminant (`switch(f()){}`→`f();`, `switch(x++){}`→`x++;`) — separate transform.

## Testing

- `closure-pass-dce`: 56 unit + integration tests pass; clippy clean. Rewrote the now-reversed identifier-discriminant test to assert the drop, added member / unary / call-keeps / empty-block-consequent coverage.
- Full `closurec` suite green (no fixture drift).
- Inline security review: **PASSED** (no new unsoundness; `is_side_effect_free` walk is O(size), no complexity DoS).

`closure-pass-dce` 0.26.0 → 0.27.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)