### PR TITLE
feat(adj-facts-stdlib): biology/vitamins — vitamin → deficiency disease table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_vitamins_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_vitamins_e2e.rs
@@ -1,0 +1,88 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/vitamins.adj`) driven through the built CLI:
+//! a native `table` of vitamin → deficiency disease resolves binding-query
+//! recalls (forward AND backward) with the source's NIH / ODS citation, and
+//! abstains on a word that is not one of these grounded vitamins (vitamin_e,
+//! deliberately left out) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsvit_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_vitamins_recall_binds_deficiency_disease_with_citation() {
+    let dir = scratch("vitamins");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/vitamins.adj");
+    std::fs::copy(&src, dir.join("vitamins.adj")).expect("copy shipped vitamins.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"vitamins.adj\"\n\
+         ? deficiency_disease(vitamin_c, $Disease)\n\
+         ? deficiency_disease(vitamin_d, $Disease)\n\
+         ? deficiency_disease(vitamin_a, $Disease)\n\
+         ? deficiency_disease(vitamin_b1, $Disease)\n\
+         ? deficiency_disease(vitamin_b3, $Disease)\n\
+         ? deficiency_disease($V, megaloblastic_anemia)\n\
+         ? deficiency_disease(vitamin_e, $Disease)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A lack of vitamin C causes scurvy; vitamin D, rickets; vitamin A,
+    // xerophthalmia; thiamin (B1), beriberi; niacin (B3), pellagra — the
+    // recalled diseases, each the word its NIH source uses (forward binds).
+    assert!(out.contains("\"Disease\":\"scurvy\""), "vitamin_c → scurvy: {out}");
+    assert!(out.contains("\"Disease\":\"rickets\""), "vitamin_d → rickets: {out}");
+    assert!(
+        out.contains("\"Disease\":\"xerophthalmia\""),
+        "vitamin_a → xerophthalmia: {out}"
+    );
+    assert!(
+        out.contains("\"Disease\":\"beriberi\""),
+        "vitamin_b1 → beriberi: {out}"
+    );
+    assert!(
+        out.contains("\"Disease\":\"pellagra\""),
+        "vitamin_b3 → pellagra: {out}"
+    );
+    // The relation runs BACKWARD: bind the disease megaloblastic_anemia, recall
+    // BOTH vitamins whose lack causes it — folate (B9) and B12.
+    assert!(
+        out.contains("\"V\":\"vitamin_b9\"") && out.contains("\"V\":\"vitamin_b12\""),
+        "megaloblastic_anemia → vitamin_b9 ; vitamin_b12 (reverse recall): {out}"
+    );
+    // The answer carries the NIH / ODS citation as its proof, at the
+    // `authoritative` trust tier for a primary U.S. government source.
+    assert!(
+        out.contains("ods.od.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // vitamin_e is a real vitamin but was deliberately NOT grounded to a single
+    // clean source-stated disease token, so it is not a row — an honest
+    // abstention, never a fabricated disease.
+    assert!(out.contains("\"abstained\":true"), "vitamin_e abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -41,6 +41,7 @@ per rotation, in parallel):
 | `biology/` | macronutrient → energy (kcal) per gram | NIH / MedlinePlus |
 | `biology/` | basic tissue type → representative example | NCI SEER Training |
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
+| `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
 | `physics/` | simple machine → everyday example | NASA |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |

--- a/code/specs/data/adj-facts-stdlib/biology/vitamins.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/vitamins.adj
@@ -1,0 +1,125 @@
+% ============================================================================
+% vitamins — each vitamin and the classic DEFICIENCY DISEASE that appears when
+% the body goes without it (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the founding facts of nutrition and clinical medicine, and a rung a
+% MEDICINE or DIETETICS agent reasons UP from: a vitamin is a substance the body
+% needs in tiny amounts but mostly cannot make for itself, so when the diet lacks
+% one, a specific, named illness follows — and historically each of these
+% "deficiency diseases" was the clue that led to the vitamin's discovery. Sailors
+% without fresh fruit got scurvy; children without sunlight or fortified food got
+% rickets; populations living on polished rice got beriberi; those on a
+% corn-heavy diet got pellagra. Knowing the vitamin -> disease pairing is the
+% bridge from a symptom back to the missing nutrient, so before you can reason
+% about a patient's diet, a supplement, or a public-health program you must first
+% know which lack causes which disease. Recall is a binding query:
+%
+%     ? deficiency_disease(vitamin_c, $Disease)   % scurvy
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `deficiency_disease(vitamin, disease)` carrying the table's citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% disease WITH its source, on the CPU, with zero model calls, and abstains on a
+% word that is not one of these vitamins (it never invents a disease).
+%
+% Each vitamin and the disease its deficiency causes, as a little truth table:
+%
+%     vitamin        deficiency disease      a beginner's cue
+%     ------------   --------------------    ---------------------------------
+%     vitamin_c      scurvy                  bleeding gums — the sailors' disease
+%     vitamin_d      rickets                 soft, bowed bones in children
+%     vitamin_a      xerophthalmia           dry eyes, can't see in low light
+%     vitamin_b1     beriberi                thiamin — the polished-rice disease
+%     vitamin_b3     pellagra                niacin — the "3 Ds": derm/diarrhea/dementia
+%     vitamin_b9     megaloblastic_anemia    folate — oversized, immature red cells
+%     vitamin_b12    megaloblastic_anemia    B12 — the same anemia folate prevents
+%
+% (Common B-vitamin aliases: vitamin_b1 is thiamin, vitamin_b3 is niacin,
+% vitamin_b9 is folate, vitamin_b12 is cobalamin. Each vitamin is written as a
+% single lowercase token — `vitamin_c`, `vitamin_b12` — and each disease as the
+% word the source uses, so a recalled disease flows straight into further
+% reasoning.)
+%
+% The query also runs BACKWARD — bind a disease and recall the vitamin(s) whose
+% lack causes it. Two vitamins share one answer here, so the reverse recall
+% returns BOTH, honestly:
+%
+%     ? deficiency_disease($V, megaloblastic_anemia)   % vitamin_b9 ; vitamin_b12
+%
+% A word that is NOT one of these vitamins — `water`, `calcium`, `protein`,
+% `vitamin_e` — is deliberately NOT a row, so a disease recall ABSTAINS on it
+% rather than inventing an illness. (`vitamin_e` and `vitamin_k` are real
+% vitamins, but their deficiencies were not grounded to a single clean
+% source-stated disease token in the pages fetched for this table, so they are
+% honestly LEFT OUT rather than guessed — see the provenance notes below.) That
+% honest-abstention property is what makes the table safe to build a reasoner on:
+% it answers exactly the vitamin -> disease pairs it can ground, and only those.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every vitamin -> disease
+% pair below was read out of a fetched NIH page, and any pair whose disease could
+% not be verified there was dropped). Each pair, with the primary source it was
+% copied from and the verbatim span that states it. Every source is an NIH Office
+% of Dietary Supplements (ods.od.nih.gov) consumer fact sheet — a primary U.S.
+% government reference — so `trust authoritative`:
+%
+%   vitamin_c -> scurvy
+%     https://ods.od.nih.gov/factsheets/VitaminC-Consumer/
+%     "People who get little or no vitamin C (below about 10 mg per day) for many
+%      weeks can get scurvy."
+%
+%   vitamin_d -> rickets
+%     https://ods.od.nih.gov/factsheets/VitaminD-Consumer/
+%     "In children, vitamin D deficiency causes rickets, a disease in which the
+%      bones become soft, weak, deformed, and painful."
+%
+%   vitamin_a -> xerophthalmia
+%     https://ods.od.nih.gov/factsheets/VitaminA-Consumer/
+%     "Xerophthalmia is the inability to see in low light, and it can lead to
+%      blindness if it isn't treated."
+%
+%   vitamin_b1 -> beriberi
+%     https://ods.od.nih.gov/factsheets/Thiamin-Consumer/
+%     "Severe thiamin deficiency leads to a disease called beriberi with the added
+%      symptoms of tingling and numbness in the feet and hands, loss of muscle,
+%      and poor reflexes."
+%
+%   vitamin_b3 -> pellagra
+%     https://ods.od.nih.gov/factsheets/Niacin-Consumer/
+%     "Severe niacin deficiency leads to a disease called pellagra."
+%
+%   vitamin_b9 -> megaloblastic_anemia
+%     https://ods.od.nih.gov/factsheets/Folate-Consumer/
+%     "Getting too little folate can result in megaloblastic anemia, a blood
+%      disorder that causes weakness, fatigue, trouble concentrating,
+%      irritability, headache, heart palpitations, and shortness of breath."
+%
+%   vitamin_b12 -> megaloblastic_anemia
+%     https://ods.od.nih.gov/factsheets/VitaminB12-Consumer/
+%     "Vitamin B12 also helps prevent megaloblastic anemia, a blood condition that
+%      makes people tired and weak."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the NIH ODS Vitamin C statement,
+% which fixes the flagship row (vitamin_c -> scurvy) in one sentence. Every other
+% row's per-fact source and verbatim span is listed above, so each value remains
+% independently checkable.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table deficiency_disease {
+    columns vitamin, disease
+
+    row (vitamin_c, scurvy)
+    row (vitamin_d, rickets)
+    row (vitamin_a, xerophthalmia)
+    row (vitamin_b1, beriberi)
+    row (vitamin_b3, pellagra)
+    row (vitamin_b9, megaloblastic_anemia)
+    row (vitamin_b12, megaloblastic_anemia)
+
+    source "People who get little or no vitamin C (below about 10 mg per day) for many weeks can get scurvy."
+    locator "https://ods.od.nih.gov/factsheets/VitaminC-Consumer/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/vitamins.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/vitamins.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% vitamins.query.adj — a worked recall over the biology vitamins library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which disease does a lack
+% of vitamin C cause?": it states no medical fact of its own — it only `import`s
+% the grounded table and asks binding queries. The engine resolves each `?`
+% against the `deficiency_disease` rows and returns the disease + the table's
+% source/locator/trust. The fifth query runs the relation BACKWARD (bind the
+% disease `megaloblastic_anemia`, recall the vitamins whose lack causes it —
+% vitamin_b9 AND vitamin_b12, both returned). A word that is not one of these
+% vitamins abstains honestly — the engine never invents a disease.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli vitamins.query.adj
+% ============================================================================
+
+import "vitamins.adj"
+
+? deficiency_disease(vitamin_c, $Disease)   % expect scurvy
+? deficiency_disease(vitamin_d, $Disease)   % expect rickets
+? deficiency_disease(vitamin_b1, $Disease)  % expect beriberi
+? deficiency_disease(vitamin_b3, $Disease)  % expect pellagra
+? deficiency_disease($V, megaloblastic_anemia) % reverse bind — expect vitamin_b9 ; vitamin_b12
+? deficiency_disease(vitamin_e, $Disease)   % expect abstain — not a grounded row


### PR DESCRIPTION
Add a grounded ADJ facts library mapping each vitamin to the classic
deficiency disease its lack causes, mirroring the merged biology/
macronutrients library (native `table`, one provenance envelope,
per-fact sources in the header, worked .query.adj, e2e test, README row).

Rows (all byte-provenanced this session; every value token is literally
present in the cited NIH source sentence):

  vitamin_c   -> scurvy
  vitamin_d   -> rickets
  vitamin_a   -> xerophthalmia
  vitamin_b1  -> beriberi                (thiamin)
  vitamin_b3  -> pellagra                (niacin)
  vitamin_b9  -> megaloblastic_anemia    (folate)
  vitamin_b12 -> megaloblastic_anemia

Provenance / trust tiers — every source is an NIH Office of Dietary
Supplements consumer fact sheet (ods.od.nih.gov), a primary U.S.
government reference, so every row is `trust authoritative`:

  scurvy       — factsheets/VitaminC-Consumer/
  rickets      — factsheets/VitaminD-Consumer/
  xerophthalmia— factsheets/VitaminA-Consumer/
  beriberi     — factsheets/Thiamin-Consumer/
  pellagra     — factsheets/Niacin-Consumer/
  megaloblastic_anemia (b9)  — factsheets/Folate-Consumer/
  megaloblastic_anemia (b12) — factsheets/VitaminB12-Consumer/

vitamin_b9 and vitamin_b12 share megaloblastic_anemia, so the relation's
reverse recall returns BOTH — a worked demonstration of backward binding.

Dropped rows (no clean single source-stated disease token in fetched
pages): vitamin_a's "night blindness" (the ODS page states
"xerophthalmia" instead, which is used); vitamin_b6 (source lists only
generic "anemia" among several symptoms); vitamin_e and vitamin_k (no
single clean disease token). These abstain honestly rather than guess.

Data-only diff: two new .adj files, one e2e test, one README index row.
No engine/grammar/adapter changes. cargo test + clippy green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
