### PR TITLE
feat(flow-matic): READ-ITEM / END OF DATA record loops (PL09 D4)

### DIFF
--- a/code/packages/rust/flow-matic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/flow-matic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.3.0 — READ-ITEM / END OF DATA record loops (PL09 D4)
+
+- `READ-ITEM <handle>` reads the next record from stdin into the file's fields:
+  the `input_more` builtin peeks whether a record remains (the EOF-aware read the
+  plain `input_i64` lacks — PL09 D4), sets the shared `_eof` flag, and reads each
+  field with `input_i64` (skipped at end-of-input, so fields keep their values).
+- `IF END OF DATA GO TO OPERATION n` now compiles — a conditional jump on the
+  `_eof` flag set by the most recent `READ-ITEM` (zero-initialised at entry, so a
+  lone one reads a defined false).
+- Completes the record-processing loop: READ → `IF END OF DATA` → process →
+  `WRITE-ITEM` → `JUMP` back. Run-verified on the VM/JIT with a stdin stream
+  ([5,3] → `5\n3\n`; multi-field; empty input → no output). `input_more` is a
+  VM/JIT builtin for now; AOT-column EOF is a follow-up (D4).
+- `TRANSFER`, `TEST`/`REWIND`/`CLOSE-OUT` remain a clean `Unsupported`.
+
 ## 0.2.0 — WRITE-ITEM → observable stdout (PL09 D4)
 
 - `WRITE-ITEM <handle>` now writes the file's record to stdout: its fields

--- a/code/packages/rust/flow-matic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/flow-matic-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flow-matic-iir-compiler"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "FLOW-MATIC (B-0) frontend for the LANG VM AOT chain — lowers a parsed FLOW-MATIC program into interpreter_ir::IIRModule so it runs on every execution backend. v0.1.0: the control-flow + scalar-field slice (operations→labels, COMPARE/IF/OTHERWISE/GO TO/JUMP/STOP, scalar-field MOVE); file record I/O is a later rung. See PL09-codegen.md."
 

--- a/code/packages/rust/flow-matic-iir-compiler/README.md
+++ b/code/packages/rust/flow-matic-iir-compiler/README.md
@@ -22,11 +22,16 @@ let module = compile_source(source, "prog")?; // interpreter_ir::IIRModule
 FLOW-MATIC is a file/record data-flow language, but its **control flow** and
 **scalar-field moves** lower with no file runtime: operations become labels,
 `COMPARE`/`IF`/`OTHERWISE`/`GO TO`/`JUMP` become the IIR's comparison and branch
-ops, `MOVE` a register copy, `WRITE-ITEM` prints the file's record (its fields via a
-synthesized digit-print helper over `putchar`), `STOP` a `ret 0`, and the
-`INPUT`/`OUTPUT`/`HSP` file declarations are no-ops. Each file-qualified field is
-an `i64` register.
+ops, `MOVE` a register copy, `READ-ITEM` reads a record from stdin into the file's
+fields (an `input_more` end-of-data peek + `input_i64` per field), `IF END OF
+DATA` branches on the resulting flag, `WRITE-ITEM` prints the file's record (its
+fields via a synthesized digit-print helper over `putchar`), `STOP` a `ret 0`,
+and the `INPUT`/`OUTPUT`/`HSP` file declarations are no-ops. Each file-qualified
+field is an `i64` register; records stream over stdin/stdout (PL09 D4 — no
+filesystem).
 
-Record input (`READ-ITEM`, which needs the EOF-aware read — PL09 D4), `TRANSFER`, tape control, and the `END OF DATA` loop are a later rung and return a descriptive error until then —
-never wrong output. See PL09 for the roadmap toward the full inventory-pricing
-program and the COBOL frontends.
+`TRANSFER` (whole-record copy) and tape control (`TEST`/`REWIND`/`CLOSE-OUT`) are
+a later rung and return a descriptive error until then — never wrong output.
+`input_more` is a VM/JIT builtin for now; the AOT-column EOF read is a follow-up
+(PL09 D4). See PL09 for the roadmap toward the full inventory-pricing program and
+the COBOL frontends.

--- a/code/packages/rust/flow-matic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/flow-matic-iir-compiler/src/lib.rs
@@ -20,15 +20,17 @@
 //! | `OTHERWISE GO TO OPERATION n` | `jmp op_n` |
 //! | `JUMP TO OPERATION n` | `jmp op_n` |
 //! | `MOVE field TO field` | `mov` between the fields' registers |
+//! | `READ-ITEM handle` | `input_more` peek → `_eof` flag, then `input_i64` per field |
+//! | `IF END OF DATA GO TO OPERATION n` | `jmp_if_true _eof, op_n` |
 //! | `WRITE-ITEM handle` | print the file's fields via `__fm_print_int`+`putchar` |
 //! | `STOP` | `ret 0` |
 //! | `INPUT`/`OUTPUT`/`HSP` (file declarations) | no-op |
 //!
 //! Each file-qualified field (`PRODUCT-NO (A)`) is a distinct `i64` register
-//! initialised to 0. `READ-ITEM` (which needs the EOF-aware input capability),
-//! `TRANSFER`, `TEST`/`REWIND`/`CLOSE-OUT`, and the `END OF DATA` loop condition
-//! are a later rung; a program that reaches one gets a clean
-//! [`CompileError::Unsupported`], never wrong output.
+//! initialised to 0; a record is read/written over the stdin/stdout stream
+//! (PL09 D4 — no filesystem). `TRANSFER` (whole-record copy) and
+//! `TEST`/`REWIND`/`CLOSE-OUT` (tape control) are a later rung; a program that
+//! reaches one gets a clean [`CompileError::Unsupported`], never wrong output.
 
 use coding_adventures_flow_matic_parser::try_parse_flow_matic;
 use interpreter_ir::function::FunctionTypeStatus;
@@ -108,6 +110,13 @@ impl Compiler {
         self.instrs.push(IIRInstr::new(op, dest.map(str::to_string), srcs, type_hint));
     }
 
+    /// A fresh unique register/label name with the given prefix.
+    fn fresh(&mut self, prefix: &str) -> String {
+        let n = self.write_counter;
+        self.write_counter += 1;
+        format!("{prefix}{n}")
+    }
+
     fn emit_program(&mut self, program: &GrammarASTNode) -> Result<(), CompileError> {
         // Pre-pass: every file-qualified field becomes an i64 register, zeroed
         // at entry (FLOW-MATIC fields start empty; a real value would arrive via
@@ -122,7 +131,7 @@ impl Compiler {
         // reads a defined `0` (false → no branch) rather than an undefined
         // register — which `module.validate()` and the backend validators do
         // NOT catch, and which would miscompile downstream.
-        for flag in [CMP_GT, CMP_EQ, CMP_LT] {
+        for flag in [CMP_GT, CMP_EQ, CMP_LT, EOF_FLAG] {
             self.emit("const", Some(flag), vec![Operand::Int(0)], "i64");
         }
 
@@ -212,6 +221,43 @@ impl Compiler {
                 Ok(())
             }
 
+            "read_item_clause" => {
+                // READ-ITEM <handle> reads the next record for the file from
+                // stdin into its fields. Per PL09 D4 the input is a stdin stream:
+                // `input_more` peeks whether a record remains (the EOF-aware read
+                // the plain `input_i64` lacks), and each field is read with
+                // `input_i64`. At end-of-input the shared EOF flag is set (read by
+                // a following `IF END OF DATA`) and the field reads are skipped.
+                let handle = first_token(inner, "NAME").ok_or_else(|| {
+                    CompileError::Malformed("READ-ITEM without a file handle".into())
+                })?;
+                let qualifier = qualifier_of_handle(&handle);
+                let suffix = format!("__{}", sanitise(&qualifier));
+                let record: Vec<String> =
+                    self.fields.iter().filter(|f| f.ends_with(&suffix)).cloned().collect();
+
+                // _eof = (input_more == 0)
+                let more = self.fresh("_more");
+                self.emit("call_builtin", Some(&more), vec![Operand::Var("input_more".into())], "i64");
+                let zero = self.fresh("_z");
+                self.emit("const", Some(&zero), vec![Operand::Int(0)], "i64");
+                self.emit("cmp_eq", Some(EOF_FLAG), vec![Operand::Var(more), Operand::Var(zero)], "i64");
+
+                // Skip the field reads at end-of-input (fields keep their values).
+                let skip = self.fresh("_rd_skip");
+                self.emit(
+                    "jmp_if_true",
+                    None,
+                    vec![Operand::Var(EOF_FLAG.into()), Operand::Var(skip.clone())],
+                    "void",
+                );
+                for field in &record {
+                    self.emit("call_builtin", Some(field), vec![Operand::Var("input_i64".into())], "i64");
+                }
+                self.emit("label", None, vec![Operand::Var(skip)], "void");
+                Ok(())
+            }
+
             "write_item_clause" => {
                 // WRITE-ITEM <handle> writes the file's record to stdout: its
                 // fields (those qualified by the handle's letter — `FILE-C` →
@@ -273,9 +319,8 @@ impl Compiler {
             Some("GREATER") => Ok(CMP_GT.to_string()),
             Some("EQUAL") => Ok(CMP_EQ.to_string()),
             Some("LESS") => Ok(CMP_LT.to_string()),
-            Some("END") => Err(CompileError::Unsupported(
-                "IF END OF DATA (the file end-of-data loop is a later rung)".into(),
-            )),
+            // END OF DATA tests the flag set by the most recent READ-ITEM.
+            Some("END") => Ok(EOF_FLAG.to_string()),
             _ => Err(CompileError::Malformed("unrecognised IF condition".into())),
         }
     }
@@ -292,6 +337,9 @@ impl Compiler {
 const CMP_GT: &str = "_cmp_gt";
 const CMP_EQ: &str = "_cmp_eq";
 const CMP_LT: &str = "_cmp_lt";
+/// The end-of-data flag the most recent `READ-ITEM` set (1 = input exhausted),
+/// read by a following `IF END OF DATA`.
+const EOF_FLAG: &str = "_eof";
 const RET_ZERO: &str = "_ret0";
 
 // ---------------------------------------------------------------------------
@@ -536,13 +584,30 @@ mod tests {
     }
 
     #[test]
-    fn record_io_is_unsupported_not_wrong() {
-        // READ-ITEM needs the file runtime — a later rung. Clean error, not a
-        // miscompile.
-        let src = "(0) READ-ITEM FILE-A ; STOP .";
-        let err = compile_source(src, "r").unwrap_err();
+    fn read_item_compiles_to_an_eof_aware_read() {
+        // READ-ITEM emits the `input_more` peek, sets the EOF flag, and reads the
+        // file's fields with `input_i64`.
+        let src = "(0) MOVE N (A) TO N (A) ; READ-ITEM FILE-A ; STOP .";
+        let module = compile_source(src, "r").unwrap();
+        assert!(module.validate().is_empty(), "{:?}", module.validate());
+        let ops: Vec<String> =
+            module.functions[0].instructions.iter().map(|i| i.op.clone()).collect();
+        // A call_builtin (input_more/input_i64) and the EOF cmp_eq are present.
+        assert!(ops.iter().filter(|o| *o == "call_builtin").count() >= 2);
+        assert!(ops.contains(&"cmp_eq".to_string()));
+        // The EOF flag is written by the READ.
+        assert!(module.functions[0]
+            .instructions
+            .iter()
+            .any(|i| i.dest.as_deref() == Some("_eof")));
+    }
+
+    #[test]
+    fn unsupported_verbs_stay_a_clean_error() {
+        // TRANSFER (whole-record copy) still needs a later rung.
+        let err = compile_source("(0) TRANSFER A TO B ; STOP .", "t").unwrap_err();
         assert!(matches!(err, CompileError::Unsupported(_)), "got {err:?}");
-        assert!(err.to_string().contains("READ-ITEM"));
+        assert!(err.to_string().contains("TRANSFER"));
     }
 
     #[test]
@@ -628,9 +693,16 @@ mod tests {
     }
 
     #[test]
-    fn end_of_data_condition_is_unsupported() {
+    fn end_of_data_condition_branches_on_the_eof_flag() {
+        // IF END OF DATA now compiles to a conditional jump on the EOF flag; a
+        // lone one (no preceding READ) reads the zero-initialised flag → false.
         let src = "(0) IF END OF DATA GO TO OPERATION 1 .\n(1) STOP .";
-        let err = compile_source(src, "e").unwrap_err();
-        assert!(matches!(err, CompileError::Unsupported(_)), "got {err:?}");
+        let module = compile_source(src, "e").unwrap();
+        assert!(module.validate().is_empty(), "{:?}", module.validate());
+        let branches_on_eof = module.functions[0].instructions.iter().any(|i| {
+            i.op == "jmp_if_true"
+                && matches!(i.srcs.first(), Some(Operand::Var(v)) if v == "_eof")
+        });
+        assert!(branches_on_eof, "END OF DATA should jmp_if_true on _eof");
     }
 }

--- a/code/packages/rust/flow-matic-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/flow-matic-iir-compiler/tests/jit_e2e.rs
@@ -11,9 +11,94 @@
 use flow_matic_iir_compiler::compile_source;
 use jit_core::core::JITCore;
 use jit_core::GenericCirJit;
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use vm_core::core::VMCore;
 use vm_core::value::Value;
+
+/// Run a program with a stdin record stream (`input`), capturing stdout. The
+/// `input_more` builtin peeks whether a record remains (the EOF-aware read from
+/// PL09 D4); `input_i64` pops the next field.
+fn run_pipe(source: &str, input: &[i64]) -> String {
+    let mut module = compile_source(source, "fm_pipe").expect("FLOW-MATIC should compile");
+    let mut vm = VMCore::new();
+    let queue: Arc<Mutex<VecDeque<i64>>> = Arc::new(Mutex::new(input.iter().copied().collect()));
+    let chars: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    {
+        let queue = Arc::clone(&queue);
+        vm.builtins_mut().register("input_more", move |_args| {
+            Ok(Value::Int(if queue.lock().unwrap().is_empty() { 0 } else { 1 }))
+        });
+    }
+    {
+        let queue = Arc::clone(&queue);
+        vm.builtins_mut().register("input_i64", move |_args| {
+            Ok(Value::Int(queue.lock().unwrap().pop_front().unwrap_or(0)))
+        });
+    }
+    {
+        let chars = Arc::clone(&chars);
+        vm.builtins_mut().register("putchar", move |args| {
+            let b = args.first().and_then(|v| v.as_i64()).unwrap_or(0);
+            chars.lock().unwrap().push(b as u8);
+            Ok(Value::Null)
+        });
+    }
+    let backend = GenericCirJit::new();
+    let error_handle = backend.error_handle();
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+    jit.execute_with_jit(&mut vm, &mut module, "main", &[])
+        .expect("JIT execution should succeed");
+    if let Some(err) = error_handle.lock().unwrap().clone() {
+        panic!("GenericCirJit reported an error: {err}");
+    }
+    let bytes = chars.lock().unwrap().clone();
+    String::from_utf8(bytes).expect("output must be valid UTF-8")
+}
+
+#[test]
+fn read_process_write_loop_echoes_records_until_end_of_data() {
+    // The canonical record-processing shape: READ a record, IF END OF DATA stop,
+    // else MOVE a field to the output record, WRITE it, and JUMP back. Feeding
+    // two records [5, 3] must echo "5\n3\n" then halt at end-of-data.
+    let src = "\
+(0) INPUT SRC FILE-A ; OUTPUT OUT FILE-C .
+(1) READ-ITEM FILE-A ; IF END OF DATA GO TO OPERATION 4 .
+(2) MOVE N (A) TO N (C) ; WRITE-ITEM FILE-C .
+(3) JUMP TO OPERATION 1 .
+(4) STOP .";
+    assert_eq!(run_pipe(src, &[5, 3]), "5\n3\n");
+}
+
+#[test]
+fn read_loop_over_empty_input_writes_nothing() {
+    // No records → the first READ hits end-of-data and the loop stops before any
+    // WRITE.
+    let src = "\
+(0) INPUT SRC FILE-A ; OUTPUT OUT FILE-C .
+(1) READ-ITEM FILE-A ; IF END OF DATA GO TO OPERATION 4 .
+(2) MOVE N (A) TO N (C) ; WRITE-ITEM FILE-C .
+(3) JUMP TO OPERATION 1 .
+(4) STOP .";
+    assert_eq!(run_pipe(src, &[]), "");
+}
+
+#[test]
+fn read_multi_field_record_reads_fields_in_order() {
+    // A two-field input record: READ pulls Q (A) then UP (A) (sorted field
+    // order), and WRITE emits both, space-separated.
+    // The MOVEs reference Q (A) and UP (A) so they are modelled as fields of
+    // file A (fields are discovered from `field` nodes; READ-ITEM/WRITE-ITEM name
+    // only the handle).
+    let src = "\
+(0) INPUT SRC FILE-A ; OUTPUT OUT FILE-A .
+(1) READ-ITEM FILE-A ; IF END OF DATA GO TO OPERATION 4 .
+(2) MOVE Q (A) TO Q (A) ; MOVE UP (A) TO UP (A) ; WRITE-ITEM FILE-A .
+(3) JUMP TO OPERATION 1 .
+(4) STOP .";
+    // Fields Q(A), UP(A) sort as [Q, UP]; input [3, 100] → "3 100\n".
+    assert_eq!(run_pipe(src, &[3, 100]), "3 100\n");
+}
 
 /// Run a program capturing everything WRITE-ITEM emits through `putchar`.
 fn run_output(source: &str) -> String {


### PR DESCRIPTION
## Summary

**The payoff of the D4 decision:** FLOW-MATIC's core record-processing loop now
runs end-to-end with real field values — **no file-open primitive**, everything
over the stdin/stdout stream.

```
(1) READ-ITEM FILE-A ; IF END OF DATA GO TO OPERATION 4 .
(2) MOVE N (A) TO N (C) ; WRITE-ITEM FILE-C .
(3) JUMP TO OPERATION 1 .
(4) STOP .
```
Feeding `[5, 3]` → `5\n3\n`.

## What it does (`flow-matic-iir-compiler` 0.3.0)
- **`READ-ITEM <handle>`** reads the next record into the file's fields: the
  `input_more` builtin peeks whether a record remains (the EOF-aware read the
  plain `input_i64` lacks — the one gap D4 identified), sets the shared `_eof`
  flag, and reads each field with `input_i64` (skipped at end-of-input, so fields
  keep their values).
- **`IF END OF DATA GO TO OPERATION n`** → `jmp_if_true` on the `_eof` flag set by
  the most recent `READ-ITEM` (`_eof` zero-initialised at entry, so a lone one
  reads a defined false).

## Verified
- 18 tests: 8 unit, 3 `backend_compat`, **7 `jit_e2e`** — including 3 that run
  record-processing pipelines on the VM/JIT with a real stdin stream
  (`[5,3]`→`5\n3\n`; a multi-field record; empty input → no output).
- **Security review PASSED** — `_eof` defined on all paths, no undefined-register
  miscompile, no panics, deterministic field order.
- `input_more` is a VM/JIT builtin for now; the AOT-column EOF read is a
  documented follow-up (D4).

## Next (per PL09)
Multi-file programs (in-memory record arrays) → the full inventory-pricing
program, then the `cobol-iir-compiler` and the two `*-to-semantic-ir` frontends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)