### PR TITLE
feat(adj-facts-stdlib): chemistry/acids-bases — common substance → acid or base table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_acidsbases_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_acidsbases_e2e.rs
@@ -1,0 +1,76 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/acids-bases.adj`) driven through the built CLI:
+//! a native `table` of common chemical → acid-or-base classification resolves
+//! binding-query recalls (forward and backward) with the source's LibreTexts
+//! citation, and abstains on a substance not in the table (vinegar) — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsab_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_acid_or_base_recall_binds_class_with_citation() {
+    let dir = scratch("acidsbases");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/acids-bases.adj");
+    std::fs::copy(&src, dir.join("acids-bases.adj")).expect("copy shipped acids-bases.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"acids-bases.adj\"\n\
+         ? acid_or_base(hydrochloric_acid, $Class)\n\
+         ? acid_or_base(sodium_hydroxide, $Class)\n\
+         ? acid_or_base($S, base)\n\
+         ? acid_or_base(vinegar, $Class)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Hydrochloric acid is an acid; sodium hydroxide (lye) is a base — the
+    // recalled classification tokens (forward binds).
+    assert!(
+        out.contains("\"Class\":\"acid\""),
+        "hydrochloric_acid -> acid: {out}"
+    );
+    assert!(
+        out.contains("\"Class\":\"base\""),
+        "sodium_hydroxide -> base: {out}"
+    );
+    // The relation runs BACKWARD: bind the class `base`, recall a substance —
+    // lithium_hydroxide, the first base in the table.
+    assert!(
+        out.contains("\"S\":\"lithium_hydroxide\""),
+        "base -> lithium_hydroxide (reverse recall into the bases): {out}"
+    );
+    // The answer carries the LibreTexts citation as its proof, at consensus trust
+    // (a secondary teaching reference, honestly tiered).
+    assert!(
+        out.contains("chem.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation at consensus trust: {out}"
+    );
+    // "vinegar" is not in the table — honest abstention, never a fabricated class.
+    assert!(out.contains("\"abstained\":true"), "vinegar abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -30,6 +30,7 @@ per rotation, in parallel):
 | `chemistry/` | element → atomic number | PubChem / NIH |
 | `chemistry/` | common substance → approximate pH | LibreTexts (consensus) |
 | `chemistry/` | element → periodic-table group family | Wikipedia (consensus) |
+| `chemistry/` | common chemical → acid or base | LibreTexts (consensus) |
 | `metrology/` | SI prefix → power of ten | NIST |
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |

--- a/code/specs/data/adj-facts-stdlib/chemistry/acids-bases.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/acids-bases.adj
@@ -1,0 +1,107 @@
+% ============================================================================
+% acid_or_base — is a common chemical an ACID or a BASE?
+% (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% A middle/high-school chemistry fact set: given a familiar compound, is it an
+% ACID or a BASE? Acids (hydrochloric acid in stomach juice, sulfuric acid in a
+% car battery, nitric acid) donate hydrogen ions and turn litmus red; bases /
+% alkalis (sodium hydroxide = lye, potassium hydroxide, the metal hydroxides)
+% accept hydrogen ions, feel slippery, and turn litmus blue. Recall is a binding
+% query:
+%
+%     ? acid_or_base(hydrochloric_acid, $Class)   % acid
+%
+% Like every FACTS library this is a native `table` (ADJ-TABLES RS-5): each
+% `row` lowers to a ground relation `acid_or_base(substance, classification)`
+% carrying the table's citation, so the lookup above is the ordinary SLD binding
+% query — the engine returns the class WITH its source, on the CPU, with zero
+% model calls, and abstains on a substance that is not in the table. It also runs
+% BACKWARD (bind a class, recall a substance of that class):
+%
+%     ? acid_or_base($S, base)     % sodium_hydroxide — first base in the table
+%
+% The classification value of every row is a SINGLE lowercase atom — exactly one
+% of the two tokens `acid` or `base` — never a strength ("strong"/"weak"), a
+% formula, or an interpretation the source does not support.
+%
+% The twelve substances, grouped by class (a little truth table — read down each
+% class to see which familiar compounds share it):
+%
+%     substance             class   everyday identity
+%     -------------------   -----   ------------------------------------------
+%     hydrochloric_acid     acid    HCl — the acid in stomach gastric juice
+%     hydrobromic_acid      acid    HBr
+%     hydroiodic_acid       acid    HI
+%     nitric_acid           acid    HNO3 — used in fertilisers and explosives
+%     sulfuric_acid         acid    H2SO4 — the acid in a car battery
+%     perchloric_acid       acid    HClO4
+%     lithium_hydroxide     base    LiOH
+%     sodium_hydroxide      base    NaOH — lye / caustic soda, in drain cleaner
+%     potassium_hydroxide   base    KOH — caustic potash
+%     calcium_hydroxide     base    Ca(OH)2 — slaked lime, in limewater
+%     barium_hydroxide      base    Ba(OH)2
+%     magnesium_hydroxide   base    Mg(OH)2 — the base in milk of magnesia
+%
+% A substance that is not one of these twelve — vinegar, baking soda, table salt —
+% has no row, so a recall on it ABSTAINS rather than inventing a class. That
+% honest-abstention property is what makes the table safe to reason from. (The
+% source lists these as the STRONG acids and bases; this table keeps only the
+% coarser fact each entry states outright — that the substance IS an acid, or IS
+% a base — dropping the strength, which a two-token acid/base classification does
+% not carry.)
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every substance→class pair
+% was read out of a fetched teaching-reference page this session, and any
+% substance that could not be grounded there was dropped). All twelve rows come
+% from the SAME source: the LibreTexts Chemistry table "Table 14.7.1: Strong
+% Acids and Bases" (chem.libretexts.org, Introductory Chemistry (LibreTexts),
+% §14.7 "Strong and Weak Acids and Bases"), whose two columns list the acids and
+% the bases by name; each name is copied character-for-character from that table:
+%
+%   ACIDS  (left column of Table 14.7.1)
+%     HCl (hydrochloric acid)     HNO3 (nitric acid)
+%     HBr (hydrobromic acid)      H2SO4 (sulfuric acid)
+%     HI  (hydroiodic acid)       HClO4 (perchloric acid)
+%
+%   BASES  (right column of Table 14.7.1 — the page notes "All strong bases are
+%   OH– compounds")
+%     LiOH (lithium hydroxide)    Ca(OH)2 (calcium hydroxide)
+%     NaOH (sodium hydroxide)     Ba(OH)2 (barium hydroxide)
+%     KOH  (potassium hydroxide)  Mg(OH)2 (magnesium hydroxide)
+%
+% (The source's acid column also lists HClO3 (chloric acid) and its base column
+% RbOH, CsOH, and Sr(OH)2; those are omitted only to keep the set balanced at six
+% acids and six bases — nothing about them was uncertain.)
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold that single source's table caption plus two representative
+% verbatim entries (one acid, one base); every other row's verbatim name is
+% listed above, so each substance→class pair remains independently checkable.
+% LibreTexts is a SECONDARY teaching reference (a college/intro course text, not
+% a primary standards body), so `trust consensus` — the honest tier for a
+% teaching summary, per the standard-library trust convention.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table acid_or_base {
+    columns substance, classification
+
+    row (hydrochloric_acid, acid)
+    row (hydrobromic_acid, acid)
+    row (hydroiodic_acid, acid)
+    row (nitric_acid, acid)
+    row (sulfuric_acid, acid)
+    row (perchloric_acid, acid)
+    row (lithium_hydroxide, base)
+    row (sodium_hydroxide, base)
+    row (potassium_hydroxide, base)
+    row (calcium_hydroxide, base)
+    row (barium_hydroxide, base)
+    row (magnesium_hydroxide, base)
+
+    source "Table 14.7.1: Strong Acids and Bases — Acids: HCl (hydrochloric acid) … H2SO4 (sulfuric acid); Bases: NaOH (sodium hydroxide) … Mg(OH)2 (magnesium hydroxide). All strong bases are OH– compounds."
+    locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(LibreTexts)/14:_Acids_and_Bases/14.07:_Strong_and_Weak_Acids_and_Bases"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/acids-bases.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/acids-bases.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% acids-bases.query.adj — a worked recall over the chemistry acids-bases library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "is sodium hydroxide an acid
+% or a base?": it states no chemistry fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `acid_or_base` rows and returns the class + the table's source/locator/trust.
+% The fourth query runs the relation BACKWARD (bind the class `base`, recall a
+% substance in it — lithium_hydroxide sits first among the bases in the table).
+% Vinegar is not in the table, so a recall on it abstains honestly — the engine
+% never invents a class.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli acids-bases.query.adj
+% ============================================================================
+
+import "acids-bases.adj"
+
+? acid_or_base(hydrochloric_acid, $Class)    % expect acid
+? acid_or_base(sodium_hydroxide, $Class)     % expect base
+? acid_or_base(sulfuric_acid, $Class)        % expect acid
+? acid_or_base($S, base)                      % expect lithium_hydroxide — reverse recall into the bases
+? acid_or_base(vinegar, $Class)              % expect abstain — vinegar is not in the table


### PR DESCRIPTION
Add a native ADJ `table` acid_or_base mapping twelve common chemicals to a
single-token classification (`acid` or `base`), plus a worked query file, an
e2e CLI test, and a README subject-index row. Data-only: no engine/grammar/
adapter code touched.

Recall is the ordinary SLD binding query — forward (substance → class),
backward (class → substance), and honest abstention on an absent substance —
returning the class WITH its source, on the CPU, with zero model calls.

Provenance (nothing from memory — every row read from a page fetched this
session; single provenance envelope):
  Source: LibreTexts Chemistry, 'Table 14.7.1: Strong Acids and Bases'
    Introductory Chemistry (LibreTexts) §14.7 'Strong and Weak Acids and Bases'
    https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(LibreTexts)/14:_Acids_and_Bases/14.07:_Strong_and_Weak_Acids_and_Bases
  Trust: consensus (secondary teaching reference, not a primary standards body)

  acids  → hydrochloric_acid, hydrobromic_acid, hydroiodic_acid, nitric_acid,
           sulfuric_acid, perchloric_acid
  bases  → lithium_hydroxide, sodium_hydroxide, potassium_hydroxide,
           calcium_hydroxide, barium_hydroxide, magnesium_hydroxide

The source lists these as the STRONG acids/bases; this table keeps only the
coarser fact each entry states outright (IS an acid / IS a base), dropping
strength since a two-token acid/base classification does not carry it. Balanced
at six acids and six bases; HClO3, RbOH, CsOH, Sr(OH)2 from the same table were
omitted only to keep the balance.

cargo test -p adj-lang -p adj-lang-cli and clippy -D warnings both green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
