### PR TITLE
feat(sql): column-defined COLLATE flows into the IN operator

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.44 — column COLLATE honored in the IN operator
+
+A column declared `COLLATE NOCASE` / `RTRIM` now folds case (etc.) in `IN`
+membership, not just `=`/`<`/… comparisons: `SELECT id FROM t WHERE name IN
+('APPLE')` on a NOCASE `name` matches both `'Apple'` and `'apple'`. `NOT IN`
+inverts it, multi-element lists fold every element, and an explicit `COLLATE
+BINARY` on the value overrides the column's NOCASE. NULL semantics are
+unchanged. Four new differential-oracle cases; sql-planner 0.2.22 (single base
+table, matching the existing WHERE-comparison restriction). `DISTINCT` and
+`GROUP BY` collation remain follow-ups.
+
 ## 0.5.43 — unary minus coerces text/blob operands
 
 `-'5'` now returns `-5`, not the string `'5'`. SQLite applies numeric affinity to

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.43"
+version = "0.5.44"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1129,6 +1129,40 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id FROM t WHERE name = 'apple' OR name = 'banana' ORDER BY id",
     },
+    // The column's collation also drives the `IN` operator: SQLite takes IN's
+    // collating sequence from the left operand, so `name IN ('APPLE')` on a
+    // NOCASE column matches both 'Apple' and 'apple'. `NOT IN` inverts it, and
+    // an explicit `COLLATE BINARY` on the value overrides the column's NOCASE.
+    Case {
+        id: "where_column_collate_nocase_in",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'BANANA'),(4,'banana')",
+        ],
+        query: "SELECT id FROM t WHERE name IN ('APPLE') ORDER BY id",
+    },
+    Case {
+        id: "where_column_collate_nocase_not_in",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'BANANA'),(4,'banana')",
+        ],
+        query: "SELECT id FROM t WHERE name NOT IN ('APPLE') ORDER BY id",
+    },
+    Case {
+        id: "where_column_collate_nocase_in_multi",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES (1,'Apple'),(2,'apple'),(3,'BANANA'),(4,'banana')",
+        ],
+        query: "SELECT id FROM t WHERE name IN ('apple','banana') ORDER BY id",
+    },
+    // (An explicit `COLLATE BINARY` on the IN *value* — `name COLLATE BINARY IN
+    // (…)` — would override the column NOCASE, but the grammar does not yet
+    // accept `COLLATE` before `IN`/`LIKE`/`BETWEEN` (only before a comparison
+    // operator), so that override is a separate grammar follow-up, not covered
+    // here. The `is_collate_call` guard in `collate_comparisons` already handles
+    // it once the syntax parses.)
     // A column WITHOUT a declared collation keeps BINARY comparison — only the
     // exact-case match qualifies. Guards against over-applying the fold.
     Case {

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.22] - Unreleased
+
+### Added
+
+- **Column-defined `COLLATE` now flows into the `IN` operator.** The
+  `collate_comparisons` post-pass gained an `SqlExpr::InList` arm: SQLite takes
+  IN's collating sequence from the left operand, so when `value` is a base-table
+  column with a declared collation (and not already `__collate`-wrapped by an
+  explicit `COLLATE`), the value and every list element are wrapped in
+  `__collate(_, coll)`. `name IN ('APPLE')` on a NOCASE column now matches
+  `'Apple'`/`'apple'`; `NOT IN` inverts it; an explicit `COLLATE BINARY` on the
+  value overrides the column's NOCASE. `__collate` passes NULL/non-text through
+  unchanged, so IN's NULL semantics are preserved. Extends the WHERE-comparison
+  collation from 0.2.20. `DISTINCT`/`GROUP BY` collation remain follow-ups.
+
 ## [0.2.21] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1269,6 +1269,37 @@ fn collate_comparisons(expr: SqlExpr, ctx: &OrderCollateCtx) -> SqlExpr {
             op: UnaryOp::Not,
             expr: Box::new(collate_comparisons(*expr, ctx)),
         },
+        // `value IN (list…)` — SQLite takes the operator's collating sequence
+        // from the LEFT operand (`value`), exactly as for a binary comparison.
+        // When `value` is a base-table column with a declared collation and it
+        // is not already `__collate`-wrapped (an explicit COLLATE outranks), we
+        // wrap the value AND every list element in `__collate(_, coll)`. The VM
+        // then canonicalises each side before the membership test, so
+        // `name IN ('APPLE')` on a NOCASE column matches `'Apple'`/`'apple'`.
+        // `__collate` passes NULL/non-text through unchanged, so IN's NULL and
+        // numeric semantics are preserved. `NOT IN` inherits this via `negated`.
+        SqlExpr::InList {
+            value,
+            list,
+            negated,
+        } => {
+            if is_collate_call(&value) {
+                return SqlExpr::InList { value, list, negated };
+            }
+            let determining = if column_in_base_table(&value, ctx) {
+                resolve_column_collation(&value, ctx)
+            } else {
+                None
+            };
+            match determining {
+                Some(name) => SqlExpr::InList {
+                    value: Box::new(wrap_collate(*value, &name)),
+                    list: list.into_iter().map(|e| wrap_collate(e, &name)).collect(),
+                    negated,
+                },
+                None => SqlExpr::InList { value, list, negated },
+            }
+        }
         other => other,
     }
 }


### PR DESCRIPTION
feat(sql): column-defined COLLATE flows into the IN operator

`SELECT id FROM t WHERE name IN ('APPLE')` on a `name TEXT COLLATE NOCASE`
column now matches both 'Apple' and 'apple', matching SQLite. Previously the
column's declared collation applied only to `=`/`<`/… comparisons (0.2.20), not
to IN, so IN compared with BINARY and the query returned nothing.

Planner-only change: `collate_comparisons` gains an `SqlExpr::InList` arm.
SQLite takes IN's collating sequence from the left operand, so when `value` is a
base-table column with a declared collation (and not already `__collate`-wrapped
by an explicit COLLATE), the value AND every list element are wrapped in
`__collate(_, coll)`. The VM canonicalises each side before the membership test.
`NOT IN` inherits it via `negated`; `__collate` passes NULL/non-text through
unchanged, so IN's NULL/numeric semantics are preserved.

- sql-planner 0.2.22, mini-sqlite 0.5.44.
- Three new differential-oracle cases (IN, NOT IN, multi-element list) match
  real sqlite3 3.51.0.
- Full suites green (sql-planner 75, mini-sqlite 45 + oracle). Inline security
  review clean (no panic/recursion/DoS; NOT IN + NULL semantics intact;
  over-application double-guarded).

Follow-ups (chipped, not here): explicit `COLLATE` before IN/LIKE/BETWEEN is a
grammar gap (`name COLLATE BINARY IN (…)` doesn't parse yet); DISTINCT/GROUP BY
collation; the `is_collate_call` guard already handles the override once the
syntax parses.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
