### PR TITLE
feat: port hash map to Lua and Perl

### DIFF
--- a/code/packages/lua/hash-map/BUILD
+++ b/code/packages/lua/hash-map/BUILD
@@ -1,0 +1,3 @@
+luarocks show coding-adventures-hash-functions >/dev/null 2>&1 || (cd ../hash-functions && luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-hash-map-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../hash-functions/src/?.lua;../../hash-functions/src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/hash-map/BUILD_windows
+++ b/code/packages/lua/hash-map/BUILD_windows
@@ -1,0 +1,3 @@
+luarocks show coding-adventures-hash-functions >nul 2>&1 || (cd ..\hash-functions && luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-hash-map-0.1.0-1.rockspec
+cd tests && set "LUA_PATH=../src/?.lua;../src/?/init.lua;../../hash-functions/src/?.lua;../../hash-functions/src/?/init.lua;;" && busted . --verbose --pattern=test_

--- a/code/packages/lua/hash-map/CHANGELOG.md
+++ b/code/packages/lua/hash-map/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-16
+
+- Add pure Lua separate-chaining and open-addressing hash maps.
+- Add tombstone deletion, automatic resizing, bulk access, merge, and cloning.
+- Use the sibling DT17 hash-functions package for deterministic bucket indexes.

--- a/code/packages/lua/hash-map/README.md
+++ b/code/packages/lua/hash-map/README.md
@@ -1,0 +1,22 @@
+# Hash Map (Lua)
+
+A pure Lua 5.4 implementation of [DT18](../../../specs/DT18-hash-map.md).
+It builds its own table storage with either separate chaining or linear-probing
+open addressing, including tombstone deletion and automatic resizing. Bucket
+selection uses the sibling `hash-functions` package.
+
+```lua
+local hash_map = require("coding_adventures.hash_map")
+
+local map = hash_map.new(16, "open_addressing", "fnv1a")
+map:set("language", "Lua")
+assert(map:get("language") == "Lua")
+
+-- Functional wrappers clone before writes.
+local next_map = hash_map.set(map, "year", 1993)
+assert(not map:has("year"))
+assert(next_map:get("year") == 1993)
+```
+
+Run the package gate from this directory with the commands in `BUILD` or
+`BUILD_windows`.

--- a/code/packages/lua/hash-map/coding-adventures-hash-map-0.1.0-1.rockspec
+++ b/code/packages/lua/hash-map/coding-adventures-hash-map-0.1.0-1.rockspec
@@ -1,0 +1,19 @@
+package = "coding-adventures-hash-map"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Hash map with chaining and open-addressing strategies",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+    "coding-adventures-hash-functions >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.hash_map"] = "src/coding_adventures/hash_map/init.lua",
+    },
+}

--- a/code/packages/lua/hash-map/required_capabilities.json
+++ b/code/packages/lua/hash-map/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/hash-map",
+  "capabilities": [],
+  "justification": "Pure in-memory hashing and array operations. No filesystem, network, process, environment, or randomness access needed."
+}

--- a/code/packages/lua/hash-map/src/coding_adventures/hash_map/init.lua
+++ b/code/packages/lua/hash-map/src/coding_adventures/hash_map/init.lua
@@ -1,0 +1,396 @@
+--- Hash map with separate-chaining and open-addressing collision strategies.
+
+local hash_functions = require("coding_adventures.hash_functions")
+
+local M = {}
+
+local DEFAULT_CAPACITY = 16
+local EMPTY = {}
+local TOMBSTONE = {}
+
+local function require_positive_integer(value, name, level)
+    if type(value) ~= "number" or math.type(value) ~= "integer" or value <= 0 then
+        error(name .. " must be a positive integer", level or 3)
+    end
+    return value
+end
+
+local function normalize_strategy(strategy, level)
+    strategy = strategy == nil and "chaining" or strategy
+    if strategy == "chaining" then
+        return strategy
+    end
+    if strategy == "open_addressing"
+        or strategy == "open-addressing"
+        or strategy == "open"
+    then
+        return "open_addressing"
+    end
+    error("strategy must be 'chaining' or 'open_addressing'", level or 3)
+end
+
+local function normalize_hash_fn(hash_fn, level)
+    hash_fn = hash_fn == nil and "fnv1a" or hash_fn
+    if hash_fn == "fnv1a" or hash_fn == "fnv1a_32" then
+        return "fnv1a"
+    end
+    if hash_fn == "murmur3" or hash_fn == "murmur3_32" then
+        return "murmur3"
+    end
+    if hash_fn == "djb2" then
+        return hash_fn
+    end
+    error("hash_fn must be 'fnv1a', 'murmur3', or 'djb2'", level or 3)
+end
+
+local function serialize_key(key)
+    local kind = type(key)
+    if kind == "string" then
+        return "string:" .. key
+    end
+    if kind == "number" then
+        return "number:" .. tostring(key)
+    end
+    if kind == "boolean" then
+        return key and "boolean:true" or "boolean:false"
+    end
+    return kind .. ":" .. tostring(key)
+end
+
+local function apply_hash(data, hash_fn)
+    if hash_fn == "murmur3" then
+        return hash_functions.murmur3_32(data)
+    end
+    if hash_fn == "djb2" then
+        return hash_functions.djb2(data)
+    end
+    return hash_functions.fnv1a_32(data)
+end
+
+local HashMap = {}
+HashMap.__index = HashMap
+
+local function initialize_storage(map)
+    if map._strategy == "chaining" then
+        map._buckets = {}
+        for index = 1, map._capacity do
+            map._buckets[index] = {}
+        end
+        map._slots = nil
+    else
+        map._slots = {}
+        for index = 1, map._capacity do
+            map._slots[index] = EMPTY
+        end
+        map._buckets = nil
+    end
+end
+
+function HashMap.new(capacity, strategy, hash_fn)
+    capacity = capacity == nil and DEFAULT_CAPACITY or capacity
+    require_positive_integer(capacity, "capacity", 2)
+    local map = setmetatable({
+        _capacity = capacity,
+        _size = 0,
+        _strategy = normalize_strategy(strategy, 2),
+        _hash_fn = normalize_hash_fn(hash_fn, 2),
+    }, HashMap)
+    initialize_storage(map)
+    return map
+end
+
+function HashMap:_bucket_index(key)
+    return (apply_hash(serialize_key(key), self._hash_fn) % self._capacity) + 1
+end
+
+function HashMap:_set_chaining(key, value)
+    local bucket = self._buckets[self:_bucket_index(key)]
+    for _, entry in ipairs(bucket) do
+        if entry.key == key then
+            entry.value = value
+            return
+        end
+    end
+    bucket[#bucket + 1] = { key = key, value = value }
+    self._size = self._size + 1
+end
+
+function HashMap:_set_open_addressing(key, value)
+    local start = self:_bucket_index(key)
+    local first_tombstone = nil
+    for probe = 0, self._capacity - 1 do
+        local index = ((start - 1 + probe) % self._capacity) + 1
+        local slot = self._slots[index]
+        if slot == EMPTY then
+            local insert_at = first_tombstone or index
+            self._slots[insert_at] = { key = key, value = value }
+            self._size = self._size + 1
+            return
+        elseif slot == TOMBSTONE then
+            first_tombstone = first_tombstone or index
+        elseif slot.key == key then
+            slot.value = value
+            return
+        end
+    end
+    if first_tombstone then
+        self._slots[first_tombstone] = { key = key, value = value }
+        self._size = self._size + 1
+        return
+    end
+    error("hash map is full; resize should have happened earlier", 2)
+end
+
+function HashMap:_set_without_resize(key, value)
+    if self._strategy == "chaining" then
+        self:_set_chaining(key, value)
+    else
+        self:_set_open_addressing(key, value)
+    end
+end
+
+function HashMap:_needs_resize()
+    local threshold = self._strategy == "chaining" and 1.0 or 0.75
+    return self:load_factor() > threshold
+end
+
+function HashMap:_resize(new_capacity)
+    local old_entries = self:entries()
+    self._capacity = new_capacity
+    self._size = 0
+    initialize_storage(self)
+    for _, entry in ipairs(old_entries) do
+        self:_set_without_resize(entry[1], entry[2])
+    end
+end
+
+--- Insert or update a key in place and return this map.
+function HashMap:set(key, value)
+    if key == nil then
+        error("key must not be nil", 2)
+    end
+    self:_set_without_resize(key, value)
+    if self:_needs_resize() then
+        self:_resize(self._capacity * 2)
+    end
+    return self
+end
+
+function HashMap:get(key)
+    if key == nil then
+        return nil
+    end
+    local start = self:_bucket_index(key)
+    if self._strategy == "chaining" then
+        for _, entry in ipairs(self._buckets[start]) do
+            if entry.key == key then
+                return entry.value
+            end
+        end
+        return nil
+    end
+    for probe = 0, self._capacity - 1 do
+        local index = ((start - 1 + probe) % self._capacity) + 1
+        local slot = self._slots[index]
+        if slot == EMPTY then
+            return nil
+        end
+        if slot ~= TOMBSTONE and slot.key == key then
+            return slot.value
+        end
+    end
+    return nil
+end
+
+function HashMap:has(key)
+    if key == nil then
+        return false
+    end
+    local start = self:_bucket_index(key)
+    if self._strategy == "chaining" then
+        for _, entry in ipairs(self._buckets[start]) do
+            if entry.key == key then
+                return true
+            end
+        end
+        return false
+    end
+    for probe = 0, self._capacity - 1 do
+        local index = ((start - 1 + probe) % self._capacity) + 1
+        local slot = self._slots[index]
+        if slot == EMPTY then
+            return false
+        end
+        if slot ~= TOMBSTONE and slot.key == key then
+            return true
+        end
+    end
+    return false
+end
+
+function HashMap:delete(key)
+    if key == nil then
+        return false
+    end
+    local start = self:_bucket_index(key)
+    if self._strategy == "chaining" then
+        local bucket = self._buckets[start]
+        for index, entry in ipairs(bucket) do
+            if entry.key == key then
+                table.remove(bucket, index)
+                self._size = self._size - 1
+                return true
+            end
+        end
+        return false
+    end
+    for probe = 0, self._capacity - 1 do
+        local index = ((start - 1 + probe) % self._capacity) + 1
+        local slot = self._slots[index]
+        if slot == EMPTY then
+            return false
+        end
+        if slot ~= TOMBSTONE and slot.key == key then
+            self._slots[index] = TOMBSTONE
+            self._size = self._size - 1
+            return true
+        end
+    end
+    return false
+end
+
+function HashMap:entries()
+    local result = {}
+    if self._strategy == "chaining" then
+        for _, bucket in ipairs(self._buckets) do
+            for _, entry in ipairs(bucket) do
+                result[#result + 1] = { entry.key, entry.value, n = 2 }
+            end
+        end
+    else
+        for _, slot in ipairs(self._slots) do
+            if slot ~= EMPTY and slot ~= TOMBSTONE then
+                result[#result + 1] = { slot.key, slot.value, n = 2 }
+            end
+        end
+    end
+    return result
+end
+
+function HashMap:keys()
+    local result = {}
+    for _, entry in ipairs(self:entries()) do
+        result[#result + 1] = entry[1]
+    end
+    return result
+end
+
+function HashMap:values()
+    local result = { n = 0 }
+    for _, entry in ipairs(self:entries()) do
+        result.n = result.n + 1
+        result[result.n] = entry[2]
+    end
+    return result
+end
+
+function HashMap:size()
+    return self._size
+end
+
+function HashMap:capacity()
+    return self._capacity
+end
+
+function HashMap:load_factor()
+    return self._size / self._capacity
+end
+
+function HashMap:strategy()
+    return self._strategy
+end
+
+function HashMap:hash_fn()
+    return self._hash_fn
+end
+
+function HashMap:clone()
+    local copy = HashMap.new(self._capacity, self._strategy, self._hash_fn)
+    for _, entry in ipairs(self:entries()) do
+        copy:_set_without_resize(entry[1], entry[2])
+    end
+    return copy
+end
+
+function HashMap:clear()
+    self._size = 0
+    initialize_storage(self)
+    return self
+end
+
+HashMap.__len = HashMap.size
+HashMap.__tostring = function(self)
+    return string.format(
+        "HashMap(strategy=%s, hash_fn=%s, size=%d, capacity=%d)",
+        self._strategy,
+        self._hash_fn,
+        self._size,
+        self._capacity
+    )
+end
+
+function M.from_entries(entries, capacity, strategy, hash_fn)
+    if type(entries) ~= "table" then
+        error("entries must be an array of key-value pairs", 2)
+    end
+    local map = HashMap.new(capacity, strategy, hash_fn)
+    for _, entry in ipairs(entries) do
+        if type(entry) ~= "table" or entry[1] == nil then
+            error("each entry must be a key-value pair with a non-nil key", 2)
+        end
+        map:set(entry[1], entry[2])
+    end
+    return map
+end
+
+function M.merge(left, right)
+    local result = HashMap.new(
+        math.max(left:capacity(), right:capacity()),
+        left:strategy(),
+        left:hash_fn()
+    )
+    for _, entry in ipairs(left:entries()) do
+        result:set(entry[1], entry[2])
+    end
+    for _, entry in ipairs(right:entries()) do
+        result:set(entry[1], entry[2])
+    end
+    return result
+end
+
+--- Functional wrappers clone before writes, leaving the input map unchanged.
+function M.set(map, key, value)
+    return map:clone():set(key, value)
+end
+
+function M.delete(map, key)
+    local copy = map:clone()
+    copy:delete(key)
+    return copy
+end
+
+function M.get(map, key) return map:get(key) end
+function M.has(map, key) return map:has(key) end
+function M.keys(map) return map:keys() end
+function M.values(map) return map:values() end
+function M.entries(map) return map:entries() end
+function M.size(map) return map:size() end
+function M.capacity(map) return map:capacity() end
+function M.load_factor(map) return map:load_factor() end
+
+M.HashMap = HashMap
+M.new = HashMap.new
+M.new_map = HashMap.new
+M.DEFAULT_CAPACITY = DEFAULT_CAPACITY
+
+return M

--- a/code/packages/lua/hash-map/tests/test_hash_map.lua
+++ b/code/packages/lua/hash-map/tests/test_hash_map.lua
@@ -1,0 +1,131 @@
+local hash_functions = require("coding_adventures.hash_functions")
+local hash_map = require("coding_adventures.hash_map")
+
+local function for_each_strategy(callback)
+    for _, strategy in ipairs({ "chaining", "open_addressing" }) do
+        callback(strategy)
+    end
+end
+
+local function entries_as_table(map)
+    local result = {}
+    for _, entry in ipairs(map:entries()) do
+        result[entry[1]] = entry[2]
+    end
+    return result
+end
+
+local function colliding_strings(capacity)
+    local first_by_bucket = {}
+    for index = 1, 1000 do
+        local key = "collision-" .. index
+        local bucket = hash_functions.fnv1a_32("string:" .. key) % capacity
+        if first_by_bucket[bucket] then
+            return first_by_bucket[bucket], key
+        end
+        first_by_bucket[bucket] = key
+    end
+    error("failed to find colliding keys")
+end
+
+describe("HashMap", function()
+    it("stores, overwrites, and deletes keys with both strategies", function()
+        for_each_strategy(function(strategy)
+            local map = hash_map.new(8, strategy)
+            assert.equals(map, map:set("hello", 42))
+            map:set("world", 7):set("hello", 99)
+            assert.equals(2, map:size())
+            assert.equals(99, map:get("hello"))
+            assert.is_true(map:has("world"))
+            assert.is_true(map:delete("hello"))
+            assert.is_false(map:delete("missing"))
+            assert.is_false(map:has("hello"))
+            assert.equals(1, #map)
+        end)
+    end)
+
+    it("stores nil values without confusing membership", function()
+        for_each_strategy(function(strategy)
+            local map = hash_map.new(8, strategy):set("nil-value", nil)
+            assert.is_true(map:has("nil-value"))
+            assert.is_nil(map:get("nil-value"))
+            assert.equals(1, map:size())
+            assert.equals(1, map:values().n)
+        end)
+    end)
+
+    it("handles collisions and resizes separate chains", function()
+        local map = hash_map.new(2, "chaining")
+        map:set("cat", 1):set("car", 2):set("cab", 3)
+        assert.equals(4, map:capacity())
+        assert.equals(1, map:get("cat"))
+        assert.equals(2, map:get("car"))
+        assert.equals(3, map:get("cab"))
+        assert.is_true(map:load_factor() <= 1.0)
+    end)
+
+    it("preserves open-addressing probe chains across tombstones", function()
+        local first, second = colliding_strings(8)
+        local map = hash_map.new(8, "open_addressing")
+        map:set(first, 1):set(second, 2)
+        assert.is_true(map:delete(first))
+        assert.equals(2, map:get(second))
+        map:set("replacement", 3)
+        assert.equals(3, map:get("replacement"))
+    end)
+
+    it("resizes open addressing at a 0.75 load factor", function()
+        local map = hash_map.new(4, "open")
+        for index = 1, 4 do
+            map:set("key-" .. index, index)
+        end
+        assert.equals(8, map:capacity())
+        assert.equals(4, map:size())
+        for index = 1, 4 do
+            assert.equals(index, map:get("key-" .. index))
+        end
+    end)
+
+    it("supports every packaged hash function", function()
+        for _, hash_fn in ipairs({ "fnv1a", "fnv1a_32", "murmur3", "murmur3_32", "djb2" }) do
+            local map = hash_map.new(4, "open_addressing", hash_fn)
+            map:set("Ada", "Lovelace")
+            assert.equals("Lovelace", map:get("Ada"))
+        end
+    end)
+
+    it("provides bulk, construction, merge, clone, and clear operations", function()
+        local left = hash_map.from_entries({ { "a", 1 }, { "b", 2 } })
+        local right = hash_map.from_entries({ { "b", 99 }, { "c", 3 } })
+        local merged = hash_map.merge(left, right)
+        local values = entries_as_table(merged)
+        assert.same({ a = 1, b = 99, c = 3 }, values)
+        assert.equals(3, #merged:keys())
+        assert.equals(3, #merged:values())
+        local clone = merged:clone()
+        clone:set("d", 4)
+        assert.is_false(merged:has("d"))
+        assert.equals(0, clone:clear():size())
+    end)
+
+    it("offers functional wrappers that leave inputs unchanged", function()
+        local empty = hash_map.new()
+        local filled = hash_map.set(empty, "a", 1)
+        local removed = hash_map.delete(filled, "a")
+        assert.equals(0, hash_map.size(empty))
+        assert.equals(1, hash_map.get(filled, "a"))
+        assert.is_false(hash_map.has(removed, "a"))
+        assert.matches("HashMap", tostring(filled), nil, true)
+    end)
+
+    it("rejects invalid configurations and nil keys", function()
+        assert.has_error(function() hash_map.new(0) end, "capacity must be a positive integer")
+        assert.has_error(function() hash_map.new(1, "quadratic") end,
+            "strategy must be 'chaining' or 'open_addressing'")
+        assert.has_error(function() hash_map.new(1, nil, "sha256") end,
+            "hash_fn must be 'fnv1a', 'murmur3', or 'djb2'")
+        assert.has_error(function() hash_map.new():set(nil, 1) end, "key must not be nil")
+        assert.has_error(function() hash_map.from_entries({ { nil, 1 } }) end,
+            "each entry must be a key-value pair with a non-nil key")
+    end)
+end)

--- a/code/packages/perl/hash-map/BUILD
+++ b/code/packages/perl/hash-map/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=../hash-functions/lib prove -l -v t/

--- a/code/packages/perl/hash-map/BUILD_windows
+++ b/code/packages/perl/hash-map/BUILD_windows
@@ -1,0 +1,1 @@
+set PERL5LIB=..\hash-functions\lib && perl -Ilib t/00-load.t && perl -Ilib t/01-hash-map.t

--- a/code/packages/perl/hash-map/CHANGELOG.md
+++ b/code/packages/perl/hash-map/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-16
+
+- Add pure Perl separate-chaining and open-addressing hash maps.
+- Add tombstone deletion, automatic resizing, bulk access, merge, and cloning.
+- Use the sibling DT17 hash-functions package for deterministic bucket indexes.

--- a/code/packages/perl/hash-map/Makefile.PL
+++ b/code/packages/perl/hash-map/Makefile.PL
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::HashMap',
+    VERSION_FROM     => 'lib/CodingAdventures/HashMap.pm',
+    ABSTRACT         => 'Hash map with chaining and open-addressing strategies',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::HashFunctions' => 0,
+        'Exporter'                        => 0,
+        'Scalar::Util'                    => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/hash-map/README.md
+++ b/code/packages/perl/hash-map/README.md
@@ -1,0 +1,21 @@
+# Hash Map (Perl)
+
+A pure Perl implementation of [DT18](../../../specs/DT18-hash-map.md). It
+builds separate-chaining and linear-probing tables from arrays, preserves open
+addressing probe chains with tombstones, and resizes automatically. Bucket
+selection comes from the sibling `hash-functions` package.
+
+```perl
+use CodingAdventures::HashMap;
+
+my $map = CodingAdventures::HashMap->new(strategy => 'open_addressing');
+$map->set(language => 'Perl');
+die unless $map->get('language') eq 'Perl';
+
+my $next = $map->with_set(year => 1987);
+die if $map->has('year');
+die unless $next->get('year') == 1987;
+```
+
+Run the package gate from this directory with the commands in `BUILD` or
+`BUILD_windows`.

--- a/code/packages/perl/hash-map/cpanfile
+++ b/code/packages/perl/hash-map/cpanfile
@@ -1,0 +1,1 @@
+requires 'CodingAdventures::HashFunctions';

--- a/code/packages/perl/hash-map/lib/CodingAdventures/HashMap.pm
+++ b/code/packages/perl/hash-map/lib/CodingAdventures/HashMap.pm
@@ -1,0 +1,371 @@
+package CodingAdventures::HashMap;
+
+use strict;
+use warnings;
+use Exporter qw(import);
+use Scalar::Util qw(blessed refaddr);
+use CodingAdventures::HashFunctions qw(fnv1a_32 murmur3_32 djb2);
+
+our $VERSION = '0.1.0';
+our @EXPORT_OK = qw(new_map from_entries merge);
+
+my $DEFAULT_CAPACITY = 16;
+my $EMPTY = undef;
+my $TOMBSTONE = bless {}, 'CodingAdventures::HashMap::Tombstone';
+
+sub _positive_integer {
+    my ($value, $name) = @_;
+    die "$name must be a positive integer\n"
+        if !defined($value) || ref($value) || "$value" !~ /\A\d+\z/ || $value <= 0;
+    return 0 + $value;
+}
+
+sub _normalize_strategy {
+    my ($strategy) = @_;
+    $strategy = 'chaining' unless defined $strategy;
+    return 'chaining' if $strategy eq 'chaining';
+    return 'open_addressing'
+        if $strategy eq 'open_addressing'
+        || $strategy eq 'open-addressing'
+        || $strategy eq 'open';
+    die "strategy must be 'chaining' or 'open_addressing'\n";
+}
+
+sub _normalize_hash_fn {
+    my ($hash_fn) = @_;
+    $hash_fn = 'fnv1a' unless defined $hash_fn;
+    return 'fnv1a' if $hash_fn eq 'fnv1a' || $hash_fn eq 'fnv1a_32';
+    return 'murmur3' if $hash_fn eq 'murmur3' || $hash_fn eq 'murmur3_32';
+    return 'djb2' if $hash_fn eq 'djb2';
+    die "hash_fn must be 'fnv1a', 'murmur3', or 'djb2'\n";
+}
+
+sub _serialize_key {
+    my ($key) = @_;
+    return 'undef:' unless defined $key;
+    return 'reference:' . ref($key) . ':' . refaddr($key) if ref($key);
+    return 'scalar:' . $key;
+}
+
+sub _keys_equal {
+    my ($left, $right) = @_;
+    return !defined($left) && !defined($right)
+        if !defined($left) || !defined($right);
+    if (ref($left) || ref($right)) {
+        return 0 unless ref($left) && ref($right);
+        return refaddr($left) == refaddr($right);
+    }
+    return $left eq $right;
+}
+
+sub _is_tombstone {
+    my ($slot) = @_;
+    return ref($slot) && refaddr($slot) == refaddr($TOMBSTONE);
+}
+
+sub _apply_hash {
+    my ($data, $hash_fn) = @_;
+    return murmur3_32($data) if $hash_fn eq 'murmur3';
+    return djb2($data) if $hash_fn eq 'djb2';
+    return fnv1a_32($data);
+}
+
+sub _hash_modulo {
+    my ($value, $modulus) = @_;
+    if (blessed($value) && $value->isa('Math::BigInt')) {
+        return $value->copy->bmod($modulus)->numify;
+    }
+    return $value % $modulus;
+}
+
+sub _initialize_storage {
+    my ($self) = @_;
+    if ($self->{strategy} eq 'chaining') {
+        $self->{buckets} = [map { [] } 1 .. $self->{capacity}];
+        delete $self->{slots};
+    } else {
+        $self->{slots} = [map { $EMPTY } 1 .. $self->{capacity}];
+        delete $self->{buckets};
+    }
+}
+
+sub new {
+    my ($class, %args) = @_;
+    my $capacity = exists($args{capacity}) ? $args{capacity} : $DEFAULT_CAPACITY;
+    $capacity = _positive_integer($capacity, 'capacity');
+    my $self = bless {
+        capacity => $capacity,
+        size     => 0,
+        strategy => _normalize_strategy($args{strategy}),
+        hash_fn  => _normalize_hash_fn($args{hash_fn}),
+    }, $class;
+    _initialize_storage($self);
+    return $self;
+}
+
+sub new_map {
+    return __PACKAGE__->new(@_);
+}
+
+sub _bucket_index {
+    my ($self, $key) = @_;
+    my $hash = _apply_hash(_serialize_key($key), $self->{hash_fn});
+    return _hash_modulo($hash, $self->{capacity});
+}
+
+sub _set_chaining {
+    my ($self, $key, $value) = @_;
+    my $bucket = $self->{buckets}->[$self->_bucket_index($key)];
+    for my $entry (@{$bucket}) {
+        if (_keys_equal($entry->[0], $key)) {
+            $entry->[1] = $value;
+            return;
+        }
+    }
+    push @{$bucket}, [$key, $value];
+    $self->{size}++;
+}
+
+sub _set_open_addressing {
+    my ($self, $key, $value) = @_;
+    my $start = $self->_bucket_index($key);
+    my $first_tombstone;
+    for my $probe (0 .. $self->{capacity} - 1) {
+        my $index = ($start + $probe) % $self->{capacity};
+        my $slot = $self->{slots}->[$index];
+        if (!defined $slot) {
+            my $insert_at = defined($first_tombstone) ? $first_tombstone : $index;
+            $self->{slots}->[$insert_at] = [$key, $value];
+            $self->{size}++;
+            return;
+        }
+        if (_is_tombstone($slot)) {
+            $first_tombstone = $index unless defined $first_tombstone;
+        } elsif (_keys_equal($slot->[0], $key)) {
+            $slot->[1] = $value;
+            return;
+        }
+    }
+    if (defined $first_tombstone) {
+        $self->{slots}->[$first_tombstone] = [$key, $value];
+        $self->{size}++;
+        return;
+    }
+    die "hash map is full; resize should have happened earlier\n";
+}
+
+sub _set_without_resize {
+    my ($self, $key, $value) = @_;
+    if ($self->{strategy} eq 'chaining') {
+        $self->_set_chaining($key, $value);
+    } else {
+        $self->_set_open_addressing($key, $value);
+    }
+}
+
+sub _needs_resize {
+    my ($self) = @_;
+    my $threshold = $self->{strategy} eq 'chaining' ? 1.0 : 0.75;
+    return $self->load_factor > $threshold;
+}
+
+sub _resize {
+    my ($self, $new_capacity) = @_;
+    my $entries = $self->entries;
+    $self->{capacity} = $new_capacity;
+    $self->{size} = 0;
+    _initialize_storage($self);
+    $self->_set_without_resize(@{$_}) for @{$entries};
+}
+
+sub set {
+    my ($self, $key, $value) = @_;
+    die "key must be defined\n" unless defined $key;
+    $self->_set_without_resize($key, $value);
+    $self->_resize($self->{capacity} * 2) if $self->_needs_resize;
+    return $self;
+}
+
+sub _find_entry {
+    my ($self, $key) = @_;
+    return unless defined $key;
+    my $start = $self->_bucket_index($key);
+    if ($self->{strategy} eq 'chaining') {
+        for my $entry (@{$self->{buckets}->[$start]}) {
+            return $entry if _keys_equal($entry->[0], $key);
+        }
+        return;
+    }
+    for my $probe (0 .. $self->{capacity} - 1) {
+        my $slot = $self->{slots}->[($start + $probe) % $self->{capacity}];
+        return unless defined $slot;
+        next if _is_tombstone($slot);
+        return $slot if _keys_equal($slot->[0], $key);
+    }
+    return;
+}
+
+sub get {
+    my ($self, $key) = @_;
+    my $entry = $self->_find_entry($key);
+    return defined($entry) ? $entry->[1] : undef;
+}
+
+sub has {
+    my ($self, $key) = @_;
+    return defined $self->_find_entry($key);
+}
+
+sub delete {
+    my ($self, $key) = @_;
+    return 0 unless defined $key;
+    my $start = $self->_bucket_index($key);
+    if ($self->{strategy} eq 'chaining') {
+        my $bucket = $self->{buckets}->[$start];
+        for my $index (0 .. $#{$bucket}) {
+            if (_keys_equal($bucket->[$index]->[0], $key)) {
+                splice @{$bucket}, $index, 1;
+                $self->{size}--;
+                return 1;
+            }
+        }
+        return 0;
+    }
+    for my $probe (0 .. $self->{capacity} - 1) {
+        my $index = ($start + $probe) % $self->{capacity};
+        my $slot = $self->{slots}->[$index];
+        return 0 unless defined $slot;
+        next if _is_tombstone($slot);
+        if (_keys_equal($slot->[0], $key)) {
+            $self->{slots}->[$index] = $TOMBSTONE;
+            $self->{size}--;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+sub entries {
+    my ($self) = @_;
+    my @entries;
+    if ($self->{strategy} eq 'chaining') {
+        for my $bucket (@{$self->{buckets}}) {
+            push @entries, map { [@{$_}] } @{$bucket};
+        }
+    } else {
+        for my $slot (@{$self->{slots}}) {
+            push @entries, [@{$slot}]
+                if defined($slot) && !_is_tombstone($slot);
+        }
+    }
+    return \@entries;
+}
+
+sub keys {
+    my ($self) = @_;
+    return [map { $_->[0] } @{$self->entries}];
+}
+
+sub values {
+    my ($self) = @_;
+    return [map { $_->[1] } @{$self->entries}];
+}
+
+sub size { return $_[0]->{size}; }
+sub capacity { return $_[0]->{capacity}; }
+sub strategy { return $_[0]->{strategy}; }
+sub hash_fn { return $_[0]->{hash_fn}; }
+
+sub load_factor {
+    my ($self) = @_;
+    return $self->{size} / $self->{capacity};
+}
+
+sub clone {
+    my ($self) = @_;
+    my $copy = __PACKAGE__->new(
+        capacity => $self->{capacity},
+        strategy => $self->{strategy},
+        hash_fn  => $self->{hash_fn},
+    );
+    $copy->_set_without_resize(@{$_}) for @{$self->entries};
+    return $copy;
+}
+
+sub clear {
+    my ($self) = @_;
+    $self->{size} = 0;
+    _initialize_storage($self);
+    return $self;
+}
+
+sub with_set {
+    my ($self, $key, $value) = @_;
+    return $self->clone->set($key, $value);
+}
+
+sub without {
+    my ($self, $key) = @_;
+    my $copy = $self->clone;
+    $copy->delete($key);
+    return $copy;
+}
+
+sub from_entries {
+    my ($invocant, @rest) = @_;
+    my ($entries, %args);
+    if (!ref($invocant) && $invocant eq __PACKAGE__) {
+        $entries = shift @rest;
+        %args = @rest;
+    } else {
+        $entries = $invocant;
+        %args = @rest;
+    }
+    die "entries must be an array reference of key-value pairs\n"
+        unless ref($entries) eq 'ARRAY';
+    my $map = __PACKAGE__->new(%args);
+    for my $entry (@{$entries}) {
+        die "each entry must be a two-item array reference with a defined key\n"
+            unless ref($entry) eq 'ARRAY' && @{$entry} == 2 && defined($entry->[0]);
+        $map->set(@{$entry});
+    }
+    return $map;
+}
+
+sub merge {
+    my ($left, $right) = @_;
+    my $capacity = $left->capacity > $right->capacity
+        ? $left->capacity
+        : $right->capacity;
+    my $result = __PACKAGE__->new(
+        capacity => $capacity,
+        strategy => $left->strategy,
+        hash_fn  => $left->hash_fn,
+    );
+    $result->set(@{$_}) for @{$left->entries};
+    $result->set(@{$_}) for @{$right->entries};
+    return $result;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::HashMap - chaining and open-addressing hash maps
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::HashMap;
+  my $map = CodingAdventures::HashMap->new(strategy => 'open_addressing');
+  $map->set(language => 'Perl');
+  say $map->get('language');
+
+=head1 DESCRIPTION
+
+Implements DT18 from first principles using the sibling DT17 hash-functions
+package. Both separate chaining and linear probing include automatic resizing;
+open addressing uses tombstones so deletion preserves probe chains.
+
+=cut

--- a/code/packages/perl/hash-map/required_capabilities.json
+++ b/code/packages/perl/hash-map/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/hash-map",
+  "capabilities": [],
+  "justification": "Pure in-memory hashing and array operations. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/perl/hash-map/t/00-load.t
+++ b/code/packages/perl/hash-map/t/00-load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+BEGIN {
+    use_ok('CodingAdventures::HashMap');
+}
+
+ok($CodingAdventures::HashMap::VERSION, 'has a VERSION');

--- a/code/packages/perl/hash-map/t/01-hash-map.t
+++ b/code/packages/perl/hash-map/t/01-hash-map.t
@@ -1,0 +1,148 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use CodingAdventures::HashFunctions qw(fnv1a_32);
+use CodingAdventures::HashMap qw(new_map from_entries merge);
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+sub collision_pair {
+    my ($capacity) = @_;
+    my %first_by_bucket;
+    for my $index (1 .. 1_000) {
+        my $key = "collision-$index";
+        my $bucket = fnv1a_32("scalar:$key") % $capacity;
+        return ($first_by_bucket{$bucket}, $key) if exists $first_by_bucket{$bucket};
+        $first_by_bucket{$bucket} = $key;
+    }
+    die "failed to find colliding keys";
+}
+
+subtest 'basic operations work with both strategies' => sub {
+    for my $strategy (qw(chaining open_addressing)) {
+        my $map = CodingAdventures::HashMap->new(capacity => 8, strategy => $strategy);
+        is($map->set('hello', 42), $map, "$strategy set returns self");
+        $map->set('world', 7)->set('hello', 99);
+        is($map->size, 2, "$strategy size");
+        is($map->get('hello'), 99, "$strategy overwrite");
+        ok($map->has('world'), "$strategy membership");
+        ok($map->delete('hello'), "$strategy delete");
+        ok(!$map->delete('missing'), "$strategy missing delete");
+        ok(!$map->has('hello'), "$strategy removed");
+    }
+};
+
+subtest 'undef values preserve membership' => sub {
+    for my $strategy (qw(chaining open_addressing)) {
+        my $map = new_map(capacity => 8, strategy => $strategy);
+        $map->set('undef-value', undef);
+        ok($map->has('undef-value'), "$strategy has undef value");
+        is($map->get('undef-value'), undef, "$strategy retrieves undef");
+        is($map->size, 1, "$strategy counts undef value");
+    }
+};
+
+subtest 'chaining handles collisions and resizes' => sub {
+    my $map = CodingAdventures::HashMap->new(capacity => 2);
+    $map->set('cat', 1)->set('car', 2)->set('cab', 3);
+    is($map->capacity, 4, 'capacity doubled');
+    is($map->get('cat'), 1, 'first key survives');
+    is($map->get('car'), 2, 'second key survives');
+    is($map->get('cab'), 3, 'third key survives');
+    cmp_ok($map->load_factor, '<=', 1.0, 'load factor restored');
+};
+
+subtest 'open addressing preserves probe chains across tombstones' => sub {
+    my ($first, $second) = collision_pair(8);
+    my $map = CodingAdventures::HashMap->new(
+        capacity => 8,
+        strategy => 'open_addressing',
+    );
+    $map->set($first, 1)->set($second, 2);
+    ok($map->delete($first), 'colliding first key deleted');
+    is($map->get($second), 2, 'second key remains behind tombstone');
+    $map->set('replacement', 3);
+    is($map->get('replacement'), 3, 'insertion after tombstone works');
+};
+
+subtest 'open addressing resizes at 0.75 load' => sub {
+    my $map = CodingAdventures::HashMap->new(capacity => 4, strategy => 'open');
+    $map->set("key-$_", $_) for 1 .. 4;
+    is($map->capacity, 8, 'capacity doubled');
+    is($map->size, 4, 'size retained');
+    is($map->get("key-$_"), $_, "key $_ retained") for 1 .. 4;
+};
+
+subtest 'all packaged hash functions and aliases work' => sub {
+    for my $hash_fn (qw(fnv1a fnv1a_32 murmur3 murmur3_32 djb2)) {
+        my $map = CodingAdventures::HashMap->new(
+            capacity => 4,
+            strategy => 'open-addressing',
+            hash_fn  => $hash_fn,
+        );
+        $map->set('Ada', 'Lovelace');
+        is($map->get('Ada'), 'Lovelace', "$hash_fn lookup");
+    }
+};
+
+subtest 'bulk, merge, clone, clear, and reference keys work' => sub {
+    my $left = from_entries([['a', 1], ['b', 2]]);
+    my $right = from_entries([['b', 99], ['c', 3]]);
+    my $merged = merge($left, $right);
+    my %entries = map { $_->[0] => $_->[1] } @{$merged->entries};
+    is_deeply(\%entries, {a => 1, b => 99, c => 3}, 'right map wins');
+    is(scalar @{$merged->keys}, 3, 'keys enumerated');
+    is(scalar @{$merged->values}, 3, 'values enumerated');
+    my $clone = $merged->clone->set('d', 4);
+    ok(!$merged->has('d'), 'clone does not mutate original');
+    is($clone->clear->size, 0, 'clear empties clone');
+    my $reference = [];
+    $merged->set($reference, 'identity');
+    is($merged->get($reference), 'identity', 'reference key found by identity');
+    ok(!$merged->has([]), 'different reference is a different key');
+};
+
+subtest 'copy-on-write helpers leave inputs unchanged' => sub {
+    my $empty = CodingAdventures::HashMap->new;
+    my $filled = $empty->with_set('a', 1);
+    my $removed = $filled->without('a');
+    is($empty->size, 0, 'with_set leaves input empty');
+    is($filled->get('a'), 1, 'with_set writes clone');
+    ok(!$removed->has('a'), 'without removes from clone');
+};
+
+subtest 'invalid configurations and keys are rejected' => sub {
+    dies_like(
+        sub { CodingAdventures::HashMap->new(capacity => 0) },
+        qr/capacity must be a positive integer/,
+        'zero capacity',
+    );
+    dies_like(
+        sub { CodingAdventures::HashMap->new(strategy => 'quadratic') },
+        qr/strategy must be 'chaining' or 'open_addressing'/,
+        'unknown strategy',
+    );
+    dies_like(
+        sub { CodingAdventures::HashMap->new(hash_fn => 'sha256') },
+        qr/hash_fn must be 'fnv1a', 'murmur3', or 'djb2'/,
+        'unknown hash',
+    );
+    dies_like(
+        sub { CodingAdventures::HashMap->new->set(undef, 1) },
+        qr/key must be defined/,
+        'undef key',
+    );
+    dies_like(
+        sub { from_entries([[undef, 1]]) },
+        qr/each entry must be a two-item array reference with a defined key/,
+        'invalid entry',
+    );
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -108,11 +108,12 @@ The missing matrix is heavily concentrated in singleton packages. Regenerated
 on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
 `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
-the paired `hash-functions` prerequisite, and the paired `bloom-filter` port:
+the paired `hash-functions` prerequisite, and the paired `bloom-filter` and
+`hash-map` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 351 |
+| Present in 10-15 languages | 172 | 349 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -158,15 +159,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 351
+The 172 packages present in at least ten implementation languages need 349
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 4 | Pair with Perl data-structure/storage wave |
-| Perl | 4 | Pair with Lua data-structure/storage wave |
+| Lua | 3 | Pair with Perl data-structure/storage wave |
+| Perl | 3 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -178,10 +179,10 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first thirteen paired Lua/Perl slices are complete: `fenwick-tree`,
+The first fourteen paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
 `avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and
-`resp-protocol`, `hash-functions`, and `bloom-filter`
+`resp-protocol`, `hash-functions`, `bloom-filter`, and `hash-map`
 now have pure implementations, package-native tests, metadata, and capability
 declarations in both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
@@ -204,6 +205,12 @@ The Bloom-filter slice uses that prerequisite for correlation-mixed double
 hashing, deterministic composite-value encoding, exact sizing helpers, and live
 fill and false-positive statistics, reducing the paired high-consensus gap to
 four packages per lane.
+The hash-map slice implements both DT18 collision strategies from first
+principles, including chaining, linear probing, tombstone deletion, automatic
+resizing, deterministic DT17 bucket hashes, bulk access, merge, and clone-based
+functional operations. It reduces the paired high-consensus gap to three
+packages per lane and supplies the direct dependency for the next `hash-set`
+slice.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure Lua and Perl DT18 hash maps with separate chaining and linear-probing open addressing
- implement tombstone deletion, automatic resizing, DT17 hash selection, bulk access, merge, clone, and copy-on-write helpers
- add package metadata, BUILD gates, native tests, README/CHANGELOG, and zero-capability manifests
- refresh the parity roadmap from 351 to 349 high-consensus missing slots and move Lua/Perl from four gaps to three

## Why

The merged Lua/Perl hash-functions slice is the direct prerequisite for hash-map. Completing this dependency-safe slice unlocks the next hash-set port and continues the smallest high-consensus parity wave.

## Validation

- LuaRocks lint and local install: passed
- Lua Busted suite: 9 successes
- Perl module compile/load and test suite: 9 subtests passed
- Perl MakeMaker generation: passed outside the repository
- randomized reference-model checks: 10,000 operations passed in each language
- parity reporter tests: 6 passed
- parity inventory: 172 high-consensus packages, 349 missing slots, zero collisions
- required-capabilities JSON Schema validation: passed
- `git diff --check`: passed