### PR TITLE
feat(tcp-runtime): outbound mailbox — post bytes to a connection from a worker thread

### DIFF
--- a/code/packages/c/http-server/tools/run.ps1
+++ b/code/packages/c/http-server/tools/run.ps1
@@ -27,11 +27,14 @@ $env:PLATFORM_INCLUDE = "$(Join-Path $self 'include') $(Join-Path $tcprt 'includ
 $env:PLATFORM_LIBS = 'ws2_32.lib'
 . (Join-Path $harness 'lib\platform-lib.ps1')
 Write-Host "http-server (windows): C compilers: $((Platform-Compilers -Lang c) -join ' ')"
+# tcp-runtime's mailbox uses os-platform's thread mutex (Win32 backend); its
+# source needs only the CRT + kernel32, linked by default.
 Platform-BuildAndRun -Lang c -Name 'http-server-tests' -Sources @(
     'tests\http_server_test.c',
     'src\http_server.c',
     (Join-Path $tcprt 'src\tcp_runtime.c'),
     (Join-Path $net 'src\net_windows.c'),
     (Join-Path $reactor 'src\reactor_windows.c'),
-    (Join-Path $http 'src\http_core.c')
+    (Join-Path $http 'src\http_core.c'),
+    (Join-Path $osp 'src\thread_windows.c')
 )

--- a/code/packages/c/http-server/tools/run.sh
+++ b/code/packages/c/http-server/tools/run.sh
@@ -36,9 +36,11 @@ fi
 export PLATFORM_DEFINES
 echo "http-server ($(platform_os)): C compilers: $(platform_compilers c)"
 rc=0
-PLATFORM_LIBS=""; export PLATFORM_LIBS
+# tcp-runtime's mailbox uses os-platform's thread mutex, so this consumer links
+# the thread backend and the OS thread library too (-pthread).
+PLATFORM_LIBS="-pthread"; export PLATFORM_LIBS
 platform_build_and_run c http-server-tests \
     tests/http_server_test.c src/http_server.c \
     "$TCPRT/src/tcp_runtime.c" "$NET/src/net_posix.c" "$REACTOR_SRC" \
-    "$HTTP/src/http_core.c" || rc=1
+    "$HTTP/src/http_core.c" "$OSP/src/thread_posix.c" || rc=1
 exit "$rc"

--- a/code/packages/c/resp-server/tools/run.ps1
+++ b/code/packages/c/resp-server/tools/run.ps1
@@ -27,11 +27,14 @@ $env:PLATFORM_INCLUDE = "$(Join-Path $self 'include') $(Join-Path $tcprt 'includ
 $env:PLATFORM_LIBS = 'ws2_32.lib'
 . (Join-Path $harness 'lib\platform-lib.ps1')
 Write-Host "resp-server (windows): C compilers: $((Platform-Compilers -Lang c) -join ' ')"
+# tcp-runtime's mailbox uses os-platform's thread mutex (Win32 backend); its
+# source needs only the CRT + kernel32, linked by default.
 Platform-BuildAndRun -Lang c -Name 'resp-server-tests' -Sources @(
     'tests\resp_server_test.c',
     'src\resp_server.c',
     (Join-Path $tcprt 'src\tcp_runtime.c'),
     (Join-Path $net 'src\net_windows.c'),
     (Join-Path $reactor 'src\reactor_windows.c'),
-    (Join-Path $resp 'src\resp_protocol.c')
+    (Join-Path $resp 'src\resp_protocol.c'),
+    (Join-Path $osp 'src\thread_windows.c')
 )

--- a/code/packages/c/resp-server/tools/run.sh
+++ b/code/packages/c/resp-server/tools/run.sh
@@ -36,9 +36,11 @@ fi
 export PLATFORM_DEFINES
 echo "resp-server ($(platform_os)): C compilers: $(platform_compilers c)"
 rc=0
-PLATFORM_LIBS=""; export PLATFORM_LIBS
+# tcp-runtime's mailbox uses os-platform's thread mutex, so this consumer links
+# the thread backend and the OS thread library too (-pthread).
+PLATFORM_LIBS="-pthread"; export PLATFORM_LIBS
 platform_build_and_run c resp-server-tests \
     tests/resp_server_test.c src/resp_server.c \
     "$TCPRT/src/tcp_runtime.c" "$NET/src/net_posix.c" "$REACTOR_SRC" \
-    "$RESP/src/resp_protocol.c" || rc=1
+    "$RESP/src/resp_protocol.c" "$OSP/src/thread_posix.c" || rc=1
 exit "$rc"

--- a/code/packages/c/tcp-runtime/CHANGELOG.md
+++ b/code/packages/c/tcp-runtime/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to semantic versioning.
 
 ### Added
 
+- **Outbound mailbox** (CCPP02 port campaign follow-up). A thread-safe way for a
+  worker thread to reply to a connection it cannot touch directly. `tcp_runtime_mailbox`
+  returns the runtime's `tcp_mailbox`; `tcp_mailbox_send`, `tcp_mailbox_send_and_close`,
+  and `tcp_mailbox_close` queue commands (send bytes / send-then-close / close) for
+  a connection id, executed on the reactor thread's next `tcp_runtime_poll`.
+  - The mailbox is a mutex-guarded FIFO of commands (the mutex is os-platform's
+    `thread` primitive — the runtime's only concurrency dependency). Enqueue copies
+    the payload; the queue is the sole shared state, so the connection table stays
+    private to the reactor thread. `poll` detaches the whole queue under the lock,
+    then writes each command **without holding the lock** (a producer never blocks
+    on I/O). A command for an unknown/closed connection id is dropped;
+    `tcp_runtime_destroy` drains and frees any still-queued commands.
+  - No cross-thread wakeup yet (a self-pipe/eventfd is a follow-up): delivery is on
+    the next poll — within one poll timeout under `tcp_runtime_serve` (100 ms).
+  - **Cross-package build change.** `tcp_runtime.c` now references `osp_mutex_*`, so
+    every package that compiles it also compiles the os-platform thread backend and
+    links the OS thread library: the `run.sh`/`run.ps1` of `tcp-runtime`,
+    `resp-server`, and `http-server` add `os-platform/src/thread_posix.c` (`-pthread`)
+    on POSIX and `thread_windows.c` (CRT-only) on Windows.
+  - Test extended (101 checks, ASan+UBSan, 0 leaks — up from 57): send delivers
+    bytes with no client write, send-and-close writes then closes, close removes a
+    connection, a command for an unknown id is dropped, and destroy frees a command
+    left queued at teardown.
+
 - **Connection cap** (CCPP02 port campaign follow-up). `tcp_runtime_set_max_connections`
   bounds concurrent connections (0 = unlimited, the default); at the cap a newly
   accepted connection is closed immediately (the client is refused) rather than

--- a/code/packages/c/tcp-runtime/README.md
+++ b/code/packages/c/tcp-runtime/README.md
@@ -47,6 +47,10 @@ tcp_runtime_destroy(rt);     /* closes the listener + every live connection */
 | `tcp_runtime_serve(rt)` | loop `poll` until stopped (blocks) |
 | `tcp_runtime_stop(rt)` | ask `serve` to return |
 | `tcp_runtime_destroy(rt)` | close everything, free |
+| `tcp_runtime_mailbox(rt)` | the outbound mailbox (post bytes from another thread) |
+| `tcp_mailbox_send(mb, id, data, len)` | queue bytes to connection `id` |
+| `tcp_mailbox_send_and_close(mb, id, data, len)` | queue bytes, then close |
+| `tcp_mailbox_close(mb, id)` | queue a close of connection `id` |
 
 **The handler** mirrors the Rust `TcpHandlerResult`: given the bytes just read,
 it fills a reply buffer and returns `{ write_len, close }` — how many bytes to
@@ -65,13 +69,41 @@ Each accepted connection is a heap node used verbatim as its reactor token, so a
 wait result maps back to its connection in O(1). (The token must be a stable
 allocation, not a slot in the reallocating connection array.)
 
+### The outbound mailbox
+
+The server touches a socket only on its reactor thread. So how does a **worker
+thread** reply to a connection? It hands the runtime a *command* — send these
+bytes to connection N, and/or close it — which the reactor thread runs on its
+next poll:
+
+```c
+tcp_mailbox *mb = tcp_runtime_mailbox(rt);   /* safe to call from any thread */
+tcp_mailbox_send(mb, conn_id, "async result\n", 13);
+tcp_mailbox_send_and_close(mb, conn_id, "done\n", 5);
+tcp_mailbox_close(mb, conn_id);
+```
+
+Each command is enqueued under a mutex (os-platform's `thread` primitive) with the
+payload **copied**; the queue is the only shared state — the connection table
+stays private to the reactor thread. `tcp_runtime_poll` detaches the whole queue
+under the lock, then writes each command **without holding the lock** (so a
+producer is never blocked on I/O). A command for an unknown or already-closed id
+is dropped. There is no cross-thread wakeup yet (a self-pipe/eventfd is a
+follow-up), so delivery happens on the next poll — within one poll timeout under
+`tcp_runtime_serve` (100 ms), or immediately if you drive `tcp_runtime_poll`.
+
+The send functions are safe to call concurrently with each other and with the
+poll, but not with `tcp_runtime_destroy` (which tears down the mailbox) — quiesce
+your producer threads before destroying the runtime, as with any shared object.
+
 ## Scope
 
 Phase-one core: one listener, many concurrent connections, a stateless handler,
-cooperative stop, and a concurrent-connection **cap**
-(`tcp_runtime_set_max_connections`). Deferred to follow-ups (mirroring the Rust
-crate's own phased plan): per-connection state, an outbound **mailbox** for worker
-threads, read-pause/resume **backpressure** (`defer_read`), socket-option policy
+cooperative stop, a concurrent-connection **cap**
+(`tcp_runtime_set_max_connections`), and a thread-safe outbound **mailbox**
+(`tcp_runtime_mailbox`). Deferred to follow-ups (mirroring the Rust crate's own
+phased plan): per-connection state, read-pause/resume **backpressure**
+(`defer_read`), a mailbox cross-thread **wakeup**, socket-option policy
 (`TCP_NODELAY`/keepalive), and multi-core reactor **sharding**. A reply larger
 than the 8 KiB per-read buffer is currently truncated.
 
@@ -80,15 +112,17 @@ than the 8 KiB per-read buffer is currently truncated.
 `tests/tcp_runtime_test.c` stands up a real server and hits it with real loopback
 clients (via `net`), stepping the server with `tcp_runtime_poll` between client
 actions — all in one thread. It proves the server **multiplexes** (two
-independent connections accepted and echoed on one reactor) and honors
-echo-and-close.
+independent connections accepted and echoed on one reactor), honors
+echo-and-close, refuses connections beyond the cap, and delivers **mailbox**
+commands (send / send-and-close / close, plus the drop of a command for an
+unknown id, and destroy draining a still-queued command).
 
 ```sh
 cd code/packages/c/tcp-runtime
 sh tools/run.sh        # macOS / Linux (Windows: tools\run.ps1 via BUILD_windows)
 ```
 
-Locally (macOS): 36 checks / 0 failed under gcc + clang; clean under ASan+UBSan;
+Locally (macOS): 101 checks / 0 failed under gcc + clang; clean under ASan+UBSan;
 0 leaks.
 
 ## Layout
@@ -98,7 +132,12 @@ tcp-runtime/
 ├── include/tcp_runtime/tcp_runtime.h   # public API (reuses os_platform/status.h)
 ├── src/tcp_runtime.c                    # the server — one OS-agnostic file
 ├── tests/tcp_runtime_test.c             # real loopback multiplexing test
-├── tools/run.sh  · run.ps1              # build with net + reactor backends
+├── tools/run.sh  · run.ps1              # build with net + reactor + os-platform thread
 ├── BUILD  · BUILD_windows               # per-OS build drivers
 └── required_capabilities.json           # CI needs gcc, clang, cl
 ```
+
+The mailbox mutex is os-platform's `thread` primitive, so the build now also
+compiles the os-platform thread backend (`-pthread` on POSIX; the CRT on
+Windows) — the same wiring is mirrored in the `resp-server` and `http-server`
+consumers, which link `tcp_runtime.c`.

--- a/code/packages/c/tcp-runtime/include/tcp_runtime/tcp_runtime.h
+++ b/code/packages/c/tcp-runtime/include/tcp_runtime/tcp_runtime.h
@@ -34,13 +34,17 @@
  *
  * SCOPE (phase-one core). One listener; many concurrent connections; a stateless
  * handler; cooperative stop; a concurrent-connection cap
- * (tcp_runtime_set_max_connections). Deliberately DEFERRED to follow-ups (as in
- * the Rust crate's own phased plan): per-connection state, an outbound mailbox
- * for worker threads, read-pause/resume backpressure (`defer_read`),
- * socket-option policy (TCP_NODELAY/keepalive), and multi-core reactor sharding.
+ * (tcp_runtime_set_max_connections); and a thread-safe outbound MAILBOX
+ * (tcp_runtime_mailbox) so a *worker thread* can push bytes to a connection by
+ * id, delivered on the reactor thread's next poll. Deliberately DEFERRED to
+ * follow-ups (as in the Rust crate's own phased plan): per-connection state,
+ * read-pause/resume backpressure (`defer_read`), socket-option policy
+ * (TCP_NODELAY/keepalive), and multi-core reactor sharding.
  *
- * BUILD. OS-agnostic — every per-OS detail lives in net and reactor — so this is
- * one source file compiled with the net + reactor backends for the target OS.
+ * BUILD. Per-OS socket/reactor detail lives in net and reactor, but the mailbox
+ * needs a mutex, which is os-platform's `thread` primitive (bucket B). So this
+ * one source file is compiled with the net + reactor backends AND the os-platform
+ * thread backend for the target OS (`-pthread` on POSIX; the CRT on Windows).
  */
 #ifndef TCP_RUNTIME_TCP_RUNTIME_H
 #define TCP_RUNTIME_TCP_RUNTIME_H
@@ -124,10 +128,68 @@ osp_status tcp_runtime_serve(tcp_runtime *rt);
 void tcp_runtime_stop(tcp_runtime *rt);
 
 /*
- * tcp_runtime_destroy — close the listener and every live connection, then free
- * the server. OSP_ERR_INVAL if rt is NULL.
+ * tcp_runtime_destroy — close the listener and every live connection, drain and
+ * free any commands still queued in the mailbox, then free the server. The caller
+ * must ensure no producer thread is still using the mailbox (see tcp_mailbox
+ * below) when this runs. OSP_ERR_INVAL if rt is NULL.
  */
 osp_status tcp_runtime_destroy(tcp_runtime *rt);
+
+/* ── Outbound mailbox (post bytes to a connection from another thread) ─────── */
+
+/*
+ * The mailbox is the answer to "how does a worker thread reply to a connection?"
+ * A tcp_runtime services sockets on ONE reactor thread, so only that thread may
+ * touch a socket. A worker instead hands the runtime a COMMAND — send these bytes
+ * to connection N, and/or close it — which the reactor thread executes on its
+ * next poll. Mirrors the Rust crate's `TcpMailbox`.
+ *
+ * Each command is enqueued under a mutex (the queue is the only shared state; the
+ * connection table stays private to the reactor thread), the payload is COPIED,
+ * and tcp_runtime_poll drains the whole queue after servicing readiness — never
+ * holding the lock across a socket write. A command for an unknown or
+ * already-closed connection id is silently dropped.
+ *
+ * DELIVERY LATENCY. There is no cross-thread wakeup (a self-pipe/eventfd is a
+ * documented follow-up), so a posted command is delivered on the reactor thread's
+ * NEXT poll — within one poll timeout when driven by tcp_runtime_serve (100 ms),
+ * or immediately if you drive tcp_runtime_poll yourself.
+ *
+ * LIFETIME (caller precondition). The mailbox lives inside its runtime. The send
+ * functions are safe to call CONCURRENTLY with each other and with the reactor
+ * thread's poll — but NOT concurrently with tcp_runtime_destroy, which tears the
+ * mailbox (and its mutex) down. Quiesce every producer thread before destroying
+ * the runtime, exactly as you would before freeing any shared object.
+ */
+typedef struct tcp_mailbox tcp_mailbox;
+
+/*
+ * tcp_runtime_mailbox — the runtime's outbound mailbox. The returned handle is
+ * owned by the runtime (freed by tcp_runtime_destroy); do not free it. Its send
+ * functions are safe to call from any thread. Returns NULL if rt is NULL.
+ */
+tcp_mailbox *tcp_runtime_mailbox(tcp_runtime *rt);
+
+/*
+ * tcp_mailbox_send — queue `len` bytes of `data` to be sent to connection
+ * `conn_id` on the next poll. The bytes are copied, so `data` need not outlive
+ * the call. OSP_ERR_INVAL (mb NULL, or data NULL with len > 0), OSP_ERR_NOMEM.
+ */
+osp_status tcp_mailbox_send(tcp_mailbox *mb, uint64_t conn_id, const void *data,
+                            size_t len);
+
+/*
+ * tcp_mailbox_send_and_close — like tcp_mailbox_send, but the connection is closed
+ * once the bytes are written (on the same poll). OSP_ERR_INVAL / OSP_ERR_NOMEM.
+ */
+osp_status tcp_mailbox_send_and_close(tcp_mailbox *mb, uint64_t conn_id,
+                                      const void *data, size_t len);
+
+/*
+ * tcp_mailbox_close — queue a close of connection `conn_id` (no bytes sent),
+ * executed on the next poll. OSP_ERR_INVAL (mb NULL), OSP_ERR_NOMEM.
+ */
+osp_status tcp_mailbox_close(tcp_mailbox *mb, uint64_t conn_id);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/code/packages/c/tcp-runtime/src/tcp_runtime.c
+++ b/code/packages/c/tcp-runtime/src/tcp_runtime.c
@@ -17,12 +17,14 @@
 #include "tcp_runtime/tcp_runtime.h"
 
 #include "net/tcp.h"
+#include "os_platform/thread.h" /* osp_mutex — guards the mailbox queue */
 #include "reactor/reactor.h"
 
 #include <stdlib.h>
+#include <string.h> /* memcpy — mailbox payloads are copied on enqueue */
 
 /* Per-read scratch. A reply larger than this is truncated (a phase-one limit;
- * streaming/mailbox output is a documented follow-up). */
+ * streaming output is a documented follow-up). */
 #define TCP_RT_BUFSZ 8192u
 /* Ready descriptors serviced per poll step before returning to the caller. */
 #define TCP_RT_MAX_EVENTS 64
@@ -31,6 +33,33 @@ struct tcp_conn {
     osp_socket *sock;
     osp_fd fd; /* cached for osp_reactor_del (the socket may be closing) */
     uint64_t id;
+};
+
+/*
+ * A queued outbound command: send `bytes`[0..`len`) to connection `conn_id`, and
+ * (if `close`) close it afterwards. `bytes` is a private copy of the caller's
+ * payload (NULL when len == 0); the reactor thread frees it after delivery. The
+ * commands form a singly-linked FIFO on the mailbox.
+ */
+struct tcp_cmd {
+    uint64_t conn_id;
+    unsigned char *bytes; /* memdup'd copy, or NULL when len == 0 */
+    size_t len;
+    int close;
+    struct tcp_cmd *next;
+};
+
+/*
+ * The outbound mailbox: a mutex-guarded FIFO of commands. Producers (any thread)
+ * append under the lock; the reactor thread detaches the whole queue under the
+ * lock and processes it unlocked. The mailbox is EMBEDDED in the runtime — its
+ * lifetime is exactly the runtime's — so tcp_runtime_mailbox hands back a pointer
+ * into the runtime, never a separate allocation.
+ */
+struct tcp_mailbox {
+    osp_mutex *lock;
+    struct tcp_cmd *head; /* oldest queued command (dequeued first) */
+    struct tcp_cmd *tail; /* newest queued command (appended here) */
 };
 
 struct tcp_runtime {
@@ -44,6 +73,7 @@ struct tcp_runtime {
     size_t count;
     size_t cap;
     size_t max_connections; /* 0 = unlimited (the default) */
+    struct tcp_mailbox mailbox;
     volatile int stopped;
 };
 
@@ -104,6 +134,110 @@ static void tcp__remove_conn(struct tcp_runtime *rt, struct tcp_conn *node) {
     free(node);
 }
 
+/* Free one command node and the payload it owns. */
+static void tcp__cmd_free(struct tcp_cmd *cmd) {
+    free(cmd->bytes);
+    free(cmd);
+}
+
+/*
+ * Enqueue a command on the mailbox. Copies `data` (so the caller need not keep it
+ * alive) and appends under the lock — the ONLY place a producer thread touches
+ * shared state. Called by the public tcp_mailbox_* wrappers, which validate args.
+ */
+static osp_status tcp__mailbox_enqueue(struct tcp_mailbox *mb, uint64_t conn_id,
+                                       const void *data, size_t len, int close) {
+    struct tcp_cmd *cmd = (struct tcp_cmd *)malloc(sizeof(*cmd));
+    if (cmd == NULL) {
+        return OSP_ERR_NOMEM;
+    }
+    cmd->bytes = NULL;
+    if (len > 0) {
+        cmd->bytes = (unsigned char *)malloc(len);
+        if (cmd->bytes == NULL) {
+            free(cmd);
+            return OSP_ERR_NOMEM;
+        }
+        memcpy(cmd->bytes, data, len);
+    }
+    cmd->conn_id = conn_id;
+    cmd->len = len;
+    cmd->close = close;
+    cmd->next = NULL;
+
+    osp_mutex_lock(mb->lock);
+    if (mb->tail == NULL) {
+        mb->head = cmd; /* first command in an empty queue */
+    } else {
+        mb->tail->next = cmd;
+    }
+    mb->tail = cmd;
+    osp_mutex_unlock(mb->lock);
+    return OSP_OK;
+}
+
+/*
+ * Detach the whole queue under the lock in one shot, then process it WITHOUT the
+ * lock held — so no socket write ever runs while the mutex is locked (a producer
+ * thread is never blocked on I/O it did not initiate). Runs on the reactor thread
+ * only, so scanning/mutating rt->conns needs no lock. A command whose connection
+ * id is unknown (never accepted, or already closed) is dropped.
+ */
+static void tcp__mailbox_drain(struct tcp_runtime *rt) {
+    struct tcp_mailbox *mb = &rt->mailbox;
+    struct tcp_cmd *cmd;
+    struct tcp_cmd *next;
+
+    osp_mutex_lock(mb->lock);
+    cmd = mb->head;
+    mb->head = NULL;
+    mb->tail = NULL;
+    osp_mutex_unlock(mb->lock);
+
+    for (; cmd != NULL; cmd = next) {
+        struct tcp_conn *node = NULL;
+        size_t i;
+        next = cmd->next; /* captured before we free cmd */
+        for (i = 0; i < rt->count; i++) {
+            if (rt->conns[i]->id == cmd->conn_id) {
+                node = rt->conns[i];
+                break;
+            }
+        }
+        if (node != NULL) {
+            if (cmd->len > 0) {
+                (void)osp_socket_send(node->sock, cmd->bytes, cmd->len, NULL);
+            }
+            if (cmd->close) {
+                tcp__remove_conn(rt, node);
+            }
+        }
+        tcp__cmd_free(cmd);
+    }
+}
+
+/* Free any commands still queued at teardown, without performing I/O (the sockets
+ * are being closed). Detaches under the lock so the mutex is left unlocked and
+ * unused, ready for osp_mutex_destroy. */
+static void tcp__mailbox_discard(struct tcp_mailbox *mb) {
+    struct tcp_cmd *cmd;
+    struct tcp_cmd *next;
+
+    if (mb->lock != NULL) {
+        osp_mutex_lock(mb->lock);
+    }
+    cmd = mb->head;
+    mb->head = NULL;
+    mb->tail = NULL;
+    if (mb->lock != NULL) {
+        osp_mutex_unlock(mb->lock);
+    }
+    for (; cmd != NULL; cmd = next) {
+        next = cmd->next;
+        tcp__cmd_free(cmd);
+    }
+}
+
 osp_status tcp_runtime_bind(tcp_runtime **out, const char *host,
                             unsigned short port, tcp_handler handler,
                             void *user) {
@@ -152,6 +286,16 @@ osp_status tcp_runtime_bind(tcp_runtime **out, const char *host,
     /* The runtime pointer is the listener's sentinel token — distinct from every
      * connection node pointer. */
     st = osp_reactor_add(rt->reactor, rt->listener_fd, OSP_READABLE, rt);
+    if (st != OSP_OK) {
+        osp_reactor_destroy(rt->reactor);
+        osp_socket_close(rt->listener);
+        free(rt);
+        osp_net_shutdown();
+        return st;
+    }
+    /* The mailbox mutex is the runtime's only concurrency primitive; the queue
+     * is already empty (calloc zeroed head/tail). */
+    st = osp_mutex_init(&rt->mailbox.lock);
     if (st != OSP_OK) {
         osp_reactor_destroy(rt->reactor);
         osp_socket_close(rt->listener);
@@ -242,6 +386,9 @@ osp_status tcp_runtime_poll(tcp_runtime *rt, int timeout_ms, int *out_handled) {
             }
         }
     }
+    /* Deliver anything a worker thread posted since the last poll — even when the
+     * reactor timed out with no events (count == 0). */
+    tcp__mailbox_drain(rt);
     *out_handled = count;
     return OSP_OK;
 }
@@ -266,10 +413,46 @@ void tcp_runtime_stop(tcp_runtime *rt) {
     }
 }
 
+tcp_mailbox *tcp_runtime_mailbox(tcp_runtime *rt) {
+    if (rt == NULL) {
+        return NULL;
+    }
+    return &rt->mailbox;
+}
+
+osp_status tcp_mailbox_send(tcp_mailbox *mb, uint64_t conn_id, const void *data,
+                            size_t len) {
+    if (mb == NULL || (data == NULL && len > 0)) {
+        return OSP_ERR_INVAL;
+    }
+    return tcp__mailbox_enqueue(mb, conn_id, data, len, 0);
+}
+
+osp_status tcp_mailbox_send_and_close(tcp_mailbox *mb, uint64_t conn_id,
+                                      const void *data, size_t len) {
+    if (mb == NULL || (data == NULL && len > 0)) {
+        return OSP_ERR_INVAL;
+    }
+    return tcp__mailbox_enqueue(mb, conn_id, data, len, 1);
+}
+
+osp_status tcp_mailbox_close(tcp_mailbox *mb, uint64_t conn_id) {
+    if (mb == NULL) {
+        return OSP_ERR_INVAL;
+    }
+    return tcp__mailbox_enqueue(mb, conn_id, NULL, 0, 1);
+}
+
 osp_status tcp_runtime_destroy(tcp_runtime *rt) {
     size_t i;
     if (rt == NULL) {
         return OSP_ERR_INVAL;
+    }
+    /* Free any commands still queued (no I/O — the sockets are about to close),
+     * then release the mutex. */
+    tcp__mailbox_discard(&rt->mailbox);
+    if (rt->mailbox.lock != NULL) {
+        osp_mutex_destroy(rt->mailbox.lock);
     }
     for (i = 0; i < rt->count; i++) {
         osp_reactor_del(rt->reactor, rt->conns[i]->fd);

--- a/code/packages/c/tcp-runtime/tests/tcp_runtime_test.c
+++ b/code/packages/c/tcp-runtime/tests/tcp_runtime_test.c
@@ -134,6 +134,91 @@ int main(void) {
         ISO_CHECK(tcp_runtime_destroy(capped) == OSP_OK);
     }
 
+    /* ── mailbox: a "worker" posts outbound bytes by connection id ───────────
+     * The mailbox bypasses the read→handler path entirely: nothing is sent BY the
+     * client; the runtime drains the queued command on its next poll and writes.
+     * We drive that poll directly (single-threaded), which exercises the exact
+     * enqueue/drain/free machinery a real worker thread would hit. The first
+     * accepted connection has id 1 (next_id starts at 1). */
+    {
+        tcp_runtime *mrt = NULL;
+        tcp_mailbox *mb = NULL;
+        osp_socket *m1 = NULL;
+        unsigned short mport = 0;
+        size_t mn = 0;
+        int mh = 0;
+        char mbuf[32];
+
+        ISO_CHECK(tcp_runtime_bind(&mrt, "127.0.0.1", 0, echo_handler, NULL) ==
+                  OSP_OK);
+        ISO_CHECK(tcp_runtime_local_port(mrt, &mport) == OSP_OK);
+        mb = tcp_runtime_mailbox(mrt);
+        ISO_CHECK_MSG(mb != NULL, "a bound runtime must expose a mailbox");
+        ISO_CHECK(tcp_runtime_mailbox(NULL) == NULL);
+
+        ISO_CHECK(osp_tcp_connect(&m1, "127.0.0.1", mport) == OSP_OK);
+        ISO_CHECK(tcp_runtime_poll(mrt, 500, &mh) == OSP_OK); /* accepts m1 (id 1) */
+        ISO_CHECK(tcp_runtime_connection_count(mrt, &mn) == OSP_OK);
+        ISO_CHECK_EQ_UINT(mn, 1u);
+
+        /* post bytes to conn 1; the next poll delivers them (client sent nothing) */
+        ISO_CHECK(tcp_mailbox_send(mb, 1, "ping", 4) == OSP_OK);
+        ISO_CHECK(tcp_runtime_poll(mrt, 200, &mh) == OSP_OK); /* drains the mailbox */
+        mn = 0;
+        ISO_CHECK(osp_socket_recv(m1, mbuf, sizeof(mbuf), &mn) == OSP_OK);
+        ISO_CHECK_EQ_UINT(mn, 4u);
+        ISO_CHECK_MEM_EQ(mbuf, "ping", 4);
+
+        /* send_and_close: bytes delivered, then the connection is closed */
+        ISO_CHECK(tcp_mailbox_send_and_close(mb, 1, "bye!", 4) == OSP_OK);
+        ISO_CHECK(tcp_runtime_poll(mrt, 200, &mh) == OSP_OK);
+        mn = 0;
+        ISO_CHECK(osp_socket_recv(m1, mbuf, sizeof(mbuf), &mn) == OSP_OK);
+        ISO_CHECK_EQ_UINT(mn, 4u);
+        ISO_CHECK_MEM_EQ(mbuf, "bye!", 4);
+        mn = 123;
+        ISO_CHECK(osp_socket_recv(m1, mbuf, sizeof(mbuf), &mn) == OSP_OK);
+        ISO_CHECK_MSG(mn == 0, "send_and_close must close the connection");
+        ISO_CHECK(tcp_runtime_connection_count(mrt, &mn) == OSP_OK);
+        ISO_CHECK_EQ_UINT(mn, 0u); /* the close removed the connection */
+        ISO_CHECK(osp_socket_close(m1) == OSP_OK);
+        m1 = NULL;
+
+        /* a command for an unknown/closed id is silently dropped (no crash) */
+        ISO_CHECK(tcp_mailbox_send(mb, 999, "x", 1) == OSP_OK);
+        ISO_CHECK(tcp_runtime_poll(mrt, 100, &mh) == OSP_OK);
+        ISO_CHECK(tcp_runtime_connection_count(mrt, &mn) == OSP_OK);
+        ISO_CHECK_EQ_UINT(mn, 0u);
+
+        /* tcp_mailbox_close on a fresh connection (id 2) removes it, no bytes sent */
+        {
+            osp_socket *m2 = NULL;
+            ISO_CHECK(osp_tcp_connect(&m2, "127.0.0.1", mport) == OSP_OK);
+            ISO_CHECK(tcp_runtime_poll(mrt, 500, &mh) == OSP_OK); /* accepts m2 (id 2) */
+            ISO_CHECK(tcp_runtime_connection_count(mrt, &mn) == OSP_OK);
+            ISO_CHECK_EQ_UINT(mn, 1u);
+            ISO_CHECK(tcp_mailbox_close(mb, 2) == OSP_OK);
+            ISO_CHECK(tcp_runtime_poll(mrt, 200, &mh) == OSP_OK);
+            ISO_CHECK(tcp_runtime_connection_count(mrt, &mn) == OSP_OK);
+            ISO_CHECK_EQ_UINT(mn, 0u);
+            mn = 123;
+            ISO_CHECK(osp_socket_recv(m2, mbuf, sizeof(mbuf), &mn) == OSP_OK);
+            ISO_CHECK_MSG(mn == 0, "tcp_mailbox_close must close the connection");
+            ISO_CHECK(osp_socket_close(m2) == OSP_OK);
+        }
+
+        /* argument validation */
+        ISO_CHECK(tcp_mailbox_send(NULL, 1, "x", 1) == OSP_ERR_INVAL);
+        ISO_CHECK(tcp_mailbox_send(mb, 1, NULL, 4) == OSP_ERR_INVAL);
+        ISO_CHECK(tcp_mailbox_send_and_close(NULL, 1, "x", 1) == OSP_ERR_INVAL);
+        ISO_CHECK(tcp_mailbox_close(NULL, 1) == OSP_ERR_INVAL);
+
+        /* a command left queued at teardown must be drained+freed by destroy
+         * (checked by ASan/leaks: no leak of the node or its payload) */
+        ISO_CHECK(tcp_mailbox_send(mb, 1, "left-pending", 12) == OSP_OK);
+        ISO_CHECK(tcp_runtime_destroy(mrt) == OSP_OK);
+    }
+
     /* ── stop before serve → serve returns immediately ──────────────────── */
     tcp_runtime_stop(rt);
     ISO_CHECK(tcp_runtime_serve(rt) == OSP_OK);

--- a/code/packages/c/tcp-runtime/tools/run.ps1
+++ b/code/packages/c/tcp-runtime/tools/run.ps1
@@ -25,9 +25,12 @@ $env:PLATFORM_INCLUDE = "$(Join-Path $self 'include') $(Join-Path $net 'include'
 $env:PLATFORM_LIBS = 'ws2_32.lib'
 . (Join-Path $harness 'lib\platform-lib.ps1')
 Write-Host "tcp-runtime (windows): C compilers: $((Platform-Compilers -Lang c) -join ' ')"
+# The mailbox mutex comes from os-platform's thread backend (Win32); its source
+# needs only the CRT + kernel32, already linked by default.
 Platform-BuildAndRun -Lang c -Name 'tcp-runtime-tests' -Sources @(
     'tests\tcp_runtime_test.c',
     'src\tcp_runtime.c',
     (Join-Path $net 'src\net_windows.c'),
-    (Join-Path $reactor 'src\reactor_windows.c')
+    (Join-Path $reactor 'src\reactor_windows.c'),
+    (Join-Path $osp 'src\thread_windows.c')
 )

--- a/code/packages/c/tcp-runtime/tools/run.sh
+++ b/code/packages/c/tcp-runtime/tools/run.sh
@@ -36,8 +36,11 @@ fi
 export PLATFORM_DEFINES
 echo "tcp-runtime ($(platform_os)): C compilers: $(platform_compilers c)"
 rc=0
-PLATFORM_LIBS=""; export PLATFORM_LIBS
+# The mailbox mutex comes from os-platform's thread backend (pthreads on POSIX),
+# so link its source and the OS thread library. _GNU_SOURCE / _DARWIN_C_SOURCE
+# (set above for the reactor) already expose the pthreads declarations.
+PLATFORM_LIBS="-pthread"; export PLATFORM_LIBS
 platform_build_and_run c tcp-runtime-tests \
     tests/tcp_runtime_test.c src/tcp_runtime.c \
-    "$NET/src/net_posix.c" "$REACTOR_SRC" || rc=1
+    "$NET/src/net_posix.c" "$REACTOR_SRC" "$OSP/src/thread_posix.c" || rc=1
 exit "$rc"


### PR DESCRIPTION
## What

The **final CCPP02 port-campaign follow-up** for `tcp-runtime`: a thread-safe outbound **mailbox** so a worker thread can reply to a connection it cannot touch directly. A `tcp_runtime` services sockets on one reactor thread; the mailbox lets any thread hand the runtime a *command* — send these bytes to connection N, and/or close it — which the reactor thread executes on its next poll. Mirrors the Rust crate's `TcpMailbox`.

```c
tcp_mailbox *mb = tcp_runtime_mailbox(rt);          // runtime-owned; call from any thread
tcp_mailbox_send(mb, conn_id, "async\n", 6);
tcp_mailbox_send_and_close(mb, conn_id, "done\n", 5);
tcp_mailbox_close(mb, conn_id);
```

## Design (safety-critical)

- Mutex-guarded singly-linked FIFO of commands; the mutex is os-platform's `thread` primitive (`osp_mutex`). Enqueue **copies** the payload.
- The mutex guards **only** the command queue. The connection table (`rt->conns`) stays private to the reactor thread, so a producer never races it and no lock is held during socket I/O.
- `poll()` detaches the whole queue under the lock, then writes each command **unlocked**. The drain re-looks-up the target by **id** per command (ids are monotonic, never reused), so a command for an already-closed connection finds nothing and is dropped — no use-after-free.
- Mutex created in `bind`, drained + destroyed in `destroy`; a command left queued at teardown is freed. Documented precondition: quiesce producers before `tcp_runtime_destroy`.

## Cross-package build change

`tcp_runtime.c` now references `osp_mutex_*`, so **every package that compiles it** also compiles the os-platform thread backend and links the OS thread library. The `run.sh` + `run.ps1` of **tcp-runtime, resp-server, and http-server** add `os-platform/src/thread_posix.c` (`-pthread`) on POSIX and `thread_windows.c` (CRT-only) on Windows. (All three already declared `c/os-platform` in their BUILD deps.)

## Verification (macOS)

- **tcp-runtime: 101 checks / 0 failed** under gcc + clang (was 57) — new mailbox block covers send, send-and-close, close, drop-of-unknown-id, and destroy draining a still-queued command.
- **resp-server: 54**, **http-server: 56** — both still green with the new wiring.
- Clean under **ASan + UBSan**; **0 leaks** under `leaks --atExit`.
- Adversarial **security review passed**: mutex lock/unlock balance, single-free of every node + payload, no UAF on the conn-by-id lookup, no I/O under lock all confirmed. The review's one note (document the no-producers-during-destroy precondition) is addressed in the header + README.

## Scope

Only three package dirs: `code/packages/c/{tcp-runtime,resp-server,http-server}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)