### PR TITLE
feat(adj-facts-stdlib): biology/tissue-types — basic tissue type → example table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_tissuetypes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_tissuetypes_e2e.rs
@@ -1,0 +1,84 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/tissue-types.adj`) driven through the built CLI:
+//! a native `table` of the four basic human tissue types → a representative
+//! example / location resolves binding-query recalls (forward AND backward)
+//! with the source's NCI SEER Training Modules citation, and abstains on a word
+//! that is not one of the four basic tissue types (the epidermis) — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factst_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_tissue_types_recall_binds_example_with_citation() {
+    let dir = scratch("tissuetypes");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/tissue-types.adj");
+    std::fs::copy(&src, dir.join("tissue-types.adj")).expect("copy shipped tissue-types.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"tissue-types.adj\"\n\
+         ? tissue_example(epithelial, $Example)\n\
+         ? tissue_example(muscle, $Example)\n\
+         ? tissue_example(nervous, $Example)\n\
+         ? tissue_example($Tissue, bone_or_blood)\n\
+         ? tissue_example(epidermis, $Example)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Epithelial tissue covers and lines, muscle tissue is cardiac and skeletal,
+    // nervous tissue is the brain and nerves — the recalled examples (forward
+    // binds).
+    assert!(
+        out.contains("\"Example\":\"covering_lining\""),
+        "epithelial → covering_lining: {out}"
+    );
+    assert!(
+        out.contains("\"Example\":\"cardiac_or_skeletal\""),
+        "muscle → cardiac_or_skeletal: {out}"
+    );
+    assert!(
+        out.contains("\"Example\":\"brain_and_nerves\""),
+        "nervous → brain_and_nerves: {out}"
+    );
+    // The relation runs BACKWARD: bind the example `bone_or_blood`, recall its
+    // tissue type.
+    assert!(
+        out.contains("\"Tissue\":\"connective\""),
+        "bone_or_blood → connective (reverse recall): {out}"
+    );
+    // The answer carries the NCI SEER Training Modules citation as its proof, at
+    // the `authoritative` trust tier for a primary U.S. government source.
+    assert!(
+        out.contains("training.seer.cancer.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The epidermis is a structure, not one of the four basic tissue types —
+    // honest abstention, never a fabricated example.
+    assert!(out.contains("\"abstained\":true"), "epidermis abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -39,6 +39,7 @@ per rotation, in parallel):
 | `agriculture/` | farm animal → product it gives | Iowa State University (CFSPH) |
 | `biology/` | common bone → body region | NIH / MedlinePlus |
 | `biology/` | macronutrient → energy (kcal) per gram | NIH / MedlinePlus |
+| `biology/` | basic tissue type → representative example | NCI SEER Training |
 | `physics/` | simple machine → everyday example | NASA |
 | … | *geography, anatomy, physical constants, …* | *(expanding)* |
 

--- a/code/specs/data/adj-facts-stdlib/biology/tissue-types.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/tissue-types.adj
@@ -1,0 +1,110 @@
+% ============================================================================
+% tissue-types — the four basic human tissue types and a representative
+% example / location each one is made of (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the first big ideas of histology, and a rung a MEDICINE agent reasons
+% UP from: every organ in the body is built out of just FOUR basic tissue
+% types, and each type has a characteristic place it lives or a characteristic
+% thing it is made of. "Epithelial tissue is the covering-and-lining tissue;
+% connective tissue includes bone and blood; muscle tissue is the cardiac and
+% skeletal muscle; nervous tissue is the brain and the nerves." Before you can
+% reason about an organ, a tumor, or a biopsy you must first know WHICH of the
+% four basic tissues you are looking at. Recall is a binding query:
+%
+%     ? tissue_example(muscle, $Example)      % cardiac_or_skeletal
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `tissue_example(tissue, example)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% example WITH its source, on the CPU, with zero model calls, and abstains on a
+% word that is not one of these four tissue types (it never invents an example).
+%
+% Each of the four basic tissue types and a representative example / location
+% the source states for it, as a little truth table:
+%
+%     tissue type   representative example / location   a beginner's cue
+%     -----------   ---------------------------------   ------------------------
+%     epithelial    covering_lining                     covers surfaces, lines cavities
+%     connective    bone_or_blood                       bone and blood are connective
+%     muscle        cardiac_or_skeletal                 heart muscle and skeletal muscle
+%     nervous       brain_and_nerves                    the brain, spinal cord, and nerves
+%
+% The query also runs BACKWARD — bind an example and recall its tissue type:
+%
+%     ? tissue_example($Tissue, bone_or_blood)   % connective
+%
+% A word that is NOT one of these four basic tissue types — `epidermis`,
+% `cartilage`, `rock` — is deliberately NOT a row, so a tissue recall ABSTAINS
+% on it rather than inventing an example. That honest-abstention property is
+% what makes the table safe to build a reasoner on: it answers exactly the
+% tissue→example pairs it can ground, and only those.
+%
+% The `example` value of every row is a SINGLE lowercase atom, chosen to be a
+% representative example / location the source EXPLICITLY states for that
+% tissue — never one the source does not support. (Where the everyday word
+% differs from the source's word — the source says "cardiac" muscle, not
+% "heart"; it says "covering"/"line", not "skin" — the atom uses the source's
+% own word, so every value stays literally checkable against the quoted span.)
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every tissue→example pair
+% below was read out of a fetched NCI SEER Training Modules page, and any pair
+% whose example could not be verified there would have been dropped). Each pair,
+% with the primary source it was copied from and the verbatim span that states
+% it:
+%
+%   epithelial → covering_lining
+%     https://training.seer.cancer.gov/anatomy/cells_tissues_membranes/tissues/epithelial.html
+%     (NCI SEER Training Modules — U.S. National Cancer Institute)
+%     "They form the covering of all body surfaces, line body cavities and
+%      hollow organs, and are the major tissue in glands."
+%
+%   connective → bone_or_blood
+%     https://training.seer.cancer.gov/anatomy/cells_tissues_membranes/tissues/connective.html
+%     (NCI SEER Training Modules — U.S. National Cancer Institute)
+%     "The types of connective tissue include loose connective tissue, adipose
+%      tissue, dense fibrous connective tissue, elastic connective tissue,
+%      cartilage, osseous tissue (bone), and blood."
+%
+%   muscle → cardiac_or_skeletal
+%     https://training.seer.cancer.gov/anatomy/cells_tissues_membranes/tissues/muscle.html
+%     (NCI SEER Training Modules — U.S. National Cancer Institute)
+%     "Skeletal muscle fibers are cylindrical, multinucleated, striated, and
+%      under voluntary control." ... "Cardiac muscle has branching fibers, one
+%      nucleus per cell, striations, and intercalated disks." (skeletal and
+%      cardiac are two of the three named muscle-tissue types)
+%
+%   nervous → brain_and_nerves
+%     https://training.seer.cancer.gov/anatomy/cells_tissues_membranes/tissues/nervous.html
+%     (NCI SEER Training Modules — U.S. National Cancer Institute)
+%     "Nervous tissue is found in the brain, spinal cord, and nerves."
+%
+% (The four-type framing itself is stated on the parent SEER page,
+% https://training.seer.cancer.gov/anatomy/cells_tissues_membranes/tissues/ —
+% "There are four main tissue types in the body: epithelial, connective,
+% muscle, and nervous." — another span of the same primary U.S. government
+% teaching resource.)
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the SEER statement that fixes the
+% first row (epithelial → covering_lining). Every OTHER row's per-fact source
+% and verbatim span is listed above, so each example remains independently
+% checkable. All sources are the NCI SEER Training Modules, a primary U.S.
+% government (National Cancer Institute) teaching resource, so `trust
+% authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table tissue_example {
+    columns tissue, example
+
+    row (epithelial, covering_lining)
+    row (connective, bone_or_blood)
+    row (muscle, cardiac_or_skeletal)
+    row (nervous, brain_and_nerves)
+
+    source "They form the covering of all body surfaces, line body cavities and hollow organs, and are the major tissue in glands."
+    locator "https://training.seer.cancer.gov/anatomy/cells_tissues_membranes/tissues/epithelial.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/tissue-types.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/tissue-types.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% tissue-types.query.adj — a worked recall over the biology tissue-types library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is muscle tissue made
+% of?": it states no histology fact of its own — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `tissue_example` rows and returns the example + the table's source/locator/
+% trust. The fourth query runs the relation BACKWARD (bind the example
+% `bone_or_blood`, recall its tissue type — connective). A word that is not one
+% of the four basic tissue types abstains honestly — the engine never invents an
+% example.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli tissue-types.query.adj
+% ============================================================================
+
+import "tissue-types.adj"
+
+? tissue_example(epithelial, $Example)   % expect covering_lining
+? tissue_example(muscle, $Example)       % expect cardiac_or_skeletal
+? tissue_example(nervous, $Example)      % expect brain_and_nerves
+? tissue_example($Tissue, bone_or_blood) % reverse bind — expect connective
+? tissue_example(epidermis, $Example)    % expect abstain — the epidermis is a structure, not one of the four basic tissue types


### PR DESCRIPTION
Add a grounded ADJ facts library mapping each of the four basic human
tissue types to a representative example / location the source states,
plus its worked .query.adj, an e2e test, and a README subject-index row.

Recall is an ordinary SLD binding query over a native `table`
(tissue_example(tissue, example)) — forward and backward — that returns
the value WITH its citation on the CPU, 0 model calls, and abstains on a
word that is not one of the four basic tissue types (never invents an
example).

Rows (all four grounded, none dropped):
  epithelial → covering_lining
  connective → bone_or_blood
  muscle     → cardiac_or_skeletal
  nervous    → brain_and_nerves

Provenance / trust tiers — every value byte-provenanced this session to
the NCI SEER Training Modules (U.S. National Cancer Institute, a primary
.gov teaching resource) → trust authoritative:
  epithelial: "They form the covering of all body surfaces, line body
    cavities and hollow organs, and are the major tissue in glands."
    .../tissues/epithelial.html
  connective: "The types of connective tissue include ... cartilage,
    osseous tissue (bone), and blood."  .../tissues/connective.html
  muscle: "Skeletal muscle fibers are ..." / "Cardiac muscle has
    branching fibers ..."  .../tissues/muscle.html
  nervous: "Nervous tissue is found in the brain, spinal cord, and
    nerves."  .../tissues/nervous.html
  (four-type framing: "There are four main tissue types in the body:
   epithelial, connective, muscle, and nervous." .../tissues/)

Values use the SOURCE's own words: the source says "cardiac" (not heart)
and "covering"/"line" (not skin), so the atoms stay literally checkable
against the quoted spans. No rows dropped — all four grounded cleanly.

Data-only change: new .adj + .query.adj, one e2e test, one README row.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
