### PR TITLE
feat(gc-core-capi): export twig-compat __twig_gc_* ABI aliases (#118b-2a)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this crate are documented here.
 
+## [0.5.0] — 2026-07-17
+
+### Added
+
+- **`__twig_gc_*` ABI aliases** (new module `twig_compat`) — `__twig_gc_alloc`,
+  `__twig_gc_collect`, `__twig_gc_safepoint`, `__twig_gc_live_bytes`,
+  `__twig_gc_collection_count`, thin `#[no_mangle]` wrappers forwarding to the
+  generic `__gc_*` ABI. The native-AOT code generators (aarch64 + LLVM backends)
+  and `dynval_runtime.c` reference the symbol names `twig_gc.c` exported; these
+  aliases let `libgc_core_capi.a` satisfy those references so `twig_gc.c` can be
+  retired without touching the emitters. Prototypes match `twig_gc.c` exactly,
+  including the `void`-returning `__twig_gc_collect` / `__twig_gc_safepoint` (the
+  generic entry points' freed-count is discarded). Verified exported as text
+  symbols in the built staticlib; host test drives the full flow. Pure Rust, no C
+  shim; deletable once the emitters emit `__gc_*` directly.
+
 ## [0.4.0] — 2026-07-17
 
 ### Added

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/README.md
+++ b/code/packages/rust/gc-core-capi/README.md
@@ -78,12 +78,17 @@ hands `[sp, base)` to `__gc_collect_region`. Supported targets are exactly the
 native-AOT ones: aarch64 (macOS) and x86_64 (Linux, Windows); anything else is a
 hard `compile_error!` rather than a silent unsound fallback.
 
+The archive also exports **twig-compat aliases** — `__twig_gc_alloc` /
+`__twig_gc_collect` / `__twig_gc_safepoint` / `__twig_gc_live_bytes` /
+`__twig_gc_collection_count` (module `twig_compat`) — thin wrappers over the
+`__gc_*` ABI. The AOT code generators and `dynval_runtime.c` reference the names
+`twig_gc.c` exported; these aliases let this archive satisfy them so `twig_gc.c`
+can be retired without changing the emitters.
+
 Still to come (own PRs):
 
-- Wire `twig-aot`'s `build.rs` to link this archive, export the twig-compat
-  aliases (`__twig_gc_alloc` / `collect` / `safepoint` / `live_bytes` /
-  `collection_count`) the emitted code already calls, and retire `twig_gc.c`
-  (golden / `*_smoke.rs` parity).
+- Wire `twig-aot`'s `build.rs` to link this archive instead of compiling
+  `twig_gc.c`, and retire `twig_gc.c` (golden / `*_smoke.rs` parity).
 - **Precise** roots (stack maps) and interior tracing (`HeapKind` field maps),
   then moving / generational — all as `gc-core` algorithms.
 

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -80,6 +80,17 @@ int64_t __gc_collection_count(void);
 /* Drop the whole heap (frees everything) and reset counters. */
 void __gc_reset(void);
 
+/* ── twig-compat aliases ────────────────────────────────────────────────────
+ * The native-AOT code generators and dynval_runtime.c reference the symbol
+ * names the retired twig_gc.c exported. These forward to the __gc_* ABI above
+ * (prototypes match twig_gc.c exactly, including the void-returning collect /
+ * safepoint). Deletable once the emitters emit the __gc_* names directly. */
+int64_t __twig_gc_alloc(int64_t n);
+void    __twig_gc_collect(void);
+void    __twig_gc_safepoint(void);
+int64_t __twig_gc_live_bytes(void);
+int64_t __twig_gc_collection_count(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -46,6 +46,11 @@ use std::sync::Mutex;
 /// `twig_gc.c`'s `__twig_gc_collect`). See [`stack_scan`].
 mod stack_scan;
 
+/// `__twig_gc_*` ABI aliases so the AOT-emitted code and `dynval_runtime.c`,
+/// which reference the names `twig_gc.c` used, link against this collector.
+/// See [`twig_compat`].
+mod twig_compat;
+
 /// The one process-wide heap.  `None` until the first allocation (lazy init);
 /// `__gc_reset` puts it back to `None`, running `FlatHeap`'s `Drop` to free
 /// every outstanding block.

--- a/code/packages/rust/gc-core-capi/src/twig_compat.rs
+++ b/code/packages/rust/gc-core-capi/src/twig_compat.rs
@@ -1,0 +1,112 @@
+//! # Twig-compat ABI aliases (`__twig_gc_*`)
+//!
+//! The native-AOT toolchain was built against `twig-aot/runtime/twig_gc.c`, whose
+//! collector exported the symbols `__twig_gc_alloc`, `__twig_gc_collect`,
+//! `__twig_gc_safepoint`, `__twig_gc_live_bytes`, and `__twig_gc_collection_count`.
+//! Those names are **baked into the code generators**: the aarch64 backend emits
+//! calls to `__twig_gc_alloc` and `__twig_gc_safepoint`, the LLVM backend
+//! references them too, and the C runtime `dynval_runtime.c` calls
+//! `__twig_gc_alloc` directly.
+//!
+//! When `twig_gc.c` is retired and this crate's `libgc_core_capi.a` provides the
+//! collector instead, those references must still resolve — otherwise every AOT
+//! link fails with undefined symbols. This module re-exports the generic `__gc_*`
+//! ABI under the `__twig_gc_*` names the emitted code expects. Each alias is a
+//! thin `#[no_mangle]` wrapper that forwards to the real entry point — pure Rust,
+//! no C shim, so the collector stays one generic implementation.
+//!
+//! ## Signature fidelity
+//!
+//! The aliases match `twig_gc.c`'s prototypes exactly, including the two that
+//! return `void` there — `__twig_gc_collect` / `__twig_gc_safepoint`. The generic
+//! `__gc_collect` / `__gc_safepoint` return the freed-object count (`i64`); the
+//! void aliases simply discard it, so a caller that declared the twig prototype
+//! (`void (*)(void)`) links and calls correctly.
+//!
+//! Once the code generators are migrated to emit the `__gc_*` names directly,
+//! this shim can be deleted.
+
+use crate::stack_scan::{__gc_collect, __gc_safepoint};
+use crate::{__gc_alloc, __gc_collection_count, __gc_live_bytes};
+
+/// `__twig_gc_alloc(n)` → [`__gc_alloc`]. Called by the emitted code and by
+/// `dynval_runtime.c` for every heap allocation.
+#[no_mangle]
+pub extern "C" fn __twig_gc_alloc(n: i64) -> i64 {
+    __gc_alloc(n)
+}
+
+/// `__twig_gc_collect()` → [`__gc_collect`] (return value discarded to match the
+/// original `void` prototype). A full conservative stack-scan collection.
+///
+/// # Safety
+///
+/// Same contract as [`__gc_collect`]: the calling thread must own its stack.
+/// `#[inline(never)]` keeps this a real frame below the mutator so the scan
+/// covers the caller.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __twig_gc_collect() {
+    let _ = __gc_collect();
+}
+
+/// `__twig_gc_safepoint()` → [`__gc_safepoint`] (return value discarded to match
+/// the original `void` prototype). A throttled collect: runs only past the
+/// adaptive threshold.
+///
+/// # Safety
+///
+/// Same contract as [`__gc_safepoint`]: the calling thread must own its stack.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __twig_gc_safepoint() {
+    let _ = __gc_safepoint();
+}
+
+/// `__twig_gc_live_bytes()` → [`__gc_live_bytes`].
+#[no_mangle]
+pub extern "C" fn __twig_gc_live_bytes() -> i64 {
+    __gc_live_bytes()
+}
+
+/// `__twig_gc_collection_count()` → [`__gc_collection_count`].
+#[no_mangle]
+pub extern "C" fn __twig_gc_collection_count() -> i64 {
+    __gc_collection_count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::__gc_reset;
+
+    /// The twig-named aliases drive the same underlying collector as the `__gc_*`
+    /// ABI: alloc through `__twig_gc_alloc`, observe it via both accessors,
+    /// collect through the throttled + full entry points.
+    #[test]
+    fn twig_aliases_forward_to_gc_core() {
+        // Serialise against the other HEAP-touching tests (shared process-wide heap).
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+
+        // Allocate through the twig alias; it must return a real, writable pointer
+        // and be reflected in both twig-named accessors.
+        let p = __twig_gc_alloc(16);
+        assert!(p != 0);
+        unsafe { *(p as *mut i64) = 0x7161 };
+        assert_eq!(__twig_gc_live_bytes(), 16);
+        assert_eq!(__twig_gc_collection_count(), 0);
+
+        // Below the 1 MiB threshold, the safepoint is a no-op (throttled).
+        unsafe { __twig_gc_safepoint() };
+        assert_eq!(__twig_gc_collection_count(), 0);
+
+        // A full collect runs a cycle; `p` is stack-rooted so it survives.
+        unsafe { __twig_gc_collect() };
+        assert_eq!(__twig_gc_collection_count(), 1);
+        assert_eq!(unsafe { *(p as *const i64) }, 0x7161);
+        core::hint::black_box(p);
+
+        __gc_reset();
+    }
+}


### PR DESCRIPTION
## What

Adds a `twig_compat` module to `gc-core-capi` exporting **`__twig_gc_alloc`, `__twig_gc_collect`, `__twig_gc_safepoint`, `__twig_gc_live_bytes`, `__twig_gc_collection_count`** — thin `#[no_mangle]` wrappers forwarding to the generic `__gc_*` ABI.

## Why

The native-AOT code generators (aarch64 + LLVM backends) and the C runtime `dynval_runtime.c` reference the symbol names the soon-to-be-retired `twig_gc.c` exported. For `twig_gc.c` to be dropped and `libgc_core_capi.a` to provide the collector instead, those references must still resolve — otherwise every AOT link fails with undefined symbols. These aliases satisfy them **without touching the emitters**.

This is the first, self-contained half of #118b — it changes **only** `gc-core-capi` (no `twig-aot` change yet), so it lands and is verified on its own. **#118b-2b** then wires `twig-aot`'s `build.rs` to link this archive instead of compiling `twig_gc.c`, and retires `twig_gc.c` (golden / `*_smoke.rs` parity).

## Fidelity

Prototypes match `twig_gc.c` exactly, including the **void-returning** `__twig_gc_collect` / `__twig_gc_safepoint` (the generic entry points' `i64` freed-count is discarded — a plain `Copy` drop, no-op). The `unsafe` qualifier is propagated so callers acknowledge the same "thread owns its stack" contract.

## Verification

- All 5 symbols export as **text (`T`) symbols** in the built `libgc_core_capi.a` (`nm`).
- Host test drives alloc → observe → throttled-safepoint (no-op below threshold) → full-collect through the twig-named entry points; the stack-rooted object survives. Passes on aarch64 + x86_64 SysV (Rosetta). 6 gc-core-capi tests green; clippy clean.

## Security review — PASSED

Wrappers preserve signatures and safety contracts; discarding the `i64` return in a `-> ()` fn is sound (no `Drop`); the extra caller frame only adds stack-scan coverage, never shrinks it (`__gc_collect` is `#[inline(never)]` and captures its own SP).

## Details

- gc-core-capi 0.4.0 → 0.5.0. Pure Rust, no C shim; deletable once the emitters emit `__gc_*` directly. CHANGELOG, README, `gc_core.h` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)