### PR TITLE
feat(closure-pass-constant-fold): quote a non-integer numeric object key ({0.5:1}→{"0.5":1})

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.97.0] - 2026-07-17
+
+### Added — a non-integer numeric object key is quoted (`{0.5:1}` → `{"0.5":1}`)
+
+An object-literal key that is a **non-integer** `NumericLiteral` now folds to a
+quoted `StringLiteral` key, matching the reference Closure Compiler at `SIMPLE`
+byte-for-byte:
+
+- `{0.5:1}` → `{"0.5":1}`, `{.5:1}` → `{"0.5":1}`, `{1.5:2,2:3}` → `{"1.5":2,2:3}`,
+  `{0.1:1}` → `{"0.1":1}`, `{3.14:1}` → `{"3.14":1}`
+
+A numeric key's property name is the ECMAScript `ToString` of its value, so
+`0.5` names the property `"0.5"`; Closure prints it as a string key, never the
+bare number. (An **integer** key stays numeric — the emitter prints `{1:1}` /
+`{1E3:1}` / `{31:1}` unquoted, which is already correct.) The `NumericLiteral`
+key at `fold_expression`'s object-literal arm is converted via `property_key_for`
+using `format_js_number` — whose shortest-round-trip output equals JS `ToString`
+exactly in the plain-decimal range.
+
+**Scope.** Converted only for a finite non-integer whose magnitude is in JS's
+plain-decimal `ToString` range `[1e-6, 1e21)`, where `format_js_number` matches
+`ToString`. Outside that range the string forms diverge — a tiny value takes
+exponent notation (`{1e-7:1}` → Closure `{"1e-7":1}`) and a large integer past
+`2^53` takes a precision-quoted decimal (`{123…680:1}` → `{"123…680":1}`) — so
+those keep their numeric key for now (valid output, byte-identical follow-up).
+This is purely a key-quoting normalization: `{0.5:1}` and `{"0.5":1}` name the
+same own property, so no runtime semantics change.
+
 ## [0.96.0] - 2026-07-16
 
 ### Added — computed string-key member → dot member: `o["foo"]` → `o.foo`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.96.0"
+version = "0.97.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -768,7 +768,39 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                             // stay exhaustive, so pass it through unchanged.
                             PropertyKey::PrivateName(p) => PropertyKey::PrivateName(p.clone()),
                             PropertyKey::StringLiteral(s) => PropertyKey::StringLiteral(s.clone()),
-                            PropertyKey::NumericLiteral(n) => PropertyKey::NumericLiteral(n.clone()),
+                            PropertyKey::NumericLiteral(n) => {
+                                // A NON-INTEGER numeric object key must be QUOTED:
+                                // its property name is the ECMAScript `ToString` of
+                                // the value, so Closure prints `{0.5:1}` as
+                                // `{"0.5":1}` (a string key), never the bare number.
+                                // (An integer key stays numeric — the emitter prints
+                                // `{1:1}` unquoted.) We convert only finite
+                                // non-integers in JS's plain-decimal `ToString` range
+                                // `[1e-6, 1e21)`, where `format_js_number` (shortest
+                                // round-trip) equals JS `ToString` exactly. Tiny
+                                // (`<1e-6`) or huge non-integers take exponent forms
+                                // (`1e-7` → `"1e-7"`), and large integers (`>2^53`)
+                                // take precision-quoting forms — both a separate
+                                // follow-up, so they stay numeric here (valid output,
+                                // just not yet byte-identical).
+                                let v = n.value;
+                                if v.is_finite()
+                                    && v.fract() != 0.0
+                                    && v.abs() >= 1e-6
+                                    && v.abs() < 1e21
+                                {
+                                    let name = format_js_number(v);
+                                    let new_cv =
+                                        st.fork_cv(&p.cv, &format!("{{{name}:…}}"), &format!("{{\"{name}\":…}}"));
+                                    let mut key = property_key_for(&name);
+                                    if let PropertyKey::StringLiteral(s) = &mut key {
+                                        s.cv = new_cv;
+                                    }
+                                    key
+                                } else {
+                                    PropertyKey::NumericLiteral(n.clone())
+                                }
+                            }
                             PropertyKey::Expression(e) => {
                                 PropertyKey::Expression(Box::new(fold_expression(e, st)))
                             }
@@ -10724,6 +10756,64 @@ mod tests {
                 assert_pair_key(a.elements[1].as_ref().unwrap(), "1.5");
             }
             other => panic!("expected array of pairs; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn noninteger_object_key_folds_to_quoted_string_key() {
+        // `{0.5: 1, 2: 3}` — the non-integer key `0.5` has property name
+        // ToString(0.5) = "0.5", so it becomes a QUOTED string key
+        // (`{"0.5": 1}`); the integer key `2` stays numeric (`{2: 3}`).
+        let o = object_lit(vec![
+            Property {
+                cv: None,
+                kind: PropertyKind::Init,
+                key: PropertyKey::NumericLiteral(NumericLiteral {
+                    cv: None,
+                    value: 0.5,
+                    raw: "0.5".to_string(),
+                }),
+                value: Box::new(num(1.0, None)),
+                shorthand: false,
+                computed: false,
+                method: false,
+            },
+            Property {
+                cv: None,
+                kind: PropertyKind::Init,
+                key: PropertyKey::NumericLiteral(NumericLiteral {
+                    cv: None,
+                    value: 2.0,
+                    raw: "2".to_string(),
+                }),
+                value: Box::new(num(3.0, None)),
+                shorthand: false,
+                computed: false,
+                method: false,
+            },
+        ]);
+        let (out, _, changed, _) = run_pass(program_with_expr(o, true));
+        assert!(changed, "a non-integer numeric key should fold to a string key");
+        match extract_expr(&out) {
+            Expression::ObjectExpression(obj) => {
+                assert_eq!(obj.properties.len(), 2);
+                match &obj.properties[0] {
+                    ObjectMember::Property(p) => match &p.key {
+                        PropertyKey::StringLiteral(s) => assert_eq!(s.value, "0.5"),
+                        other => panic!("expected a StringLiteral key for 0.5, got {:?}", other),
+                    },
+                    other => panic!("expected a Property, got {:?}", other),
+                }
+                match &obj.properties[1] {
+                    ObjectMember::Property(p) => assert!(
+                        matches!(&p.key, PropertyKey::NumericLiteral(n) if n.value == 2.0),
+                        "the integer key 2 must stay numeric; got {:?}",
+                        p.key
+                    ),
+                    other => panic!("expected a Property, got {:?}", other),
+                }
+            }
+            other => panic!("expected an ObjectExpression; got {:?}", other),
         }
     }
 


### PR DESCRIPTION
## What

An object-literal key that is a **non-integer** `NumericLiteral` folds to a quoted `StringLiteral` key, matching the reference Closure Compiler at `SIMPLE` byte-for-byte:

| input | output |
|---|---|
| `{0.5:1}` | `{"0.5":1}` |
| `{.5:1}` | `{"0.5":1}` |
| `{1.5:2,2:3}` | `{"1.5":2,2:3}` (the integer `2` stays numeric) |
| `{0.1:1}` | `{"0.1":1}` |
| `{3.14:1}` | `{"3.14":1}` |

A numeric key's property **name** is the ECMAScript `ToString` of its value, so `0.5` names the property `"0.5"`; Closure prints it as a string key, never the bare number. Integer keys stay numeric — the emitter already prints `{1:1}` / `{1E3:1}` / `{31:1}` unquoted. The key is converted via `property_key_for(format_js_number(v))` in the object-literal arm of `fold_expression`.

## Diagnosis note

This surfaced as `{0.5:1}` (SIMPLE) vs `{"0.5":1}` (oracle). The SIMPLE-vs-`WHITESPACE_ONLY` discriminator showed WHITESPACE already emits the correct `{"0.5":1}`, so the fix belongs in a **pass** (not the emitter): the numeric key needs converting to a string key before emit.

## Scope

Converted only for a finite non-integer in JS's plain-decimal `ToString` range `[1e-6, 1e21)`, where `format_js_number` (shortest round-trip) equals JS `ToString` exactly. Because `fract() != 0` forces `|v| < 2^53`, every reachable value is well inside JS's fixed-notation window, so the bytes always match. Out-of-range forms — a tiny value's exponent (`{1e-7:1}`→`{"1e-7":1}`) and a large integer past `2^53` (`{123…680:1}`→`{"123…680":1}`) — keep their numeric key for now (valid output; byte-identical **follow-up**). Purely a key-quoting normalization: `{0.5:1}` and `{"0.5":1}` name the same own property, no runtime change.

## Verification

- constant-fold `0.96.0` → `0.97.0`; CHANGELOG updated.
- 1 unit test (`{0.5:1,2:3}` → string key + numeric key). **367 lib tests pass**, clippy clean.
- **Oracle-verified byte-identical** at `SIMPLE`; full closurec suite green (no fixture drift). **Security review PASSED** (reviewer confirmed Rust `to_string` == JS `ToString` for all reachable non-integers; no quote-drop/`__proto__`/reorder risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)