### PR TITLE
feat(argon2id): add C# and F# ports

### DIFF
--- a/code/packages/csharp/argon2id/Argon2id.cs
+++ b/code/packages/csharp/argon2id/Argon2id.cs
@@ -1,0 +1,454 @@
+using System.Buffers.Binary;
+using System.Numerics;
+using CodingAdventures.Blake2b;
+using Blake2bAlgorithm = CodingAdventures.Blake2b.Blake2b;
+
+namespace CodingAdventures.Argon2id;
+
+/// <summary>Optional Argon2id inputs from RFC 9106.</summary>
+public sealed class Argon2idOptions
+{
+    /// <summary>Optional secret key K.</summary>
+    public byte[] Key { get; init; } = [];
+
+    /// <summary>Optional associated data X.</summary>
+    public byte[] AssociatedData { get; init; } = [];
+
+    /// <summary>Argon2 version. Only RFC 9106 version 0x13 is supported.</summary>
+    public uint Version { get; init; } = Argon2id.Version;
+}
+
+/// <summary>Pure C# Argon2id password hashing as specified by RFC 9106.</summary>
+public static class Argon2id
+{
+    /// <summary>Argon2 version 1.3.</summary>
+    public const uint Version = 0x13;
+
+    private const ulong Mask32 = 0xffff_ffffUL;
+    private const int BlockSize = 1024;
+    private const int BlockWords = BlockSize / sizeof(ulong);
+    private const int SyncPoints = 4;
+    private const uint TypeId = 2;
+
+    /// <summary>Compute an Argon2id tag.</summary>
+    public static byte[] Derive(
+        byte[] password,
+        byte[] salt,
+        int timeCost,
+        int memoryCost,
+        int parallelism,
+        int tagLength,
+        Argon2idOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+        ArgumentNullException.ThrowIfNull(salt);
+        options ??= new Argon2idOptions();
+        ArgumentNullException.ThrowIfNull(options.Key);
+        ArgumentNullException.ThrowIfNull(options.AssociatedData);
+        Validate(salt, timeCost, memoryCost, parallelism, tagLength, options.Version);
+
+        var segmentLength = memoryCost / (SyncPoints * parallelism);
+        var adjustedMemoryCost = segmentLength * SyncPoints * parallelism;
+        var laneLength = adjustedMemoryCost / parallelism;
+        var initialHash = InitialHash(
+            password,
+            salt,
+            timeCost,
+            memoryCost,
+            parallelism,
+            tagLength,
+            options);
+
+        var memory = new ulong[parallelism][][];
+        for (var lane = 0; lane < parallelism; lane++)
+        {
+            memory[lane] = new ulong[laneLength][];
+            for (var column = 0; column < laneLength; column++)
+            {
+                memory[lane][column] = new ulong[BlockWords];
+            }
+
+            memory[lane][0] = BytesToBlock(Blake2bLong(BlockSize, Concat(initialHash, UInt32Bytes(0), UInt32Bytes((uint)lane))));
+            memory[lane][1] = BytesToBlock(Blake2bLong(BlockSize, Concat(initialHash, UInt32Bytes(1), UInt32Bytes((uint)lane))));
+        }
+
+        for (var pass = 0; pass < timeCost; pass++)
+        {
+            for (var slice = 0; slice < SyncPoints; slice++)
+            {
+                for (var lane = 0; lane < parallelism; lane++)
+                {
+                    FillSegment(
+                        memory,
+                        pass,
+                        lane,
+                        slice,
+                        laneLength,
+                        segmentLength,
+                        parallelism,
+                        adjustedMemoryCost,
+                        timeCost);
+                }
+            }
+        }
+
+        var finalBlock = memory[0][laneLength - 1].ToArray();
+        for (var lane = 1; lane < parallelism; lane++)
+        {
+            for (var word = 0; word < BlockWords; word++)
+            {
+                finalBlock[word] ^= memory[lane][laneLength - 1][word];
+            }
+        }
+
+        return Blake2bLong(tagLength, BlockToBytes(finalBlock));
+    }
+
+    /// <summary>Compute an Argon2id tag and return lowercase hexadecimal.</summary>
+    public static string DeriveHex(
+        byte[] password,
+        byte[] salt,
+        int timeCost,
+        int memoryCost,
+        int parallelism,
+        int tagLength,
+        Argon2idOptions? options = null) =>
+        Convert.ToHexString(Derive(password, salt, timeCost, memoryCost, parallelism, tagLength, options))
+            .ToLowerInvariant();
+
+    private static void Validate(
+        byte[] salt,
+        int timeCost,
+        int memoryCost,
+        int parallelism,
+        int tagLength,
+        uint version)
+    {
+        if (salt.Length < 8)
+        {
+            throw new ArgumentException($"Salt must be at least 8 bytes, got {salt.Length}.", nameof(salt));
+        }
+
+        if (tagLength < 4)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tagLength), $"Tag length must be at least 4 bytes, got {tagLength}.");
+        }
+
+        if (parallelism is < 1 or > 0x00ff_ffff)
+        {
+            throw new ArgumentOutOfRangeException(nameof(parallelism), "Parallelism must be in [1, 2^24-1].");
+        }
+
+        if (memoryCost < 8 * parallelism)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(memoryCost),
+                $"Memory cost must be at least 8*parallelism ({8 * parallelism}), got {memoryCost}.");
+        }
+
+        if (timeCost < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeCost), "Time cost must be at least 1.");
+        }
+
+        if (version != Version)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version), $"Only Argon2 v1.3 (0x13) is supported; got 0x{version:x2}.");
+        }
+    }
+
+    private static byte[] InitialHash(
+        byte[] password,
+        byte[] salt,
+        int timeCost,
+        int memoryCost,
+        int parallelism,
+        int tagLength,
+        Argon2idOptions options)
+    {
+        var input = Concat(
+            UInt32Bytes((uint)parallelism),
+            UInt32Bytes((uint)tagLength),
+            UInt32Bytes((uint)memoryCost),
+            UInt32Bytes((uint)timeCost),
+            UInt32Bytes(options.Version),
+            UInt32Bytes(TypeId),
+            UInt32Bytes((uint)password.Length),
+            password,
+            UInt32Bytes((uint)salt.Length),
+            salt,
+            UInt32Bytes((uint)options.Key.Length),
+            options.Key,
+            UInt32Bytes((uint)options.AssociatedData.Length),
+            options.AssociatedData);
+        return Hash(input, 64);
+    }
+
+    private static void FillSegment(
+        ulong[][][] memory,
+        int pass,
+        int lane,
+        int slice,
+        int laneLength,
+        int segmentLength,
+        int parallelism,
+        int adjustedMemoryCost,
+        int timeCost)
+    {
+        var dataIndependent = pass == 0 && slice < 2;
+        var inputBlock = new ulong[BlockWords];
+        var addressBlock = new ulong[BlockWords];
+        var zeroBlock = new ulong[BlockWords];
+        inputBlock[0] = (ulong)pass;
+        inputBlock[1] = (ulong)lane;
+        inputBlock[2] = (ulong)slice;
+        inputBlock[3] = (ulong)adjustedMemoryCost;
+        inputBlock[4] = (ulong)timeCost;
+        inputBlock[5] = TypeId;
+
+        void NextAddresses()
+        {
+            inputBlock[6] = unchecked(inputBlock[6] + 1);
+            var intermediate = Compress(zeroBlock, inputBlock);
+            addressBlock = Compress(zeroBlock, intermediate);
+        }
+
+        var startingColumn = pass == 0 && slice == 0 ? 2 : 0;
+        if (dataIndependent && startingColumn != 0)
+        {
+            NextAddresses();
+        }
+
+        for (var index = startingColumn; index < segmentLength; index++)
+        {
+            if (dataIndependent
+                && index % BlockWords == 0
+                && !(pass == 0 && slice == 0 && index == 2))
+            {
+                NextAddresses();
+            }
+
+            var column = slice * segmentLength + index;
+            var previousColumn = column > 0 ? column - 1 : laneLength - 1;
+            var previousBlock = memory[lane][previousColumn];
+            var pseudoRandom = dataIndependent
+                ? addressBlock[index % BlockWords]
+                : previousBlock[0];
+            var j1 = pseudoRandom & Mask32;
+            var j2 = pseudoRandom >> 32;
+            var referenceLane = pass == 0 && slice == 0 ? lane : (int)(j2 % (ulong)parallelism);
+            var referenceColumn = IndexAlpha(
+                j1,
+                pass,
+                slice,
+                index,
+                referenceLane == lane,
+                laneLength,
+                segmentLength);
+
+            var newBlock = Compress(previousBlock, memory[referenceLane][referenceColumn]);
+            if (pass == 0)
+            {
+                memory[lane][column] = newBlock;
+            }
+            else
+            {
+                for (var word = 0; word < BlockWords; word++)
+                {
+                    memory[lane][column][word] ^= newBlock[word];
+                }
+            }
+        }
+    }
+
+    private static int IndexAlpha(
+        ulong j1,
+        int pass,
+        int slice,
+        int index,
+        bool sameLane,
+        int laneLength,
+        int segmentLength)
+    {
+        ulong window;
+        var start = 0;
+
+        if (pass == 0)
+        {
+            if (slice == 0)
+            {
+                window = (ulong)(index - 1);
+            }
+            else
+            {
+                window = sameLane
+                    ? (ulong)(slice * segmentLength + index - 1)
+                    : (ulong)(slice * segmentLength - (index == 0 ? 1 : 0));
+            }
+        }
+        else
+        {
+            window = sameLane
+                ? (ulong)(laneLength - segmentLength + index - 1)
+                : (ulong)(laneLength - segmentLength - (index == 0 ? 1 : 0));
+            start = ((slice + 1) * segmentLength) % laneLength;
+        }
+
+        var x = unchecked(j1 * j1) >> 32;
+        var y = unchecked(window * x) >> 32;
+        var relative = window - 1 - y;
+        return (int)(((ulong)start + relative) % (ulong)laneLength);
+    }
+
+    private static ulong[] Compress(ulong[] x, ulong[] y)
+    {
+        var r = new ulong[BlockWords];
+        for (var index = 0; index < BlockWords; index++)
+        {
+            r[index] = x[index] ^ y[index];
+        }
+
+        var q = r.ToArray();
+        for (var rowIndex = 0; rowIndex < 8; rowIndex++)
+        {
+            var row = new ulong[16];
+            Array.Copy(q, rowIndex * 16, row, 0, row.Length);
+            Permute(row);
+            Array.Copy(row, 0, q, rowIndex * 16, row.Length);
+        }
+
+        for (var columnIndex = 0; columnIndex < 8; columnIndex++)
+        {
+            var column = new ulong[16];
+            for (var rowIndex = 0; rowIndex < 8; rowIndex++)
+            {
+                column[2 * rowIndex] = q[rowIndex * 16 + 2 * columnIndex];
+                column[2 * rowIndex + 1] = q[rowIndex * 16 + 2 * columnIndex + 1];
+            }
+
+            Permute(column);
+            for (var rowIndex = 0; rowIndex < 8; rowIndex++)
+            {
+                q[rowIndex * 16 + 2 * columnIndex] = column[2 * rowIndex];
+                q[rowIndex * 16 + 2 * columnIndex + 1] = column[2 * rowIndex + 1];
+            }
+        }
+
+        for (var index = 0; index < BlockWords; index++)
+        {
+            r[index] ^= q[index];
+        }
+
+        return r;
+    }
+
+    private static void Permute(ulong[] values)
+    {
+        Mix(values, 0, 4, 8, 12);
+        Mix(values, 1, 5, 9, 13);
+        Mix(values, 2, 6, 10, 14);
+        Mix(values, 3, 7, 11, 15);
+        Mix(values, 0, 5, 10, 15);
+        Mix(values, 1, 6, 11, 12);
+        Mix(values, 2, 7, 8, 13);
+        Mix(values, 3, 4, 9, 14);
+    }
+
+    private static void Mix(ulong[] values, int a, int b, int c, int d)
+    {
+        var va = values[a];
+        var vb = values[b];
+        var vc = values[c];
+        var vd = values[d];
+
+        va = AddWithProduct(va, vb);
+        vd = BitOperations.RotateRight(vd ^ va, 32);
+        vc = AddWithProduct(vc, vd);
+        vb = BitOperations.RotateRight(vb ^ vc, 24);
+        va = AddWithProduct(va, vb);
+        vd = BitOperations.RotateRight(vd ^ va, 16);
+        vc = AddWithProduct(vc, vd);
+        vb = BitOperations.RotateRight(vb ^ vc, 63);
+
+        values[a] = va;
+        values[b] = vb;
+        values[c] = vc;
+        values[d] = vd;
+    }
+
+    private static ulong AddWithProduct(ulong left, ulong right) =>
+        unchecked(left + right + 2 * (left & Mask32) * (right & Mask32));
+
+    private static byte[] Blake2bLong(int outputLength, byte[] input)
+    {
+        var prefix = UInt32Bytes((uint)outputLength);
+        if (outputLength <= 64)
+        {
+            return Hash(Concat(prefix, input), outputLength);
+        }
+
+        var rounds = (outputLength + 31) / 32 - 2;
+        var value = Hash(Concat(prefix, input), 64);
+        var output = new List<byte>(outputLength);
+        output.AddRange(value[..32]);
+        for (var round = 0; round < rounds - 1; round++)
+        {
+            value = Hash(value, 64);
+            output.AddRange(value[..32]);
+        }
+
+        value = Hash(value, outputLength - 32 * rounds);
+        output.AddRange(value);
+        return output.ToArray();
+    }
+
+    private static byte[] Hash(byte[] input, int digestSize) =>
+        Blake2bAlgorithm.Hash(input, Blake2bOptions.Default.WithDigestSize(digestSize));
+
+    private static byte[] BlockToBytes(ulong[] block)
+    {
+        var result = new byte[BlockSize];
+        for (var index = 0; index < BlockWords; index++)
+        {
+            BinaryPrimitives.WriteUInt64LittleEndian(result.AsSpan(index * sizeof(ulong), sizeof(ulong)), block[index]);
+        }
+
+        return result;
+    }
+
+    private static ulong[] BytesToBlock(byte[] data)
+    {
+        if (data.Length != BlockSize)
+        {
+            throw new ArgumentException($"Block must be {BlockSize} bytes, got {data.Length}.", nameof(data));
+        }
+
+        var result = new ulong[BlockWords];
+        for (var index = 0; index < BlockWords; index++)
+        {
+            result[index] = BinaryPrimitives.ReadUInt64LittleEndian(data.AsSpan(index * sizeof(ulong), sizeof(ulong)));
+        }
+
+        return result;
+    }
+
+    private static byte[] UInt32Bytes(uint value)
+    {
+        var result = new byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(result, value);
+        return result;
+    }
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var result = new byte[parts.Sum(part => part.Length)];
+        var offset = 0;
+        foreach (var part in parts)
+        {
+            Buffer.BlockCopy(part, 0, result, offset, part.Length);
+            offset += part.Length;
+        }
+
+        return result;
+    }
+}

--- a/code/packages/csharp/argon2id/BUILD
+++ b/code/packages/csharp/argon2id/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Argon2id]*"

--- a/code/packages/csharp/argon2id/BUILD_windows
+++ b/code/packages/csharp/argon2id/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Argon2id]*"

--- a/code/packages/csharp/argon2id/CHANGELOG.md
+++ b/code/packages/csharp/argon2id/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure C# Argon2id implementation following RFC 9106.
+- Support secret keys, associated data, variable tag lengths, multiple lanes, and multiple passes.
+- Add RFC conformance, parameter validation, and hybrid address-transition tests.

--- a/code/packages/csharp/argon2id/CodingAdventures.Argon2id.csproj
+++ b/code/packages/csharp/argon2id/CodingAdventures.Argon2id.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Argon2id.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# Argon2id memory-hard password hashing</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../blake2b/CodingAdventures.Blake2b.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/argon2id/README.md
+++ b/code/packages/csharp/argon2id/README.md
@@ -1,0 +1,47 @@
+# CodingAdventures.Argon2id.CSharp
+
+Pure C# Argon2id password hashing following RFC 9106. The implementation uses
+the existing [`blake2b`](../blake2b) package for the initial and
+variable-length hashes, then implements Argon2's memory matrix, modified
+BLAKE2 round, and hybrid address selection directly.
+
+Argon2id uses data-independent addresses for the first half of its first pass,
+then switches to password-derived addresses. This balances side-channel
+resistance with protection against time-memory trade-off attacks, and RFC 9106
+recommends Argon2id for general password hashing.
+
+```csharp
+using CodingAdventures.Argon2id;
+
+byte[] tag = Argon2id.Derive(
+    "password"u8.ToArray(),
+    "random-salt"u8.ToArray(),
+    timeCost: 3,
+    memoryCost: 65_536,
+    parallelism: 4,
+    tagLength: 32);
+
+string hex = Argon2id.DeriveHex(
+    "password"u8.ToArray(),
+    "random-salt"u8.ToArray(),
+    3,
+    65_536,
+    4,
+    32,
+    new Argon2idOptions
+    {
+        Key = "server-secret"u8.ToArray(),
+        AssociatedData = "account-v1"u8.ToArray(),
+    });
+```
+
+`memoryCost` is measured in 1 KiB blocks and must be at least eight times
+`parallelism`. Only Argon2 version 1.3 (`0x13`) is supported. See
+[`KD03-argon2.md`](../../../specs/KD03-argon2.md) for the shared algorithm
+walk-through.
+
+Run the test and coverage gate with:
+
+```bash
+dotnet test tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Argon2id]*"
+```

--- a/code/packages/csharp/argon2id/required_capabilities.json
+++ b/code/packages/csharp/argon2id/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/argon2id",
+  "capabilities": [],
+  "justification": "Pure in-memory password hashing using package-local BLAKE2b and .NET numeric primitives. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/argon2id/tests/CodingAdventures.Argon2id.Tests/Argon2idTests.cs
+++ b/code/packages/csharp/argon2id/tests/CodingAdventures.Argon2id.Tests/Argon2idTests.cs
@@ -1,0 +1,108 @@
+using System.Text;
+
+namespace CodingAdventures.Argon2id.Tests;
+
+public sealed class Argon2idTests
+{
+    private static readonly byte[] RfcPassword = Enumerable.Repeat((byte)0x01, 32).ToArray();
+    private static readonly byte[] RfcSalt = Enumerable.Repeat((byte)0x02, 16).ToArray();
+
+    [Fact]
+    public void MatchesRfc9106Vector()
+    {
+        var options = new Argon2idOptions
+        {
+            Key = Enumerable.Repeat((byte)0x03, 8).ToArray(),
+            AssociatedData = Enumerable.Repeat((byte)0x04, 12).ToArray(),
+        };
+
+        var tag = Argon2id.Derive(RfcPassword, RfcSalt, 3, 32, 4, 32, options);
+
+        Assert.Equal("0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659", Convert.ToHexString(tag).ToLowerInvariant());
+    }
+
+    [Fact]
+    public void HexMatchesByteForm()
+    {
+        var tag = Argon2id.Derive(RfcPassword, RfcSalt, 3, 32, 4, 32);
+        Assert.Equal(Convert.ToHexString(tag).ToLowerInvariant(), Argon2id.DeriveHex(RfcPassword, RfcSalt, 3, 32, 4, 32));
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(16)]
+    [InlineData(32)]
+    [InlineData(64)]
+    [InlineData(65)]
+    [InlineData(128)]
+    public void SupportsVariableTagLengths(int tagLength)
+    {
+        Assert.Equal(tagLength, Argon2id.Derive("password"u8.ToArray(), "saltsalt"u8.ToArray(), 1, 8, 1, tagLength).Length);
+    }
+
+    [Fact]
+    public void SecretInputsBindTheOutput()
+    {
+        var baseline = DeriveSmall("password", "saltsalt");
+        var withKey = Argon2id.Derive(
+            "password"u8.ToArray(),
+            "saltsalt"u8.ToArray(),
+            1,
+            8,
+            1,
+            32,
+            new Argon2idOptions { Key = "secret!!"u8.ToArray() });
+        var withAssociatedData = Argon2id.Derive(
+            "password"u8.ToArray(),
+            "saltsalt"u8.ToArray(),
+            1,
+            8,
+            1,
+            32,
+            new Argon2idOptions { AssociatedData = "context"u8.ToArray() });
+
+        Assert.NotEqual(baseline, withKey);
+        Assert.NotEqual(baseline, withAssociatedData);
+    }
+
+    [Fact]
+    public void PasswordSaltAndPassCountChangeOutput()
+    {
+        var baseline = DeriveSmall("password", "saltsalt");
+        Assert.NotEqual(baseline, DeriveSmall("password2", "saltsalt"));
+        Assert.NotEqual(baseline, DeriveSmall("password", "saltsal2"));
+        Assert.NotEqual(baseline, Argon2id.Derive("password"u8.ToArray(), "saltsalt"u8.ToArray(), 2, 8, 1, 32));
+    }
+
+    [Fact]
+    public void RepeatsDeterministicallyAcrossHybridAddressBoundary()
+    {
+        var first = Argon2id.Derive("password"u8.ToArray(), "saltsalt"u8.ToArray(), 1, 520, 1, 16);
+        var second = Argon2id.Derive("password"u8.ToArray(), "saltsalt"u8.ToArray(), 1, 520, 1, 16);
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void RejectsNullInputs()
+    {
+        Assert.Throws<ArgumentNullException>(() => Argon2id.Derive(null!, "saltsalt"u8.ToArray(), 1, 8, 1, 32));
+        Assert.Throws<ArgumentNullException>(() => Argon2id.Derive([], null!, 1, 8, 1, 32));
+        Assert.Throws<ArgumentNullException>(() => Argon2id.Derive([], "saltsalt"u8.ToArray(), 1, 8, 1, 32, new Argon2idOptions { Key = null! }));
+        Assert.Throws<ArgumentNullException>(() => Argon2id.Derive([], "saltsalt"u8.ToArray(), 1, 8, 1, 32, new Argon2idOptions { AssociatedData = null! }));
+    }
+
+    [Fact]
+    public void RejectsInvalidParameters()
+    {
+        Assert.Throws<ArgumentException>(() => Argon2id.Derive([], "short"u8.ToArray(), 1, 8, 1, 32));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Argon2id.Derive([], "saltsalt"u8.ToArray(), 1, 8, 1, 3));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Argon2id.Derive([], "saltsalt"u8.ToArray(), 1, 8, 0, 32));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Argon2id.Derive([], "saltsalt"u8.ToArray(), 1, 8, 0x0100_0000, 32));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Argon2id.Derive([], "saltsalt"u8.ToArray(), 1, 7, 1, 32));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Argon2id.Derive([], "saltsalt"u8.ToArray(), 0, 8, 1, 32));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Argon2id.Derive([], "saltsalt"u8.ToArray(), 1, 8, 1, 32, new Argon2idOptions { Version = 0x10 }));
+    }
+
+    private static byte[] DeriveSmall(string password, string salt) =>
+        Argon2id.Derive(Encoding.ASCII.GetBytes(password), Encoding.ASCII.GetBytes(salt), 1, 8, 1, 32);
+}

--- a/code/packages/csharp/argon2id/tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.csproj
+++ b/code/packages/csharp/argon2id/tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Argon2id.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Blake2b]*</Exclude>
+  </PropertyGroup>
+</Project>

--- a/code/packages/fsharp/argon2id/Argon2id.fs
+++ b/code/packages/fsharp/argon2id/Argon2id.fs
@@ -1,0 +1,371 @@
+namespace CodingAdventures.Argon2id.FSharp
+
+open System
+open System.Buffers.Binary
+open System.Numerics
+open CodingAdventures.Blake2b.FSharp
+
+/// Optional Argon2id inputs from RFC 9106.
+type Argon2idOptions =
+    {
+        Key: byte array
+        AssociatedData: byte array
+        Version: uint32
+    }
+
+    static member Default =
+        {
+            Key = [||]
+            AssociatedData = [||]
+            Version = 0x13u
+        }
+
+/// Pure F# Argon2id password hashing as specified by RFC 9106.
+[<RequireQualifiedAccess>]
+module Argon2id =
+    [<Literal>]
+    let Version = 0x13u
+
+    [<Literal>]
+    let private Mask32 = 0xffff_ffffUL
+
+    [<Literal>]
+    let private BlockSize = 1024
+
+    [<Literal>]
+    let private BlockWords = 128
+
+    [<Literal>]
+    let private SyncPoints = 4
+
+    [<Literal>]
+    let private TypeId = 2u
+
+    let private uint32Bytes value =
+        let result = Array.zeroCreate<byte> sizeof<uint32>
+        BinaryPrimitives.WriteUInt32LittleEndian(result.AsSpan(), value)
+        result
+
+    let private concat (parts: byte array array) = Array.concat parts
+
+    let private hash digestSize input =
+        Blake2b.hashWithOptions (Blake2bOptions.Default.WithDigestSize(digestSize)) input
+
+    let private addWithProduct left right =
+        left + right + 2UL * (left &&& Mask32) * (right &&& Mask32)
+
+    let private mix (values: uint64 array) a b c d =
+        let mutable va = values[a]
+        let mutable vb = values[b]
+        let mutable vc = values[c]
+        let mutable vd = values[d]
+
+        va <- addWithProduct va vb
+        vd <- BitOperations.RotateRight(vd ^^^ va, 32)
+        vc <- addWithProduct vc vd
+        vb <- BitOperations.RotateRight(vb ^^^ vc, 24)
+        va <- addWithProduct va vb
+        vd <- BitOperations.RotateRight(vd ^^^ va, 16)
+        vc <- addWithProduct vc vd
+        vb <- BitOperations.RotateRight(vb ^^^ vc, 63)
+
+        values[a] <- va
+        values[b] <- vb
+        values[c] <- vc
+        values[d] <- vd
+
+    let private permute values =
+        mix values 0 4 8 12
+        mix values 1 5 9 13
+        mix values 2 6 10 14
+        mix values 3 7 11 15
+        mix values 0 5 10 15
+        mix values 1 6 11 12
+        mix values 2 7 8 13
+        mix values 3 4 9 14
+
+    let private compress (x: uint64 array) (y: uint64 array) =
+        let result = Array.init BlockWords (fun index -> x[index] ^^^ y[index])
+        let q = Array.copy result
+
+        for rowIndex = 0 to 7 do
+            let row = Array.zeroCreate<uint64> 16
+            Array.Copy(q, rowIndex * 16, row, 0, row.Length)
+            permute row
+            Array.Copy(row, 0, q, rowIndex * 16, row.Length)
+
+        for columnIndex = 0 to 7 do
+            let column = Array.zeroCreate<uint64> 16
+
+            for rowIndex = 0 to 7 do
+                column[2 * rowIndex] <- q[rowIndex * 16 + 2 * columnIndex]
+                column[2 * rowIndex + 1] <- q[rowIndex * 16 + 2 * columnIndex + 1]
+
+            permute column
+
+            for rowIndex = 0 to 7 do
+                q[rowIndex * 16 + 2 * columnIndex] <- column[2 * rowIndex]
+                q[rowIndex * 16 + 2 * columnIndex + 1] <- column[2 * rowIndex + 1]
+
+        for index = 0 to BlockWords - 1 do
+            result[index] <- result[index] ^^^ q[index]
+
+        result
+
+    let private blockToBytes (block: uint64 array) =
+        let result = Array.zeroCreate<byte> BlockSize
+
+        for index = 0 to BlockWords - 1 do
+            BinaryPrimitives.WriteUInt64LittleEndian(
+                result.AsSpan(index * sizeof<uint64>, sizeof<uint64>),
+                block[index]
+            )
+
+        result
+
+    let private bytesToBlock (data: byte array) =
+        if data.Length <> BlockSize then
+            invalidArg "data" $"Block must be {BlockSize} bytes, got {data.Length}."
+
+        Array.init BlockWords (fun index ->
+            BinaryPrimitives.ReadUInt64LittleEndian(data.AsSpan(index * sizeof<uint64>, sizeof<uint64>)))
+
+    let private blake2bLong outputLength input =
+        let prefix = uint32Bytes (uint32 outputLength)
+
+        if outputLength <= 64 then
+            hash outputLength (concat [| prefix; input |])
+        else
+            let rounds = (outputLength + 31) / 32 - 2
+            let mutable value = hash 64 (concat [| prefix; input |])
+            let output = ResizeArray<byte>(outputLength)
+            output.AddRange(value[0..31])
+
+            for _round = 0 to rounds - 2 do
+                value <- hash 64 value
+                output.AddRange(value[0..31])
+
+            value <- hash (outputLength - 32 * rounds) value
+            output.AddRange(value)
+            output.ToArray()
+
+    let private indexAlpha j1 pass slice index sameLane laneLength segmentLength =
+        let mutable start = 0
+
+        let window =
+            if pass = 0 then
+                if slice = 0 then
+                    uint64 (index - 1)
+                elif sameLane then
+                    uint64 (slice * segmentLength + index - 1)
+                else
+                    uint64 (slice * segmentLength - (if index = 0 then 1 else 0))
+            else
+                start <- ((slice + 1) * segmentLength) % laneLength
+
+                if sameLane then
+                    uint64 (laneLength - segmentLength + index - 1)
+                else
+                    uint64 (laneLength - segmentLength - (if index = 0 then 1 else 0))
+
+        let x = (j1 * j1) >>> 32
+        let y = (window * x) >>> 32
+        let relative = window - 1UL - y
+        int ((uint64 start + relative) % uint64 laneLength)
+
+    let private fillSegment
+        (memory: uint64 array array array)
+        pass
+        lane
+        slice
+        laneLength
+        segmentLength
+        parallelism
+        adjustedMemoryCost
+        timeCost
+        =
+        let dataIndependent = pass = 0 && slice < 2
+        let inputBlock = Array.zeroCreate<uint64> BlockWords
+        let mutable addressBlock = Array.zeroCreate<uint64> BlockWords
+        let zeroBlock = Array.zeroCreate<uint64> BlockWords
+        inputBlock[0] <- uint64 pass
+        inputBlock[1] <- uint64 lane
+        inputBlock[2] <- uint64 slice
+        inputBlock[3] <- uint64 adjustedMemoryCost
+        inputBlock[4] <- uint64 timeCost
+        inputBlock[5] <- uint64 TypeId
+
+        let nextAddresses () =
+            inputBlock[6] <- inputBlock[6] + 1UL
+            let intermediate = compress zeroBlock inputBlock
+            addressBlock <- compress zeroBlock intermediate
+
+        let startingColumn = if pass = 0 && slice = 0 then 2 else 0
+
+        if dataIndependent && startingColumn <> 0 then
+            nextAddresses ()
+
+        for index = startingColumn to segmentLength - 1 do
+            if
+                dataIndependent
+                && index % BlockWords = 0
+                && not (pass = 0 && slice = 0 && index = 2)
+            then
+                nextAddresses ()
+
+            let column = slice * segmentLength + index
+            let previousColumn = if column > 0 then column - 1 else laneLength - 1
+            let previousBlock = memory.[lane].[previousColumn]
+
+            let pseudoRandom =
+                if dataIndependent then
+                    addressBlock[index % BlockWords]
+                else
+                    previousBlock[0]
+
+            let j1 = pseudoRandom &&& Mask32
+            let j2 = pseudoRandom >>> 32
+
+            let referenceLane =
+                if pass = 0 && slice = 0 then lane else int (j2 % uint64 parallelism)
+
+            let referenceColumn =
+                indexAlpha
+                    j1
+                    pass
+                    slice
+                    index
+                    (referenceLane = lane)
+                    laneLength
+                    segmentLength
+
+            let newBlock = compress previousBlock memory.[referenceLane].[referenceColumn]
+
+            if pass = 0 then
+                memory.[lane].[column] <- newBlock
+            else
+                for word = 0 to BlockWords - 1 do
+                    memory.[lane].[column].[word] <- memory.[lane].[column].[word] ^^^ newBlock[word]
+
+    let private validate (salt: byte array) timeCost memoryCost parallelism tagLength (version: uint32) =
+        if salt.Length < 8 then
+            invalidArg "salt" $"Salt must be at least 8 bytes, got {salt.Length}."
+
+        if tagLength < 4 then
+            invalidArg "tagLength" $"Tag length must be at least 4 bytes, got {tagLength}."
+
+        if parallelism < 1 || parallelism > 0x00ff_ffff then
+            invalidArg "parallelism" "Parallelism must be in [1, 2^24-1]."
+
+        if memoryCost < 8 * parallelism then
+            invalidArg
+                "memoryCost"
+                $"Memory cost must be at least 8*parallelism ({8 * parallelism}), got {memoryCost}."
+
+        if timeCost < 1 then
+            invalidArg "timeCost" "Time cost must be at least 1."
+
+        if version <> Version then
+            invalidArg "version" $"Only Argon2 v1.3 (0x13) is supported; got 0x{version:x2}."
+
+    let private initialHash
+        (password: byte array)
+        (salt: byte array)
+        timeCost
+        memoryCost
+        parallelism
+        tagLength
+        (options: Argon2idOptions)
+        =
+        concat
+            [|
+                uint32Bytes (uint32 parallelism)
+                uint32Bytes (uint32 tagLength)
+                uint32Bytes (uint32 memoryCost)
+                uint32Bytes (uint32 timeCost)
+                uint32Bytes options.Version
+                uint32Bytes TypeId
+                uint32Bytes (uint32 password.Length)
+                password
+                uint32Bytes (uint32 salt.Length)
+                salt
+                uint32Bytes (uint32 options.Key.Length)
+                options.Key
+                uint32Bytes (uint32 options.AssociatedData.Length)
+                options.AssociatedData
+            |]
+        |> hash 64
+
+    /// Compute an Argon2id tag.
+    let derive
+        (password: byte array)
+        (salt: byte array)
+        timeCost
+        memoryCost
+        parallelism
+        tagLength
+        (options: Argon2idOptions)
+        =
+        if isNull password then nullArg "password"
+        if isNull salt then nullArg "salt"
+        if obj.ReferenceEquals(options, null) then nullArg "options"
+        if isNull options.Key then nullArg "options.Key"
+        if isNull options.AssociatedData then nullArg "options.AssociatedData"
+
+        validate salt timeCost memoryCost parallelism tagLength options.Version
+
+        let segmentLength = memoryCost / (SyncPoints * parallelism)
+        let adjustedMemoryCost = segmentLength * SyncPoints * parallelism
+        let laneLength = adjustedMemoryCost / parallelism
+        let initial = initialHash password salt timeCost memoryCost parallelism tagLength options
+
+        let memory =
+            Array.init parallelism (fun _ ->
+                Array.init laneLength (fun _ -> Array.zeroCreate<uint64> BlockWords))
+
+        for lane = 0 to parallelism - 1 do
+            memory.[lane].[0] <-
+                concat [| initial; uint32Bytes 0u; uint32Bytes (uint32 lane) |]
+                |> blake2bLong BlockSize
+                |> bytesToBlock
+
+            memory.[lane].[1] <-
+                concat [| initial; uint32Bytes 1u; uint32Bytes (uint32 lane) |]
+                |> blake2bLong BlockSize
+                |> bytesToBlock
+
+        for pass = 0 to timeCost - 1 do
+            for slice = 0 to SyncPoints - 1 do
+                for lane = 0 to parallelism - 1 do
+                    fillSegment
+                        memory
+                        pass
+                        lane
+                        slice
+                        laneLength
+                        segmentLength
+                        parallelism
+                        adjustedMemoryCost
+                        timeCost
+
+        let finalBlock = Array.copy memory.[0].[laneLength - 1]
+
+        for lane = 1 to parallelism - 1 do
+            for word = 0 to BlockWords - 1 do
+                finalBlock[word] <- finalBlock[word] ^^^ memory.[lane].[laneLength - 1].[word]
+
+        finalBlock |> blockToBytes |> blake2bLong tagLength
+
+    /// Compute an Argon2id tag with empty key and associated data.
+    let deriveDefault password salt timeCost memoryCost parallelism tagLength =
+        derive password salt timeCost memoryCost parallelism tagLength Argon2idOptions.Default
+
+    /// Compute an Argon2id tag and return lowercase hexadecimal.
+    let deriveHex password salt timeCost memoryCost parallelism tagLength options =
+        derive password salt timeCost memoryCost parallelism tagLength options
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    /// Compute a default-option Argon2id tag and return lowercase hexadecimal.
+    let deriveHexDefault password salt timeCost memoryCost parallelism tagLength =
+        deriveHex password salt timeCost memoryCost parallelism tagLength Argon2idOptions.Default

--- a/code/packages/fsharp/argon2id/BUILD
+++ b/code/packages/fsharp/argon2id/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Argon2id.FSharp]*"

--- a/code/packages/fsharp/argon2id/BUILD_windows
+++ b/code/packages/fsharp/argon2id/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Argon2id.FSharp]*"

--- a/code/packages/fsharp/argon2id/CHANGELOG.md
+++ b/code/packages/fsharp/argon2id/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure F# Argon2id implementation following RFC 9106.
+- Support secret keys, associated data, variable tag lengths, multiple lanes, and multiple passes.
+- Add RFC conformance, parameter validation, and hybrid address-transition tests.

--- a/code/packages/fsharp/argon2id/CodingAdventures.Argon2id.fsproj
+++ b/code/packages/fsharp/argon2id/CodingAdventures.Argon2id.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.Argon2id.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Argon2id.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# Argon2id memory-hard password hashing</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../blake2b/CodingAdventures.Blake2b.fsproj" />
+    <Compile Include="Argon2id.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/argon2id/README.md
+++ b/code/packages/fsharp/argon2id/README.md
@@ -1,0 +1,47 @@
+# CodingAdventures.Argon2id.FSharp
+
+Pure F# Argon2id password hashing following RFC 9106. The implementation uses
+the existing [`blake2b`](../blake2b) package for the initial and
+variable-length hashes, then implements Argon2's memory matrix, modified
+BLAKE2 round, and hybrid address selection directly.
+
+Argon2id uses data-independent addresses for the first half of its first pass,
+then switches to password-derived addresses. This balances side-channel
+resistance with protection against time-memory trade-off attacks, and RFC 9106
+recommends Argon2id for general password hashing.
+
+```fsharp
+open CodingAdventures.Argon2id.FSharp
+
+let tag =
+    Argon2id.deriveDefault
+        "password"B
+        "random-salt"B
+        3
+        65_536
+        4
+        32
+
+let hex =
+    Argon2id.deriveHex
+        "password"B
+        "random-salt"B
+        3
+        65_536
+        4
+        32
+        { Argon2idOptions.Default with
+            Key = "server-secret"B
+            AssociatedData = "account-v1"B }
+```
+
+`memoryCost` is measured in 1 KiB blocks and must be at least eight times
+`parallelism`. Only Argon2 version 1.3 (`0x13`) is supported. See
+[`KD03-argon2.md`](../../../specs/KD03-argon2.md) for the shared algorithm
+walk-through.
+
+Run the test and coverage gate with:
+
+```bash
+dotnet test tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Argon2id.FSharp]*"
+```

--- a/code/packages/fsharp/argon2id/required_capabilities.json
+++ b/code/packages/fsharp/argon2id/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/argon2id",
+  "capabilities": [],
+  "justification": "Pure in-memory password hashing using package-local BLAKE2b and .NET numeric primitives. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/argon2id/tests/CodingAdventures.Argon2id.Tests/Argon2idTests.fs
+++ b/code/packages/fsharp/argon2id/tests/CodingAdventures.Argon2id.Tests/Argon2idTests.fs
@@ -1,0 +1,119 @@
+namespace CodingAdventures.Argon2id.Tests
+
+open System
+open System.Text
+open Xunit
+open CodingAdventures.Argon2id.FSharp
+
+module Argon2idTests =
+    let private rfcPassword = Array.create 32 0x01uy
+    let private rfcSalt = Array.create 16 0x02uy
+
+    [<Fact>]
+    let ``matches RFC 9106 vector`` () =
+        let options =
+            {
+                Argon2idOptions.Default with
+                    Key = Array.create 8 0x03uy
+                    AssociatedData = Array.create 12 0x04uy
+            }
+
+        let tag = Argon2id.derive rfcPassword rfcSalt 3 32 4 32 options
+
+        Assert.Equal(
+            "0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659",
+            Convert.ToHexString(tag).ToLowerInvariant()
+        )
+
+    [<Fact>]
+    let ``hex matches byte form`` () =
+        let tag = Argon2id.deriveDefault rfcPassword rfcSalt 3 32 4 32
+        let expected = Convert.ToHexString(tag).ToLowerInvariant()
+        Assert.Equal(expected, Argon2id.deriveHexDefault rfcPassword rfcSalt 3 32 4 32)
+
+    [<Theory>]
+    [<InlineData(4)>]
+    [<InlineData(16)>]
+    [<InlineData(32)>]
+    [<InlineData(64)>]
+    [<InlineData(65)>]
+    [<InlineData(128)>]
+    let ``supports variable tag lengths`` tagLength =
+        let tag = Argon2id.deriveDefault "password"B "saltsalt"B 1 8 1 tagLength
+        Assert.Equal(tagLength, tag.Length)
+
+    [<Fact>]
+    let ``secret inputs bind the output`` () =
+        let baseline = Argon2id.deriveDefault "password"B "saltsalt"B 1 8 1 32
+
+        let withKey =
+            Argon2id.derive
+                "password"B
+                "saltsalt"B
+                1
+                8
+                1
+                32
+                { Argon2idOptions.Default with Key = "secret!!"B }
+
+        let withAssociatedData =
+            Argon2id.derive
+                "password"B
+                "saltsalt"B
+                1
+                8
+                1
+                32
+                { Argon2idOptions.Default with AssociatedData = "context"B }
+
+        Assert.NotEqual<byte array>(baseline, withKey)
+        Assert.NotEqual<byte array>(baseline, withAssociatedData)
+
+    [<Fact>]
+    let ``password salt and pass count change output`` () =
+        let baseline = Argon2id.deriveDefault "password"B "saltsalt"B 1 8 1 32
+        Assert.NotEqual<byte array>(baseline, Argon2id.deriveDefault "password2"B "saltsalt"B 1 8 1 32)
+        Assert.NotEqual<byte array>(baseline, Argon2id.deriveDefault "password"B "saltsal2"B 1 8 1 32)
+        Assert.NotEqual<byte array>(baseline, Argon2id.deriveDefault "password"B "saltsalt"B 2 8 1 32)
+
+    [<Fact>]
+    let ``repeats deterministically across hybrid address boundary`` () =
+        let first = Argon2id.deriveDefault "password"B "saltsalt"B 1 520 1 16
+        let second = Argon2id.deriveDefault "password"B "saltsalt"B 1 520 1 16
+        Assert.Equal<byte array>(first, second)
+
+    [<Fact>]
+    let ``rejects null inputs`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Argon2id.deriveDefault null "saltsalt"B 1 8 1 32 |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () -> Argon2id.deriveDefault [||] null 1 8 1 32 |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () -> Argon2id.derive [||] "saltsalt"B 1 8 1 32 Unchecked.defaultof<_> |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () ->
+            Argon2id.derive [||] "saltsalt"B 1 8 1 32 { Argon2idOptions.Default with Key = null }
+            |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () ->
+            Argon2id.derive [||] "saltsalt"B 1 8 1 32 { Argon2idOptions.Default with AssociatedData = null }
+            |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``rejects invalid parameters`` () =
+        let rejects action = Assert.Throws<ArgumentException>(Action action) |> ignore
+
+        rejects (fun () -> Argon2id.deriveDefault [||] "short"B 1 8 1 32 |> ignore)
+        rejects (fun () -> Argon2id.deriveDefault [||] "saltsalt"B 1 8 1 3 |> ignore)
+        rejects (fun () -> Argon2id.deriveDefault [||] "saltsalt"B 1 8 0 32 |> ignore)
+        rejects (fun () -> Argon2id.deriveDefault [||] "saltsalt"B 1 8 0x0100_0000 32 |> ignore)
+        rejects (fun () -> Argon2id.deriveDefault [||] "saltsalt"B 1 7 1 32 |> ignore)
+        rejects (fun () -> Argon2id.deriveDefault [||] "saltsalt"B 0 8 1 32 |> ignore)
+
+        rejects (fun () ->
+            Argon2id.derive [||] "saltsalt"B 1 8 1 32 { Argon2idOptions.Default with Version = 0x10u }
+            |> ignore)

--- a/code/packages/fsharp/argon2id/tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.fsproj
+++ b/code/packages/fsharp/argon2id/tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Argon2id.fsproj" />
+    <Compile Include="Argon2idTests.fs" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <Exclude>[CodingAdventures.Blake2b]*</Exclude>
+  </PropertyGroup>
+</Project>

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -111,11 +111,12 @@ on July 18, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
 and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
-`x25519`, `brainfuck-wasm-compiler`, `argon2i`, and `argon2d` ports:
+`x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
+ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 333 |
+| Present in 10-15 languages | 172 | 331 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 699 | 9,786 |
@@ -161,7 +162,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 333
+The 172 packages present in at least ten implementation languages need 331
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -170,8 +171,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 12 | Move with F# |
-| F# | 12 | Move with C# |
+| C# | 11 | Move with F# |
+| F# | 11 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -265,6 +266,14 @@ existing BLAKE2b packages. RFC vectors cover secret keys, associated data,
 multiple lanes and passes, variable tag lengths, and deterministic memory-cost
 rounding. The package now spans 12 target implementation lanes and reduces
 each paired high-consensus gap to 12.
+
+The sixth paired C#/F# slice is complete: `argon2id` now implements RFC 9106's
+recommended hybrid password hash in both lanes, using data-independent
+addresses for the first half of pass zero and data-dependent addresses
+thereafter. Canonical vectors cover the address-mode transition, secret keys,
+associated data, multiple lanes and passes, and variable tag lengths. The
+package now spans 12 target implementation lanes and reduces each paired
+high-consensus gap to 11.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add pure C# and F# Argon2id implementations backed by the existing BLAKE2b packages
- implement RFC 9106 hybrid addressing: data-independent for the first half of pass zero, then data-dependent
- cover the canonical Argon2id vector, optional key/associated data, variable tag lengths, multiple lanes/passes, validation, and the hybrid transition
- update the package-parity roadmap to 331 remaining high-consensus slots and 11 C#/F# gaps

## Validation
- `dotnet test code/packages/csharp/argon2id/tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line /p:Include=[CodingAdventures.Argon2id]*` (13 passed; 99.34% line coverage)
- `dotnet test code/packages/fsharp/argon2id/tests/CodingAdventures.Argon2id.Tests/CodingAdventures.Argon2id.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line /p:Include=[CodingAdventures.Argon2id.FSharp]*` (13 passed; 99.53% line coverage)
- `python code/scripts/tests/test_package_parity_report.py` (6 passed)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions; C# 11 gaps; F# 11 gaps)
- `dotnet format code/packages/csharp/argon2id/CodingAdventures.Argon2id.csproj --no-restore --verify-no-changes`
- `git diff origin/main...HEAD --check`