### PR TITLE
feat(adj-facts-stdlib): chemistry/subatomic-particles — particle → electric charge table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_subatomicparticles_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_subatomicparticles_e2e.rs
@@ -1,0 +1,73 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/subatomic-particles.adj`) driven through the
+//! built CLI: a native `table` of subatomic particle → electric charge resolves
+//! binding-query recalls (forward and backward) with the source's DOE citation,
+//! and abstains on a particle not in the table (positron) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factssp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_particle_charge_recall_binds_charge_with_citation() {
+    let dir = scratch("subatomicparticles");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/subatomic-particles.adj");
+    std::fs::copy(&src, dir.join("subatomic-particles.adj"))
+        .expect("copy shipped subatomic-particles.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"subatomic-particles.adj\"\n\
+         ? particle_charge(proton, $C)\n\
+         ? particle_charge(neutron, $C)\n\
+         ? particle_charge(electron, $C)\n\
+         ? particle_charge($P, negative)\n\
+         ? particle_charge(positron, $C)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The proton is positive, the neutron is neutral (no charge), the electron is
+    // negative — the recalled charge tokens (forward binds).
+    assert!(out.contains("\"C\":\"positive\""), "proton -> positive: {out}");
+    assert!(out.contains("\"C\":\"neutral\""), "neutron -> neutral: {out}");
+    assert!(out.contains("\"C\":\"negative\""), "electron -> negative: {out}");
+    // The relation runs BACKWARD: bind the charge `negative`, recall the particle
+    // — the electron, the only negatively charged one of the three.
+    assert!(
+        out.contains("\"P\":\"electron\""),
+        "negative -> electron (reverse recall to the negative particle): {out}"
+    );
+    // The answer carries the DOE citation as its proof, at authoritative trust
+    // (a primary U.S. government science source).
+    assert!(
+        out.contains("energy.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation at authoritative trust: {out}"
+    );
+    // "positron" is not in the table — honest abstention, never a fabricated
+    // charge.
+    assert!(out.contains("\"abstained\":true"), "positron abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -31,6 +31,7 @@ per rotation, in parallel):
 | `chemistry/` | common substance → approximate pH | LibreTexts (consensus) |
 | `chemistry/` | element → periodic-table group family | Wikipedia (consensus) |
 | `chemistry/` | common chemical → acid or base | LibreTexts (consensus) |
+| `chemistry/` | subatomic particle → electric charge (proton → positive) | DOE "Explains…Nuclei" (authoritative) |
 | `metrology/` | SI prefix → power of ten | NIST |
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |

--- a/code/specs/data/adj-facts-stdlib/chemistry/subatomic-particles.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/subatomic-particles.adj
@@ -1,0 +1,82 @@
+% ============================================================================
+% particle_charge — the electric charge of the three subatomic particles
+% (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% The most elementary chemistry fact set of all: an atom is built from three
+% subatomic particles, and each carries a definite electric charge. The PROTON is
+% positive, the NEUTRON is neutral (no charge), and the ELECTRON is negative.
+% Recall is a binding query:
+%
+%     ? particle_charge(proton, $C)        % positive
+%
+% Like every FACTS library this is a native `table` (ADJ-TABLES RS-5): each
+% `row` lowers to a ground relation `particle_charge(particle, charge)` carrying
+% the table's citation, so the lookup above is the ordinary SLD binding query —
+% the engine returns the charge WITH its source, on the CPU, with zero model
+% calls, and abstains on a particle that is not in the table. It also runs
+% BACKWARD (bind a charge, recall the particle that has it):
+%
+%     ? particle_charge($P, negative)      % electron — the only negative one
+%
+% WHY these three, and why the charges balance. An ordinary atom is electrically
+% NEUTRAL because it holds equal numbers of positive protons and negative
+% electrons, whose charges cancel exactly; the neutral neutrons add mass to the
+% nucleus without adding charge. So this tiny three-row table already encodes the
+% reason atoms are neutral — recall the proton's `positive` and the electron's
+% `negative`, see that they are opposite, and the cancellation follows. That is
+% the concrete bridge from particle RECALL to the neutral-atom rule, the reason a
+% grounded facts library sits at the foundation of chemistry.
+%
+% The three particles and their charges (a little truth table — the charge is the
+% one property that distinguishes them electrically):
+%
+%     particle    charge     where it sits
+%     ---------   --------   ------------------------------------
+%     proton      positive   in the nucleus (electrically positive)
+%     neutron     neutral    in the nucleus (electrically neutral — no charge)
+%     electron    negative   enshrouding the nucleus (negatively charged)
+%
+% A particle that is not one of these three — a positron, a photon, a whole
+% helium ion — has no row, so a recall on it ABSTAINS rather than inventing a
+% charge. That honest-abstention property is what makes the table safe to reason
+% from: the table states exactly the three particles its source names, no more.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every particle→charge pair
+% was read out of a fetched primary source this session, and any particle whose
+% charge could not be copied verbatim would have been dropped). All three values
+% come from the SAME source: the U.S. Department of Energy "DOE Explains…Nuclei"
+% education page (energy.gov, Office of Science), each charge word copied
+% character-for-character from that page:
+%
+%   proton   → positive   from "electrically positive protons"
+%   neutron  → neutral    from "electrically neutral neutrons"
+%   electron → negative   from "negatively charged electrons"
+%
+% Two verbatim sentences on that one page fix all three rows in text:
+%
+%   "Atomic nuclei consist of electrically positive protons and electrically
+%    neutral neutrons."
+%   "The chemical properties of a substance are determined by the negatively
+%    charged electrons enshrouding the nucleus."
+%
+% The DOE is a PRIMARY U.S. government science agency, so `trust authoritative` —
+% the honest tier for an official standards/education source, per the standard-
+% library trust convention. An ADJ `table` carries ONE provenance envelope, so
+% the `source`/`locator`/`trust` below hold this single page's two verbatim
+% sentences and its URL; each charge word above remains independently checkable.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table particle_charge {
+    columns particle, charge
+
+    row (proton, positive)
+    row (neutron, neutral)
+    row (electron, negative)
+
+    source "Atomic nuclei consist of electrically positive protons and electrically neutral neutrons. … The chemical properties of a substance are determined by the negatively charged electrons enshrouding the nucleus."
+    locator "https://www.energy.gov/science/doe-explainsnuclei"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/subatomic-particles.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/subatomic-particles.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% subatomic-particles.query.adj — a worked recall over the chemistry
+% subatomic-particles library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what charge does a proton
+% carry?": it states no chemistry fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `particle_charge` rows and returns the charge + the table's source/locator/
+% trust. The fourth query runs the relation BACKWARD (bind the charge `negative`,
+% recall the particle that has it — the electron, the only negative one). A
+% positron is not in the table, so a recall on it abstains honestly — the engine
+% never invents a charge.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli subatomic-particles.query.adj
+% ============================================================================
+
+import "subatomic-particles.adj"
+
+? particle_charge(proton, $C)     % expect positive  — the nucleus's positive particle
+? particle_charge(neutron, $C)    % expect neutral   — no charge
+? particle_charge(electron, $C)   % expect negative  — enshrouds the nucleus
+? particle_charge($P, negative)   % expect electron  — reverse recall to the negative particle
+? particle_charge(positron, $C)   % expect abstain   — a positron is not in the table


### PR DESCRIPTION
Add a grounded chemistry FACTS library mapping the three subatomic
particles to their electric charge:

    proton   → positive
    neutron  → neutral
    electron → negative

Native `table` (ADJ-TABLES RS-5): each row lowers to a ground relation
`particle_charge(particle, charge)` carrying the citation, so recall is
an ordinary SLD binding query — forward, backward, and honest-abstaining
(a positron is not in the table) — with zero answer-time model calls.

Provenance (nothing from memory — every value byte-provenanced from a
source fetched THIS session; single provenance envelope):
  - Single source: U.S. DOE "DOE Explains…Nuclei" education page
    (energy.gov, Office of Science), trust `authoritative` (primary US
    .gov science agency).
  - Two verbatim sentences on that one page fix all three rows:
      "Atomic nuclei consist of electrically positive protons and
       electrically neutral neutrons."
      "The chemical properties of a substance are determined by the
       negatively charged electrons enshrouding the nucleus."
  - Each charge word copied character-for-character: proton→positive
    ("electrically positive protons"), neutron→neutral ("electrically
    neutral neutrons"), electron→negative ("negatively charged
    electrons"). No rows dropped.

Includes worked query (.query.adj: forward + reverse + abstain) and an
e2e CLI test asserting each charge binds with the DOE citation at
authoritative trust and that an absent particle (positron) abstains.
README chemistry subject-index row added (all existing rows kept).

Data-only + test; no engine/grammar/adapter changes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
