### PR TITLE
feat(brainfuck-wasm-compiler): add C# and F# ports

### DIFF
--- a/code/packages/csharp/brainfuck-wasm-compiler/BUILD
+++ b/code/packages/csharp/brainfuck-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BrainfuckWasmCompiler.Tests/CodingAdventures.BrainfuckWasmCompiler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.BrainfuckWasmCompiler]*"

--- a/code/packages/csharp/brainfuck-wasm-compiler/BUILD_windows
+++ b/code/packages/csharp/brainfuck-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BrainfuckWasmCompiler.Tests/CodingAdventures.BrainfuckWasmCompiler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.BrainfuckWasmCompiler]*"

--- a/code/packages/csharp/brainfuck-wasm-compiler/BrainfuckWasmCompiler.cs
+++ b/code/packages/csharp/brainfuck-wasm-compiler/BrainfuckWasmCompiler.cs
@@ -1,0 +1,335 @@
+using CodingAdventures.WasmLeb128;
+using CodingAdventures.WasmTypes;
+using WasmValueType = CodingAdventures.WasmTypes.ValueType;
+
+namespace CodingAdventures.BrainfuckWasmCompiler;
+
+public static class BrainfuckWasmCompilerVersion
+{
+    public const string VERSION = "0.1.0";
+}
+
+public sealed class PackageError : Exception
+{
+    public PackageError(string stage, string message) : base(message)
+    {
+        Stage = stage;
+    }
+
+    public string Stage { get; }
+}
+
+public sealed class PackageResult
+{
+    private readonly byte[] _wasmBytes;
+
+    internal PackageResult(string source, IEnumerable<char> operations, byte[] wasmBytes, string? wasmPath)
+    {
+        Source = source;
+        Operations = Array.AsReadOnly(operations.ToArray());
+        _wasmBytes = wasmBytes.ToArray();
+        WasmPath = wasmPath;
+    }
+
+    public string Source { get; }
+
+    public IReadOnlyList<char> Operations { get; }
+
+    public byte[] WasmBytes => _wasmBytes.ToArray();
+
+    public string? WasmPath { get; }
+}
+
+public static class BrainfuckWasmCompiler
+{
+    private const int MaxSourceLength = 1_000_000;
+    private const int MaxLoopNesting = 512;
+    private const string WasiModule = "wasi_snapshot_preview1";
+
+    public static PackageResult CompileSource(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var program = Parse(source);
+        return new PackageResult(source, program.Operations, EmitModule(program), null);
+    }
+
+    public static PackageResult PackSource(string source) => CompileSource(source);
+
+    public static PackageResult WriteWasmFile(string source, string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        var result = CompileSource(source);
+        try
+        {
+            File.WriteAllBytes(path, result.WasmBytes);
+        }
+        catch (Exception error) when (error is IOException or UnauthorizedAccessException)
+        {
+            throw new PackageError("write", error.Message);
+        }
+
+        return new PackageResult(result.Source, result.Operations, result.WasmBytes, path);
+    }
+
+    private static ParsedProgram Parse(string source)
+    {
+        if (source.Length > MaxSourceLength)
+        {
+            throw new PackageError("parse", $"source exceeds {MaxSourceLength} characters");
+        }
+
+        var operations = new List<char>();
+        var stack = new Stack<int>();
+        var loopEnds = new Dictionary<int, int>();
+
+        for (var sourceIndex = 0; sourceIndex < source.Length; sourceIndex++)
+        {
+            var operation = source[sourceIndex];
+            if (!"><+-.,[]".Contains(operation, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var operationIndex = operations.Count;
+            if (operation == '[')
+            {
+                stack.Push(operationIndex);
+                if (stack.Count > MaxLoopNesting)
+                {
+                    throw new PackageError("parse", $"loop nesting exceeds {MaxLoopNesting}");
+                }
+            }
+            else if (operation == ']')
+            {
+                if (stack.Count == 0)
+                {
+                    throw new PackageError("parse", $"unmatched ] at byte {sourceIndex}");
+                }
+
+                loopEnds[stack.Pop()] = operationIndex;
+            }
+
+            operations.Add(operation);
+        }
+
+        if (stack.Count > 0)
+        {
+            throw new PackageError("parse", "unmatched [");
+        }
+
+        return new ParsedProgram(operations, loopEnds);
+    }
+
+    private static byte[] EmitModule(ParsedProgram program)
+    {
+        var needsWrite = program.Operations.Contains('.');
+        var needsRead = program.Operations.Contains(',');
+        var importCount = (needsWrite ? 1 : 0) + (needsRead ? 1 : 0);
+        var writeIndex = needsWrite ? 0 : -1;
+        var readIndex = needsRead ? (needsWrite ? 1 : 0) : -1;
+        var module = new WasmModule();
+        var wasiType = new FuncType(
+            [WasmValueType.I32, WasmValueType.I32, WasmValueType.I32, WasmValueType.I32],
+            [WasmValueType.I32]);
+
+        if (needsWrite)
+        {
+            module.Types.Add(wasiType);
+            module.Imports.Add(new Import(
+                WasiModule,
+                "fd_write",
+                ExternalKind.FUNCTION,
+                new FunctionImportDescriptor(writeIndex)));
+        }
+
+        if (needsRead)
+        {
+            module.Types.Add(wasiType);
+            module.Imports.Add(new Import(
+                WasiModule,
+                "fd_read",
+                ExternalKind.FUNCTION,
+                new FunctionImportDescriptor(readIndex)));
+        }
+
+        module.Types.Add(new FuncType([], []));
+        module.Functions.Add(importCount);
+        module.Memories.Add(new MemoryType(new Limits(1, null)));
+        module.Exports.Add(new Export("_start", ExternalKind.FUNCTION, importCount));
+        module.Exports.Add(new Export("memory", ExternalKind.MEMORY, 0));
+        module.Code.Add(new FunctionBody(
+            [WasmValueType.I32, WasmValueType.I32, WasmValueType.I32],
+            FunctionBody(program, writeIndex, readIndex)));
+
+        return WasmModuleEncoder.WasmModuleEncoder.EncodeModule(module);
+    }
+
+    private static byte[] FunctionBody(ParsedProgram program, int writeIndex, int readIndex)
+    {
+        var body = new List<byte>();
+        EmitOperations(body, program, 0, program.Operations.Count, writeIndex, readIndex);
+        body.Add(0x0B);
+        return body.ToArray();
+    }
+
+    private static void EmitOperations(
+        List<byte> output,
+        ParsedProgram program,
+        int start,
+        int end,
+        int writeIndex,
+        int readIndex)
+    {
+        var index = start;
+        while (index < end)
+        {
+            switch (program.Operations[index])
+            {
+                case '>':
+                    AddToLocal(output, 0, 1);
+                    break;
+                case '<':
+                    AddToLocal(output, 0, -1);
+                    break;
+                case '+':
+                    MutateCell(output, 1);
+                    break;
+                case '-':
+                    MutateCell(output, -1);
+                    break;
+                case '.':
+                    EmitWrite(output, writeIndex);
+                    break;
+                case ',':
+                    EmitRead(output, readIndex);
+                    break;
+                case '[':
+                    var close = program.LoopEnds[index];
+                    output.AddRange([0x02, 0x40, 0x03, 0x40]);
+                    LoadCell(output);
+                    output.Add(0x45);
+                    output.Add(0x0D);
+                    U32(output, 1);
+                    EmitOperations(output, program, index + 1, close, writeIndex, readIndex);
+                    output.Add(0x0C);
+                    U32(output, 0);
+                    output.AddRange([0x0B, 0x0B]);
+                    index = close;
+                    break;
+            }
+
+            index++;
+        }
+    }
+
+    private static void LoadCell(List<byte> output)
+    {
+        output.Add(0x20);
+        U32(output, 0);
+        output.Add(0x2D);
+        U32(output, 0);
+        U32(output, 0);
+    }
+
+    private static void MutateCell(List<byte> output, int delta)
+    {
+        LoadCell(output);
+        I32(output, delta);
+        output.Add(0x6A);
+        output.Add(0x21);
+        U32(output, 1);
+        output.Add(0x20);
+        U32(output, 0);
+        output.Add(0x20);
+        U32(output, 1);
+        output.Add(0x3A);
+        U32(output, 0);
+        U32(output, 0);
+    }
+
+    private static void AddToLocal(List<byte> output, int local, int delta)
+    {
+        output.Add(0x20);
+        U32(output, local);
+        I32(output, delta);
+        output.Add(0x6A);
+        output.Add(0x21);
+        U32(output, local);
+    }
+
+    private static void EmitWrite(List<byte> output, int writeIndex)
+    {
+        LoadCell(output);
+        output.Add(0x21);
+        U32(output, 1);
+        StoreByteConstAddress(output, 30012, 1);
+        StoreI32Const(output, 30000, 30012);
+        StoreI32Const(output, 30004, 1);
+        I32(output, 1);
+        I32(output, 30000);
+        I32(output, 1);
+        I32(output, 30008);
+        output.Add(0x10);
+        U32(output, writeIndex);
+        output.Add(0x21);
+        U32(output, 2);
+    }
+
+    private static void EmitRead(List<byte> output, int readIndex)
+    {
+        StoreByteConstAddress(output, 30012, 0);
+        StoreI32Const(output, 30000, 30012);
+        StoreI32Const(output, 30004, 1);
+        I32(output, 0);
+        I32(output, 30000);
+        I32(output, 1);
+        I32(output, 30008);
+        output.Add(0x10);
+        U32(output, readIndex);
+        output.Add(0x21);
+        U32(output, 2);
+        I32(output, 30012);
+        output.Add(0x2D);
+        U32(output, 0);
+        U32(output, 0);
+        output.Add(0x21);
+        U32(output, 1);
+        output.Add(0x20);
+        U32(output, 0);
+        output.Add(0x20);
+        U32(output, 1);
+        output.Add(0x3A);
+        U32(output, 0);
+        U32(output, 0);
+    }
+
+    private static void StoreByteConstAddress(List<byte> output, int address, int local)
+    {
+        I32(output, address);
+        output.Add(0x20);
+        U32(output, local);
+        output.Add(0x3A);
+        U32(output, 0);
+        U32(output, 0);
+    }
+
+    private static void StoreI32Const(List<byte> output, int address, int value)
+    {
+        I32(output, address);
+        I32(output, value);
+        output.Add(0x36);
+        U32(output, 2);
+        U32(output, 0);
+    }
+
+    private static void I32(List<byte> output, int value)
+    {
+        output.Add(0x41);
+        output.AddRange(WasmLeb128.WasmLeb128.EncodeSigned(value));
+    }
+
+    private static void U32(List<byte> output, int value) =>
+        output.AddRange(WasmLeb128.WasmLeb128.EncodeUnsigned(value));
+
+    private sealed record ParsedProgram(IReadOnlyList<char> Operations, IReadOnlyDictionary<int, int> LoopEnds);
+}

--- a/code/packages/csharp/brainfuck-wasm-compiler/CHANGELOG.md
+++ b/code/packages/csharp/brainfuck-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# Brainfuck parser and WebAssembly emitter.
+- Emit optional WASI input/output imports, linear memory, and `_start` exports.
+- Validate source size, loop balance, and loop nesting depth.
+- Add compile, pack, file-write, module-shape, runtime, and error-path tests.

--- a/code/packages/csharp/brainfuck-wasm-compiler/CodingAdventures.BrainfuckWasmCompiler.csproj
+++ b/code/packages/csharp/brainfuck-wasm-compiler/CodingAdventures.BrainfuckWasmCompiler.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.BrainfuckWasmCompiler.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# Brainfuck-to-WebAssembly compiler</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../wasm-leb128/CodingAdventures.WasmLeb128.csproj" />
+    <ProjectReference Include="../wasm-module-encoder/CodingAdventures.WasmModuleEncoder.csproj" />
+    <ProjectReference Include="../wasm-types/CodingAdventures.WasmTypes.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/brainfuck-wasm-compiler/README.md
+++ b/code/packages/csharp/brainfuck-wasm-compiler/README.md
@@ -1,0 +1,18 @@
+# CodingAdventures.BrainfuckWasmCompiler
+
+A pure C# Brainfuck-to-WebAssembly compiler. It ignores non-Brainfuck source
+characters, validates bracket structure and nesting depth, and emits a typed
+WebAssembly module with one memory and an exported `_start` function. Input and
+output instructions use the WASI `fd_read` and `fd_write` imports only when the
+program needs them.
+
+```csharp
+using CodingAdventures.BrainfuckWasmCompiler;
+
+PackageResult result = BrainfuckWasmCompiler.CompileSource("++[>+<-]");
+File.WriteAllBytes("program.wasm", result.WasmBytes);
+```
+
+The compiler builds the module with the sibling `wasm-types`, `wasm-leb128`,
+and `wasm-module-encoder` packages. `WriteWasmFile` is the only API that touches
+the filesystem.

--- a/code/packages/csharp/brainfuck-wasm-compiler/required_capabilities.json
+++ b/code/packages/csharp/brainfuck-wasm-compiler/required_capabilities.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/brainfuck-wasm-compiler",
+  "capabilities": [
+    "filesystem.write"
+  ],
+  "justification": "Compilation is pure, but the package also provides a helper that writes the resulting .wasm bytes to disk."
+}

--- a/code/packages/csharp/brainfuck-wasm-compiler/tests/CodingAdventures.BrainfuckWasmCompiler.Tests/BrainfuckWasmCompilerTests.cs
+++ b/code/packages/csharp/brainfuck-wasm-compiler/tests/CodingAdventures.BrainfuckWasmCompiler.Tests/BrainfuckWasmCompilerTests.cs
@@ -1,0 +1,117 @@
+using CodingAdventures.WasmRuntime;
+using CodingAdventures.WasmTypes;
+
+namespace CodingAdventures.BrainfuckWasmCompiler.Tests;
+
+public sealed class BrainfuckWasmCompilerTests
+{
+    [Fact]
+    public void CompileSourceFiltersCommentsAndBuildsLoadableModule()
+    {
+        var result = BrainfuckWasmCompiler.CompileSource("note: ++[>+<-] done");
+
+        Assert.Equal("++[>+<-]", new string(result.Operations.ToArray()));
+        Assert.Equal([0x00, 0x61, 0x73, 0x6D], result.WasmBytes[..4]);
+        Assert.Null(result.WasmPath);
+
+        var module = new WasmRuntime.WasmRuntime().Load(result.WasmBytes);
+        Assert.Empty(module.Imports);
+        Assert.Single(module.Memories);
+        Assert.Equal(["_start", "memory"], module.Exports.Select(item => item.Name));
+        new WasmRuntime.WasmRuntime().Validate(module);
+    }
+
+    [Theory]
+    [InlineData(".", "fd_write")]
+    [InlineData(",", "fd_read")]
+    [InlineData(".,", "fd_write", "fd_read")]
+    public void CompileSourceAddsOnlyRequiredWasiImports(string source, params string[] names)
+    {
+        var module = new WasmRuntime.WasmRuntime().Load(BrainfuckWasmCompiler.CompileSource(source).WasmBytes);
+
+        Assert.Equal(names, module.Imports.Select(item => item.Name));
+        Assert.All(module.Imports, item => Assert.Equal("wasi_snapshot_preview1", item.ModuleName));
+        Assert.All(module.Imports, item => Assert.Equal(ExternalKind.FUNCTION, item.Kind));
+        Assert.Equal(names.Length + 1, module.Types.Count);
+        Assert.Equal(names.Length, module.Functions.Single());
+    }
+
+    [Fact]
+    public void PackSourceIsCompileAliasAndResultsDefendTheirBytes()
+    {
+        var result = BrainfuckWasmCompiler.PackSource("+");
+        var bytes = result.WasmBytes;
+        bytes[0] = 0xFF;
+
+        Assert.Equal((byte)0x00, result.WasmBytes[0]);
+        Assert.Equal(BrainfuckWasmCompilerVersion.VERSION, "0.1.0");
+    }
+
+    [Fact]
+    public void PointerAndWrappingCellOperationsExecute()
+    {
+        var result = BrainfuckWasmCompiler.CompileSource("-+>+<");
+        var runtime = new WasmRuntime.WasmRuntime();
+        var instance = runtime.Instantiate(result.WasmBytes);
+
+        runtime.Call(instance, "_start");
+        Assert.Equal([0, 1], instance.Memory!.ReadBytes(0, 2));
+    }
+
+    [Fact]
+    public void WriteWasmFileWritesBytesAndRecordsPath()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"brainfuck-wasm-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "program.wasm");
+        try
+        {
+            var result = BrainfuckWasmCompiler.WriteWasmFile("+", path);
+
+            Assert.Equal(path, result.WasmPath);
+            Assert.Equal(result.WasmBytes, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [Fact]
+    public void WriteWasmFileWrapsFilesystemErrors()
+    {
+        var error = Assert.Throws<PackageError>(() =>
+            BrainfuckWasmCompiler.WriteWasmFile("+", Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "x.wasm")));
+
+        Assert.Equal("write", error.Stage);
+    }
+
+    [Theory]
+    [InlineData("[", "unmatched [")]
+    [InlineData("abc]", "unmatched ] at byte 3")]
+    public void CompileSourceRejectsUnmatchedLoops(string source, string message)
+    {
+        var error = Assert.Throws<PackageError>(() => BrainfuckWasmCompiler.CompileSource(source));
+
+        Assert.Equal("parse", error.Stage);
+        Assert.Equal(message, error.Message);
+    }
+
+    [Fact]
+    public void CompileSourceRejectsExcessiveNesting()
+    {
+        var error = Assert.Throws<PackageError>(() => BrainfuckWasmCompiler.CompileSource(new string('[', 513)));
+
+        Assert.Equal("parse", error.Stage);
+        Assert.Equal("loop nesting exceeds 512", error.Message);
+    }
+
+    [Fact]
+    public void CompileSourceRejectsExcessiveSourceLength()
+    {
+        var error = Assert.Throws<PackageError>(() => BrainfuckWasmCompiler.CompileSource(new string('x', 1_000_001)));
+
+        Assert.Equal("parse", error.Stage);
+        Assert.Equal("source exceeds 1000000 characters", error.Message);
+    }
+}

--- a/code/packages/csharp/brainfuck-wasm-compiler/tests/CodingAdventures.BrainfuckWasmCompiler.Tests/CodingAdventures.BrainfuckWasmCompiler.Tests.csproj
+++ b/code/packages/csharp/brainfuck-wasm-compiler/tests/CodingAdventures.BrainfuckWasmCompiler.Tests/CodingAdventures.BrainfuckWasmCompiler.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.BrainfuckWasmCompiler.csproj" />
+    <ProjectReference Include="../../../wasm-runtime/CodingAdventures.WasmRuntime.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/brainfuck-wasm-compiler/BUILD
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BrainfuckWasmCompiler.Tests/CodingAdventures.BrainfuckWasmCompiler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.BrainfuckWasmCompiler.FSharp]*"

--- a/code/packages/fsharp/brainfuck-wasm-compiler/BUILD_windows
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BrainfuckWasmCompiler.Tests/CodingAdventures.BrainfuckWasmCompiler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.BrainfuckWasmCompiler.FSharp]*"

--- a/code/packages/fsharp/brainfuck-wasm-compiler/BrainfuckWasmCompiler.fs
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/BrainfuckWasmCompiler.fs
@@ -1,0 +1,268 @@
+namespace CodingAdventures.BrainfuckWasmCompiler.FSharp
+
+open System
+open System.Collections.Generic
+open System.IO
+open CodingAdventures.WasmLeb128.FSharp
+open CodingAdventures.WasmModuleEncoder.FSharp
+open CodingAdventures.WasmTypes.FSharp
+
+module Version =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+type PackageError(stage: string, message: string) =
+    inherit Exception(message)
+    member _.Stage = stage
+
+type PackageResult(source: string, operations: char list, wasmBytes: byte array, wasmPath: string option) =
+    let copiedBytes = Array.copy wasmBytes
+
+    member _.Source = source
+    member _.Operations = operations
+    member _.WasmBytes = Array.copy copiedBytes
+    member _.WasmPath = wasmPath
+
+type private ParsedProgram =
+    {
+        Operations: char array
+        LoopEnds: IReadOnlyDictionary<int, int>
+    }
+
+[<RequireQualifiedAccess>]
+module BrainfuckWasmCompiler =
+    let private maxSourceLength = 1_000_000
+    let private maxLoopNesting = 512
+    let private wasiModule = "wasi_snapshot_preview1"
+
+    let private parse (source: string) =
+        if source.Length > maxSourceLength then
+            raise (PackageError("parse", sprintf "source exceeds %d characters" maxSourceLength))
+
+        let operations = ResizeArray<char>()
+        let stack = Stack<int>()
+        let loopEnds = Dictionary<int, int>()
+
+        for sourceIndex = 0 to source.Length - 1 do
+            let operation = source[sourceIndex]
+            if "><+-.,[]".Contains(operation) then
+                let operationIndex = operations.Count
+                match operation with
+                | '[' ->
+                    stack.Push(operationIndex)
+                    if stack.Count > maxLoopNesting then
+                        raise (PackageError("parse", sprintf "loop nesting exceeds %d" maxLoopNesting))
+                | ']' ->
+                    if stack.Count = 0 then
+                        raise (PackageError("parse", sprintf "unmatched ] at byte %d" sourceIndex))
+                    loopEnds[stack.Pop()] <- operationIndex
+                | _ -> ()
+                operations.Add(operation)
+
+        if stack.Count > 0 then
+            raise (PackageError("parse", "unmatched ["))
+
+        {
+            Operations = operations.ToArray()
+            LoopEnds = loopEnds
+        }
+
+    let private append (target: ResizeArray<byte>) (bytes: seq<byte>) =
+        target.AddRange(bytes)
+
+    let private u32 (target: ResizeArray<byte>) value =
+        append target (WasmLeb128.encodeUnsignedInt value)
+
+    let private i32 (target: ResizeArray<byte>) value =
+        target.Add(0x41uy)
+        append target (WasmLeb128.encodeSigned value)
+
+    let private loadCell (target: ResizeArray<byte>) =
+        target.Add(0x20uy)
+        u32 target 0
+        target.Add(0x2Duy)
+        u32 target 0
+        u32 target 0
+
+    let private mutateCell (target: ResizeArray<byte>) delta =
+        loadCell target
+        i32 target delta
+        target.Add(0x6Auy)
+        target.Add(0x21uy)
+        u32 target 1
+        target.Add(0x20uy)
+        u32 target 0
+        target.Add(0x20uy)
+        u32 target 1
+        target.Add(0x3Auy)
+        u32 target 0
+        u32 target 0
+
+    let private addToLocal (target: ResizeArray<byte>) local delta =
+        target.Add(0x20uy)
+        u32 target local
+        i32 target delta
+        target.Add(0x6Auy)
+        target.Add(0x21uy)
+        u32 target local
+
+    let private storeByteConstAddress (target: ResizeArray<byte>) address local =
+        i32 target address
+        target.Add(0x20uy)
+        u32 target local
+        target.Add(0x3Auy)
+        u32 target 0
+        u32 target 0
+
+    let private storeI32Const (target: ResizeArray<byte>) address value =
+        i32 target address
+        i32 target value
+        target.Add(0x36uy)
+        u32 target 2
+        u32 target 0
+
+    let private emitWrite (target: ResizeArray<byte>) writeIndex =
+        loadCell target
+        target.Add(0x21uy)
+        u32 target 1
+        storeByteConstAddress target 30012 1
+        storeI32Const target 30000 30012
+        storeI32Const target 30004 1
+        i32 target 1
+        i32 target 30000
+        i32 target 1
+        i32 target 30008
+        target.Add(0x10uy)
+        u32 target writeIndex
+        target.Add(0x21uy)
+        u32 target 2
+
+    let private emitRead (target: ResizeArray<byte>) readIndex =
+        storeByteConstAddress target 30012 0
+        storeI32Const target 30000 30012
+        storeI32Const target 30004 1
+        i32 target 0
+        i32 target 30000
+        i32 target 1
+        i32 target 30008
+        target.Add(0x10uy)
+        u32 target readIndex
+        target.Add(0x21uy)
+        u32 target 2
+        i32 target 30012
+        target.Add(0x2Duy)
+        u32 target 0
+        u32 target 0
+        target.Add(0x21uy)
+        u32 target 1
+        target.Add(0x20uy)
+        u32 target 0
+        target.Add(0x20uy)
+        u32 target 1
+        target.Add(0x3Auy)
+        u32 target 0
+        u32 target 0
+
+    let rec private emitOperations
+        (target: ResizeArray<byte>)
+        (program: ParsedProgram)
+        startIndex
+        endIndex
+        writeIndex
+        readIndex
+        =
+        let mutable index = startIndex
+        while index < endIndex do
+            match program.Operations[index] with
+            | '>' -> addToLocal target 0 1
+            | '<' -> addToLocal target 0 -1
+            | '+' -> mutateCell target 1
+            | '-' -> mutateCell target -1
+            | '.' -> emitWrite target writeIndex
+            | ',' -> emitRead target readIndex
+            | '[' ->
+                let close = program.LoopEnds[index]
+                append target [ 0x02uy; 0x40uy; 0x03uy; 0x40uy ]
+                loadCell target
+                target.Add(0x45uy)
+                target.Add(0x0Duy)
+                u32 target 1
+                emitOperations target program (index + 1) close writeIndex readIndex
+                target.Add(0x0Cuy)
+                u32 target 0
+                append target [ 0x0Buy; 0x0Buy ]
+                index <- close
+            | _ -> ()
+            index <- index + 1
+
+    let private functionBody program writeIndex readIndex =
+        let result = ResizeArray<byte>()
+        emitOperations result program 0 program.Operations.Length writeIndex readIndex
+        result.Add(0x0Buy)
+        result.ToArray()
+
+    let private emitModule program =
+        let needsWrite = program.Operations |> Array.contains '.'
+        let needsRead = program.Operations |> Array.contains ','
+        let importCount = (if needsWrite then 1 else 0) + (if needsRead then 1 else 0)
+        let writeIndex = if needsWrite then 0 else -1
+        let readIndex = if needsRead then (if needsWrite then 1 else 0) else -1
+        let moduleValue = WasmModule()
+        let wasiType =
+            WasmTypes.makeFuncType
+                [ ValueType.I32; ValueType.I32; ValueType.I32; ValueType.I32 ]
+                [ ValueType.I32 ]
+
+        if needsWrite then
+            moduleValue.Types.Add(wasiType)
+            moduleValue.Imports.Add(
+                {
+                    ModuleName = wasiModule
+                    Name = "fd_write"
+                    Kind = ExternalKind.FUNCTION
+                    Descriptor = FunctionImportDescriptor writeIndex
+                }
+            )
+
+        if needsRead then
+            moduleValue.Types.Add(wasiType)
+            moduleValue.Imports.Add(
+                {
+                    ModuleName = wasiModule
+                    Name = "fd_read"
+                    Kind = ExternalKind.FUNCTION
+                    Descriptor = FunctionImportDescriptor readIndex
+                }
+            )
+
+        moduleValue.Types.Add(WasmTypes.makeFuncType [] [])
+        moduleValue.Functions.Add(importCount)
+        moduleValue.Memories.Add({ Limits = { Min = 1; Max = None } })
+        moduleValue.Exports.Add({ Name = "_start"; Kind = ExternalKind.FUNCTION; Index = importCount })
+        moduleValue.Exports.Add({ Name = "memory"; Kind = ExternalKind.MEMORY; Index = 0 })
+        moduleValue.Code.Add(
+            FunctionBody(
+                [ ValueType.I32; ValueType.I32; ValueType.I32 ],
+                functionBody program writeIndex readIndex
+            )
+        )
+        WasmModuleEncoder.encodeModule moduleValue
+
+    let compileSource (source: string) =
+        if isNull source then
+            nullArg "source"
+        let program = parse source
+        PackageResult(source, program.Operations |> Array.toList, emitModule program, None)
+
+    let packSource source = compileSource source
+
+    let writeWasmFile source path =
+        if isNull path then
+            nullArg "path"
+        let result = compileSource source
+        try
+            File.WriteAllBytes(path, result.WasmBytes)
+        with
+        | :? IOException as error -> raise (PackageError("write", error.Message))
+        | :? UnauthorizedAccessException as error -> raise (PackageError("write", error.Message))
+        PackageResult(result.Source, result.Operations, result.WasmBytes, Some path)

--- a/code/packages/fsharp/brainfuck-wasm-compiler/CHANGELOG.md
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# Brainfuck parser and WebAssembly emitter.
+- Emit optional WASI input/output imports, linear memory, and `_start` exports.
+- Validate source size, loop balance, and loop nesting depth.
+- Add compile, pack, file-write, module-shape, runtime, and error-path tests.

--- a/code/packages/fsharp/brainfuck-wasm-compiler/CodingAdventures.BrainfuckWasmCompiler.fsproj
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/CodingAdventures.BrainfuckWasmCompiler.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.BrainfuckWasmCompiler.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BrainfuckWasmCompiler.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# Brainfuck-to-WebAssembly compiler</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="BrainfuckWasmCompiler.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../wasm-leb128/CodingAdventures.WasmLeb128.fsproj" />
+    <ProjectReference Include="../wasm-module-encoder/CodingAdventures.WasmModuleEncoder.fsproj" />
+    <ProjectReference Include="../wasm-types/CodingAdventures.WasmTypes.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/brainfuck-wasm-compiler/README.md
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/README.md
@@ -1,0 +1,18 @@
+# CodingAdventures.BrainfuckWasmCompiler.FSharp
+
+A pure F# Brainfuck-to-WebAssembly compiler. It ignores non-Brainfuck source
+characters, validates bracket structure and nesting depth, and emits a typed
+WebAssembly module with one memory and an exported `_start` function. Input and
+output instructions use the WASI `fd_read` and `fd_write` imports only when the
+program needs them.
+
+```fsharp
+open CodingAdventures.BrainfuckWasmCompiler.FSharp
+
+let result = BrainfuckWasmCompiler.compileSource "++[>+<-]"
+File.WriteAllBytes("program.wasm", result.WasmBytes)
+```
+
+The compiler builds the module with the sibling `wasm-types`, `wasm-leb128`,
+and `wasm-module-encoder` packages. `writeWasmFile` is the only API that touches
+the filesystem.

--- a/code/packages/fsharp/brainfuck-wasm-compiler/required_capabilities.json
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/required_capabilities.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/brainfuck-wasm-compiler",
+  "capabilities": [
+    "filesystem.write"
+  ],
+  "justification": "Compilation is pure, but the package also provides a helper that writes the resulting .wasm bytes to disk."
+}

--- a/code/packages/fsharp/brainfuck-wasm-compiler/tests/CodingAdventures.BrainfuckWasmCompiler.Tests/BrainfuckWasmCompilerTests.fs
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/tests/CodingAdventures.BrainfuckWasmCompiler.Tests/BrainfuckWasmCompilerTests.fs
@@ -1,0 +1,104 @@
+namespace CodingAdventures.BrainfuckWasmCompiler.FSharp.Tests
+
+open System
+open System.IO
+open CodingAdventures.BrainfuckWasmCompiler.FSharp
+open CodingAdventures.WasmRuntime.FSharp
+open CodingAdventures.WasmTypes.FSharp
+open Xunit
+
+module BrainfuckWasmCompilerTests =
+    [<Fact>]
+    let ``compile filters comments and builds a valid module`` () =
+        let result = BrainfuckWasmCompiler.compileSource "note: ++[>+<-] done"
+        Assert.Equal<char list>([ '+'; '+'; '['; '>'; '+'; '<'; '-'; ']' ], result.Operations)
+        Assert.Equal<byte array>([| 0x00uy; 0x61uy; 0x73uy; 0x6Duy |], result.WasmBytes[..3])
+        Assert.Equal(None, result.WasmPath)
+
+        let runtime = WasmRuntime()
+        let moduleValue = runtime.Load(result.WasmBytes)
+        Assert.Empty(moduleValue.Imports)
+        Assert.Single(moduleValue.Memories) |> ignore
+        Assert.Equal<string list>([ "_start"; "memory" ], moduleValue.Exports |> Seq.map _.Name |> Seq.toList)
+        runtime.Validate(moduleValue) |> ignore
+
+    [<Fact>]
+    let ``compile adds only required WASI imports`` () =
+        let cases =
+            [
+                ".", [ "fd_write" ]
+                ",", [ "fd_read" ]
+                ".,", [ "fd_write"; "fd_read" ]
+            ]
+
+        for source, expectedNames in cases do
+            let runtime = WasmRuntime()
+            let moduleValue = runtime.Load((BrainfuckWasmCompiler.compileSource source).WasmBytes)
+            Assert.Equal<string list>(expectedNames, moduleValue.Imports |> Seq.map _.Name |> Seq.toList)
+            Assert.All(
+                moduleValue.Imports,
+                fun item ->
+                    Assert.Equal("wasi_snapshot_preview1", item.ModuleName)
+                    Assert.Equal(ExternalKind.FUNCTION, item.Kind)
+            )
+            Assert.Equal(expectedNames.Length + 1, moduleValue.Types.Count)
+            Assert.Equal(expectedNames.Length, moduleValue.Functions[0])
+
+    [<Fact>]
+    let ``pack is a compile alias and results defend their bytes`` () =
+        let result = BrainfuckWasmCompiler.packSource "+"
+        let bytes = result.WasmBytes
+        bytes[0] <- 0xFFuy
+
+        Assert.Equal(0x00uy, result.WasmBytes[0])
+        Assert.Equal("0.1.0", Version.VERSION)
+
+    [<Fact>]
+    let ``pointer operations execute in the local runtime`` () =
+        let result = BrainfuckWasmCompiler.compileSource "><"
+        let runtime = WasmRuntime()
+        let instance = runtime.Instantiate(result.WasmBytes)
+
+        runtime.Call(instance, "_start", [||]) |> ignore
+        let memory = instance.Engine.Memory |> Option.get
+        Assert.Equal<byte array>([| 0uy; 0uy |], memory.ReadBytes(0, 2))
+
+    [<Fact>]
+    let ``writeWasmFile writes bytes and records path`` () =
+        let directory = Path.Combine(Path.GetTempPath(), sprintf "brainfuck-wasm-%s" (Guid.NewGuid().ToString("N")))
+        Directory.CreateDirectory(directory) |> ignore
+        let path = Path.Combine(directory, "program.wasm")
+        try
+            let result = BrainfuckWasmCompiler.writeWasmFile "+" path
+            Assert.Equal(Some path, result.WasmPath)
+            Assert.Equal<byte array>(result.WasmBytes, File.ReadAllBytes(path))
+        finally
+            Directory.Delete(directory, true)
+
+    [<Fact>]
+    let ``writeWasmFile wraps filesystem errors`` () =
+        let path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "x.wasm")
+        let error = Assert.Throws<PackageError>(fun () -> BrainfuckWasmCompiler.writeWasmFile "+" path |> ignore)
+        Assert.Equal("write", error.Stage)
+
+    [<Fact>]
+    let ``compile rejects unmatched loops`` () =
+        let cases = [ "[", "unmatched ["; "abc]", "unmatched ] at byte 3" ]
+        for source, message in cases do
+            let error = Assert.Throws<PackageError>(fun () -> BrainfuckWasmCompiler.compileSource source |> ignore)
+            Assert.Equal("parse", error.Stage)
+            Assert.Equal(message, error.Message)
+
+    [<Fact>]
+    let ``compile rejects excessive nesting`` () =
+        let error =
+            Assert.Throws<PackageError>(fun () -> BrainfuckWasmCompiler.compileSource (String('[', 513)) |> ignore)
+        Assert.Equal("parse", error.Stage)
+        Assert.Equal("loop nesting exceeds 512", error.Message)
+
+    [<Fact>]
+    let ``compile rejects excessive source length`` () =
+        let error =
+            Assert.Throws<PackageError>(fun () -> BrainfuckWasmCompiler.compileSource (String('x', 1_000_001)) |> ignore)
+        Assert.Equal("parse", error.Stage)
+        Assert.Equal("source exceeds 1000000 characters", error.Message)

--- a/code/packages/fsharp/brainfuck-wasm-compiler/tests/CodingAdventures.BrainfuckWasmCompiler.Tests/CodingAdventures.BrainfuckWasmCompiler.Tests.fsproj
+++ b/code/packages/fsharp/brainfuck-wasm-compiler/tests/CodingAdventures.BrainfuckWasmCompiler.Tests/CodingAdventures.BrainfuckWasmCompiler.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BrainfuckWasmCompiler.fsproj" />
+    <ProjectReference Include="../../../wasm-runtime/CodingAdventures.WasmRuntime.fsproj" />
+    <Compile Include="BrainfuckWasmCompilerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,21 +105,22 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 17, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
+on July 18, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
 `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
 the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
-and `hash-set` ports, and the paired `in-memory-data-store-engine` and
-`in-memory-data-store` ports:
+and `hash-set` ports, the paired `in-memory-data-store-engine` and
+`in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
+`x25519`, and `brainfuck-wasm-compiler` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 343 |
+| Present in 10-15 languages | 172 | 337 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 697 | 9,758 |
+| Present in one language | 699 | 9,786 |
 
-The loop must not start by attempting 9,758 singleton ports. It should finish
+The loop must not start by attempting 9,786 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -160,7 +161,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 339
+The 172 packages present in at least ten implementation languages need 337
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -169,8 +170,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 15 | Move with F# |
-| F# | 15 | Move with C# |
+| C# | 14 | Move with F# |
+| F# | 14 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -242,6 +243,14 @@ ladder over `2^255 - 19`. RFC scalar-multiplication, Diffie-Hellman,
 high-bit-masking, low-order rejection, and 1,000-round iterated vectors provide
 conformance coverage. The package now spans 12 implementation lanes and
 reduces each paired high-consensus gap to 15.
+
+The third paired C#/F# slice is complete: `brainfuck-wasm-compiler` now builds
+typed WebAssembly modules through the new native encoders in both lanes.
+Package-native tests cover source filtering, balanced and depth-limited loops,
+8-bit cell and pointer emission, optional WASI I/O imports, file output,
+parser/validator round trips, and locally supported runtime execution. The
+package now spans 13 implementation lanes and reduces each paired
+high-consensus gap to 14.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure C# and F# Brainfuck-to-WebAssembly compilers backed by the native wasm-types, wasm-leb128, and wasm-module-encoder packages
- emit memory, _start, balanced loops, byte-cell operations, and only the WASI fd_read/fd_write imports each program needs
- add package metadata, capability declarations, BUILD entrypoints, documentation, and update the parity roadmap from 339 to 337 high-consensus gaps

## Validation

- C#: 12 tests; 100% line/branch/method coverage
- F#: 9 tests; 95.36% line, 85.5% branch, 96% method coverage
- generated modules round-trip through the local parser and validator; the supported runtime paths execute in both lanes, with C# additionally exercising byte-cell wrapping
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py` (6 tests)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions; C#/F# each at 14 high-consensus gaps)
- `git diff --check`