### PR TITLE
feat(gc-core): flat-native heap + gc-core-capi C ABI (LANG16 gc_runtime, AOT00 T1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -141,6 +141,7 @@ members = [
     "fsharp-parser",
     "garbage-collector",
     "gc-core",
+    "gc-core-capi",
     "ge225-simulator",
     "argon2d",
     "argon2i",

--- a/code/packages/rust/gc-core-capi/BUILD
+++ b/code/packages/rust/gc-core-capi/BUILD
@@ -1,0 +1,1 @@
+cargo check

--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog — gc-core-capi
+
+All notable changes to this crate are documented here.
+
+## [0.1.0] — 2026-07-16
+
+Initial release. C ABI for `gc-core`'s flat-native heap — LANG16's
+`gc_runtime_<target>.a` companion, superseding `twig-aot/runtime/twig_gc.c`
+(AOT00 T1, spec `AOT00-T1-precise-gc.md` §3.1 / §11).
+
+### Added
+
+- `libgc_core_capi.a` / `.dylib` / `.so` exposing a stable C ABI over
+  `gc_core::FlatHeap`:
+  - `__gc_alloc(n)` — real-pointer allocation of `n` zeroed, 16-byte-aligned bytes.
+  - `__gc_alloc_kind(n, kind)` — as above with a `HeapKind` id for later precise
+    tracing.
+  - `__gc_collect_roots(roots, count)` — explicit-root mark-and-sweep; returns
+    objects freed.
+  - `__gc_live_bytes()` / `__gc_collection_count()` — introspection.
+  - `__gc_reset()` — drop the whole heap.
+- `include/gc_core.h` C header.
+- Host test exercising the full alloc → write → collect → reset flow over the
+  exported ABI (real pointers, conservative tracing, exact reclamation).
+
+### Notes
+
+- One process-wide heap behind a `Mutex` (single-threaded native runtime model,
+  matching `twig_gc.c`).
+- This is **T1 rung 0**: the linkable collector with explicit-root collection.
+  Wiring `twig-aot` to link it (retiring `twig_gc.c`), the conservative C-stack
+  scan (argument-less `collect`), and the precise/moving/generational rungs are
+  follow-up PRs.

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gc-core-capi"
+version = "0.1.0"
+edition = "2021"
+description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
+license = "MIT"
+
+# staticlib (.a) — linked into native-AOT executables as gc_runtime_<target>.a
+# cdylib     (.so/.dylib) — dynamic linking if ever needed
+# lib (rlib) — so `cargo test` can build the in-crate host tests that call the
+#              exported functions directly
+[lib]
+name = "gc_core_capi"
+crate-type = ["staticlib", "cdylib", "lib"]
+
+[dependencies]
+gc-core = { path = "../gc-core" }

--- a/code/packages/rust/gc-core-capi/README.md
+++ b/code/packages/rust/gc-core-capi/README.md
@@ -1,0 +1,77 @@
+# gc-core-capi
+
+C ABI for [`gc-core`](../gc-core)'s flat-native heap — the garbage collector a
+**native-AOT** executable links so its emitted heap ops (`alloc` / `field_load` /
+`field_store` / `safepoint`) resolve to a real collector.
+
+This crate compiles to `libgc_core_capi.a` (static) and `libgc_core_capi.dylib/.so`
+(dynamic). It is the concrete realisation of LANG16's `gc_runtime_<target>.a`
+companion archive, and it **supersedes `twig-aot/runtime/twig_gc.c`**: the same flat
+mark-and-sweep model, but one generic Rust collector shared by every native consumer
+(native-AOT, LLVM, WASM) instead of a Twig-specific C fork.
+
+See the design in [`AOT00-T1-precise-gc.md`](../../../specs/AOT00-T1-precise-gc.md)
+(§3.1 "two heap representations", §11 sequencing) and
+[`LANG16-gc-core.md`](../../../specs/LANG16-gc-core.md).
+
+## Where it fits
+
+```
+                 vm-core / jit-core ── gc-core (managed-object heap: Box<dyn HeapObject>)
+                                         │
+IIR alloc/field_*/safepoint ─ native-AOT ┴ gc-core FlatHeap (flat real-memory heap)
+                                         │
+                                    gc-core-capi  ── libgc_core_capi.a  (this crate)
+                                         │
+                              linked into the AOT'd native executable
+```
+
+The interpreters use `gc-core`'s managed-object collector; native output uses
+`gc-core`'s `FlatHeap` through this C ABI. Both run the same algorithm and share
+`gc-core`'s `HeapKind` / `RootSet` / `WriteBarrier` / adaptive-policy machinery.
+
+## The ABI (`include/gc_core.h`)
+
+| Symbol | Meaning |
+|---|---|
+| `int64_t __gc_alloc(int64_t n)` | allocate `n` zeroed bytes; returns a real pointer (as `int64`), `0` on failure/`n<=0` |
+| `int64_t __gc_alloc_kind(int64_t n, uint16_t kind)` | as above, tagging the object with a `HeapKind` id (for later precise tracing) |
+| `int64_t __gc_collect_roots(const int64_t *roots, int64_t count)` | mark from `count` root words, sweep; returns objects freed |
+| `int64_t __gc_live_bytes(void)` | live payload bytes |
+| `int64_t __gc_collection_count(void)` | collections run so far |
+| `void __gc_reset(void)` | drop the whole heap; free everything |
+
+`__gc_alloc` returns a **real, 16-byte-aligned pointer** to memory the caller reads
+and writes directly. Tracing is conservative (raw + tag-stripped candidate words);
+a live object is never freed. The heap is single-threaded (matching `twig_gc.c`), one
+process-wide instance.
+
+## Usage (C)
+
+```c
+#include "gc_core.h"
+
+int64_t cell = __gc_alloc(16);        /* a cons cell: [car][cdr] */
+*(int64_t *)cell = 42;                /* car = 42 */
+int64_t roots[1] = { cell };
+__gc_collect_roots(roots, 1);         /* cell is rooted → survives */
+```
+
+## Status
+
+This is **T1 rung 0** — the linkable flat collector with explicit-root collection.
+Still to come (own PRs):
+
+- Wire `twig-aot`'s `build.rs` to link this archive and retire `twig_gc.c`
+  (golden/smoke parity).
+- A conservative **C-stack scan** so `collect` runs with no explicit roots (the
+  drop-in for `twig_gc.c`'s argument-less `__twig_gc_collect`).
+- **Precise** roots (stack maps) and interior tracing (`HeapKind` field maps),
+  then moving / generational — all as `gc-core` algorithms.
+
+## Build & test
+
+```
+cargo build -p gc-core-capi     # produces libgc_core_capi.a
+cargo test  -p gc-core-capi     # host tests exercising the exported ABI
+```

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -1,0 +1,62 @@
+/*
+ * gc_core.h — C ABI for gc-core's flat-native heap.
+ * =================================================================
+ *
+ * Declarations for the symbols exported by `libgc_core_capi.a` (the Rust
+ * `gc-core-capi` crate). This archive is LANG16's `gc_runtime_<target>.a`:
+ * a native-AOT executable links it so its emitted `alloc` / `field_*` /
+ * `safepoint` ops resolve to a real garbage collector. It supersedes the
+ * Twig-specific `twig_gc.c` — the same flat mark-and-sweep model, but one
+ * generic collector (gc-core) shared by every native consumer.
+ *
+ * See code/specs/AOT00-T1-precise-gc.md and code/specs/LANG16-gc-core.md.
+ *
+ * Model
+ * -----
+ *   __gc_alloc(n) returns a REAL pointer (as int64_t) to n zeroed bytes; the
+ *   payload is 16-byte aligned. Compiled code reads/writes it directly at byte
+ *   offsets. A returned pointer stays valid until a __gc_collect_roots that
+ *   does not root it, or __gc_reset.
+ *
+ *   Tracing is conservative: each root word and each aligned word inside a
+ *   reachable object is treated as a candidate pointer (raw and low-3-bit
+ *   tag-stripped, for NaN-boxed heap references). False positives retain a dead
+ *   object one extra cycle; a live object is never freed.
+ *
+ *   Single-threaded (matching twig_gc.c). One process-wide heap.
+ */
+#ifndef GC_CORE_H
+#define GC_CORE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Allocate n zeroed bytes; returns the payload pointer as int64_t, or 0 on
+ * n <= 0, size overflow, or allocator failure. */
+int64_t __gc_alloc(int64_t n);
+
+/* As __gc_alloc, tagging the object with a HeapKind id (for later precise
+ * interior tracing; 0 = opaque / trace conservatively). */
+int64_t __gc_alloc_kind(int64_t n, uint16_t kind);
+
+/* Mark from `count` root words at `roots`, then sweep. Returns objects freed.
+ * A null `roots` or count <= 0 means "no roots". */
+int64_t __gc_collect_roots(const int64_t *roots, int64_t count);
+
+/* Live payload bytes. */
+int64_t __gc_live_bytes(void);
+
+/* Collections run since process start (or last __gc_reset). */
+int64_t __gc_collection_count(void);
+
+/* Drop the whole heap (frees everything) and reset counters. */
+void __gc_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GC_CORE_H */

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -1,0 +1,170 @@
+//! # `gc-core-capi` — C ABI for `gc-core`'s flat-native heap
+//!
+//! This crate exposes [`gc_core::FlatHeap`] — the real-memory mark-and-sweep
+//! collector — over a stable **C ABI**, compiled to a static archive
+//! (`libgc_core_capi.a`).  It is the concrete realisation of LANG16's
+//! `gc_runtime_<target>.a` companion: the archive a native-AOT executable links
+//! so its emitted `alloc` / `field_*` / `safepoint` ops resolve to a real
+//! garbage collector.  See `AOT00-T1-precise-gc.md` (§3.1, §11) and
+//! `LANG16-gc-core.md`.
+//!
+//! It **supersedes `twig-aot/runtime/twig_gc.c`** — the same flat mark-sweep, but
+//! one generic Rust collector shared by every native consumer instead of a
+//! Twig-specific C fork.  (Wiring `twig-aot` to link this archive, and the
+//! conservative C-stack scan that lets `collect` run with no explicit roots, are
+//! the next PR; this crate delivers the linkable collector + its explicit-root
+//! entry points.)
+//!
+//! ## The exported ABI
+//!
+//! | Symbol | Meaning |
+//! |---|---|
+//! | `__gc_alloc(n)` | allocate `n` zeroed bytes; returns a real pointer (as `int64`), or `0` on failure/`n<=0` |
+//! | `__gc_alloc_kind(n, kind)` | as above, tagging the object with a `HeapKind` id (for later precise tracing) |
+//! | `__gc_collect_roots(roots, count)` | mark from `count` root words at `roots`, sweep; returns objects freed |
+//! | `__gc_live_bytes()` | live payload bytes |
+//! | `__gc_collection_count()` | collections run so far |
+//! | `__gc_reset()` | drop the whole heap (frees everything); mainly for tests / process teardown |
+//!
+//! ## State & threading
+//!
+//! The collector is a single process-wide instance behind a `Mutex` (the native
+//! AOT runtime is single-threaded, matching `twig_gc.c`; the mutex simply makes
+//! the `static` sound in Rust's model and costs nothing uncontended).  Pointers
+//! returned by `__gc_alloc` stay valid until a `__gc_collect_roots` that does not
+//! root them, or `__gc_reset`.
+
+use gc_core::FlatHeap;
+use std::sync::Mutex;
+
+/// The one process-wide heap.  `None` until the first allocation (lazy init);
+/// `__gc_reset` puts it back to `None`, running `FlatHeap`'s `Drop` to free
+/// every outstanding block.
+static HEAP: Mutex<Option<FlatHeap>> = Mutex::new(None);
+
+/// Run `f` against the (lazily created) global heap.
+///
+/// A poisoned lock (a prior panic while holding it) is recovered with
+/// `into_inner` rather than propagated — a GC must not become unusable because
+/// some unrelated code panicked; the heap's own invariants are upheld by its
+/// methods, not by panic-freedom of callers.
+fn with_heap<R>(f: impl FnOnce(&mut FlatHeap) -> R) -> R {
+    let mut guard = HEAP.lock().unwrap_or_else(|e| e.into_inner());
+    let heap = guard.get_or_insert_with(FlatHeap::new);
+    f(heap)
+}
+
+/// Allocate `n` zeroed bytes on the GC heap; returns the payload pointer as an
+/// `int64`, or `0` on `n <= 0`, overflow, or allocator failure.
+#[no_mangle]
+pub extern "C" fn __gc_alloc(n: i64) -> i64 {
+    __gc_alloc_kind(n, 0)
+}
+
+/// As [`__gc_alloc`], tagging the object with `HeapKind` id `kind` (stored for
+/// later precise interior tracing; `0` = opaque/conservative).
+#[no_mangle]
+pub extern "C" fn __gc_alloc_kind(n: i64, kind: u16) -> i64 {
+    if n <= 0 {
+        return 0;
+    }
+    with_heap(|h| h.alloc(n as usize, kind) as i64)
+}
+
+/// Mark from the `count` root words at `roots`, then sweep.  Returns the number
+/// of objects reclaimed.  A null `roots` or `count <= 0` means "no roots" — a
+/// full collection that frees everything not otherwise reachable (here, since
+/// tracing starts only from `roots`, that is the whole heap).
+///
+/// # Safety
+///
+/// `roots` must point to `count` readable `int64` words (or be null with
+/// `count <= 0`).  This is the standard C-array contract; the generated caller
+/// (or a test) upholds it.
+#[no_mangle]
+pub unsafe extern "C" fn __gc_collect_roots(roots: *const i64, count: i64) -> i64 {
+    let root_words: Vec<usize> = if roots.is_null() || count <= 0 {
+        Vec::new()
+    } else {
+        // SAFETY: caller guarantees `roots` covers `count` readable i64 words.
+        let slice = std::slice::from_raw_parts(roots, count as usize);
+        slice.iter().map(|&w| w as usize).collect()
+    };
+    with_heap(|h| h.collect(&root_words).freed as i64)
+}
+
+/// Current live payload bytes.
+#[no_mangle]
+pub extern "C" fn __gc_live_bytes() -> i64 {
+    with_heap(|h| h.live_bytes() as i64)
+}
+
+/// Total collections run since process start (or last `__gc_reset`).
+#[no_mangle]
+pub extern "C" fn __gc_collection_count() -> i64 {
+    with_heap(|h| h.collection_count() as i64)
+}
+
+/// Drop the entire heap, freeing every outstanding block, and reset counters.
+/// Primarily for tests and deterministic process teardown.
+#[no_mangle]
+pub extern "C" fn __gc_reset() {
+    let mut guard = HEAP.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = None; // FlatHeap::drop frees all blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The exported functions share one process-wide `HEAP`, so the whole ABI
+    // flow lives in a SINGLE test — cargo runs tests in parallel threads, and
+    // interleaving two tests over the shared heap would be nondeterministic.
+    #[test]
+    fn c_abi_alloc_collect_flow() {
+        __gc_reset();
+        assert_eq!(__gc_live_bytes(), 0);
+        assert_eq!(__gc_collection_count(), 0);
+
+        // Allocate two real, distinct, writable blocks.
+        let a = __gc_alloc(16);
+        let b = __gc_alloc(16);
+        assert!(a != 0 && b != 0 && a != b);
+        assert_eq!(__gc_live_bytes(), 32);
+        // The pointers are real memory: write and read back.
+        unsafe {
+            *(a as *mut i64) = 0x1122_3344_5566_7788u64 as i64;
+            *(b as *mut i64) = -7;
+            assert_eq!(*(a as *mut i64), 0x1122_3344_5566_7788u64 as i64);
+            assert_eq!(*(b as *mut i64), -7);
+        }
+
+        // Collect rooting only `a`: `b` is reclaimed.
+        let roots = [a];
+        let freed = unsafe { __gc_collect_roots(roots.as_ptr(), 1) };
+        assert_eq!(freed, 1);
+        assert_eq!(__gc_live_bytes(), 16);
+        assert_eq!(__gc_collection_count(), 1);
+        // `a` is still valid memory.
+        unsafe {
+            assert_eq!(*(a as *mut i64), 0x1122_3344_5566_7788u64 as i64);
+        }
+
+        // Collect with no roots frees the rest.
+        let freed2 = unsafe { __gc_collect_roots(std::ptr::null(), 0) };
+        assert_eq!(freed2, 1);
+        assert_eq!(__gc_live_bytes(), 0);
+        assert_eq!(__gc_collection_count(), 2);
+
+        // Degenerate allocs fail to null.
+        assert_eq!(__gc_alloc(0), 0);
+        assert_eq!(__gc_alloc(-5), 0);
+
+        // Reset drops everything and zeroes counters.
+        __gc_alloc(64);
+        assert_eq!(__gc_live_bytes(), 64);
+        __gc_reset();
+        assert_eq!(__gc_live_bytes(), 0);
+        assert_eq!(__gc_collection_count(), 0);
+    }
+}

--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog — gc-core
 
-## 0.1.0 — initial release
+## 0.2.0 — 2026-07-16
+
+### Added
+
+- **`flat_heap` module + `FlatHeap`** — a real-memory mark-and-sweep collector
+  (the second heap representation described in `AOT00-T1-precise-gc.md` §3.1).
+  Where `GcCore` models the heap as `HashMap<usize, Box<dyn HeapObject>>` for the
+  interpreters, `FlatHeap` allocates a real machine pointer per object (32-byte
+  header + payload, 16-byte-aligned) so **native-AOT** output can read/write it
+  directly at byte offsets. `alloc`/`collect` (explicit roots, conservative
+  tracing — raw + tag-stripped candidate words), live-byte and collection
+  accounting folded into `GcProfile`. This is the generic home of
+  `twig-aot/runtime/twig_gc.c`'s flat model, shared by every native consumer
+  (native-AOT / LLVM / WASM) via the new `gc-core-capi` C ABI. Re-exported at the
+  crate root as `gc_core::FlatHeap`.
 
 ### Added
 

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "LANG16 — adaptive GC adapter layer wiring garbage-collector into the LANG VM pipeline."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/flat_heap.rs
+++ b/code/packages/rust/gc-core/src/flat_heap.rs
@@ -1,0 +1,513 @@
+//! # `flat_heap` — a real-memory mark-and-sweep heap for native consumers
+//!
+//! `gc-core`'s primary collector ([`crate::gc_core::GcCore`] over the
+//! `garbage-collector` crate) models the heap as a `HashMap<usize, Box<dyn
+//! HeapObject>>` with *synthetic* addresses.  That is exactly right for the
+//! **interpreters** (`vm-core`, `jit-core`): a running Rust interpreter always
+//! knows the static type of every slot, so a boxed trait object per heap value
+//! costs nothing conceptually and buys reflection-free tracing.
+//!
+//! It is the **wrong** model for **native-AOT** output.  There the heap must be
+//! *flat*: `alloc(n)` returns a **real machine pointer** to `n` contiguous bytes
+//! that compiled code reads and writes directly at byte offsets (the IIR
+//! `field_load`/`field_store` ops), with no map indirection and no `Box<dyn>`.
+//! A McCarthy-Lisp cons cell, a boxed integer, a closure record — all are just
+//! `alloc(16)` returning a pointer the generated machine code dereferences.
+//!
+//! This module is that flat representation, lifted into `gc-core` as a
+//! first-class **generic** algorithm (see `AOT00-T1-precise-gc.md` §3.1 and
+//! `LANG16-gc-core.md`).  It is the collector the native-AOT / LLVM / WASM
+//! columns link through the C ABI (`gc-core-capi`), and it supersedes the
+//! Twig-specific `twig-aot/runtime/twig_gc.c` — same flat model (32-byte header,
+//! 16-byte-aligned payload, intrusive free list, mark/sweep), but now one
+//! generic Rust collector every native consumer shares rather than a hand-written
+//! C fork.
+//!
+//! ## Memory layout
+//!
+//! Every allocation is one contiguous block: a fixed **32-byte header**
+//! immediately followed by the caller's payload.
+//!
+//! ```text
+//!   block ─┐
+//!          ▼
+//!   ┌──────────────── 32-byte FlatHeader ───────────────┬─ payload (n bytes) ─┐
+//!   │ next(8) │ size(8) │ marked(1) │ kind(2) │ pad(13) │  … caller's bytes …  │
+//!   └─────────────────────────────────────────────────┴──────────────────────┘
+//!   ^block                                              ^block + 32  (returned)
+//! ```
+//!
+//! The block is allocated 16-byte aligned and the header is exactly 32 bytes, so
+//! the **payload is always 16-byte aligned** — its low 4 bits are zero, which the
+//! NaN-box tag scheme (low-3-bits tag on dynamic values) requires: a real heap
+//! pointer never collides with a tagged immediate.  The caller-visible pointer is
+//! `block + 32`; the reverse map is `header = payload - 32`.
+//!
+//! ## What this PR delivers (T1 rung 0 — the flat core)
+//!
+//! A precise, *explicit-root* mark-and-sweep:
+//! - [`FlatHeap::alloc`] — real-pointer allocation, header + zeroed payload.
+//! - [`FlatHeap::collect`] — mark from a caller-supplied root list, then sweep.
+//!   Roots and interior fields are traced **conservatively** for now (every
+//!   aligned word that looks like an in-heap pointer, raw and tag-stripped, is
+//!   followed) — identical semantics to `twig_gc.c` minus the C-stack scan.
+//!   Precise roots (stack maps) and precise interior tracing (`HeapKind` field
+//!   maps) are the next rungs; the `kind` id is already stored per object so they
+//!   slot in without a layout change.
+//! - live-byte / collection-count accounting, wired into [`GcProfile`] so this
+//!   collector participates in `gc-core`'s adaptive policy like any other.
+//!
+//! The C ABI and the conservative *C-stack* scan that makes `collect()` safe to
+//! call with no explicit roots (the drop-in for `twig_gc.c`'s argument-less
+//! `__twig_gc_collect`) live in the `gc-core-capi` crate and a follow-up PR
+//! respectively.
+
+use crate::profile::{GcCycleStats, GcProfile};
+use std::alloc::{alloc_zeroed, dealloc, Layout};
+use std::ptr;
+
+/// Bytes of header prepended to every payload.  Chosen as 32 (not the natural
+/// ~24 the fields need) so that a 16-byte-aligned block yields a 16-byte-aligned
+/// payload — see the module-level layout note.
+const HEADER_SIZE: usize = 32;
+
+/// Allocation alignment.  16 bytes guarantees the low 4 payload-address bits are
+/// zero (the NaN-box tag invariant).
+const ALIGN: usize = 16;
+
+/// Per-object header, placed immediately before the payload.
+///
+/// `#[repr(C)]` + explicit padding pins `size_of::<FlatHeader>() == 32` on every
+/// target (asserted below), so `payload = (header as *mut FlatHeader).add(1)` and
+/// `header = (payload as *mut FlatHeader).sub(1)` are exact inverses.
+#[repr(C)]
+struct FlatHeader {
+    /// Intrusive singly-linked list threading **every** live block; the sweep
+    /// walks it.  Head is [`FlatHeap::all`].
+    next: *mut FlatHeader,
+    /// Payload size in bytes (excludes the header).  Drives the conservative
+    /// interior scan and reconstructs the `Layout` for `dealloc`.
+    size: usize,
+    /// Mark bit: set during mark, cleared by sweep on survivors.
+    marked: bool,
+    /// `HeapKind` id for *precise* interior tracing (a later rung).  `0` means
+    /// "opaque / trace conservatively"; unused by this PR beyond being carried.
+    kind: u16,
+    /// Explicit tail padding to reach exactly 32 bytes.
+    _pad: [u8; 12],
+}
+
+// Compile-time proof that the header is exactly 32 bytes — if a field ever
+// changes size this fails to build rather than silently misaligning payloads.
+const _: () = assert!(std::mem::size_of::<FlatHeader>() == HEADER_SIZE);
+
+/// A flat, real-memory mark-and-sweep heap.
+///
+/// Owns every block it hands out and frees them on `collect` (unreachable ones)
+/// or on `Drop` (all remaining).  Single-threaded by design — the native AOT
+/// runtime is single-threaded (matching `twig_gc.c`), so no locking lives here;
+/// the C ABI layer serialises access.
+pub struct FlatHeap {
+    /// Head of the all-blocks list.
+    all: *mut FlatHeader,
+    /// Sum of live payload bytes (updated on alloc and after each sweep).
+    live_bytes: usize,
+    /// Total collections run since creation.
+    collection_count: u64,
+    /// Adaptive-policy profile shared with the rest of `gc-core`.
+    profile: GcProfile,
+}
+
+// SAFETY: `FlatHeap` holds raw pointers (`*mut FlatHeader`), which make it
+// `!Send` by default.  The native AOT runtime is single-threaded and the C ABI
+// wrapper (`gc-core-capi`) owns the single instance behind a mutex, so the heap
+// is never touched from two threads at once.  Marking it `Send` lets that
+// wrapper store it in a `static`.
+unsafe impl Send for FlatHeap {}
+
+impl Default for FlatHeap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FlatHeap {
+    /// An empty heap.
+    pub fn new() -> Self {
+        FlatHeap {
+            all: ptr::null_mut(),
+            live_bytes: 0,
+            collection_count: 0,
+            profile: GcProfile::default(),
+        }
+    }
+
+    /// Allocate `n` zeroed bytes and return a **real pointer** to the payload.
+    ///
+    /// `kind` is the object's [`crate::kind::HeapKind`] id (`0` = opaque); it is
+    /// stored for later precise tracing and otherwise inert here.  Returns a null
+    /// pointer if `n == 0`, on `header + n` overflow, or on allocator failure —
+    /// the same fail-to-null contract the C ABI expects.
+    ///
+    /// The returned pointer is 16-byte aligned (payload alignment invariant).
+    pub fn alloc(&mut self, n: usize, kind: u16) -> *mut u8 {
+        if n == 0 {
+            return ptr::null_mut();
+        }
+        // Overflow guard: a caller-controlled `n` near usize::MAX must not wrap
+        // `HEADER_SIZE + n` to a small value (which would under-allocate while
+        // `size` still records the huge value → out-of-bounds interior scan).
+        let total = match HEADER_SIZE.checked_add(n) {
+            Some(t) => t,
+            None => return ptr::null_mut(),
+        };
+        let layout = match Layout::from_size_align(total, ALIGN) {
+            Ok(l) => l,
+            Err(_) => return ptr::null_mut(),
+        };
+        // SAFETY: `layout` has non-zero size (total >= HEADER_SIZE > 0) and a
+        // valid power-of-two alignment.  `alloc_zeroed` zero-initialises the
+        // whole block, so the payload starts as all-zero (matching `calloc`).
+        let block = unsafe { alloc_zeroed(layout) } as *mut FlatHeader;
+        if block.is_null() {
+            return ptr::null_mut();
+        }
+        // SAFETY: `block` points to `total >= 32` freshly-allocated bytes, so the
+        // header fields are in bounds; the list-prepend keeps the invariant that
+        // every handed-out block is reachable from `self.all`.
+        unsafe {
+            (*block).next = self.all;
+            (*block).size = n;
+            (*block).marked = false;
+            (*block).kind = kind;
+        }
+        self.all = block;
+        self.live_bytes += n;
+        self.profile.record_allocation(n);
+        // Payload is the byte just past the 32-byte header.
+        // SAFETY: `size_of::<FlatHeader>() == 32`, so `.add(1)` lands exactly on
+        // the payload within the same allocation.
+        unsafe { block.add(1) as *mut u8 }
+    }
+
+    /// Current live payload bytes (post-last-sweep for reclaimed blocks, plus any
+    /// allocated since).
+    pub fn live_bytes(&self) -> usize {
+        self.live_bytes
+    }
+
+    /// Total collections run.
+    pub fn collection_count(&self) -> u64 {
+        self.collection_count
+    }
+
+    /// Read-only view of the adaptive profile.
+    pub fn profile(&self) -> &GcProfile {
+        &self.profile
+    }
+
+    /// Number of live blocks (walks the list — O(n); for tests/introspection).
+    pub fn object_count(&self) -> usize {
+        let mut n = 0;
+        let mut h = self.all;
+        // SAFETY: `all` and every `next` either point at a live block we own or
+        // are null (list terminator).
+        while !h.is_null() {
+            n += 1;
+            h = unsafe { (*h).next };
+        }
+        n
+    }
+
+    /// Run one mark-and-sweep cycle rooted at `roots` (payload addresses as
+    /// `usize`).  Returns the cycle's [`GcCycleStats`] (also folded into the
+    /// profile).  Any block not reachable from `roots` is freed.
+    ///
+    /// Tracing is **conservative**: each root word, and each aligned word inside a
+    /// marked object's payload, is treated as a *candidate* pointer — both the raw
+    /// value and the value with its low 3 tag bits cleared are looked up against
+    /// the live set (so both a raw `alloc` pointer and a NaN-box-tagged heap
+    /// reference are followed).  A false positive retains a dead object for one
+    /// extra cycle; it never frees a live one.
+    pub fn collect(&mut self, roots: &[usize]) -> GcCycleStats {
+        let before = self.object_count();
+
+        // ── Mark ──────────────────────────────────────────────────────────────
+        // Iterative worklist (no recursion → no stack blow-up on deep lists).
+        let mut work: Vec<*mut FlatHeader> = Vec::new();
+        for &r in roots {
+            self.mark_word(r, &mut work);
+        }
+        while let Some(h) = work.pop() {
+            self.scan_payload(h, &mut work);
+        }
+
+        // ── Sweep ─────────────────────────────────────────────────────────────
+        let (freed, survived, live) = self.sweep();
+        self.live_bytes = live;
+
+        let stats = GcCycleStats {
+            freed,
+            survived,
+            pause_ns: 0,
+            heap_size_before: before,
+            heap_size_after: survived,
+        };
+        self.profile.record_cycle(&stats);
+        self.collection_count += 1;
+        stats
+    }
+
+    /// Mark the block a candidate `word` points into, if any, and enqueue it.
+    /// Checks both the raw word and the tag-stripped word (NaN-box compat).
+    fn mark_word(&self, word: usize, work: &mut Vec<*mut FlatHeader>) {
+        // Raw candidate.
+        let h = self.find_header(word);
+        if !h.is_null() {
+            // SAFETY: `find_header` only returns headers of live blocks we own.
+            unsafe {
+                if !(*h).marked {
+                    (*h).marked = true;
+                    work.push(h);
+                }
+            }
+        }
+        // Tag-stripped candidate (low 3 bits are a NaN-box tag on dyn values).
+        let stripped = word & !0x7usize;
+        if stripped != word && stripped != 0 {
+            let h2 = self.find_header(stripped);
+            if !h2.is_null() {
+                // SAFETY: as above.
+                unsafe {
+                    if !(*h2).marked {
+                        (*h2).marked = true;
+                        work.push(h2);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Conservatively scan `h`'s payload for further candidate pointers.
+    fn scan_payload(&self, h: *mut FlatHeader, work: &mut Vec<*mut FlatHeader>) {
+        // SAFETY: `h` is a live block; its payload is `size` bytes at `h + 32`.
+        let (base, size) = unsafe {
+            let payload = (h.add(1)) as *const u8;
+            (payload, (*h).size)
+        };
+        let mut off = 0usize;
+        while off + 8 <= size {
+            // SAFETY: `off + 8 <= size`, so the 8-byte read stays inside the
+            // payload.  `read_unaligned` tolerates any payload sub-alignment.
+            let word = unsafe { ptr::read_unaligned(base.add(off) as *const usize) };
+            self.mark_word(word, work);
+            off += 8;
+        }
+    }
+
+    /// Return the header of the live block whose payload contains `addr`, or null.
+    /// Linear scan of the all-blocks list (matching `twig_gc.c`'s V1; a sorted
+    /// interval index is a later optimisation).
+    fn find_header(&self, addr: usize) -> *mut FlatHeader {
+        if addr == 0 {
+            return ptr::null_mut();
+        }
+        let mut h = self.all;
+        // SAFETY: list walk over blocks we own / null.
+        unsafe {
+            while !h.is_null() {
+                let payload = h.add(1) as usize;
+                let end = payload + (*h).size;
+                if addr >= payload && addr < end {
+                    return h;
+                }
+                h = (*h).next;
+            }
+        }
+        ptr::null_mut()
+    }
+
+    /// Free every unmarked block; clear marks on survivors.  Returns
+    /// `(freed, survived, live_bytes)`.
+    fn sweep(&mut self) -> (usize, usize, usize) {
+        let mut freed = 0usize;
+        let mut survived = 0usize;
+        let mut live = 0usize;
+        // `cursor` points at the link that currently references the block under
+        // inspection (`&mut self.all` first, then `&mut (*prev).next`), so we can
+        // unlink in place without a previous-node special case.
+        let mut cursor: *mut *mut FlatHeader = &mut self.all;
+        // SAFETY: every dereferenced pointer is a live block we own; `dealloc`
+        // uses the exact `Layout` `alloc_zeroed` was given (same size + align).
+        unsafe {
+            while !(*cursor).is_null() {
+                let h = *cursor;
+                if (*h).marked {
+                    (*h).marked = false;
+                    survived += 1;
+                    live += (*h).size;
+                    cursor = &mut (*h).next;
+                } else {
+                    *cursor = (*h).next;
+                    let layout =
+                        Layout::from_size_align_unchecked(HEADER_SIZE + (*h).size, ALIGN);
+                    dealloc(h as *mut u8, layout);
+                    freed += 1;
+                }
+            }
+        }
+        (freed, survived, live)
+    }
+}
+
+impl Drop for FlatHeap {
+    /// Free every block still on the list — no leak when the heap itself is
+    /// dropped (e.g. a test's `FlatHeap` going out of scope).
+    fn drop(&mut self) {
+        let mut h = self.all;
+        // SAFETY: list walk freeing blocks we own with their exact layouts.
+        unsafe {
+            while !h.is_null() {
+                let next = (*h).next;
+                let layout = Layout::from_size_align_unchecked(HEADER_SIZE + (*h).size, ALIGN);
+                dealloc(h as *mut u8, layout);
+                h = next;
+            }
+        }
+        self.all = ptr::null_mut();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `alloc` returns distinct, non-null, 16-byte-aligned pointers and tracks
+    /// live bytes.
+    #[test]
+    fn alloc_returns_aligned_distinct_pointers() {
+        let mut heap = FlatHeap::new();
+        let a = heap.alloc(16, 0);
+        let b = heap.alloc(16, 0);
+        assert!(!a.is_null() && !b.is_null());
+        assert_ne!(a, b, "distinct allocations must not alias");
+        assert_eq!(a as usize % ALIGN, 0, "payload must be 16-byte aligned");
+        assert_eq!(b as usize % ALIGN, 0);
+        assert_eq!(heap.live_bytes(), 32);
+        assert_eq!(heap.object_count(), 2);
+    }
+
+    /// The payload is writable and reads back what was written (real memory, not
+    /// a synthetic handle).
+    #[test]
+    fn payload_roundtrips_values() {
+        let mut heap = FlatHeap::new();
+        let p = heap.alloc(16, 0) as *mut i64;
+        unsafe {
+            *p = 0x0102_0304_0506_0708;
+            *p.add(1) = -42;
+            assert_eq!(*p, 0x0102_0304_0506_0708);
+            assert_eq!(*p.add(1), -42);
+        }
+    }
+
+    /// `alloc_zeroed` contract: a fresh payload is all zero.
+    #[test]
+    fn fresh_payload_is_zeroed() {
+        let mut heap = FlatHeap::new();
+        let p = heap.alloc(24, 0);
+        unsafe {
+            for i in 0..24 {
+                assert_eq!(*p.add(i), 0, "byte {i} not zeroed");
+            }
+        }
+    }
+
+    /// `alloc(0)` and overflow fail to null without panicking.
+    #[test]
+    fn degenerate_allocs_fail_to_null() {
+        let mut heap = FlatHeap::new();
+        assert!(heap.alloc(0, 0).is_null());
+        assert!(heap.alloc(usize::MAX, 0).is_null());
+        assert_eq!(heap.live_bytes(), 0);
+    }
+
+    /// A rooted object survives; an unrooted one is reclaimed.
+    #[test]
+    fn collect_frees_unrooted_keeps_rooted() {
+        let mut heap = FlatHeap::new();
+        let keep = heap.alloc(16, 0) as usize;
+        let _drop = heap.alloc(16, 0); // no root → garbage
+        assert_eq!(heap.object_count(), 2);
+        assert_eq!(heap.live_bytes(), 32);
+
+        let stats = heap.collect(&[keep]);
+        assert_eq!(stats.freed, 1);
+        assert_eq!(stats.survived, 1);
+        assert_eq!(heap.object_count(), 1);
+        assert_eq!(heap.live_bytes(), 16);
+        assert_eq!(heap.collection_count(), 1);
+        // The survivor's memory is still valid (rooted pointer unchanged).
+        assert!(!heap.find_header(keep).is_null());
+    }
+
+    /// Interior pointers are followed: rooting a parent keeps a child it points
+    /// at, transitively (a 3-deep chain).
+    #[test]
+    fn collect_traces_interior_pointers_transitively() {
+        let mut heap = FlatHeap::new();
+        let c = heap.alloc(16, 0) as usize;
+        let b = heap.alloc(16, 0) as usize;
+        let a = heap.alloc(16, 0) as usize;
+        // a.field0 -> b, b.field0 -> c   (a raw cons-style chain)
+        unsafe {
+            *(a as *mut usize) = b;
+            *(b as *mut usize) = c;
+        }
+        let _garbage = heap.alloc(16, 0); // unreachable
+        assert_eq!(heap.object_count(), 4);
+
+        let stats = heap.collect(&[a]); // root only the head
+        assert_eq!(stats.survived, 3, "a→b→c must all survive");
+        assert_eq!(stats.freed, 1, "only the unreachable block is freed");
+        assert!(!heap.find_header(a).is_null());
+        assert!(!heap.find_header(b).is_null());
+        assert!(!heap.find_header(c).is_null());
+    }
+
+    /// A tagged (low-3-bits) heap reference is followed after stripping the tag.
+    #[test]
+    fn collect_follows_tagged_reference() {
+        let mut heap = FlatHeap::new();
+        let obj = heap.alloc(16, 0) as usize;
+        let tagged = obj | 0x7; // NaN-box HEAP tag in the low 3 bits
+        let stats = heap.collect(&[tagged]);
+        assert_eq!(stats.freed, 0, "tagged pointer must keep its object alive");
+        assert_eq!(stats.survived, 1);
+    }
+
+    /// Collecting with no roots frees everything.
+    #[test]
+    fn collect_no_roots_frees_all() {
+        let mut heap = FlatHeap::new();
+        heap.alloc(16, 0);
+        heap.alloc(32, 0);
+        let stats = heap.collect(&[]);
+        assert_eq!(stats.freed, 2);
+        assert_eq!(heap.object_count(), 0);
+        assert_eq!(heap.live_bytes(), 0);
+    }
+
+    /// Repeated collections are stable and keep counting.
+    #[test]
+    fn repeated_collections_count_up() {
+        let mut heap = FlatHeap::new();
+        let keep = heap.alloc(16, 0) as usize;
+        heap.collect(&[keep]);
+        heap.collect(&[keep]);
+        heap.collect(&[keep]);
+        assert_eq!(heap.collection_count(), 3);
+        assert_eq!(heap.object_count(), 1);
+        assert_eq!(heap.profile().total_collections, 3);
+    }
+}

--- a/code/packages/rust/gc-core/src/lib.rs
+++ b/code/packages/rust/gc-core/src/lib.rs
@@ -96,6 +96,7 @@
 //! ```
 
 pub mod adapter;
+pub mod flat_heap;
 pub mod gc_core;
 pub mod heap_ref;
 pub mod kind;
@@ -106,6 +107,7 @@ pub mod write_barrier;
 
 // Top-level re-exports for the most commonly used types.
 pub use adapter::GcAdapter;
+pub use flat_heap::FlatHeap;
 pub use gc_core::{GcCore, PolicyAdvisory};
 pub use heap_ref::HeapRef;
 pub use kind::{HeapKind, KindRegistry};


### PR DESCRIPTION
## What

First implementation PR of the gc-core convergence arc (spec #8418): the native-AOT
GC now lives in the **generic `gc-core`**, not the Twig-specific `twig_gc.c`.

- **`gc-core` (0.1.0 → 0.2.0)** — new `flat_heap` module + **`FlatHeap`**: a
  real-memory mark-and-sweep collector. Where `GcCore` models the heap as
  `HashMap<usize, Box<dyn HeapObject>>` (right for the `vm-core`/`jit-core`
  interpreters), `FlatHeap` returns a **real machine pointer** per object (32-byte
  header + payload, 16-byte-aligned so the NaN-box low-3-bit tag invariant holds)
  that compiled native code reads/writes directly at byte offsets. This is
  `twig_gc.c`'s flat model lifted into `gc-core` as a generic algorithm — the "two
  heap representations behind one set of abstractions" of `AOT00-T1-precise-gc.md`
  §3.1.
- **`gc-core-capi` (new crate, 0.1.0)** — `staticlib`/`cdylib` exposing `FlatHeap`
  over a stable C ABI: LANG16's **`gc_runtime_<target>.a`** companion archive.

## ABI (`gc-core-capi/include/gc_core.h`)

| Symbol | Meaning |
|---|---|
| `__gc_alloc(n)` / `__gc_alloc_kind(n, kind)` | allocate `n` zeroed bytes → real pointer (`0` on failure) |
| `__gc_collect_roots(roots, count)` | mark from roots, sweep; returns objects freed |
| `__gc_live_bytes()` / `__gc_collection_count()` | introspection |
| `__gc_reset()` | drop the whole heap |

Conservative tracing (raw + low-3-bit tag-stripped candidate words, iterative
worklist), overflow-guarded alloc, fail-to-null contract, `Drop` frees all. One
process-wide heap behind a `Mutex` (single-threaded native model, matching
`twig_gc.c`).

## Testing

- **gc-core**: 9 new `flat_heap` unit tests (16-byte alignment, payload round-trip,
  zeroing, degenerate/overflow → null, transitive interior tracing, tagged refs,
  exact reclamation, repeated-collection counting) + 45 existing + 8 integration —
  all green, no regressions.
- **gc-core-capi**: host test driving the full `alloc → write → collect → reset`
  flow over the exported ABI (real pointers, exact reclamation).
- `libgc_core_capi.a` builds; clippy clean.
- **Security-reviewed** (Rust memory-safety focus): every `unsafe` invariant
  verified — overflow guards, alloc/dealloc layout match, no UAF/double-free, sound
  `Send`, safe FFI boundary; all attacker-controlled inputs fail safely.

## Scope / next

No `twig-aot` or `lang_matrix.rs` changes here. Follow-ups under spec §11:
- **#118** — wire `twig-aot`'s `build.rs` to link this archive, **retire
  `twig_gc.c`**, golden/smoke parity.
- Conservative **C-stack scan** (argument-less `collect`), then **precise** rungs
  (stack maps → moving → generational), all as `gc-core` algorithms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)