### PR TITLE
feat(adj-facts-stdlib): anatomy/joint-types — synovial joint type → example table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_jointtypes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_jointtypes_e2e.rs
@@ -1,0 +1,79 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/joint-types.adj`) driven through the built CLI:
+//! a native `table` of synovial joint type → representative example resolves a
+//! binding-query recall with the source's StatPearls (NIH/NLM) citation, runs
+//! the relation backward (joint type → examples, and example → joint type), and
+//! abstains on a non-synovial joint (a skull suture) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsjoint_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_joint_types_recall_binds_example_with_citation() {
+    let dir = scratch("jointtypes");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/joint-types.adj");
+    std::fs::copy(&src, dir.join("joint-types.adj")).expect("copy shipped joint-types.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"joint-types.adj\"\n\
+         ? joint_example(hinge, $Ex)\n\
+         ? joint_example(saddle, $Ex)\n\
+         ? joint_example(ball_and_socket, $Ex)\n\
+         ? joint_example($T, elbow)\n\
+         ? joint_example(suture, $Ex)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The stock hinge is the elbow; the saddle joint is at the base of the thumb.
+    assert!(out.contains("\"Ex\":\"elbow\""), "hinge → elbow: {out}");
+    assert!(out.contains("\"Ex\":\"thumb\""), "saddle → thumb: {out}");
+    // ball_and_socket is one-to-many: the source names both the hip and shoulder.
+    assert!(out.contains("\"Ex\":\"hip\""), "ball_and_socket → hip: {out}");
+    assert!(
+        out.contains("\"Ex\":\"shoulder\""),
+        "ball_and_socket → shoulder: {out}"
+    );
+    // The relation runs backward: the elbow recalls the hinge shape.
+    assert!(
+        out.contains("\"T\":\"hinge\""),
+        "elbow → hinge (reverse recall): {out}"
+    );
+    // The answer carries the StatPearls (NIH/NLM) citation as its proof.
+    assert!(
+        out.contains("ncbi.nlm.nih.gov/books/NBK507893")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A skull suture is an immovable joint, not a synovial type — honest
+    // abstention, never a fabricated example.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "unknown joint type abstains: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -51,6 +51,7 @@ per rotation, in parallel):
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |
 | `anatomy/` | digestive organ → primary function it performs | NIH NIDDK / NCI SEER Training |
+| `anatomy/` | synovial joint type → representative example (hinge → elbow) | NIH / NLM StatPearls |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/anatomy/joint-types.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/joint-types.adj
@@ -1,0 +1,117 @@
+% ============================================================================
+% joint-types — a type of synovial joint → a representative example the source
+% names for it (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A musculoskeletal fact set on the way to medicine: a SYNOVIAL (freely movable)
+% joint is where two bones meet across a fluid-filled cavity, and anatomists sort
+% these joints into a handful of shapes by the motion each shape allows. The
+% first thing a learner memorizes is a canonical EXAMPLE for each shape — the one
+% joint a textbook points to so the name sticks. The elbow is the stock HINGE
+% (it swings on one axis like a door); the atlantoaxial joint at the top of the
+% neck is the stock PIVOT (it lets the head turn side to side); the knuckles are
+% CONDYLOID; the base of the thumb is the SADDLE joint; the intercarpal joints of
+% the wrist are PLANAR (gliding); and the hip and shoulder are the body's only
+% BALL-AND-SOCKET joints. Recall is a binding query:
+%
+%     ? joint_example(hinge, $Ex)          % elbow
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `joint_example(joint_type, example)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% example WITH its source, on the CPU, with zero model calls, and abstains on
+% anything that is not one of these synovial-joint types (it never invents an
+% example).
+%
+% The synovial-joint shapes, as a little truth table:
+%
+%     joint_type        example        the joint the source points to
+%     ---------------   ------------   ----------------------------------------
+%     hinge             elbow          the elbow (swings on one axis)
+%     pivot             atlantoaxial   the atlantoaxial joint (turns the head)
+%     condyloid         knuckles       the knuckles of the hand
+%     saddle            thumb          the joint at the base of the thumb
+%     planar            intercarpal    the intercarpal joints of the wrist
+%     ball_and_socket   hip            the hip …
+%     ball_and_socket   shoulder       … and the shoulder
+%
+% Each `example` value is a SINGLE lowercase token that appears VERBATIM in the
+% cited source sentence for that joint type (see the provenance block), so the
+% recall is a faithful echo of the source, not a paraphrase. `ball_and_socket`
+% is one-to-MANY: the source names BOTH the hip and the shoulder as the body's
+% only ball-and-socket joints, so the relation run BACKWARD from a joint type
+% enumerates every example the source gives it:
+%
+%     ? joint_example(ball_and_socket, $Ex)   % hip, then shoulder
+%
+% and run backward from an example recalls the shape that example illustrates:
+%
+%     ? joint_example($T, elbow)              % hinge — reverse recall
+%
+% Something that is not one of these synovial-joint shapes — a skull `suture`
+% (an immovable joint), a bone, a muscle — has no row, so a recall on it ABSTAINS
+% rather than inventing an example. That honest-abstention property is what makes
+% the table safe to reason from: a medicine agent reasons UP from "which joint
+% shape looks like what" before it can reason about a dislocated shoulder (a
+% ball-and-socket) or a jammed finger (an interphalangeal hinge).
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every joint_type→example
+% pair was read out of a page fetched this session, and any pair whose example
+% token did not appear VERBATIM in a fetched sentence was DROPPED). All seven
+% rows come from the SAME single source: the U.S. National Library of Medicine
+% (NIH) NCBI Bookshelf reference StatPearls "Anatomy, Joints"
+% (ncbi.nlm.nih.gov/books/NBK507893/). Each example token below is quoted inside
+% its verbatim source sentence so any reader can re-check it:
+%
+%   hinge → elbow
+%     "Examples include the elbow, knee, ankle, and interphalangeal joints."
+%
+%   pivot → atlantoaxial
+%     "The atlantoaxial joint, formed by the 1st (atlas) and 2nd (axis) cervical
+%      vertebrae, is a pivot joint."
+%
+%   condyloid → knuckles
+%     "Examples of condyloid joints are the knuckles, formed by the distal
+%      metacarpals and proximal phalanges of the medial 4 fingers."
+%
+%   saddle → thumb
+%     "This joint allows the thumb to flex and extend parallel to the palm and
+%      abduct and adduct perpendicular to the palm, making the digit opposable."
+%     (The saddle joint of the preceding sentence is "the joint formed by the
+%      trapezium and 1st metacarpal bone" — the base of the thumb.)
+%
+%   planar → intercarpal
+%     "Examples include the acromioclavicular, intercarpal, and intertarsal
+%      joints."
+%
+%   ball_and_socket → hip, shoulder
+%     "The body's only ball-and-socket joints are the hip and shoulder
+%      (glenohumeral) joints."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the StatPearls sentence that fixes
+% the first row (hinge → elbow). Every OTHER row's per-fact source and verbatim
+% span is listed above, so each pair remains independently checkable. All seven
+% rows share the ONE source — StatPearls, hosted and peer-reviewed on the NIH
+% National Library of Medicine's NCBI Bookshelf — so, following the same
+% NIH/NLM-primary judgement used by the sibling lung-lobes table (which cites the
+% same StatPearls corpus), `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table joint_example {
+    columns joint_type, example
+
+    row (hinge, elbow)
+    row (pivot, atlantoaxial)
+    row (condyloid, knuckles)
+    row (saddle, thumb)
+    row (planar, intercarpal)
+    row (ball_and_socket, hip)
+    row (ball_and_socket, shoulder)
+
+    source "Examples include the elbow, knee, ankle, and interphalangeal joints."
+    locator "https://www.ncbi.nlm.nih.gov/books/NBK507893/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/joint-types.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/joint-types.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% joint-types.query.adj — a worked recall over the anatomy joint-types library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what's a good example of a
+% hinge joint?": it states no anatomy fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `joint_example` rows and returns the example + the table's source/locator/trust.
+% The fourth query runs the relation BACKWARD from a joint type (bind
+% `ball_and_socket`, recall BOTH examples the source gives — the hip and the
+% shoulder). The fifth runs it backward from an example (bind `elbow`, recall the
+% shape it illustrates — hinge). A skull `suture` is an immovable joint, not one
+% of these synovial shapes, so a recall on it abstains honestly — the engine
+% never invents an example.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli joint-types.query.adj
+% ============================================================================
+
+import "joint-types.adj"
+
+? joint_example(hinge, $Ex)             % expect elbow
+? joint_example(pivot, $Ex)             % expect atlantoaxial
+? joint_example(saddle, $Ex)            % expect thumb
+? joint_example(ball_and_socket, $Ex)   % expect hip ; shoulder — one-to-many
+? joint_example($T, elbow)              % expect hinge — reverse recall
+? joint_example(suture, $Ex)            % expect abstain — a suture is immovable


### PR DESCRIPTION
Add a grounded ADJ `table` mapping each type of synovial (freely movable)
joint to a representative example the source names for it, plus a worked
`.query.adj` recall and a CLI e2e test.

    joint_type        example        cited sentence
    ---------------   ------------   ------------------------------------------
    hinge             elbow          "Examples include the elbow, knee, ankle,
                                      and interphalangeal joints."
    pivot             atlantoaxial   "The atlantoaxial joint, formed by the 1st
                                      (atlas) and 2nd (axis) cervical vertebrae,
                                      is a pivot joint."
    condyloid         knuckles       "Examples of condyloid joints are the
                                      knuckles, formed by the distal metacarpals
                                      and proximal phalanges of the medial 4
                                      fingers."
    saddle            thumb          "This joint allows the thumb to flex and
                                      extend parallel to the palm ..."
    planar            intercarpal    "Examples include the acromioclavicular,
                                      intercarpal, and intertarsal joints."
    ball_and_socket   hip, shoulder  "The body's only ball-and-socket joints are
                                      the hip and shoulder (glenohumeral) joints."

Provenance: nothing from memory. Every example token appears VERBATIM in a
sentence fetched this session from the SINGLE source — NIH / U.S. National
Library of Medicine NCBI Bookshelf StatPearls "Anatomy, Joints"
(https://www.ncbi.nlm.nih.gov/books/NBK507893/). trust authoritative, following
the same NIH/NLM-primary judgement the sibling lung-lobes table applies to the
StatPearls corpus. One clean axis (type → representative example);
ball_and_socket is one-to-many (hip and shoulder), both stated by the source.

Rows dropped: none from StatPearls — every synovial subtype it lists could be
grounded to a verbatim example token. The NCI SEER Training joints page
(articulations.html) was checked first but classifies joints only as
synarthroses/amphiarthroses/diarthroses and names NO per-type example, so it
could not source this axis.

A skull `suture` (an immovable joint, not a synovial subtype) has no row, so a
recall on it ABSTAINS rather than inventing an example.

Targeted test `cargo test -p adj-lang-cli --test facts_jointtypes_e2e` and
`cargo clippy -p adj-lang -p adj-lang-cli --all-targets -- -D warnings` both
green. Data-only diff (+ its e2e test); no engine/grammar/adapter change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
