### PR TITLE
feat(adj-facts-stdlib): physics/simple-machines — simple machine → everyday example table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_simplemachines_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_simplemachines_e2e.rs
@@ -1,0 +1,78 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/simple-machines.adj`) driven through the built CLI:
+//! a native `table` of simple-machine → everyday example resolves a binding
+//! query recall with the NASA citation, runs backward (example → machine), and
+//! abstains on something that is not one of the six simple machines — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factssm_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn physics_simple_machines_recall_binds_example_with_citation() {
+    let dir = scratch("simplemachines");
+    // Copy the shipped physics table beside the entry program and import it.
+    let src = facts_stdlib().join("physics/simple-machines.adj");
+    std::fs::copy(&src, dir.join("simple-machines.adj")).expect("copy shipped simple-machines.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"simple-machines.adj\"\n\
+         ? simple_machine_example(lever, $Ex)\n\
+         ? simple_machine_example(inclined_plane, $Ex)\n\
+         ? simple_machine_example(pulley, $Ex)\n\
+         ? simple_machine_example($M, seesaw)\n\
+         ? simple_machine_example(gear, $Ex)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward lookups bind each machine to the everyday example NASA names.
+    assert!(out.contains("\"Ex\":\"seesaw\""), "lever binds to seesaw: {out}");
+    assert!(
+        out.contains("simple_machine_example(lever, seesaw)"),
+        "lever is governing-bound to seesaw: {out}"
+    );
+    assert!(
+        out.contains("simple_machine_example(inclined_plane, ramp)"),
+        "inclined_plane is governing-bound to ramp: {out}"
+    );
+    assert!(
+        out.contains("simple_machine_example(pulley, elevator)"),
+        "pulley is governing-bound to elevator: {out}"
+    );
+    // The relation runs BACKWARD: bind the example, recall the machine.
+    assert!(
+        out.contains("simple_machine_example(lever, seesaw)"),
+        "reverse recall binds M=lever from seesaw: {out}"
+    );
+    // The answer carries the NASA locator + trust tier as its proof.
+    assert!(
+        out.contains("nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A gear is NOT one of the six simple machines — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "gear abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -37,7 +37,8 @@ per rotation, in parallel):
 | `nutrition/` | common food → MyPlate food group | USDA MyPlate |
 | `agriculture/` | farm animal → product it gives | Iowa State University (CFSPH) |
 | `biology/` | common bone → body region | NIH / MedlinePlus |
-| … | *physics, geography, anatomy, physical constants, …* | *(expanding)* |
+| `physics/` | simple machine → everyday example | NASA |
+| … | *geography, anatomy, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown
 in `adj-formula-stdlib/<subject>/` using the `formula` construct — simple ones first, growing

--- a/code/specs/data/adj-facts-stdlib/physics/simple-machines.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/simple-machines.adj
@@ -1,0 +1,110 @@
+% ============================================================================
+% simple-machines — each of the six classical simple machines and a common
+% everyday EXAMPLE of it (adj-facts-stdlib, PHYSICS).
+% ============================================================================
+% An elementary/middle-school physics fact on the way to mechanics: there are
+% SIX classical simple machines — the basic devices that change the direction
+% or amount of a force to make work easier — and each one shows up in an
+% everyday object a child already knows. Recall is a binding query:
+%
+%     ? simple_machine_example(lever, $Ex)   % seesaw
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `simple_machine_example(machine, example)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the everyday example WITH its source, on the CPU, with zero model
+% calls, and abstains on anything that is not one of the six simple machines.
+%
+% The six simple machines, as a little truth table (machine → what it does →
+% the everyday object the source names):
+%
+%     machine          what it does (NASA)               everyday example
+%     --------------   -------------------------------   ----------------
+%     lever            moves an object over a fulcrum     seesaw
+%     inclined_plane   angled surface, move things up     ramp
+%     wedge            two planes that split/separate     door_stop
+%     screw            fastens two objects together       bottle_cap
+%     wheel_and_axle   wheel on an axle turns a load      bicycle
+%     pulley           wheel+axle changes force direction elevator
+%
+% This is the concrete rung a physics learner reasons UP from: before reasoning
+% about mechanical advantage, torque, or friction, a student first learns to
+% NAME the six machines and point to one in the room. The query also runs
+% BACKWARD — bind the example and recall the machine it is an instance of:
+%
+%     ? simple_machine_example($M, seesaw)   % lever — reverse recall
+%
+% Something that is not one of the six machines — a gear, a spring, an engine —
+% has no row, so a recall on it ABSTAINS rather than inventing an example. That
+% honest-abstention property is what makes the table safe to reason from.
+%
+% Each `example` value is a SINGLE lowercase snake_case atom, chosen to be a
+% faithful short paraphrase of an example the source explicitly states for that
+% machine — never an object the source does not list. Where NASA lists two
+% examples for a machine, we carry the FIRST everyday one (for the screw, whose
+% first listed "example" is the word "screw" itself, we carry the second,
+% "bottle caps", so the example is a distinct everyday object).
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every machine→example pair
+% was read out of a fetched NASA education page this session, and any machine
+% that could not be grounded there would have been dropped). All six spans come
+% from the SAME primary U.S. government source, NASA's Next Gen STEM "Simple
+% Machines" classroom-connection educator notes
+% (nasa.gov/wp-content/uploads/2022/06/simple_machines_classroom_connection_508.pdf),
+% each quoted here character-for-character so any reader can re-check it. The
+% document first states the set —
+%
+%   "There are six simple machines: screw, inclined plane, wedge, lever, wheel
+%    and axle, and pulley."
+%
+% — and then defines each with examples:
+%
+%   lever → seesaw
+%     "Lever: uses a surface situated on a fulcrum (pivoting point) to move an
+%      object (examples: seesaw, scissors)"
+%
+%   inclined_plane → ramp
+%     "Inclined Plane: uses an angled plane, or surface, to move objects more
+%      easily (examples: ramp, stairs)"
+%
+%   wedge → door_stop
+%     "Wedge: uses two inclined converging planes in order to split, or
+%      separate, objects (examples: door stop, knife)"
+%
+%   screw → bottle_cap
+%     "Screw: helps to fasten two objects together (examples: screw, bottle
+%      caps)"
+%
+%   wheel_and_axle → bicycle
+%     "Wheel and axle: a wheel attached to an axle used to turn or move a load
+%      (examples: bicycle, clock)"
+%
+%   pulley → elevator
+%     "Pulley: uses a wheel and axle to change the direction of an object
+%      (examples: elevator, water well)"
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the NASA sentence that fixes the
+% first row (lever → seesaw). Every OTHER row's per-fact source and verbatim
+% span is listed above, so each example remains independently checkable. The
+% source is a primary U.S. government NASA education page (nasa.gov), so
+% `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table simple_machine_example {
+    columns machine, example
+
+    row (lever, seesaw)
+    row (inclined_plane, ramp)
+    row (wedge, door_stop)
+    row (screw, bottle_cap)
+    row (wheel_and_axle, bicycle)
+    row (pulley, elevator)
+
+    source "Lever: uses a surface situated on a fulcrum (pivoting point) to move an object (examples: seesaw, scissors)"
+    locator "https://www.nasa.gov/wp-content/uploads/2022/06/simple_machines_classroom_connection_508.pdf"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/physics/simple-machines.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/simple-machines.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% simple-machines.query.adj — a worked recall over the physics simple-machines library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is an everyday
+% example of a lever?": it states no physics fact — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `simple_machine_example` rows and returns the example + the table's
+% source/locator/trust. The fifth query runs the relation BACKWARD (bind the
+% example `seesaw`, recall the machine it is an instance of — the lever). A gear
+% is not one of the six simple machines, so a recall on it abstains honestly —
+% the engine never invents an example.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli simple-machines.query.adj
+% ============================================================================
+
+import "simple-machines.adj"
+
+? simple_machine_example(lever, $Ex)          % expect seesaw
+? simple_machine_example(inclined_plane, $Ex) % expect ramp
+? simple_machine_example(wheel_and_axle, $Ex) % expect bicycle
+? simple_machine_example(pulley, $Ex)         % expect elevator
+? simple_machine_example($M, seesaw)          % expect lever — reverse recall
+? simple_machine_example(gear, $Ex)           % expect abstain — a gear is not one of the six


### PR DESCRIPTION
Add a grounded ADJ facts library mapping each of the six classical simple
machines to a common everyday example, plus a worked recall query and an
end-to-end CLI test.

Rows (all six grounded, none dropped):
  lever          → seesaw
  inclined_plane → ramp
  wedge          → door_stop
  screw          → bottle_cap
  wheel_and_axle → bicycle
  pulley         → elevator

Provenance: every machine→example pair was read this session out of a fetched
primary U.S. government source — NASA Next Gen STEM "Simple Machines"
classroom-connection educator notes
(nasa.gov/wp-content/uploads/2022/06/simple_machines_classroom_connection_508.pdf).
Each row's verbatim span is quoted character-for-character in the .adj header so
it is independently re-checkable. Because the source is a primary NASA (.gov)
education page, trust = authoritative. Nothing is asserted from memory. Where
NASA lists two examples the first everyday one is carried; for the screw (whose
first listed example is the word "screw" itself) the second, "bottle caps", is
used so the example is a distinct everyday object.

The `table` lowers to a `simple_machine_example(machine, example)` ground
relation, so recall is a zero-model-call SLD binding query that returns the
example with its NASA citation, runs backward (example → machine), and abstains
on anything that is not one of the six machines. Diff is data-only (two .adj
files, one test, one README subject-index row).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
