### PR TITLE
feat(closure-emitter): drop empty () on a no-arg new; new wraps as member/call spine

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.49.0] - 2026-07-16
+
+### Changed — a no-argument `new` drops its empty `()`; `new` always wraps as a member/call spine
+
+The emitter now prints a zero-argument `NewExpression` without the empty
+parentheses — `new C()` → `new C`, `new a.b.C()` → `new a.b.C` — matching the
+reference Closure Compiler at `SIMPLE` byte-for-byte. Previously the argument
+parens were always printed.
+
+Dropping the `()` makes a `new` a bare `NewExpression` in the grammar, which
+binds **looser** than a member access or call: a following `.y` / `[k]` / `(…)`
+would otherwise re-associate onto the callee (`new C.y` parses as `new (C.y)`).
+To preserve meaning, `expr_prec` now tags every `NewExpression` at a new
+`PREC_NEW` (just below `PREC_PRIMARY`), so a member-object or call-callee parent
+wraps it. This matches Closure for **both** the argumented and no-argument
+forms:
+
+- `new C()` → `new C`
+- `new C().foo` → `(new C).foo`
+- `new C()()` → `(new C)()`
+- `new C().m()` → `(new C).m()`
+- `new C(1).foo` → `(new C(1)).foo`
+- `new C(1)()` → `(new C(1))()`
+- `new new C()` → `new (new C)`
+- `new C(1)` (standalone), `typeof new C`, `new C+1` — no wrap (looser parents)
+
+Verified byte-identical against `closure-compiler-v20260712.jar` (`SIMPLE`).
+The upstream `CodePrinterTest` `new`-operator port
+(`tests/upstream/code_printer_new_test.rs`) previously pinned the always-`()`
+spelling; its assertions were corrected to the true jar output (`new X`,
+`(new X).y`, …).
+
+Out of scope (separate divergences, unchanged here): the computed-index → dot
+normalisation (`(new C)["k"]` → `(new C).k`), sequence-at-statement splitting
+(`a,b` → `a;b`), and the space before a parenthesised callee
+(`new(f())` vs `new (f())`). MINOR bump 0.48.0 → 0.49.0.
+
 ## [0.48.0] - 2026-07-15
 
 ### Added — drop the leading zero of a bare fraction in value position (`0.5` → `.5`)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -1998,10 +1998,17 @@ impl<'a> Emitter<'a> {
     /// Emit a `new` expression — `new Ctor(a, b)`.
     ///
     /// ```text
-    ///   new X()          →  new X()
-    ///   new a.b.c()      →  new a.b.c()      member-chain callee, no wrap
-    ///   new (f())()      →  new (f())()      call in the callee spine MUST wrap
+    ///   new X(a)         →  new X(a)
+    ///   new X()          →  new X           no-arg: the empty parens are dropped
+    ///   new a.b.c()      →  new a.b.c        member-chain callee, no wrap
+    ///   new (f())(a)     →  new (f())(a)     call in the callee spine MUST wrap
     /// ```
+    ///
+    /// A **no-argument** `new` drops its empty `()` (`new C()` → `new C`),
+    /// matching the reference Closure Compiler. That makes it a bare
+    /// `NewExpression`, which `expr_prec` tags at the looser `PREC_NEW_NO_ARGS`
+    /// so a member-object / call-callee parent re-parenthesises it
+    /// (`(new C).y`, `(new C)()`) instead of mis-emitting `new C.y`.
     ///
     /// # Two seams to get right
     ///
@@ -2034,6 +2041,15 @@ impl<'a> Emitter<'a> {
             // `new`↔callee is a keyword↔word boundary — always separate.
             self.required_ws();
             self.emit_expression_inner(&n.callee, PREC_PRIMARY);
+        }
+        // A no-argument `new X` drops the empty parens entirely, emitting
+        // `new X` — matching the reference Closure Compiler (`new C()` → `new C`,
+        // `new a.b.C()` → `new a.b.C`). The looser `PREC_NEW_NO_ARGS` this form
+        // carries (see `expr_prec`) makes a member-object / call-callee parent
+        // wrap it, so `(new X()).y` still prints correctly as `(new X).y`
+        // rather than the mis-parsing `new X.y`. A `new X(a)` keeps its parens.
+        if n.arguments.is_empty() {
+            return;
         }
         self.write_str("(");
         for (i, a) in n.arguments.iter().enumerate() {
@@ -2624,6 +2640,15 @@ fn format_exponential_uppercase(n: f64) -> String {
 const PREC_SEQUENCE: u8 = 0;
 const PREC_CONDITIONAL: u8 = 2;
 const PREC_UNARY: u8 = 14;
+/// A `new` expression, just under `PREC_PRIMARY`. The reference Closure Compiler
+/// always parenthesises a `new` when it is the object of a member access or the
+/// callee of a call — for BOTH the argumented and no-argument forms:
+/// `new C(1).foo` → `(new C(1)).foo`, `new C().foo` → `(new C).foo`,
+/// `new C(1)()` → `(new C(1))()`. Tagging `new` below `PREC_PRIMARY` makes those
+/// member-object / call-callee parents (which emit their spine at
+/// `PREC_PRIMARY`) wrap it, while looser parents leave it bare (`typeof new C`,
+/// `new C+1`, `new C(1)` standalone). See `expr_prec` / `emit_new`.
+const PREC_NEW: u8 = 17;
 const PREC_PRIMARY: u8 = 18;
 const PREC_ASSIGNMENT: u8 = 1;
 
@@ -2742,15 +2767,15 @@ fn expr_prec(e: &Expression) -> u8 {
         // syntax error) and tight enough that a `!`/`typeof` parent does not
         // over-wrap it (`!x++`, `typeof x++` print bare, which is correct).
         Expression::UpdateExpression(_) => PREC_UNARY,
-        // `emit_new` ALWAYS prints the argument parens — a no-argument `new X`
-        // is emitted canonically as `new X()`. In that *argumented* spelling a
-        // `new` is a `MemberExpression` in the grammar and binds at member/call
-        // strength, so it tags at `PREC_PRIMARY` like a call: `new X().y` needs
-        // no extra parens (it already means `(new X()).y`), and as a call
-        // callee `new X().y()` stays paren-free. (Were we ever to drop the
-        // empty parens — a future minification — the no-arg form would need the
-        // looser bare-`NewExpression` precedence; we don't, so one tag suffices.)
-        Expression::NewExpression(_) => PREC_PRIMARY,
+        // A `new` expression tags at `PREC_NEW` (just under `PREC_PRIMARY`) so a
+        // member-object / call-callee parent always wraps it — matching Closure
+        // for both the argumented and no-argument forms (`new C(1).foo` →
+        // `(new C(1)).foo`, `new C().foo` → `(new C).foo`, `new C(1)()` →
+        // `(new C(1))()`). A looser parent leaves it bare (`new C(1)` standalone,
+        // `typeof new C`, `new C+1`). The no-argument form additionally drops its
+        // empty `()` in `emit_new`, which is what makes the wrapping load-bearing
+        // (`new C.y` would mis-parse as `new (C.y)`).
+        Expression::NewExpression(_) => PREC_NEW,
         // The comma operator binds looser than every other expression — a
         // sequence sub-operand must be wrapped in almost every context.
         Expression::SequenceExpression(_) => PREC_SEQUENCE,
@@ -6193,11 +6218,12 @@ mod tests {
         })
     }
 
-    /// `new X()` — plain identifier callee, empty args. A space separates the
+    /// `new X()` — plain identifier callee, empty args. The empty `()` is
+    /// dropped (matching Closure: `new X() → new X`); a space separates the
     /// `new` keyword from the identifier so they do not fuse into `newX`.
     #[test]
     fn new_identifier_no_args() {
-        assert_eq!(emit_expr(new_expr(ident("X"), vec![])), "new X();");
+        assert_eq!(emit_expr(new_expr(ident("X"), vec![])), "new X;");
     }
 
     /// `new X(a, b)` — arguments are comma-separated, no trailing-space in the
@@ -6211,11 +6237,11 @@ mod tests {
     }
 
     /// `new a.b.c()` — a pure member-chain callee is a valid `new` target and
-    /// stays paren-free; the `new` keeps its separating space.
+    /// stays paren-free; the empty `()` is dropped (`new a.b.c`).
     #[test]
     fn new_member_chain_callee_not_wrapped() {
         let callee = member(member(ident("a"), "b", false), "c", false);
-        assert_eq!(emit_expr(new_expr(callee, vec![])), "new a.b.c();");
+        assert_eq!(emit_expr(new_expr(callee, vec![])), "new a.b.c;");
     }
 
     /// `new (f())()` — a call in the callee spine MUST be parenthesised, or the
@@ -6225,7 +6251,7 @@ mod tests {
     #[test]
     fn new_call_callee_is_wrapped() {
         let callee = call(ident("f"), vec![]);
-        assert_eq!(emit_expr(new_expr(callee, vec![])), "new(f())();");
+        assert_eq!(emit_expr(new_expr(callee, vec![])), "new(f());");
     }
 
     /// `new a.b().c()` — the callee's member spine bottoms out in a call
@@ -6233,35 +6259,55 @@ mod tests {
     #[test]
     fn new_callee_with_call_in_member_spine_is_wrapped() {
         let callee = member(call(member(ident("a"), "b", false), vec![]), "c", false);
-        assert_eq!(emit_expr(new_expr(callee, vec![])), "new(a.b().c)();");
+        assert_eq!(emit_expr(new_expr(callee, vec![])), "new(a.b().c);");
     }
 
-    /// `(new X()).y` — an *argumented* `new` binds at member strength, so a
-    /// member parent needs NO extra parens (the `new X()` groups on its own):
-    /// `new X().y`.
+    /// `(new X(a)).y` — Closure parenthesises a `new` as a member object even
+    /// with arguments (`new X(a).y` would parse the same, but Closure emits the
+    /// explicit parens): `(new X(a)).y`. Driven by `new` tagging at `PREC_NEW`
+    /// (below `PREC_PRIMARY`), so the member object wraps it.
     #[test]
-    fn argumented_new_as_member_object_not_wrapped() {
+    fn argumented_new_as_member_object_is_wrapped() {
         let m = member(new_expr(ident("X"), vec![ident("a")]), "y", false);
-        assert_eq!(emit_expr(m), "new X(a).y;");
+        assert_eq!(emit_expr(m), "(new X(a)).y;");
     }
 
-    /// A no-argument `new X` is emitted canonically as `new X()` (the parens
-    /// are always printed), so it binds at member strength and as a member
-    /// object needs NO extra wrap: `new X().y`. The always-printed `()` is what
-    /// makes `new X.y` (which would reparse as `new (X.y)`) unreachable.
+    /// A no-argument `new X` drops its `()` (`new X`) and, as a member object, is
+    /// wrapped so `.y` binds to the whole `new` and not the callee: `(new X).y`
+    /// (a bare `new X.y` would reparse as `new (X.y)`).
     #[test]
-    fn no_arg_new_as_member_object_prints_argumented() {
+    fn no_arg_new_as_member_object_drops_parens_and_wraps() {
         let m = member(new_expr(ident("X"), vec![]), "y", false);
-        assert_eq!(emit_expr(m), "new X().y;");
+        assert_eq!(emit_expr(m), "(new X).y;");
     }
 
-    /// `new` nests: the inner `new X()` is a valid target (not a call), so no
-    /// wrap is forced and the outer `new` keeps its keyword space:
-    /// `new new X()()`.
+    /// `new` nests: the inner no-arg `new X` drops its `()` and, as the outer
+    /// `new`'s callee (emitted at member strength), is wrapped: `new (new X)`.
     #[test]
-    fn nested_new_inner_not_wrapped() {
+    fn nested_new_inner_wrapped() {
         let inner = new_expr(ident("X"), vec![]);
-        assert_eq!(emit_expr(new_expr(inner, vec![])), "new new X()();");
+        assert_eq!(emit_expr(new_expr(inner, vec![])), "new (new X);");
+    }
+
+    /// A no-arg `new X` as a call callee is wrapped: `(new X)()` — a bare
+    /// `new X()` would reparse as the *construction* `new X()`, not a call of it.
+    #[test]
+    fn no_arg_new_as_call_callee_is_wrapped() {
+        let c = call(new_expr(ident("X"), vec![]), vec![]);
+        assert_eq!(emit_expr(c), "(new X)();");
+    }
+
+    /// A `new` under a looser parent (here a `+` binary) is NOT wrapped — its
+    /// `PREC_NEW` is above the operand precedence: `new X+1`.
+    #[test]
+    fn new_in_binary_operand_not_wrapped() {
+        let b = Expression::BinaryExpression(BinaryExpression {
+            cv: None,
+            operator: BinaryOperator::Add,
+            left: Box::new(new_expr(ident("X"), vec![])),
+            right: Box::new(num(1.0)),
+        });
+        assert_eq!(emit_expr(b), "new X+1;");
     }
 
     // ---- SequenceExpression (CLOC12.160) -------------------------------

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_new_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_new_test.rs
@@ -18,25 +18,28 @@
 //! ## How the emitter prints a `new` expression (recap)
 //!
 //! ```text
-//!   new X()        → new X()          identifier callee, empty args
-//!   new X(a, b)    → new X(a,b)       argument list
-//!   new a.b.c()    → new a.b.c()      member-chain callee (a valid target)
+//!   new X()        → new X            no-arg: the empty parens are DROPPED
+//!   new X(a, b)    → new X(a,b)       argument list kept
+//!   new a.b.c()    → new a.b.c        member-chain callee, no-arg parens dropped
 //! ```
 //!
-//! The argument parens are **always** printed, so a no-argument node is emitted
-//! canonically as `new X()` (never bare `new X`). Every emitted `new` is
-//! therefore the *argumented* form and binds at member/call strength
-//! (`PREC_PRIMARY`), so `new X().y` needs no extra parens.
+//! A no-argument `new` drops its empty `()` (matching the reference Closure
+//! Compiler at `SIMPLE`: `new X()` → `new X`). That makes a `new` a bare
+//! `NewExpression`, tagged below member/call strength (`PREC_NEW`), so a
+//! member-object or call-callee parent **wraps** it — for both the argumented
+//! and no-argument forms: `new X(a).y` → `(new X(a)).y`, `new X().y` →
+//! `(new X).y`, `new X().m()` → `(new X).m()`. (The prior revision of this port
+//! pinned an always-`()` spelling; the jar drops them, so the assertions here
+//! were corrected to the true byte-identical output.)
 //!
 //! ## Two seams
 //!
 //! ```text
-//!   new X()         the `new` keyword needs a space before an identifier/member
+//!   new X           the `new` keyword needs a space before an identifier/member
 //!                   callee, or `newX` fuses into one identifier.
-//!   new (f())()     the `new` target is a MemberExpression per grammar and
-//!   new (a.b().c)() cannot BE a call — a callee whose member spine bottoms out
-//!                   in a call is wrapped, or the appended `(args)` binds to the
-//!                   inner call (`new f()()` = `(new f())()`, a different program).
+//!   new(f())        the `new` target is a MemberExpression per grammar and
+//!   new(a.b().c)    cannot BE a call — a callee whose member spine bottoms out
+//!                   in a call is wrapped (the parens also separate the tokens).
 //! ```
 //!
 //! ## Note on hand-constructed inputs
@@ -120,11 +123,12 @@ fn assert_emits(expr: Expression, expected: &str) {
 // Active — core shapes
 // =====================================================================
 
-/// `assertPrintSame("new X()")` — identifier callee, empty argument list. The
-/// `new` keeps a separating space so it does not fuse into `newX`.
+/// `assertPrint("new X()", "new X")` — identifier callee, empty argument list.
+/// The empty `()` is dropped; the `new` keeps a separating space so it does not
+/// fuse into `newX`.
 #[test]
 fn new_identifier_no_args() {
-    assert_emits(new_expr(ident("X"), vec![]), "new X();");
+    assert_emits(new_expr(ident("X"), vec![]), "new X;");
 }
 
 /// `assertPrintSame("new X(a,b)")` — the argument list prints comma-separated
@@ -137,12 +141,12 @@ fn new_with_args() {
     );
 }
 
-/// `assertPrintSame("new a.b.c()")` — a pure member-chain callee is a valid
-/// `new` target and stays paren-free.
+/// `assertPrint("new a.b.c()", "new a.b.c")` — a pure member-chain callee is a
+/// valid `new` target and stays paren-free; the empty `()` is dropped.
 #[test]
 fn new_member_chain_callee_not_wrapped() {
     let callee = member(member(ident("a"), "b"), "c");
-    assert_emits(new_expr(callee, vec![]), "new a.b.c();");
+    assert_emits(new_expr(callee, vec![]), "new a.b.c;");
 }
 
 /// A member operand as a `new` argument round-trips: `new X(a.b)`.
@@ -163,7 +167,7 @@ fn new_with_member_arg() {
 /// different program). The wrapping paren also removes the `new`-keyword space.
 #[test]
 fn new_call_callee_is_wrapped() {
-    assert_emits(new_expr(call(ident("f"), vec![]), vec![]), "new(f())();");
+    assert_emits(new_expr(call(ident("f"), vec![]), vec![]), "new(f());");
 }
 
 /// `new (a.b().c)()` — the callee's member spine bottoms out in a call
@@ -171,41 +175,42 @@ fn new_call_callee_is_wrapped() {
 #[test]
 fn new_callee_with_call_in_member_spine_is_wrapped() {
     let callee = member(call(member(ident("a"), "b"), vec![]), "c");
-    assert_emits(new_expr(callee, vec![]), "new(a.b().c)();");
+    assert_emits(new_expr(callee, vec![]), "new(a.b().c);");
 }
 
 // =====================================================================
-// Active — precedence (an argumented `new` is member/call strength)
+// Active — precedence (a `new` is below member/call strength, so wrapped)
 // =====================================================================
 
-/// `new X(a).y` — an argumented `new` binds at member strength, so a member
-/// parent needs NO extra parens: `new X(a).y`.
+/// `new X(a).y` — Closure parenthesises a `new` as a member object even with
+/// arguments: `(new X(a)).y`. Driven by `new` tagging at `PREC_NEW`.
 #[test]
-fn argumented_new_as_member_object_not_wrapped() {
+fn argumented_new_as_member_object_is_wrapped() {
     let m = member(new_expr(ident("X"), vec![ident("a")]), "y");
-    assert_emits(m, "new X(a).y;");
+    assert_emits(m, "(new X(a)).y;");
 }
 
-/// A no-argument `new X` is emitted canonically as `new X()` (the parens are
-/// always printed), so as a member object it needs no wrap: `new X().y`.
+/// A no-argument `new X` drops its `()` and, as a member object, is wrapped so
+/// `.y` binds to the whole `new`: `(new X).y` (bare `new X.y` = `new (X.y)`).
 #[test]
-fn no_arg_new_as_member_object_prints_argumented() {
+fn no_arg_new_as_member_object_wraps() {
     let m = member(new_expr(ident("X"), vec![]), "y");
-    assert_emits(m, "new X().y;");
+    assert_emits(m, "(new X).y;");
 }
 
-/// `new` nests: the inner `new X()` is a valid target (not a call), so no wrap
-/// is forced and the outer `new` keeps its keyword space: `new new X()()`.
+/// `new` nests: the inner no-arg `new X` drops its `()` and, as the outer
+/// `new`'s callee, is wrapped: `new (new X)`.
 #[test]
-fn nested_new_inner_not_wrapped() {
+fn nested_new_inner_wrapped() {
     let inner = new_expr(ident("X"), vec![]);
-    assert_emits(new_expr(inner, vec![]), "new new X()();");
+    assert_emits(new_expr(inner, vec![]), "new (new X);");
 }
 
 /// A `new` result called as a function: `new X().m()` — a call whose callee is
-/// a member on the argumented `new`. All bind at `PREC_PRIMARY`, so no wraps.
+/// a member on the no-arg `new`. The `new` wraps as the member object and its
+/// `()` drops: `(new X).m()`.
 #[test]
-fn call_on_new_member_is_paren_free() {
+fn call_on_new_member_wraps() {
     let e = call(member(new_expr(ident("X"), vec![]), "m"), vec![]);
-    assert_emits(e, "new X().m();");
+    assert_emits(e, "(new X).m();");
 }


### PR DESCRIPTION
## What

A zero-argument `NewExpression` now prints **without** the empty parentheses (`new C()` → `new C`, `new a.b.C()` → `new a.b.C`), matching the reference Closure Compiler at `SIMPLE` byte-for-byte. Previously the argument parens were always printed, so *every* `new X()` diverged.

### Oracle-verified byte-identity (fresh binary vs `closure-compiler-v20260712.jar`, SIMPLE)

| input | before | after / oracle |
|---|---|---|
| `new C()` | `new C()` | `new C` |
| `new a.b.C()` | `new a.b.C()` | `new a.b.C` |
| `new C().foo` | `new C().foo` | `(new C).foo` |
| `new C()()` | `new C()()` | `(new C)()` |
| `new C().m()` | `new C().m()` | `(new C).m()` |
| `new C(1).foo` | `new C(1).foo` | `(new C(1)).foo` |
| `new C(1)()` | `new C(1)()` | `(new C(1))()` |
| `new new C()` | `new new C()()` | `new (new C)` |
| `new C(1)` / `typeof new C` / `new C+1` | (same) | no wrap |

**16/16 in-scope cases byte-identical**, including nested-new.

## How

Two coupled changes:
1. **`emit_new`**: emit the `(args)` only when arguments are present; a no-arg `new` stops after the callee.
2. **`expr_prec`**: tag every `NewExpression` at a new `PREC_NEW` (17, just below `PREC_PRIMARY`=18), so a member-object / call-callee parent (which emit their spine at `PREC_PRIMARY`) wrap it — for **both** the argumented and no-argument forms. Dropping the `()` makes `new` a bare `NewExpression` that binds looser than member/call, so `new C.y` (= `new (C.y)`) is prevented by the wrap.

## Soundness

Lowering a child's precedence can only make `my_prec < parent_prec` fire **more** often — i.e. add parens, never remove them — so a complete `NewExpression` is only ever over-parenthesised, always semantically transparent. The paren-drop is safe *precisely because* the precedence change forces the wrap in the four rebind-dangerous `PREC_PRIMARY` parents (member object, computed member, call callee, outer-new callee).

## Out of scope (separate divergences, unchanged, queued as their own arcs)

`(new C)["k"]`→`(new C).k` computed-index→dot normalization, `a,b`→`a;b` sequence-at-statement split, and the `new(f())` vs `new (f())` callee space.

## Testing

- `closure-emitter`: full unit + upstream conformance suites pass; clippy clean. Updated the 7 lib + 8 upstream `new` tests to the true jar output, and **corrected the upstream `CodePrinter` new-operator port** which had pinned closurec's old always-`()` spelling. Added call-callee-wrap and loose-parent-bare tests.
- Full `closurec` suite green (`CARGO_EXIT=0`, 135 groups, **no fixture drift** — the e2e fixtures don't exercise `new` expressions).
- Inline security review: **PASSED** (confirmed the precedence coupling prevents any miscompile/invalid-JS; no panic/unsafe/recursion surface).

`closure-emitter` 0.48.0 → 0.49.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)