### PR TITLE
feat(adj-facts-stdlib): physics/states-of-matter — phase change → name table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_physstatesofmatter_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_physstatesofmatter_e2e.rs
@@ -1,0 +1,68 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/states-of-matter.adj`) driven through the built
+//! CLI: a native `table` of phase-change direction -> its name resolves a
+//! binding-query recall with the source's citation, runs BACKWARD (bind the
+//! name, recall the direction), and abstains on a direction not in the table —
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_physsom_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn physics_phase_change_recall_binds_name_with_citation_and_abstains() {
+    let dir = scratch("statesofmatter");
+    // Copy the shipped physics table beside the entry program and import it.
+    let src = facts_stdlib().join("physics/states-of-matter.adj");
+    std::fs::copy(&src, dir.join("states-of-matter.adj"))
+        .expect("copy shipped physics states-of-matter.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"states-of-matter.adj\"\n\
+         ? phase_change_name(solid_to_liquid, $Name)\n\
+         ? phase_change_name(gas_to_liquid, $Name)\n\
+         ? phase_change_name($Change, sublimation)\n\
+         ? phase_change_name(solid_to_plasma, $Name)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A solid becoming a liquid is melting; a gas becoming a liquid is condensation.
+    assert!(out.contains("\"Name\":\"melting\""), "solid_to_liquid -> melting: {out}");
+    assert!(out.contains("\"Name\":\"condensation\""), "gas_to_liquid -> condensation: {out}");
+    // The query runs backward: bind the name, recall the direction.
+    assert!(
+        out.contains("\"Change\":\"solid_to_gas\""),
+        "sublimation is the solid_to_gas change (reverse recall): {out}"
+    );
+    // The answer carries the LibreTexts citation as its proof.
+    assert!(
+        out.contains("chem.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation: {out}"
+    );
+    // solid_to_plasma is not one of the six phase changes — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "solid_to_plasma abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -44,6 +44,7 @@ per rotation, in parallel):
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
 | `physics/` | simple machine → everyday example | NASA |
+| `physics/` | phase change → its name (melting, freezing, …) | LibreTexts (consensus) |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | … | *geography, physical constants, …* | *(expanding)* |

--- a/code/specs/data/adj-facts-stdlib/physics/states-of-matter.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/states-of-matter.adj
@@ -1,0 +1,100 @@
+% ============================================================================
+% states-of-matter — each phase change between the everyday states of matter
+% and its NAME (adj-facts-stdlib, PHYSICS).
+% ============================================================================
+% A first physics fact about matter and energy: when a substance moves between
+% the three everyday states (solid, liquid, gas), each direction of change has
+% its OWN name. Melt an ice cube and you have melting; let steam hit a cold
+% window and you have condensation. This library maps the direction of a phase
+% change to the single word that names it. Recall is a binding query:
+%
+%     ? phase_change_name(solid_to_liquid, $Name)   % melting
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `phase_change_name(change, name)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% name WITH its source, on the CPU, with zero model calls, and abstains on a
+% direction that is not one of the six phase changes.
+%
+% The sibling library `chemistry/states-of-matter.adj` maps a STATE to how it
+% behaves in a container (solid → fixed_shape, …). This physics library is the
+% complementary axis: it names the TRANSITIONS between those states, the rung a
+% learner reasons up from before latent heat, phase diagrams, and enthalpy of
+% fusion/vaporization.
+%
+% The six phase changes, as a truth table (direction → the word that names it →
+% a plain gloss):
+%
+%     change            name            plain gloss
+%     ---------------   -------------   ----------------------------------
+%     solid_to_liquid   melting         a solid becomes a liquid (ice → water)
+%     liquid_to_solid   freezing        a liquid becomes a solid (water → ice)
+%     liquid_to_gas     vaporization    a liquid becomes a gas (water → steam)
+%     gas_to_liquid     condensation    a gas becomes a liquid (steam → water)
+%     solid_to_gas      sublimation     a solid becomes a gas directly (dry ice)
+%     gas_to_solid      deposition      a gas becomes a solid directly (frost)
+%
+% Each `name` value is a SINGLE lowercase atom taken verbatim from the source's
+% own defining sentence for that direction — never a synonym the source does not
+% use for that row. (The source notes `fusion` as an older word for melting and
+% `boiling` for vaporization, but the row carries the word the source uses as the
+% primary name.) A direction that is not one of the six — say `solid_to_plasma`,
+% or a nonsense key — has no row, so a recall on it ABSTAINS rather than inventing
+% a name. That honest-abstention property is what makes the table safe to reason
+% from. The query also runs BACKWARD — bind the name and recall its direction:
+%
+%     ? phase_change_name($Change, condensation)    % gas_to_liquid — reverse recall
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every direction→name pair
+% was read out of a fetched LibreTexts page this session, and any row that could
+% not be grounded there would have been dropped). Four rows come from LibreTexts
+% "9.3.1: Melting, Freezing, and Sublimation" and two from LibreTexts
+% "5.4: Phase Changes" (Heartland), each quoted here character-for-character so a
+% reader can re-check it:
+%
+%   solid_to_liquid → melting
+%     "The process of a solid becoming a liquid is called melting (an older term
+%      that you may see sometimes is fusion)."
+%
+%   liquid_to_solid → freezing
+%     "The opposite process, a liquid becoming a solid, is called freezing (some
+%      textbooks also use the word solidification for this process)."
+%
+%   solid_to_gas → sublimation  /  gas_to_solid → deposition
+%     "The solid-to-gas change is called sublimation, while the reverse process
+%      is called deposition."
+%
+%   liquid_to_gas → vaporization
+%     "Vaporization, which is more often referred to as "boiling," is the
+%      complementary process in which a chemical is converted from the liquid
+%      state of matter to a gaseous physical form."
+%
+%   gas_to_liquid → condensation
+%     "During condensation, a substance is changed from the gaseous to the liquid
+%      state of matter."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the LibreTexts sentence that
+% fixes the first row (solid_to_liquid → melting). Every OTHER row's per-fact
+% source and verbatim span is listed above, so each name remains independently
+% checkable. LibreTexts is a secondary teaching reference (not a primary source),
+% so `trust consensus`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table phase_change_name {
+    columns change, name
+
+    row (solid_to_liquid, melting)
+    row (liquid_to_solid, freezing)
+    row (liquid_to_gas, vaporization)
+    row (gas_to_liquid, condensation)
+    row (solid_to_gas, sublimation)
+    row (gas_to_solid, deposition)
+
+    source "The process of a solid becoming a liquid is called melting (an older term that you may see sometimes is fusion)."
+    locator "https://chem.libretexts.org/Courses/Madera_Community_College/MacArthur_Chemistry_3A_v_1.2/09:_Attractive_Forces/9.03:_Phase_Transitions/9.3.01:_Melting_Freezing_and_Sublimation"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/physics/states-of-matter.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/states-of-matter.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% states-of-matter.query.adj — a worked recall over the physics states-of-matter
+% (phase-change) library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the change from a
+% solid to a liquid called?": it states no physics fact — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `phase_change_name` rows and returns the name + the table's source/locator/
+% trust. A direction not in the table abstains honestly — the engine never
+% invents a name.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli states-of-matter.query.adj
+% ============================================================================
+
+import "states-of-matter.adj"
+
+? phase_change_name(solid_to_liquid, $Name)    % expect melting
+? phase_change_name(gas_to_liquid, $Name)      % expect condensation
+? phase_change_name($Change, sublimation)      % expect solid_to_gas — reverse recall
+? phase_change_name(solid_to_plasma, $Name)    % expect abstain — not one of the six phase changes


### PR DESCRIPTION
Adds a grounded FACTS library mapping each phase change between the three
everyday states of matter to the single word that names it, as a native
ADJ `table` (RS-5). Complements the existing chemistry/states-of-matter.adj
(state → container behavior) along the transition axis.

Rows (all six grounded, byte-provenanced this session; nothing from memory):
  solid_to_liquid → melting        (LibreTexts 9.3.1, consensus)
  liquid_to_solid → freezing       (LibreTexts 9.3.1, consensus)
  liquid_to_gas   → vaporization   (LibreTexts 5.4 Heartland, consensus)
  gas_to_liquid   → condensation   (LibreTexts 5.4 Heartland, consensus)
  solid_to_gas    → sublimation    (LibreTexts 9.3.1, consensus)
  gas_to_solid    → deposition     (LibreTexts 9.3.1, consensus)

Each `name` is a single lowercase token taken verbatim from the source's
own defining sentence for that direction; per-row verbatim spans are quoted
in the file header. Trust tier = consensus: LibreTexts is a secondary
teaching reference, not a primary source.

Sources:
  https://chem.libretexts.org/Courses/Madera_Community_College/MacArthur_Chemistry_3A_v_1.2/09:_Attractive_Forces/9.03:_Phase_Transitions/9.3.01:_Melting_Freezing_and_Sublimation
  https://chem.libretexts.org/Courses/Heartland_Community_College/CHEM_120:_Fundamentals_of_Chemistry/05:_Matter_and_Energy/5.04:_Evaporation_and_Condensation

Data-only diff: new physics/states-of-matter.adj + .query.adj, one e2e
test (facts_physstatesofmatter_e2e.rs), one README subject-index row.
Recall binds the name with its citation, runs backward, and abstains on a
non-phase-change key — 0 model calls. cargo test + clippy green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
