### PR TITLE
feat(sql): division / modulo by zero returns NULL

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.35 — Division / modulo by zero returns NULL
+
+`SELECT 5/0`, `5.0/0`, `0/0`, `5%0`, `5.5%0`, and `5%0.0` now return **NULL**
+like real SQLite, instead of failing the query with a "division by zero" error.
+This makes per-row expressions with an occasional zero divisor
+(`SELECT 100/n FROM t`) behave as SQLite does — the zero-divisor row is NULL and
+the rest compute normally. Four differential-oracle cases added; sql-vm 0.4.17.
+(Follow-ups: `%` integer-remainder semantics and unary `-` numeric coercion on
+text are tracked separately.)
+
 ## 0.5.34 — Column-defined COLLATE honoured in ORDER BY
 
 A column declared with `COLLATE NOCASE` / `RTRIM` now drives ordering when a

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.34"
+version = "0.5.35"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1202,6 +1202,37 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id FROM t WHERE name COLLATE NOCASE = 'apple' ORDER BY id",
     },
+    // ---- Lane 2: division / modulo by zero → NULL ------------------------
+    // SQLite yields NULL (not an error) for any division or modulo by zero,
+    // integer or float, including 0/0. Aliased so both engines name the columns
+    // identically.
+    Case {
+        id: "div_by_zero_is_null",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (5 / 0) AS a, (5.0 / 0) AS b, (0 / 0) AS c, (5 / 0.0) AS d FROM t",
+    },
+    Case {
+        id: "mod_by_zero_is_null",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (5 % 0) AS a, (5.5 % 0) AS b, (5 % 0.0) AS c FROM t",
+    },
+    // Per-row: a computed zero divisor (`n - n`) yields NULL for that row
+    // instead of aborting the whole query.
+    Case {
+        id: "div_by_computed_zero_is_null_per_row",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, n INTEGER)",
+            "INSERT INTO t VALUES (1,4),(2,0),(3,10)",
+        ],
+        query: "SELECT id, (100 / n) AS q FROM t ORDER BY id",
+    },
+    // Non-zero division/modulo still compute normally (regression guard: the
+    // NULL path must not swallow ordinary divisors).
+    Case {
+        id: "div_mod_nonzero_unaffected",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (7 / 2) AS a, (-7 / 2) AS b, (7 % 3) AS c, (7.0 / 2) AS d FROM t",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.17] - Unreleased
+
+### Changed
+
+- **Division and modulo by zero now yield `NULL`, not an error.** `x / 0`,
+  `x % 0`, `x / 0.0`, `x % 0.0`, and `0 / 0` return `SqlValue::Null` — matching
+  SQLite, where a zero divisor is a NULL result rather than a runtime failure.
+  Previously the VM raised `VmError::DivisionByZero`, which aborted the whole
+  query (a statement that runs fine in SQLite would hard-fail in mini-sqlite).
+  Applies to both integer and float zero divisors; the `Mod` arm also gained the
+  missing float-zero check (`5.5 % 0.0` → `NULL` instead of `NaN`). NULL operands
+  are still short-circuited to NULL upstream, and non-zero division/modulo is
+  unchanged. `VmError::DivisionByZero` is retained but no longer constructed.
+
 ## [0.4.16] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.16"
+version = "0.4.17"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1899,10 +1899,13 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
         BinaryOp::Sub => checked_int_binop(l, r, i64::checked_sub, |a, b| a - b, "subtraction"),
         BinaryOp::Mul => checked_int_binop(l, r, i64::checked_mul, |a, b| a * b, "multiplication"),
         BinaryOp::Div => {
-            // Division by zero → VmError.
+            // SQLite returns NULL for division by zero (integer OR float) — e.g.
+            // `SELECT 5/0`, `5.0/0`, and `0/0` all yield NULL, never an error.
+            // NULL operands were already short-circuited above, so a zero divisor
+            // here is a genuine value. `*f == 0.0` also matches `-0.0`.
             match (&l, &r) {
-                (_, SqlValue::Int(0)) => Err(VmError::DivisionByZero),
-                (_, SqlValue::Float(f)) if *f == 0.0 => Err(VmError::DivisionByZero),
+                (_, SqlValue::Int(0)) => Ok(SqlValue::Null),
+                (_, SqlValue::Float(f)) if *f == 0.0 => Ok(SqlValue::Null),
                 (SqlValue::Int(a), SqlValue::Int(b)) => {
                     a.checked_div(*b).map(SqlValue::Int).ok_or_else(|| {
                         VmError::TypeMismatch("integer overflow in division".to_string())
@@ -1918,7 +1921,10 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
             }
         }
         BinaryOp::Mod => match (&l, &r) {
-            (_, SqlValue::Int(0)) => Err(VmError::DivisionByZero),
+            // Like division, modulo by zero is NULL in SQLite (`5%0`, `5.5%0`,
+            // `5%0.0` → NULL), including a float-zero divisor — not an error.
+            (_, SqlValue::Int(0)) => Ok(SqlValue::Null),
+            (_, SqlValue::Float(f)) if *f == 0.0 => Ok(SqlValue::Null),
             (SqlValue::Int(a), SqlValue::Int(b)) => {
                 a.checked_rem(*b).map(SqlValue::Int).ok_or_else(|| {
                     VmError::TypeMismatch("integer overflow in modulo".to_string())
@@ -3149,15 +3155,32 @@ mod tests {
     }
 
     #[test]
-    fn test_div_by_zero_returns_error() {
+    fn test_div_and_mod_by_zero_return_null() {
+        // SQLite yields NULL (not an error) for `x / 0` and `x % 0`, for both
+        // integer and float zero divisors.
         let mut b = InMemoryBackend::new();
-        let err = execute(&prog(vec![
-            Instruction::LoadConst(int(1)),
-            Instruction::LoadConst(int(0)),
-            Instruction::BinaryOpInstr(BinaryOp::Div),
-            Instruction::Halt,
-        ]), &mut b);
-        assert!(matches!(err, Err(VmError::DivisionByZero)));
+        for op in [BinaryOp::Div, BinaryOp::Mod] {
+            for divisor in [int(0), SqlValue::Float(0.0)] {
+                let r = execute(
+                    &prog(vec![
+                        Instruction::BeginRow,
+                        Instruction::LoadConst(int(5)),
+                        Instruction::LoadConst(divisor.clone()),
+                        Instruction::BinaryOpInstr(op.clone()),
+                        Instruction::EmitColumn("r".to_string()),
+                        Instruction::EmitRow,
+                        Instruction::Halt,
+                    ]),
+                    &mut b,
+                )
+                .unwrap();
+                assert_eq!(
+                    r.rows,
+                    vec![vec![SqlValue::Null]],
+                    "{op:?} by {divisor:?} should be NULL"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Lane 2 (operators): division / modulo by zero → NULL

The sql-vm arithmetic evaluator raised `VmError::DivisionByZero` for `x / 0` and `x % 0`, which **aborted the entire query**. Real SQLite instead returns **NULL** for any zero divisor — so a statement that runs fine in SQLite hard-failed in mini-sqlite.

```sql
SELECT 5 / 0;      -- SQLite: NULL     mini-sqlite (before): ERROR
SELECT 5.0 / 0;    -- NULL
SELECT 0 / 0;      -- NULL
SELECT 5 % 0;      -- NULL
SELECT 5.5 % 0;    -- NULL
SELECT 100 / n FROM t;  -- per row: NULL where n=0, normal otherwise
```

### Change
Both the `Div` and `Mod` arms now return `SqlValue::Null` for an integer **or** float zero divisor (the zero guards sit first, before any arithmetic). The `Mod` arm also gained the previously-missing float-zero check (`5.5 % 0.0` returned `NaN`; now NULL). NULL operands are still short-circuited upstream, and non-zero division/modulo is unchanged. `VmError::DivisionByZero` is retained (public error type) but no longer constructed.

### Probing
Verified against real `sqlite3`: `typeof(5/0)` = `null`, `0/0` = NULL, `5.5%0` = NULL, `5%0.0` = NULL — all cases.

### Tests
- 4 differential-oracle cases against real bundled SQLite: constant zero, float zero, `0/0`, per-row computed zero (`100/n`), plus a **non-zero regression guard** (`7/2`, `-7/2`, `7%3`, `7.0/2` still compute).
- VM unit test covering Div/Mod × {int, float} zero divisors.
- Downstream consumers (mini-sqlite, storage-sqlite) green.

### Security
Adversarial subagent review: **clean** — no zero can slip through to `checked_div`/`checked_rem` or the float paths; guards catch `-0.0` too; no panic/overflow introduced.

### Follow-ups (spun off separately)
- `%` integer-remainder semantics: `7.5 % 2` should be `1.0`, not `1.5` (SQLite truncates operands to int for `%`).
- Unary `-` numeric coercion on text: `-'3.5'` should be `-3.5`, not `Text("3.5")`.

Versions: sql-vm 0.4.17, mini-sqlite 0.5.35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
