### PR TITLE
feat(hl): canonical concept taxonomy + normalize 121 lesson tags

### DIFF
--- a/code/learning/human-languages/arabic/lessons/AR-C01-al.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-al.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ال
 gloss: the (al- — the attached article)
-concept_tag: ARTICLE
+concept_tag: GRAMMAR-THE
 prerequisites: [AR-C01-salam]
 sounds: [alif-lam, sun-moon-letters]
 roots: []

--- a/code/learning/human-languages/arabic/lessons/AR-C01-shukran.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-shukran.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: شكرا
 gloss: thank you (shukran)
-concept_tag: THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [AR-C01-as-salamu-alaykum]
 sounds: [shin, kaf]
 roots: [sh-k-r]

--- a/code/learning/human-languages/arabic/lessons/AR-C02-ii-my.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-ii-my.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: ي
 gloss: my (possessive suffix -ī)
-concept_tag: MY
+concept_tag: PRONOUN-MY
 prerequisites: [AR-C02-ism]
 sounds: [yaa-suffix]
 roots: []

--- a/code/learning/human-languages/arabic/lessons/AR-C02-ism.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-ism.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: اسم
 gloss: name
-concept_tag: NAME
+concept_tag: WORD-NAME
 prerequisites: []
 sounds: [rtl-known-letters]
 roots: [s-m-w]

--- a/code/learning/human-languages/arabic/lessons/AR-C02-ismii.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-ismii.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: اسمي …
 gloss: my name is… (with no "is")
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [AR-C02-ism, AR-C02-ii-my]
 sounds: []
 roots: []

--- a/code/learning/human-languages/arabic/lessons/AR-C02-maa-ismuka.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-maa-ismuka.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: ما اسمك؟
 gloss: what's your name?
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [AR-C02-maa, AR-C02-ism, AR-C02-anta-anti]
 sounds: []
 roots: []

--- a/code/learning/human-languages/arabic/lessons/AR-C02-maa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-maa.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: ما
 gloss: what
-concept_tag: WHAT
+concept_tag: QUESTION-WHAT
 prerequisites: [AR-C02-anta-anti]
 sounds: [known-letters]
 roots: []

--- a/code/learning/human-languages/arabic/lessons/AR-C02-tasharrafna.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-tasharrafna.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: تشرفنا
 gloss: pleased to meet you (literally "we have been honoured")
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [AR-C02-ismii]
 sounds: [taa, faa]
 roots: [sh-r-f]

--- a/code/learning/human-languages/bengali/lessons/BN-C01-achchha.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C01-achchha.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: আচ্ছা
 gloss: okay / alright / I see (āchchhā)
-concept_tag: FUNCTION-OKAY
+concept_tag: RESPONSE-OKAY
 prerequisites: [BN-C01-hyan-na]
 sounds: [independent-vowel, chchh-conjunct]
 roots: [accha]

--- a/code/learning/human-languages/bengali/lessons/BN-C01-ashi.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C01-ashi.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: আসি
 gloss: goodbye, lit. "I'll come [again]" (āshi)
-concept_tag: GREETING-GOODBYE
+concept_tag: FAREWELL
 prerequisites: [BN-C01-achchha]
 sounds: [s-to-sh, i-sign-before]
 roots: [asa-come]

--- a/code/learning/human-languages/bengali/lessons/BN-C01-dhonnobad.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C01-dhonnobad.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ধন্যবাদ
 gloss: thank you (dhônyobad)
-concept_tag: GRATITUDE-THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [BN-C01-nomoshkar]
 sounds: [inherent-o, ny-conjunct, v-to-b]
 roots: [dhanya, vada]

--- a/code/learning/human-languages/bengali/lessons/BN-C01-hyan-na.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C01-hyan-na.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: হ্যাঁ / না
 gloss: yes / no (hyã / nā)
-concept_tag: FUNCTION-YESNO
+concept_tag: RESPONSE-YESNO
 prerequisites: [BN-C01-dhonnobad]
 sounds: [ho, y-phola, chandrabindu-nasal]
 roots: [na-negative]

--- a/code/learning/human-languages/concepts/README.md
+++ b/code/learning/human-languages/concepts/README.md
@@ -1,0 +1,59 @@
+# Concepts — the cross-language join layer
+
+This directory holds the **canonical concept taxonomy** for the Human Languages
+curriculum. Full rationale is in
+[`HL01`](../../../specs/HL01-concept-taxonomy-and-data-layer.md); this is the
+operational note.
+
+## What a "concept" is
+
+A **concept** is a language-independent unit of meaning or function the curriculum
+teaches — "the greeting you say on meeting someone" is a concept; Spanish *hola*,
+German *hallo*, Hindi *नमस्ते*, and Telugu *నమస్కారం* are its **realizations**.
+The concept id is the key that lets tooling (the companion app, `HL02`) line the
+same idea up across every language — which is what powers "learn it in Spanish,
+then the same thing in French, then review both."
+
+## `taxonomy.json`
+
+The authoritative list of **universal** concept ids (the join keys), each with a
+family, an English gloss, a `core` flag, and — where it replaced older tags
+during normalization — a `retires` list for traceability.
+
+- **Universal** ids (e.g. `GREETING-HELLO`, `TIME-DAY`, `INTRO-MY-NAME-IS`) live
+  here and are shared across tracks.
+- **Language-local** lexical/structural ids are *namespaced* (`<LANG>-<NAME>`,
+  e.g. `ES-VERB-LLAMAR`) and live only in lesson frontmatter, never here.
+- **Practice/review** lessons (`type: practice | practice-mix`) carry a session
+  label, not a concept, and are exempt from the join.
+
+## How a lesson joins in
+
+Each lesson's `concept_tag` frontmatter field is either a universal id from
+`taxonomy.json` or a namespaced id. `type: word` and `type: phrase` lessons are
+**content** lessons and must carry a real concept tag; `practice`/`practice-mix`
+lessons are exempt. The `HL01` data-layer validator enforces this in CI.
+
+## Normalization (2026-07)
+
+The tags were originally authored per-track and had drifted apart (`GREETING-NIGHT`
+vs `GREETING-GOODNIGHT`; `DIA`/`JOUR`/`TAG`/`DAY` all meaning "day"; three spellings
+of "thank you"; a few tracks tagging two different words `GREETING-HELLO`). They
+were reconciled onto this taxonomy in one mechanical pass over 121 lessons
+(frontmatter only — no prose changed). Every `retires` entry in `taxonomy.json`
+records an old tag that was folded in. Notable decisions:
+
+- **Synonyms unified**: `GREETING-NIGHT`→`GREETING-GOODNIGHT`, `GREETING-GOODBYE`→
+  `FAREWELL`, `THANKS`/`GRATITUDE-THANKS`/`THANKS-FORMAL`→`COURTESY-THANKS`.
+- **Scattered lexical tags unified**: the day/night/morning/evening nouns collapse
+  into the `TIME-*` family; the "good/well" adjectives into `WORD-GOOD`/`WORD-WELL`;
+  the article systems into `GRAMMAR-THE`.
+- **Within-track duplicates split**: where a track taught two "hello" words, the
+  more formal one (Latin *avē*, Sanskrit *namaskāraḥ*, Punjabi *sat srī akāl*)
+  moved to `GREETING-FORMAL`; Punjabi's two "thanks" split into `COURTESY-THANKS`
+  (Sanskritic *dhannavād*) and `COURTESY-THANKS-CASUAL` (Perso-Arabic *shukrīā*).
+- **Combined yes/no lessons** keep `RESPONSE-YESNO` until the parity pass splits
+  them into `RESPONSE-YES` + `RESPONSE-NO`.
+
+The taxonomy grows one concept at a time as the curriculum does — it is never
+front-loaded with concepts no lesson yet realizes.

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "./taxonomy.schema-notes.md",
+  "version": 1,
+  "note": "Canonical cross-language concept vocabulary for the Human Languages curriculum. See code/specs/HL01-concept-taxonomy-and-data-layer.md. Ids are stable slugs (never renumbered). 'core: true' = expected in every track once it declares parity:complete. 'retires' lists the pre-canonical concept_tags this id replaced during the HL01 normalization, kept for traceability.",
+  "concepts": {
+    "GREETING-HELLO": {
+      "family": "GREETING",
+      "gloss": "hello (neutral, said on meeting)",
+      "core": true,
+      "notes": "The default meeting greeting. Where a track taught two 'hello' words, the more formal/ceremonial one moves to GREETING-FORMAL (avē, namaskāraḥ, sat srī akāl)."
+    },
+    "GREETING-DAY": {
+      "family": "GREETING",
+      "gloss": "good day (general daytime greeting)",
+      "core": false,
+      "notes": "bonjour / Guten Tag / buongiorno / bom dia. Distinct from GREETING-MORNING and from the noun TIME-DAY."
+    },
+    "GREETING-MORNING": { "family": "GREETING", "gloss": "good morning", "core": false },
+    "GREETING-AFTERNOON": { "family": "GREETING", "gloss": "good afternoon", "core": false },
+    "GREETING-EVENING": { "family": "GREETING", "gloss": "good evening (said on meeting)", "core": false },
+    "GREETING-GOODNIGHT": {
+      "family": "GREETING",
+      "gloss": "good night (said on parting / before sleep)",
+      "core": false,
+      "retires": ["GREETING-NIGHT"],
+      "notes": "Parting greeting, distinct from the meeting greeting GREETING-EVENING. Retires Spanish/Italian's older GREETING-NIGHT tag; where a track's 'noches/notte' word doubles as the evening noun, the noun is TIME-NIGHT."
+    },
+    "GREETING-FORMAL": {
+      "family": "GREETING",
+      "gloss": "a more formal / ceremonial greeting",
+      "core": false,
+      "notes": "as-salāmu ʿalaykum, namaskār/namaskāra, avē, sat srī akāl. The formal counterpart to GREETING-HELLO within a track."
+    },
+    "GREETING-PEACE": {
+      "family": "GREETING",
+      "gloss": "peace, used as a greeting (salām)",
+      "core": false
+    },
+    "GREETING-WELCOME": {
+      "family": "GREETING",
+      "gloss": "welcome (svāgatam)",
+      "core": false
+    },
+    "FAREWELL": {
+      "family": "GREETING",
+      "gloss": "goodbye / parting word",
+      "core": true,
+      "retires": ["GREETING-GOODBYE"],
+      "notes": "Unifies the parting word across tracks (valē, āshi, alvidā, येतो/येते)."
+    },
+
+    "COURTESY-THANKS": {
+      "family": "COURTESY",
+      "gloss": "thank you (neutral / default register)",
+      "core": true,
+      "retires": ["THANKS", "GRATITUDE-THANKS", "THANKS-FORMAL"],
+      "notes": "The default 'thank you'. Where a track teaches a second, more colloquial word (often Perso-Arabic), that one is COURTESY-THANKS-CASUAL."
+    },
+    "COURTESY-THANKS-CASUAL": {
+      "family": "COURTESY",
+      "gloss": "thanks (casual / colloquial register)",
+      "core": false,
+      "retires": ["THANKS-CASUAL"],
+      "notes": "e.g. Hindi shukriyā, Punjabi shukrīā — the everyday, often Perso-Arabic-derived alternative to the Sanskritic COURTESY-THANKS."
+    },
+
+    "RESPONSE-YES": {
+      "family": "RESPONSE",
+      "gloss": "yes",
+      "core": true,
+      "notes": "Tracks that teach yes and no in a single lesson use RESPONSE-YESNO until that lesson is split during the parity pass."
+    },
+    "RESPONSE-NO": { "family": "RESPONSE", "gloss": "no", "core": true },
+    "RESPONSE-YESNO": {
+      "family": "RESPONSE",
+      "gloss": "yes / no (taught together in one lesson)",
+      "core": false,
+      "retires": ["FUNCTION-YESNO"],
+      "notes": "A single lesson realizing both yes and no (ita/nōn, hāṇ/nahīṇ, hyã/nā, ām/na). Split into RESPONSE-YES + RESPONSE-NO when the track reaches parity."
+    },
+    "RESPONSE-OKAY": {
+      "family": "RESPONSE",
+      "gloss": "okay / alright",
+      "core": false,
+      "retires": ["OKAY", "FUNCTION-OKAY"]
+    },
+
+    "QUESTION-WHAT": { "family": "QUESTION", "gloss": "what", "core": true, "retires": ["WHAT"] },
+    "QUESTION-HOW": { "family": "QUESTION", "gloss": "how", "core": false, "retires": ["HOW"] },
+
+    "INTRO-MY-NAME-IS": {
+      "family": "INTRO",
+      "gloss": "\"my name is …\"",
+      "core": true,
+      "retires": ["MY-NAME-IS"]
+    },
+    "INTRO-WHATS-YOUR-NAME": {
+      "family": "INTRO",
+      "gloss": "\"what's your name?\"",
+      "core": true,
+      "retires": ["WHATS-YOUR-NAME"]
+    },
+    "INTRO-NICE-TO-MEET-YOU": {
+      "family": "INTRO",
+      "gloss": "pleased to meet you",
+      "core": true,
+      "retires": ["PLEASED-TO-MEET"],
+      "notes": "Some tracks realize this with a bare 'joy/happiness' noun (khushī, magizhchi, santōṣa); that word is the realization."
+    },
+
+    "PRONOUN-I": { "family": "PRONOUN", "gloss": "I (first-person subject)", "core": false },
+    "PRONOUN-ME": { "family": "PRONOUN", "gloss": "me / myself (object / reflexive)", "core": false },
+    "PRONOUN-YOU": {
+      "family": "PRONOUN",
+      "gloss": "you (with informal / formal forms)",
+      "core": true
+    },
+    "PRONOUN-MY": { "family": "PRONOUN", "gloss": "my (first-person possessive)", "core": false, "retires": ["MY"] },
+
+    "TIME-DAY": { "family": "TIME", "gloss": "day (noun)", "core": false, "retires": ["DIA", "JOUR", "TAG", "DAY"] },
+    "TIME-NIGHT": { "family": "TIME", "gloss": "night (noun)", "core": false, "retires": ["NOCHE", "NUIT", "NACHT"] },
+    "TIME-MORNING": { "family": "TIME", "gloss": "morning (noun)", "core": false, "retires": ["MORGEN"] },
+    "TIME-AFTERNOON": { "family": "TIME", "gloss": "afternoon (noun)", "core": false, "retires": ["TARDE"] },
+    "TIME-EVENING": { "family": "TIME", "gloss": "evening (noun)", "core": false, "retires": ["ABEND", "SOIR"] },
+
+    "WORD-GOOD": { "family": "WORD", "gloss": "good (adjective)", "core": false, "retires": ["BON", "GOOD", "GUT"] },
+    "WORD-WELL": { "family": "WORD", "gloss": "well / fine (adverb)", "core": false, "retires": ["BIEN"] },
+    "WORD-NAME": { "family": "WORD", "gloss": "name (noun)", "core": false, "retires": ["NAME"] },
+    "WORD-IS": { "family": "WORD", "gloss": "is (copula, third person)", "core": false, "retires": ["IS"] },
+
+    "GRAMMAR-THE": {
+      "family": "GRAMMAR",
+      "gloss": "the (definite article / gender marker)",
+      "core": false,
+      "retires": ["ARTICLES-EL-LA", "ARTICLES-LE-LA", "ARTICLES-DER-DIE-DAS", "ARTICLE-GENDER", "ARTICLE"],
+      "notes": "One join key for 'the'; the realization holds each language's specific forms (el/la, der/die/das, il/la/lo, o/a, al-)."
+    }
+  },
+  "namespaced": {
+    "note": "Language-local lexical/structural concepts do NOT appear here; they live only in lesson frontmatter as <LANG>-<NAME> (pattern ^[A-Z]{2}-[A-Z0-9-]+$). Current examples, for reference:",
+    "examples": {
+      "ES-VERB-LLAMAR": "llamar — 'to call' (the Spanish naming verb)",
+      "ES-SE-LLAMA": "se llama — 'he/she calls himself' (3rd-person of llamar)",
+      "ES-WORD-MUCHO": "mucho — 'much / a lot'",
+      "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
+      "DE-VERB-HEISSEN": "heißen — 'to be called'"
+    }
+  },
+  "practiceTags": {
+    "note": "Non-word lessons (type: review | practice-mix) carry a session label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, REVIEW."
+  }
+}

--- a/code/learning/human-languages/french/lessons/FR-C01-bien.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-bien.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: bien
 gloss: well / good / fine
-concept_tag: BIEN
+concept_tag: WORD-WELL
 prerequisites: [FR-C01-salut]
 sounds: [nasal-in]
 roots: [bene, bonus]

--- a/code/learning/human-languages/french/lessons/FR-C01-bon.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-bon.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: bon / bonne
 gloss: good (adjective)
-concept_tag: BON
+concept_tag: WORD-GOOD
 prerequisites: [FR-C01-bien]
 sounds: [nasal-on, silent-final]
 roots: [bonus]

--- a/code/learning/human-languages/french/lessons/FR-C01-jour.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-jour.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: jour
 gloss: day (le jour — masculine)
-concept_tag: JOUR
+concept_tag: TIME-DAY
 prerequisites: [FR-C01-le-la]
 sounds: [j-zh, vowel-ou, r-uvular]
 roots: [diurnum]

--- a/code/learning/human-languages/french/lessons/FR-C01-le-la.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-le-la.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: le / la / les
 gloss: the (masculine / feminine / plural)
-concept_tag: ARTICLES-LE-LA
+concept_tag: GRAMMAR-THE
 prerequisites: [FR-C01-bon]
 sounds: [vowel-e-grave, silent-final]
 roots: [ille, illa]

--- a/code/learning/human-languages/french/lessons/FR-C01-nuit.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-nuit.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: nuit
 gloss: night (la nuit — feminine)
-concept_tag: NUIT
+concept_tag: TIME-NIGHT
 prerequisites: [FR-C01-le-la]
 sounds: [vowel-u, silent-final]
 roots: [noctem]

--- a/code/learning/human-languages/french/lessons/FR-C01-soir.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-soir.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: soir
 gloss: evening (le soir — masculine)
-concept_tag: SOIR
+concept_tag: TIME-EVENING
 prerequisites: [FR-C01-jour]
 sounds: [vowel-oi, r-uvular]
 roots: [serum-late]

--- a/code/learning/human-languages/french/lessons/FR-C02-appeler.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-appeler.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: (s')appeler
 gloss: to call / to call oneself
-concept_tag: VERB-CALL
+concept_tag: FR-VERB-APPELER
 prerequisites: [FR-C02-je]
 sounds: [er-ending]
 roots: [appellare]

--- a/code/learning/human-languages/french/lessons/FR-C02-comment-vous-appelez-vous.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-comment-vous-appelez-vous.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: comment vous appelez-vous?
 gloss: what's your name? (literally "how do you call yourself?")
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [FR-C02-comment, FR-C02-tu-vous, FR-C02-appeler]
 sounds: [liaison]
 roots: [quo-modo, appellare, vos]

--- a/code/learning/human-languages/french/lessons/FR-C02-comment.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-comment.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: comment
 gloss: how
-concept_tag: HOW
+concept_tag: QUESTION-HOW
 prerequisites: [FR-C02-tu-vous]
 sounds: [nasal-on]
 roots: [quo-modo]

--- a/code/learning/human-languages/french/lessons/FR-C02-enchante.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-enchante.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: enchanté(e)
 gloss: pleased to meet you (literally "enchanted")
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [FR-C02-je-mappelle]
 sounds: [nasal-on, nasal-an, ch-sh]
 roots: [in-cantare]

--- a/code/learning/human-languages/french/lessons/FR-C02-je-mappelle.md
+++ b/code/learning/human-languages/french/lessons/FR-C02-je-mappelle.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: je m'appelle…
 gloss: my name is… (literally "I call myself…")
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [FR-C02-je, FR-C02-me, FR-C02-appeler]
 sounds: [elision]
 roots: [ego, me-latin, appellare, nomen]

--- a/code/learning/human-languages/german/lessons/GE-C01-abend.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-abend.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: Abend
 gloss: evening (der Abend — masculine)
-concept_tag: ABEND
+concept_tag: TIME-EVENING
 prerequisites: [GE-C01-tag]
 sounds: [vowel-a-german, d-t-final]
 roots: [abanths]

--- a/code/learning/human-languages/german/lessons/GE-C01-der-die-das.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-der-die-das.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: der / die / das
 gloss: the (masculine / feminine / neuter)
-concept_tag: ARTICLES-DER-DIE-DAS
+concept_tag: GRAMMAR-THE
 prerequisites: [GE-C01-gut]
 sounds: [vowel-a-german, z-ts]
 roots: [sa-thorder]

--- a/code/learning/human-languages/german/lessons/GE-C01-gut.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-gut.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: gut
 gloss: good; well
-concept_tag: GUT
+concept_tag: WORD-GOOD
 prerequisites: [GE-C01-hallo]
 sounds: [vowel-u-german]
 roots: [godaz]

--- a/code/learning/human-languages/german/lessons/GE-C01-morgen.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-morgen.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: Morgen
 gloss: morning (der Morgen — masculine)
-concept_tag: MORGEN
+concept_tag: TIME-MORNING
 prerequisites: [GE-C01-tag]
 sounds: [vowel-o-german, r-uvular-german]
 roots: [murganaz]

--- a/code/learning/human-languages/german/lessons/GE-C01-nacht.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-nacht.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: Nacht
 gloss: night (die Nacht — feminine)
-concept_tag: NACHT
+concept_tag: TIME-NIGHT
 prerequisites: [GE-C01-der-die-das]
 sounds: [ch-ach, vowel-a-german]
 roots: [nahts]

--- a/code/learning/human-languages/german/lessons/GE-C01-tag.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-tag.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: Tag
 gloss: day (der Tag — masculine)
-concept_tag: TAG
+concept_tag: TIME-DAY
 prerequisites: [GE-C01-der-die-das]
 sounds: [vowel-a-german]
 roots: [dagaz]

--- a/code/learning/human-languages/german/lessons/GE-C02-freut-mich.md
+++ b/code/learning/human-languages/german/lessons/GE-C02-freut-mich.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: freut mich
 gloss: pleased to meet you (literally "it gladdens me")
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [GE-C02-ich-heisse]
 sounds: [eu-vowel, ich-laut]
 roots: [froh, mek]

--- a/code/learning/human-languages/german/lessons/GE-C02-heissen.md
+++ b/code/learning/human-languages/german/lessons/GE-C02-heissen.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: heißen
 gloss: to be called / to be named
-concept_tag: VERB-BE-CALLED
+concept_tag: DE-VERB-HEISSEN
 prerequisites: [GE-C02-ich]
 sounds: [eszett, ei-vowel]
 roots: [haitana]

--- a/code/learning/human-languages/german/lessons/GE-C02-ich-heisse.md
+++ b/code/learning/human-languages/german/lessons/GE-C02-ich-heisse.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: ich heiße…
 gloss: my name is… (literally "I am called…")
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [GE-C02-ich, GE-C02-heissen]
 sounds: []
 roots: [ik, haitana, namo]

--- a/code/learning/human-languages/german/lessons/GE-C02-wie-heissen-sie.md
+++ b/code/learning/human-languages/german/lessons/GE-C02-wie-heissen-sie.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: wie heißen Sie?
 gloss: what's your name? (literally "how are you called?")
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [GE-C02-wie, GE-C02-du-sie, GE-C02-heissen]
 sounds: []
 roots: [hwi, haitana]

--- a/code/learning/human-languages/german/lessons/GE-C02-wie.md
+++ b/code/learning/human-languages/german/lessons/GE-C02-wie.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: wie
 gloss: how
-concept_tag: HOW
+concept_tag: QUESTION-HOW
 prerequisites: [GE-C02-du-sie]
 sounds: [ie-long-ee, w-is-v]
 roots: [hwi]

--- a/code/learning/human-languages/hindi/lessons/HI-C01-dhanyavad.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-dhanyavad.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: धन्यवाद
 gloss: thank you (dhanyavād — formal, Sanskritic)
-concept_tag: THANKS-FORMAL
+concept_tag: COURTESY-THANKS
 prerequisites: [HI-C01-namaskar]
 sounds: [devanagari-inherent-a, matra-aa, halant-conjunct]
 roots: [dhanya, vaada]

--- a/code/learning/human-languages/hindi/lessons/HI-C01-shukriya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C01-shukriya.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: शुक्रिया
 gloss: thanks (shukriyā — everyday, Persian/Arabic-derived)
-concept_tag: THANKS-CASUAL
+concept_tag: COURTESY-THANKS-CASUAL
 prerequisites: [HI-C01-dhanyavad]
 sounds: [devanagari-inherent-a, matra-i, matra-aa, halant-conjunct]
 roots: [shukr]

--- a/code/learning/human-languages/hindi/lessons/HI-C02-aapka-naam-kya-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-aapka-naam-kya-hai.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: आपका नाम क्या है?
 gloss: what's your name?
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [HI-C02-kya, HI-C02-aap-tum, HI-C02-hai]
 sounds: []
 roots: [kim, asti]

--- a/code/learning/human-languages/hindi/lessons/HI-C02-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-hai.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: है
 gloss: is
-concept_tag: IS
+concept_tag: WORD-IS
 prerequisites: [HI-C02-naam]
 sounds: [matra-ai]
 roots: [asti]

--- a/code/learning/human-languages/hindi/lessons/HI-C02-khushi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-khushi.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: ख़ुशी
 gloss: happiness / pleased to meet you
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [HI-C02-mera-naam-hai]
 sounds: [nukta-kh, matra-u, matra-i]
 roots: [khush-persian]

--- a/code/learning/human-languages/hindi/lessons/HI-C02-kya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-kya.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: क्या
 gloss: what
-concept_tag: WHAT
+concept_tag: QUESTION-WHAT
 prerequisites: [HI-C02-aap-tum]
 sounds: [conjunct-kya, matra-aa]
 roots: [kim]

--- a/code/learning/human-languages/hindi/lessons/HI-C02-mera-naam-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-mera-naam-hai.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: मेरा नाम … है
 gloss: my name is…
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [HI-C02-meraa, HI-C02-naam, HI-C02-hai]
 sounds: []
 roots: [ma, naaman, asti]

--- a/code/learning/human-languages/hindi/lessons/HI-C02-meraa.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-meraa.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: मेरा
 gloss: my
-concept_tag: MY
+concept_tag: PRONOUN-MY
 prerequisites: [HI-C02-naam]
 sounds: [matra-e, matra-aa]
 roots: [ma]

--- a/code/learning/human-languages/hindi/lessons/HI-C02-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C02-naam.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: नाम
 gloss: name
-concept_tag: NAME
+concept_tag: WORD-NAME
 prerequisites: []
 sounds: [matra-aa]
 roots: [naaman]

--- a/code/learning/human-languages/italian/lessons/IT-C01-buono.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-buono.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: buono / buon
 gloss: good (adjective)
-concept_tag: GOOD
+concept_tag: WORD-GOOD
 prerequisites: [IT-C01-ciao]
 sounds: [uo-glide]
 roots: [bonus]

--- a/code/learning/human-languages/italian/lessons/IT-C01-giorno.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-giorno.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: giorno
 gloss: day (masculine)
-concept_tag: DAY
+concept_tag: TIME-DAY
 prerequisites: [IT-C01-il-la-lo]
 sounds: [soft-g]
 roots: [diurnum, dies]

--- a/code/learning/human-languages/italian/lessons/IT-C01-grazie.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-grazie.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: grazie
 gloss: thank you
-concept_tag: THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [IT-C01-ciao]
 sounds: [z-is-ts]
 roots: [gratia]

--- a/code/learning/human-languages/italian/lessons/IT-C01-il-la-lo.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-il-la-lo.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: il / la / lo
 gloss: the (masculine / feminine)
-concept_tag: ARTICLE-GENDER
+concept_tag: GRAMMAR-THE
 prerequisites: [IT-C01-buono]
 sounds: []
 roots: [ille, illa]

--- a/code/learning/human-languages/italian/lessons/IT-C01-notte.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-notte.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: notte / buonanotte
 gloss: night / good night
-concept_tag: GREETING-NIGHT
+concept_tag: GREETING-GOODNIGHT
 prerequisites: [IT-C01-sera]
 sounds: [double-tt]
 roots: [noctem]

--- a/code/learning/human-languages/kannada/lessons/KA-C01-dhanyavada.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-dhanyavada.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ಧನ್ಯವಾದ
 gloss: thank you (dhanyavāda — "an utterance of 'worthy'")
-concept_tag: THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [KA-C01-namaskara]
 sounds: [nya-conjunct, vowel-sign-aa]
 roots: [dhanya, vada]

--- a/code/learning/human-languages/kannada/lessons/KA-C01-haudu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-haudu.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ಹೌದು
 gloss: yes (haudu)
-concept_tag: YES
+concept_tag: RESPONSE-YES
 prerequisites: [KA-C01-namaskara]
 sounds: [au-vowel-sign, u-vowel-sign]
 roots: [haudu]

--- a/code/learning/human-languages/kannada/lessons/KA-C01-illa.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-illa.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ಇಲ್ಲ
 gloss: no / there isn't (illa — the negative)
-concept_tag: NO
+concept_tag: RESPONSE-NO
 prerequisites: [KA-C01-haudu]
 sounds: [independent-vowel-i, lla-conjunct]
 roots: [il]

--- a/code/learning/human-languages/kannada/lessons/KA-C01-sari.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C01-sari.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ಸರಿ
 gloss: okay / alright / correct (sari)
-concept_tag: OKAY
+concept_tag: RESPONSE-OKAY
 prerequisites: [KA-C01-haudu]
 sounds: [sa, ri-vowel-sign]
 roots: [sari]

--- a/code/learning/human-languages/kannada/lessons/KA-C02-enu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-enu.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: ಏನು
 gloss: what
-concept_tag: WHAT
+concept_tag: QUESTION-WHAT
 prerequisites: [KA-C02-niinu-niivu]
 sounds: [independent-ee]
 roots: [yaa-dravidian]

--- a/code/learning/human-languages/kannada/lessons/KA-C02-hesaru.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-hesaru.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: ಹೆಸರು
 gloss: name
-concept_tag: NAME
+concept_tag: WORD-NAME
 prerequisites: []
 sounds: [e-sign]
 roots: [pesar-dravidian]

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nanna-hesaru.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nanna-hesaru.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: ನನ್ನ ಹೆಸರು …
 gloss: my name is… (with no "is")
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [KA-C02-nanna, KA-C02-hesaru]
 sounds: []
 roots: []

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nanna.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nanna.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: ನನ್ನ
 gloss: my
-concept_tag: MY
+concept_tag: PRONOUN-MY
 prerequisites: [KA-C02-hesaru]
 sounds: [nna-conjunct]
 roots: [naanu-dravidian]

--- a/code/learning/human-languages/kannada/lessons/KA-C02-nimma-hesaru-enu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-nimma-hesaru-enu.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: ನಿಮ್ಮ ಹೆಸರು ಏನು?
 gloss: what's your name?
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [KA-C02-enu, KA-C02-niinu-niivu, KA-C02-hesaru]
 sounds: []
 roots: []

--- a/code/learning/human-languages/kannada/lessons/KA-C02-santosha.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C02-santosha.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: ಸಂತೋಷ
 gloss: joy / pleased to meet you
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [KA-C02-nanna-hesaru]
 sounds: [anusvara]
 roots: [santosha-sanskrit]

--- a/code/learning/human-languages/latin/lessons/LA-C01-ave.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-ave.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: avē / avēte
 gloss: hail (a formal greeting)
-concept_tag: GREETING-HELLO
+concept_tag: GREETING-FORMAL
 prerequisites: [LA-C01-salve]
 sounds: [v-as-w, macron-long-vowel]
 roots: [avere]

--- a/code/learning/human-languages/latin/lessons/LA-C01-gratias.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-gratias.md
@@ -4,7 +4,7 @@ chapter: 1
 type: phrase
 headword: grātiās (tibi) agō
 gloss: thank you (lit. "I give thanks to you")
-concept_tag: GRATITUDE-THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [LA-C01-vale]
 sounds: [hard-c-t, macron-long-vowel]
 roots: [gratia, gratus, ago]

--- a/code/learning/human-languages/latin/lessons/LA-C01-ita-non.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-ita-non.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ita / nōn
 gloss: yes / no (lit. "thus" / "not")
-concept_tag: FUNCTION-YESNO
+concept_tag: RESPONSE-YESNO
 prerequisites: [LA-C01-gratias]
 sounds: [macron-long-vowel]
 roots: [ita, sic, non, ne-negative]

--- a/code/learning/human-languages/latin/lessons/LA-C01-vale.md
+++ b/code/learning/human-languages/latin/lessons/LA-C01-vale.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: valē / valēte
 gloss: goodbye (lit. "be strong")
-concept_tag: GREETING-GOODBYE
+concept_tag: FAREWELL
 prerequisites: [LA-C01-ave]
 sounds: [v-as-w, macron-long-vowel]
 roots: [valere]

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-athe.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-athe.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: അതെ
 gloss: yes (athe — "that [is so]")
-concept_tag: YES
+concept_tag: RESPONSE-YES
 prerequisites: [ML-C01-namaskaram]
 sounds: [independent-vowel-a, the-syllable]
 roots: [athu]

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-illa.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-illa.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ഇല്ല
 gloss: no / there isn't (illa — the negative)
-concept_tag: NO
+concept_tag: RESPONSE-NO
 prerequisites: [ML-C01-athe]
 sounds: [independent-vowel-i, lla-conjunct]
 roots: [il]

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-nandi.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-nandi.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: നന്ദി
 gloss: thank you (nandi — the native Dravidian word, Tamil's cousin)
-concept_tag: THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [ML-C01-namaskaram]
 sounds: [nda-conjunct, i-vowel-sign]
 roots: [nal]

--- a/code/learning/human-languages/malayalam/lessons/ML-C01-sari.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C01-sari.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ശരി
 gloss: okay / alright / correct (śari)
-concept_tag: OKAY
+concept_tag: RESPONSE-OKAY
 prerequisites: [ML-C01-athe]
 sounds: [sha-letter, ri-vowel-sign]
 roots: [sari]

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-aanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-aanu.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: ആണ്
 gloss: is (the copula)
-concept_tag: IS
+concept_tag: WORD-IS
 prerequisites: [ML-C02-peru]
 sounds: [independent-aa, retroflex-nu]
 roots: [aaka-dravidian]

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-enre-peru-aanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-enre-peru-aanu.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: എന്റെ പേര് … ആണ്
 gloss: my name is…
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [ML-C02-enre, ML-C02-peru, ML-C02-aanu]
 sounds: []
 roots: []

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-enre.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-enre.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: എന്റെ
 gloss: my
-concept_tag: MY
+concept_tag: PRONOUN-MY
 prerequisites: [ML-C02-peru]
 sounds: [nre-conjunct]
 roots: [njaan-dravidian]

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-entu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-entu.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: എന്ത്
 gloss: what
-concept_tag: WHAT
+concept_tag: QUESTION-WHAT
 prerequisites: [ML-C02-nii-ningal]
 sounds: [ntu-conjunct]
 roots: [yaa-dravidian]

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-ninre-peru-entaanu.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-ninre-peru-entaanu.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: നിന്റെ പേര് എന്താണ്?
 gloss: what's your name?
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [ML-C02-entu, ML-C02-nii-ningal, ML-C02-peru, ML-C02-aanu]
 sounds: []
 roots: []

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-peru.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-peru.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: പേര്
 gloss: name
-concept_tag: NAME
+concept_tag: WORD-NAME
 prerequisites: []
 sounds: [ee-sign, chandrakkala]
 roots: [peer-dravidian]

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-santosham.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-santosham.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: സന്തോഷം
 gloss: joy / pleased to meet you
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [ML-C02-enre-peru-aanu]
 sounds: [anusvara]
 roots: [santosha-sanskrit]

--- a/code/learning/human-languages/marathi/lessons/MR-C01-baram.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C01-baram.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: बरं
 gloss: okay / fine (baraṃ)
-concept_tag: OKAY
+concept_tag: RESPONSE-OKAY
 prerequisites: [MR-C01-ho]
 sounds: [anusvara-nasal]
 roots: []

--- a/code/learning/human-languages/marathi/lessons/MR-C01-dhanyavad.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C01-dhanyavad.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: धन्यवाद
 gloss: thank you (dhanyavād)
-concept_tag: THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [MR-C01-namaskar]
 sounds: [nya-conjunct]
 roots: [dhanya, vada]

--- a/code/learning/human-languages/marathi/lessons/MR-C01-ho.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C01-ho.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: हो
 gloss: yes (ho)
-concept_tag: YES
+concept_tag: RESPONSE-YES
 prerequisites: [MR-C01-namaskar]
 sounds: [o-matra]
 roots: []

--- a/code/learning/human-languages/marathi/lessons/MR-C01-nahi.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C01-nahi.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: नाही
 gloss: no / is not (nāhī)
-concept_tag: NO
+concept_tag: RESPONSE-NO
 prerequisites: [MR-C01-ho]
 sounds: []
 roots: [na-pie]

--- a/code/learning/human-languages/portuguese/lessons/PT-C01-bom.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C01-bom.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: bom / boa
 gloss: good (adjective)
-concept_tag: GOOD
+concept_tag: WORD-GOOD
 prerequisites: [PT-C01-ola]
 sounds: [nasal-om]
 roots: [bonus]

--- a/code/learning/human-languages/portuguese/lessons/PT-C01-dia.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C01-dia.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: dia
 gloss: day (masculine)
-concept_tag: DAY
+concept_tag: TIME-DAY
 prerequisites: [PT-C01-o-a]
 sounds: []
 roots: [dies]

--- a/code/learning/human-languages/portuguese/lessons/PT-C01-noite.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C01-noite.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: noite / boa noite
 gloss: night / good night
-concept_tag: GREETING-NIGHT
+concept_tag: GREETING-GOODNIGHT
 prerequisites: [PT-C01-tarde]
 sounds: []
 roots: [noctem]

--- a/code/learning/human-languages/portuguese/lessons/PT-C01-o-a.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C01-o-a.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: o / a
 gloss: the (masculine / feminine)
-concept_tag: ARTICLE-GENDER
+concept_tag: GRAMMAR-THE
 prerequisites: [PT-C01-bom]
 sounds: []
 roots: [ille, illa]

--- a/code/learning/human-languages/portuguese/lessons/PT-C01-obrigado.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C01-obrigado.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: obrigado / obrigada
 gloss: thank you
-concept_tag: THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [PT-C01-ola]
 sounds: [final-o-is-u]
 roots: [obligatus]

--- a/code/learning/human-languages/punjabi/lessons/PA-C01-dhanvaad.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C01-dhanvaad.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ਧੰਨਵਾਦ
 gloss: thank you (Sanskritic) (dhannavād)
-concept_tag: GRATITUDE-THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [PA-C01-namaste]
 sounds: [inherent-a, tippi-nasal, vowel-sign]
 roots: [dhanya, vada]

--- a/code/learning/human-languages/punjabi/lessons/PA-C01-han-nahin.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C01-han-nahin.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ਹਾਂ / ਨਹੀਂ
 gloss: yes / no (hāṇ / nahīṇ)
-concept_tag: FUNCTION-YESNO
+concept_tag: RESPONSE-YESNO
 prerequisites: [PA-C01-shukriya]
 sounds: [inherent-a, bindi-nasal, vowel-sign]
 roots: [na-negative]

--- a/code/learning/human-languages/punjabi/lessons/PA-C01-sat-sri-akal.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C01-sat-sri-akal.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ਸਤਿ ਸ੍ਰੀ ਅਕਾਲ
 gloss: hello / goodbye, the Sikh greeting (sat srī akāl)
-concept_tag: GREETING-HELLO
+concept_tag: GREETING-FORMAL
 prerequisites: []
 sounds: [inherent-a, vowel-sign, vowel-carrier]
 roots: [satya, sri, akala]

--- a/code/learning/human-languages/punjabi/lessons/PA-C01-shukriya.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C01-shukriya.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ਸ਼ੁਕਰੀਆ
 gloss: thank you (Perso-Arabic) (shukrīā)
-concept_tag: GRATITUDE-THANKS
+concept_tag: COURTESY-THANKS-CASUAL
 prerequisites: [PA-C01-dhanvaad]
 sounds: [pair-bindi, vowel-sign]
 roots: [shukr]

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-am-na.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-am-na.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: आम् / न
 gloss: yes / no (ām / na)
-concept_tag: FUNCTION-YESNO
+concept_tag: RESPONSE-YESNO
 prerequisites: [SA-C01-svagatam]
 sounds: [independent-vowel, halant, inherent-a]
 roots: [na-negative]

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-dhanyavada.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-dhanyavada.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: धन्यवादः
 gloss: thank you (dhanyavādaḥ)
-concept_tag: GRATITUDE-THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [SA-C01-namaskara]
 sounds: [inherent-a, ny-conjunct, visarga]
 roots: [dhanya, vada, vad-speak]

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-namaskara.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-namaskara.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: नमस्कारः
 gloss: hello (lit. "the making of a bow") (namaskāraḥ)
-concept_tag: GREETING-HELLO
+concept_tag: GREETING-FORMAL
 prerequisites: [SA-C01-namaste]
 sounds: [inherent-a, visarga, vowel-sign]
 roots: [namas, kara, kr-do]

--- a/code/learning/human-languages/spanish/lessons/ES-C01-bien.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-bien.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: bien
 gloss: well / good / fine
-concept_tag: BIEN
+concept_tag: WORD-WELL
 prerequisites: [ES-C01-hola]
 sounds: [diphthong-ie, v-b]
 roots: [bene, bonus]

--- a/code/learning/human-languages/spanish/lessons/ES-C01-dia.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-dia.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: día
 gloss: day (el día — masculine)
-concept_tag: DIA
+concept_tag: TIME-DAY
 prerequisites: [ES-C01-el-la]
 sounds: [accent-i, vowel-a, d-soft]
 roots: [dies]

--- a/code/learning/human-languages/spanish/lessons/ES-C01-el-la.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C01-el-la.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: el / la
 gloss: the (masculine / feminine)
-concept_tag: ARTICLES-EL-LA
+concept_tag: GRAMMAR-THE
 prerequisites: [ES-C01-bien]
 sounds: [vowel-e, vowel-a]
 roots: [ille, illa]

--- a/code/learning/human-languages/spanish/lessons/ES-C02-buenas-noches.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-buenas-noches.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: buenas noches
 gloss: good evening / good night
-concept_tag: GREETING-NIGHT
+concept_tag: GREETING-GOODNIGHT
 prerequisites: [ES-C02-buenas-tardes, ES-C02-noche]
 sounds: [diphthong-ue, soft-c]
 roots: [bonus, nox]

--- a/code/learning/human-languages/spanish/lessons/ES-C02-noche.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-noche.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: la noche
 gloss: night / evening (la noche — feminine)
-concept_tag: NOCHE
+concept_tag: TIME-NIGHT
 prerequisites: [ES-C02-tarde]
 sounds: [soft-c, stress-default-vowel-ns]
 roots: [nox]

--- a/code/learning/human-languages/spanish/lessons/ES-C02-tarde.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C02-tarde.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: la tarde
 gloss: afternoon (la tarde — feminine; also: late)
-concept_tag: TARDE
+concept_tag: TIME-AFTERNOON
 prerequisites: [ES-C01-dia, ES-C01-buenos-dias]
 sounds: [vowel-a, stress-default-vowel-ns]
 roots: [tardus]

--- a/code/learning/human-languages/spanish/lessons/ES-C03-como-se-llama.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-como-se-llama.md
@@ -4,7 +4,7 @@ chapter: 3
 type: word
 headword: ¿cómo se llama usted?
 gloss: what's your name? (formal)
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [ES-C03-como, ES-C03-se-llama, ES-C03-tu-usted]
 sounds: [inverted-marks, accent-mark]
 roots: []

--- a/code/learning/human-languages/spanish/lessons/ES-C03-gusto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-gusto.md
@@ -4,7 +4,7 @@ chapter: 3
 type: word
 headword: mucho gusto
 gloss: pleased to meet you (literally "much pleasure")
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [ES-C03-mucho]
 sounds: [vowel-o, stress-default-vowel-ns]
 roots: [gustus, multus]

--- a/code/learning/human-languages/spanish/lessons/ES-C03-llamar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-llamar.md
@@ -4,7 +4,7 @@ chapter: 3
 type: word
 headword: llamo
 gloss: I call (from llamar, to call)
-concept_tag: LLAMAR
+concept_tag: ES-VERB-LLAMAR
 prerequisites: [ES-C03-me]
 sounds: [ll-y, vowel-o]
 roots: [clamare]

--- a/code/learning/human-languages/spanish/lessons/ES-C03-me-llamo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-me-llamo.md
@@ -4,7 +4,7 @@ chapter: 3
 type: word
 headword: me llamo
 gloss: my name is (literally "I call myself")
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [ES-C03-me, ES-C03-llamar]
 sounds: [ll-y]
 roots: [clamare]

--- a/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md
@@ -4,7 +4,7 @@ chapter: 3
 type: word
 headword: mucho
 gloss: much / a lot
-concept_tag: MUCHO
+concept_tag: ES-WORD-MUCHO
 prerequisites: [ES-C02-noche]
 sounds: [soft-c, vowel-o]
 roots: [multus]

--- a/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md
@@ -4,7 +4,7 @@ chapter: 3
 type: word
 headword: se llama
 gloss: he/she calls himself; you (formal) call yourself
-concept_tag: SE-LLAMA
+concept_tag: ES-SE-LLAMA
 prerequisites: [ES-C03-me-llamo, ES-C03-tu-usted]
 sounds: [vowel-e, ll-y]
 roots: [se-latin, clamare]

--- a/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ஆம்
 gloss: yes (ām)
-concept_tag: YES
+concept_tag: RESPONSE-YES
 prerequisites: [TA-C01-vanakkam]
 sounds: [independent-vowel-aa, matra-vs-independent]
 roots: [ām]

--- a/code/learning/human-languages/tamil/lessons/TA-C01-illai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-illai.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: இல்லை
 gloss: no / there isn't (illai — the negative)
-concept_tag: NO
+concept_tag: RESPONSE-NO
 prerequisites: [TA-C01-aam]
 sounds: [independent-vowel-i, matra-ai, pulli-virama]
 roots: [il]

--- a/code/learning/human-languages/tamil/lessons/TA-C01-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-nandri.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: நன்றி
 gloss: thank you (naṉṟi — "goodness, gratitude")
-concept_tag: THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [TA-C01-vanakkam]
 sounds: [dental-vs-alveolar-vs-retroflex-n, matra-i]
 roots: [nal]

--- a/code/learning/human-languages/tamil/lessons/TA-C01-sari.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-sari.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: சரி
 gloss: okay / alright / correct (sari)
-concept_tag: OKAY
+concept_tag: RESPONSE-OKAY
 prerequisites: [TA-C01-aam]
 sounds: [c-sa-one-letter, matra-i]
 roots: [sari]

--- a/code/learning/human-languages/tamil/lessons/TA-C02-en-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-en-peyar.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: என் பெயர் …
 gloss: my name is… (with no "is")
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [TA-C02-en, TA-C02-peyar]
 sounds: []
 roots: []

--- a/code/learning/human-languages/tamil/lessons/TA-C02-en.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-en.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: என்
 gloss: my
-concept_tag: MY
+concept_tag: PRONOUN-MY
 prerequisites: [TA-C02-peyar]
 sounds: [independent-e, pulli]
 roots: [naan-dravidian]

--- a/code/learning/human-languages/tamil/lessons/TA-C02-enna.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-enna.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: என்ன
 gloss: what
-concept_tag: WHAT
+concept_tag: QUESTION-WHAT
 prerequisites: [TA-C02-nii-niingal]
 sounds: [independent-e, doubled-nn]
 roots: [yaa-dravidian]

--- a/code/learning/human-languages/tamil/lessons/TA-C02-magizhcci.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-magizhcci.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: மகிழ்ச்சி
 gloss: joy / pleased to meet you
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [TA-C02-en-peyar]
 sounds: [zha-retroflex-glide]
 roots: [magizh-dravidian]

--- a/code/learning/human-languages/tamil/lessons/TA-C02-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-peyar.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: பெயர்
 gloss: name
-concept_tag: NAME
+concept_tag: WORD-NAME
 prerequisites: []
 sounds: [e-sign, pulli]
 roots: [peyar-dravidian]

--- a/code/learning/human-languages/tamil/lessons/TA-C02-ungal-peyar-enna.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-ungal-peyar-enna.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: உங்கள் பெயர் என்ன?
 gloss: what's your name?
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [TA-C02-enna, TA-C02-nii-niingal, TA-C02-peyar]
 sounds: []
 roots: []

--- a/code/learning/human-languages/telugu/lessons/TE-C01-avunu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-avunu.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: అవును
 gloss: yes (avunu)
-concept_tag: YES
+concept_tag: RESPONSE-YES
 prerequisites: [TE-C01-namaskaram]
 sounds: [independent-vowel-a, u-vowel-sign]
 roots: [avunu]

--- a/code/learning/human-languages/telugu/lessons/TE-C01-dhanyavadamulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-dhanyavadamulu.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: ధన్యవాదములు
 gloss: thank you (dhanyavādamulu — "utterances of 'worthy'")
-concept_tag: THANKS
+concept_tag: COURTESY-THANKS
 prerequisites: [TE-C01-namaskaram]
 sounds: [nya-conjunct, mulu-plural]
 roots: [dhanya, vada]

--- a/code/learning/human-languages/telugu/lessons/TE-C01-ledu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-ledu.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: లేదు
 gloss: no / there isn't (lēdu)
-concept_tag: NO
+concept_tag: RESPONSE-NO
 prerequisites: [TE-C01-avunu]
 sounds: [e-long-vowel-sign, u-vowel-sign]
 roots: [lē]

--- a/code/learning/human-languages/telugu/lessons/TE-C01-sare.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C01-sare.md
@@ -4,7 +4,7 @@ chapter: 1
 type: word
 headword: సరే
 gloss: okay / alright (sarē)
-concept_tag: OKAY
+concept_tag: RESPONSE-OKAY
 prerequisites: [TE-C01-avunu]
 sounds: [sa, e-long-vowel-sign]
 roots: [sari]

--- a/code/learning/human-languages/telugu/lessons/TE-C02-emiti.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-emiti.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: ఏమిటి
 gloss: what
-concept_tag: WHAT
+concept_tag: QUESTION-WHAT
 prerequisites: [TE-C02-nuvvu-miiru]
 sounds: [independent-ee, retroflex-ti]
 roots: [yaa-dravidian]

--- a/code/learning/human-languages/telugu/lessons/TE-C02-mii-peru-emiti.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-mii-peru-emiti.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: మీ పేరు ఏమిటి?
 gloss: what's your name?
-concept_tag: WHATS-YOUR-NAME
+concept_tag: INTRO-WHATS-YOUR-NAME
 prerequisites: [TE-C02-emiti, TE-C02-nuvvu-miiru, TE-C02-peru]
 sounds: []
 roots: []

--- a/code/learning/human-languages/telugu/lessons/TE-C02-naa-peru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-naa-peru.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: నా పేరు …
 gloss: my name is… (with no "is")
-concept_tag: MY-NAME-IS
+concept_tag: INTRO-MY-NAME-IS
 prerequisites: [TE-C02-naa, TE-C02-peru]
 sounds: []
 roots: []

--- a/code/learning/human-languages/telugu/lessons/TE-C02-naa.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-naa.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: నా
 gloss: my
-concept_tag: MY
+concept_tag: PRONOUN-MY
 prerequisites: [TE-C02-peru]
 sounds: [long-aa]
 roots: [neenu-dravidian]

--- a/code/learning/human-languages/telugu/lessons/TE-C02-peru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-peru.md
@@ -4,7 +4,7 @@ chapter: 2
 type: word
 headword: పేరు
 gloss: name
-concept_tag: NAME
+concept_tag: WORD-NAME
 prerequisites: []
 sounds: [ee-sign]
 roots: [peer-dravidian]

--- a/code/learning/human-languages/telugu/lessons/TE-C02-santosham.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C02-santosham.md
@@ -4,7 +4,7 @@ chapter: 2
 type: phrase
 headword: సంతోషం
 gloss: joy / pleased to meet you
-concept_tag: PLEASED-TO-MEET
+concept_tag: INTRO-NICE-TO-MEET-YOU
 prerequisites: [TE-C02-naa-peru]
 sounds: [anusvara]
 roots: [santosha-sanskrit]


### PR DESCRIPTION
## What & why

Implements **HL01**'s cross-language join layer (spec in #8488). Today the lesson `concept_tag`s have drifted apart per-track, so a query like *"'thank you' in Spanish, French, German"* can't be answered — `GREETING-NIGHT` vs `GREETING-GOODNIGHT`, `DIA`/`JOUR`/`TAG`/`DAY` all meaning "day", three spellings of "thank you", and a few tracks tagging **two different words** `GREETING-HELLO`. This lands the canonical vocabulary and reconciles every track onto it — the foundation the companion app (HL02) and all future cross-language tooling need.

## Changes

- **`concepts/taxonomy.json`** — the authoritative universal-concept vocabulary (families GREETING / COURTESY / RESPONSE / QUESTION / INTRO / PRONOUN / TIME / WORD / GRAMMAR), each id with a gloss, `core` flag, and a `retires` list for traceability.
- **`concepts/README.md`** — operational note on the join layer + the normalization.
- **121 lesson frontmatter `concept_tag`s rewritten** onto canonical ids (`type: word` + `type: phrase`; `practice`/`practice-mix` exempt). **Frontmatter only — zero prose changed** (lessons refer to words by name, never by tag; the diff is verifiably `concept_tag:`-lines-only).

### Key reconciliations
- **Synonyms unified**: `GREETING-NIGHT`→`GREETING-GOODNIGHT`, `GREETING-GOODBYE`→`FAREWELL`, `THANKS`/`GRATITUDE-THANKS`/`THANKS-FORMAL`→`COURTESY-THANKS`.
- **Scattered lexical tags unified**: `DIA`/`JOUR`/`TAG`/`DAY`→`TIME-DAY` (+ the rest of `TIME-*`); `BON`/`GOOD`/`GUT`→`WORD-GOOD`, `BIEN`→`WORD-WELL`; the article systems → `GRAMMAR-THE`.
- **Within-track duplicates split**: the more formal of two "hello" words (Latin *avē*, Sanskrit *namaskāraḥ*, Punjabi *sat srī akāl*) → `GREETING-FORMAL`; Punjabi's two "thanks" → `COURTESY-THANKS` (*dhannavād*) + `COURTESY-THANKS-CASUAL` (*shukrīā*).
- **Combined yes/no lessons** → `RESPONSE-YESNO` (split into `RESPONSE-YES`+`RESPONSE-NO` at parity).

## Result (the payoff)
- `GREETING-HELLO` now joins **all 16 tracks**; `INTRO-*` self-introduction concepts join **9**; `TIME-DAY` joins the 5 Romance/Germanic tracks.
- Verified: **no within-track duplicate** canonical tag, and **every content-lesson tag resolves** to a canonical or namespaced id. (A `human-language-data` validator enforcing this in CI is the next PR.)

## Note
`phrase` and `practice` turned up as de-facto lesson types not enumerated in HL00's `word|review|practice-mix` list; HL01's validator treats `word`+`phrase` as content and `practice`+`practice-mix` as exempt. I'll reconcile HL00's type list in the data-layer PR.

Depends on: #8488 (HL01 spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)