### PR TITLE
feat(adj-facts-stdlib): chemistry/element-groups — element → periodic-table group family table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_elementgroups_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_elementgroups_e2e.rs
@@ -1,0 +1,82 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/element-groups.adj`) driven through the built
+//! CLI: a native `table` of common element → periodic-table group family
+//! resolves binding-query recalls (forward and backward) with the source's
+//! Wikipedia citation, and abstains on an element not in the table (gold) —
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factseg_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_element_group_family_recall_binds_family_with_citation() {
+    let dir = scratch("elementgroups");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/element-groups.adj");
+    std::fs::copy(&src, dir.join("element-groups.adj")).expect("copy shipped element-groups.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"element-groups.adj\"\n\
+         ? element_group_family(sodium, $Family)\n\
+         ? element_group_family(chlorine, $Family)\n\
+         ? element_group_family(iron, $Family)\n\
+         ? element_group_family($E, noble_gas)\n\
+         ? element_group_family(gold, $Family)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Sodium is an alkali metal, chlorine a halogen, iron a transition metal —
+    // the recalled families (forward binds).
+    assert!(
+        out.contains("\"Family\":\"alkali_metal\""),
+        "sodium → alkali_metal: {out}"
+    );
+    assert!(
+        out.contains("\"Family\":\"halogen\""),
+        "chlorine → halogen: {out}"
+    );
+    assert!(
+        out.contains("\"Family\":\"transition_metal\""),
+        "iron → transition_metal: {out}"
+    );
+    // The relation runs BACKWARD: bind the family noble_gas, recall an element in
+    // it — helium, the first noble gas in the table.
+    assert!(
+        out.contains("\"E\":\"helium\""),
+        "noble_gas → helium (reverse recall into the noble gases): {out}"
+    );
+    // The answer carries the Wikipedia citation as its proof, at consensus trust
+    // (a secondary encyclopedia reference, honestly tiered).
+    assert!(
+        out.contains("en.wikipedia.org/wiki/Alkali_metal")
+            && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation at consensus trust: {out}"
+    );
+    // "gold" is not in the table — honest abstention, never a fabricated family.
+    assert!(out.contains("\"abstained\":true"), "gold abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -29,6 +29,7 @@ per rotation, in parallel):
 | `astronomy/` | planet → order from the Sun | NASA |
 | `chemistry/` | element → atomic number | PubChem / NIH |
 | `chemistry/` | common substance → approximate pH | LibreTexts (consensus) |
+| `chemistry/` | element → periodic-table group family | Wikipedia (consensus) |
 | `metrology/` | SI prefix → power of ten | NIST |
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |

--- a/code/specs/data/adj-facts-stdlib/chemistry/element-groups.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/element-groups.adj
@@ -1,0 +1,121 @@
+% ============================================================================
+% element_group_family — the periodic-table GROUP FAMILY of common elements
+% (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% A middle/high-school chemistry fact set: which FAMILY of the periodic table
+% does a familiar element belong to? The periodic table sorts the elements into
+% vertical columns whose members behave alike; several of those columns have
+% names every chemistry student learns — the ALKALI METALS (soft, very reactive
+% metals like sodium and potassium), the ALKALINE EARTH METALS (magnesium,
+% calcium), the HALOGENS (reactive nonmetals like fluorine and chlorine), the
+% NOBLE GASES (unreactive gases like helium, neon, argon), and the big middle
+% block of TRANSITION METALS (iron, nickel). Recall is a binding query:
+%
+%     ? element_group_family(sodium, $Family)   % alkali_metal
+%
+% Like every FACTS library this is a native `table` (ADJ-TABLES RS-5): each
+% `row` lowers to a ground relation `element_group_family(element, family)`
+% carrying the table's citation, so the lookup above is the ordinary SLD binding
+% query — the engine returns the family WITH its source, on the CPU, with zero
+% model calls, and abstains on an element that is not in the table. It also runs
+% BACKWARD (bind a family, recall an element in it):
+%
+%     ? element_group_family($E, noble_gas)     % helium — first gas in the family
+%
+% The fourteen elements, grouped by family (a little truth table — read down
+% each family to see which elements share a column and therefore behave alike):
+%
+%     element      family                  where it sits on the table
+%     ----------   ---------------------   ------------------------------------
+%     lithium      alkali_metal            Group 1 — soft, very reactive metals
+%     sodium       alkali_metal            Group 1
+%     potassium    alkali_metal            Group 1
+%     beryllium    alkaline_earth_metal    Group 2 — reactive metals, +2 ions
+%     magnesium    alkaline_earth_metal    Group 2
+%     calcium      alkaline_earth_metal    Group 2
+%     fluorine     halogen                 Group 17 — reactive nonmetals
+%     chlorine     halogen                 Group 17
+%     bromine      halogen                 Group 17
+%     helium       noble_gas               Group 18 — unreactive gases
+%     neon         noble_gas               Group 18
+%     argon        noble_gas               Group 18
+%     iron         transition_metal        the d-block, Groups 3–12
+%     nickel       transition_metal        the d-block, Groups 3–12
+%
+% An element that is not one of these fourteen — gold, carbon, uranium — has no
+% row, so a recall on it ABSTAINS rather than inventing a family. That
+% honest-abstention property is what makes the table safe to reason from.
+%
+% The `family` value of every row is a SINGLE lowercase atom, a faithful
+% snake_case name of the family the source assigns the element to — never an
+% interpretation the source does not support.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every element→family pair
+% was read out of a fetched reference page this session, and any element that
+% could not be grounded there was dropped). The fourteen rows are fixed by FIVE
+% Wikipedia family articles, each of which names its member elements in the
+% opening text; each membership span is quoted here character-for-character so
+% any reader can re-check it:
+%
+%   alkali_metal (lithium, sodium, potassium)
+%     "The alkali metals consist of the chemical elements lithium (Li), sodium
+%      (Na), potassium (K), rubidium (Rb), caesium (Cs), and francium (Fr)."
+%     — https://en.wikipedia.org/wiki/Alkali_metal
+%
+%   alkaline_earth_metal (beryllium, magnesium, calcium)
+%     "They are beryllium (Be), magnesium (Mg), calcium (Ca), strontium (Sr),
+%      barium (Ba), and radium (Ra)."
+%     — https://en.wikipedia.org/wiki/Alkaline_earth_metal
+%
+%   halogen (fluorine, chlorine, bromine)
+%     "The halogens are a group in the periodic table consisting of six
+%      chemically related elements: fluorine (F), chlorine (Cl), bromine (Br),
+%      iodine (I), and the radioactive elements astatine (At) and tennessine
+%      (Ts)."
+%     — https://en.wikipedia.org/wiki/Halogen
+%
+%   noble_gas (helium, neon, argon)
+%     "The noble gases ... are the members of group 18 of the periodic table:
+%      helium (He), neon (Ne), argon (Ar), krypton (Kr), xenon (Xe), radon (Rn)
+%      and, in some cases, oganesson (Og)."
+%     — https://en.wikipedia.org/wiki/Noble_gas
+%
+%   transition_metal (iron, nickel)
+%     "All of the elements that are ferromagnetic near room temperature are
+%      transition metals (iron, cobalt and nickel)."
+%     — https://en.wikipedia.org/wiki/Transition_metal
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the alkali-metal sentence that
+% fixes the first rows (lithium/sodium/potassium → alkali_metal). Every OTHER
+% family's membership span and URL is listed above, so each element→family pair
+% remains independently checkable. Wikipedia is a SECONDARY reference (an
+% encyclopedia, not a primary standards body), so `trust consensus` — the honest
+% tier for an encyclopedia, per the standard-library trust convention.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table element_group_family {
+    columns element, family
+
+    row (lithium, alkali_metal)
+    row (sodium, alkali_metal)
+    row (potassium, alkali_metal)
+    row (beryllium, alkaline_earth_metal)
+    row (magnesium, alkaline_earth_metal)
+    row (calcium, alkaline_earth_metal)
+    row (fluorine, halogen)
+    row (chlorine, halogen)
+    row (bromine, halogen)
+    row (helium, noble_gas)
+    row (neon, noble_gas)
+    row (argon, noble_gas)
+    row (iron, transition_metal)
+    row (nickel, transition_metal)
+
+    source "The alkali metals consist of the chemical elements lithium (Li), sodium (Na), potassium (K), rubidium (Rb), caesium (Cs), and francium (Fr)."
+    locator "https://en.wikipedia.org/wiki/Alkali_metal"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/element-groups.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/element-groups.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% element-groups.query.adj — a worked recall over the chemistry element-groups
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what family is sodium
+% in?": it states no chemistry fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `element_group_family` rows and returns the family + the table's
+% source/locator/trust. The fourth query runs the relation BACKWARD (bind the
+% family noble_gas, recall an element that is in it — helium, the first noble
+% gas in the table). Gold is not in the table, so a recall on it abstains
+% honestly — the engine never invents a family.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli element-groups.query.adj
+% ============================================================================
+
+import "element-groups.adj"
+
+? element_group_family(sodium, $Family)    % expect alkali_metal
+? element_group_family(chlorine, $Family)  % expect halogen
+? element_group_family(iron, $Family)      % expect transition_metal
+? element_group_family($E, noble_gas)      % expect helium — reverse recall into the noble gases
+? element_group_family(gold, $Family)      % expect abstain — gold is not in the table


### PR DESCRIPTION
Add a native `table` mapping fourteen common elements to the periodic-table
GROUP FAMILY they belong to, spanning five families:

  alkali_metal          lithium, sodium, potassium
  alkaline_earth_metal  beryllium, magnesium, calcium
  halogen               fluorine, chlorine, bromine
  noble_gas             helium, neon, argon
  transition_metal      iron, nickel

Recall is the ordinary SLD binding query: element_group_family(sodium, $F)
binds alkali_metal with the source citation, runs BACKWARD (bind a family,
recall an element in it), and ABSTAINS on an element not in the table (gold)
— 0 model calls.

Provenance (nothing from memory; every element→family pair was read out of a
page fetched this session, and any that could not be grounded was dropped).
Each family's membership is fixed by the verbatim opening text of that family's
Wikipedia article:

  alkali metal          en.wikipedia.org/wiki/Alkali_metal          (consensus)
  alkaline earth metal  en.wikipedia.org/wiki/Alkaline_earth_metal  (consensus)
  halogen               en.wikipedia.org/wiki/Halogen               (consensus)
  noble gas             en.wikipedia.org/wiki/Noble_gas             (consensus)
  transition metal      en.wikipedia.org/wiki/Transition_metal      (consensus)

Wikipedia is a secondary encyclopedia reference, so trust=consensus (honest
tier per the standard-library trust convention). The table carries ONE
provenance envelope (the alkali-metal span fixing the first rows); every other
family's verbatim membership span and URL is documented inline so each pair
stays independently checkable.

Copper was DROPPED: neither its own Wikipedia article nor the RSC element page
states "transition metal" in fetchable text (only group 11 / d-block), so it
could not be cleanly grounded; iron and nickel are both named verbatim in the
transition-metal article instead.

Data-only: two new .adj files, one e2e test, one README subject-index row.
cargo test -p adj-lang -p adj-lang-cli and clippy --all-targets -D warnings
both green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
