### PR TITLE
feat(semantic-ir-to-javascript): SIR22 array/matrix base-cut codegen (HML01 Stream A)

### DIFF
--- a/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.1.1] - 2026-07-16
+
+### Changed
+
+- **`semantic-ir-to-javascript` now accepts and correctly compiles the SIR22
+  base-cut modules this frontend produces** (a bare `ElementwiseOp`, e.g.
+  `3+4`) — no code change in this crate; that backend gained real codegen
+  for `NDArrays`/`MatrixOps`/`ArrayColumnMajor`. `Reduce`/`Scan`/
+  `OuterProduct` (this crate's own SIR22-addendum output, e.g. `+/1 2 3`,
+  `1∘.×2`) remain unimplemented there and are now rejected via that
+  backend's own dedicated tree-walk check rather than the plain
+  feature-flag capability check (which can no longer distinguish the two,
+  since they share features) — updated `tests/test_validator.rs`
+  accordingly: the plain-`ElementwiseOp` test now asserts acceptance, and
+  the `Reduce`/`OuterProduct` test now asserts on `compile()`'s rejection
+  rather than `check_module()`'s (which no longer catches it alone).
+
 ## [0.1.0] - 2026-07-12
 
 ### Added

--- a/code/packages/rust/apl-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/apl-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apl-to-semantic-ir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "APL CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-4f, the last APL rollout item per HML01."
 

--- a/code/packages/rust/apl-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/test_validator.rs
@@ -1,19 +1,24 @@
 //! Structural verification of lowered modules, mirroring
 //! `matlab-to-semantic-ir`'s own `tests/test_validator.rs` capability-
-//! rejection pattern: every module this frontend produces must pass the
+//! acceptance pattern: every module this frontend produces must pass the
 //! shared SIR validator, and (since **every** APL program here emits at
 //! least one SIR22/SIR22-addendum node -- there is no purely-scalar escape
 //! hatch the way MATLAB's literal-only subset has, see `src/lower.rs`'s
-//! module doc comment point 1) a real backend that doesn't implement SIR22
-//! codegen yet must cleanly *reject* the module rather than silently
-//! producing wrong output.
+//! module doc comment point 1) a real backend must accept or reject the
+//! module according to exactly which SIR22 node it uses.
 //!
-//! `semantic-ir-to-javascript` does not implement codegen for any SIR22 or
-//! SIR22-addendum node (see that backend's `emit.rs`, which panics with
-//! "not accepted yet" if one is ever reached post-check -- the panic only
-//! guards the capability check never drifting, since `Feature::NDArrays`/
-//! `MatrixOps` are not in that backend's `ACCEPTED_FEATURES`), so these
-//! tests confirm the *gate* works, not that codegen runs.
+//! `semantic-ir-to-javascript` now implements real codegen for the SIR22
+//! *base cut* (`ElementwiseOp` among them, which is all a simple dyadic
+//! program like `3+4` needs), so those modules are accepted. The SIR22
+//! "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/...) remain
+//! deferred — this crate's own lowering is exactly what motivated adding
+//! `semantic-ir-to-javascript`'s dedicated tree-walk rejection for them
+//! (see that crate's `find_unimplemented_sir22_addendum_node`), since they
+//! share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the now-accepted
+//! base cut and so are NOT caught by the plain `Backend::check_module`
+//! feature check alone — the `reduce_and_outer_product_modules...` test
+//! below calls `compile()`, not `check_module()` directly, for exactly
+//! that reason.
 
 use apl_to_semantic_ir::compile_source;
 use semantic_ir::backend::Backend;
@@ -31,15 +36,15 @@ fn assert_valid(src: &str) -> semantic_ir::Module {
 }
 
 #[test]
-fn every_apl_program_validates_but_the_js_backend_rejects_it() {
+fn a_simple_dyadic_program_validates_and_the_js_backend_accepts_it() {
     // Even the simplest possible dyadic program -- `3+4` -- lowers to an
-    // `ElementwiseOp`, which is a SIR22 node no backend accepts yet.
+    // `ElementwiseOp`, which is now real SIR22-base-cut codegen.
     let module = assert_valid("3+4\n");
     let backend = JavaScriptBackend;
     let errors = backend.check_module(&module);
     assert!(
-        !errors.is_empty(),
-        "expected the JS backend to reject an ElementwiseOp-using module"
+        errors.is_empty(),
+        "expected the JS backend to accept an ElementwiseOp-using module, got: {errors:?}"
     );
 }
 
@@ -47,8 +52,7 @@ fn every_apl_program_validates_but_the_js_backend_rejects_it() {
 fn a_pure_scalar_literal_with_no_operator_at_all_still_validates() {
     // The one shape of APL program that emits *no* SIR22 node at all: a
     // bare literal with nothing applied to it. `print` is a plain builtin
-    // every backend already implements, so this is the sole case that could
-    // in principle run through the JS backend today.
+    // every backend already implements.
     let module = assert_valid("5\n");
     let backend = JavaScriptBackend;
     let errors = backend.check_module(&module);
@@ -59,11 +63,26 @@ fn a_pure_scalar_literal_with_no_operator_at_all_still_validates() {
 }
 
 #[test]
-fn reduce_and_outer_product_modules_validate_but_are_rejected_by_js() {
+fn reduce_and_outer_product_modules_validate_but_compile_still_rejects_them() {
+    // `Reduce`/`OuterProduct` share `NDArrays`/`MatrixOps`/`ArrayColumnMajor`
+    // with the SIR22 base cut the JS backend now accepts, so
+    // `check_module()` alone (a plain feature-flag check) no longer
+    // catches these -- only the dedicated tree-walk inside `compile()`
+    // does. Confirms both that the module still fails cleanly (not a
+    // panic) AND that the coarse feature check by itself is genuinely
+    // insufficient here (documenting, not just asserting, the gap).
     let module = assert_valid("+/1 2 3\n");
     let backend = JavaScriptBackend;
-    assert!(!backend.check_module(&module).is_empty());
+    assert!(
+        backend.check_module(&module).is_empty(),
+        "check_module alone no longer rejects Reduce -- it shares features with the accepted base cut"
+    );
+    let err = semantic_ir_to_javascript::compile(&module)
+        .expect_err("compile() should still cleanly reject a Reduce-using module");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
 
     let module = assert_valid("1∘.×2\n");
-    assert!(!backend.check_module(&module).is_empty());
+    let err = semantic_ir_to_javascript::compile(&module)
+        .expect_err("compile() should still cleanly reject an OuterProduct-using module");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
 }

--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`semantic-ir-to-javascript` now accepts and correctly compiles the
+  SIR22 array/matrix modules this frontend produces** — no code change in
+  this crate; that backend gained real codegen for `NDArrays`/`MatrixOps`/
+  `ArrayColumnMajor` (previously deferred/rejected). Updated
+  `tests/test_validator.rs`'s three tests from "the backend rejects this"
+  to "the backend accepts this," and added four real `node`-execution
+  tests to `tests/e2e_node.rs` proving actual MATLAB source using matrix
+  multiplication, elementwise scalar broadcast (`A .* 2`), indexed
+  assignment, and range+transpose all compile and run correctly — not
+  just that the module passes validation.
+
 ### Fixed
 
 - **Correctness: `Feature::Floats` was never observed for a `FloatLit`.**

--- a/code/packages/rust/matlab-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/e2e_node.rs
@@ -9,10 +9,14 @@
 //! As `test_validator.rs`'s module doc comment explains, this crate's
 //! "scalar fast path" only recognises *purely literal* arithmetic as
 //! provably scalar — any variable-involving arithmetic takes the
-//! `ElementwiseOp`/`MatMul` path, which the JS backend does not implement
-//! codegen for yet. So, for now, only a purely-literal MATLAB program can
-//! make it all the way through this pipeline; that is exactly what this
-//! test proves, gated on `node` availability like its JS counterpart.
+//! `ElementwiseOp`/`MatMul` path. The JS backend now implements real codegen
+//! for that path (the SIR22 base cut), so a real array/matrix MATLAB
+//! program round-trips through this pipeline too — the tests below prove
+//! that with actual `A = [1 2; 3 4]; B = A * A;`-style source, not hand-built
+//! SIR. `disp` on a computed matrix has no display-formatting story yet
+//! (out of scope for the codegen PR that unblocked this file), so each test
+//! reads back a single element via MATLAB indexing (`disp(B(1, 1))`) rather
+//! than `disp`-ing the whole matrix.
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
@@ -118,4 +122,69 @@ fn a_call_before_its_textual_definition_runs_in_node() {
         "disp(double_seven());\nfunction r = double_seven()\n  r = 3 + 4 + 3 + 4;\nend\n",
     );
     assert_eq!(out, "14");
+}
+
+#[test]
+fn matrix_multiplication_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping matrix_multiplication_runs_in_node: `node` not available");
+        return;
+    }
+    // A * A where A = [1 2; 3 4] -> [7 10; 15 22] (standard matrix
+    // product, not elementwise). A(1, 1) (1-based MATLAB indexing) is
+    // the top-left element, 7.
+    let out = run_via_node(
+        "matmul",
+        "A = [1 2; 3 4];\nB = A * A;\ndisp(B(1, 1));\n",
+    );
+    assert_eq!(out, "7");
+}
+
+#[test]
+fn elementwise_scale_with_a_bare_scalar_operand_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping elementwise_scale_with_a_bare_scalar_operand_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    // A .* 2 -- the frontend emits `2` as a bare (unwrapped) scalar
+    // ElementwiseOp operand, exactly the shape
+    // `semantic-ir-to-javascript`'s runtime coercion exists for. A(2, 2)
+    // is 4 before scaling, 8 after.
+    let out = run_via_node(
+        "elementwise_scalar",
+        "A = [1 2; 3 4];\nB = A .* 2;\ndisp(B(2, 2));\n",
+    );
+    assert_eq!(out, "8");
+}
+
+#[test]
+fn indexed_assignment_mutates_in_place_and_reads_back_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping indexed_assignment_mutates_in_place_and_reads_back_in_node: `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node("index_set", "A = [1 2 3];\nA(2) = 9;\ndisp(A(2));\n");
+    assert_eq!(out, "9");
+}
+
+#[test]
+fn range_and_transpose_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping range_and_transpose_run_in_node: `node` not available");
+        return;
+    }
+    // transpose([1 2; 3 4]) = [1 2; 3 4] with rows/cols swapped, i.e.
+    // [1 3; 2 4]; B(2, 1) (1-based) is the original A(1, 2) = 2. The
+    // range `v = 1:5` is exercised for its manifest/codegen path
+    // (compiles and runs without error) even though this particular
+    // program never reads `v` back.
+    let out = run_via_node(
+        "range_and_transpose",
+        "A = [1 2; 3 4];\nv = 1:5;\nB = A';\ndisp(B(2, 1));\n",
+    );
+    assert_eq!(out, "2");
 }

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_validator.rs
@@ -1,18 +1,18 @@
 //! Structural verification of lowered modules: every module this frontend
 //! produces must pass the shared SIR validator, and any module using the
-//! SIR22 array/matrix domain must be correctly *rejected* by a backend that
-//! does not declare `Feature::NDArrays`/`MatrixOps` — mirroring exactly the
-//! capability-rejection verification pattern used to land SIR22/SIR23
+//! SIR22 array/matrix domain must be correctly *accepted* by the
+//! `semantic-ir-to-javascript` backend — mirroring exactly the
+//! capability-acceptance verification pattern used to land SIR22/SIR23
 //! themselves (a real `Module`, checked through the actual
 //! `Backend::check_module` path, not an isolated unit assertion).
 //!
-//! `semantic-ir-to-javascript` does not yet implement codegen for the
-//! SIR22 nodes (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
-//! `IndexGet`/`IndexSet` all panic with "not accepted yet" if ever reached
-//! post-check — see that backend's `emit.rs`), so these tests confirm the
-//! *gate* works, not that codegen runs; a genuine array/matrix round-trip
-//! through a real backend is future work tracked separately (see this
-//! crate's README).
+//! `semantic-ir-to-javascript` now implements real codegen for the SIR22
+//! *base cut* (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
+//! `IndexGet`/`IndexSet` all lower to calls into its inlined
+//! `__Sir.Array.*` runtime — see that backend's `emit.rs`/`runtime.rs`),
+//! so these tests confirm the *gate* now lets these modules through; a
+//! genuine array/matrix round-trip through real execution lives in
+//! `e2e_node.rs`.
 //!
 //! Note on scope: the "scalar fast path" described in `lower.rs`'s module
 //! doc comment only recognises operands built *purely from literals* as
@@ -21,11 +21,10 @@
 //! inference, so ordinary variable arithmetic (`total + i`, `x * x` for a
 //! parameter `x`, ...) always takes the `ElementwiseOp`/`MatMul` path and
 //! therefore always needs `MatrixOps`/`ArrayColumnMajor` declared — even
-//! though, at runtime, such values are almost always genuine scalars. This
-//! is why only a *purely-literal* program can round-trip through the
-//! current JS backend today; seeing `control_flow_and_loops_validate`
-//! below need the array-domain features makes that limitation concrete
-//! rather than a claim in a doc comment.
+//! though, at runtime, such values are almost always genuine scalars.
+//! `control_flow_and_loops_validate` below documents this by asserting the
+//! manifest directly, rather than relying on backend rejection to make it
+//! concrete (the backend now accepts these features too).
 
 use matlab_to_semantic_ir::compile_source;
 use semantic_ir::backend::Backend;
@@ -93,7 +92,7 @@ fn control_flow_with_a_variable_accumulator_validates_but_needs_array_features()
 }
 
 #[test]
-fn a_matrix_program_validates_but_the_js_backend_rejects_it() {
+fn a_matrix_program_validates_and_the_js_backend_accepts_it() {
     let module = assert_valid("A = [1 2; 3 4];\nB = A * A;\ndisp(B);\n");
     assert!(module
         .manifest
@@ -102,30 +101,29 @@ fn a_matrix_program_validates_but_the_js_backend_rejects_it() {
     let backend = JavaScriptBackend;
     let errors = backend.check_module(&module);
     assert!(
-        !errors.is_empty(),
-        "expected the JS backend to reject a module using SIR22 array/matrix features \
-         (codegen for them isn't implemented there yet)"
+        errors.is_empty(),
+        "expected the JS backend to accept a module using SIR22 array/matrix features, got: {errors:?}"
     );
 }
 
 #[test]
-fn an_indexing_program_validates_but_the_js_backend_rejects_it() {
+fn an_indexing_program_validates_and_the_js_backend_accepts_it() {
     let module = assert_valid("A = [1 2 3];\nA(2) = 9;\ndisp(A(2));\n");
     let backend = JavaScriptBackend;
     let errors = backend.check_module(&module);
     assert!(
-        !errors.is_empty(),
-        "expected the JS backend to reject a module using IndexGet/IndexSet"
+        errors.is_empty(),
+        "expected the JS backend to accept a module using IndexGet/IndexSet, got: {errors:?}"
     );
 }
 
 #[test]
-fn a_range_and_transpose_program_validates_but_the_js_backend_rejects_it() {
+fn a_range_and_transpose_program_validates_and_the_js_backend_accepts_it() {
     let module = assert_valid("A = [1 2; 3 4];\nv = 1:5;\nB = A';\ndisp(B);\n");
     let backend = JavaScriptBackend;
     let errors = backend.check_module(&module);
     assert!(
-        !errors.is_empty(),
-        "expected the JS backend to reject a module using Range/Transpose"
+        errors.is_empty(),
+        "expected the JS backend to accept a module using Range/Transpose, got: {errors:?}"
     );
 }

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -108,6 +108,19 @@ JavaScript artifact stays self-contained.
   so `range` returned a valid-looking `[1, 0]`-shaped empty array with no
   error. Fixed with an explicit `Number.isFinite` check on all three
   arguments before the loop runs.
+- **`set(a, r, c, value)`'s bounds check had the same NaN-unsafe OR-form
+  as the pre-fix `indexSet`, found in the follow-up confirmation review
+  of the fix above.** `set` is not reachable with an unvalidated `NaN`
+  through any current codegen path (every caller resolves positions
+  through `assertValidPosition` first), but it is part of this module's
+  exported public surface, so a future direct caller of `Array.set` — or
+  a refactor of `indexSet` that skips `resolvePositions` — would silently
+  reintroduce the same bug with nothing catching it, since `set` looks
+  unchanged and "already fine" next to its now-fixed neighbors. Fixed by
+  writing the check as the negation of `get`'s AND-form
+  (`!(r >= 0 && ...)`) rather than an OR-form, matching how `get` was
+  already written — a true NaN-safe negation, unlike `A || B`, which is
+  not the same thing as `!(A && B)` when either side can be `NaN`.
 
 ## 0.35.0 — SIR23 symbolic-expression + pattern/rewrite codegen (HML01 Stream B, item 7 JS half)
 

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -77,6 +77,38 @@ JavaScript artifact stays self-contained.
   assert on `compile()`'s new tree-walk rejection rather than the now-
   insufficient-by-itself `check_module()`).
 
+### Fixed (found by `/security-review` before this feature's first push)
+
+- **`NaN` silently bypassed the linear (1-argument) `indexGet`/`indexSet`
+  bounds check, causing a silent wrong read and a silently-dropped write.**
+  `get(a, r, c)`'s 2-argument bounds check is an AND-form
+  (`r >= 0 && r < nrows(a)`), which correctly falls through to "out of
+  bounds" for `r = NaN` (every relational comparison with `NaN` is
+  `false`, so the whole AND is `false`). The linear path instead used an
+  OR-form (`i < 0 || i >= length`) that is *not* the same check's negation
+  under IEEE-754: for `i = NaN`, both halves are `false`, so the "out of
+  bounds" throw was skipped entirely. `indexGet` then silently returned
+  `undefined` from `a.data[NaN]` (a stray, non-index property read on the
+  `Float64Array`, not a buffer read); `indexSet` silently no-opped —
+  `a.data[NaN] = v` sets a stray object property rather than writing the
+  buffer, with no exception at all, so a caller had no way to detect the
+  mutation never happened. `NDArray` index values come from the *compiled
+  program's own runtime arithmetic* (e.g. `0/0`), not just a hand-built
+  edge case. Fixed by validating every resolved position is a real
+  integer once, at `resolvePositions` — the single choke point both
+  `indexGet` and `indexSet` route through — rather than re-deriving a
+  NaN-safe bounds check at each call site. Three new `node`-execution
+  regression tests (NaN scalar `IndexGet`, NaN scalar `IndexSet`, and the
+  related `range()` NaN-bound case below), each confirmed to fail without
+  the fix (node exits 0 silently) and pass with it (a clean, catchable
+  `Error`).
+- **`range()` silently returned an empty vector instead of erroring on a
+  `NaN` `start`/`stop`/`step`.** Same root cause as above: the loop
+  condition is `false` on the very first check whenever a bound is `NaN`,
+  so `range` returned a valid-looking `[1, 0]`-shaped empty array with no
+  error. Fixed with an explicit `Number.isFinite` check on all three
+  arguments before the loop runs.
+
 ## 0.35.0 — SIR23 symbolic-expression + pattern/rewrite codegen (HML01 Stream B, item 7 JS half)
 
 Real codegen for the SIR23 symbolic/pattern domain, replacing the deferred

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,82 @@
 # Changelog
 
+## 0.36.0 — SIR22 array/matrix base-cut codegen (HML01 Stream A)
+
+Real codegen for the SIR22 array/matrix domain's *base cut* — `ArrayLit`,
+`Range`, `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`), and
+`IndexSet` (a `Stmt`) — replacing the deferred `panic!` placeholder these
+seven nodes had. Mirrors the SIR23 codegen's own inlined-runtime treatment:
+targets a new `__Sir.Array` sub-runtime (a plain-JS port of the published
+`sir-runtime-array` npm package) rather than an imported package, so the
+JavaScript artifact stays self-contained.
+
+- `runtime.rs` gains `__Sir.Array`, a plain-JS port of `sir-runtime-array`'s
+  `ndarray`/`elementwise`/`matmul`/`transpose`/`range`/`indexGet`/`indexSet`
+  — dense, column-major `f64` storage (mirroring `array_runtime::value::Array`
+  field-for-field), the same `MAX_ELEMENTS` (2^26) allocation-size guard
+  validated *before* every `new Float64Array(...)` call, and the same
+  APL-style `1`/`0` (never native `boolean`) comparison-result convention.
+- New `toArrayValue` coercion in `elementwise`: `matlab-to-semantic-ir`'s
+  lowerer emits a *bare* (unwrapped) scalar operand for `.* ./ .\` and for
+  `* /` when exactly one side is provably scalar (e.g. `A .* 2` — the `2`
+  arrives as a plain `IntLit`, not an `ArrayLit`), so `elementwise` coerces
+  a raw JS `number` into a scalar `NDArray` itself rather than assuming both
+  operands already carry `.data`/`.shape`. Found and fixed during this PR's
+  own real-MATLAB-source end-to-end testing, not a hand-built edge case —
+  confirmed as a genuine regression by temporarily reverting the coercion
+  and watching `elementwise_mul_with_a_bare_scalar_operand_broadcasts`
+  (this crate) and `elementwise_scale_with_a_bare_scalar_operand_runs_in_node`
+  (`matlab-to-semantic-ir`) both fail with a `node` crash.
+- `emit.rs`: the seven base-cut arms emit real `__Sir.Array.*` calls. Note
+  `Expr::Range`'s field order is `start, step, stop`, but
+  `__Sir.Array.range(start, stop, step)` takes `stop` before `step` —
+  covered by a dedicated argument-order regression test.
+- **Scope boundary, not silently swept away**: the SIR22 "APL addendum"
+  nodes (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+  `IndexOf`/`Ravel`/`Catenate`) remain deferred — `sir-runtime-array` itself
+  never implemented them (no frontend needed them when that package
+  shipped), and porting `array_runtime::ops::{reduce,scan,outer}` +
+  `apl-runtime::builtins`'s bespoke shape/reshape/iota/index-of/ravel/
+  catenate logic is a properly-scoped follow-up, not part of this PR.
+  **Found while auditing downstream consumers for this PR**: these nine
+  variants share `Feature::NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the
+  now-accepted base cut (the SIR22 addendum spec gives them no flag of
+  their own), and `apl-to-semantic-ir`'s *real* lowering (not just a test
+  fixture) emits `Reduce`/`Scan`/`OuterProduct` for APL's `+/`/`+\`/`∘.×`
+  operators today — contradicting that spec's now-stale "no frontend
+  crate consumes these yet" claim. Without a fix, such a module would pass
+  `accepts_features()` and panic inside `emit`. Fixed with a new
+  `find_unimplemented_sir22_addendum_node` tree walk (using the
+  `semantic_ir::Visitor` trait) wired into `JavaScriptBackend::compile()`
+  as an explicit step, mirroring the existing `TailCalls` belt-and-
+  suspenders check — a module using any of these nine now fails cleanly
+  with `BackendErrorKind::UnsupportedFeature`, never a panic.
+- `lib.rs`: `Feature::NDArrays`, `Feature::MatrixOps`, and
+  `Feature::ArrayColumnMajor` join `ACCEPTED_FEATURES`.
+- New `tests/sir22_array.rs`: seven real `node`-execution tests (matmul,
+  the scalar-broadcast fix above, transpose, MATLAB-colon-semantics range,
+  in-place `indexSet` — including whole-column broadcast — and a
+  non-conformable-matmul clean-error-exit case). `lib.rs`'s own test module
+  gains shape-assertion and regression tests (op-name casing, `Range`
+  argument order, `IndexSet` statement shape, the new addendum-node
+  rejection). `runtime.rs` gains four new tests
+  (`runtime_defines_array_matrix_domain`,
+  `array_runtime_validates_shape_before_allocating`,
+  `array_elementwise_coerces_bare_scalar_operands`,
+  `array_elementwise_comparisons_return_apl_style_numbers_not_booleans`).
+  129 tests now in this crate's `--lib` suite alone (`cargo test -p
+  semantic-ir-to-javascript --lib`), plus the seven in the new
+  `sir22_array.rs` integration test file.
+- Downstream consumers updated in lockstep: `matlab-to-semantic-ir`'s
+  `tests/test_validator.rs` (three tests converted from "the backend
+  rejects this" to "the backend accepts this") and `tests/e2e_node.rs`
+  (four new real-MATLAB-source `node`-execution tests: matrix multiply,
+  elementwise scalar broadcast, indexed assignment, range+transpose) and
+  `apl-to-semantic-ir`'s `tests/test_validator.rs` (the plain-`ElementwiseOp`
+  test converted to acceptance; the `Reduce`/`OuterProduct` test updated to
+  assert on `compile()`'s new tree-walk rejection rather than the now-
+  insufficient-by-itself `check_module()`).
+
 ## 0.35.0 — SIR23 symbolic-expression + pattern/rewrite codegen (HML01 Stream B, item 7 JS half)
 
 Real codegen for the SIR23 symbolic/pattern domain, replacing the deferred

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -89,16 +89,32 @@ lowering is direct.
 | `ClassVars` (O3)                |                                          |
 | `Modules` (MX4 mixins)          |                                          |
 | `Constants`                     |                                          |
-| `SymbolicExpr` (SIR23)          | `NDArrays` / `MatrixOps` (SIR22)         |
+| `SymbolicExpr` (SIR23)          |                                          |
 | `PatternMatching` (SIR23)       |                                          |
 | `Rationals` (shared w/ SIR22)   |                                          |
+| `NDArrays` (SIR22 base cut)     |                                          |
+| `MatrixOps` (SIR22 base cut)    |                                          |
+| `ArrayColumnMajor` (SIR22)      |                                          |
 
 `accepts_intrinsics()` is empty. The accept-set is deliberately matched
 to what `emit` handles, so a module using a deferred node is turned away
 *before* lowering rather than mis-compiled — and every accepted feature
 has a real emit arm (the residual `panic!` guards cover only the
 still-deferred SIR18 nodes — `SingletonClassDef` OOP dispatch and string
-interpolation).
+interpolation — plus the still-unimplemented SIR22 "APL addendum" nodes,
+one caveat below).
+
+**One caveat on `NDArrays`/`MatrixOps`/`ArrayColumnMajor`**: the SIR22
+*base cut* (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
+`IndexGet`/`IndexSet`) has real codegen against an inlined `__Sir.Array`
+runtime (a plain-JS port of the published `sir-runtime-array` package —
+see `runtime.rs`). The SIR22 *addendum* nodes (`Reduce`/`Scan`/
+`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
+`Catenate`) share these same three features and remain deferred, so this
+backend adds a dedicated tree-walk check inside `compile()` (beyond the
+ordinary feature-flag capability check) that cleanly rejects a module
+using any of the nine rather than let it slip through and panic in
+`emit` — see `find_unimplemented_sir22_addendum_node` in `lib.rs`.
 
 `Classes` now covers **full user-defined-class OOP (O3)**: a `ClassDef`
 supplies its `superclass` *ancestry edge* (so `raise MyErr; rescue
@@ -389,6 +405,45 @@ found.
 (`f(x, 1/3)`-style), reached from `formatSeen` by checking for a plain
 object carrying a `.kind` tag.
 
+### Array/matrix domain (SIR22 base cut)
+
+The inlined `__Sir` also carries `Array` — a plain-JS port of the
+published `@coding-adventures/sir-runtime-array` TypeScript package, so
+the artifact stays self-contained:
+
+| SIR                                    | JavaScript emitted                                                       |
+|------------------------------------------|---------------------------------------------------------------------------|
+| `ArrayLit([[1, 2], [3, 4]])`             | `__Sir.Array.fromRows([[1, 2], [3, 4]])`                                 |
+| `Range(1, Some(2), 10)`                  | `__Sir.Array.range(1, 10, 2)` — note the argument ORDER: `stop` before `step` |
+| `MatMul(a, b)`                           | `__Sir.Array.matmul(a, b)`                                               |
+| `ElementwiseOp(Mul, a, b)`               | `__Sir.Array.elementwise("Mul", a, b)`                                   |
+| `Transpose(a, conjugate: true)`         | `__Sir.Array.transpose(a, true)`                                         |
+| `IndexGet(a, [Scalar(0), Whole])`        | `__Sir.Array.indexGet(a, [{ kind: "scalar", value: 0 }, { kind: "whole" }])` |
+| `IndexSet(a, [Scalar(0)], v)` (a `Stmt`) | `__Sir.Array.indexSet(a, [{ kind: "scalar", value: 0 }], v);`            |
+
+`NDArray` is `{ shape: number[], data: Float64Array }` — dense,
+COLUMN-MAJOR storage (Fortran/MATLAB order), mirroring
+`array_runtime::value::Array` field-for-field. `elementwise` coerces a
+bare JS `number` operand into a scalar `NDArray` (`toArrayValue`) because
+`matlab-to-semantic-ir`'s lowerer emits a mixed number/`NDArray` operand
+pair whenever exactly one side of `.* ./ .\`/`* /` is provably scalar
+(`A .* 2` passes `2` through unwrapped, not as an `ArrayLit`).
+
+**Not implemented**: the SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
+`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
+`Catenate`) — see the capability table's caveat above for why a module
+using one of these fails cleanly rather than through the ordinary
+feature-flag check.
+
+**Security.** Every factory that computes an output size from
+caller-supplied numbers (`matmul`'s `[m, n]`, `indexGet`'s two
+independently-bounded row/column selections, `range`'s element count, ...)
+validates via `checkedShapeSize`/an explicit `MAX_ELEMENTS` (2^26) check
+*before* allocating a `Float64Array`, matching `matlab-runtime`'s own
+`MAX_RANGE` bound — an unbounded or malformed shape fails with a
+catchable `Error`, not an uncaught `RangeError` or a stalled huge
+allocation.
+
 ## Output format
 
 - 2-space indentation, semicolons always (no ASI reliance).
@@ -442,3 +497,8 @@ cargo test -p semantic-ir-to-javascript
   symbolic domain — `replaceRepeated` reduces `Add(Add(z, 0), 0)` to the bare
   symbol `z` via `x_ + 0 -> x_`, `replaceAll`'s single-pass (no-retry)
   contract, and a head-typed blank (`x_Integer`) matching selectively.
+- `tests/sir22_array.rs`: real `node`-execution tests for the SIR22
+  array/matrix base cut — matrix multiplication, the bare-scalar-operand
+  `elementwise` coercion fix, transpose, MATLAB-colon range semantics,
+  in-place `indexSet` (including whole-column broadcast), and a
+  non-conformable-matmul clean-error-exit case.

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -82,7 +82,10 @@
 use std::cell::Cell;
 use std::fmt::Write;
 
-use semantic_ir::{Block, Expr, Function, Global, Module, Param, ParamKind, Scope, Stmt};
+use semantic_ir::{
+    Block, ElementwiseOpKind, Expr, Function, Global, IndexArg, Module, Param, ParamKind, Scope,
+    Stmt,
+};
 
 use crate::runtime::RUNTIME;
 
@@ -645,17 +648,83 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             }
             out.push('\n');
         }
-        // ── SIR22: array/matrix indexed assignment (deferred) ───────
-        // `Feature::NDArrays` is not in `ACCEPTED_FEATURES` (see lib.rs),
-        // so `check_module` rejects any module using `IndexSet` before
-        // lowering reaches this emitter. Panic here only guards against
-        // that capability check ever drifting — mirrors the `StrConcat`/
-        // `Intrinsic` deferred-kind panics in `emit_expr` below.  Real
-        // codegen (`__SirArray.indexSet(...)`, per the SIR22 spec's
-        // "Backend impact") lands in a follow-up PR.
-        Stmt::IndexSet { span, .. } => {
-            panic!("javascript backend reached a deferred `IndexSet` at {span} — not accepted yet");
+        // ── SIR22: array/matrix indexed assignment ──────────────────
+        // `target[indices...] = value;` — mutates in place via
+        // `__Sir.Array.indexSet` (see `runtime.rs`'s "array/matrix
+        // domain" section), matching the SIR22 spec's own note that
+        // `IndexSet` is a `Stmt`, not a pure `Expr`, for exactly this
+        // in-place-mutation reason.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            out.push_str(&pad);
+            out.push_str("__Sir.Array.indexSet(");
+            emit_expr(out, target, indent);
+            out.push_str(", [");
+            emit_index_args(out, indices, indent);
+            out.push_str("], ");
+            emit_expr(out, value, indent);
+            out.push_str(");\n");
         }
+    }
+}
+
+/// The JS string `__Sir.Array.elementwise`'s `applyOp` switches on —
+/// exact `ElementwiseOpKind` variant names, not `.name()`'s lowercase
+/// forms (`"add"`, etc., used elsewhere for e.g. debug/display), since
+/// this string is a real runtime dispatch key, not a cosmetic label.
+fn elementwise_op_js_name(op: ElementwiseOpKind) -> &'static str {
+    match op {
+        ElementwiseOpKind::Add => "Add",
+        ElementwiseOpKind::Sub => "Sub",
+        ElementwiseOpKind::Mul => "Mul",
+        ElementwiseOpKind::Div => "Div",
+        ElementwiseOpKind::Pow => "Pow",
+        ElementwiseOpKind::Max => "Max",
+        ElementwiseOpKind::Min => "Min",
+        ElementwiseOpKind::Eq => "Eq",
+        ElementwiseOpKind::Ne => "Ne",
+        ElementwiseOpKind::Lt => "Lt",
+        ElementwiseOpKind::Le => "Le",
+        ElementwiseOpKind::Ge => "Ge",
+        ElementwiseOpKind::Gt => "Gt",
+    }
+}
+
+/// Emit one `IndexArg` as the JS object literal `__Sir.Array.indexGet`/
+/// `indexSet` expect: `{ kind: "scalar", value }` / `{ kind: "whole" }` /
+/// `{ kind: "range", indices: <NDArray> }`. The `Range` case reuses
+/// `emit_expr` on the inner `Expr::Range` node directly — that node's own
+/// `Expr::Range` arm already emits a call into `__Sir.Array.range(...)`,
+/// which returns exactly the `NDArray` shape `indices` needs, so no
+/// separate handling is needed here.
+fn emit_index_arg(out: &mut String, arg: &IndexArg, indent: usize) {
+    match arg {
+        IndexArg::Scalar(e) => {
+            out.push_str("{ kind: \"scalar\", value: ");
+            emit_expr(out, e, indent);
+            out.push_str(" }");
+        }
+        IndexArg::Whole => {
+            out.push_str("{ kind: \"whole\" }");
+        }
+        IndexArg::Range(e) => {
+            out.push_str("{ kind: \"range\", indices: ");
+            emit_expr(out, e, indent);
+            out.push_str(" }");
+        }
+    }
+}
+
+fn emit_index_args(out: &mut String, indices: &[IndexArg], indent: usize) {
+    for (i, arg) in indices.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        emit_index_arg(out, arg, indent);
     }
 }
 
@@ -835,26 +904,101 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::KeywordArg { span, .. } => {
             panic!("javascript backend reached a `KeywordArg` outside call-argument position at {span} — this is a backend bug (keyword args are collapsed by emit_call_args)");
         }
-        // ── SIR22: array/matrix nodes (deferred) ──────────────────────
-        // Neither `Feature::NDArrays` nor `Feature::MatrixOps` is in
-        // `ACCEPTED_FEATURES` (see lib.rs), so `check_module` rejects any
-        // module using these nodes before lowering reaches this emitter —
-        // per the SIR22 spec's "Backend impact": real codegen (calls into
-        // `sir-runtime-array`'s `__SirArray.matmul`/`elementwise`/`range`/
-        // `indexGet`) is a first-wave-JS follow-up PR, not required for
-        // this spec to land safely.  These panics only guard against the
-        // capability check ever drifting, exactly like `StrConcat` above.
-        Expr::ArrayLit { span, .. }
-        | Expr::Range { span, .. }
-        | Expr::MatMul { span, .. }
-        | Expr::ElementwiseOp { span, .. }
-        | Expr::Transpose { span, .. }
-        | Expr::IndexGet { span, .. }
-        // SIR22 addendum: APL primitive operators — same deferral as the
-        // base SIR22 nodes above; `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
-        // are still the gating features, so none of these nine reach this
-        // emitter in a validated module either.
-        | Expr::Reduce { span, .. }
+        // ── SIR22: array/matrix nodes (base cut) ──────────────────────
+        // Real codegen: calls into the inlined `__Sir.Array.*` sub-runtime
+        // (see `runtime.rs`'s "array/matrix domain" section) — a plain-JS
+        // port of `sir-runtime-array`, mirroring how the SIR23 `Sym*` arms
+        // above call into `__Sir.Symbolic.*`. `rows` is row-major in the
+        // literal syntax (per the SIR22 spec); `__Sir.Array.fromRows`
+        // reconciles that with column-major storage, so the emitter just
+        // nests the row/element expressions unchanged.
+        Expr::ArrayLit { rows, .. } => {
+            out.push_str("__Sir.Array.fromRows([");
+            for (i, row) in rows.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push('[');
+                emit_args(out, row, indent);
+                out.push(']');
+            }
+            out.push_str("])");
+        }
+        // `__Sir.Array.range(start, stop, step)` — note the argument
+        // ORDER: the SIR node's own field order is `start, step, stop`,
+        // but `sir-runtime-array`'s `range(start, stop, step = 1)`
+        // (and this runtime's port of it) takes `stop` before `step`.
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            out.push_str("__Sir.Array.range(");
+            emit_expr(out, start, indent);
+            out.push_str(", ");
+            emit_expr(out, stop, indent);
+            out.push_str(", ");
+            match step {
+                Some(step) => emit_expr(out, step, indent),
+                None => out.push('1'),
+            }
+            out.push(')');
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            out.push_str("__Sir.Array.matmul(");
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        // The op name must match `applyOp`'s switch in `runtime.rs`
+        // exactly (`"Add"`, not `.name()`'s lowercase `"add"`).
+        Expr::ElementwiseOp { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "__Sir.Array.elementwise({}, ",
+                quote_js_string(elementwise_op_js_name(*op))
+            );
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::Transpose {
+            target, conjugate, ..
+        } => {
+            out.push_str("__Sir.Array.transpose(");
+            emit_expr(out, target, indent);
+            let _ = write!(out, ", {conjugate})");
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            out.push_str("__Sir.Array.indexGet(");
+            emit_expr(out, target, indent);
+            out.push_str(", [");
+            emit_index_args(out, indices, indent);
+            out.push_str("])");
+        }
+        // ── SIR22 addendum: APL primitive operators (still deferred) ──
+        // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+        // `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` observe the SAME
+        // `NDArrays`/`MatrixOps`/`ArrayColumnMajor` features as the base
+        // cut above (the SIR22 addendum gives them no feature flag of
+        // their own), so accepting those features for the base cut also
+        // lets a module using these nine past the capability check —
+        // unlike every other still-deferred arm in this function, these
+        // nine are NOT purely a "capability check ever drifts" guard.
+        // This is safe today only because no frontend crate emits any of
+        // these nine `Expr` variants yet (`apl-to-semantic-ir` does not
+        // lower APL's reduce/scan/outer-product/shape/reshape/iota/
+        // index-of/ravel/catenate operators to them — see the SIR22 spec's
+        // addendum and `sir-runtime-array`'s own README, which scoped them
+        // out of the runtime package for the identical reason). Wiring
+        // real codegen for these requires porting `array_runtime::ops::
+        // {reduce,scan,outer}` and `apl-runtime::builtins`'s bespoke
+        // shape/reshape/iota/index-of/ravel/catenate logic into this
+        // runtime first — a natural, cleanly-scoped follow-up once a
+        // frontend actually needs them, not part of this PR.
+        Expr::Reduce { span, .. }
         | Expr::Scan { span, .. }
         | Expr::OuterProduct { span, .. }
         | Expr::Shape { span, .. }

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -54,11 +54,21 @@
 //! published `sir-runtime-symbolic`/`symbolic-ir`/`cas-pattern-matching`
 //! TypeScript packages, so the artifact stays self-contained.
 //!
+//! It also accepts the SIR22 array/matrix domain's base cut (`NDArrays`,
+//! `MatrixOps`, `ArrayColumnMajor`): an `ArrayLit`/`Range`/`MatMul`/
+//! `ElementwiseOp`/`Transpose`/`IndexGet`/`IndexSet` node lowers to a call
+//! into the inlined `__Sir.Array.*` runtime — a plain-JS port of the
+//! published `sir-runtime-array` TypeScript package, so the artifact stays
+//! self-contained. The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
+//! `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
+//! `Catenate`) remain deferred — no frontend crate emits them yet, and
+//! `sir-runtime-array` itself deliberately does not implement them (see
+//! `emit`'s own doc comment for the resulting capability/emit caveat).
+//!
 //! It **rejects** everything else at the capability check — the
-//! remaining SIR18 features (e.g. string interpolation), the SIR22
-//! array/matrix domain (`NDArrays`, `MatrixOps`), `TailCalls` (V8 does not
-//! reliably tail-call optimise), and `Intrinsics` (empty whitelist).  The
-//! accept-set is deliberately matched to exactly what
+//! remaining SIR18 features (e.g. string interpolation), `TailCalls` (V8
+//! does not reliably tail-call optimise), and `Intrinsics` (empty
+//! whitelist).  The accept-set is deliberately matched to exactly what
 //! [`emit`](crate::emit) lowers, so a module that uses a deferred node is
 //! turned away *before* lowering rather than producing wrong code.
 //!
@@ -69,7 +79,8 @@ mod emit;
 mod runtime;
 
 use semantic_ir::{
-    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Feature, Module,
+    walk_expr_default, Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr,
+    Feature, Module, Span, Visitor,
 };
 
 pub use emit::sanitize_ident;
@@ -78,6 +89,59 @@ pub use emit::sanitize_ident;
 /// checks, rejects unsupported features, and lowers to JavaScript.
 pub fn compile(module: &Module) -> Result<Artifact, BackendError> {
     JavaScriptBackend::new().compile(module)
+}
+
+/// Finds the first (if any) SIR22 "APL addendum" node anywhere in a
+/// module — `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+/// `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`.
+///
+/// These nine variants share `Feature::NDArrays`/`MatrixOps`/
+/// `ArrayColumnMajor` with the SIR22 *base* cut this backend accepts —
+/// the SIR22 addendum spec gives them no feature flag of their own — so
+/// the ordinary `accepts_features()` capability check cannot tell a
+/// module using only the base cut (real codegen, safe) from one that
+/// also uses these nine (still deferred in `emit`, would panic). This
+/// walk is the finer-grained check that closes that gap: found by
+/// auditing `apl-to-semantic-ir`'s downstream tests while wiring this
+/// backend's SIR22 codegen — that crate's *real* lowering logic (not
+/// just a hand-built test fixture) emits `Reduce`/`Scan`/`OuterProduct`
+/// for APL's `+/`/`+\`/`∘.×` operators today, contradicting the SIR22
+/// addendum spec's now-stale "no frontend crate consumes these yet"
+/// claim. Without this check, compiling such a module would sail past
+/// `accepts_features()` (since `NDArrays`/`MatrixOps` are now accepted)
+/// and panic inside `emit` instead of failing cleanly at the capability
+/// boundary — exactly the class of regression the existing `TailCalls`
+/// belt-and-suspenders check in [`JavaScriptBackend::compile`] guards
+/// against for a different feature. See `emit`'s own doc comment on
+/// these nine nodes for why they remain unimplemented.
+fn find_unimplemented_sir22_addendum_node(module: &Module) -> Option<(&'static str, Span)> {
+    struct Finder(Option<(&'static str, Span)>);
+    impl Visitor for Finder {
+        fn visit_expr(&mut self, e: &Expr, depth: usize) {
+            if self.0.is_none() {
+                let hit = match e {
+                    Expr::Reduce { span, .. } => Some(("Reduce", span.clone())),
+                    Expr::Scan { span, .. } => Some(("Scan", span.clone())),
+                    Expr::OuterProduct { span, .. } => Some(("OuterProduct", span.clone())),
+                    Expr::Shape { span, .. } => Some(("Shape", span.clone())),
+                    Expr::Reshape { span, .. } => Some(("Reshape", span.clone())),
+                    Expr::IndexGenerator { span, .. } => Some(("IndexGenerator", span.clone())),
+                    Expr::IndexOf { span, .. } => Some(("IndexOf", span.clone())),
+                    Expr::Ravel { span, .. } => Some(("Ravel", span.clone())),
+                    Expr::Catenate { span, .. } => Some(("Catenate", span.clone())),
+                    _ => None,
+                };
+                if hit.is_some() {
+                    self.0 = hit;
+                    return;
+                }
+            }
+            walk_expr_default(self, e, depth);
+        }
+    }
+    let mut finder = Finder(None);
+    finder.visit_module(module);
+    finder.0
 }
 
 /// The v0 JavaScript backend.
@@ -190,10 +254,25 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // section and `runtime.rs`'s "Symbolic expressions" section.
     Feature::SymbolicExpr,
     Feature::PatternMatching,
-    // A `SymRational` node sets this (shared with the still-deferred SIR22
-    // array/matrix domain rather than a flag of its own — mirroring the
+    // A `SymRational` node sets this (shared with the SIR22 array/matrix
+    // domain below rather than a flag of its own — mirroring the
     // TypeScript backend's identical choice).
     Feature::Rationals,
+    // SIR22: the array/matrix domain's *base cut* — `ArrayLit`, `Range`,
+    // `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`) and
+    // `IndexSet` (a `Stmt`) lower to calls into the inlined
+    // `__Sir.Array.*` runtime (a plain-JS port of the published
+    // `sir-runtime-array` TypeScript package — see `runtime.rs`'s
+    // "array/matrix domain" section and `emit`'s SIR22 arms). The SIR22
+    // "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) share these
+    // SAME three features (the addendum gives them no flag of their own)
+    // but remain deferred in `emit` — see that module's own doc comment
+    // on why accepting these three features doesn't fully close the
+    // capability/emit gap for those nine specifically.
+    Feature::NDArrays,
+    Feature::MatrixOps,
+    Feature::ArrayColumnMajor,
 ];
 
 impl Backend for JavaScriptBackend {
@@ -241,6 +320,27 @@ impl Backend for JavaScriptBackend {
             });
         }
 
+        // 3b. The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
+        //     `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+        //     `IndexOf`/`Ravel`/`Catenate`) share `NDArrays`/`MatrixOps`/
+        //     `ArrayColumnMajor` with the SIR22 base cut this backend
+        //     accepts (the addendum gives them no flag of their own), so
+        //     step 2's coarse feature check cannot reject a module using
+        //     them — an explicit tree walk is the only way to catch this
+        //     before `emit` panics on one. See
+        //     `find_unimplemented_sir22_addendum_node`'s doc comment for
+        //     why this is a real, not theoretical, gap (`apl-to-semantic-ir`
+        //     emits these from real APL source today).
+        if let Some((kind, span)) = find_unimplemented_sir22_addendum_node(module) {
+            return Err(BackendError {
+                kind: BackendErrorKind::UnsupportedFeature,
+                message: format!(
+                    "javascript backend does not yet implement the SIR22 addendum node `{kind}`"
+                ),
+                span,
+            });
+        }
+
         // 4. Lower.
         let source = emit::emit_module(module);
         let metadata = ArtifactMetadata {
@@ -260,7 +360,7 @@ impl Backend for JavaScriptBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{Block, EffectSet, Expr, FeatureManifest, Function, Metadata, Span, Stmt};
+    use semantic_ir::{Block, EffectSet, Expr, FeatureManifest, Function, Metadata, Scope, Span, Stmt};
 
     fn s() -> Span {
         Span::synthetic()
@@ -399,38 +499,64 @@ mod tests {
         );
     }
 
-    // ── SIR22: array/matrix capability-rejection tests ────────────────
+    // ── SIR22: array/matrix codegen ────────────────────────────────────
     //
-    // Per the SIR22 spec's "Backend impact": "Rust/Go/Python backends: not
-    // required to support this in the first wave; they reject modules
-    // declaring NDArrays/MatrixOps per the existing capability-rejection
-    // path."  This JavaScript backend is likewise not updated for real
-    // SIR22 codegen in this PR, so it must reject the same way, via the
-    // same SIR10 capability-check mechanism `rejects_tail_calls_feature`
-    // above already exercises for `Feature::TailCalls`.
+    // The base cut (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+    // `Transpose`/`IndexGet`/`IndexSet`) is accepted and lowers to calls
+    // into the inlined `__Sir.Array.*` runtime; see `runtime.rs`'s "array/
+    // matrix domain" section and `emit`'s SIR22 arms. Behavioural (actual
+    // `node` execution) coverage lives in `tests/sir22_array.rs`, mirroring
+    // how `tests/sir23_symbolic.rs` complements the shape assertions here.
 
     #[test]
-    fn rejects_nd_arrays_feature() {
+    fn accepts_nd_arrays_feature() {
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[Feature::NDArrays]);
-        let err = compile(&m).expect_err("nd-arrays rejected");
-        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        compile(&m).expect("nd-arrays accepted");
     }
 
     #[test]
-    fn rejects_matrix_ops_feature() {
+    fn accepts_matrix_ops_feature() {
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[Feature::MatrixOps]);
-        let err = compile(&m).expect_err("matrix-ops rejected");
+        compile(&m).expect("matrix-ops accepted");
+    }
+
+    /// Regression test for the gap `find_unimplemented_sir22_addendum_node`
+    /// closes: `apl-to-semantic-ir`'s real lowering emits `Expr::Reduce`
+    /// (APL `+/A`) with exactly these three features, and — before this
+    /// check existed — that module would sail past `accepts_features()`
+    /// (since `NDArrays`/`MatrixOps` are now accepted for the SIR22 base
+    /// cut) and panic inside `emit`. Must instead fail cleanly with
+    /// `UnsupportedFeature`, the same error kind every other still-
+    /// deferred node produces, not a panic.
+    #[test]
+    fn rejects_reduce_node_cleanly_instead_of_panicking_in_emit() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::Reduce {
+            op: semantic_ir::ElementwiseOpKind::Add,
+            target: Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            }),
+            span: s(),
+        };
+        let err = compile(&m).expect_err("Reduce node rejected cleanly, not a panic");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
     }
 
     /// End-to-end version: a real module body using `Expr::ArrayLit` and
     /// `Expr::MatMul` (the concrete SIR22 nodes the spec names), not just a
-    /// hand-set manifest flag — proving the rejection path works from
-    /// actual node usage.
+    /// hand-set manifest flag — proving real codegen runs from actual node
+    /// usage, and asserting the exact generated call shape.
     #[test]
-    fn rejects_module_body_using_array_lit_and_matmul() {
+    fn emits_array_lit_and_matmul_as_sir_array_calls() {
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[
             Feature::NDArrays,
@@ -455,8 +581,102 @@ mod tests {
             }),
             span: s(),
         };
-        let err = compile(&m).expect_err("array/matmul body rejected");
-        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        let artifact = compile(&m).expect("array/matmul body compiles");
+        assert!(
+            artifact
+                .source
+                .contains("__Sir.Array.matmul(__Sir.Array.fromRows([[1]]), __Sir.Array.fromRows([[2]]))"),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    #[test]
+    fn emits_elementwise_op_with_pascal_case_op_name() {
+        // The op name must match `runtime.rs`'s `applyOp` switch exactly
+        // (`"Mul"`, not `ElementwiseOpKind::name()`'s lowercase `"mul"`).
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::ElementwiseOp {
+            op: semantic_ir::ElementwiseOpKind::Mul,
+            lhs: Box::new(Expr::IntLit { value: 2, span: s() }),
+            rhs: Box::new(Expr::IntLit { value: 3, span: s() }),
+            span: s(),
+        };
+        let artifact = compile(&m).expect("elementwise body compiles");
+        assert!(
+            artifact.source.contains("__Sir.Array.elementwise(\"Mul\", 2, 3)"),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    #[test]
+    fn emits_range_with_stop_before_step_argument_order() {
+        // `Expr::Range`'s own field order is `start, step, stop`, but
+        // `__Sir.Array.range(start, stop, step)` takes `stop` before
+        // `step` — a real ordering bug here would silently swap the
+        // wrong two arguments rather than fail to compile.
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::NDArrays]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::Range {
+            start: Box::new(Expr::IntLit { value: 1, span: s() }),
+            step: Some(Box::new(Expr::IntLit { value: 2, span: s() })),
+            stop: Box::new(Expr::IntLit { value: 10, span: s() }),
+            span: s(),
+        };
+        let artifact = compile(&m).expect("range body compiles");
+        assert!(
+            artifact.source.contains("__Sir.Array.range(1, 10, 2)"),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    #[test]
+    fn emits_index_set_as_a_statement_not_an_assignment() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::ArrayColumnMajor,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.stmts.push(Stmt::LetBinding {
+            name: "a".into(),
+            sir_type: None,
+            value: Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            },
+            span: s(),
+        });
+        main.body.stmts.push(Stmt::IndexSet {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            indices: vec![
+                semantic_ir::IndexArg::Scalar(Box::new(Expr::IntLit { value: 0, span: s() })),
+                semantic_ir::IndexArg::Whole,
+            ],
+            value: Box::new(Expr::IntLit { value: 9, span: s() }),
+            span: s(),
+        });
+        let artifact = compile(&m).expect("index-set body compiles");
+        assert!(
+            artifact
+                .source
+                .contains("__Sir.Array.indexSet(a, [{ kind: \"scalar\", value: 0 }, { kind: \"whole\" }], 9);"),
+            "got:\n{}",
+            artifact.source
+        );
     }
 
     // ── SIR23: symbolic-expression/pattern codegen ─────────────────────

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -2944,6 +2944,17 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       if (step === 0) {
         throw new Error("range: step cannot be zero");
       }
+      // SECURITY: the loop condition below is false on its very first
+      // check whenever start/stop/step is NaN (every relational
+      // comparison with NaN is false), so an unguarded NaN bound would
+      // silently produce an empty range instead of erroring -- the same
+      // "NaN defeats a comparison-based check" class the linear
+      // indexGet/indexSet fix below closes. Reject non-finite bounds
+      // up front instead of letting them fall through to a
+      // quietly-wrong empty result.
+      if (!Number.isFinite(start) || !Number.isFinite(stop) || !Number.isFinite(step)) {
+        throw new Error(`range: start/stop/step must be finite numbers, got (${start}, ${stop}, ${step})`);
+      }
       const values = [];
       let x = start;
       while ((step > 0 && x <= stop + RANGE_EPSILON) || (step < 0 && x >= stop - RANGE_EPSILON)) {
@@ -2967,12 +2978,40 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // frontend resolves `end` to a concrete 0-based `scalar` index
     // before emitting `IndexGet`/`IndexSet`.
 
+    /**
+     * Validate one resolved position is a real, finite integer.
+     *
+     * SECURITY: `indexGet`/`indexSet`'s own linear (1-argument) bounds
+     * checks are written as `i < 0 || i >= length` — the negation of
+     * `get`'s `r >= 0 && r < nrows(a)` AND-form. Under IEEE-754, `NaN`
+     * fails *every* relational comparison, so for `i = NaN` **both**
+     * halves of that OR are `false`, and the "out of bounds" check is
+     * silently skipped entirely — `a.data[NaN]` then reads/writes a
+     * stray, non-index `"NaN"` property on the `Float64Array` object
+     * rather than the buffer, so a NaN index makes `indexGet` silently
+     * return `undefined` (not throw) and makes `indexSet` silently drop
+     * the write (not throw, not mutate). This is the exact "malformed
+     * input crosses a JS boundary and must fail loudly, not fall
+     * through to `undefined`/corrupt data" hazard this file's other
+     * `default:` guards (`applyOp`, this function's own `default` arm)
+     * already guard against — validating here, once, at the single
+     * choke point both `indexGet` and `indexSet` resolve every position
+     * through, closes it for both without duplicating a NaN-safe bounds
+     * check at every call site.
+     */
+    function assertValidPosition(i) {
+      if (!Number.isInteger(i)) {
+        throw new Error(`resolvePositions: index ${i} is not a finite integer`);
+      }
+      return i;
+    }
+
     /** Resolve one `IndexArg` against a dimension of size `dimSize` into a flat list of 0-based positions along that dimension. */
     function resolvePositions(arg, dimSize) {
       switch (arg.kind) {
-        case "scalar": return [arg.value];
+        case "scalar": return [assertValidPosition(arg.value)];
         case "whole": return Array.from({ length: dimSize }, (_, i) => i);
-        case "range": return Array.from(arg.indices.data, (x) => Math.trunc(x));
+        case "range": return Array.from(arg.indices.data, (x) => assertValidPosition(Math.trunc(x)));
         default:
           // Emitted code crosses a JS runtime boundary the emitter can't
           // enforce at the actual call site — a malformed `kind` must

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -2665,6 +2665,438 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     };
   })();
 
+  // ── array/matrix domain (SIR22) ────────────────────────────────
+  //
+  // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+  // (and `IndexSet`, a `Stmt`) lower to calls into `Array.*` below — a
+  // plain-JS port of the published `@coding-adventures/sir-runtime-array`
+  // TypeScript package this backend's TypeScript sibling *imports*, so
+  // the JavaScript artifact stays self-contained — the same treatment
+  // `Symbolic` above already got for SIR23.
+  //
+  // ## Value model
+  //
+  // `{ shape: number[], data: Float64Array }` — dense, rectangular,
+  // COLUMN-MAJOR storage (Fortran/MATLAB order), mirroring
+  // `array_runtime::value::Array` (`code/packages/rust/array-runtime/src/value.rs`)
+  // field-for-field. `shape == []` is a scalar, `[n]` a vector (an `n×1`
+  // column for row/column purposes), `[r, c]` a matrix — this port's
+  // whole scope, like the Rust reference and the TypeScript sibling, is
+  // rank ≤ 2.
+  //
+  // ## Scope: the SIR22 "APL addendum" is NOT ported here
+  //
+  // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+  // `IndexOf`/`Ravel`/`Catenate` remain deferred in `emit.rs` (still a
+  // `panic!`, unchanged by this port) — no frontend crate emits these
+  // nine `Expr` variants yet (`apl-to-semantic-ir` does not lower APL's
+  // reduce/scan/outer-product operators to them), and the TypeScript
+  // sibling package deliberately scoped them out for the same reason
+  // (see `sir-runtime-array`'s own `src/index.ts` doc comment). Porting
+  // them now would be speculative rather than filling a real gap —
+  // exactly the same reasoning that package's own README states.
+  const ArrayRt = (() => {
+    // SECURITY: every factory below validates a shape/output size
+    // *before* allocating a `Float64Array` from it — a compiled
+    // program's array sizes come from potentially attacker-influenced
+    // runtime values (loop counts, parsed input, ...), not fixed
+    // compile-time constants, so an unbounded or malformed shape must
+    // fail cleanly with a catchable `Error` rather than let
+    // `new Float64Array(n)` itself throw an uncaught `RangeError` or
+    // stall attempting a huge allocation. Mirrors `matlab-runtime`'s own
+    // `MAX_RANGE` bound and the TypeScript sibling's `MAX_ELEMENTS`
+    // exactly, so behaviour is identical across both backends.
+    const MAX_ELEMENTS = 1 << 26; // 67,108,864
+
+    function checkedShapeSize(shape) {
+      if (!shape.every((d) => Number.isInteger(d) && d >= 0)) {
+        throw new Error(`checkedShapeSize: shape ${JSON.stringify(shape)} has a negative or non-integer dimension`);
+      }
+      const n = shape.reduce((acc, d) => acc * d, 1);
+      if (!Number.isFinite(n) || n > MAX_ELEMENTS) {
+        throw new Error(`checkedShapeSize: shape ${JSON.stringify(shape)} (${n} elements) exceeds the ${MAX_ELEMENTS}-element cap`);
+      }
+      return n;
+    }
+
+    function ndarray(shape, data) {
+      if (!(data instanceof Float64Array)) {
+        throw new Error("ndarray: data must be a Float64Array");
+      }
+      const n = checkedShapeSize(shape);
+      if (n !== data.length) {
+        throw new Error(`ndarray: shape ${JSON.stringify(shape)} implies ${n} elements, got ${data.length}`);
+      }
+      return { shape, data };
+    }
+
+    function fromRows(rows) {
+      const nrowsIn = rows.length;
+      if (nrowsIn === 0) {
+        return ndarray([0, 0], new Float64Array(0));
+      }
+      const ncolsIn = rows[0].length;
+      if (rows.some((r) => r.length !== ncolsIn)) {
+        throw new Error("fromRows: ragged rows");
+      }
+      const n = checkedShapeSize([nrowsIn, ncolsIn]);
+      const data = new Float64Array(n);
+      for (let r = 0; r < nrowsIn; r++) {
+        for (let c = 0; c < ncolsIn; c++) {
+          data[c * nrowsIn + r] = rows[r][c]; // column-major store
+        }
+      }
+      return ndarray([nrowsIn, ncolsIn], data);
+    }
+
+    /**
+     * Coerce a bare JS `number` into a rank-0 (scalar) `NDArray`; an
+     * already-`NDArray` value passes through unchanged. Needed because
+     * `matlab-to-semantic-ir`'s lowerer emits a mixed operand pair for
+     * `.* ./ .\` and for `* /` when exactly one side is scalar (e.g.
+     * `A .* 2`) — the *bare* scalar sub-expression is passed through
+     * `ElementwiseOp` unwrapped (a plain `IntLit`/`FloatLit`/arithmetic
+     * result, which emits as an ordinary JS `number`), not wrapped in an
+     * `ArrayLit`/scalar-array constructor first. Every function below
+     * that accepts an "array" operand normalizes through this first, so
+     * a raw number never reaches `.data`/`.shape` and throws a
+     * `TypeError` instead of behaving correctly.
+     */
+    function toArrayValue(v) {
+      return typeof v === "number" ? { shape: [], data: Float64Array.of(v) } : v;
+    }
+
+    function isScalar(a) { return a.data.length === 1; }
+
+    /** Rows, treating a scalar as `1×1` and a vector `[n]` as `n×1`. */
+    function nrows(a) {
+      switch (a.shape.length) {
+        case 0: return 1;
+        default: return a.shape[0];
+      }
+    }
+
+    /** Columns, treating a scalar as `1×1` and a vector `[n]` as `n×1`. */
+    function ncols(a) {
+      switch (a.shape.length) {
+        case 0:
+        case 1: return 1;
+        default: return a.shape[1];
+      }
+    }
+
+    /** Element `(r, c)` (column-major), or `undefined` if out of bounds. */
+    function get(a, r, c) {
+      if (r >= 0 && c >= 0 && r < nrows(a) && c < ncols(a)) {
+        return a.data[c * nrows(a) + r];
+      }
+      return undefined;
+    }
+
+    /**
+     * Set element `(r, c)` in place (column-major) — mutates `a.data`
+     * directly, matching MATLAB assignment semantics (`A(i,j) = v`
+     * rebinds one element of the existing array, it does not produce a
+     * new one). This is why `Stmt::IndexSet` is a statement, not a pure
+     * expression, in the SIR22 spec.
+     */
+    function set(a, r, c, value) {
+      if (r < 0 || c < 0 || r >= nrows(a) || c >= ncols(a)) {
+        throw new Error(`set: index (${r}, ${c}) out of bounds for shape ${JSON.stringify(a.shape)}`);
+      }
+      a.data[c * nrows(a) + r] = value;
+    }
+
+    // ── elementwise binary ops ────────────────────────────────────
+    // Comparisons follow the same APL-style boolean convention
+    // `array_runtime::BinOp` uses: `1` for true, `0` for false (never a
+    // native `boolean`), since the result must stay a plain array
+    // element like every other value here.
+    function applyOp(op, a, b) {
+      const b2f = (cond) => (cond ? 1 : 0);
+      switch (op) {
+        case "Add": return a + b;
+        case "Sub": return a - b;
+        case "Mul": return a * b;
+        case "Div": return a / b;
+        case "Pow": return Math.pow(a, b);
+        case "Max": return Math.max(a, b);
+        case "Min": return Math.min(a, b);
+        case "Eq": return b2f(a === b);
+        case "Ne": return b2f(a !== b);
+        case "Lt": return b2f(a < b);
+        case "Le": return b2f(a <= b);
+        case "Ge": return b2f(a >= b);
+        case "Gt": return b2f(a > b);
+        default:
+          // Same "crosses a JS runtime boundary the emitter can't
+          // enforce" reasoning `resolvePositions` below documents: an
+          // unrecognised `op` must fail loudly here, not fall through
+          // to `undefined`, which would otherwise silently corrupt data
+          // as `NaN` instead of erroring.
+          throw new Error(`applyOp: unrecognised ElementwiseOpKind ${JSON.stringify(op)}`);
+      }
+    }
+
+    function sameShape(a, b) {
+      return a.length === b.length && a.every((d, i) => d === b[i]);
+    }
+
+    /**
+     * Elementwise binary op with scalar broadcasting. Either operand may
+     * be a scalar; otherwise the shapes must match exactly (full
+     * NumPy/MATLAB broadcasting is out of scope, same as the Rust
+     * reference). Result takes the non-scalar operand's shape (or the
+     * scalar's, if both are).
+     */
+    function elementwise(op, a, b) {
+      a = toArrayValue(a);
+      b = toArrayValue(b);
+      const ad = a.data;
+      const bd = b.data;
+      let data;
+      if (isScalar(a)) {
+        data = Float64Array.from(bd, (y) => applyOp(op, ad[0], y));
+      } else if (isScalar(b)) {
+        data = Float64Array.from(ad, (x) => applyOp(op, x, bd[0]));
+      } else {
+        if (!sameShape(a.shape, b.shape)) {
+          throw new Error(`elementwise: non-conformable arrays: ${JSON.stringify(a.shape)} vs ${JSON.stringify(b.shape)}`);
+        }
+        data = new Float64Array(ad.length);
+        for (let i = 0; i < data.length; i++) {
+          data[i] = applyOp(op, ad[i], bd[i]);
+        }
+      }
+      const shape = isScalar(a) ? b.shape : a.shape;
+      return ndarray(shape, data);
+    }
+
+    /**
+     * Matrix product `[m, k] · [k, n] → [m, n]` (column-major
+     * throughout). `m` and `n` come from two *independent* operands
+     * (each individually under `MAX_ELEMENTS`, but their product isn't
+     * bounded by that alone — an outer-product-shaped call could still
+     * ask for a huge output), so `checkedShapeSize` validates `[m, n]`
+     * *before* allocating `out`, not after.
+     */
+    function matmul(a, b) {
+      const m = nrows(a);
+      const ka = ncols(a);
+      const kb = nrows(b);
+      const n = ncols(b);
+      if (ka !== kb) {
+        throw new Error(`matmul: inner dimensions disagree (${m}x${ka} . ${kb}x${n})`);
+      }
+      const outLen = checkedShapeSize([m, n]);
+      const ad = a.data;
+      const bd = b.data;
+      const out = new Float64Array(outLen);
+      for (let j = 0; j < n; j++) {
+        for (let i = 0; i < m; i++) {
+          let acc = 0;
+          for (let p = 0; p < ka; p++) {
+            acc += ad[p * m + i] * bd[j * kb + p]; // column-major indexing
+          }
+          out[j * m + i] = acc;
+        }
+      }
+      return ndarray([m, n], out);
+    }
+
+    /**
+     * Matrix transpose. `conjugate` distinguishes MATLAB `'` (`true`)
+     * from `.'` (`false`) — this runtime has no `Complex` value type yet
+     * (matching `array-runtime`'s own real-only scope today), so a
+     * conjugate transpose of real data is identical to a plain
+     * transpose; `conjugate` is accepted for call-shape parity with the
+     * SIR spec only.
+     */
+    function transpose(a, conjugate) {
+      void conjugate;
+      const m = nrows(a);
+      const n = ncols(a);
+      const ad = a.data;
+      const out = new Float64Array(ad.length);
+      for (let j = 0; j < n; j++) {
+        for (let i = 0; i < m; i++) {
+          out[i * n + j] = ad[j * m + i];
+        }
+      }
+      return ndarray([n, m], out);
+    }
+
+    // ── range ───────────────────────────────────────────────────────
+    // Tolerance for the inclusive-stop boundary check, matching
+    // `matlab-runtime`'s own `eval_colon` exactly — a floating step
+    // (e.g. `1:0.1:2`) can drift a few ULPs short of `stop` by the final
+    // iteration, and MATLAB's `a:step:b` is inclusive of `b`.
+    const RANGE_EPSILON = 1e-9;
+
+    /**
+     * Materialize a MATLAB-style range `start:step:stop` (default
+     * `step = 1`) as a `1×n` row vector — MATLAB's `:` always produces
+     * a row, never a column. Bounded by `MAX_ELEMENTS` so a compiled
+     * program's `1:1e18`-style range can't exhaust memory before this
+     * function ever gets to materialize anything.
+     */
+    function range(start, stop, step = 1) {
+      if (step === 0) {
+        throw new Error("range: step cannot be zero");
+      }
+      const values = [];
+      let x = start;
+      while ((step > 0 && x <= stop + RANGE_EPSILON) || (step < 0 && x >= stop - RANGE_EPSILON)) {
+        if (values.length >= MAX_ELEMENTS) {
+          throw new Error(`range: produces more than ${MAX_ELEMENTS} elements`);
+        }
+        values.push(x);
+        x += step;
+      }
+      return ndarray(
+        values.length === 0 ? [1, 0] : [1, values.length],
+        Float64Array.from(values),
+      );
+    }
+
+    // ── indexing ────────────────────────────────────────────────────
+    // One MATLAB-style index-position argument, mirroring the SIR22
+    // spec's `IndexArg` exactly: `{kind:"scalar",value}` /
+    // `{kind:"whole"}` / `{kind:"range",indices: <NDArray>}`. `end`-
+    // relative indices are never seen here — per SIR10 discipline, the
+    // frontend resolves `end` to a concrete 0-based `scalar` index
+    // before emitting `IndexGet`/`IndexSet`.
+
+    /** Resolve one `IndexArg` against a dimension of size `dimSize` into a flat list of 0-based positions along that dimension. */
+    function resolvePositions(arg, dimSize) {
+      switch (arg.kind) {
+        case "scalar": return [arg.value];
+        case "whole": return Array.from({ length: dimSize }, (_, i) => i);
+        case "range": return Array.from(arg.indices.data, (x) => Math.trunc(x));
+        default:
+          // Emitted code crosses a JS runtime boundary the emitter can't
+          // enforce at the actual call site — a malformed `kind` must
+          // fail cleanly here, not fall through to `undefined` and
+          // surface as a confusing `TypeError` several calls further down.
+          throw new Error(`resolvePositions: unrecognised IndexArg ${JSON.stringify(arg)}`);
+      }
+    }
+
+    /**
+     * `A(i)` / `A(i, j)` — read one element or a sub-array. Scoped to 1
+     * or 2 index arguments (rank ≤ 2): a single argument indexes `a`'s
+     * underlying column-major data linearly (MATLAB's own single-
+     * subscript convention, which is column-major too); two arguments
+     * index `(row, col)`. Returns a bare `number` when every argument is
+     * `scalar` (a single element), otherwise an `NDArray`.
+     */
+    function indexGet(a, indices) {
+      if (indices.length === 1) {
+        const [arg] = indices;
+        const positions = resolvePositions(arg, a.data.length);
+        const read = (i) => {
+          if (i < 0 || i >= a.data.length) {
+            throw new Error(`indexGet: linear index ${i} out of bounds`);
+          }
+          return a.data[i];
+        };
+        if (arg.kind === "scalar") {
+          return read(positions[0]);
+        }
+        return ndarray([1, positions.length], Float64Array.from(positions, read));
+      }
+      if (indices.length === 2) {
+        const [rowArg, colArg] = indices;
+        const rows = resolvePositions(rowArg, nrows(a));
+        const cols = resolvePositions(colArg, ncols(a));
+        const read = (r, c) => {
+          const v = get(a, r, c);
+          if (v === undefined) {
+            throw new Error(`indexGet: (${r}, ${c}) out of bounds for shape ${JSON.stringify(a.shape)}`);
+          }
+          return v;
+        };
+        if (rowArg.kind === "scalar" && colArg.kind === "scalar") {
+          return read(rows[0], cols[0]);
+        }
+        // `rows.length`/`cols.length` are each individually bounded by
+        // `a`'s own dimensions (`whole`) or by a `range` NDArray's own
+        // `MAX_ELEMENTS` cap — but nothing bounds their *product* on its
+        // own, so this is the exact outer-product-shaped allocation
+        // `matmul` guards against, one level up. Validate before
+        // allocating, not after.
+        const outLen = checkedShapeSize([rows.length, cols.length]);
+        const data = new Float64Array(outLen);
+        for (let c = 0; c < cols.length; c++) {
+          for (let r = 0; r < rows.length; r++) {
+            data[c * rows.length + r] = read(rows[r], cols[c]);
+          }
+        }
+        return ndarray([rows.length, cols.length], data);
+      }
+      throw new Error(`indexGet: only 1 or 2 index arguments are supported (rank <= 2 scope), got ${indices.length}`);
+    }
+
+    /** Broadcast a scalar-or-`NDArray` right-hand side to exactly `count` values (mirrors `elementwise`'s scalar-broadcast rule). */
+    function broadcastValues(value, count) {
+      if (typeof value === "number") {
+        return new Float64Array(count).fill(value);
+      }
+      if (value.data.length === 1) {
+        return new Float64Array(count).fill(value.data[0]);
+      }
+      if (value.data.length !== count) {
+        throw new Error(`indexSet: value has ${value.data.length} elements, expected ${count}`);
+      }
+      return value.data;
+    }
+
+    /**
+     * `A(i) = v` / `A(i, j) = v` — write one element or a sub-array, IN
+     * PLACE (see `set`'s doc comment above for why this mutates rather
+     * than returns a new array). `value` may be a scalar (broadcast to
+     * every selected position) or an `NDArray` with exactly as many
+     * elements as positions are selected.
+     */
+    function indexSet(a, indices, value) {
+      if (indices.length === 1) {
+        const [arg] = indices;
+        const positions = resolvePositions(arg, a.data.length);
+        const values = broadcastValues(value, positions.length);
+        positions.forEach((i, k) => {
+          if (i < 0 || i >= a.data.length) {
+            throw new Error(`indexSet: linear index ${i} out of bounds`);
+          }
+          a.data[i] = values[k];
+        });
+        return;
+      }
+      if (indices.length === 2) {
+        const [rowArg, colArg] = indices;
+        const rows = resolvePositions(rowArg, nrows(a));
+        const cols = resolvePositions(colArg, ncols(a));
+        // Same product-of-two-independent-selections gap `indexGet`
+        // closes above — validate before `broadcastValues` allocates.
+        const count = checkedShapeSize([rows.length, cols.length]);
+        const values = broadcastValues(value, count);
+        let k = 0;
+        for (let c = 0; c < cols.length; c++) {
+          for (let r = 0; r < rows.length; r++) {
+            set(a, rows[r], cols[c], values[k]);
+            k++;
+          }
+        }
+        return;
+      }
+      throw new Error(`indexSet: only 1 or 2 index arguments are supported (rank <= 2 scope), got ${indices.length}`);
+    }
+
+    return {
+      ndarray, fromRows, isScalar, nrows, ncols, get, set,
+      elementwise, matmul, transpose, range, indexGet, indexSet,
+    };
+  })();
+
   return {
     Sym, Pair, Closure,
     intern, applyClosure, truthy, format, print, puts,
@@ -2682,6 +3114,12 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // the published sir-runtime-symbolic/symbolic-ir/cas-pattern-matching
     // TypeScript packages so this backend stays self-contained.
     Symbolic,
+    // SIR22: array/matrix domain, ported from the published
+    // sir-runtime-array TypeScript package so this backend stays
+    // self-contained. Exposed as `Array` (a property key, not a `const`
+    // binding — this never shadows the global `Array` constructor
+    // anywhere in this file).
+    Array: ArrayRt,
   };
 })();
 "##;
@@ -2979,5 +3417,77 @@ mod tests {
         // `.kind` tag.
         assert!(RUNTIME.contains("typeof v.kind === \"string\""));
         assert!(RUNTIME.contains("Symbolic.toDisplayString(v)"));
+    }
+
+    #[test]
+    fn runtime_defines_array_matrix_domain() {
+        // SIR22: the emitter's ArrayLit/Range/MatMul/ElementwiseOp/
+        // Transpose/IndexGet/IndexSet arms all call into `Array.*` — this
+        // must stay inlined (no import/require), matching every other
+        // domain in this file.
+        assert!(RUNTIME.contains("const ArrayRt = (() => {"));
+        assert!(RUNTIME.contains("Array: ArrayRt,"), "Array must be exported");
+        for needed in [
+            "function checkedShapeSize(",
+            "function ndarray(",
+            "function fromRows(",
+            "function isScalar(",
+            "function nrows(",
+            "function ncols(",
+            "function get(",
+            "function set(",
+            "function applyOp(",
+            "function elementwise(",
+            "function matmul(",
+            "function transpose(",
+            "function range(",
+            "function resolvePositions(",
+            "function indexGet(",
+            "function indexSet(",
+            "function toArrayValue(",
+        ] {
+            assert!(RUNTIME.contains(needed), "Array runtime missing `{needed}`");
+        }
+        assert!(!RUNTIME.contains("import "));
+        assert!(!RUNTIME.contains("require("));
+    }
+
+    #[test]
+    fn array_runtime_validates_shape_before_allocating() {
+        // SECURITY: every factory that computes an output size from
+        // caller-supplied numbers must validate via `checkedShapeSize`
+        // *before* `new Float64Array(...)` runs, not after — an
+        // unbounded or malformed shape must fail with a catchable
+        // `Error`, not an uncaught `RangeError` or a stalled huge
+        // allocation. Spot-check the two shapes most likely to regress:
+        // an outer-product-shaped `matmul`/`indexGet` (two independently-
+        // bounded dimensions whose product isn't bounded by either
+        // alone) and `range`'s own element cap.
+        assert!(RUNTIME.contains("const MAX_ELEMENTS = 1 << 26;"));
+        assert!(RUNTIME.contains("checkedShapeSize([m, n])"));
+        assert!(RUNTIME.contains("checkedShapeSize([rows.length, cols.length])"));
+        assert!(RUNTIME.contains(
+            "if (values.length >= MAX_ELEMENTS) {\n          throw new Error(`range: produces more than ${MAX_ELEMENTS} elements`);"
+        ));
+    }
+
+    #[test]
+    fn array_elementwise_coerces_bare_scalar_operands() {
+        // `matlab-to-semantic-ir`'s lowerer emits a mixed number/NDArray
+        // operand pair for `.* ./ .\` and for `* /` when exactly one side
+        // is scalar (e.g. `A .* 2`) — the bare scalar sub-expression is
+        // passed through `ElementwiseOp` unwrapped, so `elementwise` must
+        // coerce a plain JS `number` into a scalar NDArray itself rather
+        // than assume both operands already carry `.data`/`.shape`.
+        assert!(RUNTIME.contains("a = toArrayValue(a);"));
+        assert!(RUNTIME.contains("b = toArrayValue(b);"));
+    }
+
+    #[test]
+    fn array_elementwise_comparisons_return_apl_style_numbers_not_booleans() {
+        // Comparisons (`Eq`/`Ne`/`Lt`/`Le`/`Ge`/`Gt`) must return `1`/`0`,
+        // never a native `boolean` — the result has to stay a plain
+        // Float64Array element like every other value here.
+        assert!(RUNTIME.contains("const b2f = (cond) => (cond ? 1 : 0);"));
     }
 }

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -2801,7 +2801,22 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
      * expression, in the SIR22 spec.
      */
     function set(a, r, c, value) {
-      if (r < 0 || c < 0 || r >= nrows(a) || c >= ncols(a)) {
+      // SECURITY: written as the negation of `get`'s AND-form
+      // (`!(r >= 0 && ...)`), not as an OR-form (`r < 0 || ...`) --
+      // under IEEE-754 those are NOT equivalent for NaN: every
+      // relational comparison with NaN is false, so an OR-form check
+      // would have every branch evaluate false for r=NaN, silently
+      // skipping the throw. `a.data[c * nrows(a) + NaN] = value` would
+      // then set a stray, non-index property on the Float64Array rather
+      // than writing the buffer -- the exact same silent-write-drop bug
+      // this file's `resolvePositions`/`assertValidPosition` fix closed
+      // for `indexSet`'s call path into this function. `set` itself is
+      // not reachable with an unvalidated NaN today (every caller
+      // resolves positions through `assertValidPosition` first), but it
+      // is part of this module's exported public surface, so it stays
+      // NaN-safe on its own rather than relying on every future caller
+      // to re-derive that invariant.
+      if (!(r >= 0 && c >= 0 && r < nrows(a) && c < ncols(a))) {
         throw new Error(`set: index (${r}, ${c}) out of bounds for shape ${JSON.stringify(a.shape)}`);
       }
       a.data[c * nrows(a) + r] = value;
@@ -3528,5 +3543,20 @@ mod tests {
         // never a native `boolean` — the result has to stay a plain
         // Float64Array element like every other value here.
         assert!(RUNTIME.contains("const b2f = (cond) => (cond ? 1 : 0);"));
+    }
+
+    #[test]
+    fn array_set_bounds_check_is_a_nan_safe_negated_and_not_an_or() {
+        // Security-review follow-up: `set`'s bounds check must be the
+        // negation of `get`'s AND-form (`!(r >= 0 && ...)`), not an
+        // OR-form (`r < 0 || ...`) -- those are NOT equivalent for NaN
+        // under IEEE-754 (every relational comparison with NaN is
+        // false), so an OR-form would silently skip the throw and let
+        // `a.data[c * nrows(a) + NaN] = value` silently drop the write.
+        // `set` is not reachable with an unvalidated NaN through any
+        // current codegen path (every caller resolves positions through
+        // `assertValidPosition` first), but it is part of this module's
+        // exported public surface, so it must stay NaN-safe on its own.
+        assert!(RUNTIME.contains("if (!(r >= 0 && c >= 0 && r < nrows(a) && c < ncols(a))) {"));
     }
 }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir22_array.rs
@@ -1,0 +1,396 @@
+//! End-to-end integration test: hand-built SIR22 nodes → JavaScript →
+//! `node`.
+//!
+//! `src/lib.rs`'s own test module proves the emitted *shape* (exact
+//! substring assertions on generated source, mirroring the TypeScript
+//! backend's SIR22 tests-to-come). This file proves the emitted
+//! *behaviour*: a `MatMul`/`ElementwiseOp`/`Transpose`/`Range`/
+//! `IndexGet`/`IndexSet` node, run for real under Node.js, must actually
+//! compute the right numbers — not just produce plausible-looking source.
+//!
+//! Node is optional at test time; when unavailable the test degrades to
+//! a no-op rather than failing (mirroring `run_with_node.rs`/
+//! `sir23_symbolic.rs`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, IndexArg,
+    Metadata, Module, Scope, Span, Stmt,
+};
+use semantic_ir_to_javascript::compile;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn sp() -> Span {
+    Span::synthetic()
+}
+
+fn int(value: i64) -> Expr {
+    Expr::IntLit { value, span: sp() }
+}
+
+fn local(name: &str) -> Expr {
+    Expr::VarRef {
+        name: name.into(),
+        scope: Scope::Local,
+        span: sp(),
+    }
+}
+
+fn array_lit(rows: Vec<Vec<Expr>>) -> Expr {
+    Expr::ArrayLit { rows, span: sp() }
+}
+
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: sp(),
+    }
+}
+
+fn print(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: bc("print", vec![arg]),
+        span: sp(),
+    }
+}
+
+fn let_binding(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding {
+        name: name.into(),
+        sir_type: None,
+        value,
+        span: sp(),
+    }
+}
+
+fn module_with_main(stmts: Vec<Stmt>, value: Expr, features: &[Feature]) -> Module {
+    Module {
+        name: "sir22".into(),
+        manifest: FeatureManifest::from_features(features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value,
+                span: sp(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: sp(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    }
+}
+
+/// Every test in this file uses `NDArrays` + `MatrixOps` + `ArrayColumnMajor`
+/// together — a hand-built module never needs a fine-grained subset the way
+/// a real frontend's per-construct feature-tracking might.
+const ARRAY_FEATURES: &[Feature] = &[
+    Feature::NDArrays,
+    Feature::MatrixOps,
+    Feature::ArrayColumnMajor,
+];
+
+fn run_module(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node")
+        .arg(&path)
+        .output()
+        .expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        artifact.source,
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    Some(stdout.trim_end_matches(['\n', '\r']).to_string())
+}
+
+#[test]
+fn matmul_of_two_by_two_matrices_computes_the_right_product() {
+    // [1 2; 3 4] * [5 6; 7 8] = [19 22; 43 50] (standard matrix product).
+    // Printed via two scalar IndexGet reads (top-left, bottom-right) --
+    // sidesteps needing an NDArray display/format story, which is out of
+    // this PR's scope.
+    let a = array_lit(vec![vec![int(1), int(2)], vec![int(3), int(4)]]);
+    let b = array_lit(vec![vec![int(5), int(6)], vec![int(7), int(8)]]);
+    let product = Expr::MatMul {
+        lhs: Box::new(a),
+        rhs: Box::new(b),
+        span: sp(),
+    };
+    let stmts = vec![
+        let_binding("p", product),
+        print(Expr::IndexGet {
+            target: Box::new(local("p")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(0))),
+                IndexArg::Scalar(Box::new(int(0))),
+            ],
+            span: sp(),
+        }),
+        print(Expr::IndexGet {
+            target: Box::new(local("p")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(1))),
+                IndexArg::Scalar(Box::new(int(1))),
+            ],
+            span: sp(),
+        }),
+    ];
+    let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
+    if let Some(stdout) = run_module(&module, "matmul") {
+        assert_eq!(stdout, "19\n50");
+    }
+}
+
+#[test]
+fn elementwise_mul_with_a_bare_scalar_operand_broadcasts() {
+    // MATLAB `A .* 2` -- matlab-to-semantic-ir emits the `2` as a bare
+    // IntLit operand, unwrapped (not an ArrayLit), when exactly one side
+    // is scalar. This is the exact shape `toArrayValue`'s coercion in
+    // runtime.rs exists for; a regression there crashes with a
+    // `TypeError: Cannot read properties of undefined (reading 'length')`
+    // instead of computing [2 4; 6 8].
+    let a = array_lit(vec![vec![int(1), int(2)], vec![int(3), int(4)]]);
+    let scaled = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Mul,
+        lhs: Box::new(a),
+        rhs: Box::new(int(2)),
+        span: sp(),
+    };
+    let stmts = vec![
+        let_binding("s", scaled),
+        print(Expr::IndexGet {
+            target: Box::new(local("s")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(0))),
+                IndexArg::Scalar(Box::new(int(0))),
+            ],
+            span: sp(),
+        }),
+        print(Expr::IndexGet {
+            target: Box::new(local("s")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(1))),
+                IndexArg::Scalar(Box::new(int(1))),
+            ],
+            span: sp(),
+        }),
+    ];
+    let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
+    if let Some(stdout) = run_module(&module, "elementwise_scalar_broadcast") {
+        assert_eq!(stdout, "2\n8");
+    }
+}
+
+#[test]
+fn transpose_swaps_rows_and_columns() {
+    // transpose([1 2 3; 4 5 6]) = [1 4; 2 5; 3 6] -- read back element
+    // (2, 0) (0-based), which should be the original (0, 2) = 3.
+    let a = array_lit(vec![
+        vec![int(1), int(2), int(3)],
+        vec![int(4), int(5), int(6)],
+    ]);
+    let transposed = Expr::Transpose {
+        target: Box::new(a),
+        conjugate: false,
+        span: sp(),
+    };
+    let stmts = vec![
+        let_binding("t", transposed),
+        print(Expr::IndexGet {
+            target: Box::new(local("t")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(2))),
+                IndexArg::Scalar(Box::new(int(0))),
+            ],
+            span: sp(),
+        }),
+    ];
+    let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
+    if let Some(stdout) = run_module(&module, "transpose") {
+        assert_eq!(stdout, "3");
+    }
+}
+
+#[test]
+fn range_materializes_a_row_vector_with_the_matlab_colon_semantics() {
+    // 1:2:10 -> [1, 3, 5, 7, 9] (5 elements; MATLAB's colon is inclusive
+    // of the stop bound, so this must NOT stop one short). Read back the
+    // last element via scalar IndexGet -- proves both the element count
+    // (index 4 must be in bounds) and the inclusive-stop value (9, not
+    // 7) are right.
+    let r = Expr::Range {
+        start: Box::new(int(1)),
+        step: Some(Box::new(int(2))),
+        stop: Box::new(int(10)),
+        span: sp(),
+    };
+    let stmts = vec![
+        let_binding("r", r),
+        print(Expr::IndexGet {
+            target: Box::new(local("r")),
+            indices: vec![IndexArg::Scalar(Box::new(int(4)))],
+            span: sp(),
+        }),
+    ];
+    let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
+    if let Some(stdout) = run_module(&module, "range_scalar_readback") {
+        assert_eq!(stdout, "9");
+    }
+}
+
+#[test]
+fn index_set_mutates_in_place() {
+    // A(0, 1) = 99 on [1 2; 3 4] -> reading it back must see 99, not the
+    // original 2 -- proves IndexSet is a real in-place mutation, not a
+    // no-op or a copy-and-discard.
+    let a = array_lit(vec![vec![int(1), int(2)], vec![int(3), int(4)]]);
+    let stmts = vec![
+        let_binding("a", a),
+        Stmt::IndexSet {
+            target: Box::new(local("a")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(0))),
+                IndexArg::Scalar(Box::new(int(1))),
+            ],
+            value: Box::new(int(99)),
+            span: sp(),
+        },
+        print(Expr::IndexGet {
+            target: Box::new(local("a")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(0))),
+                IndexArg::Scalar(Box::new(int(1))),
+            ],
+            span: sp(),
+        }),
+    ];
+    let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
+    if let Some(stdout) = run_module(&module, "index_set") {
+        assert_eq!(stdout, "99");
+    }
+}
+
+#[test]
+fn index_set_with_whole_column_broadcasts_a_scalar() {
+    // A(:, 0) = 7 on [1 2; 3 4] -> column 0 becomes [7; 7]; column 1
+    // (untouched) stays [2; 4].
+    let a = array_lit(vec![vec![int(1), int(2)], vec![int(3), int(4)]]);
+    let stmts = vec![
+        let_binding("a", a),
+        Stmt::IndexSet {
+            target: Box::new(local("a")),
+            indices: vec![IndexArg::Whole, IndexArg::Scalar(Box::new(int(0)))],
+            value: Box::new(int(7)),
+            span: sp(),
+        },
+        print(Expr::IndexGet {
+            target: Box::new(local("a")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(0))),
+                IndexArg::Scalar(Box::new(int(0))),
+            ],
+            span: sp(),
+        }),
+        print(Expr::IndexGet {
+            target: Box::new(local("a")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(1))),
+                IndexArg::Scalar(Box::new(int(0))),
+            ],
+            span: sp(),
+        }),
+        print(Expr::IndexGet {
+            target: Box::new(local("a")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(0))),
+                IndexArg::Scalar(Box::new(int(1))),
+            ],
+            span: sp(),
+        }),
+    ];
+    let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
+    if let Some(stdout) = run_module(&module, "index_set_whole_broadcast") {
+        assert_eq!(stdout, "7\n7\n2");
+    }
+}
+
+#[test]
+fn matmul_with_non_conformable_shapes_throws_a_catchable_error() {
+    // [1 2] (1x2) * [1 2] (1x2) -- inner dimensions (2 vs 1) disagree, so
+    // `__Sir.Array.matmul` must throw a plain JS `Error` (with a message
+    // naming the disagreement) rather than silently produce a
+    // wrong-shaped result. Left uncaught here, so it propagates out of
+    // `main()` and node exits non-zero -- inverts `run_module`'s usual
+    // success assumption for this one case, since a *clean* rejection is
+    // exactly what this test wants to see.
+    let a = array_lit(vec![vec![int(1), int(2)]]);
+    let b = array_lit(vec![vec![int(1), int(2)]]);
+    let stmts = vec![let_binding(
+        "p",
+        Expr::MatMul {
+            lhs: Box::new(a),
+            rhs: Box::new(b),
+            span: sp(),
+        },
+    )];
+    let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
+    let artifact = compile(&module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `matmul_non_conformable`");
+        return;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!(
+        "sir_js_matmul_non_conformable_{}.js",
+        std::process::id()
+    ));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node")
+        .arg(&path)
+        .output()
+        .expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !output.status.success(),
+        "expected node to exit non-zero on a non-conformable matmul, but it succeeded:\n{}",
+        artifact.source
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("matmul: inner dimensions disagree"),
+        "got stderr:\n{stderr}"
+    );
+}

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir22_array.rs
@@ -111,6 +111,16 @@ const ARRAY_FEATURES: &[Feature] = &[
     Feature::ArrayColumnMajor,
 ];
 
+/// `ARRAY_FEATURES` plus `Floats` — for the NaN regression tests below,
+/// which use an `Expr::FloatLit { value: f64::NAN, .. }` to construct a
+/// NaN index/range-bound at compile time.
+const ARRAY_AND_FLOAT_FEATURES: &[Feature] = &[
+    Feature::NDArrays,
+    Feature::MatrixOps,
+    Feature::ArrayColumnMajor,
+    Feature::Floats,
+];
+
 fn run_module(module: &Module, tag: &str) -> Option<String> {
     let artifact = compile(module).expect("compile to javascript");
     if !node_available() {
@@ -347,15 +357,46 @@ fn index_set_with_whole_column_broadcasts_a_scalar() {
     }
 }
 
+/// Compile `module`, run it under `node`, and assert it exits NON-zero
+/// with `expected_stderr_substring` somewhere in stderr -- for tests
+/// proving a malformed input is cleanly REJECTED (a thrown, uncaught JS
+/// `Error` propagating out of `main()`), inverting `run_module`'s usual
+/// "must succeed" assumption. A silent, zero-exit-code "success" here
+/// would mean the malformed input was accepted and silently mishandled
+/// instead of raising -- exactly the failure mode these tests exist to
+/// catch.
+fn run_module_expecting_failure(module: &Module, tag: &str, expected_stderr_substring: &str) {
+    let artifact = compile(module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node")
+        .arg(&path)
+        .output()
+        .expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !output.status.success(),
+        "expected node to exit non-zero for `{tag}`, but it succeeded:\n{}",
+        artifact.source
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected_stderr_substring),
+        "got stderr:\n{stderr}"
+    );
+}
+
 #[test]
 fn matmul_with_non_conformable_shapes_throws_a_catchable_error() {
     // [1 2] (1x2) * [1 2] (1x2) -- inner dimensions (2 vs 1) disagree, so
     // `__Sir.Array.matmul` must throw a plain JS `Error` (with a message
     // naming the disagreement) rather than silently produce a
-    // wrong-shaped result. Left uncaught here, so it propagates out of
-    // `main()` and node exits non-zero -- inverts `run_module`'s usual
-    // success assumption for this one case, since a *clean* rejection is
-    // exactly what this test wants to see.
+    // wrong-shaped result.
     let a = array_lit(vec![vec![int(1), int(2)]]);
     let b = array_lit(vec![vec![int(1), int(2)]]);
     let stmts = vec![let_binding(
@@ -367,30 +408,90 @@ fn matmul_with_non_conformable_shapes_throws_a_catchable_error() {
         },
     )];
     let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
-    let artifact = compile(&module).expect("compile to javascript");
-    if !node_available() {
-        eprintln!("note: `node` unavailable — skipping execution for `matmul_non_conformable`");
-        return;
-    }
-    let mut path: PathBuf = std::env::temp_dir();
-    path.push(format!(
-        "sir_js_matmul_non_conformable_{}.js",
-        std::process::id()
-    ));
-    std::fs::write(&path, &artifact.source).expect("write temp js");
-    let output = Command::new("node")
-        .arg(&path)
-        .output()
-        .expect("spawn node");
-    let _ = std::fs::remove_file(&path);
-    assert!(
-        !output.status.success(),
-        "expected node to exit non-zero on a non-conformable matmul, but it succeeded:\n{}",
-        artifact.source
+    run_module_expecting_failure(
+        &module,
+        "matmul_non_conformable",
+        "matmul: inner dimensions disagree",
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("matmul: inner dimensions disagree"),
-        "got stderr:\n{stderr}"
+}
+
+fn nan() -> Expr {
+    Expr::FloatLit {
+        value: f64::NAN,
+        span: sp(),
+    }
+}
+
+#[test]
+fn scalar_index_get_with_a_nan_index_throws_instead_of_silently_returning_undefined() {
+    // Security-review finding: `get(a, r, c)`'s 2-arg bounds check is an
+    // AND-form (`r >= 0 && r < nrows(a)`), which correctly falls through
+    // to "out of bounds" for r=NaN (NaN fails every relational
+    // comparison). But the linear (1-arg) `indexGet` path used an OR-form
+    // (`i < 0 || i >= length`) that is NOT the same check's negation for
+    // NaN -- both halves are false, so the "out of bounds" throw was
+    // skipped entirely and `a.data[NaN]` silently read `undefined`
+    // instead of raising. `i` here (a NaN scalar index) is exactly the
+    // kind of value a compiled program's own arithmetic can produce at
+    // its own runtime boundary (e.g. `0/0`), not just a hand-built edge
+    // case. Must now throw a catchable Error, not silently succeed with a
+    // wrong (or missing) value.
+    let a = array_lit(vec![vec![int(1), int(2), int(3)]]);
+    let stmts = vec![let_binding("a", a)];
+    let value = Expr::IndexGet {
+        target: Box::new(local("a")),
+        indices: vec![IndexArg::Scalar(Box::new(nan()))],
+        span: sp(),
+    };
+    let module = module_with_main(stmts, value, ARRAY_AND_FLOAT_FEATURES);
+    run_module_expecting_failure(
+        &module,
+        "index_get_nan",
+        "resolvePositions: index NaN is not a finite integer",
+    );
+}
+
+#[test]
+fn scalar_index_set_with_a_nan_index_throws_instead_of_silently_dropping_the_write() {
+    // Same root cause as the IndexGet test above, but on the write side:
+    // `a.data[NaN] = v` sets a stray, non-index property on the
+    // `Float64Array` object rather than writing into the buffer -- the
+    // pre-fix behavior silently dropped the write with no exception at
+    // all, so a caller had no way to detect the mutation never happened.
+    let a = array_lit(vec![vec![int(1), int(2), int(3)]]);
+    let stmts = vec![
+        let_binding("a", a),
+        Stmt::IndexSet {
+            target: Box::new(local("a")),
+            indices: vec![IndexArg::Scalar(Box::new(nan()))],
+            value: Box::new(int(99)),
+            span: sp(),
+        },
+    ];
+    let module = module_with_main(stmts, int(0), ARRAY_AND_FLOAT_FEATURES);
+    run_module_expecting_failure(
+        &module,
+        "index_set_nan",
+        "resolvePositions: index NaN is not a finite integer",
+    );
+}
+
+#[test]
+fn range_with_a_nan_bound_throws_instead_of_silently_returning_empty() {
+    // Same NaN-defeats-a-comparison-based-check root cause: `range`'s
+    // loop condition is false on the first check whenever start/stop is
+    // NaN, so an unguarded NaN bound silently produced an empty (but
+    // otherwise valid-looking) row vector instead of erroring.
+    let value = Expr::Range {
+        start: Box::new(nan()),
+        step: None,
+        stop: Box::new(int(10)),
+        span: sp(),
+    };
+    let module = module_with_main(vec![], value, ARRAY_AND_FLOAT_FEATURES);
+    run_module_expecting_failure(
+        &module,
+        "range_nan",
+        "range: start/stop/step must be finite numbers",
     );
 }

--- a/code/specs/SIR22-array-matrix-semantic-ir.md
+++ b/code/specs/SIR22-array-matrix-semantic-ir.md
@@ -211,12 +211,22 @@ operation as `MatMul`/`Transpose` above. `IndexGenerator`/`IndexOf` observe
 only `Feature::NDArrays` — they construct/query arrays without inherently
 being a "matrix op" any more than `Range`/`IndexGet` are.
 
-No frontend crate consumes any of these nine variants yet. This addendum
-is IR-substrate-only, mirroring how `array-runtime`'s AR-2 task preceded
-`apl-runtime` as its own separate step before that runtime crate could be
-built — the actual `apl-to-semantic-ir` frontend that will emit these
-nodes from parsed APL source is a follow-up task, not part of this
-addendum.
+No frontend crate consumed any of these nine variants at the time this
+addendum was written — it was IR-substrate-only, mirroring how
+`array-runtime`'s AR-2 task preceded `apl-runtime` as its own separate
+step before that runtime crate could be built. **This is no longer
+true**: `apl-to-semantic-ir` (a follow-up task after this addendum, as
+anticipated) does emit `Reduce`/`Scan`/`OuterProduct` from APL's
+`+/`/`+\`/`∘.×` operators. No backend implements codegen for any of the
+nine yet, though — `sir-runtime-array` (the JS/TS runtime package)
+deliberately scoped them out (see that package's own `src/index.ts` doc
+comment) since no frontend needed them when it shipped, and
+`semantic-ir-to-javascript`'s later SIR22 base-cut codegen PR found that,
+because these nine share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with
+the base cut, a plain feature-flag capability check can no longer tell
+"safe" modules from "still unimplemented" ones — see that crate's
+`find_unimplemented_sir22_addendum_node` for the dedicated tree-walk this
+now requires.
 
 ## Storage convention
 
@@ -261,12 +271,24 @@ is lowered as a `Stmt`-position operation (like `Assign`), not a value-producing
 
 ## Backend impact
 
-- **JS/TS** (`semantic-ir-to-javascript`/`-to-typescript`): new `match` arms
-  emit calls into `sir-runtime-array` (`__SirArray.matmul(...)`,
-  `__SirArray.elementwise(...)`, `__SirArray.range(...)`,
-  `__SirArray.indexGet(...)`/`indexSet(...)`), imported only when
-  `Feature::MatrixOps`/`NDArrays` is in the manifest — same gating pattern as
-  the existing OOP/exception runtime imports.
+- **JS** (`semantic-ir-to-javascript`) — **done**: new `match` arms emit calls
+  into an *inlined* `__Sir.Array.*` sub-runtime (a plain-JS port of
+  `sir-runtime-array`, not an `import`/`require` — this backend always
+  inlines its runtime helpers, unlike the TS backend's imported-package
+  model) for the base cut (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+  `Transpose`/`IndexGet`/`IndexSet`). `NDArrays`/`MatrixOps`/
+  `ArrayColumnMajor` are in `ACCEPTED_FEATURES`. The SIR22 "APL addendum"
+  nodes below share these same three features but remain deferred — this
+  backend adds a dedicated tree-walk check inside `compile()` (beyond the
+  ordinary feature-flag capability check) so a module using one of the
+  nine still fails cleanly rather than reaching an emit-time panic; see
+  that crate's `find_unimplemented_sir22_addendum_node`.
+- **TS** (`semantic-ir-to-typescript`) — not yet done: still rejects
+  `NDArrays`/`MatrixOps`/`ArrayColumnMajor` via the plain capability-
+  rejection path (a real `import { ... } from
+  "@coding-adventures/sir-runtime-array"` codegen PR, mirroring the JS
+  backend's call shapes but against the published npm package instead of
+  an inlined port, is a follow-up).
 - **Rust/Go/Python backends**: not required to support this in the first
   wave; they reject modules declaring `NDArrays`/`MatrixOps` per the existing
   capability-rejection path. No code changes required to these backends for


### PR DESCRIPTION
## Summary

- Wires real JS codegen for the SIR22 array/matrix domain's base cut — `ArrayLit`, `Range`, `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`), and `IndexSet` (a `Stmt`) — replacing the deferred `panic!` placeholder these seven nodes had. Mirrors the SIR23 symbolic-domain codegen's own inlined-runtime treatment: a new `__Sir.Array` sub-runtime, a plain-JS port of the published `sir-runtime-array` npm package.
- Found and fixed during real-MATLAB-source end-to-end testing (not a hand-built edge case): `matlab-to-semantic-ir`'s lowerer emits a bare, unwrapped scalar operand for `.* ./ .\` and `* /` when exactly one side is provably scalar (e.g. `A .* 2`), so `elementwise` now coerces a raw JS number into a scalar `NDArray` rather than assuming both operands already carry `.data`/`.shape`.
- Found while auditing downstream consumers: the SIR22 "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/etc.) share the same feature flags as the now-accepted base cut, and `apl-to-semantic-ir`'s *real* lowering (not a test fixture) emits `Reduce`/`Scan`/`OuterProduct` for APL's `+/`/`+\`/`∘.×` operators today — contradicting the SIR22 spec's stale "no frontend consumes these yet" claim. Without a fix, such a module would pass the feature-flag capability check and panic inside `emit`. Fixed with a dedicated tree-walk (using `semantic_ir`'s `Visitor` trait) wired into `JavaScriptBackend::compile()`, mirroring the existing `TailCalls` belt-and-suspenders check.
- Three rounds of `/security-review`, each finding and fixing a real issue in the new `__Sir.Array` runtime:
  1. `indexGet`/`indexSet`'s linear (1-argument) bounds check used an OR-form that is not NaN-safe (unlike its 2-argument sibling `get`'s AND-form) — a NaN index silently returned `undefined` from a read, or silently dropped a write with no exception at all. Fixed by validating every resolved position is a real integer at the single choke point (`resolvePositions`) both functions route through. Same root cause fixed in `range()`, which silently returned an empty vector for a NaN bound.
  2. Follow-up confirmation review found `set()` (never reachable with an unvalidated NaN today, but part of the exported public surface) had the identical NaN-unsafe OR-form pattern — fixed for consistency and defense-in-depth before it could become a landmine for a future direct caller.
- Downstream consumers updated: `matlab-to-semantic-ir`'s `test_validator.rs` (three tests converted from rejection to acceptance) and a new `e2e_node.rs` suite (four real MATLAB-source `node`-execution tests: matrix multiply, elementwise scalar broadcast, indexed assignment, range+transpose); `apl-to-semantic-ir`'s `test_validator.rs` (updated to assert on `compile()`'s new tree-walk rejection for `Reduce`/`OuterProduct`, since `check_module()` alone no longer catches it).
- Specs updated: `SIR22`'s "Backend impact" section and its now-corrected APL-addendum note.

## Test plan

- [x] `cargo test -p semantic-ir-to-javascript -p matlab-to-semantic-ir -p apl-to-semantic-ir -p wolfram-to-semantic-ir -p javascript-to-semantic-ir -p octave-to-semantic-ir` — all green (only a confirmed pre-existing, unrelated `wolfram-to-semantic-ir` failure remains, flagged separately)
- [x] `cargo clippy -p semantic-ir-to-javascript -p matlab-to-semantic-ir -p apl-to-semantic-ir --all-targets` — clean
- [x] Real `node`-execution tests: `tests/sir22_array.rs` (10 tests) and `matlab-to-semantic-ir`'s `tests/e2e_node.rs` (4 new tests) — actual MATLAB source compiled and run, not just hand-built SIR
- [x] Three rounds of `/security-review`, each converged with a real fix + regression test, each confirmed to fail without the fix and pass with it
- [x] Clean merge with `origin/main`, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)