### PR TITLE
fix(sql): upper()/lower() are ASCII-only, matching SQLite

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.39 — upper()/lower() are ASCII-only
+
+`upper()` and `lower()` now match SQLite: they case-fold only ASCII letters and
+leave accented / non-Latin characters untouched — `upper('naïve')` is `'NAïVE'`
+and `upper('straße')` is `'STRAßE'`. Two differential-oracle cases; sql-vm 0.4.21.
+
 ## 0.5.38 — LIKE … ESCAPE, and NOT LIKE inversion fix
 
 `X LIKE Y ESCAPE Z` now parses and evaluates: the escape character makes a

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.38"
+version = "0.5.39"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1345,6 +1345,24 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id FROM t WHERE code LIKE '%#%%' ESCAPE '#' ORDER BY id",
     },
+    // ---- Lane 2: upper()/lower() are ASCII-only ----------------------------
+    // SQLite's built-in UPPER/LOWER case-fold only ASCII a–z/A–Z; accented and
+    // non-Latin characters pass through unchanged (unlike a full-Unicode fold).
+    Case {
+        id: "upper_lower_ascii_only",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT upper('naïve') AS a, lower('ÀBC') AS b, upper('café') AS c, \
+                lower('CAFÉ') AS d, upper('straße') AS e, upper('abc123!') AS f FROM t",
+    },
+    // Per-row over a text column with mixed scripts.
+    Case {
+        id: "upper_lower_per_row",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1,'Hello'),(2,'naïve'),(3,'ПРИВЕТ')",
+        ],
+        query: "SELECT id, upper(s) AS u, lower(s) AS l FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.21] - Unreleased
+
+### Fixed
+
+- `UPPER`/`LOWER` are now ASCII-only, matching SQLite's built-ins: only `a`–`z`/
+  `A`–`Z` fold, and accented or non-Latin characters pass through unchanged
+  (`upper('naïve')` → `'NAïVE'`, not `'NAÏVE'`). Previously they used Rust's
+  full-Unicode `to_uppercase`/`to_lowercase`.
+
 ## [0.4.20] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1309,7 +1309,10 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             }
             match &args[0] {
                 SqlValue::Null => Ok(SqlValue::Null),
-                SqlValue::Text(s) => Ok(SqlValue::Text(s.to_uppercase())),
+                // SQLite's built-in UPPER only case-folds ASCII `a`–`z`; every
+                // other byte (accented letters, non-Latin scripts) is left as-is.
+                // Rust's `to_uppercase` is full-Unicode, so use the ASCII variant.
+                SqlValue::Text(s) => Ok(SqlValue::Text(s.to_ascii_uppercase())),
                 other => Err(VmError::TypeMismatch(format!("UPPER expects TEXT, got {:?}", other))),
             }
         }
@@ -1320,7 +1323,8 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             }
             match &args[0] {
                 SqlValue::Null => Ok(SqlValue::Null),
-                SqlValue::Text(s) => Ok(SqlValue::Text(s.to_lowercase())),
+                // ASCII-only, mirroring SQLite's built-in LOWER (see UPPER above).
+                SqlValue::Text(s) => Ok(SqlValue::Text(s.to_ascii_lowercase())),
                 other => Err(VmError::TypeMismatch(format!("LOWER expects TEXT, got {:?}", other))),
             }
         }


### PR DESCRIPTION
## Cycle 3, lane 2: `upper()`/`lower()` are ASCII-only

After probing real SQLite across `round`/`printf`/`typeof`/string functions, found that the engine's `UPPER`/`LOWER` do **full-Unicode** case folding, but SQLite's built-ins fold **only ASCII** `a`–`z`/`A`–`Z` — everything else passes through unchanged:

| call | SQLite | mini-sqlite (before) |
|---|---|---|
| `upper('naïve')` | `'NAïVE'` | `'NAÏVE'` |
| `lower('CAFÉ')` | `'cafÉ'` | `'café'` |
| `upper('straße')` | `'STRAßE'` | `'STRAßE'` (ok) / would be `SS` under Unicode |

Switched to `to_ascii_uppercase` / `to_ascii_lowercase`. Verified against real `sqlite3` across accented Latin, German ß, and Cyrillic.

### Tests
Two differential-oracle cases (mixed-script literals + a per-row column). sql-vm + storage-sqlite suites green. The source change is a same-length, panic-free stdlib method swap — no new attack surface.

### Follow-ups (spun off)
- `printf()` float conversions (`%f`/`%e`/`%g`) currently **error** — implement C-style float formatting.
- `round(x, n)` precision (`round(1.2345, 3)` should be `1.234`, engine gives `1.235`).

Versions: sql-vm 0.4.21, mini-sqlite 0.5.39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
