### PR TITLE
feat: port hash set to Lua and Perl

### DIFF
--- a/code/packages/lua/hash-set/BUILD
+++ b/code/packages/lua/hash-set/BUILD
@@ -1,0 +1,4 @@
+luarocks show coding-adventures-hash-functions >/dev/null 2>&1 || (cd ../hash-functions && luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec)
+luarocks show coding-adventures-hash-map >/dev/null 2>&1 || (cd ../hash-map && luarocks make --local --deps-mode=none coding-adventures-hash-map-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-hash-set-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../hash-map/src/?.lua;../../hash-map/src/?/init.lua;../../hash-functions/src/?.lua;../../hash-functions/src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/hash-set/BUILD_windows
+++ b/code/packages/lua/hash-set/BUILD_windows
@@ -1,0 +1,4 @@
+luarocks show coding-adventures-hash-functions >nul 2>&1 || (cd ..\hash-functions && luarocks make --local --deps-mode=none coding-adventures-hash-functions-0.1.0-1.rockspec)
+luarocks show coding-adventures-hash-map >nul 2>&1 || (cd ..\hash-map && luarocks make --local --deps-mode=none coding-adventures-hash-map-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-hash-set-0.1.0-1.rockspec
+cd tests && set "LUA_PATH=../src/?.lua;../src/?/init.lua;../../hash-map/src/?.lua;../../hash-map/src/?/init.lua;../../hash-functions/src/?.lua;../../hash-functions/src/?/init.lua;;" && busted . --verbose --pattern=test_

--- a/code/packages/lua/hash-set/CHANGELOG.md
+++ b/code/packages/lua/hash-set/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - 2026-07-16
+
+- Add a persistent DT19 hash set backed by the Lua DT18 hash map.
+- Add complete set algebra, relation predicates, option preservation, and
+  reference-identity support.
+- Add LuaRocks metadata, capability declaration, and Busted coverage.

--- a/code/packages/lua/hash-set/README.md
+++ b/code/packages/lua/hash-set/README.md
@@ -1,0 +1,25 @@
+# Hash Set (Lua)
+
+A pure Lua 5.4 implementation of [DT19](../../../specs/DT19-hash-set.md).
+It wraps the sibling DT18 `hash-map` package and stores elements as keys with a
+single sentinel value. Add and remove operations are persistent: they return a
+new set and leave the input unchanged.
+
+```lua
+local hash_set = require("coding_adventures.hash_set")
+
+local base = hash_set.from_list({ "Ada", "Grace", "Ada" })
+local next_set = base:add("Linus")
+
+assert(base:size() == 2)
+assert(next_set:contains("Linus"))
+assert(next_set:intersection(base):equals(base))
+```
+
+The package includes union, intersection, difference, symmetric difference,
+subset, superset, disjoint, and equality operations. Hash-map capacity,
+collision strategy, and hash-function options are preserved across persistent
+operations.
+
+Run the package gate from this directory with the commands in `BUILD` or
+`BUILD_windows`.

--- a/code/packages/lua/hash-set/coding-adventures-hash-set-0.1.0-1.rockspec
+++ b/code/packages/lua/hash-set/coding-adventures-hash-set-0.1.0-1.rockspec
@@ -1,0 +1,19 @@
+package = "coding-adventures-hash-set"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Persistent hash set with complete set algebra",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+    "coding-adventures-hash-map >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.hash_set"] = "src/coding_adventures/hash_set/init.lua",
+    },
+}

--- a/code/packages/lua/hash-set/required_capabilities.json
+++ b/code/packages/lua/hash-set/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/hash-set",
+  "capabilities": [],
+  "justification": "Pure in-memory set algebra over the sibling hash-map package. No filesystem, network, process, environment, or randomness access needed."
+}

--- a/code/packages/lua/hash-set/src/coding_adventures/hash_set/init.lua
+++ b/code/packages/lua/hash-set/src/coding_adventures/hash_set/init.lua
@@ -1,0 +1,214 @@
+--- Persistent hash set built on the DT18 hash map package.
+
+local hash_map = require("coding_adventures.hash_map")
+
+local M = {}
+local PRESENT = true
+
+local HashSet = {}
+HashSet.__index = HashSet
+
+local function wrap(map)
+    return setmetatable({ _map = map }, HashSet)
+end
+
+local function require_elements(elements, level)
+    if type(elements) ~= "table" then
+        error("elements must be an array", level or 3)
+    end
+    return elements
+end
+
+local function require_element(element, level)
+    if element == nil then
+        error("element must not be nil", level or 3)
+    end
+    return element
+end
+
+local function empty_like(set)
+    return wrap(hash_map.new(set:capacity(), set:strategy(), set:hash_fn()))
+end
+
+function HashSet.new(capacity, strategy, hash_fn)
+    return wrap(hash_map.new(capacity, strategy, hash_fn))
+end
+
+function HashSet.with_options(capacity, strategy, hash_fn)
+    return HashSet.new(capacity, strategy, hash_fn)
+end
+
+function HashSet.from_list(elements, capacity, strategy, hash_fn)
+    require_elements(elements, 2)
+    local map = hash_map.new(capacity, strategy, hash_fn)
+    for _, element in ipairs(elements) do
+        map:set(require_element(element, 2), PRESENT)
+    end
+    return wrap(map)
+end
+
+function HashSet.from_list_with_options(elements, capacity, strategy, hash_fn)
+    return HashSet.from_list(elements, capacity, strategy, hash_fn)
+end
+
+function HashSet:clone()
+    return wrap(self._map:clone())
+end
+
+--- Return a new set containing element, leaving this set unchanged.
+function HashSet:add(element)
+    require_element(element, 2)
+    return wrap(hash_map.set(self._map, element, PRESENT))
+end
+
+--- Return a new set without element. Missing elements are ignored.
+function HashSet:remove(element)
+    return wrap(hash_map.delete(self._map, element))
+end
+
+HashSet.discard = HashSet.remove
+
+function HashSet:contains(element)
+    return self._map:has(element)
+end
+
+HashSet.has = HashSet.contains
+
+function HashSet:size()
+    return self._map:size()
+end
+
+HashSet.len = HashSet.size
+
+function HashSet:is_empty()
+    return self:size() == 0
+end
+
+function HashSet:to_list()
+    return self._map:keys()
+end
+
+function HashSet:capacity()
+    return self._map:capacity()
+end
+
+function HashSet:strategy()
+    return self._map:strategy()
+end
+
+function HashSet:hash_fn()
+    return self._map:hash_fn()
+end
+
+function HashSet:union(other)
+    local result = self:clone()
+    for _, element in ipairs(other:to_list()) do
+        result._map:set(element, PRESENT)
+    end
+    return result
+end
+
+function HashSet:intersection(other)
+    local smaller = self:size() <= other:size() and self or other
+    local larger = smaller == self and other or self
+    local result = empty_like(self)
+    for _, element in ipairs(smaller:to_list()) do
+        if larger:contains(element) then
+            result._map:set(element, PRESENT)
+        end
+    end
+    return result
+end
+
+function HashSet:difference(other)
+    local result = empty_like(self)
+    for _, element in ipairs(self:to_list()) do
+        if not other:contains(element) then
+            result._map:set(element, PRESENT)
+        end
+    end
+    return result
+end
+
+function HashSet:symmetric_difference(other)
+    local result = empty_like(self)
+    for _, element in ipairs(self:to_list()) do
+        if not other:contains(element) then
+            result._map:set(element, PRESENT)
+        end
+    end
+    for _, element in ipairs(other:to_list()) do
+        if not self:contains(element) then
+            result._map:set(element, PRESENT)
+        end
+    end
+    return result
+end
+
+function HashSet:is_subset(other)
+    if self:size() > other:size() then
+        return false
+    end
+    for _, element in ipairs(self:to_list()) do
+        if not other:contains(element) then
+            return false
+        end
+    end
+    return true
+end
+
+function HashSet:is_superset(other)
+    return other:is_subset(self)
+end
+
+function HashSet:is_disjoint(other)
+    local smaller = self:size() <= other:size() and self or other
+    local larger = smaller == self and other or self
+    for _, element in ipairs(smaller:to_list()) do
+        if larger:contains(element) then
+            return false
+        end
+    end
+    return true
+end
+
+function HashSet:equals(other)
+    return self:size() == other:size() and self:is_subset(other)
+end
+
+HashSet.__len = HashSet.size
+HashSet.__tostring = function(self)
+    return string.format(
+        "HashSet(strategy=%s, hash_fn=%s, size=%d, capacity=%d)",
+        self:strategy(),
+        self:hash_fn(),
+        self:size(),
+        self:capacity()
+    )
+end
+
+function M.add(set, element) return set:add(element) end
+function M.remove(set, element) return set:remove(element) end
+function M.discard(set, element) return set:discard(element) end
+function M.contains(set, element) return set:contains(element) end
+function M.has(set, element) return set:has(element) end
+function M.size(set) return set:size() end
+function M.is_empty(set) return set:is_empty() end
+function M.to_list(set) return set:to_list() end
+function M.union(set, other) return set:union(other) end
+function M.intersection(set, other) return set:intersection(other) end
+function M.difference(set, other) return set:difference(other) end
+function M.symmetric_difference(set, other) return set:symmetric_difference(other) end
+function M.is_subset(set, other) return set:is_subset(other) end
+function M.is_superset(set, other) return set:is_superset(other) end
+function M.is_disjoint(set, other) return set:is_disjoint(other) end
+function M.equals(set, other) return set:equals(other) end
+
+M.HashSet = HashSet
+M.new = HashSet.new
+M.new_set = HashSet.new
+M.with_options = HashSet.with_options
+M.from_list = HashSet.from_list
+M.from_list_with_options = HashSet.from_list_with_options
+
+return M

--- a/code/packages/lua/hash-set/tests/test_hash_set.lua
+++ b/code/packages/lua/hash-set/tests/test_hash_set.lua
@@ -1,0 +1,139 @@
+local hash_set = require("coding_adventures.hash_set")
+
+local function sorted(values)
+    table.sort(values)
+    return values
+end
+
+local function for_each_strategy(callback)
+    for _, strategy in ipairs({ "chaining", "open_addressing" }) do
+        callback(strategy)
+    end
+end
+
+describe("HashSet", function()
+    it("deduplicates elements and checks membership with both strategies", function()
+        for_each_strategy(function(strategy)
+            local set = hash_set.from_list({ 1, 1, 2, 2, 3 }, 4, strategy)
+            assert.equals(3, set:size())
+            assert.equals(3, #set)
+            assert.is_true(set:contains(1))
+            assert.is_true(set:has(2))
+            assert.is_false(set:contains(4))
+            assert.is_false(set:is_empty())
+            assert.same({ 1, 2, 3 }, sorted(set:to_list()))
+        end)
+    end)
+
+    it("adds, removes, and discards persistently", function()
+        local base = hash_set.from_list({ "alpha", "beta" })
+        local added = base:add("gamma")
+        local removed = added:remove("alpha")
+        local unchanged = removed:discard("missing")
+        assert.same({ "alpha", "beta" }, sorted(base:to_list()))
+        assert.same({ "alpha", "beta", "gamma" }, sorted(added:to_list()))
+        assert.same({ "beta", "gamma" }, sorted(removed:to_list()))
+        assert.same({ "beta", "gamma" }, sorted(unchanged:to_list()))
+    end)
+
+    it("supports complete set algebra", function()
+        local left = hash_set.from_list({ 1, 2, 3, 4, 5 })
+        local right = hash_set.from_list({ 3, 4, 5, 6, 7 })
+        assert.same({ 1, 2, 3, 4, 5, 6, 7 }, sorted(left:union(right):to_list()))
+        assert.same({ 3, 4, 5 }, sorted(left:intersection(right):to_list()))
+        assert.same({ 1, 2 }, sorted(left:difference(right):to_list()))
+        assert.same({ 1, 2, 6, 7 }, sorted(left:symmetric_difference(right):to_list()))
+        assert.same({ 1, 2, 3, 4, 5 }, sorted(left:to_list()))
+    end)
+
+    it("supports subset, superset, disjoint, and equality checks", function()
+        local subset = hash_set.from_list({ 1, 2, 3 })
+        local superset = hash_set.from_list({ 1, 2, 3, 4, 5 })
+        local disjoint = hash_set.from_list({ 10, 20 })
+        assert.is_true(subset:is_subset(superset))
+        assert.is_true(superset:is_superset(subset))
+        assert.is_false(superset:is_subset(subset))
+        assert.is_true(subset:is_disjoint(disjoint))
+        assert.is_false(subset:is_disjoint(superset))
+        assert.is_true(subset:equals(hash_set.from_list({ 3, 2, 1 })))
+        assert.is_false(subset:equals(superset))
+        assert.is_true(hash_set.new():is_subset(subset))
+    end)
+
+    it("preserves hash-map options across persistent operations", function()
+        local set = hash_set.with_options(4, "open", "murmur3_32")
+            :add("Ada")
+            :add("Grace")
+        assert.equals("open_addressing", set:strategy())
+        assert.equals("murmur3", set:hash_fn())
+        assert.is_true(set:capacity() >= 4)
+        local seeded = hash_set.from_list_with_options(
+            { "a", "b", "b", "c" },
+            2,
+            "chaining",
+            "djb2"
+        )
+        assert.equals(3, seeded:size())
+        assert.equals("chaining", seeded:strategy())
+        assert.equals("djb2", seeded:hash_fn())
+        assert.equals("open_addressing", set:intersection(seeded):strategy())
+        assert.equals("open_addressing", set:union(seeded):strategy())
+    end)
+
+    it("offers free-function wrappers", function()
+        local set = hash_set.from_list({ 10, 20 })
+        set = hash_set.add(set, 30)
+        assert.is_true(hash_set.contains(set, 30))
+        set = hash_set.remove(set, 20)
+        assert.is_false(hash_set.has(set, 20))
+        set = hash_set.discard(set, 99)
+        local other = hash_set.from_list({ 30, 40 })
+        local unioned = hash_set.union(set, other)
+        assert.same({ 10, 30, 40 }, sorted(hash_set.to_list(unioned)))
+        assert.same({ 30 }, sorted(hash_set.intersection(set, other):to_list()))
+        assert.same({ 10 }, sorted(hash_set.difference(set, other):to_list()))
+        assert.same({ 10, 40 }, sorted(hash_set.symmetric_difference(set, other):to_list()))
+        assert.is_true(hash_set.is_subset(set, unioned))
+        assert.is_true(hash_set.is_superset(unioned, set))
+        assert.is_true(hash_set.is_disjoint(set, hash_set.from_list({ 999 })))
+        assert.is_true(hash_set.equals(set, set:clone()))
+    end)
+
+    it("uses identity semantics for reference elements", function()
+        local reference = {}
+        local other_reference = {}
+        local set = hash_set.from_list({ reference, reference, other_reference })
+        assert.equals(2, set:size())
+        assert.is_true(set:contains(reference))
+        assert.is_true(set:contains(other_reference))
+        assert.is_false(set:contains({}))
+        assert.is_true(set:remove(reference):contains(other_reference))
+    end)
+
+    it("retains all elements through underlying map resizes", function()
+        for_each_strategy(function(strategy)
+            local set = hash_set.new(2, strategy)
+            for index = 1, 100 do
+                set = set:add("key-" .. index)
+            end
+            assert.equals(100, set:size())
+            assert.is_true(set:capacity() >= 100)
+            for index = 1, 100 do
+                assert.is_true(set:contains("key-" .. index))
+            end
+        end)
+    end)
+
+    it("rejects invalid constructors and nil elements", function()
+        assert.has_error(function() hash_set.from_list("not-an-array") end,
+            "elements must be an array")
+        assert.has_error(function() hash_set.new(0) end,
+            "capacity must be a positive integer")
+        assert.has_error(function() hash_set.new(4, "quadratic") end,
+            "strategy must be 'chaining' or 'open_addressing'")
+        assert.has_error(function() hash_set.new(4, nil, "sha256") end,
+            "hash_fn must be 'fnv1a', 'murmur3', or 'djb2'")
+        assert.has_error(function() hash_set.new():add(nil) end,
+            "element must not be nil")
+    end)
+end)

--- a/code/packages/perl/hash-set/BUILD
+++ b/code/packages/perl/hash-set/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=../hash-map/lib:../hash-functions/lib prove -l -v t/

--- a/code/packages/perl/hash-set/BUILD_windows
+++ b/code/packages/perl/hash-set/BUILD_windows
@@ -1,0 +1,1 @@
+set PERL5LIB=..\hash-map\lib;..\hash-functions\lib && perl -Ilib t/00-load.t && perl -Ilib t/01-hash-set.t

--- a/code/packages/perl/hash-set/CHANGELOG.md
+++ b/code/packages/perl/hash-set/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - 2026-07-16
+
+- Add a persistent DT19 hash set backed by the Perl DT18 hash map.
+- Add complete set algebra, relation predicates, option preservation, and
+  reference-identity support.
+- Add MakeMaker metadata, capability declaration, and Test::More coverage.

--- a/code/packages/perl/hash-set/Makefile.PL
+++ b/code/packages/perl/hash-set/Makefile.PL
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::HashSet',
+    VERSION_FROM     => 'lib/CodingAdventures/HashSet.pm',
+    ABSTRACT         => 'Persistent hash set with complete set algebra',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::HashMap' => 0,
+        'Exporter'                  => 0,
+        'Scalar::Util'              => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/hash-set/README.md
+++ b/code/packages/perl/hash-set/README.md
@@ -1,0 +1,25 @@
+# Hash Set (Perl)
+
+A pure Perl implementation of [DT19](../../../specs/DT19-hash-set.md). It
+wraps the sibling DT18 `hash-map` package and stores elements as keys with one
+sentinel value. Every add and remove returns a new set while leaving the input
+unchanged.
+
+```perl
+use CodingAdventures::HashSet qw(from_list);
+
+my $base = from_list([qw(Ada Grace Ada)]);
+my $next = $base->add('Linus');
+
+die unless $base->size == 2;
+die unless $next->contains('Linus');
+die unless $next->intersection($base)->equals($base);
+```
+
+The package includes union, intersection, difference, symmetric difference,
+subset, superset, disjoint, and equality operations. Hash-map capacity,
+collision strategy, and hash-function options are preserved across persistent
+operations.
+
+Run the package gate from this directory with the commands in `BUILD` or
+`BUILD_windows`.

--- a/code/packages/perl/hash-set/cpanfile
+++ b/code/packages/perl/hash-set/cpanfile
@@ -1,0 +1,1 @@
+requires 'CodingAdventures::HashMap', '>= 0.1.0';

--- a/code/packages/perl/hash-set/lib/CodingAdventures/HashSet.pm
+++ b/code/packages/perl/hash-set/lib/CodingAdventures/HashSet.pm
@@ -1,0 +1,244 @@
+package CodingAdventures::HashSet;
+
+use strict;
+use warnings;
+use Exporter qw(import);
+use Scalar::Util qw(blessed);
+use CodingAdventures::HashMap;
+
+our $VERSION = '0.1.0';
+our @EXPORT_OK = qw(
+    new_set with_options from_list from_list_with_options
+    add remove discard contains has size is_empty to_list
+    union intersection difference symmetric_difference
+    is_subset is_superset is_disjoint equals
+);
+
+my $PRESENT = 1;
+
+sub _from_map {
+    my ($invocant, $map) = @_;
+    my $class = ref($invocant) || $invocant;
+    return bless { map => $map }, $class;
+}
+
+sub _require_set {
+    my ($value, $name) = @_;
+    die "$name must be a CodingAdventures::HashSet\n"
+        unless blessed($value) && $value->isa(__PACKAGE__);
+    return $value;
+}
+
+sub new {
+    my ($class, %args) = @_;
+    my %map_args;
+    $map_args{capacity} = $args{capacity} if exists $args{capacity};
+    $map_args{strategy} = $args{strategy} if exists $args{strategy};
+    $map_args{hash_fn} = $args{hash_fn} if exists $args{hash_fn};
+    return $class->_from_map(CodingAdventures::HashMap->new(%map_args));
+}
+
+sub new_set {
+    return __PACKAGE__->new(@_);
+}
+
+sub with_options {
+    my ($first, @rest) = @_;
+    my ($class, $capacity, $strategy, $hash_fn);
+    if (!ref($first) && defined($first) && $first eq __PACKAGE__) {
+        $class = $first;
+        ($capacity, $strategy, $hash_fn) = @rest;
+    } else {
+        $class = __PACKAGE__;
+        ($capacity, $strategy, $hash_fn) = ($first, @rest);
+    }
+    return $class->new(
+        capacity => $capacity,
+        strategy => $strategy,
+        hash_fn  => $hash_fn,
+    );
+}
+
+sub from_list {
+    my ($first, @rest) = @_;
+    my ($class, $elements);
+    if (!ref($first) && defined($first) && $first eq __PACKAGE__) {
+        $class = $first;
+        $elements = shift @rest;
+    } else {
+        $class = __PACKAGE__;
+        $elements = $first;
+    }
+    die "elements must be an array reference\n" unless ref($elements) eq 'ARRAY';
+    die "options must be key-value pairs\n" if @rest % 2;
+    my $set = $class->new(@rest);
+    for my $element (@{$elements}) {
+        die "element must be defined\n" unless defined $element;
+        $set->{map}->set($element, $PRESENT);
+    }
+    return $set;
+}
+
+sub from_list_with_options {
+    my ($first, @rest) = @_;
+    my ($class, $elements);
+    if (!ref($first) && defined($first) && $first eq __PACKAGE__) {
+        $class = $first;
+        $elements = shift @rest;
+    } else {
+        $class = __PACKAGE__;
+        $elements = $first;
+    }
+    my ($capacity, $strategy, $hash_fn) = @rest;
+    return $class->from_list(
+        $elements,
+        capacity => $capacity,
+        strategy => $strategy,
+        hash_fn  => $hash_fn,
+    );
+}
+
+sub clone {
+    my ($self) = @_;
+    return $self->_from_map($self->{map}->clone);
+}
+
+sub add {
+    my ($self, $element) = @_;
+    die "element must be defined\n" unless defined $element;
+    return $self->_from_map($self->{map}->with_set($element, $PRESENT));
+}
+
+sub remove {
+    my ($self, $element) = @_;
+    return $self->_from_map($self->{map}->without($element));
+}
+
+sub discard {
+    my ($self, $element) = @_;
+    return $self->remove($element);
+}
+
+sub contains {
+    my ($self, $element) = @_;
+    return $self->{map}->has($element);
+}
+
+sub has { return shift->contains(@_); }
+sub size { return $_[0]->{map}->size; }
+sub len { return $_[0]->size; }
+sub is_empty { return $_[0]->size == 0; }
+sub to_list { return $_[0]->{map}->keys; }
+sub capacity { return $_[0]->{map}->capacity; }
+sub strategy { return $_[0]->{map}->strategy; }
+sub hash_fn { return $_[0]->{map}->hash_fn; }
+
+sub _empty_like {
+    my ($self) = @_;
+    return $self->_from_map(CodingAdventures::HashMap->new(
+        capacity => $self->capacity,
+        strategy => $self->strategy,
+        hash_fn  => $self->hash_fn,
+    ));
+}
+
+sub union {
+    my ($self, $other) = @_;
+    _require_set($other, 'other');
+    my $result = $self->clone;
+    $result->{map}->set($_, $PRESENT) for @{$other->to_list};
+    return $result;
+}
+
+sub intersection {
+    my ($self, $other) = @_;
+    _require_set($other, 'other');
+    my ($smaller, $larger) = $self->size <= $other->size
+        ? ($self, $other)
+        : ($other, $self);
+    my $result = $self->_empty_like;
+    for my $element (@{$smaller->to_list}) {
+        $result->{map}->set($element, $PRESENT) if $larger->contains($element);
+    }
+    return $result;
+}
+
+sub difference {
+    my ($self, $other) = @_;
+    _require_set($other, 'other');
+    my $result = $self->_empty_like;
+    for my $element (@{$self->to_list}) {
+        $result->{map}->set($element, $PRESENT) unless $other->contains($element);
+    }
+    return $result;
+}
+
+sub symmetric_difference {
+    my ($self, $other) = @_;
+    _require_set($other, 'other');
+    my $result = $self->_empty_like;
+    for my $element (@{$self->to_list}) {
+        $result->{map}->set($element, $PRESENT) unless $other->contains($element);
+    }
+    for my $element (@{$other->to_list}) {
+        $result->{map}->set($element, $PRESENT) unless $self->contains($element);
+    }
+    return $result;
+}
+
+sub is_subset {
+    my ($self, $other) = @_;
+    _require_set($other, 'other');
+    return 0 if $self->size > $other->size;
+    for my $element (@{$self->to_list}) {
+        return 0 unless $other->contains($element);
+    }
+    return 1;
+}
+
+sub is_superset {
+    my ($self, $other) = @_;
+    _require_set($other, 'other');
+    return $other->is_subset($self);
+}
+
+sub is_disjoint {
+    my ($self, $other) = @_;
+    _require_set($other, 'other');
+    my ($smaller, $larger) = $self->size <= $other->size
+        ? ($self, $other)
+        : ($other, $self);
+    for my $element (@{$smaller->to_list}) {
+        return 0 if $larger->contains($element);
+    }
+    return 1;
+}
+
+sub equals {
+    my ($self, $other) = @_;
+    _require_set($other, 'other');
+    return $self->size == $other->size && $self->is_subset($other);
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+CodingAdventures::HashSet - persistent DT19 hash set
+
+=head1 SYNOPSIS
+
+  use CodingAdventures::HashSet qw(from_list);
+  my $base = from_list([qw(Ada Grace Ada)]);
+  my $next = $base->add('Linus');
+  die unless $base->size == 2 && $next->contains('Linus');
+
+=head1 DESCRIPTION
+
+Wraps the sibling DT18 hash map with a keys-only persistent set abstraction.
+Includes full set algebra, relation predicates, option preservation, and
+reference-identity semantics.
+
+=cut

--- a/code/packages/perl/hash-set/required_capabilities.json
+++ b/code/packages/perl/hash-set/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/hash-set",
+  "capabilities": [],
+  "justification": "Pure in-memory set algebra over the sibling hash-map package. No filesystem, network, process, environment, or randomness access needed."
+}

--- a/code/packages/perl/hash-set/t/00-load.t
+++ b/code/packages/perl/hash-set/t/00-load.t
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+BEGIN { use_ok('CodingAdventures::HashSet') }
+
+ok(defined $CodingAdventures::HashSet::VERSION, 'has a VERSION');

--- a/code/packages/perl/hash-set/t/01-hash-set.t
+++ b/code/packages/perl/hash-set/t/01-hash-set.t
@@ -1,0 +1,145 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::HashSet qw(
+    new_set with_options from_list from_list_with_options
+    add remove discard contains has size is_empty to_list
+    union intersection difference symmetric_difference
+    is_subset is_superset is_disjoint equals
+);
+
+sub sorted_numbers {
+    my ($set) = @_;
+    return [sort { $a <=> $b } @{$set->to_list}];
+}
+
+sub sorted_strings {
+    my ($set) = @_;
+    return [sort @{$set->to_list}];
+}
+
+sub dies_like {
+    my ($code, $pattern, $name) = @_;
+    my $ok = !eval { $code->(); 1 };
+    ok($ok, $name);
+    like($@, $pattern, "$name message") if $ok;
+}
+
+subtest 'deduplicates and checks membership with both strategies' => sub {
+    for my $strategy (qw(chaining open_addressing)) {
+        my $set = CodingAdventures::HashSet->from_list(
+            [1, 1, 2, 2, 3],
+            capacity => 4,
+            strategy => $strategy,
+        );
+        is($set->size, 3, "$strategy size");
+        is($set->len, 3, "$strategy len");
+        ok($set->contains(1), "$strategy contains");
+        ok($set->has(2), "$strategy has alias");
+        ok(!$set->contains(4), "$strategy missing");
+        ok(!$set->is_empty, "$strategy nonempty");
+        is_deeply(sorted_numbers($set), [1, 2, 3], "$strategy values");
+    }
+};
+
+subtest 'add remove and discard are persistent' => sub {
+    my $base = from_list([qw(alpha beta)]);
+    my $added = $base->add('gamma');
+    my $removed = $added->remove('alpha');
+    my $unchanged = $removed->discard('missing');
+    is_deeply(sorted_strings($base), [qw(alpha beta)], 'base unchanged');
+    is_deeply(sorted_strings($added), [qw(alpha beta gamma)], 'add result');
+    is_deeply(sorted_strings($removed), [qw(beta gamma)], 'remove result');
+    is_deeply(sorted_strings($unchanged), [qw(beta gamma)], 'discard missing');
+};
+
+subtest 'complete set algebra works' => sub {
+    my $left = from_list([1, 2, 3, 4, 5]);
+    my $right = from_list([3, 4, 5, 6, 7]);
+    is_deeply(sorted_numbers($left->union($right)), [1 .. 7], 'union');
+    is_deeply(sorted_numbers($left->intersection($right)), [3, 4, 5], 'intersection');
+    is_deeply(sorted_numbers($left->difference($right)), [1, 2], 'difference');
+    is_deeply(sorted_numbers($left->symmetric_difference($right)), [1, 2, 6, 7], 'symmetric difference');
+    is_deeply(sorted_numbers($left), [1, 2, 3, 4, 5], 'left unchanged');
+};
+
+subtest 'relation predicates cover empty and overlapping sets' => sub {
+    my $subset = from_list([1, 2, 3]);
+    my $superset = from_list([1, 2, 3, 4, 5]);
+    my $disjoint = from_list([10, 20]);
+    ok($subset->is_subset($superset), 'subset');
+    ok($superset->is_superset($subset), 'superset');
+    ok(!$superset->is_subset($subset), 'not subset');
+    ok($subset->is_disjoint($disjoint), 'disjoint');
+    ok(!$subset->is_disjoint($superset), 'overlap');
+    ok($subset->equals(from_list([3, 2, 1])), 'equals');
+    ok(!$subset->equals($superset), 'not equals');
+    ok(new_set()->is_subset($subset), 'empty subset');
+};
+
+subtest 'hash map options are preserved' => sub {
+    my $set = with_options(4, 'open', 'murmur3_32')->add('Ada')->add('Grace');
+    is($set->strategy, 'open_addressing', 'strategy normalized');
+    is($set->hash_fn, 'murmur3', 'hash normalized');
+    cmp_ok($set->capacity, '>=', 4, 'capacity preserved');
+    my $seeded = from_list_with_options([qw(a b b c)], 2, 'chaining', 'djb2');
+    is($seeded->size, 3, 'seeded deduplicates');
+    is($seeded->strategy, 'chaining', 'seeded strategy');
+    is($seeded->hash_fn, 'djb2', 'seeded hash');
+    is($set->intersection($seeded)->strategy, 'open_addressing', 'left options preserved');
+    is($set->union($seeded)->strategy, 'open_addressing', 'union preserves left options');
+};
+
+subtest 'exported functional wrappers work' => sub {
+    my $set = from_list([10, 20]);
+    $set = add($set, 30);
+    ok(contains($set, 30), 'contains wrapper');
+    $set = remove($set, 20);
+    ok(!has($set, 20), 'remove and has wrappers');
+    $set = discard($set, 99);
+    my $other = from_list([30, 40]);
+    my $unioned = union($set, $other);
+    is_deeply(sorted_numbers($unioned), [10, 30, 40], 'union wrapper');
+    is_deeply(sorted_numbers(intersection($set, $other)), [30], 'intersection wrapper');
+    is_deeply(sorted_numbers(difference($set, $other)), [10], 'difference wrapper');
+    is_deeply(sorted_numbers(symmetric_difference($set, $other)), [10, 40], 'symmetric wrapper');
+    ok(is_subset($set, $unioned), 'subset wrapper');
+    ok(is_superset($unioned, $set), 'superset wrapper');
+    ok(is_disjoint($set, from_list([999])), 'disjoint wrapper');
+    ok(equals($set, $set->clone), 'equals wrapper');
+    is(size($set), 2, 'size wrapper');
+    ok(!is_empty($set), 'empty wrapper');
+    is_deeply([sort { $a <=> $b } @{to_list($set)}], [10, 30], 'list wrapper');
+};
+
+subtest 'reference elements use identity semantics' => sub {
+    my $reference = [];
+    my $other_reference = [];
+    my $set = from_list([$reference, $reference, $other_reference]);
+    is($set->size, 2, 'duplicate reference ignored');
+    ok($set->contains($reference), 'first reference found');
+    ok($set->contains($other_reference), 'second reference found');
+    ok(!$set->contains([]), 'different reference absent');
+    ok($set->remove($reference)->contains($other_reference), 'other reference survives');
+};
+
+subtest 'underlying map resizes retain every element' => sub {
+    for my $strategy (qw(chaining open_addressing)) {
+        my $set = new_set(capacity => 2, strategy => $strategy);
+        $set = $set->add("key-$_") for 1 .. 100;
+        is($set->size, 100, "$strategy size");
+        cmp_ok($set->capacity, '>=', 100, "$strategy capacity");
+        ok($set->contains("key-$_"), "$strategy key $_") for 1 .. 100;
+    }
+};
+
+subtest 'invalid inputs are rejected' => sub {
+    dies_like(sub { from_list('not-an-array') }, qr/elements must be an array reference/, 'non-array');
+    dies_like(sub { new_set(capacity => 0) }, qr/capacity must be a positive integer/, 'zero capacity');
+    dies_like(sub { new_set(strategy => 'quadratic') }, qr/strategy must be 'chaining' or 'open_addressing'/, 'strategy');
+    dies_like(sub { new_set(hash_fn => 'sha256') }, qr/hash_fn must be 'fnv1a', 'murmur3', or 'djb2'/, 'hash');
+    dies_like(sub { new_set()->add(undef) }, qr/element must be defined/, 'undef element');
+    dies_like(sub { new_set()->union('not-a-set') }, qr/other must be a CodingAdventures::HashSet/, 'other type');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -109,11 +109,11 @@ on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
 `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
 the paired `hash-functions` prerequisite, and the paired `bloom-filter` and
-`hash-map` ports:
+`hash-map` and `hash-set` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 349 |
+| Present in 10-15 languages | 172 | 347 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -166,8 +166,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 3 | Pair with Perl data-structure/storage wave |
-| Perl | 3 | Pair with Lua data-structure/storage wave |
+| Lua | 2 | Pair with Perl data-structure/storage wave |
+| Perl | 2 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -179,10 +179,10 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first fourteen paired Lua/Perl slices are complete: `fenwick-tree`,
+The first fifteen paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
-`avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and
-`resp-protocol`, `hash-functions`, `bloom-filter`, and `hash-map`
+`avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, `radix-tree`,
+`resp-protocol`, `hash-functions`, `bloom-filter`, `hash-map`, and `hash-set`
 now have pure implementations, package-native tests, metadata, and capability
 declarations in both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
@@ -209,8 +209,13 @@ The hash-map slice implements both DT18 collision strategies from first
 principles, including chaining, linear probing, tombstone deletion, automatic
 resizing, deterministic DT17 bucket hashes, bulk access, merge, and clone-based
 functional operations. It reduces the paired high-consensus gap to three
-packages per lane and supplies the direct dependency for the next `hash-set`
-slice.
+packages per lane and supplies the direct dependency for the `hash-set` slice.
+The hash-set slice composes that map into a persistent DT19 collection with
+copy-on-write add and remove, complete set algebra and relation predicates,
+option preservation, identity-safe reference elements, and resize coverage for
+both collision strategies. It reduces the paired high-consensus gap to two
+packages per lane, leaving the higher in-memory data store layers as the final
+paired wave.
 
 Recommended family order:
 


### PR DESCRIPTION
## What

- add native DT19 `hash-set` packages for Lua and Perl, built on their DT18 `hash-map` ports
- implement persistent add/remove/discard operations, membership, cloning, list conversion, full set algebra, subset/superset/disjoint/equality predicates, and functional wrapper APIs
- preserve capacity, collision-strategy, and custom-hash options across derived sets, with reference keys compared by identity
- update the package-parity roadmap and measured inventory

## Why this is next

After the paired Lua/Perl `hash-map` port merged, `hash-set` became the smallest dependency-safe high-consensus gap. The only paired gaps now remaining in these languages are `in-memory-data-store` and `in-memory-data-store-engine`.

## Validation

- LuaRocks lint and local install
- Lua Busted suite: 9 successes, 0 failures
- Perl syntax/load checks and Test::More suite: 9 subtests
- randomized reference-model validation: 10,000 operations in each language
- Perl MakeMaker generation outside the repository, warning-free
- both capability manifests validated against the repository schema
- parity reporter unit tests: 6 passed
- fresh parity report: 172 high-consensus packages, 347 missing slots, 0 collisions
- `git diff --check`

## Remaining paired gaps

- Lua: `in-memory-data-store`, `in-memory-data-store-engine`
- Perl: `in-memory-data-store`, `in-memory-data-store-engine`
