### PR TITLE
feat: port hash functions to Lua and Perl

### DIFF
--- a/code/packages/lua/hash-functions/BUILD
+++ b/code/packages/lua/hash-functions/BUILD
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/hash-functions/BUILD_windows
+++ b/code/packages/lua/hash-functions/BUILD_windows
@@ -1,0 +1,2 @@
+luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec
+cd tests && set "LUA_PATH=../src/?.lua;../src/?/init.lua;;" && busted . --verbose --pattern=test_

--- a/code/packages/lua/hash-functions/CHANGELOG.md
+++ b/code/packages/lua/hash-functions/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-16
+
+- Add pure Lua FNV-1a 32/64, DJB2, polynomial rolling, and MurmurHash3 hashes.
+- Add deterministic avalanche and bucket-distribution analysis helpers.
+- Preserve binary input and exact 64-bit bit patterns without dependencies.

--- a/code/packages/lua/hash-functions/README.md
+++ b/code/packages/lua/hash-functions/README.md
@@ -1,0 +1,30 @@
+# hash-functions (Lua)
+
+Pure Lua 5.4 implementations of non-cryptographic hash primitives used by the
+hash-map and Bloom-filter packages.
+
+## API
+
+- `fnv1a_32(data)` and `fnv1a_64(data)`
+- `djb2(data)`
+- `polynomial_rolling(data, base?, modulus?)`
+- `murmur3_32(data, seed?)`
+- `avalanche_score(hash_fn, output_bits, sample_size?)`
+- `distribution_test(hash_fn, inputs, num_buckets)`
+- `uint64_hex(value)` for viewing a signed Lua integer as an unsigned word
+
+Lua strings are byte sequences, so every function is binary-safe. UTF-8 text
+is hashed as its encoded bytes. Lua 5.4 represents integers as signed 64-bit
+values; `fnv1a_64` and `djb2` return the exact two's-complement word and may
+therefore be negative. `uint64_hex` exposes the corresponding unsigned bits.
+
+These functions are educational, deterministic, and dependency-free. They are
+not cryptographic hashes and must not be used for passwords or signatures.
+
+## Development
+
+```bash
+luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec
+cd tests
+LUA_PATH="../src/?.lua;../src/?/init.lua;;" busted . --verbose --pattern=test_
+```

--- a/code/packages/lua/hash-functions/coding-adventures-hash-functions-0.1.0-1.rockspec
+++ b/code/packages/lua/hash-functions/coding-adventures-hash-functions-0.1.0-1.rockspec
@@ -1,0 +1,18 @@
+package = "coding-adventures-hash-functions"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Pure non-cryptographic hash functions",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.hash_functions"] = "src/coding_adventures/hash_functions/init.lua",
+    },
+}

--- a/code/packages/lua/hash-functions/required_capabilities.json
+++ b/code/packages/lua/hash-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/hash-functions",
+  "capabilities": [],
+  "justification": "Pure in-memory computation. No filesystem, network, process, environment, or randomness access needed."
+}

--- a/code/packages/lua/hash-functions/src/coding_adventures/hash_functions/init.lua
+++ b/code/packages/lua/hash-functions/src/coding_adventures/hash_functions/init.lua
@@ -1,0 +1,287 @@
+--- Pure non-cryptographic hash functions and deterministic analysis helpers.
+---
+--- Lua 5.4 integers are signed 64-bit values. Functions that produce a
+--- 64-bit word therefore return the exact two's-complement bit pattern, which
+--- may be negative. `uint64_hex` exposes the corresponding unsigned bits.
+
+local M = {}
+
+local MASK32 = 0xffffffff
+local FNV32_OFFSET_BASIS = 0x811c9dc5
+local FNV32_PRIME = 0x01000193
+local FNV64_OFFSET_BASIS = 0xcbf29ce484222325
+local FNV64_PRIME = 0x00000100000001b3
+local POLYNOMIAL_DEFAULT_BASE = 31
+local POLYNOMIAL_DEFAULT_MODULUS = (1 << 61) - 1
+local MURMUR3_C1 = 0xcc9e2d51
+local MURMUR3_C2 = 0x1b873593
+
+M.FNV32_OFFSET_BASIS = FNV32_OFFSET_BASIS
+M.FNV32_PRIME = FNV32_PRIME
+M.FNV64_OFFSET_BASIS = FNV64_OFFSET_BASIS
+M.FNV64_PRIME = FNV64_PRIME
+M.POLYNOMIAL_ROLLING_DEFAULT_BASE = POLYNOMIAL_DEFAULT_BASE
+M.POLYNOMIAL_ROLLING_DEFAULT_MODULUS = POLYNOMIAL_DEFAULT_MODULUS
+
+local function require_string(data, level)
+    if type(data) ~= "string" then
+        error("data must be a string", level or 3)
+    end
+    return data
+end
+
+local function require_integer(value, name, level)
+    if type(value) ~= "number" or math.type(value) ~= "integer" then
+        error(name .. " must be an integer", level or 3)
+    end
+    return value
+end
+
+local function add_mod(left, right, modulus)
+    -- left and right are already normalized into [0, modulus). Comparing
+    -- before adding avoids signed 64-bit overflow.
+    local distance = modulus - right
+    if left >= distance then
+        return left - distance
+    end
+    return left + right
+end
+
+local function multiply_mod(left, right, modulus)
+    left = left % modulus
+    right = right % modulus
+    local result = 0
+    while right > 0 do
+        if (right & 1) ~= 0 then
+            result = add_mod(result, left, modulus)
+        end
+        right = right >> 1
+        if right > 0 then
+            left = add_mod(left, left, modulus)
+        end
+    end
+    return result
+end
+
+--- Compute the 32-bit Fowler-Noll-Vo FNV-1a hash.
+function M.fnv1a_32(data)
+    data = require_string(data, 2)
+    local hash = FNV32_OFFSET_BASIS
+    for index = 1, #data do
+        hash = ((hash ~ string.byte(data, index)) * FNV32_PRIME) & MASK32
+    end
+    return hash
+end
+
+--- Compute the 64-bit Fowler-Noll-Vo FNV-1a bit pattern.
+function M.fnv1a_64(data)
+    data = require_string(data, 2)
+    local hash = FNV64_OFFSET_BASIS
+    for index = 1, #data do
+        hash = (hash ~ string.byte(data, index)) * FNV64_PRIME
+    end
+    return hash
+end
+
+--- Compute Dan Bernstein's DJB2 hash, bounded to 64 bits.
+function M.djb2(data)
+    data = require_string(data, 2)
+    local hash = 5381
+    for index = 1, #data do
+        hash = (hash << 5) + hash + string.byte(data, index)
+    end
+    return hash
+end
+
+--- Format a signed Lua integer as its exact unsigned 64-bit hexadecimal word.
+function M.uint64_hex(value)
+    require_integer(value, "value", 2)
+    return string.format("%016x", value)
+end
+
+--- Compute a polynomial rolling hash with overflow-safe modular arithmetic.
+function M.polynomial_rolling(data, base, modulus)
+    data = require_string(data, 2)
+    base = base == nil and POLYNOMIAL_DEFAULT_BASE or base
+    modulus = modulus == nil and POLYNOMIAL_DEFAULT_MODULUS or modulus
+    require_integer(base, "base", 2)
+    require_integer(modulus, "modulus", 2)
+    if modulus <= 0 then
+        error("modulus must be positive", 2)
+    end
+
+    local normalized_base = base % modulus
+    local hash = 0
+    for index = 1, #data do
+        hash = multiply_mod(hash, normalized_base, modulus)
+        hash = add_mod(hash, string.byte(data, index) % modulus, modulus)
+    end
+    return hash
+end
+
+local function rotate_left_32(value, count)
+    return ((value << count) | (value >> (32 - count))) & MASK32
+end
+
+local function fmix32(hash)
+    hash = (hash ~ (hash >> 16)) & MASK32
+    hash = (hash * 0x85ebca6b) & MASK32
+    hash = (hash ~ (hash >> 13)) & MASK32
+    hash = (hash * 0xc2b2ae35) & MASK32
+    return (hash ~ (hash >> 16)) & MASK32
+end
+
+--- Compute Austin Appleby's MurmurHash3 32-bit variant.
+function M.murmur3_32(data, seed)
+    data = require_string(data, 2)
+    seed = seed == nil and 0 or seed
+    require_integer(seed, "seed", 2)
+
+    local length = #data
+    local hash = seed & MASK32
+    local block_count = length >> 2
+
+    for block_index = 0, block_count - 1 do
+        local offset = block_index * 4 + 1
+        local k = string.byte(data, offset)
+            | (string.byte(data, offset + 1) << 8)
+            | (string.byte(data, offset + 2) << 16)
+            | (string.byte(data, offset + 3) << 24)
+
+        k = (k * MURMUR3_C1) & MASK32
+        k = rotate_left_32(k, 15)
+        k = (k * MURMUR3_C2) & MASK32
+
+        hash = hash ~ k
+        hash = rotate_left_32(hash, 13)
+        hash = (hash * 5 + 0xe6546b64) & MASK32
+    end
+
+    local tail_offset = block_count * 4 + 1
+    local remaining = length & 3
+    local k = 0
+    if remaining >= 3 then
+        k = k ~ (string.byte(data, tail_offset + 2) << 16)
+    end
+    if remaining >= 2 then
+        k = k ~ (string.byte(data, tail_offset + 1) << 8)
+    end
+    if remaining >= 1 then
+        k = k ~ string.byte(data, tail_offset)
+        k = (k * MURMUR3_C1) & MASK32
+        k = rotate_left_32(k, 15)
+        k = (k * MURMUR3_C2) & MASK32
+        hash = hash ~ k
+    end
+
+    hash = hash ~ length
+    return fmix32(hash)
+end
+
+local function deterministic_bytes(sample_index)
+    local state = (0x9e3779b9 ~ sample_index) & MASK32
+    local bytes = {}
+    for index = 1, 8 do
+        state = (state * 1664525 + 1013904223) & MASK32
+        bytes[index] = state & 0xff
+    end
+    return bytes
+end
+
+local function hash_result(hash_fn, data)
+    local value = hash_fn(data)
+    if type(value) ~= "number" or math.type(value) ~= "integer" then
+        error("hash function must return an integer", 4)
+    end
+    return value
+end
+
+local function popcount_width(value, width)
+    local count = 0
+    for _ = 1, width do
+        count = count + (value & 1)
+        value = value >> 1
+    end
+    return count
+end
+
+--- Estimate the fraction of output bits flipped by one input-bit change.
+function M.avalanche_score(hash_fn, output_bits, sample_size)
+    if type(hash_fn) ~= "function" then
+        error("hash_fn must be a function", 2)
+    end
+    require_integer(output_bits, "output_bits", 2)
+    if output_bits < 1 or output_bits > 64 then
+        error("output_bits must be in 1..64", 2)
+    end
+    sample_size = sample_size == nil and 100 or sample_size
+    require_integer(sample_size, "sample_size", 2)
+    if sample_size <= 0 then
+        error("sample_size must be positive", 2)
+    end
+
+    local total_bit_flips = 0
+    local total_trials = 0
+    for sample_index = 0, sample_size - 1 do
+        local bytes = deterministic_bytes(sample_index)
+        local original = hash_result(hash_fn, string.char(table.unpack(bytes)))
+        for bit_position = 0, 63 do
+            local byte_index = (bit_position >> 3) + 1
+            local bit_mask = 1 << (bit_position & 7)
+            bytes[byte_index] = bytes[byte_index] ~ bit_mask
+            local changed = hash_result(hash_fn, string.char(table.unpack(bytes)))
+            bytes[byte_index] = bytes[byte_index] ~ bit_mask
+            total_bit_flips = total_bit_flips
+                + popcount_width(original ~ changed, output_bits)
+            total_trials = total_trials + output_bits
+        end
+    end
+    return total_bit_flips / total_trials
+end
+
+local function power_of_two_mod(exponent, modulus)
+    local result = 1 % modulus
+    for _ = 1, exponent do
+        result = add_mod(result, result, modulus)
+    end
+    return result
+end
+
+--- Return the chi-squared statistic for a hash function's bucket spread.
+function M.distribution_test(hash_fn, inputs, num_buckets)
+    if type(hash_fn) ~= "function" then
+        error("hash_fn must be a function", 2)
+    end
+    if type(inputs) ~= "table" or #inputs == 0 then
+        error("inputs must be a non-empty array", 2)
+    end
+    require_integer(num_buckets, "num_buckets", 2)
+    if num_buckets <= 0 then
+        error("num_buckets must be positive", 2)
+    end
+
+    local counts = {}
+    for bucket = 1, num_buckets do
+        counts[bucket] = 0
+    end
+    local unsigned_wrap = power_of_two_mod(64, num_buckets)
+    for index = 1, #inputs do
+        require_string(inputs[index], 2)
+        local value = hash_result(hash_fn, inputs[index])
+        local bucket = value % num_buckets
+        if value < 0 then
+            bucket = add_mod(bucket, unsigned_wrap, num_buckets)
+        end
+        counts[bucket + 1] = counts[bucket + 1] + 1
+    end
+
+    local expected = #inputs / num_buckets
+    local chi_squared = 0.0
+    for bucket = 1, num_buckets do
+        local difference = counts[bucket] - expected
+        chi_squared = chi_squared + difference * difference / expected
+    end
+    return chi_squared
+end
+
+return M

--- a/code/packages/lua/hash-functions/tests/test_hash_functions.lua
+++ b/code/packages/lua/hash-functions/tests/test_hash_functions.lua
@@ -1,0 +1,112 @@
+package.path = table.concat({
+    "../src/?.lua",
+    "../src/?/init.lua",
+    package.path,
+}, ";")
+
+local hashes = require("coding_adventures.hash_functions")
+
+describe("hash-functions", function()
+    it("matches FNV-1a 32-bit vectors and handles arbitrary bytes", function()
+        assert.equals(2166136261, hashes.fnv1a_32(""))
+        assert.equals(3826002220, hashes.fnv1a_32("a"))
+        assert.equals(440920331, hashes.fnv1a_32("abc"))
+        assert.equals(1335831723, hashes.fnv1a_32("hello"))
+        assert.equals(3214735720, hashes.fnv1a_32("foobar"))
+
+        local all_bytes = {}
+        for byte = 0, 255 do
+            all_bytes[#all_bytes + 1] = string.char(byte)
+        end
+        local payload = table.concat(all_bytes)
+        assert.equals(hashes.fnv1a_32(payload), hashes.fnv1a_32(payload))
+        assert.not_equals(hashes.fnv1a_32("a\0b"), hashes.fnv1a_32("ab"))
+    end)
+
+    it("matches exact FNV-1a 64-bit words", function()
+        assert.equals("cbf29ce484222325", hashes.uint64_hex(hashes.fnv1a_64("")))
+        assert.equals("af63dc4c8601ec8c", hashes.uint64_hex(hashes.fnv1a_64("a")))
+        assert.equals("e71fa2190541574b", hashes.uint64_hex(hashes.fnv1a_64("abc")))
+        assert.equals("a430d84680aabd0b", hashes.uint64_hex(hashes.fnv1a_64("hello")))
+    end)
+
+    it("matches DJB2 vectors and preserves 64-bit wrapping", function()
+        assert.equals(5381, hashes.djb2(""))
+        assert.equals(177670, hashes.djb2("a"))
+        assert.equals(193485963, hashes.djb2("abc"))
+        assert.equals(210714636441, hashes.djb2("hello"))
+        assert.equals("cb2c236ad13cc66d", hashes.uint64_hex(hashes.djb2(string.rep("a", 1000))))
+    end)
+
+    it("computes polynomial hashes without integer overflow", function()
+        assert.equals(0, hashes.polynomial_rolling(""))
+        assert.equals(97, hashes.polynomial_rolling("a"))
+        assert.equals(3105, hashes.polynomial_rolling("ab"))
+        assert.equals(96354, hashes.polynomial_rolling("abc"))
+        assert.not_equals(
+            hashes.polynomial_rolling("hello", 31),
+            hashes.polynomial_rolling("hello", 37)
+        )
+        assert.is_true(hashes.polynomial_rolling("hello world", 31, 100) < 100)
+
+        local long = string.rep("hash me", 500)
+        local default_modulus = (1 << 61) - 1
+        assert.is_true(hashes.polynomial_rolling(long) < default_modulus)
+        assert.has_error(function()
+            hashes.polynomial_rolling("x", 31, 0)
+        end, "modulus must be positive")
+    end)
+
+    it("matches MurmurHash3 vectors and all tail paths", function()
+        assert.equals(0, hashes.murmur3_32("", 0))
+        assert.equals(0x514e28b7, hashes.murmur3_32("", 1))
+        assert.equals(0x3c2569b2, hashes.murmur3_32("a", 0))
+        assert.equals(0xb3dd93fa, hashes.murmur3_32("abc", 0))
+        assert.not_equals(hashes.murmur3_32("abcd"), hashes.murmur3_32("abce"))
+        assert.is_true(hashes.murmur3_32("abcde") >= 0)
+        assert.is_true(hashes.murmur3_32("abcdef") >= 0)
+        assert.is_true(hashes.murmur3_32("abcdefg") >= 0)
+        assert.not_equals(hashes.murmur3_32("hello", 0), hashes.murmur3_32("hello", 1))
+    end)
+
+    it("computes deterministic avalanche and distribution metrics", function()
+        local fnv_score = hashes.avalanche_score(hashes.fnv1a_32, 32, 8)
+        local murmur_score = hashes.avalanche_score(hashes.murmur3_32, 32, 8)
+        assert.is_true(fnv_score >= 0 and fnv_score <= 1)
+        assert.is_true(murmur_score >= 0 and murmur_score <= 1)
+        assert.equals(fnv_score, hashes.avalanche_score(hashes.fnv1a_32, 32, 8))
+
+        local chi_squared = hashes.distribution_test(function()
+            return 0
+        end, { "a", "b", "c", "d" }, 4)
+        assert.equals(12, chi_squared)
+
+        local signed_word_chi = hashes.distribution_test(
+            hashes.fnv1a_64,
+            { "a", "b", "c", "d", "e" },
+            7
+        )
+        assert.is_true(signed_word_chi >= 0)
+    end)
+
+    it("validates public inputs", function()
+        assert.has_error(function()
+            hashes.fnv1a_32({})
+        end, "data must be a string")
+        assert.has_error(function()
+            hashes.murmur3_32("x", 1.5)
+        end, "seed must be an integer")
+        assert.has_error(function()
+            hashes.avalanche_score(hashes.fnv1a_32, 0, 1)
+        end, "output_bits must be in 1..64")
+        assert.has_error(function()
+            hashes.avalanche_score(hashes.fnv1a_32, 32, 0)
+        end, "sample_size must be positive")
+        assert.has_error(function()
+            hashes.distribution_test(hashes.fnv1a_32, {}, 10)
+        end, "inputs must be a non-empty array")
+        assert.has_error(function()
+            hashes.distribution_test(hashes.fnv1a_32, { "x" }, 0)
+        end, "num_buckets must be positive")
+    end)
+end)

--- a/code/packages/perl/hash-functions/BUILD
+++ b/code/packages/perl/hash-functions/BUILD
@@ -1,0 +1,1 @@
+prove -l -v t/

--- a/code/packages/perl/hash-functions/BUILD_windows
+++ b/code/packages/perl/hash-functions/BUILD_windows
@@ -1,0 +1,1 @@
+perl -Ilib t/00-load.t && perl -Ilib t/01-hash-functions.t

--- a/code/packages/perl/hash-functions/CHANGELOG.md
+++ b/code/packages/perl/hash-functions/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Perl package with binary-safe FNV-1a, DJB2, polynomial rolling,
+  MurmurHash3 x86_32, and deterministic avalanche and distribution helpers.
+- Preserve exact 64-bit results with core `Math::BigInt` values.

--- a/code/packages/perl/hash-functions/Makefile.PL
+++ b/code/packages/perl/hash-functions/Makefile.PL
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::HashFunctions',
+    VERSION_FROM     => 'lib/CodingAdventures/HashFunctions.pm',
+    ABSTRACT         => 'Educational non-cryptographic hash functions and analysis helpers',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'Encode'       => 0,
+        'Exporter'     => 0,
+        'Math::BigInt' => 0,
+        'Scalar::Util' => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/hash-functions/README.md
+++ b/code/packages/perl/hash-functions/README.md
@@ -1,0 +1,32 @@
+# CodingAdventures::HashFunctions
+
+Pure-Perl implementations of five educational, non-cryptographic hash
+functions:
+
+- FNV-1a in 32-bit and 64-bit forms
+- DJB2 with 64-bit wrapping
+- polynomial rolling hash with configurable base and modulus
+- MurmurHash3 x86_32 with a configurable seed
+
+The package also includes deterministic avalanche and bucket-distribution
+helpers for comparing hash behavior.
+
+```perl
+use CodingAdventures::HashFunctions qw(
+    fnv1a_32 fnv1a_64 murmur3_32 uint64_hex
+);
+
+my $short = fnv1a_32('hello');
+my $exact = fnv1a_64('hello');
+my $bits  = uint64_hex($exact);       # a430d84680aabd0b
+my $mixed = murmur3_32('hello', 42);
+```
+
+Inputs are binary-safe byte strings. UTF-8 flagged strings are encoded to
+UTF-8 first, which makes text behavior explicit and repeatable. The 64-bit
+functions return core `Math::BigInt` values so results remain exact on every
+supported Perl build.
+
+These algorithms are for learning, hash tables, and checksums. They are not
+cryptographic hashes and must not be used for passwords, signatures, or other
+security-sensitive purposes.

--- a/code/packages/perl/hash-functions/cpanfile
+++ b/code/packages/perl/hash-functions/cpanfile
@@ -1,0 +1,1 @@
+# No non-core dependencies.

--- a/code/packages/perl/hash-functions/lib/CodingAdventures/HashFunctions.pm
+++ b/code/packages/perl/hash-functions/lib/CodingAdventures/HashFunctions.pm
@@ -1,0 +1,264 @@
+package CodingAdventures::HashFunctions;
+
+use strict;
+use warnings;
+use Encode qw(encode FB_CROAK);
+use Exporter qw(import);
+use Math::BigInt;
+use Scalar::Util qw(blessed);
+
+our $VERSION = '0.1.0';
+our @EXPORT_OK = qw(
+    fnv1a_32
+    fnv1a_64
+    djb2
+    polynomial_rolling
+    murmur3_32
+    avalanche_score
+    distribution_test
+    uint64_hex
+);
+
+my $UINT32_MASK = 0xffffffff;
+my $FNV32_OFFSET_BASIS = 0x811c9dc5;
+my $FNV32_PRIME = 0x01000193;
+my $FNV64_OFFSET_BASIS = Math::BigInt->from_hex('0xcbf29ce484222325');
+my $FNV64_PRIME = Math::BigInt->from_hex('0x00000100000001b3');
+my $UINT64_MODULUS = Math::BigInt->new(2)->bpow(64);
+my $POLYNOMIAL_DEFAULT_BASE = Math::BigInt->new(31);
+my $POLYNOMIAL_DEFAULT_MODULUS = Math::BigInt->new(2)->bpow(61)->bsub(1);
+my $MURMUR3_C1 = 0xcc9e2d51;
+my $MURMUR3_C2 = 0x1b873593;
+
+sub _to_bytes {
+    my ($data) = @_;
+    die "data must be a scalar\n" if !defined($data) || ref($data);
+    return utf8::is_utf8($data) ? encode('UTF-8', $data, FB_CROAK) : "$data";
+}
+
+sub _native_integer {
+    my ($value, $name) = @_;
+    die "$name must be an integer\n"
+        if !defined($value) || ref($value) || "$value" !~ /\A[+-]?\d+\z/;
+    return 0 + $value;
+}
+
+sub _big_integer {
+    my ($value, $name) = @_;
+    if (blessed($value) && $value->isa('Math::BigInt')) {
+        return $value->copy;
+    }
+    die "$name must be an integer\n"
+        if !defined($value) || ref($value) || "$value" !~ /\A[+-]?\d+\z/;
+    return Math::BigInt->new("$value");
+}
+
+sub fnv1a_32 {
+    my ($data) = @_;
+    my $hash = $FNV32_OFFSET_BASIS;
+    for my $byte (unpack('C*', _to_bytes($data))) {
+        $hash = (($hash ^ $byte) * $FNV32_PRIME) & $UINT32_MASK;
+    }
+    return $hash;
+}
+
+sub fnv1a_64 {
+    my ($data) = @_;
+    my $hash = $FNV64_OFFSET_BASIS->copy;
+    for my $byte (unpack('C*', _to_bytes($data))) {
+        $hash->bxor($byte);
+        $hash->bmul($FNV64_PRIME)->bmod($UINT64_MODULUS);
+    }
+    return $hash;
+}
+
+sub djb2 {
+    my ($data) = @_;
+    my $hash = Math::BigInt->new(5381);
+    for my $byte (unpack('C*', _to_bytes($data))) {
+        $hash->bmul(33)->badd($byte)->bmod($UINT64_MODULUS);
+    }
+    return $hash;
+}
+
+sub uint64_hex {
+    my ($value) = @_;
+    my $word = _big_integer($value, 'value')->bmod($UINT64_MODULUS);
+    my $hex = $word->as_hex;
+    $hex =~ s/\A0x//;
+    return ('0' x (16 - length($hex))) . lc($hex);
+}
+
+sub polynomial_rolling {
+    my ($data, $base, $modulus) = @_;
+    my $raw = _to_bytes($data);
+    $base = defined($base) ? _big_integer($base, 'base') : $POLYNOMIAL_DEFAULT_BASE->copy;
+    $modulus = defined($modulus)
+        ? _big_integer($modulus, 'modulus')
+        : $POLYNOMIAL_DEFAULT_MODULUS->copy;
+    die "modulus must be positive\n" if $modulus->is_zero || $modulus->is_neg;
+
+    $base->bmod($modulus);
+    my $hash = Math::BigInt->bzero;
+    for my $byte (unpack('C*', $raw)) {
+        $hash->bmul($base)->badd($byte)->bmod($modulus);
+    }
+    return $hash;
+}
+
+sub _rotate_left_32 {
+    my ($value, $count) = @_;
+    return (($value << $count) | ($value >> (32 - $count))) & $UINT32_MASK;
+}
+
+sub _fmix32 {
+    my ($hash) = @_;
+    $hash = ($hash ^ ($hash >> 16)) & $UINT32_MASK;
+    $hash = ($hash * 0x85ebca6b) & $UINT32_MASK;
+    $hash = ($hash ^ ($hash >> 13)) & $UINT32_MASK;
+    $hash = ($hash * 0xc2b2ae35) & $UINT32_MASK;
+    return ($hash ^ ($hash >> 16)) & $UINT32_MASK;
+}
+
+sub murmur3_32 {
+    my ($data, $seed) = @_;
+    my @bytes = unpack('C*', _to_bytes($data));
+    $seed = defined($seed) ? _native_integer($seed, 'seed') : 0;
+    my $hash = $seed & $UINT32_MASK;
+    my $length = scalar(@bytes);
+    my $block_count = int($length / 4);
+
+    for (my $block_index = 0; $block_index < $block_count; $block_index++) {
+        my $offset = $block_index * 4;
+        my $k = $bytes[$offset]
+            | ($bytes[$offset + 1] << 8)
+            | ($bytes[$offset + 2] << 16)
+            | ($bytes[$offset + 3] << 24);
+
+        $k = ($k * $MURMUR3_C1) & $UINT32_MASK;
+        $k = _rotate_left_32($k, 15);
+        $k = ($k * $MURMUR3_C2) & $UINT32_MASK;
+
+        $hash ^= $k;
+        $hash = _rotate_left_32($hash, 13);
+        $hash = ($hash * 5 + 0xe6546b64) & $UINT32_MASK;
+    }
+
+    my $tail_offset = $block_count * 4;
+    my $remaining = $length & 3;
+    my $k = 0;
+    $k ^= $bytes[$tail_offset + 2] << 16 if $remaining >= 3;
+    $k ^= $bytes[$tail_offset + 1] << 8 if $remaining >= 2;
+    if ($remaining >= 1) {
+        $k ^= $bytes[$tail_offset];
+        $k = ($k * $MURMUR3_C1) & $UINT32_MASK;
+        $k = _rotate_left_32($k, 15);
+        $k = ($k * $MURMUR3_C2) & $UINT32_MASK;
+        $hash ^= $k;
+    }
+
+    $hash ^= $length;
+    return _fmix32($hash);
+}
+
+sub _deterministic_bytes {
+    my ($sample_index) = @_;
+    my $state = (0x9e3779b9 ^ $sample_index) & $UINT32_MASK;
+    my @bytes;
+    for (1 .. 8) {
+        $state = ($state * 1664525 + 1013904223) & $UINT32_MASK;
+        push @bytes, $state & 0xff;
+    }
+    return @bytes;
+}
+
+sub _normalized_hash {
+    my ($value, $width) = @_;
+    my $hash = _big_integer($value, 'hash function result');
+    my $modulus = Math::BigInt->new(2)->bpow($width);
+    return $hash->bmod($modulus);
+}
+
+sub _popcount {
+    my ($value) = @_;
+    my $binary = $value->as_bin;
+    $binary =~ s/\A0b//;
+    return $binary =~ tr/1/1/;
+}
+
+sub avalanche_score {
+    my ($hash_fn, $output_bits, $sample_size) = @_;
+    die "hash_fn must be a code reference\n" unless ref($hash_fn) eq 'CODE';
+    $output_bits = _native_integer($output_bits, 'output_bits');
+    die "output_bits must be in 1..64\n"
+        if $output_bits < 1 || $output_bits > 64;
+    $sample_size = defined($sample_size)
+        ? _native_integer($sample_size, 'sample_size')
+        : 100;
+    die "sample_size must be positive\n" if $sample_size <= 0;
+
+    my $total_bit_flips = 0;
+    my $total_trials = 0;
+    for my $sample_index (0 .. $sample_size - 1) {
+        my @bytes = _deterministic_bytes($sample_index);
+        my $original = _normalized_hash($hash_fn->(pack('C*', @bytes)), $output_bits);
+        for my $bit_position (0 .. 63) {
+            my $byte_index = int($bit_position / 8);
+            my $bit_mask = 1 << ($bit_position & 7);
+            $bytes[$byte_index] ^= $bit_mask;
+            my $changed = _normalized_hash(
+                $hash_fn->(pack('C*', @bytes)),
+                $output_bits,
+            );
+            $bytes[$byte_index] ^= $bit_mask;
+            $total_bit_flips += _popcount($original->copy->bxor($changed));
+            $total_trials += $output_bits;
+        }
+    }
+    return $total_bit_flips / $total_trials;
+}
+
+sub distribution_test {
+    my ($hash_fn, $inputs, $num_buckets) = @_;
+    die "hash_fn must be a code reference\n" unless ref($hash_fn) eq 'CODE';
+    die "inputs must be a non-empty array reference\n"
+        unless ref($inputs) eq 'ARRAY' && @{$inputs};
+    $num_buckets = _native_integer($num_buckets, 'num_buckets');
+    die "num_buckets must be positive\n" if $num_buckets <= 0;
+
+    my @counts = (0) x $num_buckets;
+    for my $input (@{$inputs}) {
+        my $hash = _normalized_hash($hash_fn->(_to_bytes($input)), 64);
+        my $bucket = $hash->bmod($num_buckets)->numify;
+        $counts[$bucket]++;
+    }
+
+    my $expected = @{$inputs} / $num_buckets;
+    my $chi_squared = 0.0;
+    for my $observed (@counts) {
+        my $difference = $observed - $expected;
+        $chi_squared += $difference * $difference / $expected;
+    }
+    return $chi_squared;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::HashFunctions - pure non-cryptographic hash functions
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::HashFunctions qw(fnv1a_32 murmur3_32);
+  my $hash = fnv1a_32("hello");
+
+=head1 DESCRIPTION
+
+Implements FNV-1a, DJB2, polynomial rolling hash, MurmurHash3, and small
+deterministic quality-analysis helpers. These functions are not suitable for
+passwords, signatures, or other cryptographic uses.
+
+=cut

--- a/code/packages/perl/hash-functions/required_capabilities.json
+++ b/code/packages/perl/hash-functions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/hash-functions",
+  "capabilities": [],
+  "justification": "Pure byte-string hashing and deterministic analysis. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/hash-functions/t/00-load.t
+++ b/code/packages/perl/hash-functions/t/00-load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+BEGIN {
+    use_ok('CodingAdventures::HashFunctions');
+}
+
+ok($CodingAdventures::HashFunctions::VERSION, 'has a VERSION');

--- a/code/packages/perl/hash-functions/t/01-hash-functions.t
+++ b/code/packages/perl/hash-functions/t/01-hash-functions.t
@@ -1,0 +1,130 @@
+use strict;
+use warnings;
+use utf8;
+use Encode qw(encode);
+use Test::More;
+use CodingAdventures::HashFunctions qw(
+    fnv1a_32
+    fnv1a_64
+    djb2
+    polynomial_rolling
+    murmur3_32
+    avalanche_score
+    distribution_test
+    uint64_hex
+);
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'FNV-1a 32-bit vectors and binary input' => sub {
+    is(fnv1a_32(''), 2166136261, 'empty');
+    is(fnv1a_32('a'), 3826002220, 'a');
+    is(fnv1a_32('abc'), 440920331, 'abc');
+    is(fnv1a_32('hello'), 1335831723, 'hello');
+    is(fnv1a_32('foobar'), 3214735720, 'foobar');
+
+    my $all_bytes = pack('C*', 0 .. 255);
+    is(fnv1a_32($all_bytes), fnv1a_32($all_bytes), 'all bytes deterministic');
+    isnt(fnv1a_32("a\0b"), fnv1a_32('ab'), 'null byte participates');
+    my $text = "caf\x{e9}";
+    utf8::upgrade($text);
+    is(fnv1a_32($text), fnv1a_32(encode('UTF-8', $text)), 'UTF-8 text');
+};
+
+subtest 'exact FNV-1a 64-bit vectors' => sub {
+    is(fnv1a_64('')->bstr, '14695981039346656037', 'empty decimal');
+    is(fnv1a_64('a')->bstr, '12638187200555641996', 'a decimal');
+    is(fnv1a_64('abc')->bstr, '16654208175385433931', 'abc decimal');
+    is(fnv1a_64('hello')->bstr, '11831194018420276491', 'hello decimal');
+    is(uint64_hex(fnv1a_64('hello')), 'a430d84680aabd0b', 'hello bits');
+};
+
+subtest 'DJB2 vectors and 64-bit wrapping' => sub {
+    is(djb2('')->bstr, '5381', 'empty');
+    is(djb2('a')->bstr, '177670', 'a');
+    is(djb2('abc')->bstr, '193485963', 'abc');
+    is(djb2('hello')->bstr, '210714636441', 'hello');
+    is(uint64_hex(djb2('a' x 1000)), 'cb2c236ad13cc66d', 'long word wraps');
+};
+
+subtest 'polynomial rolling parameters and large intermediates' => sub {
+    is(polynomial_rolling('')->bstr, '0', 'empty');
+    is(polynomial_rolling('a')->bstr, '97', 'a');
+    is(polynomial_rolling('ab')->bstr, '3105', 'ab');
+    is(polynomial_rolling('abc')->bstr, '96354', 'abc');
+    isnt(
+        polynomial_rolling('hello', 31)->bstr,
+        polynomial_rolling('hello', 37)->bstr,
+        'custom base',
+    );
+    cmp_ok(polynomial_rolling('hello world', 31, 100)->numify, '<', 100, 'custom modulus');
+    cmp_ok(polynomial_rolling('hash me' x 500)->numify, '>=', 0, 'long input');
+    dies_like(
+        sub { polynomial_rolling('x', 31, 0) },
+        qr/modulus must be positive/,
+        'zero modulus rejected',
+    );
+};
+
+subtest 'MurmurHash3 vectors and tail paths' => sub {
+    is(murmur3_32('', 0), 0, 'empty seed zero');
+    is(murmur3_32('', 1), 0x514e28b7, 'empty seed one');
+    is(murmur3_32('a', 0), 0x3c2569b2, 'a');
+    is(murmur3_32('abc', 0), 0xb3dd93fa, 'abc');
+    isnt(murmur3_32('abcd'), murmur3_32('abce'), 'full block changes');
+    cmp_ok(murmur3_32('abcde'), '>=', 0, 'one-byte tail');
+    cmp_ok(murmur3_32('abcdef'), '>=', 0, 'two-byte tail');
+    cmp_ok(murmur3_32('abcdefg'), '>=', 0, 'three-byte tail');
+    isnt(murmur3_32('hello', 0), murmur3_32('hello', 1), 'seed changes hash');
+};
+
+subtest 'deterministic quality metrics' => sub {
+    my $fnv_score = avalanche_score(\&fnv1a_32, 32, 8);
+    my $murmur_score = avalanche_score(\&murmur3_32, 32, 8);
+    cmp_ok($fnv_score, '>=', 0, 'FNV score lower bound');
+    cmp_ok($fnv_score, '<=', 1, 'FNV score upper bound');
+    cmp_ok($murmur_score, '>=', 0, 'Murmur score lower bound');
+    cmp_ok($murmur_score, '<=', 1, 'Murmur score upper bound');
+    is(avalanche_score(\&fnv1a_32, 32, 8), $fnv_score, 'analysis deterministic');
+
+    my $chi_squared = distribution_test(sub { 0 }, [qw(a b c d)], 4);
+    is($chi_squared, 12, 'exact clustered statistic');
+    cmp_ok(
+        distribution_test(\&fnv1a_64, [qw(a b c d e)], 7),
+        '>=',
+        0,
+        'big integer distribution',
+    );
+};
+
+subtest 'public input validation' => sub {
+    dies_like(sub { fnv1a_32({}) }, qr/data must be a scalar/, 'reference input');
+    dies_like(sub { murmur3_32('x', 1.5) }, qr/seed must be an integer/, 'fractional seed');
+    dies_like(
+        sub { avalanche_score(\&fnv1a_32, 0, 1) },
+        qr/output_bits must be in 1\.\.64/,
+        'output width',
+    );
+    dies_like(
+        sub { avalanche_score(\&fnv1a_32, 32, 0) },
+        qr/sample_size must be positive/,
+        'sample size',
+    );
+    dies_like(
+        sub { distribution_test(\&fnv1a_32, [], 10) },
+        qr/inputs must be a non-empty array reference/,
+        'empty inputs',
+    );
+    dies_like(
+        sub { distribution_test(\&fnv1a_32, ['x'], 0) },
+        qr/num_buckets must be positive/,
+        'bucket count',
+    );
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -107,12 +107,13 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 The missing matrix is heavily concentrated in singleton packages. Regenerated
 on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
-`skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports:
+`skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports and
+the paired `hash-functions` prerequisite:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 349 |
-| Present in 5-9 languages | 122 | 917 |
+| Present in 10-15 languages | 172 | 353 |
+| Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
 
@@ -157,7 +158,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 349
+The 172 packages present in at least ten implementation languages need 353
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -169,10 +170,10 @@ ports to reach all 15. After Priority 1, select work in this order:
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
-| Swift | 50 | Data structures and generated frontends before native app surfaces |
-| Java | 57 | Move with Kotlin |
-| Kotlin | 57 | Move with Java |
-| Dart | 106 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
+| Swift | 51 | Data structures and generated frontends before native app surfaces |
+| Java | 58 | Move with Kotlin |
+| Kotlin | 58 | Move with Java |
+| Dart | 107 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
 
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
@@ -195,6 +196,10 @@ retaining Unicode-safe splits, post-deletion merges, and mid-edge prefix scans.
 The RESP2 slice adds a typed, binary-safe wire codec with distinct null bulk and
 null array values plus an incremental decoder tested across arbitrary stream
 fragmentation, establishing the wire layer needed by the higher storage stack.
+The paired `hash-functions` prerequisite adds binary-safe FNV-1a, DJB2,
+polynomial rolling, and MurmurHash3 implementations with deterministic analysis
+helpers. It moves the package from 9 to 11 implementation lanes and unblocks
+the remaining Bloom-filter and hash-map slices without external dependencies.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure Lua 5.4 implementations of FNV-1a 32/64, DJB2, polynomial rolling hash, and MurmurHash3 x86_32
- add matching pure Perl implementations, using core `Math::BigInt` for exact 64-bit results
- add deterministic avalanche and bucket-distribution helpers, package-native tests, documentation, build metadata, and capability declarations in both lanes
- refresh the package-parity roadmap from the live reporter inventory

## Why

`hash-functions` was already present in 9 of the 15 implementation languages. These Lua and Perl ports move it into the high-consensus band at 11 of 15 and provide the dependency prerequisite for the remaining paired Bloom-filter and hash-map work.

## Impact

Both packages are binary-safe, deterministic, dependency-free, and explicit about their non-cryptographic purpose. Lua exposes exact unsigned 64-bit words through a hexadecimal helper; Perl preserves them as exact core `Math::BigInt` values.

## Validation

- `luac -p src/coding_adventures/hash_functions/init.lua`
- `luarocks lint coding-adventures-hash-functions-0.1.0-1.rockspec`
- local LuaRocks install and Busted suite: 7 successes
- Perl syntax and load checks plus algorithm suite: 7 passing subtests
- `py -3.13 -B -m pytest code/scripts/tests/test_package_parity_report.py -q`: 6 passed
- parity reporter with `--fail-on-collisions`: 0 collisions; `hash-functions` at 11 implementation languages
- `git diff --check`
