### PR TITLE
feat(cobol-iir-compiler): IF/ELSE with relational conditions (PL09 step 4, PR4)

### DIFF
--- a/code/packages/rust/cobol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/cobol-iir-compiler/CHANGELOG.md
@@ -8,6 +8,28 @@ tag.
 
 ## [Unreleased]
 
+### Added — v0.4.0: IF / ELSE with relational conditions (PL09 step 4, PR4)
+
+- **`IF condition then-stmts [ELSE else-stmts]`** → a three-way branch: the
+  condition lowers to a boolean register, a `jmp_if_false` skips the then-branch
+  to the else, and a `jmp` past it closes the then-branch. Nested `IF`s recurse.
+- **Relational conditions** (`operand relop operand`): numeric comparison, with
+  operands aligned to a common scale (the same implied-point machinery as ADD),
+  then `cmp_gt` / `cmp_lt` / `cmp_eq`. **`NOT` inverts the relation directly**
+  (NOT GREATER → `cmp_le`, NOT LESS → `cmp_ge`, NOT EQUAL → `cmp_ne`) — the
+  `cmp_*` ops return a `Value::Bool` that `jmp_if_false` consumes, so inverting
+  the boolean with an integer compare would be a type mismatch.
+- **`STOP RUN` inside a branch** ends the program correctly (the branch's `ret`
+  precedes the branch-closing jump, which is then unreachable).
+- **Deferred** (clean `Unsupported`): alphanumeric comparison (space-padded
+  string compare) is a later rung.
+- **Tests.** Unit tests for the branch shape, the negation-as-cmp_le lowering,
+  and the alphanumeric-comparison boundary; six new `jit_e2e.rs` cases
+  (true/false branches, EQUAL/LESS/negated, multi-statement then, STOP-in-branch,
+  scaled comparison by value, nested IF) each byte-identical to the oracle; an
+  IF `backend_compat` program; and an IF `lang_matrix.rs` COBOL row (`5 > 3`
+  → `BIG`).
+
 ### Added — v0.3.0: scaled-decimal ADD/SUBTRACT + item-to-item MOVE (PL09 step 4, PR3)
 
 - **Scaled-decimal `ADD` / `SUBTRACT`** on `PIC …V…` fields. Terms are aligned to

--- a/code/packages/rust/cobol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/cobol-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cobol-iir-compiler"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "COBOL-60 frontend for the LANG VM AOT chain — lowers a parsed COBOL program into interpreter_ir::IIRModule so it runs on every execution backend. v0.3.0: DISPLAY / MOVE / STOP RUN, integer ADD/SUBTRACT/MULTIPLY/DIVIDE, and scaled-decimal (PIC …V…) ADD/SUBTRACT with implied-point alignment + ROUNDED, plus numeric item-to-item MOVE reshaping — over scaled-i64 slots, byte-identical to the cobol-runtime oracle. Scaled MULTIPLY/DIVIDE, ON SIZE ERROR, IF, PERFORM, COMPUTE, GO TO and signed numerics are later rungs. See PL09-codegen.md."
+description = "COBOL-60 frontend for the LANG VM AOT chain — lowers a parsed COBOL program into interpreter_ir::IIRModule so it runs on every execution backend. v0.4.0: DISPLAY / MOVE / STOP RUN, integer + scaled-decimal (PIC …V…) ADD/SUBTRACT (implied-point alignment + ROUNDED), integer MULTIPLY/DIVIDE, numeric item-to-item MOVE reshaping, and IF/ELSE with relational conditions — over scaled-i64 slots, byte-identical to the cobol-runtime oracle. Scaled MULTIPLY/DIVIDE, ON SIZE ERROR, PERFORM, COMPUTE, GO TO and signed numerics are later rungs. See PL09-codegen.md."
 
 [dependencies]
 coding-adventures-cobol-parser  = { path = "../cobol-parser" }

--- a/code/packages/rust/cobol-iir-compiler/README.md
+++ b/code/packages/rust/cobol-iir-compiler/README.md
@@ -36,6 +36,7 @@ integer `123`); an **alphanumeric** item (`PIC X`/`A`) is a `str`.
 | `VALUE <lit>` / `MOVE <lit> TO item` | the register's `const`/`str_const` — the literal formatted into the item's picture at compile time |
 | `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE … [GIVING r]` | `add`/`sub`/`mul`/`div` on the `i64` slots, the result reduced to the receiver's field |
 | `DISPLAY op…` | each operand's image emitted, then `putchar('\n')` — a literal prints its source text, a numeric item via the fixed-width digit helper, an alphanumeric via `print_str` |
+| `IF cond then… [ELSE else…]` | `cmp_*` on the aligned operands → `jmp_if_false` over the then-branch; `NOT` inverts the relation |
 | `STOP RUN` | `ret 0` |
 
 ### Why it is exact
@@ -61,8 +62,8 @@ source value into the receiver's picture the same way.
 
 Each of these is a clean `CompileError::Unsupported` (never wrong output), landing
 on its own PR: **scaled** `MULTIPLY`/`DIVIDE` (a `V` operand) and their `ROUNDED`,
-`ON SIZE ERROR` (needs the `IF` rung's branching), alphanumeric item `MOVE`,
-`COMPUTE`, `IF`, `PERFORM`, `GO TO`, group items, and signed numerics (`PIC S9…`,
+`ON SIZE ERROR`, alphanumeric item `MOVE` and alphanumeric comparison,
+`COMPUTE`, `PERFORM`, `GO TO`, group items, and signed numerics (`PIC S9…`,
 trailing-overpunch display).
 
 ## Usage

--- a/code/packages/rust/cobol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/cobol-iir-compiler/src/lib.rs
@@ -316,6 +316,7 @@ impl Compiler {
             "subtract_stmt" => self.emit_subtract(verb),
             "multiply_stmt" => self.emit_multiply(verb),
             "divide_stmt" => self.emit_divide(verb),
+            "if_stmt" => self.emit_if(verb),
             other => Err(CompileError::Unsupported(format!(
                 "the {} statement is a later rung",
                 verb_name(other)
@@ -430,6 +431,100 @@ impl Compiler {
         } else {
             Err(CompileError::Unsupported("STOP <literal> (only STOP RUN is modelled)".into()))
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Conditionals
+    // -----------------------------------------------------------------------
+
+    /// `IF condition then-stmts [ELSE else-stmts]` — a relational test over a
+    /// three-way branch. The condition lowers to a boolean register; then a
+    /// `jmp_if_false` skips the then-branch to the else-branch (a jump past it
+    /// closes the then-branch). Nested `IF`s recurse through `emit_statement`.
+    fn emit_if(&mut self, verb: &GrammarASTNode) -> Result<(), CompileError> {
+        let cond_node = child_node(verb, "condition")
+            .ok_or_else(|| CompileError::Malformed("IF without a condition".into()))?;
+        let cond = self.emit_condition(cond_node)?;
+
+        // Split the statement children at the ELSE keyword (as the oracle does).
+        let mut then_stmts = Vec::new();
+        let mut else_stmts = Vec::new();
+        let mut seen_else = false;
+        for child in &verb.children {
+            match child {
+                ASTNodeOrToken::Token(t) if t.value == "ELSE" && t.effective_type_name() == "KEYWORD" => {
+                    seen_else = true;
+                }
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => {
+                    if seen_else {
+                        else_stmts.push(n);
+                    } else {
+                        then_stmts.push(n);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let else_lbl = self.fresh("if_else");
+        let end_lbl = self.fresh("if_end");
+        self.emit("jmp_if_false", None, vec![Operand::Var(cond), Operand::Var(else_lbl.clone())], "void");
+        for stmt in then_stmts {
+            self.emit_statement(stmt)?;
+        }
+        self.emit("jmp", None, vec![Operand::Var(end_lbl.clone())], "void");
+        self.emit("label", None, vec![Operand::Var(else_lbl)], "void");
+        for stmt in else_stmts {
+            self.emit_statement(stmt)?;
+        }
+        self.emit("label", None, vec![Operand::Var(end_lbl)], "void");
+        Ok(())
+    }
+
+    /// Evaluate a `condition` (`operand relop operand`) to a boolean `i64`
+    /// register (1 = true). Numeric comparison only: operands align to a common
+    /// scale, then `cmp_gt`/`cmp_lt`/`cmp_eq` per the relation; `NOT` inverts.
+    /// Alphanumeric comparison (space-padded strings) is a later rung.
+    fn emit_condition(&mut self, cond: &GrammarASTNode) -> Result<String, CompileError> {
+        let operands = child_nodes(cond, "operand");
+        if operands.len() != 2 {
+            return Err(CompileError::Malformed("condition must be operand relop operand".into()));
+        }
+        let left = self.read_arith_term(operands[0])?;
+        let right = self.read_arith_term(operands[1])?;
+        let w = self.term_scale(&left).max(self.term_scale(&right));
+        let a = self.emit_term_at_scale(&left, w);
+        let b = self.emit_term_at_scale(&right, w);
+
+        let relop = child_node(cond, "relop")
+            .ok_or_else(|| CompileError::Malformed("condition without a relational operator".into()))?;
+        let toks = child_tokens(relop);
+        let negated = toks.iter().any(|(k, v)| k == "KEYWORD" && v == "NOT");
+        let base = toks
+            .iter()
+            .find_map(|(k, v)| match (k.as_str(), v.as_str()) {
+                ("KEYWORD", "GREATER") => Some("GREATER"),
+                ("KEYWORD", "LESS") => Some("LESS"),
+                ("KEYWORD", "EQUAL") => Some("EQUAL"),
+                _ => None,
+            })
+            .ok_or_else(|| CompileError::Malformed("unrecognised relational operator".into()))?;
+
+        // `NOT` inverts the *relation* directly, so the comparison op still yields
+        // a single boolean (the cmp_* ops return `Value::Bool`, which
+        // `jmp_if_false` consumes — inverting the boolean itself with an integer
+        // `cmp_eq … 0` would be a type mismatch).
+        let op = match (base, negated) {
+            ("GREATER", false) => "cmp_gt",
+            ("GREATER", true) => "cmp_le",
+            ("LESS", false) => "cmp_lt",
+            ("LESS", true) => "cmp_ge",
+            ("EQUAL", false) => "cmp_eq",
+            _ => "cmp_ne", // ("EQUAL", true)
+        };
+        let cond_reg = self.fresh("_cond");
+        self.emit(op, Some(&cond_reg), vec![a, b], "i64");
+        Ok(cond_reg)
     }
 
     // -----------------------------------------------------------------------
@@ -1309,6 +1404,45 @@ mod tests {
                 &["MULTIPLY 999999999 BY 999999999 GIVING R.", "STOP RUN."],
             ),
             "mv",
+        )
+        .unwrap_err();
+        assert!(matches!(err, CompileError::Unsupported(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn if_compiles_with_branches_and_validates() {
+        let module = compile_source(
+            &wrap(
+                &["01  N  PIC 9(3) VALUE 5."],
+                &["IF N GREATER 3 DISPLAY \"BIG\" ELSE DISPLAY \"SMALL\".", "STOP RUN."],
+            ),
+            "if",
+        )
+        .unwrap();
+        assert!(module.validate().is_empty(), "{:?}", module.validate());
+        let os = ops(&module);
+        assert!(os.contains(&"cmp_gt".to_string()));
+        assert!(os.contains(&"jmp_if_false".to_string()));
+        assert!(os.contains(&"label".to_string()));
+    }
+
+    #[test]
+    fn if_negation_inverts_the_relation() {
+        // IS NOT GREATER lowers to cmp_le (not an integer boolean inversion).
+        let module = compile_source(
+            &wrap(&["01  N  PIC 9(3) VALUE 3."], &["IF N IS NOT GREATER THAN 5 DISPLAY \"OK\".", "STOP RUN."]),
+            "n",
+        )
+        .unwrap();
+        assert!(ops(&module).contains(&"cmp_le".to_string()));
+    }
+
+    #[test]
+    fn alphanumeric_comparison_is_deferred() {
+        // Comparing a character field is a later rung (space-padded string compare).
+        let err = compile_source(
+            &wrap(&["01  W  PIC X(4) VALUE \"AB\"."], &["IF W EQUAL \"AB\" DISPLAY \"M\".", "STOP RUN."]),
+            "a",
         )
         .unwrap_err();
         assert!(matches!(err, CompileError::Unsupported(_)), "got {err:?}");

--- a/code/packages/rust/cobol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/cobol-iir-compiler/tests/backend_compat.rs
@@ -128,3 +128,22 @@ fn scaled_decimal_program_accepted_by_print_backends() {
     let m = compile_source(&src, "scaled").unwrap();
     assert_accepted_by_print_backends(&m, "scaled-decimal arithmetic");
 }
+
+#[test]
+fn if_else_program_accepted_by_print_backends() {
+    // IF/ELSE lowers to cmp_* + jmp_if_false + jmp + label. Every print backend
+    // must accept the branch structure and the comparison op.
+    let src = program(&[
+        "IDENTIFICATION DIVISION.",
+        "PROGRAM-ID. P.",
+        "DATA DIVISION.",
+        "WORKING-STORAGE SECTION.",
+        "01  N  PIC 9(3) VALUE 5.",
+        "PROCEDURE DIVISION.",
+        "MAIN.",
+        "    IF N GREATER 3 DISPLAY \"BIG\" ELSE DISPLAY \"SMALL\".",
+        "    STOP RUN.",
+    ]);
+    let m = compile_source(&src, "if").unwrap();
+    assert_accepted_by_print_backends(&m, "if/else branch");
+}

--- a/code/packages/rust/cobol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/cobol-iir-compiler/tests/jit_e2e.rs
@@ -242,6 +242,85 @@ fn overflow_without_handler_truncates_high_order() {
 }
 
 // -------------------------------------------------------------------------
+// IF / ELSE + relational conditions (PR4) — vs the oracle.
+// -------------------------------------------------------------------------
+
+/// Run a program with `01 N PIC 9(3) VALUE <n>` and the given procedure body,
+/// asserting the compiled output matches the oracle.
+fn run_if(n: &str, body: &[&str]) -> String {
+    let mut data = vec![format!("01  N  PIC 9(3) VALUE {n}.")];
+    let mut proc: Vec<String> = body.iter().map(|s| s.to_string()).collect();
+    let _ = &mut data;
+    let _ = &mut proc;
+    let data_refs: Vec<&str> = data.iter().map(|s| s.as_str()).collect();
+    let proc_refs: Vec<&str> = proc.iter().map(|s| s.as_str()).collect();
+    assert_matches_oracle(&wrap(&data_refs, &proc_refs))
+}
+
+#[test]
+fn if_numeric_true_and_false_branches() {
+    // N=5 > 3 → THEN "BIG"; N=1 not > 3 → ELSE "SMALL".
+    assert_eq!(
+        run_if("5", &["IF N GREATER 3 DISPLAY \"BIG\" ELSE DISPLAY \"SMALL\".", "STOP RUN."]),
+        "BIG\n"
+    );
+    assert_eq!(
+        run_if("1", &["IF N GREATER 3 DISPLAY \"BIG\" ELSE DISPLAY \"SMALL\".", "STOP RUN."]),
+        "SMALL\n"
+    );
+}
+
+#[test]
+fn if_equal_less_and_negated() {
+    assert_eq!(run_if("7", &["IF N EQUAL 7 DISPLAY \"EQ\".", "STOP RUN."]), "EQ\n");
+    assert_eq!(run_if("2", &["IF N LESS 5 DISPLAY \"LT\".", "STOP RUN."]), "LT\n");
+    // IS NOT GREATER: 3 is not > 5 → true.
+    assert_eq!(run_if("3", &["IF N IS NOT GREATER THAN 5 DISPLAY \"OK\".", "STOP RUN."]), "OK\n");
+    // A false condition with no ELSE displays nothing.
+    assert_eq!(run_if("9", &["IF N LESS 5 DISPLAY \"NO\".", "STOP RUN."]), "");
+}
+
+#[test]
+fn if_then_branch_runs_multiple_statements() {
+    // Both then-statements run when the condition holds.
+    assert_eq!(
+        run_if("5", &["IF N GREATER 3 MOVE 8 TO N DISPLAY N.", "STOP RUN."]),
+        "008\n"
+    );
+}
+
+#[test]
+fn stop_run_inside_a_branch_ends_the_program() {
+    // STOP RUN in the THEN branch ends everything; the trailing DISPLAY never runs.
+    assert_eq!(
+        run_if("5", &["IF N GREATER 3 DISPLAY \"IN\" STOP RUN.", "DISPLAY \"AFTER\".", "STOP RUN."]),
+        "IN\n"
+    );
+}
+
+#[test]
+fn if_on_scaled_decimal_compares_by_value() {
+    // 2.50 vs 2.5 compare equal despite different receiver scales.
+    let out = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(2)V99 VALUE 2.5."],
+        &["IF R EQUAL 2.5 DISPLAY \"EQ\" ELSE DISPLAY \"NE\".", "STOP RUN."],
+    ));
+    assert_eq!(out, "EQ\n");
+}
+
+#[test]
+fn nested_if_selects_the_inner_branch() {
+    let out = assert_matches_oracle(&wrap(
+        &["01  N  PIC 9(3) VALUE 5."],
+        &[
+            "IF N GREATER 3 IF N LESS 9 DISPLAY \"MID\" ELSE DISPLAY \"HI\".",
+            "STOP RUN.",
+        ],
+    ));
+    assert_eq!(out, "MID\n");
+}
+
+// -------------------------------------------------------------------------
 // Scaled-decimal ADD / SUBTRACT + item→item MOVE (PR3) — vs the oracle.
 // -------------------------------------------------------------------------
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -2933,6 +2933,27 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("0375"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // COBOL-60 — IF / ELSE with a relational condition (PL09 step 4, PR4). The
+    // condition lowers to a `cmp_gt` on the aligned values; `jmp_if_false` skips
+    // the then-branch to the else. Here N=5 > 3 → the then-branch runs, printing
+    // `BIG`. This proves the three-way branch (cmp / conditional jump / labels)
+    // lowers correctly on every backend that runs the shared control-flow + print
+    // substrate.
+    Prog {
+        lang: Language::Cobol60,
+        ext: "cob",
+        src: "000000 IDENTIFICATION DIVISION.\n\
+               000000 PROGRAM-ID. P.\n\
+               000000 DATA DIVISION.\n\
+               000000 WORKING-STORAGE SECTION.\n\
+               000000 01  N  PIC 9(3) VALUE 5.\n\
+               000000 PROCEDURE DIVISION.\n\
+               000000 MAIN.\n\
+               000000     IF N GREATER 3 DISPLAY \"BIG\" ELSE DISPLAY \"SMALL\".\n\
+               000000     STOP RUN.",
+        expect: Expect::Stdout("BIG"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
 ];
 
 /// Is a usable native linker present on this host? On Linux/macOS the AOT path uses


### PR DESCRIPTION
## What

PR4 of the COBOL-60 → IIR arc: **IF/ELSE + relational conditions** — the first control-flow rung. Builds on [#8459](https://github.com/adhithyan15/coding-adventures/pull/8459).

## The slice

- **`IF condition then-stmts [ELSE else-stmts]`** → a three-way branch: the condition lowers to a boolean register, a `jmp_if_false` skips the then-branch to the else-branch, and a `jmp` past it closes the then-branch. Statement children split at the `ELSE` token (mirroring the oracle); nested `IF`s recurse.
- **Relational conditions** (`operand relop operand`): numeric comparison with operands aligned to a common scale (the same implied-point machinery as scaled ADD), then `cmp_gt` / `cmp_lt` / `cmp_eq`.
- **`NOT` inverts the relation directly** — NOT GREATER → `cmp_le`, NOT LESS → `cmp_ge`, NOT EQUAL → `cmp_ne`.
- **`STOP RUN` inside a branch** ends the program correctly.

### A real bug the oracle caught

My first cut inverted `NOT` by emitting `cmp_eq(cond, 0)`. The IIR *looked* correct and `module.validate()` passed — but the `cmp_*` ops return `Value::Bool`, not `Int`, so comparing the boolean against integer `0` was a silent type mismatch that always picked the wrong branch. Only the `jit_e2e` oracle-conformance test caught it (validators don't type-check `Bool`-vs-`Int` operand use). The fix inverts the *relation*, using native comparison ops. Lesson saved to memory.

## Deferred (clean `Unsupported`)

Alphanumeric comparison (space-padded string compare) is a later rung; `ON SIZE ERROR` will reuse this branch machinery on its own PR.

## Testing
- **15 unit tests** — branch shape, negation-as-`cmp_le` lowering, alphanumeric-comparison boundary.
- **`jit_e2e.rs` (29 tests)** — six new IF cases (true/false branches, EQUAL/LESS/negated, multi-statement then, STOP-in-branch, scaled comparison by value, nested IF) each **byte-identical to the `cobol-runtime` oracle**, plus all prior cases.
- **`backend_compat.rs`** — an IF/ELSE program accepted by the wasm/jvm/clr validators.
- **`lang_matrix.rs`** — an IF COBOL row (`N=5 > 3` → `BIG`).
- Security-reviewed: recursion bounded by the parser's CST depth cap, single-term comparison operands stay `< i64::MAX` under the 9-digit cap, branch labels/jumps all valid.

> As before, the full `lang_matrix` native-AOT/JVM columns fail *locally* on a pre-existing Twig toolchain breakage (reproduced on pristine `main`); the COBOL VM/JIT paths are proven by `jit_e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)