### PR TITLE
feat(sql): || concatenates blobs as raw bytes

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.46 — `||` concatenates blobs as raw bytes
+
+`X'41' || 'B'` now returns `'AB'` (0x41 = 'A'), not `"x'41'B"`. The `||` operator
+was rendering a blob operand in its `x'…'` hex *display* form; it now uses the
+blob's raw bytes as text, matching SQLite (the result is TEXT). blob||text,
+text||blob, and blob||blob all fold to the byte string. One new
+differential-oracle case; sql-vm 0.4.24. (The `1 IN (1.0)` numeric-equality gap
+noted alongside this remains a separate follow-up.)
+
 ## 0.5.45 — LENGTH() over blobs and numbers
 
 `LENGTH(x'0102ff')` now returns 3 (the byte count) instead of erroring, and

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.45"
+version = "0.5.46"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -654,6 +654,14 @@ const CASES: &[Case] = &[
         setup: &[],
         query: "SELECT QUOTE(X'DEADBEEF') AS q, HEX(X'ab') AS h",
     },
+    // The `||` operator concatenates a blob as its RAW bytes (as text), not the
+    // `x'…'` display form: `X'41' || 'B'` = 'AB' (0x41 = 'A'), and the result is
+    // TEXT. Blob||text, text||blob, and blob||blob all fold to the byte string.
+    Case {
+        id: "concat_blob_raw_bytes",
+        setup: &[],
+        query: "SELECT X'41' || 'B' AS a, 'A' || X'42' AS b, X'48' || X'69' AS c, TYPEOF(X'41' || 'B') AS t",
+    },
     // OCTET_LENGTH counts BYTES (UTF-8), where LENGTH counts characters:
     // 'héllo' is 5 characters but 6 bytes.
     Case {

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.24] - Unreleased
+
+### Fixed
+
+- **`||` (concatenate) now treats a blob operand as its raw bytes.** `X'41' ||
+  'B'` was producing `"x'41'B"` (the hex *display* form of the blob) instead of
+  SQLite's `'AB'` (0x41 = 'A'). The `Concat` arm now stringifies a blob via its
+  raw bytes (`concat_operand_to_str`, lossy-UTF-8) while `sql_to_str` keeps its
+  reversible `x'…'` form for display everywhere else. Result is TEXT; NULL still
+  propagates. blob||text, text||blob, and blob||blob all fold to the byte string.
+
 ## [0.4.23] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -2013,8 +2013,12 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
             if matches!(l, SqlValue::Null) || matches!(r, SqlValue::Null) {
                 return Ok(SqlValue::Null);
             }
-            let ls = sql_to_str(&l);
-            let rs = sql_to_str(&r);
+            // `||` yields TEXT. A BLOB operand contributes its RAW bytes (as
+            // text), NOT the `x'…'` hex-literal spelling `sql_to_str` uses for
+            // display: SQLite evaluates `X'41' || 'B'` to `'AB'` (0x41 = 'A'),
+            // not `"x'41'B"`. Other types stringify as usual.
+            let ls = concat_operand_to_str(&l);
+            let rs = concat_operand_to_str(&r);
             Ok(SqlValue::Text(ls + &rs))
         }
 
@@ -2667,6 +2671,21 @@ fn sql_to_str(v: &SqlValue) -> String {
             format!("x'{}'", hex)
         }
         SqlValue::Null => String::new(),
+    }
+}
+
+/// Stringify an operand of the `||` (concatenate) operator.
+///
+/// Identical to [`sql_to_str`] EXCEPT for blobs: `||` treats a blob as its raw
+/// byte sequence interpreted as text, so `X'41' || 'B'` is `'AB'` (0x41 = 'A'),
+/// whereas [`sql_to_str`] renders the reversible display form `x'41'`. Invalid
+/// UTF-8 bytes become the replacement character (U+FFFD) — a rare edge for
+/// non-textual blobs; the common ASCII/UTF-8 case round-trips exactly. NULL is
+/// handled by the caller (it propagates through `||`).
+fn concat_operand_to_str(v: &SqlValue) -> String {
+    match v {
+        SqlValue::Blob(b) => String::from_utf8_lossy(b).into_owned(),
+        other => sql_to_str(other),
     }
 }
 
@@ -4680,6 +4699,32 @@ mod tests {
             Instruction::Halt,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![text("Hello World")]]);
+    }
+
+    #[test]
+    fn test_concat_blob_uses_raw_bytes() {
+        // `||` concatenates a blob as its RAW bytes (as text), not the `x'…'`
+        // display form: `X'41' || 'B'` = 'AB'. Result is TEXT; NULL propagates.
+        let cat = |l: SqlValue, r: SqlValue| eval_binary(&BinaryOp::Concat, l, r).unwrap();
+        assert_eq!(
+            cat(SqlValue::Blob(vec![0x41]), SqlValue::Text("B".into())),
+            SqlValue::Text("AB".into())
+        );
+        assert_eq!(
+            cat(SqlValue::Text("A".into()), SqlValue::Blob(vec![0x42])),
+            SqlValue::Text("AB".into())
+        );
+        assert_eq!(
+            cat(SqlValue::Blob(vec![0x48]), SqlValue::Blob(vec![0x69])),
+            SqlValue::Text("Hi".into())
+        );
+        // `sql_to_str` (the display form) still renders the hex literal — the
+        // concat path must NOT regress that helper's behavior.
+        assert_eq!(sql_to_str(&SqlValue::Blob(vec![0x41])), "x'41'");
+        assert_eq!(
+            cat(SqlValue::Blob(vec![0x41]), SqlValue::Null),
+            SqlValue::Null
+        );
     }
 
     // ── 20. Label / Jump / JumpIfTrue ─────────────────────────────────────────


### PR DESCRIPTION
## What

`X'41' || 'B'` now returns `'AB'` (0x41 = 'A'), not `"x'41'B"`. The `||` operator stringified a blob operand via `sql_to_str`, which renders the `x'…'` hex **display** form; concat now uses the blob's raw bytes as text, matching real sqlite3 3.51.0. The result is TEXT; `blob||text`, `text||blob`, and `blob||blob` all fold to the byte string.

Lane-2 (operators) increment in the mini-sqlite conformance rotation. Found while probing blob behavior after the blob-literal / LENGTH work merged.

## Change

`sql-vm` 0.4.24 — the `Concat` arm routes operands through a new `concat_operand_to_str` (blob → `from_utf8_lossy`, everything else → `sql_to_str`). `sql_to_str` is **unchanged** — its reversible `x'…'` display form is still used everywhere else (a unit test guards against regressing it). `mini-sqlite` 0.5.46.

## Tests

- Differential-oracle case (`X'41'||'B'`, `'A'||X'42'`, `X'48'||X'69'`, `typeof`) matches real SQLite.
- sql-vm unit test covering blob||text, text||blob, blob||blob, NULL propagation, and the `sql_to_str` display-form guard.
- Suites green (sql-vm 104, mini-sqlite 45 + oracle). Downstream consumers build. **Security review clean** (`from_utf8_lossy` never panics; no overflow/loop/DoS; NULL intact; blast radius limited to the Concat arm).

## Edges / follow-ups (not here)

- Invalid-UTF-8 blob bytes become U+FFFD (a consequence of the `Text(String)` value model) — documented.
- `1 IN (1.0)` numeric equality (the other half of the chip this came from) remains a separate follow-up.

## Notes

Never self-merge — queued for review. No `_grammar.rs` touched (pure VM change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
