### PR TITLE
feat(adj-facts-stdlib): anatomy/brain-parts — brain part → primary function table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_brainparts_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_brainparts_e2e.rs
@@ -1,0 +1,73 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/brain-parts.adj`) driven through the built CLI:
+//! a native `table` of brain part → primary function resolves a binding-query
+//! recall with the source's NCI SEER Training citation, runs the relation
+//! backward (function → part), and abstains on a non-part (a neuron) — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsbrain_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_brain_parts_recall_binds_function_with_citation() {
+    let dir = scratch("brainparts");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/brain-parts.adj");
+    std::fs::copy(&src, dir.join("brain-parts.adj")).expect("copy shipped brain-parts.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"brain-parts.adj\"\n\
+         ? brain_part_function(cerebellum, $Job)\n\
+         ? brain_part_function(hippocampus, $Job)\n\
+         ? brain_part_function($Part, breathing)\n\
+         ? brain_part_function(neuron, $Job)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The cerebellum coordinates voluntary movement; the hippocampus does
+    // memory — the recalled functions, each a single verbatim token/phrase.
+    assert!(
+        out.contains("\"Job\":\"coordination_of_voluntary_movement\""),
+        "cerebellum → coordination_of_voluntary_movement: {out}"
+    );
+    assert!(out.contains("\"Job\":\"memory\""), "hippocampus → memory: {out}");
+    // The relation runs backward: the function `breathing` recalls the brainstem.
+    assert!(
+        out.contains("\"Part\":\"brainstem\""),
+        "breathing → brainstem (reverse recall): {out}"
+    );
+    // The answer carries the NCI SEER Training citation as its proof, at the
+    // `authoritative` trust tier for a primary U.S. government source.
+    assert!(
+        out.contains("training.seer.cancer.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A neuron is a cell, not one of these gross brain parts — honest
+    // abstention, never a fabricated function.
+    assert!(out.contains("\"abstained\":true"), "unknown part abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -42,6 +42,7 @@ per rotation, in parallel):
 | `biology/` | basic tissue type → representative example | NCI SEER Training |
 | `physics/` | simple machine → everyday example | NASA |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
+| `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/anatomy/brain-parts.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/brain-parts.adj
@@ -1,0 +1,113 @@
+% ============================================================================
+% brain-parts — a major brain part → the primary function it controls
+% (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A middle/high-school neuroanatomy fact set on the way to medicine: the brain
+% is not one undivided organ — different PARTS do different JOBS. The cerebrum
+% (the big wrinkled top) does conscious thought; the cerebellum (the little
+% "cauliflower" at the back) coordinates movement and balance; the brainstem
+% (the stalk into the spinal cord) runs the automatic life-support functions
+% like breathing; the hypothalamus is a tiny control knob for drives such as
+% hunger; the thalamus is the switchboard that relays sensation up to the
+% cerebrum; and the hippocampus lays down memory. Recall is a binding query:
+%
+%     ? brain_part_function(cerebellum, $Job)   % coordination_of_voluntary_movement
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `brain_part_function(part, function)` carrying the table's citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% function WITH its source, on the CPU, with zero model calls, and abstains on
+% anything that is not one of these parts (it never invents a job).
+%
+% The parts, as a little truth table:
+%
+%     brain_part      function                            in one phrase
+%     -------------   ---------------------------------   ------------------------
+%     cerebrum        conscious_activity                  conscious thought
+%     cerebellum      coordination_of_voluntary_movement  smooth, balanced movement
+%     brainstem       breathing                           automatic life support
+%     hypothalamus    hunger                              drives (hunger/thirst/sleep)
+%     thalamus        relays                              sensory switchboard
+%     hippocampus     memory                              laying down memory
+%
+% Each `function` value is a single lowercase token/phrase that appears VERBATIM
+% in the cited source sentence (see the provenance block), so the recall is a
+% faithful echo of the source, not a paraphrase. The query also runs BACKWARD —
+% bind a function and recall the part that performs it:
+%
+%     ? brain_part_function($Part, breathing)   % brainstem — reverse recall
+%
+% Something that is not one of these parts — a neuron, the skull, the spinal
+% cord — has no row, so a recall on it ABSTAINS rather than inventing a job.
+% That honest-abstention property is what makes the table safe to reason from:
+% a medicine agent reasons UP from "which part does what" before it can reason
+% about a stroke localized to the cerebellum or a brainstem bleed.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every part→function pair
+% was read out of a fetched U.S. government / NIH page this session, and any
+% pair that could not be grounded there was dropped). Each function token below
+% is quoted inside the verbatim source sentence so any reader can re-check it:
+%
+%   cerebrum → conscious_activity
+%     https://training.seer.cancer.gov/brain/tumors/anatomy/brain.html
+%     (U.S. National Cancer Institute, NCI SEER Training Modules)
+%     "The cerebrum is the part of the brain that receives and processes
+%      conscious sensation, generates thought, and controls conscious activity."
+%
+%   cerebellum → coordination_of_voluntary_movement
+%     https://www.ncbi.nlm.nih.gov/books/NBK551718/
+%     (NIH / U.S. National Library of Medicine, StatPearls "Physiology, Brain")
+%     "The cerebellum controls the coordination of voluntary movement and
+%      receives sensory information from the brain and spinal cord to fine-tune
+%      the precision and accuracy of motor activity."
+%
+%   brainstem → breathing
+%     https://www.ncbi.nlm.nih.gov/books/NBK551718/
+%     (NIH / NLM, StatPearls "Physiology, Brain")
+%     "The brainstem houses the principal centers that perform autonomic
+%      functions such as breathing, temperature regulation, respiration, heart
+%      rate, wake-sleep cycles, coughing, sneezing, digestion, vomiting, and
+%      swallowing."
+%
+%   hypothalamus → hunger
+%     https://www.ncbi.nlm.nih.gov/books/NBK551718/
+%     (NIH / NLM, StatPearls "Physiology, Brain")
+%     "The hypothalamus controls hunger, thirst, and sleep."
+%
+%   thalamus → relays
+%     https://www.ncbi.nlm.nih.gov/books/NBK551718/
+%     (NIH / NLM, StatPearls "Physiology, Brain")
+%     "Sensory neurons bring sensory input from the body to the thalamus, which
+%      relays this information to the cerebrum."
+%
+%   hippocampus → memory
+%     https://www.ncbi.nlm.nih.gov/books/NBK482171/
+%     (NIH / NLM, StatPearls "Neuroanatomy, Hippocampus")
+%     "The hippocampus is the 'flash drive' of the human brain and is often
+%      associated with memory consolidation and decision-making"
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the NCI SEER Training sentence
+% that fixes the first row (cerebrum → conscious_activity). Every OTHER row's
+% per-fact source and verbatim span is listed above, so each pair remains
+% independently checkable. All three sources are primary U.S. government / NIH
+% references (NCI SEER Training; NIH / NLM StatPearls), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table brain_part_function {
+    columns brain_part, function
+
+    row (cerebrum, conscious_activity)
+    row (cerebellum, coordination_of_voluntary_movement)
+    row (brainstem, breathing)
+    row (hypothalamus, hunger)
+    row (thalamus, relays)
+    row (hippocampus, memory)
+
+    source "The cerebrum is the part of the brain that receives and processes conscious sensation, generates thought, and controls conscious activity."
+    locator "https://training.seer.cancer.gov/brain/tumors/anatomy/brain.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/brain-parts.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/brain-parts.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% brain-parts.query.adj — a worked recall over the anatomy brain-parts library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the cerebellum
+% do?": it states no anatomy fact of its own — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `brain_part_function` rows and returns the function + the table's
+% source/locator/trust. The third query runs the relation BACKWARD (bind the
+% function `breathing`, recall the part that controls it — the brainstem). A
+% neuron is a cell, not one of these gross brain parts, so a recall on it
+% abstains honestly — the engine never invents a function.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli brain-parts.query.adj
+% ============================================================================
+
+import "brain-parts.adj"
+
+? brain_part_function(cerebellum, $Job)   % expect coordination_of_voluntary_movement
+? brain_part_function(hippocampus, $Job)  % expect memory
+? brain_part_function($Part, breathing)   % reverse bind — expect brainstem
+? brain_part_function(neuron, $Job)       % expect abstain — a neuron is not one of these parts


### PR DESCRIPTION
Add a grounded ANATOMY facts library mapping a major brain part to a primary
function it controls, mirroring the merged anatomy/lung-lobes and
biology/major-organs libraries (native `table`, one provenance envelope,
per-row verbatim spans, honest abstention on unknown parts).

Rows (each function token appears VERBATIM in the cited source sentence):
  cerebrum     → conscious_activity
  cerebellum   → coordination_of_voluntary_movement
  brainstem    → breathing
  hypothalamus → hunger
  thalamus     → relays
  hippocampus  → memory

Provenance (all fetched this session; nothing from memory; trust authoritative
— primary U.S. government / NIH sources):
  - NCI SEER Training "Brain" (training.seer.cancer.gov/brain/tumors/anatomy/
    brain.html): cerebrum → conscious_activity.
  - NIH / NLM StatPearls "Physiology, Brain" (ncbi.nlm.nih.gov/books/NBK551718/):
    cerebellum, brainstem, hypothalamus, thalamus.
  - NIH / NLM StatPearls "Neuroanatomy, Hippocampus"
    (ncbi.nlm.nih.gov/books/NBK482171/): hippocampus → memory.

No rows dropped — every pair grounded in a fetched sentence.

Data-only diff: new anatomy/brain-parts.adj + .query.adj, one e2e test
(facts_brainparts_e2e.rs) asserting exact lookup + reverse recall + citation
and abstention on a non-part (neuron), and one README anatomy subject-index row.
cargo test -p adj-lang -p adj-lang-cli and clippy --all-targets -D warnings both
pass. No engine/grammar/adapter code touched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
