### PR TITLE
feat: port RESP protocol to Lua and Perl

### DIFF
--- a/code/packages/lua/resp-protocol/BUILD
+++ b/code/packages/lua/resp-protocol/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-resp-protocol-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/resp-protocol/BUILD_windows
+++ b/code/packages/lua/resp-protocol/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-resp-protocol-0.1.0-1.rockspec
+cd tests && set LUA_PATH=..\src\?.lua;..\src\?\init.lua;; && busted . --verbose --pattern=test_

--- a/code/packages/lua/resp-protocol/CHANGELOG.md
+++ b/code/packages/lua/resp-protocol/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Lua RESP2 package with typed values, binary-safe encoding, incremental
+  decoding, inline commands, concatenated frames, and a streaming decoder.

--- a/code/packages/lua/resp-protocol/README.md
+++ b/code/packages/lua/resp-protocol/README.md
@@ -1,0 +1,24 @@
+# coding-adventures-resp-protocol
+
+A dependency-free Lua 5.4 encoder and incremental decoder for the Redis
+Serialization Protocol (RESP2). The package preserves simple strings, errors,
+integers, bulk strings, arrays, and the distinct null bulk/array wire types.
+
+```lua
+local resp = require("coding_adventures.resp_protocol")
+
+local command = resp.Value.array({
+    resp.Value.bulk_string("SET"),
+    resp.Value.bulk_string("key"),
+    resp.Value.bulk_string("value"),
+})
+
+local wire = resp.encode(command)
+local decoded, next_offset = resp.decode(wire)
+assert(resp.equal(command, decoded))
+assert(next_offset == #wire + 1)
+```
+
+Bulk strings are binary-safe. `decode` returns `nil` without consuming bytes
+for incomplete input, while malformed frames raise an error. `Decoder` handles
+arbitrary stream fragmentation and multiple messages per chunk.

--- a/code/packages/lua/resp-protocol/coding-adventures-resp-protocol-0.1.0-1.rockspec
+++ b/code/packages/lua/resp-protocol/coding-adventures-resp-protocol-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-resp-protocol"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "RESP2 encoder and incremental streaming decoder",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.resp_protocol"] = "src/coding_adventures/resp_protocol/init.lua",
+    },
+}

--- a/code/packages/lua/resp-protocol/required_capabilities.json
+++ b/code/packages/lua/resp-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/resp-protocol",
+  "capabilities": [],
+  "justification": "Pure byte-string codec. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/lua/resp-protocol/src/coding_adventures/resp_protocol/init.lua
+++ b/code/packages/lua/resp-protocol/src/coding_adventures/resp_protocol/init.lua
@@ -1,0 +1,428 @@
+--- RESP2 typed values, binary-safe encoding, and incremental decoding.
+
+local M = { VERSION = "0.1.0" }
+
+local MAX_BULK_LENGTH = 512 * 1024 * 1024
+local MAX_ARRAY_LENGTH = 1000000
+local MAX_NESTING_DEPTH = 128
+
+local valid_kinds = {
+    simple_string = true,
+    error = true,
+    integer = true,
+    bulk_string = true,
+    array = true,
+}
+
+local Value = {}
+Value.__index = Value
+
+local function is_value(value)
+    return type(value) == "table" and getmetatable(value) == Value
+end
+
+local function assert_string(value, name, level)
+    if type(value) ~= "string" then
+        error(name .. " must be a string", level or 3)
+    end
+end
+
+local function assert_integer(value, name, level)
+    if type(value) ~= "number" or math.type(value) ~= "integer" then
+        error(name .. " must be an integer", level or 3)
+    end
+end
+
+local function copy_values(values)
+    local result = {}
+    for index, value in ipairs(values) do
+        if not is_value(value) then
+            error(string.format("array value[%d] must be a RESP Value", index), 4)
+        end
+        result[index] = value
+    end
+    return result
+end
+
+function Value.new(kind, value)
+    if not valid_kinds[kind] then
+        error("invalid RESP kind: " .. tostring(kind), 2)
+    end
+
+    local result = { kind = kind, value = value, is_null = false }
+    if kind == "simple_string" or kind == "error" then
+        assert_string(value, kind .. " value", 2)
+        if value:find("\r", 1, true) or value:find("\n", 1, true) then
+            error(kind .. " value must not contain CR or LF", 2)
+        end
+        if kind == "error" then
+            local error_type, detail = value:match("^(%S+)%s?(.*)$")
+            result.error_type = error_type or ""
+            result.detail = detail or ""
+        end
+    elseif kind == "integer" then
+        assert_integer(value, "integer value", 2)
+    elseif kind == "bulk_string" then
+        if value == nil then
+            result.is_null = true
+        else
+            assert_string(value, "bulk_string value", 2)
+        end
+    elseif kind == "array" then
+        if value == nil then
+            result.is_null = true
+        elseif type(value) ~= "table" then
+            error("array value must be a table or nil", 2)
+        else
+            result.value = copy_values(value)
+        end
+    end
+    return setmetatable(result, Value)
+end
+
+function Value.simple_string(value)
+    return Value.new("simple_string", value)
+end
+
+function Value.error(value)
+    return Value.new("error", value)
+end
+
+function Value.integer(value)
+    return Value.new("integer", value)
+end
+
+function Value.bulk_string(value)
+    return Value.new("bulk_string", value)
+end
+
+function Value.null_bulk_string()
+    return Value.new("bulk_string", nil)
+end
+
+function Value.array(value)
+    return Value.new("array", value)
+end
+
+function Value.null_array()
+    return Value.new("array", nil)
+end
+
+Value.__tostring = function(self)
+    if self.is_null then
+        return self.kind .. "(null)"
+    end
+    if self.kind == "array" then
+        return string.format("array(%d values)", #self.value)
+    end
+    return string.format("%s(%s)", self.kind, tostring(self.value))
+end
+
+local function equal(left, right)
+    if not is_value(left) or not is_value(right) then
+        return false
+    end
+    if left.kind ~= right.kind or left.is_null ~= right.is_null then
+        return false
+    end
+    if left.is_null then
+        return true
+    end
+    if left.kind ~= "array" then
+        return left.value == right.value
+    end
+    if #left.value ~= #right.value then
+        return false
+    end
+    for index = 1, #left.value do
+        if not equal(left.value[index], right.value[index]) then
+            return false
+        end
+    end
+    return true
+end
+
+Value.__eq = equal
+
+local function encode_simple_string(value)
+    return "+" .. Value.simple_string(value).value .. "\r\n"
+end
+
+local function encode_error(value)
+    return "-" .. Value.error(value).value .. "\r\n"
+end
+
+local function encode_integer(value)
+    assert_integer(value, "value", 2)
+    return ":" .. tostring(value) .. "\r\n"
+end
+
+local function encode_bulk_string(value)
+    if value == nil then
+        return "$-1\r\n"
+    end
+    assert_string(value, "value", 2)
+    if #value > MAX_BULK_LENGTH then
+        error("bulk string exceeds maximum length", 2)
+    end
+    return "$" .. tostring(#value) .. "\r\n" .. value .. "\r\n"
+end
+
+local encode
+
+local function encode_array(values)
+    if values == nil then
+        return "*-1\r\n"
+    end
+    if type(values) ~= "table" then
+        error("values must be a table or nil", 2)
+    end
+    if #values > MAX_ARRAY_LENGTH then
+        error("array exceeds maximum length", 2)
+    end
+    local parts = { "*", tostring(#values), "\r\n" }
+    for _, value in ipairs(values) do
+        parts[#parts + 1] = encode(value)
+    end
+    return table.concat(parts)
+end
+
+local function encode_value(value)
+    if value.kind == "simple_string" then
+        return encode_simple_string(value.value)
+    elseif value.kind == "error" then
+        return encode_error(value.value)
+    elseif value.kind == "integer" then
+        return encode_integer(value.value)
+    elseif value.kind == "bulk_string" then
+        return encode_bulk_string(value.is_null and nil or value.value)
+    elseif value.kind == "array" then
+        return encode_array(value.is_null and nil or value.value)
+    end
+    error("invalid RESP kind: " .. tostring(value.kind), 2)
+end
+
+encode = function(value)
+    if is_value(value) then
+        return encode_value(value)
+    elseif value == nil then
+        return encode_bulk_string(nil)
+    elseif type(value) == "boolean" then
+        return encode_integer(value and 1 or 0)
+    elseif type(value) == "number" then
+        return encode_integer(value)
+    elseif type(value) == "string" then
+        return encode_bulk_string(value)
+    elseif type(value) == "table" then
+        return encode_array(value)
+    end
+    error("cannot encode value of type " .. type(value), 2)
+end
+
+local function encode_many(values)
+    if type(values) ~= "table" then
+        error("values must be a table", 2)
+    end
+    local result = {}
+    for index, value in ipairs(values) do
+        result[index] = encode(value)
+    end
+    return table.concat(result)
+end
+
+local function read_line(data, offset)
+    local line_end = data:find("\r\n", offset, true)
+    if line_end == nil then
+        return nil, offset
+    end
+    return data:sub(offset, line_end - 1), line_end + 2
+end
+
+local function parse_integer(text, context)
+    if not text:match("^-?%d+$") then
+        error("invalid " .. context .. ": " .. text, 3)
+    end
+    local value = tonumber(text)
+    if value == nil or math.type(value) ~= "integer" then
+        error(context .. " is outside the signed 64-bit range", 3)
+    end
+    return value
+end
+
+local decode_value
+
+decode_value = function(data, offset, depth)
+    if depth > MAX_NESTING_DEPTH then
+        error("RESP array nesting exceeds maximum depth", 3)
+    end
+    if offset > #data then
+        return nil, offset
+    end
+
+    local prefix = data:sub(offset, offset)
+    if prefix == "+" or prefix == "-" or prefix == ":" then
+        local line, next_offset = read_line(data, offset + 1)
+        if line == nil then
+            return nil, offset
+        end
+        if prefix == "+" then
+            return Value.simple_string(line), next_offset
+        elseif prefix == "-" then
+            return Value.error(line), next_offset
+        end
+        return Value.integer(parse_integer(line, "RESP integer")), next_offset
+    elseif prefix == "$" then
+        local length_text, payload_offset = read_line(data, offset + 1)
+        if length_text == nil then
+            return nil, offset
+        end
+        local length = parse_integer(length_text, "bulk length")
+        if length == -1 then
+            return Value.null_bulk_string(), payload_offset
+        elseif length < -1 then
+            error("invalid negative bulk length: " .. tostring(length), 3)
+        elseif length > MAX_BULK_LENGTH then
+            error("bulk length exceeds maximum", 3)
+        end
+
+        local terminator_offset = payload_offset + length
+        if terminator_offset + 1 > #data then
+            return nil, offset
+        end
+        if data:sub(terminator_offset, terminator_offset + 1) ~= "\r\n" then
+            error("bulk string missing trailing CRLF", 3)
+        end
+        local payload = data:sub(payload_offset, terminator_offset - 1)
+        return Value.bulk_string(payload), terminator_offset + 2
+    elseif prefix == "*" then
+        local count_text, cursor = read_line(data, offset + 1)
+        if count_text == nil then
+            return nil, offset
+        end
+        local count = parse_integer(count_text, "array length")
+        if count == -1 then
+            return Value.null_array(), cursor
+        elseif count < -1 then
+            error("invalid negative array length: " .. tostring(count), 3)
+        elseif count > MAX_ARRAY_LENGTH then
+            error("array length exceeds maximum", 3)
+        end
+
+        local values = {}
+        for index = 1, count do
+            local value, next_offset = decode_value(data, cursor, depth + 1)
+            if value == nil then
+                return nil, offset
+            end
+            values[index] = value
+            cursor = next_offset
+        end
+        return Value.array(values), cursor
+    end
+
+    local line, next_offset = read_line(data, offset)
+    if line == nil then
+        return nil, offset
+    end
+    local values = {}
+    for token in line:gmatch("%S+") do
+        values[#values + 1] = Value.bulk_string(token)
+    end
+    return Value.array(values), next_offset
+end
+
+local function decode(data, offset)
+    assert_string(data, "data", 2)
+    offset = offset == nil and 1 or offset
+    assert_integer(offset, "offset", 2)
+    if offset < 1 or offset > #data + 1 then
+        error("offset is outside data", 2)
+    end
+    return decode_value(data, offset, 0)
+end
+
+local function decode_all(data, offset)
+    assert_string(data, "data", 2)
+    offset = offset == nil and 1 or offset
+    assert_integer(offset, "offset", 2)
+    if offset < 1 or offset > #data + 1 then
+        error("offset is outside data", 2)
+    end
+
+    local values = {}
+    local cursor = offset
+    while cursor <= #data do
+        local value, next_offset = decode_value(data, cursor, 0)
+        if value == nil then
+            break
+        end
+        values[#values + 1] = value
+        cursor = next_offset
+    end
+    return values, cursor
+end
+
+local Decoder = {}
+Decoder.__index = Decoder
+
+function Decoder.new()
+    return setmetatable({ _buffer = "", _queue = {} }, Decoder)
+end
+
+function Decoder:feed(data)
+    assert_string(data, "data", 2)
+    self._buffer = self._buffer .. data
+    local values, next_offset = decode_all(self._buffer)
+    for _, value in ipairs(values) do
+        self._queue[#self._queue + 1] = value
+    end
+    if next_offset > 1 then
+        self._buffer = self._buffer:sub(next_offset)
+    end
+    return self
+end
+
+function Decoder:has_message()
+    return #self._queue > 0
+end
+
+function Decoder:get_message()
+    if #self._queue == 0 then
+        error("no decoded message is available", 2)
+    end
+    return table.remove(self._queue, 1)
+end
+
+function Decoder:drain()
+    local result = self._queue
+    self._queue = {}
+    return result
+end
+
+function Decoder:decode_all(data)
+    self:feed(data)
+    return self:drain()
+end
+
+function Decoder:pending_bytes()
+    return #self._buffer
+end
+
+M.Value = Value
+M.Decoder = Decoder
+M.is_value = is_value
+M.equal = equal
+M.encode = encode
+M.encode_many = encode_many
+M.encode_simple_string = encode_simple_string
+M.encode_error = encode_error
+M.encode_integer = encode_integer
+M.encode_bulk_string = encode_bulk_string
+M.encode_array = encode_array
+M.decode = decode
+M.decode_all = decode_all
+M.MAX_BULK_LENGTH = MAX_BULK_LENGTH
+M.MAX_ARRAY_LENGTH = MAX_ARRAY_LENGTH
+M.MAX_NESTING_DEPTH = MAX_NESTING_DEPTH
+
+return M

--- a/code/packages/lua/resp-protocol/tests/test_resp_protocol.lua
+++ b/code/packages/lua/resp-protocol/tests/test_resp_protocol.lua
@@ -1,0 +1,146 @@
+package.path = table.concat({
+    "../src/?.lua",
+    "../src/?/init.lua",
+    package.path,
+}, ";")
+
+local resp = require("coding_adventures.resp_protocol")
+local Value = resp.Value
+
+local function assert_round_trip(value)
+    local wire = resp.encode(value)
+    local decoded, next_offset = resp.decode(wire)
+    assert.equals(#wire + 1, next_offset)
+    assert.is_true(resp.equal(value, decoded))
+end
+
+describe("RESP values", function()
+    it("constructs and validates every wire kind", function()
+        assert.equals("OK", Value.simple_string("OK").value)
+        local err = Value.error("WRONGTYPE bad value")
+        assert.equals("WRONGTYPE", err.error_type)
+        assert.equals("bad value", err.detail)
+        assert.equals(42, Value.integer(42).value)
+        assert.is_true(Value.null_bulk_string().is_null)
+        assert.is_true(Value.null_array().is_null)
+        assert.is_truthy(tostring(Value.array({})):match("0 values"))
+
+        assert.has_error(function() Value.new("unknown") end, "invalid RESP kind: unknown")
+        assert.has_error(function() Value.simple_string("bad\rline") end, "simple_string value must not contain CR or LF")
+        assert.has_error(function() Value.integer(1.5) end, "integer value must be an integer")
+        assert.has_error(function() Value.array({ "not-a-value" }) end, "array value[1] must be a RESP Value")
+    end)
+end)
+
+describe("RESP encoding", function()
+    it("encodes scalar and null values exactly", function()
+        assert.equals("+OK\r\n", resp.encode(Value.simple_string("OK")))
+        assert.equals("-ERR boom\r\n", resp.encode(Value.error("ERR boom")))
+        assert.equals(":-42\r\n", resp.encode(Value.integer(-42)))
+        assert.equals("$5\r\nhello\r\n", resp.encode(Value.bulk_string("hello")))
+        assert.equals("$0\r\n\r\n", resp.encode(Value.bulk_string("")))
+        assert.equals("$-1\r\n", resp.encode(Value.null_bulk_string()))
+        assert.equals("*-1\r\n", resp.encode(Value.null_array()))
+    end)
+
+    it("encodes binary and nested arrays", function()
+        local binary = "\0foo\r\nbar\255"
+        assert.equals("$10\r\n" .. binary .. "\r\n", resp.encode_bulk_string(binary))
+        local command = Value.array({
+            Value.bulk_string("SET"),
+            Value.bulk_string("key"),
+            Value.array({ Value.integer(1), Value.null_bulk_string() }),
+        })
+        assert.equals(
+            "*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n*2\r\n:1\r\n$-1\r\n",
+            resp.encode(command)
+        )
+        assert.equals(":1\r\n:0\r\n$1\r\nx\r\n", resp.encode_many({ true, false, "x" }))
+    end)
+end)
+
+describe("RESP decoding", function()
+    it("decodes all typed values and offsets", function()
+        local wire = "+OK\r\n-ERR boom\r\n:42\r\n$3\r\nfoo\r\n$-1\r\n*-1\r\n"
+        local values, next_offset = resp.decode_all(wire)
+        assert.equals(6, #values)
+        assert.equals(#wire + 1, next_offset)
+        assert.equals("simple_string", values[1].kind)
+        assert.equals("error", values[2].kind)
+        assert.equals(42, values[3].value)
+        assert.equals("foo", values[4].value)
+        assert.is_true(values[5].is_null)
+        assert.is_true(values[6].is_null)
+        assert.equals("array", values[6].kind)
+    end)
+
+    it("returns no value and consumes nothing for every incomplete prefix", function()
+        local full = "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"
+        for length = 0, #full - 1 do
+            local value, next_offset = resp.decode(full:sub(1, length))
+            assert.is_nil(value)
+            assert.equals(1, next_offset)
+        end
+        local value, next_offset = resp.decode(full)
+        assert.equals(#full + 1, next_offset)
+        assert.equals(3, #value.value)
+    end)
+
+    it("rejects malformed integers, lengths, and terminators", function()
+        assert.has_error(function() resp.decode(":abc\r\n") end, "invalid RESP integer: abc")
+        assert.has_error(function() resp.decode("$-2\r\n") end, "invalid negative bulk length: -2")
+        assert.has_error(function() resp.decode("*-2\r\n") end, "invalid negative array length: -2")
+        assert.has_error(function() resp.decode("$3\r\nfooXX") end, "bulk string missing trailing CRLF")
+        assert.has_error(function() resp.decode("+OK\r\n", 0) end, "offset is outside data")
+    end)
+
+    it("decodes inline commands and preserves incomplete tails", function()
+        local inline, next_offset = resp.decode("SET key value\r\n")
+        assert.equals(3, #inline.value)
+        assert.equals("SET", inline.value[1].value)
+        assert.equals(16, next_offset)
+
+        local values, tail_offset = resp.decode_all("+OK\r\n:1\r\n$5\r\nhel")
+        assert.equals(2, #values)
+        assert.equals(10, tail_offset)
+    end)
+end)
+
+describe("round trips and streaming", function()
+    it("round-trips nested and all-byte bulk values", function()
+        local bytes = {}
+        for value = 0, 255 do
+            bytes[#bytes + 1] = string.char(value)
+        end
+        assert_round_trip(Value.bulk_string(table.concat(bytes)))
+        assert_round_trip(Value.array({
+            Value.simple_string("OK"),
+            Value.error("ERR boom"),
+            Value.integer(-1),
+            Value.bulk_string("payload\0"),
+            Value.null_bulk_string(),
+            Value.array({ Value.integer(2) }),
+            Value.null_array(),
+        }))
+    end)
+
+    it("handles byte-by-byte fragmentation and multiple messages", function()
+        local expected = {
+            Value.array({ Value.bulk_string("PING") }),
+            Value.integer(42),
+            Value.error("ERR bad"),
+        }
+        local wire = resp.encode_many(expected)
+        local decoder = resp.Decoder.new()
+        for index = 1, #wire do
+            decoder:feed(wire:sub(index, index))
+        end
+        assert.equals(0, decoder:pending_bytes())
+        for _, value in ipairs(expected) do
+            assert.is_true(decoder:has_message())
+            assert.is_true(resp.equal(value, decoder:get_message()))
+        end
+        assert.is_false(decoder:has_message())
+        assert.has_error(function() decoder:get_message() end, "no decoded message is available")
+    end)
+end)

--- a/code/packages/perl/resp-protocol/BUILD
+++ b/code/packages/perl/resp-protocol/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/resp-protocol/BUILD_windows
+++ b/code/packages/perl/resp-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-resp-protocol.t

--- a/code/packages/perl/resp-protocol/CHANGELOG.md
+++ b/code/packages/perl/resp-protocol/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Perl RESP2 package with typed values, binary-safe encoding,
+  incremental decoding, inline commands, concatenated frames, and a streaming
+  decoder.

--- a/code/packages/perl/resp-protocol/Makefile.PL
+++ b/code/packages/perl/resp-protocol/Makefile.PL
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::RespProtocol',
+    VERSION_FROM     => 'lib/CodingAdventures/RespProtocol.pm',
+    ABSTRACT         => 'RESP2 encoder and incremental streaming decoder',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {},
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/resp-protocol/README.md
+++ b/code/packages/perl/resp-protocol/README.md
@@ -1,0 +1,22 @@
+# CodingAdventures::RespProtocol
+
+A dependency-free Perl encoder and incremental decoder for the Redis
+Serialization Protocol (RESP2). Typed values preserve all five RESP2 kinds and
+distinguish null bulk strings from null arrays.
+
+```perl
+use CodingAdventures::RespProtocol qw(encode decode);
+
+my $Value = 'CodingAdventures::RespProtocol::Value';
+my $command = $Value->array([
+    $Value->bulk_string('PING'),
+    $Value->bulk_string('hello'),
+]);
+
+my $wire = encode($command);
+my ($decoded, $next_offset) = @{decode($wire)};
+```
+
+Bulk strings are binary-safe. Incomplete frames return `undef` without
+consuming input; malformed frames raise an exception. The streaming decoder
+handles arbitrary fragmentation and multiple messages in one chunk.

--- a/code/packages/perl/resp-protocol/cpanfile
+++ b/code/packages/perl/resp-protocol/cpanfile
@@ -1,0 +1,1 @@
+# No non-core dependencies.

--- a/code/packages/perl/resp-protocol/lib/CodingAdventures/RespProtocol.pm
+++ b/code/packages/perl/resp-protocol/lib/CodingAdventures/RespProtocol.pm
@@ -1,0 +1,375 @@
+package CodingAdventures::RespProtocol;
+
+use strict;
+use warnings;
+use utf8;
+use Encode ();
+use Exporter 'import';
+use Scalar::Util qw(blessed looks_like_number);
+
+our $VERSION = '0.1.0';
+our @EXPORT_OK = qw(
+    simple_string error_value integer bulk_string null_bulk_string
+    array_value null_array encode encode_many encode_simple_string
+    encode_error encode_integer encode_bulk_string encode_array decode
+    decode_all equal
+);
+
+use constant MAX_BULK_LENGTH  => 512 * 1024 * 1024;
+use constant MAX_ARRAY_LENGTH => 1_000_000;
+use constant MAX_NESTING_DEPTH => 128;
+
+our %VALID_KIND = map { $_ => 1 } qw(
+    simple_string error integer bulk_string array
+);
+
+sub _is_value {
+    my ($value) = @_;
+    return blessed($value) && $value->isa('CodingAdventures::RespProtocol::Value');
+}
+
+sub _assert_scalar {
+    my ($value, $name) = @_;
+    die "$name must be a string\n" if !defined($value) || ref($value);
+}
+
+sub _to_bytes {
+    my ($value, $name) = @_;
+    _assert_scalar($value, $name);
+    return utf8::is_utf8($value) ? Encode::encode_utf8($value) : $value;
+}
+
+sub _decode_text {
+    my ($bytes, $context) = @_;
+    my $value = eval { Encode::decode('UTF-8', $bytes, Encode::FB_CROAK) };
+    die "invalid UTF-8 in $context\n" if !defined($value) || $@;
+    return $value;
+}
+
+sub _parse_i64 {
+    my ($text, $context) = @_;
+    die "invalid $context: $text\n" if !defined($text) || $text !~ /^-?\d+$/;
+
+    my $negative = $text =~ /^-/ ? 1 : 0;
+    my $digits = $negative ? substr($text, 1) : $text;
+    $digits =~ s/^0+(?=\d)//;
+    my $limit = $negative ? '9223372036854775808' : '9223372036854775807';
+    if (length($digits) > length($limit)
+        || (length($digits) == length($limit) && $digits gt $limit)) {
+        die "$context is outside the signed 64-bit range\n";
+    }
+    my $normalized = $negative && $digits ne '0' ? "-$digits" : $digits;
+    return 0 + $normalized;
+}
+
+sub simple_string { return 'CodingAdventures::RespProtocol::Value'->simple_string(@_); }
+sub error_value   { return 'CodingAdventures::RespProtocol::Value'->error(@_); }
+sub integer       { return 'CodingAdventures::RespProtocol::Value'->integer(@_); }
+sub bulk_string   { return 'CodingAdventures::RespProtocol::Value'->bulk_string(@_); }
+sub null_bulk_string { return 'CodingAdventures::RespProtocol::Value'->null_bulk_string(@_); }
+sub array_value   { return 'CodingAdventures::RespProtocol::Value'->array(@_); }
+sub null_array    { return 'CodingAdventures::RespProtocol::Value'->null_array(@_); }
+
+sub equal {
+    my ($left, $right) = @_;
+    return 0 if !_is_value($left) || !_is_value($right);
+    return 0 if $left->kind ne $right->kind || $left->is_null != $right->is_null;
+    return 1 if $left->is_null;
+    if ($left->kind ne 'array') {
+        return $left->value eq $right->value ? 1 : 0;
+    }
+    my $left_values = $left->value;
+    my $right_values = $right->value;
+    return 0 if @$left_values != @$right_values;
+    for my $index (0 .. $#$left_values) {
+        return 0 if !equal($left_values->[$index], $right_values->[$index]);
+    }
+    return 1;
+}
+
+sub encode_simple_string {
+    my ($value) = @_;
+    _assert_scalar($value, 'value');
+    die "simple string must not contain CR or LF\n" if $value =~ /[\r\n]/;
+    return '+' . _to_bytes($value, 'value') . "\r\n";
+}
+
+sub encode_error {
+    my ($value) = @_;
+    _assert_scalar($value, 'value');
+    die "error string must not contain CR or LF\n" if $value =~ /[\r\n]/;
+    return '-' . _to_bytes($value, 'value') . "\r\n";
+}
+
+sub encode_integer {
+    my ($value) = @_;
+    die "value must be an integer\n"
+        if !defined($value) || ref($value) || "$value" !~ /^-?\d+$/;
+    my $number = _parse_i64("$value", 'integer');
+    return ':' . $number . "\r\n";
+}
+
+sub encode_bulk_string {
+    my ($value) = @_;
+    return "\$-1\r\n" if !defined $value;
+    my $bytes = _to_bytes($value, 'value');
+    die "bulk string exceeds maximum length\n" if length($bytes) > MAX_BULK_LENGTH;
+    return '$' . length($bytes) . "\r\n" . $bytes . "\r\n";
+}
+
+sub encode_array {
+    my ($values) = @_;
+    return "*-1\r\n" if !defined $values;
+    die "values must be an array reference or undef\n" if ref($values) ne 'ARRAY';
+    die "array exceeds maximum length\n" if @$values > MAX_ARRAY_LENGTH;
+    return '*' . scalar(@$values) . "\r\n" . join('', map { encode($_) } @$values);
+}
+
+sub _encode_value {
+    my ($value) = @_;
+    return encode_simple_string($value->value) if $value->kind eq 'simple_string';
+    return encode_error($value->value) if $value->kind eq 'error';
+    return encode_integer($value->value) if $value->kind eq 'integer';
+    if ($value->kind eq 'bulk_string') {
+        return encode_bulk_string($value->is_null ? undef : $value->value);
+    }
+    if ($value->kind eq 'array') {
+        return encode_array($value->is_null ? undef : $value->value);
+    }
+    die 'invalid RESP kind: ' . $value->kind . "\n";
+}
+
+sub encode {
+    my ($value) = @_;
+    return _encode_value($value) if _is_value($value);
+    return encode_bulk_string(undef) if !defined $value;
+    return encode_array($value) if ref($value) eq 'ARRAY';
+    if (!ref($value)) {
+        return encode_integer($value)
+            if looks_like_number($value) && "$value" =~ /^-?\d+$/;
+        return encode_bulk_string($value);
+    }
+    die 'cannot encode value of type ' . ref($value) . "\n";
+}
+
+sub encode_many {
+    my ($values) = @_;
+    die "values must be an array reference\n" if ref($values) ne 'ARRAY';
+    return join('', map { encode($_) } @$values);
+}
+
+sub _read_line {
+    my ($data, $offset) = @_;
+    my $end = index($data, "\r\n", $offset);
+    return undef if $end < 0;
+    return [substr($data, $offset, $end - $offset), $end + 2];
+}
+
+sub _decode_value {
+    my ($data, $offset, $depth) = @_;
+    die "RESP array nesting exceeds maximum depth\n" if $depth > MAX_NESTING_DEPTH;
+    return undef if $offset >= length($data);
+
+    my $prefix = substr($data, $offset, 1);
+    if ($prefix eq '+' || $prefix eq '-' || $prefix eq ':') {
+        my $line = _read_line($data, $offset + 1);
+        return undef if !defined $line;
+        my ($payload, $next) = @$line;
+        if ($prefix eq '+') {
+            return [simple_string(_decode_text($payload, 'simple string')), $next];
+        }
+        if ($prefix eq '-') {
+            return [error_value(_decode_text($payload, 'error string')), $next];
+        }
+        return [integer(_parse_i64($payload, 'RESP integer')), $next];
+    }
+
+    if ($prefix eq '$') {
+        my $line = _read_line($data, $offset + 1);
+        return undef if !defined $line;
+        my ($length_text, $payload_offset) = @$line;
+        my $length = _parse_i64($length_text, 'bulk length');
+        return [null_bulk_string(), $payload_offset] if $length == -1;
+        die "invalid negative bulk length: $length\n" if $length < -1;
+        die "bulk length exceeds maximum\n" if $length > MAX_BULK_LENGTH;
+
+        my $terminator_offset = $payload_offset + $length;
+        return undef if $terminator_offset + 2 > length($data);
+        die "bulk string missing trailing CRLF\n"
+            if substr($data, $terminator_offset, 2) ne "\r\n";
+        my $payload = substr($data, $payload_offset, $length);
+        return [bulk_string($payload), $terminator_offset + 2];
+    }
+
+    if ($prefix eq '*') {
+        my $line = _read_line($data, $offset + 1);
+        return undef if !defined $line;
+        my ($count_text, $cursor) = @$line;
+        my $count = _parse_i64($count_text, 'array length');
+        return [null_array(), $cursor] if $count == -1;
+        die "invalid negative array length: $count\n" if $count < -1;
+        die "array length exceeds maximum\n" if $count > MAX_ARRAY_LENGTH;
+
+        my @values;
+        for (1 .. $count) {
+            my $decoded = _decode_value($data, $cursor, $depth + 1);
+            return undef if !defined $decoded;
+            push @values, $decoded->[0];
+            $cursor = $decoded->[1];
+        }
+        return [array_value(\@values), $cursor];
+    }
+
+    my $line = _read_line($data, $offset);
+    return undef if !defined $line;
+    my ($payload, $next) = @$line;
+    my @tokens = grep { length } split /\s+/, $payload;
+    return [array_value([map { bulk_string($_) } @tokens]), $next];
+}
+
+sub decode {
+    my ($data, $offset) = @_;
+    $data = _to_bytes($data, 'data');
+    $offset = 0 if !defined $offset;
+    die "offset must be an integer\n" if ref($offset) || "$offset" !~ /^\d+$/;
+    die "offset is outside data\n" if $offset < 0 || $offset > length($data);
+    return _decode_value($data, $offset, 0);
+}
+
+sub decode_all {
+    my ($data, $offset) = @_;
+    $data = _to_bytes($data, 'data');
+    $offset = 0 if !defined $offset;
+    die "offset must be an integer\n" if ref($offset) || "$offset" !~ /^\d+$/;
+    die "offset is outside data\n" if $offset < 0 || $offset > length($data);
+
+    my @values;
+    my $cursor = $offset;
+    while ($cursor < length($data)) {
+        my $decoded = _decode_value($data, $cursor, 0);
+        last if !defined $decoded;
+        push @values, $decoded->[0];
+        $cursor = $decoded->[1];
+    }
+    return [\@values, $cursor];
+}
+
+package CodingAdventures::RespProtocol::Value;
+
+use strict;
+use warnings;
+use overload '""' => 'as_string', fallback => 1;
+
+sub new {
+    my ($class, $kind, $value) = @_;
+    die 'invalid RESP kind: ' . (defined($kind) ? $kind : 'undef') . "\n"
+        if !$CodingAdventures::RespProtocol::VALID_KIND{$kind};
+
+    my $self = { kind => $kind, value => $value, is_null => 0 };
+    if ($kind eq 'simple_string' || $kind eq 'error') {
+        CodingAdventures::RespProtocol::_assert_scalar($value, "$kind value");
+        die "$kind value must not contain CR or LF\n" if $value =~ /[\r\n]/;
+        if ($kind eq 'error') {
+            my ($error_type, $detail) = split / /, $value, 2;
+            $self->{error_type} = defined($error_type) ? $error_type : '';
+            $self->{detail} = defined($detail) ? $detail : '';
+        }
+    } elsif ($kind eq 'integer') {
+        die "integer value must be an integer\n"
+            if !defined($value) || ref($value) || "$value" !~ /^-?\d+$/;
+        $self->{value} = CodingAdventures::RespProtocol::_parse_i64("$value", 'integer');
+    } elsif ($kind eq 'bulk_string') {
+        if (!defined $value) {
+            $self->{is_null} = 1;
+        } else {
+            CodingAdventures::RespProtocol::_assert_scalar($value, 'bulk_string value');
+        }
+    } elsif ($kind eq 'array') {
+        if (!defined $value) {
+            $self->{is_null} = 1;
+        } else {
+            die "array value must be an array reference or undef\n" if ref($value) ne 'ARRAY';
+            my @copy;
+            for my $index (0 .. $#$value) {
+                die "array value[$index] must be a RESP Value\n"
+                    if !CodingAdventures::RespProtocol::_is_value($value->[$index]);
+                push @copy, $value->[$index];
+            }
+            $self->{value} = \@copy;
+        }
+    }
+    return bless $self, $class;
+}
+
+sub simple_string { my ($class, $value) = @_; return $class->new('simple_string', $value); }
+sub error         { my ($class, $value) = @_; return $class->new('error', $value); }
+sub integer       { my ($class, $value) = @_; return $class->new('integer', $value); }
+sub bulk_string   { my ($class, $value) = @_; return $class->new('bulk_string', $value); }
+sub null_bulk_string { my ($class) = @_; return $class->new('bulk_string', undef); }
+sub array         { my ($class, $value) = @_; return $class->new('array', $value); }
+sub null_array    { my ($class) = @_; return $class->new('array', undef); }
+
+sub kind       { return $_[0]->{kind}; }
+sub value      { return $_[0]->{value}; }
+sub is_null    { return $_[0]->{is_null}; }
+sub error_type { return $_[0]->{error_type}; }
+sub detail     { return $_[0]->{detail}; }
+
+sub as_string {
+    my ($self) = @_;
+    return $self->{kind} . '(null)' if $self->{is_null};
+    return sprintf('array(%d values)', scalar @{$self->{value}}) if $self->{kind} eq 'array';
+    return $self->{kind} . '(' . $self->{value} . ')';
+}
+
+package CodingAdventures::RespProtocol::Decoder;
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class) = @_;
+    return bless { buffer => '', queue => [] }, $class;
+}
+
+sub feed {
+    my ($self, $data) = @_;
+    $self->{buffer} .= CodingAdventures::RespProtocol::_to_bytes($data, 'data');
+    my ($values, $next) = @{CodingAdventures::RespProtocol::decode_all($self->{buffer})};
+    push @{$self->{queue}}, @$values;
+    $self->{buffer} = substr($self->{buffer}, $next) if $next > 0;
+    return $self;
+}
+
+sub has_message { return @{$_[0]->{queue}} ? 1 : 0; }
+
+sub get_message {
+    my ($self) = @_;
+    die "no decoded message is available\n" if !@{$self->{queue}};
+    return shift @{$self->{queue}};
+}
+
+sub drain {
+    my ($self) = @_;
+    my $result = $self->{queue};
+    $self->{queue} = [];
+    return $result;
+}
+
+sub decode_all {
+    my ($self, $data) = @_;
+    $self->feed($data);
+    return $self->drain;
+}
+
+sub pending_bytes { return length($_[0]->{buffer}); }
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::RespProtocol - typed RESP2 codec and streaming decoder
+
+=cut

--- a/code/packages/perl/resp-protocol/required_capabilities.json
+++ b/code/packages/perl/resp-protocol/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/resp-protocol",
+  "capabilities": [],
+  "justification": "Pure byte-string codec. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/resp-protocol/t/00-load.t
+++ b/code/packages/perl/resp-protocol/t/00-load.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+ok(eval { require CodingAdventures::RespProtocol; 1 }, 'CodingAdventures::RespProtocol loads');
+ok(CodingAdventures::RespProtocol->VERSION, 'has a VERSION');
+
+done_testing;

--- a/code/packages/perl/resp-protocol/t/01-resp-protocol.t
+++ b/code/packages/perl/resp-protocol/t/01-resp-protocol.t
@@ -1,0 +1,143 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use CodingAdventures::RespProtocol qw(
+    encode encode_many encode_bulk_string decode decode_all equal
+);
+
+my $Value = 'CodingAdventures::RespProtocol::Value';
+my $Decoder = 'CodingAdventures::RespProtocol::Decoder';
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+sub round_trip {
+    my ($value) = @_;
+    my $wire = encode($value);
+    my $decoded = decode($wire);
+    ok(defined($decoded), 'round trip decoded');
+    is($decoded->[1], length($wire), 'round trip consumed all bytes');
+    ok(equal($value, $decoded->[0]), 'round trip value matches');
+}
+
+subtest 'typed value construction and validation' => sub {
+    is($Value->simple_string('OK')->value, 'OK', 'simple string');
+    my $error = $Value->error('WRONGTYPE bad value');
+    is($error->error_type, 'WRONGTYPE', 'error type');
+    is($error->detail, 'bad value', 'error detail');
+    is($Value->integer(42)->value, 42, 'integer');
+    ok($Value->null_bulk_string->is_null, 'null bulk');
+    ok($Value->null_array->is_null, 'null array');
+    like('' . $Value->array([]), qr/0 values/, 'string rendering');
+
+    dies_like(sub { $Value->new('unknown') }, qr/invalid RESP kind: unknown/, 'invalid kind');
+    dies_like(sub { $Value->simple_string("bad\rline") }, qr/must not contain CR or LF/, 'invalid line');
+    dies_like(sub { $Value->integer(1.5) }, qr/must be an integer/, 'invalid integer');
+    dies_like(sub { $Value->array(['not-a-value']) }, qr/array value\[0\] must be a RESP Value/, 'invalid array');
+};
+
+subtest 'exact scalar and null encoding' => sub {
+    is(encode($Value->simple_string('OK')), "+OK\r\n", 'simple');
+    is(encode($Value->error('ERR boom')), "-ERR boom\r\n", 'error');
+    is(encode($Value->integer(-42)), ":-42\r\n", 'integer');
+    is(encode($Value->bulk_string('hello')), "\$5\r\nhello\r\n", 'bulk');
+    is(encode($Value->bulk_string('')), "\$0\r\n\r\n", 'empty bulk');
+    is(encode($Value->null_bulk_string), "\$-1\r\n", 'null bulk');
+    is(encode($Value->null_array), "*-1\r\n", 'null array');
+};
+
+subtest 'binary and nested array encoding' => sub {
+    my $binary = "\0foo\r\nbar\xFF";
+    is(encode_bulk_string($binary), "\$10\r\n" . $binary . "\r\n", 'binary bulk');
+    my $command = $Value->array([
+        $Value->bulk_string('SET'),
+        $Value->bulk_string('key'),
+        $Value->array([$Value->integer(1), $Value->null_bulk_string]),
+    ]);
+    is(
+        encode($command),
+        "*3\r\n\$3\r\nSET\r\n\$3\r\nkey\r\n*2\r\n:1\r\n\$-1\r\n",
+        'nested array',
+    );
+    is(encode_many([$Value->integer(1), $Value->integer(0), 'x']), ":1\r\n:0\r\n\$1\r\nx\r\n", 'many');
+};
+
+subtest 'typed decoding and offsets' => sub {
+    my $wire = "+OK\r\n-ERR boom\r\n:42\r\n\$3\r\nfoo\r\n\$-1\r\n*-1\r\n";
+    my ($values, $next) = @{decode_all($wire)};
+    is(@$values, 6, 'value count');
+    is($next, length($wire), 'consumed all');
+    is($values->[0]->kind, 'simple_string', 'simple kind');
+    is($values->[1]->kind, 'error', 'error kind');
+    is($values->[2]->value, 42, 'integer value');
+    is($values->[3]->value, 'foo', 'bulk value');
+    ok($values->[4]->is_null, 'null bulk decoded');
+    ok($values->[5]->is_null && $values->[5]->kind eq 'array', 'null array decoded');
+};
+
+subtest 'every incomplete prefix consumes nothing' => sub {
+    my $full = "*3\r\n\$3\r\nSET\r\n\$3\r\nfoo\r\n\$3\r\nbar\r\n";
+    for my $length (0 .. length($full) - 1) {
+        is(decode(substr($full, 0, $length)), undef, "incomplete prefix $length");
+    }
+    my $decoded = decode($full);
+    is($decoded->[1], length($full), 'full frame consumed');
+    is(@{$decoded->[0]->value}, 3, 'three elements');
+};
+
+subtest 'malformed frames are rejected' => sub {
+    dies_like(sub { decode(":abc\r\n") }, qr/invalid RESP integer: abc/, 'invalid integer');
+    dies_like(sub { decode("\$-2\r\n") }, qr/invalid negative bulk length: -2/, 'negative bulk');
+    dies_like(sub { decode("*-2\r\n") }, qr/invalid negative array length: -2/, 'negative array');
+    dies_like(sub { decode("\$3\r\nfooXX") }, qr/bulk string missing trailing CRLF/, 'bad terminator');
+    dies_like(sub { decode("+OK\r\n", 99) }, qr/offset is outside data/, 'bad offset');
+};
+
+subtest 'inline commands and incomplete tails' => sub {
+    my $inline = decode("SET key value\r\n");
+    is(@{$inline->[0]->value}, 3, 'three inline tokens');
+    is($inline->[0]->value->[0]->value, 'SET', 'first token');
+    is($inline->[1], 15, 'inline consumed');
+
+    my ($values, $next) = @{decode_all("+OK\r\n:1\r\n\$5\r\nhel")};
+    is(@$values, 2, 'two complete values');
+    is($next, 9, 'tail begins at third frame');
+};
+
+subtest 'round trips nested and all-byte values' => sub {
+    round_trip($Value->bulk_string(join('', map { chr($_) } 0 .. 255)));
+    round_trip($Value->array([
+        $Value->simple_string('OK'),
+        $Value->error('ERR boom'),
+        $Value->integer(-1),
+        $Value->bulk_string("payload\0"),
+        $Value->null_bulk_string,
+        $Value->array([$Value->integer(2)]),
+        $Value->null_array,
+    ]));
+};
+
+subtest 'streaming handles byte fragmentation and multiple messages' => sub {
+    my @expected = (
+        $Value->array([$Value->bulk_string('PING')]),
+        $Value->integer(42),
+        $Value->error('ERR bad'),
+    );
+    my $wire = encode_many(\@expected);
+    my $decoder = $Decoder->new;
+    $decoder->feed(substr($wire, $_, 1)) for 0 .. length($wire) - 1;
+    is($decoder->pending_bytes, 0, 'no pending bytes');
+    for my $value (@expected) {
+        ok($decoder->has_message, 'message available');
+        ok(equal($value, $decoder->get_message), 'message matches');
+    }
+    ok(!$decoder->has_message, 'queue empty');
+    dies_like(sub { $decoder->get_message }, qr/no decoded message is available/, 'empty queue');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -107,11 +107,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 The missing matrix is heavily concentrated in singleton packages. Regenerated
 on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
-`skip-list`, `hyperloglog`, `trie`, and `radix-tree` ports:
+`skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 351 |
+| Present in 10-15 languages | 171 | 349 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -157,15 +157,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 351
+The 171 packages present in at least ten implementation languages need 349
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 6 | Pair with Perl data-structure/storage wave |
-| Perl | 6 | Pair with Lua data-structure/storage wave |
+| Lua | 5 | Pair with Perl data-structure/storage wave |
+| Perl | 5 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -177,9 +177,10 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first ten paired Lua/Perl slices are complete: `fenwick-tree`,
+The first eleven paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
-`avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, and `radix-tree`
+`avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and
+`resp-protocol`
 now have pure implementations, package-native tests, metadata, and capability
 declarations in both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
@@ -191,6 +192,9 @@ The trie slice adds Unicode-aware prefix storage with sorted scans, pruning
 deletion, and longest-prefix matching without introducing new dependencies.
 The radix-tree slice compresses those paths into whole-substring edges while
 retaining Unicode-safe splits, post-deletion merges, and mid-edge prefix scans.
+The RESP2 slice adds a typed, binary-safe wire codec with distinct null bulk and
+null array values plus an incremental decoder tested across arbitrary stream
+fragmentation, establishing the wire layer needed by the higher storage stack.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure Lua and Perl RESP2 protocol packages with explicit typed values
- support exact binary-safe encoding, incremental decoding, inline commands, null bulk strings, null arrays, nested arrays, and concatenated frames
- add package-native tests, metadata, capability declarations, and BUILD recipes
- refresh the package-parity roadmap after reducing the high-consensus gap from 351 to 349

## Why

`resp-protocol` was the smallest remaining dependency-free Lua/Perl parity gap. Completing it establishes the wire layer needed before the higher in-memory storage packages can be ported safely.

## Impact

Lua and Perl now have standalone RESP2 codecs with streaming decoders that distinguish incomplete input from malformed frames. The ports introduce no runtime dependencies and preserve binary payloads byte-for-byte.

## Validation

- LuaRocks lint and local package install
- Lua Busted suite: 9 successes, 0 failures
- Perl load test and protocol suite: all 9 subtests passed
- package parity reporter tests: 6 passed
- parity collision gate: 0 collisions; Lua and Perl high-consensus gaps are 5 each
- Lua syntax check, Perl module load, capability JSON parsing, and `git diff --check`
