### PR TITLE
feat(adj-facts-stdlib): physics/forces — force → example table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_forces_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_forces_e2e.rs
@@ -1,0 +1,81 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/forces.adj`) driven through the built CLI:
+//! a native `table` of common force → everyday example resolves a binding
+//! query recall with the NASA citation, runs backward (example → force), and
+//! abstains on a force the source never illustrates — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsforces_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn physics_forces_recall_binds_example_with_citation() {
+    let dir = scratch("forces");
+    // Copy the shipped physics table beside the entry program and import it.
+    let src = facts_stdlib().join("physics/forces.adj");
+    std::fs::copy(&src, dir.join("forces.adj")).expect("copy shipped forces.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"forces.adj\"\n\
+         ? force_example(gravity, $Ex)\n\
+         ? force_example(applied, $Ex)\n\
+         ? force_example(friction, $Ex)\n\
+         ? force_example($F, ropes)\n\
+         ? force_example(magnetism, $Ex)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward lookups bind each force to the everyday example NASA names.
+    assert!(
+        out.contains("\"Ex\":\"waterfall\""),
+        "gravity binds to waterfall: {out}"
+    );
+    assert!(
+        out.contains("force_example(gravity, waterfall)"),
+        "gravity is governing-bound to waterfall: {out}"
+    );
+    assert!(
+        out.contains("force_example(applied, ball)"),
+        "applied is governing-bound to ball: {out}"
+    );
+    assert!(
+        out.contains("force_example(friction, wheels)"),
+        "friction is governing-bound to wheels: {out}"
+    );
+    // The relation runs BACKWARD: bind the example, recall the force.
+    assert!(
+        out.contains("force_example(tension, ropes)"),
+        "reverse recall binds F=tension from ropes: {out}"
+    );
+    // The answer carries the NASA locator + trust tier as its proof.
+    assert!(
+        out.contains("nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Magnetism is a real force, but the poster never illustrates it — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "magnetism abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -48,6 +48,7 @@ per rotation, in parallel):
 | `physics/` | simple machine → everyday example | NASA |
 | `physics/` | phase change → its name (melting, freezing, …) | LibreTexts (consensus) |
 | `physics/` | energy form → defining token (chemical → bonds, thermal → heat) | EIA (energy.gov) |
+| `physics/` | common force → everyday example NASA uses (gravity → waterfall, tension → ropes) | NASA GSFC Swift (authoritative) |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |

--- a/code/specs/data/adj-facts-stdlib/physics/forces.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/forces.adj
@@ -1,0 +1,100 @@
+% ============================================================================
+% forces — a named common force and the everyday EXAMPLE a NASA education
+% poster uses to illustrate it (adj-facts-stdlib, PHYSICS).
+% ============================================================================
+% An elementary/middle-school physics fact on the way to mechanics: a FORCE is
+% a push or a pull, and the way a learner first meets each kind of force is
+% through a familiar everyday scene — water falling, a thrown ball, a swing, a
+% car's wheels, a launching rocket. This little table pairs each named force
+% with the concrete example NASA's Newton's-Second-Law classroom poster uses to
+% show it. Recall is a binding query:
+%
+%     ? force_example(gravity, $Ex)   % waterfall
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `force_example(force, example)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the
+% everyday example WITH its source, on the CPU, with zero model calls, and
+% abstains on anything the poster does not illustrate.
+%
+% The forces, as a little truth table (force → the everyday scene NASA uses to
+% illustrate it):
+%
+%     force      what it is (a push/pull that…)        NASA's everyday example
+%     --------   -----------------------------------   -----------------------
+%     gravity    pulls things downward                  waterfall (falling water)
+%     applied    a push/pull you exert on an object     ball (a girl throwing it)
+%     tension    pull carried along a rope/string       ropes (of a swing)
+%     friction   opposes motion between surfaces        wheels (of a car)
+%     booster    thrust that pushes a rocket up         rocket (at launch)
+%
+% This is the concrete rung a physics learner reasons UP from: before reasoning
+% about F = ma, net force, or free-body diagrams, a student first learns to NAME
+% a force and point to it in a scene they already know. The query also runs
+% BACKWARD — bind the example and recall the force it illustrates:
+%
+%     ? force_example($F, ropes)   % tension — reverse recall
+%
+% A force the poster never illustrates — magnetism, the normal force, air
+% resistance — has no row, so a recall on it ABSTAINS rather than inventing an
+% example. That honest-abstention property is what makes the table safe to
+% reason from: the table claims ONLY the five force→example pairings NASA's
+% document explicitly states, not the whole of physics.
+%
+% Each `example` value is a SINGLE lowercase snake_case atom, chosen to be a
+% faithful short paraphrase of the everyday object the source names for that
+% force — never a scene the source does not use.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every force→example pair
+% was read out of a fetched NASA education document this session, and any force
+% that could not be grounded there was dropped). All five spans come from the
+% SAME primary U.S. government source, NASA Goddard's Swift mission education
+% poster "Newton's Second Law: Force, Velocity and Acceleration"
+% (imagine.gsfc.nasa.gov/observatories/learning/swift/classroom/docs/law2_guide.pdf),
+% each quoted here character-for-character so any reader can re-check it. The
+% poster illustrates each force with an everyday scene:
+%
+%   gravity → waterfall
+%     "As the water flows over the edge of the rocks, gravity, which exerts a
+%      downward force on it, causes it to accelerate downward: the water moves
+%      faster the longer it falls."
+%
+%   applied → ball
+%     "When the girl throws the ball, she is applying a force to it and
+%      accelerating it."
+%
+%   tension → ropes
+%     "the force of the tension in the ropes makes her move in an arc upwards"
+%
+%   friction → wheels
+%     "When a driver hits the gas, the wheels apply a force on the ground due to
+%      friction."
+%
+%   booster → rocket
+%     "F_booster is the force from the rocket boosters, and it pushes the rocket
+%      away from the Earth."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the NASA sentence that fixes the
+% first row (gravity → waterfall). Every OTHER row's per-fact source and verbatim
+% span is listed above, so each example remains independently checkable. The
+% source is a primary U.S. government NASA (Goddard Space Flight Center)
+% education page (gsfc.nasa.gov), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table force_example {
+    columns force, example
+
+    row (gravity, waterfall)
+    row (applied, ball)
+    row (tension, ropes)
+    row (friction, wheels)
+    row (booster, rocket)
+
+    source "As the water flows over the edge of the rocks, gravity, which exerts a downward force on it, causes it to accelerate downward: the water moves faster the longer it falls."
+    locator "https://imagine.gsfc.nasa.gov/observatories/learning/swift/classroom/docs/law2_guide.pdf"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/physics/forces.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/forces.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% forces.query.adj — a worked recall over the physics forces library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what everyday example does
+% NASA use to illustrate gravity?": it states no physics fact — it only
+% `import`s the grounded table and asks binding queries. The engine resolves
+% each `?` against the `force_example` rows and returns the example + the
+% table's source/locator/trust. The fifth query runs the relation BACKWARD (bind
+% the example `ropes`, recall the force it illustrates — tension). Magnetism is a
+% real force, but NASA's poster never illustrates it, so a recall on it abstains
+% honestly — the engine never invents an example.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli forces.query.adj
+% ============================================================================
+
+import "forces.adj"
+
+? force_example(gravity, $Ex)    % expect waterfall
+? force_example(applied, $Ex)    % expect ball
+? force_example(friction, $Ex)   % expect wheels
+? force_example(booster, $Ex)    % expect rocket
+? force_example($F, ropes)       % expect tension — reverse recall
+? force_example(magnetism, $Ex)  % expect abstain — the poster never illustrates it


### PR DESCRIPTION
A native `table` mapping a named common force to the everyday example
NASA's Newton's-Second-Law classroom poster uses to illustrate it. Recall
is an ordinary SLD binding query resolved on the CPU with zero model calls,
runs backward (example → force), and abstains honestly on a force the
source never illustrates (magnetism).

Rows (single axis: common force → everyday example NASA names):
    gravity  → waterfall
    applied  → ball
    tension  → ropes
    friction → wheels
    booster  → rocket

Provenance — every pair read this session out of a single primary U.S.
government source, NASA Goddard's Swift mission education poster "Newton's
Second Law: Force, Velocity and Acceleration"
(imagine.gsfc.nasa.gov/observatories/learning/swift/classroom/docs/law2_guide.pdf),
trust `authoritative`. Verbatim spans:
  gravity → waterfall: "As the water flows over the edge of the rocks,
    gravity, which exerts a downward force on it, causes it to accelerate
    downward: the water moves faster the longer it falls."
  applied → ball: "When the girl throws the ball, she is applying a force
    to it and accelerating it."
  tension → ropes: "the force of the tension in the ropes makes her move
    in an arc upwards"
  friction → wheels: "When a driver hits the gas, the wheels apply a force
    on the ground due to friction."
  booster → rocket: "F_booster is the force from the rocket boosters, and
    it pushes the rocket away from the Earth."

Forces the source does not illustrate (magnetism, normal force, air
resistance) were dropped rather than invented, so a recall on them abstains.

Adds physics/forces.adj + forces.query.adj (forward + reverse + abstain),
a CLI e2e test (facts_forces_e2e.rs), and a physics README index row.
Targeted test green; clippy clean on adj-lang + adj-lang-cli.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
