### PR TITLE
feat(sql): column-defined COLLATE in WHERE comparisons

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.41 — column-defined COLLATE in WHERE comparisons
+
+A column declared `COLLATE NOCASE` / `RTRIM` now folds in WHERE comparisons, not
+just ORDER BY: `SELECT id FROM t WHERE name = 'apple'` on a NOCASE `name` matches
+both `'Apple'` and `'apple'`, and RTRIM ignores trailing spaces (`'hi   ' =
+'hi'`). Comparison operators `=`, `<>`, `<`, `<=`, `>`, `>=` all honour the
+column's sequence, and it flows through `AND`/`OR`/`NOT`. An explicit `COLLATE
+BINARY` on the comparison overrides the column's NOCASE (byte-exact match), and a
+column without a declared collation stays BINARY. Seven new differential-oracle
+cases pass against real SQLite. `DISTINCT`, `GROUP BY`, and `IN` collation remain
+follow-ups. Touches sql-planner 0.2.20 (single base table only, matching the
+ORDER BY restriction).
+
 ## 0.5.40 — ORDER BY positional (ordinal) column references
 
 `ORDER BY <n>` now treats a bare integer as a 1-based reference to the n-th

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.40"
+version = "0.5.41"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1040,6 +1040,101 @@ const CASES: &[Case] = &[
         setup: &[],
         query: "CREATE TABLE t (x TEXT COLLATE BOGUS)",
     },
+    // ---- Lane 3: column-DEFINED COLLATE flows into WHERE comparisons ------
+    // A `COLLATE NOCASE` column makes a bare `WHERE name = 'apple'` fold case,
+    // matching every row that equals 'apple' case-insensitively. Before this the
+    // column collation was ignored in comparisons and only 'apple' matched.
+    Case {
+        id: "where_column_collate_nocase_eq",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'BANANA'),(4,'cherry')",
+        ],
+        query: "SELECT id FROM t WHERE name = 'apple' ORDER BY id",
+    },
+    // `<>` (not-equal) honours the column collation too: case-insensitive
+    // inequality excludes both 'Apple' and 'apple'.
+    Case {
+        id: "where_column_collate_nocase_ne",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'BANANA'),(4,'cherry')",
+        ],
+        query: "SELECT id FROM t WHERE name <> 'apple' ORDER BY id",
+    },
+    // Ordered comparison (`<`) folds case: 'Apple'/'apple' both sort below 'b'.
+    Case {
+        id: "where_column_collate_nocase_lt",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'ZED'),(4,'cherry')",
+        ],
+        query: "SELECT id FROM t WHERE name < 'b' ORDER BY id",
+    },
+    // Column-defined RTRIM: trailing spaces are ignored in the comparison, so
+    // 'hi   ' = 'hi'.
+    Case {
+        id: "where_column_collate_rtrim_eq",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT COLLATE RTRIM)",
+            "INSERT INTO t VALUES (1,'hi   '),(2,'hi'),(3,'ho')",
+        ],
+        query: "SELECT id FROM t WHERE s = 'hi' ORDER BY id",
+    },
+    // An explicit `COLLATE BINARY` on the comparison OVERRIDES the column's
+    // NOCASE, forcing byte order so only the exact-case 'apple' matches.
+    Case {
+        id: "where_column_collate_explicit_binary_override",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'cherry')",
+        ],
+        query: "SELECT id FROM t WHERE name = 'apple' COLLATE BINARY ORDER BY id",
+    },
+    // The column collation flows through the boolean structure (AND/OR) to each
+    // comparison: both `name = 'apple'` and `name = 'banana'` fold case.
+    Case {
+        id: "where_column_collate_nocase_or",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'BANANA'),(4,'cherry')",
+        ],
+        query: "SELECT id FROM t WHERE name = 'apple' OR name = 'banana' ORDER BY id",
+    },
+    // A column WITHOUT a declared collation keeps BINARY comparison — only the
+    // exact-case match qualifies. Guards against over-applying the fold.
+    Case {
+        id: "where_plain_column_stays_binary",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple')",
+        ],
+        query: "SELECT id FROM t WHERE name = 'apple' ORDER BY id",
+    },
+    // Left-operand precedence: when BOTH operands are columns, SQLite uses the
+    // LEFT column's collation. `bin = nocase` compares byte-exact (the left
+    // BINARY column wins — it must NOT defer to the right NOCASE column), while
+    // the mirror `nocase = bin` folds case. The two therefore disagree, exactly
+    // as in SQLite; getting this wrong (OR-ing past a BINARY left column) would
+    // make both fold.
+    Case {
+        id: "where_column_collation_left_precedence",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, cs TEXT, ci TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'foo','FOO'),(2,'bar','bar')",
+        ],
+        query: "SELECT id FROM t WHERE cs = ci ORDER BY id",
+    },
+    // The mirror image folds: a NOCASE left column drives the comparison, so
+    // 'FOO' = 'foo' matches.
+    Case {
+        id: "where_column_collation_left_precedence_mirror",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, cs TEXT, ci TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'foo','FOO'),(2,'bar','bar')",
+        ],
+        query: "SELECT id FROM t WHERE ci = cs ORDER BY id",
+    },
     // ---- Lane 1: simple (operand) CASE ----------------------------------
     // `CASE x WHEN v THEN r … ELSE d END` compares the operand to each value
     // for equality; a NULL operand matches nothing (x = NULL is never true)

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.20] - Unreleased
+
+### Added
+
+- **Column-defined `COLLATE` now flows into WHERE comparisons.** A column
+  declared `COLLATE NOCASE` / `RTRIM` previously only affected ORDER BY; bare
+  comparisons in a WHERE predicate compared with BINARY, diverging from SQLite.
+  A post-planning pass (`collate_comparisons`) over the WHERE predicate now
+  wraps both operands of a comparison (`=`, `<>`, `<`, `<=`, `>`, `>=`) in the
+  internal `__collate(_, coll)` when a column operand declares a collation —
+  reusing the exact mechanism an explicit `COLLATE` clause already uses — so the
+  byte comparison honours the column's sequence.
+  - SQLite's collation-resolution order is followed: an explicit `COLLATE` on
+    either operand wins; else the left operand's column collation; else the
+    right operand's; else BINARY. The pass recurses through `AND`/`OR`/`NOT`.
+  - An explicit `COLLATE BINARY` now correctly **overrides** a column's NOCASE:
+    `collate_name_after` reports BINARY (instead of collapsing it to "no
+    collation"), so it is lowered to the identity `__collate(_, 'BINARY')`,
+    which both forces byte order and marks the comparison as explicitly
+    collated so the column-collation pass leaves it alone.
+  - Applies to a single base table (no JOINs), matching the ORDER BY
+    restriction. `DISTINCT`, `GROUP BY`, and `IN` collation remain follow-ups.
+
 ## [0.2.19] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -690,7 +690,16 @@ fn plan_select(
     if let Some(where_clause) = find_node(stmt, "where_clause") {
         // Grammar: where_clause = WHERE expr
         // The WHERE clause wraps an expr node; we skip the WHERE keyword token.
-        let predicate = extract_clause_expr(where_clause)?;
+        let mut predicate = extract_clause_expr(where_clause)?;
+        // Column-defined COLLATE flows into WHERE comparisons only for a single
+        // base table (no JOINs), matching the ORDER BY restriction — with joins,
+        // column→table resolution is ambiguous and out of scope for this pass.
+        if find_nodes(stmt, "join_clause").is_empty() {
+            if let Some((table, alias)) = base_table_ref.as_ref() {
+                let ctx = build_collate_ctx(schema, table, alias.as_deref());
+                predicate = collate_comparisons(predicate, &ctx);
+            }
+        }
         plan = LogicalPlan::Filter {
             input: Box::new(plan),
             predicate,
@@ -1158,6 +1167,112 @@ struct OrderCollateCtx<'a> {
 /// column was declared with a non-default `COLLATE`. Anything else — a computed
 /// expression, an alias to an output column, a qualifier that doesn't match the
 /// base table — yields `None`, and the key keeps the default BINARY ordering.
+/// Build the single-base-table collation context: the table's name + optional
+/// alias plus its precomputed lowercased `column → COLLATE` map. Shared by the
+/// ORDER BY and WHERE-comparison collation passes so the schema is queried once.
+fn build_collate_ctx<'a>(
+    schema: &dyn SchemaProvider,
+    table: &'a str,
+    alias: Option<&'a str>,
+) -> OrderCollateCtx<'a> {
+    let collations = schema
+        .table_collations(table)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(name, coll)| (name.to_ascii_lowercase(), coll))
+        .collect();
+    OrderCollateCtx {
+        table,
+        alias,
+        collations,
+    }
+}
+
+/// Is `op` a binary comparison whose result depends on collation? These are the
+/// operators SQLite subjects to collating-sequence resolution; arithmetic /
+/// logical / bitwise operators are not.
+fn is_comparison_op(op: &BinaryOp) -> bool {
+    matches!(
+        op,
+        BinaryOp::Eq | BinaryOp::Neq | BinaryOp::Lt | BinaryOp::Lte | BinaryOp::Gt | BinaryOp::Gte
+    )
+}
+
+/// Does this expression already carry an explicit collation, i.e. is it an
+/// `__collate(_, _)` call produced by `wrap_collate`? Such an operand means a
+/// `COLLATE` clause was written on the comparison, which outranks any
+/// column-defined collation — so the column-collation pass must leave it alone.
+fn is_collate_call(expr: &SqlExpr) -> bool {
+    matches!(expr, SqlExpr::FunctionCall { name, .. } if name == "__collate")
+}
+
+/// Push column-defined `COLLATE` into the comparisons of a WHERE/HAVING
+/// predicate. SQLite resolves a binary comparison's collating sequence as:
+/// explicit `COLLATE` on either operand → the left operand's column collation →
+/// the right operand's → BINARY. The explicit case is already lowered onto
+/// `__collate` in `plan_comparison`; this pass handles the column cases.
+///
+/// It walks the boolean skeleton (`AND` / `OR` / `NOT`) down to each comparison
+/// and, when neither operand is already `__collate`-wrapped and a column operand
+/// declares a collation, wraps BOTH operands in `__collate(_, coll)` — turning
+/// the collated comparison into a plain byte comparison of canonicalised values,
+/// reusing the exact mechanism explicit `COLLATE` already uses. Non-comparison
+/// leaves pass through unchanged. Only invoked for a single base table (no
+/// JOINs), matching the ORDER BY collation restriction.
+fn collate_comparisons(expr: SqlExpr, ctx: &OrderCollateCtx) -> SqlExpr {
+    match expr {
+        SqlExpr::BinaryOp { op, left, right } if is_comparison_op(&op) => {
+            // An explicit COLLATE (already `__collate`-wrapped) outranks the
+            // column's declared collation — leave the comparison untouched.
+            if is_collate_call(&left) || is_collate_call(&right) {
+                return SqlExpr::BinaryOp { op, left, right };
+            }
+            // SQLite picks the comparison's collation from the LEFT operand if it
+            // is a column, otherwise the right operand if IT is a column, else
+            // BINARY. Crucially, a *column* determines the collation even when
+            // that collation is the default BINARY: `bin_col = nocase_col` uses
+            // BINARY (the left column), it does NOT fall through to the right
+            // column's NOCASE. So we resolve on the first operand that is a
+            // base-table column and stop there — never OR-ing past a BINARY
+            // column into the other operand. A resolved BINARY collation
+            // (`None`) means byte order, so we leave the comparison bare rather
+            // than wrapping it (which would also needlessly strip the column
+            // reference that drives type affinity).
+            let determining = if column_in_base_table(&left, ctx) {
+                resolve_column_collation(&left, ctx)
+            } else if column_in_base_table(&right, ctx) {
+                resolve_column_collation(&right, ctx)
+            } else {
+                None
+            };
+            match determining {
+                Some(name) => SqlExpr::BinaryOp {
+                    op,
+                    left: Box::new(wrap_collate(*left, &name)),
+                    right: Box::new(wrap_collate(*right, &name)),
+                },
+                None => SqlExpr::BinaryOp { op, left, right },
+            }
+        }
+        // Recurse through boolean connectives to reach nested comparisons.
+        SqlExpr::BinaryOp { op, left, right } if matches!(op, BinaryOp::And | BinaryOp::Or) => {
+            SqlExpr::BinaryOp {
+                op,
+                left: Box::new(collate_comparisons(*left, ctx)),
+                right: Box::new(collate_comparisons(*right, ctx)),
+            }
+        }
+        SqlExpr::UnaryOp {
+            op: UnaryOp::Not,
+            expr,
+        } => SqlExpr::UnaryOp {
+            op: UnaryOp::Not,
+            expr: Box::new(collate_comparisons(*expr, ctx)),
+        },
+        other => other,
+    }
+}
+
 fn resolve_column_collation(expr: &SqlExpr, ctx: &OrderCollateCtx) -> Option<String> {
     let SqlExpr::Column { table, name } = expr else {
         return None;
@@ -1172,6 +1287,26 @@ fn resolve_column_collation(expr: &SqlExpr, ctx: &OrderCollateCtx) -> Option<Str
         }
     }
     ctx.collations.get(&name.to_ascii_lowercase()).cloned()
+}
+
+/// Is `expr` a reference to a column of the single base table (optionally
+/// qualified by the table's name or alias)? Distinct from
+/// [`resolve_column_collation`], which returns `None` for a column whose
+/// collation is the default BINARY — here even a BINARY column is `true`,
+/// because *being a column* is what makes an operand determine a comparison's
+/// collating sequence (a left BINARY column forces byte order rather than
+/// deferring to the other operand).
+fn column_in_base_table(expr: &SqlExpr, ctx: &OrderCollateCtx) -> bool {
+    let SqlExpr::Column { table, .. } = expr else {
+        return false;
+    };
+    match table {
+        None => true,
+        Some(qual) => {
+            qual.eq_ignore_ascii_case(ctx.table)
+                || ctx.alias.is_some_and(|a| qual.eq_ignore_ascii_case(a))
+        }
+    }
 }
 
 /// Plan a single `order_item` node.
@@ -2416,7 +2551,9 @@ fn plan_comparison(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         // therefore lower the collation onto the internal `__collate` builtin
         // wrapping BOTH operands, reusing the VM's existing collation helper —
         // no new comparison opcode, mirroring the `GLOB → glob()` lowering.
-        // `COLLATE BINARY` is the default, so it is a no-op.
+        // `COLLATE BINARY` wraps too — an identity transform in the VM, but it
+        // marks the comparison as explicitly collated so a column-defined
+        // collation can't later override it.
         let (left, right) = match collate_name_after(&direct_tok_uppers)? {
             Some(name) => (wrap_collate(left, &name), wrap_collate(right, &name)),
             None => (left, right),
@@ -2434,9 +2571,11 @@ fn plan_comparison(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
 }
 
 /// Find the collation name in a comparison's direct tokens, if it carries a
-/// `COLLATE name` clause. Returns `None` when absent or `COLLATE BINARY` (the
-/// default, a no-op); `Some(NAME)` for `NOCASE`/`RTRIM`; and an error for an
-/// unknown collation, matching SQLite's "no such collating sequence".
+/// `COLLATE name` clause. Returns `None` only when no `COLLATE` clause is
+/// present; `Some(NAME)` for `NOCASE`/`RTRIM`/`BINARY` (BINARY is the identity
+/// transform but is still reported so an explicit clause overrides an operand's
+/// column-defined collation); and an error for an unknown collation, matching
+/// SQLite's "no such collating sequence".
 fn collate_name_after(direct_tok_uppers: &[String]) -> Result<Option<String>, PlanError> {
     let Some(pos) = direct_tok_uppers.iter().position(|t| t == "COLLATE") else {
         return Ok(None);
@@ -2445,7 +2584,15 @@ fn collate_name_after(direct_tok_uppers: &[String]) -> Result<Option<String>, Pl
         PlanError::UnsupportedStatement("COLLATE clause missing collation name".to_string())
     })?;
     match name.as_str() {
-        "BINARY" => Ok(None),
+        // `COLLATE BINARY` is the default byte order, so at first glance it needs
+        // no wrapping. But it must still be *recorded* as an explicit collation:
+        // it forces byte order even when an operand's column is declared NOCASE,
+        // and the column-collation pass below keys off "is either operand already
+        // `__collate`-wrapped?" to decide whether an explicit collation is
+        // present. Wrapping in the identity `__collate(_, 'BINARY')` (the VM
+        // treats an unknown/BINARY collation as a no-op transform) both preserves
+        // byte semantics and marks the comparison as explicitly collated.
+        "BINARY" => Ok(Some(name.clone())),
         "NOCASE" | "RTRIM" => Ok(Some(name.clone())),
         other => Err(PlanError::UnsupportedStatement(format!(
             "no such collating sequence: {other}"
@@ -3686,6 +3833,122 @@ mod tests {
         // `id` has no declared collation, so its sort key stays BINARY (None).
         let plan = plan_sql("SELECT id FROM tc ORDER BY id", &CollSchema).unwrap();
         assert_eq!(sort_keys(&plan)[0].collation, None);
+    }
+
+    /// Pull the WHERE `Filter` predicate out of a plan built against a given
+    /// schema (Filter sits under the outermost Project).
+    fn filter_predicate(plan: &LogicalPlan) -> SqlExpr {
+        fn walk(p: &LogicalPlan) -> Option<SqlExpr> {
+            match p {
+                LogicalPlan::Filter { predicate, .. } => Some(predicate.clone()),
+                LogicalPlan::Project { input, .. }
+                | LogicalPlan::Sort { input, .. }
+                | LogicalPlan::Distinct(input)
+                | LogicalPlan::Limit { input, .. } => walk(input),
+                _ => None,
+            }
+        }
+        walk(plan).expect("expected a Filter in the plan")
+    }
+
+    /// If `expr` is a `__collate(inner, 'NAME')` call, return `NAME`.
+    fn collate_wrapper(expr: &SqlExpr) -> Option<String> {
+        if let SqlExpr::FunctionCall { name, args, .. } = expr {
+            if name == "__collate" {
+                if let Some(SqlExpr::Literal(SqlValue::Text(coll))) = args.get(1) {
+                    return Some(coll.clone());
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_where_comparison_inherits_column_collation() {
+        // A bare `WHERE name = 'x'` on a NOCASE column wraps BOTH operands in
+        // `__collate(_, 'NOCASE')`, so the byte comparison folds case.
+        let plan = plan_sql("SELECT id FROM tc WHERE name = 'apple'", &CollSchema).unwrap();
+        let SqlExpr::BinaryOp { op, left, right } = filter_predicate(&plan) else {
+            panic!("expected a comparison predicate");
+        };
+        assert_eq!(op, BinaryOp::Eq);
+        assert_eq!(collate_wrapper(&left).as_deref(), Some("NOCASE"));
+        assert_eq!(collate_wrapper(&right).as_deref(), Some("NOCASE"));
+    }
+
+    #[test]
+    fn test_where_explicit_collate_binary_overrides_column() {
+        // An explicit `COLLATE BINARY` outranks the column's NOCASE: the operands
+        // are wrapped in the identity `__collate(_, 'BINARY')`, NOT NOCASE, so the
+        // comparison is byte-exact.
+        let plan =
+            plan_sql("SELECT id FROM tc WHERE name = 'apple' COLLATE BINARY", &CollSchema).unwrap();
+        let SqlExpr::BinaryOp { left, right, .. } = filter_predicate(&plan) else {
+            panic!("expected a comparison predicate");
+        };
+        assert_eq!(collate_wrapper(&left).as_deref(), Some("BINARY"));
+        assert_eq!(collate_wrapper(&right).as_deref(), Some("BINARY"));
+    }
+
+    #[test]
+    fn test_where_binary_left_column_does_not_inherit_right_collation() {
+        // `id = name`: the LEFT operand `id` is a column with the default BINARY
+        // collation, so it determines the comparison — the pass must NOT fall
+        // through to the right NOCASE column `name`. Result: no `__collate` wrap.
+        let plan = plan_sql("SELECT id FROM tc WHERE id = name", &CollSchema).unwrap();
+        let SqlExpr::BinaryOp { left, right, .. } = filter_predicate(&plan) else {
+            panic!("expected a comparison predicate");
+        };
+        assert_eq!(collate_wrapper(&left), None, "BINARY left column stays bare");
+        assert_eq!(collate_wrapper(&right), None);
+
+        // The mirror `name = id` is driven by the NOCASE left column, so BOTH
+        // operands are wrapped in NOCASE.
+        let plan = plan_sql("SELECT id FROM tc WHERE name = id", &CollSchema).unwrap();
+        let SqlExpr::BinaryOp { left, right, .. } = filter_predicate(&plan) else {
+            panic!("expected a comparison predicate");
+        };
+        assert_eq!(collate_wrapper(&left).as_deref(), Some("NOCASE"));
+        assert_eq!(collate_wrapper(&right).as_deref(), Some("NOCASE"));
+    }
+
+    #[test]
+    fn test_where_plain_column_comparison_stays_binary() {
+        // `id` has no declared collation, so its comparison is left bare — no
+        // `__collate` wrapping, plain byte comparison.
+        let plan = plan_sql("SELECT id FROM tc WHERE id = 5", &CollSchema).unwrap();
+        let SqlExpr::BinaryOp { left, right, .. } = filter_predicate(&plan) else {
+            panic!("expected a comparison predicate");
+        };
+        assert_eq!(collate_wrapper(&left), None);
+        assert_eq!(collate_wrapper(&right), None);
+    }
+
+    #[test]
+    fn test_where_column_collation_flows_through_and_or() {
+        // The pass recurses through boolean connectives: each comparison under an
+        // `OR` independently picks up the column's NOCASE collation.
+        let plan = plan_sql(
+            "SELECT id FROM tc WHERE name = 'a' OR name = 'b'",
+            &CollSchema,
+        )
+        .unwrap();
+        let SqlExpr::BinaryOp { op, left, right } = filter_predicate(&plan) else {
+            panic!("expected a boolean predicate");
+        };
+        assert_eq!(op, BinaryOp::Or);
+        for side in [&left, &right] {
+            let SqlExpr::BinaryOp {
+                left: l,
+                right: r,
+                ..
+            } = side.as_ref()
+            else {
+                panic!("expected a comparison on each side of OR");
+            };
+            assert_eq!(collate_wrapper(l).as_deref(), Some("NOCASE"));
+            assert_eq!(collate_wrapper(r).as_deref(), Some("NOCASE"));
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## What

A column declared `COLLATE NOCASE` / `RTRIM` now folds in **WHERE comparisons**,
not just ORDER BY. Before this, `SELECT id FROM t WHERE name = 'apple'` on a
NOCASE `name` matched only `'apple'` (BINARY), diverging from SQLite which also
matches `'Apple'`.

## How

A planner post-pass (`collate_comparisons`) walks the WHERE predicate's
`AND`/`OR`/`NOT` skeleton down to each comparison (`=`, `<>`, `<`, `<=`, `>`,
`>=`) and, when a column operand declares a collation, wraps both operands in the
internal `__collate(_, coll)` builtin — the exact mechanism an explicit `COLLATE`
clause already uses. Single base table only (no JOINs), matching the ORDER BY
restriction.

SQLite's collation-resolution order is followed precisely:

| comparison | collation used |
|---|---|
| explicit `COLLATE` on either operand | that (wins) |
| left operand is a column | **that column's** collation (incl. BINARY) |
| else right operand is a column | that column's collation |
| else | BINARY |

The **left-column-including-BINARY** rule is the subtle one: `bin_col = nocase_col`
must compare byte-exact (left BINARY column wins — it does *not* defer to the
right NOCASE), while the mirror `nocase_col = bin_col` folds. A new
`column_in_base_table` helper distinguishes "is a column" (determines collation)
from "has a non-BINARY collation", so precedence is right in both directions.

Explicit `COLLATE BINARY` now correctly **overrides** a column's NOCASE:
`collate_name_after` reports BINARY as `Some("BINARY")`, lowering to the identity
`__collate(_, 'BINARY')` — byte-exact, and marking the comparison as explicitly
collated so the column pass skips it. Plain (no-collation) columns stay bare.

## Tests

- **5 new sql-planner unit tests**: wrap on NOCASE column, explicit-BINARY
  override, plain-column-stays-bare, AND/OR recursion, and left-operand
  precedence in both directions.
- **9 new differential-oracle cases** vs real bundled SQLite: `=`, `<>`, `<`,
  RTRIM, explicit-BINARY override, `OR`, plain-column-binary, and the
  bin-vs-nocase left-precedence pair.
- Full sql-planner (68), sql-vm (101), sql-codegen, sql-optimizer, and
  mini-sqlite suites pass.

Inline adversarial security review caught one real bug — a left BINARY column
wrongly inheriting the right operand's collation — which is **fixed and
regression-tested**; its other flags (recursion depth, type-affinity,
comma-joins) are non-issues here (comma-joins don't even parse in mini-sqlite;
affinity isn't modeled, and the pass leaves plain columns bare).

`DISTINCT`, `GROUP BY`, and `IN` collation remain follow-ups.

Bumps **sql-planner 0.2.18 → 0.2.19**, **mini-sqlite 0.5.38 → 0.5.39** (same
bumps as #8445 — expect a routine version-only rebase whichever merges second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
