### PR TITLE
feat(reduce-lexer): reduce.tokens + reduce-lexer crate (MA08 R-2)

### DIFF
--- a/code/grammars/reduce/reduce.tokens
+++ b/code/grammars/reduce/reduce.tokens
@@ -1,0 +1,174 @@
+# Reduce Token Grammar
+# ============================================================================
+#
+# Tokenizes the R-1-scoped subset of REDUCE (Anthony C. Hearn,
+# Stanford/Rand Corporation, 1968; open-sourced 2008; still actively
+# maintained) — one of the two oldest CAS ever built (alongside Macsyma,
+# both 1968). REDUCE's "algebraic mode" (the only mode this subset covers;
+# see code/specs/MA08-reduce-language.md §1) reads like an ordinary Algol/
+# Pascal-family imperative language at the *statement* level (`:=`
+# assignment, `if`/`then`/`else`, `<< ... >>` statement grouping) but every
+# *expression* is built from ordinary infix operators and `f(args)`-shaped
+# calls — exactly the same `IRNode::Apply { head, args }` shape Macsyma/
+# Wolfram/Derive already lower to.
+#
+# REDUCE is CASE-SENSITIVE, but unlike Derive (whose boolean keywords
+# `AND`/`OR`/`NOT` are UPPERCASE, matching Derive's own conventionally-
+# uppercase built-in names), REDUCE's real surface spells its word
+# operators and statement keywords in LOWERCASE (`and`, `or`, `not`, `neq`,
+# `if`, `then`, `else` — manual §2.7/§5.3) — so the `keywords:` block below
+# lists the lowercase spellings, and `AND`/`IF`/etc. in uppercase lex as
+# ordinary NAMEs here, the mirror image of derive.tokens's case rule.
+#
+# Statement separation is `;` or `$` (manual §5.1), never a significant
+# newline — REDUCE has no numbered-worksheet-prompt convention the way
+# Derive's `#n:` does, so (unlike derive.tokens/wolfram.tokens) this file
+# has no NEWLINE token and needs no bracket-interior-newline post-tokenize
+# hook; every newline is ordinary whitespace, mirroring macsyma.tokens's
+# identical `;`/`$`-terminated statement model exactly (see its SECTION 5
+# comment: "MACSYMA newlines are NOT significant").
+#
+# @version 1
+
+# Strings and comments are out of this subset's scope entirely (no STRING
+# token, no comment skip pattern) — MA08 §4 explicitly excludes both:
+# "This subset's programs are a flat sequence of expression statements,
+# assignments, and simple operator/procedure definitions."
+escapes: none
+
+# ============================================================================
+# SECTION 1: Multi-character operators
+#
+# Longest-match-first: every multi-character operator is listed before any
+# shorter operator it begins with, so `:=` wins over there being no bare
+# `:` at all in this subset (same defensive convention derive.tokens uses
+# for its own `:=`), `<=`/`<<` and `>=`/`>>` win over bare `<`/`>`, and `**`
+# wins over bare `*`.
+# ============================================================================
+
+# REDUCE's one assignment operator (manual §5.1) — a statement, never a
+# value-producing expression the way `=` (SECTION 2) is.
+ASSIGN      = ":="
+
+LE          = "<="
+GE          = ">="
+
+# `**` and `^` (SECTION 2) are literally the same power operator — manual
+# §2.7's own precedence table lists them as one tier. Both are kept as
+# distinct token types (rather than collapsed into one), mirroring how
+# macsyma.tokens keeps `;`/`$` as distinct SEMI/DOLLAR tokens even though
+# "[REDUCE's] parser treats them identically" — the *parser* (R-3), not
+# this lexer, is where the two spellings collapse onto one production.
+POW         = "**"
+
+# `<< ... >>` group-statement delimiters (manual §5.2) — REDUCE's spelling
+# of what Wolfram calls `CompoundExpression[...]` and Algol calls
+# `begin ... end`.
+GROUP_OPEN  = "<<"
+GROUP_CLOSE = ">>"
+
+# ============================================================================
+# SECTION 2: Single-character operators and delimiters
+# ============================================================================
+
+PLUS        = "+"
+MINUS       = "-"
+TIMES       = "*"
+SLASH       = "/"
+CARET       = "^"
+
+# `=` is REDUCE's equation operator (Boolean-valued, e.g. usable as an
+# `if` condition) — NEVER assignment; manual §3.4 confirms `=` never
+# assigns, only `on evallhseqp` even evaluates its left side. Mirrors
+# Derive's and Macsyma's identical `=`-is-equation / `:=`-is-assignment
+# split.
+EQ          = "="
+LESS        = "<"
+GREATER     = ">"
+
+LPAREN      = "("
+RPAREN      = ")"
+
+# List literals use CURLY braces (`{a, b, c}`, manual §4.1) — NOT square
+# brackets the way Derive's `[a,b,c]` vector literal or APL/J/MATLAB array
+# syntax do. This is the one bracket pair this subset needs; REDUCE's
+# array-declaration syntax (`array a(10,10)`) is out of scope (MA08 §4),
+# so `a(5)` lexes through the ordinary LPAREN/RPAREN call syntax below,
+# never through a bracket.
+LBRACE      = "{"
+RBRACE      = "}"
+
+COMMA       = ","
+
+# The ONLY use of `;` in this subset is a statement separator (manual
+# §5.1), interchangeable with `$` below — REDUCE has no matrix-row-
+# separator use of `;` the way Derive's vector/matrix literal does, since
+# matrices are out of scope here (MA08 §4).
+SEMI        = ";"
+
+# REDUCE's other statement separator (manual §5.1) — like Macsyma's `$`,
+# distinguished from `;` only by convention (result-suppression, an
+# interactive-session concern out of scope for a compiled subset); the
+# parser (R-3) treats both as the same statement-terminator production,
+# exactly mirroring macsyma.tokens's SEMI/DOLLAR split.
+DOLLAR      = "$"
+
+# The cons operator (`a . {b, c}`, manual §4.1) — prepends `a` onto list
+# `{b,c}`. Never ambiguous with a decimal point: NUMBER (SECTION 3) always
+# requires at least one leading digit, so a bare `.` at any position where
+# NUMBER could instead have matched a full `3.14`-shaped literal is not
+# reachable — the two patterns only compete when a digit is already
+# consumed, at which point NUMBER's own optional-dot clause has already
+# claimed it.
+DOT         = "."
+
+# ============================================================================
+# SECTION 3: Literal value tokens
+#
+# NUMBER requires a leading digit, so a bare `.5` is not a number (matches
+# every sibling symbolic-family lexer's convention — derive.tokens,
+# macsyma.tokens, wolfram.tokens). NAME is a case-sensitive identifier;
+# operator/procedure names (`df`, `log`, `first`, `list`, ...) are ordinary
+# NAMEs resolved later by the runtime (R-4), exactly like Derive's SIN/DIF
+# and Macsyma's built-in function names — so, aside from the `keywords:`
+# block below, there is no reserved-word list here.
+# ============================================================================
+
+NUMBER = /[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?/
+NAME   = /[a-zA-Z][a-zA-Z0-9]*/
+
+# ============================================================================
+# SECTION 4: Skip patterns
+#
+# REDUCE newlines are NOT significant — statements end with `;` or `$`
+# (manual §5.1), exactly mirroring macsyma.tokens's identical rationale —
+# so newlines are just whitespace here, and (unlike derive.tokens/
+# wolfram.tokens) this file declares no NEWLINE token and needs no
+# bracket-interior-newline post-tokenize hook in reduce-lexer.
+# ============================================================================
+
+skip:
+  WHITESPACE = /[ \t\r\n]+/
+
+# ============================================================================
+# SECTION 5: Keywords
+#
+# These words are NAMEs at the lexer level but are reclassified to their
+# own KEYWORD token by the grammar-driven lexer, matched by EXACT
+# lowercase spelling — `AND`/`IF`/etc. in uppercase lex as ordinary NAMEs,
+# the mirror image of derive.tokens's case rule (whose keywords ARE
+# uppercase). `neq` (manual §2.7) is REDUCE's word-spelled "not equal"
+# relational operator, alongside the symbolic `=`/`<`/`>`/`<=`/`>=`
+# (SECTION 1/2) — grouped here with `and`/`or`/`not` since all four are
+# word tokens, not symbols. `if`/`then`/`else` are the R-3 parser's
+# conditional-statement keywords (manual §5.3).
+# ============================================================================
+
+keywords:
+  and
+  or
+  not
+  neq
+  if
+  then
+  else

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -258,6 +258,7 @@ members = [
     "j-parser",
     "j-runtime",
     "j-repl",
+    "reduce-lexer",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/reduce-lexer/BUILD
+++ b/code/packages/rust/reduce-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-reduce-lexer -- --nocapture

--- a/code/packages/rust/reduce-lexer/BUILD_windows
+++ b/code/packages/rust/reduce-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-reduce-lexer -- --nocapture

--- a/code/packages/rust/reduce-lexer/CHANGELOG.md
+++ b/code/packages/rust/reduce-lexer/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## [0.1.0] - 2026-07-17
+
+### Added
+
+- Initial grammar-driven Rust REDUCE tokenizer (MA08 §2, task R-2).
+- Statically linked compiled token grammar
+  (`code/grammars/reduce/reduce.tokens`), covering the R-1-scoped surface
+  (MA08 §3): ordinary-parenthesis function/procedure application
+  (`df(x, y)`, `h(l, m)`), the single `:=` assignment operator, `=` as the
+  *equation* operator (never assignment — shared with Derive/Macsyma's
+  convention), comparison (`< > <= >= neq`), the word-spelled logical
+  keywords `and`/`or`/`not` (lowercase reserved words — the mirror image
+  of `derive-lexer`'s uppercase `AND`/`OR`/`NOT`), the `if`/`then`/`else`
+  conditional keywords, `{a, b, c}` curly-brace list literals (not
+  Derive's `[a,b,c]` vector literal, and not APL/J/MATLAB array syntax),
+  the `.` cons operator (never ambiguous with a decimal point, since
+  `NUMBER` always requires a leading digit), `<< ... >>` group-statement
+  delimiters, both statement terminators `;` and `$` (kept as distinct
+  `SEMI`/`DOLLAR` tokens, mirroring `macsyma-lexer`'s identical split),
+  and arithmetic `+ - * / ^ **` (`^`/`**` are the same power operator per
+  the manual, kept as distinct `CARET`/`POW` tokens — the parser, not this
+  lexer, is where the two spellings collapse onto one production).
+- No `NEWLINE` token and no post-tokenize hook: REDUCE's `;`/`$`-
+  terminated statement model (manual §5.1) has no significant newlines,
+  mirroring `macsyma-lexer` exactly rather than `derive-lexer`/
+  `wolfram-lexer`'s worksheet-style significant-newline model.
+- 17 tests covering function/procedure application, `:=` vs `=`
+  disambiguation, curly-brace list literals, the cons `.` operator vs.
+  decimal points, the lowercase `and`/`or`/`not`/`neq` keywords (and that
+  uppercase spellings are NOT promoted — the mirror image of
+  `derive-lexer`'s own case-sensitivity test), `if`/`then`/`else`
+  keyword promotion, `<< >>` group-statement delimiters, `;`/`$`
+  terminator distinctness, comparison/arithmetic operators, longest-match
+  precedence (`:=`, `**`, `<<`/`>>`), newlines being plain whitespace, and
+  case-sensitive names.

--- a/code/packages/rust/reduce-lexer/Cargo.toml
+++ b/code/packages/rust/reduce-lexer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-reduce-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "Tokenizer for the REDUCE symbolic-CAS frontend (R-2)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/reduce-lexer/README.md
+++ b/code/packages/rust/reduce-lexer/README.md
@@ -1,0 +1,81 @@
+# coding-adventures-reduce-lexer
+
+REDUCE tokenizer backed by `code/grammars/reduce/reduce.tokens`, compiled to
+Rust and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the R-1-scoped subset fixed by
+[MA08 §3](../../../specs/MA08-reduce-language.md): ordinary-parenthesis
+function/procedure application (`df(x, y)`, `h(l, m)`), the single `:=`
+assignment operator, `=` as the *equation* operator (never assignment),
+comparison (`< > <= >= neq`), the word-spelled logical keywords
+`and`/`or`/`not`, the `if`/`then`/`else` conditional keywords, `{a, b, c}`
+curly-brace list literals, the `.` cons operator, `<< ... >>` group-
+statement delimiters, both statement terminators `;` and `$`, and
+arithmetic `+ - * / ^ **`.
+
+## REDUCE's keywords are lowercase — the mirror image of Derive's
+
+Unlike [`derive-lexer`](../derive-lexer) (whose boolean-algebra keywords
+`AND`/`OR`/`NOT` are UPPERCASE, matching Derive's own conventionally-
+uppercase built-in names), REDUCE's real surface spells its word operators
+and statement keywords in lowercase — `and`, `or`, `not`, `neq`, `if`,
+`then`, `else` (manual §2.7/§5.3). `reduce.tokens`'s `keywords:` block
+lists the lowercase spellings and matches case-sensitively, so `AND`/`IF`/
+etc. in uppercase lex as ordinary `NAME`s here — exactly the opposite of
+`derive-lexer`'s case rule.
+
+## `^` and `**` are the same operator, kept as distinct tokens
+
+REDUCE's manual states `^` and `**` are literally the same power operator
+(one precedence tier). Rather than collapsing them into one token type,
+this crate keeps `CARET`/`POW` distinct — mirroring how `macsyma-lexer`
+keeps its own two statement terminators (`;`/`$`) as distinct `SEMI`/
+`DOLLAR` tokens even though "the parser treats them identically." The
+*parser* (R-3), not this lexer, is where the two power spellings collapse
+onto one production.
+
+## No significant newlines — the same statement model as Macsyma
+
+Unlike `derive-lexer`/`wolfram-lexer` (whose worksheet-style grammars have
+a significant top-level `NEWLINE`, needing a bracket-interior newline-
+dropping post-tokenize hook), REDUCE statements are separated by `;` or
+`$` (manual §5.1) — a newline is never significant. This mirrors
+`macsyma-lexer`'s identical `;`/`$`-terminated statement model exactly:
+`reduce.tokens` emits no `NEWLINE` token at all (every newline is ordinary
+skipped whitespace), so this crate needs nothing beyond a bare
+`GrammarLexer::new` — no post-tokenize hook, unlike `derive-lexer`.
+
+## List literals use curly braces, not square brackets
+
+`{a, b, c}` (manual §4.1) is REDUCE's list literal — **not** Derive's
+`[a,b,c]` vector-literal syntax, and not APL/J/MATLAB array syntax either.
+This subset's array-declaration syntax (`array a(10,10)`) is out of scope
+(MA08 §4), so a subscripted read like `a(5)` lexes through the ordinary
+`LPAREN`/`RPAREN` call syntax, never through a bracket.
+
+## Usage
+
+```rust
+use coding_adventures_reduce_lexer::tokenize_reduce;
+
+let tokens = tokenize_reduce("h(l, m) := l + m$\nh(1, 2)$");
+```
+
+`tokenize_reduce` panics on a malformed source string; use
+`create_reduce_lexer` directly if you need the `Result`-returning
+`GrammarLexer::tokenize` instead, or the crate-level `try_tokenize_reduce`
+convenience wrapper.
+
+## Where this fits
+
+`reduce-lexer` is the first of REDUCE's frontend crates (R-2); the sibling
+`reduce-parser` crate (R-3) will consume this crate's token stream against
+`code/grammars/reduce/reduce.grammar` to build the `GrammarASTNode` CST a
+future `reduce-runtime` (R-4) will lower into `symbolic_ir::IRNode` and
+evaluate with `symbolic_vm::VM`'s shared `SymbolicBackend`, reused
+unchanged.

--- a/code/packages/rust/reduce-lexer/required_capabilities.json
+++ b/code/packages/rust/reduce-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/reduce-lexer",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/reduce-lexer/src/_grammar.rs
+++ b/code/packages/rust/reduce-lexer/src/_grammar.rs
@@ -1,0 +1,209 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: reduce.tokens
+// Regenerate with: grammar-tools compile-tokens reduce.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"ASSIGN"#.to_string(),
+                pattern: r#":="#.to_string(),
+                is_regex: false,
+                line_number: 51,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LE"#.to_string(),
+                pattern: r#"<="#.to_string(),
+                is_regex: false,
+                line_number: 53,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GE"#.to_string(),
+                pattern: r#">="#.to_string(),
+                is_regex: false,
+                line_number: 54,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"POW"#.to_string(),
+                pattern: r#"**"#.to_string(),
+                is_regex: false,
+                line_number: 62,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GROUP_OPEN"#.to_string(),
+                pattern: r#"<<"#.to_string(),
+                is_regex: false,
+                line_number: 67,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GROUP_CLOSE"#.to_string(),
+                pattern: r#">>"#.to_string(),
+                is_regex: false,
+                line_number: 68,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PLUS"#.to_string(),
+                pattern: r#"+"#.to_string(),
+                is_regex: false,
+                line_number: 74,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"MINUS"#.to_string(),
+                pattern: r#"-"#.to_string(),
+                is_regex: false,
+                line_number: 75,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"TIMES"#.to_string(),
+                pattern: r#"*"#.to_string(),
+                is_regex: false,
+                line_number: 76,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SLASH"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 77,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"CARET"#.to_string(),
+                pattern: r#"^"#.to_string(),
+                is_regex: false,
+                line_number: 78,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQ"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 85,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LESS"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 86,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GREATER"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 87,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 89,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 90,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACE"#.to_string(),
+                pattern: r#"{"#.to_string(),
+                is_regex: false,
+                line_number: 98,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACE"#.to_string(),
+                pattern: r#"}"#.to_string(),
+                is_regex: false,
+                line_number: 99,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMA"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 101,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SEMI"#.to_string(),
+                pattern: r#";"#.to_string(),
+                is_regex: false,
+                line_number: 107,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"DOLLAR"#.to_string(),
+                pattern: r#"$"#.to_string(),
+                is_regex: false,
+                line_number: 114,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"DOT"#.to_string(),
+                pattern: r#"."#.to_string(),
+                is_regex: false,
+                line_number: 123,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 137,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[a-zA-Z][a-zA-Z0-9]*"#.to_string(),
+                is_regex: true,
+                line_number: 138,
+                alias: None,
+            },
+        ],
+        keywords: vec![r#"and"#.to_string(), r#"or"#.to_string(), r#"not"#.to_string(), r#"neq"#.to_string(), r#"if"#.to_string(), r#"then"#.to_string(), r#"else"#.to_string()],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t\r\n]+"#.to_string(),
+                is_regex: true,
+                line_number: 151,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: Some(r#"none"#.to_string()),
+        error_definitions: vec![],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
+    }
+}

--- a/code/packages/rust/reduce-lexer/src/lib.rs
+++ b/code/packages/rust/reduce-lexer/src/lib.rs
@@ -1,0 +1,285 @@
+//! # Reduce Lexer — tokenizing the REDUCE symbolic-CAS subset (R-2).
+//!
+//! REDUCE (Anthony C. Hearn, Stanford/Rand Corporation, 1968;
+//! open-sourced 2008; still actively maintained) is one of the two oldest
+//! CAS ever built (alongside Macsyma, both 1968). Its "algebraic mode"
+//! reads like an ordinary Algol/Pascal-family imperative language at the
+//! *statement* level (`:=` assignment, `if`/`then`/`else`, `<< ... >>`
+//! statement grouping) but every *expression* is an ordinary infix/
+//! `f(args)`-call expression, exactly the same shape Macsyma/Wolfram/
+//! Derive already lower to. This crate is a thin wrapper over the generic
+//! [`GrammarLexer`] (a sibling of `derive-lexer`/`wolfram-lexer`/
+//! `macsyma-lexer`). See `code/specs/MA08-reduce-language.md`.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! reduce.tokens       (grammar file — declares every token pattern)
+//!     |  (compiled ahead of time into src/_grammar.rs)
+//!     v
+//! lexer::GrammarLexer (tokenizes source using the embedded TokenGrammar)
+//!     |
+//!     v
+//! reduce-lexer        (this crate)
+//! ```
+//!
+//! ## No post-tokenize hook needed
+//!
+//! Unlike `derive-lexer`/`wolfram-lexer` (whose worksheet-style grammars
+//! have a significant top-level `NEWLINE` and so need a bracket-interior
+//! newline-dropping hook), REDUCE statements are separated by `;` or `$`
+//! (manual §5.1) — a newline is never significant, exactly mirroring
+//! `macsyma-lexer`'s identical `;`/`$`-terminated statement model. So
+//! `reduce.tokens` emits no `NEWLINE` token at all (every newline is
+//! ordinary skipped whitespace), and this crate needs nothing beyond a
+//! bare [`GrammarLexer::new`] — the same shape as `macsyma-lexer`/
+//! `j-lexer`.
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+/// Create a [`GrammarLexer`] configured for REDUCE source text.
+pub fn create_reduce_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    GrammarLexer::new(source, &grammar)
+}
+
+/// Tokenize REDUCE source text into a vector of tokens (ending in an `EOF`).
+///
+/// # Panics
+///
+/// Panics on an unrecognized character. Use [`try_tokenize_reduce`] for a
+/// `Result`.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_reduce_lexer::tokenize_reduce;
+/// let tokens = tokenize_reduce("df(x, y)$");
+/// assert_eq!(tokens[0].value, "df");
+/// assert_eq!(tokens[1].effective_type_name(), "LPAREN");
+/// ```
+pub fn tokenize_reduce(source: &str) -> Vec<Token> {
+    create_reduce_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Reduce tokenization failed: {e}"))
+}
+
+/// Tokenize REDUCE source text, returning a `Result` instead of panicking.
+pub fn try_tokenize_reduce(source: &str) -> Result<Vec<Token>, String> {
+    create_reduce_lexer(source)
+        .tokenize()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lexer::token::TokenType;
+
+    /// Lex, dropping the trailing EOF, into `(effective_type_name, value)` pairs.
+    fn lex(source: &str) -> Vec<(String, String)> {
+        tokenize_reduce(source)
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| (t.effective_type_name().to_string(), t.value.clone()))
+            .collect()
+    }
+
+    fn pair(p: &[(String, String)], i: usize, ty: &str, val: &str) {
+        assert_eq!(
+            (p[i].0.as_str(), p[i].1.as_str()),
+            (ty, val),
+            "tok {i} in {p:?}"
+        );
+    }
+
+    fn types(p: &[(String, String)]) -> Vec<&str> {
+        p.iter().map(|t| t.0.as_str()).collect()
+    }
+
+    // --- Function/procedure application uses ordinary parens -------------
+
+    #[test]
+    fn function_application_uses_ordinary_parens() {
+        let p = lex("df(x, y)$");
+        pair(&p, 0, "NAME", "df");
+        pair(&p, 1, "LPAREN", "(");
+        pair(&p, 2, "NAME", "x");
+        pair(&p, 3, "COMMA", ",");
+        pair(&p, 4, "NAME", "y");
+        pair(&p, 5, "RPAREN", ")");
+    }
+
+    // --- `:=` is assignment, `=` is equation, never confused --------------
+
+    #[test]
+    fn assign_and_eq_are_distinct_tokens() {
+        pair(&lex("x := 5"), 1, "ASSIGN", ":=");
+        pair(&lex("h(l, m) := l + m"), 6, "ASSIGN", ":=");
+        let p = lex("x = 4");
+        pair(&p, 1, "EQ", "=");
+        assert!(!types(&p).contains(&"ASSIGN"));
+    }
+
+    // --- List literals use CURLY braces, not square brackets --------------
+
+    #[test]
+    fn list_literal_lexes_with_braces_and_commas() {
+        let p = lex("{a, b, c}");
+        assert_eq!(
+            types(&p),
+            vec!["LBRACE", "NAME", "COMMA", "NAME", "COMMA", "NAME", "RBRACE"]
+        );
+    }
+
+    // --- Cons operator `.` never confused with a decimal point ------------
+
+    #[test]
+    fn cons_dot_is_distinct_from_a_decimal_number() {
+        let p = lex("a . {b, c}");
+        assert_eq!(
+            types(&p),
+            vec!["NAME", "DOT", "LBRACE", "NAME", "COMMA", "NAME", "RBRACE"]
+        );
+        pair(&lex("3.14$"), 0, "NUMBER", "3.14");
+    }
+
+    // --- Word-spelled logical/relational keywords, lowercase only ---------
+
+    #[test]
+    fn logical_and_relational_keywords_promote_to_keyword_token_type() {
+        let p = lex("a and b or not c neq d");
+        assert_eq!(
+            p,
+            vec![
+                ("NAME".to_string(), "a".to_string()),
+                ("KEYWORD".to_string(), "and".to_string()),
+                ("NAME".to_string(), "b".to_string()),
+                ("KEYWORD".to_string(), "or".to_string()),
+                ("KEYWORD".to_string(), "not".to_string()),
+                ("NAME".to_string(), "c".to_string()),
+                ("KEYWORD".to_string(), "neq".to_string()),
+                ("NAME".to_string(), "d".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn uppercase_keyword_spellings_are_ordinary_names_not_keywords() {
+        // REDUCE's keywords are lowercase — the mirror image of Derive's
+        // uppercase AND/OR/NOT. AND/OR/NOT/NEQ in uppercase are NOT the
+        // reserved words here; only the exact lowercase spellings are.
+        let p = lex("AND OR NOT NEQ");
+        assert_eq!(types(&p), vec!["NAME", "NAME", "NAME", "NAME"]);
+    }
+
+    // --- `if`/`then`/`else` conditional keywords ---------------------------
+
+    #[test]
+    fn if_then_else_promote_to_keyword_token_type() {
+        let p = lex("if a > b then a else b");
+        pair(&p, 0, "KEYWORD", "if");
+        pair(&p, 4, "KEYWORD", "then");
+        pair(&p, 6, "KEYWORD", "else");
+    }
+
+    // --- Comparison and arithmetic operators -------------------------------
+
+    #[test]
+    fn comparison_and_arithmetic_operators() {
+        for (src, ty) in [
+            ("a <= b$", "LE"),
+            ("a >= b$", "GE"),
+            ("a < b$", "LESS"),
+            ("a > b$", "GREATER"),
+            ("a ^ b$", "CARET"),
+            ("a ** b$", "POW"),
+            ("a * b$", "TIMES"),
+            ("a / b$", "SLASH"),
+        ] {
+            assert!(
+                types(&lex(src)).contains(&ty),
+                "expected {ty} in {src:?}: {:?}",
+                types(&lex(src))
+            );
+        }
+    }
+
+    // --- Group statement `<< ... >>` ---------------------------------------
+
+    #[test]
+    fn group_statement_delimiters() {
+        let p = lex("<< a := 1; b := 2 >>$");
+        assert_eq!(p[0].0, "GROUP_OPEN");
+        assert_eq!(p.last().unwrap().0, "DOLLAR");
+        assert!(types(&p).contains(&"GROUP_CLOSE"));
+        assert!(types(&p).contains(&"SEMI"));
+    }
+
+    // --- `;` and `$` are both statement terminators, kept distinct --------
+
+    #[test]
+    fn semi_and_dollar_are_distinct_terminator_tokens() {
+        assert_eq!(lex("a := 1;").last().unwrap().0, "SEMI");
+        assert_eq!(lex("a := 1$").last().unwrap().0, "DOLLAR");
+    }
+
+    // --- Longest-match: multi-char operators never split ------------------
+
+    #[test]
+    fn assign_wins_over_any_shorter_prefix() {
+        assert!(types(&lex("x:=5$")).contains(&"ASSIGN"));
+        assert!(!types(&lex("x:=5$")).contains(&"EQ"));
+    }
+
+    #[test]
+    fn double_star_wins_over_two_single_stars() {
+        let p = lex("a**b$");
+        assert_eq!(types(&p).iter().filter(|t| **t == "TIMES").count(), 0);
+        assert!(types(&p).contains(&"POW"));
+    }
+
+    #[test]
+    fn double_angle_wins_over_comparison_operators() {
+        let p = lex("<<a>>$");
+        assert!(types(&p).contains(&"GROUP_OPEN"));
+        assert!(types(&p).contains(&"GROUP_CLOSE"));
+        assert!(!types(&p).contains(&"LESS"));
+        assert!(!types(&p).contains(&"GREATER"));
+        assert!(!types(&p).contains(&"LE"));
+        assert!(!types(&p).contains(&"GE"));
+    }
+
+    // --- Newlines are ordinary whitespace, never a distinct token ---------
+
+    #[test]
+    fn newlines_are_plain_whitespace_not_a_token() {
+        let p = lex("a := 1;\nb := 2$\n");
+        assert!(!types(&p).contains(&"NEWLINE"));
+    }
+
+    // --- Case sensitivity of ordinary symbols ------------------------------
+
+    #[test]
+    fn names_are_case_sensitive() {
+        pair(&lex("Df$"), 0, "NAME", "Df");
+        pair(&lex("df$"), 0, "NAME", "df");
+    }
+
+    // --- Literals and errors -------------------------------------------------
+
+    #[test]
+    fn numbers_and_symbols() {
+        pair(&lex("3.14$"), 0, "NUMBER", "3.14");
+        pair(&lex("42$"), 0, "NUMBER", "42");
+        pair(&lex("x$"), 0, "NAME", "x");
+    }
+
+    #[test]
+    fn unknown_char_is_an_error() {
+        assert!(try_tokenize_reduce("x ~ y$").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the REDUCE symbolic-CAS tokenizer per [MA08 §2](code/specs/MA08-reduce-language.md) item R-2 — a sibling of `derive-lexer`/`wolfram-lexer`/`macsyma-lexer`.
- New `code/grammars/reduce/reduce.tokens` (grammar-tools source, validated with `grammar-tools validate-tokens`) and the compiled `code/packages/rust/reduce-lexer` crate (`_grammar.rs` generated via `grammar-tools compile-tokens`).
- Covers the R-1-scoped surface (MA08 §3): ordinary-parenthesis function/procedure application, the single `:=` assignment operator, `=` as equation (never assignment), comparison including the word-form `neq`, the **lowercase** `and`/`or`/`not` logical keywords (the mirror image of `derive-lexer`'s uppercase `AND`/`OR`/`NOT`), `if`/`then`/`else`, curly-brace `{a, b, c}` list literals, the `.` cons operator, `<< ... >>` group statements, both `;`/`$` statement terminators (kept distinct, mirroring `macsyma-lexer`), and arithmetic including `^`/`**` (also kept distinct — the R-3 parser collapses both spellings onto one production).
- No `NEWLINE` token and no post-tokenize hook needed: REDUCE's `;`/`$`-terminated statement model has no significant newlines, mirroring `macsyma-lexer` exactly rather than `derive-lexer`/`wolfram-lexer`'s worksheet-style model.
- Registers `reduce-lexer` in the Cargo workspace.

## Test plan

- [x] `cargo run --bin grammar-tools -- validate-tokens code/grammars/reduce/reduce.tokens` — OK (24 tokens)
- [x] `cargo test -p coding-adventures-reduce-lexer` — 17 unit tests + 1 doctest, all passing
- [x] `cargo clippy -p coding-adventures-reduce-lexer --all-targets` — clean
- [x] `/security-review` — SECURITY REVIEW PASSED (no ReDoS risk in NUMBER/NAME/WHITESPACE patterns; panic-on-error path matches established sibling-crate convention)
- [x] README/CHANGELOG/BUILD/BUILD_windows/required_capabilities.json present

🤖 Generated with [Claude Code](https://claude.com/claude-code)