### PR TITLE
feat: port radix tree to Lua and Perl

### DIFF
--- a/code/packages/lua/radix-tree/BUILD
+++ b/code/packages/lua/radix-tree/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-radix-tree-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/radix-tree/BUILD_windows
+++ b/code/packages/lua/radix-tree/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-radix-tree-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/radix-tree/CHANGELOG.md
+++ b/code/packages/lua/radix-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Lua radix-tree package with UTF-8 path compression, split insertion,
+  merge deletion, prefix scans, longest-prefix matching, and validation helpers.

--- a/code/packages/lua/radix-tree/README.md
+++ b/code/packages/lua/radix-tree/README.md
@@ -1,0 +1,21 @@
+# coding-adventures-radix-tree
+
+A dependency-free Lua 5.4 radix tree for UTF-8 string keys and arbitrary
+values. Unlike a character-per-node trie, it stores whole substrings on edges
+and preserves that compression after deletion.
+
+```lua
+local RadixTree = require("coding_adventures.radix_tree").RadixTree
+
+local tree = RadixTree.new()
+tree:insert("search", 1)
+tree:insert("searcher", 2)
+
+assert(tree:search("search") == 1)
+assert(tree:longest_prefix_match("search-party") == "search")
+assert(tree:node_count() == 3) -- root plus two compressed key nodes
+```
+
+The public API includes exact lookup and membership, sorted key and prefix
+enumeration, longest-prefix matching, deletion, map export, node counting, and
+structural validation. Empty-string keys and Unicode keys are supported.

--- a/code/packages/lua/radix-tree/coding-adventures-radix-tree-0.1.0-1.rockspec
+++ b/code/packages/lua/radix-tree/coding-adventures-radix-tree-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-radix-tree"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Path-compressed radix tree for UTF-8 string keys",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.radix_tree"] = "src/coding_adventures/radix_tree/init.lua",
+    },
+}

--- a/code/packages/lua/radix-tree/required_capabilities.json
+++ b/code/packages/lua/radix-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/radix-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/radix-tree/src/coding_adventures/radix_tree/init.lua
+++ b/code/packages/lua/radix-tree/src/coding_adventures/radix_tree/init.lua
@@ -1,0 +1,477 @@
+--- A path-compressed radix tree for UTF-8 string keys and arbitrary values.
+
+local RadixTree = {}
+RadixTree.__index = RadixTree
+
+local function new_node(terminal, value)
+    return {
+        children = {},
+        terminal = terminal or false,
+        value = value,
+    }
+end
+
+local function assert_string(value, name, level)
+    if type(value) ~= "string" then
+        error(name .. " must be a string", level or 3)
+    end
+end
+
+local function characters(value)
+    local result = {}
+    for _, codepoint in utf8.codes(value) do
+        result[#result + 1] = utf8.char(codepoint)
+    end
+    return result
+end
+
+local function slice(chars, first)
+    local result = {}
+    for index = first, #chars do
+        result[#result + 1] = chars[index]
+    end
+    return result
+end
+
+local function concatenate(left, right)
+    local result = {}
+    for _, character in ipairs(left) do
+        result[#result + 1] = character
+    end
+    for _, character in ipairs(right) do
+        result[#result + 1] = character
+    end
+    return result
+end
+
+local function common_prefix_length(left, right)
+    local limit = math.min(#left, #right)
+    local index = 0
+    while index < limit and left[index + 1] == right[index + 1] do
+        index = index + 1
+    end
+    return index
+end
+
+local function child_count(node)
+    local count = 0
+    for _ in pairs(node.children) do
+        count = count + 1
+    end
+    return count
+end
+
+local function only_child(node)
+    for _, edge in pairs(node.children) do
+        return edge
+    end
+    return nil
+end
+
+local function insert_recursive(node, key, value)
+    if #key == 0 then
+        local added = not node.terminal
+        node.terminal = true
+        node.value = value
+        return added
+    end
+
+    local first = key[1]
+    local edge = node.children[first]
+    if edge == nil then
+        node.children[first] = {
+            label = key,
+            child = new_node(true, value),
+        }
+        return true
+    end
+
+    local common = common_prefix_length(key, edge.label)
+    if common == #edge.label then
+        return insert_recursive(edge.child, slice(key, common + 1), value)
+    end
+
+    local common_label = {}
+    for index = 1, common do
+        common_label[index] = edge.label[index]
+    end
+    local old_rest = slice(edge.label, common + 1)
+    local key_rest = slice(key, common + 1)
+    local split_node = new_node()
+    split_node.children[old_rest[1]] = {
+        label = old_rest,
+        child = edge.child,
+    }
+
+    if #key_rest == 0 then
+        split_node.terminal = true
+        split_node.value = value
+    else
+        split_node.children[key_rest[1]] = {
+            label = key_rest,
+            child = new_node(true, value),
+        }
+    end
+
+    node.children[first] = {
+        label = common_label,
+        child = split_node,
+    }
+    return true
+end
+
+local function find_node(self, key)
+    local chars = characters(key)
+    local node = self._root
+    local index = 1
+
+    while index <= #chars do
+        local edge = node.children[chars[index]]
+        if edge == nil then
+            return nil
+        end
+        for offset = 1, #edge.label do
+            if chars[index + offset - 1] ~= edge.label[offset] then
+                return nil
+            end
+        end
+        index = index + #edge.label
+        node = edge.child
+    end
+    return node
+end
+
+local function delete_recursive(node, key)
+    if #key == 0 then
+        if not node.terminal then
+            return false, false
+        end
+        node.terminal = false
+        node.value = nil
+        return true, child_count(node) == 1
+    end
+
+    local first = key[1]
+    local edge = node.children[first]
+    if edge == nil then
+        return false, false
+    end
+
+    local common = common_prefix_length(key, edge.label)
+    if common < #edge.label then
+        return false, false
+    end
+
+    local deleted, child_mergeable = delete_recursive(
+        edge.child,
+        slice(key, common + 1)
+    )
+    if not deleted then
+        return false, false
+    end
+
+    if child_mergeable then
+        local grandchild = only_child(edge.child)
+        node.children[first] = {
+            label = concatenate(edge.label, grandchild.label),
+            child = grandchild.child,
+        }
+    elseif not edge.child.terminal and child_count(edge.child) == 0 then
+        node.children[first] = nil
+    end
+
+    return true, not node.terminal and child_count(node) == 1
+end
+
+local function sorted_child_keys(node)
+    local result = {}
+    for first in pairs(node.children) do
+        result[#result + 1] = first
+    end
+    table.sort(result)
+    return result
+end
+
+local function collect_entries(node, current, results)
+    if node.terminal then
+        results[#results + 1] = { current, node.value }
+    end
+    for _, first in ipairs(sorted_child_keys(node)) do
+        local edge = node.children[first]
+        collect_entries(edge.child, current .. table.concat(edge.label), results)
+    end
+end
+
+local function count_nodes(node)
+    local count = 1
+    for _, edge in pairs(node.children) do
+        count = count + count_nodes(edge.child)
+    end
+    return count
+end
+
+local function validate_node(node, is_root)
+    local endpoints = node.terminal and 1 or 0
+    local children = 0
+
+    for first, edge in pairs(node.children) do
+        children = children + 1
+        if type(edge.label) ~= "table"
+            or #edge.label == 0
+            or edge.label[1] ~= first
+            or type(edge.child) ~= "table"
+        then
+            return false, 0
+        end
+        local valid, child_endpoints = validate_node(edge.child, false)
+        if not valid then
+            return false, 0
+        end
+        endpoints = endpoints + child_endpoints
+    end
+
+    if not is_root and not node.terminal and children <= 1 then
+        return false, 0
+    end
+    return true, endpoints
+end
+
+function RadixTree.new(entries)
+    entries = entries == nil and {} or entries
+    if type(entries) ~= "table" then
+        error("entries must be a table", 2)
+    end
+
+    local self = setmetatable({
+        _root = new_node(),
+        _size = 0,
+    }, RadixTree)
+
+    for index, entry in ipairs(entries) do
+        if type(entry) ~= "table" or entry[1] == nil then
+            error("entry at index " .. index .. " must contain a key", 2)
+        end
+        self:insert(entry[1], entry[2])
+    end
+    return self
+end
+
+function RadixTree:insert(key, value)
+    assert_string(key, "key", 2)
+    if value == nil then
+        value = true
+    end
+    if insert_recursive(self._root, characters(key), value) then
+        self._size = self._size + 1
+    end
+    return self
+end
+
+function RadixTree:search(key)
+    assert_string(key, "key", 2)
+    local node = find_node(self, key)
+    if node ~= nil and node.terminal then
+        return node.value
+    end
+    return nil
+end
+
+function RadixTree:contains_key(key)
+    assert_string(key, "key", 2)
+    local node = find_node(self, key)
+    return node ~= nil and node.terminal
+end
+
+RadixTree.key_exists = RadixTree.contains_key
+RadixTree.contains = RadixTree.contains_key
+
+function RadixTree:delete(key)
+    assert_string(key, "key", 2)
+    local deleted = delete_recursive(self._root, characters(key))
+    if deleted then
+        self._size = self._size - 1
+    end
+    return deleted
+end
+
+function RadixTree:starts_with(prefix)
+    assert_string(prefix, "prefix", 2)
+    if prefix == "" then
+        return self._size > 0
+    end
+
+    local chars = characters(prefix)
+    local node = self._root
+    local index = 1
+    while index <= #chars do
+        local edge = node.children[chars[index]]
+        if edge == nil then
+            return false
+        end
+
+        local remaining = #chars - index + 1
+        local limit = math.min(remaining, #edge.label)
+        for offset = 1, limit do
+            if chars[index + offset - 1] ~= edge.label[offset] then
+                return false
+            end
+        end
+        if remaining <= #edge.label then
+            return true
+        end
+        index = index + #edge.label
+        node = edge.child
+    end
+    return node.terminal or child_count(node) > 0
+end
+
+function RadixTree:entries()
+    local results = {}
+    collect_entries(self._root, "", results)
+    return results
+end
+
+RadixTree.all_entries = RadixTree.entries
+
+function RadixTree:keys()
+    local result = {}
+    for _, entry in ipairs(self:entries()) do
+        result[#result + 1] = entry[1]
+    end
+    return result
+end
+
+RadixTree.all_words = RadixTree.keys
+
+function RadixTree:words_with_prefix(prefix)
+    assert_string(prefix, "prefix", 2)
+    if prefix == "" then
+        return self:keys()
+    end
+
+    local chars = characters(prefix)
+    local node = self._root
+    local index = 1
+    local path = ""
+
+    while index <= #chars do
+        local edge = node.children[chars[index]]
+        if edge == nil then
+            return {}
+        end
+
+        local remaining = #chars - index + 1
+        local limit = math.min(remaining, #edge.label)
+        for offset = 1, limit do
+            if chars[index + offset - 1] ~= edge.label[offset] then
+                return {}
+            end
+        end
+
+        path = path .. table.concat(edge.label)
+        if remaining <= #edge.label then
+            local entries = {}
+            collect_entries(edge.child, path, entries)
+            local result = {}
+            for _, entry in ipairs(entries) do
+                result[#result + 1] = entry[1]
+            end
+            return result
+        end
+        index = index + #edge.label
+        node = edge.child
+    end
+
+    local entries = {}
+    collect_entries(node, path, entries)
+    local result = {}
+    for _, entry in ipairs(entries) do
+        result[#result + 1] = entry[1]
+    end
+    return result
+end
+
+function RadixTree:longest_prefix_match(input)
+    assert_string(input, "input", 2)
+    local chars = characters(input)
+    local node = self._root
+    local index = 1
+    local path = ""
+    local best = node.terminal and "" or nil
+
+    while index <= #chars do
+        local edge = node.children[chars[index]]
+        if edge == nil then
+            break
+        end
+        local matches = true
+        for offset = 1, #edge.label do
+            if chars[index + offset - 1] ~= edge.label[offset] then
+                matches = false
+                break
+            end
+        end
+        if not matches then
+            break
+        end
+        path = path .. table.concat(edge.label)
+        index = index + #edge.label
+        node = edge.child
+        if node.terminal then
+            best = path
+        end
+    end
+    return best
+end
+
+function RadixTree:to_table()
+    local result = {}
+    for _, entry in ipairs(self:entries()) do
+        result[entry[1]] = entry[2]
+    end
+    return result
+end
+
+RadixTree.to_map = RadixTree.to_table
+
+function RadixTree:each(callback)
+    if type(callback) ~= "function" then
+        error("callback must be a function", 2)
+    end
+    for _, entry in ipairs(self:entries()) do
+        callback(entry[1], entry[2])
+    end
+    return self
+end
+
+function RadixTree:size()
+    return self._size
+end
+
+RadixTree.length = RadixTree.size
+
+function RadixTree:is_empty()
+    return self._size == 0
+end
+
+function RadixTree:node_count()
+    return count_nodes(self._root)
+end
+
+function RadixTree:is_valid()
+    local valid, endpoints = validate_node(self._root, true)
+    return valid and endpoints == self._size
+end
+
+RadixTree.__len = function(self)
+    return self._size
+end
+
+RadixTree.__tostring = function(self)
+    return string.format("RadixTree(%d keys, %d nodes)", self._size, self:node_count())
+end
+
+return {
+    RadixTree = RadixTree,
+    new = RadixTree.new,
+}

--- a/code/packages/lua/radix-tree/tests/test_radix_tree.lua
+++ b/code/packages/lua/radix-tree/tests/test_radix_tree.lua
@@ -1,0 +1,180 @@
+package.path = table.concat({
+    "../src/?.lua",
+    "../src/?/init.lua",
+    package.path,
+}, ";")
+
+local module = require("coding_adventures.radix_tree")
+local RadixTree = module.RadixTree
+
+local function make_tree(...)
+    local tree = RadixTree.new()
+    for index, key in ipairs({ ... }) do
+        tree:insert(key, index)
+    end
+    return tree
+end
+
+describe("RadixTree", function()
+    it("represents an empty tree", function()
+        local tree = RadixTree.new()
+        assert.equals(0, tree:size())
+        assert.equals(0, #tree)
+        assert.is_true(tree:is_empty())
+        assert.equals(1, tree:node_count())
+        assert.is_nil(tree:search("anything"))
+        assert.is_false(tree:starts_with(""))
+        assert.is_true(tree:is_valid())
+    end)
+
+    it("covers all compressed-edge insertion cases and updates", function()
+        local tree = RadixTree.new()
+        tree:insert("application", 1)
+        tree:insert("apple", 2)
+        tree:insert("app", 3)
+        tree:insert("apt", 4)
+
+        assert.equals(1, tree:search("application"))
+        assert.equals(2, tree:search("apple"))
+        assert.equals(3, tree:search("app"))
+        assert.equals(4, tree:search("apt"))
+        assert.is_nil(tree:search("appl"))
+
+        tree:insert("app", 99)
+        tree:insert("disabled", false)
+        assert.equals(99, tree:search("app"))
+        assert.is_false(tree:search("disabled"))
+        assert.is_true(tree:contains_key("disabled"))
+        assert.equals(5, tree:length())
+        assert.is_true(tree:is_valid())
+    end)
+
+    it("answers mid-edge prefix queries in sorted order", function()
+        local tree = make_tree("search", "searcher", "searching", "banana")
+        assert.is_true(tree:starts_with("sear"))
+        assert.is_false(tree:starts_with("seek"))
+        assert.are.same({ "search", "searcher", "searching" }, tree:words_with_prefix("sear"))
+        assert.are.same({ "search", "searcher", "searching" }, tree:words_with_prefix("search"))
+        assert.are.same({}, tree:words_with_prefix("xyz"))
+        assert.are.same({ "banana", "search", "searcher", "searching" }, tree:keys())
+        assert.equals(5, tree:node_count())
+    end)
+
+    it("deletes keys and merges compressed edges", function()
+        local tree = make_tree("app", "apple", "apt")
+        assert.is_true(tree:delete("app"))
+        assert.is_false(tree:contains("app"))
+        assert.equals(2, tree:search("apple"))
+        assert.equals(3, tree:search("apt"))
+        assert.is_false(tree:delete("missing"))
+        assert.is_false(tree:delete("ap"))
+        assert.is_true(tree:delete("apple"))
+        assert.equals(2, tree:node_count())
+        assert.is_true(tree:is_valid())
+    end)
+
+    it("supports longest-prefix matching and empty-string keys", function()
+        local tree = module.new({
+            { "", "root" },
+            { "a", 1 },
+            { "ab", 2 },
+            { "abc", 3 },
+            { "application", 4 },
+        })
+        assert.equals("abc", tree:longest_prefix_match("abcdef"))
+        assert.equals("application", tree:longest_prefix_match("application/json"))
+        assert.equals("", tree:longest_prefix_match("xyz"))
+        assert.equals("root", tree:search(""))
+        assert.is_true(tree:starts_with(""))
+        assert.is_true(tree:delete(""))
+        assert.is_nil(tree:longest_prefix_match("xyz"))
+    end)
+
+    it("keeps UTF-8 labels intact while splitting and merging", function()
+        local tree = RadixTree.new()
+        tree:insert("caf\u{00e9}", "single")
+        tree:insert("cafe\u{0301}", "combining")
+        tree:insert("cafeteria", "food")
+        tree:insert("\u{732b}", "cat")
+
+        assert.equals("single", tree:search("caf\u{00e9}"))
+        assert.are.same({ "cafeteria" }, tree:words_with_prefix("cafet"))
+        assert.equals("cafe\u{0301}", tree:longest_prefix_match("cafe\u{0301}-au-lait"))
+        assert.is_true(tree:delete("cafe\u{0301}"))
+        assert.equals("food", tree:search("cafeteria"))
+        assert.is_true(tree:is_valid())
+    end)
+
+    it("agrees with a table across deterministic mixed mutations", function()
+        local tree = RadixTree.new()
+        local expected = {}
+        for index = 1, 200 do
+            local key = string.format("route/%02d/%03d", index % 17, (index * 37) % 211)
+            tree:insert(key, index)
+            expected[key] = index
+        end
+
+        local expected_keys = {}
+        for key, value in pairs(expected) do
+            assert.equals(value, tree:search(key))
+            expected_keys[#expected_keys + 1] = key
+        end
+        table.sort(expected_keys)
+        assert.are.same(expected_keys, tree:keys())
+        assert.equals(#expected_keys, tree:size())
+
+        local to_delete = {}
+        for key, value in pairs(expected) do
+            if value % 2 == 0 then
+                to_delete[#to_delete + 1] = key
+            end
+        end
+        for _, key in ipairs(to_delete) do
+            assert.is_true(tree:delete(key))
+            expected[key] = nil
+        end
+
+        local prefix = "route/03"
+        local prefix_keys = {}
+        for key in pairs(expected) do
+            if key:sub(1, #prefix) == prefix then
+                prefix_keys[#prefix_keys + 1] = key
+            end
+        end
+        table.sort(prefix_keys)
+        assert.are.same(prefix_keys, tree:words_with_prefix(prefix))
+        assert.is_true(tree:is_valid())
+    end)
+
+    it("exports values, iterates, and validates public inputs", function()
+        local tree = module.new({ { "b", 2 }, { "a", 1 } })
+        assert.are.same({ { "a", 1 }, { "b", 2 } }, tree:entries())
+        assert.are.same({ a = 1, b = 2 }, tree:to_table())
+
+        local seen = {}
+        tree:each(function(key, value)
+            seen[#seen + 1] = { key, value }
+        end)
+        assert.are.same(tree:entries(), seen)
+        assert.is_truthy(tostring(tree):match("2 keys"))
+
+        assert.has_error(function()
+            RadixTree.new("not-a-table")
+        end, "entries must be a table")
+        assert.has_error(function()
+            RadixTree.new({ {} })
+        end, "entry at index 1 must contain a key")
+        assert.has_error(function()
+            tree:insert({})
+        end, "key must be a string")
+        assert.has_error(function()
+            tree:starts_with({})
+        end, "prefix must be a string")
+        assert.has_error(function()
+            tree:longest_prefix_match({})
+        end, "input must be a string")
+        assert.has_error(function()
+            tree:each("not-a-function")
+        end, "callback must be a function")
+    end)
+end)

--- a/code/packages/perl/radix-tree/BUILD
+++ b/code/packages/perl/radix-tree/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/radix-tree/BUILD_windows
+++ b/code/packages/perl/radix-tree/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-radix-tree.t

--- a/code/packages/perl/radix-tree/CHANGELOG.md
+++ b/code/packages/perl/radix-tree/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Perl radix-tree package with Unicode path compression, split
+  insertion, merge deletion, prefix scans, longest-prefix matching, and
+  validation helpers.

--- a/code/packages/perl/radix-tree/Makefile.PL
+++ b/code/packages/perl/radix-tree/Makefile.PL
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::RadixTree',
+    VERSION_FROM     => 'lib/CodingAdventures/RadixTree.pm',
+    ABSTRACT         => 'Path-compressed radix tree for Unicode string keys',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {},
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/radix-tree/README.md
+++ b/code/packages/perl/radix-tree/README.md
@@ -1,0 +1,19 @@
+# CodingAdventures::RadixTree
+
+A dependency-free Perl radix tree for Unicode string keys and arbitrary
+values. Whole substrings are stored on edges, and deletion merges redundant
+paths to preserve the compressed representation.
+
+```perl
+use CodingAdventures::RadixTree;
+
+my $tree = CodingAdventures::RadixTree->new;
+$tree->insert('search', 1)->insert('searcher', 2);
+
+print $tree->search('search');                    # 1
+print $tree->longest_prefix_match('search-path'); # search
+```
+
+The public API includes exact lookup and membership, sorted key and prefix
+enumeration, longest-prefix matching, deletion, hash export, node counting,
+and structural validation. Empty-string keys are supported.

--- a/code/packages/perl/radix-tree/cpanfile
+++ b/code/packages/perl/radix-tree/cpanfile
@@ -1,0 +1,1 @@
+# No non-core dependencies.

--- a/code/packages/perl/radix-tree/lib/CodingAdventures/RadixTree.pm
+++ b/code/packages/perl/radix-tree/lib/CodingAdventures/RadixTree.pm
@@ -1,0 +1,422 @@
+package CodingAdventures::RadixTree;
+
+use strict;
+use warnings;
+use utf8;
+use overload '""' => 'as_string', fallback => 1;
+
+our $VERSION = '0.1.0';
+
+sub _new_node {
+    my ($terminal, $value) = @_;
+    return {
+        children => {},
+        terminal => $terminal ? 1 : 0,
+        value    => $value,
+    };
+}
+
+sub _assert_string {
+    my ($value, $name) = @_;
+    die "$name must be a string\n" if !defined($value) || ref($value);
+}
+
+sub _characters {
+    my ($value) = @_;
+    return [split //u, $value];
+}
+
+sub _slice {
+    my ($characters, $start) = @_;
+    return [] if $start > $#$characters;
+    return [@$characters[$start .. $#$characters]];
+}
+
+sub _concatenate {
+    my ($left, $right) = @_;
+    return [@$left, @$right];
+}
+
+sub _common_prefix_length {
+    my ($left, $right) = @_;
+    my $limit = @$left < @$right ? scalar @$left : scalar @$right;
+    my $index = 0;
+    $index++ while $index < $limit && $left->[$index] eq $right->[$index];
+    return $index;
+}
+
+sub _child_count {
+    my ($node) = @_;
+    return scalar keys %{$node->{children}};
+}
+
+sub _only_child {
+    my ($node) = @_;
+    return (values %{$node->{children}})[0];
+}
+
+sub _insert_recursive {
+    my ($node, $key, $value) = @_;
+    if (!@$key) {
+        my $added = !$node->{terminal};
+        $node->{terminal} = 1;
+        $node->{value} = $value;
+        return $added;
+    }
+
+    my $first = $key->[0];
+    my $edge = $node->{children}{$first};
+    if (!defined $edge) {
+        $node->{children}{$first} = {
+            label => $key,
+            child => _new_node(1, $value),
+        };
+        return 1;
+    }
+
+    my $common = _common_prefix_length($key, $edge->{label});
+    if ($common == @{$edge->{label}}) {
+        return _insert_recursive($edge->{child}, _slice($key, $common), $value);
+    }
+
+    my $common_label = [@{$edge->{label}}[0 .. $common - 1]];
+    my $old_rest = _slice($edge->{label}, $common);
+    my $key_rest = _slice($key, $common);
+    my $split_node = _new_node();
+    $split_node->{children}{$old_rest->[0]} = {
+        label => $old_rest,
+        child => $edge->{child},
+    };
+
+    if (!@$key_rest) {
+        $split_node->{terminal} = 1;
+        $split_node->{value} = $value;
+    } else {
+        $split_node->{children}{$key_rest->[0]} = {
+            label => $key_rest,
+            child => _new_node(1, $value),
+        };
+    }
+
+    $node->{children}{$first} = {
+        label => $common_label,
+        child => $split_node,
+    };
+    return 1;
+}
+
+sub _find_node {
+    my ($self, $key) = @_;
+    my $characters = _characters($key);
+    my $node = $self->{root};
+    my $index = 0;
+
+    while ($index < @$characters) {
+        my $edge = $node->{children}{$characters->[$index]};
+        return undef if !defined $edge;
+        for my $offset (0 .. $#{$edge->{label}}) {
+            return undef
+                if !defined($characters->[$index + $offset])
+                || $characters->[$index + $offset] ne $edge->{label}[$offset];
+        }
+        $index += @{$edge->{label}};
+        $node = $edge->{child};
+    }
+    return $node;
+}
+
+sub _delete_recursive {
+    my ($node, $key) = @_;
+    if (!@$key) {
+        return (0, 0) if !$node->{terminal};
+        $node->{terminal} = 0;
+        $node->{value} = undef;
+        return (1, _child_count($node) == 1 ? 1 : 0);
+    }
+
+    my $first = $key->[0];
+    my $edge = $node->{children}{$first};
+    return (0, 0) if !defined $edge;
+
+    my $common = _common_prefix_length($key, $edge->{label});
+    return (0, 0) if $common < @{$edge->{label}};
+
+    my ($deleted, $child_mergeable) = _delete_recursive(
+        $edge->{child},
+        _slice($key, $common),
+    );
+    return (0, 0) if !$deleted;
+
+    if ($child_mergeable) {
+        my $grandchild = _only_child($edge->{child});
+        $node->{children}{$first} = {
+            label => _concatenate($edge->{label}, $grandchild->{label}),
+            child => $grandchild->{child},
+        };
+    } elsif (!$edge->{child}{terminal} && _child_count($edge->{child}) == 0) {
+        delete $node->{children}{$first};
+    }
+
+    my $mergeable = !$node->{terminal} && _child_count($node) == 1;
+    return (1, $mergeable ? 1 : 0);
+}
+
+sub _collect_entries {
+    my ($node, $current, $results) = @_;
+    push @$results, [$current, $node->{value}] if $node->{terminal};
+    for my $first (sort keys %{$node->{children}}) {
+        my $edge = $node->{children}{$first};
+        _collect_entries(
+            $edge->{child},
+            $current . join('', @{$edge->{label}}),
+            $results,
+        );
+    }
+}
+
+sub _count_nodes {
+    my ($node) = @_;
+    my $count = 1;
+    $count += _count_nodes($_->{child}) for values %{$node->{children}};
+    return $count;
+}
+
+sub _validate_node {
+    my ($node, $is_root) = @_;
+    my $endpoints = $node->{terminal} ? 1 : 0;
+    my $children = 0;
+
+    while (my ($first, $edge) = each %{$node->{children}}) {
+        $children++;
+        return (0, 0)
+            if ref($edge->{label}) ne 'ARRAY'
+            || !@{$edge->{label}}
+            || $edge->{label}[0] ne $first
+            || ref($edge->{child}) ne 'HASH';
+        my ($valid, $child_endpoints) = _validate_node($edge->{child}, 0);
+        return (0, 0) if !$valid;
+        $endpoints += $child_endpoints;
+    }
+
+    return (0, 0) if !$is_root && !$node->{terminal} && $children <= 1;
+    return (1, $endpoints);
+}
+
+sub new {
+    my ($class, $entries) = @_;
+    $entries = [] if !defined $entries;
+    die "entries must be an array reference\n" if ref($entries) ne 'ARRAY';
+
+    my $self = bless {
+        root => _new_node(),
+        size => 0,
+    }, $class;
+
+    for my $index (0 .. $#$entries) {
+        my $entry = $entries->[$index];
+        die "entry at index $index must contain a key\n"
+            if ref($entry) ne 'ARRAY' || !@$entry;
+        my $value = @$entry >= 2 ? $entry->[1] : 1;
+        $self->insert($entry->[0], $value);
+    }
+    return $self;
+}
+
+sub insert {
+    my ($self, $key) = @_;
+    my $value = @_ >= 3 ? $_[2] : 1;
+    _assert_string($key, 'key');
+    $self->{size}++ if _insert_recursive($self->{root}, _characters($key), $value);
+    return $self;
+}
+
+sub search {
+    my ($self, $key) = @_;
+    _assert_string($key, 'key');
+    my $node = $self->_find_node($key);
+    return defined($node) && $node->{terminal} ? $node->{value} : undef;
+}
+
+sub contains_key {
+    my ($self, $key) = @_;
+    _assert_string($key, 'key');
+    my $node = $self->_find_node($key);
+    return defined($node) && $node->{terminal} ? 1 : 0;
+}
+
+sub key_exists { return shift->contains_key(@_); }
+sub contains   { return shift->contains_key(@_); }
+
+sub delete {
+    my ($self, $key) = @_;
+    _assert_string($key, 'key');
+    my ($deleted) = _delete_recursive($self->{root}, _characters($key));
+    $self->{size}-- if $deleted;
+    return $deleted;
+}
+
+sub starts_with {
+    my ($self, $prefix) = @_;
+    _assert_string($prefix, 'prefix');
+    return $self->{size} > 0 ? 1 : 0 if $prefix eq '';
+
+    my $characters = _characters($prefix);
+    my $node = $self->{root};
+    my $index = 0;
+    while ($index < @$characters) {
+        my $edge = $node->{children}{$characters->[$index]};
+        return 0 if !defined $edge;
+
+        my $remaining = @$characters - $index;
+        my $limit = $remaining < @{$edge->{label}}
+            ? $remaining
+            : scalar @{$edge->{label}};
+        for my $offset (0 .. $limit - 1) {
+            return 0 if $characters->[$index + $offset] ne $edge->{label}[$offset];
+        }
+        return 1 if $remaining <= @{$edge->{label}};
+        $index += @{$edge->{label}};
+        $node = $edge->{child};
+    }
+    return $node->{terminal} || _child_count($node) ? 1 : 0;
+}
+
+sub entries {
+    my ($self) = @_;
+    my $results = [];
+    _collect_entries($self->{root}, '', $results);
+    return $results;
+}
+
+sub all_entries { return shift->entries(@_); }
+
+sub keys {
+    my ($self) = @_;
+    return [map { $_->[0] } @{$self->entries}];
+}
+
+sub all_words { return shift->keys(@_); }
+
+sub words_with_prefix {
+    my ($self, $prefix) = @_;
+    _assert_string($prefix, 'prefix');
+    return $self->keys if $prefix eq '';
+
+    my $characters = _characters($prefix);
+    my $node = $self->{root};
+    my $index = 0;
+    my $path = '';
+
+    while ($index < @$characters) {
+        my $edge = $node->{children}{$characters->[$index]};
+        return [] if !defined $edge;
+
+        my $remaining = @$characters - $index;
+        my $limit = $remaining < @{$edge->{label}}
+            ? $remaining
+            : scalar @{$edge->{label}};
+        for my $offset (0 .. $limit - 1) {
+            return [] if $characters->[$index + $offset] ne $edge->{label}[$offset];
+        }
+
+        $path .= join('', @{$edge->{label}});
+        if ($remaining <= @{$edge->{label}}) {
+            my $entries = [];
+            _collect_entries($edge->{child}, $path, $entries);
+            return [map { $_->[0] } @$entries];
+        }
+        $index += @{$edge->{label}};
+        $node = $edge->{child};
+    }
+
+    my $entries = [];
+    _collect_entries($node, $path, $entries);
+    return [map { $_->[0] } @$entries];
+}
+
+sub longest_prefix_match {
+    my ($self, $input) = @_;
+    _assert_string($input, 'input');
+    my $characters = _characters($input);
+    my $node = $self->{root};
+    my $index = 0;
+    my $path = '';
+    my $best = $node->{terminal} ? '' : undef;
+
+    while ($index < @$characters) {
+        my $edge = $node->{children}{$characters->[$index]};
+        last if !defined $edge;
+
+        my $matches = 1;
+        for my $offset (0 .. $#{$edge->{label}}) {
+            if (!defined($characters->[$index + $offset])
+                || $characters->[$index + $offset] ne $edge->{label}[$offset]) {
+                $matches = 0;
+                last;
+            }
+        }
+        last if !$matches;
+
+        $path .= join('', @{$edge->{label}});
+        $index += @{$edge->{label}};
+        $node = $edge->{child};
+        $best = $path if $node->{terminal};
+    }
+    return $best;
+}
+
+sub to_hash {
+    my ($self) = @_;
+    my $result = {};
+    $result->{$_->[0]} = $_->[1] for @{$self->entries};
+    return $result;
+}
+
+sub to_map { return shift->to_hash(@_); }
+
+sub each {
+    my ($self, $callback) = @_;
+    die "callback must be a code reference\n" if ref($callback) ne 'CODE';
+    $callback->(@$_) for @{$self->entries};
+    return $self;
+}
+
+sub size   { return $_[0]->{size}; }
+sub length { return $_[0]->{size}; }
+
+sub is_empty {
+    my ($self) = @_;
+    return $self->{size} == 0 ? 1 : 0;
+}
+
+sub node_count {
+    my ($self) = @_;
+    return _count_nodes($self->{root});
+}
+
+sub is_valid {
+    my ($self) = @_;
+    my ($valid, $endpoints) = _validate_node($self->{root}, 1);
+    return $valid && $endpoints == $self->{size} ? 1 : 0;
+}
+
+sub as_string {
+    my ($self) = @_;
+    return sprintf('RadixTree(%d keys, %d nodes)', $self->{size}, $self->node_count);
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::RadixTree - path-compressed radix tree for Unicode keys
+
+=head1 SYNOPSIS
+
+  my $tree = CodingAdventures::RadixTree->new;
+  $tree->insert('app', 1)->insert('apple', 2);
+  my $match = $tree->longest_prefix_match('apples');
+
+=cut

--- a/code/packages/perl/radix-tree/required_capabilities.json
+++ b/code/packages/perl/radix-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/radix-tree",
+  "capabilities": [],
+  "justification": "Pure in-memory data structure. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/radix-tree/t/00-load.t
+++ b/code/packages/perl/radix-tree/t/00-load.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::RadixTree; 1 }, 'CodingAdventures::RadixTree loads');
+ok(CodingAdventures::RadixTree->VERSION, 'has a VERSION');
+
+done_testing;

--- a/code/packages/perl/radix-tree/t/01-radix-tree.t
+++ b/code/packages/perl/radix-tree/t/01-radix-tree.t
@@ -1,0 +1,180 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use CodingAdventures::RadixTree;
+
+sub make_tree {
+    my $tree = CodingAdventures::RadixTree->new;
+    my $index = 0;
+    $tree->insert($_, ++$index) for @_;
+    return $tree;
+}
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'empty tree' => sub {
+    my $tree = CodingAdventures::RadixTree->new;
+    is($tree->size, 0, 'size');
+    is($tree->length, 0, 'length');
+    ok($tree->is_empty, 'empty');
+    is($tree->node_count, 1, 'root only');
+    is($tree->search('anything'), undef, 'missing search');
+    ok(!$tree->starts_with(''), 'empty prefix does not match empty tree');
+    ok($tree->is_valid, 'valid');
+};
+
+subtest 'compressed-edge insertion cases and updates' => sub {
+    my $tree = CodingAdventures::RadixTree->new;
+    $tree->insert('application', 1);
+    $tree->insert('apple', 2);
+    $tree->insert('app', 3);
+    $tree->insert('apt', 4);
+
+    is($tree->search('application'), 1, 'extension');
+    is($tree->search('apple'), 2, 'partial split');
+    is($tree->search('app'), 3, 'prefix split');
+    is($tree->search('apt'), 4, 'divergent split');
+    is($tree->search('appl'), undef, 'prefix-only key absent');
+
+    $tree->insert('app', 99);
+    $tree->insert('undefined', undef);
+    is($tree->search('app'), 99, 'value updated');
+    ok($tree->contains_key('undefined'), 'terminal key may store undef');
+    is($tree->size, 5, 'update did not grow size');
+    ok($tree->is_valid, 'valid after splits');
+};
+
+subtest 'mid-edge prefix queries and sorted keys' => sub {
+    my $tree = make_tree(qw(search searcher searching banana));
+    ok($tree->starts_with('sear'), 'mid-edge prefix');
+    ok(!$tree->starts_with('seek'), 'missing prefix');
+    is_deeply(
+        $tree->words_with_prefix('sear'),
+        [qw(search searcher searching)],
+        'mid-edge prefix results',
+    );
+    is_deeply(
+        $tree->words_with_prefix('search'),
+        [qw(search searcher searching)],
+        'node-aligned prefix results',
+    );
+    is_deeply($tree->words_with_prefix('xyz'), [], 'missing prefix results');
+    is_deeply($tree->keys, [qw(banana search searcher searching)], 'sorted keys');
+    is($tree->node_count, 5, 'compressed node count');
+};
+
+subtest 'delete merges compressed edges' => sub {
+    my $tree = make_tree(qw(app apple apt));
+    ok($tree->delete('app'), 'delete shared prefix');
+    ok(!$tree->contains('app'), 'deleted key absent');
+    is($tree->search('apple'), 2, 'longer key preserved');
+    is($tree->search('apt'), 3, 'sibling preserved');
+    ok(!$tree->delete('missing'), 'missing delete');
+    ok(!$tree->delete('ap'), 'prefix-only delete');
+    ok($tree->delete('apple'), 'delete leaf');
+    is($tree->node_count, 2, 'redundant path merged');
+    ok($tree->is_valid, 'valid after merge');
+};
+
+subtest 'longest prefix and empty-string keys' => sub {
+    my $tree = CodingAdventures::RadixTree->new([
+        ['', 'root'], ['a', 1], ['ab', 2], ['abc', 3], ['application', 4],
+    ]);
+    is($tree->longest_prefix_match('abcdef'), 'abc', 'longest match');
+    is($tree->longest_prefix_match('application/json'), 'application', 'long edge match');
+    is($tree->longest_prefix_match('xyz'), '', 'empty key is a prefix');
+    is($tree->search(''), 'root', 'empty key value');
+    ok($tree->starts_with(''), 'empty prefix matches non-empty tree');
+    ok($tree->delete(''), 'delete empty key');
+    is($tree->longest_prefix_match('xyz'), undef, 'no match after deletion');
+};
+
+subtest 'Unicode labels survive splits and merges' => sub {
+    my $tree = CodingAdventures::RadixTree->new;
+    $tree->insert("caf\x{00e9}", 'single');
+    $tree->insert("cafe\x{0301}", 'combining');
+    $tree->insert('cafeteria', 'food');
+    $tree->insert("\x{732b}", 'cat');
+
+    is($tree->search("caf\x{00e9}"), 'single', 'single-codepoint accent');
+    is_deeply($tree->words_with_prefix('cafet'), ['cafeteria'], 'Unicode branch prefix');
+    is(
+        $tree->longest_prefix_match("cafe\x{0301}-au-lait"),
+        "cafe\x{0301}",
+        'Unicode longest prefix',
+    );
+    ok($tree->delete("cafe\x{0301}"), 'delete Unicode key');
+    is($tree->search('cafeteria'), 'food', 'sibling remains');
+    ok($tree->is_valid, 'valid Unicode structure');
+};
+
+subtest 'deterministic mixed mutations agree with a hash' => sub {
+    my $tree = CodingAdventures::RadixTree->new;
+    my %expected;
+    for my $index (1 .. 200) {
+        my $key = sprintf('route/%02d/%03d', $index % 17, ($index * 37) % 211);
+        $tree->insert($key, $index);
+        $expected{$key} = $index;
+    }
+
+    is($tree->size, scalar(keys %expected), 'unique size');
+    is($tree->search($_), $expected{$_}, "lookup $_") for sort keys %expected;
+    is_deeply($tree->keys, [sort keys %expected], 'keys match hash');
+
+    my @to_delete = grep { $expected{$_} % 2 == 0 } keys %expected;
+    for my $key (@to_delete) {
+        ok($tree->delete($key), "delete $key");
+        delete $expected{$key};
+    }
+
+    my $prefix = 'route/03';
+    my @prefix_keys = sort grep { index($_, $prefix) == 0 } keys %expected;
+    is_deeply($tree->words_with_prefix($prefix), \@prefix_keys, 'prefix keys match hash');
+    ok($tree->is_valid, 'valid after mixed mutations');
+};
+
+subtest 'export, iteration, and input validation' => sub {
+    my $tree = CodingAdventures::RadixTree->new([['b', 2], ['a', 1]]);
+    is_deeply($tree->entries, [['a', 1], ['b', 2]], 'sorted entries');
+    is_deeply($tree->to_hash, {a => 1, b => 2}, 'hash export');
+
+    my @seen;
+    $tree->each(sub { push @seen, [@_] });
+    is_deeply(\@seen, $tree->entries, 'sorted callback iteration');
+    like("$tree", qr/2 keys/, 'string rendering');
+
+    dies_like(
+        sub { CodingAdventures::RadixTree->new('not-an-array') },
+        qr/entries must be an array reference/,
+        'constructor validation',
+    );
+    dies_like(
+        sub { CodingAdventures::RadixTree->new([[]]) },
+        qr/entry at index 0 must contain a key/,
+        'entry validation',
+    );
+    dies_like(sub { $tree->insert([]) }, qr/key must be a string/, 'key validation');
+    dies_like(
+        sub { $tree->starts_with({}) },
+        qr/prefix must be a string/,
+        'prefix validation',
+    );
+    dies_like(
+        sub { $tree->longest_prefix_match([]) },
+        qr/input must be a string/,
+        'input validation',
+    );
+    dies_like(
+        sub { $tree->each('not-code') },
+        qr/callback must be a code reference/,
+        'callback validation',
+    );
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -107,11 +107,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 The missing matrix is heavily concentrated in singleton packages. Regenerated
 on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
-`skip-list`, `hyperloglog`, and `trie` ports:
+`skip-list`, `hyperloglog`, `trie`, and `radix-tree` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 353 |
+| Present in 10-15 languages | 171 | 351 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -157,15 +157,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 355
+The 171 packages present in at least ten implementation languages need 351
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 7 | Pair with Perl data-structure/storage wave |
-| Perl | 7 | Pair with Lua data-structure/storage wave |
+| Lua | 6 | Pair with Perl data-structure/storage wave |
+| Perl | 6 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -177,11 +177,11 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first nine paired Lua/Perl slices are complete: `fenwick-tree`,
+The first ten paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
-`avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, and `trie` now have pure
-implementations, package-native tests, metadata, and capability declarations in
-both lanes.
+`avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, and `radix-tree`
+now have pure implementations, package-native tests, metadata, and capability
+declarations in both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
 in-memory data store layers move; the AVL slice supplies the ordered backend
 for `tree-set`; and the dependency-free skip-list slice adds a span-augmented
@@ -189,6 +189,8 @@ ordered map with logarithmic rank and selection. The HyperLogLog slice adds a
 fixed-memory approximate distinct counter with deterministic internal hashing.
 The trie slice adds Unicode-aware prefix storage with sorted scans, pruning
 deletion, and longest-prefix matching without introducing new dependencies.
+The radix-tree slice compresses those paths into whole-substring edges while
+retaining Unicode-safe splits, post-deletion merges, and mid-edge prefix scans.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add dependency-free Lua and Perl `radix-tree` packages
- implement real UTF-8/Unicode path compression with edge splitting on insert and edge merging on delete
- support exact lookup, sorted prefix scans (including prefixes ending mid-edge), longest-prefix matching, empty-string keys, map export, node counts, and structural validation
- update the package-parity roadmap from 353 to 351 high-consensus missing slots and from seven to six remaining Lua/Perl gaps per lane

## Why

`radix-tree` was the smallest remaining dependency-safe leaf in the paired Lua/Perl high-consensus wave. A pure port closes two portable-core gaps without introducing new package dependencies.

## Impact

Lua and Perl users now have package-native compressed prefix trees whose behavior matches the established radix-tree implementations. The new tests exercise split and merge cases, Unicode labels, empty keys, sorted enumeration, and 200-key mixed mutation comparisons against native maps.

## Validation

- `luarocks lint coding-adventures-radix-tree-0.1.0-1.rockspec`
- `luarocks make --local --deps-mode=none coding-adventures-radix-tree-0.1.0-1.rockspec`
- Lua Busted suite: 8 successes
- `perl -Ilib -c lib/CodingAdventures/RadixTree.pm`
- `perl -Ilib t/00-load.t`
- `perl -Ilib t/01-radix-tree.t`: 8 subtests passed
- package parity reporter tests: 6 passed
- `package_parity_report.py --format json --fail-on-collisions`
- capability JSON parsing and `git diff --check`
