### PR TITLE
feat(xml-lexer): add C# and F# ports

### DIFF
--- a/code/packages/csharp/xml-lexer/BUILD
+++ b/code/packages/csharp/xml-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.XmlLexer]*"

--- a/code/packages/csharp/xml-lexer/BUILD_windows
+++ b/code/packages/csharp/xml-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.XmlLexer]*"

--- a/code/packages/csharp/xml-lexer/CHANGELOG.md
+++ b/code/packages/csharp/xml-lexer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add pure C# XML tokenization across content, tag, comment, CDATA, and PI modes.
+- Emit the existing lexer package's token model and shared XML token names.
+- Cover attributes, namespaces, references, whitespace, EOF, and invalid input.

--- a/code/packages/csharp/xml-lexer/CodingAdventures.XmlLexer.csproj
+++ b/code/packages/csharp/xml-lexer/CodingAdventures.XmlLexer.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.XmlLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Context-sensitive XML tokenizer for C#</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\lexer\CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/xml-lexer/README.md
+++ b/code/packages/csharp/xml-lexer/README.md
@@ -1,0 +1,26 @@
+# CodingAdventures.XmlLexer.CSharp
+
+A context-sensitive XML tokenizer that emits the shared XML grammar's token
+names using the existing C# lexer token model.
+
+## Usage
+
+```csharp
+using CodingAdventures.XmlLexer;
+
+var tokens = XmlTokenizer.TokenizeXml("<p>Hello &amp; world</p>");
+```
+
+The scanner switches among content, tag, comment, CDATA, and processing
+instruction modes. Whitespace is skipped only when it begins a match in the
+content or tag modes; whitespace inside comments, CDATA, and processing
+instructions is preserved.
+
+The result always ends with an `EOF` token. `CreateXmlLexer` is available when
+an explicitly configured lexer object is preferred.
+
+## Testing
+
+```sh
+dotnet test tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.csproj
+```

--- a/code/packages/csharp/xml-lexer/XmlLexer.cs
+++ b/code/packages/csharp/xml-lexer/XmlLexer.cs
@@ -1,0 +1,346 @@
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.XmlLexer;
+
+/// <summary>Tokenizes XML using the token names defined by the shared XML grammar.</summary>
+public sealed class XmlLexer
+{
+    private enum Mode
+    {
+        Content,
+        Tag,
+        Comment,
+        CData,
+        ProcessingInstruction,
+    }
+
+    private readonly string _source;
+    private int _position;
+    private int _line = 1;
+    private int _column = 1;
+    private bool _precededByNewline;
+    private Mode _mode;
+    private bool _processingInstructionNeedsTarget;
+
+    /// <summary>Creates a configured XML lexer for <paramref name="source"/>.</summary>
+    public XmlLexer(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        _source = source;
+    }
+
+    /// <summary>Tokenizes the configured XML source and appends an EOF token.</summary>
+    public IReadOnlyList<Token> Tokenize()
+    {
+        var tokens = new List<Token>();
+
+        while (_position < _source.Length)
+        {
+            switch (_mode)
+            {
+                case Mode.Content:
+                    ScanContent(tokens);
+                    break;
+                case Mode.Tag:
+                    ScanTag(tokens);
+                    break;
+                case Mode.Comment:
+                    ScanDelimitedContent(tokens, "-->", "COMMENT_TEXT", "COMMENT_END");
+                    break;
+                case Mode.CData:
+                    ScanDelimitedContent(tokens, "]]>", "CDATA_TEXT", "CDATA_END");
+                    break;
+                case Mode.ProcessingInstruction:
+                    ScanProcessingInstruction(tokens);
+                    break;
+            }
+        }
+
+        tokens.Add(new Token(TokenType.EOF, string.Empty, _line, _column, "EOF"));
+        return tokens;
+    }
+
+    private void ScanContent(List<Token> tokens)
+    {
+        if (IsXmlWhitespace(_source[_position]))
+        {
+            SkipWhitespace();
+            return;
+        }
+
+        if (TryEmitLiteral(tokens, "<!--", "COMMENT_START"))
+        {
+            _mode = Mode.Comment;
+            return;
+        }
+
+        if (TryEmitLiteral(tokens, "<![CDATA[", "CDATA_START"))
+        {
+            _mode = Mode.CData;
+            return;
+        }
+
+        if (TryEmitLiteral(tokens, "<?", "PI_START"))
+        {
+            _mode = Mode.ProcessingInstruction;
+            _processingInstructionNeedsTarget = true;
+            return;
+        }
+
+        if (TryEmitLiteral(tokens, "</", "CLOSE_TAG_START") ||
+            TryEmitLiteral(tokens, "<", "OPEN_TAG_START"))
+        {
+            _mode = Mode.Tag;
+            return;
+        }
+
+        if (_source[_position] == '&')
+        {
+            ScanReference(tokens);
+            return;
+        }
+
+        var end = FindContentEnd(_position);
+        Emit(tokens, "TEXT", _source.Substring(_position, end - _position));
+    }
+
+    private int FindContentEnd(int start)
+    {
+        var end = start;
+        while (end < _source.Length && _source[end] != '<' && _source[end] != '&')
+        {
+            end++;
+        }
+
+        return end;
+    }
+
+    private void ScanTag(List<Token> tokens)
+    {
+        if (IsXmlWhitespace(_source[_position]))
+        {
+            SkipWhitespace();
+            return;
+        }
+
+        if (TryEmitLiteral(tokens, "/>", "SELF_CLOSE"))
+        {
+            _mode = Mode.Content;
+            return;
+        }
+
+        if (TryEmitLiteral(tokens, ">", "TAG_CLOSE"))
+        {
+            _mode = Mode.Content;
+            return;
+        }
+
+        if (TryEmitLiteral(tokens, "=", "ATTR_EQUALS") ||
+            TryEmitLiteral(tokens, "/", "SLASH"))
+        {
+            return;
+        }
+
+        var current = _source[_position];
+        if (current is '\'' or '"')
+        {
+            var end = _source.IndexOf(current, _position + 1);
+            if (end < 0)
+            {
+                ThrowUnexpected();
+            }
+
+            Emit(tokens, "ATTR_VALUE", _source.Substring(_position, end - _position + 1));
+            return;
+        }
+
+        if (IsNameStart(current))
+        {
+            var end = _position + 1;
+            while (end < _source.Length && IsNamePart(_source[end]))
+            {
+                end++;
+            }
+
+            Emit(tokens, "TAG_NAME", _source.Substring(_position, end - _position));
+            return;
+        }
+
+        ThrowUnexpected();
+    }
+
+    private void ScanReference(List<Token> tokens)
+    {
+        var end = _position + 1;
+        var typeName = "ENTITY_REF";
+
+        if (end < _source.Length && _source[end] == '#')
+        {
+            typeName = "CHAR_REF";
+            end++;
+            var hexadecimal = end < _source.Length && _source[end] == 'x';
+            if (hexadecimal)
+            {
+                end++;
+            }
+
+            var digitStart = end;
+            while (end < _source.Length && (hexadecimal ? IsHexDigit(_source[end]) : char.IsAsciiDigit(_source[end])))
+            {
+                end++;
+            }
+
+            if (end == digitStart)
+            {
+                ThrowUnexpected();
+            }
+        }
+        else
+        {
+            if (end >= _source.Length || !IsAsciiLetter(_source[end]))
+            {
+                ThrowUnexpected();
+            }
+
+            end++;
+            while (end < _source.Length && (IsAsciiLetter(_source[end]) || char.IsAsciiDigit(_source[end])))
+            {
+                end++;
+            }
+        }
+
+        if (end >= _source.Length || _source[end] != ';')
+        {
+            ThrowUnexpected();
+        }
+
+        Emit(tokens, typeName, _source.Substring(_position, end - _position + 1));
+    }
+
+    private void ScanDelimitedContent(List<Token> tokens, string delimiter, string textType, string endType)
+    {
+        if (TryEmitLiteral(tokens, delimiter, endType))
+        {
+            _mode = Mode.Content;
+            return;
+        }
+
+        var end = _source.IndexOf(delimiter, _position, StringComparison.Ordinal);
+        if (end < 0)
+        {
+            end = _source.Length;
+        }
+
+        Emit(tokens, textType, _source.Substring(_position, end - _position));
+    }
+
+    private void ScanProcessingInstruction(List<Token> tokens)
+    {
+        if (TryEmitLiteral(tokens, "?>", "PI_END"))
+        {
+            _mode = Mode.Content;
+            return;
+        }
+
+        if (_processingInstructionNeedsTarget && IsNameStart(_source[_position]))
+        {
+            var end = _position + 1;
+            while (end < _source.Length && IsNamePart(_source[end]))
+            {
+                end++;
+            }
+
+            Emit(tokens, "PI_TARGET", _source.Substring(_position, end - _position));
+            _processingInstructionNeedsTarget = false;
+            return;
+        }
+
+        var textEnd = _source.IndexOf("?>", _position, StringComparison.Ordinal);
+        if (textEnd < 0)
+        {
+            textEnd = _source.Length;
+        }
+
+        Emit(tokens, "PI_TEXT", _source.Substring(_position, textEnd - _position));
+        _processingInstructionNeedsTarget = false;
+    }
+
+    private bool TryEmitLiteral(List<Token> tokens, string literal, string typeName)
+    {
+        if (!_source.AsSpan(_position).StartsWith(literal, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        Emit(tokens, typeName, literal);
+        return true;
+    }
+
+    private void Emit(List<Token> tokens, string typeName, string value)
+    {
+        var flags = _precededByNewline ? Token.FlagPrecededByNewline : 0;
+        tokens.Add(new Token(TokenType.Grammar, value, _line, _column, typeName, flags));
+        AdvanceToken(value);
+        _precededByNewline = false;
+    }
+
+    private void SkipWhitespace()
+    {
+        while (_position < _source.Length && IsXmlWhitespace(_source[_position]))
+        {
+            var character = _source[_position++];
+            if (character == '\n')
+            {
+                _line++;
+                _column = 1;
+                _precededByNewline = true;
+            }
+            else
+            {
+                _column++;
+            }
+        }
+    }
+
+    private void AdvanceToken(string value)
+    {
+        foreach (var character in value)
+        {
+            if (character == '\n')
+            {
+                _line++;
+                _column = 1;
+            }
+            else
+            {
+                _column++;
+            }
+        }
+
+        _position += value.Length;
+    }
+
+    private void ThrowUnexpected() =>
+        throw new LexerError($"Unexpected character '{_source[_position]}'", _line, _column);
+
+    private static bool IsXmlWhitespace(char character) => character is ' ' or '\t' or '\r' or '\n';
+
+    private static bool IsAsciiLetter(char character) =>
+        character is >= 'A' and <= 'Z' or >= 'a' and <= 'z';
+
+    private static bool IsHexDigit(char character) =>
+        char.IsAsciiDigit(character) || character is >= 'A' and <= 'F' or >= 'a' and <= 'f';
+
+    private static bool IsNameStart(char character) => IsAsciiLetter(character) || character == '_';
+
+    private static bool IsNamePart(char character) =>
+        IsNameStart(character) || char.IsAsciiDigit(character) || character is ':' or '.' or '-';
+}
+
+/// <summary>Convenience factory and one-shot XML tokenization helpers.</summary>
+public static class XmlTokenizer
+{
+    public static XmlLexer CreateXmlLexer(string source) => new(source);
+
+    public static IReadOnlyList<Token> TokenizeXml(string source) => CreateXmlLexer(source).Tokenize();
+}

--- a/code/packages/csharp/xml-lexer/required_capabilities.json
+++ b/code/packages/csharp/xml-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/xml-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory XML tokenization with no filesystem, process, environment, or network access."
+}

--- a/code/packages/csharp/xml-lexer/tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.csproj
+++ b/code/packages/csharp/xml-lexer/tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.XmlLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/xml-lexer/tests/CodingAdventures.XmlLexer.Tests/XmlLexerTests.cs
+++ b/code/packages/csharp/xml-lexer/tests/CodingAdventures.XmlLexer.Tests/XmlLexerTests.cs
@@ -1,0 +1,125 @@
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.XmlLexer.Tests;
+
+public sealed class XmlLexerTests
+{
+    [Fact]
+    public void TokenizesSimpleNamespacedAndSelfClosingElements()
+    {
+        Assert.Equal(
+            [
+                ("OPEN_TAG_START", "<"), ("TAG_NAME", "ns:tag"), ("TAG_CLOSE", ">"),
+                ("TEXT", "text"), ("CLOSE_TAG_START", "</"), ("TAG_NAME", "ns:tag"),
+                ("TAG_CLOSE", ">"), ("OPEN_TAG_START", "<"), ("TAG_NAME", "br"),
+                ("SELF_CLOSE", "/>"),
+            ],
+            Pairs("<ns:tag>text</ns:tag><br />"));
+    }
+
+    [Fact]
+    public void TokenizesSingleAndDoubleQuotedAttributes()
+    {
+        Assert.Equal(
+            [
+                ("OPEN_TAG_START", "<"), ("TAG_NAME", "div"), ("TAG_NAME", "id"),
+                ("ATTR_EQUALS", "="), ("ATTR_VALUE", "\"main\""), ("TAG_NAME", "data-v"),
+                ("ATTR_EQUALS", "="), ("ATTR_VALUE", "'x'"), ("TAG_CLOSE", ">"),
+            ],
+            Pairs("<div id=\"main\" data-v='x'>"));
+    }
+
+    [Fact]
+    public void PreservesCommentAndCDataContent()
+    {
+        Assert.Equal(
+            [
+                ("COMMENT_START", "<!--"), ("COMMENT_TEXT", "  a-b\t "), ("COMMENT_END", "-->"),
+                ("CDATA_START", "<![CDATA["), ("CDATA_TEXT", " x < y\n "), ("CDATA_END", "]]>"),
+            ],
+            Pairs("<!--  a-b\t --><![CDATA[ x < y\n ]]>"));
+    }
+
+    [Fact]
+    public void TokenizesProcessingInstructions()
+    {
+        Assert.Equal(
+            [
+                ("PI_START", "<?"), ("PI_TARGET", "xml-stylesheet"),
+                ("PI_TEXT", " type=\"text/xsl\""), ("PI_END", "?>"),
+            ],
+            Pairs("<?xml-stylesheet type=\"text/xsl\"?>"));
+    }
+
+    [Fact]
+    public void TokenizesNamedDecimalAndHexReferences()
+    {
+        Assert.Equal(
+            [
+                ("TEXT", "a"), ("ENTITY_REF", "&amp;"), ("CHAR_REF", "&#65;"),
+                ("CHAR_REF", "&#x41;"), ("TEXT", "b"),
+            ],
+            Pairs("a&amp;&#65;&#x41;b"));
+    }
+
+    [Fact]
+    public void SkipsWhitespaceThatStartsAContentOrTagMatch()
+    {
+        var tokens = XmlTokenizer.TokenizeXml("\n  <a> <b/></a>");
+        Assert.DoesNotContain(tokens, token => token.EffectiveTypeName == "TEXT");
+        Assert.True(tokens[0].HasFlag(Token.FlagPrecededByNewline));
+        Assert.Equal((2, 3), (tokens[0].Line, tokens[0].Column));
+    }
+
+    [Fact]
+    public void TextMayContainWhitespaceAfterItsFirstCharacter()
+    {
+        Assert.Equal([("TEXT", "Hello world ")], Pairs("Hello world "));
+    }
+
+    [Fact]
+    public void EmptyAndUnterminatedDelimitedInputsFollowGrammarLexerBehavior()
+    {
+        Assert.Equal("EOF", Assert.Single(XmlTokenizer.TokenizeXml(string.Empty)).EffectiveTypeName);
+        Assert.Equal(
+            [("COMMENT_START", "<!--"), ("COMMENT_TEXT", "open" )],
+            Pairs("<!--open"));
+        Assert.Equal(
+            [("CDATA_START", "<![CDATA["), ("CDATA_TEXT", "open")],
+            Pairs("<![CDATA[open"));
+        Assert.Equal(
+            [("PI_START", "<?"), ("PI_TARGET", "open")],
+            Pairs("<?open"));
+    }
+
+    [Fact]
+    public void EmitsSlashTokenInsideTags()
+    {
+        Assert.Contains(("SLASH", "/"), Pairs("</a/ >"));
+    }
+
+    [Theory]
+    [InlineData("&bad")]
+    [InlineData("&#;")]
+    [InlineData("&#x;")]
+    [InlineData("<a value=\"unterminated>")]
+    public void RejectsInputThatMatchesNoGrammarPattern(string source)
+    {
+        var error = Assert.Throws<LexerError>(() => XmlTokenizer.TokenizeXml(source));
+        Assert.True(error.Line >= 1);
+        Assert.True(error.Column >= 1);
+    }
+
+    [Fact]
+    public void FactoryReturnsReusableLexerObject()
+    {
+        var lexer = XmlTokenizer.CreateXmlLexer("<root/>");
+        Assert.Equal("EOF", lexer.Tokenize()[^1].EffectiveTypeName);
+    }
+
+    private static (string Type, string Value)[] Pairs(string source) =>
+        XmlTokenizer.TokenizeXml(source)
+            .Where(token => token.Type != TokenType.EOF)
+            .Select(token => (token.EffectiveTypeName, token.Value))
+            .ToArray();
+}

--- a/code/packages/fsharp/xml-lexer/BUILD
+++ b/code/packages/fsharp/xml-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.XmlLexer.FSharp]*"

--- a/code/packages/fsharp/xml-lexer/BUILD_windows
+++ b/code/packages/fsharp/xml-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.XmlLexer.FSharp]*"

--- a/code/packages/fsharp/xml-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/xml-lexer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add pure F# XML tokenization across content, tag, comment, CDATA, and PI modes.
+- Emit the existing lexer package's token model and shared XML token names.
+- Cover attributes, namespaces, references, whitespace, EOF, and invalid input.

--- a/code/packages/fsharp/xml-lexer/CodingAdventures.XmlLexer.fsproj
+++ b/code/packages/fsharp/xml-lexer/CodingAdventures.XmlLexer.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.XmlLexer.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.XmlLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Context-sensitive XML tokenizer for F#</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\lexer\CodingAdventures.Lexer.fsproj" />
+    <Compile Include="XmlLexer.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/xml-lexer/README.md
+++ b/code/packages/fsharp/xml-lexer/README.md
@@ -1,0 +1,26 @@
+# CodingAdventures.XmlLexer.FSharp
+
+A context-sensitive XML tokenizer that emits the shared XML grammar's token
+names using the existing F# lexer token model.
+
+## Usage
+
+```fsharp
+open CodingAdventures.XmlLexer.FSharp
+
+let tokens = XmlTokenizer.tokenizeXml "<p>Hello &amp; world</p>"
+```
+
+The scanner switches among content, tag, comment, CDATA, and processing
+instruction modes. Whitespace is skipped only when it begins a match in the
+content or tag modes; whitespace inside comments, CDATA, and processing
+instructions is preserved.
+
+The result always ends with an `EOF` token. `createXmlLexer` is available when
+an explicitly configured lexer object is preferred.
+
+## Testing
+
+```sh
+dotnet test tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.fsproj
+```

--- a/code/packages/fsharp/xml-lexer/XmlLexer.fs
+++ b/code/packages/fsharp/xml-lexer/XmlLexer.fs
@@ -1,0 +1,240 @@
+namespace CodingAdventures.XmlLexer.FSharp
+
+open System
+open System.Collections.Generic
+open CodingAdventures.Lexer.FSharp
+
+type private Mode =
+    | Content
+    | Tag
+    | Comment
+    | CData
+    | ProcessingInstruction
+
+/// Tokenizes XML using the token names defined by the shared XML grammar.
+type XmlLexer(input: string) =
+    let source =
+        if isNull input then
+            nullArg "input"
+
+        input
+
+    let mutable position = 0
+    let mutable line = 1
+    let mutable column = 1
+    let mutable precededByNewline = false
+    let mutable mode = Content
+    let mutable processingInstructionNeedsTarget = false
+
+    let isXmlWhitespace character =
+        character = ' ' || character = '\t' || character = '\r' || character = '\n'
+
+    let isAsciiLetter character =
+        (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')
+
+    let isAsciiDigit character = character >= '0' && character <= '9'
+
+    let isHexDigit character =
+        isAsciiDigit character
+        || (character >= 'A' && character <= 'F')
+        || (character >= 'a' && character <= 'f')
+
+    let isNameStart character = isAsciiLetter character || character = '_'
+
+    let isNamePart character =
+        isNameStart character
+        || isAsciiDigit character
+        || character = ':'
+        || character = '.'
+        || character = '-'
+
+    let startsWith (literal: string) =
+        position + literal.Length <= source.Length
+        && String.CompareOrdinal(source, position, literal, 0, literal.Length) = 0
+
+    let unexpected () =
+        raise (LexerError(sprintf "Unexpected character '%c'" source[position], line, column))
+
+    let advanceToken (value: string) =
+        for character in value do
+            if character = '\n' then
+                line <- line + 1
+                column <- 1
+            else
+                column <- column + 1
+
+        position <- position + value.Length
+
+    let emit (tokens: ResizeArray<Token>) typeName value =
+        let flags =
+            if precededByNewline then
+                Token.FlagPrecededByNewline
+            else
+                0
+
+        tokens.Add(Token(TokenType.Grammar, value, line, column, typeName, flags))
+        advanceToken value
+        precededByNewline <- false
+
+    let tryEmitLiteral tokens literal typeName =
+        if startsWith literal then
+            emit tokens typeName literal
+            true
+        else
+            false
+
+    let skipWhitespace () =
+        while position < source.Length && isXmlWhitespace source[position] do
+            let character = source[position]
+            position <- position + 1
+
+            if character = '\n' then
+                line <- line + 1
+                column <- 1
+                precededByNewline <- true
+            else
+                column <- column + 1
+
+    let scanReference tokens =
+        let mutable finish = position + 1
+        let mutable typeName = "ENTITY_REF"
+
+        if finish < source.Length && source[finish] = '#' then
+            typeName <- "CHAR_REF"
+            finish <- finish + 1
+            let hexadecimal = finish < source.Length && source[finish] = 'x'
+
+            if hexadecimal then
+                finish <- finish + 1
+
+            let digitStart = finish
+
+            while
+                finish < source.Length
+                && (if hexadecimal then isHexDigit source[finish] else isAsciiDigit source[finish])
+                do
+                finish <- finish + 1
+
+            if finish = digitStart then
+                unexpected ()
+        else
+            if finish >= source.Length || not (isAsciiLetter source[finish]) then
+                unexpected ()
+
+            finish <- finish + 1
+
+            while finish < source.Length && (isAsciiLetter source[finish] || isAsciiDigit source[finish]) do
+                finish <- finish + 1
+
+        if finish >= source.Length || source[finish] <> ';' then
+            unexpected ()
+
+        emit tokens typeName (source.Substring(position, finish - position + 1))
+
+    let scanContent tokens =
+        if isXmlWhitespace source[position] then
+            skipWhitespace ()
+        elif tryEmitLiteral tokens "<!--" "COMMENT_START" then
+            mode <- Comment
+        elif tryEmitLiteral tokens "<![CDATA[" "CDATA_START" then
+            mode <- CData
+        elif tryEmitLiteral tokens "<?" "PI_START" then
+            mode <- ProcessingInstruction
+            processingInstructionNeedsTarget <- true
+        elif tryEmitLiteral tokens "</" "CLOSE_TAG_START" then
+            mode <- Tag
+        elif tryEmitLiteral tokens "<" "OPEN_TAG_START" then
+            mode <- Tag
+        elif source[position] = '&' then
+            scanReference tokens
+        else
+            let mutable finish = position
+
+            while finish < source.Length && source[finish] <> '<' && source[finish] <> '&' do
+                finish <- finish + 1
+
+            emit tokens "TEXT" (source.Substring(position, finish - position))
+
+    let scanTag tokens =
+        if isXmlWhitespace source[position] then
+            skipWhitespace ()
+        elif tryEmitLiteral tokens "/>" "SELF_CLOSE" then
+            mode <- Content
+        elif tryEmitLiteral tokens ">" "TAG_CLOSE" then
+            mode <- Content
+        elif tryEmitLiteral tokens "=" "ATTR_EQUALS" then
+            ()
+        elif tryEmitLiteral tokens "/" "SLASH" then
+            ()
+        else
+            let current = source[position]
+
+            if current = '\'' || current = '"' then
+                let finish = source.IndexOf(current, position + 1)
+
+                if finish < 0 then
+                    unexpected ()
+
+                emit tokens "ATTR_VALUE" (source.Substring(position, finish - position + 1))
+            elif isNameStart current then
+                let mutable finish = position + 1
+
+                while finish < source.Length && isNamePart source[finish] do
+                    finish <- finish + 1
+
+                emit tokens "TAG_NAME" (source.Substring(position, finish - position))
+            else
+                unexpected ()
+
+    let scanDelimitedContent tokens delimiter textType endType =
+        if tryEmitLiteral tokens delimiter endType then
+            mode <- Content
+        else
+            let delimiterPosition = source.IndexOf(delimiter, position, StringComparison.Ordinal)
+
+            let finish =
+                if delimiterPosition < 0 then source.Length else delimiterPosition
+
+            emit tokens textType (source.Substring(position, finish - position))
+
+    let scanProcessingInstruction tokens =
+        if tryEmitLiteral tokens "?>" "PI_END" then
+            mode <- Content
+        elif processingInstructionNeedsTarget && isNameStart source[position] then
+            let mutable finish = position + 1
+
+            while finish < source.Length && isNamePart source[finish] do
+                finish <- finish + 1
+
+            emit tokens "PI_TARGET" (source.Substring(position, finish - position))
+            processingInstructionNeedsTarget <- false
+        else
+            let delimiterPosition = source.IndexOf("?>", position, StringComparison.Ordinal)
+
+            let finish =
+                if delimiterPosition < 0 then source.Length else delimiterPosition
+
+            emit tokens "PI_TEXT" (source.Substring(position, finish - position))
+            processingInstructionNeedsTarget <- false
+
+    /// Tokenizes the configured XML source and appends an EOF token.
+    member _.Tokenize() : IReadOnlyList<Token> =
+        let tokens = ResizeArray<Token>()
+
+        while position < source.Length do
+            match mode with
+            | Content -> scanContent tokens
+            | Tag -> scanTag tokens
+            | Comment -> scanDelimitedContent tokens "-->" "COMMENT_TEXT" "COMMENT_END"
+            | CData -> scanDelimitedContent tokens "]]>" "CDATA_TEXT" "CDATA_END"
+            | ProcessingInstruction -> scanProcessingInstruction tokens
+
+        tokens.Add(Token(TokenType.EOF, String.Empty, line, column, "EOF"))
+        tokens :> IReadOnlyList<Token>
+
+/// Convenience factory and one-shot XML tokenization helpers.
+[<RequireQualifiedAccess>]
+module XmlTokenizer =
+    let createXmlLexer source = XmlLexer(source)
+
+    let tokenizeXml source = (createXmlLexer source).Tokenize()

--- a/code/packages/fsharp/xml-lexer/required_capabilities.json
+++ b/code/packages/fsharp/xml-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/xml-lexer",
+  "capabilities": [],
+  "justification": "Pure in-memory XML tokenization with no filesystem, process, environment, or network access."
+}

--- a/code/packages/fsharp/xml-lexer/tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.fsproj
+++ b/code/packages/fsharp/xml-lexer/tests/CodingAdventures.XmlLexer.Tests/CodingAdventures.XmlLexer.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.XmlLexer.fsproj" />
+    <Compile Include="XmlLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/xml-lexer/tests/CodingAdventures.XmlLexer.Tests/XmlLexerTests.fs
+++ b/code/packages/fsharp/xml-lexer/tests/CodingAdventures.XmlLexer.Tests/XmlLexerTests.fs
@@ -1,0 +1,130 @@
+namespace CodingAdventures.XmlLexer.FSharp.Tests
+
+open System
+open CodingAdventures.Lexer.FSharp
+open CodingAdventures.XmlLexer.FSharp
+open Xunit
+
+module XmlLexerTests =
+    let private pairs source =
+        XmlTokenizer.tokenizeXml source
+        |> Seq.filter (fun token -> token.Type <> TokenType.EOF)
+        |> Seq.map (fun token -> token.EffectiveTypeName, token.Value)
+        |> Seq.toArray
+
+    [<Fact>]
+    let ``tokenizes simple namespaced and self-closing elements`` () =
+        Assert.Equal<(string * string) array>(
+            [|
+                "OPEN_TAG_START", "<"
+                "TAG_NAME", "ns:tag"
+                "TAG_CLOSE", ">"
+                "TEXT", "text"
+                "CLOSE_TAG_START", "</"
+                "TAG_NAME", "ns:tag"
+                "TAG_CLOSE", ">"
+                "OPEN_TAG_START", "<"
+                "TAG_NAME", "br"
+                "SELF_CLOSE", "/>"
+            |],
+            pairs "<ns:tag>text</ns:tag><br />")
+
+    [<Fact>]
+    let ``tokenizes single and double quoted attributes`` () =
+        Assert.Equal<(string * string) array>(
+            [|
+                "OPEN_TAG_START", "<"
+                "TAG_NAME", "div"
+                "TAG_NAME", "id"
+                "ATTR_EQUALS", "="
+                "ATTR_VALUE", "\"main\""
+                "TAG_NAME", "data-v"
+                "ATTR_EQUALS", "="
+                "ATTR_VALUE", "'x'"
+                "TAG_CLOSE", ">"
+            |],
+            pairs "<div id=\"main\" data-v='x'>")
+
+    [<Fact>]
+    let ``preserves comment and CDATA content`` () =
+        Assert.Equal<(string * string) array>(
+            [|
+                "COMMENT_START", "<!--"
+                "COMMENT_TEXT", "  a-b\t "
+                "COMMENT_END", "-->"
+                "CDATA_START", "<![CDATA["
+                "CDATA_TEXT", " x < y\n "
+                "CDATA_END", "]]>"
+            |],
+            pairs "<!--  a-b\t --><![CDATA[ x < y\n ]]>")
+
+    [<Fact>]
+    let ``tokenizes processing instructions`` () =
+        Assert.Equal<(string * string) array>(
+            [|
+                "PI_START", "<?"
+                "PI_TARGET", "xml-stylesheet"
+                "PI_TEXT", " type=\"text/xsl\""
+                "PI_END", "?>"
+            |],
+            pairs "<?xml-stylesheet type=\"text/xsl\"?>")
+
+    [<Fact>]
+    let ``tokenizes named decimal and hexadecimal references`` () =
+        Assert.Equal<(string * string) array>(
+            [|
+                "TEXT", "a"
+                "ENTITY_REF", "&amp;"
+                "CHAR_REF", "&#65;"
+                "CHAR_REF", "&#x41;"
+                "TEXT", "b"
+            |],
+            pairs "a&amp;&#65;&#x41;b")
+
+    [<Fact>]
+    let ``skips whitespace that starts a content or tag match`` () =
+        let tokens = XmlTokenizer.tokenizeXml "\n  <a> <b/></a>"
+        Assert.DoesNotContain(tokens, fun token -> token.EffectiveTypeName = "TEXT")
+        Assert.True(tokens[0].HasFlag(Token.FlagPrecededByNewline))
+        Assert.Equal(2, tokens[0].Line)
+        Assert.Equal(3, tokens[0].Column)
+
+    [<Fact>]
+    let ``text may contain whitespace after its first character`` () =
+        Assert.Equal<(string * string) array>([| "TEXT", "Hello world " |], pairs "Hello world ")
+
+    [<Fact>]
+    let ``empty and unterminated delimited inputs follow grammar lexer behavior`` () =
+        let emptyTokens = XmlTokenizer.tokenizeXml String.Empty
+        Assert.Equal("EOF", emptyTokens[0].EffectiveTypeName)
+
+        Assert.Equal<(string * string) array>(
+            [| "COMMENT_START", "<!--"; "COMMENT_TEXT", "open" |],
+            pairs "<!--open")
+
+        Assert.Equal<(string * string) array>(
+            [| "CDATA_START", "<![CDATA["; "CDATA_TEXT", "open" |],
+            pairs "<![CDATA[open")
+
+        Assert.Equal<(string * string) array>(
+            [| "PI_START", "<?"; "PI_TARGET", "open" |],
+            pairs "<?open")
+
+    [<Fact>]
+    let ``emits slash token inside tags`` () =
+        Assert.Contains(("SLASH", "/"), pairs "</a/ >")
+
+    [<Theory>]
+    [<InlineData("&bad")>]
+    [<InlineData("&#;")>]
+    [<InlineData("&#x;")>]
+    [<InlineData("<a value=\"unterminated>")>]
+    let ``rejects input that matches no grammar pattern`` source =
+        let error = Assert.Throws<LexerError>(fun () -> XmlTokenizer.tokenizeXml source |> ignore)
+        Assert.True(error.Line >= 1)
+        Assert.True(error.Column >= 1)
+
+    [<Fact>]
+    let ``factory returns configured lexer object`` () =
+        let tokens = (XmlTokenizer.createXmlLexer "<root/>").Tokenize()
+        Assert.Equal("EOF", tokens[tokens.Count - 1].EffectiveTypeName)

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -112,11 +112,11 @@ the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
 and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
 `x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
-ports, and the paired C#/F# `chacha20-poly1305` ports:
+ports, and the paired C#/F# `chacha20-poly1305` and `xml-lexer` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 329 |
+| Present in 10-15 languages | 172 | 327 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 699 | 9,786 |
@@ -162,7 +162,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 331
+The 172 packages present in at least ten implementation languages need 327
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -171,8 +171,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 10 | Move with F# |
-| F# | 10 | Move with C# |
+| C# | 9 | Move with F# |
+| F# | 9 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -282,6 +282,15 @@ AEAD vectors cover the full construction, while multiblock round trips and
 tamper tests verify counter progression and authenticate-before-decrypt
 behavior. The package now spans 12 implementation lanes and reduces each
 paired high-consensus gap to 10.
+
+The eighth paired C#/F# slice is complete: `xml-lexer` now provides native,
+context-sensitive scanners in both lanes while reusing their existing lexer
+token models. Package-local state transitions match the shared XML grammar's
+content, tag, comment, CDATA, and processing-instruction groups; tests cover
+namespaces, quoted attributes, entity and character references, significant
+whitespace, token positions, malformed input, and EOF behavior. The package
+now spans 12 implementation lanes, reduces the high-consensus backlog to 327
+slots, and leaves 9 paired gaps in each lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add native C# and F# `xml-lexer` packages that emit the existing lexer token models
- implement the shared XML grammar's content, tag, comment, CDATA, and processing-instruction modes
- cover namespaces, quoted attributes, entities, character references, significant whitespace, token positions, malformed input, and EOF behavior
- refresh the package-parity roadmap from the live reporter

## Why

`xml-lexer` was a portable 10-of-15 high-consensus package with missing C# and F# lanes. The existing generic lexer packages do not yet expose pattern-group callbacks, so these ports use small package-local state scanners while preserving the shared grammar's ordered token semantics and public token representation.

## Impact

The package now spans 12 established implementation languages. The high-consensus backlog falls from 329 to 327 missing slots, and the paired C#/F# gap falls from 10 to 9 packages per lane.

## Validation

- C#: 14/14 tests; 95.57% line, 90.66% branch, 100% method coverage
- F#: 14/14 tests; 97.87% line, 90.66% branch, 100% method coverage
- `dotnet format CodingAdventures.XmlLexer.csproj --verify-no-changes --no-restore`
- package parity reporter tests: 6/6
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: 0 collisions, 327 high-consensus missing slots, 9 remaining C# and F# gaps
- `git diff origin/main...HEAD --check`
