### PR TITLE
feat(x25519): add C# and F# ports

### DIFF
--- a/code/packages/csharp/x25519/BUILD
+++ b/code/packages/csharp/x25519/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.X25519.Tests/CodingAdventures.X25519.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/x25519/BUILD_windows
+++ b/code/packages/csharp/x25519/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.X25519.Tests/CodingAdventures.X25519.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/csharp/x25519/CHANGELOG.md
+++ b/code/packages/csharp/x25519/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# X25519 implementation from RFC 7748.
+- Support base-point public-key derivation and shared-secret computation.
+- Validate key lengths and reject low-order all-zero results.
+- Add RFC scalar, key-agreement, masking, and iterated-vector tests.

--- a/code/packages/csharp/x25519/CodingAdventures.X25519.csproj
+++ b/code/packages/csharp/x25519/CodingAdventures.X25519.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.X25519.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# X25519 key agreement from RFC 7748</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/x25519/README.md
+++ b/code/packages/csharp/x25519/README.md
@@ -1,0 +1,18 @@
+# CodingAdventures.X25519
+
+A pure C# implementation of X25519 elliptic-curve Diffie-Hellman from RFC
+7748. The implementation uses the Montgomery ladder over `2^255 - 19`, masks
+and clamps inputs as required by the RFC, and rejects low-order inputs that
+produce an all-zero shared secret.
+
+```csharp
+using CodingAdventures.X25519;
+
+byte[] alicePublic = Curve25519.GenerateKeypair(alicePrivate);
+byte[] bobPublic = Curve25519.GenerateKeypair(bobPrivate);
+byte[] shared = Curve25519.Compute(alicePrivate, bobPublic);
+```
+
+The package is dependency-free beyond the .NET standard library. It uses
+`BigInteger` for clarity, so the arithmetic is not guaranteed to be
+constant-time and should be treated as an educational implementation.

--- a/code/packages/csharp/x25519/X25519.cs
+++ b/code/packages/csharp/x25519/X25519.cs
@@ -1,0 +1,148 @@
+using System.Numerics;
+
+namespace CodingAdventures.X25519;
+
+/// <summary>
+/// X25519 elliptic-curve Diffie-Hellman from RFC 7748.
+/// </summary>
+/// <remarks>
+/// This educational implementation uses <see cref="BigInteger"/> field
+/// arithmetic. The Montgomery ladder has a fixed algorithmic shape, but
+/// <see cref="BigInteger"/> is not guaranteed to execute in constant time.
+/// </remarks>
+public static class Curve25519
+{
+    /// <summary>The encoded size of an X25519 scalar or u-coordinate.</summary>
+    public const int KeyLength = 32;
+
+    private static readonly BigInteger Prime = (BigInteger.One << 255) - 19;
+    private static readonly BigInteger PrimeMinusTwo = Prime - 2;
+    private static readonly BigInteger A24 = 121665;
+
+    private static readonly byte[] BasePointBytes =
+        [9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+    /// <summary>Return the standard Curve25519 base point, u = 9.</summary>
+    public static byte[] BasePoint => BasePointBytes.ToArray();
+
+    /// <summary>
+    /// Multiply a 32-byte scalar by a 32-byte Montgomery u-coordinate.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">An input is null.</exception>
+    /// <exception cref="ArgumentException">An input is not exactly 32 bytes.</exception>
+    /// <exception cref="InvalidOperationException">The result is all zero.</exception>
+    public static byte[] Compute(byte[] scalar, byte[] uCoordinate)
+    {
+        ValidateInput(scalar, nameof(scalar));
+        ValidateInput(uCoordinate, nameof(uCoordinate));
+
+        var k = DecodeScalar(scalar);
+        var u = DecodeUCoordinate(uCoordinate);
+
+        var x1 = u;
+        var x2 = BigInteger.One;
+        var z2 = BigInteger.Zero;
+        var x3 = u;
+        var z3 = BigInteger.One;
+        var swap = 0;
+
+        for (var bit = 254; bit >= 0; bit--)
+        {
+            var scalarBit = (int)((k >> bit) & BigInteger.One);
+            swap ^= scalarBit;
+            ConditionalSwap(swap, ref x2, ref x3);
+            ConditionalSwap(swap, ref z2, ref z3);
+            swap = scalarBit;
+
+            var a = Add(x2, z2);
+            var aa = Square(a);
+            var b = Subtract(x2, z2);
+            var bb = Square(b);
+            var e = Subtract(aa, bb);
+            var c = Add(x3, z3);
+            var d = Subtract(x3, z3);
+            var da = Multiply(d, a);
+            var cb = Multiply(c, b);
+
+            x3 = Square(Add(da, cb));
+            z3 = Multiply(x1, Square(Subtract(da, cb)));
+            x2 = Multiply(aa, bb);
+            z2 = Multiply(e, Add(aa, Multiply(A24, e)));
+        }
+
+        ConditionalSwap(swap, ref x2, ref x3);
+        ConditionalSwap(swap, ref z2, ref z3);
+
+        var affine = Multiply(x2, BigInteger.ModPow(z2, PrimeMinusTwo, Prime));
+        var encoded = EncodeUCoordinate(affine);
+        if (encoded.All(value => value == 0))
+        {
+            throw new InvalidOperationException(
+                "X25519 produced the all-zero output (low-order point).");
+        }
+
+        return encoded;
+    }
+
+    /// <summary>Derive a public key by multiplying by the base point.</summary>
+    public static byte[] ComputeBase(byte[] scalar) => Compute(scalar, BasePointBytes);
+
+    /// <summary>Derive the public key for a 32-byte private key.</summary>
+    public static byte[] GenerateKeypair(byte[] privateKey) => ComputeBase(privateKey);
+
+    private static void ValidateInput(byte[]? value, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(value, parameterName);
+        if (value.Length != KeyLength)
+        {
+            throw new ArgumentException("X25519 inputs must be exactly 32 bytes.", parameterName);
+        }
+    }
+
+    private static BigInteger DecodeScalar(byte[] scalar)
+    {
+        var clamped = scalar.ToArray();
+        clamped[0] &= 248;
+        clamped[31] &= 127;
+        clamped[31] |= 64;
+        return new BigInteger(clamped, isUnsigned: true, isBigEndian: false);
+    }
+
+    private static BigInteger DecodeUCoordinate(byte[] uCoordinate)
+    {
+        var masked = uCoordinate.ToArray();
+        masked[31] &= 127;
+        return new BigInteger(masked, isUnsigned: true, isBigEndian: false);
+    }
+
+    private static byte[] EncodeUCoordinate(BigInteger value)
+    {
+        var encoded = Mod(value).ToByteArray(isUnsigned: true, isBigEndian: false);
+        var result = new byte[KeyLength];
+        encoded.CopyTo(result, 0);
+        return result;
+    }
+
+    private static void ConditionalSwap(int swap, ref BigInteger left, ref BigInteger right)
+    {
+        var mask = -new BigInteger(swap);
+        var difference = mask & (left ^ right);
+        left ^= difference;
+        right ^= difference;
+    }
+
+    private static BigInteger Add(BigInteger left, BigInteger right) => Mod(left + right);
+
+    private static BigInteger Subtract(BigInteger left, BigInteger right) => Mod(left - right);
+
+    private static BigInteger Multiply(BigInteger left, BigInteger right) => Mod(left * right);
+
+    private static BigInteger Square(BigInteger value) => Mod(value * value);
+
+    private static BigInteger Mod(BigInteger value)
+    {
+        var reduced = value % Prime;
+        return reduced.Sign < 0 ? reduced + Prime : reduced;
+    }
+}

--- a/code/packages/csharp/x25519/required_capabilities.json
+++ b/code/packages/csharp/x25519/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/x25519",
+  "capabilities": [],
+  "justification": "Pure in-memory RFC 7748 field arithmetic using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/x25519/tests/CodingAdventures.X25519.Tests/CodingAdventures.X25519.Tests.csproj
+++ b/code/packages/csharp/x25519/tests/CodingAdventures.X25519.Tests/CodingAdventures.X25519.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.X25519.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/x25519/tests/CodingAdventures.X25519.Tests/X25519Tests.cs
+++ b/code/packages/csharp/x25519/tests/CodingAdventures.X25519.Tests/X25519Tests.cs
@@ -1,0 +1,114 @@
+using X25519Algorithm = CodingAdventures.X25519.Curve25519;
+
+namespace CodingAdventures.X25519.Tests;
+
+public sealed class X25519Tests
+{
+    [Theory]
+    [InlineData(
+        "a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4",
+        "e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c",
+        "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552")]
+    [InlineData(
+        "4b66e9d4d1b4673c5ad22691957d6af5c11b6421e0ea01d42ca4169e7918ba0d",
+        "e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a493",
+        "95cbde9476e8907d7aade45cb4b873f88b595a68799fa152e6f8f7647aac7957")]
+    public void ComputeMatchesRfc7748Vectors(string scalar, string u, string expected)
+    {
+        Assert.Equal(Hex(expected), X25519Algorithm.Compute(Hex(scalar), Hex(u)));
+    }
+
+    [Fact]
+    public void ComputeBaseMatchesAliceAndBobPublicKeys()
+    {
+        Assert.Equal(
+            Hex("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"),
+            X25519Algorithm.ComputeBase(Hex("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a")));
+        Assert.Equal(
+            Hex("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f"),
+            X25519Algorithm.ComputeBase(Hex("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb")));
+    }
+
+    [Fact]
+    public void BothPartiesDeriveTheRfcSharedSecret()
+    {
+        var alicePrivate = Hex("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a");
+        var bobPrivate = Hex("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb");
+        var alicePublic = X25519Algorithm.ComputeBase(alicePrivate);
+        var bobPublic = X25519Algorithm.ComputeBase(bobPrivate);
+        var expected = Hex("4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742");
+
+        Assert.Equal(expected, X25519Algorithm.Compute(alicePrivate, bobPublic));
+        Assert.Equal(expected, X25519Algorithm.Compute(bobPrivate, alicePublic));
+    }
+
+    [Fact]
+    public void GenerateKeypairAliasesBaseMultiplication()
+    {
+        var privateKey = Enumerable.Range(0, 32).Select(value => (byte)value).ToArray();
+        Assert.Equal(X25519Algorithm.ComputeBase(privateKey), X25519Algorithm.GenerateKeypair(privateKey));
+    }
+
+    [Fact]
+    public void IteratedRfcVectorMatchesAfterOneThousandRounds()
+    {
+        var scalar = new byte[32];
+        var u = new byte[32];
+        scalar[0] = 9;
+        u[0] = 9;
+
+        for (var iteration = 0; iteration < 1_000; iteration++)
+        {
+            var next = X25519Algorithm.Compute(scalar, u);
+            u = scalar;
+            scalar = next;
+        }
+
+        Assert.Equal(
+            Hex("684cf59ba83309552800ef566f2f4d3c1c3887c49360e3875f2eb94d99532c51"),
+            scalar);
+    }
+
+    [Fact]
+    public void DecodeMasksTheHighBitOfTheUCoordinate()
+    {
+        var scalar = Enumerable.Repeat((byte)0x42, 32).ToArray();
+        var canonical = X25519Algorithm.BasePoint;
+        var highBitSet = canonical.ToArray();
+        highBitSet[31] = 0x80;
+
+        Assert.Equal(
+            X25519Algorithm.Compute(scalar, canonical),
+            X25519Algorithm.Compute(scalar, highBitSet));
+    }
+
+    [Fact]
+    public void RejectsNullAndWrongLengthInputs()
+    {
+        Assert.Throws<ArgumentNullException>(() => X25519Algorithm.Compute(null!, new byte[32]));
+        Assert.Throws<ArgumentNullException>(() => X25519Algorithm.Compute(new byte[32], null!));
+        Assert.Throws<ArgumentException>(() => X25519Algorithm.Compute(new byte[31], new byte[32]));
+        Assert.Throws<ArgumentException>(() => X25519Algorithm.Compute(new byte[32], new byte[33]));
+    }
+
+    [Fact]
+    public void RejectsLowOrderAllZeroOutput()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            X25519Algorithm.Compute(Enumerable.Repeat((byte)0x11, 32).ToArray(), new byte[32]));
+    }
+
+    [Fact]
+    public void BasePointReturnsAnIndependentCopy()
+    {
+        var first = X25519Algorithm.BasePoint;
+        first[0] = 0;
+        var second = X25519Algorithm.BasePoint;
+
+        Assert.Equal(32, second.Length);
+        Assert.Equal(9, second[0]);
+        Assert.All(second.Skip(1), value => Assert.Equal(0, value));
+    }
+
+    private static byte[] Hex(string value) => Convert.FromHexString(value);
+}

--- a/code/packages/fsharp/x25519/BUILD
+++ b/code/packages/fsharp/x25519/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.X25519.Tests/CodingAdventures.X25519.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/x25519/BUILD_windows
+++ b/code/packages/fsharp/x25519/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.X25519.Tests/CodingAdventures.X25519.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/x25519/CHANGELOG.md
+++ b/code/packages/fsharp/x25519/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# X25519 implementation from RFC 7748.
+- Support base-point public-key derivation and shared-secret computation.
+- Validate key lengths and reject low-order all-zero results.
+- Add RFC scalar, key-agreement, masking, and iterated-vector tests.

--- a/code/packages/fsharp/x25519/CodingAdventures.X25519.fsproj
+++ b/code/packages/fsharp/x25519/CodingAdventures.X25519.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.X25519.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# X25519 key agreement from RFC 7748</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="X25519.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/x25519/README.md
+++ b/code/packages/fsharp/x25519/README.md
@@ -1,0 +1,18 @@
+# CodingAdventures.X25519.FSharp
+
+A pure F# implementation of X25519 elliptic-curve Diffie-Hellman from RFC
+7748. The implementation uses the Montgomery ladder over `2^255 - 19`, masks
+and clamps inputs as required by the RFC, and rejects low-order inputs that
+produce an all-zero shared secret.
+
+```fsharp
+open CodingAdventures.X25519.FSharp
+
+let alicePublic = X25519.generateKeypair alicePrivate
+let bobPublic = X25519.generateKeypair bobPrivate
+let shared = X25519.x25519 alicePrivate bobPublic
+```
+
+The package is dependency-free beyond the .NET standard library. It uses
+`BigInteger` for clarity, so the arithmetic is not guaranteed to be
+constant-time and should be treated as an educational implementation.

--- a/code/packages/fsharp/x25519/X25519.fs
+++ b/code/packages/fsharp/x25519/X25519.fs
@@ -1,0 +1,130 @@
+namespace CodingAdventures.X25519.FSharp
+
+open System
+open System.Numerics
+
+/// X25519 elliptic-curve Diffie-Hellman from RFC 7748.
+/// This educational implementation uses BigInteger field arithmetic, which is
+/// not guaranteed to execute in constant time.
+[<RequireQualifiedAccess>]
+module X25519 =
+    [<Literal>]
+    let KeyLength = 32
+
+    let private prime = (BigInteger.One <<< 255) - 19I
+    let private primeMinusTwo = prime - 2I
+    let private a24 = 121665I
+
+    let private validateInput parameterName (value: byte array) =
+        if isNull value then
+            nullArg parameterName
+
+        if value.Length <> KeyLength then
+            invalidArg parameterName "X25519 inputs must be exactly 32 bytes."
+
+    let private decodeLittleEndian (bytes: byte array) =
+        let mutable result = BigInteger.Zero
+
+        for index = bytes.Length - 1 downto 0 do
+            result <- (result <<< 8) ||| bigint bytes[index]
+
+        result
+
+    let private decodeScalar (scalar: byte array) =
+        let clamped = Array.copy scalar
+        clamped[0] <- clamped[0] &&& 248uy
+        clamped[31] <- clamped[31] &&& 127uy
+        clamped[31] <- clamped[31] ||| 64uy
+        decodeLittleEndian clamped
+
+    let private decodeUCoordinate (uCoordinate: byte array) =
+        let masked = Array.copy uCoordinate
+        masked[31] <- masked[31] &&& 127uy
+        decodeLittleEndian masked
+
+    let private modulo value =
+        let reduced = value % prime
+        if reduced.Sign < 0 then reduced + prime else reduced
+
+    let private add left right = modulo (left + right)
+    let private subtract left right = modulo (left - right)
+    let private multiply left right = modulo (left * right)
+    let private square value = modulo (value * value)
+
+    let private encodeUCoordinate value =
+        let result = Array.zeroCreate<byte> KeyLength
+        let mutable remaining = modulo value
+
+        for index = 0 to KeyLength - 1 do
+            result[index] <- byte (remaining &&& 255I)
+            remaining <- remaining >>> 8
+
+        result
+
+    let private conditionalSwap (swap: int) (left: bigint) (right: bigint) =
+        let mask = -(bigint swap)
+        let difference = mask &&& (left ^^^ right)
+        left ^^^ difference, right ^^^ difference
+
+    /// Return a new copy of the standard Curve25519 base point, u = 9.
+    let basePoint () =
+        let result = Array.zeroCreate<byte> KeyLength
+        result[0] <- 9uy
+        result
+
+    /// Multiply a 32-byte scalar by a 32-byte Montgomery u-coordinate.
+    let x25519 (scalar: byte array) (uCoordinate: byte array) =
+        validateInput "scalar" scalar
+        validateInput "uCoordinate" uCoordinate
+
+        let k = decodeScalar scalar
+        let u = decodeUCoordinate uCoordinate
+        let x1 = u
+        let mutable x2 = BigInteger.One
+        let mutable z2 = BigInteger.Zero
+        let mutable x3 = u
+        let mutable z3 = BigInteger.One
+        let mutable swap = 0
+
+        for bit = 254 downto 0 do
+            let scalarBit = int ((k >>> bit) &&& BigInteger.One)
+            swap <- swap ^^^ scalarBit
+
+            let nextX2, nextX3 = conditionalSwap swap x2 x3
+            let nextZ2, nextZ3 = conditionalSwap swap z2 z3
+            x2 <- nextX2
+            x3 <- nextX3
+            z2 <- nextZ2
+            z3 <- nextZ3
+            swap <- scalarBit
+
+            let a = add x2 z2
+            let aa = square a
+            let b = subtract x2 z2
+            let bb = square b
+            let e = subtract aa bb
+            let c = add x3 z3
+            let d = subtract x3 z3
+            let da = multiply d a
+            let cb = multiply c b
+
+            x3 <- square (add da cb)
+            z3 <- multiply x1 (square (subtract da cb))
+            x2 <- multiply aa bb
+            z2 <- multiply e (add aa (multiply a24 e))
+
+        let finalX2, _ = conditionalSwap swap x2 x3
+        let finalZ2, _ = conditionalSwap swap z2 z3
+        let affine = multiply finalX2 (BigInteger.ModPow(finalZ2, primeMinusTwo, prime))
+        let encoded = encodeUCoordinate affine
+
+        if encoded |> Array.forall ((=) 0uy) then
+            raise (InvalidOperationException("X25519 produced the all-zero output (low-order point)."))
+
+        encoded
+
+    /// Derive a public key by multiplying by the standard base point.
+    let x25519Base scalar = x25519 scalar (basePoint ())
+
+    /// Derive the public key for a 32-byte private key.
+    let generateKeypair privateKey = x25519Base privateKey

--- a/code/packages/fsharp/x25519/required_capabilities.json
+++ b/code/packages/fsharp/x25519/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/x25519",
+  "capabilities": [],
+  "justification": "Pure in-memory RFC 7748 field arithmetic using the .NET standard library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/x25519/tests/CodingAdventures.X25519.Tests/CodingAdventures.X25519.Tests.fsproj
+++ b/code/packages/fsharp/x25519/tests/CodingAdventures.X25519.Tests/CodingAdventures.X25519.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.X25519.fsproj" />
+    <Compile Include="X25519Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/x25519/tests/CodingAdventures.X25519.Tests/X25519Tests.fs
+++ b/code/packages/fsharp/x25519/tests/CodingAdventures.X25519.Tests/X25519Tests.fs
@@ -1,0 +1,103 @@
+namespace CodingAdventures.X25519.FSharp.Tests
+
+open System
+open Xunit
+open CodingAdventures.X25519.FSharp
+
+module X25519Tests =
+    let private hex (value: string) = Convert.FromHexString value
+
+    [<Theory>]
+    [<InlineData(
+        "a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4",
+        "e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c",
+        "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552")>]
+    [<InlineData(
+        "4b66e9d4d1b4673c5ad22691957d6af5c11b6421e0ea01d42ca4169e7918ba0d",
+        "e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a493",
+        "95cbde9476e8907d7aade45cb4b873f88b595a68799fa152e6f8f7647aac7957")>]
+    let ``x25519 matches RFC 7748 vectors`` scalar u expected =
+        Assert.Equal<byte array>(hex expected, X25519.x25519 (hex scalar) (hex u))
+
+    [<Fact>]
+    let ``base multiplication matches Alice and Bob public keys`` () =
+        Assert.Equal<byte array>(
+            hex "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a",
+            X25519.x25519Base (hex "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"))
+
+        Assert.Equal<byte array>(
+            hex "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f",
+            X25519.x25519Base (hex "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"))
+
+    [<Fact>]
+    let ``both parties derive the RFC shared secret`` () =
+        let alicePrivate = hex "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"
+        let bobPrivate = hex "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"
+        let alicePublic = X25519.x25519Base alicePrivate
+        let bobPublic = X25519.x25519Base bobPrivate
+        let expected = hex "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742"
+
+        Assert.Equal<byte array>(expected, X25519.x25519 alicePrivate bobPublic)
+        Assert.Equal<byte array>(expected, X25519.x25519 bobPrivate alicePublic)
+
+    [<Fact>]
+    let ``generateKeypair aliases base multiplication`` () =
+        let privateKey = [| 0uy .. 31uy |]
+        Assert.Equal<byte array>(X25519.x25519Base privateKey, X25519.generateKeypair privateKey)
+
+    [<Fact>]
+    let ``iterated RFC vector matches after one thousand rounds`` () =
+        let mutable scalar = Array.zeroCreate<byte> 32
+        let mutable u = Array.zeroCreate<byte> 32
+        scalar[0] <- 9uy
+        u[0] <- 9uy
+
+        for _ = 1 to 1_000 do
+            let next = X25519.x25519 scalar u
+            u <- scalar
+            scalar <- next
+
+        Assert.Equal<byte array>(
+            hex "684cf59ba83309552800ef566f2f4d3c1c3887c49360e3875f2eb94d99532c51",
+            scalar)
+
+    [<Fact>]
+    let ``u-coordinate high bit is masked`` () =
+        let scalar = Array.create 32 0x42uy
+        let canonical = X25519.basePoint ()
+        let highBitSet = Array.copy canonical
+        highBitSet[31] <- 0x80uy
+
+        Assert.Equal<byte array>(
+            X25519.x25519 scalar canonical,
+            X25519.x25519 scalar highBitSet)
+
+    [<Fact>]
+    let ``null and wrong length inputs are rejected`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> X25519.x25519 null (Array.zeroCreate 32) |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () -> X25519.x25519 (Array.zeroCreate 32) null |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentException>(fun () -> X25519.x25519 (Array.zeroCreate 31) (Array.zeroCreate 32) |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentException>(fun () -> X25519.x25519 (Array.zeroCreate 32) (Array.zeroCreate 33) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``low-order all-zero output is rejected`` () =
+        Assert.Throws<InvalidOperationException>(fun () ->
+            X25519.x25519 (Array.create 32 0x11uy) (Array.zeroCreate 32) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``basePoint returns an independent copy`` () =
+        let first = X25519.basePoint ()
+        first[0] <- 0uy
+        let second = X25519.basePoint ()
+
+        Assert.Equal(32, second.Length)
+        Assert.Equal(9uy, second[0])
+        Assert.All(second[1..], fun value -> Assert.Equal(0uy, value))

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -160,7 +160,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 341
+The 172 packages present in at least ten implementation languages need 339
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -169,8 +169,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 16 | Move with F# |
-| F# | 16 | Move with C# |
+| C# | 15 | Move with F# |
+| F# | 15 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -235,6 +235,13 @@ implementations in both lanes, built on their existing `wasm-leb128` and
 sections and import descriptor validation. The package now spans 12 lanes,
 reduces each paired high-consensus gap to 16, and unlocks the later
 `brainfuck-wasm-compiler` and `nib-wasm-compiler` ports.
+
+The second paired C#/F# slice is complete: `x25519` now has native,
+dependency-free implementations in both lanes using the RFC 7748 Montgomery
+ladder over `2^255 - 19`. RFC scalar-multiplication, Diffie-Hellman,
+high-bit-masking, low-order rejection, and 1,000-round iterated vectors provide
+conformance coverage. The package now spans 12 implementation lanes and
+reduces each paired high-consensus gap to 15.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add dependency-free C# and F# X25519 implementations from RFC 7748
- cover scalar multiplication, public-key derivation, shared-secret agreement, strict input validation, and low-order rejection
- refresh the package-parity roadmap from measured inventory counts

## Validation
- C#: 10 tests passed; 100% line, branch, and method coverage
- F#: 10 tests passed; 100% line, branch, and method coverage
- package parity reporter: 6 tests passed; zero collisions
- dotnet format verified the C# project; F# formatting is not supported by dotnet format and was validated by compilation and tests
- git diff --check