### PR TITLE
feat(sql): unary minus coerces text/blob operands via numeric affinity

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.43 — unary minus coerces text/blob operands
+
+`-'5'` now returns `-5`, not the string `'5'`. SQLite applies numeric affinity to
+the operand of unary minus before negating; the engine previously left text
+unchanged. Now `-'12abc'` = -12 (leading numeric prefix), `-'abc'` = 0, `-'3.5'`
+= -3.5, and leading whitespace is tolerated (`-'  7'` = -7). One new
+differential-oracle case + a sql-vm unit test; sql-vm 0.4.22. An exponent-form
+string (`-'3e2'`) is a documented edge left for a float-affinity follow-up.
+
 ## 0.5.42 — blob literals `x'…'` parse
 
 SQL blob literals `x'48656C6C6F'` / `X'FF00'` now parse end to end. Previously

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.42"
+version = "0.5.43"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1356,6 +1356,16 @@ const CASES: &[Case] = &[
         setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
         query: "SELECT (7 / 2) AS a, (-7 / 2) AS b, (7 % 3) AS c, (7.0 / 2) AS d FROM t",
     },
+    // Unary minus applies NUMERIC affinity to a text/blob operand before
+    // negating, matching SQLite: `-'5'` = -5, `-'12abc'` = -12 (leading numeric
+    // prefix), `-'abc'` = 0 (no prefix → 0), `-'3.5'` = -3.5, and leading
+    // whitespace is tolerated (`-'  7'` = -7). Previously the engine left text
+    // unchanged, so `-'5'` wrongly returned the string `'5'`.
+    Case {
+        id: "unary_minus_text_numeric_affinity",
+        setup: &[],
+        query: "SELECT -'5' AS a, -'12abc' AS b, -'abc' AS c, -'3.5' AS d, -'  7' AS e",
+    },
     // ---- Lane 1: CAST … AS NUMERIC (affinity) ----------------------------
     // NUMERIC prefers INTEGER when the value is integral and fits i64, else
     // REAL. Text `'3.0'` and `'1e3'` are integral → INTEGER; `'3.5'` → REAL;

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.22] - Unreleased
+
+### Fixed
+
+- **Unary minus now applies numeric affinity to a text/blob operand.** SQLite
+  coerces the operand of `-` to a number before negating; `eval_unary`'s `Neg`
+  arm previously left non-numeric values unchanged, so `-'5'` wrongly returned
+  the string `'5'`. It now coerces through the shared `text_to_numeric` helper:
+  `-'5'` = -5, `-'12abc'` = -12 (leading numeric prefix), `-'abc'` = 0 (no
+  prefix), `-'3.5'` = -3.5, `-'  7'` = -7 (whitespace tolerated), `-TRUE` = -1.
+  The `-i64::MIN` overflow guard is preserved. Known edge left for later: an
+  exponent-form string (`'3e2'`) stays REAL in SQLite but collapses to an
+  integer here.
+
 ## [0.4.21] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -2141,19 +2141,37 @@ fn eval_unary(op: &UnaryOp, v: SqlValue) -> Result<SqlValue, VmError> {
     match v {
         SqlValue::Null => Ok(SqlValue::Null),
         _ => match op {
-            UnaryOp::Neg => match v {
-                SqlValue::Int(n) => {
+            UnaryOp::Neg => {
+                // SQLite applies numeric affinity to the operand *before*
+                // negating, so `-` on text/blob coerces first:
+                //   `-'5'`   = -5      `-'12abc'` = -12    `-'abc'` = 0
+                //   `-'3.5'` = -3.5    `-'  7'`   = -7     `-TRUE`  = -1
+                // A leading numeric prefix is taken (whitespace-trimmed) and the
+                // rest ignored; text with no numeric prefix is 0. `text_to_numeric`
+                // is the shared affinity helper (Int when integral, else Float).
+                // Known edge left for later: a string in *exponent* form such as
+                // `'3e2'` stays REAL in SQLite (`-'3e2'` = -300.0) but collapses to
+                // an integer here — see the float-affinity follow-up.
+                let num = match v {
+                    SqlValue::Int(_) | SqlValue::Float(_) => v,
+                    SqlValue::Bool(b) => SqlValue::Int(b as i64),
+                    SqlValue::Text(s) => text_to_numeric(&s),
+                    SqlValue::Blob(b) => text_to_numeric(&String::from_utf8_lossy(&b)),
+                    SqlValue::Null => unreachable!("NULL handled by the outer match"),
+                };
+                match num {
                     // -i64::MIN overflows; use checked_neg to return an error
                     // instead of panicking (debug) or wrapping (release).
-                    n.checked_neg()
+                    SqlValue::Int(n) => n
+                        .checked_neg()
                         .map(SqlValue::Int)
                         .ok_or_else(|| VmError::TypeMismatch(
-                            "integer overflow in unary negation (value is i64::MIN)".to_string()
-                        ))
+                            "integer overflow in unary negation (value is i64::MIN)".to_string(),
+                        )),
+                    SqlValue::Float(f) => Ok(SqlValue::Float(-f)),
+                    _ => unreachable!("text_to_numeric returns Int or Float"),
                 }
-                SqlValue::Float(f) => Ok(SqlValue::Float(-f)),
-                other => Ok(other), // non-numeric: leave unchanged
-            },
+            }
             UnaryOp::Not => Ok(SqlValue::Bool(!is_truthy(&v))),
             // `~x` — coerce to integer (SQLite integer affinity) then complement.
             // `~0` = -1, `~-1` = 0. NULL was handled above.
@@ -3714,6 +3732,27 @@ mod tests {
             Instruction::Halt,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(-5)]]);
+    }
+
+    #[test]
+    fn test_unary_neg_text_numeric_affinity() {
+        // Unary minus coerces a text operand through numeric affinity, then
+        // negates — matching SQLite.
+        let neg = |s: &str| eval_unary(&UnaryOp::Neg, SqlValue::Text(s.to_string())).unwrap();
+        assert_eq!(neg("5"), SqlValue::Int(-5));
+        assert_eq!(neg("12abc"), SqlValue::Int(-12));
+        assert_eq!(neg("abc"), SqlValue::Int(0)); // no numeric prefix → 0
+        assert_eq!(neg("3.5"), SqlValue::Float(-3.5));
+        assert_eq!(neg("  7"), SqlValue::Int(-7)); // leading whitespace tolerated
+        // Blob operand coerces via its UTF-8 bytes; NULL stays NULL.
+        assert_eq!(
+            eval_unary(&UnaryOp::Neg, SqlValue::Blob(b"9".to_vec())).unwrap(),
+            SqlValue::Int(-9)
+        );
+        assert_eq!(
+            eval_unary(&UnaryOp::Neg, SqlValue::Null).unwrap(),
+            SqlValue::Null
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`-'5'` now returns `-5` instead of the string `'5'`. SQLite applies **numeric affinity** to the operand of unary minus before negating; mini-sqlite's `eval_unary` `Neg` arm previously left non-numeric operands unchanged (`other => Ok(other)`), so negating a text value was a no-op.

Found by probing real `sqlite3` 3.51.0 during the conformance rotation (lane-2, operators). This is the next increment after blob literals (#8467) merged — rotated to a different lane rather than stacking more front-end work.

## Behavior (matches real sqlite3)

| Expr | Before | After / SQLite |
|------|--------|----------------|
| `-'5'` | `'5'` ❌ | `-5` |
| `-'12abc'` | `'12abc'` ❌ | `-12` (leading numeric prefix) |
| `-'abc'` | `'abc'` ❌ | `0` (no prefix → 0) |
| `-'3.5'` | `'3.5'` ❌ | `-3.5` |
| `-'  7'` | `'  7'` ❌ | `-7` (whitespace tolerated) |
| `-TRUE` | `TRUE` ❌ | `-1` |

## Change

`sql-vm` 0.4.22 — the `Neg` arm coerces text/blob/bool operands through the shared `text_to_numeric` affinity helper (Int when integral, else Float), then negates. The `-i64::MIN` overflow guard is preserved (returns a `VmError`, never panics); `NULL` still short-circuits to `NULL` in the outer match. `mini-sqlite` 0.5.43 rolls it up.

## Tests

- **sql-vm unit test** `test_unary_neg_text_numeric_affinity` — text, blob, and NULL operands.
- **Differential oracle** (vs real bundled SQLite): `SELECT -'5', -'12abc', -'abc', -'3.5', -'  7'` matches.
- Full suites green: sql-vm (102), mini-sqlite (45) + oracle. Downstream consumers (sql-execution-engine, storage-sqlite, mini-sqlite) build clean.
- Inline adversarial security review: **clean** — both `unreachable!()` arms verified genuinely unreachable, `-i64::MIN` overflow returns an error not a panic, `from_utf8_lossy` safe, no OOB/ReDoS/recursion, no regression on the Int/Float paths.

## Follow-up (documented, not in this PR)

An exponent-form string (`-'3e2'`) stays REAL in SQLite (`-300.0`) but `text_to_numeric` collapses it to an integer here — a float-affinity edge left for later. Separately spotted and to be chipped: `NOT 'abc'` truthiness coercion, blob `||` concat, and `1 IN (1.0)` numeric equality.

## Notes

- Never self-merge — queued for your review.
- No `_grammar.rs` touched (pure VM change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
