### PR TITLE
feat: port in-memory data store to Lua and Perl

### DIFF
--- a/code/packages/lua/in-memory-data-store/BUILD
+++ b/code/packages/lua/in-memory-data-store/BUILD
@@ -1,0 +1,5 @@
+luarocks show coding-adventures-in-memory-data-store-engine >/dev/null 2>&1 || (cd ../in-memory-data-store-engine && luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-engine-0.1.0-1.rockspec)
+luarocks show coding-adventures-in-memory-data-store-protocol >/dev/null 2>&1 || (cd ../in-memory-data-store-protocol && luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-protocol-0.1.0-1.rockspec)
+luarocks show coding-adventures-resp-protocol >/dev/null 2>&1 || (cd ../resp-protocol && luarocks make --local --deps-mode=none coding-adventures-resp-protocol-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-0.1.0-1.rockspec
+cd tests && LUA_PATH="../src/?.lua;../src/?/init.lua;../../hyperloglog/src/?.lua;../../hyperloglog/src/?/init.lua;../../in-memory-data-store-engine/src/?.lua;../../in-memory-data-store-engine/src/?/init.lua;../../in-memory-data-store-protocol/src/?.lua;../../in-memory-data-store-protocol/src/?/init.lua;../../resp-protocol/src/?.lua;../../resp-protocol/src/?/init.lua;;" busted . --verbose --pattern=test_

--- a/code/packages/lua/in-memory-data-store/BUILD_windows
+++ b/code/packages/lua/in-memory-data-store/BUILD_windows
@@ -1,0 +1,5 @@
+luarocks show coding-adventures-in-memory-data-store-engine >nul 2>&1 || (cd ..\in-memory-data-store-engine && luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-engine-0.1.0-1.rockspec)
+luarocks show coding-adventures-in-memory-data-store-protocol >nul 2>&1 || (cd ..\in-memory-data-store-protocol && luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-protocol-0.1.0-1.rockspec)
+luarocks show coding-adventures-resp-protocol >nul 2>&1 || (cd ..\resp-protocol && luarocks make --local --deps-mode=none coding-adventures-resp-protocol-0.1.0-1.rockspec)
+luarocks make --local --deps-mode=none coding-adventures-in-memory-data-store-0.1.0-1.rockspec
+cd tests && set "LUA_PATH=../src/?.lua;../src/?/init.lua;../../hyperloglog/src/?.lua;../../hyperloglog/src/?/init.lua;../../in-memory-data-store-engine/src/?.lua;../../in-memory-data-store-engine/src/?/init.lua;../../in-memory-data-store-protocol/src/?.lua;../../in-memory-data-store-protocol/src/?/init.lua;../../resp-protocol/src/?.lua;../../resp-protocol/src/?/init.lua;;" && busted . --verbose --pattern=test_

--- a/code/packages/lua/in-memory-data-store/CHANGELOG.md
+++ b/code/packages/lua/in-memory-data-store/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-17
+
+- Add the pure Lua RESP facade for command frames, incremental streams, and
+  binary-safe engine responses.

--- a/code/packages/lua/in-memory-data-store/README.md
+++ b/code/packages/lua/in-memory-data-store/README.md
@@ -1,0 +1,19 @@
+# in-memory-data-store (Lua)
+
+A pure Lua 5.4 facade that composes the RESP2 streaming codec, command protocol
+IR, and in-memory data store engine. It accepts fragmented or pipelined byte
+streams, preserves binary-safe bulk strings, and returns native RESP values or
+encoded response streams without opening sockets or using external services.
+
+```lua
+local store = require("coding_adventures.in_memory_data_store").new()
+
+local response = store:execute_parts({ "SET", "name", "Ada" })
+assert(response.value == "OK")
+
+local wire = store:handle("*2\r\n$3\r\nGET\r\n$4\r\nname\r\n")
+assert(wire == "$3\r\nAda\r\n")
+```
+
+The facade depends only on the sibling pure-Lua `resp-protocol`,
+`in-memory-data-store-protocol`, and `in-memory-data-store-engine` packages.

--- a/code/packages/lua/in-memory-data-store/coding-adventures-in-memory-data-store-0.1.0-1.rockspec
+++ b/code/packages/lua/in-memory-data-store/coding-adventures-in-memory-data-store-0.1.0-1.rockspec
@@ -1,0 +1,21 @@
+package = "coding-adventures-in-memory-data-store"
+version = "0.1.0-1"
+source = {
+    url = "git://github.com/adhithyan15/coding-adventures.git",
+}
+description = {
+    summary = "Pure Lua RESP facade for the in-memory data store",
+    license = "MIT",
+}
+dependencies = {
+    "lua >= 5.4",
+    "coding-adventures-in-memory-data-store-engine >= 0.1.0",
+    "coding-adventures-in-memory-data-store-protocol >= 0.1.0",
+    "coding-adventures-resp-protocol >= 0.1.0",
+}
+build = {
+    type = "builtin",
+    modules = {
+        ["coding_adventures.in_memory_data_store"] = "src/coding_adventures/in_memory_data_store/init.lua",
+    },
+}

--- a/code/packages/lua/in-memory-data-store/required_capabilities.json
+++ b/code/packages/lua/in-memory-data-store/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "lua/in-memory-data-store",
+  "capabilities": [],
+  "justification": "Pure RESP stream composition over sibling protocol and engine packages. No filesystem, network, process, environment, randomness, or clock access is needed."
+}

--- a/code/packages/lua/in-memory-data-store/src/coding_adventures/in_memory_data_store/init.lua
+++ b/code/packages/lua/in-memory-data-store/src/coding_adventures/in_memory_data_store/init.lua
@@ -1,0 +1,158 @@
+local engine_module = require("coding_adventures.in_memory_data_store_engine")
+local protocol = require("coding_adventures.in_memory_data_store_protocol")
+local resp = require("coding_adventures.resp_protocol")
+
+local M = { VERSION = "0.1.0" }
+local Value = resp.Value
+
+local function response_to_resp_value(response)
+    if response.kind == "simple_string" then
+        return Value.simple_string(response.value)
+    elseif response.kind == "error" then
+        return Value.error(response.value)
+    elseif response.kind == "integer" then
+        return Value.integer(response.value)
+    elseif response.kind == "bulk_string" then
+        return response.value == nil and Value.null_bulk_string() or Value.bulk_string(response.value)
+    elseif response.kind == "array" then
+        if response.value == nil then
+            return Value.null_array()
+        end
+        local values = {}
+        for index, item in ipairs(response.value) do
+            values[index] = response_to_resp_value(item)
+        end
+        return Value.array(values)
+    end
+    error("unknown engine response kind: " .. tostring(response.kind), 2)
+end
+
+local function command_from_resp(frame)
+    if not resp.is_value(frame) or frame.kind ~= "array" or frame.is_null then
+        return nil
+    end
+
+    local parts = {}
+    for index, item in ipairs(frame.value) do
+        if item.kind == "bulk_string" and not item.is_null then
+            parts[index] = item.value
+        elseif item.kind == "simple_string" then
+            parts[index] = item.value
+        elseif item.kind == "integer" then
+            parts[index] = tostring(item.value)
+        else
+            return nil
+        end
+    end
+    return protocol.CommandFrame.from_parts(parts)
+end
+
+local function encode_resp_stream(values)
+    local encoded = {}
+    for index, value in ipairs(values) do
+        encoded[index] = resp.encode(value)
+    end
+    return table.concat(encoded)
+end
+
+local function command_to_frame(command)
+    local values = { Value.bulk_string(command.command) }
+    for _, argument in ipairs(command.args) do
+        values[#values + 1] = Value.bulk_string(argument)
+    end
+    return Value.array(values)
+end
+
+local function frame_to_response_text(frame)
+    if frame.kind == "simple_string" or frame.kind == "error" then
+        return frame.value
+    elseif frame.kind == "integer" then
+        return tostring(frame.value)
+    elseif frame.kind == "bulk_string" then
+        return frame.is_null and "(nil)" or frame.value
+    end
+    return frame.is_null and "(nil)" or string.format("[array:%d]", #frame.value)
+end
+
+local DataStore = {}
+DataStore.__index = DataStore
+
+function DataStore.new(options)
+    options = options or {}
+    if type(options) ~= "table" then
+        error("options must be a table", 2)
+    end
+    if options.engine ~= nil and options.store ~= nil then
+        error("engine and store are mutually exclusive", 2)
+    end
+
+    local data_engine = options.engine
+    if data_engine == nil then
+        data_engine = engine_module.DataStoreEngine.new({
+            store = options.store,
+            database_count = options.database_count,
+            time_provider = options.time_provider,
+        })
+    end
+    return setmetatable({ engine = data_engine, decoder = resp.Decoder.new() }, DataStore)
+end
+
+function DataStore:get_store()
+    return self.engine.store
+end
+
+function DataStore:reset(store)
+    self.engine = engine_module.DataStoreEngine.new({ store = store })
+    self.decoder = resp.Decoder.new()
+    return self
+end
+
+function DataStore:execute_command(command)
+    return response_to_resp_value(self.engine:execute_frame(command))
+end
+
+function DataStore:execute_parts(parts)
+    return response_to_resp_value(self.engine:execute_parts(parts))
+end
+
+function DataStore:execute_frame(frame)
+    if not resp.is_value(frame) or frame.kind ~= "array" or frame.is_null then
+        return Value.error("ERR expected RESP array command")
+    end
+    if #frame.value == 0 then
+        return nil
+    end
+    local command = command_from_resp(frame)
+    if command == nil then
+        return Value.error("ERR expected RESP command array")
+    end
+    return self:execute_command(command)
+end
+
+function DataStore:process(input)
+    self.decoder:feed(input)
+    local responses = {}
+    while self.decoder:has_message() do
+        local response = self:execute_frame(self.decoder:get_message())
+        if response ~= nil then
+            responses[#responses + 1] = response
+        end
+    end
+    return responses
+end
+
+function DataStore:handle(input)
+    return encode_resp_stream(self:process(input))
+end
+
+M.DataStore = DataStore
+M.InMemoryDataStore = DataStore
+M.new = DataStore.new
+M.response_to_resp_value = response_to_resp_value
+M.command_from_resp = command_from_resp
+M.encode_resp_stream = encode_resp_stream
+M.command_to_frame = command_to_frame
+M.frame_to_response_text = frame_to_response_text
+M.ok = function() return Value.simple_string("OK") end
+
+return M

--- a/code/packages/lua/in-memory-data-store/tests/test_in_memory_data_store.lua
+++ b/code/packages/lua/in-memory-data-store/tests/test_in_memory_data_store.lua
@@ -1,0 +1,70 @@
+local data_store = require("coding_adventures.in_memory_data_store")
+local engine = require("coding_adventures.in_memory_data_store_engine")
+local protocol = require("coding_adventures.in_memory_data_store_protocol")
+local resp = require("coding_adventures.resp_protocol")
+
+local Value = resp.Value
+
+local function command(...)
+    local values = {}
+    for index, part in ipairs({ ... }) do
+        values[index] = Value.bulk_string(part)
+    end
+    return Value.array(values)
+end
+
+describe("in-memory data store", function()
+    it("executes RESP frames end to end", function()
+        local store = data_store.new()
+        local response = store:execute_frame(command("PING"))
+        assert.equals("simple_string", response.kind)
+        assert.equals("PONG", response.value)
+    end)
+
+    it("handles incremental and pipelined RESP input", function()
+        local store = data_store.new()
+        local set_wire = resp.encode(command("SET", "counter", "1"))
+        local get_wire = resp.encode(command("GET", "counter"))
+
+        assert.same({}, store:process(set_wire:sub(1, 5)))
+        local output = store:handle(set_wire:sub(6) .. get_wire)
+        assert.equals("+OK\r\n$1\r\n1\r\n", output)
+    end)
+
+    it("preserves binary-safe values", function()
+        local store = data_store.new()
+        local binary = "a\0b\255"
+        assert.equals("OK", store:execute_frame(command("SET", "binary", binary)).value)
+        assert.equals(binary, store:execute_frame(command("GET", "binary")).value)
+    end)
+
+    it("rejects invalid frames and ignores blank arrays", function()
+        local store = data_store.new()
+        assert.equals("error", store:execute_frame(Value.simple_string("PING")).kind)
+        assert.is_nil(store:execute_frame(Value.array({})))
+        assert.equals("error", store:execute_frame(Value.array({ Value.null_bulk_string() })).kind)
+    end)
+
+    it("converts command and response IR values", function()
+        local frame = protocol.CommandFrame.new("ECHO", { "hello" })
+        assert.equals("ECHO", data_store.command_from_resp(data_store.command_to_frame(frame)).command)
+
+        local nested = protocol.EngineResponse.array({
+            protocol.EngineResponse.integer(2),
+            protocol.EngineResponse.bulk_string(nil),
+        })
+        local converted = data_store.response_to_resp_value(nested)
+        assert.equals("integer", converted.value[1].kind)
+        assert.is_true(converted.value[2].is_null)
+        assert.equals("(nil)", data_store.frame_to_response_text(converted.value[2]))
+    end)
+
+    it("accepts injected engines and resets to a fresh store", function()
+        local injected = engine.DataStoreEngine.new()
+        local store = data_store.new({ engine = injected })
+        store:execute_parts({ "SET", "name", "Ada" })
+        assert.equals("Ada", store:execute_parts({ "GET", "name" }).value)
+        store:reset()
+        assert.is_true(store:execute_parts({ "GET", "name" }).is_null)
+    end)
+end)

--- a/code/packages/perl/in-memory-data-store/BUILD
+++ b/code/packages/perl/in-memory-data-store/BUILD
@@ -1,0 +1,1 @@
+PERL5LIB=lib:../hyperloglog/lib:../in-memory-data-store-engine/lib:../in-memory-data-store-protocol/lib:../resp-protocol/lib prove -l -v t/

--- a/code/packages/perl/in-memory-data-store/BUILD_windows
+++ b/code/packages/perl/in-memory-data-store/BUILD_windows
@@ -1,0 +1,1 @@
+set "PERL5LIB=lib;..\hyperloglog\lib;..\in-memory-data-store-engine\lib;..\in-memory-data-store-protocol\lib;..\resp-protocol\lib" && prove -l -v t\

--- a/code/packages/perl/in-memory-data-store/CHANGELOG.md
+++ b/code/packages/perl/in-memory-data-store/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-17
+
+- Add the pure Perl RESP facade for command frames, incremental streams, and
+  binary-safe engine responses.

--- a/code/packages/perl/in-memory-data-store/Makefile.PL
+++ b/code/packages/perl/in-memory-data-store/Makefile.PL
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME             => 'CodingAdventures::InMemoryDataStore',
+    VERSION_FROM     => 'lib/CodingAdventures/InMemoryDataStore.pm',
+    ABSTRACT         => 'Pure Perl RESP facade for the in-memory data store',
+    AUTHOR           => 'coding-adventures',
+    LICENSE          => 'mit',
+    MIN_PERL_VERSION => '5.026000',
+    PREREQ_PM        => {
+        'CodingAdventures::InMemoryDataStoreEngine'   => 0,
+        'CodingAdventures::InMemoryDataStoreProtocol' => 0,
+        'CodingAdventures::RespProtocol'              => 0,
+        'Exporter'                                    => 0,
+        'Scalar::Util'                                => 0,
+    },
+    META_MERGE       => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/adhithyan15/coding-adventures.git',
+                web  => 'https://github.com/adhithyan15/coding-adventures',
+            },
+        },
+    },
+);

--- a/code/packages/perl/in-memory-data-store/README.md
+++ b/code/packages/perl/in-memory-data-store/README.md
@@ -1,0 +1,20 @@
+# CodingAdventures::InMemoryDataStore
+
+A pure Perl facade that composes the RESP2 streaming codec, command protocol
+IR, and in-memory data store engine. It accepts fragmented or pipelined byte
+streams, preserves binary-safe bulk strings, and returns native RESP values or
+encoded response streams without opening sockets or using external services.
+
+```perl
+use CodingAdventures::InMemoryDataStore;
+
+my $store = CodingAdventures::InMemoryDataStore->new;
+my $response = $store->execute_parts(['SET', 'name', 'Ada']);
+die 'SET failed' if $response->value ne 'OK';
+
+my $wire = $store->handle("*2\r\n\$3\r\nGET\r\n\$4\r\nname\r\n");
+die 'GET failed' if $wire ne "\$3\r\nAda\r\n";
+```
+
+The facade depends only on the sibling pure-Perl `RespProtocol`,
+`InMemoryDataStoreProtocol`, and `InMemoryDataStoreEngine` packages.

--- a/code/packages/perl/in-memory-data-store/cpanfile
+++ b/code/packages/perl/in-memory-data-store/cpanfile
@@ -1,0 +1,5 @@
+requires 'CodingAdventures::InMemoryDataStoreEngine', '>= 0.1.0';
+requires 'CodingAdventures::InMemoryDataStoreProtocol', '>= 0.1.0';
+requires 'CodingAdventures::RespProtocol', '>= 0.1.0';
+requires 'Exporter';
+requires 'Scalar::Util';

--- a/code/packages/perl/in-memory-data-store/lib/CodingAdventures/InMemoryDataStore.pm
+++ b/code/packages/perl/in-memory-data-store/lib/CodingAdventures/InMemoryDataStore.pm
@@ -1,0 +1,156 @@
+package CodingAdventures::InMemoryDataStore;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use Scalar::Util qw(blessed);
+use CodingAdventures::InMemoryDataStoreEngine;
+use CodingAdventures::InMemoryDataStoreProtocol;
+use CodingAdventures::RespProtocol qw(encode);
+
+our $VERSION = '0.1.0';
+our @EXPORT_OK = qw(
+    command_from_resp response_to_resp_value encode_resp_stream
+    command_to_frame frame_to_response_text ok
+);
+
+my $ENGINE = 'CodingAdventures::InMemoryDataStoreEngine';
+my $FRAME = 'CodingAdventures::InMemoryDataStoreProtocol::CommandFrame';
+my $VALUE = 'CodingAdventures::RespProtocol::Value';
+my $DECODER = 'CodingAdventures::RespProtocol::Decoder';
+
+sub new {
+    my ($class, @arguments) = @_;
+    die "constructor expects key/value options\n" if @arguments % 2;
+    my %options = @arguments;
+    die "engine and store are mutually exclusive\n"
+        if defined($options{engine}) && defined($options{store});
+
+    my $engine = $options{engine};
+    if (!defined $engine) {
+        my %engine_options;
+        $engine_options{store} = $options{store} if defined $options{store};
+        $engine_options{database_count} = $options{database_count}
+            if defined $options{database_count};
+        $engine_options{time_provider} = $options{time_provider}
+            if defined $options{time_provider};
+        $engine = $ENGINE->new(%engine_options);
+    }
+    return bless {engine => $engine, decoder => $DECODER->new}, $class;
+}
+
+sub engine { return $_[0]->{engine}; }
+sub store { return $_[0]->{engine}->store; }
+
+sub reset {
+    my ($self, $store) = @_;
+    $self->{engine} = defined($store) ? $ENGINE->new(store => $store) : $ENGINE->new;
+    $self->{decoder} = $DECODER->new;
+    return $self;
+}
+
+sub execute_command {
+    my ($self, $command) = @_;
+    return response_to_resp_value($self->{engine}->execute_frame($command));
+}
+
+sub execute_parts {
+    my ($self, $parts) = @_;
+    return response_to_resp_value($self->{engine}->execute_parts($parts));
+}
+
+sub execute_frame {
+    my ($self, $frame) = @_;
+    return $VALUE->error('ERR expected RESP array command')
+        if !blessed($frame) || !$frame->isa($VALUE)
+        || $frame->kind ne 'array' || $frame->is_null;
+    return undef if !@{$frame->value};
+    my $command = command_from_resp($frame);
+    return $VALUE->error('ERR expected RESP command array') if !defined $command;
+    return $self->execute_command($command);
+}
+
+sub process {
+    my ($self, $input) = @_;
+    $self->{decoder}->feed($input);
+    my @responses;
+    while ($self->{decoder}->has_message) {
+        my $response = $self->execute_frame($self->{decoder}->get_message);
+        push @responses, $response if defined $response;
+    }
+    return \@responses;
+}
+
+sub handle {
+    my ($self, $input) = @_;
+    return encode_resp_stream($self->process($input));
+}
+
+sub command_from_resp {
+    my ($value) = @_;
+    return undef if !blessed($value) || !$value->isa($VALUE)
+        || $value->kind ne 'array' || $value->is_null;
+
+    my @parts;
+    for my $item (@{$value->value}) {
+        return undef if !blessed($item) || !$item->isa($VALUE);
+        if ($item->kind eq 'bulk_string' && !$item->is_null) {
+            push @parts, $item->value;
+        } elsif ($item->kind eq 'simple_string' || $item->kind eq 'integer') {
+            push @parts, '' . $item->value;
+        } else {
+            return undef;
+        }
+    }
+    return $FRAME->from_parts(\@parts);
+}
+
+sub response_to_resp_value {
+    my ($response) = @_;
+    my $kind = $response->kind;
+    return $VALUE->simple_string($response->value) if $kind eq 'simple_string';
+    return $VALUE->error($response->value) if $kind eq 'error';
+    return $VALUE->integer($response->value) if $kind eq 'integer';
+    if ($kind eq 'bulk_string') {
+        return defined($response->value)
+            ? $VALUE->bulk_string($response->value)
+            : $VALUE->null_bulk_string;
+    }
+    if ($kind eq 'array') {
+        my $values = $response->value;
+        return $VALUE->null_array if !defined $values;
+        return $VALUE->array([map { response_to_resp_value($_) } @$values]);
+    }
+    die "unknown engine response kind: $kind\n";
+}
+
+sub encode_resp_stream {
+    my ($values) = @_;
+    return join('', map { encode($_) } @$values);
+}
+
+sub command_to_frame {
+    my ($command) = @_;
+    return $VALUE->array([
+        $VALUE->bulk_string($command->command),
+        map { $VALUE->bulk_string($_) } @{$command->args},
+    ]);
+}
+
+sub frame_to_response_text {
+    my ($frame) = @_;
+    return $frame->value if $frame->kind eq 'simple_string' || $frame->kind eq 'error';
+    return '' . $frame->value if $frame->kind eq 'integer';
+    return $frame->is_null ? '(nil)' : $frame->value if $frame->kind eq 'bulk_string';
+    return $frame->is_null ? '(nil)' : '[array:' . scalar(@{$frame->value}) . ']';
+}
+
+sub ok { return $VALUE->simple_string('OK'); }
+
+package CodingAdventures::InMemoryDataStore::DataStore;
+
+use strict;
+use warnings;
+our @ISA = ('CodingAdventures::InMemoryDataStore');
+
+1;

--- a/code/packages/perl/in-memory-data-store/required_capabilities.json
+++ b/code/packages/perl/in-memory-data-store/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "perl/in-memory-data-store",
+  "capabilities": [],
+  "justification": "Pure RESP stream composition over sibling protocol and engine packages. No filesystem, network, process, environment, randomness, or clock access is needed."
+}

--- a/code/packages/perl/in-memory-data-store/t/00-load.t
+++ b/code/packages/perl/in-memory-data-store/t/00-load.t
@@ -1,0 +1,6 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+BEGIN { use_ok('CodingAdventures::InMemoryDataStore') }
+ok(CodingAdventures::InMemoryDataStore->VERSION, 'has a version');

--- a/code/packages/perl/in-memory-data-store/t/01-in-memory-data-store.t
+++ b/code/packages/perl/in-memory-data-store/t/01-in-memory-data-store.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+use Test::More;
+use CodingAdventures::InMemoryDataStore qw(
+    command_from_resp response_to_resp_value command_to_frame
+    frame_to_response_text
+);
+use CodingAdventures::InMemoryDataStoreEngine;
+use CodingAdventures::InMemoryDataStoreProtocol;
+use CodingAdventures::RespProtocol qw(encode);
+
+my $Value = 'CodingAdventures::RespProtocol::Value';
+my $Response = 'CodingAdventures::InMemoryDataStoreProtocol::EngineResponse';
+
+sub command {
+    return $Value->array([map { $Value->bulk_string($_) } @_]);
+}
+
+subtest 'executes RESP frames end to end' => sub {
+    my $store = CodingAdventures::InMemoryDataStore->new;
+    my $response = $store->execute_frame(command('PING'));
+    is($response->kind, 'simple_string', 'simple string response');
+    is($response->value, 'PONG', 'PONG response');
+};
+
+subtest 'handles incremental and pipelined RESP input' => sub {
+    my $store = CodingAdventures::InMemoryDataStore->new;
+    my $set_wire = encode(command('SET', 'counter', '1'));
+    my $get_wire = encode(command('GET', 'counter'));
+    is_deeply($store->process(substr($set_wire, 0, 5)), [], 'incomplete frame buffered');
+    is($store->handle(substr($set_wire, 5) . $get_wire), "+OK\r\n\$1\r\n1\r\n", 'pipeline encoded');
+};
+
+subtest 'preserves binary-safe values' => sub {
+    my $store = CodingAdventures::InMemoryDataStore->new;
+    my $binary = "a\0b\xFF";
+    is($store->execute_frame(command('SET', 'binary', $binary))->value, 'OK', 'SET succeeds');
+    is($store->execute_frame(command('GET', 'binary'))->value, $binary, 'binary value round trips');
+};
+
+subtest 'rejects invalid frames and ignores blank arrays' => sub {
+    my $store = CodingAdventures::InMemoryDataStore->new;
+    is($store->execute_frame($Value->simple_string('PING'))->kind, 'error', 'scalar rejected');
+    is($store->execute_frame($Value->array([])), undef, 'blank array ignored');
+    is($store->execute_frame($Value->array([$Value->null_bulk_string]))->kind, 'error', 'null part rejected');
+};
+
+subtest 'converts command and response IR values' => sub {
+    my $frame = CodingAdventures::InMemoryDataStoreProtocol::CommandFrame->new('ECHO', ['hello']);
+    is(command_from_resp(command_to_frame($frame))->command, 'ECHO', 'command round trip');
+    my $nested = $Response->array([
+        $Response->integer(2),
+        $Response->bulk_string(undef),
+    ]);
+    my $converted = response_to_resp_value($nested);
+    is($converted->value->[0]->kind, 'integer', 'integer converted');
+    ok($converted->value->[1]->is_null, 'null bulk converted');
+    is(frame_to_response_text($converted->value->[1]), '(nil)', 'null display');
+};
+
+subtest 'accepts injected engines and resets to a fresh store' => sub {
+    my $engine = CodingAdventures::InMemoryDataStoreEngine->new;
+    my $store = CodingAdventures::InMemoryDataStore->new(engine => $engine);
+    $store->execute_parts(['SET', 'name', 'Ada']);
+    is($store->execute_parts(['GET', 'name'])->value, 'Ada', 'injected engine used');
+    $store->reset;
+    ok($store->execute_parts(['GET', 'name'])->is_null, 'reset clears state');
+};
+
+done_testing;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,20 +105,21 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 16, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
+on July 17, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
 `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
 the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
-and `hash-set` ports, and the paired `in-memory-data-store-engine` port:
+and `hash-set` ports, and the paired `in-memory-data-store-engine` and
+`in-memory-data-store` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 345 |
+| Present in 10-15 languages | 172 | 343 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 695 | 9,730 |
+| Present in one language | 697 | 9,758 |
 
-The loop must not start by attempting 9,730 singleton ports. It should finish
+The loop must not start by attempting 9,758 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -159,15 +160,15 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 345
+The 172 packages present in at least ten implementation languages need 343
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
 | Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 1 | Pair with Perl data-structure/storage wave |
-| Perl | 1 | Pair with Lua data-structure/storage wave |
+| Lua | 0 | Complete; paired data-structure/storage wave |
+| Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
@@ -179,12 +180,13 @@ ports to reach all 15. After Priority 1, select work in this order:
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.
 
-The first sixteen paired Lua/Perl slices are complete: `fenwick-tree`,
+The first seventeen paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
 `avl-tree`, `tree-set`, `skip-list`, `hyperloglog`, `trie`, `radix-tree`,
-`resp-protocol`, `hash-functions`, `bloom-filter`, `hash-map`, `hash-set`, and
-`in-memory-data-store-engine` now have pure implementations, package-native
-tests, metadata, and capability declarations in both lanes.
+`resp-protocol`, `hash-functions`, `bloom-filter`, `hash-map`, `hash-set`,
+`in-memory-data-store-engine`, and `in-memory-data-store` now have pure
+implementations, package-native tests, metadata, and capability declarations
+in both lanes.
 The protocol slice establishes the dependency-free IR needed before the higher
 in-memory data store layers move; the AVL slice supplies the ordered backend
 for `tree-set`; and the dependency-free skip-list slice adds a span-augmented
@@ -221,6 +223,11 @@ provide binary-safe strings, typed collections, sorted sets, expiry, 16 logical
 databases, deterministic response ordering, and the complete 57-command
 execution surface. It reduces the paired high-consensus gap to one package per
 lane, leaving only the top-level `in-memory-data-store` facade.
+The facade slice composes the RESP2 streaming decoder, command protocol IR, and
+execution engine into incremental and pipelined byte-stream entry points with
+binary-safe response conversion. It moves the package from 11 to 13
+implementation lanes and closes the remaining high-consensus gaps in both Lua
+and Perl.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure Lua and Perl `in-memory-data-store` facades over the existing RESP, protocol, HyperLogLog, and engine packages
- support typed command execution, binary-safe response conversion, fragmented input, and pipelined RESP streams
- update the package-parity roadmap and close the remaining Lua/Perl high-consensus gaps

## Validation

- Lua dependency chain: RESP protocol (9), data-store protocol (8), HyperLogLog (6), engine (8), facade (6) Busted tests
- Perl dependency chain: RESP protocol (11), data-store protocol (10), HyperLogLog (8), engine (10), facade (8) tests
- `python code/scripts/tests/test_package_parity_report.py`
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- capability manifest JSON parsing
- `git diff --check origin/main...HEAD`