### PR TITLE
fix(javascript-parser): keyword-content string literal must stay a string (bridge miscompile)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.58.0] - 2026-07-16
+
+### Fixed — string literal whose content is a keyword no longer mis-bridged to that keyword (miscompile)
+
+`convert_primary_token` matched the token **value** (`this`/`true`/`false`/`null`/`undefined`) to
+produce the keyword-primary node *before* consulting the `TokenType` discriminant. A `String`
+literal token whose text happens to equal one of those words was therefore mis-encoded as the
+keyword literal:
+
+- `f("true")` → `f(true)` (a string argument silently became the **boolean** `true`; at `SIMPLE`,
+  emitted as `f(!0)`)
+- `f("false")` → `f(false)`, `f("null")` → `f(null)`, `f("undefined")` → `f(undefined)` (`void 0`)
+- `f("this")` → `f(this)` (a string became the **`this`** value — a semantics change *and* a
+  potential `ReferenceError`/wrong-receiver bug)
+- `x = "undefined"` → `x = void 0`; `o["true"]` → `o[true]`; etc.
+
+This is a hard miscompile — a string argument/value changing type — and it diverged from the
+reference Closure Compiler, which keeps the string. The value match is now **gated on the token
+type**: only `TokenType::Name | TokenType::Keyword` tokens are eligible to become a keyword
+primary, so `String`/`Number` literal tokens flow to the type-discriminant arms below
+(`TokenType::String` → `StringLiteral`). Genuine keyword primaries (`this`, `true`, `false`,
+`null`, `undefined` as bare words) are unaffected — they are `Name`/`Keyword` tokens and still
+bridge to their literal nodes.
+
+Regression tests `string_literal_with_keyword_content_stays_a_string` (the five keyword-content
+strings stay `StringLiteral`) and `bare_keyword_primaries_still_bridge` (bare keywords still fold)
+guard both directions. Verified byte-identical to the reference Closure Compiler at `SIMPLE`. Bug
+fix; MINOR bump 0.57.0 → 0.58.0.
+
 ## [0.57.0] - 2026-07-14
 
 ### Added — bridge async arrow functions (`async () => expr`) — CLOC12.192

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -3673,13 +3673,39 @@ fn split_regex_literal(raw: &str) -> Option<(String, String)> {
 /// REGEX has `type_ = TokenType::Name` and `type_name = Some("REGEX")`.
 fn convert_primary_token(t: &Token, ctx: &GrammarASTNode) -> Result<Expression, BridgeError> {
     // Value-based checks first (keywords: this, true, false, null, undefined).
-    match t.value.as_str() {
-        "this" => return Ok(Expression::ThisExpression(ThisExpression { cv: t.cv.clone() })),
-        "null" => return Ok(Expression::NullLiteral(NullLiteral { cv: t.cv.clone() })),
-        "undefined" => return Ok(Expression::UndefinedLiteral(UndefinedLiteral { cv: t.cv.clone() })),
-        "true" => return Ok(Expression::BooleanLiteral(BooleanLiteral { cv: t.cv.clone(), value: true })),
-        "false" => return Ok(Expression::BooleanLiteral(BooleanLiteral { cv: t.cv.clone(), value: false })),
-        _ => {}
+    //
+    // These MUST be gated on the token TYPE: only an identifier-like token
+    // (`Name`/`Keyword`) may be reinterpreted as one of these keyword primaries.
+    // A `String`/`Number` *literal* token whose text happens to equal a keyword
+    // — a string whose content is `this`/`true`/`false`/`null`/`undefined`, or
+    // the value `"true"` in source — is NOT that keyword and must flow to the
+    // type-discriminant arms below (`TokenType::String` → `StringLiteral`, etc.).
+    // Without this gate `f("true")` mis-encodes to `f(true)` and `f("this")` to
+    // `f(this)` — a hard miscompile: a string argument silently becomes a
+    // boolean / the `this` value. (The reference Closure Compiler keeps the
+    // string.) Matching the documented design: "NUMBER/STRING/NAME are encoded
+    // in `t.type_`" — the value match is only for the keyword primaries.
+    if matches!(t.type_, TokenType::Name | TokenType::Keyword) {
+        match t.value.as_str() {
+            "this" => return Ok(Expression::ThisExpression(ThisExpression { cv: t.cv.clone() })),
+            "null" => return Ok(Expression::NullLiteral(NullLiteral { cv: t.cv.clone() })),
+            "undefined" => {
+                return Ok(Expression::UndefinedLiteral(UndefinedLiteral { cv: t.cv.clone() }))
+            }
+            "true" => {
+                return Ok(Expression::BooleanLiteral(BooleanLiteral {
+                    cv: t.cv.clone(),
+                    value: true,
+                }))
+            }
+            "false" => {
+                return Ok(Expression::BooleanLiteral(BooleanLiteral {
+                    cv: t.cv.clone(),
+                    value: false,
+                }))
+            }
+            _ => {}
+        }
     }
 
     // BIGINT: type_ == TokenType::Name but type_name == Some("BIGINT").
@@ -5282,6 +5308,56 @@ mod tests {
             }
             _ => panic!("expected ExpressionStatement"),
         }
+    }
+
+    /// A STRING literal whose *content* is a keyword must bridge to a
+    /// `StringLiteral`, never to the keyword primary. `convert_primary_token`
+    /// used to match `t.value` before the type discriminant, so `"true"` became
+    /// `BooleanLiteral(true)` and `"this"` became `ThisExpression` — a hard
+    /// miscompile: `f("true")` would call `f` with the boolean, `f("this")` with
+    /// the `this` value. The value match is now gated on the token *type*.
+    #[test]
+    fn string_literal_with_keyword_content_stays_a_string() {
+        use coding_adventures_javascript_ast::statement::TaggedStatement;
+        for (src, want) in [
+            ("\"true\";", "true"),
+            ("\"false\";", "false"),
+            ("\"null\";", "null"),
+            ("\"undefined\";", "undefined"),
+            ("\"this\";", "this"),
+        ] {
+            let p = bridge_ok(src);
+            match &p.body[0] {
+                ProgramItem::Statement(Statement::Tagged(
+                    TaggedStatement::ExpressionStatement(es),
+                )) => match &es.expression {
+                    Expression::StringLiteral(s) => assert_eq!(s.value, want, "for {src}"),
+                    other => panic!("expected StringLiteral({want:?}) for {src}, got {other:?}"),
+                },
+                other => panic!("expected an ExpressionStatement for {src}, got {other:?}"),
+            }
+        }
+    }
+
+    /// The genuine keyword primaries must still bridge to their literal nodes —
+    /// the type gate keeps `Name`/`Keyword` tokens on the value-match path.
+    #[test]
+    fn bare_keyword_primaries_still_bridge() {
+        use coding_adventures_javascript_ast::statement::TaggedStatement;
+        let expr_of = |src: &str| -> Expression {
+            let p = bridge_ok(src);
+            match &p.body[0] {
+                ProgramItem::Statement(Statement::Tagged(
+                    TaggedStatement::ExpressionStatement(es),
+                )) => es.expression.clone(),
+                other => panic!("expected an ExpressionStatement for {src}, got {other:?}"),
+            }
+        };
+        assert!(matches!(expr_of("this;"), Expression::ThisExpression(_)));
+        assert!(matches!(expr_of("null;"), Expression::NullLiteral(_)));
+        assert!(matches!(expr_of("undefined;"), Expression::UndefinedLiteral(_)));
+        assert!(matches!(expr_of("true;"), Expression::BooleanLiteral(b) if b.value));
+        assert!(matches!(expr_of("false;"), Expression::BooleanLiteral(b) if !b.value));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## The miscompile

The parser bridge's `convert_primary_token` matched a token's **value** (`this`/`true`/`false`/`null`/`undefined`) to produce the keyword-primary AST node *before* consulting the `TokenType` discriminant. A `String` literal token holds its **unquoted** content as `value`, so any string whose text equals a keyword was mis-encoded as that keyword literal — a string argument/value silently changing type:

| input | closurec (before) | oracle |
|---|---|---|
| `f("true")` | `f(!0)` | `f("true")` |
| `f("false")` | `f(!1)` | `f("false")` |
| `f("null")` | `f(null)` | `f("null")` |
| `f("undefined")` | `f(void 0)` | `f("undefined")` |
| `f("this")` | `f(this)` | `f("this")` |
| `x="undefined"` | `x=void 0` | `x="undefined"` |
| `o["true"]` | `o[!0]` | `o["true"]` |

`f("this")→f(this)` is the smoking gun — a string became the `this` value (a semantics change and a potential wrong-receiver / `ReferenceError` bug). Every case diverged from the reference Closure Compiler.

## The fix

Gate the value-match on the token type: only `TokenType::Name | TokenType::Keyword` tokens are eligible to become a keyword primary. `String`/`Number` literal tokens now flow to the type-discriminant arms below (`TokenType::String` → `StringLiteral`). This matches the function's own documented design ("NUMBER/STRING/NAME are encoded in `t.type_`") and the **identical gate already used** by the sibling `convert_property_key` and the class-element loop — this was the only site with the residual value-before-type confusion.

Genuine keyword primaries (bare `this`/`true`/`false`/`null`/`undefined`) are `Name`/`Keyword` tokens and are unaffected — they still fold to their literal nodes.

## Verification

- javascript-parser `0.57.0` → `0.58.0`; CHANGELOG updated.
- Regression tests both directions: `string_literal_with_keyword_content_stays_a_string` (five keyword-content strings stay `StringLiteral`) and `bare_keyword_primaries_still_bridge` (bare keywords still fold). **256 lib tests pass**, clippy clean.
- **Oracle-verified byte-identical** at `SIMPLE` for the whole family; genuine keywords still fold (`f(true)→f(!0)`, `var a=this`).
- Full closurec suite green (**no fixture drift**); consumer crates green (constant-fold 366, dce 73, fcf 65, emitter 251). Security review **PASSED** (confirmed sole site, no new issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)