### PR TITLE
feat(tcp-runtime): connection cap (tcp_runtime_set_max_connections)

### DIFF
--- a/code/packages/c/tcp-runtime/CHANGELOG.md
+++ b/code/packages/c/tcp-runtime/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to semantic versioning.
 
 ### Added
 
+- **Connection cap** (CCPP02 port campaign follow-up). `tcp_runtime_set_max_connections`
+  bounds concurrent connections (0 = unlimited, the default); at the cap a newly
+  accepted connection is closed immediately (the client is refused) rather than
+  tracked, so `accept` still dequeues it and the listener stops re-reporting
+  readable. `tcp_runtime_connection_count` reports the current live count. Test
+  extended: with a cap of 1, a second client is accepted-then-closed while the
+  first is served, count stays at 1 (57 checks, ASan+UBSan, 0 leaks). Note: the
+  outbound mailbox and read-pause/resume backpressure remain follow-ups (the
+  mailbox needs the os-platform thread backend linked into all consumers;
+  backpressure needs the per-connection-state follow-up).
+
 - **Initial package — reactor-driven TCP server** (CCPP02 port campaign, PR 2;
   the first consumer that drives `net` + `reactor` together end-to-end). The C
   port of the Rust `tcp-runtime` crate's phase-one core: one thread on a reactor

--- a/code/packages/c/tcp-runtime/README.md
+++ b/code/packages/c/tcp-runtime/README.md
@@ -41,6 +41,8 @@ tcp_runtime_destroy(rt);     /* closes the listener + every live connection */
 |----------|---------|
 | `tcp_runtime_bind(&rt, host, port, handler, user)` | listen + register the reactor |
 | `tcp_runtime_local_port(rt, &port)` | the bound port (for port 0) |
+| `tcp_runtime_set_max_connections(rt, max)` | cap concurrent connections (0 = unlimited); refuse beyond it |
+| `tcp_runtime_connection_count(rt, &n)` | current live connection count |
 | `tcp_runtime_poll(rt, timeout_ms, &n)` | one reactor step: accept + service ready sockets |
 | `tcp_runtime_serve(rt)` | loop `poll` until stopped (blocks) |
 | `tcp_runtime_stop(rt)` | ask `serve` to return |
@@ -66,11 +68,12 @@ allocation, not a slot in the reallocating connection array.)
 ## Scope
 
 Phase-one core: one listener, many concurrent connections, a stateless handler,
-cooperative stop. Deferred to follow-ups (mirroring the Rust crate's own phased
-plan): per-connection state, an outbound **mailbox** for worker threads,
-read-pause/resume **backpressure** (`defer_read`), socket-option policy
-(`TCP_NODELAY`/keepalive), connection caps, and multi-core reactor **sharding**.
-A reply larger than the 8 KiB per-read buffer is currently truncated.
+cooperative stop, and a concurrent-connection **cap**
+(`tcp_runtime_set_max_connections`). Deferred to follow-ups (mirroring the Rust
+crate's own phased plan): per-connection state, an outbound **mailbox** for worker
+threads, read-pause/resume **backpressure** (`defer_read`), socket-option policy
+(`TCP_NODELAY`/keepalive), and multi-core reactor **sharding**. A reply larger
+than the 8 KiB per-read buffer is currently truncated.
 
 ## Build & test
 

--- a/code/packages/c/tcp-runtime/include/tcp_runtime/tcp_runtime.h
+++ b/code/packages/c/tcp-runtime/include/tcp_runtime/tcp_runtime.h
@@ -33,10 +33,11 @@
  *      }
  *
  * SCOPE (phase-one core). One listener; many concurrent connections; a stateless
- * handler; cooperative stop. Deliberately DEFERRED to follow-ups (as in the Rust
- * crate's own phased plan): per-connection state, an outbound mailbox for worker
- * threads, read-pause/resume backpressure (`defer_read`), socket-option policy
- * (TCP_NODELAY/keepalive), connection caps, and multi-core reactor sharding.
+ * handler; cooperative stop; a concurrent-connection cap
+ * (tcp_runtime_set_max_connections). Deliberately DEFERRED to follow-ups (as in
+ * the Rust crate's own phased plan): per-connection state, an outbound mailbox
+ * for worker threads, read-pause/resume backpressure (`defer_read`),
+ * socket-option policy (TCP_NODELAY/keepalive), and multi-core reactor sharding.
  *
  * BUILD. OS-agnostic — every per-OS detail lives in net and reactor — so this is
  * one source file compiled with the net + reactor backends for the target OS.
@@ -86,6 +87,19 @@ osp_status tcp_runtime_bind(tcp_runtime **out, const char *host,
 
 /* The actual bound port (useful when binding to port 0). OSP_ERR_INVAL / OSP_ERR_OS. */
 osp_status tcp_runtime_local_port(tcp_runtime *rt, unsigned short *out_port);
+
+/*
+ * tcp_runtime_set_max_connections — cap the number of concurrent connections.
+ * 0 means unlimited (the default). While at the cap, a newly accepted connection
+ * is closed immediately (the client is refused) rather than tracked. The limit
+ * applies to future accepts; connections already open are left in place.
+ * OSP_ERR_INVAL if rt is NULL.
+ */
+osp_status tcp_runtime_set_max_connections(tcp_runtime *rt,
+                                           size_t max_connections);
+
+/* The current number of live connections. OSP_ERR_INVAL if rt/out_count NULL. */
+osp_status tcp_runtime_connection_count(tcp_runtime *rt, size_t *out_count);
 
 /*
  * tcp_runtime_poll — run ONE reactor step: wait up to `timeout_ms` (negative =

--- a/code/packages/c/tcp-runtime/src/tcp_runtime.c
+++ b/code/packages/c/tcp-runtime/src/tcp_runtime.c
@@ -43,6 +43,7 @@ struct tcp_runtime {
     struct tcp_conn **conns; /* array of stable node pointers */
     size_t count;
     size_t cap;
+    size_t max_connections; /* 0 = unlimited (the default) */
     volatile int stopped;
 };
 
@@ -169,6 +170,24 @@ osp_status tcp_runtime_local_port(tcp_runtime *rt, unsigned short *out_port) {
     return osp_tcp_local_port(rt->listener, out_port);
 }
 
+osp_status tcp_runtime_set_max_connections(tcp_runtime *rt,
+                                           size_t max_connections) {
+    if (rt == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    /* Applies to future accepts; existing connections are left in place. */
+    rt->max_connections = max_connections;
+    return OSP_OK;
+}
+
+osp_status tcp_runtime_connection_count(tcp_runtime *rt, size_t *out_count) {
+    if (rt == NULL || out_count == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    *out_count = rt->count;
+    return OSP_OK;
+}
+
 osp_status tcp_runtime_poll(tcp_runtime *rt, int timeout_ms, int *out_handled) {
     osp_event events[TCP_RT_MAX_EVENTS];
     char rbuf[TCP_RT_BUFSZ];
@@ -192,7 +211,13 @@ osp_status tcp_runtime_poll(tcp_runtime *rt, int timeout_ms, int *out_handled) {
              * so any further pending connections re-report next poll). */
             osp_socket *conn = NULL;
             if (osp_tcp_accept(rt->listener, &conn) == OSP_OK) {
-                if (tcp__add_conn(rt, conn) != OSP_OK) {
+                /* Accept dequeues the pending connection (so the listener stops
+                 * reporting readable); if we are at the cap, close it right away
+                 * to refuse the client rather than track it. */
+                if (rt->max_connections != 0 &&
+                    rt->count >= rt->max_connections) {
+                    osp_socket_close(conn); /* at capacity → refuse */
+                } else if (tcp__add_conn(rt, conn) != OSP_OK) {
                     osp_socket_close(conn); /* could not track it */
                 }
             }

--- a/code/packages/c/tcp-runtime/tests/tcp_runtime_test.c
+++ b/code/packages/c/tcp-runtime/tests/tcp_runtime_test.c
@@ -88,6 +88,52 @@ int main(void) {
     c2 = NULL;
     ISO_CHECK(tcp_runtime_poll(rt, 500, &handled) == OSP_OK);
 
+    /* ── connection cap: max_connections = 1 refuses the 2nd client ─────── */
+    {
+        tcp_runtime *capped = NULL;
+        osp_socket *k1 = NULL;
+        osp_socket *k2 = NULL;
+        unsigned short cport = 0;
+        size_t nconn = 0;
+        size_t cn = 0;
+        int h = 0;
+        char cbuf[8];
+
+        ISO_CHECK(tcp_runtime_bind(&capped, "127.0.0.1", 0, echo_handler, NULL) ==
+                  OSP_OK);
+        ISO_CHECK(tcp_runtime_set_max_connections(capped, 1) == OSP_OK);
+        ISO_CHECK(tcp_runtime_local_port(capped, &cport) == OSP_OK);
+
+        ISO_CHECK(osp_tcp_connect(&k1, "127.0.0.1", cport) == OSP_OK);
+        ISO_CHECK(osp_tcp_connect(&k2, "127.0.0.1", cport) == OSP_OK);
+        ISO_CHECK(tcp_runtime_poll(capped, 500, &h) == OSP_OK); /* accepts k1 */
+        ISO_CHECK(tcp_runtime_poll(capped, 500, &h) == OSP_OK); /* k2 → refused */
+
+        ISO_CHECK(tcp_runtime_connection_count(capped, &nconn) == OSP_OK);
+        ISO_CHECK_EQ_UINT(nconn, 1u); /* only k1 is tracked */
+
+        /* k1 (under the cap) is served normally */
+        ISO_CHECK(osp_socket_send(k1, "hi", 2, &cn) == OSP_OK);
+        ISO_CHECK(tcp_runtime_poll(capped, 500, &h) == OSP_OK);
+        cn = 0;
+        ISO_CHECK(osp_socket_recv(k1, cbuf, sizeof(cbuf), &cn) == OSP_OK);
+        ISO_CHECK_EQ_UINT(cn, 2u);
+
+        /* k2 (over the cap) was accepted then closed → its recv sees EOF */
+        cn = 123;
+        ISO_CHECK(osp_socket_recv(k2, cbuf, sizeof(cbuf), &cn) == OSP_OK);
+        ISO_CHECK_MSG(cn == 0, "a connection beyond the cap must be closed");
+
+        /* NULL validation for the new accessors */
+        ISO_CHECK(tcp_runtime_set_max_connections(NULL, 1) == OSP_ERR_INVAL);
+        ISO_CHECK(tcp_runtime_connection_count(NULL, &nconn) == OSP_ERR_INVAL);
+        ISO_CHECK(tcp_runtime_connection_count(capped, NULL) == OSP_ERR_INVAL);
+
+        ISO_CHECK(osp_socket_close(k1) == OSP_OK);
+        ISO_CHECK(osp_socket_close(k2) == OSP_OK);
+        ISO_CHECK(tcp_runtime_destroy(capped) == OSP_OK);
+    }
+
     /* ── stop before serve → serve returns immediately ──────────────────── */
     tcp_runtime_stop(rt);
     ISO_CHECK(tcp_runtime_serve(rt) == OSP_OK);


### PR DESCRIPTION
## Port campaign — tcp-runtime follow-up: connection cap

Loop item D, scoped to its clean, single-package slice. Bounds the number of concurrent connections a runtime will track.

```c
tcp_runtime_set_max_connections(rt, max);   /* 0 = unlimited (default) */
size_t n;
tcp_runtime_connection_count(rt, &n);
```

At the cap, a newly accepted connection is **closed immediately** (the client is refused) rather than tracked. It's still `accept()`ed first, so it's dequeued from the listener's backlog and the level-triggered reactor stops re-reporting the listener readable (a *don't-accept* approach would busy-loop). The cap applies to future accepts; open connections are left in place.

**Purely additive** — no new external symbols, so the already-merged consumers (`resp-server`, `http-server`) still link unchanged (verified locally: 54 / 56 checks green against this branch).

### Test

`tcp_runtime_test.c` extended: a second runtime with `max_connections = 1` — connect two clients, poll twice; the first is accepted and served normally, the second is accepted-then-closed (its `recv` sees EOF), and `connection_count` stays `1`. Plus NULL validation.

### Verification

- **Local (macOS/arm64):** 57 checks (was 36) / 0 failed under gcc + clang. Clean under **ASan + UBSan**; **0 leaks**.
- **Security review:** passed — the refused socket is freed exactly once (no leak/double-free), the `>=` boundary is correct (N allowed, N+1th refused), `max_connections==0` bypasses the cap, accessors are NULL-safe, and dequeue-before-close avoids a reactor busy-loop.
- Windows + Linux/epoll (and the two consumers) exercised by the 3-OS CI.

### Why not the mailbox (yet)

This is the clean part of the "backpressure + caps" follow-up. The outbound **mailbox** (worker-thread `send`/`close` by connection id) is deliberately deferred to its own PR: it would make `tcp_runtime.c` reference os-platform's `osp_mutex`, forcing **every** `tcp_runtime` consumer's build to newly link the os-platform thread backend — a coordinated cross-package build change. True read-pause/resume **backpressure** (`defer_read`) needs the per-connection-state follow-up. Both remain documented follow-ups.

Spec: [`CCPP02-os-platform-lane.md`](code/specs/CCPP02-os-platform-lane.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)