### PR TITLE
feat(gc-core): adaptive collection threshold + paced __gc_safepoint (#118b-1.5)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this crate are documented here.
 
+## [0.4.0] — 2026-07-17
+
+### Added
+
+- **`__gc_safepoint()`** — the throttled, paced collect (drop-in for `twig_gc.c`'s
+  `__twig_gc_safepoint`). Runs `__gc_collect` only when the heap has reached its
+  adaptive threshold (`FlatHeap::should_collect`), else returns `0`. The native
+  backend emits a `safepoint` op at loop back-edges / function entries; collecting
+  at every one would be ruinous, so each merely asks "over threshold yet?" —
+  keeping GC cost proportional to allocation and stopping a tight allocation loop
+  from ever starving the collector.
+
+### Changed
+
+- **`__gc_alloc` / `__gc_alloc_kind` now collect under pressure** — before
+  allocating, if `should_collect()`, they run a conservative stack-scan collect
+  (matching `__twig_gc_alloc`). Collecting *before* the new allocation means the
+  new object does not exist yet and cannot be wrongly reclaimed; every root that
+  must survive is the caller's, already live on the scanned stack. Below the 1 MiB
+  threshold (host tests, light workloads) this path is never taken — allocation
+  stays a plain bump. Host tests serialised via a shared `TEST_LOCK` (the
+  process-wide `HEAP` is now touched by more than one test).
+
 ## [0.3.0] — 2026-07-17
 
 ### Added

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/README.md
+++ b/code/packages/rust/gc-core-capi/README.md
@@ -39,6 +39,7 @@ The interpreters use `gc-core`'s managed-object collector; native output uses
 | `int64_t __gc_collect_roots(const int64_t *roots, int64_t count)` | mark from `count` root words, sweep; returns objects freed |
 | `int64_t __gc_collect_region(const uint8_t *base, int64_t len)` | mark from every candidate pointer in a raw region, sweep; returns objects freed |
 | `int64_t __gc_collect(void)` | conservative collection rooted at this thread's live stack + callee-saved registers (no caller roots); returns objects freed |
+| `int64_t __gc_safepoint(void)` | paced collect — runs `__gc_collect` only when the live set has reached the adaptive threshold; returns objects freed (0 if throttled) |
 | `int64_t __gc_live_bytes(void)` | live payload bytes |
 | `int64_t __gc_collection_count(void)` | collections run so far |
 | `void __gc_reset(void)` | drop the whole heap; free everything |
@@ -64,7 +65,9 @@ __gc_collect_roots(roots, 1);         /* cell is rooted → survives */
 This is **T1 rung 0** — the linkable flat collector. It now covers the full
 conservative collector `twig_gc.c` shipped, in three layers: explicit roots
 (`__gc_collect_roots`), a raw memory region (`__gc_collect_region`), and the
-argument-less **conservative C-stack scan** (`__gc_collect`) — all pure Rust, no C.
+argument-less **conservative C-stack scan** (`__gc_collect`) — plus the **paced**
+`__gc_safepoint` (collect only past the adaptive threshold) that `__gc_alloc` also
+drives under memory pressure. All pure Rust, no C.
 
 `__gc_collect` is the drop-in for `twig_gc.c`'s `__twig_gc_collect`: it spills the
 callee-saved registers to the stack (an `asm!` block replacing `setjmp`), reads the

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -63,6 +63,14 @@ int64_t __gc_collect_region(const uint8_t *base, int64_t len);
  * whatever the machine is holding. Returns objects freed. Single-threaded. */
 int64_t __gc_collect(void);
 
+/* Paced collect: run __gc_collect ONLY if the live set has reached the heap's
+ * adaptive threshold; otherwise do nothing. Returns objects freed (0 if no
+ * collection ran). Drop-in for twig_gc.c's __twig_gc_safepoint — the native
+ * backend calls it at loop back-edges and function entries, and it collects
+ * only under memory pressure so a tight allocation loop can't starve the GC.
+ * __gc_alloc also runs this same paced collect before allocating. */
+int64_t __gc_safepoint(void);
+
 /* Live payload bytes. */
 int64_t __gc_live_bytes(void);
 

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -25,6 +25,7 @@
 //! | `__gc_collect_roots(roots, count)` | mark from `count` root words at `roots`, sweep; returns objects freed |
 //! | `__gc_collect_region(base, len)` | mark from every candidate pointer in a raw region, sweep; returns objects freed |
 //! | `__gc_collect()` | conservative collect rooted at this thread's live stack + callee-saved registers; returns objects freed |
+//! | `__gc_safepoint()` | paced collect — runs `__gc_collect` only when live bytes reach the adaptive threshold; returns objects freed |
 //! | `__gc_live_bytes()` | live payload bytes |
 //! | `__gc_collection_count()` | collections run so far |
 //! | `__gc_reset()` | drop the whole heap (frees everything); mainly for tests / process teardown |
@@ -49,6 +50,16 @@ mod stack_scan;
 /// `__gc_reset` puts it back to `None`, running `FlatHeap`'s `Drop` to free
 /// every outstanding block.
 static HEAP: Mutex<Option<FlatHeap>> = Mutex::new(None);
+
+/// Serialises tests that touch the single process-wide `HEAP`.
+///
+/// `cargo test` runs unit tests on parallel threads; two tests that each
+/// `__gc_reset` and mutate `HEAP` would otherwise interleave nondeterministically.
+/// Every `HEAP`-touching test — here and in [`stack_scan`] — takes this lock first,
+/// making them mutually exclusive regardless of the runner's thread count. A
+/// poisoned lock is recovered (a panicking test must not wedge the rest).
+#[cfg(test)]
+pub(crate) static TEST_LOCK: Mutex<()> = Mutex::new(());
 
 /// Run `f` against the (lazily created) global heap.
 ///
@@ -75,6 +86,18 @@ pub extern "C" fn __gc_alloc(n: i64) -> i64 {
 pub extern "C" fn __gc_alloc_kind(n: i64, kind: u16) -> i64 {
     if n <= 0 {
         return 0;
+    }
+    // Paced collection: if the live set has reached the adaptive threshold, run a
+    // conservative stack-scan collect BEFORE allocating — exactly where
+    // `twig_gc.c`'s `__twig_gc_alloc` collects. Doing it *before* the allocation
+    // means the new object does not exist yet, so it cannot be wrongly reclaimed;
+    // every root that must survive is the caller's, already live on the stack this
+    // scan walks. Below the 1 MiB threshold (host tests, light workloads) this is
+    // never taken, so allocation stays a plain bump with no surprise scan.
+    if with_heap(|h| h.should_collect()) {
+        // SAFETY: `__gc_alloc*` is only ever called by the single-threaded native
+        // runtime on a thread that owns its stack — `__gc_collect`'s contract.
+        unsafe { stack_scan::__gc_collect() };
     }
     with_heap(|h| h.alloc(n as usize, kind) as i64)
 }
@@ -153,6 +176,7 @@ mod tests {
     // interleaving two tests over the shared heap would be nondeterministic.
     #[test]
     fn c_abi_alloc_collect_flow() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         __gc_reset();
         assert_eq!(__gc_live_bytes(), 0);
         assert_eq!(__gc_collection_count(), 0);

--- a/code/packages/rust/gc-core-capi/src/stack_scan.rs
+++ b/code/packages/rust/gc-core-capi/src/stack_scan.rs
@@ -59,8 +59,19 @@ use crate::with_heap;
 // `spill_and_sp(buf)` stores every callee-saved *integer* register (the only
 // class that can hold a managed pointer) into `buf`, then returns the current
 // stack pointer. `buf` must hold at least [`SPILL_SLOTS`] words. The register
-// list is ABI-specific; floating-point callee-saved registers are omitted (they
-// never hold GC references).
+// list is ABI-specific.
+//
+// **Callee-saved FP/SIMD registers (aarch64 `d8`–`d15`, Win64 `xmm6`–`xmm15`) are
+// NOT spilled.** This relies on a codegen invariant: the native backend's value
+// model is **tagged i64**, so every managed reference — including a NaN-box-tagged
+// one — lives in an integer register or on the stack, never solely in a
+// floating-point register across a safepoint/alloc call. That invariant makes the
+// omission sound today. It is, however, load-bearing (the paced `__gc_alloc` now
+// scans implicitly), and `twig_gc.c`'s `setjmp` *did* save `d8`–`d15` / `xmm6`–15
+// on those ABIs — so a future NaN-boxing-in-FP codegen would silently reintroduce
+// a missed-root use-after-free. Spilling the callee-saved FP registers to close
+// that gap is tracked as a T1 hardening task; until then the invariant above is
+// the contract, not a blanket "FP never holds references" claim.
 //
 // The buffer pointer and the SP output are pinned to caller-saved scratch
 // registers (`x8`/`x9`, `r10`/`r11`) so the register allocator can never place
@@ -256,6 +267,30 @@ pub unsafe extern "C" fn __gc_collect() -> i64 {
     freed
 }
 
+/// A **paced** collect: run [`__gc_collect`] only if the heap has reached its
+/// adaptive threshold ([`gc_core::FlatHeap::should_collect`]); otherwise do
+/// nothing. Returns objects freed (`0` if no collection ran).
+///
+/// This is the drop-in for `twig_gc.c`'s `__twig_gc_safepoint`. The native
+/// backend emits a `safepoint` op at loop back-edges and function entries — cheap,
+/// frequent checkpoints. Collecting at *every* one would be ruinous; instead each
+/// safepoint asks "are we over the threshold yet?" and collects only then, so GC
+/// cost stays proportional to allocation, and a tight allocation loop can never
+/// starve the collector (the twig_gc.c comment's original motivation).
+///
+/// # Safety
+///
+/// Same contract as [`__gc_collect`]: the calling thread must own its stack.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __gc_safepoint() -> i64 {
+    if with_heap(|h| h.should_collect()) {
+        __gc_collect()
+    } else {
+        0
+    }
+}
+
 /// Upper bound on how many bytes of stack a single conservative scan will walk
 /// (256 MiB). A corrupt or absurd `base` (far above `sp`) would otherwise make
 /// `collect_region` read hundreds of GB and appear to hang — an
@@ -278,12 +313,48 @@ mod tests {
     /// folded away.
     #[test]
     fn stack_scan_keeps_live_local_frees_dead() {
-        // Shares the process-wide heap with the lib.rs ABI test; both are in one
-        // test each and cargo isolates integration vs. unit — but reset first to
-        // be order-independent within this binary.
+        // Serialise against every other HEAP-touching test (see crate::TEST_LOCK),
+        // then reset so this case is order-independent within the binary.
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         __gc_reset();
         run_stack_scan_case();
         __gc_reset();
+    }
+
+    /// `__gc_safepoint` is **throttled**: below the collection threshold it does
+    /// nothing; at/over the threshold it runs a stack-scan collect and re-tunes.
+    /// Also exercises `__gc_alloc`'s auto-collect under the same threshold.
+    #[test]
+    fn safepoint_throttles_then_collects_at_threshold() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+        run_safepoint_case();
+        __gc_reset();
+    }
+
+    #[inline(never)]
+    fn run_safepoint_case() {
+        use gc_core::flat_heap::INITIAL_THRESHOLD;
+
+        // Under the threshold (a single tiny object): the safepoint is a no-op.
+        let small = __gc_alloc(16);
+        assert!(small != 0);
+        assert_eq!(unsafe { __gc_safepoint() }, 0, "no collect below threshold");
+        assert_eq!(__gc_collection_count(), 0, "throttled: no cycle ran");
+        core::hint::black_box(small);
+
+        // Push the live set to the 1 MiB threshold with one big block, held live on
+        // the stack. Now the safepoint is due and must collect.
+        let big = __gc_alloc(INITIAL_THRESHOLD as i64);
+        assert!(big != 0);
+        assert!(__gc_live_bytes() as usize >= INITIAL_THRESHOLD);
+        unsafe { *(big as *mut i64) = 0xB16 };
+
+        let _ = unsafe { __gc_safepoint() }; // over threshold → collects
+        assert_eq!(__gc_collection_count(), 1, "safepoint collected at threshold");
+        // `big` is stack-rooted, so it survives the conservative scan.
+        assert_eq!(unsafe { *(big as *const i64) }, 0xB16, "live big block survives");
+        core::hint::black_box(big);
     }
 
     #[inline(never)]

--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — gc-core
 
+## 0.4.0 — 2026-07-17
+
+### Added
+
+- **`FlatHeap` adaptive collection threshold** — the GC-pacing policy ported from
+  `twig_gc.c`. New `collect_threshold` field (starts at `INITIAL_THRESHOLD` = 1
+  MiB), plus `should_collect()` (live bytes ≥ threshold → a cycle is due) and
+  `collect_threshold()`. After every cycle, `collect`/`collect_region` re-tune the
+  threshold (`adapt_threshold`): **double** it (capped at `MAX_THRESHOLD` = 256
+  MiB) when >½ the pre-cycle live set survived, else **halve** it (floored at 1
+  MiB). The 256 MiB cap is a safety bound — without it a live-heavy program could
+  grow the threshold toward `usize::MAX` and effectively disable the GC (a
+  memory-exhaustion vector). `should_collect` is the *policy* half (when to
+  collect); the *mechanism* half (finding roots) stays with the caller —
+  `gc-core-capi`'s `__gc_safepoint` / `__gc_alloc` drive collection off it. New
+  `pub const INITIAL_THRESHOLD` / `MAX_THRESHOLD`. 7 unit tests.
+
 ## 0.3.0 — 2026-07-17
 
 ### Added

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "LANG16 — adaptive GC adapter layer wiring garbage-collector into the LANG VM pipeline."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/flat_heap.rs
+++ b/code/packages/rust/gc-core/src/flat_heap.rs
@@ -114,9 +114,25 @@ pub struct FlatHeap {
     live_bytes: usize,
     /// Total collections run since creation.
     collection_count: u64,
+    /// Soft ceiling on `live_bytes` that triggers a collection. Consulted by
+    /// [`Self::should_collect`]; re-tuned by [`Self::adapt_threshold`] after each
+    /// cycle. See [`INITIAL_THRESHOLD`] / [`MAX_THRESHOLD`].
+    collect_threshold: usize,
     /// Adaptive-policy profile shared with the rest of `gc-core`.
     profile: GcProfile,
 }
+
+/// Initial collection threshold, and the floor `adapt_threshold` never drops
+/// below: **1 MiB**. Small enough that a real workload collects promptly, large
+/// enough that a burst of tiny allocations does not thrash the collector. Matches
+/// `twig_gc.c`'s `GC_INITIAL_THRESHOLD`.
+pub const INITIAL_THRESHOLD: usize = 1024 * 1024;
+
+/// Ceiling `adapt_threshold` never grows past: **256 MiB**. Bounds the worst-case
+/// live-set overshoot between collections and stops a live-heavy program from
+/// doubling the threshold up to `usize::MAX` (which would disable the GC and let
+/// an untrusted program exhaust memory). Matches `twig_gc.c`'s `GC_MAX_THRESHOLD`.
+pub const MAX_THRESHOLD: usize = 256 * 1024 * 1024;
 
 // SAFETY: `FlatHeap` holds raw pointers (`*mut FlatHeader`), which make it
 // `!Send` by default.  The native AOT runtime is single-threaded and the C ABI
@@ -138,6 +154,7 @@ impl FlatHeap {
             all: ptr::null_mut(),
             live_bytes: 0,
             collection_count: 0,
+            collect_threshold: INITIAL_THRESHOLD,
             profile: GcProfile::default(),
         }
     }
@@ -206,6 +223,49 @@ impl FlatHeap {
         &self.profile
     }
 
+    /// The current collection threshold in bytes (see [`INITIAL_THRESHOLD`]).
+    pub fn collect_threshold(&self) -> usize {
+        self.collect_threshold
+    }
+
+    /// Whether the live set has reached the threshold — i.e. a collection is due.
+    ///
+    /// This is the *policy* half of paced collection: it answers "should I collect
+    /// now?" from live-byte accounting alone, with no knowledge of *where* the
+    /// roots are. The *mechanism* half — actually finding the roots and running a
+    /// cycle — lives with the caller (for native AOT, `gc-core-capi`'s stack scan),
+    /// because only the caller knows how to enumerate its roots. A safepoint or an
+    /// allocation consults this and, when true, drives a collect.
+    pub fn should_collect(&self) -> bool {
+        self.live_bytes >= self.collect_threshold
+    }
+
+    /// Re-tune the threshold after a cycle, given the live bytes *before* it.
+    ///
+    /// The heuristic (ported verbatim from `twig_gc.c`): if **more than half** the
+    /// pre-cycle live set survived, the program is holding a large working set —
+    /// **double** the threshold (capped at [`MAX_THRESHOLD`]) so we collect less
+    /// often and waste less time on low-yield sweeps. Otherwise most of the heap
+    /// was garbage — **halve** it (floored at [`INITIAL_THRESHOLD`]) so we collect
+    /// sooner and keep the footprint tight.
+    ///
+    /// ```text
+    ///   survived > prev/2  →  threshold = min(threshold*2, MAX)   (grow: retain-heavy)
+    ///   survived ≤ prev/2  →  threshold = max(threshold/2, INITIAL) (shrink: garbage-heavy)
+    /// ```
+    ///
+    /// The cap is load-bearing for safety, not just tuning: without it a live-heavy
+    /// program could double the threshold toward `usize::MAX`, making
+    /// `should_collect` never fire — the GC effectively off, an unbounded
+    /// memory-exhaustion vector for untrusted input.
+    fn adapt_threshold(&mut self, prev_live: usize) {
+        if self.live_bytes > prev_live / 2 {
+            self.collect_threshold = (self.collect_threshold * 2).min(MAX_THRESHOLD);
+        } else {
+            self.collect_threshold = (self.collect_threshold / 2).max(INITIAL_THRESHOLD);
+        }
+    }
+
     /// Number of live blocks (walks the list — O(n); for tests/introspection).
     pub fn object_count(&self) -> usize {
         let mut n = 0;
@@ -231,6 +291,7 @@ impl FlatHeap {
     /// extra cycle; it never frees a live one.
     pub fn collect(&mut self, roots: &[usize]) -> GcCycleStats {
         let before = self.object_count();
+        let prev_live = self.live_bytes;
 
         // ── Mark ──────────────────────────────────────────────────────────────
         // Iterative worklist (no recursion → no stack blow-up on deep lists).
@@ -245,6 +306,7 @@ impl FlatHeap {
         // ── Sweep ─────────────────────────────────────────────────────────────
         let (freed, survived, live) = self.sweep();
         self.live_bytes = live;
+        self.adapt_threshold(prev_live);
 
         let stats = GcCycleStats {
             freed,
@@ -287,6 +349,7 @@ impl FlatHeap {
     /// scanning starts at `base` and a sub-8-byte tail is ignored.
     pub unsafe fn collect_region(&mut self, base: *const u8, len: usize) -> GcCycleStats {
         let before = self.object_count();
+        let prev_live = self.live_bytes;
 
         let mut work: Vec<*mut FlatHeader> = Vec::new();
         // SAFETY: caller guarantees `[base, base+len)` is readable.
@@ -297,6 +360,7 @@ impl FlatHeap {
 
         let (freed, survived, live) = self.sweep();
         self.live_bytes = live;
+        self.adapt_threshold(prev_live);
 
         let stats = GcCycleStats {
             freed,
@@ -649,5 +713,80 @@ mod tests {
             unsafe { heap.collect_region(region.as_ptr() as *const u8, std::mem::size_of_val(&region)) };
         assert_eq!(stats.survived, 3);
         assert_eq!(stats.freed, 1);
+    }
+
+    // ── Adaptive collection threshold (GC pacing) ──────────────────────────────
+
+    /// A fresh heap starts at the initial threshold and is not yet due to collect.
+    #[test]
+    fn fresh_heap_starts_at_initial_threshold() {
+        let heap = FlatHeap::new();
+        assert_eq!(heap.collect_threshold(), INITIAL_THRESHOLD);
+        assert!(!heap.should_collect());
+    }
+
+    /// `should_collect` flips true exactly when live bytes reach the threshold.
+    #[test]
+    fn should_collect_fires_at_threshold() {
+        let mut heap = FlatHeap::new();
+        heap.collect_threshold = 100;
+        heap.live_bytes = 99;
+        assert!(!heap.should_collect());
+        heap.live_bytes = 100;
+        assert!(heap.should_collect());
+        heap.live_bytes = 101;
+        assert!(heap.should_collect());
+    }
+
+    /// Retention-heavy cycle (> half survived) doubles the threshold.
+    #[test]
+    fn adapt_threshold_doubles_when_retention_high() {
+        let mut heap = FlatHeap::new();
+        heap.collect_threshold = 4 * INITIAL_THRESHOLD;
+        heap.live_bytes = 100; // survived
+        heap.adapt_threshold(150); // prev/2 = 75 < 100 → grow
+        assert_eq!(heap.collect_threshold(), 8 * INITIAL_THRESHOLD);
+    }
+
+    /// Garbage-heavy cycle (≤ half survived) halves the threshold.
+    #[test]
+    fn adapt_threshold_halves_when_retention_low() {
+        let mut heap = FlatHeap::new();
+        heap.collect_threshold = 4 * INITIAL_THRESHOLD;
+        heap.live_bytes = 10; // survived
+        heap.adapt_threshold(100); // prev/2 = 50 ≥ 10 → shrink
+        assert_eq!(heap.collect_threshold(), 2 * INITIAL_THRESHOLD);
+    }
+
+    /// Growth is capped at `MAX_THRESHOLD` — the safety cap that keeps the GC from
+    /// being tuned off entirely.
+    #[test]
+    fn adapt_threshold_caps_at_max() {
+        let mut heap = FlatHeap::new();
+        heap.collect_threshold = MAX_THRESHOLD;
+        heap.live_bytes = MAX_THRESHOLD; // fully retained → wants to grow
+        heap.adapt_threshold(1);
+        assert_eq!(heap.collect_threshold(), MAX_THRESHOLD);
+    }
+
+    /// Shrinking never drops below the initial floor.
+    #[test]
+    fn adapt_threshold_floors_at_initial() {
+        let mut heap = FlatHeap::new();
+        heap.collect_threshold = INITIAL_THRESHOLD;
+        heap.live_bytes = 0; // nothing survived → wants to shrink
+        heap.adapt_threshold(1000);
+        assert_eq!(heap.collect_threshold(), INITIAL_THRESHOLD);
+    }
+
+    /// A real collect that reclaims everything (0 survivors) shrinks the threshold
+    /// — end-to-end proof the cycle re-tunes pacing, not just the direct unit test.
+    #[test]
+    fn collect_retunes_threshold_end_to_end() {
+        let mut heap = FlatHeap::new();
+        heap.collect_threshold = 4 * INITIAL_THRESHOLD;
+        heap.alloc(64, 0); // unrooted → freed by the collect below
+        let _ = heap.collect(&[]); // 0 survive ≤ prev/2 → halve
+        assert_eq!(heap.collect_threshold(), 2 * INITIAL_THRESHOLD);
     }
 }


### PR DESCRIPTION
## What

Ports `twig_gc.c`'s **GC-pacing policy** to the pure-Rust collector, so the coming twig-aot swap (#118b-2) preserves collection cadence instead of collecting on every op (perf) or never (leak). Splits cleanly into a *policy* half (gc-core) and a *mechanism* half (gc-core-capi).

## gc-core (`FlatHeap`) — the policy

- New `collect_threshold` field (starts at `INITIAL_THRESHOLD` = 1 MiB) + `should_collect()` (`live_bytes >= threshold`) + `collect_threshold()`.
- After every cycle, `collect`/`collect_region` call `adapt_threshold(prev_live)`: **double** the threshold (capped at `MAX_THRESHOLD` = 256 MiB) when >½ the pre-cycle live set survived, else **halve** it (floored at 1 MiB) — verbatim `twig_gc.c` heuristic.
- The 256 MiB cap is a **safety bound**, not just tuning: without it a live-heavy program could grow the threshold toward `usize::MAX` and disable the GC (a memory-exhaustion vector). New `pub const INITIAL_THRESHOLD` / `MAX_THRESHOLD`. 7 unit tests.

## gc-core-capi — the mechanism (drives collection off the policy)

- **`__gc_safepoint()`** — the throttled collect (drop-in for `__twig_gc_safepoint`). Runs `__gc_collect` only when `should_collect()`, else returns `0`. The backend emits `safepoint` at loop back-edges / fn entries; collecting at every one would be ruinous, so each just asks "over threshold yet?" — GC cost stays proportional to allocation, and a tight allocation loop can't starve the GC.
- **`__gc_alloc` / `__gc_alloc_kind` now collect under pressure** — a paced stack-scan collect *before* allocating when over threshold (matching `__twig_gc_alloc`). Before-not-after means the new object doesn't exist yet and can't be wrongly reclaimed; every root that must survive is the caller's, already live on the scanned stack. Below 1 MiB (host tests, light loads) the path is never taken — allocation stays a plain bump.
- Host tests that touch the process-wide `HEAP` now serialise via a `#[cfg(test)] TEST_LOCK` (cargo runs unit tests on parallel threads; two `HEAP`-mutating tests would otherwise interleave). New safepoint test proves throttle-below / collect-at threshold.

## Validation

- `cargo test -p gc-core -p gc-core-capi` — gc-core 20 `flat_heap` (incl. 7 threshold) + 45 lib + gc-core-capi 5 + 8 doctests, all green.
- Register-spill collect exercised at **runtime** on aarch64 (native) and x86_64 SysV (Rosetta).

## Security review — PASSED

Pacing arithmetic (threshold provably in `[1 MiB, 256 MiB]` → no overflow), the DoS cap, `should_collect` gating, `HEAP`-lock non-reentrancy, and the `__gc_alloc` auto-collect root-soundness all cleared. One **LOW** finding: the conservative scan omits callee-saved FP/SIMD registers (aarch64 `d8`–`d15`, Win64 `xmm6`–`xmm15`) that `twig_gc.c`'s `setjmp` saved — sound today because the native backend is **tagged-i64** (refs live in integer registers), but load-bearing. Corrected the misleading "FP never holds references" comment to the real tagged-i64 invariant; **spilling the FP registers is tracked as a separate T1 hardening task**.

## Details

- gc-core 0.3.0 → 0.4.0; gc-core-capi 0.3.0 → 0.4.0. Header, README, CHANGELOGs updated. Builds on #118b-1 (merged). Next: #118b-2 wires twig-aot and retires `twig_gc.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)