### PR TITLE
feat: port Bloom filter to Lua and Perl

### DIFF
--- a/code/packages/lua/bloom-filter/BUILD
+++ b/code/packages/lua/bloom-filter/BUILD
@@ -1,0 +1,3 @@
+luarocks show coding-adventures-hash-functions >/dev/null 2>&1 || (cd ../hash-functions && luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-bloom-filter-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../hash-functions/src/?.lua;../../hash-functions/src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/bloom-filter/BUILD_windows
+++ b/code/packages/lua/bloom-filter/BUILD_windows
@@ -1,0 +1,3 @@
+luarocks show coding-adventures-hash-functions >nul 2>&1 || (cd ..\hash-functions && luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-bloom-filter-0.1.0-1.rockspec
+cd tests && set "LUA_PATH=../src/?.lua;../src/?/init.lua;../../hash-functions/src/?.lua;../../hash-functions/src/?/init.lua;;" && busted . --verbose --pattern=test_

--- a/code/packages/lua/bloom-filter/CHANGELOG.md
+++ b/code/packages/lua/bloom-filter/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-16
+
+- Add a pure Lua Bloom filter with automatic and explicit sizing.
+- Add deterministic double hashing, fill and false-positive statistics,
+  over-capacity detection, and stable composite-value encoding.

--- a/code/packages/lua/bloom-filter/README.md
+++ b/code/packages/lua/bloom-filter/README.md
@@ -1,0 +1,33 @@
+# bloom-filter (Lua)
+
+A dependency-light Lua 5.4 Bloom filter for space-efficient probabilistic set
+membership. Inserted values never produce false negatives; positive lookups may
+be false positives at the configured rate.
+
+```lua
+local bloom_filter = require("coding_adventures.bloom_filter")
+
+local filter = bloom_filter.new(1000, 0.01)
+filter:add("hello")
+
+assert(filter:contains("hello"))
+print(filter:fill_ratio())
+print(filter:estimated_false_positive_rate())
+```
+
+The filter computes its bit count and hash count from the expected number of
+items and target false-positive rate. `from_params(bit_count, hash_count)` is
+available for explicit layouts. String inputs are binary-safe; scalar and table
+values use a deterministic encoding, including stable map-key ordering.
+
+Double hashing derives every probe from FNV-1a and DJB2 supplied by the sibling
+`hash-functions` package. MurmurHash3 finalization removes correlation between
+the two base hashes, and the probe step is forced odd for good coverage.
+
+## Development
+
+```bash
+luarocks make --local --deps-mode=none coding-adventures-bloom-filter-0.1.0-1.rockspec
+cd tests
+LUA_PATH="../src/?.lua;../src/?/init.lua;../../hash-functions/src/?.lua;../../hash-functions/src/?/init.lua;;" busted . --verbose --pattern=test_
+```

--- a/code/packages/lua/bloom-filter/coding-adventures-bloom-filter-0.1.0-1.rockspec
+++ b/code/packages/lua/bloom-filter/coding-adventures-bloom-filter-0.1.0-1.rockspec
@@ -1,0 +1,19 @@
+package = "coding-adventures-bloom-filter"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Space-efficient probabilistic set membership",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+    "coding-adventures-hash-functions >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.bloom_filter"] = "src/coding_adventures/bloom_filter/init.lua",
+    },
+}

--- a/code/packages/lua/bloom-filter/required_capabilities.json
+++ b/code/packages/lua/bloom-filter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/bloom-filter",
+  "capabilities": [],
+  "justification": "Pure in-memory hashing and bit-array operations. No filesystem, network, process, environment, or randomness access needed."
+}

--- a/code/packages/lua/bloom-filter/src/coding_adventures/bloom_filter/init.lua
+++ b/code/packages/lua/bloom-filter/src/coding_adventures/bloom_filter/init.lua
@@ -1,0 +1,234 @@
+--- Space-efficient probabilistic set membership with no false negatives.
+
+local hash_functions = require("coding_adventures.hash_functions")
+
+local M = {}
+
+local DEFAULT_EXPECTED_ITEMS = 1000
+local DEFAULT_FALSE_POSITIVE_RATE = 0.01
+local MASK32 = 0xffffffff
+
+local function require_positive_integer(value, name, level)
+    if type(value) ~= "number" or math.type(value) ~= "integer" or value <= 0 then
+        error(name .. " must be a positive integer", level or 3)
+    end
+    return value
+end
+
+local function require_nonnegative_integer(value, name, level)
+    if type(value) ~= "number" or math.type(value) ~= "integer" or value < 0 then
+        error(name .. " must be a nonnegative integer", level or 3)
+    end
+    return value
+end
+
+local function require_false_positive_rate(value, level)
+    if type(value) ~= "number"
+        or value ~= value
+        or value == math.huge
+        or value == -math.huge
+        or value <= 0
+        or value >= 1
+    then
+        error("false_positive_rate must be in the open interval (0, 1)", level or 3)
+    end
+    return value
+end
+
+local function stable_encode(value, seen)
+    local kind = type(value)
+    if kind == "string" then
+        return value
+    elseif kind == "number" then
+        return tostring(value)
+    elseif kind == "boolean" then
+        return value and "true" or "false"
+    elseif kind == "nil" then
+        return "nil"
+    elseif kind ~= "table" then
+        error("element must be nil, a scalar, or a table", 4)
+    end
+
+    if seen[value] then
+        error("element tables must not contain cycles", 4)
+    end
+    seen[value] = true
+    local entries = {}
+    for key, item in pairs(value) do
+        local encoded_key = stable_encode(key, seen)
+        local encoded_value = stable_encode(item, seen)
+        entries[#entries + 1] = #encoded_key
+            .. ":"
+            .. encoded_key
+            .. "="
+            .. #encoded_value
+            .. ":"
+            .. encoded_value
+    end
+    seen[value] = nil
+    table.sort(entries)
+    return "{" .. table.concat(entries, ",") .. "}"
+end
+
+local function element_bytes(value)
+    return stable_encode(value, {})
+end
+
+local function fmix32(value)
+    value = (value ~ (value >> 16)) & MASK32
+    value = (value * 0x85ebca6b) & MASK32
+    value = (value ~ (value >> 13)) & MASK32
+    value = (value * 0xc2b2ae35) & MASK32
+    return (value ~ (value >> 16)) & MASK32
+end
+
+function M.optimal_m(expected_items, false_positive_rate)
+    require_positive_integer(expected_items, "expected_items", 2)
+    require_false_positive_rate(false_positive_rate, 2)
+    local logarithm = math.log(2)
+    return math.ceil(
+        -expected_items * math.log(false_positive_rate) / (logarithm * logarithm)
+    )
+end
+
+function M.optimal_k(bit_count, expected_items)
+    require_positive_integer(bit_count, "bit_count", 2)
+    require_positive_integer(expected_items, "expected_items", 2)
+    local rounded = math.floor((bit_count / expected_items) * math.log(2) + 0.5)
+    return math.max(1, rounded)
+end
+
+function M.capacity_for_memory(memory_bytes, false_positive_rate)
+    require_nonnegative_integer(memory_bytes, "memory_bytes", 2)
+    require_false_positive_rate(false_positive_rate, 2)
+    local logarithm = math.log(2)
+    return math.floor(
+        -(memory_bytes * 8) * (logarithm * logarithm)
+            / math.log(false_positive_rate)
+    )
+end
+
+local BloomFilter = {}
+BloomFilter.__index = BloomFilter
+
+local function from_parts(bit_count, hash_count, expected_items)
+    local byte_count = (bit_count + 7) // 8
+    local bits = {}
+    for index = 1, byte_count do
+        bits[index] = 0
+    end
+    return setmetatable({
+        _bit_count = bit_count,
+        _hash_count = hash_count,
+        _expected_items = expected_items,
+        _bits = bits,
+        _bits_set = 0,
+        _items_added = 0,
+    }, BloomFilter)
+end
+
+function BloomFilter.new(expected_items, false_positive_rate)
+    expected_items = expected_items == nil and DEFAULT_EXPECTED_ITEMS or expected_items
+    false_positive_rate = false_positive_rate == nil
+        and DEFAULT_FALSE_POSITIVE_RATE
+        or false_positive_rate
+    require_positive_integer(expected_items, "expected_items", 2)
+    require_false_positive_rate(false_positive_rate, 2)
+    local bit_count = M.optimal_m(expected_items, false_positive_rate)
+    local hash_count = M.optimal_k(bit_count, expected_items)
+    return from_parts(bit_count, hash_count, expected_items)
+end
+
+function BloomFilter.from_params(bit_count, hash_count)
+    require_positive_integer(bit_count, "bit_count", 2)
+    require_positive_integer(hash_count, "hash_count", 2)
+    return from_parts(bit_count, hash_count, 0)
+end
+
+function BloomFilter:_hash_indices(element)
+    local raw = element_bytes(element)
+    local first = fmix32(hash_functions.fnv1a_32(raw))
+    local second_word = hash_functions.djb2(raw)
+    local second = fmix32((second_word ~ (second_word >> 32)) & MASK32) | 1
+    local indices = {}
+    for index = 0, self._hash_count - 1 do
+        indices[index + 1] = (first + index * second) % self._bit_count
+    end
+    return indices
+end
+
+function BloomFilter:add(element)
+    for _, bit_index in ipairs(self:_hash_indices(element)) do
+        local byte_index = (bit_index // 8) + 1
+        local bit_mask = 1 << (bit_index & 7)
+        if (self._bits[byte_index] & bit_mask) == 0 then
+            self._bits[byte_index] = self._bits[byte_index] | bit_mask
+            self._bits_set = self._bits_set + 1
+        end
+    end
+    self._items_added = self._items_added + 1
+end
+
+function BloomFilter:contains(element)
+    for _, bit_index in ipairs(self:_hash_indices(element)) do
+        local byte_index = (bit_index // 8) + 1
+        local bit_mask = 1 << (bit_index & 7)
+        if (self._bits[byte_index] & bit_mask) == 0 then
+            return false
+        end
+    end
+    return true
+end
+
+function BloomFilter:bit_count()
+    return self._bit_count
+end
+
+function BloomFilter:hash_count()
+    return self._hash_count
+end
+
+function BloomFilter:bits_set()
+    return self._bits_set
+end
+
+function BloomFilter:fill_ratio()
+    return self._bits_set / self._bit_count
+end
+
+function BloomFilter:estimated_false_positive_rate()
+    if self._bits_set == 0 then
+        return 0.0
+    end
+    return self:fill_ratio() ^ self._hash_count
+end
+
+function BloomFilter:is_over_capacity()
+    return self._expected_items > 0 and self._items_added > self._expected_items
+end
+
+function BloomFilter:size_bytes()
+    return #self._bits
+end
+
+function BloomFilter:to_string()
+    return string.format(
+        "BloomFilter(m=%d, k=%d, bits_set=%d/%d (%.2f%%), ~fp=%.4f%%)",
+        self._bit_count,
+        self._hash_count,
+        self._bits_set,
+        self._bit_count,
+        self:fill_ratio() * 100,
+        self:estimated_false_positive_rate() * 100
+    )
+end
+
+BloomFilter.__tostring = BloomFilter.to_string
+
+M.BloomFilter = BloomFilter
+M.new = BloomFilter.new
+M.from_params = BloomFilter.from_params
+M.DEFAULT_EXPECTED_ITEMS = DEFAULT_EXPECTED_ITEMS
+M.DEFAULT_FALSE_POSITIVE_RATE = DEFAULT_FALSE_POSITIVE_RATE
+
+return M

--- a/code/packages/lua/bloom-filter/tests/test_bloom_filter.lua
+++ b/code/packages/lua/bloom-filter/tests/test_bloom_filter.lua
@@ -1,0 +1,110 @@
+local bloom_filter = require("coding_adventures.bloom_filter")
+
+describe("BloomFilter", function()
+    it("starts empty with the default sizing", function()
+        local filter = bloom_filter.new()
+        assert.equals(9586, filter:bit_count())
+        assert.equals(7, filter:hash_count())
+        assert.equals(1199, filter:size_bytes())
+        assert.equals(0, filter:bits_set())
+        assert.equals(0, filter:fill_ratio())
+        assert.equals(0, filter:estimated_false_positive_rate())
+        assert.is_false(filter:is_over_capacity())
+        assert.is_false(filter:contains("anything"))
+    end)
+
+    it("has no false negatives for inserted values", function()
+        local filter = bloom_filter.new(1000, 0.01)
+        for index = 1, 250 do
+            filter:add("item-" .. index)
+        end
+        for index = 1, 250 do
+            assert.is_true(filter:contains("item-" .. index))
+        end
+        assert.is_true(filter:bits_set() > 0)
+    end)
+
+    it("supports explicit parameters", function()
+        local filter = bloom_filter.from_params(10000, 7)
+        assert.equals(10000, filter:bit_count())
+        assert.equals(7, filter:hash_count())
+        assert.equals(1250, filter:size_bytes())
+        filter:add("hello")
+        assert.is_true(filter:contains("hello"))
+        assert.is_false(filter:is_over_capacity())
+    end)
+
+    it("counts each set bit only once", function()
+        local filter = bloom_filter.new(100, 0.01)
+        filter:add("duplicate")
+        local after_first = filter:bits_set()
+        filter:add("duplicate")
+        assert.equals(after_first, filter:bits_set())
+    end)
+
+    it("computes sizing helpers", function()
+        local bit_count = bloom_filter.optimal_m(1000000, 0.01)
+        assert.equals(9585059, bit_count)
+        assert.equals(7, bloom_filter.optimal_k(bit_count, 1000000))
+        assert.equals(834632, bloom_filter.capacity_for_memory(1000000, 0.01))
+        assert.equals(0, bloom_filter.capacity_for_memory(0, 0.01))
+    end)
+
+    it("tracks capacity and renders useful statistics", function()
+        local filter = bloom_filter.new(3, 0.01)
+        filter:add("a")
+        filter:add("b")
+        filter:add("c")
+        assert.is_false(filter:is_over_capacity())
+        filter:add("d")
+        assert.is_true(filter:is_over_capacity())
+        assert.is_true(filter:estimated_false_positive_rate() > 0)
+        assert.matches("BloomFilter", tostring(filter), nil, true)
+        assert.matches("bits_set=", filter:to_string(), nil, true)
+    end)
+
+    it("encodes scalar and composite elements deterministically", function()
+        local filter = bloom_filter.new(100, 0.01)
+        local values = {
+            "cafe\204\129",
+            42,
+            3.14,
+            true,
+            { name = "Ada", tags = { "math", "code" } },
+        }
+        for _, value in ipairs(values) do
+            filter:add(value)
+            assert.is_true(filter:contains(value))
+        end
+        assert.is_true(filter:contains({ tags = { "math", "code" }, name = "Ada" }))
+        filter:add(nil)
+        assert.is_true(filter:contains(nil))
+    end)
+
+    it("rejects invalid parameters and cyclic elements", function()
+        assert.has_error(function()
+            bloom_filter.new(0, 0.01)
+        end, "expected_items must be a positive integer")
+        assert.has_error(function()
+            bloom_filter.new(1, 0)
+        end, "false_positive_rate must be in the open interval (0, 1)")
+        assert.has_error(function()
+            bloom_filter.new(1, 0 / 0)
+        end, "false_positive_rate must be in the open interval (0, 1)")
+        assert.has_error(function()
+            bloom_filter.from_params(0, 1)
+        end, "bit_count must be a positive integer")
+        assert.has_error(function()
+            bloom_filter.from_params(1, 0)
+        end, "hash_count must be a positive integer")
+        local cyclic = {}
+        cyclic.self = cyclic
+        local filter = bloom_filter.new()
+        assert.has_error(function()
+            filter:add(cyclic)
+        end, "element tables must not contain cycles")
+        assert.has_error(function()
+            filter:add(function() end)
+        end, "element must be nil, a scalar, or a table")
+    end)
+end)

--- a/code/packages/perl/bloom-filter/BUILD
+++ b/code/packages/perl/bloom-filter/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=../hash-functions/lib prove -l -v t/

--- a/code/packages/perl/bloom-filter/BUILD_windows
+++ b/code/packages/perl/bloom-filter/BUILD_windows
@@ -1,0 +1,1 @@
+set PERL5LIB=..\hash-functions\lib && perl -Ilib t/00-load.t && perl -Ilib t/01-bloom-filter.t

--- a/code/packages/perl/bloom-filter/CHANGELOG.md
+++ b/code/packages/perl/bloom-filter/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Perl Bloom filter with automatic and explicit sizing.
+- Add deterministic double hashing, fill and false-positive statistics,
+  over-capacity detection, and stable composite-value encoding.

--- a/code/packages/perl/bloom-filter/Makefile.PL
+++ b/code/packages/perl/bloom-filter/Makefile.PL
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::BloomFilter',
+    VERSION_FROM     => 'lib/CodingAdventures/BloomFilter.pm',
+    ABSTRACT         => 'Space-efficient probabilistic set membership',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::HashFunctions' => 0,
+        'Encode'                          => 0,
+        'Exporter'                        => 0,
+        'POSIX'                           => 0,
+        'Scalar::Util'                    => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/bloom-filter/README.md
+++ b/code/packages/perl/bloom-filter/README.md
@@ -1,0 +1,26 @@
+# CodingAdventures::BloomFilter
+
+A pure-Perl Bloom filter for compact probabilistic set membership. Inserted
+values never produce false negatives; positive lookups may be false positives
+at the configured rate.
+
+```perl
+use CodingAdventures::BloomFilter;
+
+my $filter = CodingAdventures::BloomFilter->new(
+    expected_items => 1_000,
+    false_positive_rate => 0.01,
+);
+$filter->add('hello');
+die 'missing' unless $filter->contains('hello');
+```
+
+The filter automatically derives its bit count and hash count, or accepts an
+explicit layout through `from_params`. It exposes the number of set bits, fill
+ratio, estimated current false-positive rate, byte size, and over-capacity
+state. Scalars are byte-safe, while arrays and hashes use a deterministic
+encoding with stable hash-key order.
+
+Double hashing uses FNV-1a and DJB2 from the sibling `hash-functions` package.
+MurmurHash3 finalization reduces correlation between the base hashes and an odd
+probe step improves bit-array coverage.

--- a/code/packages/perl/bloom-filter/cpanfile
+++ b/code/packages/perl/bloom-filter/cpanfile
@@ -1,0 +1,1 @@
+requires 'CodingAdventures::HashFunctions';

--- a/code/packages/perl/bloom-filter/lib/CodingAdventures/BloomFilter.pm
+++ b/code/packages/perl/bloom-filter/lib/CodingAdventures/BloomFilter.pm
@@ -1,0 +1,259 @@
+package CodingAdventures::BloomFilter;
+
+use strict;
+use warnings;
+use Encode qw(encode FB_CROAK);
+use Exporter qw(import);
+use POSIX qw(ceil floor);
+use Scalar::Util qw(looks_like_number refaddr);
+use CodingAdventures::HashFunctions qw(fnv1a_32 djb2);
+
+our $VERSION = '0.1.0';
+our @EXPORT_OK = qw(optimal_m optimal_k capacity_for_memory);
+
+use overload q{""} => 'to_string', fallback => 1;
+
+my $DEFAULT_EXPECTED_ITEMS = 1_000;
+my $DEFAULT_FALSE_POSITIVE_RATE = 0.01;
+my $UINT32_MASK = 0xffffffff;
+
+sub _positive_integer {
+    my ($value, $name) = @_;
+    die "$name must be a positive integer\n"
+        if !defined($value) || ref($value) || "$value" !~ /\A\d+\z/ || $value <= 0;
+    return 0 + $value;
+}
+
+sub _nonnegative_integer {
+    my ($value, $name) = @_;
+    die "$name must be a nonnegative integer\n"
+        if !defined($value) || ref($value) || "$value" !~ /\A\d+\z/;
+    return 0 + $value;
+}
+
+sub _false_positive_rate {
+    my ($value) = @_;
+    die "false_positive_rate must be in the open interval (0, 1)\n"
+        if !defined($value)
+        || ref($value)
+        || !looks_like_number($value)
+        || $value != $value
+        || $value <= 0
+        || $value >= 1;
+    return 0.0 + $value;
+}
+
+sub _scalar_bytes {
+    my ($value) = @_;
+    return 'undef' if !defined($value);
+    return utf8::is_utf8($value) ? encode('UTF-8', $value, FB_CROAK) : "$value";
+}
+
+sub _stable_encode {
+    my ($value, $seen) = @_;
+    return _scalar_bytes($value) unless ref($value);
+
+    my $kind = ref($value);
+    die "element must be undef, a scalar, an array reference, or a hash reference\n"
+        unless $kind eq 'ARRAY' || $kind eq 'HASH' || $kind eq 'SCALAR';
+    my $address = refaddr($value);
+    die "element references must not contain cycles\n" if $seen->{$address};
+    $seen->{$address} = 1;
+
+    my $encoded;
+    if ($kind eq 'ARRAY') {
+        my @items = map {
+            my $item = _stable_encode($_, $seen);
+            length($item) . ':' . $item;
+        } @{$value};
+        $encoded = '[' . join(',', @items) . ']';
+    } elsif ($kind eq 'HASH') {
+        my @items;
+        for my $key (keys %{$value}) {
+            my $encoded_key = _scalar_bytes($key);
+            my $encoded_value = _stable_encode($value->{$key}, $seen);
+            push @items,
+                length($encoded_key) . ':' . $encoded_key
+                . '='
+                . length($encoded_value) . ':' . $encoded_value;
+        }
+        $encoded = '{' . join(',', sort @items) . '}';
+    } else {
+        my $item = _stable_encode(${$value}, $seen);
+        $encoded = '\\' . length($item) . ':' . $item;
+    }
+
+    delete $seen->{$address};
+    return $encoded;
+}
+
+sub _element_bytes {
+    my ($value) = @_;
+    return _stable_encode($value, {});
+}
+
+sub _fmix32 {
+    my ($value) = @_;
+    $value = ($value ^ ($value >> 16)) & $UINT32_MASK;
+    $value = ($value * 0x85ebca6b) & $UINT32_MASK;
+    $value = ($value ^ ($value >> 13)) & $UINT32_MASK;
+    $value = ($value * 0xc2b2ae35) & $UINT32_MASK;
+    return ($value ^ ($value >> 16)) & $UINT32_MASK;
+}
+
+sub optimal_m {
+    my ($expected_items, $false_positive_rate) = @_;
+    $expected_items = _positive_integer($expected_items, 'expected_items');
+    $false_positive_rate = _false_positive_rate($false_positive_rate);
+    return ceil(
+        -$expected_items * log($false_positive_rate) / (log(2) ** 2)
+    );
+}
+
+sub optimal_k {
+    my ($bit_count, $expected_items) = @_;
+    $bit_count = _positive_integer($bit_count, 'bit_count');
+    $expected_items = _positive_integer($expected_items, 'expected_items');
+    my $rounded = floor(($bit_count / $expected_items) * log(2) + 0.5);
+    return $rounded > 1 ? $rounded : 1;
+}
+
+sub capacity_for_memory {
+    my ($memory_bytes, $false_positive_rate) = @_;
+    $memory_bytes = _nonnegative_integer($memory_bytes, 'memory_bytes');
+    $false_positive_rate = _false_positive_rate($false_positive_rate);
+    return floor(
+        -($memory_bytes * 8) * (log(2) ** 2) / log($false_positive_rate)
+    );
+}
+
+sub _from_parts {
+    my ($class, $bit_count, $hash_count, $expected_items) = @_;
+    my $byte_count = int(($bit_count + 7) / 8);
+    return bless {
+        bit_count      => $bit_count,
+        hash_count     => $hash_count,
+        expected_items => $expected_items,
+        bits           => "\0" x $byte_count,
+        bits_set       => 0,
+        items_added    => 0,
+    }, $class;
+}
+
+sub new {
+    my ($class, %args) = @_;
+    my $expected_items = exists($args{expected_items})
+        ? $args{expected_items}
+        : $DEFAULT_EXPECTED_ITEMS;
+    my $false_positive_rate = exists($args{false_positive_rate})
+        ? $args{false_positive_rate}
+        : $DEFAULT_FALSE_POSITIVE_RATE;
+    $expected_items = _positive_integer($expected_items, 'expected_items');
+    $false_positive_rate = _false_positive_rate($false_positive_rate);
+    my $bit_count = optimal_m($expected_items, $false_positive_rate);
+    my $hash_count = optimal_k($bit_count, $expected_items);
+    return _from_parts($class, $bit_count, $hash_count, $expected_items);
+}
+
+sub from_params {
+    my ($class, $bit_count, $hash_count) = @_;
+    $bit_count = _positive_integer($bit_count, 'bit_count');
+    $hash_count = _positive_integer($hash_count, 'hash_count');
+    return _from_parts($class, $bit_count, $hash_count, 0);
+}
+
+sub _hash_indices {
+    my ($self, $element) = @_;
+    my $raw = _element_bytes($element);
+    my $first = _fmix32(fnv1a_32($raw));
+    my $second_word = djb2($raw);
+    my $folded = $second_word->copy;
+    $folded->bxor($second_word->copy->brsft(32))->bmod(4_294_967_296);
+    my $second = _fmix32($folded->numify) | 1;
+    my @indices;
+    for my $index (0 .. $self->{hash_count} - 1) {
+        push @indices,
+            ($first + $index * $second) % $self->{bit_count};
+    }
+    return @indices;
+}
+
+sub add {
+    my ($self, $element) = @_;
+    for my $bit_index ($self->_hash_indices($element)) {
+        if (!vec($self->{bits}, $bit_index, 1)) {
+            vec($self->{bits}, $bit_index, 1) = 1;
+            $self->{bits_set}++;
+        }
+    }
+    $self->{items_added}++;
+    return;
+}
+
+sub contains {
+    my ($self, $element) = @_;
+    for my $bit_index ($self->_hash_indices($element)) {
+        return 0 unless vec($self->{bits}, $bit_index, 1);
+    }
+    return 1;
+}
+
+sub bit_count { return $_[0]->{bit_count}; }
+sub hash_count { return $_[0]->{hash_count}; }
+sub bits_set { return $_[0]->{bits_set}; }
+sub size_bytes { return length($_[0]->{bits}); }
+
+sub fill_ratio {
+    my ($self) = @_;
+    return $self->{bits_set} / $self->{bit_count};
+}
+
+sub estimated_false_positive_rate {
+    my ($self) = @_;
+    return 0.0 if $self->{bits_set} == 0;
+    return $self->fill_ratio ** $self->{hash_count};
+}
+
+sub is_over_capacity {
+    my ($self) = @_;
+    return $self->{expected_items} > 0
+        && $self->{items_added} > $self->{expected_items};
+}
+
+sub to_string {
+    my ($self) = @_;
+    return sprintf(
+        'BloomFilter(m=%d, k=%d, bits_set=%d/%d (%.2f%%), ~fp=%.4f%%)',
+        $self->{bit_count},
+        $self->{hash_count},
+        $self->{bits_set},
+        $self->{bit_count},
+        $self->fill_ratio * 100,
+        $self->estimated_false_positive_rate * 100,
+    );
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::BloomFilter - probabilistic set membership
+
+=head1 SYNOPSIS
+
+  my $filter = CodingAdventures::BloomFilter->new(
+      expected_items => 1000,
+      false_positive_rate => 0.01,
+  );
+  $filter->add('hello');
+  say $filter->contains('hello');
+
+=head1 DESCRIPTION
+
+Implements a compact Bloom filter using FNV-1a and DJB2 double hashing. A
+negative lookup is definitive; a positive lookup may be a false positive at
+the configured rate.
+
+=cut

--- a/code/packages/perl/bloom-filter/required_capabilities.json
+++ b/code/packages/perl/bloom-filter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/bloom-filter",
+  "capabilities": [],
+  "justification": "Pure in-memory hashing and bit-vector operations. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/bloom-filter/t/00-load.t
+++ b/code/packages/perl/bloom-filter/t/00-load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+BEGIN {
+    use_ok('CodingAdventures::BloomFilter');
+}
+
+ok($CodingAdventures::BloomFilter::VERSION, 'has a VERSION');

--- a/code/packages/perl/bloom-filter/t/01-bloom-filter.t
+++ b/code/packages/perl/bloom-filter/t/01-bloom-filter.t
@@ -1,0 +1,148 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use CodingAdventures::BloomFilter qw(
+    optimal_m
+    optimal_k
+    capacity_for_memory
+);
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'default filter starts empty' => sub {
+    my $filter = CodingAdventures::BloomFilter->new;
+    is($filter->bit_count, 9586, 'default bit count');
+    is($filter->hash_count, 7, 'default hash count');
+    is($filter->size_bytes, 1199, 'allocated bytes');
+    is($filter->bits_set, 0, 'no bits set');
+    is($filter->fill_ratio, 0, 'zero fill');
+    is($filter->estimated_false_positive_rate, 0, 'zero estimated FPR');
+    ok(!$filter->is_over_capacity, 'not over capacity');
+    ok(!$filter->contains('anything'), 'empty filter misses value');
+};
+
+subtest 'inserted values have no false negatives' => sub {
+    my $filter = CodingAdventures::BloomFilter->new(
+        expected_items => 1_000,
+        false_positive_rate => 0.01,
+    );
+    for my $index (1 .. 250) {
+        $filter->add("item-$index");
+    }
+    my $all_present = 1;
+    for my $index (1 .. 250) {
+        $all_present &&= $filter->contains("item-$index");
+    }
+    ok($all_present, 'contains every inserted value');
+    cmp_ok($filter->bits_set, '>', 0, 'adding values sets bits');
+};
+
+subtest 'explicit parameters are preserved' => sub {
+    my $filter = CodingAdventures::BloomFilter->from_params(10_000, 7);
+    is($filter->bit_count, 10_000, 'bit count');
+    is($filter->hash_count, 7, 'hash count');
+    is($filter->size_bytes, 1_250, 'byte count');
+    $filter->add('hello');
+    ok($filter->contains('hello'), 'contains inserted value');
+    ok(!$filter->is_over_capacity, 'explicit filter does not track capacity');
+};
+
+subtest 'duplicate adds do not recount bits' => sub {
+    my $filter = CodingAdventures::BloomFilter->new(expected_items => 100);
+    $filter->add('duplicate');
+    my $after_first = $filter->bits_set;
+    $filter->add('duplicate');
+    is($filter->bits_set, $after_first, 'bit count remains stable');
+};
+
+subtest 'sizing helpers match the formulas' => sub {
+    my $bit_count = optimal_m(1_000_000, 0.01);
+    is($bit_count, 9_585_059, 'optimal bit count');
+    is(optimal_k($bit_count, 1_000_000), 7, 'optimal hash count');
+    is(capacity_for_memory(1_000_000, 0.01), 834_632, 'memory capacity');
+    is(capacity_for_memory(0, 0.01), 0, 'zero memory capacity');
+};
+
+subtest 'capacity and rendering reflect use' => sub {
+    my $filter = CodingAdventures::BloomFilter->new(
+        expected_items => 3,
+        false_positive_rate => 0.01,
+    );
+    $filter->add($_) for qw(a b c);
+    ok(!$filter->is_over_capacity, 'at capacity');
+    $filter->add('d');
+    ok($filter->is_over_capacity, 'over capacity');
+    cmp_ok($filter->estimated_false_positive_rate, '>', 0, 'positive FPR');
+    like("$filter", qr/BloomFilter/, 'stringifies with class name');
+    like($filter->to_string, qr/bits_set=/, 'renders statistics');
+};
+
+subtest 'scalar and composite values are deterministic' => sub {
+    my $filter = CodingAdventures::BloomFilter->new(expected_items => 100);
+    my @values = (
+        "cafe\x{301}",
+        42,
+        3.14,
+        1,
+        undef,
+        ['math', 'code'],
+        { name => 'Ada', tags => ['math', 'code'] },
+    );
+    for my $value (@values) {
+        $filter->add($value);
+        ok($filter->contains($value), 'contains encoded value');
+    }
+    ok(
+        $filter->contains({ tags => ['math', 'code'], name => 'Ada' }),
+        'hash ordering is stable',
+    );
+};
+
+subtest 'invalid configurations and values are rejected' => sub {
+    dies_like(
+        sub { CodingAdventures::BloomFilter->new(expected_items => 0) },
+        qr/expected_items must be a positive integer/,
+        'zero expected items',
+    );
+    dies_like(
+        sub { CodingAdventures::BloomFilter->new(false_positive_rate => 0) },
+        qr/false_positive_rate must be in the open interval/,
+        'zero false-positive rate',
+    );
+    dies_like(
+        sub { CodingAdventures::BloomFilter->new(false_positive_rate => 1) },
+        qr/false_positive_rate must be in the open interval/,
+        'unit false-positive rate',
+    );
+    dies_like(
+        sub { CodingAdventures::BloomFilter->from_params(0, 1) },
+        qr/bit_count must be a positive integer/,
+        'zero bit count',
+    );
+    dies_like(
+        sub { CodingAdventures::BloomFilter->from_params(1, 0) },
+        qr/hash_count must be a positive integer/,
+        'zero hash count',
+    );
+    my $cycle = [];
+    push @{$cycle}, $cycle;
+    my $filter = CodingAdventures::BloomFilter->new;
+    dies_like(
+        sub { $filter->add($cycle) },
+        qr/element references must not contain cycles/,
+        'cyclic value',
+    );
+    dies_like(
+        sub { $filter->add(sub { 1 }) },
+        qr/element must be undef, a scalar, an array reference, or a hash reference/,
+        'unsupported reference',
+    );
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -107,12 +107,12 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 The missing matrix is heavily concentrated in singleton packages. Regenerated
 on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
-`skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports and
-the paired `hash-functions` prerequisite:
+`skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
+the paired `hash-functions` prerequisite, and the paired `bloom-filter` port:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 353 |
+| Present in 10-15 languages | 172 | 351 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -158,15 +158,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 353
+The 172 packages present in at least ten implementation languages need 351
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 5 | Pair with Perl data-structure/storage wave |
-| Perl | 5 | Pair with Lua data-structure/storage wave |
+| Lua | 4 | Pair with Perl data-structure/storage wave |
+| Perl | 4 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -178,10 +178,10 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first eleven paired Lua/Perl slices are complete: `fenwick-tree`,
+The first thirteen paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
 `avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and
-`resp-protocol`
+`resp-protocol`, `hash-functions`, and `bloom-filter`
 now have pure implementations, package-native tests, metadata, and capability
 declarations in both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
@@ -200,6 +200,10 @@ The paired `hash-functions` prerequisite adds binary-safe FNV-1a, DJB2,
 polynomial rolling, and MurmurHash3 implementations with deterministic analysis
 helpers. It moves the package from 9 to 11 implementation lanes and unblocks
 the remaining Bloom-filter and hash-map slices without external dependencies.
+The Bloom-filter slice uses that prerequisite for correlation-mixed double
+hashing, deterministic composite-value encoding, exact sizing helpers, and live
+fill and false-positive statistics, reducing the paired high-consensus gap to
+four packages per lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure Lua and Perl Bloom-filter packages backed by the newly available hash-functions ports
- support automatic and explicit sizing, deterministic composite-value encoding, correlation-mixed double hashing, and live utilization / false-positive statistics
- refresh the parity roadmap: Bloom filter now spans 13 implementation lanes, the high-consensus backlog drops from 353 to 351 missing slots, and the Lua/Perl lanes each drop from five gaps to four

## Validation

- Lua syntax validation with `luac -p`
- LuaRock metadata validation with `luarocks lint`
- local LuaRock installation with `luarocks make --local --deps-mode=none`
- Lua package tests: 8 passed with Busted
- Perl module syntax and load tests passed
- Perl package tests: 8 subtests passed
- parity reporter tests: 6 passed
- regenerated parity inventory: 172 high-consensus packages / 351 missing slots / 0 collisions
- `git diff --check`
