### PR TITLE
feat(adj-facts-stdlib): chemistry/chemical-bonds — bond type → defining token table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_chemicalbonds_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_chemicalbonds_e2e.rs
@@ -1,0 +1,81 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/chemical-bonds.adj`) driven through the built
+//! CLI: a native `table` of bond type → defining token resolves binding-query
+//! recalls (forward and backward) with the source's LibreTexts citation, and
+//! abstains on a bond type this source does not pin to a token (hydrogen) —
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factscb_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_chemical_bonds_recall_binds_token_with_citation() {
+    let dir = scratch("chemicalbonds");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/chemical-bonds.adj");
+    std::fs::copy(&src, dir.join("chemical-bonds.adj")).expect("copy shipped chemical-bonds.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"chemical-bonds.adj\"\n\
+         ? chemical_bond_token(ionic, $T)\n\
+         ? chemical_bond_token(covalent, $T)\n\
+         ? chemical_bond_token(metallic, $T)\n\
+         ? chemical_bond_token($B, weak)\n\
+         ? chemical_bond_token(hydrogen, $T)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward lookups bind each bond to the token the source uses to define it.
+    assert!(out.contains("\"T\":\"transfer\""), "ionic binds to transfer: {out}");
+    assert!(
+        out.contains("chemical_bond_token(ionic, transfer)"),
+        "ionic is governing-bound to transfer: {out}"
+    );
+    assert!(
+        out.contains("chemical_bond_token(covalent, sharing)"),
+        "covalent is governing-bound to sharing: {out}"
+    );
+    assert!(
+        out.contains("chemical_bond_token(metallic, gas)"),
+        "metallic is governing-bound to gas: {out}"
+    );
+    // The relation runs BACKWARD: bind the token `weak`, recall the bond type.
+    assert!(
+        out.contains("chemical_bond_token(van_der_waals, weak)"),
+        "reverse recall binds B=van_der_waals from weak: {out}"
+    );
+    // The answer carries the LibreTexts locator + trust tier as its proof, at
+    // consensus trust (a secondary teaching reference, honestly tiered).
+    assert!(
+        out.contains("chem.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation at consensus trust: {out}"
+    );
+    // Hydrogen bonding is NOT pinned to a token by this source — honest
+    // abstention, never a fabricated token.
+    assert!(out.contains("\"abstained\":true"), "hydrogen abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -32,6 +32,7 @@ per rotation, in parallel):
 | `chemistry/` | element → periodic-table group family | Wikipedia (consensus) |
 | `chemistry/` | common chemical → acid or base | LibreTexts (consensus) |
 | `chemistry/` | subatomic particle → electric charge (proton → positive) | DOE "Explains…Nuclei" (authoritative) |
+| `chemistry/` | chemical bond type → defining token (ionic → transfer) | LibreTexts (consensus) |
 | `metrology/` | SI prefix → power of ten | NIST |
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |

--- a/code/specs/data/adj-facts-stdlib/chemistry/chemical-bonds.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/chemical-bonds.adj
@@ -1,0 +1,100 @@
+% ============================================================================
+% chemical-bonds — each named TYPE of chemical bond and the single defining
+% token the source uses to characterize it (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% One of the first organizing facts in chemistry: atoms hold together in a few
+% NAMED kinds of bond, and each kind is pinned by one characteristic word — an
+% ionic bond is about TRANSFER of electrons, a covalent bond is about SHARING
+% electrons, a metallic bond pictures a GAS of free electrons, and the van der
+% Waals (secondary) bond is WEAK. Before a learner reasons about why table salt
+% is brittle or why metals conduct, they first learn to NAME the bond types and
+% attach each to the word that defines it. Recall is a binding query:
+%
+%     ? chemical_bond_token(ionic, $T)      % transfer
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `chemical_bond_token(bond, token)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% defining token WITH its source, on the CPU, with zero model calls, and
+% abstains on a bond type this source does not name.
+%
+% The bond types, as a little truth table (bond → what the LibreTexts sentence
+% says → the single defining token we carry):
+%
+%     bond            what the source sentence says                    token
+%     -------------   ----------------------------------------------   --------
+%     ionic           "...arises from complete transfer of ...         transfer
+%                      one or more electrons from one atom to another"
+%     covalent        "...arises from the sharing of two or more        sharing
+%                      electrons between atoms."
+%     metallic        "...a lattice of ion cores being held             gas
+%                      together by a gas of free electrons."
+%     van_der_waals   "...secondary bonding is weak, involving          weak
+%                      energies ranging from about 0.1 to 10 kJ/mole."
+%
+% The source groups these into two families — PRIMARY bonding (ionic, covalent,
+% metallic — "strong", 100 to 1000 kJ/mole) and SECONDARY / van der Waals
+% bonding ("weak", 0.1 to 10 kJ/mole) — but the family split is not part of this
+% table; the table is the single clean axis bond → defining token. The query
+% also runs BACKWARD — bind the token and recall the bond it defines:
+%
+%     ? chemical_bond_token($B, weak)       % van_der_waals — reverse recall
+%
+% Every `token` is a SINGLE lowercase atom that appears VERBATIM inside that
+% bond's own defining sentence (quoted per-row in the provenance block below),
+% never a synonym or a word the source does not use. A bond type this source
+% does NOT pin to a defining token — HYDROGEN bonding, for instance, which the
+% page mentions but only as an interaction it says "can as yet not be
+% formulated" — has no row, so a recall on it ABSTAINS rather than inventing a
+% token. That honest-abstention property is what makes the table safe to reason
+% from.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every bond→token pair was
+% read out of a fetched LibreTexts page this session, and any bond whose token
+% could not be found verbatim in its own characterizing sentence was dropped —
+% hydrogen bonding was dropped for exactly that reason). All four tokens come
+% from the SAME source, the LibreTexts "Introduction to Solid State Chemistry"
+% §1.2 "Chemical Bonding" (chem.libretexts.org), each sentence quoted here
+% character-for-character so any reader can re-check it:
+%
+%   ionic → transfer
+%     "Electrovalent bonding arises from complete transfer of one or more
+%      electrons from one atom to another"
+%
+%   covalent → sharing
+%     "covalent bonding arises from the sharing of two or more electrons
+%      between atoms."
+%
+%   metallic → gas
+%     "We may therefore visualize metals as a lattice of ion cores being held
+%      together by a gas of free electrons."
+%
+%   van_der_waals → weak
+%     "In contrast, secondary bonding is weak, involving energies ranging from
+%      about 0.1 to 10 kJ/mole." (the page labels this "Secondary (van der
+%      WAALS) bonding".)
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the sentence that fixes the
+% first row (ionic → transfer). Every OTHER row's per-fact source and verbatim
+% span is listed above, so each token remains independently checkable.
+% LibreTexts is a SECONDARY teaching reference (a college course text, not a
+% primary standards body), so `trust consensus` — the honest tier for a
+% teaching summary, per the standard-library trust convention.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table chemical_bond_token {
+    columns bond, token
+
+    row (ionic, transfer)
+    row (covalent, sharing)
+    row (metallic, gas)
+    row (van_der_waals, weak)
+
+    source "Electrovalent bonding arises from complete transfer of one or more electrons from one atom to another"
+    locator "https://chem.libretexts.org/Bookshelves/Inorganic_Chemistry/Introduction_to_Solid_State_Chemistry/01:_Lectures/1.02:_Chemical_Bonding"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/chemical-bonds.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/chemical-bonds.query.adj
@@ -1,0 +1,25 @@
+% ============================================================================
+% chemical-bonds.query.adj — a worked recall over the chemistry chemical-bonds
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what word defines an ionic
+% bond?": it states no chemistry fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `chemical_bond_token` rows and returns the token + the table's
+% source/locator/trust. The fourth query runs the relation BACKWARD (bind the
+% token `weak`, recall the bond type that has it — van der Waals, the secondary
+% bond). Hydrogen bonding is not in the table — the source mentions it but does
+% not pin it to a defining token — so a recall on it abstains honestly; the
+% engine never invents a token.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli chemical-bonds.query.adj
+% ============================================================================
+
+import "chemical-bonds.adj"
+
+? chemical_bond_token(ionic, $T)      % expect transfer — electrons handed over
+? chemical_bond_token(covalent, $T)   % expect sharing  — electrons shared
+? chemical_bond_token(metallic, $T)   % expect gas      — a gas of free electrons
+? chemical_bond_token($B, weak)        % expect van_der_waals — reverse recall
+? chemical_bond_token(hydrogen, $T)    % expect abstain — not pinned by this source


### PR DESCRIPTION
A native ADJ `table` mapping each named type of chemical bond to the single
defining token the source uses to characterize it, on one clean axis
bond → token. Recall is an ordinary SLD binding query resolved on the CPU with
zero model calls, running forward (bond → token) and backward (token → bond),
carrying the source citation, and abstaining on a bond type the source does not
pin to a token.

Rows (all four grounded verbatim from ONE source):
  ionic         → transfer   "Electrovalent bonding arises from complete
                              transfer of one or more electrons from one atom
                              to another"
  covalent      → sharing    "covalent bonding arises from the sharing of two
                              or more electrons between atoms."
  metallic      → gas        "We may therefore visualize metals as a lattice of
                              ion cores being held together by a gas of free
                              electrons."
  van_der_waals → weak       "In contrast, secondary bonding is weak, involving
                              energies ranging from about 0.1 to 10 kJ/mole."

Source: LibreTexts "Introduction to Solid State Chemistry" §1.2 "Chemical
Bonding" (chem.libretexts.org). A secondary teaching reference, so
`trust consensus`. Each token is a single lowercase atom appearing verbatim in
its bond's own characterizing sentence; each sentence is quoted per-row in the
library's provenance block, so every token is independently checkable.

Dropped: HYDROGEN bonding — the page mentions it but only as an interaction it
says "can as yet not be formulated", giving no clean defining token, so it has
no row and a recall on it abstains honestly.

Adds:
  - chemistry/chemical-bonds.adj — the grounded table + literate provenance
  - chemistry/chemical-bonds.query.adj — worked forward/reverse/abstain recall
  - adj-lang-cli tests/facts_chemicalbonds_e2e.rs — drives the CLI end-to-end
  - README subject-index row (all existing rows preserved)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
