### PR TITLE
feat(closure-pass-dce): extract a side-effecting discriminant from an empty-body switch

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.28.0] - 2026-07-16
+
+### Added — extract a side-effecting discriminant from an empty-body switch
+
+The mirror of the 0.27.0 empty-switch *removal*. Same shape — every consequent
+empty, every case test a literal or absent — but the discriminant **has a side
+effect**, so the switch can't simply vanish: its one observable act is
+evaluating the discriminant once. It collapses to a bare expression statement of
+the discriminant, matching the reference Closure Compiler at `SIMPLE`
+byte-for-byte:
+
+- `switch (f()) {}` → `f();`
+- `switch (a.b()) {}` → `a.b();`
+- `switch (x++) {}` → `x++;`
+- `switch (x = y) {}` → `x = y;`
+- `switch (f()) { case 1: }` → `f();` (empty literal-test case)
+- `switch (f()) { default: }` → `f();`
+
+**Scope — a new `is_terminal_impure_expr` gate.** Only a discriminant Closure
+leaves AS-IS in statement position is extracted: a **call**, an **assignment**,
+or an **update** (`++`/`--`) — each always impure and already in minimal
+statement form. A discriminant Closure *further* simplifies once extracted is
+**declined** (the switch is kept, no regression), because emitting the raw form
+would diverge and reproducing the simplified form needs a separate
+"remove useless code in statement position" pass:
+
+- `switch (f() ? a : b) {}` → Closure `f();` (pure branches dropped) — declined
+- `switch (f().x) {}` → Closure `f();` (pure member read dropped) — declined
+- `switch (-f()) {}` → Closure `f();` (pure unary dropped) — declined
+- `switch (g(), h()) {}` → Closure `g(); h();` (sequence split) — declined
+
+A case test with its own side effect (`switch (f()) { case g(): }`) also
+declines: `all_tests_pure_or_none` is false, so — as with the removal above —
+the switch is kept rather than dropping the test's effect.
+
+**Statement-start safety.** Extraction moves the discriminant to statement-start
+position, so it also declines (via `leftmost_is_object_literal`) when the
+discriminant's leftmost token is an object literal — `switch (({}).f()) {}` is
+kept, because the extracted `{}.f();` would begin with a `{` that opens a block
+and mis-parses. (The underlying emitter gap — no statement-start parens for a
+compound expression whose leftmost token is `{` — is tracked as a separate fix;
+once it lands this guard can be relaxed.)
+
+Additive; MINOR bump 0.27.0 → 0.28.0.
+
 ## [0.27.0] - 2026-07-16
 
 ### Changed — empty-switch removal: broaden the DISCRIMINANT gate to any side-effect-free expression

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -70,7 +70,7 @@ use coding_adventures_closure_pass_pipeline::{
 };
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
-    statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
+    statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentTarget, BigIntLiteral,
     BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression, ImportExpression,
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
@@ -311,6 +311,68 @@ fn is_side_effect_free(expr: &Expression) -> bool {
         // Anything else (Call / New / Assignment / Update / Sequence / Yield /
         // Await / TaggedTemplate / ImportExpression / …) is treated as possibly
         // side-effecting and is NOT removed.
+        _ => false,
+    }
+}
+
+/// Is `expr` a **side-effecting** expression that the reference Closure Compiler
+/// leaves UNCHANGED once it sits in statement position — so a construct whose
+/// only observable effect is evaluating it (e.g. an empty-body `switch` with a
+/// side-effecting discriminant) can be replaced by `<expr>;` byte-identically?
+///
+/// True for the always-impure, always-minimal forms: a **call** (`f()`,
+/// `a.b()`), an **assignment** (`x = y`, `x += 1`), and an **update**
+/// (`x++` / `--y`). Each of these carries a side effect that cannot be reduced
+/// away, and Closure prints it as-is in statement position.
+///
+/// Deliberately NARROW. Closure *further* simplifies several other impure
+/// forms once they reach statement position, because the discarded value lets
+/// pure wrappers fall away:
+///
+/// - `f() ? a : b` → `f();`   (pure branches dropped)
+/// - `f().x`       → `f();`   (pure member read dropped)
+/// - `-f()`        → `f();`   (pure unary dropped)
+/// - `g(), h()`    → `g(); h();`  (sequence split into statements)
+///
+/// Extracting any of those *raw* would diverge from Closure's simplified output,
+/// so they are excluded here — reproducing them needs the separate
+/// "remove useless code in statement position" transform. Declining leaves the
+/// enclosing construct intact (no regression).
+fn is_terminal_impure_expr(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::CallExpression(_)
+            | Expression::AssignmentExpression(_)
+            | Expression::UpdateExpression(_)
+    )
+}
+
+/// Would emitting `expr` at the START of a statement begin with a `{` that the
+/// code printer leaves UNPARENTHESISED — so the `{` opens a *block* and the
+/// program mis-parses? True when the leftmost leaf along the
+/// member-object / call-callee / postfix-update / assignment-member-target
+/// spine is an **object literal** (`{…}`). The emitter tags an object literal
+/// at primary precedence and so does not wrap it in those positions
+/// (`({}).f()` prints as `{}.f()`), which is fine mid-expression but a
+/// mis-parse at statement start.
+///
+/// A rewrite that moves an expression to statement-start position — like the
+/// extract-discriminant fold below — must DECLINE when this holds, or a valid
+/// `switch (({}).f()) {}` would become the broken `{}.f();`. (A leftmost
+/// *function*/*class* expression is NOT a hazard: the emitter already wraps
+/// those in member-object / call-callee position. The underlying gap — no
+/// statement-start parens for a compound expression whose leftmost token is
+/// `{` — is a separate emitter fix.)
+fn leftmost_is_object_literal(expr: &Expression) -> bool {
+    match expr {
+        Expression::ObjectExpression(_) => true,
+        Expression::MemberExpression(m) => leftmost_is_object_literal(&m.object),
+        Expression::CallExpression(c) => leftmost_is_object_literal(&c.callee),
+        Expression::UpdateExpression(u) if !u.prefix => leftmost_is_object_literal(&u.argument),
+        Expression::AssignmentExpression(a) => match &a.left {
+            AssignmentTarget::MemberExpression(m) => leftmost_is_object_literal(&m.object),
+            AssignmentTarget::Identifier(_) => false,
+        },
         _ => false,
     }
 }
@@ -719,6 +781,55 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
                     "EmptyStatement",
                 );
                 return TaggedStatement::EmptyStatement(EmptyStatement { cv: s.cv.clone() });
+            }
+
+            // gap-014 step 2b — extract a SIDE-EFFECTING discriminant.
+            //
+            // The mirror of the removal above: SAME shape (every consequent
+            // empty, every case test a literal or absent), but the discriminant
+            // HAS a side effect, so the switch cannot simply vanish — its one
+            // observable act is evaluating the discriminant once (no consequent
+            // runs, and the literal case tests are side-effect-free). So it
+            // collapses to a bare expression statement of the discriminant,
+            // matching the reference Closure Compiler:
+            //
+            //   switch (f())    {}          → f();
+            //   switch (a.b())  {}          → a.b();
+            //   switch (x++)    {}          → x++;
+            //   switch (x = y)  {}          → x = y;
+            //   switch (f()) { case 1: }    → f();      (empty literal-test case)
+            //   switch (f()) { default: }   → f();
+            //
+            // SCOPE — only a discriminant Closure leaves AS-IS in statement
+            // position is extracted (`is_terminal_impure_expr`: call, assignment,
+            // update). A discriminant Closure *further* simplifies once extracted
+            // (`f() ? a : b` → `f();`, `f().x` → `f();`, `-f()` → `f();`,
+            // `g(), h()` → `g(); h();`) is DECLINED — extracting the raw form
+            // would diverge, and reproducing it needs the separate
+            // statement-simplification pass. A case test with its own side effect
+            // (`switch (f()) { case g(): }`) is also declined: `all_tests_pure_or_none`
+            // is false, so both this and the removal above leave the switch intact
+            // (dropping the switch would drop the test's effect).
+            // The extra `!leftmost_is_object_literal` guard prevents a
+            // statement-start mis-parse: extracting `switch (({}).f()) {}` would
+            // otherwise emit `{}.f();`, where the leading `{` opens a block. The
+            // switch is kept instead (it emits correctly — its discriminant is
+            // not at statement start).
+            if all_consequents_empty
+                && all_tests_pure_or_none
+                && is_terminal_impure_expr(&new_disc)
+                && !leftmost_is_object_literal(&new_disc)
+            {
+                st.record(
+                    &s.cv,
+                    "switch_discriminant_extracted",
+                    "SwitchStatement{<empty body>, side-effecting discriminant}",
+                    "ExpressionStatement",
+                );
+                return TaggedStatement::ExpressionStatement(ExpressionStatement {
+                    cv: s.cv.clone(),
+                    expression: new_disc,
+                });
             }
 
             // gap-014 step 4 / CLOC12.36 — constant-discriminant
@@ -2734,15 +2845,54 @@ mod tests {
         assert!(block.body.is_empty(), "expected empty body; got {:?}", block.body);
     }
 
-    /// A side-EFFECTING discriminant keeps the switch. `switch (f()) {}`
-    /// is NOT side-effect-free (the call runs), so this path declines.
-    /// (The reference compiler instead extracts the discriminant to
-    /// `f();`, a separate transform we do not perform here — declining
-    /// keeps the switch intact rather than dropping the call, so no
-    /// unsound removal and no regression.)
+    /// A side-EFFECTING **call** discriminant on an empty-body switch is
+    /// EXTRACTED to a bare expression statement: `switch (f()) {}` → `f();`
+    /// (the switch's only observable act is evaluating `f()`). Matches Closure.
     #[test]
-    fn empty_switch_with_call_discriminant_keeps_switch() {
+    fn empty_switch_with_call_discriminant_extracts() {
         let body = vec![switch_stmt(call0("f"), vec![])];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, changed, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(changed);
+        match &block.body[0] {
+            Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => {
+                assert!(
+                    matches!(&es.expression, Expression::CallExpression(_)),
+                    "expected the discriminant call as the expression; got {:?}",
+                    es.expression
+                );
+            }
+            other => panic!("expected ExpressionStatement (extracted call); got {:?}", other),
+        }
+        assert!(contribs.iter().any(|c| c.tag == "switch_discriminant_extracted"));
+        assert!(!contribs.iter().any(|c| c.tag == "switch_eliminated"));
+    }
+
+    /// Extraction still applies with an empty literal-test case:
+    /// `switch (f()) { case 1: }` → `f();`.
+    #[test]
+    fn empty_switch_with_call_discriminant_and_literal_case_extracts() {
+        let cases = vec![case_empty(Some(num(1.0)))];
+        let body = vec![switch_stmt(call0("f"), cases)];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(matches!(
+            &block.body[0],
+            Statement::Tagged(TaggedStatement::ExpressionStatement(_))
+        ));
+        assert!(contribs.iter().any(|c| c.tag == "switch_discriminant_extracted"));
+    }
+
+    /// A side-effecting discriminant that is NOT a terminal-impure form is
+    /// DECLINED (kept), because Closure further simplifies it once extracted and
+    /// we don't reproduce that here. `switch (f().x) {}` — a member read on a
+    /// call — is kept (Closure would emit `f();`, dropping the pure `.x`).
+    #[test]
+    fn empty_switch_with_member_discriminant_keeps_switch() {
+        let disc = member(call0("f"), "x"); // f().x — impure but not terminal
+        let body = vec![switch_stmt(disc, vec![])];
         let prog = program_with_function(body, Some("fn.1"));
         let (out, contribs, _, _) = run_pass(prog);
         let block = extract_function_body(&out);
@@ -2750,7 +2900,49 @@ mod tests {
             &block.body[0],
             Statement::Tagged(TaggedStatement::SwitchStatement(_))
         ));
-        assert!(!contribs.iter().any(|c| c.tag == "switch_eliminated"));
+        assert!(!contribs.iter().any(|c| c.tag == "switch_discriminant_extracted"));
+    }
+
+    /// A discriminant whose leftmost token is an object literal is NOT extracted
+    /// — emitting it at statement start would begin with `{` and mis-parse as a
+    /// block. `switch (({}).f()) {}` is kept (it emits correctly as a switch),
+    /// rather than rewritten to the broken `{}.f();`.
+    #[test]
+    fn empty_switch_with_object_literal_leftmost_discriminant_keeps_switch() {
+        let obj = Expression::ObjectExpression(ObjectExpression { cv: None, properties: vec![] });
+        // ({}).f()
+        let disc = Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(member(obj, "f")),
+            arguments: vec![],
+        });
+        let body = vec![switch_stmt(disc, vec![])];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(
+            matches!(&block.body[0], Statement::Tagged(TaggedStatement::SwitchStatement(_))),
+            "object-literal-rooted discriminant must keep the switch; got {:?}",
+            block.body[0]
+        );
+        assert!(!contribs.iter().any(|c| c.tag == "switch_discriminant_extracted"));
+    }
+
+    /// A case test with its OWN side effect blocks extraction — dropping the
+    /// switch would drop that effect. `switch (f()) { case g(): }` is kept
+    /// (`all_tests_pure_or_none` is false for the call test).
+    #[test]
+    fn empty_switch_with_impure_case_test_keeps_switch() {
+        let cases = vec![case_empty(Some(call0("g")))];
+        let body = vec![switch_stmt(call0("f"), cases)];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(matches!(
+            &block.body[0],
+            Statement::Tagged(TaggedStatement::SwitchStatement(_))
+        ));
+        assert!(!contribs.iter().any(|c| c.tag == "switch_discriminant_extracted"));
     }
 
     /// A case whose only consequent is an empty block (`case 1: {}`)


### PR DESCRIPTION
## What

The impure mirror of the merged empty-switch **removal** (#8375). Same shape — every consequent empty, every case test a literal-or-absent — but the discriminant **has a side effect**, so the switch can't vanish: its one observable act is evaluating the discriminant once. It collapses to a bare expression statement, matching the reference Closure Compiler at `SIMPLE` byte-for-byte.

### Oracle-verified (fresh binary vs `closure-compiler-v20260712.jar`, SIMPLE)

| input | after / oracle |
|---|---|
| `switch(f()){}` | `f();` |
| `switch(a.b()){}` | `a.b();` |
| `switch(x++){}` | `x++;` |
| `switch(x=y){}` / `switch(x+=1){}` | `x=y;` / `x+=1;` |
| `switch(f()){case 1:}` | `f();` |
| `switch(f()){default:}` / `switch(f()){case 1:default:}` | `f();` |

**9/9 in-scope cases byte-identical.**

## Scope — `is_terminal_impure_expr`

Only a discriminant Closure leaves **as-is** in statement position is extracted: a **call**, **assignment**, or **update** (always impure, already in minimal statement form). A discriminant Closure *further* simplifies once extracted is **declined** (switch kept, no regression) — reproducing it needs a separate "remove useless code in statement position" pass:

- `switch(f()?a:b){}` → Closure `f();` (pure branches dropped) — declined
- `switch(f().x){}` → Closure `f();` (pure member read) — declined
- `switch(-f()){}` → Closure `f();` (pure unary) — declined
- `switch(g(),h()){}` → Closure `g();h();` (sequence split) — declined

A case test with its own side effect (`switch(f()){case g():}`) also declines (`all_tests_pure_or_none` is false) — dropping the switch would drop the test's effect.

## Statement-start safety (from the security review)

Extraction moves the discriminant to statement-start position. A `leftmost_is_object_literal` guard declines when the discriminant's leftmost token is an object literal — `switch(({}).f()){}` is **kept**, because the extracted `{}.f();` would begin with a `{` that opens a block and mis-parses. (The underlying emitter gap — no statement-start parens for a compound expression whose leftmost token is `{` — is a genuine pre-existing miscompile, tracked as a separate fix; once it lands this guard relaxes.)

## Testing

- `closure-pass-dce`: 73 tests (was 72) pass; clippy clean. Added extract (call), extract-with-literal-case, and three decline tests (member-rooted, impure-case-test, object-literal-leftmost).
- Full `closurec` suite green (`CARGO_EXIT=0`, 135 groups, no fixture drift).
- Inline security review: **PASSED** (transform is behavior-preserving — discriminant evaluated once, value discarded both ways; the one finding, a statement-start object-literal mis-parse, is fixed by the guard above).

`closure-pass-dce` 0.27.0 → 0.28.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)