### PR TITLE
feat: port data store engine to Lua and Perl

### DIFF
--- a/code/packages/lua/in-memory-data-store-engine/BUILD
+++ b/code/packages/lua/in-memory-data-store-engine/BUILD
@@ -1,0 +1,4 @@
+luarocks show coding-adventures-hyperloglog >/dev/null 2>&1 || (cd ../hyperloglog && luarocks make --local --deps-mode=none coding-adventures-hyperloglog-0.1.0-1.rockspec)
+luarocks show coding-adventures-in-memory-data-store-protocol >/dev/null 2>&1 || (cd ../in-memory-data-store-protocol && luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-protocol-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-engine-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../hyperloglog/src/?.lua;../../hyperloglog/src/?/init.lua;../../in-memory-data-store-protocol/src/?.lua;../../in-memory-data-store-protocol/src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/in-memory-data-store-engine/BUILD_windows
+++ b/code/packages/lua/in-memory-data-store-engine/BUILD_windows
@@ -1,0 +1,4 @@
+luarocks show coding-adventures-hyperloglog >nul 2>&1 || (cd ..\hyperloglog && luarocks make --local --deps-mode=none coding-adventures-hyperloglog-0.1.0-1.rockspec)
+luarocks show coding-adventures-in-memory-data-store-protocol >nul 2>&1 || (cd ..\in-memory-data-store-protocol && luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-protocol-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-engine-0.1.0-1.rockspec
+cd tests && set "LUA_PATH=../src/?.lua;../src/?/init.lua;../../hyperloglog/src/?.lua;../../hyperloglog/src/?/init.lua;../../in-memory-data-store-protocol/src/?.lua;../../in-memory-data-store-protocol/src/?/init.lua;;" && busted . --verbose --pattern=test_

--- a/code/packages/lua/in-memory-data-store-engine/CHANGELOG.md
+++ b/code/packages/lua/in-memory-data-store-engine/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-16
+
+- Add the full in-memory data store execution engine for Lua.
+- Cover typed collections, sorted sets, HyperLogLog, TTLs, logical databases,
+  protocol errors, deterministic ordering, and binary-safe values.

--- a/code/packages/lua/in-memory-data-store-engine/README.md
+++ b/code/packages/lua/in-memory-data-store-engine/README.md
@@ -1,0 +1,24 @@
+# In-Memory Data Store Engine (Lua)
+
+A pure Lua 5.4 execution engine for the repository's in-memory data store
+stack. It consumes `CommandFrame` values from the sibling protocol package and
+returns the shared `EngineResponse` IR.
+
+```lua
+local engine = require("coding_adventures.in_memory_data_store_engine").new()
+
+engine:execute_parts({"SET", "answer", "41"})
+assert(engine:execute_parts({"INCR", "answer"}).value == 42)
+```
+
+The engine implements binary-safe strings, hashes, lists, sets, sorted sets,
+HyperLogLog, expiry and persistence, globbed key lookup, 16 logical databases,
+and administrative commands. Its 57-command surface includes the Redis-style
+string, hash, list, set, sorted-set, HLL, TTL, database, and server operations
+implemented by the other language lanes.
+
+`DataStoreEngine.new` accepts optional `store`, `database_count`, and
+`time_provider` fields. The clock hook makes TTL behavior deterministic in
+tests without filesystem, network, process, environment, or randomness access.
+
+Run the package gate from this directory with `BUILD` or `BUILD_windows`.

--- a/code/packages/lua/in-memory-data-store-engine/coding-adventures-in-memory-data-store-engine-0.1.0-1.rockspec
+++ b/code/packages/lua/in-memory-data-store-engine/coding-adventures-in-memory-data-store-engine-0.1.0-1.rockspec
@@ -1,0 +1,20 @@
+package = "coding-adventures-in-memory-data-store-engine"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Pure Lua execution engine for the in-memory data store",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+    "coding-adventures-hyperloglog >= 0.1.0",
+    "coding-adventures-in-memory-data-store-protocol >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.in_memory_data_store_engine"] = "src/coding_adventures/in_memory_data_store_engine/init.lua",
+    },
+}

--- a/code/packages/lua/in-memory-data-store-engine/required_capabilities.json
+++ b/code/packages/lua/in-memory-data-store-engine/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/in-memory-data-store-engine",
+  "capabilities": [],
+  "justification": "Pure in-memory command execution over protocol IR and HyperLogLog. No filesystem, network, process, environment, or randomness access is needed."
+}

--- a/code/packages/lua/in-memory-data-store-engine/src/coding_adventures/in_memory_data_store_engine/init.lua
+++ b/code/packages/lua/in-memory-data-store-engine/src/coding_adventures/in_memory_data_store_engine/init.lua
@@ -1,0 +1,877 @@
+local protocol = require("coding_adventures.in_memory_data_store_protocol")
+local HyperLogLog = require("coding_adventures.hyperloglog").HyperLogLog
+
+local Response = protocol.EngineResponse
+local M = { VERSION = "0.1.0" }
+
+local EntryType = {
+    STRING = "string",
+    HASH = "hash",
+    LIST = "list",
+    SET = "set",
+    ZSET = "zset",
+    HLL = "hll",
+}
+
+local function system_now_ms()
+    return os.time() * 1000
+end
+
+local function count_keys(values)
+    local count = 0
+    for _ in pairs(values) do
+        count = count + 1
+    end
+    return count
+end
+
+local function sorted_keys(values)
+    local keys = {}
+    for key in pairs(values) do
+        keys[#keys + 1] = key
+    end
+    table.sort(keys)
+    return keys
+end
+
+local function glob_match(pattern, value)
+    local pattern_index, value_index = 1, 1
+    local star_index, retry_value_index
+    while value_index <= #value do
+        local pattern_byte = string.byte(pattern, pattern_index)
+        local value_byte = string.byte(value, value_index)
+        if pattern_index <= #pattern and (pattern_byte == string.byte("?") or pattern_byte == value_byte) then
+            pattern_index = pattern_index + 1
+            value_index = value_index + 1
+        elseif pattern_index <= #pattern and pattern_byte == string.byte("*") then
+            star_index = pattern_index
+            retry_value_index = value_index
+            pattern_index = pattern_index + 1
+        elseif star_index ~= nil then
+            retry_value_index = retry_value_index + 1
+            value_index = retry_value_index
+            pattern_index = star_index + 1
+        else
+            return false
+        end
+    end
+    while pattern_index <= #pattern and string.byte(pattern, pattern_index) == string.byte("*") do
+        pattern_index = pattern_index + 1
+    end
+    return pattern_index > #pattern
+end
+
+local Entry = {}
+Entry.__index = Entry
+
+function Entry.new(entry_type, value, expires_at_ms)
+    return setmetatable({ type = entry_type, value = value, expires_at_ms = expires_at_ms }, Entry)
+end
+
+local SortedSet = {}
+SortedSet.__index = SortedSet
+
+function SortedSet.new()
+    return setmetatable({ scores = {} }, SortedSet)
+end
+
+function SortedSet:insert(score, member)
+    local is_new = self.scores[member] == nil
+    self.scores[member] = score
+    return is_new
+end
+
+function SortedSet:remove(member)
+    if self.scores[member] == nil then
+        return false
+    end
+    self.scores[member] = nil
+    return true
+end
+
+function SortedSet:ordered_entries()
+    local result = {}
+    for member, score in pairs(self.scores) do
+        result[#result + 1] = { member = member, score = score }
+    end
+    table.sort(result, function(left, right)
+        return left.score < right.score or (left.score == right.score and left.member < right.member)
+    end)
+    return result
+end
+
+function SortedSet:rank(member)
+    for index, item in ipairs(self:ordered_entries()) do
+        if item.member == member then
+            return index - 1
+        end
+    end
+    return nil
+end
+
+function SortedSet:score(member)
+    return self.scores[member]
+end
+
+function SortedSet:size()
+    return count_keys(self.scores)
+end
+
+function SortedSet:range_by_index(start_index, end_index)
+    local entries = self:ordered_entries()
+    local length = #entries
+    if length == 0 then
+        return {}
+    end
+    if start_index < 0 then
+        start_index = length + start_index
+    end
+    if end_index < 0 then
+        end_index = length + end_index
+    end
+    if start_index < 0 or end_index < 0 or start_index >= length or start_index > end_index then
+        return {}
+    end
+    end_index = math.min(end_index, length - 1)
+    local result = {}
+    for index = start_index + 1, end_index + 1 do
+        result[#result + 1] = entries[index]
+    end
+    return result
+end
+
+function SortedSet:range_by_score(minimum, maximum)
+    local result = {}
+    for _, item in ipairs(self:ordered_entries()) do
+        if item.score >= minimum and item.score <= maximum then
+            result[#result + 1] = item
+        end
+    end
+    return result
+end
+
+local Database = {}
+Database.__index = Database
+
+function Database.new(now_provider)
+    return setmetatable({ entries = {}, now_provider = now_provider or system_now_ms }, Database)
+end
+
+function Database:get(key)
+    local entry = self.entries[key]
+    if entry ~= nil and entry.expires_at_ms ~= nil and entry.expires_at_ms <= self.now_provider() then
+        self.entries[key] = nil
+        return nil
+    end
+    return entry
+end
+
+function Database:set(key, entry)
+    self.entries[key] = entry
+end
+
+function Database:delete(key)
+    if self.entries[key] == nil then
+        return false
+    end
+    self.entries[key] = nil
+    return true
+end
+
+function Database:expire_lazy(key)
+    self:get(key)
+end
+
+function Database:active_expire()
+    local now = self.now_provider()
+    for key, entry in pairs(self.entries) do
+        if entry.expires_at_ms ~= nil and entry.expires_at_ms <= now then
+            self.entries[key] = nil
+        end
+    end
+end
+
+function Database:keys(pattern)
+    self:active_expire()
+    local result = {}
+    for key in pairs(self.entries) do
+        if glob_match(pattern, key) then
+            result[#result + 1] = key
+        end
+    end
+    table.sort(result)
+    return result
+end
+
+function Database:clear()
+    self.entries = {}
+end
+
+local Store = {}
+Store.__index = Store
+
+function Store.new(database_count, now_provider)
+    database_count = database_count == nil and 16 or database_count
+    if type(database_count) ~= "number" or database_count % 1 ~= 0 or database_count <= 0 then
+        error("database_count must be positive", 2)
+    end
+    local databases = {}
+    for index = 1, database_count do
+        databases[index] = Database.new(now_provider)
+    end
+    return setmetatable({ databases = databases, active_db = 0 }, Store)
+end
+
+function Store:active_database()
+    return self.databases[self.active_db + 1]
+end
+
+function Store:select(index)
+    self.active_db = index
+end
+
+function Store:flushdb()
+    self:active_database():clear()
+end
+
+function Store:flushall()
+    for _, database in ipairs(self.databases) do
+        database:clear()
+    end
+end
+
+local function bulk(value)
+    return Response.bulk_string(value)
+end
+
+local function integer(value)
+    return Response.integer(value)
+end
+
+local function array(values)
+    return Response.array(values)
+end
+
+local function err(message)
+    return Response.error(message)
+end
+
+local function wrong_arity(command)
+    return err(string.format("ERR wrong number of arguments for '%s' command", command))
+end
+
+local function wrong_type()
+    return err("WRONGTYPE Operation against a key holding the wrong kind of value")
+end
+
+local function integer_error()
+    return err("ERR value is not an integer or out of range")
+end
+
+local function float_error()
+    return err("ERR value is not a valid float")
+end
+
+local function parse_i64(value)
+    if type(value) ~= "string" or not value:match("^[+-]?%d+$") then
+        return nil
+    end
+    local parsed = tonumber(value)
+    if parsed == nil or math.type(parsed) ~= "integer" then
+        return nil
+    end
+    return parsed
+end
+
+local function parse_float(value)
+    local parsed = tonumber(value)
+    if parsed == nil or parsed ~= parsed or parsed == math.huge or parsed == -math.huge then
+        return nil
+    end
+    return parsed
+end
+
+local function format_score(score)
+    if score == math.floor(score) then
+        return string.format("%.0f", score)
+    end
+    local text = string.format("%.15f", score)
+    text = text:gsub("0+$", ""):gsub("%.$", "")
+    return text
+end
+
+local DataStoreEngine = {}
+DataStoreEngine.__index = DataStoreEngine
+
+function DataStoreEngine.new(options)
+    options = options or {}
+    if getmetatable(options) == Store then
+        options = { store = options }
+    end
+    local now_provider = options.time_provider or system_now_ms
+    local self = setmetatable({ now_provider = now_provider }, DataStoreEngine)
+    self.store = options.store or Store.new(options.database_count, now_provider)
+    return self
+end
+
+function DataStoreEngine:current_time_ms()
+    return self.now_provider()
+end
+
+function DataStoreEngine:key_entry(key)
+    return self.store:active_database():get(key)
+end
+
+function DataStoreEngine:ensure_collection(key, entry_type, factory)
+    local entry = self:key_entry(key)
+    if entry == nil then
+        entry = Entry.new(entry_type, factory())
+        self.store:active_database():set(key, entry)
+    end
+    if entry.type ~= entry_type then
+        return nil
+    end
+    return entry
+end
+
+function DataStoreEngine:execute_frame(frame)
+    if frame == nil then
+        return err("ERR protocol error: expected array of bulk strings")
+    end
+    self.store:active_database():active_expire()
+    local command = string.upper(frame.command)
+    local handler = self["command_" .. string.lower(command)]
+    if handler == nil then
+        return err(string.format("ERR unknown command '%s'", string.lower(frame.command)))
+    end
+    return handler(self, frame.args)
+end
+
+function DataStoreEngine:execute_parts(parts)
+    return self:execute_frame(protocol.CommandFrame.from_parts(parts))
+end
+
+function DataStoreEngine:command_ping(args)
+    if #args == 0 then return Response.simple_string("PONG") end
+    if #args == 1 then return bulk(args[1]) end
+    return wrong_arity("ping")
+end
+
+function DataStoreEngine:command_echo(args)
+    return #args == 1 and bulk(args[1]) or wrong_arity("echo")
+end
+
+function DataStoreEngine:command_set(args)
+    if #args ~= 2 then return wrong_arity("set") end
+    self.store:active_database():set(args[1], Entry.new(EntryType.STRING, args[2]))
+    return Response.ok()
+end
+
+function DataStoreEngine:command_get(args)
+    if #args ~= 1 then return wrong_arity("get") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.null() end
+    if entry.type ~= EntryType.STRING then return wrong_type() end
+    return bulk(entry.value)
+end
+
+function DataStoreEngine:command_del(args)
+    if #args == 0 then return wrong_arity("del") end
+    local removed = 0
+    for _, key in ipairs(args) do
+        if self.store:active_database():delete(key) then removed = removed + 1 end
+    end
+    return integer(removed)
+end
+
+function DataStoreEngine:command_exists(args)
+    if #args == 0 then return wrong_arity("exists") end
+    local found = 0
+    for _, key in ipairs(args) do
+        if self:key_entry(key) ~= nil then found = found + 1 end
+    end
+    return integer(found)
+end
+
+function DataStoreEngine:command_keys(args)
+    if #args ~= 1 then return wrong_arity("keys") end
+    local result = {}
+    for _, key in ipairs(self.store:active_database():keys(args[1])) do
+        result[#result + 1] = bulk(key)
+    end
+    return array(result)
+end
+
+function DataStoreEngine:command_type(args)
+    if #args ~= 1 then return wrong_arity("type") end
+    local entry = self:key_entry(args[1])
+    return Response.simple_string(entry and entry.type or "none")
+end
+
+function DataStoreEngine:command_rename(args)
+    if #args ~= 2 then return wrong_arity("rename") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return err("ERR no such key") end
+    if args[1] ~= args[2] then
+        self.store:active_database():delete(args[1])
+        self.store:active_database():set(args[2], entry)
+    end
+    return Response.ok()
+end
+
+function DataStoreEngine:command_append(args)
+    if #args ~= 2 then return wrong_arity("append") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then
+        self.store:active_database():set(args[1], Entry.new(EntryType.STRING, args[2]))
+        return integer(#args[2])
+    end
+    if entry.type ~= EntryType.STRING then return wrong_type() end
+    entry.value = entry.value .. args[2]
+    return integer(#entry.value)
+end
+
+function DataStoreEngine:incr_by(args, fixed_delta, command)
+    local expected = fixed_delta == nil and 2 or 1
+    if #args ~= expected then return wrong_arity(command) end
+    local delta = fixed_delta or parse_i64(args[2])
+    if delta == nil then return integer_error() end
+    local entry = self:key_entry(args[1])
+    if entry ~= nil and entry.type ~= EntryType.STRING then return wrong_type() end
+    local current = entry == nil and 0 or parse_i64(entry.value)
+    if current == nil then return integer_error() end
+    if (delta > 0 and current > math.maxinteger - delta)
+        or (delta < 0 and current < math.mininteger - delta)
+    then
+        return integer_error()
+    end
+    local result = current + delta
+    self.store:active_database():set(args[1], Entry.new(EntryType.STRING, tostring(result), entry and entry.expires_at_ms))
+    return integer(result)
+end
+
+function DataStoreEngine:command_incr(args) return self:incr_by(args, 1, "incr") end
+function DataStoreEngine:command_decr(args) return self:incr_by(args, -1, "decr") end
+function DataStoreEngine:command_incrby(args) return self:incr_by(args, nil, "incrby") end
+
+function DataStoreEngine:command_decrby(args)
+    if #args ~= 2 then return wrong_arity("decrby") end
+    local delta = parse_i64(args[2])
+    if delta == nil or delta == math.mininteger then return integer_error() end
+    return self:incr_by({ args[1], tostring(-delta) }, nil, "decrby")
+end
+
+function DataStoreEngine:command_hset(args)
+    if #args < 3 or #args % 2 == 0 then return wrong_arity("hset") end
+    local entry = self:ensure_collection(args[1], EntryType.HASH, function() return {} end)
+    if entry == nil then return wrong_type() end
+    local added = 0
+    for index = 2, #args, 2 do
+        if entry.value[args[index]] == nil then added = added + 1 end
+        entry.value[args[index]] = args[index + 1]
+    end
+    return integer(added)
+end
+
+function DataStoreEngine:command_hget(args)
+    if #args ~= 2 then return wrong_arity("hget") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.null() end
+    if entry.type ~= EntryType.HASH then return wrong_type() end
+    return bulk(entry.value[args[2]])
+end
+
+function DataStoreEngine:command_hdel(args)
+    if #args < 2 then return wrong_arity("hdel") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.HASH then return wrong_type() end
+    local removed = 0
+    for index = 2, #args do
+        if entry.value[args[index]] ~= nil then
+            entry.value[args[index]] = nil
+            removed = removed + 1
+        end
+    end
+    if count_keys(entry.value) == 0 then self.store:active_database():delete(args[1]) end
+    return integer(removed)
+end
+
+function DataStoreEngine:hash_array(args, command, values_only)
+    if #args ~= 1 then return wrong_arity(command) end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return array({}) end
+    if entry.type ~= EntryType.HASH then return wrong_type() end
+    local result = {}
+    for _, field in ipairs(sorted_keys(entry.value)) do
+        if values_only ~= true then result[#result + 1] = bulk(field) end
+        if values_only ~= false then result[#result + 1] = bulk(entry.value[field]) end
+    end
+    return array(result)
+end
+
+function DataStoreEngine:command_hgetall(args) return self:hash_array(args, "hgetall", nil) end
+function DataStoreEngine:command_hkeys(args) return self:hash_array(args, "hkeys", false) end
+function DataStoreEngine:command_hvals(args) return self:hash_array(args, "hvals", true) end
+
+function DataStoreEngine:command_hlen(args)
+    if #args ~= 1 then return wrong_arity("hlen") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.HASH then return wrong_type() end
+    return integer(count_keys(entry.value))
+end
+
+function DataStoreEngine:command_hexists(args)
+    if #args ~= 2 then return wrong_arity("hexists") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.HASH then return wrong_type() end
+    return integer(entry.value[args[2]] ~= nil and 1 or 0)
+end
+
+function DataStoreEngine:push_list(args, left)
+    local command = left and "lpush" or "rpush"
+    if #args < 2 then return wrong_arity(command) end
+    local entry = self:ensure_collection(args[1], EntryType.LIST, function() return {} end)
+    if entry == nil then return wrong_type() end
+    for index = 2, #args do
+        if left then table.insert(entry.value, 1, args[index]) else entry.value[#entry.value + 1] = args[index] end
+    end
+    return integer(#entry.value)
+end
+
+function DataStoreEngine:command_lpush(args) return self:push_list(args, true) end
+function DataStoreEngine:command_rpush(args) return self:push_list(args, false) end
+
+function DataStoreEngine:pop_list(args, left)
+    local command = left and "lpop" or "rpop"
+    if #args ~= 1 then return wrong_arity(command) end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.null() end
+    if entry.type ~= EntryType.LIST then return wrong_type() end
+    local value = table.remove(entry.value, left and 1 or #entry.value)
+    if #entry.value == 0 then self.store:active_database():delete(args[1]) end
+    return bulk(value)
+end
+
+function DataStoreEngine:command_lpop(args) return self:pop_list(args, true) end
+function DataStoreEngine:command_rpop(args) return self:pop_list(args, false) end
+
+function DataStoreEngine:command_llen(args)
+    if #args ~= 1 then return wrong_arity("llen") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.LIST then return wrong_type() end
+    return integer(#entry.value)
+end
+
+function DataStoreEngine:command_lindex(args)
+    if #args ~= 2 then return wrong_arity("lindex") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.null() end
+    if entry.type ~= EntryType.LIST then return wrong_type() end
+    local index = parse_i64(args[2])
+    if index == nil then return integer_error() end
+    if index < 0 then index = #entry.value + index end
+    return bulk(entry.value[index + 1])
+end
+
+function DataStoreEngine:command_lrange(args)
+    if #args ~= 3 then return wrong_arity("lrange") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return array({}) end
+    if entry.type ~= EntryType.LIST then return wrong_type() end
+    local start_index, stop_index = parse_i64(args[2]), parse_i64(args[3])
+    if start_index == nil or stop_index == nil then return integer_error() end
+    local length = #entry.value
+    if start_index < 0 then start_index = length + start_index end
+    if stop_index < 0 then stop_index = length + stop_index end
+    start_index = math.max(0, start_index)
+    stop_index = math.min(length - 1, stop_index)
+    if length == 0 or start_index > stop_index or start_index >= length then return array({}) end
+    local result = {}
+    for index = start_index + 1, stop_index + 1 do result[#result + 1] = bulk(entry.value[index]) end
+    return array(result)
+end
+
+function DataStoreEngine:command_sadd(args)
+    if #args < 2 then return wrong_arity("sadd") end
+    local entry = self:ensure_collection(args[1], EntryType.SET, function() return {} end)
+    if entry == nil then return wrong_type() end
+    local added = 0
+    for index = 2, #args do
+        if entry.value[args[index]] == nil then added = added + 1 end
+        entry.value[args[index]] = true
+    end
+    return integer(added)
+end
+
+function DataStoreEngine:command_srem(args)
+    if #args < 2 then return wrong_arity("srem") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.SET then return wrong_type() end
+    local removed = 0
+    for index = 2, #args do
+        if entry.value[args[index]] then entry.value[args[index]], removed = nil, removed + 1 end
+    end
+    if count_keys(entry.value) == 0 then self.store:active_database():delete(args[1]) end
+    return integer(removed)
+end
+
+function DataStoreEngine:command_sismember(args)
+    if #args ~= 2 then return wrong_arity("sismember") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.SET then return wrong_type() end
+    return integer(entry.value[args[2]] and 1 or 0)
+end
+
+function DataStoreEngine:command_smembers(args)
+    if #args ~= 1 then return wrong_arity("smembers") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return array({}) end
+    if entry.type ~= EntryType.SET then return wrong_type() end
+    local result = {}
+    for _, value in ipairs(sorted_keys(entry.value)) do result[#result + 1] = bulk(value) end
+    return array(result)
+end
+
+function DataStoreEngine:command_scard(args)
+    if #args ~= 1 then return wrong_arity("scard") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.SET then return wrong_type() end
+    return integer(count_keys(entry.value))
+end
+
+function DataStoreEngine:set_operation(args, command, operation)
+    if #args == 0 then return wrong_arity(command) end
+    local result = {}
+    local first = self:key_entry(args[1])
+    if first ~= nil and first.type ~= EntryType.SET then return wrong_type() end
+    if first ~= nil then for value in pairs(first.value) do result[value] = true end end
+    if operation == "union" then
+        for index = 2, #args do
+            local entry = self:key_entry(args[index])
+            if entry ~= nil and entry.type ~= EntryType.SET then return wrong_type() end
+            if entry ~= nil then for value in pairs(entry.value) do result[value] = true end end
+        end
+    else
+        for index = 2, #args do
+            local entry = self:key_entry(args[index])
+            if entry ~= nil and entry.type ~= EntryType.SET then return wrong_type() end
+            if operation == "intersection" then
+                for value in pairs(result) do
+                    if entry == nil or not entry.value[value] then result[value] = nil end
+                end
+            elseif entry ~= nil then
+                for value in pairs(entry.value) do result[value] = nil end
+            end
+        end
+    end
+    local responses = {}
+    for _, value in ipairs(sorted_keys(result)) do responses[#responses + 1] = bulk(value) end
+    return array(responses)
+end
+
+function DataStoreEngine:command_sunion(args) return self:set_operation(args, "sunion", "union") end
+function DataStoreEngine:command_sinter(args) return self:set_operation(args, "sinter", "intersection") end
+function DataStoreEngine:command_sdiff(args) return self:set_operation(args, "sdiff", "difference") end
+
+function DataStoreEngine:command_zadd(args)
+    if #args < 3 or #args % 2 == 0 then return wrong_arity("zadd") end
+    local parsed = {}
+    for index = 2, #args, 2 do
+        local score = parse_float(args[index])
+        if score == nil then return float_error() end
+        parsed[#parsed + 1] = { score = score, member = args[index + 1] }
+    end
+    local entry = self:ensure_collection(args[1], EntryType.ZSET, SortedSet.new)
+    if entry == nil then return wrong_type() end
+    local added = 0
+    for _, item in ipairs(parsed) do if entry.value:insert(item.score, item.member) then added = added + 1 end end
+    return integer(added)
+end
+
+function DataStoreEngine:flatten_zset(values, with_scores)
+    local result = {}
+    for _, item in ipairs(values) do
+        result[#result + 1] = bulk(item.member)
+        if with_scores then result[#result + 1] = bulk(format_score(item.score)) end
+    end
+    return result
+end
+
+function DataStoreEngine:command_zrange(args)
+    if #args ~= 3 and #args ~= 4 then return wrong_arity("zrange") end
+    local start_index, end_index = parse_i64(args[2]), parse_i64(args[3])
+    if start_index == nil or end_index == nil then return integer_error() end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return array({}) end
+    if entry.type ~= EntryType.ZSET then return wrong_type() end
+    local with_scores = #args == 4 and string.upper(args[4]) == "WITHSCORES"
+    return array(self:flatten_zset(entry.value:range_by_index(start_index, end_index), with_scores))
+end
+
+function DataStoreEngine:command_zrangebyscore(args)
+    if #args ~= 3 and #args ~= 4 then return wrong_arity("zrangebyscore") end
+    local minimum, maximum = parse_float(args[2]), parse_float(args[3])
+    if minimum == nil or maximum == nil then return float_error() end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return array({}) end
+    if entry.type ~= EntryType.ZSET then return wrong_type() end
+    local with_scores = #args == 4 and string.upper(args[4]) == "WITHSCORES"
+    return array(self:flatten_zset(entry.value:range_by_score(minimum, maximum), with_scores))
+end
+
+function DataStoreEngine:command_zrank(args)
+    if #args ~= 2 then return wrong_arity("zrank") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.null() end
+    if entry.type ~= EntryType.ZSET then return wrong_type() end
+    local rank = entry.value:rank(args[2])
+    return rank == nil and Response.null() or integer(rank)
+end
+
+function DataStoreEngine:command_zscore(args)
+    if #args ~= 2 then return wrong_arity("zscore") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.null() end
+    if entry.type ~= EntryType.ZSET then return wrong_type() end
+    local score = entry.value:score(args[2])
+    return score == nil and Response.null() or bulk(format_score(score))
+end
+
+function DataStoreEngine:command_zcard(args)
+    if #args ~= 1 then return wrong_arity("zcard") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.ZSET then return wrong_type() end
+    return integer(entry.value:size())
+end
+
+function DataStoreEngine:command_zrem(args)
+    if #args < 2 then return wrong_arity("zrem") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    if entry.type ~= EntryType.ZSET then return wrong_type() end
+    local removed = 0
+    for index = 2, #args do if entry.value:remove(args[index]) then removed = removed + 1 end end
+    if entry.value:size() == 0 then self.store:active_database():delete(args[1]) end
+    return integer(removed)
+end
+
+function DataStoreEngine:command_pfadd(args)
+    if #args < 2 then return wrong_arity("pfadd") end
+    local entry = self:ensure_collection(args[1], EntryType.HLL, HyperLogLog.new)
+    if entry == nil then return wrong_type() end
+    local before = table.concat(entry.value:registers(), ",")
+    for index = 2, #args do entry.value:add(args[index]) end
+    return integer(before ~= table.concat(entry.value:registers(), ",") and 1 or 0)
+end
+
+function DataStoreEngine:command_pfcount(args)
+    if #args == 0 then return wrong_arity("pfcount") end
+    local aggregate
+    for _, key in ipairs(args) do
+        local entry = self:key_entry(key)
+        if entry ~= nil and entry.type ~= EntryType.HLL then return wrong_type() end
+        if entry ~= nil then aggregate = aggregate == nil and entry.value or aggregate:merge(entry.value) end
+    end
+    return integer(aggregate == nil and 0 or aggregate:count())
+end
+
+function DataStoreEngine:command_pfmerge(args)
+    if #args < 2 then return wrong_arity("pfmerge") end
+    local aggregate
+    for index = 2, #args do
+        local entry = self:key_entry(args[index])
+        if entry ~= nil and entry.type ~= EntryType.HLL then return wrong_type() end
+        if entry ~= nil then aggregate = aggregate == nil and entry.value or aggregate:merge(entry.value) end
+    end
+    local destination = self:key_entry(args[1])
+    self.store:active_database():set(args[1], Entry.new(EntryType.HLL, aggregate or HyperLogLog.new(), destination and destination.expires_at_ms))
+    return Response.ok()
+end
+
+function DataStoreEngine:expire(args, absolute)
+    local command = absolute and "expireat" or "expire"
+    if #args ~= 2 then return wrong_arity(command) end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return Response.zero() end
+    local seconds = parse_i64(args[2])
+    if seconds == nil then return integer_error() end
+    entry.expires_at_ms = absolute and seconds * 1000 or self.now_provider() + seconds * 1000
+    return Response.one()
+end
+
+function DataStoreEngine:command_expire(args) return self:expire(args, false) end
+function DataStoreEngine:command_expireat(args) return self:expire(args, true) end
+
+function DataStoreEngine:command_ttl(args)
+    if #args ~= 1 then return wrong_arity("ttl") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return integer(-2) end
+    if entry.expires_at_ms == nil then return integer(-1) end
+    return integer(math.max(-2, math.floor((entry.expires_at_ms - self.now_provider()) / 1000)))
+end
+
+function DataStoreEngine:command_pttl(args)
+    if #args ~= 1 then return wrong_arity("pttl") end
+    local entry = self:key_entry(args[1])
+    if entry == nil then return integer(-2) end
+    if entry.expires_at_ms == nil then return integer(-1) end
+    return integer(math.max(-1, entry.expires_at_ms - self.now_provider()))
+end
+
+function DataStoreEngine:command_persist(args)
+    if #args ~= 1 then return wrong_arity("persist") end
+    local entry = self:key_entry(args[1])
+    if entry == nil or entry.expires_at_ms == nil then return Response.zero() end
+    entry.expires_at_ms = nil
+    return Response.one()
+end
+
+function DataStoreEngine:command_select(args)
+    if #args ~= 1 then return wrong_arity("select") end
+    local index = parse_i64(args[1])
+    if index == nil or index < 0 or index >= #self.store.databases then return err("ERR DB index is out of range") end
+    self.store:select(index)
+    return Response.ok()
+end
+
+function DataStoreEngine:command_flushdb(args)
+    if #args ~= 0 then return wrong_arity("flushdb") end
+    self.store:flushdb()
+    return Response.ok()
+end
+
+function DataStoreEngine:command_flushall(args)
+    if #args ~= 0 then return wrong_arity("flushall") end
+    self.store:flushall()
+    return Response.ok()
+end
+
+function DataStoreEngine:command_dbsize(args)
+    if #args ~= 0 then return wrong_arity("dbsize") end
+    self.store:active_database():active_expire()
+    return integer(count_keys(self.store:active_database().entries))
+end
+
+function DataStoreEngine:command_info(args)
+    if #args ~= 0 then return wrong_arity("info") end
+    local text = string.format("# Server\r\nin_memory_data_store_version:0.1.0\r\nactive_db:%d\r\ndbsize:%d\r\n", self.store.active_db, count_keys(self.store:active_database().entries))
+    return bulk(text)
+end
+
+M.EntryType = EntryType
+M.Entry = Entry
+M.SortedSet = SortedSet
+M.Database = Database
+M.Store = Store
+M.DataStoreEngine = DataStoreEngine
+M.new = DataStoreEngine.new
+
+return M

--- a/code/packages/lua/in-memory-data-store-engine/tests/test_engine.lua
+++ b/code/packages/lua/in-memory-data-store-engine/tests/test_engine.lua
@@ -1,0 +1,229 @@
+local engine_module = require("coding_adventures.in_memory_data_store_engine")
+
+local function execute(engine, ...)
+    return engine:execute_parts({...})
+end
+
+local function values(response)
+    assert.equals("array", response.kind)
+    local result = {}
+    for index, item in ipairs(response.value) do
+        result[index] = item.value
+    end
+    return result
+end
+
+local function assert_error(response, text)
+    assert.equals("error", response.kind)
+    assert.is_truthy(response.value:find(text, 1, true))
+end
+
+describe("DataStoreEngine", function()
+    it("handles strings, integers, and keyspace commands", function()
+        local engine = engine_module.new()
+        assert.equals("PONG", execute(engine, "PING").value)
+        assert.equals("hello", execute(engine, "PING", "hello").value)
+        assert.equals("\0binary", execute(engine, "ECHO", "\0binary").value)
+        assert.equals("OK", execute(engine, "SET", "user:1", "40").value)
+        assert.equals("40", execute(engine, "GET", "user:1").value)
+        assert.equals(1, execute(engine, "EXISTS", "user:1", "missing").value)
+        assert.equals("string", execute(engine, "TYPE", "user:1").value)
+        assert.equals("none", execute(engine, "TYPE", "missing").value)
+        assert.equals(41, execute(engine, "INCR", "user:1").value)
+        assert.equals(43, execute(engine, "INCRBY", "user:1", "2").value)
+        assert.equals(42, execute(engine, "DECR", "user:1").value)
+        assert.equals(40, execute(engine, "DECRBY", "user:1", "2").value)
+        assert.equals(3, execute(engine, "APPEND", "user:1", "!").value)
+        assert.equals(3, execute(engine, "APPEND", "new", "abc").value)
+        execute(engine, "SET", "user:2", "Lin")
+        assert.same({"user:1", "user:2"}, values(execute(engine, "KEYS", "user:*")))
+        assert.equals("OK", execute(engine, "RENAME", "user:2", "user:two").value)
+        assert.equals("Lin", execute(engine, "GET", "user:two").value)
+        execute(engine, "SET", "literal[1]", "yes")
+        assert.same({"literal[1]"}, values(execute(engine, "KEYS", "literal[1]")))
+        assert.equals(1, execute(engine, "DEL", "user:1", "missing").value)
+        assert.is_nil(execute(engine, "GET", "user:1").value)
+    end)
+
+    it("handles hashes and lists", function()
+        local engine = engine_module.new()
+        assert.equals(2, execute(engine, "HSET", "user", "name", "Ada", "city", "London").value)
+        assert.equals(0, execute(engine, "HSET", "user", "name", "Augusta").value)
+        assert.equals("Augusta", execute(engine, "HGET", "user", "name").value)
+        assert.equals(1, execute(engine, "HEXISTS", "user", "city").value)
+        assert.equals(2, execute(engine, "HLEN", "user").value)
+        assert.same({"city", "name"}, values(execute(engine, "HKEYS", "user")))
+        assert.same({"London", "Augusta"}, values(execute(engine, "HVALS", "user")))
+        assert.same({"city", "London", "name", "Augusta"}, values(execute(engine, "HGETALL", "user")))
+        assert.equals(1, execute(engine, "HDEL", "user", "city", "missing").value)
+        assert.equals(1, execute(engine, "HDEL", "user", "name").value)
+        assert.equals(0, execute(engine, "HLEN", "user").value)
+        assert.equals(2, execute(engine, "LPUSH", "queue", "b", "a").value)
+        assert.equals(3, execute(engine, "RPUSH", "queue", "c").value)
+        assert.equals(3, execute(engine, "LLEN", "queue").value)
+        assert.equals("c", execute(engine, "LINDEX", "queue", "-1").value)
+        assert.same({"a", "b", "c"}, values(execute(engine, "LRANGE", "queue", "0", "-1")))
+        assert.equals("a", execute(engine, "LPOP", "queue").value)
+        assert.equals("c", execute(engine, "RPOP", "queue").value)
+        assert.equals("b", execute(engine, "RPOP", "queue").value)
+        assert.is_nil(execute(engine, "LPOP", "queue").value)
+    end)
+
+    it("handles sets, sorted sets, and HyperLogLog", function()
+        local engine = engine_module.new()
+        assert.equals(3, execute(engine, "SADD", "left", "a", "b", "c", "a").value)
+        assert.equals(3, execute(engine, "SADD", "right", "b", "c", "d").value)
+        assert.equals(1, execute(engine, "SISMEMBER", "left", "b").value)
+        assert.equals(3, execute(engine, "SCARD", "left").value)
+        assert.same({"a", "b", "c"}, values(execute(engine, "SMEMBERS", "left")))
+        assert.same({"a", "b", "c", "d"}, values(execute(engine, "SUNION", "left", "right")))
+        assert.same({"b", "c"}, values(execute(engine, "SINTER", "left", "right")))
+        assert.same({"a"}, values(execute(engine, "SDIFF", "left", "right")))
+        assert.same({}, values(execute(engine, "SINTER", "left", "missing")))
+        assert.equals(1, execute(engine, "SREM", "left", "a", "missing").value)
+        assert.equals(3, execute(engine, "ZADD", "scores", "1", "alice", "2", "bob", "1.5", "cara").value)
+        assert.equals(0, execute(engine, "ZADD", "scores", "3", "alice").value)
+        assert.same({"cara", "bob", "alice"}, values(execute(engine, "ZRANGE", "scores", "0", "-1")))
+        assert.same({"cara", "1.5", "bob", "2"}, values(execute(engine, "ZRANGE", "scores", "0", "1", "WITHSCORES")))
+        assert.same({"cara", "bob"}, values(execute(engine, "ZRANGEBYSCORE", "scores", "1", "2")))
+        assert.equals(1, execute(engine, "ZRANK", "scores", "bob").value)
+        assert.equals("1.5", execute(engine, "ZSCORE", "scores", "cara").value)
+        assert.equals(3, execute(engine, "ZCARD", "scores").value)
+        assert.equals(1, execute(engine, "ZREM", "scores", "bob", "missing").value)
+        assert.equals(1, execute(engine, "PFADD", "visitors", "alice", "bob").value)
+        assert.equals(0, execute(engine, "PFADD", "visitors", "alice").value)
+        assert.equals(1, execute(engine, "PFADD", "other", "cara").value)
+        assert.is_true(execute(engine, "PFCOUNT", "visitors").value >= 2)
+        assert.is_true(execute(engine, "PFCOUNT", "visitors", "other").value >= 3)
+        assert.equals("OK", execute(engine, "PFMERGE", "all", "visitors", "other").value)
+        assert.is_true(execute(engine, "PFCOUNT", "all").value >= 3)
+    end)
+
+    it("handles expiry, logical databases, and admin commands", function()
+        local now = 2000000
+        local engine = engine_module.new({time_provider = function() return now end})
+        execute(engine, "SET", "temporary", "value")
+        assert.equals(-1, execute(engine, "TTL", "temporary").value)
+        assert.equals(0, execute(engine, "PERSIST", "temporary").value)
+        assert.equals(1, execute(engine, "EXPIRE", "temporary", "10").value)
+        assert.equals(10, execute(engine, "TTL", "temporary").value)
+        assert.equals(10000, execute(engine, "PTTL", "temporary").value)
+        assert.equals(1, execute(engine, "PERSIST", "temporary").value)
+        assert.equals(1, execute(engine, "EXPIREAT", "temporary", "1999").value)
+        assert.is_nil(execute(engine, "GET", "temporary").value)
+        assert.equals(-2, execute(engine, "TTL", "temporary").value)
+        execute(engine, "SET", "db0", "zero")
+        assert.equals("OK", execute(engine, "SELECT", "1").value)
+        execute(engine, "SET", "db1", "one")
+        assert.equals(1, execute(engine, "DBSIZE").value)
+        assert.is_truthy(execute(engine, "INFO").value:find("active_db:1", 1, true))
+        assert.equals("OK", execute(engine, "FLUSHDB").value)
+        assert.equals(0, execute(engine, "DBSIZE").value)
+        execute(engine, "SET", "again", "one")
+        assert.equals("OK", execute(engine, "FLUSHALL").value)
+        execute(engine, "SELECT", "0")
+        assert.equals(0, execute(engine, "DBSIZE").value)
+    end)
+
+    it("returns protocol, arity, type, and parse errors", function()
+        local engine = engine_module.new()
+        assert_error(engine:execute_frame(nil), "protocol error")
+        assert_error(execute(engine, "NOPE"), "unknown command")
+        for _, parts in ipairs({
+            {"PING", "a", "b"}, {"ECHO"}, {"SET", "a"}, {"GET"}, {"DEL"},
+            {"HSET", "a", "b"}, {"LPUSH", "a"}, {"SADD", "a"},
+            {"ZADD", "a", "1"}, {"PFADD", "a"}, {"EXPIRE", "a"},
+            {"SELECT"}, {"FLUSHDB", "x"}, {"INFO", "x"},
+        }) do
+            assert_error(engine:execute_parts(parts), "wrong number")
+        end
+        assert_error(execute(engine, "RENAME", "missing", "other"), "no such key")
+        assert_error(execute(engine, "SELECT", "99"), "DB index")
+        execute(engine, "SET", "string", "value")
+        for _, parts in ipairs({
+            {"HGET", "string", "field"}, {"LPUSH", "string", "value"},
+            {"SADD", "string", "value"}, {"ZADD", "string", "1", "value"},
+            {"PFADD", "string", "value"}, {"SUNION", "string"},
+        }) do
+            assert_error(engine:execute_parts(parts), "WRONGTYPE")
+        end
+        assert_error(execute(engine, "INCR", "string"), "integer")
+        assert_error(execute(engine, "INCRBY", "n", "bad"), "integer")
+        assert_error(execute(engine, "DECRBY", "n", "-9223372036854775808"), "integer")
+        execute(engine, "SET", "max", "9223372036854775807")
+        assert_error(execute(engine, "INCR", "max"), "integer")
+        assert_error(execute(engine, "ZADD", "z", "nan", "a"), "float")
+    end)
+
+    it("exposes storage and sorted-set helpers", function()
+        assert.has_error(function() engine_module.Store.new(0) end, "database_count must be positive")
+        local store = engine_module.Store.new(2)
+        store:select(1)
+        assert.equals(1, store.active_db)
+        local now = 50000
+        local database = engine_module.Database.new(function() return now end)
+        database:set("live", engine_module.Entry.new(engine_module.EntryType.STRING, "yes"))
+        database:set("old", engine_module.Entry.new(engine_module.EntryType.STRING, "no", now - 1))
+        assert.is_nil(database:get("old"))
+        assert.same({"live"}, database:keys("l?ve"))
+        database:clear()
+        assert.same({}, database.entries)
+        local sorted_set = engine_module.SortedSet.new()
+        assert.is_true(sorted_set:insert(1, "b"))
+        assert.is_true(sorted_set:insert(1, "a"))
+        assert.is_false(sorted_set:insert(2, "b"))
+        assert.equals(0, sorted_set:rank("a"))
+        assert.same({{member = "a", score = 1}}, sorted_set:range_by_score(0, 1.5))
+        assert.is_true(sorted_set:remove("a"))
+    end)
+
+    it("accepts public frames and preserves binary strings", function()
+        local engine = engine_module.new({time_provider = function() return 1234 end})
+        assert.equals(1234, engine:current_time_ms())
+        local frame = require("coding_adventures.in_memory_data_store_protocol").CommandFrame.new("ping")
+        assert.equals("PONG", engine:execute_frame(frame).value)
+        local binary = "\0\255\1"
+        execute(engine, "SET", binary, binary)
+        assert.equals(binary, execute(engine, "GET", binary).value)
+    end)
+
+    it("matches a deterministic randomized string reference model", function()
+        local engine = engine_module.new()
+        local model = {}
+        local state = 20260716
+        local function next_random(limit)
+            state = (state * 1103515245 + 12345) & 0x7fffffff
+            return state % limit
+        end
+        for _ = 1, 5000 do
+            local key = "key:" .. next_random(31)
+            local choice = next_random(6)
+            if choice == 0 then
+                local value = tostring(next_random(10000))
+                assert.equals("OK", execute(engine, "SET", key, value).value)
+                model[key] = value
+            elseif choice == 1 then
+                assert.equals(model[key], execute(engine, "GET", key).value)
+            elseif choice == 2 then
+                local expected = model[key] == nil and 0 or 1
+                assert.equals(expected, execute(engine, "DEL", key).value)
+                model[key] = nil
+            elseif choice == 3 then
+                assert.equals(model[key] == nil and 0 or 1, execute(engine, "EXISTS", key).value)
+            elseif choice == 4 then
+                local suffix = string.char(97 + next_random(26))
+                model[key] = (model[key] or "") .. suffix
+                assert.equals(#model[key], execute(engine, "APPEND", key, suffix).value)
+            else
+                local current = model[key]
+                if current == nil or current:match("^[+-]?%d+$") then
+                    local expected = (tonumber(current) or 0) + 1
+                    assert.equals(expected, execute(engine, "INCR", key).value)
+                    model[key] = tostring(expected)
+                else
+                    assert_error(execute(engine, "INCR", key), "integer")
+                end
+            end
+        end
+    end)
+end)

--- a/code/packages/perl/in-memory-data-store-engine/BUILD
+++ b/code/packages/perl/in-memory-data-store-engine/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=lib:../hyperloglog/lib:../in-memory-data-store-protocol/lib prove -l -v t/

--- a/code/packages/perl/in-memory-data-store-engine/BUILD_windows
+++ b/code/packages/perl/in-memory-data-store-engine/BUILD_windows
@@ -1,0 +1,1 @@
+set "PERL5LIB=lib;..\hyperloglog\lib;..\in-memory-data-store-protocol\lib" && prove -l -v t\

--- a/code/packages/perl/in-memory-data-store-engine/CHANGELOG.md
+++ b/code/packages/perl/in-memory-data-store-engine/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-16
+
+- Add the full in-memory data store execution engine for Perl.
+- Cover typed collections, sorted sets, HyperLogLog, TTLs, logical databases,
+  protocol errors, deterministic ordering, and binary-safe values.

--- a/code/packages/perl/in-memory-data-store-engine/Makefile.PL
+++ b/code/packages/perl/in-memory-data-store-engine/Makefile.PL
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::InMemoryDataStoreEngine',
+    VERSION_FROM     => 'lib/CodingAdventures/InMemoryDataStoreEngine.pm',
+    ABSTRACT         => 'Pure Perl execution engine for the in-memory data store',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::HyperLogLog'                 => 0,
+        'CodingAdventures::InMemoryDataStoreProtocol'   => 0,
+        'POSIX'                                         => 0,
+        'Time::HiRes'                                   => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/in-memory-data-store-engine/README.md
+++ b/code/packages/perl/in-memory-data-store-engine/README.md
@@ -1,0 +1,25 @@
+# In-Memory Data Store Engine (Perl)
+
+A pure Perl execution engine for the repository's in-memory data store stack.
+It consumes `CommandFrame` objects from the sibling protocol package and
+returns the shared `EngineResponse` IR.
+
+```perl
+use CodingAdventures::InMemoryDataStoreEngine;
+
+my $engine = CodingAdventures::InMemoryDataStoreEngine->new;
+$engine->execute_parts(['SET', 'answer', '41']);
+die unless $engine->execute_parts(['INCR', 'answer'])->value == 42;
+```
+
+The engine implements binary-safe strings, hashes, lists, sets, sorted sets,
+HyperLogLog, expiry and persistence, globbed key lookup, 16 logical databases,
+and administrative commands. Its 57-command surface matches the Redis-style
+string, hash, list, set, sorted-set, HLL, TTL, database, and server operations
+implemented by the other language lanes.
+
+The constructor accepts optional `store`, `database_count`, and `time_provider`
+options. The clock hook makes TTL behavior deterministic in tests without
+filesystem, network, process, environment, or randomness access.
+
+Run the package gate from this directory with `BUILD` or `BUILD_windows`.

--- a/code/packages/perl/in-memory-data-store-engine/cpanfile
+++ b/code/packages/perl/in-memory-data-store-engine/cpanfile
@@ -1,0 +1,4 @@
+requires 'CodingAdventures::HyperLogLog', '>= 0.1.0';
+requires 'CodingAdventures::InMemoryDataStoreProtocol', '>= 0.1.0';
+requires 'POSIX';
+requires 'Time::HiRes';

--- a/code/packages/perl/in-memory-data-store-engine/lib/CodingAdventures/InMemoryDataStoreEngine.pm
+++ b/code/packages/perl/in-memory-data-store-engine/lib/CodingAdventures/InMemoryDataStoreEngine.pm
@@ -1,0 +1,872 @@
+package CodingAdventures::InMemoryDataStoreEngine;
+
+use strict;
+use warnings;
+use POSIX qw(isfinite);
+use Time::HiRes qw(time);
+use CodingAdventures::HyperLogLog;
+use CodingAdventures::InMemoryDataStoreProtocol;
+
+our $VERSION = '0.1.0';
+
+my $RESPONSE = 'CodingAdventures::InMemoryDataStoreProtocol::EngineResponse';
+my $FRAME = 'CodingAdventures::InMemoryDataStoreProtocol::CommandFrame';
+my $I64_MAX = 9223372036854775807;
+my $I64_MIN = -9223372036854775807 - 1;
+
+sub new {
+    my ($class, @arguments) = @_;
+    die "constructor expects key/value options\n" if @arguments % 2;
+    my %options = @arguments;
+    my $now_provider = $options{time_provider} || sub { int(time() * 1000) };
+    my $store = $options{store} || CodingAdventures::InMemoryDataStoreEngine::Store->new(
+        database_count => $options{database_count},
+        time_provider  => $now_provider,
+    );
+    return bless {store => $store, time_provider => $now_provider}, $class;
+}
+
+sub store { return $_[0]->{store}; }
+sub current_time_ms { return $_[0]->{time_provider}->(); }
+
+sub execute_frame {
+    my ($self, $frame) = @_;
+    return _error('ERR protocol error: expected array of bulk strings') if !defined $frame;
+    $self->{store}->active_database->active_expire;
+    my $command = uc($frame->command);
+    my $method = '_cmd_' . lc($command);
+    return _error("ERR unknown command '" . lc($frame->command) . "'") if !$self->can($method);
+    return $self->$method($frame->args);
+}
+
+sub execute_parts {
+    my ($self, $parts) = @_;
+    return $self->execute_frame($FRAME->from_parts($parts));
+}
+
+sub _entry {
+    my ($self, $key) = @_;
+    return $self->{store}->active_database->get($key);
+}
+
+sub _ensure_collection {
+    my ($self, $key, $type, $factory) = @_;
+    my $entry = $self->_entry($key);
+    if (!defined $entry) {
+        $entry = CodingAdventures::InMemoryDataStoreEngine::Entry->new($type, $factory->());
+        $self->{store}->active_database->set($key, $entry);
+    }
+    return $entry->{type} eq $type ? $entry : undef;
+}
+
+sub _cmd_ping {
+    my ($self, $args) = @_;
+    return $RESPONSE->simple_string('PONG') if !@$args;
+    return _bulk($args->[0]) if @$args == 1;
+    return _wrong_arity('ping');
+}
+
+sub _cmd_echo {
+    my ($self, $args) = @_;
+    return @$args == 1 ? _bulk($args->[0]) : _wrong_arity('echo');
+}
+
+sub _cmd_set {
+    my ($self, $args) = @_;
+    return _wrong_arity('set') if @$args != 2;
+    $self->{store}->active_database->set(
+        $args->[0],
+        CodingAdventures::InMemoryDataStoreEngine::Entry->new('string', $args->[1]),
+    );
+    return $RESPONSE->ok;
+}
+
+sub _cmd_get {
+    my ($self, $args) = @_;
+    return _wrong_arity('get') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->null if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'string';
+    return _bulk($entry->{value});
+}
+
+sub _cmd_del {
+    my ($self, $args) = @_;
+    return _wrong_arity('del') if !@$args;
+    my $removed = 0;
+    $removed += $self->{store}->active_database->delete($_) for @$args;
+    return _integer($removed);
+}
+
+sub _cmd_exists {
+    my ($self, $args) = @_;
+    return _wrong_arity('exists') if !@$args;
+    my $found = 0;
+    $found++ for grep { defined $self->_entry($_) } @$args;
+    return _integer($found);
+}
+
+sub _cmd_keys {
+    my ($self, $args) = @_;
+    return _wrong_arity('keys') if @$args != 1;
+    return _array([map { _bulk($_) } @{$self->{store}->active_database->keys($args->[0])}]);
+}
+
+sub _cmd_type {
+    my ($self, $args) = @_;
+    return _wrong_arity('type') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->simple_string(defined($entry) ? $entry->{type} : 'none');
+}
+
+sub _cmd_rename {
+    my ($self, $args) = @_;
+    return _wrong_arity('rename') if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    return _error('ERR no such key') if !defined $entry;
+    if ($args->[0] ne $args->[1]) {
+        $self->{store}->active_database->delete($args->[0]);
+        $self->{store}->active_database->set($args->[1], $entry);
+    }
+    return $RESPONSE->ok;
+}
+
+sub _cmd_append {
+    my ($self, $args) = @_;
+    return _wrong_arity('append') if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    if (!defined $entry) {
+        $self->{store}->active_database->set(
+            $args->[0],
+            CodingAdventures::InMemoryDataStoreEngine::Entry->new('string', $args->[1]),
+        );
+        return _integer(length($args->[1]));
+    }
+    return _wrong_type() if $entry->{type} ne 'string';
+    $entry->{value} .= $args->[1];
+    return _integer(length($entry->{value}));
+}
+
+sub _incr_by {
+    my ($self, $args, $fixed_delta, $command) = @_;
+    my $expected = defined($fixed_delta) ? 1 : 2;
+    return _wrong_arity($command) if @$args != $expected;
+    my $delta = defined($fixed_delta) ? $fixed_delta : _parse_i64($args->[1]);
+    return _integer_error() if !defined $delta;
+    my $entry = $self->_entry($args->[0]);
+    return _wrong_type() if defined($entry) && $entry->{type} ne 'string';
+    my $current = defined($entry) ? _parse_i64($entry->{value}) : 0;
+    return _integer_error() if !defined $current;
+    return _integer_error()
+        if ($delta > 0 && $current > $I64_MAX - $delta)
+        || ($delta < 0 && $current < $I64_MIN - $delta);
+    my $result = $current + $delta;
+    $self->{store}->active_database->set(
+        $args->[0],
+        CodingAdventures::InMemoryDataStoreEngine::Entry->new(
+            'string', "$result", defined($entry) ? $entry->{expires_at_ms} : undef,
+        ),
+    );
+    return _integer($result);
+}
+
+sub _cmd_incr { return $_[0]->_incr_by($_[1], 1, 'incr'); }
+sub _cmd_decr { return $_[0]->_incr_by($_[1], -1, 'decr'); }
+sub _cmd_incrby { return $_[0]->_incr_by($_[1], undef, 'incrby'); }
+
+sub _cmd_decrby {
+    my ($self, $args) = @_;
+    return _wrong_arity('decrby') if @$args != 2;
+    my $delta = _parse_i64($args->[1]);
+    return _integer_error() if !defined($delta) || $delta == $I64_MIN;
+    return $self->_incr_by([$args->[0], '' . -$delta], undef, 'decrby');
+}
+
+sub _cmd_hset {
+    my ($self, $args) = @_;
+    return _wrong_arity('hset') if @$args < 3 || @$args % 2 == 0;
+    my $entry = $self->_ensure_collection($args->[0], 'hash', sub { {} });
+    return _wrong_type() if !defined $entry;
+    my $added = 0;
+    for (my $index = 1; $index < @$args; $index += 2) {
+        $added++ if !exists $entry->{value}{$args->[$index]};
+        $entry->{value}{$args->[$index]} = $args->[$index + 1];
+    }
+    return _integer($added);
+}
+
+sub _cmd_hget {
+    my ($self, $args) = @_;
+    return _wrong_arity('hget') if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->null if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'hash';
+    return _bulk($entry->{value}{$args->[1]});
+}
+
+sub _cmd_hdel {
+    my ($self, $args) = @_;
+    return _wrong_arity('hdel') if @$args < 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'hash';
+    my $removed = 0;
+    for my $field (@$args[1 .. $#$args]) {
+        if (exists $entry->{value}{$field}) {
+            delete $entry->{value}{$field};
+            $removed++;
+        }
+    }
+    $self->{store}->active_database->delete($args->[0]) if !keys %{$entry->{value}};
+    return _integer($removed);
+}
+
+sub _hash_array {
+    my ($self, $args, $command, $mode) = @_;
+    return _wrong_arity($command) if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return _array([]) if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'hash';
+    my @values;
+    for my $field (sort keys %{$entry->{value}}) {
+        push @values, _bulk($field) if $mode ne 'values';
+        push @values, _bulk($entry->{value}{$field}) if $mode ne 'keys';
+    }
+    return _array(\@values);
+}
+
+sub _cmd_hgetall { return $_[0]->_hash_array($_[1], 'hgetall', 'all'); }
+sub _cmd_hkeys { return $_[0]->_hash_array($_[1], 'hkeys', 'keys'); }
+sub _cmd_hvals { return $_[0]->_hash_array($_[1], 'hvals', 'values'); }
+
+sub _cmd_hlen {
+    my ($self, $args) = @_;
+    return _wrong_arity('hlen') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'hash';
+    return _integer(scalar keys %{$entry->{value}});
+}
+
+sub _cmd_hexists {
+    my ($self, $args) = @_;
+    return _wrong_arity('hexists') if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'hash';
+    return _integer(exists($entry->{value}{$args->[1]}) ? 1 : 0);
+}
+
+sub _push_list {
+    my ($self, $args, $left) = @_;
+    my $command = $left ? 'lpush' : 'rpush';
+    return _wrong_arity($command) if @$args < 2;
+    my $entry = $self->_ensure_collection($args->[0], 'list', sub { [] });
+    return _wrong_type() if !defined $entry;
+    for my $value (@$args[1 .. $#$args]) {
+        $left ? unshift(@{$entry->{value}}, $value) : push(@{$entry->{value}}, $value);
+    }
+    return _integer(scalar @{$entry->{value}});
+}
+
+sub _cmd_lpush { return $_[0]->_push_list($_[1], 1); }
+sub _cmd_rpush { return $_[0]->_push_list($_[1], 0); }
+
+sub _pop_list {
+    my ($self, $args, $left) = @_;
+    my $command = $left ? 'lpop' : 'rpop';
+    return _wrong_arity($command) if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->null if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'list';
+    my $value = $left ? shift(@{$entry->{value}}) : pop(@{$entry->{value}});
+    $self->{store}->active_database->delete($args->[0]) if !@{$entry->{value}};
+    return _bulk($value);
+}
+
+sub _cmd_lpop { return $_[0]->_pop_list($_[1], 1); }
+sub _cmd_rpop { return $_[0]->_pop_list($_[1], 0); }
+
+sub _cmd_llen {
+    my ($self, $args) = @_;
+    return _wrong_arity('llen') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'list';
+    return _integer(scalar @{$entry->{value}});
+}
+
+sub _cmd_lindex {
+    my ($self, $args) = @_;
+    return _wrong_arity('lindex') if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->null if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'list';
+    my $index = _parse_i64($args->[1]);
+    return _integer_error() if !defined $index;
+    $index += @{$entry->{value}} if $index < 0;
+    return $RESPONSE->null if $index < 0 || $index >= @{$entry->{value}};
+    return _bulk($entry->{value}[$index]);
+}
+
+sub _cmd_lrange {
+    my ($self, $args) = @_;
+    return _wrong_arity('lrange') if @$args != 3;
+    my $entry = $self->_entry($args->[0]);
+    return _array([]) if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'list';
+    my $start = _parse_i64($args->[1]);
+    my $stop = _parse_i64($args->[2]);
+    return _integer_error() if !defined($start) || !defined($stop);
+    my $length = @{$entry->{value}};
+    $start += $length if $start < 0;
+    $stop += $length if $stop < 0;
+    $start = 0 if $start < 0;
+    $stop = $length - 1 if $stop >= $length;
+    return _array([]) if !$length || $start > $stop || $start >= $length;
+    return _array([map { _bulk($entry->{value}[$_]) } $start .. $stop]);
+}
+
+sub _cmd_sadd {
+    my ($self, $args) = @_;
+    return _wrong_arity('sadd') if @$args < 2;
+    my $entry = $self->_ensure_collection($args->[0], 'set', sub { {} });
+    return _wrong_type() if !defined $entry;
+    my $added = 0;
+    for my $value (@$args[1 .. $#$args]) {
+        $added++ if !exists $entry->{value}{$value};
+        $entry->{value}{$value} = 1;
+    }
+    return _integer($added);
+}
+
+sub _cmd_srem {
+    my ($self, $args) = @_;
+    return _wrong_arity('srem') if @$args < 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'set';
+    my $removed = 0;
+    for my $value (@$args[1 .. $#$args]) {
+        if (exists $entry->{value}{$value}) {
+            delete $entry->{value}{$value};
+            $removed++;
+        }
+    }
+    $self->{store}->active_database->delete($args->[0]) if !keys %{$entry->{value}};
+    return _integer($removed);
+}
+
+sub _cmd_sismember {
+    my ($self, $args) = @_;
+    return _wrong_arity('sismember') if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'set';
+    return _integer(exists($entry->{value}{$args->[1]}) ? 1 : 0);
+}
+
+sub _cmd_smembers {
+    my ($self, $args) = @_;
+    return _wrong_arity('smembers') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return _array([]) if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'set';
+    return _array([map { _bulk($_) } sort keys %{$entry->{value}}]);
+}
+
+sub _cmd_scard {
+    my ($self, $args) = @_;
+    return _wrong_arity('scard') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'set';
+    return _integer(scalar keys %{$entry->{value}});
+}
+
+sub _set_operation {
+    my ($self, $args, $command, $operation) = @_;
+    return _wrong_arity($command) if !@$args;
+    my $first = $self->_entry($args->[0]);
+    return _wrong_type() if defined($first) && $first->{type} ne 'set';
+    my %result = defined($first) ? %{$first->{value}} : ();
+    for my $key (@$args[1 .. $#$args]) {
+        my $entry = $self->_entry($key);
+        return _wrong_type() if defined($entry) && $entry->{type} ne 'set';
+        if ($operation eq 'union') {
+            $result{$_} = 1 for defined($entry) ? keys %{$entry->{value}} : ();
+        } elsif ($operation eq 'intersection') {
+            delete $result{$_} for grep { !defined($entry) || !exists($entry->{value}{$_}) } keys %result;
+        } elsif (defined $entry) {
+            delete $result{$_} for keys %{$entry->{value}};
+        }
+    }
+    return _array([map { _bulk($_) } sort keys %result]);
+}
+
+sub _cmd_sunion { return $_[0]->_set_operation($_[1], 'sunion', 'union'); }
+sub _cmd_sinter { return $_[0]->_set_operation($_[1], 'sinter', 'intersection'); }
+sub _cmd_sdiff { return $_[0]->_set_operation($_[1], 'sdiff', 'difference'); }
+
+sub _cmd_zadd {
+    my ($self, $args) = @_;
+    return _wrong_arity('zadd') if @$args < 3 || @$args % 2 == 0;
+    my @parsed;
+    for (my $index = 1; $index < @$args; $index += 2) {
+        my $score = _parse_float($args->[$index]);
+        return _float_error() if !defined $score;
+        push @parsed, [$score, $args->[$index + 1]];
+    }
+    my $entry = $self->_ensure_collection(
+        $args->[0], 'zset', sub { CodingAdventures::InMemoryDataStoreEngine::SortedSet->new },
+    );
+    return _wrong_type() if !defined $entry;
+    my $added = 0;
+    $added += $entry->{value}->insert(@$_) for @parsed;
+    return _integer($added);
+}
+
+sub _flatten_zset {
+    my ($values, $with_scores) = @_;
+    my @result;
+    for my $item (@$values) {
+        push @result, _bulk($item->[0]);
+        push @result, _bulk(_format_score($item->[1])) if $with_scores;
+    }
+    return \@result;
+}
+
+sub _cmd_zrange {
+    my ($self, $args) = @_;
+    return _wrong_arity('zrange') if @$args != 3 && @$args != 4;
+    my $start = _parse_i64($args->[1]);
+    my $end = _parse_i64($args->[2]);
+    return _integer_error() if !defined($start) || !defined($end);
+    my $entry = $self->_entry($args->[0]);
+    return _array([]) if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'zset';
+    my $with_scores = @$args == 4 && uc($args->[3]) eq 'WITHSCORES';
+    return _array(_flatten_zset($entry->{value}->range_by_index($start, $end), $with_scores));
+}
+
+sub _cmd_zrangebyscore {
+    my ($self, $args) = @_;
+    return _wrong_arity('zrangebyscore') if @$args != 3 && @$args != 4;
+    my $minimum = _parse_float($args->[1]);
+    my $maximum = _parse_float($args->[2]);
+    return _float_error() if !defined($minimum) || !defined($maximum);
+    my $entry = $self->_entry($args->[0]);
+    return _array([]) if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'zset';
+    my $with_scores = @$args == 4 && uc($args->[3]) eq 'WITHSCORES';
+    return _array(_flatten_zset($entry->{value}->range_by_score($minimum, $maximum), $with_scores));
+}
+
+sub _cmd_zrank {
+    my ($self, $args) = @_;
+    return _wrong_arity('zrank') if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->null if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'zset';
+    my $rank = $entry->{value}->rank($args->[1]);
+    return defined($rank) ? _integer($rank) : $RESPONSE->null;
+}
+
+sub _cmd_zscore {
+    my ($self, $args) = @_;
+    return _wrong_arity('zscore') if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->null if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'zset';
+    my $score = $entry->{value}->score($args->[1]);
+    return defined($score) ? _bulk(_format_score($score)) : $RESPONSE->null;
+}
+
+sub _cmd_zcard {
+    my ($self, $args) = @_;
+    return _wrong_arity('zcard') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'zset';
+    return _integer($entry->{value}->size);
+}
+
+sub _cmd_zrem {
+    my ($self, $args) = @_;
+    return _wrong_arity('zrem') if @$args < 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    return _wrong_type() if $entry->{type} ne 'zset';
+    my $removed = 0;
+    $removed += $entry->{value}->remove($_) for @$args[1 .. $#$args];
+    $self->{store}->active_database->delete($args->[0]) if !$entry->{value}->size;
+    return _integer($removed);
+}
+
+sub _cmd_pfadd {
+    my ($self, $args) = @_;
+    return _wrong_arity('pfadd') if @$args < 2;
+    my $entry = $self->_ensure_collection(
+        $args->[0], 'hll', sub { CodingAdventures::HyperLogLog->new },
+    );
+    return _wrong_type() if !defined $entry;
+    my $before = join(',', @{$entry->{value}->registers});
+    $entry->{value}->add($_) for @$args[1 .. $#$args];
+    return _integer($before ne join(',', @{$entry->{value}->registers}) ? 1 : 0);
+}
+
+sub _cmd_pfcount {
+    my ($self, $args) = @_;
+    return _wrong_arity('pfcount') if !@$args;
+    my $aggregate;
+    for my $key (@$args) {
+        my $entry = $self->_entry($key);
+        next if !defined $entry;
+        return _wrong_type() if $entry->{type} ne 'hll';
+        $aggregate = defined($aggregate) ? $aggregate->merge($entry->{value}) : $entry->{value};
+    }
+    return _integer(defined($aggregate) ? $aggregate->count : 0);
+}
+
+sub _cmd_pfmerge {
+    my ($self, $args) = @_;
+    return _wrong_arity('pfmerge') if @$args < 2;
+    my $aggregate;
+    for my $key (@$args[1 .. $#$args]) {
+        my $entry = $self->_entry($key);
+        next if !defined $entry;
+        return _wrong_type() if $entry->{type} ne 'hll';
+        $aggregate = defined($aggregate) ? $aggregate->merge($entry->{value}) : $entry->{value};
+    }
+    my $destination = $self->_entry($args->[0]);
+    $self->{store}->active_database->set(
+        $args->[0],
+        CodingAdventures::InMemoryDataStoreEngine::Entry->new(
+            'hll',
+            defined($aggregate) ? $aggregate : CodingAdventures::HyperLogLog->new,
+            defined($destination) ? $destination->{expires_at_ms} : undef,
+        ),
+    );
+    return $RESPONSE->ok;
+}
+
+sub _expire {
+    my ($self, $args, $absolute) = @_;
+    my $command = $absolute ? 'expireat' : 'expire';
+    return _wrong_arity($command) if @$args != 2;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined $entry;
+    my $seconds = _parse_i64($args->[1]);
+    return _integer_error() if !defined $seconds;
+    $entry->{expires_at_ms} = $absolute
+        ? $seconds * 1000
+        : $self->{time_provider}->() + $seconds * 1000;
+    return $RESPONSE->one;
+}
+
+sub _cmd_expire { return $_[0]->_expire($_[1], 0); }
+sub _cmd_expireat { return $_[0]->_expire($_[1], 1); }
+
+sub _cmd_ttl {
+    my ($self, $args) = @_;
+    return _wrong_arity('ttl') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return _integer(-2) if !defined $entry;
+    return _integer(-1) if !defined $entry->{expires_at_ms};
+    my $remaining = int(($entry->{expires_at_ms} - $self->{time_provider}->()) / 1000);
+    return _integer($remaining < -2 ? -2 : $remaining);
+}
+
+sub _cmd_pttl {
+    my ($self, $args) = @_;
+    return _wrong_arity('pttl') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return _integer(-2) if !defined $entry;
+    return _integer(-1) if !defined $entry->{expires_at_ms};
+    my $remaining = $entry->{expires_at_ms} - $self->{time_provider}->();
+    return _integer($remaining < -1 ? -1 : $remaining);
+}
+
+sub _cmd_persist {
+    my ($self, $args) = @_;
+    return _wrong_arity('persist') if @$args != 1;
+    my $entry = $self->_entry($args->[0]);
+    return $RESPONSE->zero if !defined($entry) || !defined($entry->{expires_at_ms});
+    $entry->{expires_at_ms} = undef;
+    return $RESPONSE->one;
+}
+
+sub _cmd_select {
+    my ($self, $args) = @_;
+    return _wrong_arity('select') if @$args != 1;
+    my $index = _parse_i64($args->[0]);
+    return _error('ERR DB index is out of range')
+        if !defined($index) || $index < 0 || $index >= @{$self->{store}->{databases}};
+    $self->{store}->select($index);
+    return $RESPONSE->ok;
+}
+
+sub _cmd_flushdb {
+    my ($self, $args) = @_;
+    return _wrong_arity('flushdb') if @$args;
+    $self->{store}->flushdb;
+    return $RESPONSE->ok;
+}
+
+sub _cmd_flushall {
+    my ($self, $args) = @_;
+    return _wrong_arity('flushall') if @$args;
+    $self->{store}->flushall;
+    return $RESPONSE->ok;
+}
+
+sub _cmd_dbsize {
+    my ($self, $args) = @_;
+    return _wrong_arity('dbsize') if @$args;
+    $self->{store}->active_database->active_expire;
+    return _integer(scalar keys %{$self->{store}->active_database->{entries}});
+}
+
+sub _cmd_info {
+    my ($self, $args) = @_;
+    return _wrong_arity('info') if @$args;
+    my $size = scalar keys %{$self->{store}->active_database->{entries}};
+    return _bulk(
+        "# Server\r\nin_memory_data_store_version:0.1.0\r\n"
+        . "active_db:$self->{store}->{active_db}\r\ndbsize:$size\r\n"
+    );
+}
+
+sub _bulk { return $RESPONSE->bulk_string($_[0]); }
+sub _integer { return $RESPONSE->integer(0 + $_[0]); }
+sub _array { return $RESPONSE->array($_[0]); }
+sub _error { return $RESPONSE->error($_[0]); }
+sub _wrong_arity { return _error("ERR wrong number of arguments for '$_[0]' command"); }
+sub _wrong_type { return _error('WRONGTYPE Operation against a key holding the wrong kind of value'); }
+sub _integer_error { return _error('ERR value is not an integer or out of range'); }
+sub _float_error { return _error('ERR value is not a valid float'); }
+
+sub _parse_i64 {
+    my ($value) = @_;
+    return undef if !defined($value) || ref($value) || $value !~ /\A([+-]?)(\d+)\z/;
+    my ($sign, $digits) = ($1, $2);
+    $digits =~ s/\A0+(?=\d)//;
+    my $limit = $sign eq '-' ? '9223372036854775808' : '9223372036854775807';
+    return undef if length($digits) > length($limit)
+        || (length($digits) == length($limit) && $digits gt $limit);
+    return 0 + $value;
+}
+
+sub _parse_float {
+    my ($value) = @_;
+    return undef if !defined($value) || ref($value)
+        || $value !~ /\A[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?\z/;
+    my $parsed = 0.0 + $value;
+    return isfinite($parsed) ? $parsed : undef;
+}
+
+sub _format_score {
+    my ($score) = @_;
+    return sprintf('%.0f', $score) if $score == int($score);
+    my $text = sprintf('%.15f', $score);
+    $text =~ s/0+\z//;
+    $text =~ s/\.\z//;
+    return $text;
+}
+
+package CodingAdventures::InMemoryDataStoreEngine::EntryType;
+
+use strict;
+use warnings;
+use constant {
+    STRING => 'string',
+    HASH   => 'hash',
+    LIST   => 'list',
+    SET    => 'set',
+    ZSET   => 'zset',
+    HLL    => 'hll',
+};
+
+package CodingAdventures::InMemoryDataStoreEngine::Entry;
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $type, $value, $expires_at_ms) = @_;
+    return bless {type => $type, value => $value, expires_at_ms => $expires_at_ms}, $class;
+}
+
+sub type { return $_[0]->{type}; }
+sub value { return $_[0]->{value}; }
+sub expires_at_ms { return $_[0]->{expires_at_ms}; }
+
+package CodingAdventures::InMemoryDataStoreEngine::SortedSet;
+
+use strict;
+use warnings;
+
+sub new { return bless {scores => {}}, $_[0]; }
+
+sub insert {
+    my ($self, $score, $member) = @_;
+    my $is_new = !exists $self->{scores}{$member};
+    $self->{scores}{$member} = $score;
+    return $is_new ? 1 : 0;
+}
+
+sub remove {
+    my ($self, $member) = @_;
+    return 0 if !exists $self->{scores}{$member};
+    delete $self->{scores}{$member};
+    return 1;
+}
+
+sub ordered_entries {
+    my ($self) = @_;
+    return [map { [$_, $self->{scores}{$_}] }
+        sort { $self->{scores}{$a} <=> $self->{scores}{$b} || $a cmp $b }
+        keys %{$self->{scores}}];
+}
+
+sub rank {
+    my ($self, $member) = @_;
+    my $entries = $self->ordered_entries;
+    for my $index (0 .. $#$entries) {
+        return $index if $entries->[$index][0] eq $member;
+    }
+    return undef;
+}
+
+sub score {
+    my ($self, $member) = @_;
+    return $self->{scores}{$member};
+}
+
+sub size { return scalar keys %{$_[0]->{scores}}; }
+
+sub range_by_index {
+    my ($self, $start, $end) = @_;
+    my $entries = $self->ordered_entries;
+    my $length = @$entries;
+    return [] if !$length;
+    $start += $length if $start < 0;
+    $end += $length if $end < 0;
+    return [] if $start < 0 || $end < 0 || $start >= $length || $start > $end;
+    $end = $length - 1 if $end >= $length;
+    return [@$entries[$start .. $end]];
+}
+
+sub range_by_score {
+    my ($self, $minimum, $maximum) = @_;
+    return [grep { $_->[1] >= $minimum && $_->[1] <= $maximum } @{$self->ordered_entries}];
+}
+
+package CodingAdventures::InMemoryDataStoreEngine::Database;
+
+use strict;
+use warnings;
+use Time::HiRes qw(time);
+
+sub new {
+    my ($class, %options) = @_;
+    return bless {
+        entries       => {},
+        time_provider => $options{time_provider} || sub { int(time() * 1000) },
+    }, $class;
+}
+
+sub get {
+    my ($self, $key) = @_;
+    my $entry = $self->{entries}{$key};
+    if (defined($entry) && defined($entry->{expires_at_ms})
+        && $entry->{expires_at_ms} <= $self->{time_provider}->()) {
+        delete $self->{entries}{$key};
+        return undef;
+    }
+    return $entry;
+}
+
+sub set { $_[0]->{entries}{$_[1]} = $_[2]; return $_[2]; }
+
+sub delete {
+    my ($self, $key) = @_;
+    return 0 if !exists $self->{entries}{$key};
+    delete $self->{entries}{$key};
+    return 1;
+}
+
+sub expire_lazy { $_[0]->get($_[1]); return; }
+
+sub active_expire {
+    my ($self) = @_;
+    my $now = $self->{time_provider}->();
+    for my $key (keys %{$self->{entries}}) {
+        my $entry = $self->{entries}{$key};
+        delete $self->{entries}{$key}
+            if defined($entry->{expires_at_ms}) && $entry->{expires_at_ms} <= $now;
+    }
+    return;
+}
+
+sub keys {
+    my ($self, $pattern) = @_;
+    $self->active_expire;
+    return [sort grep { _glob_match($pattern, $_) } keys %{$self->{entries}}];
+}
+
+sub clear { $_[0]->{entries} = {}; return; }
+sub entries { return $_[0]->{entries}; }
+
+sub _glob_match {
+    my ($pattern, $value) = @_;
+    my ($pi, $vi) = (0, 0);
+    my ($star, $retry) = (-1, 0);
+    while ($vi < length($value)) {
+        if ($pi < length($pattern)
+            && (substr($pattern, $pi, 1) eq '?' || substr($pattern, $pi, 1) eq substr($value, $vi, 1))) {
+            $pi++; $vi++;
+        } elsif ($pi < length($pattern) && substr($pattern, $pi, 1) eq '*') {
+            $star = $pi; $retry = $vi; $pi++;
+        } elsif ($star >= 0) {
+            $retry++; $vi = $retry; $pi = $star + 1;
+        } else {
+            return 0;
+        }
+    }
+    $pi++ while $pi < length($pattern) && substr($pattern, $pi, 1) eq '*';
+    return $pi == length($pattern) ? 1 : 0;
+}
+
+package CodingAdventures::InMemoryDataStoreEngine::Store;
+
+use strict;
+use warnings;
+use Time::HiRes qw(time);
+
+sub new {
+    my ($class, %options) = @_;
+    my $count = defined($options{database_count}) ? $options{database_count} : 16;
+    die "database_count must be positive\n"
+        if $count !~ /\A\d+\z/ || $count <= 0;
+    my $provider = $options{time_provider} || sub { int(time() * 1000) };
+    my @databases = map {
+        CodingAdventures::InMemoryDataStoreEngine::Database->new(time_provider => $provider)
+    } 1 .. $count;
+    return bless {databases => \@databases, active_db => 0}, $class;
+}
+
+sub active_db { return $_[0]->{active_db}; }
+sub databases { return [@{$_[0]->{databases}}]; }
+sub active_database { return $_[0]->{databases}[$_[0]->{active_db}]; }
+sub select { $_[0]->{active_db} = $_[1]; return; }
+sub flushdb { $_[0]->active_database->clear; return; }
+sub flushall { $_->clear for @{$_[0]->{databases}}; return; }
+
+package CodingAdventures::InMemoryDataStoreEngine::DataStoreEngine;
+
+use strict;
+use warnings;
+our @ISA = ('CodingAdventures::InMemoryDataStoreEngine');
+
+1;

--- a/code/packages/perl/in-memory-data-store-engine/required_capabilities.json
+++ b/code/packages/perl/in-memory-data-store-engine/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/in-memory-data-store-engine",
+  "capabilities": [],
+  "justification": "Pure in-memory command execution over protocol IR and HyperLogLog. No filesystem, network, process, environment, or randomness access is needed."
+}

--- a/code/packages/perl/in-memory-data-store-engine/t/00-load.t
+++ b/code/packages/perl/in-memory-data-store-engine/t/00-load.t
@@ -1,0 +1,6 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+use_ok('CodingAdventures::InMemoryDataStoreEngine');
+ok($CodingAdventures::InMemoryDataStoreEngine::VERSION, 'has a VERSION');

--- a/code/packages/perl/in-memory-data-store-engine/t/01-engine.t
+++ b/code/packages/perl/in-memory-data-store-engine/t/01-engine.t
@@ -1,0 +1,235 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::InMemoryDataStoreEngine;
+use CodingAdventures::InMemoryDataStoreProtocol;
+
+sub execute {
+    my ($engine, @parts) = @_;
+    return $engine->execute_parts(\@parts);
+}
+
+sub response_values {
+    my ($response) = @_;
+    is($response->kind, 'array', 'array response');
+    return [map { $_->value } @{$response->value}];
+}
+
+sub error_like {
+    my ($response, $text, $name) = @_;
+    is($response->kind, 'error', "$name kind");
+    like($response->value, qr/\Q$text\E/, $name);
+}
+
+subtest 'strings integers and keyspace commands' => sub {
+    my $engine = CodingAdventures::InMemoryDataStoreEngine->new;
+    is(execute($engine, 'PING')->value, 'PONG', 'ping');
+    is(execute($engine, 'PING', 'hello')->value, 'hello', 'ping payload');
+    is(execute($engine, 'ECHO', "\0binary")->value, "\0binary", 'binary echo');
+    is(execute($engine, 'SET', 'user:1', '40')->value, 'OK', 'set');
+    is(execute($engine, 'GET', 'user:1')->value, '40', 'get');
+    is(execute($engine, 'EXISTS', 'user:1', 'missing')->value, 1, 'exists');
+    is(execute($engine, 'TYPE', 'user:1')->value, 'string', 'type');
+    is(execute($engine, 'TYPE', 'missing')->value, 'none', 'missing type');
+    is(execute($engine, 'INCR', 'user:1')->value, 41, 'incr');
+    is(execute($engine, 'INCRBY', 'user:1', '2')->value, 43, 'incrby');
+    is(execute($engine, 'DECR', 'user:1')->value, 42, 'decr');
+    is(execute($engine, 'DECRBY', 'user:1', '2')->value, 40, 'decrby');
+    is(execute($engine, 'APPEND', 'user:1', '!')->value, 3, 'append');
+    is(execute($engine, 'APPEND', 'new', 'abc')->value, 3, 'append new');
+    execute($engine, 'SET', 'user:2', 'Lin');
+    is_deeply(response_values(execute($engine, 'KEYS', 'user:*')), ['user:1', 'user:2'], 'keys');
+    is(execute($engine, 'RENAME', 'user:2', 'user:two')->value, 'OK', 'rename');
+    is(execute($engine, 'GET', 'user:two')->value, 'Lin', 'renamed value');
+    execute($engine, 'SET', 'literal[1]', 'yes');
+    is_deeply(response_values(execute($engine, 'KEYS', 'literal[1]')), ['literal[1]'], 'literal glob');
+    is(execute($engine, 'DEL', 'user:1', 'missing')->value, 1, 'delete');
+    ok(!defined(execute($engine, 'GET', 'user:1')->value), 'deleted value');
+};
+
+subtest 'hashes and lists' => sub {
+    my $engine = CodingAdventures::InMemoryDataStoreEngine->new;
+    is(execute($engine, 'HSET', 'user', 'name', 'Ada', 'city', 'London')->value, 2, 'hset');
+    is(execute($engine, 'HSET', 'user', 'name', 'Augusta')->value, 0, 'hset update');
+    is(execute($engine, 'HGET', 'user', 'name')->value, 'Augusta', 'hget');
+    is(execute($engine, 'HEXISTS', 'user', 'city')->value, 1, 'hexists');
+    is(execute($engine, 'HLEN', 'user')->value, 2, 'hlen');
+    is_deeply(response_values(execute($engine, 'HKEYS', 'user')), ['city', 'name'], 'hkeys');
+    is_deeply(response_values(execute($engine, 'HVALS', 'user')), ['London', 'Augusta'], 'hvals');
+    is_deeply(response_values(execute($engine, 'HGETALL', 'user')), ['city', 'London', 'name', 'Augusta'], 'hgetall');
+    is(execute($engine, 'HDEL', 'user', 'city', 'missing')->value, 1, 'hdel');
+    is(execute($engine, 'HDEL', 'user', 'name')->value, 1, 'hdel final');
+    is(execute($engine, 'HLEN', 'user')->value, 0, 'empty hash removed');
+    is(execute($engine, 'LPUSH', 'queue', 'b', 'a')->value, 2, 'lpush');
+    is(execute($engine, 'RPUSH', 'queue', 'c')->value, 3, 'rpush');
+    is(execute($engine, 'LLEN', 'queue')->value, 3, 'llen');
+    is(execute($engine, 'LINDEX', 'queue', '-1')->value, 'c', 'lindex');
+    is_deeply(response_values(execute($engine, 'LRANGE', 'queue', '0', '-1')), ['a', 'b', 'c'], 'lrange');
+    is(execute($engine, 'LPOP', 'queue')->value, 'a', 'lpop');
+    is(execute($engine, 'RPOP', 'queue')->value, 'c', 'rpop');
+    is(execute($engine, 'RPOP', 'queue')->value, 'b', 'rpop final');
+    ok(!defined(execute($engine, 'LPOP', 'queue')->value), 'empty pop');
+};
+
+subtest 'sets sorted sets and HyperLogLog' => sub {
+    my $engine = CodingAdventures::InMemoryDataStoreEngine->new;
+    is(execute($engine, 'SADD', 'left', qw(a b c a))->value, 3, 'sadd left');
+    is(execute($engine, 'SADD', 'right', qw(b c d))->value, 3, 'sadd right');
+    is(execute($engine, 'SISMEMBER', 'left', 'b')->value, 1, 'sismember');
+    is(execute($engine, 'SCARD', 'left')->value, 3, 'scard');
+    is_deeply(response_values(execute($engine, 'SMEMBERS', 'left')), [qw(a b c)], 'smembers');
+    is_deeply(response_values(execute($engine, 'SUNION', 'left', 'right')), [qw(a b c d)], 'sunion');
+    is_deeply(response_values(execute($engine, 'SINTER', 'left', 'right')), [qw(b c)], 'sinter');
+    is_deeply(response_values(execute($engine, 'SDIFF', 'left', 'right')), ['a'], 'sdiff');
+    is_deeply(response_values(execute($engine, 'SINTER', 'left', 'missing')), [], 'missing intersection');
+    is(execute($engine, 'SREM', 'left', 'a', 'missing')->value, 1, 'srem');
+    is(execute($engine, 'ZADD', 'scores', '1', 'alice', '2', 'bob', '1.5', 'cara')->value, 3, 'zadd');
+    is(execute($engine, 'ZADD', 'scores', '3', 'alice')->value, 0, 'zadd update');
+    is_deeply(response_values(execute($engine, 'ZRANGE', 'scores', '0', '-1')), [qw(cara bob alice)], 'zrange');
+    is_deeply(response_values(execute($engine, 'ZRANGE', 'scores', '0', '1', 'WITHSCORES')), ['cara', '1.5', 'bob', '2'], 'zrange scores');
+    is_deeply(response_values(execute($engine, 'ZRANGEBYSCORE', 'scores', '1', '2')), [qw(cara bob)], 'zrangebyscore');
+    is(execute($engine, 'ZRANK', 'scores', 'bob')->value, 1, 'zrank');
+    is(execute($engine, 'ZSCORE', 'scores', 'cara')->value, '1.5', 'zscore');
+    is(execute($engine, 'ZCARD', 'scores')->value, 3, 'zcard');
+    is(execute($engine, 'ZREM', 'scores', 'bob', 'missing')->value, 1, 'zrem');
+    is(execute($engine, 'PFADD', 'visitors', qw(alice bob))->value, 1, 'pfadd');
+    is(execute($engine, 'PFADD', 'visitors', 'alice')->value, 0, 'pfadd no change');
+    is(execute($engine, 'PFADD', 'other', 'cara')->value, 1, 'pfadd other');
+    cmp_ok(execute($engine, 'PFCOUNT', 'visitors')->value, '>=', 2, 'pfcount');
+    cmp_ok(execute($engine, 'PFCOUNT', 'visitors', 'other')->value, '>=', 3, 'pfcount merge');
+    is(execute($engine, 'PFMERGE', 'all', 'visitors', 'other')->value, 'OK', 'pfmerge');
+    cmp_ok(execute($engine, 'PFCOUNT', 'all')->value, '>=', 3, 'merged count');
+};
+
+subtest 'expiry logical databases and admin commands' => sub {
+    my $now = 2_000_000;
+    my $engine = CodingAdventures::InMemoryDataStoreEngine->new(time_provider => sub { $now });
+    execute($engine, 'SET', 'temporary', 'value');
+    is(execute($engine, 'TTL', 'temporary')->value, -1, 'ttl persistent');
+    is(execute($engine, 'PERSIST', 'temporary')->value, 0, 'persist none');
+    is(execute($engine, 'EXPIRE', 'temporary', '10')->value, 1, 'expire');
+    is(execute($engine, 'TTL', 'temporary')->value, 10, 'ttl');
+    is(execute($engine, 'PTTL', 'temporary')->value, 10_000, 'pttl');
+    is(execute($engine, 'PERSIST', 'temporary')->value, 1, 'persist');
+    is(execute($engine, 'EXPIREAT', 'temporary', '1999')->value, 1, 'expireat');
+    ok(!defined(execute($engine, 'GET', 'temporary')->value), 'expired');
+    is(execute($engine, 'TTL', 'temporary')->value, -2, 'missing ttl');
+    execute($engine, 'SET', 'db0', 'zero');
+    is(execute($engine, 'SELECT', '1')->value, 'OK', 'select');
+    execute($engine, 'SET', 'db1', 'one');
+    is(execute($engine, 'DBSIZE')->value, 1, 'dbsize');
+    like(execute($engine, 'INFO')->value, qr/active_db:1/, 'info');
+    is(execute($engine, 'FLUSHDB')->value, 'OK', 'flushdb');
+    is(execute($engine, 'DBSIZE')->value, 0, 'empty db');
+    execute($engine, 'SET', 'again', 'one');
+    is(execute($engine, 'FLUSHALL')->value, 'OK', 'flushall');
+    execute($engine, 'SELECT', '0');
+    is(execute($engine, 'DBSIZE')->value, 0, 'all empty');
+};
+
+subtest 'protocol arity type and parse errors' => sub {
+    my $engine = CodingAdventures::InMemoryDataStoreEngine->new;
+    error_like($engine->execute_frame(undef), 'protocol error', 'protocol');
+    error_like(execute($engine, 'NOPE'), 'unknown command', 'unknown');
+    for my $parts (
+        ['PING', 'a', 'b'], ['ECHO'], ['SET', 'a'], ['GET'], ['DEL'],
+        ['HSET', 'a', 'b'], ['LPUSH', 'a'], ['SADD', 'a'],
+        ['ZADD', 'a', '1'], ['PFADD', 'a'], ['EXPIRE', 'a'],
+        ['SELECT'], ['FLUSHDB', 'x'], ['INFO', 'x'],
+    ) {
+        error_like($engine->execute_parts($parts), 'wrong number', join(' ', @$parts));
+    }
+    error_like(execute($engine, 'RENAME', 'missing', 'other'), 'no such key', 'rename missing');
+    error_like(execute($engine, 'SELECT', '99'), 'DB index', 'select range');
+    execute($engine, 'SET', 'string', 'value');
+    for my $parts (
+        ['HGET', 'string', 'field'], ['LPUSH', 'string', 'value'],
+        ['SADD', 'string', 'value'], ['ZADD', 'string', '1', 'value'],
+        ['PFADD', 'string', 'value'], ['SUNION', 'string'],
+    ) {
+        error_like($engine->execute_parts($parts), 'WRONGTYPE', join(' ', @$parts));
+    }
+    error_like(execute($engine, 'INCR', 'string'), 'integer', 'incr text');
+    error_like(execute($engine, 'INCRBY', 'n', 'bad'), 'integer', 'incrby text');
+    error_like(execute($engine, 'DECRBY', 'n', '-9223372036854775808'), 'integer', 'decrby minimum');
+    execute($engine, 'SET', 'max', '9223372036854775807');
+    error_like(execute($engine, 'INCR', 'max'), 'integer', 'overflow');
+    error_like(execute($engine, 'ZADD', 'z', 'nan', 'a'), 'float', 'nan');
+};
+
+subtest 'storage and sorted set helpers' => sub {
+    is(CodingAdventures::InMemoryDataStoreEngine::EntryType::STRING(), 'string', 'entry type constant');
+    my $error = !eval { CodingAdventures::InMemoryDataStoreEngine::Store->new(database_count => 0); 1 };
+    ok($error, 'rejects zero databases');
+    my $store = CodingAdventures::InMemoryDataStoreEngine::Store->new(database_count => 2);
+    $store->select(1);
+    is($store->active_db, 1, 'active database');
+    my $now = 50_000;
+    my $database = CodingAdventures::InMemoryDataStoreEngine::Database->new(time_provider => sub { $now });
+    $database->set('live', CodingAdventures::InMemoryDataStoreEngine::Entry->new('string', 'yes'));
+    $database->set('old', CodingAdventures::InMemoryDataStoreEngine::Entry->new('string', 'no', $now - 1));
+    ok(!defined($database->get('old')), 'lazy expiry');
+    is_deeply($database->keys('l?ve'), ['live'], 'glob');
+    $database->clear;
+    is_deeply($database->{entries}, {}, 'clear');
+    my $sorted = CodingAdventures::InMemoryDataStoreEngine::SortedSet->new;
+    ok($sorted->insert(1, 'b'), 'new b');
+    ok($sorted->insert(1, 'a'), 'new a');
+    ok(!$sorted->insert(2, 'b'), 'update b');
+    is($sorted->rank('a'), 0, 'rank');
+    is_deeply($sorted->range_by_score(0, 1.5), [['a', 1]], 'score range');
+    ok($sorted->remove('a'), 'remove');
+};
+
+subtest 'public frames and binary strings' => sub {
+    my $engine = CodingAdventures::InMemoryDataStoreEngine->new(time_provider => sub { 1234 });
+    is($engine->current_time_ms, 1234, 'clock');
+    my $frame = CodingAdventures::InMemoryDataStoreProtocol::CommandFrame->new('ping');
+    is($engine->execute_frame($frame)->value, 'PONG', 'frame');
+    my $binary = "\0\xff\1";
+    execute($engine, 'SET', $binary, $binary);
+    is(execute($engine, 'GET', $binary)->value, $binary, 'binary round trip');
+};
+
+subtest 'deterministic randomized string reference model' => sub {
+    my $engine = CodingAdventures::InMemoryDataStoreEngine->new;
+    my %model;
+    my $state = 20260716;
+    my $next_random = sub {
+        my ($limit) = @_;
+        $state = ($state * 1103515245 + 12345) & 0x7fffffff;
+        return $state % $limit;
+    };
+    for (1 .. 5000) {
+        my $key = 'key:' . $next_random->(31);
+        my $choice = $next_random->(6);
+        if ($choice == 0) {
+            my $value = '' . $next_random->(10000);
+            is(execute($engine, 'SET', $key, $value)->value, 'OK', 'random set');
+            $model{$key} = $value;
+        } elsif ($choice == 1) {
+            is(execute($engine, 'GET', $key)->value, $model{$key}, 'random get');
+        } elsif ($choice == 2) {
+            my $expected = exists($model{$key}) ? 1 : 0;
+            is(execute($engine, 'DEL', $key)->value, $expected, 'random delete');
+            delete $model{$key};
+        } elsif ($choice == 3) {
+            is(execute($engine, 'EXISTS', $key)->value, exists($model{$key}) ? 1 : 0, 'random exists');
+        } elsif ($choice == 4) {
+            my $suffix = chr(97 + $next_random->(26));
+            $model{$key} = (defined($model{$key}) ? $model{$key} : '') . $suffix;
+            is(execute($engine, 'APPEND', $key, $suffix)->value, length($model{$key}), 'random append');
+        } else {
+            my $current = $model{$key};
+            if (!defined($current) || $current =~ /\A[+-]?\d+\z/) {
+                my $expected = (defined($current) ? $current : 0) + 1;
+                is(execute($engine, 'INCR', $key)->value, $expected, 'random incr');
+                $model{$key} = "$expected";
+            } else {
+                error_like(execute($engine, 'INCR', $key), 'integer', 'random invalid incr');
+            }
+        }
+    }
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -108,12 +108,12 @@ The missing matrix is heavily concentrated in singleton packages. Regenerated
 on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
 `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
-the paired `hash-functions` prerequisite, and the paired `bloom-filter` and
-`hash-map` and `hash-set` ports:
+the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
+and `hash-set` ports, and the paired `in-memory-data-store-engine` port:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 347 |
+| Present in 10-15 languages | 172 | 345 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 695 | 9,730 |
@@ -159,15 +159,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 349
+The 172 packages present in at least ten implementation languages need 345
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 2 | Pair with Perl data-structure/storage wave |
-| Perl | 2 | Pair with Lua data-structure/storage wave |
+| Lua | 1 | Pair with Perl data-structure/storage wave |
+| Perl | 1 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -179,12 +179,12 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first fifteen paired Lua/Perl slices are complete: `fenwick-tree`,
+The first sixteen paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
 `avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, `radix-tree`,
-`resp-protocol`, `hash-functions`, `bloom-filter`, `hash-map`, and `hash-set`
-now have pure implementations, package-native tests, metadata, and capability
-declarations in both lanes.
+`resp-protocol`, `hash-functions`, `bloom-filter`, `hash-map`, `hash-set`, and
+`in-memory-data-store-engine` now have pure implementations, package-native
+tests, metadata, and capability declarations in both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
 in-memory data store layers move; the AVL slice supplies the ordered backend
 for `tree-set`; and the dependency-free skip-list slice adds a span-augmented
@@ -216,6 +216,11 @@ option preservation, identity-safe reference elements, and resize coverage for
 both collision strategies. It reduces the paired high-consensus gap to two
 packages per lane, leaving the higher in-memory data store layers as the final
 paired wave.
+The engine slice consumes the existing protocol IR and HyperLogLog packages to
+provide binary-safe strings, typed collections, sorted sets, expiry, 16 logical
+databases, deterministic response ordering, and the complete 57-command
+execution surface. It reduces the paired high-consensus gap to one package per
+lane, leaving only the top-level `in-memory-data-store` facade.
 
 Recommended family order:
 


### PR DESCRIPTION
## What

- add pure Lua and Perl `in-memory-data-store-engine` packages over the existing protocol IR and HyperLogLog ports
- implement the complete 57-command surface for binary-safe strings, hashes, lists, sets, sorted sets, HLL, expiry, 16 logical databases, keyspace operations, and administration
- expose storage helpers, deterministic ordering, injectable clocks, shared response semantics, package metadata, capability declarations, and native build gates
- update the measured package-parity roadmap, leaving only the paired top-level `in-memory-data-store` facade

## Why this is next

After the paired hash-set port merged, Lua and Perl had two high-consensus gaps. The top-level data-store package depends on this engine, so the engine is the next dependency-safe layer.

## Validation

- exact command-registry comparison: Python 57, Lua 57, Perl 57, with no missing or extra commands
- LuaRocks lint and local installation with dependencies resolved
- Lua Busted suite: 8 successes, including a deterministic 5,000-operation reference model
- Perl Test::Harness gate: 2 files and 10 tests, including a deterministic 5,000-operation reference model
- warning-free Perl MakeMaker generation outside the repository
- both capability manifests validated against the repository schema
- parity reporter unit tests: 6 passed
- fresh parity report: 172 high-consensus packages, 345 missing slots, 0 collisions
- `git diff --check`

## Remaining paired gap

- Lua: `in-memory-data-store`
- Perl: `in-memory-data-store`
