### PR TITLE
feat(adj-facts-stdlib): biology/blood-vessels — blood vessel type → function table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_bloodvessels_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_bloodvessels_e2e.rs
@@ -1,0 +1,87 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/blood-vessels.adj`) driven through the built CLI:
+//! a native `table` of the three main blood-vessel types → the defining
+//! function each performs resolves binding-query recalls (forward AND backward)
+//! with the source's NCI SEER Training Modules citation, and abstains on a word
+//! that is not one of the three main blood vessels (a lymphatic vessel) — 0
+//! model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsbv_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_blood_vessels_recall_binds_function_with_citation() {
+    let dir = scratch("bloodvessels");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/blood-vessels.adj");
+    std::fs::copy(&src, dir.join("blood-vessels.adj")).expect("copy shipped blood-vessels.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"blood-vessels.adj\"\n\
+         ? vessel_function(artery, $Function)\n\
+         ? vessel_function(vein, $Function)\n\
+         ? vessel_function(capillary, $Function)\n\
+         ? vessel_function($Vessel, toward_heart)\n\
+         ? vessel_function(lymphatic, $Function)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Arteries carry blood away from the heart, veins carry blood toward the
+    // heart, and capillaries are where the exchange of materials happens — the
+    // recalled functions (forward binds).
+    assert!(
+        out.contains("\"Function\":\"away_from_heart\""),
+        "artery → away_from_heart: {out}"
+    );
+    assert!(
+        out.contains("\"Function\":\"toward_heart\""),
+        "vein → toward_heart: {out}"
+    );
+    assert!(
+        out.contains("\"Function\":\"exchange_of_materials\""),
+        "capillary → exchange_of_materials: {out}"
+    );
+    // The relation runs BACKWARD: bind the function `toward_heart`, recall its
+    // vessel type.
+    assert!(
+        out.contains("\"Vessel\":\"vein\""),
+        "toward_heart → vein (reverse recall): {out}"
+    );
+    // The answer carries the NCI SEER Training Modules citation as its proof, at
+    // the `authoritative` trust tier for a primary U.S. government source.
+    assert!(
+        out.contains("training.seer.cancer.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A lymphatic vessel is not one of the three main blood vessels — honest
+    // abstention, never a fabricated function.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "lymphatic abstains: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -41,6 +41,7 @@ per rotation, in parallel):
 | `biology/` | common bone → body region | NIH / MedlinePlus |
 | `biology/` | macronutrient → energy (kcal) per gram | NIH / MedlinePlus |
 | `biology/` | basic tissue type → representative example | NCI SEER Training |
+| `biology/` | blood-vessel type → defining function (artery → away from heart) | NCI SEER Training |
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
 | `physics/` | simple machine → everyday example | NASA |

--- a/code/specs/data/adj-facts-stdlib/biology/blood-vessels.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/blood-vessels.adj
@@ -1,0 +1,102 @@
+% ============================================================================
+% blood-vessels — the three main types of blood vessel and the defining
+% function each one performs in the circulatory system (adj-facts-stdlib,
+% BIOLOGY).
+% ============================================================================
+% One of the very first facts of the circulatory system, and a rung a MEDICINE
+% agent reasons UP from: blood travels in a closed loop of vessels, and there
+% are just THREE main kinds. "Arteries carry blood AWAY from the heart; veins
+% carry blood TOWARD the heart; capillaries are the tiny connecting vessels
+% where the actual EXCHANGE of materials between blood and tissue happens."
+% Before you can reason about circulation, blood pressure, or a blockage you
+% must first know WHICH kind of vessel you are looking at and which direction it
+% moves blood. Recall is a binding query:
+%
+%     ? vessel_function(artery, $Function)     % away_from_heart
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `vessel_function(vessel, function)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% function WITH its source, on the CPU, with zero model calls, and abstains on a
+% word that is not one of these three vessel types (it never invents a
+% function).
+%
+% Each of the three main blood-vessel types and the defining function the
+% source states for it, as a little truth table:
+%
+%     vessel type   defining function        a beginner's cue
+%     -----------   ----------------------   ---------------------------------
+%     artery        away_from_heart          arteries carry blood away
+%     vein          toward_heart             veins carry blood back
+%     capillary     exchange_of_materials    tiny walls where trade happens
+%
+% The query also runs BACKWARD — bind a function and recall its vessel type:
+%
+%     ? vessel_function($Vessel, toward_heart)   % vein
+%
+% A word that is NOT one of these three main blood-vessel types — `lymphatic`
+% (a lymph vessel, not a blood vessel), `nerve`, `rock` — is deliberately NOT a
+% row, so a vessel recall ABSTAINS on it rather than inventing a function. That
+% honest-abstention property is what makes the table safe to build a reasoner
+% on: it answers exactly the vessel→function pairs it can ground, and only
+% those.
+%
+% The `function` value of every row is a SINGLE lowercase phrase, chosen to be a
+% span the source EXPLICITLY states for that vessel — never one the source does
+% not support. Where the everyday phrasing differs from the source's words, the
+% atom uses the source's OWN words ("away from the heart", "toward the heart",
+% "exchange of materials"), so every value stays literally checkable against the
+% quoted span.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every vessel→function pair
+% below was read out of a fetched NCI SEER Training Modules page, and any pair
+% whose function could not be verified there would have been dropped). Each
+% pair, with the primary source it was copied from and the verbatim span that
+% states it:
+%
+%   artery → away_from_heart
+%     https://training.seer.cancer.gov/anatomy/cardiovascular/blood/classification.html
+%     (NCI SEER Training Modules — U.S. National Cancer Institute)
+%     "Arteries carry blood away from the heart."
+%
+%   vein → toward_heart
+%     https://training.seer.cancer.gov/anatomy/cardiovascular/blood/classification.html
+%     (NCI SEER Training Modules — U.S. National Cancer Institute)
+%     "Veins carry blood toward the heart."
+%
+%   capillary → exchange_of_materials
+%     https://training.seer.cancer.gov/anatomy/cardiovascular/blood/classification.html
+%     (NCI SEER Training Modules — U.S. National Cancer Institute)
+%     "The primary function of capillaries is the exchange of materials between
+%      the blood and tissue cells." (capillaries are also described there as
+%      forming "the connection between the vessels that carry blood away from
+%      the heart (arteries) and the vessels that return blood to the heart
+%      (veins)".)
+%
+% (The three-vessel framing itself is stated on the same primary U.S.
+% government teaching resource — "a closed system of vessels called arteries,
+% veins, and capillaries" — another span of the same page's parent module.)
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the SEER statement that fixes the
+% first row (artery → away_from_heart). Every OTHER row's per-fact source and
+% verbatim span is listed above, so each function remains independently
+% checkable. All sources are the NCI SEER Training Modules, a primary U.S.
+% government (National Cancer Institute) teaching resource, so `trust
+% authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table vessel_function {
+    columns vessel, function
+
+    row (artery, away_from_heart)
+    row (vein, toward_heart)
+    row (capillary, exchange_of_materials)
+
+    source "Arteries carry blood away from the heart."
+    locator "https://training.seer.cancer.gov/anatomy/cardiovascular/blood/classification.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/blood-vessels.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/blood-vessels.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% blood-vessels.query.adj — a worked recall over the biology blood-vessels library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does an artery do?":
+% it states no anatomy fact of its own — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `vessel_function` rows and returns the function + the table's source/locator/
+% trust. The fourth query runs the relation BACKWARD (bind the function
+% `toward_heart`, recall its vessel type — vein). A word that is not one of the
+% three main blood-vessel types abstains honestly — the engine never invents a
+% function.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli blood-vessels.query.adj
+% ============================================================================
+
+import "blood-vessels.adj"
+
+? vessel_function(artery, $Function)      % expect away_from_heart
+? vessel_function(vein, $Function)        % expect toward_heart
+? vessel_function(capillary, $Function)   % expect exchange_of_materials
+? vessel_function($Vessel, toward_heart)  % reverse bind — expect vein
+? vessel_function(lymphatic, $Function)   % expect abstain — a lymphatic vessel is not one of the three main blood vessels


### PR DESCRIPTION
Add a grounded biology FACTS library mapping each of the three main
blood-vessel types to the defining function the source states for it,
mirroring the merged biology/tissue-types library exactly (native `table`,
worked .query.adj, e2e test, README subject-index row).

Rows (relation vessel_function(vessel, function)):
  artery    → away_from_heart
  vein      → toward_heart
  capillary → exchange_of_materials

Provenance — every value byte-provenanced from a source fetched this
session; nothing from memory. All three pairs read from one primary U.S.
government teaching resource, the NCI SEER Training Modules "Classification
& Structure of Blood Vessels" page, so trust = authoritative:

  https://training.seer.cancer.gov/anatomy/cardiovascular/blood/classification.html
    "Arteries carry blood away from the heart."
    "Veins carry blood toward the heart."
    "The primary function of capillaries is the exchange of materials
     between the blood and tissue cells."

Each value is a single lowercase phrase built from the source's own words,
so it stays literally checkable against the quoted span. A word that is not
one of the three main blood vessels (e.g. a lymphatic vessel) is not a row,
so recall abstains honestly rather than inventing a function. Zero rows
dropped — all three grounded cleanly on the same authoritative page.

Data-only: new .adj table + .query.adj + one e2e test + one README row. No
engine/grammar/adapter changes. cargo test -p adj-lang -p adj-lang-cli and
cargo clippy --all-targets -D warnings both green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
