### PR TITLE
feat(sql): ORDER BY <n> positional (ordinal) column references

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.40 — ORDER BY positional (ordinal) column references
+
+`ORDER BY <n>` now treats a bare integer as a 1-based reference to the n-th
+SELECT output column, matching SQLite: `SELECT a, b FROM u ORDER BY 2` sorts by
+`b`. Direction, collation, and multi-key tie-breaks carry through
+(`ORDER BY 2 DESC, 1`). The rule is narrow — only a lone integer literal is
+positional, so `ORDER BY 1+0` still sorts by the constant `1` (no reordering),
+and an out-of-range ordinal errors like SQLite's "ORDER BY term out of range".
+Four new differential-oracle cases pass; a fifth — positional over an *aggregate*
+output column — is a documented ledger entry (the sort can't re-evaluate an
+aggregate per row yet). `SELECT *` positional keys are left unchanged for now.
+Touches sql-planner 0.2.19.
+
 ## 0.5.39 — upper()/lower() are ASCII-only
 
 `upper()` and `lower()` now match SQLite: they case-fold only ASCII letters and

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.39"
+version = "0.5.40"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1363,6 +1363,57 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id, upper(s) AS u, lower(s) AS l FROM t ORDER BY id",
     },
+    // ----- ORDER BY positional (ordinal) column references -----
+    // A bare integer in ORDER BY is a 1-based reference to the n-th output
+    // column: `ORDER BY 2` sorts by the second SELECT column (`b`).
+    Case {
+        id: "order_by_ordinal_single",
+        setup: &[
+            "CREATE TABLE u (a INTEGER, b TEXT)",
+            "INSERT INTO u VALUES (3,'x'),(1,'z'),(2,'y')",
+        ],
+        query: "SELECT a, b FROM u ORDER BY 2",
+    },
+    // Multiple positional keys, mixed direction: primary `2 DESC`, tie-break `1`.
+    Case {
+        id: "order_by_ordinal_multi",
+        setup: &[
+            "CREATE TABLE u (a INTEGER, b TEXT)",
+            "INSERT INTO u VALUES (3,'x'),(1,'x'),(2,'y')",
+        ],
+        query: "SELECT a, b FROM u ORDER BY 2 DESC, 1",
+    },
+    // A positional key referencing an aliased output column sorts by that column.
+    Case {
+        id: "order_by_ordinal_alias",
+        setup: &[
+            "CREATE TABLE u (a INTEGER, b TEXT)",
+            "INSERT INTO u VALUES (3,'x'),(1,'z'),(2,'y')",
+        ],
+        query: "SELECT a AS k, b FROM u ORDER BY 1 DESC",
+    },
+    // Out-of-range ordinal: SQLite errors at prepare time ("ORDER BY term out of
+    // range"); mini-sqlite errors too, so the case agrees by both-fail.
+    Case {
+        id: "order_by_ordinal_out_of_range",
+        setup: &[
+            "CREATE TABLE u (a INTEGER)",
+            "INSERT INTO u VALUES (1),(2)",
+        ],
+        query: "SELECT a FROM u ORDER BY 5",
+    },
+    // Positional reference to an AGGREGATE output column. SQLite sorts by the
+    // computed aggregate (`SUM(v)`); mini-sqlite cannot re-evaluate an aggregate
+    // in the per-row sort path, so it leaves the rows in group order. Documented
+    // in LEDGER until the sort can bind to an already-materialized output column.
+    Case {
+        id: "order_by_ordinal_over_aggregate",
+        setup: &[
+            "CREATE TABLE g (k TEXT, v INTEGER)",
+            "INSERT INTO g VALUES ('a',1),('b',2),('a',3)",
+        ],
+        query: "SELECT k, sum(v) FROM g GROUP BY k ORDER BY 2",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but
@@ -1389,12 +1440,17 @@ const CASES: &[Case] = &[
 /// A newly discovered divergence is added back here with a reason rather than
 /// silently skipped, so the list stays an honest measure.
 const LEDGER: &[(&str, &str)] = &[
-    // Empty — every seed case now matches real SQLite. The ledger opened at ten
-    // reproduced gaps and has been driven to zero, one oracle-gated increment at
-    // a time: INNER/LEFT/RIGHT/FULL JOIN semantics, scalar-function results and
-    // names, and finally aggregate computed-column names (`agg_N` → `COUNT(*)`/
-    // `SUM(n)`). New divergences, when found, are added back here with a reason
-    // rather than silently skipped — shrinking this list remains the metric.
+    // Positional `ORDER BY <n>` that points at an AGGREGATE output column.
+    // Non-aggregate positional keys are fully supported (see the
+    // `order_by_ordinal_*` gated cases); the aggregate case remains open because
+    // the sort path re-evaluates its key per row, and an aggregate has no per-row
+    // value. Closing it means teaching the sort to bind a positional key to an
+    // already-materialized output column by index instead of substituting its
+    // expression. Until then this is a documented divergence, not a silent skip.
+    (
+        "order_by_ordinal_over_aggregate",
+        "positional ORDER BY over an aggregate output column not yet re-bound to the materialized column",
+    ),
 ];
 
 #[test]

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.19] - Unreleased
+
+### Added
+
+- **Positional `ORDER BY <n>` (ordinal column references).** A *bare integer
+  literal* in an ORDER BY term is now resolved to the n-th (1-based) column of
+  the SELECT output list, matching SQLite: `SELECT a, b FROM t ORDER BY 2` sorts
+  by `b`. Direction, `NULLS FIRST/LAST`, `COLLATE`, and multi-key tie-breaks all
+  carry through, because the ordinal is rewritten to the real output expression
+  and then flows through the ordinary sort machinery.
+  - The rule is deliberately narrow — only a lone integer literal is positional.
+    An *expression* that evaluates to an integer is **not**: `ORDER BY 1+0` sorts
+    by the constant `1` (no reordering), exactly as in SQLite.
+  - An out-of-range ordinal (`< 1` or `> column count`) is a planning error,
+    matching SQLite's prepare-time "ORDER BY term out of range" — diagnosed only
+    when the select list is fully explicit.
+  - `SELECT *` positional keys are left unchanged (the column count/identity is
+    not known at plan time); positional-over-star and positional-over-aggregate
+    remain follow-ups.
+
 ## [0.2.18] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.18"
+version = "0.2.19"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -769,6 +769,25 @@ fn plan_select(
     }
 
     // -----------------------------------------------------------------------
+    // Projected output columns — computed HERE (before ORDER BY) so a
+    // positional `ORDER BY <n>` can resolve the integer to the n-th output
+    // expression. The same list is reused for the outermost Project (step 9),
+    // so `plan_select_list` runs exactly once.
+    // -----------------------------------------------------------------------
+    let output_columns: Vec<OutputColumn> = if let Some(sl) = select_list {
+        plan_select_list(sl)?
+    } else {
+        // Fallback: treat as SELECT * (shouldn't happen with a valid grammar).
+        vec![OutputColumn {
+            expr: SqlExpr::Column {
+                table: None,
+                name: "*".to_string(),
+            },
+            alias: None,
+        }]
+    };
+
+    // -----------------------------------------------------------------------
     // Step 7: ORDER BY.
     // -----------------------------------------------------------------------
     if let Some(order_clause) = find_node(stmt, "order_clause") {
@@ -781,7 +800,7 @@ fn plan_select(
         } else {
             None
         };
-        let keys = plan_order_by(order_clause, schema, collate_ctx)?;
+        let keys = plan_order_by(order_clause, schema, collate_ctx, &output_columns)?;
         plan = LogicalPlan::Sort {
             input: Box::new(plan),
             keys,
@@ -807,23 +826,12 @@ fn plan_select(
     //
     // The SELECT list tells us which columns (or expressions) to include in the
     // output.  This wrapping happens AFTER sort/limit so those operations can
-    // still access columns that aren't in the final output.
-    let columns = if let Some(sl) = select_list {
-        plan_select_list(sl)?
-    } else {
-        // Fallback: treat as SELECT * (shouldn't happen with a valid grammar).
-        vec![OutputColumn {
-            expr: SqlExpr::Column {
-                table: None,
-                name: "*".to_string(),
-            },
-            alias: None,
-        }]
-    };
-
+    // still access columns that aren't in the final output.  The list was
+    // already computed above (before ORDER BY) so positional sort keys could
+    // resolve against it; reuse it here rather than re-planning.
     plan = LogicalPlan::Project {
         input: Box::new(plan),
-        columns,
+        columns: output_columns,
     };
 
     Ok(plan)
@@ -988,6 +996,7 @@ fn plan_order_by(
     order_clause: &GrammarASTNode,
     schema: &dyn SchemaProvider,
     collate_ctx: Option<(&str, Option<&str>)>,
+    output_columns: &[OutputColumn],
 ) -> Result<Vec<SortKey>, PlanError> {
     // Fetch the base table's declared collations exactly ONCE (not per sort
     // key). A bare `ORDER BY c0, c0, …` over a very wide table would otherwise
@@ -1009,8 +1018,128 @@ fn plan_order_by(
     });
     find_nodes(order_clause, "order_item")
         .iter()
-        .map(|item| plan_order_item(item, order_ctx.as_ref()))
+        .map(|item| plan_order_item(item, order_ctx.as_ref(), output_columns))
         .collect()
+}
+
+/// Resolve a **positional** `ORDER BY <n>` key: SQLite treats a *bare integer
+/// literal* in ORDER BY as a 1-based reference to the n-th column of the SELECT
+/// output list (`SELECT a, b FROM t ORDER BY 2` sorts by `b`).
+///
+/// The rule is deliberately narrow — only a lone integer literal is positional.
+/// An *expression* that happens to evaluate to an integer is NOT: `ORDER BY 1+0`
+/// sorts by the constant `1`, i.e. does not reorder at all. So we match strictly
+/// on `Literal(Int(_))` and nothing else.
+///
+/// | ORDER BY term | interpreted as              |
+/// |---------------|-----------------------------|
+/// | `1`           | the 1st output column       |
+/// | `2 DESC`      | the 2nd output column, desc |
+/// | `1+0`         | constant `1` (no reorder)   |
+/// | `name`        | column/alias `name`         |
+///
+/// Returns:
+/// - `Ok(Some(expr))` — the key was a positional reference; `expr` is the
+///   substituted n-th output expression.
+/// - `Ok(None)` — the key is not positional (leave it as written). Also the
+///   escape hatch for `SELECT *`, whose column count/identity isn't known at
+///   plan time; we leave such a key unchanged rather than guess.
+/// - `Err(..)` — a positional reference out of range, matching SQLite's
+///   "ORDER BY term out of range" (only diagnosed for a fully-explicit list).
+fn resolve_positional_key(
+    expr: &SqlExpr,
+    outputs: &[OutputColumn],
+) -> Result<Option<SqlExpr>, PlanError> {
+    // Only a bare integer literal is a positional reference.
+    let SqlExpr::Literal(SqlValue::Int(n)) = expr else {
+        return Ok(None);
+    };
+    let n = *n;
+
+    // If the output list contains an unexpanded `*` (or `t.*`), we can't count
+    // or identify columns at plan time. Leave the key unchanged — no regression
+    // versus prior behavior; positional-over-star is a documented follow-up.
+    let has_star = outputs.iter().any(|c| {
+        matches!(&c.expr, SqlExpr::Column { name, .. } if name == "*")
+    });
+    if has_star {
+        return Ok(None);
+    }
+
+    // Fully explicit list: range-check exactly like SQLite (1..=ncols). Compare
+    // in i64 (not `n as usize`) so a huge ordinal like 2^32 can't truncate to an
+    // in-range value on a 32-bit `usize` and then index out of bounds; on any
+    // platform, an out-of-range `n` is rejected here before it becomes an index.
+    if n < 1 || n > outputs.len() as i64 {
+        return Err(PlanError::UnsupportedStatement(format!(
+            "ORDER BY term out of range - should be between 1 and {}",
+            outputs.len()
+        )));
+    }
+
+    // Safe: `1 <= n <= outputs.len()`, so `n - 1` is a valid 0-based index that
+    // fits `usize` on every platform.
+    let target = &outputs[(n - 1) as usize].expr;
+
+    // If the target is (or contains) an aggregate, we cannot substitute its
+    // expression: aggregates are computed once per group, not re-evaluated per
+    // row in the sort path, so routing `SUM(v)` back through the sort would
+    // ignore it. Sorting by a positional aggregate is left unchanged here (a
+    // known-divergence ledger entry) rather than silently mis-sorting. The
+    // non-aggregate case — the overwhelming majority — resolves below.
+    if expr_contains_aggregate(target) {
+        return Ok(None);
+    }
+
+    // Substitute the n-th output expression. Routing the real expression through
+    // the ordinary sort path means positional keys inherit all the existing
+    // machinery (hidden sort-key columns, collation, NULL placement) for free.
+    Ok(Some(target.clone()))
+}
+
+/// Does this expression tree contain an aggregate function anywhere?
+///
+/// Used to keep positional `ORDER BY <n>` from substituting an aggregate output
+/// expression back into the (per-row) sort path, where it can't be recomputed.
+fn expr_contains_aggregate(expr: &SqlExpr) -> bool {
+    match expr {
+        SqlExpr::Aggregate { .. } => true,
+        SqlExpr::Literal(_) | SqlExpr::Column { .. } => false,
+        SqlExpr::BinaryOp { left, right, .. } => {
+            expr_contains_aggregate(left) || expr_contains_aggregate(right)
+        }
+        SqlExpr::UnaryOp { expr, .. }
+        | SqlExpr::IsNull(expr)
+        | SqlExpr::IsNotNull(expr)
+        | SqlExpr::Cast { expr, .. } => expr_contains_aggregate(expr),
+        SqlExpr::Between {
+            value, low, high, ..
+        } => {
+            expr_contains_aggregate(value)
+                || expr_contains_aggregate(low)
+                || expr_contains_aggregate(high)
+        }
+        SqlExpr::Like {
+            value,
+            pattern,
+            escape,
+            ..
+        } => {
+            expr_contains_aggregate(value)
+                || expr_contains_aggregate(pattern)
+                || escape.as_deref().is_some_and(expr_contains_aggregate)
+        }
+        SqlExpr::InList { value, list, .. } => {
+            expr_contains_aggregate(value) || list.iter().any(expr_contains_aggregate)
+        }
+        SqlExpr::FunctionCall { args, .. } => args.iter().any(expr_contains_aggregate),
+        SqlExpr::Case { branches, else_val } => {
+            branches
+                .iter()
+                .any(|(c, v)| expr_contains_aggregate(c) || expr_contains_aggregate(v))
+                || else_val.as_deref().is_some_and(expr_contains_aggregate)
+        }
+    }
 }
 
 /// Single base table (name + alias) plus its precomputed `column → COLLATE`
@@ -1053,6 +1182,7 @@ fn resolve_column_collation(expr: &SqlExpr, ctx: &OrderCollateCtx) -> Option<Str
 fn plan_order_item(
     item: &GrammarASTNode,
     collate_ctx: Option<&OrderCollateCtx>,
+    output_columns: &[OutputColumn],
 ) -> Result<SortKey, PlanError> {
     // The first child Node is the expression; check for ASC/DESC tokens.
     let expr_node = item
@@ -1067,7 +1197,17 @@ fn plan_order_item(
         })
         .ok_or_else(|| PlanError::UnsupportedStatement("empty order_item".to_string()))?;
 
-    let expr = plan_expression(expr_node)?;
+    let raw_expr = plan_expression(expr_node)?;
+
+    // A bare integer literal is a *positional* reference to the n-th output
+    // column (`ORDER BY 2` → sort by the 2nd SELECT column). Resolve it to the
+    // real output expression BEFORE collation inheritance below, so a positional
+    // key over a `COLLATE NOCASE` column still picks up that collation. Non-
+    // positional keys (and `SELECT *`) pass through unchanged.
+    let expr = match resolve_positional_key(&raw_expr, output_columns)? {
+        Some(resolved) => resolved,
+        None => raw_expr,
+    };
 
     // ASC is the default; DESC reverses.
     let ascending = !has_token(item, "DESC");
@@ -4128,5 +4268,94 @@ mod tests {
                 assert!(keys[0].ascending, "Default ORDER BY should be ASC");
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // ORDER BY positional (ordinal) column references
+    // -----------------------------------------------------------------------
+
+    /// Pull the sort keys out of a planned `SELECT … ORDER BY …`.
+    fn sort_keys_of(sql: &str) -> Vec<SortKey> {
+        match plan_ok(sql) {
+            LogicalPlan::Project { input, .. } => match *input {
+                LogicalPlan::Sort { keys, .. } => keys,
+                other => panic!("expected Sort under Project, got {other:?}"),
+            },
+            other => panic!("expected Project at root, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_order_by_ordinal_resolves_to_nth_column() {
+        // `ORDER BY 2` sorts by the 2nd output column (`b`), not the constant 2.
+        let keys = sort_keys_of("SELECT a, b, c FROM t ORDER BY 2");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(
+            keys[0].expr,
+            SqlExpr::Column {
+                table: None,
+                name: "b".to_string()
+            }
+        );
+        assert!(keys[0].ascending);
+    }
+
+    #[test]
+    fn test_order_by_ordinal_carries_direction() {
+        // Direction and multi-key tie-breaks apply to the resolved columns.
+        let keys = sort_keys_of("SELECT a, b, c FROM t ORDER BY 3 DESC, 1");
+        assert_eq!(keys.len(), 2);
+        assert_eq!(
+            keys[0].expr,
+            SqlExpr::Column {
+                table: None,
+                name: "c".to_string()
+            }
+        );
+        assert!(!keys[0].ascending);
+        assert_eq!(
+            keys[1].expr,
+            SqlExpr::Column {
+                table: None,
+                name: "a".to_string()
+            }
+        );
+        assert!(keys[1].ascending);
+    }
+
+    #[test]
+    fn test_order_by_integer_expression_is_not_positional() {
+        // Only a BARE integer literal is positional. `1+0` is an expression that
+        // happens to equal 1, so it sorts by the constant — it must stay a
+        // BinaryOp, NOT be rewritten to the first output column.
+        let keys = sort_keys_of("SELECT a, b FROM t ORDER BY 1+0");
+        assert_eq!(keys.len(), 1);
+        assert!(
+            matches!(keys[0].expr, SqlExpr::BinaryOp { op: BinaryOp::Add, .. }),
+            "1+0 must remain an expression, got {:?}",
+            keys[0].expr
+        );
+    }
+
+    #[test]
+    fn test_order_by_ordinal_out_of_range_errors() {
+        // `SELECT a` has one output column; `ORDER BY 2` (and `ORDER BY 0`) are
+        // out of range, matching SQLite's prepare-time error.
+        let err = plan_err("SELECT a FROM t ORDER BY 2");
+        assert!(
+            format!("{err}").contains("out of range"),
+            "expected out-of-range error, got {err}"
+        );
+        let err0 = plan_err("SELECT a FROM t ORDER BY 0");
+        assert!(format!("{err0}").contains("out of range"));
+    }
+
+    #[test]
+    fn test_order_by_ordinal_over_star_is_unchanged() {
+        // With `SELECT *` the output column count/identity isn't known at plan
+        // time, so a positional key is left as the literal (no guess, no error).
+        let keys = sort_keys_of("SELECT * FROM t ORDER BY 1");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].expr, SqlExpr::Literal(SqlValue::Int(1)));
     }
 }


### PR DESCRIPTION
## What

`ORDER BY <n>` now treats a **bare integer literal** as a 1-based reference to
the n-th column of the SELECT output list — SQLite's *positional* (ordinal)
column reference. Before this, mini-sqlite evaluated that integer as a constant,
so `SELECT a, b FROM u ORDER BY 2` sorted by the value `2` (a no-op) instead of
by column `b`.

## How

The planner computes the projected output columns once (reused for the outermost
`Project`, so `plan_select_list` still runs a single time) and threads them into
`plan_order_by`. A sort key that is a lone `Literal(Int(n))` is rewritten to the
n-th output expression, so it flows through the ordinary sort path and inherits
direction, `NULLS FIRST/LAST`, `COLLATE`, and multi-key tie-breaks for free.

The rule is deliberately narrow, matching SQLite exactly:

| ORDER BY term | interpreted as |
|---|---|
| `1` | the 1st output column |
| `2 DESC` | the 2nd output column, descending |
| `1+0` | the constant `1` (an **expression**, not positional — no reorder) |
| `name` | column/alias `name` |

An out-of-range ordinal (`< 1` or `> column count`) is a planning error mirroring
SQLite's prepare-time *"ORDER BY term out of range"*, diagnosed only for a
fully-explicit list. The range check compares in `i64` (not `n as usize`) so a
huge ordinal like `2^32` can't truncate to an in-range value and index out of
bounds on a 32-bit `usize` — a hardening applied from the inline security review.

## Scoped escape hatches (no regression; follow-ups filed)

- **`SELECT *`** — the column count/identity isn't known at plan time, so a
  positional key is left unchanged rather than guessed.
- **Positional key over an aggregate output column** — the sort path
  re-evaluates its key per row and an aggregate has no per-row value, so it's
  left unchanged and recorded as a differential-oracle **LEDGER** divergence.

## Tests

- **5 new sql-planner unit tests**: resolution to the n-th column, direction +
  multi-key, `1+0`-is-not-positional, out-of-range error, star-unchanged.
- **4 new gated differential-oracle cases** against real bundled SQLite: single,
  multi-key, alias, out-of-range (both-fail agreement).
- **1 new LEDGER case**: positional-over-aggregate (documented divergence).
- Full sql-planner (68), sql-codegen, sql-optimizer, sql-vm, and mini-sqlite
  suites pass. Inline adversarial security review found no exploitable
  panic/OOB on the 64-bit target; the one portability hardening it flagged is
  applied.

Bumps **sql-planner 0.2.18 → 0.2.19**, **mini-sqlite 0.5.38 → 0.5.39**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
