### PR TITLE
feat(wolfram-runtime): D[expr, x] (W-22 fourth cas-* head)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.20.2] — 2026-07-16
+
+### Changed
+
+- `handlers::derivative_handler`'s differentiate-then-simplify logic is now
+  a `pub` free function, `handlers::differentiate(vm, f, x)`. No behavior
+  change for `derivative_handler` itself (it now just calls the extracted
+  function) — this only widens visibility so other language runtimes
+  sharing this crate's `VM`/`IRNode` types can reuse the exact same
+  differentiation pipeline Macsyma's own `D` already runs, rather than
+  reimplementing or duplicating it. Unlike `factor_handler` (made `pub`
+  directly, since it already did its own arity check), `derivative_handler`
+  itself still panics on the wrong argument count — a real internal
+  invariant for this crate's own dispatch table — so callers with a
+  fail-soft contract (leave the form unevaluated instead of panicking)
+  validate arity themselves and call `differentiate` with the unpacked
+  `f`/`x` instead of the whole `IRApply`. First consumer: `wolfram-runtime`'s
+  `D[expr, x]` wiring (W-22, see that crate's own changelog).
+
 ## [0.20.1] — 2026-07-12
 
 ### Changed

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1489,6 +1489,32 @@ fn list_handler(_simplify: bool) -> Handler {
 // Symbolic differentiation
 // ---------------------------------------------------------------------------
 
+/// Differentiate `f` with respect to `x`, then — unless the result is just
+/// the unevaluated `D(f, x)` form `diff` couldn't reduce further — run it
+/// back through the VM's own `eval` so constant folding and nested `D`
+/// calls the recursive rules produced (e.g. inside a chain rule) resolve
+/// all the way down, not just one layer of differentiation rules.
+///
+/// This is `derivative_handler`'s own logic, pulled out into a `pub` free
+/// function so other language runtimes sharing this crate's `VM`/`IRNode`
+/// types (e.g. `wolfram-runtime`'s `D[expr, x]`) can reuse the exact same
+/// differentiation-plus-simplification pipeline Macsyma's `D` already uses,
+/// rather than reimplementing or duplicating it — mirrors why
+/// `factor_handler` was made `pub` for the same crate's `Factor[...]`
+/// wiring. Unlike `factor_handler`, this takes `f`/`x` already unpacked
+/// rather than a whole `IRApply`, since callers with a different arity
+/// contract (Wolfram's fail-soft "leave it unevaluated" instead of this
+/// crate's panic) need to do their own argument validation first.
+pub fn differentiate(vm: &mut VM, f: IRNode, x: &str) -> IRNode {
+    let result = diff(&f, x);
+    let original = apply_node(D, vec![f, IRNode::Symbol(x.to_string())]);
+    if result == original {
+        result
+    } else {
+        vm.eval(result)
+    }
+}
+
 fn derivative_handler() -> Handler {
     std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
         if expr.args.len() != 2 {
@@ -1501,13 +1527,7 @@ fn derivative_handler() -> Handler {
             _ => return IRNode::Apply(Box::new(expr)),
         };
 
-        let result = diff(&f, &x);
-        let original = apply_node(D, vec![f, IRNode::Symbol(x)]);
-        if result == original {
-            result
-        } else {
-            vm.eval(result)
-        }
+        differentiate(vm, f, &x)
     })
 }
 

--- a/code/packages/rust/wolfram-runtime/CHANGELOG.md
+++ b/code/packages/rust/wolfram-runtime/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `wolfram-runtime` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.19.4] — 2026-07-16
+
+### Added (W-22 — `D`, fourth `cas-*` head)
+
+- `D[expr, x]` — the symbolic derivative of `expr` with respect to the
+  symbol `x`: sum/product/quotient/power/chain rules plus the elementary
+  transcendental functions (`Sin`, `Cos`, `Exp`, `Log`, `Sqrt`, inverse and
+  hyperbolic trig), fully recursed and re-evaluated so constant folding and
+  nested rule output collapse into one final form (`D[x^3, x]` → `3 * x^2`,
+  not a half-reduced intermediate). Like `Factor`, the actual differentiation
+  logic lives directly in `symbolic-vm` itself: this wiring calls the new
+  `symbolic_vm::handlers::differentiate` — the exact pipeline Macsyma's own
+  `D` already runs, extracted into a `pub` free function specifically for
+  this reuse (see `symbolic-vm`'s own changelog). No algorithm is
+  reimplemented or duplicated; a parity test pins both languages' call sites
+  to agree on the same input, exactly like `Simplify`/`Expand`/`Factor`'s own
+  parity tests.
+- Like every W-5+ built-in, `D` is an ordinary eager `Head[args]` form
+  requiring exactly two arguments, the second of which must be a bare
+  symbol; any other shape leaves the form unevaluated. Unlike `Factor`
+  (whose arity check lives inside `factor_handler` itself), this wrapper
+  does its own check — `derivative_handler`'s existing arity contract
+  panics on the wrong count, which is right for `symbolic-vm`'s own internal
+  dispatch but wrong for Wolfram's fail-soft contract, so `d_handler`
+  validates the shape before ever calling through.
+
 ## [0.19.3] — 2026-07-16
 
 ### Changed

--- a/code/packages/rust/wolfram-runtime/Cargo.toml
+++ b/code/packages/rust/wolfram-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-wolfram-runtime"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 description = "Wolfram Language runtime — lowers M-expressions to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"

--- a/code/packages/rust/wolfram-runtime/src/builtins.rs
+++ b/code/packages/rust/wolfram-runtime/src/builtins.rs
@@ -254,12 +254,17 @@ pub fn build_wolfram_builtins() -> HashMap<String, Handler> {
     // `Factor` is the third, reusing `symbolic-vm`'s own `factor_handler`
     // (the exact function Macsyma's `factor` surface function already calls)
     // rather than `cas-simplify`, since factoring lives directly in the
-    // shared VM crate, not a separate `cas-*` crate. Further heads (`Solve`,
-    // `D`, `Integrate`, ...) are added one at a time, each its own PR, per
-    // HML00's one-item-per-PR discipline.
+    // shared VM crate, not a separate `cas-*` crate. `D` is the fourth,
+    // reusing `symbolic-vm`'s own `differentiate` (same idea as `Factor`,
+    // but this wrapper does its own arity/shape check first, since `D`'s
+    // fail-soft "leave it unevaluated" contract differs from
+    // `derivative_handler`'s panic-on-bad-arity one). Further heads
+    // (`Solve`, `Integrate`, ...) are added one at a time, each its own PR,
+    // per HML00's one-item-per-PR discipline.
     m.insert("Simplify".to_string(), handler_fn(simplify_handler));
     m.insert("Expand".to_string(), handler_fn(expand_handler));
     m.insert("Factor".to_string(), handler_fn(factor_handler));
+    m.insert("D".to_string(), handler_fn(d_handler));
 
     // W-18 pattern-matching predicates (MA04 §19). HELD (see `PATTERN_HEADS`):
     // each handler evaluates ONLY its subject and matches against the *literal*
@@ -3378,6 +3383,41 @@ fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
     symbolic_vm::handlers::factor_handler(vm, expr)
 }
 
+/// `D[expr, x]` → the symbolic derivative of `expr` with respect to the
+/// symbol `x`: the standard sum/product/quotient/power/chain rules, plus
+/// the elementary transcendental functions (`Sin`, `Cos`, `Exp`, `Log`,
+/// `Sqrt`, the inverse and hyperbolic trig functions, …), fully recursed
+/// and then run back through the VM's evaluator so constant folding and any
+/// nested rule output collapse into one final form (e.g. `D[x^3, x]` →
+/// `3 * x^2`, not a half-reduced intermediate).
+///
+/// Like `Factor` (and unlike `Simplify`/`Expand`), the actual
+/// differentiation logic lives directly in `symbolic-vm` itself: this is a
+/// thin call into `symbolic_vm::handlers::differentiate` — the exact
+/// pipeline Macsyma's own `derivative_handler` already runs, extracted into
+/// a `pub` free function specifically so this wiring can reuse it (see
+/// that crate's own changelog). No algorithm is reimplemented or
+/// duplicated. Unlike `factor_handler`, `differentiate` cannot do its own
+/// arity check — `derivative_handler`'s existing contract *panics* on the
+/// wrong number of arguments, which is right for a genuine internal
+/// invariant violation but wrong for Wolfram's fail-soft "leave it
+/// unevaluated" contract every other W-22/W-15 built-in follows — so this
+/// wrapper validates the shape itself before calling through: exactly two
+/// arguments, and the second must be a bare symbol (`D[expr, 2]` or
+/// `D[expr]` stay unevaluated, matching `derivative_handler`'s own
+/// non-symbol case).
+fn d_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 2 {
+        return unevaluated(expr);
+    }
+    let x = match &expr.args[1] {
+        IRNode::Symbol(s) => s.clone(),
+        _ => return unevaluated(expr),
+    };
+    let f = expr.args[0].clone();
+    symbolic_vm::handlers::differentiate(vm, f, &x)
+}
+
 // ---------------------------------------------------------------------------
 // W-12 string builtins
 // ---------------------------------------------------------------------------
@@ -6334,6 +6374,73 @@ mod tests {
                     apply(sym(ADD), vec![int(1), sym("x")]),
                     apply(sym(ADD), vec![int(-1), sym("x")]),
                 ],
+            )
+        );
+    }
+
+    #[test]
+    fn d_computes_the_symbolic_derivative_of_a_power() {
+        // D[x^3, x] -> 3 * x^2, the exact same power-rule result `d(x^3)`
+        // produces in `symbolic-vm`'s own `derivative_power_rules` test
+        // (`symbolic-vm/tests/test_vm.rs`).
+        let x_cubed = apply(sym(symbolic_ir::POW), vec![sym("x"), int(3)]);
+        assert_eq!(
+            run("D", vec![x_cubed, sym("x")]),
+            apply(
+                sym(MUL),
+                vec![int(3), apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)])],
+            )
+        );
+    }
+
+    #[test]
+    fn d_leaves_a_non_symbol_second_argument_unevaluated() {
+        // D[x^2, 2] -- the second argument isn't a symbol, so this stays
+        // unevaluated exactly like `derivative_handler`'s own non-symbol
+        // case (`symbolic-vm/src/handlers.rs`).
+        let x_squared = apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)]);
+        assert_eq!(
+            run("D", vec![x_squared.clone(), int(2)]),
+            apply(sym("D"), vec![x_squared, int(2)])
+        );
+    }
+
+    #[test]
+    fn d_agrees_with_macsyma_on_the_same_underlying_call() {
+        // Both Wolfram's D and Macsyma's D dispatch to the exact same
+        // symbolic_vm::handlers::differentiate -- this pins that the
+        // Wolfram wiring doesn't diverge from the reference call. Needs a
+        // fresh VM on each side since `differentiate` takes `&mut VM`
+        // (unlike Simplify/Expand's parity tests, which call a plain free
+        // function).
+        let x_cubed = apply(sym(symbolic_ir::POW), vec![sym("x"), int(3)]);
+        let via_wolfram = run("D", vec![x_cubed.clone(), sym("x")]);
+        let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+        let via_macsyma_path = symbolic_vm::handlers::differentiate(&mut vm, x_cubed, "x");
+        assert_eq!(via_wolfram, via_macsyma_path);
+    }
+
+    #[test]
+    fn d_with_wrong_arity_stays_unevaluated() {
+        assert_eq!(run("D", vec![]), apply(sym("D"), vec![]));
+        assert_eq!(run("D", vec![sym("x")]), apply(sym("D"), vec![sym("x")]));
+        assert_eq!(
+            run("D", vec![sym("x"), sym("y"), sym("z")]),
+            apply(sym("D"), vec![sym("x"), sym("y"), sym("z")])
+        );
+    }
+
+    #[test]
+    fn d_dispatches_end_to_end_through_the_wolfram_backend() {
+        // x^3 differentiates through the full VM eval dispatch on a real
+        // WolframBackend, exactly mirroring
+        // `factor_dispatches_end_to_end_through_the_wolfram_backend` above.
+        let x_cubed = apply(sym(symbolic_ir::POW), vec![sym("x"), int(3)]);
+        assert_eq!(
+            eval_full(apply(sym("D"), vec![x_cubed, sym("x")])),
+            apply(
+                sym(MUL),
+                vec![int(3), apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)])],
             )
         );
     }

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -93,13 +93,14 @@ Following [HML00 §6](HML00-historical-math-languages-roadmap.md)'s breakdown:
   (with `checked_mul`) before allocation (§19.5). No grammar change.
 - **W-22 — the `cas-*` function surface under Wolfram names.** *(in
   progress — see §24.)* Wires the existing `cas-*` crates in one head at a
-  time: `Simplify` (a thin call into `cas-simplify`'s `simplify()`) and
-  `Expand` (a thin call into `cas-simplify`'s `expand()`) are both
-  delivered — each the same function its Macsyma counterpart calls, so the
-  two languages agree on every result this crate can produce. Remaining:
-  `Factor`, `Solve`, `D`, `Integrate`, each its own item — no grammar
-  change for any of them (all ordinary `Head[args]` forms the existing
-  grammar already parses).
+  time: `Simplify` (a thin call into `cas-simplify`'s `simplify()`),
+  `Expand` (a thin call into `cas-simplify`'s `expand()`), `Factor` (a
+  direct call into `symbolic-vm`'s own `factor_handler`), and `D` (a direct
+  call into `symbolic-vm`'s own `differentiate`) are all delivered — each
+  the same function its Macsyma counterpart calls, so the two languages
+  agree on every result this crate can produce. Remaining: `Solve`,
+  `Integrate`, each its own item — no grammar change for any of them (all
+  ordinary `Head[args]` forms the existing grammar already parses).
 
 ## §3 The supported surface (the grammar)
 
@@ -2098,7 +2099,7 @@ it). `ReplaceRepeated` retains its §22.4 hard iteration cap
 (`REPLACE_GROWTH_NODE_CAP`) — the `//.` operator lowers to the very same head, so
 the DoS bounds apply identically whether written as operator or `Head[args]`.
 
-## §24 W-22 the `cas-*` function surface under Wolfram names — `Simplify`, `Expand`, `Factor` (in progress)
+## §24 W-22 the `cas-*` function surface under Wolfram names — `Simplify`, `Expand`, `Factor`, `D` (in progress)
 
 W-22 starts closing §2's previously unnumbered "Future" item: wiring the
 existing `cas-*` algorithm crates under Wolfram's own head names. Unlike
@@ -2187,9 +2188,43 @@ Factor[x^2 - 1]     (* (1 + x) * (-1 + x) *)
 Factor[x + y]       (* x + y — unevaluated, no recognised pattern *)
 ```
 
-### §24.4 Remaining (not yet delivered)
+### §24.4 `D` (delivered)
 
-`Solve`, `D`, `Integrate`, and the rest of §2's original list — each is a
+`D[expr, x]` is a thin call into `symbolic_vm::handlers::differentiate` —
+**the exact pipeline** Macsyma's own `D` already runs via
+`derivative_handler` (`macsyma-runtime`'s own dispatch). Unlike
+`Simplify`/`Expand` (thin calls into the standalone `cas-simplify` crate),
+the differentiation logic lives directly inside `symbolic-vm` itself, same
+as `Factor`; `differentiate` was extracted out of `derivative_handler`'s
+closure body and made `pub` in `symbolic-vm` specifically for this
+cross-language reuse (see that crate's own changelog). No algorithm is
+reimplemented; a test pins both languages' call sites to agree on the same
+input, exactly like `Simplify`/`Expand`/`Factor`'s own parity tests.
+
+`differentiate` applies the standard sum/product/quotient/power/chain
+rules plus the elementary transcendental functions (`Sin`, `Cos`, `Exp`,
+`Log`, `Sqrt`, the inverse and hyperbolic trig functions, …), fully
+recursing `diff` and then running the result back through the VM's `eval`
+so constant folding and any nested rule output collapse into one final
+form — see `symbolic-vm`'s own module docs for the full rule inventory
+(shared, not reimplemented, with Macsyma).
+
+Unlike `Factor` — whose arity check lives inside `factor_handler` itself,
+so the Wolfram wiring needs none of its own — `derivative_handler`'s
+existing arity contract *panics* on the wrong argument count (a genuine
+internal invariant for `symbolic-vm`'s own dispatch table, not a fail-soft
+contract). Since `D` still needs Wolfram's usual "leave it unevaluated"
+behaviour, `D`'s wrapper validates the shape itself before calling through:
+exactly two arguments, and the second must be a bare symbol.
+
+```
+D[x^3, x]      (* 3 * x^2 *)
+D[x^2, 2]      (* x^2 unevaluated — second argument isn't a symbol *)
+```
+
+### §24.5 Remaining (not yet delivered)
+
+`Solve`, `Integrate`, and the rest of §2's original list — each is a
 separate future item, no grammar change required for any of them (all are
 ordinary `Head[args]` forms the existing grammar already parses).
 


### PR DESCRIPTION
## Summary

- Wires Wolfram's `D[expr, x]` to the same differentiation pipeline Macsyma's `D` already runs, so both languages agree on every derivative this crate can compute.
- Extracts `derivative_handler`'s differentiate-then-simplify logic into a new `pub fn symbolic_vm::handlers::differentiate(vm, f, x)` — mirrors why `factor_handler` was made `pub` for the same reuse pattern. `derivative_handler` itself is behaviorally unchanged (now just calls the extracted fn).
- `wolfram-runtime`'s new `d_handler` validates arity/shape itself (exactly 2 args, second must be a symbol) before delegating — `derivative_handler`'s own arity contract panics rather than failing soft, so this wrapper can't reuse it directly the way `factor_handler` (which does its own arity check) was reused as-is.
- MA04 §24: adds §24.4 for `D` (delivered), renumbers the remaining stub to §24.5, and fixes the §2 overview bullet which had gone stale after `Factor` shipped (it still listed `Factor` under "Remaining").

Bumps `symbolic-vm` 0.20.1 → 0.20.2, `wolfram-runtime` 0.19.3 → 0.19.4.

## Test plan

- [x] `cargo test -p symbolic-vm -p coding-adventures-wolfram-runtime` — all pass, including 5 new `D`-specific tests (power rule, non-symbol second arg, wrong arity, Wolfram/Macsyma parity, full-backend dispatch)
- [x] `cargo test` on every crate depending on `symbolic-vm` (`coding-adventures-derive-runtime`, `coding-adventures-macsyma-runtime`, `cas-summation`, `task-core`) — all pass, no regression from the `derivative_handler` refactor
- [x] `/security-review` — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)