### PR TITLE
feat(adj-facts-stdlib): anatomy/muscle-groups — skeletal muscle → body region table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_musclegroups_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_musclegroups_e2e.rs
@@ -1,0 +1,72 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/muscle-groups.adj`) driven through the built CLI:
+//! a native `table` of skeletal muscle → body region resolves a binding-query
+//! recall with the source's Wikipedia (consensus) citation, runs the relation
+//! backward (region → every muscle in it, one-to-many), and abstains on a
+//! non-muscle (the femur, a bone) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsmuscle_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_muscle_groups_recall_binds_region_with_citation() {
+    let dir = scratch("musclegroups");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/muscle-groups.adj");
+    std::fs::copy(&src, dir.join("muscle-groups.adj")).expect("copy shipped muscle-groups.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"muscle-groups.adj\"\n\
+         ? muscle_region(biceps_brachii, $R)\n\
+         ? muscle_region(deltoid, $R)\n\
+         ? muscle_region(quadriceps, $R)\n\
+         ? muscle_region($M, arm)\n\
+         ? muscle_region(femur, $R)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Each named muscle binds its body region — a single lowercase token echoed
+    // verbatim from the source sentence.
+    assert!(out.contains("\"R\":\"arm\""), "biceps_brachii → arm: {out}");
+    assert!(out.contains("\"R\":\"shoulder\""), "deltoid → shoulder: {out}");
+    assert!(out.contains("\"R\":\"thigh\""), "quadriceps → thigh: {out}");
+    // The relation runs backward and is one-to-many: the region `arm` recalls
+    // BOTH the biceps and the triceps.
+    assert!(
+        out.contains("\"M\":\"biceps_brachii\"") && out.contains("\"M\":\"triceps_brachii\""),
+        "arm → biceps_brachii AND triceps_brachii (reverse recall): {out}"
+    );
+    // The answer carries the Wikipedia citation as its proof, at consensus trust.
+    assert!(
+        out.contains("en.wikipedia.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation: {out}"
+    );
+    // The femur is a bone, not a muscle — honest abstention, never a fabricated
+    // location.
+    assert!(out.contains("\"abstained\":true"), "unknown muscle abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -46,6 +46,7 @@ per rotation, in parallel):
 | `physics/` | simple machine → everyday example | NASA |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
+| `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/anatomy/muscle-groups.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/muscle-groups.adj
@@ -1,0 +1,132 @@
+% ============================================================================
+% muscle-groups — a named skeletal muscle → the body region it is located in
+% (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A middle/high-school musculoskeletal fact set on the way to medicine: the body
+% has hundreds of skeletal muscles, and the first thing a learner memorizes is
+% simply WHERE each big named muscle sits. The biceps brachii is in the arm; the
+% deltoid caps the shoulder; the pectoralis major fans across the chest; the
+% rectus abdominis (the "six-pack") runs down the abdomen; the gluteus maximus
+% is the great muscle of the hip; the quadriceps and sartorius run down the
+% thigh; the gastrocnemius bulges the back of the leg. Recall is a binding query:
+%
+%     ? muscle_region(biceps_brachii, $Region)   % arm
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `muscle_region(muscle, region)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the region
+% WITH its source, on the CPU, with zero model calls, and abstains on anything
+% that is not one of these muscles (it never invents a location).
+%
+% The muscles, as a little truth table:
+%
+%     muscle              region     everyday name of the spot
+%     -----------------   --------   ---------------------------------
+%     biceps_brachii      arm        front of the upper arm
+%     triceps_brachii     arm        back of the upper arm
+%     deltoid             shoulder   the rounded cap of the shoulder
+%     pectoralis_major    chest      the fan across the chest
+%     rectus_abdominis    abdomen    the "six-pack" of the belly wall
+%     gluteus_maximus     hip        the big muscle of the hip/buttock
+%     quadriceps          thigh      front of the thigh
+%     sartorius           thigh      the long strap down the thigh
+%     gastrocnemius       leg        the calf, back of the lower leg
+%
+% Each `region` value is a SINGLE lowercase token that appears VERBATIM in the
+% cited source sentence (see the provenance block), so the recall is a faithful
+% echo of the source, not a paraphrase. Note that a region is one-to-MANY: `arm`
+% holds both the biceps and the triceps, and `thigh` holds both the quadriceps
+% and the sartorius — so the relation run BACKWARD enumerates every muscle in a
+% region:
+%
+%     ? muscle_region($M, arm)   % biceps_brachii, then triceps_brachii
+%
+% Something that is not one of these muscles — a bone (the femur), a tendon, the
+% heart — has no row, so a recall on it ABSTAINS rather than inventing a place.
+% That honest-abstention property is what makes the table safe to reason from: a
+% medicine agent reasons UP from "which muscle lives where" before it can reason
+% about a torn hamstring in the thigh or a rotator-cuff problem at the shoulder.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every muscle→region pair was
+% read out of a page fetched this session, and any pair that could not be cleanly
+% grounded was DROPPED; the masseter and sternocleidomastoid were dropped because
+% no fetched source stated their location with a single clean region token in one
+% sentence). Each region token below is quoted inside the verbatim source
+% sentence so any reader can re-check it. All nine sources are the corresponding
+% English Wikipedia muscle articles — a widely-reviewed SECONDARY reference, so
+% this table is `trust consensus` (NOT authoritative: no primary U.S. government
+% / NIH page stated these single-token locations in fetchable text this session):
+%
+%   biceps_brachii → arm
+%     https://en.wikipedia.org/wiki/Biceps
+%     "The biceps or biceps brachii is a large muscle that lies on the front of
+%      the upper arm between the shoulder and the elbow."
+%
+%   triceps_brachii → arm
+%     https://en.wikipedia.org/wiki/Triceps
+%     "The triceps, or triceps brachii (Latin for "three-headed muscle of the
+%      arm"), is a large muscle on the back of the upper limb of many
+%      vertebrates."
+%
+%   deltoid → shoulder
+%     https://en.wikipedia.org/wiki/Deltoid_muscle
+%     "The deltoid muscle (or musculus deltoideus) is the muscle forming the
+%      rounded contour of the human shoulder."
+%
+%   pectoralis_major → chest
+%     https://en.wikipedia.org/wiki/Pectoralis_major
+%     "The pectoralis major (from Latin pectus 'breast') is a thick, fan-shaped
+%      or triangular convergent muscle of the human chest."
+%
+%   rectus_abdominis → abdomen
+%     https://en.wikipedia.org/wiki/Rectus_abdominis_muscle
+%     "The rectus abdominis ... is a pair of segmented skeletal muscle on the
+%      ventral aspect of a person's abdomen."
+%
+%   gluteus_maximus → hip
+%     https://en.wikipedia.org/wiki/Gluteus_maximus_muscle
+%     "The gluteus maximus is the main extensor muscle of the hip in humans."
+%
+%   quadriceps → thigh
+%     https://en.wikipedia.org/wiki/Quadriceps
+%     "The quadriceps femoris muscle is a large muscle group that includes the
+%      four prevailing muscles on the front of the thigh."
+%
+%   sartorius → thigh
+%     https://en.wikipedia.org/wiki/Sartorius_muscle
+%     "It is a long, thin, superficial muscle that runs down the length of the
+%      thigh in the anterior compartment."
+%
+%   gastrocnemius → leg
+%     https://en.wikipedia.org/wiki/Gastrocnemius_muscle
+%     "It is located superficial to the soleus in the posterior (back)
+%      compartment of the leg."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the Wikipedia sentence that fixes
+% the first row (biceps_brachii → arm). Every OTHER row's per-fact source and
+% verbatim span is listed above, so each pair remains independently checkable.
+% All nine sources are the same secondary reference (English Wikipedia), so
+% `trust consensus`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table muscle_region {
+    columns muscle, region
+
+    row (biceps_brachii, arm)
+    row (triceps_brachii, arm)
+    row (deltoid, shoulder)
+    row (pectoralis_major, chest)
+    row (rectus_abdominis, abdomen)
+    row (gluteus_maximus, hip)
+    row (quadriceps, thigh)
+    row (sartorius, thigh)
+    row (gastrocnemius, leg)
+
+    source "The biceps or biceps brachii is a large muscle that lies on the front of the upper arm between the shoulder and the elbow."
+    locator "https://en.wikipedia.org/wiki/Biceps"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/muscle-groups.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/muscle-groups.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% muscle-groups.query.adj — a worked recall over the anatomy muscle-groups lib.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "where is the biceps?": it
+% states no anatomy fact — it only `import`s the grounded table and asks binding
+% queries. The engine resolves each `?` against the `muscle_region` rows and
+% returns the region + the table's source/locator/trust. The third query runs
+% the relation BACKWARD (bind the region `arm`, recall every muscle in it — the
+% biceps AND the triceps). The femur is a bone, not a muscle, so a recall on it
+% abstains honestly — the engine never invents a location.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli muscle-groups.query.adj
+% ============================================================================
+
+import "muscle-groups.adj"
+
+? muscle_region(biceps_brachii, $R)    % expect arm
+? muscle_region(deltoid, $R)           % expect shoulder
+? muscle_region(quadriceps, $R)        % expect thigh
+? muscle_region($M, arm)               % expect biceps_brachii, triceps_brachii
+? muscle_region(femur, $R)             % expect abstain — the femur is a bone


### PR DESCRIPTION
Adds a grounded ANATOMY facts library mapping a named skeletal muscle to the
single lowercase body-region token literally stated in its source sentence,
mirroring the existing anatomy/lung-lobes and anatomy/brain-parts libraries
(native `table`, one provenance envelope, honest abstention on non-muscles).

Rows (9 muscles → 6 regions), each region echoed verbatim from the cited
sentence; region is one-to-many (arm holds biceps+triceps, thigh holds
quadriceps+sartorius) so reverse recall enumerates every muscle in a region:

  biceps_brachii   → arm
  triceps_brachii  → arm
  deltoid          → shoulder
  pectoralis_major → chest
  rectus_abdominis → abdomen
  gluteus_maximus  → hip
  quadriceps       → thigh
  sartorius        → thigh
  gastrocnemius    → leg

Provenance / trust: every pair was byte-grounded from a page fetched this
session — the corresponding English Wikipedia muscle article — with the
verbatim source sentence quoted per row in the file header. Wikipedia is a
secondary reference, so the table ships `trust consensus` (NOT authoritative):
no primary U.S. government / NIH page stated these single-token locations in
fetchable text this session. The NCI SEER Training muscular-system pages were
fetched first but describe muscles by GROUP and by the movement they cause,
not with a clean per-muscle "located in the <region>" single-token sentence.

Dropped for lack of clean provenance: masseter and sternocleidomastoid — no
fetched source stated their location with a single clean region token in one
sentence (SEER lists them only by group; Wikipedia opens on function/mastication
and "cervical", not a plain "jaw"/"neck" location clause).

Diff is data-only: new anatomy/muscle-groups.adj + .query.adj, one e2e test
(facts_musclegroups_e2e.rs) asserting an exact lookup binds the region with the
citation and that a non-muscle (femur) abstains, and one README subject-index
row. No engine/grammar/adapter code touched. cargo test -p adj-lang
-p adj-lang-cli and clippy -D warnings both green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
