### PR TITLE
feat(sql): blob literals x'..' parse into SqlValue::Blob

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.42 — blob literals `x'…'` parse
+
+SQL blob literals `x'48656C6C6F'` / `X'FF00'` now parse end to end. Previously
+the lexer split `x'414243'` into a `NAME` and a `STRING` and the query failed;
+now the whole literal is one token that the planner decodes into raw bytes.
+`HEX(x'414243')` is `'414243'`, `TYPEOF(x'00')` is `'blob'`, `QUOTE(X'DEADBEEF')`
+is `X'DEADBEEF'`, and `WHERE b = x'0102'` filters by byte-exact blob equality.
+The empty literal `x''` is the zero-byte blob; an odd number of hex digits is a
+parse error, as in SQLite. The VM already supported `Blob` values, so this is a
+pure front-end (lexer→parser→planner) fix. Touches sql-lexer 0.1.3, sql-parser
+0.1.20, sql-planner 0.2.21. `LENGTH()` over a blob is a documented follow-up.
+
 ## 0.5.41 — column-defined COLLATE in WHERE comparisons
 
 A column declared `COLLATE NOCASE` / `RTRIM` now folds in WHERE comparisons, not

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.41"
+version = "0.5.42"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -626,6 +626,34 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT HEX(s) AS h, TYPEOF(HEX(s)) AS t FROM t ORDER BY id",
     },
+    // Blob literals `x'…'` / `X'…'` now parse into raw bytes. HEX round-trips
+    // them (upper-case), and TYPEOF reports `blob`. The empty literal `x''` is
+    // the zero-byte blob, so HEX(x'') is the empty string. These exercise the
+    // lexer→parser→planner→VM path end to end for a value kind the VM already
+    // handled but the front end could not previously produce. (LENGTH() over a
+    // blob — byte count — is a separate VM-builtin gap, spun off as a follow-up.)
+    Case {
+        id: "blob_literal_hex_typeof",
+        setup: &[],
+        query: "SELECT HEX(x'48656C6C6F') AS h, TYPEOF(x'00') AS t, HEX(x'') AS e",
+    },
+    // A blob literal compares byte-for-byte and orders after text/numbers per
+    // SQLite's storage-class ordering; here two rows filter on blob equality.
+    Case {
+        id: "blob_literal_equality",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, b BLOB)",
+            "INSERT INTO t VALUES (1, x'0102'), (2, x'03')",
+        ],
+        query: "SELECT id FROM t WHERE b = x'0102' ORDER BY id",
+    },
+    // Upper-case `X'…'` is equivalent to lower-case, and quote() renders a blob
+    // as the `X'…'` SQL literal form.
+    Case {
+        id: "blob_literal_uppercase_quote",
+        setup: &[],
+        query: "SELECT QUOTE(X'DEADBEEF') AS q, HEX(X'ab') AS h",
+    },
     // OCTET_LENGTH counts BYTES (UTF-8), where LENGTH counts characters:
     // 'héllo' is 5 characters but 6 bytes.
     Case {

--- a/code/packages/rust/sql-lexer/CHANGELOG.md
+++ b/code/packages/rust/sql-lexer/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - Unreleased
+
+### Added
+
+- **Blob-literal token `BLOB_HEX`.** The token grammar already declared
+  `BLOB_HEX = /[xX]'[0-9A-Fa-f]*'/ -> BLOB` but the generated token table did
+  not carry it, so `x'414243'` mis-lexed as a `NAME` (`x`) followed by a
+  `STRING` (`'414243'`). The rule is now emitted, placed **before** `NAME` so
+  first-match-wins picks the whole `x'…'` blob literal. It aliases to `BLOB`;
+  because `TokenType` has no blob variant the lexer records the name in
+  `type_name` (with `type_` falling back to `Name`), which the planner keys on.
+
 ## [0.1.2] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-lexer/Cargo.toml
+++ b/code/packages/rust/sql-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-lexer"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "SQL lexer — tokenizes SQL source text using the grammar-driven lexer and the sql.tokens grammar file"
 

--- a/code/packages/rust/sql-lexer/src/_grammar.rs
+++ b/code/packages/rust/sql-lexer/src/_grammar.rs
@@ -13,6 +13,21 @@ use std::collections::HashMap;
 pub fn token_grammar() -> TokenGrammar {
     TokenGrammar {
         definitions: vec![
+            // Blob literal `x'48656C6C6F'` / `X'...'` — a quoted run of hex
+            // digit pairs. MUST precede NAME: with first-match-wins semantics,
+            // NAME would otherwise consume the leading `x`/`X` and leave the
+            // quoted body to be mis-lexed as a STRING. The alias is `BLOB` so
+            // the parser's `primary` rule references a single `BLOB` token; the
+            // planner decodes the hex body (rejecting odd length) into raw
+            // bytes. The `*` allows the empty blob `x''` (SQLite's zero-byte
+            // blob); odd-length or non-hex content is caught downstream.
+            TokenDefinition {
+                name: r#"BLOB_HEX"#.to_string(),
+                pattern: r#"[xX]'[0-9A-Fa-f]*'"#.to_string(),
+                is_regex: true,
+                line_number: 23,
+                alias: Some(r#"BLOB"#.to_string()),
+            },
             TokenDefinition {
                 name: r#"NAME"#.to_string(),
                 pattern: r#"[a-zA-Z_][a-zA-Z0-9_]*"#.to_string(),

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.20] - Unreleased
+
+### Added
+
+- **`primary` now accepts a `BLOB` literal token** (`x'…'` / `X'…'`), placed
+  after `STRING` in the alternation. The planner decodes the hex body into raw
+  bytes. Pairs with sql-lexer 0.1.3's `BLOB_HEX` token.
+
 ## [0.1.19] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -668,6 +668,9 @@ pub fn parser_grammar() -> ParserGrammar {
             body: GrammarElement::Alternation { choices: vec![
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                // Blob literal `x'..'` (lexed as the `BLOB` token). The planner
+                // decodes the hex body into raw bytes (SqlValue::Blob).
+                GrammarElement::TokenReference { name: r#"BLOB"#.to_string() },
                 GrammarElement::Literal { value: r#"NULL"#.to_string() },
                 GrammarElement::Literal { value: r#"TRUE"#.to_string() },
                 GrammarElement::Literal { value: r#"FALSE"#.to_string() },

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.21] - Unreleased
+
+### Added
+
+- **Blob literals `x'…'` / `X'…'` plan to `SqlValue::Blob`.** `plan_primary_token`
+  recognises the lexer's `BLOB` token (via `type_name`) and decodes the hex body
+  into raw bytes through the new `decode_blob_literal` helper: `x'414243'` → the
+  three bytes `41 42 43`, `X'FF00'` → `FF 00`, and the empty literal `x''` → the
+  zero-byte blob. An odd number of hex digits is rejected with a plan error,
+  matching SQLite's tokenizer (`x'012'` is a syntax error there); a non-hex digit
+  is guarded defensively even though the lexer regex already excludes it. The VM
+  already handled `Blob` values (HEX/QUOTE/TYPEOF/equality), so this closes the
+  front-end gap that prevented producing them. `LENGTH()` over a blob (byte count)
+  is a separate VM-builtin follow-up.
+
 ## [0.2.20] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.20"
+version = "0.2.21"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -2981,6 +2981,17 @@ fn plan_primary_token(tok: &Token) -> Result<SqlExpr, PlanError> {
 
     let val = &tok.value;
 
+    // Blob literal `x'48656C6C6F'` / `X'…'`. The lexer's `BLOB_HEX` rule aliases
+    // it to `BLOB`; because `TokenType` has no `Blob` variant, the lexer records
+    // the name in `type_name` and falls `type_` back to `Name`. Decode the hex
+    // body into raw bytes: SQLite reads `x'414243'` as the three bytes
+    // `41 42 43`. An odd number of hex digits is a tokenizer error in SQLite
+    // (`x'012'` → "unrecognized token"); we surface it as a plan error rather
+    // than silently truncating. The empty blob `x''` is the zero-byte blob.
+    if tok.type_name.as_deref() == Some("BLOB") || tok.type_name.as_deref() == Some("BLOB_HEX") {
+        return decode_blob_literal(val).map(|bytes| SqlExpr::Literal(SqlValue::Blob(bytes)));
+    }
+
     // NUMBER literal: try integer first, then float.
     if let Ok(i) = val.parse::<i64>() {
         return Ok(SqlExpr::Literal(SqlValue::Int(i)));
@@ -2994,6 +3005,62 @@ fn plan_primary_token(tok: &Token) -> Result<SqlExpr, PlanError> {
         table: None,
         name: val.clone(),
     })
+}
+
+/// Decode the body of a blob literal `x'…'` / `X'…'` into raw bytes.
+///
+/// The `raw` argument is the token text as the lexer captured it. The
+/// `BLOB_HEX` rule (`[xX]'[0-9A-Fa-f]*'`) keeps the surrounding `x'` / `'`, so
+/// we strip them here; we also tolerate a body that has already been unquoted,
+/// so the function is robust to either shape.
+///
+/// SQLite semantics:
+///
+/// | Literal        | Bytes            | Notes                                  |
+/// |----------------|------------------|----------------------------------------|
+/// | `x'414243'`    | `41 42 43`       | two hex digits per byte, case-insens.  |
+/// | `X'FF00'`      | `FF 00`          | leading `X` is equivalent to `x`       |
+/// | `x''`          | *(empty)*        | the zero-byte blob                     |
+/// | `x'012'`       | *error*          | odd digit count is a tokenizer error   |
+///
+/// The lexer's regex already guarantees the body is all hex digits, so the only
+/// failure this needs to guard is an odd digit count; the non-hex check is kept
+/// as defence in depth.
+fn decode_blob_literal(raw: &str) -> Result<Vec<u8>, PlanError> {
+    // Strip a leading `x'` / `X'` and the trailing `'` when present.
+    let body = raw
+        .strip_prefix("x'")
+        .or_else(|| raw.strip_prefix("X'"))
+        .and_then(|s| s.strip_suffix('\''))
+        .unwrap_or(raw);
+
+    if body.len() % 2 != 0 {
+        return Err(PlanError::UnsupportedStatement(format!(
+            "blob literal has an odd number of hex digits: x'{body}'"
+        )));
+    }
+
+    let hex = body.as_bytes();
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    let mut i = 0;
+    while i < hex.len() {
+        // Decode a nibble pair straight from the byte slice. Slicing the *bytes*
+        // (never the `&str`) sidesteps any UTF-8 char-boundary panic if a
+        // non-ASCII body ever reaches here; `from_utf8` then rejects it as a
+        // non-hex digit instead. `i` steps by two and `body.len()` is even, so
+        // `i + 2 <= hex.len()` always holds — the slice cannot go out of bounds.
+        let pair = std::str::from_utf8(&hex[i..i + 2])
+            .ok()
+            .and_then(|s| u8::from_str_radix(s, 16).ok())
+            .ok_or_else(|| {
+                PlanError::UnsupportedStatement(format!(
+                    "blob literal has a non-hex digit: x'{body}'"
+                ))
+            })?;
+        bytes.push(pair);
+        i += 2;
+    }
+    Ok(bytes)
 }
 
 /// Plan a `column_ref` node.
@@ -4020,6 +4087,35 @@ mod tests {
     fn test_expr_null_literal() {
         let expr = plan_where_expr("SELECT * FROM t WHERE x IS NULL");
         assert!(matches!(expr, SqlExpr::IsNull(_)));
+    }
+
+    #[test]
+    fn test_expr_blob_literal() {
+        // `x'414243'` → the three bytes `A B C`; upper-case `X'…'` is equivalent.
+        let expr = plan_where_expr("SELECT * FROM t WHERE b = x'414243'");
+        if let SqlExpr::BinaryOp { right, .. } = expr {
+            assert_eq!(*right, SqlExpr::Literal(SqlValue::Blob(vec![0x41, 0x42, 0x43])));
+        } else {
+            panic!("Expected blob literal");
+        }
+        let upper = plan_where_expr("SELECT * FROM t WHERE b = X'FF00'");
+        if let SqlExpr::BinaryOp { right, .. } = upper {
+            assert_eq!(*right, SqlExpr::Literal(SqlValue::Blob(vec![0xFF, 0x00])));
+        } else {
+            panic!("Expected upper-case blob literal");
+        }
+    }
+
+    #[test]
+    fn test_decode_blob_literal() {
+        assert_eq!(decode_blob_literal("x'414243'").unwrap(), vec![0x41, 0x42, 0x43]);
+        assert_eq!(decode_blob_literal("X'FF00'").unwrap(), vec![0xFF, 0x00]);
+        // Empty blob.
+        assert_eq!(decode_blob_literal("x''").unwrap(), Vec::<u8>::new());
+        // Already-unquoted body is tolerated.
+        assert_eq!(decode_blob_literal("0a0B").unwrap(), vec![0x0A, 0x0B]);
+        // Odd digit count is rejected (matches SQLite's tokenizer error).
+        assert!(decode_blob_literal("x'012'").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

SQL blob literals `x'48656C6C6F'` / `X'FF00'` now parse end to end in mini-sqlite. Previously the lexer split `x'414243'` into a `NAME` (`x`) and a `STRING` (`'414243'`) and the query failed with a parse error; the whole literal is now one token that the planner decodes into raw bytes.

This is the next conformance-rotation increment (lane-1) after the four-lane batch (#8436/#8445/#8446/#8448) drained. Probed against real `sqlite3` 3.51.0 first.

## Why it was a gap

The VM already fully supported `Blob` values (`HEX`/`QUOTE`/`TYPEOF`/equality all work on blobs), but nothing on the front end could *produce* one — the `BLOB_HEX` token was declared in `sql.tokens` yet missing from the generated lexer table, `primary` didn't reference `BLOB`, and the planner had no blob-literal path.

## Change (front-end only, three layers)

| Crate | Version | Change |
|-------|---------|--------|
| `sql-lexer` | 0.1.2 → **0.1.3** | Emit `BLOB_HEX` (`[xX]'[0-9A-Fa-f]*'`, alias `BLOB`), placed **before** `NAME` so first-match-wins picks the whole `x'..'`. |
| `sql-parser` | 0.1.19 → **0.1.20** | `primary` accepts the `BLOB` token after `STRING`. |
| `sql-planner` | 0.2.20 → **0.2.21** | `plan_primary_token` recognises the `BLOB` token (via `type_name`) and decodes the hex body with the new `decode_blob_literal`. |
| `mini-sqlite` | 0.5.41 → **0.5.42** | Oracle cases + rollup. |

Semantics match SQLite: `x'414243'` → bytes `41 42 43`; `X'FF00'` → `FF 00`; empty `x''` → the zero-byte blob; an odd number of hex digits → parse error (`x'012'` is a tokenizer error in SQLite too). Decoding slices the **byte** array (never the `&str`), so it is panic-free on any input.

## Tests

- **Differential oracle** (vs real bundled SQLite): three new gated cases — `HEX`/`TYPEOF` of blob literals + empty blob; byte-exact `WHERE b = x'0102'`; upper-case `X'..'` + `QUOTE`. All match.
- **sql-planner unit tests**: `test_expr_blob_literal` (planning) and `test_decode_blob_literal` (empty, upper/lower, odd-length error).
- Full suites green: sql-lexer, sql-parser, sql-planner (75), mini-sqlite (45) + oracle.
- Inline adversarial security review: clean — no OOB (odd-length guard + even-step, bounds-gated loop), no ReDoS (linear regex), no overflow/`as usize` truncation, and `BLOB_HEX`-before-`NAME` cannot steal identifiers (the patterns diverge on char 2, a `'`).

## Follow-up (spun off, not in this PR)

`LENGTH()` over a blob (byte count) — the VM's `LENGTH` builtin rejects `Blob` input; real SQLite returns the byte count. Separate VM-builtin increment.

## Notes

- `sql _grammar.rs` files are the hand-edited source of truth (per repo convention) — edited directly, not regenerated.
- Never self-merge; this is queued for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
