### PR TITLE
feat(sql): LIKE … ESCAPE clause (+ fix NOT LIKE inversion)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.38 — LIKE … ESCAPE, and NOT LIKE inversion fix
+
+`X LIKE Y ESCAPE Z` now parses and evaluates: the escape character makes a
+following `%`, `_`, or itself a literal in the pattern (e.g. `'100%' LIKE '100#%'
+ESCAPE '#'`). While wiring the negation through, this also fixes a pre-existing
+bug where **`NOT LIKE` behaved exactly like `LIKE`** (the `NOT` was dropped);
+`NOT LIKE` now correctly inverts the match, with `NULL` operands staying `NULL`.
+Three differential-oracle cases; touches sql-parser 0.1.19, sql-planner 0.2.18,
+sql-codegen 0.6.6, sql-optimizer 0.1.5, sql-vm 0.4.20. (Note: `ESCAPE '\'` with
+a *string-literal* pattern is still affected by a separate lexer bug that strips
+backslashes in string literals — tracked separately; column-valued patterns and
+non-backslash escape characters work.)
+
 ## 0.5.37 — substr() start-zero and negative-length edge cases
 
 `substr()` now matches SQLite on its two fiddly edges: `substr('hello',0)` is

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.37"
+version = "0.5.38"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1312,6 +1312,39 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id, substr(s,2,-1) AS a, substr(s,0) AS b FROM t ORDER BY id",
     },
+    // ---- Lane 2: LIKE … ESCAPE ------------------------------------------
+    // The escape character makes a following `%`/`_`/itself a literal. We use
+    // `#`/`/` (not backslash) as the escape so the string lexer doesn't touch
+    // the pattern literal.
+    Case {
+        id: "like_escape_literal_wildcards",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT ('a%b' LIKE 'a#%b' ESCAPE '#') AS a, \
+                ('100x' LIKE '100#%' ESCAPE '#') AS b, \
+                ('a_b' LIKE 'a#_b' ESCAPE '#') AS c, \
+                ('axb' LIKE 'a#_b' ESCAPE '#') AS d, \
+                ('50%off' LIKE '50#%%' ESCAPE '#') AS e, \
+                ('a/b' LIKE 'a//b' ESCAPE '/') AS f FROM t",
+    },
+    // NOT LIKE (with and without ESCAPE) inverts the match; NULL stays NULL.
+    Case {
+        id: "not_like_and_null",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT ('abc' NOT LIKE 'x%') AS a, ('abc' NOT LIKE 'a%') AS b, \
+                ('a%c' NOT LIKE 'a#%c' ESCAPE '#') AS c, \
+                ('abc' NOT LIKE 'a#%c' ESCAPE '#') AS d, \
+                (NULL LIKE 'x') AS e, (NULL NOT LIKE 'x' ESCAPE '#') AS f FROM t",
+    },
+    // Per-row LIKE ESCAPE over a column: match rows whose code contains a
+    // literal percent sign.
+    Case {
+        id: "like_escape_per_row",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, code TEXT)",
+            "INSERT INTO t VALUES (1,'10%'),(2,'10x'),(3,'a%b')",
+        ],
+        query: "SELECT id FROM t WHERE code LIKE '%#%%' ESCAPE '#' ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.6.6] - Unreleased
+
+### Changed
+
+- `Instruction::Like` now carries a `bool` `NOT` flag, and a new
+  `Instruction::LikeEscape(bool)` handles `LIKE … ESCAPE`. `NOT LIKE` is lowered
+  by setting the flag rather than being dropped, so the VM applies a NULL-aware
+  inversion.
+
 ## [0.6.5] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -292,13 +292,24 @@ pub enum Instruction {
     /// ## Stack effect: `[..., value, low, high] → [..., Bool]`
     Between(bool), // inclusive
 
-    /// SQL `LIKE` pattern match.
+    /// SQL `LIKE` / `NOT LIKE` pattern match.
     ///
-    /// Expects `[..., value, pattern]` (pattern on top).
-    /// Pops both; pushes a Bool result.
+    /// Expects `[..., value, pattern]` (pattern on top). Pops both; pushes a
+    /// Bool result (or NULL if either operand is NULL). The `bool` payload is the
+    /// `NOT` flag: when `true`, the (non-NULL) match result is inverted.
     ///
     /// ## Stack effect: `[..., value, pattern] → [..., Bool]`
-    Like,
+    Like(bool),
+
+    /// SQL `LIKE` / `NOT LIKE` with an `ESCAPE ch` clause.
+    ///
+    /// Expects `[..., value, pattern, escape]` (escape on top). The escape
+    /// value's first character makes a following `%`, `_`, or the escape
+    /// character itself a literal in the pattern. The `bool` payload is the `NOT`
+    /// flag (see [`Instruction::Like`]).
+    ///
+    /// ## Stack effect: `[..., value, pattern, escape] → [..., Bool]`
+    LikeEscape(bool),
 
     /// SQL `CAST(value AS type)` — pop one value, push its conversion.
     ///
@@ -2022,14 +2033,22 @@ impl Compiler {
             SqlExpr::Like {
                 value,
                 pattern,
-                negated: _,
+                negated,
+                escape,
             } => {
-                // Stack: [value, pattern] (pattern on top).
-                // The VM applies the LIKE match.  For NOT LIKE, the caller
-                // (optimizer or VM) applies NOT to the result.
+                // Stack: [value, pattern] (pattern on top), plus [escape] when an
+                // ESCAPE clause is present. The VM applies the LIKE match and,
+                // for `NOT LIKE`, the NULL-aware inversion carried by the
+                // instruction's `negated` flag.
                 self.compile_expr(value);
                 self.compile_expr(pattern);
-                self.emit(Instruction::Like);
+                match escape {
+                    Some(escape_expr) => {
+                        self.compile_expr(escape_expr);
+                        self.emit(Instruction::LikeEscape(*negated));
+                    }
+                    None => self.emit(Instruction::Like(*negated)),
+                }
             }
 
             // ── CAST ─────────────────────────────────────────────────────────
@@ -3406,10 +3425,11 @@ mod tests {
                 value: Box::new(col("name")),
                 pattern: Box::new(lit_text("A%")),
                 negated: false,
+                escape: None,
             },
         });
         let v = instrs(&plan);
-        assert!(v.iter().any(|i| matches!(i, Instruction::Like)));
+        assert!(v.iter().any(|i| matches!(i, Instruction::Like(_))));
     }
 
     #[test]

--- a/code/packages/rust/sql-optimizer/CHANGELOG.md
+++ b/code/packages/rust/sql-optimizer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this crate will be documented here.
 
+## [0.1.5] - Unreleased
+
+### Changed
+
+- Constant folding and column collection recurse into the new `SqlExpr::Like`
+  `escape` operand.
+
 ## [0.1.4] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-optimizer/Cargo.toml
+++ b/code/packages/rust/sql-optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-optimizer"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Logical query plan optimizer for the Mini-SQLite SQL pipeline (Level 1)"
 authors = ["Adhithya Rajasekaran <adhithyan15@gmail.com>"]

--- a/code/packages/rust/sql-optimizer/src/lib.rs
+++ b/code/packages/rust/sql-optimizer/src/lib.rs
@@ -657,10 +657,12 @@ fn fold_expr(expr: SqlExpr) -> SqlExpr {
             value,
             pattern,
             negated,
+            escape,
         } => Like {
             value: Box::new(fold_expr(*value)),
             pattern: Box::new(fold_expr(*pattern)),
             negated,
+            escape: escape.map(|e| Box::new(fold_expr(*e))),
         },
 
         InList {
@@ -1319,9 +1321,17 @@ fn collect_columns_in_expr(expr: &SqlExpr, out: &mut HashSet<String>) {
             collect_columns_in_expr(low, out);
             collect_columns_in_expr(high, out);
         }
-        SqlExpr::Like { value, pattern, .. } => {
+        SqlExpr::Like {
+            value,
+            pattern,
+            escape,
+            ..
+        } => {
             collect_columns_in_expr(value, out);
             collect_columns_in_expr(pattern, out);
+            if let Some(escape) = escape {
+                collect_columns_in_expr(escape, out);
+            }
         }
         SqlExpr::InList { value, list, .. } => {
             collect_columns_in_expr(value, out);

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.19] - Unreleased
+
+### Added
+
+- Grammar for the `LIKE pattern ESCAPE ch` clause (and `NOT LIKE … ESCAPE`). The
+  ESCAPE variants are ordered before the plain `LIKE pattern` alternatives so the
+  backtracking parser prefers the longer match when an `ESCAPE` clause is present.
+
 ## [0.1.18] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -496,8 +496,25 @@ pub fn parser_grammar() -> ParserGrammar {
                             GrammarElement::RuleReference { name: r#"value_list"#.to_string() },
                             GrammarElement::Literal { value: r#")"#.to_string() },
                         ] },
+                        // `x LIKE pattern ESCAPE ch` — the ESCAPE variant is
+                        // listed BEFORE the plain `LIKE pattern` so the
+                        // backtracking parser prefers the longer match when an
+                        // `ESCAPE` clause is present, and falls back otherwise.
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"LIKE"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
+                            GrammarElement::Literal { value: r#"ESCAPE"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"LIKE"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"NOT"#.to_string() },
+                            GrammarElement::Literal { value: r#"LIKE"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
+                            GrammarElement::Literal { value: r#"ESCAPE"#.to_string() },
                             GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         GrammarElement::Sequence { elements: vec![

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.18] - Unreleased
+
+### Added
+
+- `SqlExpr::Like` gained an `escape: Option<Box<SqlExpr>>` field, and the
+  comparison parser now reads the optional `ESCAPE ch` operand of `LIKE` /
+  `NOT LIKE`.
+
 ## [0.2.17] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -115,13 +115,17 @@ pub enum SqlExpr {
         negated: bool,
     },
 
-    /// `value LIKE pattern` — SQL pattern matching.
+    /// `value LIKE pattern [ESCAPE ch]` — SQL pattern matching.
     ///
-    /// `negated = true` for `NOT LIKE`.
+    /// `negated = true` for `NOT LIKE`. `escape` carries the optional
+    /// `ESCAPE ch` operand (an expression, usually a one-character string
+    /// literal); when present, that character makes a following `%`, `_`, or
+    /// escape character itself a literal in the pattern.
     Like {
         value: Box<SqlExpr>,
         pattern: Box<SqlExpr>,
         negated: bool,
+        escape: Option<Box<SqlExpr>>,
     },
 
     /// `value IN (v1, v2, ...)` — membership test.
@@ -2147,18 +2151,28 @@ fn plan_comparison(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         });
     }
 
-    // LIKE / NOT LIKE
-    // Grammar: `[NOT] LIKE additive`
-    // The pattern is the 2nd child node.
+    // LIKE / NOT LIKE  [ESCAPE ch]
+    // Grammar: `[NOT] LIKE additive [ESCAPE additive]`
+    // Child nodes: [left, pattern] or [left, pattern, escape]; the `ESCAPE`
+    // keyword shows up as a direct token.
     if direct_tok_uppers.contains(&"LIKE".to_string()) {
         let negated = direct_tok_uppers.contains(&"NOT".to_string());
         let pattern_node = child_nodes_ordered
             .get(1)
             .ok_or_else(|| PlanError::UnsupportedStatement("LIKE missing pattern".to_string()))?;
+        let escape = if direct_tok_uppers.contains(&"ESCAPE".to_string()) {
+            let escape_node = child_nodes_ordered.get(2).ok_or_else(|| {
+                PlanError::UnsupportedStatement("LIKE ESCAPE missing character".to_string())
+            })?;
+            Some(Box::new(plan_expression(escape_node)?))
+        } else {
+            None
+        };
         return Ok(SqlExpr::Like {
             value: Box::new(left),
             pattern: Box::new(plan_expression(pattern_node)?),
             negated,
+            escape,
         });
     }
 

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.20] - Unreleased
+
+### Added
+
+- `Instruction::LikeEscape(negated)` implements `LIKE … ESCAPE` via
+  `like_match_escape`: the escape character before a `%`, `_`, or itself makes
+  that character a literal.
+
+### Fixed
+
+- **`NOT LIKE` was inverted** — the `negated` flag was dropped, so `NOT LIKE`
+  behaved like `LIKE`. `Instruction::Like` now carries the flag and both LIKE
+  instructions apply a NULL-aware inversion (`NULL` stays `NULL`;
+  `matched ^ negated` otherwise).
+
 ## [0.4.19] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -356,14 +356,56 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
                 stack.push(SqlValue::Bool(!matches!(v, SqlValue::Null)));
             }
 
-            // ─────────────── LIKE ──────────────────────────────────────────
-            Instruction::Like => {
+            // ─────────────── LIKE / NOT LIKE ────────────────────────────────
+            Instruction::Like(negated) => {
                 // Stack (top → bottom): pattern, value
                 let pat = pop(&mut stack)?;
                 let val = pop(&mut stack)?;
                 let result = match (&val, &pat) {
+                    // A NULL operand makes the whole predicate NULL, and `NOT`
+                    // leaves NULL unchanged (NULL is neither true nor false).
                     (SqlValue::Null, _) | (_, SqlValue::Null) => SqlValue::Null,
-                    _ => SqlValue::Bool(like_match(&sql_to_str(&val), &sql_to_str(&pat))),
+                    _ => {
+                        let matched = like_match(&sql_to_str(&val), &sql_to_str(&pat));
+                        SqlValue::Bool(matched ^ negated)
+                    }
+                };
+                stack.push(result);
+            }
+
+            // ─────────────── LIKE / NOT LIKE … ESCAPE ───────────────────────
+            Instruction::LikeEscape(negated) => {
+                // Stack (top → bottom): escape, pattern, value
+                let esc = pop(&mut stack)?;
+                let pat = pop(&mut stack)?;
+                let val = pop(&mut stack)?;
+                let result = match (&val, &pat, &esc) {
+                    // Any NULL operand — including a NULL escape — yields NULL,
+                    // which `NOT` leaves unchanged.
+                    (SqlValue::Null, _, _) | (_, SqlValue::Null, _) | (_, _, SqlValue::Null) => {
+                        SqlValue::Null
+                    }
+                    _ => {
+                        // SQLite requires the ESCAPE string to be exactly one
+                        // character; anything else is a runtime error.
+                        let esc_str = sql_to_str(&esc);
+                        let mut chars = esc_str.chars();
+                        match (chars.next(), chars.next()) {
+                            (Some(e), None) => {
+                                let matched = like_match_escape(
+                                    &sql_to_str(&val),
+                                    &sql_to_str(&pat),
+                                    e,
+                                );
+                                SqlValue::Bool(matched ^ negated)
+                            }
+                            _ => {
+                                return Err(VmError::TypeMismatch(
+                                    "ESCAPE expression must be a single character".to_string(),
+                                ))
+                            }
+                        }
+                    }
                 };
                 stack.push(result);
             }
@@ -2209,6 +2251,60 @@ fn like_match(text: &str, pattern: &str) -> bool {
     pi == p.len()
 }
 
+/// `LIKE` matching with an `ESCAPE` character, per SQLite. Identical to
+/// [`like_match`] except that `escape` immediately before a `%`, `_`, or the
+/// escape character itself makes that character a **literal** (matched
+/// case-insensitively) rather than a wildcard — so `'100%' LIKE '100\%'
+/// ESCAPE '\'` is true and matches only a trailing percent sign.
+fn like_match_escape(text: &str, pattern: &str, escape: char) -> bool {
+    let t: Vec<char> = text.chars().collect();
+    let p: Vec<char> = pattern.chars().collect();
+
+    let (mut ti, mut pi) = (0usize, 0usize);
+    let (mut star_pi, mut star_ti) = (usize::MAX, 0usize);
+
+    // `chars_eq` folds ASCII/Unicode case exactly as the wildcard-free path does.
+    let chars_eq = |a: char, b: char| a.to_lowercase().next() == b.to_lowercase().next();
+
+    while ti < t.len() {
+        if pi + 1 < p.len() && p[pi] == escape {
+            // Escaped literal: the character after `escape` must match verbatim.
+            if chars_eq(p[pi + 1], t[ti]) {
+                ti += 1;
+                pi += 2;
+            } else if star_pi != usize::MAX {
+                star_ti += 1;
+                ti = star_ti;
+                pi = star_pi + 1;
+            } else {
+                return false;
+            }
+        } else if pi < p.len() && p[pi] == '%' {
+            // `%` matches zero or more; record the backtrack point.
+            star_pi = pi;
+            pi += 1;
+            star_ti = ti;
+        } else if pi < p.len() && (p[pi] == '_' || chars_eq(p[pi], t[ti])) {
+            ti += 1;
+            pi += 1;
+        } else if star_pi != usize::MAX {
+            star_ti += 1;
+            ti = star_ti;
+            pi = star_pi + 1;
+        } else {
+            return false;
+        }
+    }
+
+    // Only trailing `%` can match the empty suffix; an escaped literal or `_`
+    // still demands a character, so the pattern fails to consume fully.
+    while pi < p.len() && p[pi] == '%' {
+        pi += 1;
+    }
+
+    pi == p.len()
+}
+
 /// Try to match a GLOB character class `[...]` in `p` starting at `p[start]`
 /// (which must be `'['`) against `ch`. Returns `Some((matched, after))` where
 /// `after` is the pattern index just past the closing `']'`; or `None` if there
@@ -3418,6 +3514,23 @@ mod tests {
     }
 
     #[test]
+    fn test_like_match_escape() {
+        // Escaped `%`/`_` become literals; unescaped ones stay wildcards.
+        assert!(like_match_escape("a%b", "a#%b", '#'));
+        assert!(!like_match_escape("100x", "100#%", '#'));
+        assert!(like_match_escape("a_b", "a#_b", '#'));
+        assert!(!like_match_escape("axb", "a#_b", '#'));
+        // Literal escape then a real wildcard.
+        assert!(like_match_escape("50%off", "50#%%", '#'));
+        // The escape character escaping itself.
+        assert!(like_match_escape("a/b", "a//b", '/'));
+        // Plain wildcards still work with an escape char defined.
+        assert!(like_match_escape("anything", "%", '#'));
+        // Case-insensitive literal match, like the wildcard-free path.
+        assert!(like_match_escape("A%C", "a#%c", '#'));
+    }
+
+    #[test]
     fn test_float_arithmetic() {
         let mut b = InMemoryBackend::new();
         let r = execute(&prog(vec![
@@ -3664,7 +3777,7 @@ mod tests {
             Instruction::BeginRow,
             Instruction::LoadConst(null()),
             Instruction::LoadConst(text("%")),
-            Instruction::Like,
+            Instruction::Like(false),
             Instruction::EmitColumn("r".to_string()),
             Instruction::EmitRow,
             Instruction::Halt,


### PR DESCRIPTION
## Cycle 2, lane 2: `LIKE … ESCAPE` (+ fix `NOT LIKE` inversion)

Probing lane 3 (NULLS/COLLATE) showed the engine already matches SQLite exactly (multi-key NULLS FIRST/LAST + DESC, explicit COLLATE in ORDER BY) — lane 3 is done. Rotated to a fresh lane-2 gap and found `X LIKE Y ESCAPE Z` **fails to parse**.

### What shipped
`LIKE … ESCAPE` now works end to end — the escape character before a `%`, `_`, or itself makes it a **literal**, so `'100%' LIKE '100#%' ESCAPE '#'` is true.

**Bonus fix:** wiring the negation through surfaced a pre-existing bug — the `negated` flag was dropped in codegen, so **`NOT LIKE` behaved exactly like `LIKE`**. `NOT LIKE` now correctly inverts (NULL stays NULL).

### Layers
- **sql-parser**: grammar for `[NOT] LIKE pattern ESCAPE ch` (ESCAPE variants ordered before plain LIKE so the backtracking parser prefers the longer match).
- **sql-planner**: `SqlExpr::Like.escape: Option<Box<SqlExpr>>`.
- **sql-codegen**: `Instruction::Like(bool)` carries the NOT flag; new `LikeEscape(bool)`.
- **sql-optimizer**: fold/column-collection recurse into `escape`.
- **sql-vm**: `like_match_escape` (single backtrack pointer, **O(n·m), no ReDoS**) + NULL-aware `matched ^ negated`.

### Verification
- 3 differential-oracle cases vs real bundled SQLite (literal-wildcard escapes; NOT LIKE with/without ESCAPE + NULL; per-row column match) — escapes use `#`/`/`, not backslash.
- VM unit test for `like_match_escape`.
- All 6 affected crates + storage-sqlite test suites green.
- **Security review** (adversarial): clean — matcher termination proven O(n·m), all indexing bounds-guarded, negation NULL-safe.

### Follow-up (spun off)
The string lexer strips backslash escapes in string literals (non-conformant), which breaks `ESCAPE '\'` with a *literal* pattern. Column-valued patterns and non-backslash escapes are unaffected.

Versions: sql-parser 0.1.19, sql-planner 0.2.18, sql-codegen 0.6.6, sql-optimizer 0.1.5, sql-vm 0.4.20, mini-sqlite 0.5.38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
