### PR TITLE
feat(gc-core-capi): pure-Rust conservative C-stack scan __gc_collect (#118b-1)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this crate are documented here.
 
+## [0.3.0] — 2026-07-17
+
+### Added
+
+- **`__gc_collect()`** — the argument-less conservative C-stack scan (new module
+  `stack_scan`). The drop-in for `twig_gc.c`'s `__twig_gc_collect`: roots from this
+  thread's live stack + callee-saved registers with **no caller-supplied roots**,
+  the way the native backend's collect/safepoint points call it. Pure Rust, no C:
+  a per-arch `asm!` block spills callee-saved integer registers to the stack
+  (replacing `setjmp`), reads the stack pointer, finds the thread's stack base via
+  bare `extern` bindings to the platform thread API (`pthread_get_stackaddr_np` on
+  macOS, `pthread_getattr_np`/`pthread_attr_getstack` on Linux,
+  `GetCurrentThreadStackLimits` on Windows), and hands `[sp, base)` to
+  `__gc_collect_region`. Supported targets are exactly the native-AOT ones —
+  aarch64 (macOS), x86_64 (Linux, Windows); any other `(arch, os)` is a hard
+  `compile_error!`, never a silent unsound fallback. A `MAX_STACK_SCAN` (256 MiB)
+  ceiling fences off a bogus stack base (algorithmic-DoS guard). Register-spill
+  asm runtime-validated on both aarch64 and x86_64 (SysV); 3 unit tests (live
+  stack local survives + dead object freed; SP sanity vs. stack base; real
+  `FlatHeap`).
+- With this, `gc-core-capi` covers the **whole** conservative collector
+  `twig_gc.c` shipped — explicit roots, region scan, and stack scan — in generic
+  Rust. Next PR wires `twig-aot` to link the archive and retires `twig_gc.c`.
+
 ## [0.2.0] — 2026-07-17
 
 ### Added

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/README.md
+++ b/code/packages/rust/gc-core-capi/README.md
@@ -38,6 +38,7 @@ The interpreters use `gc-core`'s managed-object collector; native output uses
 | `int64_t __gc_alloc_kind(int64_t n, uint16_t kind)` | as above, tagging the object with a `HeapKind` id (for later precise tracing) |
 | `int64_t __gc_collect_roots(const int64_t *roots, int64_t count)` | mark from `count` root words, sweep; returns objects freed |
 | `int64_t __gc_collect_region(const uint8_t *base, int64_t len)` | mark from every candidate pointer in a raw region, sweep; returns objects freed |
+| `int64_t __gc_collect(void)` | conservative collection rooted at this thread's live stack + callee-saved registers (no caller roots); returns objects freed |
 | `int64_t __gc_live_bytes(void)` | live payload bytes |
 | `int64_t __gc_collection_count(void)` | collections run so far |
 | `void __gc_reset(void)` | drop the whole heap; free everything |
@@ -60,17 +61,26 @@ __gc_collect_roots(roots, 1);         /* cell is rooted → survives */
 
 ## Status
 
-This is **T1 rung 0** — the linkable flat collector with explicit-root and
-region-scan collection. `__gc_collect_region` is the platform-independent core of
-the conservative stack scan: give it any span of raw memory and it roots from every
-candidate pointer inside. Still to come (own PRs):
+This is **T1 rung 0** — the linkable flat collector. It now covers the full
+conservative collector `twig_gc.c` shipped, in three layers: explicit roots
+(`__gc_collect_roots`), a raw memory region (`__gc_collect_region`), and the
+argument-less **conservative C-stack scan** (`__gc_collect`) — all pure Rust, no C.
 
-- Wire `twig-aot`'s `build.rs` to link this archive and retire `twig_gc.c`
-  (golden/smoke parity).
-- The argument-less **C-stack scan** so `collect` runs with no explicit roots (the
-  drop-in for `twig_gc.c`'s `__twig_gc_collect`): discover the current stack pointer
-  and the thread's stack base, spill callee-saved registers, and hand that span to
-  `__gc_collect_region`.
+`__gc_collect` is the drop-in for `twig_gc.c`'s `__twig_gc_collect`: it spills the
+callee-saved registers to the stack (an `asm!` block replacing `setjmp`), reads the
+stack pointer, finds the thread's stack base via the platform thread API (bare
+`extern` bindings — `pthread_get_stackaddr_np` on macOS, `pthread_getattr_np` /
+`pthread_attr_getstack` on Linux, `GetCurrentThreadStackLimits` on Windows), and
+hands `[sp, base)` to `__gc_collect_region`. Supported targets are exactly the
+native-AOT ones: aarch64 (macOS) and x86_64 (Linux, Windows); anything else is a
+hard `compile_error!` rather than a silent unsound fallback.
+
+Still to come (own PRs):
+
+- Wire `twig-aot`'s `build.rs` to link this archive, export the twig-compat
+  aliases (`__twig_gc_alloc` / `collect` / `safepoint` / `live_bytes` /
+  `collection_count`) the emitted code already calls, and retire `twig_gc.c`
+  (golden / `*_smoke.rs` parity).
 - **Precise** roots (stack maps) and interior tracing (`HeapKind` field maps),
   then moving / generational — all as `gc-core` algorithms.
 

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -54,6 +54,15 @@ int64_t __gc_collect_roots(const int64_t *roots, int64_t count);
  * range and call this. A null `base` or len <= 0 means "no region" → free all. */
 int64_t __gc_collect_region(const uint8_t *base, int64_t len);
 
+/* Run a full conservative collection rooted at THIS THREAD'S live C stack and
+ * callee-saved registers — no caller-supplied roots. Spills callee-saved
+ * registers to the stack, reads the stack pointer, finds the thread's stack
+ * base (pthread on macOS/Linux, GetCurrentThreadStackLimits on Windows), and
+ * hands [sp, base) to __gc_collect_region. This is the drop-in for the native
+ * backend's argument-less collect/safepoint points, where the only roots are
+ * whatever the machine is holding. Returns objects freed. Single-threaded. */
+int64_t __gc_collect(void);
+
 /* Live payload bytes. */
 int64_t __gc_live_bytes(void);
 

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -10,10 +10,11 @@
 //!
 //! It **supersedes `twig-aot/runtime/twig_gc.c`** — the same flat mark-sweep, but
 //! one generic Rust collector shared by every native consumer instead of a
-//! Twig-specific C fork.  (Wiring `twig-aot` to link this archive, and the
-//! conservative C-stack scan that lets `collect` run with no explicit roots, are
-//! the next PR; this crate delivers the linkable collector + its explicit-root
-//! entry points.)
+//! Twig-specific C fork.  It now covers the whole conservative collector: explicit
+//! roots, a raw region ([`__gc_collect_region`]), and the argument-less
+//! conservative C-stack scan ([`__gc_collect`], see [`stack_scan`]) — all pure
+//! Rust.  (Wiring `twig-aot` to link this archive and retiring `twig_gc.c` is the
+//! next PR.)
 //!
 //! ## The exported ABI
 //!
@@ -22,6 +23,8 @@
 //! | `__gc_alloc(n)` | allocate `n` zeroed bytes; returns a real pointer (as `int64`), or `0` on failure/`n<=0` |
 //! | `__gc_alloc_kind(n, kind)` | as above, tagging the object with a `HeapKind` id (for later precise tracing) |
 //! | `__gc_collect_roots(roots, count)` | mark from `count` root words at `roots`, sweep; returns objects freed |
+//! | `__gc_collect_region(base, len)` | mark from every candidate pointer in a raw region, sweep; returns objects freed |
+//! | `__gc_collect()` | conservative collect rooted at this thread's live stack + callee-saved registers; returns objects freed |
 //! | `__gc_live_bytes()` | live payload bytes |
 //! | `__gc_collection_count()` | collections run so far |
 //! | `__gc_reset()` | drop the whole heap (frees everything); mainly for tests / process teardown |
@@ -36,6 +39,11 @@
 
 use gc_core::FlatHeap;
 use std::sync::Mutex;
+
+/// Conservative C-stack scan — the argument-less `__gc_collect` that roots from
+/// this thread's live stack + callee-saved registers (the drop-in for
+/// `twig_gc.c`'s `__twig_gc_collect`). See [`stack_scan`].
+mod stack_scan;
 
 /// The one process-wide heap.  `None` until the first allocation (lazy init);
 /// `__gc_reset` puts it back to `None`, running `FlatHeap`'s `Drop` to free

--- a/code/packages/rust/gc-core-capi/src/stack_scan.rs
+++ b/code/packages/rust/gc-core-capi/src/stack_scan.rs
@@ -1,0 +1,346 @@
+//! # Conservative C-stack scan — the argument-less `__gc_collect`
+//!
+//! [`__gc_collect_roots`](crate) and [`__gc_collect_region`](crate) both need the
+//! caller to *hand the collector its roots* — a slice of words, or a span of raw
+//! memory. But the native-AOT backend emits **argument-less** collection points:
+//! `__twig_gc_collect()` at an explicit collect, `__twig_gc_safepoint()` at every
+//! call site. There is no root list at those points — the live references are
+//! wherever the machine happens to be keeping them: some in memory on the call
+//! stack, some still in callee-saved registers. This module is the piece that
+//! finds *all* of them and roots from them, with **no help from the caller**.
+//!
+//! It is the pure-Rust replacement for `twig-aot/runtime/twig_gc.c`'s `gc_mark`
+//! (the `setjmp` + stack-base scan). Same conservative technique, no C:
+//!
+//! 1. **Spill callee-saved registers to the stack.** A live pointer may sit only
+//!    in a callee-saved register that no frame above us has spilled (the frame is
+//!    still running and keeping it in-register). The ABI guarantees callee-saved
+//!    registers are preserved across our call, so at the instant we run they
+//!    *still* hold the mutator's values. We copy them into a stack buffer with a
+//!    tiny `asm!` block — the exact job `setjmp` does by saving them into a
+//!    `jmp_buf`. `asm!` without `options(nomem)` is a compiler memory barrier, so
+//!    the spill is not reordered or elided.
+//!
+//! 2. **Read the current stack pointer.** The same `asm!` returns `sp` — the
+//!    lowest address of live stack. Everything the mutator can still reach lives
+//!    between `sp` and the top of the stack.
+//!
+//! 3. **Find the thread's stack base** (the high end, since every supported
+//!    target grows the stack downward) via the platform thread API — declared
+//!    here as bare `extern` bindings to the system libraries, no third-party
+//!    crate: `pthread_get_stackaddr_np` (macOS), `pthread_getattr_np` +
+//!    `pthread_attr_getstack` (Linux), `GetCurrentThreadStackLimits` (Windows).
+//!
+//! 4. **Hand `[sp, base)` to [`FlatHeap::collect_region`].** That span contains
+//!    the spill buffer (it lives in this frame, above `sp`) and every caller
+//!    frame, so it conservatively roots from all of them.
+//!
+//! ## Why this is safe to run with no explicit roots
+//!
+//! The failure mode to fear is a collect that *misses* a live reference and frees
+//! it → use-after-free. Missing a root requires a live pointer to be neither on
+//! the scanned stack span nor in a spilled register — impossible here: registers
+//! are spilled in step 1 and the whole live stack is scanned in step 4. False
+//! *positives* (a stack integer that looks like a pointer) only retain a dead
+//! object one extra cycle — the defining, intended imprecision of a conservative
+//! scan, never unsound.
+//!
+//! ## Supported targets
+//!
+//! The native-AOT columns are aarch64 (macOS) and x86_64 (Linux, Windows); the
+//! crate's host tests also run on exactly those. Each is implemented precisely.
+//! Any other `(arch, os)` is a hard `compile_error!` rather than a silent unsafe
+//! fallback — an unsound "free everything" default is worse than not compiling.
+
+use crate::with_heap;
+
+// ── 1 + 2. Register spill + stack-pointer read ─────────────────────────────
+//
+// `spill_and_sp(buf)` stores every callee-saved *integer* register (the only
+// class that can hold a managed pointer) into `buf`, then returns the current
+// stack pointer. `buf` must hold at least [`SPILL_SLOTS`] words. The register
+// list is ABI-specific; floating-point callee-saved registers are omitted (they
+// never hold GC references).
+//
+// The buffer pointer and the SP output are pinned to caller-saved scratch
+// registers (`x8`/`x9`, `r10`/`r11`) so the register allocator can never place
+// them on top of a register we are trying to read — those scratch registers are
+// not in any saved-register list below, so overwriting them loses nothing.
+
+/// Size of the spill buffer, in words: the largest callee-saved integer-register
+/// set across supported ABIs. **aarch64 x19–x28 = 10** is the maximum (Win64 = 8,
+/// SysV = 6), so 10 words (80 bytes) is what every `spill_and_sp` below must fit
+/// into. Getting this too small is an out-of-bounds stack write on every collect;
+/// x86_64 simply leaves the extra slots zero (read as null candidates, ignored).
+const SPILL_SLOTS: usize = 10;
+
+#[cfg(target_arch = "aarch64")]
+#[inline(never)]
+unsafe fn spill_and_sp(buf: *mut usize) -> usize {
+    // AAPCS64 callee-saved integer registers: x19–x28 (10). x29 = frame pointer,
+    // x30 = link register; neither carries a mutator GC value. These 10 words are
+    // exactly SPILL_SLOTS — the last `stp` writes bytes 64..80, filling the buffer.
+    let sp: usize;
+    core::arch::asm!(
+        "stp x19, x20, [x8, #0]",
+        "stp x21, x22, [x8, #16]",
+        "stp x23, x24, [x8, #32]",
+        "stp x25, x26, [x8, #48]",
+        "stp x27, x28, [x8, #64]",
+        "mov x9, sp",
+        in("x8") buf,
+        out("x9") sp,
+        // No options(nomem): the store through x8 must be visible as a memory
+        // write so the compiler materialises `buf` and does not reorder past it.
+        options(nostack),
+    );
+    sp
+}
+
+#[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]
+#[inline(never)]
+unsafe fn spill_and_sp(buf: *mut usize) -> usize {
+    // System V AMD64 callee-saved integer registers: rbx, rbp, r12–r15 (6).
+    let sp: usize;
+    core::arch::asm!(
+        "mov [r10 + 0],  rbx",
+        "mov [r10 + 8],  rbp",
+        "mov [r10 + 16], r12",
+        "mov [r10 + 24], r13",
+        "mov [r10 + 32], r14",
+        "mov [r10 + 40], r15",
+        "mov r11, rsp",
+        in("r10") buf,
+        out("r11") sp,
+        options(nostack, preserves_flags),
+    );
+    sp
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
+#[inline(never)]
+unsafe fn spill_and_sp(buf: *mut usize) -> usize {
+    // Win64 callee-saved integer registers add rdi & rsi to the SysV set:
+    // rbx, rbp, rdi, rsi, r12–r15 (8).
+    let sp: usize;
+    core::arch::asm!(
+        "mov [r10 + 0],  rbx",
+        "mov [r10 + 8],  rbp",
+        "mov [r10 + 16], rdi",
+        "mov [r10 + 24], rsi",
+        "mov [r10 + 32], r12",
+        "mov [r10 + 40], r13",
+        "mov [r10 + 48], r14",
+        "mov [r10 + 56], r15",
+        "mov r11, rsp",
+        in("r10") buf,
+        out("r11") sp,
+        options(nostack, preserves_flags),
+    );
+    sp
+}
+
+// ── 3. Thread stack base (the high end of the down-growing stack) ───────────
+
+/// macOS: `pthread_get_stackaddr_np` returns the base (highest address) directly.
+#[cfg(target_os = "macos")]
+unsafe fn stack_base() -> usize {
+    // Opaque `pthread_t` handled as a raw pointer for FFI; we never dereference it.
+    extern "C" {
+        fn pthread_self() -> *mut core::ffi::c_void;
+        fn pthread_get_stackaddr_np(thread: *mut core::ffi::c_void) -> *mut core::ffi::c_void;
+    }
+    pthread_get_stackaddr_np(pthread_self()) as usize
+}
+
+/// Linux: `pthread_getattr_np` fills a `pthread_attr_t`, from which
+/// `pthread_attr_getstack` yields the *lowest* address + size; base = low + size.
+#[cfg(target_os = "linux")]
+unsafe fn stack_base() -> usize {
+    // `pthread_attr_t` is an opaque fixed-size blob: 56 bytes on x86_64 glibc,
+    // 64 on aarch64. An 8-word (64-byte), 16-aligned buffer covers both. We only
+    // ever pass its address to the pthread calls, never interpret its contents.
+    #[repr(C, align(16))]
+    struct PthreadAttr([u64; 8]);
+
+    extern "C" {
+        fn pthread_self() -> usize;
+        fn pthread_getattr_np(thread: usize, attr: *mut PthreadAttr) -> i32;
+        fn pthread_attr_getstack(
+            attr: *const PthreadAttr,
+            stackaddr: *mut *mut core::ffi::c_void,
+            stacksize: *mut usize,
+        ) -> i32;
+        fn pthread_attr_destroy(attr: *mut PthreadAttr) -> i32;
+    }
+
+    let mut attr = PthreadAttr([0; 8]);
+    let mut addr: *mut core::ffi::c_void = core::ptr::null_mut();
+    let mut size: usize = 0;
+    if pthread_getattr_np(pthread_self(), &mut attr) != 0 {
+        return 0; // caller treats 0 base as "no scan"; never frees live objects
+    }
+    let ok = pthread_attr_getstack(&attr, &mut addr, &mut size) == 0;
+    pthread_attr_destroy(&mut attr);
+    if !ok {
+        return 0;
+    }
+    (addr as usize).wrapping_add(size)
+}
+
+/// Windows: `GetCurrentThreadStackLimits` returns [low, high]; base = high.
+#[cfg(target_os = "windows")]
+unsafe fn stack_base() -> usize {
+    extern "system" {
+        fn GetCurrentThreadStackLimits(low: *mut usize, high: *mut usize);
+    }
+    let mut low: usize = 0;
+    let mut high: usize = 0;
+    GetCurrentThreadStackLimits(&mut low, &mut high);
+    high
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+compile_error!(
+    "gc-core-capi conservative stack scan supports only macOS, Linux, and Windows \
+     (the native-AOT host targets); no unsound fallback is provided"
+);
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+compile_error!(
+    "gc-core-capi conservative stack scan supports only aarch64 and x86_64 \
+     (the native-AOT code-generation targets)"
+);
+
+// ── 4. The exported entry point ────────────────────────────────────────────
+
+/// Run a full conservative collection rooted at **this thread's live C stack and
+/// callee-saved registers** — no caller-supplied roots.
+///
+/// This is the drop-in for `twig_gc.c`'s argument-less `__twig_gc_collect`: the
+/// native backend calls it at explicit collects and (via the safepoint wrapper)
+/// at call sites, where the only roots are whatever the machine is holding.
+/// Returns the number of objects reclaimed.
+///
+/// `#[inline(never)]` keeps this frame — and the spill buffer inside it — *below*
+/// every mutator frame, so the scanned span `[sp, base)` covers them all.
+///
+/// # Safety
+///
+/// Sound to call from any thread that owns its stack (the single-threaded native
+/// runtime always does). It reads this thread's stack and the global heap; it
+/// must not run while another thread mutates the same heap.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __gc_collect() -> i64 {
+    // Spill callee-saved registers into a stack buffer, then capture SP.
+    let mut regs = [0usize; SPILL_SLOTS];
+    let sp = spill_and_sp(regs.as_mut_ptr());
+
+    let base = stack_base();
+
+    // Every supported target grows the stack downward, so a valid scan needs
+    // sp < base. If stack-base detection failed (base == 0) or anything looks
+    // wrong, scan nothing — freeing on an empty root set would be a
+    // use-after-free, so we bias to leaking this cycle instead.
+    let freed = if base != 0 && sp < base && base - sp <= MAX_STACK_SCAN {
+        with_heap(|h| h.collect_region(sp as *const u8, base - sp).freed as i64)
+    } else {
+        0
+    };
+
+    // Keep `regs` materialised across the scan: its address is what makes the
+    // spilled register values part of `[sp, base)`. Without this the optimiser
+    // could reuse the slot before `collect_region` reads it.
+    core::hint::black_box(&regs);
+    freed
+}
+
+/// Upper bound on how many bytes of stack a single conservative scan will walk
+/// (256 MiB). A corrupt or absurd `base` (far above `sp`) would otherwise make
+/// `collect_region` read hundreds of GB and appear to hang — an
+/// algorithmic-complexity DoS. Real thread stacks are single-digit MiB, so this
+/// ceiling never truncates a legitimate scan; it only fences off a bogus range.
+const MAX_STACK_SCAN: usize = 256 * 1024 * 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{__gc_alloc, __gc_collection_count, __gc_live_bytes, __gc_reset};
+    use gc_core::FlatHeap;
+
+    /// End-to-end: an object whose pointer is held in a **live stack local**
+    /// survives an argument-less `__gc_collect` (the stack scan finds it), while
+    /// an object with no live reference is reclaimed.
+    ///
+    /// `#[inline(never)]` on the helper guarantees `kept` really is a distinct
+    /// stack slot in a frame above `__gc_collect`, not something the optimiser
+    /// folded away.
+    #[test]
+    fn stack_scan_keeps_live_local_frees_dead() {
+        // Shares the process-wide heap with the lib.rs ABI test; both are in one
+        // test each and cargo isolates integration vs. unit — but reset first to
+        // be order-independent within this binary.
+        __gc_reset();
+        run_stack_scan_case();
+        __gc_reset();
+    }
+
+    #[inline(never)]
+    fn run_stack_scan_case() {
+        // A live pointer on the stack: `kept` holds a real heap address.
+        let kept = __gc_alloc(16);
+        assert!(kept != 0);
+        // A dead object: nothing references `_dead` after this line, but its
+        // returned address is deliberately dropped so no stack slot retains it.
+        let _ = __gc_alloc(16);
+        assert_eq!(__gc_live_bytes(), 32);
+
+        // Write through `kept` so the compiler cannot discard the local.
+        unsafe { *(kept as *mut i64) = 0x5eed };
+
+        let freed = unsafe { __gc_collect() };
+
+        // `kept` must survive; at least the dead object should be freed. (A
+        // conservative scan may *retain* extra objects if a stray stack word
+        // happens to look like a pointer, so we assert a lower bound on freeing
+        // and that the live object is definitely still there.)
+        assert!(freed >= 1, "the unreferenced object must be reclaimed");
+        assert_eq!(
+            unsafe { *(kept as *const i64) },
+            0x5eed,
+            "the stack-rooted object must survive and keep its value"
+        );
+        assert!(
+            __gc_live_bytes() >= 16,
+            "the live object's bytes remain accounted"
+        );
+        assert_eq!(__gc_collection_count(), 1);
+
+        core::hint::black_box(kept);
+    }
+
+    /// `spill_and_sp` returns a plausible stack pointer (non-zero, and below the
+    /// detected stack base on these down-growing targets) and does not crash.
+    #[test]
+    fn spill_and_sp_reports_a_sane_stack_pointer() {
+        let mut buf = [0usize; SPILL_SLOTS];
+        let sp = unsafe { spill_and_sp(buf.as_mut_ptr()) };
+        assert!(sp != 0);
+        let base = unsafe { stack_base() };
+        if base != 0 {
+            assert!(sp < base, "stack grows down: sp {sp:#x} < base {base:#x}");
+            assert!(base - sp < MAX_STACK_SCAN, "current frame is near the base");
+        }
+        core::hint::black_box(&buf);
+    }
+
+    /// `FlatHeap` is the type the scan collects over — a direct sanity check that
+    /// the module's import is the real collector, not a stray re-export.
+    #[test]
+    fn uses_real_flatheap() {
+        let mut h = FlatHeap::new();
+        let _ = h.alloc(8, 0);
+        assert_eq!(h.object_count(), 1);
+    }
+}


### PR DESCRIPTION
## What

Adds **`__gc_collect()`** to `gc-core-capi` — the argument-less conservative collector that roots from **this thread's live stack + callee-saved registers**, with no caller-supplied roots. Pure Rust, no C.

This is the drop-in for `twig_gc.c`'s `__twig_gc_collect`: the native-AOT backend calls it at explicit collects and (via the safepoint wrapper) at call sites, where the only roots are whatever the machine happens to be holding. With this, `gc-core-capi` covers the **whole** conservative collector `twig_gc.c` shipped — explicit roots (#118a `__gc_collect_roots`), a raw region (#118a `__gc_collect_region`), and now the stack scan — all as generic Rust.

Per the user's "everything in Rust" decision, the platform primitive is pure Rust (`asm!` + bare pthread/Win32 FFI), not a C helper.

## Technique (new module `stack_scan`, porting `twig_gc.c`'s `gc_mark`)

1. **Spill callee-saved integer registers** to a stack buffer via a per-arch `asm!` block — the job `setjmp` did in C. A live pointer may sit only in a callee-saved register no frame above us has spilled; the ABI preserves those across our call, so at the instant we run they still hold the mutator's values. Omitting `options(nomem)` makes the spill a compiler memory barrier. Buffer/SP pins use caller-saved scratch regs (`x8`/`x9`, `r10`/`r11`) so the allocator can't clobber a register being read.
2. **Read SP** from the same `asm!`.
3. **Find the thread's stack base** via bare `extern` bindings — no third-party crate: `pthread_get_stackaddr_np` (macOS), `pthread_getattr_np` + `pthread_attr_getstack` (Linux), `GetCurrentThreadStackLimits` (Windows).
4. **Hand `[sp, base)` to `__gc_collect_region`** (#118a). The spill buffer lives in this frame above `sp`, so it and every caller frame get scanned.

## Safety

A missed root (→ UAF) needs a live pointer neither spilled nor on the scanned span — impossible here (registers spilled, whole live stack scanned). False positives only retain a dead object one cycle (intended conservative imprecision). `#[inline(never)]` keeps this frame below the mutator frames; `black_box(&regs)` keeps the spill buffer materialized in `[sp, base)` across the collect. `base == 0` (detection failed) → scan nothing and leak this cycle, never free on empty roots. A `MAX_STACK_SCAN` (256 MiB) ceiling fences a bogus base (algorithmic-DoS guard). Supported targets are exactly the native-AOT ones — aarch64 (macOS), x86_64 (Linux, Windows); any other `(arch, os)` is a hard `compile_error!`, never a silent unsound fallback.

## Validation

Register-spill asm exercised at **runtime** on both **aarch64** (native) and **x86_64 SysV** (Rosetta): the live stack local survives, the dead object is freed. 3 unit tests. Windows path (structurally identical + `rdi`/`rsi`) validates in CI.

**Security review: PASSED** — and it earned its keep: the review caught a **CRITICAL** where `SPILL_SLOTS` was sized to 8 (Win64) but aarch64 spills 10 registers (x19–x28 = 80 bytes), a 16-byte out-of-bounds stack write on every collect that the tests were passing through by UB luck. Fixed to 10; re-reviewed clean.

## Details

- **gc-core-capi 0.2.0 → 0.3.0**: `__gc_collect` + `stack_scan` module + `gc_core.h` decl. README ABI table + status, CHANGELOG, lib.rs module docs updated.
- No `gc-core` source change (reuses #118a's `FlatHeap::collect_region`).

## Next (#118b-2)

Wire `twig-aot`'s `build.rs` to link `libgc_core_capi.a`, export the twig-compat aliases (`__twig_gc_alloc`/`collect`/`safepoint`/`live_bytes`/`collection_count`) the emitted code already calls, and **retire `twig_gc.c`** (golden + `*_smoke.rs` parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)