### PR TITLE
feat(semantic-ir-to-typescript): SIR22 array/matrix codegen (HML01 Stream A, item 7 TS half)

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## 0.10.0 — SIR22 array/matrix codegen (HML01 Stream A, item 7 TS half)
+
+Real codegen for the SIR22 array/matrix domain's *base cut* — `ArrayLit`,
+`Range`, `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`), and
+`IndexSet` (a `Stmt`) — replacing the deferred `panic!` placeholder these
+seven nodes had. Mirrors the SIR23 codegen's own imported-package treatment
+(0.9.0, above): targets the published `@coding-adventures/sir-runtime-array`
+npm package via `import * as __SirArray from "@coding-adventures/sir-runtime-array"`,
+rather than an inlined runtime — the same contrast the JavaScript backend's
+own SIR22 PR (0.36.0) draws with its inlined `__Sir.Array` port.
+
+- `runtime.rs` gains `RUNTIME_ARRAY`, the `__SirArray` import header, emitted
+  only when `emit::uses_array` finds `Feature::NDArrays`/`MatrixOps`/
+  `ArrayColumnMajor` on the module — a pure-numeric or pure-OOP module never
+  gains the dependency.
+- `emit.rs`: the seven base-cut arms emit real `__SirArray.*` calls,
+  matching the JS backend's call shapes exactly (down to `Expr::Range`'s
+  `start, step, stop` field order vs. `__SirArray.range(start, stop, step)`'s
+  `stop`-before-`step` parameter order, and the `elementwise_op_ts_name`/
+  `emit_index_arg`/`emit_index_args` helpers).
+- **Scope boundary, not silently swept away**: the SIR22 "APL addendum"
+  nodes (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+  `IndexOf`/`Ravel`/`Catenate`) remain deferred — `sir-runtime-array` itself
+  never implemented them, and porting `array_runtime::ops::{reduce,scan,outer}`
+  + `apl-runtime::builtins`'s bespoke shape/reshape/iota/index-of/ravel/
+  catenate logic is a properly-scoped follow-up, not part of this PR. These
+  nine variants share `Feature::NDArrays`/`MatrixOps`/`ArrayColumnMajor`
+  with the now-accepted base cut (the SIR22 addendum spec gives them no
+  flag of their own), and `apl-to-semantic-ir`'s real lowering emits
+  `Reduce`/`Scan`/`OuterProduct` for APL's `+/`/`+\`/`∘.×` operators today —
+  so without a fix, such a module would pass `accepts_features()` and panic
+  inside `emit`. Fixed with a new `find_unimplemented_sir22_addendum_node`
+  tree walk (using the `semantic_ir::Visitor` trait) wired into
+  `TypeScriptBackend::compile()` as an explicit step, mirroring the
+  identical check the JS backend already has and the existing `TailCalls`
+  belt-and-suspenders check just above it in this same `compile()` — a
+  module using any of these nine now fails cleanly with
+  `BackendErrorKind::UnsupportedFeature`, never a panic.
+- `lib.rs`: `Feature::NDArrays`, `Feature::MatrixOps`, and
+  `Feature::ArrayColumnMajor` join `ACCEPTED_FEATURES`.
+- **Consuming this package for the first time surfaced four latent bugs in
+  `sir-runtime-array` itself**, already found and fixed in the JS backend's
+  own inlined port of this same logic (its 0.36.0 CHANGELOG entry) but never
+  triggered in the TypeScript package before now, since nothing called it —
+  see that package's own 0.2.0 CHANGELOG entry for the full writeup (NaN
+  bypassing the linear `indexGet`/`indexSet` bounds check, `range()` silently
+  returning empty on a NaN bound, `set()`'s NaN-unsafe OR-form bounds check,
+  and `elementwise()` assuming both operands were already `NDArray` when
+  `matlab-to-semantic-ir`'s lowering can emit a bare scalar operand).
+- New tests: `accepts_nd_arrays_feature`/`accepts_matrix_ops_feature`
+  (capability acceptance), `non_array_module_omits_sir_runtime_array_import`/
+  `array_module_imports_sir_runtime_array` (import gating),
+  `rejects_reduce_node_cleanly_instead_of_panicking_in_emit` (the addendum
+  guard), `emits_array_lit_and_matmul_as_sir_array_calls`,
+  `emits_elementwise_op_with_pascal_case_op_name` (op-name casing),
+  `emits_range_with_stop_before_step_argument_order`,
+  `emits_index_set_as_a_statement_not_an_assignment`, and
+  `end_to_end_matlab_matmul_compiles_and_emits_expected_calls` (a real
+  MATLAB program through `matlab-to-semantic-ir`, mirroring
+  `end_to_end_wolfram_replace_all_compiles_and_emits_expected_calls`'s
+  precedent for SIR23). New dev-dependency: `matlab-to-semantic-ir`.
+
 ## 0.9.0 — SIR23 symbolic/pattern codegen (HML01 Stream B, item 7)
 
 Real codegen for the SIR23 symbolic-expression + pattern/rewrite domain —

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 
@@ -11,3 +11,4 @@ semantic-ir = { path = "../semantic-ir" }
 twig-to-semantic-ir = { path = "../twig-to-semantic-ir" }
 ruby-to-semantic-ir = { path = "../ruby-to-semantic-ir" }
 wolfram-to-semantic-ir = { path = "../wolfram-to-semantic-ir" }
+matlab-to-semantic-ir = { path = "../matlab-to-semantic-ir" }

--- a/code/packages/rust/semantic-ir-to-typescript/README.md
+++ b/code/packages/rust/semantic-ir-to-typescript/README.md
@@ -74,6 +74,19 @@ The TypeScript backend accepts these SIR features:
 - `Rationals` (shared with SIR22) — accepted only for `SymRational`
   (`__SirSym.rational(numer, denom)`); no other construct in this backend
   triggers it yet.
+- `NDArrays` / `MatrixOps` / `ArrayColumnMajor` (SIR22) — a compiled
+  MATLAB/Octave program's array/matrix nodes (`ArrayLit`/`Range`/`MatMul`/
+  `ElementwiseOp`/`Transpose`/`IndexGet`/`IndexSet`) construct/consume a
+  real `NDArray` value at runtime via the imported
+  `@coding-adventures/sir-runtime-array` package, bound as `__SirArray`
+  (gated by any of the three features, so a purely-symbolic or purely-OOP
+  module never gains the dependency). `A * A` (matrix product) emits
+  `__SirArray.matmul(A, A)`. The SIR22 "APL addendum" nodes (`Reduce`/
+  `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+  `Ravel`/`Catenate`) share these same three features but remain deferred —
+  a dedicated tree walk (`find_unimplemented_sir22_addendum_node`) rejects
+  a module using one of them cleanly rather than reaching an emit-time
+  panic.
 
 It **rejects**:
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -21,7 +21,8 @@ use std::collections::HashSet;
 use std::fmt::Write;
 
 use semantic_ir::{
-    Block, Expr, Feature, Function, Global, IndexArg, Module, ParamKind, Scope, Stmt,
+    Block, ElementwiseOpKind, Expr, Feature, Function, Global, IndexArg, Module, ParamKind, Scope,
+    Stmt,
 };
 
 use crate::runtime::RUNTIME;
@@ -266,6 +267,17 @@ fn uses_range(m: &Module) -> bool {
 /// `apply` from this package.
 fn uses_symbolic(m: &Module) -> bool {
     m.manifest.contains(Feature::SymbolicExpr) || m.manifest.contains(Feature::PatternMatching)
+}
+
+/// True if the module uses the SIR22 array/matrix domain, in which case the
+/// emitted artifact imports `@coding-adventures/sir-runtime-array`. Any of
+/// the three SIR22 features gates the same single import — a module using
+/// only a bare `ArrayLit`/`IndexGet` with no `MatMul`/`ElementwiseOp`/
+/// `Transpose` still needs `fromRows`/`indexGet` from this package.
+fn uses_array(m: &Module) -> bool {
+    m.manifest.contains(Feature::NDArrays)
+        || m.manifest.contains(Feature::MatrixOps)
+        || m.manifest.contains(Feature::ArrayColumnMajor)
 }
 
 /// Walk every function body for a `BuiltinCall` named `name` — gates
@@ -552,6 +564,10 @@ pub fn emit_module(m: &Module) -> String {
     // Only symbolic/pattern-using modules import the SIR23 runtime.
     if uses_symbolic(m) {
         out.push_str(crate::runtime::RUNTIME_SYM);
+    }
+    // Only array/matrix-using modules import the SIR22 runtime.
+    if uses_array(m) {
+        out.push_str(crate::runtime::RUNTIME_ARRAY);
     }
     // E2: thread user `class Child < Parent` ancestry into the exception
     // matcher at program init, *before* any function or main body runs, so a
@@ -1362,18 +1378,83 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             }
             out.push('\n');
         }
-        // SIR22 array/matrix indexed assignment.  This backend does not
-        // declare `Feature::NDArrays`/`Feature::MatrixOps` in
-        // `accepts_features` (see lib.rs), so `Backend::check_module`
-        // rejects any module containing this node before it ever reaches
-        // emission.  Panic here to catch a backend/validator drift, mirroring
-        // the `Expr::Intrinsic` guard below.
-        Stmt::IndexSet { span, .. } => {
-            panic!(
-                "typescript backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet",
-                span
-            );
+        // SIR22: array/matrix indexed assignment — `target[indices...] =
+        // value;`, mutating in place via `__SirArray.indexSet` (the
+        // imported `@coding-adventures/sir-runtime-array` package, gated by
+        // `uses_array` — see `emit_module`). Matches the SIR22 spec's own
+        // note that `IndexSet` is a `Stmt`, not a pure `Expr`, for exactly
+        // this in-place-mutation reason.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            out.push_str(&pad);
+            out.push_str("__SirArray.indexSet(");
+            emit_expr(out, target, indent);
+            out.push_str(", [");
+            emit_index_args(out, indices, indent);
+            out.push_str("], ");
+            emit_expr(out, value, indent);
+            out.push_str(");\n");
         }
+    }
+}
+
+/// The `@coding-adventures/sir-runtime-array` string `elementwise`'s
+/// `applyOp` switches on — exact `ElementwiseOpKind` variant names, not
+/// `.name()`'s lowercase forms, since this string is a real runtime
+/// dispatch key, not a cosmetic label.
+fn elementwise_op_ts_name(op: ElementwiseOpKind) -> &'static str {
+    match op {
+        ElementwiseOpKind::Add => "Add",
+        ElementwiseOpKind::Sub => "Sub",
+        ElementwiseOpKind::Mul => "Mul",
+        ElementwiseOpKind::Div => "Div",
+        ElementwiseOpKind::Pow => "Pow",
+        ElementwiseOpKind::Max => "Max",
+        ElementwiseOpKind::Min => "Min",
+        ElementwiseOpKind::Eq => "Eq",
+        ElementwiseOpKind::Ne => "Ne",
+        ElementwiseOpKind::Lt => "Lt",
+        ElementwiseOpKind::Le => "Le",
+        ElementwiseOpKind::Ge => "Ge",
+        ElementwiseOpKind::Gt => "Gt",
+    }
+}
+
+/// Emit one `IndexArg` as the object literal `__SirArray.indexGet`/
+/// `indexSet` expect: `{ kind: "scalar", value }` / `{ kind: "whole" }` /
+/// `{ kind: "range", indices: <NDArray> }`. The `Range` case reuses
+/// `emit_expr` on the inner `Expr::Range` node directly — that node's own
+/// `Expr::Range` arm already emits a call into `__SirArray.range(...)`,
+/// which returns exactly the `NDArray` shape `indices` needs, so no
+/// separate handling is needed here.
+fn emit_index_arg(out: &mut String, arg: &IndexArg, indent: usize) {
+    match arg {
+        IndexArg::Scalar(e) => {
+            out.push_str("{ kind: \"scalar\", value: ");
+            emit_expr(out, e, indent);
+            out.push_str(" }");
+        }
+        IndexArg::Whole => {
+            out.push_str("{ kind: \"whole\" }");
+        }
+        IndexArg::Range(e) => {
+            out.push_str("{ kind: \"range\", indices: ");
+            emit_expr(out, e, indent);
+            out.push_str(" }");
+        }
+    }
+}
+
+fn emit_index_args(out: &mut String, indices: &[IndexArg], indent: usize) {
+    for (i, arg) in indices.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        emit_index_arg(out, arg, indent);
     }
 }
 
@@ -1554,23 +1635,98 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 span
             );
         }
-        // SIR22 array/matrix expressions (`ArrayLit`/`Range`/`MatMul`/
-        // `ElementwiseOp`/`Transpose`/`IndexGet`).  This backend does not
-        // declare `Feature::NDArrays`/`Feature::MatrixOps` in
-        // `accepts_features` (see lib.rs), so `Backend::check_module` rejects
-        // any module using these nodes before it ever reaches emission.
-        // Panic here to catch a backend/validator drift (mirrors the
-        // `Intrinsic` guard above).
-        Expr::ArrayLit { .. }
-        | Expr::Range { .. }
-        | Expr::MatMul { .. }
-        | Expr::ElementwiseOp { .. }
-        | Expr::Transpose { .. }
-        | Expr::IndexGet { .. }
-        // SIR22 addendum: APL primitive operators — same deferral rationale
-        // (gated by the same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
-        // features, which this backend still doesn't declare).
-        | Expr::Reduce { .. }
+        // ── SIR22: array/matrix nodes (base cut) ──────────────────────
+        // Real codegen: calls into the imported `@coding-adventures/sir-runtime-array`
+        // package (bound as `__SirArray`, gated by `uses_array` — see
+        // `emit_module`), mirroring how the SIR23 `Sym*` arms above call
+        // into `__SirSym.*`. `rows` is row-major in the literal syntax (per
+        // the SIR22 spec); `__SirArray.fromRows` reconciles that with
+        // column-major storage, so the emitter just nests the row/element
+        // expressions unchanged.
+        Expr::ArrayLit { rows, .. } => {
+            out.push_str("__SirArray.fromRows([");
+            for (i, row) in rows.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push('[');
+                emit_args(out, row, indent);
+                out.push(']');
+            }
+            out.push_str("])");
+        }
+        // `__SirArray.range(start, stop, step)` — note the argument ORDER:
+        // the SIR node's own field order is `start, step, stop`, but
+        // `sir-runtime-array`'s `range(start, stop, step = 1)` takes `stop`
+        // before `step`.
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            out.push_str("__SirArray.range(");
+            emit_expr(out, start, indent);
+            out.push_str(", ");
+            emit_expr(out, stop, indent);
+            out.push_str(", ");
+            match step {
+                Some(step) => emit_expr(out, step, indent),
+                None => out.push('1'),
+            }
+            out.push(')');
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            out.push_str("__SirArray.matmul(");
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        // The op name must match `elementwise`'s `applyOp` switch (in
+        // `sir-runtime-array`) exactly (`"Add"`, not `.name()`'s lowercase
+        // `"add"`).
+        Expr::ElementwiseOp { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "__SirArray.elementwise({}, ",
+                quote_ts_string(elementwise_op_ts_name(*op))
+            );
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::Transpose {
+            target, conjugate, ..
+        } => {
+            out.push_str("__SirArray.transpose(");
+            emit_expr(out, target, indent);
+            let _ = write!(out, ", {conjugate})");
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            out.push_str("__SirArray.indexGet(");
+            emit_expr(out, target, indent);
+            out.push_str(", [");
+            emit_index_args(out, indices, indent);
+            out.push_str("])");
+        }
+        // ── SIR22 addendum: APL primitive operators (still deferred) ──
+        // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+        // `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` observe the SAME
+        // `NDArrays`/`MatrixOps`/`ArrayColumnMajor` features as the base
+        // cut above (the SIR22 addendum spec gives them no feature flag of
+        // their own) — `sir-runtime-array` itself never implemented them
+        // (no frontend needed them when that package shipped), so
+        // real codegen for these nine requires porting
+        // `array_runtime::ops::{reduce,scan,outer}` +
+        // `apl-runtime::builtins`'s bespoke shape/reshape/iota/index-of/
+        // ravel/catenate logic into that package first — a natural,
+        // cleanly-scoped follow-up, not part of this PR. See `lib.rs`'s
+        // `find_unimplemented_sir22_addendum_node` for why accepting
+        // `NDArrays`/`MatrixOps`/`ArrayColumnMajor` for the base cut above
+        // does not, by itself, silently let one of these nine slip past
+        // the capability check and reach this panic.
+        Expr::Reduce { .. }
         | Expr::Scan { .. }
         | Expr::OuterProduct { .. }
         | Expr::Shape { .. }

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -40,7 +40,8 @@ mod emit;
 mod runtime;
 
 use semantic_ir::{
-    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Feature, Module,
+    walk_expr_default, Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr,
+    Feature, Module, Span, Visitor,
 };
 
 pub use emit::sanitize_ident;
@@ -49,6 +50,57 @@ pub use emit::sanitize_ident;
 /// capability checks, and lowers to TypeScript source.
 pub fn compile(module: &Module) -> Result<Artifact, BackendError> {
     TypeScriptBackend::new().compile(module)
+}
+
+/// Finds the first (if any) SIR22 "APL addendum" node anywhere in a module —
+/// `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+/// `IndexOf`/`Ravel`/`Catenate`.
+///
+/// These nine variants share `Feature::NDArrays`/`MatrixOps`/
+/// `ArrayColumnMajor` with the SIR22 *base* cut this backend accepts — the
+/// SIR22 addendum spec gives them no feature flag of their own — so the
+/// ordinary `accepts_features()` capability check cannot tell a module using
+/// only the base cut (real codegen, safe) from one that also uses these nine
+/// (still deferred in `emit`, would panic). This walk is the finer-grained
+/// check that closes that gap, mirroring the identical guard
+/// `semantic-ir-to-javascript` added for its own SIR22 codegen (found there
+/// by auditing `apl-to-semantic-ir`'s downstream tests: that crate's *real*
+/// lowering logic, not just a hand-built test fixture, emits `Reduce`/
+/// `Scan`/`OuterProduct` for APL's `+/`/`+\`/`∘.×` operators today,
+/// contradicting the SIR22 addendum spec's "no frontend crate consumes these
+/// yet" claim). Without this check, compiling such a module would sail past
+/// `accepts_features()` and panic inside `emit` instead of failing cleanly
+/// at the capability boundary — exactly the class of regression the
+/// existing `TailCalls` belt-and-suspenders check in
+/// [`TypeScriptBackend::compile`] guards against for a different feature.
+fn find_unimplemented_sir22_addendum_node(module: &Module) -> Option<(&'static str, Span)> {
+    struct Finder(Option<(&'static str, Span)>);
+    impl Visitor for Finder {
+        fn visit_expr(&mut self, e: &Expr, depth: usize) {
+            if self.0.is_none() {
+                let hit = match e {
+                    Expr::Reduce { span, .. } => Some(("Reduce", span.clone())),
+                    Expr::Scan { span, .. } => Some(("Scan", span.clone())),
+                    Expr::OuterProduct { span, .. } => Some(("OuterProduct", span.clone())),
+                    Expr::Shape { span, .. } => Some(("Shape", span.clone())),
+                    Expr::Reshape { span, .. } => Some(("Reshape", span.clone())),
+                    Expr::IndexGenerator { span, .. } => Some(("IndexGenerator", span.clone())),
+                    Expr::IndexOf { span, .. } => Some(("IndexOf", span.clone())),
+                    Expr::Ravel { span, .. } => Some(("Ravel", span.clone())),
+                    Expr::Catenate { span, .. } => Some(("Catenate", span.clone())),
+                    _ => None,
+                };
+                if hit.is_some() {
+                    self.0 = hit;
+                    return;
+                }
+            }
+            walk_expr_default(self, e, depth);
+        }
+    }
+    let mut finder = Finder(None);
+    finder.visit_module(module);
+    finder.0
 }
 
 /// The v0 TypeScript backend.
@@ -136,6 +188,22 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // construct in this backend triggers it yet, so accepting it is scoped
     // exactly to `SymRational`.
     Feature::Rationals,
+    // SIR22: the array/matrix domain's *base cut* — `ArrayLit`, `Range`,
+    // `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`) and
+    // `IndexSet` (a `Stmt`) lower to calls into the imported
+    // `@coding-adventures/sir-runtime-array` package (`__SirArray`), gated
+    // by `uses_array` — see `emit`'s SIR22 arms and
+    // `code/specs/SIR22-array-matrix-semantic-ir.md` §"Backend impact".
+    // The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/
+    // `Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) share
+    // these SAME three features (the addendum gives them no flag of their
+    // own) but remain deferred in `emit` — see
+    // `find_unimplemented_sir22_addendum_node`'s doc comment for why
+    // accepting these three features doesn't fully close the
+    // capability/emit gap for those nine specifically.
+    Feature::NDArrays,
+    Feature::MatrixOps,
+    Feature::ArrayColumnMajor,
 ];
 
 impl Backend for TypeScriptBackend {
@@ -178,6 +246,27 @@ impl Backend for TypeScriptBackend {
                 kind: BackendErrorKind::UnsupportedFeature,
                 message: "typescript backend cannot satisfy `tail_calls` feature".into(),
                 span: module.span.clone(),
+            });
+        }
+
+        // 3b. The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
+        //     `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+        //     `Ravel`/`Catenate`) share `NDArrays`/`MatrixOps`/
+        //     `ArrayColumnMajor` with the SIR22 base cut this backend
+        //     accepts (the addendum gives them no flag of their own), so
+        //     step 2's coarse feature check cannot reject a module using
+        //     them — an explicit tree walk is the only way to catch this
+        //     before `emit` panics on one. See
+        //     `find_unimplemented_sir22_addendum_node`'s doc comment for
+        //     why this is a real, not theoretical, gap (`apl-to-semantic-ir`
+        //     emits these from real APL source today).
+        if let Some((kind, span)) = find_unimplemented_sir22_addendum_node(module) {
+            return Err(BackendError {
+                kind: BackendErrorKind::UnsupportedFeature,
+                message: format!(
+                    "typescript backend does not yet implement the SIR22 addendum node `{kind}`"
+                ),
+                span,
             });
         }
 
@@ -1816,6 +1905,240 @@ mod tests {
         );
         assert!(
             a.source.contains(r#"__SirSym.unwrap(__SirSym.replaceAll(__SirSym.sym("x"), [__SirSym.rule(__SirSym.sym("a"), __SirSym.sym("b"))]))"#),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    // ── SIR22: array/matrix codegen (HML01 Stream A, item 7 TS half) ───
+    //
+    // The base cut (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
+    // `IndexGet`/`IndexSet`) is accepted and lowers to calls into the
+    // imported `@coding-adventures/sir-runtime-array` runtime; see
+    // `runtime.rs`'s `RUNTIME_ARRAY` and `emit`'s SIR22 arms.
+
+    #[test]
+    fn accepts_nd_arrays_feature() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::NDArrays]);
+        compile(&m).expect("nd-arrays accepted");
+    }
+
+    #[test]
+    fn accepts_matrix_ops_feature() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::MatrixOps]);
+        compile(&m).expect("matrix-ops accepted");
+    }
+
+    #[test]
+    fn non_array_module_omits_sir_runtime_array_import() {
+        let a = compile(&minimal_module()).expect("compile");
+        assert!(
+            !a.source.contains("sir-runtime-array"),
+            "a module with no array node must not import sir-runtime-array; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn array_module_imports_sir_runtime_array() {
+        let m = module_with_main_body(
+            vec![],
+            Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            },
+            &[Feature::NDArrays, Feature::ArrayColumnMajor],
+        );
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source.contains(
+                r#"import * as __SirArray from "@coding-adventures/sir-runtime-array";"#
+            ),
+            "a module using ArrayLit must import sir-runtime-array; got:\n{}",
+            a.source
+        );
+    }
+
+    /// Regression test for the gap `find_unimplemented_sir22_addendum_node`
+    /// closes: `apl-to-semantic-ir`'s real lowering emits `Expr::Reduce`
+    /// (APL `+/A`) with exactly these three features, and — before this
+    /// check existed — that module would sail past `accepts_features()`
+    /// (since `NDArrays`/`MatrixOps` are now accepted for the SIR22 base
+    /// cut) and panic inside `emit`. Must instead fail cleanly with
+    /// `UnsupportedFeature`, the same error kind every other still-deferred
+    /// node produces, not a panic.
+    #[test]
+    fn rejects_reduce_node_cleanly_instead_of_panicking_in_emit() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::Reduce {
+            op: semantic_ir::ElementwiseOpKind::Add,
+            target: Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            }),
+            span: s(),
+        };
+        let err = compile(&m).expect_err("Reduce node rejected cleanly, not a panic");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+    }
+
+    /// End-to-end version: a real module body using `Expr::ArrayLit` and
+    /// `Expr::MatMul` (the concrete SIR22 nodes the spec names), not just a
+    /// hand-set manifest flag — proving real codegen runs from actual node
+    /// usage, and asserting the exact generated call shape.
+    #[test]
+    fn emits_array_lit_and_matmul_as_sir_array_calls() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::MatMul {
+            lhs: Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            }),
+            rhs: Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 2, span: s() }]],
+                span: s(),
+            }),
+            span: s(),
+        };
+        let artifact = compile(&m).expect("array/matmul body compiles");
+        assert!(
+            artifact.source.contains(
+                "__SirArray.matmul(__SirArray.fromRows([[1]]), __SirArray.fromRows([[2]]))"
+            ),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    #[test]
+    fn emits_elementwise_op_with_pascal_case_op_name() {
+        // The op name must match `sir-runtime-array`'s `applyOp` switch
+        // exactly (`"Mul"`, not `ElementwiseOpKind::name()`'s lowercase
+        // `"mul"`).
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::ElementwiseOp {
+            op: semantic_ir::ElementwiseOpKind::Mul,
+            lhs: Box::new(Expr::IntLit { value: 2, span: s() }),
+            rhs: Box::new(Expr::IntLit { value: 3, span: s() }),
+            span: s(),
+        };
+        let artifact = compile(&m).expect("elementwise body compiles");
+        assert!(
+            artifact.source.contains("__SirArray.elementwise(\"Mul\", 2, 3)"),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    #[test]
+    fn emits_range_with_stop_before_step_argument_order() {
+        // `Expr::Range`'s own field order is `start, step, stop`, but
+        // `__SirArray.range(start, stop, step)` takes `stop` before
+        // `step` — a real ordering bug here would silently swap the
+        // wrong two arguments rather than fail to compile.
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::NDArrays]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::Range {
+            start: Box::new(Expr::IntLit { value: 1, span: s() }),
+            step: Some(Box::new(Expr::IntLit { value: 2, span: s() })),
+            stop: Box::new(Expr::IntLit { value: 10, span: s() }),
+            span: s(),
+        };
+        let artifact = compile(&m).expect("range body compiles");
+        assert!(
+            artifact.source.contains("__SirArray.range(1, 10, 2)"),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    #[test]
+    fn emits_index_set_as_a_statement_not_an_assignment() {
+        use semantic_ir::{IndexArg, Scope, Stmt};
+        let mut m = minimal_module();
+        m.manifest =
+            FeatureManifest::from_features(&[Feature::NDArrays, Feature::ArrayColumnMajor]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.stmts.push(Stmt::LetBinding {
+            name: "a".into(),
+            sir_type: None,
+            value: Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            },
+            span: s(),
+        });
+        main.body.stmts.push(Stmt::IndexSet {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            indices: vec![
+                IndexArg::Scalar(Box::new(Expr::IntLit { value: 0, span: s() })),
+                IndexArg::Whole,
+            ],
+            value: Box::new(Expr::IntLit { value: 9, span: s() }),
+            span: s(),
+        });
+        let artifact = compile(&m).expect("index-set body compiles");
+        assert!(
+            artifact.source.contains(
+                "__SirArray.indexSet(a, [{ kind: \"scalar\", value: 0 }, { kind: \"whole\" }], 9);"
+            ),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_matlab_matmul_compiles_and_emits_expected_calls() {
+        // A real MATLAB program (not a hand-built IR) through the actual
+        // matlab-to-semantic-ir frontend, proving this backend's SIR22
+        // codegen matches what the frontend genuinely produces — mirrors
+        // `end_to_end_wolfram_replace_all_compiles_and_emits_expected_calls`
+        // above for SIR23.
+        let module = matlab_to_semantic_ir::compile_source(
+            "A = [1 2; 3 4];\nB = A * A;\ndisp(B(1, 1));\n",
+            "demo",
+        )
+        .expect("lower matlab");
+        let a = compile(&module).expect("compile to ts");
+        assert!(
+            a.source.contains(
+                r#"import * as __SirArray from "@coding-adventures/sir-runtime-array";"#
+            ),
+            "got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains("const A: __Sir.Val = __SirArray.fromRows([[1, 2], [3, 4]]);"),
+            "got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains("__SirArray.matmul(A, A)"),
             "got:\n{}",
             a.source
         );

--- a/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
@@ -72,6 +72,17 @@ pub const RUNTIME_RANGE: &str = r##"import * as __SirRange from "@coding-adventu
 pub const RUNTIME_SYM: &str = r##"import * as __SirSym from "@coding-adventures/sir-runtime-symbolic";
 "##;
 
+/// The array/matrix runtime import, emitted **only** when a module uses the
+/// SIR22 array/matrix domain (`Feature::NDArrays`, `Feature::MatrixOps`, or
+/// `Feature::ArrayColumnMajor` — an `ArrayLit`/`Range`/`MatMul`/
+/// `ElementwiseOp`/`Transpose`/`IndexGet`/`IndexSet` node). Pure non-array
+/// modules (e.g. a Wolfram program with no matrix literal) never gain a
+/// dependency on it. Bound as `__SirArray` so the emitter's `__SirArray.*`
+/// call sites resolve; see
+/// `code/specs/SIR22-array-matrix-semantic-ir.md` §"Backend impact".
+pub const RUNTIME_ARRAY: &str = r##"import * as __SirArray from "@coding-adventures/sir-runtime-array";
+"##;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,5 +131,13 @@ mod tests {
             r#"import * as __SirSym from "@coding-adventures/sir-runtime-symbolic";"#
         ));
         assert!(RUNTIME_SYM.ends_with('\n'));
+    }
+
+    #[test]
+    fn array_import_binds_its_namespace() {
+        assert!(RUNTIME_ARRAY.contains(
+            r#"import * as __SirArray from "@coding-adventures/sir-runtime-array";"#
+        ));
+        assert!(RUNTIME_ARRAY.ends_with('\n'));
     }
 }

--- a/code/packages/typescript/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-array/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-07-17
+
+This package went from "built but unconsumed" to actually imported —
+`semantic-ir-to-typescript`'s SIR22 codegen (HML01 Stream A, item 7 TS half)
+now wires real call sites into it as `__SirArray`. Auditing this package
+against the equivalent fixes already made in `semantic-ir-to-javascript`'s
+own inlined port of this same logic (that crate's 0.36.0 CHANGELOG entry)
+found the identical latent bugs here, never triggered before because
+nothing called this package yet.
+
+### Fixed
+
+- **`NaN` silently bypassed the linear (1-argument) `indexGet`/`indexSet`
+  bounds check**, causing a silent wrong read and a silently-dropped write.
+  `get(a, r, c)`'s 2-argument bounds check is an AND-form
+  (`r >= 0 && r < nrows(a)`), which correctly falls through to "out of
+  bounds" for `r = NaN` (every relational comparison with `NaN` is `false`,
+  so the whole AND is `false`). `resolvePositions`'s linear path instead had
+  no check at all before this release. `NDArray` index values come from the
+  *compiled program's own runtime arithmetic* (e.g. `0/0`), not just a
+  hand-built edge case. Fixed by validating every resolved position is a
+  real, finite integer once, in a new `assertValidPosition` helper inside
+  `resolvePositions` — the single choke point both `indexGet` and `indexSet`
+  route through — rather than re-deriving a NaN-safe bounds check at each
+  call site.
+- **`range()` silently returned an empty vector instead of erroring on a
+  `NaN` `start`/`stop`/`step`.** Same root cause: the loop condition is
+  `false` on the very first check whenever a bound is `NaN`, so `range`
+  returned a valid-looking `[1, 0]`-shaped empty array with no error. Fixed
+  with an explicit `Number.isFinite` check on all three arguments before the
+  loop runs.
+- **`set(a, r, c, value)`'s bounds check had the same NaN-unsafe OR-form.**
+  Not reachable with an unvalidated `NaN` through any current call path
+  (every caller resolves positions through `assertValidPosition` first), but
+  it is part of this module's exported public surface, so a future direct
+  caller — or a refactor of `indexSet` that skips `resolvePositions` — would
+  silently reintroduce the bug. Fixed by writing the check as the negation
+  of `get`'s AND-form (`!(r >= 0 && ...)`) rather than an OR-form, matching
+  how `get` was already written.
+- **`elementwise(op, a, b)` assumed both operands were already `NDArray`.**
+  `matlab-to-semantic-ir`'s lowering emits a *bare* (unwrapped) scalar
+  operand for `.* ./ .\` and for `* /` when exactly one side is provably
+  scalar (e.g. `A .* 2` — the `2` arrives as a plain number literal, not an
+  `ArrayLit`/scalar-array constructor). Fixed with a new `toArrayValue`
+  coercion, applied to both operands before either is read as `.data`/
+  `.shape`; `elementwise`'s signature widens to `(op, a: number | NDArray, b:
+  number | NDArray)` accordingly.
+
+Ten new regression tests (NaN scalar `indexGet`/`indexSet`, a non-integer
+scalar index, `set`'s direct NaN case, three `range` NaN-bound cases, and
+three bare-number `elementwise` operand cases), each confirmed to fail
+without its fix and pass with it. `npm run build` (`tsc`) and `npm test`
+(`vitest`) both clean.
+
 ## [0.1.0] - 2026-07-14
 
 ### Added

--- a/code/packages/typescript/sir-runtime-array/README.md
+++ b/code/packages/typescript/sir-runtime-array/README.md
@@ -29,18 +29,21 @@ on every result.
 | Range | `range(start, stop, step?)` | `matlab-runtime`'s `eval_colon` |
 | Indexing | `indexGet`/`indexSet` | (SIR-level only — no Rust runtime equivalent yet) |
 
-## Why this package exists before any backend consumes it
+## Backend consumers
 
-This mirrors exactly how `sir-runtime-symbolic` (SIR23's runtime) landed
-*before* the Stream-B codegen that calls it. `semantic-ir-to-javascript` and
-`semantic-ir-to-typescript` currently hard-reject `Feature::NDArrays`/
-`Feature::MatrixOps` and hit a deferred `panic!` at every SIR22 `Expr` match
-arm (see those crates' `emit.rs`) — real codegen is a first-wave-JS
-follow-up PR, not part of this package. Building the runtime primitives
-first means that follow-up PR only has to wire up calls, not design an
-array representation from scratch.
+Both `semantic-ir-to-javascript` and `semantic-ir-to-typescript` now accept
+`Feature::NDArrays`/`Feature::MatrixOps`/`Feature::ArrayColumnMajor` and emit
+real codegen for the SIR22 base cut. `semantic-ir-to-typescript` imports this
+package directly (`import * as __SirArray from "@coding-adventures/sir-runtime-array"`);
+`semantic-ir-to-javascript` inlines its own plain-JS port of the same logic
+instead (that backend always inlines runtime helpers rather than importing
+packages) — see each crate's own `emit.rs`/`runtime.rs` and CHANGELOG for
+the wiring. This package landed first (mirroring exactly how
+`sir-runtime-symbolic`, SIR23's runtime, preceded its own Stream-B codegen)
+so those backend PRs only had to wire up calls, not design an array
+representation from scratch.
 
-## How emitted code will use it (once the backend PR lands)
+## How emitted code uses it
 
 ```ts
 import * as __SirArray from "@coding-adventures/sir-runtime-array";
@@ -89,11 +92,15 @@ const row0 = __SirArray.indexGet(A, [{ kind: "scalar", value: 0 }, { kind: "whol
 The SIR22 spec's "APL addendum" `Expr` variants (`Reduce`/`Scan`/
 `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
 `Catenate`) are **not** implemented here, even though `array_runtime::ops`
-already has Rust reference implementations for `reduce`/`scan`/`outer` — no
-frontend crate emits these nine `Expr` variants yet, so porting them now
-would be speculative rather than filling a real gap. They are a natural,
-cleanly-scoped follow-up once `apl-to-semantic-ir`'s own JS-backend
-consumption needs them.
+already has Rust reference implementations for `reduce`/`scan`/`outer` and
+`apl-to-semantic-ir`'s real lowering already emits `Reduce`/`Scan`/
+`OuterProduct` for APL's `+/`/`+\`/`∘.×` operators — porting them is a
+natural, cleanly-scoped follow-up once a JS/TS-backend consumer actually
+needs them, not speculative work. Both backend consumers guard against a
+module using one of these nine slipping past their feature-flag check (the
+addendum shares its three features with the base cut above) via an explicit
+tree walk that fails cleanly instead of reaching an emit-time panic — see
+`find_unimplemented_sir22_addendum_node` in each backend crate.
 
 `Complex`/`Rational` scalar support (shared `SirType`s with SIR23) is also
 out of scope for the same reason.

--- a/code/packages/typescript/sir-runtime-array/package.json
+++ b/code/packages/typescript/sir-runtime-array/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-array",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "N-D array/matrix runtime for Semantic-IR-emitted TypeScript/JavaScript (SIR22)",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-array/src/elementwise.ts
+++ b/code/packages/typescript/sir-runtime-array/src/elementwise.ts
@@ -12,6 +12,22 @@
  */
 import { ndarray, isScalar, type NDArray } from "./ndarray.js";
 
+/**
+ * Coerce a bare `number` into a rank-0 (scalar) `NDArray`; an already-`NDArray`
+ * value passes through unchanged. Needed because a compiled frontend's
+ * lowering can emit a *bare* (unwrapped) scalar operand for `.* ./ .\` and for
+ * `* /` when exactly one side is provably scalar (e.g. `A .* 2` — the `2`
+ * arrives as a plain number literal, not an `ArrayLit`/scalar-array
+ * constructor) — mirrors `matlab-to-semantic-ir`'s lowering convention (see
+ * `code/specs/SIR22-array-matrix-semantic-ir.md`). Every function below that
+ * accepts an "array" operand normalizes through this first, so a raw number
+ * never reaches `.data`/`.shape` and throws a confusing `TypeError` instead of
+ * behaving correctly.
+ */
+function toArrayValue(v: number | NDArray): NDArray {
+  return typeof v === "number" ? { shape: [], data: Float64Array.of(v) } : v;
+}
+
 export type ElementwiseOpKind =
   | "Add"
   | "Sub"
@@ -77,7 +93,9 @@ function sameShape(a: readonly number[], b: readonly number[]): boolean {
  * a scalar; otherwise the shapes must match exactly (full NumPy/MATLAB
  * broadcasting is out of scope here, same as the Rust reference).
  */
-export function elementwise(op: ElementwiseOpKind, a: NDArray, b: NDArray): NDArray {
+export function elementwise(op: ElementwiseOpKind, a: number | NDArray, b: number | NDArray): NDArray {
+  a = toArrayValue(a);
+  b = toArrayValue(b);
   const { data: ad } = a;
   const { data: bd } = b;
   let data: Float64Array;

--- a/code/packages/typescript/sir-runtime-array/src/indexing.ts
+++ b/code/packages/typescript/sir-runtime-array/src/indexing.ts
@@ -18,15 +18,36 @@ export type IndexArg =
   | { kind: "whole" }
   | { kind: "range"; indices: NDArray };
 
+/**
+ * Validate one resolved position is a real, finite integer.
+ *
+ * SECURITY: `indexGet`/`indexSet`'s own bounds checks further down this
+ * file compare a position against `0`/`dimSize` with `<`/`>=`. Under
+ * IEEE-754, every relational comparison with `NaN` is `false` — so a
+ * comparison-based check alone would let `i = NaN` sail through as
+ * neither "too small" nor "too large", silently reading/writing a stray
+ * non-index property instead of throwing. A position reaching this
+ * function comes from the *compiled program's own runtime arithmetic*
+ * (e.g. `0/0`), not just a hand-built edge case, so this validates once,
+ * here — the single choke point every `resolvePositions` caller routes
+ * through — rather than re-deriving a NaN-safe check at each call site.
+ */
+function assertValidPosition(i: number): number {
+  if (!Number.isInteger(i)) {
+    throw new Error(`resolvePositions: index ${i} is not a finite integer`);
+  }
+  return i;
+}
+
 /** Resolve one `IndexArg` against a dimension of size `dimSize` into a flat list of 0-based positions along that dimension. */
 function resolvePositions(arg: IndexArg, dimSize: number): number[] {
   switch (arg.kind) {
     case "scalar":
-      return [arg.value];
+      return [assertValidPosition(arg.value)];
     case "whole":
       return Array.from({ length: dimSize }, (_, i) => i);
     case "range":
-      return Array.from(arg.indices.data, (x) => Math.trunc(x));
+      return Array.from(arg.indices.data, (x) => assertValidPosition(Math.trunc(x)));
     default:
       // Emitted code crosses a JS runtime boundary that TypeScript can't
       // enforce at the actual call site — a malformed `kind` must fail

--- a/code/packages/typescript/sir-runtime-array/src/ndarray.ts
+++ b/code/packages/typescript/sir-runtime-array/src/ndarray.ts
@@ -178,7 +178,22 @@ export function get(a: NDArray, r: number, c: number): number | undefined {
  * reason.
  */
 export function set(a: NDArray, r: number, c: number, value: number): void {
-  if (r < 0 || c < 0 || r >= nrows(a) || c >= ncols(a)) {
+  // SECURITY: written as the negation of `get`'s AND-form
+  // (`!(r >= 0 && ...)`), not as an OR-form (`r < 0 || ...`) — under
+  // IEEE-754 those are NOT equivalent for NaN: every relational
+  // comparison with NaN is false, so an OR-form check would have every
+  // branch evaluate false for r=NaN, silently skipping the throw.
+  // `a.data[c * nrows(a) + NaN] = value` would then set a stray,
+  // non-index property on the `Float64Array` rather than writing the
+  // buffer — the exact same silent-write-drop bug `indexSet`'s own fix
+  // (via `resolvePositions`/`assertValidPosition` in `indexing.ts`)
+  // closes for its call path into this function. `set` itself is not
+  // reachable with an unvalidated NaN today (every caller resolves
+  // positions through `assertValidPosition` first), but it is part of
+  // this module's exported public surface, so it stays NaN-safe on its
+  // own rather than relying on every future caller to re-derive that
+  // invariant.
+  if (!(r >= 0 && c >= 0 && r < nrows(a) && c < ncols(a))) {
     throw new Error(`set: index (${r}, ${c}) out of bounds for shape ${JSON.stringify(a.shape)}`);
   }
   a.data[c * nrows(a) + r] = value;

--- a/code/packages/typescript/sir-runtime-array/src/range.ts
+++ b/code/packages/typescript/sir-runtime-array/src/range.ts
@@ -24,6 +24,16 @@ export function range(start: number, stop: number, step = 1): NDArray {
   if (step === 0) {
     throw new Error("range: step cannot be zero");
   }
+  // SECURITY: the loop condition below is false on its very first check
+  // whenever start/stop/step is NaN (every relational comparison with
+  // NaN is false), so an unguarded NaN bound would silently produce an
+  // empty range instead of erroring — the same "NaN defeats a
+  // comparison-based check" class `indexGet`/`indexSet`'s fix closes.
+  // Reject non-finite bounds up front instead of letting them fall
+  // through to a quietly-wrong empty result.
+  if (!Number.isFinite(start) || !Number.isFinite(stop) || !Number.isFinite(step)) {
+    throw new Error(`range: start/stop/step must be finite numbers, got (${start}, ${stop}, ${step})`);
+  }
   const values: number[] = [];
   let x = start;
   while ((step > 0 && x <= stop + RANGE_EPSILON) || (step < 0 && x >= stop - RANGE_EPSILON)) {

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -179,6 +179,22 @@ describe("elementwise", () => {
     expect(q.data[0]).toBe(Infinity);
     expect(Number.isNaN(q.data[1])).toBe(true);
   });
+
+  it("a bare number operand is coerced to a scalar, not read as `.data`/`.shape` directly", () => {
+    // Mirrors matlab-to-semantic-ir's lowering: `A .* 2` emits `2` as a bare
+    // number, not wrapped in an ArrayLit/scalar-array constructor first.
+    const v = arr.fromVec([1, 2, 3]);
+    const r = arr.elementwise("Mul", v, 2);
+    expect(Array.from(r.data)).toEqual([2, 4, 6]);
+    const r2 = arr.elementwise("Add", 10, v);
+    expect(Array.from(r2.data)).toEqual([11, 12, 13]);
+  });
+
+  it("two bare number operands both coerce and stay a scalar", () => {
+    const r = arr.elementwise("Add", 2, 40);
+    expect(arr.isScalar(r)).toBe(true);
+    expect(Array.from(r.data)).toEqual([42]);
+  });
 });
 
 describe("matmul", () => {
@@ -302,6 +318,16 @@ describe("range", () => {
     // values, not fixed at compile time) — this proves the cap actually
     // trips rather than trusting the code that it would.
     expect(() => arr.range(1, Number.MAX_SAFE_INTEGER)).toThrow(/produces more than/);
+  });
+
+  it("a NaN start/stop/step is a clean error, not a silently empty range", () => {
+    // Without the Number.isFinite guard, the while loop's condition is
+    // false on its very first check for a NaN bound (every relational
+    // comparison with NaN is false), so this would silently return a
+    // valid-looking `[1, 0]` empty array instead of erroring.
+    expect(() => arr.range(NaN, 5)).toThrow(/must be finite/);
+    expect(() => arr.range(1, NaN)).toThrow(/must be finite/);
+    expect(() => arr.range(1, 5, NaN)).toThrow(/must be finite/);
   });
 });
 
@@ -454,5 +480,37 @@ describe("indexGet / indexSet", () => {
     // TypeScript's own type-checking can't police at runtime.
     const malformed = { kind: "bogus" } as unknown as arr.IndexArg;
     expect(() => arr.indexGet(a, [malformed])).toThrow(/unrecognised IndexArg/);
+  });
+
+  it("a NaN scalar index is a clean error for indexGet, not a silent wrong read", () => {
+    // `NDArray` index values come from the compiled program's own runtime
+    // arithmetic (e.g. `0/0`), not just a hand-built edge case. Without
+    // `assertValidPosition`, the linear path's bounds check
+    // (`i < 0 || i >= length`) is an OR-form that is NOT the negation of a
+    // comparison under IEEE-754 for i=NaN (every relational comparison with
+    // NaN is false), so the throw would be skipped and `a.data[NaN]` would
+    // silently return `undefined` instead.
+    const a = arr.fromVec([1, 2, 3]);
+    expect(() => arr.indexGet(a, [{ kind: "scalar", value: NaN }])).toThrow(/not a finite integer/);
+  });
+
+  it("a NaN scalar index is a clean error for indexSet, not a silently dropped write", () => {
+    const a = arr.zeros(1, 3);
+    expect(() => arr.indexSet(a, [{ kind: "scalar", value: NaN }], 9)).toThrow(/not a finite integer/);
+  });
+
+  it("a non-integer scalar index is a clean error, not truncated silently", () => {
+    const a = arr.fromVec([1, 2, 3]);
+    expect(() => arr.indexGet(a, [{ kind: "scalar", value: 1.5 }])).toThrow(/not a finite integer/);
+  });
+
+  it("set() itself rejects a NaN row/col even though not reachable via indexGet/indexSet today", () => {
+    // `set` is part of this module's exported public surface; every
+    // current caller resolves positions through `assertValidPosition`
+    // first, but `set` stays NaN-safe on its own rather than relying on
+    // that invariant holding forever.
+    const a = arr.zeros(2, 2);
+    expect(() => arr.set(a, NaN, 0, 9)).toThrow(/out of bounds/);
+    expect(() => arr.set(a, 0, NaN, 9)).toThrow(/out of bounds/);
   });
 });

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -313,12 +313,21 @@ describe("range", () => {
     expect(() => arr.range(1, 5, 0)).toThrow(/step cannot be zero/);
   });
 
-  it("a range that would produce more than MAX_ELEMENTS is a clean error, not an OOM", () => {
-    // A compiled program's range bounds can be attacker-influenced (runtime
-    // values, not fixed at compile time) — this proves the cap actually
-    // trips rather than trusting the code that it would.
-    expect(() => arr.range(1, Number.MAX_SAFE_INTEGER)).toThrow(/produces more than/);
-  });
+  it(
+    "a range that would produce more than MAX_ELEMENTS is a clean error, not an OOM",
+    () => {
+      // A compiled program's range bounds can be attacker-influenced (runtime
+      // values, not fixed at compile time) — this proves the cap actually
+      // trips rather than trusting the code that it would. Pushing ~2^26
+      // elements before the cap trips is inherently CPU-bound work, not a
+      // hang — the default 5000ms timeout is too tight on a loaded CI
+      // runner (observed timing out on macOS), so this test gets a longer
+      // budget rather than a smaller repro that wouldn't actually exercise
+      // the cap.
+      expect(() => arr.range(1, Number.MAX_SAFE_INTEGER)).toThrow(/produces more than/);
+    },
+    20000,
+  );
 
   it("a NaN start/stop/step is a clean error, not a silently empty range", () => {
     // Without the Number.isFinite guard, the while loop's condition is

--- a/code/specs/SIR22-array-matrix-semantic-ir.md
+++ b/code/specs/SIR22-array-matrix-semantic-ir.md
@@ -283,12 +283,26 @@ is lowered as a `Stmt`-position operation (like `Assign`), not a value-producing
   ordinary feature-flag capability check) so a module using one of the
   nine still fails cleanly rather than reaching an emit-time panic; see
   that crate's `find_unimplemented_sir22_addendum_node`.
-- **TS** (`semantic-ir-to-typescript`) — not yet done: still rejects
-  `NDArrays`/`MatrixOps`/`ArrayColumnMajor` via the plain capability-
-  rejection path (a real `import { ... } from
-  "@coding-adventures/sir-runtime-array"` codegen PR, mirroring the JS
-  backend's call shapes but against the published npm package instead of
-  an inlined port, is a follow-up).
+- **TS** (`semantic-ir-to-typescript`) — **done**: new `match` arms emit
+  calls into the *imported* `@coding-adventures/sir-runtime-array` package
+  (`import * as __SirArray from "@coding-adventures/sir-runtime-array"`,
+  bound as `__SirArray`, gated by `uses_array` — this backend imports
+  published packages rather than inlining runtime helpers, unlike the JS
+  backend's inlined-port model) for the same base cut
+  (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/
+  `IndexSet`). `NDArrays`/`MatrixOps`/`ArrayColumnMajor` are in
+  `ACCEPTED_FEATURES`. Wiring this package in surfaced the identical
+  latent NaN-bypass/bare-scalar-operand bugs the JS backend's own inlined
+  port had already found and fixed in its 0.36.0 release — `sir-runtime-array`
+  itself (0.1.0 → 0.2.0) picked up the same four fixes (`resolvePositions`'s
+  `assertValidPosition`, `range`'s `Number.isFinite` guard, `set`'s
+  AND-negation bounds check, `elementwise`'s `toArrayValue` coercion), since
+  this PR is what made the package's dormant code paths reachable for the
+  first time. The SIR22 "APL addendum" nodes below share these same three
+  features but remain deferred — this backend adds the identical dedicated
+  tree-walk check inside `compile()` the JS backend uses, so a module using
+  one of the nine still fails cleanly rather than reaching an emit-time
+  panic; see that crate's own `find_unimplemented_sir22_addendum_node`.
 - **Rust/Go/Python backends**: not required to support this in the first
   wave; they reject modules declaring `NDArrays`/`MatrixOps` per the existing
   capability-rejection path. No code changes required to these backends for


### PR DESCRIPTION
## Summary

- Wires the SIR22 array/matrix domain's base cut (`ArrayLit`, `Range`, `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet`, `IndexSet`) into `semantic-ir-to-typescript`, mirroring `semantic-ir-to-javascript`'s already-merged codegen but against the *imported* `@coding-adventures/sir-runtime-array` npm package instead of an inlined port — the same imported-vs-inlined contrast already established for SIR23/`sir-runtime-symbolic`.
- Adds a `find_unimplemented_sir22_addendum_node` tree-walk guard (mirroring the JS backend's identical guard) so the nine APL-addendum nodes — which share the same three feature flags as the base cut but aren't implemented, and which `apl-to-semantic-ir`'s real lowering actually emits — fail cleanly with `UnsupportedFeature` instead of reaching an emit-time panic.
- Wiring `sir-runtime-array` into a real backend for the first time surfaced four latent bugs already found and fixed in the JS backend's own inlined port of this same logic: a NaN value bypassing `indexGet`/`indexSet`'s bounds check, `range()` silently returning empty on a NaN bound, `set()`'s NaN-unsafe OR-form check, and `elementwise()` assuming both operands were already an `NDArray` when `matlab-to-semantic-ir`'s lowering can emit a bare scalar operand. Fixed all four with the same approach already validated in the JS runtime (bumps `sir-runtime-array` 0.1.0 → 0.2.0).
- Updates the SIR22 spec's "Backend impact" section to mark the TS backend done, and both packages' READMEs to drop now-stale "not yet consumed"/"once the backend PR lands" language.

Bumps `semantic-ir-to-typescript` 0.9.0 → 0.10.0, `sir-runtime-array` 0.1.0 → 0.2.0.

## Test plan

- [x] `cargo test -p semantic-ir-to-typescript` — all pass, including 9 new SIR22 tests (capability acceptance, import gating, the addendum-rejection guard, op-name casing, `Range` argument order, `IndexSet` statement shape, and a real MATLAB-source end-to-end test through `matlab-to-semantic-ir`)
- [x] `cargo test -p matlab-to-semantic-ir -p apl-to-semantic-ir -p semantic-ir` — no regressions from the shared `semantic-ir` core
- [x] `npm test` / `npm run build` (`vitest` + `tsc`) in `sir-runtime-array` — all 64 tests pass (10 new regression tests for the bug fixes), clean type-check
- [x] `/security-review` — passed; an independent subagent verified the addendum guard covers every deferred node kind exhaustively (including tracing the depth-cap/validation ordering) and that all four TypeScript bug fixes are complete closures, not partial mitigations

🤖 Generated with [Claude Code](https://claude.com/claude-code)