### PR TITLE
feat(reduce): MA08 R-3 -- reduce.grammar + reduce-parser crate

### DIFF
--- a/code/grammars/reduce/reduce.grammar
+++ b/code/grammars/reduce/reduce.grammar
@@ -1,0 +1,244 @@
+# @version 1
+
+# =============================================================================
+# reduce.grammar — Parser grammar for Reduce (a subset)
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from reduce-lexer (R-2). Every Reduce expression parses
+# down to ordinary infix/postfix operators over `head(args)`-shaped calls,
+# with a small statement layer (`:=`, `if/then/else`, `<< ... >>`) sitting on
+# top — the R-4 runtime lowers each rule into the canonical symbolic-ir head
+# (`Plus`/`Times`/`Power`/`Assign`/`Define`/`If`/`CompoundExpression`/`List`/
+# `Cons`/…). See code/specs/MA08-reduce-language.md §3 for the full surface
+# table this grammar implements.
+#
+# Token names (UPPERCASE) come from the Reduce lexer
+# (code/grammars/reduce/reduce.tokens):
+#   NUMBER NAME                 literals and symbols
+#   ASSIGN (:=)                  Reduce's one assignment/definition operator
+#   EQ (=)  LESS (<)  GREATER (>)  LE (<=)  GE (>=)  "neq"   comparison (`=` is
+#                                  an equation, NEVER assignment — MA08 §3)
+#   PLUS MINUS TIMES SLASH CARET POW (`^`/`**`, same operator)   arithmetic
+#   LPAREN RPAREN                grouping AND function/procedure application
+#                                  F(...), per MA08 §3's single call-shaped
+#                                  production for both `f(a,b)` and `a(5)`
+#   LBRACE RBRACE                list literal `{a, b, c}` — curly braces, NOT
+#                                  Derive's square brackets (MA08 §1/§3)
+#   DOT                          cons (`a . {b, c}`)
+#   COMMA SEMI DOLLAR            argument/list separator, statement separator
+#                                  (`;`/`$` are interchangeable, MA08 §3)
+#   GROUP_OPEN/GROUP_CLOSE (`<<`/`>>`)   group-statement delimiters (MA08 §3)
+#   "and"/"or"/"not"/"neq"/"if"/"then"/"else"   lowercase KEYWORD tokens
+#                                  (reduce.tokens's own `keywords:` block —
+#                                  matched here by literal spelling, same
+#                                  convention as macsyma.grammar's/
+#                                  derive.grammar's own word-operator rules)
+#
+# Precedence cascade (loosest binds first -> tightest binds last), per MA08
+# §3's own transcription of the manual's `⟨infix operator⟩` production:
+# ---------------------------------------------------------------
+#   assignment      :=                 (right-associative, MA08 §3)
+#   logical_or      or
+#   logical_and     and
+#   logical_not     not                (prefix)
+#   comparison      = neq < > <= >=    (flat, non-chaining — MA08 §3's own
+#                                        explicit first-cut simplification)
+#   cons            .                  (right-associative — see "Design
+#                                        decision: where `.` (cons) binds"
+#                                        below; MA08 §3 leaves this tier
+#                                        UNSPECIFIED, so this is this crate's
+#                                        own documented first cut)
+#   additive        + -
+#   multiplicative  * /
+#   unary           -                  (prefix)
+#   power           ^ **               (right-associative; same operator,
+#                                        MA08 §3)
+#   postfix         f(...)             (function/procedure/array-subscript
+#                                        application — one production for all
+#                                        three per MA08 §3)
+#   atom            literals, symbols, lists `{...}`, `( ... )`
+#
+# Two control-flow forms sit ABOVE `assignment` (MA08 §3 explicitly says both
+# are "usable as an expression": `if` "returns whichever branch ran", and the
+# group statement "evaluates to its last statement's value") — mirroring
+# macsyma.grammar's own `expression = if_expr | for_expr | ... | assign` PEG
+# ordered-choice shape (see that file's header comment): each control-flow
+# alternative leads with a unique keyword/delimiter, so the parser commits
+# immediately after seeing it and never backtracks across alternatives.
+# `expr`'s fallthrough to `assignment` means every one of `if`'s branches,
+# `<<...>>`'s statements, an assignment's own right-hand side, and a call's
+# arguments can themselves be a nested `if`/group/assignment — matching MA08
+# §3's own claim that these are expression-shaped, not statement-only.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Design decision: where `.` (cons) binds
+# -----------------------------------------------------------------------------
+# MA08 §3 explicitly flags that the manual's own precedence table never
+# places `.` in the same `⟨infix operator⟩` production this subset otherwise
+# transcribes verbatim, and asks this crate to "pick a tier... and document
+# the choice" — the same kind of first-cut, disclosed simplification
+# derive.grammar's vector/matrix-row-counting note or macsyma.grammar's
+# if_expr-placement note already make elsewhere in this repo.
+#
+# This grammar binds `cons` looser than `additive` but tighter than
+# `comparison`. Rationale: `.` combines an already-fully-reduced scalar/list
+# value with another one (`a . {b, c}`, `1+2 . {3,4}` meaning `(1+2) . {3,4}`,
+# never `1 + (2 . {3,4})` — adding a number to a list is nonsensical, so `.`
+# must bind LOOSER than `+`/`-`/`*`/`/`/`^` so those all group first). Binding
+# it tighter than `and`/`or`/comparison (rather than, say, at the very
+# bottom next to assignment) keeps `a . {b} = c . {d}` parsing as an equation
+# between two cons expressions, the most natural reading. Right-associative
+# (`cons`'s own optional continuation references itself), matching cons's
+# natural Lisp-style right-nesting: `a . b . {c}` is `a . (b . {c})`.
+# -----------------------------------------------------------------------------
+
+# A program is zero or more `;`/`$`-terminated statements, optionally
+# followed by ONE final statement with no terminator at all (so a source
+# file need not end with a trailing `;`/`$`).
+#
+# Why the optional tail sits OUTSIDE the repetition rather than folded into
+# `statement_line` as a third alternative (`statement_line = statement (SEMI
+# | DOLLAR) | statement`, which would look like a natural generalisation of
+# macsyma.grammar's mandatory-terminator `statement = expression ( SEMI |
+# DOLLAR )`): a bare, terminator-less `statement` alternative INSIDE a
+# repeated rule is silently re-triable on every iteration, not just the
+# final one, so `{ statement_line }` would greedily accept `a AND b;` as
+# THREE separate bare-statement iterations (`a`, then `AND`, then `b;`) —
+# `AND` uppercase lexes as an ordinary NAME (reduce.tokens' keywords are
+# lowercase-only), and implicit multiplication by juxtaposition is out of
+# scope (MA08 §4), so three bare names in a row with no operator between
+# them must be a syntax error, not three separate statements that happen to
+# consume all the input. Moving the terminator-less case to a single
+# `[ statement ]` *outside* the repetition means it can only ever match
+# once, and only once `{ statement_line }` has already failed to find a
+# terminator for whatever comes next — exactly the "last statement, no
+# trailing terminator" case this is meant to support, and nothing broader.
+# Confirmed by this crate's own
+# `bare_juxtaposed_names_with_no_operator_is_rejected` regression test.
+program = { statement_line } [ statement ] ;
+
+# Reduce has no significant newline (reduce.tokens's own header) — statements
+# end with `;` or `$` (manual §5.1); a lone terminator with no statement
+# before it (a blank interactive-session line) is not part of this grammar's
+# `statement_line` — a run of terminators would need to appear between two
+# statements to matter here, and MA08's grammar has no such convention to
+# preserve (unlike derive.grammar's blank-`NEWLINE`-line case, which exists
+# only because Derive's own statement separator IS the newline).
+statement_line = statement ( SEMI | DOLLAR ) ;
+
+statement = expr ;
+
+# Ordered-choice (PEG) semantics guarantee an unambiguous parse: `if_expr`
+# commits on the `if` keyword, `group_expr` commits on `<<`, so `assignment`
+# is only ever tried once neither leading token is present — no ambiguity,
+# no backtracking across alternatives (mirrors macsyma.grammar's identical
+# `expression = if_expr | for_expr | ... | assign` reasoning).
+expr = if_expr
+     | group_expr
+     | assignment ;
+
+# `if b then s1 else s2` (MA08 §3) — right-associative per manual §5.3,
+# which this shape gives for free: the dangling-else case (`if a then if b
+# then c else d`) attaches `else` to the NEAREST still-open `if`, because the
+# inner `if_expr`'s own optional `[ "else" expr ]` is tried immediately after
+# its `then`-branch is parsed, before the outer `if_expr` ever gets a chance
+# to look for its own `else` — ordinary recursive-descent/PEG behaviour,
+# needs no special dangling-else handling. Both branches are `expr` (not a
+# narrower `statement`), so `if a then x:=1 else x:=2` and nested
+# `if`/`<<...>>` branches parse directly, matching MA08 §3's "usable as an
+# expression" claim; there is no dedicated `elseif` keyword (unlike
+# macsyma.grammar's `if_expr`) because the manual's own examples spell this
+# out as ordinary nested `if ... else if ... else ...`, not a distinct
+# elseif form (MA08 §3/§4 make no mention of one).
+if_expr = "if" expr "then" expr [ "else" expr ] ;
+
+# `<< s1; s2; ... >>` (MA08 §3, manual §5.2) — sequences statements where one
+# is expected, evaluating to the last one's value. This first cut does not
+# accept a trailing separator before `>>` (`<< a:=1; a+1; >>`) — not
+# confirmed as real Reduce syntax by the manual excerpts MA08 §6 cites, and
+# an easy incremental addition later if it turns out real Reduce allows it;
+# keeping the shape simple for a first cut, mirroring MA08 §4's own
+# "narrowly scoped, documented" convention.
+group_expr = GROUP_OPEN expr { ( SEMI | DOLLAR ) expr } GROUP_CLOSE ;
+
+# `:=` (MA08 §3) — right-associative (manual §2.7: "a:=b:=c evaluates as
+# a:=(b:=c)"), the loosest tier of the ordinary operator cascade. The
+# right-hand side is `expr` (not a narrower self-reference the way
+# derive.grammar's `assignment = logical_or [ ASSIGN assignment ]` uses) —
+# a deliberate, disclosed divergence from Derive's identical-looking shape:
+# Reduce's `if`/`<<...>>` are genuinely usable as expressions (MA08 §3, with
+# no Derive analogue), and the most natural place to consume that value is
+# exactly here, e.g. `x := if a>0 then 1 else -1`. This still parses `a :=
+# b := c` as `a := (b := c)`, since `expr` falls through to `assignment`
+# again when neither `if` nor `<<` leads — a strict generalisation of
+# Derive's shape, not a narrowing of it.
+#
+# `h(l, m) := e` (function/procedure definition, MA08 §3) reduces through
+# this SAME production (the left-hand side is parsed as an ordinary
+# `logical_or` that bottoms out at a `postfix` call `h(l, m)`) — the R-4
+# lowering, not this grammar, disambiguates plain variable assignment from
+# procedure definition by inspecting the parsed left-hand shape, mirroring
+# derive.grammar's identical `assignment`/`ASSIGN` comment almost verbatim.
+assignment = logical_or [ ASSIGN expr ] ;
+
+logical_or  = logical_and { "or" logical_and } ;
+logical_and = logical_not { "and" logical_not } ;
+logical_not = "not" logical_not | comparison ;
+
+# A single (non-chained) comparison — MA08 §3 explicitly treats the whole
+# `= neq < > <= >=` group as one flat, non-chaining tier (a disclosed
+# first-cut simplification, not a verified claim about real Reduce's exact
+# grammar), mirroring derive.grammar's/macsyma.grammar's identical
+# non-chaining `comparison` shape. `neq` is a lowercase KEYWORD token
+# (reduce.tokens's `keywords:` block), matched here by literal spelling
+# alongside the symbolic operators, the same convention `and`/`or`/`not`
+# already use above.
+comparison = cons [ ( EQ | "neq" | LESS | GREATER | LE | GE ) cons ] ;
+
+# See "Design decision: where `.` (cons) binds" above.
+cons = additive [ DOT cons ] ;
+
+additive       = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+multiplicative = unary { ( TIMES | SLASH ) unary } ;
+
+# Prefix minus (MA08 §3 lists only unary `-`, no unary `+`, matching
+# derive.grammar's identical asymmetry). Binds looser than Power, so `-x^2`
+# is `Times[-1, Power[x, 2]]`.
+unary = MINUS unary | power ;
+
+# Exponentiation is right-associative: `a^b^c` = `a^(b^c)`. Both `^` and
+# `**` are accepted as the exact same operator (MA08 §3: "manual §2.7's own
+# precedence table lists them as one tier") — mirrors reduce.tokens's own
+# CARET/POW comment that the *parser*, not the lexer, is where the two
+# spellings collapse onto one production (the same convention reduce.tokens
+# already uses for its own SEMI/DOLLAR split).
+power = postfix [ ( CARET | POW ) unary ] ;
+
+# Function/procedure/array-subscript application — MA08 §3's single
+# call-shaped production covers `f(a, b)`, `h(l, m) := e`'s left-hand side,
+# and `a(5)`/`b(i, q)` (array-name-with-subscript reads the same as a call;
+# array *declaration*/indexed *write* are out of scope, MA08 §4) all at
+# once. `list(a, b, c)` (the function-call spelling of a list literal) and
+# the list accessors/constructors (`first`/`rest`/`part`/`append`/`reverse`)
+# fall out of this production for free — they are ordinary NAMEs followed by
+# a call, needing no dedicated grammar rule, mirroring how derive.grammar's
+# `postfix` needs no special case for `SIN`/`DIF`/etc.
+postfix = atom { LPAREN [ arglist ] RPAREN } ;
+
+arglist = expr { COMMA expr } ;
+
+atom = NUMBER
+     | NAME
+     | list_literal
+     | group ;
+
+# `{a, b, c}` (MA08 §3, manual §4.1) — curly braces, NOT Derive's square
+# brackets. Reduce's list is always flat (no row-separator/matrix-literal
+# shape the way derive.grammar's `vector`/`row` split needs — matrices are
+# out of scope entirely, MA08 §4), so one `arglist` reuse covers both a
+# function call's arguments and a list literal's elements.
+list_literal = LBRACE [ arglist ] RBRACE ;
+
+group = LPAREN expr RPAREN ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -260,6 +260,7 @@ members = [
     "j-repl",
     "j-to-semantic-ir",
     "reduce-lexer",
+    "reduce-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/reduce-parser/BUILD
+++ b/code/packages/rust/reduce-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-reduce-parser -- --nocapture

--- a/code/packages/rust/reduce-parser/BUILD_windows
+++ b/code/packages/rust/reduce-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-reduce-parser -- --nocapture

--- a/code/packages/rust/reduce-parser/CHANGELOG.md
+++ b/code/packages/rust/reduce-parser/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+## [0.1.0] - 2026-07-17
+
+### Added
+
+- Initial grammar-driven Rust Reduce parser (MA08 §2, task R-3).
+- `reduce.grammar` (compiled ahead of time into the committed
+  `src/_grammar.rs`), implementing the R-1-scoped precedence cascade from
+  MA08 §3: `if`/`<< ... >>` (usable as expressions, sitting above
+  assignment via an ordered-choice `expr = if_expr | group_expr |
+  assignment` shape mirroring `macsyma-parser`'s own `expression`) →
+  assignment (`:=`, right-associative, shared by both variable assignment
+  and procedure definition) → `or` → `and` → `not` → comparison (`=`/
+  `neq`/`<`/`>`/`<=`/`>=`, flat non-chaining) → cons (`.`, right-
+  associative — a tier MA08 itself leaves unplaced in the manual's own
+  precedence table; this crate binds it looser than `additive` but
+  tighter than `comparison`, documented in `reduce.grammar`'s header and
+  in a new MA08 §3 addendum) → additive → multiplicative → unary minus →
+  power (`^`/`**`, same operator, right-associative) → postfix
+  function/procedure/array-subscript call (one production for all three
+  per MA08 §3) → atoms, plus curly-brace list literals (`{a, b, c}`).
+- A bespoke `MAX_RULE_DEPTH = 128` recursion-depth cap. Five distinct
+  self-referential productions were measured independently (parenthesised
+  nesting, a `:=` chain, an `if`/`else` chain, a cons chain, a power
+  chain) — every "flat chain of one operator" production written with
+  EBNF `{ x }` repetition instead was separately confirmed, via a
+  throwaway probe grammar, to cost *zero* native stack regardless of
+  width (parsed one million repeated items on a default-stack thread with
+  no crash), so those needed no measurement at all.
+- A genuine surprise once each shape's *nesting-count* crash floor was
+  converted into *rule-frame* terms (the units `MAX_RULE_DEPTH` actually
+  bounds): the cons chain tolerates the *most* nesting levels of the five
+  (163 safe / 164 crash) but has the *lowest* rule-frame floor (179 safe /
+  180 crash) — lower than parenthesised nesting's 289/290, despite parens
+  crashing at far fewer levels (19/20). Parenthesised nesting binds for
+  nearly every sibling `*-parser` crate in this repo; here it does not
+  once measured in the frame terms the depth guard actually enforces, and
+  assuming it did (without the second, rule-frame-terms measurement)
+  would have shipped a cap unsafe specifically for cons chains. `128` sits
+  about 28.5% below the binding 179 floor. Full measurement table and
+  reasoning in `MAX_RULE_DEPTH`'s own doc comment (`src/lib.rs`).
+- Caught and fixed a bug in this crate's *own measurement methodology*
+  along the way: an early cons-chain probe built from repeated `1.1.1...`
+  NUMBER literals silently measured a diluted, halved chain, because
+  `NUMBER`'s own regex (`[0-9]+\.?[0-9]*`) greedily absorbs one trailing
+  `.digit` run per token — switching the probe to `NAME` atoms (`a.a.a...`,
+  immune to the ambiguity) produced a floor consistent with the other
+  four shapes.
+- 36 tests covering every construct in the R-1 surface grammar (function/
+  procedure calls, array-subscript reads, the shared `:=` token across
+  both assignment forms, `=`-vs-`:=` disambiguation, every comparison
+  operator, curly-brace list literals and the `list(...)` spelling, the
+  cons operator and its precedence relative to `additive`, list
+  accessors/constructors, arithmetic precedence and associativity,
+  `^`/`**` as the same operator, grouping, the boolean keywords and their
+  lowercase-only case sensitivity, `if`/`else` including dangling-else
+  resolution and usability as an expression, group statements and their
+  usability as an expression, multi-statement programs, syntax-error
+  rejection) plus a regression test for a juxtaposition-acceptance bug
+  found while writing this crate (see below) and 3 depth-guard tests
+  exercising all five measured shapes at once (deep adversarial input on
+  an enlarged-stack thread returns a clean error for every shape, the cap
+  trips before the native stack would overflow even on a default-stack
+  thread for every shape, and reasonable hand-written nesting for every
+  shape stays well under the cap).
+- Fixed a grammar-design bug found while writing this crate's own tests:
+  an early draft of `program`'s grammar folded "the last statement may
+  have no trailing terminator" into `statement_line` itself as a third
+  alternative, tried on *every* repetition iteration rather than only at
+  the very end — so `a AND b;` (with `AND` lexing as an ordinary `NAME`,
+  since `reduce.tokens`' keywords are lowercase-only, and implicit
+  multiplication by juxtaposition out of scope per MA08 §4) silently
+  parsed as three separate no-terminator statements (`a`, `AND`, `b;`)
+  instead of failing as a syntax error. Fixed by moving the terminator-
+  less case to a single `[ statement ]` *outside* the repetition, so it
+  can only ever match once. Documented in `reduce.grammar`'s own `program`
+  comment; regression test:
+  `bare_juxtaposed_names_with_no_operator_is_rejected`.

--- a/code/packages/rust/reduce-parser/Cargo.toml
+++ b/code/packages/rust/reduce-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-reduce-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for Reduce (a subset, R-3)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-reduce-lexer = { path = "../reduce-lexer" }

--- a/code/packages/rust/reduce-parser/README.md
+++ b/code/packages/rust/reduce-parser/README.md
@@ -1,0 +1,131 @@
+# coding-adventures-reduce-parser
+
+Reduce parser backed by `code/grammars/reduce/reduce.grammar`, compiled to
+Rust and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the R-1-scoped subset fixed by
+[MA08 §3](../../../specs/MA08-reduce-language.md). Every Reduce expression
+parses down to ordinary infix/postfix operators over `head(args)`-shaped
+calls, with a small statement layer (`:=`, `if`/`then`/`else`, `<< ... >>`)
+sitting on top — Reduce's algebraic mode is a *statement* language, not just
+an expression-and-worksheet one, unlike Derive or Wolfram.
+
+## `:=` is genuinely one grammar rule doing two jobs
+
+Mirroring `derive-parser`'s own identical convention: `x := 5` (variable
+assignment) and `h(l, m) := x - 2*y` (procedure definition) parse through
+the *same* `assignment` rule — its left-hand side is just the next-tighter
+precedence level (`logical_or`), which naturally reduces down to a bare
+`NAME` or a `postfix` call `h(l, m)` depending on what's actually written.
+This parser does not (and does not need to) distinguish the two cases; a
+future `reduce-runtime` (R-4) tells them apart by inspecting the parsed
+left-hand side's shape.
+
+## `if` and `<< ... >>` are usable as expressions
+
+MA08 §3 confirms both are value-producing: `if b then s1 else s2` "returns
+whichever branch ran", and `<< s1; s2; ... >>` "evaluates to its last
+statement's value". So `expr = if_expr | group_expr | assignment` sits
+*above* `assignment` in the precedence cascade — an ordered-choice (PEG)
+shape mirroring `macsyma-parser`'s own `expression = if_expr | for_expr |
+... | assign` — meaning `if`/`<<...>>` can appear nested inside an
+assignment's right-hand side, an argument list, or each other, not just as
+a standalone top-level statement.
+
+## Precedence, loosest to tightest
+
+```
+expr = if_expr | group_expr | assignment
+  assignment (:=, right-assoc, RHS is `expr`)
+    → OR
+      → AND
+        → NOT (prefix)
+          → comparison (= neq < > <= >=, flat non-chaining)
+            → cons (., right-assoc -- see below)
+              → additive (+ -)
+                → multiplicative (* /)
+                  → unary minus (prefix)
+                    → power (^ / **, same operator, right-assoc)
+                      → postfix application  f(...)
+                        → atom  (NUMBER, NAME, {list literal}, ( ... ))
+```
+
+`=` is Reduce's *equation* operator (Boolean-valued) — never assignment;
+`:=` alone owns that role. `neq`/`and`/`or`/`not` are lowercase `KEYWORD`
+tokens (the mirror image of `derive-lexer`'s uppercase `AND`/`OR`/`NOT`),
+matched by literal spelling.
+
+### Where `.` (cons) binds — a gap MA08 itself leaves open
+
+The manual's own precedence table never places `.` in the same chain this
+grammar otherwise transcribes verbatim (MA08 §3 flags this explicitly).
+`reduce.grammar` binds it looser than `additive` but tighter than
+`comparison`: `1+2 . {3,4}` parses as `(1+2) . {3,4}`, never `1 + (2 .
+{3,4})` (adding a number to a list is nonsensical), while `a . {b} = c .
+{d}` still parses as an equation between two cons expressions. See
+`reduce.grammar`'s own header comment for the full reasoning.
+
+## List literals use curly braces
+
+`{a, b, c}` (not Derive's `[a, b, c]` square brackets) is a flat list —
+Reduce has no matrix-literal row-separator syntax the way Derive's vector
+does, so one `arglist` production covers both a function call's arguments
+and a list literal's elements. `list(a, b, c)` (the function-call spelling)
+and the list accessors (`first`/`rest`/`part`/`append`/`reverse`) need no
+dedicated grammar rule — they fall out of the ordinary `postfix` call
+production, since they're just NAMEs followed by `(...)`.
+
+## Usage
+
+```rust
+use coding_adventures_reduce_parser::parse_reduce;
+
+let ast = parse_reduce("h(l, m) := l + m;\nh(1, 2);\n");
+assert_eq!(ast.rule_name, "program");
+```
+
+`parse_reduce` panics on a malformed source string; use `try_parse_reduce`
+for the `Result`-returning form, or `create_reduce_parser` directly if you
+need the raw `GrammarParser`.
+
+## Recursion-depth guard: five shapes, and a rule-frame surprise
+
+`reduce.grammar` has five distinct self-referential (right-recursive)
+productions — parenthesised grouping, a `:=` chain, an `if`/`else` chain, a
+cons (`.`) chain, and a power (`^`) chain — each measured independently
+(binary search, uncapped parser, default-stack worker thread, debug build),
+per [MA06](../../../specs/MA06-j-language.md) §6's established methodology.
+Every "flat chain of one operator" production that uses EBNF `{ x }`
+repetition instead (`logical_or`, `logical_and`, `additive`,
+`multiplicative`, `postfix`'s call chain, `arglist`, `group_expr`'s
+statement sequence) was directly confirmed *not* to cost native stack
+regardless of width — a throwaway probe grammar built from
+`GrammarElement::Repetition` alone parsed one million repeated items on a
+default-stack thread with zero crashes, since `match_element`'s own
+`Repetition` arm is a plain iterative loop.
+
+The genuine surprise: converting each shape's nesting-count crash floor
+into rule-frame terms (the units `MAX_RULE_DEPTH` actually bounds) shows
+the cons chain — which tolerates the *most* nesting levels of the five
+(163) — has the *lowest* rule-frame floor (179), because each `cons` link's
+persistent per-level cost is cheaper (one rule-frame) than the other four
+shapes' (two), yet its own call chain evidently costs more native-stack
+bytes per crossing. Parenthesised nesting — the shape that binds for nearly
+every sibling `*-parser` crate in this repo, and would naively look like
+Reduce's own binding shape too (crashing at the fewest *levels*, 19) — is
+*not* the binding constraint here once measured in the frame terms that
+actually matter. See `MAX_RULE_DEPTH`'s own doc comment in `src/lib.rs` for
+the full measurement table and reasoning.
+
+## Where this fits
+
+`reduce-parser` is R-3 of Reduce's frontend crates, consuming the token
+stream from `reduce-lexer` (R-2) against
+`code/grammars/reduce/reduce.grammar` to build the `GrammarASTNode` CST a
+future `reduce-runtime` (R-4) will lower into `symbolic_ir::IRNode` and
+evaluate with `symbolic_vm::VM`.

--- a/code/packages/rust/reduce-parser/required_capabilities.json
+++ b/code/packages/rust/reduce-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/reduce-parser",
+  "capabilities": [],
+  "justification": "Pure computation. The Reduce grammar is embedded as generated Rust code; tokenizing and parsing need no filesystem, network, or process access."
+}

--- a/code/packages/rust/reduce-parser/src/_grammar.rs
+++ b/code/packages/rust/reduce-parser/src/_grammar.rs
@@ -1,0 +1,256 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: reduce.grammar
+// Regenerate with: grammar-tools compile-grammar reduce.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+            ] },
+            line_number: 120,
+        },
+        GrammarRule {
+            name: r#"statement_line"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"SEMI"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"DOLLAR"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 129,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            line_number: 131,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"if_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"group_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+            ] },
+            line_number: 138,
+        },
+        GrammarRule {
+            name: r#"if_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"if"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Literal { value: r#"then"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"else"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 155,
+        },
+        GrammarRule {
+            name: r#"group_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"GROUP_OPEN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"SEMI"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"DOLLAR"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"GROUP_CLOSE"#.to_string() },
+            ] },
+            line_number: 164,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"ASSIGN"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 184,
+        },
+        GrammarRule {
+            name: r#"logical_or"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"or"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 186,
+        },
+        GrammarRule {
+            name: r#"logical_and"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"and"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 187,
+        },
+        GrammarRule {
+            name: r#"logical_not"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"not"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
+            ] },
+            line_number: 188,
+        },
+        GrammarRule {
+            name: r#"comparison"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"cons"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                                GrammarElement::Literal { value: r#"neq"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LESS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GREATER"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"cons"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 198,
+        },
+        GrammarRule {
+            name: r#"cons"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"cons"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 201,
+        },
+        GrammarRule {
+            name: r#"additive"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 203,
+        },
+        GrammarRule {
+            name: r#"multiplicative"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"TIMES"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 204,
+        },
+        GrammarRule {
+            name: r#"unary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"power"#.to_string() },
+            ] },
+            line_number: 209,
+        },
+        GrammarRule {
+            name: r#"power"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"postfix"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"CARET"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"POW"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 217,
+        },
+        GrammarRule {
+            name: r#"postfix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"atom"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arglist"#.to_string() }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 228,
+        },
+        GrammarRule {
+            name: r#"arglist"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 230,
+        },
+        GrammarRule {
+            name: r#"atom"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"list_literal"#.to_string() },
+                GrammarElement::RuleReference { name: r#"group"#.to_string() },
+            ] },
+            line_number: 232,
+        },
+        GrammarRule {
+            name: r#"list_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arglist"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 242,
+        },
+        GrammarRule {
+            name: r#"group"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 244,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/reduce-parser/src/lib.rs
+++ b/code/packages/rust/reduce-parser/src/lib.rs
@@ -1,0 +1,600 @@
+//! # Reduce Parser — building a syntax tree for Reduce (a subset).
+//!
+//! Turns the token stream from [`coding_adventures_reduce_lexer`] into a
+//! parse tree using the generic
+//! [`GrammarParser`](parser::grammar_parser::GrammarParser), driven by the
+//! embedded `reduce.grammar` (`src/_grammar.rs`). It hand-writes no parsing
+//! logic. A sibling of `derive-parser` / `macsyma-parser` / `wolfram-parser`.
+//! See `code/specs/MA08-reduce-language.md`.
+//!
+//! ## What the tree captures
+//!
+//! Every Reduce expression parses down to ordinary infix/postfix operators
+//! over `head(args)`-shaped calls, with a small statement layer (`:=`,
+//! `if/then/else`, `<< ... >>`) on top; this parser produces the surface
+//! tree whose rule names (`assignment`, `if_expr`, `group_expr`,
+//! `logical_or`, `comparison`, `cons`, `additive`, `multiplicative`,
+//! `power`, `postfix`, `atom`, `list_literal`, …) a future `reduce-runtime`
+//! (R-4) will lower into the canonical `symbolic-ir` heads (`Plus`/`Times`/
+//! `Power`/`Assign`/`Define`/`If`/`CompoundExpression`/`List`/`Cons`/…).
+//!
+//! ```text
+//! Reduce source
+//!    |
+//!    v
+//! coding_adventures_reduce_lexer::tokenize_reduce  ->  Vec<Token>
+//!    |
+//!    v
+//! parser::GrammarParser  (driven by the embedded reduce.grammar)
+//!    |
+//!    v
+//! GrammarASTNode  <- the tree R-4 lowers to symbolic-ir
+//! ```
+
+use coding_adventures_reduce_lexer::{tokenize_reduce, try_tokenize_reduce};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+mod _grammar;
+
+/// Recursion-depth cap for the Reduce [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own `Result`-returning entry points ever get a chance to report
+/// anything).
+///
+/// # Five recursion shapes, not one — measured independently, per MA06 §6's
+/// established methodology
+///
+/// `reduce.grammar` has no analogue of `apl.grammar`/`j.grammar`'s own
+/// right-recursive `noun_expr` chain — every "chain of operators at one
+/// precedence tier" production here (`logical_or`, `logical_and`,
+/// `additive`, `multiplicative`, `postfix`'s call chain, `arglist`,
+/// `group_expr`'s statement sequence) is written with EBNF `{ x }`
+/// repetition, not right-recursive self-reference. This was checked
+/// directly, not assumed: a throwaway probe grammar built from
+/// [`GrammarElement::Repetition`](grammar_tools::parser_grammar::GrammarElement)
+/// alone (mirroring `arglist = expr { COMMA expr }`'s exact shape) was fed
+/// up to *one million* repeated items on a default-stack (~2 MiB) worker
+/// thread with an uncapped parser — zero crashes. `match_element`'s own
+/// `Repetition` arm (`parser::grammar_parser`) is a plain `loop { ... }`:
+/// each iteration's `match_element` call returns before the next iteration
+/// begins, so the *native* call stack never grows with iteration count,
+/// only with the nesting *within* one iteration's own match. Width alone is
+/// not a recursion-depth risk in this grammar engine — measuring it as if
+/// it might be (the way MA06 §6 asked future crates to treat `j.grammar`'s
+/// own `verb_train` flat repetition) would have been assuming a *shape*
+/// analogy the actual `Repetition` implementation does not bear out here.
+///
+/// What genuinely recurses in `reduce.grammar` are its five distinct
+/// self-referential (right-recursive, `[ x ]`-optional-wrapped or
+/// ordered-choice-cycling) productions, each measured independently below
+/// with the same methodology every sibling `*-parser` crate's own
+/// `MAX_RULE_DEPTH` doc comment uses: binary search, an *uncapped*
+/// `GrammarParser` (`max_depth = usize::MAX`), a `std::thread::spawn`
+/// worker with the **default ~2 MiB stack** (no `stack_size` override), one
+/// fresh **subprocess per data point** (a real native-stack overflow calls
+/// `process::abort()`, which kills the whole process, not just the
+/// offending thread — an in-process loop cannot survive past the first
+/// crash to report a clean number), in a **debug** build (`cargo test`'s
+/// own default) since debug frames are meaningfully larger than release
+/// frames.
+///
+/// 1. **Parenthesised nesting**, `((((…5…))))` — `group -> expr -> (
+///    if_expr/group_expr fail ) -> assignment -> logical_or -> logical_and
+///    -> logical_not -> comparison -> cons -> additive -> multiplicative ->
+///    unary -> power -> postfix -> atom -> group -> …` — cycles through the
+///    *entire* precedence cascade every nesting level. Measured: parses
+///    safely up to **19 levels**, crashes the process at **20**.
+/// 2. **A flat, right-associative `:=` chain**, `a:=a:=a:=…:=5` —
+///    `assignment`'s own `[ ASSIGN expr ]` continuation. Measured: parses
+///    safely up to **102 levels**, crashes at **103**.
+/// 3. **A flat `if`/`else` chain**, `if 1 then 1 else if 1 then 1 else …
+///    else 5` — `if_expr`'s own `[ "else" expr ]` continuation, where
+///    `expr` tries (and immediately commits to) `if_expr` again. Measured:
+///    parses safely up to **102 levels**, crashes at **103**.
+/// 4. **A flat cons (`.`) chain**, `a.a.a. … .a` — `cons`'s own `[ DOT cons
+///    ]` continuation. Built from `NAME` atoms, not `NUMBER` literals: an
+///    early draft of this measurement used `1.1.1. … .1`, but `NUMBER`'s
+///    own regex (`[0-9]+\.?[0-9]*`) greedily absorbs one trailing
+///    `.digit` run per token, so `1.1.1.1` lexes as `NUMBER("1.1") DOT
+///    NUMBER("1.1")`, not `NUMBER("1") DOT NUMBER("1") DOT NUMBER("1") DOT
+///    NUMBER("1")` — silently *halving* the intended chain length. Caught
+///    by cross-checking this shape's nesting-count floor against its
+///    independently-measured rule-frame floor (see the table below): the
+///    numeric-literal version measured a suspiciously high 327-safe /
+///    328-crash floor with no per-level frame cost consistent with the
+///    other four shapes; switching to `NAME` atoms (immune to the digit-
+///    merging ambiguity) produced a floor that *is* consistent. Measured
+///    (`NAME` version): parses safely up to **163 levels**, crashes at
+///    **164**.
+/// 5. **A flat power (`^`) chain**, `1^1^1^ … ^1` — `power`'s own `[ CARET
+///    unary ]` continuation (through `unary`, which falls back to `power`
+///    absent a leading `-`; `^` shares no characters with `NUMBER`'s own
+///    pattern, so it cannot suffer the cons-chain's digit-merging
+///    ambiguity). Measured: parses safely up to **102 levels**, crashes at
+///    **103**.
+///
+/// # The binding constraint is a rule-frame floor, not a nesting-count one
+///
+/// Naively, the *nesting-count* floors above suggest parenthesised nesting
+/// binds (crashing at the lowest count, 19) — matching `derive-parser`'s
+/// own finding, the opposite of `j-parser`'s "genuine surprise". But
+/// `MAX_RULE_DEPTH` caps `self.depth`, a raw count of *named-rule*
+/// invocations on the call stack — nesting-count doesn't directly say how
+/// many `self.depth` units that costs, because a `Sequence`/`Optional`/
+/// `Alternation` match element recurses through `match_element` regardless
+/// of whether it crosses into a new *named* rule, and those crossings are
+/// invisible to `self.depth` yet still consume real native stack. So each
+/// nesting-count floor was independently re-measured in **rule-frame
+/// terms**: binary search over candidate `with_max_depth` values against a
+/// fixed 5000-level/link input of that shape (deep enough that the *cap
+/// itself*, not the input's own finite length, is always what triggers
+/// first) — the same conversion `derive-parser`'s own doc comment performs
+/// for its one measured shape, done here for all five:
+///
+/// | Shape | Nesting-count floor | Rule-frame floor |
+/// |---|---|---|
+/// | Parens | 19 safe / 20 crash | 289 safe / 290 crash |
+/// | `:=` chain | 102 safe / 103 crash | 220 safe / 221 crash |
+/// | `if`/`else` chain | 102 safe / 103 crash | 220 safe / 221 crash |
+/// | cons (`.`) chain | 163 safe / 164 crash | **179 safe / 180 crash** |
+/// | power (`^`) chain | 102 safe / 103 crash | 220 safe / 221 crash |
+///
+/// The cons chain — which *tolerates the most nesting levels* of the five
+/// (163) — has the *lowest* rule-frame floor (179): each `cons` link's
+/// *persistent* per-level cost is just one `cons` rule-frame (its leaf
+/// operand, `additive`, fully parses and pops before the `[ DOT cons ]`
+/// continuation is ever attempted, so that sub-chain's own several rule-
+/// frames never accumulate across levels) — but whatever native-stack
+/// bytes `cons`'s own call chain uses per crossing evidently costs more
+/// than parens'/assign's/if-else's/power's own per-frame cost, so it
+/// reaches the native ceiling at a *lower total frame count* despite
+/// needing *more* levels to get there. This generalises MA06 §6's warning
+/// one step further: not just "does a shape's floor transfer from a
+/// sibling crate", but "does a shape's *nesting-count* floor even predict
+/// which shape *actually* binds the frame-count cap this crate's own guard
+/// enforces" — it does not, here, and assuming parenthesised nesting (the
+/// nesting-count-lowest, and every sibling `*-parser`'s own historically-
+/// dominant shape) was the binding constraint without this second,
+/// rule-frame-terms measurement would have shipped a cap unsafe for cons
+/// chains specifically.
+///
+/// `MAX_RULE_DEPTH` is set to **128** — about 28.5% below the binding
+/// cons-chain rule-frame floor of 179 (comparable margin to `apl-parser`'s
+/// own ~26.5%, `j-parser`'s ~30%, `derive-parser`'s ~33%), and therefore
+/// safely below all four other rule-frame floors (220, 220, 220, 289) as
+/// well. `128` also happens to equal
+/// [`DEFAULT_MAX_RULE_DEPTH`](parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH)
+/// — a coincidence of this grammar's own measured floors, not a decision
+/// to reuse the shared default; it was derived independently from the
+/// table above and simply landed there.
+///
+/// Measured real-input headroom at `128` (using the CAPPED parser, i.e.
+/// `create_reduce_parser`/`try_parse_reduce`, so no crash risk at all):
+/// parenthesised nesting parses cleanly up to 8 levels (9 trips the cap);
+/// a `:=` chain, an `if`/`else` chain, and a power chain each parse cleanly
+/// up to 56 levels (57 trips); a cons chain parses cleanly up to 112
+/// levels (113 trips) — all comfortably beyond anything a hand-written
+/// Reduce expression needs, and all five independently confirmed not to
+/// crash a default-stack thread even thousands of levels/links past the
+/// cap (see this crate's tests).
+const MAX_RULE_DEPTH: usize = 128;
+
+/// Create a [`GrammarParser`] wired to the Reduce grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+pub fn create_reduce_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_reduce(source);
+    GrammarParser::new(tokens, _grammar::parser_grammar()).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Parse Reduce source text into a [`GrammarASTNode`] rooted at `program`.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_reduce`] to handle
+/// errors.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_reduce_parser::parse_reduce;
+/// let ast = parse_reduce("x := 5;\n");
+/// assert_eq!(ast.rule_name, "program");
+/// ```
+pub fn parse_reduce(source: &str) -> GrammarASTNode {
+    create_reduce_parser(source)
+        .parse()
+        .unwrap_or_else(|e| panic!("Reduce parse failed: {e}"))
+}
+
+/// Parse Reduce source text, returning a `Result` instead of panicking.
+pub fn try_parse_reduce(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_reduce(source)?;
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+        .with_max_depth(MAX_RULE_DEPTH)
+        .parse()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        node.rule_name == name
+            || node.children.iter().any(|c| match c {
+                ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                ASTNodeOrToken::Token(_) => false,
+            })
+    }
+
+    fn parses(src: &str) -> bool {
+        try_parse_reduce(src).is_ok()
+    }
+
+    #[test]
+    fn program_is_the_root() {
+        assert_eq!(parse_reduce("1;\n").rule_name, "program");
+    }
+
+    #[test]
+    fn bare_trailing_statement_with_no_terminator_parses() {
+        assert!(parses("1"));
+    }
+
+    #[test]
+    fn semi_and_dollar_are_interchangeable_terminators() {
+        assert!(parses("x := 1; y := 2$"));
+    }
+
+    #[test]
+    fn function_call_uses_ordinary_parens() {
+        let ast = parse_reduce("df(x, z);\n");
+        assert!(contains_rule(&ast, "postfix"));
+        assert!(contains_rule(&ast, "arglist"));
+    }
+
+    #[test]
+    fn array_subscript_read_shares_the_call_production() {
+        // MA08 §3: `a(5)`/`b(i, q)` parse the same as an ordinary call.
+        assert!(parses("a(5);\n"));
+        assert!(parses("b(i, q);\n"));
+    }
+
+    #[test]
+    fn assignment_and_procedure_definition_share_one_production() {
+        assert!(parses("x := 5;\n"));
+        let ast = parse_reduce("h(l, m) := x - 2*y;\n");
+        assert!(contains_rule(&ast, "assignment"));
+    }
+
+    #[test]
+    fn assignment_right_associates() {
+        // a := b := c evaluates as a := (b := c) (manual §2.7).
+        assert!(parses("a := b := 5;\n"));
+    }
+
+    #[test]
+    fn eq_is_equation_distinct_from_assign() {
+        assert!(parses("x = 4;\n"));
+        assert!(contains_rule(&parse_reduce("x = 4;\n"), "comparison"));
+    }
+
+    #[test]
+    fn every_comparison_operator_parses() {
+        for op in ["=", "neq", "<", ">", "<=", ">="] {
+            let src = format!("a {op} b;\n");
+            assert!(parses(&src), "`{src}` should parse");
+        }
+    }
+
+    #[test]
+    fn list_literal_uses_curly_braces() {
+        let ast = parse_reduce("{a, b, c};\n");
+        assert!(contains_rule(&ast, "list_literal"));
+    }
+
+    #[test]
+    fn list_function_call_spelling_parses_like_any_other_call() {
+        assert!(parses("list(a, b, c);\n"));
+    }
+
+    #[test]
+    fn cons_operator_parses() {
+        let ast = parse_reduce("a . {b, c};\n");
+        assert!(contains_rule(&ast, "cons"));
+    }
+
+    #[test]
+    fn cons_binds_looser_than_additive() {
+        // `1+2 . {3,4}` must parse as `(1+2) . {3,4}` -- `cons`'s own
+        // production wraps `additive`, so the additive sub-expression is
+        // fully reduced before cons ever sees it. Structurally: the tree
+        // must contain both `additive` and `cons`.
+        let ast = parse_reduce("1+2 . {3,4};\n");
+        assert!(contains_rule(&ast, "additive"));
+        assert!(contains_rule(&ast, "cons"));
+    }
+
+    #[test]
+    fn list_accessor_and_constructor_calls_parse() {
+        for src in [
+            "first(l);\n",
+            "second(l);\n",
+            "third(l);\n",
+            "rest(l);\n",
+            "part(l, n);\n",
+            "append(l1, l2);\n",
+            "reverse(l);\n",
+        ] {
+            assert!(parses(src), "`{src}` should parse");
+        }
+    }
+
+    #[test]
+    fn arithmetic_precedence() {
+        let ast = parse_reduce("2 + 3 * 4 ^ 2;\n");
+        assert!(contains_rule(&ast, "additive"));
+        assert!(contains_rule(&ast, "multiplicative"));
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn caret_and_double_star_are_the_same_operator() {
+        assert!(parses("a ^ b;\n"));
+        assert!(parses("a ** b;\n"));
+    }
+
+    #[test]
+    fn unary_minus_binds_looser_than_power() {
+        let ast = parse_reduce("-x^2;\n");
+        assert!(contains_rule(&ast, "unary"));
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn power_is_right_associative_by_shape() {
+        assert!(parses("4^3^2;\n"));
+    }
+
+    #[test]
+    fn grouping_parens_parse() {
+        assert!(parses("(1 + 2) * 3;\n"));
+        assert!(contains_rule(&parse_reduce("(1 + 2) * 3;\n"), "group"));
+    }
+
+    #[test]
+    fn boolean_keywords_parse() {
+        assert!(parses("a and b or not c;\n"));
+        assert!(contains_rule(&parse_reduce("a and b;\n"), "logical_and"));
+        assert!(contains_rule(&parse_reduce("a or b;\n"), "logical_or"));
+        assert!(contains_rule(&parse_reduce("not a;\n"), "logical_not"));
+    }
+
+    #[test]
+    fn uppercase_keyword_spellings_lex_as_plain_names_not_keywords() {
+        // reduce.tokens' keywords are lowercase-only (the mirror image of
+        // derive.tokens' uppercase AND/OR/NOT) -- `AND` here is just a NAME,
+        // so this is a bare `a AND b` juxtaposition with no operator
+        // between two names, which is not valid syntax in this subset
+        // (implicit multiplication by juxtaposition is out of scope, MA08
+        // §4) and must fail to parse as a single statement.
+        assert!(try_parse_reduce("a AND b;\n").is_err());
+    }
+
+    #[test]
+    fn bare_juxtaposed_names_with_no_operator_is_rejected() {
+        // `a AND b` (with `AND` lexing as an ordinary NAME, not a keyword —
+        // see the test above) has three bare names with no operator
+        // between them. Implicit multiplication by juxtaposition is out of
+        // scope (MA08 §4), so this must be a syntax error -- NOT silently
+        // accepted as three separate terminator-less statements. This is a
+        // regression test for exactly the bug `program`'s own grammar
+        // comment documents: an earlier draft folded the "no terminator"
+        // case into `statement_line` itself (tried per repetition
+        // iteration, not just once at the very end), which let `a`, `AND`,
+        // and `b;` each parse as their own bare statement and silently
+        // consumed the entire input as three separate program items.
+        assert!(try_parse_reduce("a AND b;\n").is_err());
+        assert!(try_parse_reduce("a b\n").is_err());
+    }
+
+    #[test]
+    fn if_then_parses_without_an_else() {
+        let ast = parse_reduce("if a then b;\n");
+        assert!(contains_rule(&ast, "if_expr"));
+    }
+
+    #[test]
+    fn if_then_else_parses() {
+        let ast = parse_reduce("if a=b then c else d;\n");
+        assert!(contains_rule(&ast, "if_expr"));
+    }
+
+    #[test]
+    fn if_is_usable_as_an_expression() {
+        // MA08 §3: "usable as an expression, returning whichever branch
+        // ran" -- nested directly as an assignment's right-hand side.
+        let ast = parse_reduce("x := if a>0 then 1 else -1;\n");
+        assert!(contains_rule(&ast, "if_expr"));
+        assert!(contains_rule(&ast, "assignment"));
+    }
+
+    #[test]
+    fn dangling_else_attaches_to_the_nearest_if() {
+        // `if a then if b then c else d` must parse as
+        // `if a then (if b then c else d)`, not `(if a then if b then c)
+        // else d` -- there is only one `if_expr` node nested inside the
+        // outer `then`-branch's own recursive `expr`, matching ordinary
+        // recursive-descent dangling-else resolution.
+        assert!(parses("if a then if b then c else d;\n"));
+    }
+
+    #[test]
+    fn group_statement_parses() {
+        let ast = parse_reduce("<< a := 1; a + 1 >>;\n");
+        assert!(contains_rule(&ast, "group_expr"));
+    }
+
+    #[test]
+    fn group_statement_is_usable_as_an_expression() {
+        // MA08 §3: "evaluates to its last statement's value".
+        let ast = parse_reduce("x := << a := 1; a + 1 >>;\n");
+        assert!(contains_rule(&ast, "group_expr"));
+        assert!(contains_rule(&ast, "assignment"));
+    }
+
+    #[test]
+    fn group_statement_with_a_single_statement_parses() {
+        assert!(parses("<< a + 1 >>;\n"));
+    }
+
+    #[test]
+    fn nested_function_calls_parse() {
+        assert!(parses("log(y/m);\n"));
+    }
+
+    #[test]
+    fn multi_arg_calls_parse() {
+        assert!(parses("df(x, z, a, b);\n"));
+    }
+
+    #[test]
+    fn a_multi_statement_program_parses() {
+        let ast = parse_reduce("x := 1; y := 2; x + y;\n");
+        let stmt_lines: usize = ast
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement_line"))
+            .count();
+        assert_eq!(stmt_lines, 3);
+    }
+
+    #[test]
+    fn syntax_error_is_reported() {
+        assert!(try_parse_reduce("1 +\n").is_err());
+        assert!(try_parse_reduce("(1 + 2\n").is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- exercises all five
+    // independently-measured shapes documented on `MAX_RULE_DEPTH`.
+    // -------------------------------------------------------------------
+
+    fn nested_paren_source(n: usize) -> String {
+        format!("{}5{};\n", "(".repeat(n), ")".repeat(n))
+    }
+
+    fn assign_chain_source(n: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str("a:=");
+        }
+        s.push_str("5;\n");
+        s
+    }
+
+    fn if_else_chain_source(n: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str("if 1 then 1 else ");
+        }
+        s.push_str("5;\n");
+        s
+    }
+
+    fn cons_chain_source(n: usize) -> String {
+        // NAME atoms, not NUMBER literals -- see MAX_RULE_DEPTH's doc
+        // comment ("A flat cons (`.`) chain") for why `1.1.1...` silently
+        // halves the intended chain length via NUMBER's own greedy
+        // `.digit`-absorbing regex.
+        let mut s = String::from("a");
+        for _ in 0..n {
+            s.push_str(".a");
+        }
+        s.push_str(";\n");
+        s
+    }
+
+    fn power_chain_source(n: usize) -> String {
+        let mut s = String::from("1");
+        for _ in 0..n {
+            s.push_str("^1");
+        }
+        s.push_str(";\n");
+        s
+    }
+
+    /// Deeply-nested input, for every measured shape, must produce a
+    /// recoverable error, not overflow the native stack. Parses 5000
+    /// levels/links -- far past `MAX_RULE_DEPTH` -- on a worker thread with
+    /// a generous 32 MiB stack, so the *guard* is what stops the
+    /// recursion, not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow_for_every_shape() {
+        let sources = vec![
+            nested_paren_source(5000),
+            assign_chain_source(5000),
+            if_else_chain_source(5000),
+            cons_chain_source(5000),
+            power_chain_source(5000),
+        ];
+        let handle = std::thread::Builder::new()
+            .name("reduce-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                for src in sources {
+                    let result = try_parse_reduce(&src);
+                    assert!(
+                        result.is_err(),
+                        "deeply-nested input must fail with an error, not parse or crash"
+                    );
+                }
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. Parses far-too-deep input, for every
+    /// shape, on a worker thread with **no** `stack_size` override (the
+    /// same ~2 MiB a default thread gets).
+    #[test]
+    fn test_cap_trips_before_overflow_on_default_stack_for_every_shape() {
+        let sources = vec![
+            nested_paren_source(5000),
+            assign_chain_source(5000),
+            if_else_chain_source(5000),
+            cons_chain_source(5000),
+            power_chain_source(5000),
+        ];
+        let handle = std::thread::spawn(move || {
+            for src in sources {
+                let result = try_parse_reduce(&src);
+                assert!(result.is_err(), "deeply-nested input must error, not crash");
+            }
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// Reasonable, hand-writable nesting for every shape stays well under
+    /// the cap.
+    #[test]
+    fn test_reasonable_nesting_stays_under_the_cap_for_every_shape() {
+        assert!(try_parse_reduce(&nested_paren_source(3)).is_ok());
+        assert!(try_parse_reduce(&assign_chain_source(10)).is_ok());
+        assert!(try_parse_reduce(&if_else_chain_source(10)).is_ok());
+        assert!(try_parse_reduce(&cons_chain_source(10)).is_ok());
+        assert!(try_parse_reduce(&power_chain_source(10)).is_ok());
+    }
+}

--- a/code/specs/MA08-reduce-language.md
+++ b/code/specs/MA08-reduce-language.md
@@ -138,6 +138,18 @@ real Reduce's exact grammar) → additive (`+`/`-`) → multiplicative
 `a:=(b:=c)`"); this subset's `if`/`else` is likewise right-associative
 per §5.3.
 
+Note this table (and the manual's own `⟨infix operator⟩` production it
+transcribes) never places the cons operator `.` (§3, `a . {b, c}`)
+anywhere in this chain — a genuine gap, not an omission of this spec's own
+making. R-3's `reduce.grammar` resolves it by binding `cons` looser than
+`additive` but tighter than the comparison tier: an already-fully-reduced
+arithmetic expression on each side (`1+2 . {3,4}` means `(1+2) . {3,4}`,
+never `1 + (2 . {3,4})`), while still nesting inside an equation (`a . {b}
+= c . {d}`). This is a first-cut, disclosed simplification in the same
+spirit as this section's own comparison-tier note above, not a verified
+claim about real Reduce's exact grammar; see `reduce.grammar`'s own header
+comment for the full reasoning.
+
 Comments, Reduce's mode-switch mechanism (`on rounded;`, `on complex;`,
 …), and its symbolic (raw-Lisp) mode are not part of this grammar; see §4.
 


### PR DESCRIPTION
## Summary
- Implements Reduce's R-1-scoped surface grammar (MA08 §3) over the shared `grammar-tools`/`parser::GrammarParser` engine: full precedence cascade with `if`/`<<...>>` as expression-level ordered-choice alternatives above assignment (both usable as expressions per MA08 §3), resolving a genuine gap the spec itself flags (where the cons operator `.` binds — documented in `reduce.grammar`'s header and a new MA08 §3 addendum).
- `MAX_RULE_DEPTH = 128`, derived by independently measuring all five of this grammar's distinct self-referential recursion shapes (parens, `:=` chain, `if`/`else` chain, cons chain, power chain) in both nesting-count and rule-frame terms — per MA06 §6's established methodology. Surfaced a genuine finding: the cons chain tolerates the *most* nesting levels (163) but has the *lowest* rule-frame floor (179), the opposite of parenthesised nesting (which binds for nearly every sibling `*-parser` crate in this repo but does not here). Full table + reasoning in `MAX_RULE_DEPTH`'s doc comment.
- Also fixes a grammar-design bug found while writing tests: an earlier draft let `a AND b;` (with `AND` lexing as a plain `NAME`, since `reduce.tokens`' keywords are lowercase-only) silently parse as three separate no-terminator statements instead of failing. Fixed by moving the "last statement may have no terminator" case to a single `[ statement ]` outside `program`'s repetition.
- 36 tests + 1 doctest, all passing. `/security-review` passed clean (no findings).

## Test plan
- [x] `cargo test -p coding-adventures-reduce-parser` — 36 tests + 1 doctest pass
- [x] `cargo clippy -p coding-adventures-reduce-parser --all-targets` — clean
- [x] `grammar-tools validate`/`compile-grammar` — grammar validates and compiles cleanly
- [x] Depth-guard regression tests exercise all 5 measured recursion shapes on both enlarged-stack and default-stack worker threads
- [x] `/security-review` — SECURITY REVIEW PASSED, no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)