### PR TITLE
feat(wolfram-runtime): wire Integrate[expr, x] (W-22 fifth cas-* head)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.20.3] — 2026-07-17
+
+### Changed
+
+- `handlers::integrate_handler`'s indefinite-integral (2-argument) pipeline
+  is now a `pub` free function, `handlers::integrate_expr(vm, f, x)`. No
+  behavior change for `integrate_handler` itself (its 2-argument branch now
+  just calls the extracted function; its 4-argument definite-integral
+  branch and its existing panic-on-bad-arity contract are untouched) — this
+  only widens visibility so other language runtimes sharing this crate's
+  `VM`/`IRNode` types can reuse the exact same integration pipeline
+  Macsyma's own `integrate` already runs, rather than reimplementing or
+  duplicating it. Mirrors `handlers::differentiate`'s identical extraction
+  for `D` (0.20.2) exactly, including the same "still panics internally,
+  caller with a fail-soft contract must validate arity first" shape.
+  `integrate_expr` installs its own `AssumptionGuard` snapshot of
+  `vm.assumptions` so it is correct standalone even if a caller hasn't
+  already installed one — `AssumptionGuard`'s RAII design explicitly
+  supports a redundant nested install (see `handlers.rs`'s own module
+  docs), so this adds no correctness hazard for `integrate_handler`'s
+  existing internal caller, which already installs one ahead of both its
+  2- and 4-argument branches. First consumer: `wolfram-runtime`'s
+  `Integrate[expr, x]` wiring (W-22, see that crate's own changelog).
+
 ## [0.20.2] — 2026-07-16
 
 ### Changed

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.20.2"
+version = "0.20.3"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -2423,21 +2423,42 @@ fn integrate_handler() -> Handler {
             return IRNode::Apply(Box::new(expr));
         }
 
-        let result = integrate(&f, &x);
-        let original = apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.clone())]);
-        if result == original {
-            // Track E2: generic tabular IBP fallback.  Fires after every
-            // shape-specific handler in `integrate` returned the original
-            // unevaluated `Integrate(...)` form.  Mirrors the Python
-            // ``try_ibp_tabular`` hook in ``integrate.py``.
-            if let Some(ibp_result) = try_ibp_tabular(&f, &x, vm) {
-                return vm.eval(ibp_result);
-            }
-            result
-        } else {
-            vm.eval(result)
-        }
+        integrate_expr(vm, f, x)
     })
+}
+
+/// The indefinite-integral pipeline: `∫ f dx`, published as a reusable `pub`
+/// entry point so other languages' surface functions (Wolfram's
+/// `Integrate[expr, x]`) can call the exact same logic
+/// `integrate_handler`'s 2-argument branch runs, rather than duplicating or
+/// reimplementing it — mirrors [`differentiate`]'s identical extraction for
+/// `D`/`DIF`/`df`.
+///
+/// Installs its own [`AssumptionGuard`] snapshot of `vm.assumptions` so this
+/// function is correct standalone, regardless of whether a caller already
+/// installed one of its own (`integrate_handler`'s remaining 4-argument
+/// branch does, ahead of a call here from its own 2-argument branch) — a
+/// nested install is exactly what `AssumptionGuard` is designed to support
+/// safely (its own doc comment: "an RAII guard restores the previous value
+/// on Drop so nested integrals ... cannot strand it"), so this is a cheap
+/// redundant snapshot in the already-installed case, not a correctness
+/// hazard.
+pub fn integrate_expr(vm: &mut VM, f: IRNode, x: String) -> IRNode {
+    let _assumption_guard = AssumptionGuard::install(vm.assumptions.clone());
+    let result = integrate(&f, &x);
+    let original = apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.clone())]);
+    if result == original {
+        // Track E2: generic tabular IBP fallback.  Fires after every
+        // shape-specific handler in `integrate` returned the original
+        // unevaluated `Integrate(...)` form.  Mirrors the Python
+        // ``try_ibp_tabular`` hook in ``integrate.py``.
+        if let Some(ibp_result) = try_ibp_tabular(&f, &x, vm) {
+            return vm.eval(ibp_result);
+        }
+        result
+    } else {
+        vm.eval(result)
+    }
 }
 
 fn integrate(f: &IRNode, x: &str) -> IRNode {

--- a/code/packages/rust/wolfram-runtime/CHANGELOG.md
+++ b/code/packages/rust/wolfram-runtime/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to `wolfram-runtime` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.19.5] — 2026-07-17
+
+### Added (W-22 — `Integrate`, fifth `cas-*` head)
+
+- `Integrate[expr, x]` — the indefinite integral of `expr` with respect to
+  the symbol `x`: shape-specific closed forms (polynomial power rule,
+  elementary transcendentals, the Weierstrass trig-rational substitution,
+  incomplete-elliptic recognition, …) tried in sequence, falling back to a
+  generic tabular integration-by-parts sweep, exactly the same pipeline
+  Macsyma's own `integrate` already runs. Like `D`, the actual integration
+  logic lives directly in `symbolic-vm` itself: this wiring calls the new
+  `symbolic_vm::handlers::integrate_expr` — the exact indefinite-integral
+  pipeline `integrate_handler`'s own 2-argument branch runs, extracted into
+  a `pub` free function specifically for this reuse (see `symbolic-vm`'s
+  own changelog). No algorithm is reimplemented or duplicated; a parity
+  test pins both languages' call sites to agree on the same input, exactly
+  like `Simplify`/`Expand`/`Factor`/`D`'s own parity tests.
+- Like every W-5+ built-in, `Integrate` is an ordinary eager `Head[args]`
+  form requiring exactly two arguments, the second of which must be a bare
+  symbol; any other shape leaves the form unevaluated. Unlike `Factor`
+  (whose arity check lives inside `factor_handler` itself), this wrapper
+  does its own check — `integrate_handler`'s existing arity contract
+  panics on an argument count other than 2 or 4, which is right for
+  `symbolic-vm`'s own internal dispatch but wrong for Wolfram's fail-soft
+  contract, so `integrate_handler` (this crate's own wrapper) validates the
+  shape before ever calling through.
+- Scope note: only the indefinite (2-argument) form is wired under the
+  Wolfram name. The 4-argument definite-integral shape
+  `integrate_handler` also supports internally (this repo's flat
+  `Integrate[f, x, a, b]` convention for the complete-elliptic-integral
+  recognisers) is deliberately not exposed yet — real Wolfram spells a
+  definite integral `Integrate[f, {x, a, b}]`, bounds wrapped in a `List`,
+  a different shape needing its own `List`-destructuring wrapper as a
+  follow-up rather than a same-shape passthrough.
+
 ## [0.19.4] — 2026-07-16
 
 ### Added (W-22 — `D`, fourth `cas-*` head)

--- a/code/packages/rust/wolfram-runtime/Cargo.toml
+++ b/code/packages/rust/wolfram-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-wolfram-runtime"
-version = "0.19.4"
+version = "0.19.5"
 edition = "2021"
 description = "Wolfram Language runtime — lowers M-expressions to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"

--- a/code/packages/rust/wolfram-runtime/src/builtins.rs
+++ b/code/packages/rust/wolfram-runtime/src/builtins.rs
@@ -258,13 +258,23 @@ pub fn build_wolfram_builtins() -> HashMap<String, Handler> {
     // reusing `symbolic-vm`'s own `differentiate` (same idea as `Factor`,
     // but this wrapper does its own arity/shape check first, since `D`'s
     // fail-soft "leave it unevaluated" contract differs from
-    // `derivative_handler`'s panic-on-bad-arity one). Further heads
-    // (`Solve`, `Integrate`, ...) are added one at a time, each its own PR,
-    // per HML00's one-item-per-PR discipline.
+    // `derivative_handler`'s panic-on-bad-arity one). `Integrate` is the
+    // fifth, reusing `symbolic-vm`'s own `integrate_expr` (same
+    // extract-then-wrap idea as `D`/`differentiate`) — indefinite
+    // (2-argument) form only; the 4-argument definite-integral shape
+    // `integrate_handler` also supports internally is deliberately not
+    // exposed here yet (real Wolfram spells that `Integrate[f, {x, a, b}]`
+    // with a `List` bound, a different shape from this repo's flat 4-arg
+    // convention, so it needs its own follow-on rather than a same-shape
+    // passthrough). `Solve` remains a separate future item, no grammar
+    // change required (an ordinary `Head[args]` form the existing grammar
+    // already parses) — added one at a time, each its own PR, per HML00's
+    // one-item-per-PR discipline.
     m.insert("Simplify".to_string(), handler_fn(simplify_handler));
     m.insert("Expand".to_string(), handler_fn(expand_handler));
     m.insert("Factor".to_string(), handler_fn(factor_handler));
     m.insert("D".to_string(), handler_fn(d_handler));
+    m.insert("Integrate".to_string(), handler_fn(integrate_handler));
 
     // W-18 pattern-matching predicates (MA04 §19). HELD (see `PATTERN_HEADS`):
     // each handler evaluates ONLY its subject and matches against the *literal*
@@ -3418,6 +3428,53 @@ fn d_handler(vm: &mut VM, expr: IRApply) -> IRNode {
     symbolic_vm::handlers::differentiate(vm, f, &x)
 }
 
+/// `Integrate[expr, x]` → the indefinite integral of `expr` with respect to
+/// the symbol `x`: shape-specific closed forms (polynomial power rule,
+/// elementary transcendentals, the Weierstrass trig-rational substitution,
+/// incomplete-elliptic recognition, …) tried in sequence, falling back to a
+/// generic tabular integration-by-parts sweep, exactly the same pipeline
+/// Macsyma's own `integrate` surface function already runs.
+///
+/// Like `D` (and unlike `Factor`), the actual integration logic lives
+/// directly in `symbolic-vm` itself but cannot be reused via a single
+/// no-arity-check call the way `factor_handler` can: this is a thin call
+/// into `symbolic_vm::handlers::integrate_expr` — the exact indefinite-
+/// integral pipeline `integrate_handler`'s own 2-argument branch runs,
+/// extracted into a `pub` free function specifically so this wiring can
+/// reuse it (see that crate's own changelog). No algorithm is reimplemented
+/// or duplicated. `integrate_handler`'s existing contract *panics* on an
+/// argument count other than 2 or 4 — right for a genuine internal
+/// invariant violation but wrong for Wolfram's fail-soft "leave it
+/// unevaluated" contract every other W-22/W-15 built-in follows — so this
+/// wrapper validates the shape itself before calling through: exactly two
+/// arguments, and the second must be a bare symbol (`Integrate[expr, 2]` or
+/// `Integrate[expr]` stay unevaluated).
+///
+/// The 4-argument definite-integral shape `integrate_handler` also supports
+/// (`Integrate[f, x, a, b]`, this repo's flat convention for the complete-
+/// elliptic-integral recognisers) is deliberately **not** exposed under the
+/// Wolfram name yet — real Wolfram spells a definite integral
+/// `Integrate[f, {x, a, b}]`, bounds wrapped in a `List`, a different shape
+/// from the flat 4-arg convention `integrate_handler` uses internally, so
+/// building that surface needs its own `List`-destructuring wrapper as a
+/// follow-up rather than a same-shape passthrough.
+///
+/// ```text
+/// Integrate[x^2, x]      (* x^3 / 3 *)
+/// Integrate[x^2, 2]      (* x^2 unevaluated — second argument isn't a symbol *)
+/// ```
+fn integrate_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 2 {
+        return unevaluated(expr);
+    }
+    let x = match &expr.args[1] {
+        IRNode::Symbol(s) => s.clone(),
+        _ => return unevaluated(expr),
+    };
+    let f = expr.args[0].clone();
+    symbolic_vm::handlers::integrate_expr(vm, f, x)
+}
+
 // ---------------------------------------------------------------------------
 // W-12 string builtins
 // ---------------------------------------------------------------------------
@@ -6441,6 +6498,82 @@ mod tests {
             apply(
                 sym(MUL),
                 vec![int(3), apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)])],
+            )
+        );
+    }
+
+    #[test]
+    fn integrate_computes_the_indefinite_integral_of_a_power() {
+        // Integrate[x^2, x] -> (1/3) * x^3, the exact same power-rule result
+        // `integrate(x^2)` produces in `symbolic-vm`'s own
+        // `integrate_power_rules` test (`symbolic-vm/tests/test_vm.rs`).
+        let x_squared = apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)]);
+        assert_eq!(
+            run("Integrate", vec![x_squared, sym("x")]),
+            apply(
+                sym(MUL),
+                vec![
+                    IRNode::Rational(1, 3),
+                    apply(sym(symbolic_ir::POW), vec![sym("x"), int(3)]),
+                ],
+            )
+        );
+    }
+
+    #[test]
+    fn integrate_leaves_a_non_symbol_second_argument_unevaluated() {
+        // Integrate[x^2, 2] -- the second argument isn't a symbol, so this
+        // stays unevaluated exactly like `D`'s own non-symbol case above.
+        let x_squared = apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)]);
+        assert_eq!(
+            run("Integrate", vec![x_squared.clone(), int(2)]),
+            apply(sym("Integrate"), vec![x_squared, int(2)])
+        );
+    }
+
+    #[test]
+    fn integrate_agrees_with_macsyma_on_the_same_underlying_call() {
+        // Both Wolfram's Integrate and Macsyma's integrate dispatch to the
+        // exact same symbolic_vm::handlers::integrate_expr -- this pins
+        // that the Wolfram wiring doesn't diverge from the reference call.
+        // Needs a fresh VM on each side since `integrate_expr` takes
+        // `&mut VM` (unlike Simplify/Expand's parity tests, which call a
+        // plain free function).
+        let x_squared = apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)]);
+        let via_wolfram = run("Integrate", vec![x_squared.clone(), sym("x")]);
+        let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+        let via_macsyma_path =
+            symbolic_vm::handlers::integrate_expr(&mut vm, x_squared, "x".to_string());
+        assert_eq!(via_wolfram, via_macsyma_path);
+    }
+
+    #[test]
+    fn integrate_with_wrong_arity_stays_unevaluated() {
+        assert_eq!(run("Integrate", vec![]), apply(sym("Integrate"), vec![]));
+        assert_eq!(
+            run("Integrate", vec![sym("x")]),
+            apply(sym("Integrate"), vec![sym("x")])
+        );
+        assert_eq!(
+            run("Integrate", vec![sym("x"), sym("y"), sym("z")]),
+            apply(sym("Integrate"), vec![sym("x"), sym("y"), sym("z")])
+        );
+    }
+
+    #[test]
+    fn integrate_dispatches_end_to_end_through_the_wolfram_backend() {
+        // x^2 integrates through the full VM eval dispatch on a real
+        // WolframBackend, exactly mirroring
+        // `d_dispatches_end_to_end_through_the_wolfram_backend` above.
+        let x_squared = apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)]);
+        assert_eq!(
+            eval_full(apply(sym("Integrate"), vec![x_squared, sym("x")])),
+            apply(
+                sym(MUL),
+                vec![
+                    IRNode::Rational(1, 3),
+                    apply(sym(symbolic_ir::POW), vec![sym("x"), int(3)]),
+                ],
             )
         );
     }

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -95,12 +95,13 @@ Following [HML00 §6](HML00-historical-math-languages-roadmap.md)'s breakdown:
   progress — see §24.)* Wires the existing `cas-*` crates in one head at a
   time: `Simplify` (a thin call into `cas-simplify`'s `simplify()`),
   `Expand` (a thin call into `cas-simplify`'s `expand()`), `Factor` (a
-  direct call into `symbolic-vm`'s own `factor_handler`), and `D` (a direct
-  call into `symbolic-vm`'s own `differentiate`) are all delivered — each
-  the same function its Macsyma counterpart calls, so the two languages
-  agree on every result this crate can produce. Remaining: `Solve`,
-  `Integrate`, each its own item — no grammar change for any of them (all
-  ordinary `Head[args]` forms the existing grammar already parses).
+  direct call into `symbolic-vm`'s own `factor_handler`), `D` (a direct
+  call into `symbolic-vm`'s own `differentiate`), and `Integrate` (a direct
+  call into `symbolic-vm`'s own `integrate_expr`, indefinite form only) are
+  all delivered — each the same function its Macsyma counterpart calls, so
+  the two languages agree on every result this crate can produce.
+  Remaining: `Solve`, each its own item — no grammar change (an ordinary
+  `Head[args]` form the existing grammar already parses).
 
 ## §3 The supported surface (the grammar)
 
@@ -2222,11 +2223,54 @@ D[x^3, x]      (* 3 * x^2 *)
 D[x^2, 2]      (* x^2 unevaluated — second argument isn't a symbol *)
 ```
 
-### §24.5 Remaining (not yet delivered)
+### §24.5 `Integrate` (delivered, indefinite form only)
 
-`Solve`, `Integrate`, and the rest of §2's original list — each is a
-separate future item, no grammar change required for any of them (all are
-ordinary `Head[args]` forms the existing grammar already parses).
+`Integrate[expr, x]` is a thin call into
+`symbolic_vm::handlers::integrate_expr` — **the exact indefinite-integral
+pipeline** `integrate_handler`'s own 2-argument branch runs, which is in
+turn the same pipeline Macsyma's own `integrate` surface function already
+calls. Unlike `Simplify`/`Expand` (thin calls into the standalone
+`cas-simplify` crate), the integration logic lives directly inside
+`symbolic-vm` itself, same as `Factor`/`D`; `integrate_expr` was extracted
+out of `integrate_handler`'s closure body and made `pub` in `symbolic-vm`
+specifically for this cross-language reuse (see that crate's own
+changelog). No algorithm is reimplemented; a test pins both languages'
+call sites to agree on the same input, exactly like
+`Simplify`/`Expand`/`Factor`/`D`'s own parity tests.
+
+`integrate_expr` tries shape-specific closed forms in sequence (polynomial
+power rule, elementary transcendentals, the Weierstrass trig-rational
+substitution, incomplete-elliptic recognition, …), falling back to a
+generic tabular integration-by-parts sweep when none apply — see
+`symbolic-vm`'s own module docs for the full algorithm inventory (shared,
+not reimplemented, with Macsyma).
+
+Like `D`, `Integrate`'s underlying handler (`integrate_handler`) has an
+existing arity contract that *panics* on the wrong argument count (2 or 4
+expected — a genuine internal invariant for `symbolic-vm`'s own dispatch,
+not a fail-soft contract). Since `Integrate` still needs Wolfram's usual
+"leave it unevaluated" behaviour, `Integrate`'s wrapper validates the shape
+itself before calling through: exactly two arguments, and the second must
+be a bare symbol.
+
+Only the indefinite (2-argument) form is wired under the Wolfram name here.
+The 4-argument definite-integral shape `integrate_handler` also supports
+internally (this repo's flat `Integrate[f, x, a, b]` convention for the
+complete-elliptic-integral recognisers) is deliberately not exposed yet —
+real Wolfram spells a definite integral `Integrate[f, {x, a, b}]`, bounds
+wrapped in a `List`, a different shape needing its own `List`-destructuring
+wrapper as a follow-up rather than a same-shape passthrough.
+
+```
+Integrate[x^2, x]      (* x^3 / 3 *)
+Integrate[x^2, 2]      (* x^2 unevaluated — second argument isn't a symbol *)
+```
+
+### §24.6 Remaining (not yet delivered)
+
+`Solve`, and the rest of §2's original list — each is a separate future
+item, no grammar change required (an ordinary `Head[args]` form the
+existing grammar already parses).
 
 ### §6 References
 


### PR DESCRIPTION
## Summary

- Wires `Integrate[expr, x]` (indefinite integration) into `wolfram-runtime`, the fifth W-22 `cas-*` head after `Simplify`/`Expand`/`Factor`/`D` — per [MA04 §24.5](code/specs/MA04-wolfram-language.md).
- Extracts the indefinite-integral (2-argument) code path out of `symbolic-vm`'s private `integrate_handler` into a new `pub fn integrate_expr(vm: &mut VM, f: IRNode, x: String) -> IRNode`, mirroring exactly how `differentiate` was extracted from `derivative_handler` for `D` (#8420). No algorithm reimplemented — Wolfram and Macsyma now call the identical function and are pinned to agree via a parity test.
- `integrate_handler`'s 4-argument definite-integral branch and its existing panic-on-bad-arity contract are **untouched**, preserving Macsyma's existing behavior exactly.
- `integrate_expr` installs its own `AssumptionGuard` snapshot so it's correct standalone regardless of caller — a redundant nested install is explicitly safe by that guard's own RAII/Drop design (verified this holds under panic-unwind too, since the workspace never sets `panic = "abort"`).
- `wolfram-runtime`'s new `integrate_handler` wrapper validates arity itself (exactly 2 args, second must be a bare `Symbol`) before delegating, matching every other W-22/W-15 built-in's fail-soft "leave unevaluated" contract.
- Deliberately scoped to the **indefinite** form only — real Wolfram's definite-integral spelling (`Integrate[f, {x, a, b}]`, `List`-wrapped bounds) differs from this repo's flat 4-arg convention and needs its own follow-up.
- Updates MA04 spec (§24.5 Integrate delivered, remaining stub renumbered to §24.6). Bumps `symbolic-vm` 0.20.2→0.20.3, `wolfram-runtime` 0.19.4→0.19.5, with changelog entries for both.

## Test plan

- [x] `cargo test -p symbolic-vm` — 225 + 8 weierstrass tests + 2 doctests, all passing
- [x] `cargo test -p coding-adventures-wolfram-runtime` — full suite passing, including 5 new `Integrate` tests (power-rule correctness, non-symbol-arg fail-soft, Wolfram/Macsyma parity, wrong-arity fail-soft, end-to-end backend dispatch)
- [x] Downstream consumers of `symbolic-vm` re-tested since this touches a shared handler: `cas-summation`, `coding-adventures-derive-runtime`, `coding-adventures-macsyma-runtime`, `task-core` — all green, including the elliptic-integral/Weierstrass tests that exercise the `AssumptionGuard` path this refactor touches
- [x] `cargo clippy -p symbolic-vm -p coding-adventures-wolfram-runtime --all-targets` — clean
- [x] `/security-review` — SECURITY REVIEW PASSED (verified the `AssumptionGuard` nested-install/panic-unwind safety claim structurally, not just by assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)