### PR TITLE
feat(sql): CAST(x AS NUMERIC) affinity

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.36 — CAST … AS NUMERIC
+
+`CAST(x AS NUMERIC)` (and NUMERIC-affinity type names like `DECIMAL`, `BOOLEAN`)
+now work instead of erroring. NUMERIC prefers INTEGER when the value is integral
+and fits i64 — `CAST('3.0' AS NUMERIC)` → `3`, `CAST('1e3' AS NUMERIC)` → `1000`
+— and REAL otherwise (`CAST('3.5' AS NUMERIC)` → `3.5`; an i64-overflowing
+integer → real). A number is left unchanged: `CAST(3.0 AS NUMERIC)` stays `3.0`.
+Six differential-oracle cases; sql-planner 0.2.17, sql-vm 0.4.18. (`CAST … AS
+BLOB` is still rejected — a spun-off follow-up.)
+
 ## 0.5.35 — Division / modulo by zero returns NULL
 
 `SELECT 5/0`, `5.0/0`, `0/0`, `5%0`, `5.5%0`, and `5%0.0` now return **NULL**

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.35"
+version = "0.5.36"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1233,6 +1233,50 @@ const CASES: &[Case] = &[
         setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
         query: "SELECT (7 / 2) AS a, (-7 / 2) AS b, (7 % 3) AS c, (7.0 / 2) AS d FROM t",
     },
+    // ---- Lane 1: CAST … AS NUMERIC (affinity) ----------------------------
+    // NUMERIC prefers INTEGER when the value is integral and fits i64, else
+    // REAL. Text `'3.0'` and `'1e3'` are integral → INTEGER; `'3.5'` → REAL;
+    // an i64-overflowing integer → REAL. `typeof` is compared implicitly via
+    // the cell's storage class (Int vs Float sort/compare differently).
+    Case {
+        id: "cast_numeric_text_int_vs_real",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT CAST('42' AS NUMERIC) AS a, CAST('3.0' AS NUMERIC) AS b, \
+                CAST('3.5' AS NUMERIC) AS c, CAST('1e3' AS NUMERIC) AS d, \
+                CAST('42abc' AS NUMERIC) AS e, CAST('abc' AS NUMERIC) AS f FROM t",
+    },
+    // A REAL value stays REAL (the cast is a no-op on numbers), an INTEGER stays
+    // INTEGER, and NULL stays NULL.
+    Case {
+        id: "cast_numeric_number_is_noop",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT CAST(3.0 AS NUMERIC) AS a, CAST(3.5 AS NUMERIC) AS b, \
+                CAST(42 AS NUMERIC) AS c, CAST(NULL AS NUMERIC) AS d FROM t",
+    },
+    // An integer that overflows i64 falls through to REAL.
+    Case {
+        id: "cast_numeric_overflow_is_real",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT CAST('99999999999999999999' AS NUMERIC) AS a, \
+                CAST('9223372036854775807' AS NUMERIC) AS b FROM t",
+    },
+    // NUMERIC is the default affinity for non-INT/TEXT/REAL/BLOB type names, so
+    // DECIMAL and BOOLEAN behave identically to NUMERIC.
+    Case {
+        id: "cast_decimal_boolean_are_numeric",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT CAST('42.5' AS DECIMAL) AS a, CAST('7' AS BOOLEAN) AS b FROM t",
+    },
+    // Per-row over a real column: NUMERIC keeps reals real but collapses an
+    // integral text column to INTEGER.
+    Case {
+        id: "cast_numeric_per_row",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1,'10'),(2,'2.5'),(3,'30.0')",
+        ],
+        query: "SELECT id, CAST(s AS NUMERIC) AS n FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.17] - Unreleased
+
+### Added
+
+- **`CAST(x AS NUMERIC)` and the NUMERIC default affinity.** The CAST type-name
+  resolver now follows SQLite's full type-name → affinity rules: a name matching
+  none of INTEGER / TEXT / REAL / BLOB resolves to the new `CastType::Numeric`
+  (so `NUMERIC`, `DECIMAL`, `BOOLEAN`, `DATE`, … all take numeric affinity)
+  instead of erroring with "CAST to unsupported type". `BLOB` casts are rejected
+  explicitly (still unimplemented) rather than mis-routed into the NUMERIC
+  fallback. See sql-vm 0.4.18 for the runtime conversion.
+
 ## [0.2.16] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -233,6 +233,14 @@ pub enum CastType {
     Real,
     /// `CAST(x AS TEXT)` — render the value as its text representation.
     Text,
+    /// `CAST(x AS NUMERIC)` — SQLite's NUMERIC affinity, and the *default*
+    /// affinity for any type name that is not INTEGER/TEXT/REAL/BLOB (e.g.
+    /// `NUMERIC`, `DECIMAL`, `BOOLEAN`, `DATE`). An INTEGER stays INTEGER and a
+    /// REAL stays REAL (the cast is a no-op on numbers — `CAST(3.0 AS NUMERIC)`
+    /// is `3.0`, not `3`). Text/blob is parsed to a number, preferring INTEGER
+    /// when the value is integral and fits i64 (`'3.0'`→`3`, `'1e3'`→`1000`),
+    /// otherwise REAL (`'3.5'`→`3.5`, an i64-overflowing integer→real).
+    Numeric,
 }
 
 /// An aggregate function name.
@@ -2497,17 +2505,24 @@ fn plan_cast(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         found.ok_or_else(|| PlanError::UnsupportedStatement("CAST missing type name".to_string()))?
     };
 
-    // SQLite's type-affinity substring rule, restricted to the supported types.
+    // SQLite's type-name → affinity rules (https://sqlite.org/datatype3.html
+    // §3.1), applied in order: INT → INTEGER; CHAR/CLOB/TEXT → TEXT; BLOB (or an
+    // empty name) → BLOB; REAL/FLOA/DOUB → REAL; anything else → NUMERIC. NUMERIC
+    // is therefore the default for `NUMERIC`, `DECIMAL`, `BOOLEAN`, `DATE`, … .
+    // BLOB casts are not yet implemented, so we reject them explicitly rather
+    // than silently mis-routing them into the NUMERIC fallback.
     let ty = if type_name.contains("INT") {
         CastType::Integer
     } else if type_name.contains("CHAR") || type_name.contains("CLOB") || type_name.contains("TEXT") {
         CastType::Text
+    } else if type_name.contains("BLOB") {
+        return Err(PlanError::UnsupportedStatement(
+            "CAST to BLOB is not yet supported".to_string(),
+        ));
     } else if type_name.contains("REAL") || type_name.contains("FLOA") || type_name.contains("DOUB") {
         CastType::Real
     } else {
-        return Err(PlanError::UnsupportedStatement(format!(
-            "CAST to unsupported type: {type_name}"
-        )));
+        CastType::Numeric
     };
 
     Ok(SqlExpr::Cast {

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.18] - Unreleased
+
+### Added
+
+- **`CAST(… AS NUMERIC)` runtime conversion** (`CastType::Numeric`). Applies
+  SQLite's NUMERIC affinity: a number is unchanged (INTEGER stays INTEGER, REAL
+  stays REAL — `CAST(3.0 AS NUMERIC)` is `3.0`, not `3`); text/blob is parsed and
+  collapsed to INTEGER when the value is integral and fits `i64` (`'3.0'`→`3`,
+  `'1e3'`→`1000`, `'42abc'`→`42`), otherwise REAL (`'3.5'`, an i64-overflowing
+  integer like `'99999999999999999999'`→`1e20`); non-numeric text → `0`. The
+  integer prefix is parsed exactly (not via f64) so `i64::MAX` round-trips as an
+  integer. New helpers `cast_to_numeric` / `text_to_numeric`.
+
 ## [0.4.17] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -2561,6 +2561,80 @@ fn apply_cast(val: &SqlValue, ty: &CastType) -> SqlValue {
             SqlValue::Bool(b) => (*b as i64).to_string(),
             _ => sql_to_str(val),
         }),
+        CastType::Numeric => cast_to_numeric(val),
+    }
+}
+
+/// Value → INTEGER or REAL for `CAST(… AS NUMERIC)` (SQLite's NUMERIC affinity).
+///
+/// A number is left unchanged — an INTEGER stays INTEGER and a REAL stays REAL,
+/// so `CAST(3.0 AS NUMERIC)` is `3.0`, not `3`. Text and blob are parsed to a
+/// number, preferring INTEGER when the value is integral and fits `i64`,
+/// otherwise REAL (see [`text_to_numeric`]). NULL was already handled by the
+/// caller.
+fn cast_to_numeric(val: &SqlValue) -> SqlValue {
+    match val {
+        SqlValue::Int(i) => SqlValue::Int(*i),
+        // A stored bool stands in for the integer 1/0.
+        SqlValue::Bool(b) => SqlValue::Int(*b as i64),
+        SqlValue::Float(f) => SqlValue::Float(*f),
+        SqlValue::Text(s) => text_to_numeric(s),
+        SqlValue::Blob(b) => text_to_numeric(&String::from_utf8_lossy(b)),
+        SqlValue::Null => SqlValue::Null,
+    }
+}
+
+/// Parse text to a NUMERIC value, matching SQLite's `sqlite3VdbeMemNumerify`:
+/// prefer INTEGER when the leading numeric prefix denotes an integer that fits
+/// `i64`, otherwise REAL. Non-numeric text yields `0` (integer), like the other
+/// numeric casts.
+///
+/// | input        | result      | why                                    |
+/// |--------------|-------------|----------------------------------------|
+/// | `'42'`       | `Int(42)`   | pure integer prefix                    |
+/// | `'42abc'`    | `Int(42)`   | integer prefix, trailing junk ignored  |
+/// | `'3.0'`      | `Int(3)`    | real syntax, but value is integral     |
+/// | `'1e3'`      | `Int(1000)` | exponent, but value is integral        |
+/// | `'3.5'`      | `Float(3.5)`| non-integral                           |
+/// | `'9e99'`     | `Float(..)` | integral but overflows i64 → real      |
+/// | `'abc'`      | `Int(0)`    | no numeric prefix                       |
+fn text_to_numeric(s: &str) -> SqlValue {
+    let t = s.trim_start();
+    let bytes = t.as_bytes();
+    let mut i = 0;
+    if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+        i += 1;
+    }
+    let digit_start = i;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    let has_int_digits = i > digit_start;
+    // A `.`/`e`/`E` immediately after the integer digits means the prefix is a
+    // real literal, not a plain integer.
+    let real_syntax =
+        i < bytes.len() && matches!(bytes[i], b'.' | b'e' | b'E');
+
+    if has_int_digits && !real_syntax {
+        // Pure integer prefix (e.g. `42`, `-7`, `42abc`). Parse it exactly so an
+        // i64 overflow falls through to the real value rather than saturating.
+        if let Ok(n) = t[..i].parse::<i64>() {
+            return SqlValue::Int(n);
+        }
+        return SqlValue::Float(parse_real_prefix(s));
+    }
+
+    // Real-syntax or digit-less prefix: take the real value, then collapse it to
+    // an integer when it is integral and fits i64 (`3.0`→3, `1e3`→1000), else
+    // keep it real (`3.5`, overflow). `parse_real_prefix` returns 0.0 for
+    // non-numeric text, so `'abc'`→`Int(0)`.
+    let r = parse_real_prefix(s);
+    // 2^63 as f64; the half-open range keeps `r as i64` exact (no saturation).
+    const I64_LIMIT: f64 = 9_223_372_036_854_775_808.0;
+    if r.is_finite() && r.fract() == 0.0 && (-I64_LIMIT..I64_LIMIT).contains(&r) {
+        SqlValue::Int(r as i64)
+    } else {
+        SqlValue::Float(r)
     }
 }
 
@@ -3196,6 +3270,35 @@ mod tests {
             Instruction::Halt,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)]]);
+    }
+
+    #[test]
+    fn test_cast_numeric_affinity() {
+        let num = |v: SqlValue| apply_cast(&v, &CastType::Numeric);
+
+        // Text → INTEGER when integral & fits i64; else REAL.
+        assert_eq!(num(SqlValue::Text("42".into())), SqlValue::Int(42));
+        assert_eq!(num(SqlValue::Text("3.0".into())), SqlValue::Int(3));
+        assert_eq!(num(SqlValue::Text("1e3".into())), SqlValue::Int(1000));
+        assert_eq!(num(SqlValue::Text("42abc".into())), SqlValue::Int(42));
+        assert_eq!(num(SqlValue::Text("abc".into())), SqlValue::Int(0));
+        assert_eq!(num(SqlValue::Text("3.5".into())), SqlValue::Float(3.5));
+        // i64-overflowing integer text → REAL.
+        match num(SqlValue::Text("99999999999999999999".into())) {
+            SqlValue::Float(f) => assert!((f - 1e20).abs() < 1e6),
+            other => panic!("expected REAL, got {other:?}"),
+        }
+        // i64::MAX parses exactly as INTEGER (no f64-rounding surprise).
+        assert_eq!(
+            num(SqlValue::Text("9223372036854775807".into())),
+            SqlValue::Int(i64::MAX)
+        );
+        // Numbers are a no-op: INTEGER stays INTEGER, REAL stays REAL (even 3.0).
+        assert_eq!(num(SqlValue::Int(42)), SqlValue::Int(42));
+        assert_eq!(num(SqlValue::Float(3.0)), SqlValue::Float(3.0));
+        assert_eq!(num(SqlValue::Float(3.5)), SqlValue::Float(3.5));
+        // NULL stays NULL.
+        assert_eq!(num(SqlValue::Null), SqlValue::Null);
     }
 
     #[test]


### PR DESCRIPTION
## Cycle 2, lane 1 (CAST): `CAST(x AS NUMERIC)` affinity

`CAST(x AS NUMERIC)` previously failed with *"CAST to unsupported type: NUMERIC"*. It now works — and NUMERIC becomes the **default affinity** for any type name that isn't INTEGER/TEXT/REAL/BLOB, so `DECIMAL`, `BOOLEAN`, `DATE`, … all cast as NUMERIC too (SQLite's type-name → affinity rules, datatype3 §3.1).

I probed real SQLite across the whole CAST surface first: INTEGER/REAL/TEXT already conform exactly (prefix-parse, truncation, whitespace) — **NUMERIC was the one unsupported target**.

### Semantics (verified against real `sqlite3`)
- A number is unchanged: **INTEGER stays INTEGER, REAL stays REAL** — `CAST(3.0 AS NUMERIC)` is `3.0`, not `3`.
- Text/blob is parsed and collapsed to **INTEGER when the value is integral and fits i64** (`'3.0'`→`3`, `'1e3'`→`1000`, `'42abc'`→`42`), otherwise **REAL** (`'3.5'`→`3.5`; an i64-overflowing integer `'99999999999999999999'`→`1e20`). Non-numeric text → `0`. The integer prefix is parsed **exactly** (not via f64) so `i64::MAX` round-trips as an integer.

### Implementation
- **sql-planner**: new `CastType::Numeric`; the resolver falls back to it for unrecognized names and now **rejects BLOB explicitly** (still unimplemented) rather than mis-routing it into the NUMERIC fallback.
- **sql-vm**: `cast_to_numeric` / `text_to_numeric` — a single-pass, ASCII-only scan.

### Tests
- 6 differential-oracle cases vs real bundled SQLite: int-vs-real text, number no-op, overflow→real, DECIMAL/BOOLEAN fallback, per-row column.
- VM unit test asserting exact `Int`/`Float` storage classes (incl. `i64::MAX` and overflow→real).
- Downstream consumers (planner/codegen/optimizer/mini-sqlite/storage-sqlite) green.

### Security
Adversarial subagent review: **clean** — `t[..i]` is char-boundary-safe (the scan only advances over ASCII sign/digit/`.eE` bytes), the int/real boundary is exact (`2^63` half-open range, no f64 saturation), parsing is single-pass and bounded.

### Follow-up (spun off)
`CAST(x AS BLOB)` — still rejected; implement as the bytes of the value's text rendering.

Versions: sql-planner 0.2.17, sql-vm 0.4.18, mini-sqlite 0.5.36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
