### PR TITLE
feat(adj-facts-stdlib): physics/energy-forms — energy form → example table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_energyforms_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_energyforms_e2e.rs
@@ -1,0 +1,78 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/energy-forms.adj`) driven through the built CLI:
+//! a native `table` of energy form → defining token resolves a binding query
+//! recall with the EIA citation, runs backward (token → form), and abstains on
+//! something that is not one of the enumerated forms — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsef_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn physics_energy_forms_recall_binds_token_with_citation() {
+    let dir = scratch("energyforms");
+    // Copy the shipped physics table beside the entry program and import it.
+    let src = facts_stdlib().join("physics/energy-forms.adj");
+    std::fs::copy(&src, dir.join("energy-forms.adj")).expect("copy shipped energy-forms.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"energy-forms.adj\"\n\
+         ? energy_form_token(chemical, $T)\n\
+         ? energy_form_token(nuclear, $T)\n\
+         ? energy_form_token(electrical, $T)\n\
+         ? energy_form_token($F, heat)\n\
+         ? energy_form_token(magnetic, $T)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward lookups bind each form to the token EIA uses to define it.
+    assert!(out.contains("\"T\":\"bonds\""), "chemical binds to bonds: {out}");
+    assert!(
+        out.contains("energy_form_token(chemical, bonds)"),
+        "chemical is governing-bound to bonds: {out}"
+    );
+    assert!(
+        out.contains("energy_form_token(nuclear, nucleus)"),
+        "nuclear is governing-bound to nucleus: {out}"
+    );
+    assert!(
+        out.contains("energy_form_token(electrical, electrons)"),
+        "electrical is governing-bound to electrons: {out}"
+    );
+    // The relation runs BACKWARD: bind the token, recall the form.
+    assert!(
+        out.contains("energy_form_token(thermal, heat)"),
+        "reverse recall binds F=thermal from heat: {out}"
+    );
+    // The answer carries the EIA locator + trust tier as its proof.
+    assert!(
+        out.contains("eia.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Magnetic energy is NOT one of the enumerated forms — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "magnetic abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -47,6 +47,7 @@ per rotation, in parallel):
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
 | `physics/` | simple machine → everyday example | NASA |
 | `physics/` | phase change → its name (melting, freezing, …) | LibreTexts (consensus) |
+| `physics/` | energy form → defining token (chemical → bonds, thermal → heat) | EIA (energy.gov) |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |

--- a/code/specs/data/adj-facts-stdlib/physics/energy-forms.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/energy-forms.adj
@@ -1,0 +1,111 @@
+% ============================================================================
+% energy-forms — each named FORM of energy and the single defining token the
+% source uses to describe it (adj-facts-stdlib, PHYSICS).
+% ============================================================================
+% One of the first organizing facts in physics: energy comes in NAMED FORMS,
+% and each form is pinned by one characteristic word — chemical energy is about
+% BONDS, nuclear energy is about the NUCLEUS, thermal energy is HEAT, motion
+% energy is about things MOVING. Before a learner reasons about conservation of
+% energy or converts one form into another, they first learn to NAME the forms
+% and attach each to the word that defines it. Recall is a binding query:
+%
+%     ? energy_form_token(chemical, $T)      % bonds
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `energy_form_token(form, token)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% defining token WITH its source, on the CPU, with zero model calls, and
+% abstains on anything that is not one of the enumerated forms.
+%
+% The forms, as a little truth table (form → what the EIA sentence says → the
+% single defining token we carry):
+%
+%     form            what the EIA definition says                 token
+%     -------------   ------------------------------------------   -------------
+%     chemical        "...stored in the bonds of atoms..."         bonds
+%     mechanical      "...stored in objects by tension"            tension
+%     nuclear         "...stored in the nucleus of an atom..."     nucleus
+%     gravitational   "...stored in an object's height"            height
+%     radiant         "...electromagnetic energy that travels..."  electromagnetic
+%     thermal         "Thermal energy, or heat, is..."             heat
+%     motion          "...stored in moving objects"                moving
+%     electrical      "...charged particles, called electrons..."  electrons
+%
+% EIA groups these forms into two families — POTENTIAL energy (chemical,
+% mechanical, nuclear, gravitational) and KINETIC energy (radiant, thermal,
+% motion, electrical) — but the family split is not part of this table; the
+% table is the single clean axis form → defining token. The query also runs
+% BACKWARD — bind the token and recall the form it defines:
+%
+%     ? energy_form_token($F, heat)          % thermal — reverse recall
+%
+% Every `token` is a SINGLE lowercase atom that appears VERBATIM inside that
+% form's own EIA definition sentence (quoted per-row in the provenance block
+% below), never a synonym or a word the source does not use. Something that is
+% not one of the enumerated forms — magnetic energy, for instance, which is real
+% physics but is NOT one of the forms this EIA page names — has no row, so a
+% recall on it ABSTAINS rather than inventing a token. That honest-abstention
+% property is what makes the table safe to reason from.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every form→token pair was
+% read out of a fetched U.S. Energy Information Administration page this session,
+% and any form whose token could not be found verbatim in its own definition
+% sentence would have been dropped). All eight tokens come from the SAME primary
+% U.S. government source, the EIA "Energy Explained — Forms of energy" page
+% (eia.gov/energyexplained/what-is-energy/forms-of-energy.php), each definition
+% sentence quoted here character-for-character so any reader can re-check it:
+%
+%   chemical → bonds
+%     "Chemical energy is energy stored in the bonds of atoms and molecules."
+%
+%   mechanical → tension
+%     "Mechanical energy is energy stored in objects by tension."
+%
+%   nuclear → nucleus
+%     "Nuclear energy is energy stored in the nucleus of an atom—the energy that
+%      holds the nucleus together."
+%
+%   gravitational → height
+%     "Gravitational energy is energy stored in an object's height."
+%
+%   radiant → electromagnetic
+%     "Radiant energy is electromagnetic energy that travels in transverse waves."
+%
+%   thermal → heat
+%     "Thermal energy, or heat, is the energy that comes from atoms and molecules
+%      moving in a substance."
+%
+%   motion → moving
+%     "Motion energy is energy stored in moving objects."
+%
+%   electrical → electrons
+%     "Electrical energy is delivered by tiny, charged particles, called
+%      electrons, that typically move through a wire."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the EIA sentence that fixes the
+% first row (chemical → bonds). Every OTHER row's per-fact source and verbatim
+% span is listed above, so each token remains independently checkable. The
+% source is a primary U.S. government EIA education page (eia.gov), so
+% `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table energy_form_token {
+    columns form, token
+
+    row (chemical, bonds)
+    row (mechanical, tension)
+    row (nuclear, nucleus)
+    row (gravitational, height)
+    row (radiant, electromagnetic)
+    row (thermal, heat)
+    row (motion, moving)
+    row (electrical, electrons)
+
+    source "Chemical energy is energy stored in the bonds of atoms and molecules."
+    locator "https://www.eia.gov/energyexplained/what-is-energy/forms-of-energy.php"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/physics/energy-forms.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/energy-forms.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% energy-forms.query.adj — a worked recall over the physics energy-forms library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what word defines chemical
+% energy?": it states no physics fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `energy_form_token` rows and returns the token + the table's source/locator/
+% trust. The fifth query runs the relation BACKWARD (bind the token `heat`,
+% recall the form it defines — thermal). Magnetic energy is not one of the forms
+% this EIA page enumerates, so a recall on it abstains honestly — the engine
+% never invents a token.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli energy-forms.query.adj
+% ============================================================================
+
+import "energy-forms.adj"
+
+? energy_form_token(chemical, $T)      % expect bonds
+? energy_form_token(nuclear, $T)       % expect nucleus
+? energy_form_token(thermal, $T)       % expect heat
+? energy_form_token(electrical, $T)    % expect electrons
+? energy_form_token($F, heat)          % expect thermal — reverse recall
+? energy_form_token(magnetic, $T)      % expect abstain — not one of the enumerated forms


### PR DESCRIPTION
Adds a physics FACTS library mapping each named form of energy to the
single defining token its source sentence uses (chemical → bonds,
mechanical → tension, nuclear → nucleus, gravitational → height,
radiant → electromagnetic, thermal → heat, motion → moving,
electrical → electrons). Native ADJ `table`; recall is an SLD binding
query returning the token with its citation, runs backward (token →
form), and abstains honestly on forms the source does not enumerate
(e.g. magnetic). Zero model calls.

Provenance: every form→token pair is byte-provenanced against a single
primary U.S. government source fetched this session — the EIA "Energy
Explained — Forms of energy" page
(eia.gov/energyexplained/what-is-energy/forms-of-energy.php). Each
token appears VERBATIM inside that form's own EIA definition sentence,
all quoted character-for-character in the file's provenance block. EIA
is a primary U.S. government (energy.gov) source → trust authoritative.
Nothing asserted from memory; sound (an available form) was left out to
keep every value a distinct clean single-noun token.

Files (data-only; no engine/grammar/adapter):
- physics/energy-forms.adj — the grounded table + literate provenance
- physics/energy-forms.query.adj — worked forward/reverse/abstain recall
- adj-lang-cli/tests/facts_energyforms_e2e.rs — e2e recall through the CLI
- adj-facts-stdlib/README.md — physics subject-index row

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
