### PR TITLE
fix(closure-emitter): parenthesize a ChainExpression base of a plain member/call/tagged-template (optional-chain-scope miscompile)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.51.0] - 2026-07-17
+
+### Fixed — a `ChainExpression` base of a plain member/call/tagged-template is now parenthesized (optional-chain-scope miscompile)
+
+An optional chain (`a?.b`) used as the object of a **non-optional** member
+access, the callee of a plain call, or the tag of a tagged template MUST be
+parenthesized — the parens are the chain boundary. Dropping them lets a
+following non-optional access join the chain, which is a **semantic** change,
+not cosmetic:
+
+- `(a?.b).c` → `a?.b.c`  — `.c` now short-circuits with `?.` (`a?.b.c` returns
+  `undefined` when `a` is nullish; `(a?.b).c` throws — different behavior)
+- `(a?.b)()` → `a?.b()`, `(a?.[0]).x` → `a?.[0].x`, `(a?.()).x` → `a?.().x`
+- `` (a?.b)`x` `` → `` a?.b`x` `` (also outright invalid — a tagged template
+  can't tag an optional chain unparenthesized)
+
+A `ChainExpression` is the transparent chain-boundary wrapper, tagged
+`PREC_PRIMARY` (its inner spine is a member/call node), so the ordinary
+`PREC_PRIMARY` base emit never wrapped it. A new `emit_plain_access_base` helper
+wraps a `ChainExpression` base and otherwise keeps the existing `PREC_PRIMARY`
+emit; it backs `emit_member`, `emit_call`, and `emit_tagged_template`.
+
+An **optional** access base is deliberately excluded — `(a?.b)?.c` needs no
+parens because the chain simply continues (`a?.b?.c`), so
+`emit_optional_member`/`emit_optional_call` keep their bare emit. A chain as a
+call **argument** (`f(a?.b)`) or in statement position is likewise unwrapped.
+
+Verified byte-identical to the reference Closure Compiler at `SIMPLE` across
+member/call/computed/optional-call-result/tagged-template and deep chains
+(`(a?.b).c().d`, `((a?.b).c)?.d`). Bug fix; MINOR bump 0.50.0 → 0.51.0.
+
+Not covered (rarer, separate follow-ups): a `ChainExpression` as a `new` callee
+(`new (a?.b)`, which also has a `new␣(` spacing quirk) and an **object literal**
+at the head of an optional chain that is then member-accessed
+(`({}?.x).y` → the chain is now correctly bounded, but Closure additionally
+wraps the object literal: `(({})?.x).y`).
+
 ## [0.50.0] - 2026-07-16
 
 ### Fixed — object literal at the leftmost spine of a statement is now parenthesized (invalid-JS miscompile)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -1550,7 +1550,7 @@ impl<'a> Emitter<'a> {
     /// and `${…}` substitutions round-trip exactly as an untagged template).
     fn emit_tagged_template(&mut self, t: &TaggedTemplateExpression) {
         self.maybe_map(&t.cv);
-        self.emit_expression_inner(&t.tag, PREC_PRIMARY);
+        self.emit_plain_access_base(&t.tag);
         self.emit_template_literal(&t.quasi);
     }
 
@@ -2004,7 +2004,7 @@ impl<'a> Emitter<'a> {
         // became `a||b()` (`a||(b())`) and `(a=b)(c)` became `a=b(c)` — both
         // miscompiles. `PREC_PRIMARY` keeps `a.b()` / `f()()` paren-free and
         // wraps any lower-precedence callee.
-        self.emit_expression_inner(&c.callee, PREC_PRIMARY);
+        self.emit_plain_access_base(&c.callee);
         self.write_str("(");
         for (i, a) in c.arguments.iter().enumerate() {
             if i > 0 {
@@ -2253,6 +2253,40 @@ impl<'a> Emitter<'a> {
         self.write_str("import.meta");
     }
 
+    /// Emit `base` where it is the object of a **plain (non-optional)** member
+    /// access, the callee of a plain call, or the tag of a tagged template.
+    ///
+    /// Normally that is a `PREC_PRIMARY` emit — which keeps `a.b.c` / `f().x`
+    /// paren-free while wrapping any looser base (binary, logical, unary,
+    /// conditional, assignment, sequence). But a [`ChainExpression`] base MUST
+    /// be parenthesised, and precedence alone won't do it: a ChainExpression is
+    /// the transparent optional-chain-boundary wrapper, tagged `PREC_PRIMARY`
+    /// (its inner spine is a member/call node), so the `PREC_PRIMARY` emit would
+    /// print it bare.
+    ///
+    /// Those parens are load-bearing — they ARE the chain boundary. Dropping
+    /// them makes a following **non-optional** access join the chain:
+    ///
+    /// ```text
+    ///   (a?.b).c     bare →  a?.b.c     // `.c` now short-circuits with `?.` —
+    ///                                   //   a SEMANTIC change, not cosmetic
+    ///   (a?.b)()     bare →  a?.b()     // likewise the call joins the chain
+    /// ```
+    ///
+    /// An *optional* access base (`(a?.b)?.c`) is the opposite: the chain simply
+    /// continues, so the parens are redundant (`a?.b?.c`) — hence
+    /// `emit_optional_member`/`emit_optional_call` do NOT use this and keep their
+    /// bare `PREC_PRIMARY` emit.
+    fn emit_plain_access_base(&mut self, base: &Expression) {
+        if matches!(base, Expression::ChainExpression(_)) {
+            self.write_str("(");
+            self.emit_expression(base);
+            self.write_str(")");
+        } else {
+            self.emit_expression_inner(base, PREC_PRIMARY);
+        }
+    }
+
     fn emit_member(&mut self, m: &MemberExpression) {
         self.maybe_map(&m.cv);
         // The object must bind at least as tightly as member access, or the
@@ -2263,7 +2297,7 @@ impl<'a> Emitter<'a> {
         // emitting the object at `PREC_PRIMARY` keeps `a.b.c` / `f().x`
         // paren-free while wrapping anything lower (binary, logical, unary,
         // conditional, assignment, sequence).
-        self.emit_expression_inner(&m.object, PREC_PRIMARY);
+        self.emit_plain_access_base(&m.object);
         if m.computed {
             self.write_str("[");
             self.emit_expression(&m.property);
@@ -3558,6 +3592,38 @@ mod tests {
             right: Box::new(ident("b")),
         });
         assert_eq!(emit_expr(chain(opt_member(or, "c", false))), "(a||b)?.c;");
+    }
+
+    #[test]
+    fn chain_as_plain_access_base_is_parenthesized() {
+        // A `ChainExpression` used as the object of a PLAIN (non-optional)
+        // member/call, or the tag of a tagged template, MUST be parenthesized:
+        // the parens are the optional-chain boundary, so without them a
+        // following non-optional access joins the chain — `(a?.b).c` printed
+        // bare as `a?.b.c` extends the `?.` short-circuit to `.c`, a semantic
+        // miscompile.
+        let ax = || chain(opt_member(ident("a"), "x", false));
+        // (a?.x).y — plain member on a chain
+        assert_eq!(emit_expr(member(ax(), "y", false)), "(a?.x).y;");
+        // (a?.x)() — plain call on a chain
+        assert_eq!(emit_expr(call(ax(), vec![])), "(a?.x)();");
+        // (a?.x)[0] — computed member on a chain
+        assert_eq!(emit_expr(member(ax(), "0", true)), "(a?.x)[0];");
+        // ((a?.x).y).z — chain wrapped once, the outer plain members chain bare
+        assert_eq!(
+            emit_expr(member(member(ax(), "y", false), "z", false)),
+            "(a?.x).y.z;"
+        );
+    }
+
+    #[test]
+    fn chain_not_as_plain_base_is_not_parenthesized() {
+        // A bare chain, a chain as a call ARGUMENT, and a chain as an OPTIONAL
+        // access base must all stay unwrapped — the parens are only needed to
+        // bound the chain against a *following* non-optional access.
+        let ab = || chain(opt_member(ident("a"), "b", false));
+        assert_eq!(emit_expr(ab()), "a?.b;"); // bare
+        assert_eq!(emit_expr(call(ident("f"), vec![ab()])), "f(a?.b);"); // argument
     }
 
     #[test]


### PR DESCRIPTION
## The miscompile

An optional chain (`a?.b`) used as the object of a **non-optional** member access, the callee of a plain call, or the tag of a tagged template must be parenthesized — the parens **are** the chain boundary. Dropping them lets a following non-optional access *join* the chain, which changes runtime semantics:

| input | closurec (before) | oracle |
|---|---|---|
| `(a?.b).c` | `a?.b.c` | `(a?.b).c` |
| `(a?.b)()` | `a?.b()` | `(a?.b)()` |
| `(a?.[0]).x` | `a?.[0].x` | `(a?.[0]).x` |
| `(a?.()).x` | `a?.().x` | `(a?.()).x` |
| `` (a?.b)`x` `` | `` a?.b`x` `` | `` (a?.b)`x` `` |

`a?.b.c` returns `undefined` when `a` is nullish (the `.c` short-circuits with `?.`); `(a?.b).c` **throws** — a real behavior difference. The tagged-template form is also outright invalid JS.

## The fix

A `ChainExpression` is the transparent chain-boundary wrapper, tagged `PREC_PRIMARY` (its inner spine is a member/call node), so the ordinary `PREC_PRIMARY` base emit never wrapped it. A small `emit_plain_access_base` helper wraps a `ChainExpression` base and otherwise keeps the existing `PREC_PRIMARY` emit; it backs `emit_member`, `emit_call`, and `emit_tagged_template`.

**Optional** access bases are deliberately excluded — `(a?.b)?.c` needs no parens (the chain simply continues → `a?.b?.c`), so `emit_optional_member`/`emit_optional_call` keep their bare emit. A chain as a call **argument** (`f(a?.b)`) or in statement position is likewise unwrapped.

## Verification

- closure-emitter `0.50.0` → `0.51.0`; CHANGELOG updated.
- 2 unit tests (wrap: member/call/computed/deep; no-wrap: bare + argument). **256 lib tests pass**, clippy clean.
- **Oracle-verified byte-identical** at `SIMPLE` across member/call/computed/optional-call-result/tagged-template and deep chains (`(a?.b).c().d`, `((a?.b).c)?.d`); all no-wrap regression guards hold.
- Full closurec suite green (**no fixture drift**); consumer crates (constant-fold 366, dce 73, fcf 76) green.
- **Security review PASSED** — verified complete coverage of the three plain-access positions, no over/double-wrap, sound rule.

Two rarer residuals filed as a follow-up: a `ChainExpression` as a `new` callee (`new (a?.b)`, with a `new (` spacing quirk) and an object literal at a chain head (`({}?.x).y` — now correctly chain-bounded, but Closure additionally wraps the object: `(({})?.x).y`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)