### PR TITLE
feat(net): osp_socket_fd — expose the descriptor for reactor integration

### DIFF
--- a/code/packages/c/net/CHANGELOG.md
+++ b/code/packages/c/net/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to semantic versioning.
 
 ### Added
 
+- **`osp_socket_fd` accessor** (CCPP02 port campaign). Exposes a socket's
+  underlying OS descriptor (an `int` fd on POSIX, a `SOCKET` on Windows) widened
+  to `uintptr_t`, so a `net` socket can be watched by an external event loop (the
+  `reactor`) instead of blocking in accept/recv — the seam the `tcp-runtime`
+  server builds on. The descriptor stays owned by the socket. Test extended to
+  assert each of listener/client/connection exposes a distinct descriptor, plus
+  NULL validation; clean under ASan+UBSan, 0 leaks.
 - **Initial package + `tcp` sockets** (CCPP02 Phase 3, PR 1). Real blocking TCP
   over IPv4, on top of the `os-platform` core (reuses `osp_status`). Built by
   `platform-harness`; per-OS source selection via `BUILD` / `BUILD_windows`.

--- a/code/packages/c/net/README.md
+++ b/code/packages/c/net/README.md
@@ -33,6 +33,9 @@ osp_socket_send(cli, "hello", 5, &n);             /* sends ALL bytes */
 char buf[64];
 osp_socket_recv(conn, buf, sizeof buf, &n);       /* n == 0 => peer closed */
 
+uintptr_t fd;
+osp_socket_fd(conn, &fd);      /* raw descriptor → hand to the reactor */
+
 osp_socket_close(cli); osp_socket_close(conn); osp_socket_close(lis);
 osp_net_shutdown();
 ```
@@ -49,8 +52,10 @@ osp_net_shutdown();
 - `osp_socket_send` is send-**all** (loops over partial sends, retries `EINTR`);
   `osp_socket_recv` is a single `recv` reporting the byte count (`0` = orderly
   peer shutdown).
-- Blocking I/O only. Non-blocking readiness (epoll/kqueue/iocp) is the next
-  primitive, `reactor`.
+- Blocking I/O only. To multiplex many sockets on one thread, hand each socket's
+  descriptor — `osp_socket_fd(s, &fd)`, an `int` fd on POSIX / `SOCKET` on Windows
+  widened to `uintptr_t` — to the `reactor` and cast to its `osp_fd`. This is the
+  seam the `tcp-runtime` server builds on.
 - SIGPIPE on a dead peer is suppressed portably (Linux `MSG_NOSIGNAL`, macOS
   `SO_NOSIGPIPE` — selected by feature-macro presence, not by OS name).
 

--- a/code/packages/c/net/include/net/tcp.h
+++ b/code/packages/c/net/include/net/tcp.h
@@ -38,6 +38,7 @@
 #define NET_TCP_H
 
 #include <stddef.h> /* size_t */
+#include <stdint.h> /* uintptr_t */
 
 #include "os_platform/status.h" /* osp_status — shared platform error codes */
 
@@ -101,6 +102,17 @@ osp_status osp_socket_recv(osp_socket *s, void *buf, size_t len, size_t *out_n);
  * close failure.
  */
 osp_status osp_socket_close(osp_socket *s);
+
+/*
+ * osp_socket_fd — expose the underlying OS descriptor (an int fd on POSIX, a
+ * SOCKET on Windows), widened to uintptr_t so one signature serves both. This
+ * lets an external event loop — e.g. the `reactor` — watch this socket for
+ * readiness instead of blocking in accept/recv. The descriptor stays owned by
+ * the socket; do not close it directly (use osp_socket_close). A consumer feeds
+ * it to the reactor by casting to the reactor's osp_fd (an int on POSIX, a
+ * uintptr_t on Windows). OSP_ERR_INVAL if s or out is NULL.
+ */
+osp_status osp_socket_fd(const osp_socket *s, uintptr_t *out);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/code/packages/c/net/src/net_posix.c
+++ b/code/packages/c/net/src/net_posix.c
@@ -213,3 +213,11 @@ osp_status osp_socket_close(osp_socket *s) {
     free(s);
     return st;
 }
+
+osp_status osp_socket_fd(const osp_socket *s, uintptr_t *out) {
+    if (s == NULL || out == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    *out = (uintptr_t)s->fd;
+    return OSP_OK;
+}

--- a/code/packages/c/net/src/net_windows.c
+++ b/code/packages/c/net/src/net_windows.c
@@ -197,3 +197,11 @@ osp_status osp_socket_close(osp_socket *s) {
     free(s);
     return st;
 }
+
+osp_status osp_socket_fd(const osp_socket *s, uintptr_t *out) {
+    if (s == NULL || out == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    *out = (uintptr_t)s->sock;
+    return OSP_OK;
+}

--- a/code/packages/c/net/tests/net_test.c
+++ b/code/packages/c/net/tests/net_test.c
@@ -45,6 +45,23 @@ int main(void) {
     ISO_CHECK(osp_tcp_connect(&client, "127.0.0.1", port) == OSP_OK);
     ISO_CHECK(osp_tcp_accept(listener, &conn) == OSP_OK);
 
+    /* ── the descriptor accessor exposes a distinct OS descriptor per socket,
+     *    so an external event loop (the reactor) can watch each one ───────── */
+    {
+        uintptr_t fd_listen = 0;
+        uintptr_t fd_client = 0;
+        uintptr_t fd_conn = 0;
+        ISO_CHECK(osp_socket_fd(listener, &fd_listen) == OSP_OK);
+        ISO_CHECK(osp_socket_fd(client, &fd_client) == OSP_OK);
+        ISO_CHECK(osp_socket_fd(conn, &fd_conn) == OSP_OK);
+        ISO_CHECK_MSG(fd_listen != fd_client && fd_client != fd_conn &&
+                          fd_listen != fd_conn,
+                      "each socket must expose a distinct OS descriptor");
+        /* NULL-argument validation (done here while a live socket is on hand) */
+        ISO_CHECK(osp_socket_fd(NULL, &fd_listen) == OSP_ERR_INVAL);
+        ISO_CHECK(osp_socket_fd(listener, NULL) == OSP_ERR_INVAL);
+    }
+
     /* ── client → server ────────────────────────────────────────────────── */
     ISO_CHECK(osp_socket_send(client, msg, msglen, &n) == OSP_OK);
     ISO_CHECK_EQ_UINT(n, msglen);


### PR DESCRIPTION
## Starting the port campaign — fixing the first integration gap it surfaced

With the `os-platform` substrate complete, the port campaign begins: taking previously-deferred networked consumers and running them on the substrate. Trying to build the first one (a reactor-driven TCP server — `tcp-runtime`, next PR) immediately surfaced a real gap:

> **`net`'s `osp_socket` is fully opaque — there's no way to get its descriptor, so a `net` socket can't be handed to the `reactor` to be watched.** `net` and `reactor` couldn't compose.

This PR fixes exactly that, and nothing more:

```c
osp_status osp_socket_fd(const osp_socket *s, uintptr_t *out);
```

Returns the underlying OS descriptor — an `int` fd on POSIX, a `SOCKET` on Windows — widened to `uintptr_t` so one signature serves both. A consumer feeds it to the reactor by casting to the reactor's `osp_fd` (`int` on POSIX / `uintptr_t` on Windows). The descriptor stays **owned by the socket** — callers still release it with `osp_socket_close`.

### Design

- **`net` stays independent of `reactor`.** The `uintptr_t` carrier avoids a dependency inversion (no `reactor` include in `net`); the consumer does the cast.
- Backends: `net_posix.c` → `*out = (uintptr_t)s->fd`; `net_windows.c` → `*out = (uintptr_t)s->sock`. `tcp.h` gains `<stdint.h>`.
- Read-only, `const`-qualified, NULL-guarded — no allocation, no new lifetime hazard.

### Verification

- **Local (macOS/arm64):** 33 checks / 0 failed under gcc + clang (up from 28 — the test now asserts each of listener/client/connection exposes a **distinct** descriptor, plus NULL validation). Clean under **ASan + UBSan**; **0 leaks**.
- **Security review:** passed — a read-only accessor returning a descriptor the caller's own socket already owns; no deref-before-NULL-check, no info disclosure, no double-close/UAF, no write through the const pointer.

This is the enabling seam for the **`tcp-runtime`** server port (next PR): a reactor-driven TCP server that multiplexes many `net` sockets on one thread — the first real consumer that drives `net` + `reactor` together end-to-end.

Spec: [`CCPP02-os-platform-lane.md`](code/specs/CCPP02-os-platform-lane.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)