### PR TITLE
feat(adj-facts-stdlib): anatomy/skin-layers — skin layer → property table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_skinlayers_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_skinlayers_e2e.rs
@@ -1,0 +1,69 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/skin-layers.adj`) driven through the built CLI:
+//! a native `table` of skin layer → defining property resolves a binding-query
+//! recall with the source's NCI SEER Training citation, runs the relation
+//! backward (property → layer), and abstains on a non-layer (a bone) —
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsskin_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_skin_layers_recall_binds_property_with_citation() {
+    let dir = scratch("skinlayers");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/skin-layers.adj");
+    std::fs::copy(&src, dir.join("skin-layers.adj")).expect("copy shipped skin-layers.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"skin-layers.adj\"\n\
+         ? skin_layer_property(epidermis, $P)\n\
+         ? skin_layer_property(dermis, $P)\n\
+         ? skin_layer_property(subcutaneous, $P)\n\
+         ? skin_layer_property($L, fat)\n\
+         ? skin_layer_property(bone, $P)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Each layer binds to the defining descriptor the source states verbatim.
+    assert!(out.contains("\"P\":\"outermost\""), "epidermis → outermost: {out}");
+    assert!(out.contains("\"P\":\"thickest\""), "dermis → thickest: {out}");
+    assert!(out.contains("\"P\":\"fat\""), "subcutaneous → fat: {out}");
+    // The relation runs backward: the descriptor `fat` recalls the subcutaneous layer.
+    assert!(
+        out.contains("\"L\":\"subcutaneous\""),
+        "fat → subcutaneous (reverse recall): {out}"
+    );
+    // The answer carries the NCI SEER Training citation as its proof.
+    assert!(
+        out.contains("training.seer.cancer.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A bone is not a skin layer — honest abstention, never a fabricated descriptor.
+    assert!(out.contains("\"abstained\":true"), "unknown layer abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -55,6 +55,7 @@ per rotation, in parallel):
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |
 | `anatomy/` | digestive organ → primary function it performs | NIH NIDDK / NCI SEER Training |
 | `anatomy/` | synovial joint type → representative example (hinge → elbow) | NIH / NLM StatPearls |
+| `anatomy/` | skin layer → defining descriptor (epidermis → outermost, subcutaneous → fat) | NIH / NCI SEER Training |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/anatomy/skin-layers.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/skin-layers.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% skin-layers — the defining descriptor the source gives each of the three main
+% layers of human skin (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% An integumentary-anatomy fact on the way to medicine: human skin is built in
+% THREE stacked layers, and the source's opening sentence for each one hands it a
+% single defining descriptor. From the surface inward:
+%
+%     epidermis     — the OUTERMOST layer (the protective surface)
+%     dermis        — the THICKEST layer (≈90% of the skin, holds vessels/nerves)
+%     subcutaneous  — the innermost layer, which consists of FAT (the hypodermis)
+%
+% Recall is a binding query:
+%
+%     ? skin_layer_property(epidermis, $P)     % outermost
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `skin_layer_property(layer, property)` carrying the table's citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% descriptor WITH its source, on the CPU, with zero model calls, and abstains on
+% anything that is not one of the three skin layers (it never invents one).
+%
+% The three layers, as a little truth table:
+%
+%     layer          property     what the source says
+%     ------------   ----------   -----------------------------------------
+%     epidermis      outermost    "the outermost layer of the skin"
+%     dermis         thickest     "the thickest of the three layers of the skin"
+%     subcutaneous   fat          "consists of a network of fat and collagen cells"
+%
+% Why "property" and not a strict top-to-bottom position axis: the source names
+% the epidermis "outermost" and the subcutis "innermost" verbatim, but it never
+% calls the dermis the "middle" layer — so grounding the dermis to a fabricated
+% "middle" token would violate byte-provenance. Instead each layer is mapped to
+% the ONE defining descriptor its own opening sentence states verbatim
+% (outermost / thickest / fat), exactly as the sibling energy-forms table maps
+% each form to its own defining token. Every value is therefore a word the
+% source literally uses about that layer, re-checkable below.
+%
+% The query also runs BACKWARD — bind a descriptor and recall the layer:
+%
+%     ? skin_layer_property($L, fat)           % subcutaneous — reverse recall
+%
+% Something that is not one of the three skin layers — a bone, a nail, a single
+% epidermal sublayer — has no row, so a recall on it ABSTAINS rather than
+% inventing a descriptor. That honest-abstention property is what makes the
+% table safe to reason from before a dermatology or wound-care agent reasons up
+% to burn depth (which is defined precisely by WHICH of these layers is injured).
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every layer→property pair
+% was read out of a fetched U.S. government / NIH page this session, and any pair
+% that could not be grounded there would have been dropped). All three pairs come
+% from the SAME primary U.S. National Cancer Institute reference, NCI SEER
+% Training "Layers of the Skin"
+% (training.seer.cancer.gov/melanoma/anatomy/layers.html), each quoted here
+% character-for-character so any reader can re-check it:
+%
+%   epidermis → outermost
+%     "The epidermis is the outermost layer of the skin, and protects the body
+%      from the environment."
+%
+%   dermis → thickest
+%     "The dermis is located beneath the epidermis and is the thickest of the
+%      three layers of the skin (1.5 to 4 mm thick), making up approximately 90
+%      percent of the thickness of the skin."
+%
+%   subcutaneous → fat
+%     "The subcutis is the innermost layer of the skin, and consists of a network
+%      of fat and collagen cells."
+%   ...the same page names this layer the subcutaneous layer:
+%     "The subcutis is also known as the hypodermis or subcutaneous layer, and
+%      functions as both an insulator, conserving the body's heat, and as a
+%      shock-absorber, protecting the inner organs."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the NCI SEER Training sentence
+% that fixes the first row (epidermis → outermost). The other rows' per-fact
+% source and verbatim span are listed above, so each pair remains independently
+% checkable. All three rows share the ONE source — NCI SEER Training, a primary
+% U.S. government / NIH reference — so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table skin_layer_property {
+    columns layer, property
+
+    row (epidermis, outermost)
+    row (dermis, thickest)
+    row (subcutaneous, fat)
+
+    source "The epidermis is the outermost layer of the skin, and protects the body from the environment."
+    locator "https://training.seer.cancer.gov/melanoma/anatomy/layers.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/skin-layers.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/skin-layers.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% skin-layers.query.adj — a worked recall over the anatomy skin-layers library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the defining
+% descriptor of the epidermis?": it states no anatomy fact — it only `import`s
+% the grounded table and asks binding queries. The engine resolves each `?`
+% against the `skin_layer_property` rows and returns the descriptor + the table's
+% source/locator/trust. The fourth query runs the relation BACKWARD (bind the
+% descriptor `fat`, recall the layer that has it — the subcutaneous layer). A
+% bone is not a skin layer, so a recall on it abstains honestly — the engine
+% never invents a descriptor.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli skin-layers.query.adj
+% ============================================================================
+
+import "skin-layers.adj"
+
+? skin_layer_property(epidermis, $P)     % expect outermost
+? skin_layer_property(dermis, $P)        % expect thickest
+? skin_layer_property(subcutaneous, $P)  % expect fat
+? skin_layer_property($L, fat)           % expect subcutaneous — reverse recall
+? skin_layer_property(bone, $P)          % expect abstain — a bone is not a skin layer


### PR DESCRIPTION
Add a grounded ADJ facts library mapping each of the three main layers of
human skin to the defining descriptor its opening sentence states verbatim,
plus a worked .query.adj (forward + reverse + abstain) and a CLI e2e test.

Single source, single axis ("the defining descriptor the source gives the
layer"), each value token verbatim from the source sentence. Everything is
byte-provenanced from a page fetched this session — nothing from memory.

Source (primary U.S. government / NIH; trust authoritative):
NCI SEER Training, "Layers of the Skin",
https://training.seer.cancer.gov/melanoma/anatomy/layers.html

Rows (each value verbatim from the fetched page):
  epidermis    → outermost
    "The epidermis is the outermost layer of the skin, and protects the body
     from the environment."
  dermis       → thickest
    "The dermis is located beneath the epidermis and is the thickest of the
     three layers of the skin (1.5 to 4 mm thick), making up approximately 90
     percent of the thickness of the skin."
  subcutaneous → fat
    "The subcutis is the innermost layer of the skin, and consists of a
     network of fat and collagen cells."
    (same page: "The subcutis is also known as the hypodermis or subcutaneous
     layer...")

Dermis is grounded to the verbatim descriptor "thickest" rather than the
task-suggested "middle": the source never calls the dermis the middle layer,
so a "middle" token would be fabricated. No rows dropped — all three main
layers ground cleanly from the one source.

Targeted test green: cargo test -p adj-lang-cli --test facts_skinlayers_e2e.
Clippy clean: cargo clippy -p adj-lang -p adj-lang-cli --all-targets -D warnings.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
