### PR TITLE
feat(adj-facts-stdlib): anatomy/lung-lobes — lung → lobe count table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_lunglobes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_lunglobes_e2e.rs
@@ -1,0 +1,67 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/lung-lobes.adj`) driven through the built CLI:
+//! a native `table` of lung → lobe count resolves a binding-query recall with
+//! the source's NCI SEER Training citation, runs the relation backward
+//! (count → lung), and abstains on a non-lung (the trachea) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factslung_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_lung_lobes_recall_binds_count_with_citation() {
+    let dir = scratch("lunglobes");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/lung-lobes.adj");
+    std::fs::copy(&src, dir.join("lung-lobes.adj")).expect("copy shipped lung-lobes.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"lung-lobes.adj\"\n\
+         ? lung_lobe_count(right_lung, $N)\n\
+         ? lung_lobe_count(left_lung, $N)\n\
+         ? lung_lobe_count($L, 3)\n\
+         ? lung_lobe_count(trachea, $N)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The right lung has three lobes; the left lung has two — the recalled
+    // counts, each a plain number.
+    assert!(out.contains("\"N\":\"3\""), "right_lung → 3: {out}");
+    assert!(out.contains("\"N\":\"2\""), "left_lung → 2: {out}");
+    // The relation runs backward: the count 3 recalls the right lung.
+    assert!(
+        out.contains("\"L\":\"right_lung\""),
+        "3 → right_lung (reverse recall): {out}"
+    );
+    // The answer carries the NCI SEER Training citation as its proof.
+    assert!(
+        out.contains("training.seer.cancer.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The trachea is not a lung — honest abstention, never a fabricated count.
+    assert!(out.contains("\"abstained\":true"), "unknown lung abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -40,7 +40,8 @@ per rotation, in parallel):
 | `biology/` | common bone → body region | NIH / MedlinePlus |
 | `biology/` | macronutrient → energy (kcal) per gram | NIH / MedlinePlus |
 | `physics/` | simple machine → everyday example | NASA |
-| … | *geography, anatomy, physical constants, …* | *(expanding)* |
+| `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
+| … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown
 in `adj-formula-stdlib/<subject>/` using the `formula` construct — simple ones first, growing

--- a/code/specs/data/adj-facts-stdlib/anatomy/lung-lobes.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/lung-lobes.adj
@@ -1,0 +1,87 @@
+% ============================================================================
+% lung-lobes — how many lobes each human lung has
+% (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A respiratory-anatomy fact on the way to medicine: the two human lungs are
+% NOT mirror images. The RIGHT lung is divided into THREE lobes (superior/upper,
+% middle, inferior/lower); the LEFT lung has only TWO lobes (superior/upper,
+% inferior/lower), because the heart sits slightly left of the midline and its
+% apex presses a notch — the cardiac notch — into the left lung's medial
+% surface, leaving no room for a middle lobe. Recall is a binding query:
+%
+%     ? lung_lobe_count(right_lung, $N)     % 3
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `lung_lobe_count(lung, count)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the number
+% WITH its source, on the CPU, with zero model calls, and abstains on anything
+% that is not one of the two lungs (it never invents a lobe count).
+%
+% The two lungs, as a little truth table:
+%
+%     lung          lobes   which lobes
+%     -----------   -----   ------------------------------------
+%     right_lung      3     superior (upper), middle, inferior (lower)
+%     left_lung       2     superior (upper), inferior (lower)
+%
+% Because each `count` value is a NUMBER (not a label), a recalled count
+% composes straight into arithmetic and constraint checks: the two lungs sum to
+% 3 + 2 = 5 lobes total; a radiology note describing a "middle lobe" collapse on
+% the LEFT is suspect precisely because the left lung has no middle lobe. That
+% is the concrete bridge from anatomy RECALL to COMPUTE, and the rung a medicine
+% agent reasons UP from before it can reason about a lobectomy or a lobar
+% pneumonia. The query also runs BACKWARD — bind a count and recall the lung
+% that has it:
+%
+%     ? lung_lobe_count($L, 3)              % right_lung — reverse recall
+%
+% Something that is not one of the two lungs — the trachea, the heart, a single
+% lobe — has no row, so a recall on it ABSTAINS rather than inventing a count.
+% That honest-abstention property is what makes the table safe to reason from.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every lung→count pair was
+% read out of a fetched U.S. government / NIH page this session, and any count
+% that could not be grounded there would have been dropped). Both counts come
+% from the SAME primary U.S. National Cancer Institute reference, NCI SEER
+% Training "Bronchi, Bronchial Tree, & Lungs"
+% (training.seer.cancer.gov/anatomy/respiratory/passages/bronchi.html), each
+% quoted here character-for-character so any reader can re-check it:
+%
+%   right_lung → 3
+%     "The right lung is shorter, broader, and has a greater volume than the
+%      left lung. It is divided into three lobes and each lobe is supplied by
+%      one of the secondary bronchi."
+%
+%   left_lung → 2
+%     "The left lung has two lobes."
+%
+% The individual lobe NAMES (superior/upper, middle, inferior/lower) are
+% corroborated by a second primary U.S. government NIH / National Library of
+% Medicine reference, StatPearls "Anatomy, Thorax, Lungs"
+% (ncbi.nlm.nih.gov/books/NBK470197/):
+%
+%     "The right lung is comprised of the right upper (RUL), middle (RML), and
+%      lower (RLL) lobes. The left lung consists of the left upper (LUL) and
+%      lower (LLL) lobes."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the NCI SEER Training sentence
+% that fixes the first row (right_lung → 3). The other row's per-fact source and
+% verbatim span is listed above, so each count remains independently checkable.
+% Both sources are primary U.S. government NIH references (NCI SEER Training;
+% NIH / NLM StatPearls), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table lung_lobe_count {
+    columns lung, count
+
+    row (right_lung, 3)
+    row (left_lung, 2)
+
+    source "The right lung is shorter, broader, and has a greater volume than the left lung. It is divided into three lobes and each lobe is supplied by one of the secondary bronchi."
+    locator "https://training.seer.cancer.gov/anatomy/respiratory/passages/bronchi.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/lung-lobes.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/lung-lobes.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% lung-lobes.query.adj — a worked recall over the anatomy lung-lobes library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how many lobes does the
+% right lung have?": it states no anatomy fact — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `lung_lobe_count` rows and returns the count + the table's source/locator/trust.
+% The third query runs the relation BACKWARD (bind the count 3, recall the lung
+% that has it — the right lung). The trachea is not a lung, so a recall on it
+% abstains honestly — the engine never invents a lobe count.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli lung-lobes.query.adj
+% ============================================================================
+
+import "lung-lobes.adj"
+
+? lung_lobe_count(right_lung, $N)   % expect 3
+? lung_lobe_count(left_lung, $N)    % expect 2
+? lung_lobe_count($L, 3)            % expect right_lung — reverse recall
+? lung_lobe_count(trachea, $N)      % expect abstain — the trachea is not a lung


### PR DESCRIPTION
Add a grounded ADJ facts library mapping each human lung to its number
of lobes (right_lung → 3, left_lung → 2), mirroring the anatomy
heart-chambers / body-counts pattern: a native `table` whose rows lower
to a `lung_lobe_count(lung, count)` relation carrying one provenance
envelope. Recall is a zero-model-call binding query that returns the
count with its citation, runs backward (count → lung), and abstains on
a non-lung.

Provenance (every value byte-provenanced from a source fetched this
session; nothing from memory):
  - right_lung → 3 and left_lung → 2: NCI SEER Training, "Bronchi,
    Bronchial Tree, & Lungs" — primary U.S. government (National Cancer
    Institute) reference → trust authoritative.
    "It is divided into three lobes ..." / "The left lung has two lobes."
  - Individual lobe names (superior/upper, middle, inferior/lower)
    corroborated by NIH / NLM StatPearls "Anatomy, Thorax, Lungs"
    (NBK470197) — also authoritative.

Data-only change: new lung-lobes.adj + lung-lobes.query.adj, one e2e
test (facts_lunglobes_e2e.rs), and one README subject-index row for
anatomy/. No engine/grammar/adapter code touched. cargo test + clippy
green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
