### PR TITLE
feat(task-core): Workspace model — projects become first-class and nestable

### DIFF
--- a/code/packages/rust/task-core/CHANGELOG.md
+++ b/code/packages/rust/task-core/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to `task-core` are documented here.
 
 ### Added
 
+- **`Workspace` — projects become first-class, plural, and nestable** (Phase 2 PR-1 of
+  `code/specs/task-app-workspace.md`). The model layer only; no behaviour changes yet.
+  - `Workspace { id, name, projects, roots, cross_project_dependencies,
+    shared_resources, settings }` — the container of every project. The `projects` map
+    is **flat**; nesting is expressed by id via the new `ProjectState::parent`, matching
+    how the rest of the model relates entities. That lets the scheduler (PR-2) build one
+    graph over every task without walking an ownership tree, and keeps snapshots simple.
+  - `ProjectState::parent: Option<ProjectId>` — `None` means a top-level project (listed
+    in `Workspace::roots`). Serialized with `skip_serializing_if`, so root projects omit
+    the field entirely and **pre-workspace snapshots still deserialize** (serde default).
+  - `WorkspaceId` id newtype; `WorkspaceSettings { schedule_as_one_network }` — defaults
+    to `false` (schedule each project independently, i.e. today's behaviour). Turning it
+    on is the "incrementally add complexity" step from portfolio-less to portfolio.
+  - Helpers: `Workspace::empty` (new-document state: one un-nested project),
+    `from_project` (the migration path that wraps a pre-workspace `ProjectState`),
+    `children_of`, `ancestors_of` (cycle-guarded so a corrupt snapshot truncates rather
+    than hangs), and `project_of_task` (task ids are **workspace-global**, which is what
+    lets a cross-project dependency be an ordinary `DependencyLink`).
+  - 7 tests: forest construction/traversal, cycle-guard termination, global task
+    ownership, single-project wrap equivalence, JSON round-trip with `parent` omitted on
+    roots, and old-snapshot compatibility.
+
 - **The data model** — the foundational entity set for a Microsoft Project-class,
   "one model, many views" task engine:
   - `Task` — the central entity, with an optional `TaskSchedule` block (task-type

--- a/code/packages/rust/task-core/src/ids.rs
+++ b/code/packages/rust/task-core/src/ids.rs
@@ -58,7 +58,13 @@ macro_rules! id_type {
 }
 
 id_type!(
-    /// Identifies a whole project (one open document).
+    /// Identifies a whole workspace — the container of every project.
+    WorkspaceId
+);
+id_type!(
+    /// Identifies a single project. A project may *nest* inside another (see
+    /// `ProjectState::parent`), so this addresses a node in the project forest,
+    /// not necessarily a top-level document.
     ProjectId
 );
 id_type!(

--- a/code/packages/rust/task-core/src/lib.rs
+++ b/code/packages/rust/task-core/src/lib.rs
@@ -26,7 +26,8 @@
 //! - [`primitives`] — `Date`, `Duration`, `Work`, `Money`: the units the model
 //!   measures in, with civil-date arithmetic delegated to `datetime-core`.
 //! - [`model`] — the entities: `Task`, links, resources, calendars, fields,
-//!   workflow, baselines, views, and the root `ProjectState`.
+//!   workflow, baselines, views, the `ProjectState` root, and the `Workspace` that
+//!   holds every project and how they nest.
 //! - [`calendar`] — the working-time engine: resolve calendars, snap into working
 //!   time, add working durations, and count working minutes. The unit the scheduler
 //!   measures in.
@@ -163,6 +164,132 @@ mod tests {
             Constraint::StartNoEarlierThan(_)
         ));
         assert_eq!(project.assignments[0].units, 1.0);
+    }
+
+    // ── Workspace: projects are first-class, plural, and nestable ───────────────
+
+    /// Build the three-level forest used by the nesting tests:
+    ///   apollo ─ lander ─ avionics
+    fn nested_workspace() -> Workspace {
+        let mut ws = Workspace::empty(WorkspaceId::from_raw("w1"), ProjectId::from_raw("apollo"));
+        for (id, parent) in [("lander", "apollo"), ("avionics", "lander")] {
+            let mut p = ProjectState::empty(ProjectId::from_raw(id));
+            p.parent = Some(ProjectId::from_raw(parent));
+            ws.projects.insert(p.id.clone(), p);
+        }
+        ws
+    }
+
+    #[test]
+    fn an_empty_workspace_holds_one_root_project() {
+        // The "new document" state: one project, un-nested — i.e. exactly today's
+        // single-project world, which is what keeps the simple case simple.
+        let ws = Workspace::empty(WorkspaceId::from_raw("w1"), ProjectId::from_raw("p1"));
+        assert_eq!(ws.projects.len(), 1);
+        assert_eq!(ws.roots, vec![ProjectId::from_raw("p1")]);
+        assert!(ws.projects[&ProjectId::from_raw("p1")].parent.is_none());
+        assert!(ws.cross_project_dependencies.is_empty());
+        // Scheduling stays per-project until you opt in.
+        assert!(!ws.settings.schedule_as_one_network);
+    }
+
+    #[test]
+    fn projects_nest_and_expose_their_forest() {
+        let ws = nested_workspace();
+
+        // Direct children only — apollo owns lander, not avionics.
+        let kids: Vec<_> = ws
+            .children_of(&ProjectId::from_raw("apollo"))
+            .iter()
+            .map(|p| p.id.clone())
+            .collect();
+        assert_eq!(kids, vec![ProjectId::from_raw("lander")]);
+        assert!(ws.children_of(&ProjectId::from_raw("avionics")).is_empty());
+
+        // Ancestors walk nearest-parent-first, all the way to the root.
+        assert_eq!(
+            ws.ancestors_of(&ProjectId::from_raw("avionics")),
+            vec![ProjectId::from_raw("lander"), ProjectId::from_raw("apollo")]
+        );
+        assert!(ws.ancestors_of(&ProjectId::from_raw("apollo")).is_empty());
+    }
+
+    #[test]
+    fn ancestors_of_a_corrupt_parent_cycle_terminates() {
+        // Ops reject cycles, but a snapshot arrives from outside the engine — so the
+        // walk must not hang on hostile data. It truncates rather than looping.
+        let mut ws = nested_workspace();
+        ws.projects
+            .get_mut(&ProjectId::from_raw("apollo"))
+            .unwrap()
+            .parent = Some(ProjectId::from_raw("avionics"));
+
+        let chain = ws.ancestors_of(&ProjectId::from_raw("avionics"));
+        assert!(
+            chain.len() <= ws.projects.len(),
+            "cycle guard bounds the walk"
+        );
+    }
+
+    #[test]
+    fn task_ids_are_workspace_global_so_ownership_is_resolvable() {
+        // This index is what lets the scheduler tell an intra-project edge from a
+        // cross-project one without compound (ProjectId, TaskId) keys.
+        let mut ws = nested_workspace();
+        let t = Task::new(TaskId::from_raw("wiring"), "Wiring");
+        ws.projects
+            .get_mut(&ProjectId::from_raw("avionics"))
+            .unwrap()
+            .tasks
+            .insert(t.id.clone(), t);
+
+        assert_eq!(
+            ws.project_of_task(&TaskId::from_raw("wiring")),
+            Some(&ProjectId::from_raw("avionics"))
+        );
+        assert_eq!(ws.project_of_task(&TaskId::from_raw("nope")), None);
+    }
+
+    #[test]
+    fn a_single_project_wraps_into_an_equivalent_workspace() {
+        // The migration path for pre-workspace snapshots: the project must survive
+        // the wrap untouched, and land as the sole root.
+        let mut project = ProjectState::empty(ProjectId::from_raw("p1"));
+        let t = Task::new(TaskId::from_raw("t1"), "Ship it");
+        project.tasks.insert(t.id.clone(), t);
+
+        let ws = Workspace::from_project(WorkspaceId::from_raw("w1"), project.clone());
+        assert_eq!(ws.roots, vec![ProjectId::from_raw("p1")]);
+        assert_eq!(ws.projects[&ProjectId::from_raw("p1")], project);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn workspace_json_round_trips_and_omits_parent_for_root_projects() {
+        let ws = nested_workspace();
+        let json = serde_json::to_string(&ws).unwrap();
+
+        // Wire contract: camelCase, bare-string ids, nesting by id.
+        assert!(json.contains("\"crossProjectDependencies\":[]"));
+        assert!(json.contains("\"parent\":\"apollo\""));
+        // A root project omits `parent` entirely rather than emitting null — the
+        // JSON stays clean and old single-project snapshots remain valid input.
+        assert!(!json.contains("\"parent\":null"));
+
+        let back: Workspace = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ws);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn a_pre_workspace_project_snapshot_still_deserialises() {
+        // Backward compatibility: JSON written before `parent` existed must still
+        // load (serde default), so Phase-1 persisted data keeps working.
+        let json = serde_json::to_string(&ProjectState::empty(ProjectId::from_raw("p1")))
+            .unwrap()
+            .replace(",\"parent\":null", ""); // simulate the older shape
+        let back: ProjectState = serde_json::from_str(&json).unwrap();
+        assert!(back.parent.is_none());
     }
 
     #[cfg(feature = "serde")]

--- a/code/packages/rust/task-core/src/model.rs
+++ b/code/packages/rust/task-core/src/model.rs
@@ -7,6 +7,12 @@
 //! ([`Resource`], [`Calendar`], [`FieldDef`], [`Workflow`], [`Baseline`], [`View`])
 //! surround the task, and [`ProjectState`] is the flat, normalised root that holds
 //! them all.
+//!
+//! Above a single project sits [`Workspace`]: every project, plus how they nest.
+//! Projects are first-class and plural — you can keep many, nest one inside another,
+//! and schedule them as one network with dependencies crossing project boundaries.
+//! A workspace with one un-nested project behaves exactly like a bare
+//! [`ProjectState`], so the simple case pays nothing for the capability.
 
 use crate::ids::*;
 use crate::primitives::*;
@@ -813,6 +819,18 @@ pub struct ProjectState {
     pub id: ProjectId,
     /// Project name.
     pub name: String,
+    /// The parent project, if this project is nested inside another. `None` means
+    /// a top-level project (listed in [`Workspace::roots`]).
+    ///
+    /// Nesting is expressed **by id**, like every other relationship in this model —
+    /// a sub-project is not physically contained in its parent. That keeps the
+    /// projects map flat, snapshots simple, and lets the scheduler treat the whole
+    /// workspace as one graph without walking a tree of owned structs.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub parent: Option<ProjectId>,
     /// All tasks, by id.
     pub tasks: BTreeMap<TaskId, Task>,
     /// The scheduling network.
@@ -851,6 +869,7 @@ impl ProjectState {
         ProjectState {
             id,
             name: String::new(),
+            parent: None,
             tasks: BTreeMap::new(),
             dependencies: Vec::new(),
             links: Vec::new(),
@@ -865,4 +884,170 @@ impl ProjectState {
             settings: ProjectSettings::default(),
         }
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workspace
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The root container: **every project**, and how they nest.
+///
+/// Where [`ProjectState`] is one plan, a `Workspace` is the whole desk. It exists so
+/// projects can be *first-class and plural*: you can keep many, nest one inside
+/// another to arbitrary depth, and — the point of the whole design — **schedule them
+/// as a single network**, with dependencies crossing project boundaries and
+/// sub-project dates rolling up into their parent. That unifies what Microsoft
+/// Project calls master/subprojects and what Primavera calls an EPS.
+///
+/// ## Shape
+///
+/// ```text
+///   Workspace
+///     roots: [ apollo ]                  ← display order of top-level projects
+///     projects:                          ← FLAT map; nesting is by id, not containment
+///       apollo    { parent: None }
+///       lander    { parent: Some(apollo) }
+///       avionics  { parent: Some(lander) }
+///     cross_project_dependencies:
+///       [ avionics::wiring ──FS──▶ lander::assembly ]
+/// ```
+///
+/// The projects map is **flat** and nesting is expressed by
+/// [`ProjectState::parent`], matching how the rest of this model relates entities
+/// (by id, never by nesting — see the module header). One consequence matters a lot:
+/// the scheduler can build a single graph over every task in the workspace without
+/// walking an ownership tree, and a snapshot stays a simple, stable map.
+///
+/// ## Task ids are workspace-global
+///
+/// A [`TaskId`] is unique across the *whole* workspace, not per project. That is what
+/// lets a cross-project dependency be an ordinary [`DependencyLink`] whose two
+/// endpoints merely happen to live in different projects — no compound
+/// `(ProjectId, TaskId)` keys, no second link type, and the existing cycle detection
+/// works unchanged across boundaries.
+///
+/// ## Progressive disclosure
+///
+/// A workspace holding one project with no `parent` and no cross-project links
+/// behaves *exactly* like a bare [`ProjectState`] does today. Nesting and
+/// cross-project scheduling cost nothing until you use them — the simple case stays
+/// simple, which is the standing rule for this product.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Workspace {
+    /// Workspace identity.
+    pub id: WorkspaceId,
+    /// Workspace name.
+    pub name: String,
+    /// Every project, by id — including nested ones. Flat by design (see above).
+    pub projects: BTreeMap<ProjectId, ProjectState>,
+    /// The display order of top-level projects (those with `parent == None`).
+    /// A `BTreeMap` orders by id, which is stable but arbitrary; user-visible
+    /// ordering is a product decision, so it is stored explicitly.
+    pub roots: Vec<ProjectId>,
+    /// Dependencies whose endpoints live in **different** projects. Dependencies
+    /// within one project stay on that project's `dependencies`, untouched; the
+    /// scheduler simply unions the two sets.
+    pub cross_project_dependencies: Vec<DependencyLink>,
+    /// A resource pool shared across projects. Per-project `ProjectState::resources`
+    /// remain valid for project-local resources; this pool is additive, and is what
+    /// cross-project levelling will draw on later.
+    pub shared_resources: BTreeMap<ResourceId, Resource>,
+    /// Workspace-wide settings.
+    pub settings: WorkspaceSettings,
+}
+
+impl Workspace {
+    /// A workspace holding exactly one empty project — the "new document" state, and
+    /// the shape that reproduces today's single-project behaviour.
+    pub fn empty(id: WorkspaceId, project: ProjectId) -> Workspace {
+        let mut projects = BTreeMap::new();
+        projects.insert(project.clone(), ProjectState::empty(project.clone()));
+        Workspace {
+            id,
+            name: String::new(),
+            projects,
+            roots: vec![project],
+            cross_project_dependencies: Vec::new(),
+            shared_resources: BTreeMap::new(),
+            settings: WorkspaceSettings::default(),
+        }
+    }
+
+    /// Wrap a single existing project as a one-project workspace.
+    ///
+    /// This is the migration path for snapshots written before workspaces existed
+    /// (see `code/specs/task-app-workspace.md` §5): an old bare-`ProjectState` JSON
+    /// loads, then becomes a workspace through here.
+    pub fn from_project(id: WorkspaceId, project: ProjectState) -> Workspace {
+        let pid = project.id.clone();
+        let mut projects = BTreeMap::new();
+        projects.insert(pid.clone(), project);
+        Workspace {
+            id,
+            name: String::new(),
+            projects,
+            roots: vec![pid],
+            cross_project_dependencies: Vec::new(),
+            shared_resources: BTreeMap::new(),
+            settings: WorkspaceSettings::default(),
+        }
+    }
+
+    /// The direct sub-projects of `parent`, in `projects` (id) order.
+    pub fn children_of(&self, parent: &ProjectId) -> Vec<&ProjectState> {
+        self.projects
+            .values()
+            .filter(|p| p.parent.as_ref() == Some(parent))
+            .collect()
+    }
+
+    /// The chain of ancestors of `project`, nearest parent first.
+    ///
+    /// Walks defensively: it stops after `projects.len()` hops so a corrupted
+    /// snapshot containing a parent cycle degrades to a truncated chain instead of
+    /// looping forever. Ops reject cycles up front; this is belt-and-braces for data
+    /// that arrives from outside.
+    pub fn ancestors_of(&self, project: &ProjectId) -> Vec<ProjectId> {
+        let mut out = Vec::new();
+        let mut cursor = self.projects.get(project).and_then(|p| p.parent.clone());
+        while let Some(id) = cursor {
+            if out.len() >= self.projects.len() {
+                break; // cycle guard
+            }
+            cursor = self.projects.get(&id).and_then(|p| p.parent.clone());
+            out.push(id);
+        }
+        out
+    }
+
+    /// Which project owns `task`, if any.
+    ///
+    /// Task ids are workspace-global, so this is the index the scheduler uses to
+    /// tell an intra-project edge from a cross-project one. It is *derived*, never
+    /// stored — the projects map is the single source of truth.
+    pub fn project_of_task(&self, task: &TaskId) -> Option<&ProjectId> {
+        self.projects
+            .iter()
+            .find(|(_, p)| p.tasks.contains_key(task))
+            .map(|(id, _)| id)
+    }
+}
+
+/// Workspace-wide settings. Deliberately thin: anything that can sensibly differ
+/// per project (calendars, duration units, currency) stays on [`ProjectSettings`],
+/// so a project remains self-describing and can be moved between workspaces.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct WorkspaceSettings {
+    /// Schedule every project as one network: honour cross-project dependencies and
+    /// roll sub-projects up into their parents.
+    ///
+    /// `false` (the default) schedules each project independently — the simple,
+    /// today's-behaviour case. Turning this on is exactly the "incrementally add
+    /// complexity" step for someone who starts with one board and grows into a
+    /// portfolio.
+    pub schedule_as_one_network: bool,
 }


### PR DESCRIPTION
**Phase 2, PR-1 of 5** from `code/specs/task-app-workspace.md`. Model layer only — adds the container and the nesting relationship with **no behaviour change**: all 50 pre-existing tests pass untouched and scheduling still runs per-project. The cross-project scheduler is PR-2.

## What's added
- **`Workspace`** `{ id, name, projects, roots, cross_project_dependencies, shared_resources, settings }` — the container of every project.
- **`ProjectState.parent: Option<ProjectId>`** — `None` = a top-level project (listed in `roots`).
- `WorkspaceId` newtype; `WorkspaceSettings { schedule_as_one_network }`.
- Helpers: `empty`, `from_project` (migration path), `children_of`, `ancestors_of`, `project_of_task`.

## Three decisions worth reviewing
1. **The projects map is flat; nesting is by id, not containment.** Matches how the rest of the model relates entities, lets PR-2's scheduler build one graph over every task without walking an ownership tree, and keeps snapshots simple. Security-relevant too: it makes `Workspace` a *non-recursive type*, so `serde_json`'s recursion depth is bounded by the type rather than by attacker-influenced IndexedDB data.
2. **Task ids are workspace-global.** This is what lets a cross-project dependency be an ordinary `DependencyLink` whose endpoints merely sit in different projects — no compound `(ProjectId, TaskId)` keys, no second link type, and existing cycle detection works across boundaries unchanged.
3. **Progressive disclosure holds.** `schedule_as_one_network` defaults to `false`, and a workspace with one un-nested project behaves exactly like a bare `ProjectState`. The capability costs the simple case nothing.

## Backward compatibility
`parent` uses `skip_serializing_if`, so root projects omit the field entirely and **pre-workspace snapshots still deserialize** (serde `default`) — the Phase-1 IndexedDB data keeps loading. `ancestors_of` is iterative and cycle-guarded, so a corrupt snapshot truncates rather than hanging the WASM module.

## Verification
7 new tests (**57 total pass**): forest construction/traversal, cycle-guard termination, global task ownership, single-project wrap equivalence, JSON round-trip with `parent` omitted on roots, old-snapshot compatibility. Clippy clean **with and without** `--all-features`; `task-wasm` still builds and lints. Security-reviewed clean (reviewer independently verified the cycle guard's termination bound and the non-recursive deserialization property).

🤖 Generated with [Claude Code](https://claude.com/claude-code)