### PR TITLE
feat(adj-facts-stdlib): biology/kingdoms — kingdom → example organism table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_kingdoms_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_kingdoms_e2e.rs
@@ -1,0 +1,84 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/kingdoms.adj`) driven through the built CLI:
+//! a native `table` of the biological kingdoms of life → a representative
+//! example organism resolves binding-query recalls (forward AND backward) with
+//! the source's Science Notes citation at the `consensus` trust tier, and
+//! abstains on a word that is not one of these kingdoms (a virus) — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_kingdoms_recall_binds_example_with_citation() {
+    let dir = scratch("kingdoms");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/kingdoms.adj");
+    std::fs::copy(&src, dir.join("kingdoms.adj")).expect("copy shipped kingdoms.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"kingdoms.adj\"\n\
+         ? kingdom_example(animalia, $Example)\n\
+         ? kingdom_example(fungi, $Example)\n\
+         ? kingdom_example(bacteria, $Example)\n\
+         ? kingdom_example($Kingdom, mushrooms)\n\
+         ? kingdom_example(virus, $Example)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The animal kingdom's listed example is humans, the fungus kingdom's is
+    // mushrooms, the bacteria kingdom's is cyanobacteria — the recalled examples
+    // (forward binds).
+    assert!(
+        out.contains("\"Example\":\"humans\""),
+        "animalia → humans: {out}"
+    );
+    assert!(
+        out.contains("\"Example\":\"mushrooms\""),
+        "fungi → mushrooms: {out}"
+    );
+    assert!(
+        out.contains("\"Example\":\"cyanobacteria\""),
+        "bacteria → cyanobacteria: {out}"
+    );
+    // The relation runs BACKWARD: bind the example `mushrooms`, recall its
+    // kingdom.
+    assert!(
+        out.contains("\"Kingdom\":\"fungi\""),
+        "mushrooms → fungi (reverse recall): {out}"
+    );
+    // The answer carries the Science Notes citation as its proof, at the
+    // `consensus` trust tier for a secondary teaching source.
+    assert!(
+        out.contains("sciencenotes.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation: {out}"
+    );
+    // A virus is not placed in any of these kingdoms — honest abstention, never
+    // a fabricated example.
+    assert!(out.contains("\"abstained\":true"), "virus abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -42,6 +42,7 @@ per rotation, in parallel):
 | `biology/` | common bone → body region | NIH / MedlinePlus |
 | `biology/` | macronutrient → energy (kcal) per gram | NIH / MedlinePlus |
 | `biology/` | basic tissue type → representative example | NCI SEER Training |
+| `biology/` | kingdom of life → representative example organism (fungi → mushrooms) | Science Notes (consensus) |
 | `biology/` | blood-vessel type → defining function (artery → away from heart) | NCI SEER Training |
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |

--- a/code/specs/data/adj-facts-stdlib/biology/kingdoms.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/kingdoms.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% kingdoms — each biological kingdom of life mapped to a representative example
+% organism the source lists for it (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the very first ideas a biology learner meets: every living thing on
+% Earth is sorted into a small number of top-level KINGDOMS, and each kingdom
+% has familiar example organisms that live in it. "Animals are in Animalia;
+% flowering plants are in Plantae; mushrooms are Fungi; amoebas are Protista;
+% cyanobacteria are Bacteria." Before you can reason about an organism at all,
+% it helps to know WHICH kingdom it belongs to. Recall is a binding query:
+%
+%     ? kingdom_example(fungi, $Example)      % mushrooms
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `kingdom_example(kingdom, example)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% example WITH its source, on the CPU, with zero model calls, and abstains on a
+% word that is not one of these kingdoms (it never invents an example).
+%
+% Each kingdom below and the representative example the source lists first for
+% it, as a little truth table:
+%
+%     kingdom     representative example   a beginner's cue
+%     ---------   ----------------------   ----------------------------------
+%     animalia    humans                   the animal kingdom — humans, birds…
+%     plantae     flowers                  the plant kingdom — flowers, ferns…
+%     fungi       mushrooms                the fungus kingdom — mushrooms, molds
+%     protista    amoebas                  single-celled eukaryotes — amoebas…
+%     bacteria    cyanobacteria            the prokaryote kingdom — cyanobacteria
+%
+% The query also runs BACKWARD — bind an example and recall its kingdom:
+%
+%     ? kingdom_example($Kingdom, mushrooms)   % fungi
+%
+% A word that is NOT one of these kingdoms — `virus`, `mineral`, `rock` — is
+% deliberately NOT a row, so a kingdom recall ABSTAINS on it rather than
+% inventing an example. (Viruses are a classic example: they are not placed in
+% any of these kingdoms, so the table honestly abstains on `virus`.) That
+% honest-abstention property is what makes the table safe to build a reasoner
+% on: it answers exactly the kingdom→example pairs it can ground, and only those.
+%
+% The `example` value of every row is a SINGLE lowercase atom, chosen to be the
+% first single-organism example the source EXPLICITLY lists for that kingdom —
+% never one the source does not support. (The source's word is kept, lowercased:
+% it writes "Humans"/"Flowers"/"Mushrooms"/"Amoebas", so every value stays
+% literally checkable against the quoted "Examples:" span.)
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every kingdom→example pair
+% below was read out of a single fetched Science Notes "Kingdoms of Life in
+% Biology" page, and any pair whose example could not be verified there would
+% have been dropped). Each pair, with the verbatim "Examples:" span that states
+% it (all from the one source below):
+%
+%   animalia → humans
+%     "Examples: Humans, birds, crustaceans, sponges"
+%   plantae → flowers
+%     "Examples: Flowers, grasses, conifers, multicellular algae, ferns, mosses"
+%   fungi → mushrooms
+%     "Examples: Mushrooms, yeast, molds"
+%   protista → amoebas
+%     "Examples: Amoebas, diatoms, dinoflagellates, ciliates, slime molds,
+%      single-celled algae"
+%   bacteria → cyanobacteria
+%     "Examples: Gram-positive and Gram-negative bacteria, cyanobacteria,
+%      actinobacteria"
+%
+% All five spans are from the same page,
+% https://sciencenotes.org/kingdoms-of-life-in-biology/ — a secondary science
+% teaching resource, so `trust consensus` (not a primary .gov/.edu source).
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the "Examples:" line that fixes
+% the first row (animalia → humans). Every OTHER row's verbatim "Examples:" span
+% is listed above, so each example remains independently checkable.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table kingdom_example {
+    columns kingdom, example
+
+    row (animalia, humans)
+    row (plantae, flowers)
+    row (fungi, mushrooms)
+    row (protista, amoebas)
+    row (bacteria, cyanobacteria)
+
+    source "Examples: Humans, birds, crustaceans, sponges"
+    locator "https://sciencenotes.org/kingdoms-of-life-in-biology/"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/biology/kingdoms.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/kingdoms.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% kingdoms.query.adj — a worked recall over the biology kingdoms library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is an example of a
+% fungus?": it states no biology fact of its own — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `kingdom_example` rows and returns the example + the table's source/
+% locator/trust. The fourth query runs the relation BACKWARD (bind the example
+% `mushrooms`, recall its kingdom — fungi). A word that is not one of these
+% kingdoms abstains honestly — the engine never invents an example.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli kingdoms.query.adj
+% ============================================================================
+
+import "kingdoms.adj"
+
+? kingdom_example(animalia, $Example)   % expect humans
+? kingdom_example(fungi, $Example)      % expect mushrooms
+? kingdom_example(bacteria, $Example)   % expect cyanobacteria
+? kingdom_example($Kingdom, mushrooms)  % reverse bind — expect fungi
+? kingdom_example(virus, $Example)      % expect abstain — viruses are not placed in any of these kingdoms


### PR DESCRIPTION
Add a native ADJ `table` mapping each biological kingdom of life to a
representative example organism the source explicitly lists, plus a worked
`.query.adj` recall and a CLI e2e test.

Single clean axis (kingdom → representative example), single source: the
Science Notes "Kingdoms of Life in Biology" page. Every value token is verbatim
(lowercased) from that kingdom's "Examples:" span; any pair that could not be
grounded there was dropped. Nothing asserted from memory.

Rows (each grounded to its verbatim "Examples:" span on the one source):
  animalia → humans        "Examples: Humans, birds, crustaceans, sponges"
  plantae  → flowers       "Examples: Flowers, grasses, conifers, multicellular algae, ferns, mosses"
  fungi    → mushrooms     "Examples: Mushrooms, yeast, molds"
  protista → amoebas       "Examples: Amoebas, diatoms, dinoflagellates, ciliates, slime molds, single-celled algae"
  bacteria → cyanobacteria "Examples: Gram-positive and Gram-negative bacteria, cyanobacteria, actinobacteria"

Source: https://sciencenotes.org/kingdoms-of-life-in-biology/ (secondary science
teaching resource → trust consensus, not a primary .gov/.edu source).

The table carries ONE provenance envelope holding the cleanest single span
(animalia → humans); every other row's verbatim "Examples:" span is listed in
the file header so each example stays independently checkable. Forward and
reverse binding queries both resolve on the CPU with 0 model calls; a word that
is not one of these kingdoms (e.g. `virus`) abstains honestly.

Also add a biology subject-index row to adj-facts-stdlib/README.md (all existing
rows kept).

Targeted e2e (cargo test -p adj-lang-cli --test facts_kingdoms_e2e) and
clippy (-D warnings on adj-lang + adj-lang-cli) both green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
