### PR TITLE
feat(chacha20-poly1305): add C# and F# ports

### DIFF
--- a/code/packages/csharp/chacha20-poly1305/BUILD
+++ b/code/packages/csharp/chacha20-poly1305/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.ChaCha20Poly1305]*"

--- a/code/packages/csharp/chacha20-poly1305/BUILD_windows
+++ b/code/packages/csharp/chacha20-poly1305/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.ChaCha20Poly1305]*"

--- a/code/packages/csharp/chacha20-poly1305/CHANGELOG.md
+++ b/code/packages/csharp/chacha20-poly1305/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add pure C# ChaCha20 stream encryption and Poly1305 authentication.
+- Add RFC 8439 ChaCha20-Poly1305 AEAD encryption and authenticated decryption.
+- Verify the RFC block, stream, MAC, and AEAD vectors plus tamper rejection.

--- a/code/packages/csharp/chacha20-poly1305/ChaCha20Poly1305.cs
+++ b/code/packages/csharp/chacha20-poly1305/ChaCha20Poly1305.cs
@@ -1,0 +1,256 @@
+using System.Buffers.Binary;
+using System.Numerics;
+using System.Security.Cryptography;
+
+namespace CodingAdventures.ChaCha20Poly1305;
+
+/// <summary>The result of ChaCha20-Poly1305 authenticated encryption.</summary>
+public sealed record AeadResult(byte[] Ciphertext, byte[] Tag);
+
+/// <summary>
+/// Pure C# ChaCha20-Poly1305 authenticated encryption from RFC 8439.
+/// </summary>
+/// <remarks>
+/// This educational implementation uses <see cref="BigInteger"/> for
+/// Poly1305 arithmetic. It avoids data-dependent branches in tag comparison,
+/// but <see cref="BigInteger"/> is not guaranteed to execute in constant time.
+/// </remarks>
+public static class ChaCha20Poly1305
+{
+    /// <summary>The required ChaCha20 key size in bytes.</summary>
+    public const int KeyLength = 32;
+
+    /// <summary>The required IETF ChaCha20 nonce size in bytes.</summary>
+    public const int NonceLength = 12;
+
+    /// <summary>The Poly1305 authentication tag size in bytes.</summary>
+    public const int TagLength = 16;
+
+    private const int BlockLength = 64;
+    private static readonly BigInteger Poly1305Prime = (BigInteger.One << 130) - 5;
+    private static readonly BigInteger TagMask = (BigInteger.One << 128) - 1;
+
+    /// <summary>Generate one 64-byte ChaCha20 keystream block.</summary>
+    public static byte[] ChaCha20Block(byte[] key, uint counter, byte[] nonce)
+    {
+        ValidateLength(key, KeyLength, nameof(key), "Key");
+        ValidateLength(nonce, NonceLength, nameof(nonce), "Nonce");
+
+        uint[] state =
+        [
+            0x61707865u, 0x3320646eu, 0x79622d32u, 0x6b206574u,
+            ReadUInt32(key, 0), ReadUInt32(key, 4), ReadUInt32(key, 8), ReadUInt32(key, 12),
+            ReadUInt32(key, 16), ReadUInt32(key, 20), ReadUInt32(key, 24), ReadUInt32(key, 28),
+            counter, ReadUInt32(nonce, 0), ReadUInt32(nonce, 4), ReadUInt32(nonce, 8),
+        ];
+
+        var initial = state.ToArray();
+        for (var round = 0; round < 10; round++)
+        {
+            QuarterRound(state, 0, 4, 8, 12);
+            QuarterRound(state, 1, 5, 9, 13);
+            QuarterRound(state, 2, 6, 10, 14);
+            QuarterRound(state, 3, 7, 11, 15);
+            QuarterRound(state, 0, 5, 10, 15);
+            QuarterRound(state, 1, 6, 11, 12);
+            QuarterRound(state, 2, 7, 8, 13);
+            QuarterRound(state, 3, 4, 9, 14);
+        }
+
+        var block = new byte[BlockLength];
+        for (var index = 0; index < state.Length; index++)
+        {
+            state[index] = unchecked(state[index] + initial[index]);
+            BinaryPrimitives.WriteUInt32LittleEndian(block.AsSpan(index * 4, 4), state[index]);
+        }
+
+        return block;
+    }
+
+    /// <summary>
+    /// Encrypt or decrypt bytes with the ChaCha20 stream cipher.
+    /// </summary>
+    public static byte[] ChaCha20Encrypt(
+        byte[] data,
+        byte[] key,
+        byte[] nonce,
+        uint counter = 0)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ValidateLength(key, KeyLength, nameof(key), "Key");
+        ValidateLength(nonce, NonceLength, nameof(nonce), "Nonce");
+
+        var result = new byte[data.Length];
+        var offset = 0;
+        var currentCounter = counter;
+
+        while (offset < data.Length)
+        {
+            var keystream = ChaCha20Block(key, currentCounter, nonce);
+            var chunkLength = Math.Min(BlockLength, data.Length - offset);
+            for (var index = 0; index < chunkLength; index++)
+            {
+                result[offset + index] = (byte)(data[offset + index] ^ keystream[index]);
+            }
+
+            offset += chunkLength;
+            currentCounter = unchecked(currentCounter + 1);
+        }
+
+        return result;
+    }
+
+    /// <summary>Compute a 16-byte Poly1305 one-time authenticator.</summary>
+    public static byte[] Poly1305Mac(byte[] message, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ValidateLength(key, KeyLength, nameof(key), "Poly1305 key");
+
+        var rBytes = key[..16].ToArray();
+        rBytes[3] &= 0x0f;
+        rBytes[7] &= 0x0f;
+        rBytes[11] &= 0x0f;
+        rBytes[15] &= 0x0f;
+        rBytes[4] &= 0xfc;
+        rBytes[8] &= 0xfc;
+        rBytes[12] &= 0xfc;
+
+        var r = DecodeLittleEndian(rBytes);
+        var s = DecodeLittleEndian(key.AsSpan(16, 16));
+        var accumulator = BigInteger.Zero;
+        Span<byte> augmented = stackalloc byte[17];
+
+        for (var offset = 0; offset < message.Length; offset += 16)
+        {
+            var chunkLength = Math.Min(16, message.Length - offset);
+            augmented.Clear();
+            message.AsSpan(offset, chunkLength).CopyTo(augmented);
+            augmented[chunkLength] = 1;
+            var block = DecodeLittleEndian(augmented[..(chunkLength + 1)]);
+            accumulator = ((accumulator + block) * r) % Poly1305Prime;
+        }
+
+        return EncodeLittleEndian((accumulator + s) & TagMask, TagLength);
+    }
+
+    /// <summary>Encrypt and authenticate data using RFC 8439 AEAD.</summary>
+    public static AeadResult AeadEncrypt(
+        byte[] plaintext,
+        byte[] key,
+        byte[] nonce,
+        byte[]? additionalData = null)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        ValidateLength(key, KeyLength, nameof(key), "Key");
+        ValidateLength(nonce, NonceLength, nameof(nonce), "Nonce");
+        additionalData ??= [];
+
+        var polyKey = ChaCha20Block(key, 0, nonce)[..KeyLength];
+        var ciphertext = ChaCha20Encrypt(plaintext, key, nonce, 1);
+        var tag = Poly1305Mac(BuildMacData(additionalData, ciphertext), polyKey);
+        return new AeadResult(ciphertext, tag);
+    }
+
+    /// <summary>
+    /// Authenticate and decrypt RFC 8439 AEAD ciphertext.
+    /// </summary>
+    /// <exception cref="CryptographicException">Authentication fails.</exception>
+    public static byte[] AeadDecrypt(
+        byte[] ciphertext,
+        byte[] key,
+        byte[] nonce,
+        byte[]? additionalData,
+        byte[] tag)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+        ValidateLength(key, KeyLength, nameof(key), "Key");
+        ValidateLength(nonce, NonceLength, nameof(nonce), "Nonce");
+        ValidateLength(tag, TagLength, nameof(tag), "Tag");
+        additionalData ??= [];
+
+        var polyKey = ChaCha20Block(key, 0, nonce)[..KeyLength];
+        var expectedTag = Poly1305Mac(BuildMacData(additionalData, ciphertext), polyKey);
+        if (!ConstantTimeEquals(expectedTag, tag))
+        {
+            throw new CryptographicException("Authentication failed: tag mismatch.");
+        }
+
+        return ChaCha20Encrypt(ciphertext, key, nonce, 1);
+    }
+
+    private static void QuarterRound(uint[] state, int a, int b, int c, int d)
+    {
+        state[a] = unchecked(state[a] + state[b]);
+        state[d] = BitOperations.RotateLeft(state[d] ^ state[a], 16);
+        state[c] = unchecked(state[c] + state[d]);
+        state[b] = BitOperations.RotateLeft(state[b] ^ state[c], 12);
+        state[a] = unchecked(state[a] + state[b]);
+        state[d] = BitOperations.RotateLeft(state[d] ^ state[a], 8);
+        state[c] = unchecked(state[c] + state[d]);
+        state[b] = BitOperations.RotateLeft(state[b] ^ state[c], 7);
+    }
+
+    private static uint ReadUInt32(byte[] value, int offset) =>
+        BinaryPrimitives.ReadUInt32LittleEndian(value.AsSpan(offset, 4));
+
+    private static BigInteger DecodeLittleEndian(ReadOnlySpan<byte> value) =>
+        new(value, isUnsigned: true, isBigEndian: false);
+
+    private static byte[] EncodeLittleEndian(BigInteger value, int length)
+    {
+        var encoded = value.ToByteArray(isUnsigned: true, isBigEndian: false);
+        var result = new byte[length];
+        encoded.AsSpan(0, Math.Min(encoded.Length, length)).CopyTo(result);
+        return result;
+    }
+
+    private static byte[] BuildMacData(byte[] additionalData, byte[] ciphertext)
+    {
+        var aadPadding = PaddingLength(additionalData.Length);
+        var ciphertextPadding = PaddingLength(ciphertext.Length);
+        var result = new byte[checked(
+            additionalData.Length + aadPadding + ciphertext.Length + ciphertextPadding + 16)];
+        var offset = 0;
+
+        additionalData.CopyTo(result, offset);
+        offset += additionalData.Length + aadPadding;
+        ciphertext.CopyTo(result, offset);
+        offset += ciphertext.Length + ciphertextPadding;
+        BinaryPrimitives.WriteUInt64LittleEndian(result.AsSpan(offset, 8), (ulong)additionalData.Length);
+        BinaryPrimitives.WriteUInt64LittleEndian(result.AsSpan(offset + 8, 8), (ulong)ciphertext.Length);
+        return result;
+    }
+
+    private static int PaddingLength(int length) => (16 - (length % 16)) % 16;
+
+    private static bool ConstantTimeEquals(byte[] left, byte[] right)
+    {
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        var difference = 0;
+        for (var index = 0; index < left.Length; index++)
+        {
+            difference |= left[index] ^ right[index];
+        }
+
+        return difference == 0;
+    }
+
+    private static void ValidateLength(
+        byte[]? value,
+        int expectedLength,
+        string parameterName,
+        string displayName)
+    {
+        ArgumentNullException.ThrowIfNull(value, parameterName);
+        if (value.Length != expectedLength)
+        {
+            throw new ArgumentException(
+                $"{displayName} must be {expectedLength} bytes, got {value.Length}.",
+                parameterName);
+        }
+    }
+}

--- a/code/packages/csharp/chacha20-poly1305/CodingAdventures.ChaCha20Poly1305.csproj
+++ b/code/packages/csharp/chacha20-poly1305/CodingAdventures.ChaCha20Poly1305.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ChaCha20Poly1305.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# ChaCha20-Poly1305 authenticated encryption from RFC 8439</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/chacha20-poly1305/README.md
+++ b/code/packages/csharp/chacha20-poly1305/README.md
@@ -1,0 +1,40 @@
+# CodingAdventures.ChaCha20Poly1305.CSharp
+
+Pure C# implementation of ChaCha20-Poly1305 authenticated encryption from
+[RFC 8439](https://www.rfc-editor.org/rfc/rfc8439).
+
+## What It Implements
+
+- the 20-round IETF ChaCha20 block and stream cipher with 256-bit keys;
+- Poly1305 one-time authentication over `2^130 - 5`;
+- ChaCha20-Poly1305 AEAD with 96-bit nonces and additional authenticated data;
+- constant-work tag comparison and authenticate-before-decrypt behavior.
+
+## Usage
+
+```csharp
+using Cipher = CodingAdventures.ChaCha20Poly1305.ChaCha20Poly1305;
+
+var encrypted = Cipher.AeadEncrypt(plaintext, key32, nonce12, aad);
+var decrypted = Cipher.AeadDecrypt(
+    encrypted.Ciphertext,
+    key32,
+    nonce12,
+    aad,
+    encrypted.Tag);
+```
+
+The nonce must be unique for each key. Reusing a key/nonce pair repeats both
+the ChaCha20 keystream and the one-time Poly1305 key.
+
+## Design Notes
+
+The implementation is self-contained and uses `BigInteger` for readable
+Poly1305 field arithmetic. It is intended for learning and conformance work;
+production systems should use a carefully audited platform cryptography API.
+
+## Testing
+
+```sh
+dotnet test tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.csproj
+```

--- a/code/packages/csharp/chacha20-poly1305/required_capabilities.json
+++ b/code/packages/csharp/chacha20-poly1305/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/chacha20-poly1305",
+  "capabilities": [],
+  "justification": "Pure in-memory RFC 8439 arithmetic with no filesystem, process, environment, or network access."
+}

--- a/code/packages/csharp/chacha20-poly1305/tests/CodingAdventures.ChaCha20Poly1305.Tests/ChaCha20Poly1305Tests.cs
+++ b/code/packages/csharp/chacha20-poly1305/tests/CodingAdventures.ChaCha20Poly1305.Tests/ChaCha20Poly1305Tests.cs
@@ -1,0 +1,155 @@
+using System.Security.Cryptography;
+using System.Text;
+using Cipher = CodingAdventures.ChaCha20Poly1305.ChaCha20Poly1305;
+
+namespace CodingAdventures.ChaCha20Poly1305.Tests;
+
+public sealed class ChaCha20Poly1305Tests
+{
+    private static readonly byte[] ChaChaKey = Hex(
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    private static readonly byte[] ChaChaNonce = Hex("000000000000004a00000000");
+    private static readonly byte[] ChaChaPlaintext = Encoding.ASCII.GetBytes(
+        "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.");
+    private static readonly byte[] ChaChaCiphertext = Hex(
+        "6e2e359a2568f98041ba0728dd0d6981e97e7aec1d4360c20a27afccfd9fae0b" +
+        "f91b65c5524733ab8f593dabcd62b3571639d624e65152ab8f530c359f0861d8" +
+        "07ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806818ce91ab7793736" +
+        "5af90bbf74a35be6b40b8eedf2785e42874d");
+    private static readonly byte[] AeadKey = Hex(
+        "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f");
+    private static readonly byte[] AeadNonce = Hex("070000004041424344454647");
+    private static readonly byte[] AeadAad = Hex("50515253c0c1c2c3c4c5c6c7");
+    private static readonly byte[] AeadCiphertext = Hex(
+        "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d6" +
+        "3dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b36" +
+        "92ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc" +
+        "3ff4def08e4b7a9de576d26586cec64b6116");
+    private static readonly byte[] AeadTag = Hex("1ae10b594f09e26a7e902ecbd0600691");
+
+    [Fact]
+    public void BlockMatchesRfc8439Section232()
+    {
+        var block = Cipher.ChaCha20Block(
+            ChaChaKey,
+            1,
+            Hex("000000090000004a00000000"));
+
+        Assert.Equal(64, block.Length);
+        Assert.Equal(Hex("10f1e7e4d13b5915500fdd1fa32071c4"), block[..16]);
+    }
+
+    [Fact]
+    public void StreamCipherMatchesRfc8439Section242()
+    {
+        Assert.Equal(
+            ChaChaCiphertext,
+            Cipher.ChaCha20Encrypt(ChaChaPlaintext, ChaChaKey, ChaChaNonce, 1));
+    }
+
+    [Fact]
+    public void StreamCipherIsSymmetricAcrossMultipleBlocks()
+    {
+        var plaintext = Enumerable.Range(0, 512).Select(index => (byte)index).ToArray();
+        var encrypted = Cipher.ChaCha20Encrypt(plaintext, ChaChaKey, ChaChaNonce, 7);
+
+        Assert.Equal(plaintext, Cipher.ChaCha20Encrypt(encrypted, ChaChaKey, ChaChaNonce, 7));
+        Assert.Empty(Cipher.ChaCha20Encrypt([], ChaChaKey, ChaChaNonce));
+    }
+
+    [Fact]
+    public void Poly1305MatchesRfc8439Section252()
+    {
+        Assert.Equal(
+            Hex("a8061dc1305136c6c22b8baf0c0127a9"),
+            Cipher.Poly1305Mac(
+                Encoding.ASCII.GetBytes("Cryptographic Forum Research Group"),
+                Hex("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b")));
+    }
+
+    [Fact]
+    public void Poly1305HandlesEmptyAndPartialBlocks()
+    {
+        var key = Enumerable.Range(0, 32).Select(index => (byte)index).ToArray();
+        Assert.Equal(16, Cipher.Poly1305Mac([], key).Length);
+        Assert.NotEqual(Cipher.Poly1305Mac([0], key), Cipher.Poly1305Mac([0, 0], key));
+    }
+
+    [Fact]
+    public void AeadEncryptMatchesRfc8439Section282()
+    {
+        var result = Cipher.AeadEncrypt(ChaChaPlaintext, AeadKey, AeadNonce, AeadAad);
+        Assert.Equal(AeadCiphertext, result.Ciphertext);
+        Assert.Equal(AeadTag, result.Tag);
+    }
+
+    [Fact]
+    public void AeadDecryptMatchesRfc8439Section282()
+    {
+        Assert.Equal(
+            ChaChaPlaintext,
+            Cipher.AeadDecrypt(AeadCiphertext, AeadKey, AeadNonce, AeadAad, AeadTag));
+    }
+
+    [Fact]
+    public void AeadRoundTripsEmptyAndLargePlaintexts()
+    {
+        var key = Enumerable.Range(0, 32).Select(index => (byte)index).ToArray();
+        var nonce = Enumerable.Range(0, 12).Select(index => (byte)index).ToArray();
+        foreach (var plaintext in new[] { Array.Empty<byte>(), Enumerable.Repeat((byte)0x41, 1024).ToArray() })
+        {
+            var result = Cipher.AeadEncrypt(plaintext, key, nonce, null);
+            Assert.Equal(plaintext, Cipher.AeadDecrypt(result.Ciphertext, key, nonce, null, result.Tag));
+        }
+    }
+
+    [Fact]
+    public void TamperedCiphertextIsRejected()
+    {
+        var result = Cipher.AeadEncrypt(Encoding.ASCII.GetBytes("secret"), AeadKey, AeadNonce, AeadAad);
+        result.Ciphertext[0] ^= 1;
+
+        Assert.Throws<CryptographicException>(() =>
+            Cipher.AeadDecrypt(result.Ciphertext, AeadKey, AeadNonce, AeadAad, result.Tag));
+    }
+
+    [Fact]
+    public void TamperedTagAndWrongAadAreRejected()
+    {
+        var result = Cipher.AeadEncrypt(Encoding.ASCII.GetBytes("secret"), AeadKey, AeadNonce, AeadAad);
+        var badTag = result.Tag.ToArray();
+        badTag[^1] ^= 1;
+
+        Assert.Throws<CryptographicException>(() =>
+            Cipher.AeadDecrypt(result.Ciphertext, AeadKey, AeadNonce, AeadAad, badTag));
+        Assert.Throws<CryptographicException>(() =>
+            Cipher.AeadDecrypt(result.Ciphertext, AeadKey, AeadNonce, [1, 2, 3], result.Tag));
+    }
+
+    [Fact]
+    public void InvalidKeyLengthsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => Cipher.ChaCha20Encrypt([], null!, ChaChaNonce));
+        Assert.Throws<ArgumentException>(() => Cipher.ChaCha20Encrypt([], new byte[31], ChaChaNonce));
+        Assert.Throws<ArgumentException>(() => Cipher.Poly1305Mac([], new byte[33]));
+    }
+
+    [Fact]
+    public void InvalidNonceAndTagLengthsAreRejected()
+    {
+        Assert.Throws<ArgumentException>(() => Cipher.ChaCha20Encrypt([], ChaChaKey, new byte[11]));
+        Assert.Throws<ArgumentException>(() =>
+            Cipher.AeadDecrypt([], ChaChaKey, ChaChaNonce, [], new byte[15]));
+    }
+
+    [Fact]
+    public void NullDataInputsAreRejected()
+    {
+        Assert.Throws<ArgumentNullException>(() => Cipher.ChaCha20Encrypt(null!, ChaChaKey, ChaChaNonce));
+        Assert.Throws<ArgumentNullException>(() => Cipher.Poly1305Mac(null!, ChaChaKey));
+        Assert.Throws<ArgumentNullException>(() => Cipher.AeadEncrypt(null!, ChaChaKey, ChaChaNonce));
+        Assert.Throws<ArgumentNullException>(() => Cipher.AeadDecrypt(null!, ChaChaKey, ChaChaNonce, [], new byte[16]));
+    }
+
+    private static byte[] Hex(string value) => Convert.FromHexString(value);
+}

--- a/code/packages/csharp/chacha20-poly1305/tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.csproj
+++ b/code/packages/csharp/chacha20-poly1305/tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.ChaCha20Poly1305.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/chacha20-poly1305/BUILD
+++ b/code/packages/fsharp/chacha20-poly1305/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.ChaCha20Poly1305]*"

--- a/code/packages/fsharp/chacha20-poly1305/BUILD_windows
+++ b/code/packages/fsharp/chacha20-poly1305/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.ChaCha20Poly1305]*"

--- a/code/packages/fsharp/chacha20-poly1305/CHANGELOG.md
+++ b/code/packages/fsharp/chacha20-poly1305/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add pure F# ChaCha20 stream encryption and Poly1305 authentication.
+- Add RFC 8439 ChaCha20-Poly1305 AEAD encryption and authenticated decryption.
+- Verify the RFC block, stream, MAC, and AEAD vectors plus tamper rejection.

--- a/code/packages/fsharp/chacha20-poly1305/ChaCha20Poly1305.fs
+++ b/code/packages/fsharp/chacha20-poly1305/ChaCha20Poly1305.fs
@@ -1,0 +1,258 @@
+namespace CodingAdventures.ChaCha20Poly1305.FSharp
+
+open System
+open System.Numerics
+open System.Security.Cryptography
+
+/// The result of ChaCha20-Poly1305 authenticated encryption.
+type AeadResult =
+    { Ciphertext: byte array
+      Tag: byte array }
+
+/// Pure F# ChaCha20-Poly1305 authenticated encryption from RFC 8439.
+/// This educational implementation uses BigInteger for Poly1305 arithmetic,
+/// which is not guaranteed to execute in constant time.
+[<RequireQualifiedAccess>]
+module ChaCha20Poly1305 =
+    [<Literal>]
+    let KeyLength = 32
+
+    [<Literal>]
+    let NonceLength = 12
+
+    [<Literal>]
+    let TagLength = 16
+
+    [<Literal>]
+    let private BlockLength = 64
+
+    let private poly1305Prime = (BigInteger.One <<< 130) - 5I
+    let private tagMask = (BigInteger.One <<< 128) - 1I
+
+    let private validateLength expectedLength parameterName displayName (value: byte array) =
+        if isNull value then
+            nullArg parameterName
+
+        if value.Length <> expectedLength then
+            invalidArg parameterName $"{displayName} must be {expectedLength} bytes, got {value.Length}."
+
+    let private readUInt32 (value: byte array) offset =
+        uint32 value[offset]
+        ||| (uint32 value[offset + 1] <<< 8)
+        ||| (uint32 value[offset + 2] <<< 16)
+        ||| (uint32 value[offset + 3] <<< 24)
+
+    let private writeUInt32 (buffer: byte array) offset (value: uint32) =
+        buffer[offset] <- byte value
+        buffer[offset + 1] <- byte (value >>> 8)
+        buffer[offset + 2] <- byte (value >>> 16)
+        buffer[offset + 3] <- byte (value >>> 24)
+
+    let private quarterRound (state: uint32 array) a b c d =
+        state[a] <- state[a] + state[b]
+        state[d] <- BitOperations.RotateLeft(state[d] ^^^ state[a], 16)
+        state[c] <- state[c] + state[d]
+        state[b] <- BitOperations.RotateLeft(state[b] ^^^ state[c], 12)
+        state[a] <- state[a] + state[b]
+        state[d] <- BitOperations.RotateLeft(state[d] ^^^ state[a], 8)
+        state[c] <- state[c] + state[d]
+        state[b] <- BitOperations.RotateLeft(state[b] ^^^ state[c], 7)
+
+    /// Generate one 64-byte ChaCha20 keystream block.
+    let chacha20Block (key: byte array) (counter: uint32) (nonce: byte array) =
+        validateLength KeyLength "key" "Key" key
+        validateLength NonceLength "nonce" "Nonce" nonce
+
+        let state =
+            [| 0x61707865u
+               0x3320646eu
+               0x79622d32u
+               0x6b206574u
+               readUInt32 key 0
+               readUInt32 key 4
+               readUInt32 key 8
+               readUInt32 key 12
+               readUInt32 key 16
+               readUInt32 key 20
+               readUInt32 key 24
+               readUInt32 key 28
+               counter
+               readUInt32 nonce 0
+               readUInt32 nonce 4
+               readUInt32 nonce 8 |]
+
+        let initial = Array.copy state
+
+        for _ = 1 to 10 do
+            quarterRound state 0 4 8 12
+            quarterRound state 1 5 9 13
+            quarterRound state 2 6 10 14
+            quarterRound state 3 7 11 15
+            quarterRound state 0 5 10 15
+            quarterRound state 1 6 11 12
+            quarterRound state 2 7 8 13
+            quarterRound state 3 4 9 14
+
+        let block = Array.zeroCreate<byte> BlockLength
+
+        for index = 0 to state.Length - 1 do
+            state[index] <- state[index] + initial[index]
+            writeUInt32 block (index * 4) state[index]
+
+        block
+
+    /// Encrypt or decrypt bytes with the ChaCha20 stream cipher.
+    let chacha20Encrypt
+        (data: byte array)
+        (key: byte array)
+        (nonce: byte array)
+        (counter: uint32)
+        =
+        if isNull data then
+            nullArg "data"
+
+        validateLength KeyLength "key" "Key" key
+        validateLength NonceLength "nonce" "Nonce" nonce
+
+        let result = Array.zeroCreate<byte> data.Length
+        let mutable offset = 0
+        let mutable currentCounter = counter
+
+        while offset < data.Length do
+            let keystream = chacha20Block key currentCounter nonce
+            let chunkLength = min BlockLength (data.Length - offset)
+
+            for index = 0 to chunkLength - 1 do
+                result[offset + index] <- data[offset + index] ^^^ keystream[index]
+
+            offset <- offset + chunkLength
+            currentCounter <- currentCounter + 1u
+
+        result
+
+    let private decodeLittleEndian (value: byte array) offset count =
+        let mutable result = BigInteger.Zero
+
+        for index = offset + count - 1 downto offset do
+            result <- (result <<< 8) ||| bigint value[index]
+
+        result
+
+    let private encodeLittleEndian length value =
+        let result = Array.zeroCreate<byte> length
+        let mutable remaining = value
+
+        for index = 0 to length - 1 do
+            result[index] <- byte (remaining &&& 255I)
+            remaining <- remaining >>> 8
+
+        result
+
+    /// Compute a 16-byte Poly1305 one-time authenticator.
+    let poly1305Mac (message: byte array) (key: byte array) =
+        if isNull message then
+            nullArg "message"
+
+        validateLength KeyLength "key" "Poly1305 key" key
+
+        let rBytes = key[..15]
+        rBytes[3] <- rBytes[3] &&& 0x0fuy
+        rBytes[7] <- rBytes[7] &&& 0x0fuy
+        rBytes[11] <- rBytes[11] &&& 0x0fuy
+        rBytes[15] <- rBytes[15] &&& 0x0fuy
+        rBytes[4] <- rBytes[4] &&& 0xfcuy
+        rBytes[8] <- rBytes[8] &&& 0xfcuy
+        rBytes[12] <- rBytes[12] &&& 0xfcuy
+
+        let r = decodeLittleEndian rBytes 0 rBytes.Length
+        let s = decodeLittleEndian key 16 16
+        let mutable accumulator = BigInteger.Zero
+        let mutable offset = 0
+
+        while offset < message.Length do
+            let chunkLength = min 16 (message.Length - offset)
+            let augmented = Array.zeroCreate<byte> (chunkLength + 1)
+            Array.blit message offset augmented 0 chunkLength
+            augmented[chunkLength] <- 1uy
+            let block = decodeLittleEndian augmented 0 augmented.Length
+            accumulator <- ((accumulator + block) * r) % poly1305Prime
+            offset <- offset + chunkLength
+
+        encodeLittleEndian TagLength ((accumulator + s) &&& tagMask)
+
+    let private paddingLength length = (16 - (length % 16)) % 16
+
+    let private writeUInt64 (buffer: byte array) offset (value: uint64) =
+        for index = 0 to 7 do
+            buffer[offset + index] <- byte (value >>> (index * 8))
+
+    let private buildMacData (additionalData: byte array) (ciphertext: byte array) =
+        let aadPadding = paddingLength additionalData.Length
+        let ciphertextPadding = paddingLength ciphertext.Length
+
+        let result =
+            Array.zeroCreate<byte>
+                (additionalData.Length + aadPadding + ciphertext.Length + ciphertextPadding + 16)
+
+        let mutable offset = 0
+        Array.blit additionalData 0 result offset additionalData.Length
+        offset <- offset + additionalData.Length + aadPadding
+        Array.blit ciphertext 0 result offset ciphertext.Length
+        offset <- offset + ciphertext.Length + ciphertextPadding
+        writeUInt64 result offset (uint64 additionalData.Length)
+        writeUInt64 result (offset + 8) (uint64 ciphertext.Length)
+        result
+
+    let private constantTimeEquals (left: byte array) (right: byte array) =
+        if left.Length <> right.Length then
+            false
+        else
+            let mutable difference = 0
+
+            for index = 0 to left.Length - 1 do
+                difference <- difference ||| int (left[index] ^^^ right[index])
+
+            difference = 0
+
+    /// Encrypt and authenticate data using RFC 8439 AEAD.
+    let aeadEncrypt
+        (plaintext: byte array)
+        (key: byte array)
+        (nonce: byte array)
+        (additionalData: byte array)
+        =
+        if isNull plaintext then
+            nullArg "plaintext"
+
+        validateLength KeyLength "key" "Key" key
+        validateLength NonceLength "nonce" "Nonce" nonce
+        let aad = if isNull additionalData then Array.empty else additionalData
+        let polyKey = (chacha20Block key 0u nonce)[.. KeyLength - 1]
+        let ciphertext = chacha20Encrypt plaintext key nonce 1u
+        let tag = poly1305Mac (buildMacData aad ciphertext) polyKey
+
+        { Ciphertext = ciphertext
+          Tag = tag }
+
+    /// Authenticate and decrypt RFC 8439 AEAD ciphertext.
+    let aeadDecrypt
+        (ciphertext: byte array)
+        (key: byte array)
+        (nonce: byte array)
+        (additionalData: byte array)
+        (tag: byte array)
+        =
+        if isNull ciphertext then
+            nullArg "ciphertext"
+
+        validateLength KeyLength "key" "Key" key
+        validateLength NonceLength "nonce" "Nonce" nonce
+        validateLength TagLength "tag" "Tag" tag
+        let aad = if isNull additionalData then Array.empty else additionalData
+        let polyKey = (chacha20Block key 0u nonce)[.. KeyLength - 1]
+        let expectedTag = poly1305Mac (buildMacData aad ciphertext) polyKey
+
+        if not (constantTimeEquals expectedTag tag) then
+            raise (CryptographicException("Authentication failed: tag mismatch."))
+
+        chacha20Encrypt ciphertext key nonce 1u

--- a/code/packages/fsharp/chacha20-poly1305/CodingAdventures.ChaCha20Poly1305.fsproj
+++ b/code/packages/fsharp/chacha20-poly1305/CodingAdventures.ChaCha20Poly1305.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.ChaCha20Poly1305.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# ChaCha20-Poly1305 authenticated encryption from RFC 8439</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ChaCha20Poly1305.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/chacha20-poly1305/README.md
+++ b/code/packages/fsharp/chacha20-poly1305/README.md
@@ -1,0 +1,37 @@
+# CodingAdventures.ChaCha20Poly1305.FSharp
+
+Pure F# implementation of ChaCha20-Poly1305 authenticated encryption from
+[RFC 8439](https://www.rfc-editor.org/rfc/rfc8439).
+
+## What It Implements
+
+- the 20-round IETF ChaCha20 block and stream cipher with 256-bit keys;
+- Poly1305 one-time authentication over `2^130 - 5`;
+- ChaCha20-Poly1305 AEAD with 96-bit nonces and additional authenticated data;
+- constant-work tag comparison and authenticate-before-decrypt behavior.
+
+## Usage
+
+```fsharp
+open CodingAdventures.ChaCha20Poly1305.FSharp
+
+let encrypted = ChaCha20Poly1305.aeadEncrypt plaintext key32 nonce12 aad
+let decrypted =
+    ChaCha20Poly1305.aeadDecrypt
+        encrypted.Ciphertext key32 nonce12 aad encrypted.Tag
+```
+
+The nonce must be unique for each key. Reusing a key/nonce pair repeats both
+the ChaCha20 keystream and the one-time Poly1305 key.
+
+## Design Notes
+
+The implementation is self-contained and uses `BigInteger` for readable
+Poly1305 field arithmetic. It is intended for learning and conformance work;
+production systems should use a carefully audited platform cryptography API.
+
+## Testing
+
+```sh
+dotnet test tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.fsproj
+```

--- a/code/packages/fsharp/chacha20-poly1305/required_capabilities.json
+++ b/code/packages/fsharp/chacha20-poly1305/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/chacha20-poly1305",
+  "capabilities": [],
+  "justification": "Pure in-memory RFC 8439 arithmetic with no filesystem, process, environment, or network access."
+}

--- a/code/packages/fsharp/chacha20-poly1305/tests/CodingAdventures.ChaCha20Poly1305.Tests/ChaCha20Poly1305Tests.fs
+++ b/code/packages/fsharp/chacha20-poly1305/tests/CodingAdventures.ChaCha20Poly1305.Tests/ChaCha20Poly1305Tests.fs
@@ -1,0 +1,197 @@
+namespace CodingAdventures.ChaCha20Poly1305.FSharp.Tests
+
+open System
+open System.Security.Cryptography
+open System.Text
+open Xunit
+open CodingAdventures.ChaCha20Poly1305.FSharp
+
+module ChaCha20Poly1305Tests =
+    let private hex (value: string) = Convert.FromHexString value
+
+    let private chachaKey =
+        hex "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+
+    let private chachaNonce = hex "000000000000004a00000000"
+
+    let private plaintext =
+        Encoding.ASCII.GetBytes(
+            "Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.")
+
+    let private chachaCiphertext =
+        hex (
+            "6e2e359a2568f98041ba0728dd0d6981e97e7aec1d4360c20a27afccfd9fae0b"
+            + "f91b65c5524733ab8f593dabcd62b3571639d624e65152ab8f530c359f0861d8"
+            + "07ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806818ce91ab7793736"
+            + "5af90bbf74a35be6b40b8eedf2785e42874d"
+        )
+
+    let private aeadKey =
+        hex "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+
+    let private aeadNonce = hex "070000004041424344454647"
+    let private aeadAad = hex "50515253c0c1c2c3c4c5c6c7"
+
+    let private aeadCiphertext =
+        hex (
+            "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d6"
+            + "3dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b36"
+            + "92ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc"
+            + "3ff4def08e4b7a9de576d26586cec64b6116"
+        )
+
+    let private aeadTag = hex "1ae10b594f09e26a7e902ecbd0600691"
+
+    [<Fact>]
+    let ``block matches RFC 8439 section 2.3.2`` () =
+        let block =
+            ChaCha20Poly1305.chacha20Block
+                chachaKey
+                1u
+                (hex "000000090000004a00000000")
+
+        Assert.Equal(64, block.Length)
+        Assert.Equal<byte array>(hex "10f1e7e4d13b5915500fdd1fa32071c4", block[..15])
+
+    [<Fact>]
+    let ``stream cipher matches RFC 8439 section 2.4.2`` () =
+        Assert.Equal<byte array>(
+            chachaCiphertext,
+            ChaCha20Poly1305.chacha20Encrypt plaintext chachaKey chachaNonce 1u)
+
+    [<Fact>]
+    let ``stream cipher is symmetric across multiple blocks`` () =
+        let data = Array.init 512 (fun index -> byte (index &&& 0xff))
+        let encrypted = ChaCha20Poly1305.chacha20Encrypt data chachaKey chachaNonce 7u
+
+        Assert.Equal<byte array>(
+            data,
+            ChaCha20Poly1305.chacha20Encrypt encrypted chachaKey chachaNonce 7u)
+
+        Assert.Empty(ChaCha20Poly1305.chacha20Encrypt Array.empty chachaKey chachaNonce 0u)
+
+    [<Fact>]
+    let ``Poly1305 matches RFC 8439 section 2.5.2`` () =
+        Assert.Equal<byte array>(
+            hex "a8061dc1305136c6c22b8baf0c0127a9",
+            ChaCha20Poly1305.poly1305Mac
+                (Encoding.ASCII.GetBytes("Cryptographic Forum Research Group"))
+                (hex "85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b"))
+
+    [<Fact>]
+    let ``Poly1305 handles empty and partial blocks`` () =
+        let key = Array.init 32 byte
+        Assert.Equal(16, (ChaCha20Poly1305.poly1305Mac Array.empty key).Length)
+
+        Assert.NotEqual<byte array>(
+            ChaCha20Poly1305.poly1305Mac [| 0uy |] key,
+            ChaCha20Poly1305.poly1305Mac [| 0uy; 0uy |] key)
+
+    [<Fact>]
+    let ``AEAD encrypt matches RFC 8439 section 2.8.2`` () =
+        let result = ChaCha20Poly1305.aeadEncrypt plaintext aeadKey aeadNonce aeadAad
+        Assert.Equal<byte array>(aeadCiphertext, result.Ciphertext)
+        Assert.Equal<byte array>(aeadTag, result.Tag)
+
+    [<Fact>]
+    let ``AEAD decrypt matches RFC 8439 section 2.8.2`` () =
+        Assert.Equal<byte array>(
+            plaintext,
+            ChaCha20Poly1305.aeadDecrypt aeadCiphertext aeadKey aeadNonce aeadAad aeadTag)
+
+    [<Fact>]
+    let ``AEAD round trips empty and large plaintexts`` () =
+        let key = Array.init 32 byte
+        let nonce = Array.init 12 byte
+
+        for input in [| Array.empty<byte>; Array.create 1024 0x41uy |] do
+            let result = ChaCha20Poly1305.aeadEncrypt input key nonce null
+
+            Assert.Equal<byte array>(
+                input,
+                ChaCha20Poly1305.aeadDecrypt result.Ciphertext key nonce null result.Tag)
+
+    [<Fact>]
+    let ``tampered ciphertext is rejected`` () =
+        let result =
+            ChaCha20Poly1305.aeadEncrypt
+                (Encoding.ASCII.GetBytes("secret"))
+                aeadKey
+                aeadNonce
+                aeadAad
+
+        result.Ciphertext[0] <- result.Ciphertext[0] ^^^ 1uy
+
+        Assert.Throws<CryptographicException>(fun () ->
+            ChaCha20Poly1305.aeadDecrypt
+                result.Ciphertext aeadKey aeadNonce aeadAad result.Tag
+            |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``tampered tag and wrong AAD are rejected`` () =
+        let result =
+            ChaCha20Poly1305.aeadEncrypt
+                (Encoding.ASCII.GetBytes("secret"))
+                aeadKey
+                aeadNonce
+                aeadAad
+
+        let badTag = Array.copy result.Tag
+        badTag[badTag.Length - 1] <- badTag[badTag.Length - 1] ^^^ 1uy
+
+        Assert.Throws<CryptographicException>(fun () ->
+            ChaCha20Poly1305.aeadDecrypt result.Ciphertext aeadKey aeadNonce aeadAad badTag
+            |> ignore)
+        |> ignore
+
+        Assert.Throws<CryptographicException>(fun () ->
+            ChaCha20Poly1305.aeadDecrypt result.Ciphertext aeadKey aeadNonce [| 1uy; 2uy; 3uy |] result.Tag
+            |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``invalid key lengths are rejected`` () =
+        Assert.Throws<ArgumentNullException>(fun () ->
+            ChaCha20Poly1305.chacha20Encrypt Array.empty null chachaNonce 0u |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentException>(fun () ->
+            ChaCha20Poly1305.chacha20Encrypt Array.empty (Array.zeroCreate 31) chachaNonce 0u
+            |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentException>(fun () ->
+            ChaCha20Poly1305.poly1305Mac Array.empty (Array.zeroCreate 33) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``invalid nonce and tag lengths are rejected`` () =
+        Assert.Throws<ArgumentException>(fun () ->
+            ChaCha20Poly1305.chacha20Encrypt Array.empty chachaKey (Array.zeroCreate 11) 0u
+            |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentException>(fun () ->
+            ChaCha20Poly1305.aeadDecrypt Array.empty chachaKey chachaNonce Array.empty (Array.zeroCreate 15)
+            |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``null data inputs are rejected`` () =
+        Assert.Throws<ArgumentNullException>(fun () ->
+            ChaCha20Poly1305.chacha20Encrypt null chachaKey chachaNonce 0u |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () ->
+            ChaCha20Poly1305.poly1305Mac null chachaKey |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () ->
+            ChaCha20Poly1305.aeadEncrypt null chachaKey chachaNonce Array.empty |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () ->
+            ChaCha20Poly1305.aeadDecrypt null chachaKey chachaNonce Array.empty (Array.zeroCreate 16)
+            |> ignore)
+        |> ignore

--- a/code/packages/fsharp/chacha20-poly1305/tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.fsproj
+++ b/code/packages/fsharp/chacha20-poly1305/tests/CodingAdventures.ChaCha20Poly1305.Tests/CodingAdventures.ChaCha20Poly1305.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.ChaCha20Poly1305.fsproj" />
+    <Compile Include="ChaCha20Poly1305Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -112,11 +112,11 @@ the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
 and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
 `x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
-ports:
+ports, and the paired C#/F# `chacha20-poly1305` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 331 |
+| Present in 10-15 languages | 172 | 329 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 699 | 9,786 |
@@ -171,8 +171,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 11 | Move with F# |
-| F# | 11 | Move with C# |
+| C# | 10 | Move with F# |
+| F# | 10 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -274,6 +274,14 @@ thereafter. Canonical vectors cover the address-mode transition, secret keys,
 associated data, multiple lanes and passes, and variable tag lengths. The
 package now spans 12 target implementation lanes and reduces each paired
 high-consensus gap to 11.
+
+The seventh paired C#/F# slice is complete: `chacha20-poly1305` now implements
+the self-contained RFC 8439 ChaCha20 stream cipher, Poly1305 one-time MAC, and
+combined AEAD construction in both lanes. Canonical block, stream, MAC, and
+AEAD vectors cover the full construction, while multiblock round trips and
+tamper tests verify counter progression and authenticate-before-decrypt
+behavior. The package now spans 12 implementation lanes and reduces each
+paired high-consensus gap to 10.
 
 Recommended family order:
 


### PR DESCRIPTION
## What changed

- add pure C# and F# ChaCha20 block/stream implementations
- add Poly1305 one-time authentication and RFC 8439 AEAD encryption/decryption
- add package metadata, capability declarations, documentation, and native xUnit suites
- refresh the parity roadmap from 331 to 329 high-consensus missing slots and from 11 to 10 gaps in each paired lane

## Why this slice is next

`chacha20-poly1305` is the smallest remaining dependency-safe C#/F# consensus port. It is self-contained; the superficially smaller `nib-wasm-compiler` is blocked by missing Nib and IR dependencies, while `xml-lexer` depends on the grammar/lexer stack.

## Validation

- C#: 13/13 tests; 98.7% line, 95.45% branch, 100% method coverage
- F#: 13/13 tests; 99.35% line, 84.61% branch, 100% method coverage
- parity reporter tests: 6/6
- parity report: zero canonical collisions, 329 high-consensus missing slots
- `dotnet format` C# verification and `git diff --check`

## Remaining paired C#/F# gaps

`asciidoc-parser`, `block-ram`, `dartmouth-basic-lexer`, `dartmouth-basic-parser`, `ed25519`, `font-parser`, `fpga`, `nib-wasm-compiler`, `xml-lexer`, and `zstd`.