### PR TITLE
feat(sql): LENGTH() accepts blobs and numbers

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.45 — LENGTH() over blobs and numbers
+
+`LENGTH(x'0102ff')` now returns 3 (the byte count) instead of erroring, and
+`LENGTH(12345)` returns 5 (decimal-text length). LENGTH previously accepted only
+text/NULL; now a blob measures its raw bytes (distinct from text's *character*
+count) and a number its text-form length, matching SQLite. Blob literals (0.5.42)
+made the blob case reachable from SQL. Two new differential-oracle cases; sql-vm
+0.4.23. Floats remain declined (subtle text form).
+
 ## 0.5.44 — column COLLATE honored in the IN operator
 
 A column declared `COLLATE NOCASE` / `RTRIM` now folds case (etc.) in `IN`

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.44"
+version = "0.5.45"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -664,6 +664,25 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT OCTET_LENGTH(s) AS o, LENGTH(s) AS l FROM t ORDER BY id",
     },
+    // LENGTH counts BYTES for a blob but CHARACTERS for text, and measures a
+    // number by its decimal-text length. `length(x'0102ff')` = 3, `length(x'')`
+    // = 0, `length(12345)` = 5, `length('héllo')` = 5. Previously LENGTH errored
+    // on anything but text/NULL; blob literals (0.5.42) made the blob case
+    // reachable from SQL.
+    Case {
+        id: "length_blob_int_text",
+        setup: &[],
+        query: "SELECT LENGTH(x'0102ff') AS a, LENGTH(x'') AS b, LENGTH(12345) AS c, LENGTH(-7) AS d, LENGTH('héllo') AS e",
+    },
+    // LENGTH over a blob column (byte count), including the empty blob.
+    Case {
+        id: "length_blob_column",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, b BLOB)",
+            "INSERT INTO t VALUES (1, x'DEADBEEF'), (2, x''), (3, NULL)",
+        ],
+        query: "SELECT LENGTH(b) AS l FROM t ORDER BY id",
+    },
     // LIKELY / UNLIKELY / LIKELIHOOD are planner hints — semantically the
     // identity function on their first argument.
     Case {

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.23] - Unreleased
+
+### Fixed
+
+- **`LENGTH()` now accepts blobs and numbers.** It previously errored on
+  anything but text/NULL; `LENGTH` now measures a blob by its raw byte count
+  (`length(x'0102ff')` = 3, `length(x'')` = 0 — distinct from text's character
+  count) and a number by its decimal-text length (`length(12345)` = 5,
+  `length(-7)` = 2), matching SQLite. Blob literals (0.5.42 / this engine's
+  front end) made the blob case reachable from SQL. Floats stay declined (their
+  text form is subtle — same stance as `OCTET_LENGTH`/`HEX`/`QUOTE`).
+
 ## [0.4.22] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1196,13 +1196,24 @@ fn trim_builtin(name: &str, args: &[SqlValue], left: bool, right: bool) -> Resul
 fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
     match name {
         "LENGTH" => {
+            // LENGTH(X) counts *characters* for text and *bytes* for a blob,
+            // matching SQLite: `length('héllo')` = 5 (5 chars, though 6 bytes)
+            // but `length(x'0102ff')` = 3 (raw bytes, NOT text-converted). A
+            // number is measured as the character count of its decimal-text form
+            // (`length(12345)` = 5, `length(-7)` = 2). NULL → NULL. Floats are
+            // declined — their SQLite text form (`3.0` vs Rust's `3`, exponent
+            // notation, …) is subtle enough that we don't guess here (same stance
+            // as OCTET_LENGTH / HEX / QUOTE).
             if args.len() != 1 {
                 return Err(VmError::TypeMismatch(format!("LENGTH expects 1 arg, got {}", args.len())));
             }
             match &args[0] {
                 SqlValue::Null => Ok(SqlValue::Null),
                 SqlValue::Text(s) => Ok(SqlValue::Int(s.chars().count() as i64)),
-                other => Err(VmError::TypeMismatch(format!("LENGTH expects TEXT, got {:?}", other))),
+                SqlValue::Blob(b) => Ok(SqlValue::Int(b.len() as i64)),
+                SqlValue::Int(i) => Ok(SqlValue::Int(i.to_string().chars().count() as i64)),
+                SqlValue::Bool(b) => Ok(SqlValue::Int((*b as i64).to_string().chars().count() as i64)),
+                other => Err(VmError::TypeMismatch(format!("LENGTH expects TEXT/BLOB/INTEGER, got {:?}", other))),
             }
         }
 
@@ -5258,6 +5269,23 @@ mod tests {
         assert!(call_builtin("LIKELIHOOD", vec![SqlValue::Int(1), SqlValue::Float(1.5)]).is_err());
         assert!(call_builtin("LIKELIHOOD", vec![SqlValue::Int(1), SqlValue::Text("x".into())]).is_err());
         assert!(call_builtin("LIKELIHOOD", vec![SqlValue::Int(1)]).is_err());
+    }
+
+    #[test]
+    fn builtin_length_blob_and_number() {
+        let len = |v: SqlValue| call_builtin("LENGTH", vec![v]).unwrap();
+        // Text → character count; a blob → raw byte count (contrast the text
+        // char count); a number → its decimal-text length. NULL propagates.
+        assert_eq!(len(SqlValue::Text("héllo".into())), SqlValue::Int(5)); // 5 chars
+        assert_eq!(len(SqlValue::Blob(vec![0x01, 0x02, 0xff])), SqlValue::Int(3));
+        assert_eq!(len(SqlValue::Blob(vec![])), SqlValue::Int(0));
+        assert_eq!(len(SqlValue::Int(12345)), SqlValue::Int(5));
+        assert_eq!(len(SqlValue::Int(-7)), SqlValue::Int(2));
+        assert_eq!(len(SqlValue::Bool(true)), SqlValue::Int(1));
+        assert_eq!(len(SqlValue::Null), SqlValue::Null);
+        // Floats are declined (text-form length is subtle); wrong arity errors.
+        assert!(call_builtin("LENGTH", vec![SqlValue::Float(3.14)]).is_err());
+        assert!(call_builtin("LENGTH", vec![]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
feat(sql): LENGTH() accepts blobs and numbers

`LENGTH(x'0102ff')` now returns 3 (byte count) instead of erroring, and
`LENGTH(12345)` returns 5. The `LENGTH` builtin previously accepted only
text/NULL and errored on everything else; now it measures a blob by its raw byte
count (distinct from text's *character* count) and a number by its decimal-text
length, matching SQLite. Blob literals (0.5.42) made the blob case reachable
from SQL.

- sql-vm 0.4.23: LENGTH handles Blob (bytes), Int/Bool (text-form chars); Float
  stays declined (its exact SQLite text form is subtle — same stance as the
  sibling OCTET_LENGTH). Mirrors OCTET_LENGTH's type coverage.
- mini-sqlite 0.5.45: two differential-oracle cases (mixed-type LENGTH, and a
  blob column incl. the empty blob and NULL) match real sqlite3 3.51.0.

Full suites green (sql-vm 103, mini-sqlite 45 + oracle). Downstream consumers
(sql-execution-engine, storage-sqlite) build clean. Inline security review clean
(b.len() as i64 can't realistically overflow; no panic/loop; float-declined is
the intentional documented gap).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
