### PR TITLE
docs(hl): HL01 concept taxonomy + data layer, HL02 companion app specs

### DIFF
--- a/code/specs/HL00-human-language-curriculum-framework.md
+++ b/code/specs/HL00-human-language-curriculum-framework.md
@@ -11,9 +11,13 @@ publication, that grows one chapter at a time.
 
 This is the first spec in the **HL** series. It defines the pedagogical
 framework, the content schema every lesson file follows, and the divergence
-from this repo's standard software-package process. `HL01`+ are reserved for
-per-language notes as new tracks are added (French, German, Arabic, Hindi,
-Tamil, Kannada, Telugu, Malayalam) after the Spanish pilot proves the format.
+from this repo's standard software-package process. Later specs build on it:
+[`HL01`](./HL01-concept-taxonomy-and-data-layer.md) defines the cross-language
+**concept taxonomy** and the machine-readable **data layer** derived from these
+lessons; [`HL02`](./HL02-companion-practice-app.md) defines the **companion
+practice app** and the learning-science method behind it. (An earlier draft
+reserved `HL01`+ for per-language notes; those never materialized and the
+numbers are repurposed here — nothing is released, so this is a free change.)
 
 ```
                     ┌───────────────────────────┐      Markdown lesson files
@@ -216,8 +220,18 @@ sounds: [accent-i, d-soft]   # ids into pronunciation-reference.md
 roots: [dies]                # Latin/other roots excavated, for indexing
 est_minutes: 4
 reviews_of: []               # lesson ids resurfaced (review/practice-mix only)
+# Optional, added by HL01 for the data layer (back-compatible — omit freely):
+romanization: DEE-ah        # required for non-Latin scripts; omit for Latin (defaults to headword)
+etymology_hook: "día ← Latin dies → diary, dial, diurnal"   # ≤120-char memory anchor
 ---
 ```
+
+The `concept_tag` is the cross-language join key: [`HL01`](./HL01-concept-taxonomy-and-data-layer.md)
+canonicalizes it (universal ids like `GREETING-HELLO` live in
+`concepts/taxonomy.json`; language-local lexical tags are namespaced, e.g.
+`ES-WORD-DIA`). `romanization` and `etymology_hook` are the two optional fields
+`HL01` adds so the data layer and companion app can be **derived** from these
+lessons rather than maintained as a separate, drift-prone copy.
 
 Body sections match the Lesson Anatomy above: `## Warm-up`,
 `## You'll want to know first` (optional), `## Sounds you'll need`,

--- a/code/specs/HL01-concept-taxonomy-and-data-layer.md
+++ b/code/specs/HL01-concept-taxonomy-and-data-layer.md
@@ -1,0 +1,293 @@
+# HL01 — Cross-Language Concept Taxonomy & Structured Data Layer
+
+## Overview
+
+`HL00` defines the **content** of the Human Languages curriculum: per-language
+Markdown lessons and a LaTeX book, each lesson excavating one word or phrase with
+its etymology "cousin web." This spec, `HL01`, defines the **data layer** that
+sits on top of that content — the machine-readable bridge that lets software (the
+companion app in `HL02`, and anything later) reason about the curriculum
+*across* languages.
+
+The single idea here is the **concept**: a language-independent unit of meaning
+or function that the curriculum teaches. "The greeting you say when you meet
+someone" is a concept; Spanish *hola*, German *hallo*, Hindi *नमस्ते*, and Telugu
+*నమస్కారం* are its **realizations** in four languages. Concepts are the join key
+that makes cross-language study possible.
+
+```
+   lessons/*.md (frontmatter)              concepts/taxonomy.json
+        │  concept_tag: GREETING-HELLO          │  canonical universal concepts
+        │  headword: hola                        │  (the controlled vocabulary)
+        ▼                                        ▼
+   ┌────────────────────────────────────────────────────┐
+   │  data layer: concept  ──►  { language: realization } │
+   │  (derived by parsing frontmatter, validated in CI)   │
+   └────────────────────────────────────────────────────┘
+        │                                        │
+        ▼                                        ▼
+   languagesForConcept("GREETING-HELLO")   conceptsByLanguage("spanish")
+        = [spanish, german, hindi, …]           = [GREETING-HELLO, WORD-DAY, …]
+```
+
+## Why this spec exists — the discovery that forced it
+
+The lesson schema in `HL00` already carries a `concept_tag` field. In principle
+that is the join key. In practice, an audit of the existing 16 tracks found the
+tags are **not a shared vocabulary yet**:
+
+- Spanish tags its good-night greeting `GREETING-NIGHT`; French and German tag
+  the same function `GREETING-GOODNIGHT`.
+- Spanish `DIA`, French `JOUR`, German has no "day" lexical tag — the same
+  concept (the noun "day") wears three unrelated, language-local names.
+- Telugu and Hindi both tag `WHATS-YOUR-NAME`; Spanish's equivalent lesson uses
+  `ES-C03-como-se-llama` with tag `CH...`.
+
+So a query like *"show me 'thank you' in Spanish, French, and German"* cannot be
+answered reliably today. Before any cross-language tooling can exist, the tags
+must be **reconciled onto a canonical taxonomy**. That reconciliation, plus the
+schema and validator that keep it honest, is what `HL01` delivers.
+
+## Two tiers of concept
+
+Not every lesson teaches something that crosses languages cleanly, and forcing it
+to would be dishonest. So concepts come in two tiers.
+
+### 1. Universal concepts (the interleaving join keys)
+
+A **universal concept** is a meaning or function that most languages realize with
+*some* word — the thing a learner would ask "how do you say X in this language?"
+about. These are the concepts the companion app interleaves across languages.
+
+Their ids are **canonical, language-independent, and listed in `taxonomy.json`**.
+Examples: `GREETING-HELLO`, `COURTESY-THANKS`, `RESPONSE-YES`, `RESPONSE-NO`,
+`QUESTION-WHAT`, `INTRO-MY-NAME-IS`, `NUMBER-3`.
+
+Id format: `FAMILY-NAME`, SCREAMING-KEBAB-CASE, family prefix from the fixed
+family list below. Ids are **stable slugs, never renumbered** (same rule as
+`HL00` lesson ids), so inserting a concept never cascades.
+
+### 2. Lexical / structural concepts (language-local)
+
+Some lessons excavate a **building block specific to one language** — a particular
+root word (Spanish *día* ← Latin *dies*), or a structural feature (the Spanish
+*el/la* article system, German's three-way *der/die/das*). These do not have a
+clean one-to-one sibling in every other language, so forcing them into the
+universal vocabulary would create false equivalences.
+
+They keep a **namespaced tag**: `<LANG>-<NAME>`, e.g. `ES-WORD-DIA`,
+`DE-ARTICLES-DER-DIE-DAS`. They are still first-class data — the app can drill
+them *within* a language — but the cross-language interleaver does not expect
+them to have realizations elsewhere.
+
+A concept that starts life language-local can be *promoted* to universal later
+(e.g. once "day/noche/día" is authored in enough tracks, a `WORD-DAY` universal
+concept with per-language realizations becomes worthwhile). Promotion is a
+taxonomy edit plus a retag; nothing renumbers.
+
+## Concept Families (fixed prefixes)
+
+| Family | Meaning | Example ids |
+|---|---|---|
+| `GREETING-` | greeting/parting formulas | `GREETING-HELLO`, `GREETING-MORNING`, `GREETING-AFTERNOON`, `GREETING-EVENING`, `GREETING-GOODNIGHT`, `FAREWELL` |
+| `COURTESY-` | politeness formulas | `COURTESY-THANKS`, `COURTESY-THANKS-FORMAL`, `COURTESY-PLEASE`, `COURTESY-SORRY`, `COURTESY-WELCOME` |
+| `RESPONSE-` | minimal answers | `RESPONSE-YES`, `RESPONSE-NO`, `RESPONSE-OKAY` |
+| `QUESTION-` | interrogative words | `QUESTION-WHAT`, `QUESTION-WHERE`, `QUESTION-WHEN`, `QUESTION-WHO`, `QUESTION-WHY`, `QUESTION-HOW` |
+| `INTRO-` | self-introduction moves | `INTRO-MY-NAME-IS`, `INTRO-WHATS-YOUR-NAME`, `INTRO-NICE-TO-MEET-YOU`, `INTRO-HOW-ARE-YOU`, `INTRO-IM-WELL` |
+| `PRONOUN-` | personal pronouns | `PRONOUN-I`, `PRONOUN-YOU-INFORMAL`, `PRONOUN-YOU-FORMAL` |
+| `NUMBER-` | cardinal numbers | `NUMBER-0` … `NUMBER-10` |
+| `TIME-` | time-of-day / calendar nouns | `TIME-DAY`, `TIME-NIGHT`, `TIME-MORNING`, `TIME-EVENING` |
+| `WORD-` | promoted cross-language lexical items | `WORD-GOOD`, `WORD-WELL` |
+| *(namespaced)* | language-local lexical/structural | `ES-WORD-DIA`, `DE-ARTICLES-DER-DIE-DAS` |
+
+The family list is closed — adding a family is a spec edit — but ids within a
+family are open. `taxonomy.json` is the authoritative enumeration of every
+universal id; namespaced ids live only in lesson frontmatter.
+
+## `concepts/taxonomy.json`
+
+Lives at the curriculum root (`code/learning/human-languages/concepts/taxonomy.json`).
+One entry per universal concept:
+
+```json
+{
+  "GREETING-HELLO": {
+    "family": "GREETING",
+    "gloss": "hello (neutral, said on meeting)",
+    "core": true,
+    "notes": "The default meeting greeting. A language may realize it with a
+              formal/informal split (see PRONOUN-YOU-*); pick the neutral form."
+  },
+  "GREETING-GOODNIGHT": {
+    "family": "GREETING",
+    "gloss": "good night (said on parting at night / before sleep)",
+    "core": true,
+    "notes": "Distinct from GREETING-EVENING, which is a meeting greeting. This
+              retires Spanish's older GREETING-NIGHT tag."
+  }
+}
+```
+
+- **`core: true`** marks concepts expected in *every* track (the greetings,
+  yes/no, thanks, the numbers). The validator reports missing core realizations
+  as a coverage gap (a warning, since some tracks are still being authored — it
+  hard-fails only once a track is declared "parity-complete" in its README).
+- **`gloss`** is the English handle the app shows.
+- **`notes`** records reconciliation decisions (which old tags this id retires),
+  so the history of the normalization is legible.
+
+## Per-language realization schema
+
+For each (concept, language) the data layer derives a **realization**. Most fields
+come straight from lesson frontmatter; a few new optional frontmatter fields
+(below) supply what the body prose currently holds implicitly.
+
+```ts
+interface Realization {
+  concept: string;        // canonical or namespaced concept id
+  language: string;       // track slug: "spanish", "telugu", …
+  lessonId: string;       // ES-C01-hola
+  chapter: number;
+  headword: string;       // "hola" / "నమస్కారం"
+  gloss: string;          // "hello"
+  romanization: string;   // "OH-lah" / "namaskāram" — = headword for Latin script
+  script: string;         // "latin" | "devanagari" | "telugu" | … (font key)
+  gender: "masc" | "fem" | "neut" | null;
+  sounds: string[];       // ids into pronunciation-reference.md
+  roots: string[];        // etymological roots (for indexing)
+  etymologyHook: string;  // ≤120-char memory anchor; falls back to gloss
+}
+```
+
+### New optional frontmatter fields (added to the `HL00` schema)
+
+To keep the data layer **derived from the lessons** (never a hand-maintained
+parallel copy that drifts), two optional fields are added to lesson frontmatter:
+
+```yaml
+romanization: OH-lah        # required for non-Latin scripts; omit for Latin (defaults to headword)
+etymology_hook: "gracia ← Latin gratia → grace, gratitude, gratis"   # optional ≤120 chars
+```
+
+Both are optional and back-compatible: a lesson without them still parses, and
+the validator emits a *warning* (not an error) for a non-Latin lesson missing
+`romanization`, or any lesson missing `etymology_hook`. Authoring them is folded
+into the normalization pass and the ongoing parity work, not a blocking upfront
+migration.
+
+`script` is inferred from the track (each track declares its script once in its
+`README.md` frontmatter / a `track.json`); `glyphs` used by a headword are
+resolved against the script data below, not stored per lesson.
+
+## Script & character-breakdown data — `data/scripts/<script>.json`
+
+This is **new authored data**, separate from concepts, that powers the app's
+"learn to write, piece by piece" study view (`HL02`). One file per non-Latin
+script (`devanagari`, `bengali`, `gurmukhi`, `tamil`, `telugu`, `kannada`,
+`malayalam`, `arabic`; `latin` needs none). Sourced from each track's existing
+`pronunciation-reference.md` plus standard handwriting convention.
+
+```json
+{
+  "script": "telugu",
+  "font": "_fonts/NotoSansTelugu-Static.ttf",
+  "abugida": true,
+  "glyphs": [
+    {
+      "glyph": "క",
+      "sound": "ka",
+      "type": "consonant",
+      "inherentVowel": "a",
+      "components": [
+        "talakaṭṭu — the small check-mark hat on top",
+        "the main round body",
+        "the short tail curling right"
+      ],
+      "strokeOrder": [
+        "draw the round body clockwise from the top-left",
+        "add the talakaṭṭu hat",
+        "finish the tail"
+      ],
+      "strokeOrderNote": "typical handwriting order — conventional, not canonical",
+      "notes": "Carries an inherent -a; add a vowel sign to change it."
+    }
+  ],
+  "vowelSigns": [
+    { "sign": "ా", "sound": "ā", "attachesAs": "long stroke to the right",
+      "example": { "base": "క", "combined": "కా", "sound": "kā" } }
+  ],
+  "conjunctRule": "A virama stacks the bare consonant below the next (స + క → స్క, ska)."
+}
+```
+
+Design commitments:
+
+- **Compositional, not rote.** Abugidas build syllables systematically (base
+  consonant + vowel sign + conjunct rule). The data captures the *system* — the
+  vowel-sign table and the conjunct rule — so the app teaches the generative
+  pattern, not a flat list of thousands of syllables. This is the neuroscience
+  point made concrete (see `HL02`).
+- **Stroke order is flagged conventional.** Freely-licensed authoritative
+  stroke-order data does not exist for these scripts; the `strokeOrder` we author
+  is standard handwriting practice, and every glyph carries `strokeOrderNote`
+  saying so. The app renders it as "a typical way to write this," never as law.
+- **Components are the "pieces."** The `components` array is the literal answer to
+  the user's request — each glyph broken into named visual parts you can practice
+  one at a time on paper.
+
+## The data-layer package — `human-language-data`
+
+`code/packages/typescript/human-language-data/` (src layout, publishable shell per
+repo convention, though `private`). Responsibilities:
+
+1. **Parse** every `lessons/*.md` frontmatter + `concepts/taxonomy.json` +
+   `data/scripts/*.json` into an in-memory model.
+2. **Expose typed accessors**:
+   - `allConcepts(): Concept[]`
+   - `conceptsByLanguage(lang): Concept[]`
+   - `languagesForConcept(concept): Realization[]`  ← the interleaver's workhorse
+   - `script(name): ScriptData`
+3. **Validate** (see below), exposed both as a library function and a CLI
+   (`human-language-data validate`) wired into CI.
+
+The package ships the parsed dataset as a JSON artifact at build time so the app
+can import it without re-parsing Markdown in the browser.
+
+## The round-trip validator
+
+Run as a `vitest` suite *and* a CI step (the repo favours round-trip checkers).
+It asserts:
+
+1. **Every `concept_tag` resolves** — it is either a key in `taxonomy.json`
+   (universal) or matches the namespaced pattern `^[A-Z]{2}-[A-Z0-9-]+$` (lexical).
+   An unknown bare tag is an **error**.
+2. **One realization per (concept, language)** for `type: word` lessons — a
+   universal concept realized twice in the same track is an error (ambiguous
+   join). `review`/`practice-mix` lessons are exempt.
+3. **Required realization fields present** — `headword`, `gloss`, `chapter`.
+4. **Script references resolve** — every glyph a non-Latin headword uses appears
+   in that script's `data/scripts/*.json` (warning while scripts are being
+   authored; error once the script file declares itself complete).
+5. **Core-concept coverage** — for each track whose `README.md` declares
+   `parity: complete`, every `core: true` concept has a realization (error);
+   otherwise reported as an informational coverage table.
+6. **Field-shape checks** — `romanization` present for non-Latin `word` lessons
+   (warning), `etymology_hook` ≤120 chars, `gender ∈ {masc,fem,neut,null}`.
+
+Errors fail CI; warnings print a report. Coverage ≥95% for the package's own
+logic (parsing, accessors, validation rules) per repo standard.
+
+## Divergence & scope notes
+
+- Like `HL00`, the *curriculum content* diverges from standard package process
+  (no build/tests for Markdown). The **data-layer package is normal code** and
+  follows full repo standards (tests, coverage, README, CHANGELOG, BUILD).
+- This spec adds two optional frontmatter fields to the `HL00` schema
+  (`romanization`, `etymology_hook`). `HL00`'s schema section should gain a
+  one-line pointer to them; they are optional and back-compatible.
+- Reconciling the existing tags onto the taxonomy is a content edit only — lesson
+  *prose* refers to words by name, never by tag, so retagging never touches prose
+  and never breaks a cross-link.
+- Out of scope here: the app itself (`HL02`), audio/TTS, and any concept beyond
+  what Chapters 1–3 across the tracks require (the taxonomy grows with the
+  curriculum, one concept at a time, never front-loaded).

--- a/code/specs/HL02-companion-practice-app.md
+++ b/code/specs/HL02-companion-practice-app.md
@@ -1,0 +1,222 @@
+# HL02 — Companion Practice App & the Learning-Science Method
+
+## Overview
+
+The Human Languages **book** (`HL00`) teaches; this **app** drives *practice to
+mastery*. The division of labour is deliberate and load-bearing:
+
+> **You learn a concept from the book. Then you practise it in the app until it
+> sticks — across every language you're learning, on the app's schedule, not
+> yours.**
+
+The app is a **companion**, not a replacement: it never teaches a concept cold.
+It walks the book's already-learned content in **randomized** order, **tracks
+progress per language**, and sequences practice using evidence-based learning
+science. Its data comes entirely from the `HL01` data layer, so it stays a true
+mirror of the book.
+
+**v1 is reading-focused.** It builds recognition (glyph → sound/meaning) and
+recall (prompt → pick the glyph), and — for the scripts the learner can't yet
+read — it **decomposes each character into learnable pieces** so the learner can
+practise *writing on paper*. There is no in-app handwriting capture in v1.
+
+## The learner's method, which this app is built around
+
+The user described a specific practice pattern that works for them, and the app's
+scheduler is built to execute exactly it:
+
+> Learn a word in Spanish. Then learn the same word in French. Then review both
+> Spanish and French together. Then add German. Then review Spanish, French, and
+> German together. And so on.
+
+This is **progressive cross-language interleaving**: introduce one new
+(concept, language) at a time, then immediately fold it into cumulative,
+mixed review of everything introduced so far. It is not an idiosyncrasy — it
+is, almost exactly, the combination of learning-science principles below applied
+to a multilingual learner. The app generalizes it into a scheduler (see
+"The interleaving scheduler").
+
+## What the science says actually works (and how the app uses each)
+
+The user asked, specifically, what neuroscience says works for learning a script.
+The app commits to the following findings; each maps to a concrete mechanism.
+
+| Principle | Finding | Mechanism in the app |
+|---|---|---|
+| **Retrieval practice / testing effect** | *Being tested* on material builds durable memory far better than restudying it (Roediger & Karpicke). The most robust result in the field. | Every item is a **test**: recall the sound, choose the glyph — never a passive flashcard flip. "Reveal" comes *after* an attempt. |
+| **Spaced repetition** | Memory is strengthened most when review happens as the trace is about to fade; expanding intervals beat massed practice. | An **adaptive scheduler**: each item's next-due gap expands on success, contracts on failure (Leitner/SM-2-lite), measured in **sessions**, matching `HL00`'s N+1/N+3/N+7/N+15 open-loop baseline but now closed-loop. |
+| **Interleaving** | Mixing related items in one session beats blocking one item at a time — it forces discrimination and transfers better (Rohrer & Taylor). | The session **mixes concepts and languages**. The learner's cross-language method *is* interleaving; it is the scheduler's default ordering. |
+| **Generation effect** | Producing an answer beats recognizing one. | Recall mode makes you **produce/choose the glyph** from distractors, not just rate your recall. |
+| **Elaborative encoding** | New material bonds to memory by connecting to what you already know. | Each item surfaces its **etymology hook** (the `HL01` `etymologyHook` / the book's cousin web) on reveal — the same principle the whole curriculum is built on. |
+| **Dual coding** | Pairing verbal + visual codes strengthens recall. | Items pair **glyph + sound + meaning + root** simultaneously. |
+| **Desirable difficulty** | Effortful (but succeeding) retrieval encodes better than easy retrieval. | Spacing, interleaving, and generation are all tuned to keep retrieval *just* hard enough — the app avoids re-showing an item while it's still easy. |
+
+### Specifically for learning a script
+
+Reading a new writing system is **grapheme→phoneme mapping** plus, for the Indic
+abugidas, learning a **combination system**. Two evidence-aligned commitments:
+
+1. **Teach the system, not the syllabary.** A Telugu or Kannada abugida generates
+   thousands of syllables from ~40 base consonants × ~12 vowel signs + conjunct
+   rules. Drilling syllables as flat flashcards fights the structure. The app
+   drills the **bases, the vowel-sign transformations, and the conjunct rule**,
+   so the learner internalizes the generator (this is why the `HL01` script data
+   is compositional).
+2. **Letters in real words.** Consistent with `HL00`'s "letters taught inside the
+   word," the app's script items are drawn from actual headwords the learner is
+   studying, not an abstract chart — the word is the vehicle for its letters.
+
+## The interleaving scheduler (the core module)
+
+A **pure, deterministic, unit-tested** module — the heart of the app, and where
+test coverage matters most. Given the learner's history and a random seed, it
+produces the next session's item queue.
+
+### State per item
+
+An **item** is a (concept, language, mode) triple — e.g. (`GREETING-HELLO`,
+`telugu`, `recognize`). Its state:
+
+```ts
+interface ItemState {
+  box: number;         // Leitner box 0..N; higher = longer interval
+  dueAtSession: number;// session index when it next becomes due
+  introducedAt: number;// session it first appeared
+  lapses: number;      // times failed after being learned
+}
+```
+
+### The progressive-introduction rule (the user's method, generalized)
+
+1. **One new thing per step.** A session introduces a *small, bounded* number of
+   new items (default: 1–3, configurable), never a flood. A "new item" is a
+   (concept, language) the learner has marked learned-in-the-book but hasn't
+   practised yet.
+2. **Cross-language before cross-concept.** When the learner is studying a
+   concept in multiple languages, the scheduler prefers to introduce *the same
+   concept in the next language* over a brand-new concept — reproducing "learn it
+   in Spanish, then the same word in French." Order of languages follows the
+   learner's configured priority.
+3. **Cumulative interleaved review.** After the new item, the session fills with
+   **due** items from the whole history, **interleaved** across concepts and
+   languages (shuffled by the seed), oldest-most-overdue first. This is the
+   "review Spanish + French together, then add German, then review all three."
+4. **Expanding spacing.** A correct answer promotes the item a box (next due gap
+   ×≈2); a wrong answer demotes to box 0 (due next session) and increments
+   `lapses`. Baseline gaps follow `HL00`: 1, 3, 7, 15 sessions, then a long-term
+   pool.
+
+### Determinism & testability
+
+The scheduler takes `(history, config, seed)` and is a pure function — no clock,
+no `Math.random` inside (seeded PRNG passed in), matching this repo's constraint
+that `Date.now`/`Math.random` are avoided in deterministic cores. Invariants the
+tests assert:
+
+- a new item is introduced **exactly once**;
+- an item answered correctly at session *N* does not reappear before its box
+  interval elapses;
+- a lapsed item reappears at *N+1*;
+- the due-set ordering is **stable for a fixed seed** (reproducible sessions);
+- cross-language preference: with two languages queued for the same concept, the
+  second language's item is introduced before an unrelated new concept.
+
+## Progress model
+
+Per-language, persisted in `localStorage` (no backend, matching repo app
+convention). Shape:
+
+```ts
+interface Progress {
+  version: 1;
+  sessionIndex: number;                    // monotonic session counter
+  learnedInBook: Record<string, boolean>;  // "concept|language" → learned flag
+  items: Record<string, ItemState>;        // "concept|language|mode" → state
+  perLanguage: Record<string, {            // rollups for the dashboard
+    learned: number; mastered: number; due: number;
+  }>;
+}
+```
+
+- **`learnedInBook`** is the gate: an item can't enter practice until the learner
+  flags they've met it in the book. This keeps the app a companion, never a
+  first-teacher.
+- **"Mastered"** = reached the top Leitner box with no recent lapse.
+- Export/import the JSON (a settings action) so progress survives a browser wipe;
+  no accounts.
+
+## Practice modes (v1)
+
+1. **Recognize** — show the glyph/word; learner recalls sound + meaning; reveal
+   shows romanization, gloss, and the etymology hook. (Reading, testing effect.)
+2. **Recall / generate** — show the romanization + gloss; learner **picks the
+   correct glyph/word** from distractors drawn from the same script/language
+   (generation effect, reading-friendly — no handwriting needed).
+3. **Character breakdown (study, not tested)** — for a non-Latin script, a screen
+   that decomposes the selected glyph into its **components** and shows the
+   **typical stroke order** and the vowel-sign/conjunct system around it (from
+   `HL01` `data/scripts/*.json`). This is the "learn to write, piece by piece"
+   surface, for paper practice. Reading-only; no in-app tracing in v1.
+
+Distractor selection for Recall is its own small tested helper: same-script,
+same-length-ish, visually-confusable-preferred glyphs, seeded.
+
+## Architecture
+
+`code/programs/typescript/human-languages-companion/`, scaffolded with the repo's
+**`web-app-scaffold-generator`** (`visualization` template):
+
+- **Vite + React 19 + TypeScript + Vitest**, styled with the internal **Lattice**
+  stack (`vite-plugin-lattice`), deployed to GitHub Pages via a
+  `deploy-human-languages-companion.yml` workflow — all standard for this repo.
+- Depends on **`@coding-adventures/human-language-data`** (`HL01`) via a `file:`
+  dependency for the concept dataset and script data.
+- Renders every script with the **vendored Noto fonts already in `_fonts/`**
+  (bundled via Vite `?url` imports / `@font-face`), so local and deployed builds
+  render identically — the same guarantee the books make.
+- Layers: **data** (thin wrapper over the `HL01` package) → **scheduler** (pure)
+  → **progress store** (localStorage adapter) → **React UI** (session runner,
+  mode screens, per-language dashboard, character-breakdown view). The scheduler
+  and store are pure/mockable and carry the coverage weight; the UI is thin.
+
+## Extensibility — adding a script or language (the Gujarati on-ramp)
+
+The whole stack is built so that a new language or script is **data, not code**:
+
+- **A new language track** = a new `lessons/*.md` set tagged with canonical
+  concepts (`HL01`) + its script declared. It appears in the app automatically
+  once the data layer picks it up. No app code changes.
+- **A new script** (e.g. **Gujarati**, explicitly wanted) = (1) author the
+  Gujarati HL track per `HL00`; (2) vendor `NotoSansGujarati-Static.ttf` into
+  `_fonts/`; (3) author `data/scripts/gujarati.json` per `HL01`. The app's
+  character-breakdown view and drills then work for it with no new code.
+
+Gujarati has none of these today (no track, no font, no data), so it is a
+**documented future on-ramp**, not part of v1 — but v1 must be built so that
+delivering it is exactly the three data steps above and nothing more. A
+`docs/adding-a-script.md` in the app records the checklist.
+
+## v1 Scope
+
+**In:** the three practice modes above; the interleaving scheduler; per-language
+progress in localStorage; the character-breakdown study view for all vendored
+non-Latin scripts; a per-language dashboard; export/import of progress.
+
+**Out (future):** in-app handwriting/tracing capture and scoring; audio/TTS
+playback and speech scoring (the `HL00` "voice work"); server-side accounts/sync;
+Gujarati and any script without a vendored font + `HL01` data; grammar-drill
+modes beyond vocabulary/script recognition.
+
+## Verification
+
+- **Scheduler**: `vitest` unit tests asserting every invariant in "Determinism &
+  testability" above; ≥95% coverage on the scheduler and distractor helper.
+- **Progress store**: tests for persistence round-trip, migration/versioning,
+  export/import.
+- **End-to-end**: `preview_start` the dev server; drive a full session with the
+  browser tools — pick a language, flag a concept learned-in-book, run a
+  Recognize drill and a Recall drill, open a character breakdown, reload the page
+  and confirm progress persisted; verify each script's glyphs render with the
+  vendored font; screenshot as proof.
+- **Data contract**: the app's data wrapper is tested against the `HL01`
+  validator's output so a taxonomy/lesson change that breaks the app fails CI.


### PR DESCRIPTION
## What & why

First deliverable of the Human Languages program (content parity + a book-companion practice app). Per the repo's specs-first rule, the two new specs land before any implementation.

### HL01 — Cross-language concept taxonomy & data layer
The load-bearing discovery: today's lesson `concept_tag`s are **not a shared vocabulary** across tracks (`GREETING-NIGHT` vs `GREETING-GOODNIGHT`; `DIA` vs `JOUR` for "day"). A query like *"'thank you' in Spanish, French, German"* can't be answered. HL01 defines:
- The **concept** as the language-independent join key; a canonical `concepts/taxonomy.json` of universal ids + namespaced language-local lexical ids.
- A per-language **realization** schema, derived from lesson frontmatter (+ two optional back-compat fields `romanization`, `etymology_hook`).
- **`data/scripts/*.json`** — compositional abugida data + per-glyph component decomposition + typical stroke order (the "learn to write, piece by piece" source).
- A `human-language-data` TS package + round-trip validator wired into CI.

### HL02 — Companion practice app & the learning-science method
- App is a **companion** to the book: never teaches cold, drives practice-to-mastery, per-language progress in `localStorage`, reading-focused v1.
- Documents the evidence base (testing effect, spacing, interleaving, generation effect, elaborative encoding, dual coding) and, for scripts, *teach the system not the syllabary*.
- Generalizes the learner's own method (learn in Spanish → then French → review both → add German → …) into a **deterministic, seeded, unit-tested progressive cross-language interleaving scheduler**.
- Vite+React+Lattice architecture; **Gujarati** documented as a data-only future on-ramp.

### HL00
Cross-links HL01/HL02, notes the two new optional frontmatter fields, repurposes the stale "HL01+ = per-language notes" reservation.

## Scope
Docs-only — three specification Markdown files, no executable code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)