### PR TITLE
feat(adj-facts-stdlib): biology/macronutrients — macronutrient → energy-per-gram table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_macronutrients_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_macronutrients_e2e.rs
@@ -1,0 +1,75 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/macronutrients.adj`) driven through the built CLI:
+//! a native `table` of macronutrient → kilocalories-per-gram resolves binding-
+//! query recalls (forward AND backward) with the source's NIH / MedlinePlus
+//! citation, and abstains on a word that is not one of these macronutrients
+//! (water, which supplies no Calories) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsmn_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_macronutrients_recall_binds_energy_with_citation() {
+    let dir = scratch("macronutrients");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/macronutrients.adj");
+    std::fs::copy(&src, dir.join("macronutrients.adj")).expect("copy shipped macronutrients.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"macronutrients.adj\"\n\
+         ? kcal_per_gram(fat, $Kcal)\n\
+         ? kcal_per_gram(carbohydrate, $Kcal)\n\
+         ? kcal_per_gram(protein, $Kcal)\n\
+         ? kcal_per_gram(alcohol, $Kcal)\n\
+         ? kcal_per_gram($Nutrient, 4)\n\
+         ? kcal_per_gram(water, $Kcal)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A gram of fat gives 9 Calories; a gram of carbohydrate or protein gives 4;
+    // a gram of alcohol gives 7 — the recalled numbers, each a plain integer.
+    assert!(out.contains("\"Kcal\":\"9\""), "fat → 9: {out}");
+    assert!(out.contains("\"Kcal\":\"4\""), "carbohydrate/protein → 4: {out}");
+    assert!(out.contains("\"Kcal\":\"7\""), "alcohol → 7: {out}");
+    // The relation runs BACKWARD: bind the value 4, recall the macronutrients
+    // that supply it — carbohydrate and protein.
+    assert!(
+        out.contains("\"Nutrient\":\"carbohydrate\"") && out.contains("\"Nutrient\":\"protein\""),
+        "4 → carbohydrate ; protein (reverse recall): {out}"
+    );
+    // The answer carries the NIH / NLM MedlinePlus citation as its proof, at the
+    // `authoritative` trust tier for a primary U.S. government source.
+    assert!(
+        out.contains("medlineplus.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Water supplies no Calories — it is not one of the energy-yielding
+    // macronutrients, so an energy recall abstains honestly rather than
+    // fabricating a number.
+    assert!(out.contains("\"abstained\":true"), "water abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -38,6 +38,7 @@ per rotation, in parallel):
 | `nutrition/` | common food → MyPlate food group | USDA MyPlate |
 | `agriculture/` | farm animal → product it gives | Iowa State University (CFSPH) |
 | `biology/` | common bone → body region | NIH / MedlinePlus |
+| `biology/` | macronutrient → energy (kcal) per gram | NIH / MedlinePlus |
 | `physics/` | simple machine → everyday example | NASA |
 | … | *geography, anatomy, physical constants, …* | *(expanding)* |
 

--- a/code/specs/data/adj-facts-stdlib/biology/macronutrients.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/macronutrients.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% macronutrients — each energy-yielding macronutrient and how many kilocalories
+% one gram of it supplies (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the first quantitative facts of human nutrition, and a rung a MEDICINE
+% or DIETETICS agent reasons UP from: the food you eat carries energy, and that
+% energy comes from a small set of macronutrients — carbohydrate, protein, fat,
+% and (when present) alcohol — each of which releases a fixed number of Calories
+% per gram when the body burns it. "A gram of fat gives 9 Calories; a gram of
+% carbohydrate or protein gives 4; a gram of alcohol gives 7." These four
+% Atwater-style factors are what turn a food's gram breakdown into its Calorie
+% count, so before you can reason about a diet, a label, or an energy balance you
+% must first know the per-gram energy of each macronutrient. Recall is a binding
+% query:
+%
+%     ? kcal_per_gram(fat, $Kcal)        % 9
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `kcal_per_gram(nutrient, kcal)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the number
+% WITH its source, on the CPU, with zero model calls, and abstains on a word that
+% is not one of these macronutrients (it never invents an energy value).
+%
+% Each macronutrient and its energy per gram, as a little truth table:
+%
+%     macronutrient   kcal per gram   a beginner's cue
+%     -------------   -------------   ------------------------------------------
+%     carbohydrate    4               sugars & starches — 4 Calories per gram
+%     protein         4               same energy density as carbohydrate — 4
+%     fat             9               the richest — more than 2x carb/protein — 9
+%     alcohol         7               not a nutrient, but yields 7 Calories/gram
+%
+% (Here "Calorie" is the food/dietary Calorie = one kilocalorie, kcal — the unit
+% every U.S. nutrition source and food label uses. The value is a plain integer
+% so a recalled factor flows straight into arithmetic: grams x kcal_per_gram =
+% Calories, the bridge from recall to compute.)
+%
+% The query also runs BACKWARD — bind an energy value and recall the
+% macronutrient(s) that supply it:
+%
+%     ? kcal_per_gram($Nutrient, 4)   % carbohydrate ; protein
+%
+% A word that is NOT one of these macronutrients — `water`, `vitamin`, `fiber`,
+% `rock` — is deliberately NOT a row, so an energy recall ABSTAINS on it rather
+% than inventing a number. (Water and most vitamins supply no Calories at all;
+% dietary fiber is a carbohydrate the body does not fully burn — none of them is
+% one of the four energy-yielding macronutrients, so none is a row.) That
+% honest-abstention property is what makes the table safe to build a reasoner on:
+% it answers exactly the macronutrient->energy pairs it can ground, and only
+% those.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every macronutrient->energy
+% pair below was read out of a fetched U.S. government / NIH page, and any pair
+% whose value could not be verified there would have been dropped). Each pair,
+% with the primary source it was copied from and the verbatim span that states
+% it:
+%
+%   fat -> 9, carbohydrate -> 4, protein -> 4
+%     https://medlineplus.gov/ency/patientinstructions/000104.htm
+%       (NIH / NLM, MedlinePlus — "Dietary fats explained")
+%     "Fat has 9 calories per gram, more than 2 times the number of calories in
+%      carbohydrates and protein, which each have 4 calories per gram."
+%
+%   alcohol -> 7  (and carbohydrate -> 4, protein -> 4 again, independently)
+%     https://medlineplus.gov/ency/patientinstructions/000889.htm
+%       (NIH / NLM, MedlinePlus — "Weight loss and alcohol")
+%     "This means it has calories (7 per gram versus 4 per gram for carbohydrate
+%      and protein) but no nutrients."
+%
+% Both sources are primary U.S. government / NIH (NLM MedlinePlus) references, so
+% `trust authoritative`. An ADJ `table` carries ONE provenance envelope, so the
+% `source`/`locator`/`trust` below hold the single cleanest span: the MedlinePlus
+% "Dietary fats explained" statement, which fixes three of the four rows (fat 9,
+% carbohydrate 4, protein 4) in one sentence. The alcohol row's per-fact source
+% and verbatim span is listed above, so its value remains independently
+% checkable.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table kcal_per_gram {
+    columns nutrient, kcal
+
+    row (carbohydrate, 4)
+    row (protein, 4)
+    row (fat, 9)
+    row (alcohol, 7)
+
+    source "Fat has 9 calories per gram, more than 2 times the number of calories in carbohydrates and protein, which each have 4 calories per gram."
+    locator "https://medlineplus.gov/ency/patientinstructions/000104.htm"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/macronutrients.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/macronutrients.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% macronutrients.query.adj — a worked recall over the biology macronutrients library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how many Calories are in a
+% gram of fat?": it states no nutrition fact of its own — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `kcal_per_gram` rows and returns the number + the table's source/locator/
+% trust. The fourth query runs the relation BACKWARD (bind the value `4`, recall
+% the macronutrients that supply it — carbohydrate, protein). A word that is not
+% one of these macronutrients abstains honestly — the engine never invents an
+% energy value.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli macronutrients.query.adj
+% ============================================================================
+
+import "macronutrients.adj"
+
+? kcal_per_gram(fat, $Kcal)          % expect 9
+? kcal_per_gram(carbohydrate, $Kcal) % expect 4
+? kcal_per_gram(alcohol, $Kcal)      % expect 7
+? kcal_per_gram($Nutrient, 4)        % reverse bind — expect carbohydrate ; protein
+? kcal_per_gram(water, $Kcal)        % expect abstain — water supplies no Calories


### PR DESCRIPTION
Add a grounded biology FACTS library mapping each energy-yielding
macronutrient to how many kilocalories one gram of it supplies, mirroring
the existing biology/skeleton-bones library exactly (native `table`,
`.query.adj` worked recall, e2e test, README subject-index row).

Table `kcal_per_gram(nutrient, kcal)`:
  carbohydrate → 4
  protein      → 4
  fat          → 9
  alcohol      → 7

Provenance (every pair byte-provenanced from a fetched NIH/NLM source this
session; nothing from memory):
  - fat→9, carbohydrate→4, protein→4
    https://medlineplus.gov/ency/patientinstructions/000104.htm
    "Fat has 9 calories per gram, more than 2 times the number of calories
     in carbohydrates and protein, which each have 4 calories per gram."
  - alcohol→7 (and carbohydrate/protein→4 again, independently)
    https://medlineplus.gov/ency/patientinstructions/000889.htm
    "This means it has calories (7 per gram versus 4 per gram for
     carbohydrate and protein) but no nutrients."

Both sources are primary U.S. government / NIH (NLM MedlinePlus)
references, so trust = authoritative. The table envelope carries the
cleanest span (000104.htm, which fixes three of four rows); the alcohol
row's per-fact source is listed in the file's provenance comments so every
value remains independently checkable. No rows dropped.

The recall abstains honestly on `water` (supplies no Calories, so not a
row). Data-only change: two new .adj files, one e2e test, one README row.
No engine/grammar/adapter code touched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
