### PR TITLE
feat(adj-facts-stdlib): anatomy/digestive-organs — digestive organ → function table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_digestiveorgans_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_digestiveorgans_e2e.rs
@@ -1,0 +1,80 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/digestive-organs.adj`) driven through the built
+//! CLI: a native `table` of digestive-system organ → primary function resolves a
+//! binding-query recall with the source's NIH NIDDK / NCI SEER Training
+//! (authoritative) citation, runs the relation backward (function → the organ
+//! that owns it), and abstains on a non-digestive organ (the heart) — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("adjcli_factsdigest_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_digestive_organs_recall_binds_function_with_citation() {
+    let dir = scratch("digestiveorgans");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/digestive-organs.adj");
+    std::fs::copy(&src, dir.join("digestive-organs.adj"))
+        .expect("copy shipped digestive-organs.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"digestive-organs.adj\"\n\
+         ? organ_function(stomach, $Job)\n\
+         ? organ_function(small_intestine, $Job)\n\
+         ? organ_function(liver, $Job)\n\
+         ? organ_function($Organ, absorbs_water)\n\
+         ? organ_function(heart, $Job)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Each named organ binds its headline function — a single lowercase token
+    // echoed verbatim from the source sentence.
+    assert!(out.contains("\"Job\":\"break_down_food\""), "stomach → break_down_food: {out}");
+    assert!(
+        out.contains("\"Job\":\"absorbs_nutrients\""),
+        "small_intestine → absorbs_nutrients: {out}"
+    );
+    assert!(out.contains("\"Job\":\"bile\""), "liver → bile: {out}");
+    // The relation runs backward: the function `absorbs_water` recalls the organ
+    // that owns it — the large intestine.
+    assert!(
+        out.contains("\"Organ\":\"large_intestine\""),
+        "absorbs_water → large_intestine (reverse recall): {out}"
+    );
+    // The answer carries the primary NIH / NCI citation as its proof, at
+    // authoritative trust.
+    assert!(
+        (out.contains("seer.cancer.gov") || out.contains("niddk.nih.gov"))
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The heart is a circulatory organ, not a digestive one — honest abstention,
+    // never a fabricated function.
+    assert!(out.contains("\"abstained\":true"), "unknown organ abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -48,6 +48,7 @@ per rotation, in parallel):
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |
+| `anatomy/` | digestive organ → primary function it performs | NIH NIDDK / NCI SEER Training |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/anatomy/digestive-organs.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/digestive-organs.adj
@@ -1,0 +1,124 @@
+% ============================================================================
+% digestive-organs — a digestive-system organ → a primary function it performs
+% (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A middle-school biology fact set on the way to medicine: food takes a one-way
+% trip down the alimentary canal, and each organ along the way does ONE headline
+% job. The esophagus is the passageway that carries a swallow down to the
+% stomach; the stomach's acid and enzymes break down food; the small intestine
+% absorbs the nutrients into the blood; the large intestine absorbs the leftover
+% water; and three accessory organs feed the tube — the liver makes bile, the
+% gallbladder stores that bile, and the pancreas makes the digestive enzymes.
+% Recall is a binding query:
+%
+%     ? organ_function(stomach, $Job)   % breaks_down_food → break_down_food
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `organ_function(organ, function)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% function WITH its source, on the CPU, with zero model calls, and abstains on
+% anything that is not one of these organs (it never invents a job).
+%
+% The organs, as a little truth table:
+%
+%     organ             function            everyday gloss of the job
+%     ---------------   -----------------   ---------------------------------
+%     esophagus         passageway          the tube food is swallowed down
+%     stomach           break_down_food     acid + enzymes break food apart
+%     small_intestine   absorbs_nutrients   nutrients cross into the blood
+%     large_intestine   absorbs_water       reclaims water, forms the stool
+%     liver             bile                makes bile to help digest fats
+%     gallbladder       stores_bile         holds the liver's bile until a meal
+%     pancreas          digestive_enzymes   secretes the enzymes that digest
+%
+% Each `function` value is a SINGLE lowercase token/phrase that appears VERBATIM
+% inside the cited source sentence (see the provenance block), so the recall is a
+% faithful echo of the source, not a paraphrase. Note the value is one-to-MANY in
+% neither direction here — each organ has its own headline job — but the relation
+% still runs BACKWARD to name the organ that owns a job:
+%
+%     ? organ_function($Organ, absorbs_water)   % large_intestine
+%
+% Something that is not one of these organs — the heart, a tooth, the tongue —
+% has no row, so a recall on it ABSTAINS rather than inventing a function. That
+% honest-abstention property is what makes the table safe to reason from: a
+% medicine agent reasons UP from "which organ does what" before it can reason
+% about heartburn in the esophagus or malabsorption in the small intestine.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every organ→function pair
+% was read out of a U.S. government / NIH page fetched this session, and any pair
+% that could not be cleanly grounded with a single-token function inside one
+% verbatim sentence was DROPPED; the mouth was dropped because no fetched page
+% stated its job with a single clean token in one sentence). Each function token
+% below is quoted inside the verbatim source sentence so any reader can re-check
+% it. Two primary U.S. references are used — NIH NIDDK "Your Digestive System &
+% How It Works" and the NCI SEER Training Modules — so this table is
+% `trust authoritative`:
+%
+%   esophagus → passageway
+%     https://training.seer.cancer.gov/anatomy/digestive/regions/pharynx.html
+%     (U.S. National Cancer Institute, NCI SEER Training Modules)
+%     "The esophagus is a collapsible muscular tube that serves as a passageway
+%      between the pharynx and stomach."
+%
+%   stomach → break_down_food
+%     https://www.niddk.nih.gov/health-information/digestive-diseases/digestive-system-how-it-works
+%     (NIH / National Institute of Diabetes and Digestive and Kidney Diseases)
+%     "Glands in your stomach lining make stomach acid and enzymes that break
+%      down food."
+%
+%   small_intestine → absorbs_nutrients
+%     https://training.seer.cancer.gov/anatomy/digestive/regions/intestine.html
+%     (U.S. National Cancer Institute, NCI SEER Training Modules)
+%     "The small intestine finishes the process of digestion, absorbs the
+%      nutrients, and passes the residue on to the large intestine."
+%
+%   large_intestine → absorbs_water
+%     https://www.niddk.nih.gov/health-information/digestive-diseases/digestive-system-how-it-works
+%     (NIH / NIDDK)
+%     "The large intestine absorbs water and changes the waste from liquid into
+%      stool."
+%
+%   liver → bile
+%     https://www.niddk.nih.gov/health-information/digestive-diseases/digestive-system-how-it-works
+%     (NIH / NIDDK)
+%     "Your liver makes a digestive juice called bile that helps digest fats and
+%      some vitamins."
+%
+%   gallbladder → stores_bile
+%     https://www.niddk.nih.gov/health-information/digestive-diseases/digestive-system-how-it-works
+%     (NIH / NIDDK)
+%     "Your gallbladder stores bile between meals."
+%
+%   pancreas → digestive_enzymes
+%     https://training.seer.cancer.gov/anatomy/digestive/regions/accessory.html
+%     (U.S. National Cancer Institute, NCI SEER Training Modules)
+%     "It consists of pancreatic acinar cells that secrete digestive enzymes into
+%      tiny ducts interwoven between the cells."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the NCI SEER Training sentence
+% that fixes the first row (esophagus → passageway). Every OTHER row's per-fact
+% source and verbatim span is listed above, so each pair remains independently
+% checkable. Both sources are primary U.S. government / NIH references (NIH
+% NIDDK; NCI SEER Training), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table organ_function {
+    columns organ, function
+
+    row (esophagus, passageway)
+    row (stomach, break_down_food)
+    row (small_intestine, absorbs_nutrients)
+    row (large_intestine, absorbs_water)
+    row (liver, bile)
+    row (gallbladder, stores_bile)
+    row (pancreas, digestive_enzymes)
+
+    source "The esophagus is a collapsible muscular tube that serves as a passageway between the pharynx and stomach."
+    locator "https://training.seer.cancer.gov/anatomy/digestive/regions/pharynx.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/digestive-organs.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/digestive-organs.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% digestive-organs.query.adj — a worked recall over the anatomy digestive-organs
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the stomach do?":
+% it states no anatomy fact of its own — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the `organ_function`
+% rows and returns the function + the table's source/locator/trust. The fourth
+% query runs the relation BACKWARD (bind the function `absorbs_water`, recall the
+% organ that owns it — the large intestine). The heart is a circulatory organ,
+% not one of these digestive organs, so a recall on it abstains honestly — the
+% engine never invents a function.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli digestive-organs.query.adj
+% ============================================================================
+
+import "digestive-organs.adj"
+
+? organ_function(stomach, $Job)            % expect break_down_food
+? organ_function(small_intestine, $Job)    % expect absorbs_nutrients
+? organ_function(liver, $Job)              % expect bile
+? organ_function($Organ, absorbs_water)    % reverse bind — expect large_intestine
+? organ_function(heart, $Job)              % expect abstain — the heart is not a digestive organ


### PR DESCRIPTION
A native ADJ `table` mapping a digestive-system organ to a primary function it
performs, for the ANATOMY facts stdlib. Recall is an ordinary SLD binding query
(`? organ_function(stomach, $Job)`) that returns the function WITH its source on
the CPU, 0 model calls, and abstains on any organ not in the table.

Grounded organ → function pairs (7 rows), every value a lowercase token/phrase
quoted VERBATIM inside the cited sentence — nothing from memory, each pair read
from a page fetched this session:

  esophagus        → passageway         (NCI SEER Training, pharynx.html)
  stomach          → break_down_food    (NIH NIDDK)
  small_intestine  → absorbs_nutrients  (NCI SEER Training, intestine.html)
  large_intestine  → absorbs_water      (NIH NIDDK)
  liver            → bile               (NIH NIDDK)
  gallbladder      → stores_bile        (NIH NIDDK)
  pancreas         → digestive_enzymes  (NCI SEER Training, accessory.html)

Sources & trust tiers: both are primary U.S. government / NIH references —
NIH NIDDK "Your Digestive System & How It Works" and the NCI SEER Training
Modules — so the table is `trust authoritative`. The full per-row verbatim
sentences and locators are in the .adj provenance block, each independently
re-checkable.

Dropped for lack of clean single-token provenance this session: the mouth (no
fetched page stated its job with one clean token in a single sentence).

Includes a worked `.query.adj` (forward lookups, one reverse bind on
`absorbs_water` → large_intestine, and an honest abstain on `heart`) and an e2e
test `facts_digestiveorgans_e2e.rs` mirroring the existing anatomy facts tests
(asserts exact function binding + authoritative citation, and abstention on a
non-digestive organ). README subject-index row added; existing rows preserved.
Diff is data-only.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
