### PR TITLE
feat(cobol-iir-compiler): scaled-decimal MULTIPLY/DIVIDE (PL09 step 4, PR3b)

### DIFF
--- a/code/packages/rust/cobol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/cobol-iir-compiler/CHANGELOG.md
@@ -8,6 +8,33 @@ tag.
 
 ## [Unreleased]
 
+### Added — v0.5.0: scaled-decimal MULTIPLY / DIVIDE (PL09 step 4, PR3b)
+
+- **Scaled `MULTIPLY`** on `PIC …V…` operands: the raw product of the two scaled
+  `i64` slots carries scale `sa + sb`; `store_scaled` then rounds/truncates it to
+  the receiver's scale. Each operand is ≤ 9 digits, so the product is `< 10^18`
+  and never overflows `i64`.
+- **Scaled `DIVIDE`**: the quotient is computed at working scale `w` = the
+  receiver's `dec_digits` (plus one guard digit when `ROUNDED`) by scaling the
+  dividend up before the truncating integer division —
+  `floor(B·10^(sa+w−sb) / A)` — then `store_scaled` truncates or rounds `w →
+  dec_digits`. One guard digit matches the oracle's `round()`, which inspects
+  only the first dropped digit (half away from zero).
+- **`ROUNDED`** is honoured on both, via the shared `store_scaled` bias-rounding.
+- **Overflow-safe** (security-reviewed style): `DIVIDE` rejects a dividend with
+  more fractional digits than the result precision, and any intermediate whose
+  digit width would exceed 18 (`b_int + sa + w > 18`) — a clean `Unsupported`.
+- **Still deferred**: `ON SIZE ERROR` on the arithmetic verbs (needs the `IF`
+  rung's branch machinery).
+- The now-redundant integer-only operand path (`int_operand` etc.) is removed —
+  every arithmetic verb shares the scaled `Term` machinery and `store_scaled`.
+- **Tests.** Unit tests for the new capability and the retained `ON SIZE ERROR`
+  boundary; seven new `jit_e2e.rs` cases (fixed-point multiply truncate/round,
+  BY-field update, divide truncate to receiver decimals, divide rounded, dividend
+  update, decimal-field multiply) each byte-identical to the oracle; a scaled
+  multiply/divide `backend_compat` program; and a `lang_matrix.rs` COBOL row
+  (`20 / 3` rounded in `V99` → `0667`).
+
 ### Added — v0.4.0: IF / ELSE with relational conditions (PL09 step 4, PR4)
 
 - **`IF condition then-stmts [ELSE else-stmts]`** → a three-way branch: the

--- a/code/packages/rust/cobol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/cobol-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cobol-iir-compiler"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "COBOL-60 frontend for the LANG VM AOT chain — lowers a parsed COBOL program into interpreter_ir::IIRModule so it runs on every execution backend. v0.4.0: DISPLAY / MOVE / STOP RUN, integer + scaled-decimal (PIC …V…) ADD/SUBTRACT (implied-point alignment + ROUNDED), integer MULTIPLY/DIVIDE, numeric item-to-item MOVE reshaping, and IF/ELSE with relational conditions — over scaled-i64 slots, byte-identical to the cobol-runtime oracle. Scaled MULTIPLY/DIVIDE, ON SIZE ERROR, PERFORM, COMPUTE, GO TO and signed numerics are later rungs. See PL09-codegen.md."
+description = "COBOL-60 frontend for the LANG VM AOT chain — lowers a parsed COBOL program into interpreter_ir::IIRModule so it runs on every execution backend. v0.5.0: DISPLAY / MOVE / STOP RUN, integer + scaled-decimal (PIC …V…) ADD/SUBTRACT (implied-point alignment + ROUNDED), integer + scaled-decimal MULTIPLY/DIVIDE (with ROUNDED), numeric item-to-item MOVE reshaping, and IF/ELSE with relational conditions — over scaled-i64 slots, byte-identical to the cobol-runtime oracle. ON SIZE ERROR, PERFORM, COMPUTE, GO TO and signed numerics are later rungs. See PL09-codegen.md."
 
 [dependencies]
 coding-adventures-cobol-parser  = { path = "../cobol-parser" }

--- a/code/packages/rust/cobol-iir-compiler/README.md
+++ b/code/packages/rust/cobol-iir-compiler/README.md
@@ -50,21 +50,22 @@ this reuse — and stores the resulting scaled value. A numeric *literal* in a
 `DISPLAY`, by contrast, shows its **source text** (`DISPLAY 42` → `42`).
 
 Runtime arithmetic (unsigned receivers) is native `i64` over the scaled slots.
-**Integer** `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` compute directly; **scaled-decimal**
-`ADD`/`SUBTRACT` (`PIC …V…`) align the implied point to a common working scale,
-accumulate, then store into the receiver's scale — rounding **half away from
-zero** with `ROUNDED`, else truncating. Every store takes the magnitude and keeps
-the low-order `int_digits + dec_digits` digits (COBOL's unsigned-magnitude and
-silent-overflow-truncation rules). Numeric **item-to-item `MOVE`** reshapes the
-source value into the receiver's picture the same way.
+`ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` all honour the implied point (`PIC …V…`):
+additive verbs align operands to a common working scale then accumulate;
+`MULTIPLY` products carry scale `sa + sb`; `DIVIDE` scales the dividend up before
+the truncating division to land the receiver's decimals (plus a guard digit for
+rounding). Every store rounds **half away from zero** with `ROUNDED` (else
+truncates), takes the magnitude, and keeps the low-order `int_digits + dec_digits`
+digits (COBOL's unsigned-magnitude and silent-overflow-truncation rules). Numeric
+**item-to-item `MOVE`** reshapes the source value into the receiver's picture the
+same way. **`IF`** compares operands at a common scale and branches.
 
 ### Deliberately a later rung
 
 Each of these is a clean `CompileError::Unsupported` (never wrong output), landing
-on its own PR: **scaled** `MULTIPLY`/`DIVIDE` (a `V` operand) and their `ROUNDED`,
-`ON SIZE ERROR`, alphanumeric item `MOVE` and alphanumeric comparison,
-`COMPUTE`, `PERFORM`, `GO TO`, group items, and signed numerics (`PIC S9…`,
-trailing-overpunch display).
+on its own PR: `ON SIZE ERROR`, alphanumeric item `MOVE` and alphanumeric
+comparison, `COMPUTE`, `PERFORM`, `GO TO`, group items, and signed numerics
+(`PIC S9…`, trailing-overpunch display).
 
 ## Usage
 

--- a/code/packages/rust/cobol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/cobol-iir-compiler/src/lib.rs
@@ -603,44 +603,90 @@ impl Compiler {
         self.store_scaled(&recv, &acc, w, max_int + count_digits, rounded)
     }
 
-    /// `MULTIPLY a BY b [GIVING g]` — `a * b` into `g` (or `b`).
+    /// `MULTIPLY a BY b [GIVING g]` — `a * b` into `g` (or `b`). The raw product
+    /// of the two scaled `i64` slots carries scale `sa + sb`; store_scaled then
+    /// rounds/truncates it to the receiver's scale. Each operand is ≤ 9 digits, so
+    /// the product is < 10^18 and never overflows `i64`.
     fn emit_multiply(&mut self, verb: &GrammarASTNode) -> Result<(), CompileError> {
-        self.reject_rounded_or_size_error(verb, "MULTIPLY")?;
+        self.reject_size_error(verb, "MULTIPLY")?;
+        let rounded = has_rounded(verb);
         let ops = child_nodes(verb, "operand");
         if ops.len() != 2 {
             return Err(CompileError::Malformed("MULTIPLY needs two operands".into()));
         }
-        let a = self.int_operand(ops[0])?;
-        let b = self.int_operand(ops[1])?;
+        let at = self.read_arith_term(ops[0])?;
+        let bt = self.read_arith_term(ops[1])?;
+        let (sa, sb) = (self.term_scale(&at), self.term_scale(&bt));
+        let a = self.emit_term_at_scale(&at, sa);
+        let b = self.emit_term_at_scale(&bt, sb);
         let prod = self.fresh("_prod");
         self.emit("mul", Some(&prod), vec![a, b], "i64");
         let target = self.giving_or_operand_name(verb, ops[1], "MULTIPLY … BY <literal>")?;
-        // The operands are integer (scale 0), so the product is scale 0; its
-        // integer part is < 10^(a_int + b_int). The receiver may be a `V` field,
-        // into which store_scaled scales up — bounded by that digit count.
-        let prod_int = self.operand_int_digits(ops[0])? + self.operand_int_digits(ops[1])?;
-        self.store_scaled(&target, &prod, 0, prod_int, false)
+        // The product's integer part is < 10^(a_int + b_int); store_scaled bounds
+        // any up-scale into a wider-scale receiver by that count.
+        let prod_int = self.term_int_digits(&at) + self.term_int_digits(&bt);
+        self.store_scaled(&target, &prod, sa + sb, prod_int, rounded)
     }
 
-    /// `DIVIDE a INTO b [GIVING g]` — `b / a` (truncating) into `g` (or `b`).
+    /// `DIVIDE a INTO b [GIVING g]` — `b / a` into `g` (or `b`).
+    ///
+    /// The quotient is computed at working scale `w` = the receiver's `dec_digits`
+    /// (plus one guard digit when `ROUNDED`), by scaling the dividend up so the
+    /// integer division lands `w` fractional digits: with `b = B/10^sb` and
+    /// `a = A/10^sa`, the value scaled by `10^w` is `floor(B·10^(sa+w−sb) / A)`.
+    /// store_scaled then truncates or rounds `w → dec_digits`. A dividend with
+    /// more fractional digits than the result precision, or an intermediate that
+    /// would exceed `i64`, is a clean error.
     fn emit_divide(&mut self, verb: &GrammarASTNode) -> Result<(), CompileError> {
-        self.reject_rounded_or_size_error(verb, "DIVIDE")?;
+        self.reject_size_error(verb, "DIVIDE")?;
+        let rounded = has_rounded(verb);
         let ops = child_nodes(verb, "operand");
         if ops.len() != 2 {
             return Err(CompileError::Malformed("DIVIDE needs two operands".into()));
         }
-        let divisor = self.int_operand(ops[0])?;
-        let dividend = self.int_operand(ops[1])?;
-        let quot = self.fresh("_quot");
-        // Integer division truncates toward zero — COBOL's behaviour into an
-        // integer receiver. (A zero divisor traps at run time, matching the
-        // oracle's hard DivideByZero for the handler-less case.)
-        self.emit("div", Some(&quot), vec![dividend, divisor], "i64");
+        let divisor_t = self.read_arith_term(ops[0])?; // a
+        let dividend_t = self.read_arith_term(ops[1])?; // b
+        let (sa, sb) = (self.term_scale(&divisor_t), self.term_scale(&dividend_t));
         let target = self.giving_or_operand_name(verb, ops[1], "DIVIDE … INTO <literal>")?;
-        // The quotient b/a is ≤ the dividend b, so its integer part is bounded by
-        // the dividend's integer digits.
-        let quot_int = self.operand_int_digits(ops[1])?;
-        self.store_scaled(&target, &quot, 0, quot_int, false)
+        let recv_dec = self.numeric_dims(self.numeric_index(&target)?).1;
+        let w = recv_dec + usize::from(rounded);
+
+        if sa + w < sb {
+            return Err(CompileError::Unsupported(
+                "DIVIDE with a dividend of more fractional digits than the result precision \
+                 is a later rung"
+                    .into(),
+            ));
+        }
+        let e = sa + w - sb;
+        let b_int = self.term_int_digits(&dividend_t);
+        // numerator = b_scaled · 10^e < 10^(b_int + sa + w); keep it in i64.
+        if b_int + sa + w > 18 {
+            return Err(CompileError::Unsupported(
+                "DIVIDE intermediate at the requested precision could overflow i64 — a later rung"
+                    .into(),
+            ));
+        }
+
+        let b_val = self.emit_term_at_scale(&dividend_t, sb);
+        let num = if e > 0 {
+            let pr = self.fresh("_dp");
+            self.emit("const", Some(&pr), vec![Operand::Int(10i64.pow(e as u32))], "i64");
+            let n = self.fresh("_num");
+            self.emit("mul", Some(&n), vec![b_val, Operand::Var(pr)], "i64");
+            Operand::Var(n)
+        } else {
+            b_val
+        };
+        let a_val = self.emit_term_at_scale(&divisor_t, sa);
+        let quot = self.fresh("_quot");
+        // i64 division truncates toward zero, as COBOL does. A zero divisor faults
+        // at run time — matching the oracle's hard DivideByZero without a handler.
+        self.emit("div", Some(&quot), vec![num, a_val], "i64");
+        // The quotient at scale w is < 10^(b_int + sa + w); its integer part is
+        // < 10^(b_int + sa). store_scaled only down-scales here (w ≥ dec_digits),
+        // so this bound is a formality.
+        self.store_scaled(&target, &quot, w, b_int + sa, rounded)
     }
 
     /// Store a computed `value_reg` (carrying `value_scale` fractional digits)
@@ -748,21 +794,8 @@ impl Compiler {
         self.emit("label", None, vec![Operand::Var(skip)], "void");
     }
 
-    /// Reject `ROUNDED` / `ON SIZE ERROR` on a verb whose scaled path is a later
-    /// rung (MULTIPLY / DIVIDE): ignoring them would silently produce wrong output.
-    fn reject_rounded_or_size_error(
-        &self,
-        verb: &GrammarASTNode,
-        name: &str,
-    ) -> Result<(), CompileError> {
-        if has_rounded(verb) {
-            return Err(CompileError::Unsupported(format!("{name} … ROUNDED is a later rung")));
-        }
-        self.reject_size_error(verb, name)
-    }
-
-    /// Reject only `ON SIZE ERROR` (it needs the branch machinery of a later
-    /// rung); `ROUNDED` is handled by `store_scaled`.
+    /// Reject `ON SIZE ERROR` (it needs the branch machinery of a later rung);
+    /// `ROUNDED` is handled by `store_scaled`.
     fn reject_size_error(&self, verb: &GrammarASTNode, name: &str) -> Result<(), CompileError> {
         if child_node(verb, "size_error").is_some() {
             return Err(CompileError::Unsupported(format!(
@@ -898,61 +931,6 @@ impl Compiler {
                     Operand::Var(out)
                 }
             }
-        }
-    }
-
-    /// An arithmetic operand as an IIR `i64` [`Operand`]: an integer literal
-    /// becomes a `const`-free immediate; a data-name becomes its register.
-    /// Fractional literals/fields, alphanumerics, and over-wide fields are a
-    /// later rung. Used by MULTIPLY/DIVIDE, whose scaled path is a later rung.
-    fn int_operand(&self, op: &GrammarASTNode) -> Result<Operand, CompileError> {
-        match read_operand(op)? {
-            Operandy::Literal(Src::Num(s)) => {
-                let d = Decimal::parse_literal(&s)
-                    .ok_or_else(|| CompileError::Malformed(format!("numeric literal {s}")))?;
-                Ok(Operand::Int(integer_decimal(&d).map_err(CompileError::Unsupported)?))
-            }
-            Operandy::Literal(Src::Zero) => Ok(Operand::Int(0)),
-            Operandy::Literal(_) => Err(CompileError::Unsupported(
-                "an alphanumeric operand in arithmetic".into(),
-            )),
-            Operandy::Name(n) => self.int_operand_from_name(&n),
-        }
-    }
-
-    /// The integer-digit bound of a MULTIPLY/DIVIDE operand (a literal's trimmed
-    /// integer length, or an item's `int_digits`) — used to bound the store's
-    /// up-scale against `i64` overflow.
-    fn operand_int_digits(&self, op: &GrammarASTNode) -> Result<usize, CompileError> {
-        match read_operand(op)? {
-            Operandy::Literal(Src::Num(s)) => Ok(Decimal::parse_literal(&s)
-                .map(|d| d.int.trim_start_matches('0').len())
-                .unwrap_or(0)),
-            Operandy::Literal(_) => Ok(0),
-            Operandy::Name(n) => Ok(self.numeric_dims(self.item_index(&n)?).0),
-        }
-    }
-
-    /// An integer numeric item's register as an arithmetic operand.
-    fn int_operand_from_name(&self, name: &str) -> Result<Operand, CompileError> {
-        let idx = self.item_index(name)?;
-        match &self.items[idx].kind {
-            ItemKind::Numeric { int_digits, dec_digits, .. } => {
-                if *dec_digits != 0 {
-                    return Err(CompileError::Unsupported(format!(
-                        "arithmetic on scaled-decimal field {name} (PIC …V…) is a later rung"
-                    )));
-                }
-                if *int_digits > ARITH_MAX_DIGITS {
-                    return Err(CompileError::Unsupported(format!(
-                        "arithmetic on field {name} wider than {ARITH_MAX_DIGITS} digits is a later rung"
-                    )));
-                }
-                Ok(Operand::Var(self.items[idx].reg.clone()))
-            }
-            ItemKind::Char { .. } => Err(CompileError::Unsupported(format!(
-                "arithmetic on non-numeric field {name}"
-            ))),
         }
     }
 
@@ -1192,22 +1170,6 @@ fn decimal_scaled_to(d: &Decimal, w: usize) -> i64 {
     }
 }
 
-/// An integer-valued [`Decimal`] as `i64`, for an arithmetic operand. A non-zero
-/// fractional part (a scaled-decimal literal) or an over-wide magnitude is a
-/// later rung.
-fn integer_decimal(d: &Decimal) -> Result<i64, String> {
-    if d.frac.chars().any(|c| c != '0') {
-        return Err(format!("scaled-decimal literal {}.{} in arithmetic is a later rung", d.int, d.frac));
-    }
-    let int_part = d.int.trim_start_matches('0');
-    if int_part.len() > ARITH_MAX_DIGITS {
-        return Err(format!(
-            "numeric literal wider than {ARITH_MAX_DIGITS} digits in arithmetic is a later rung"
-        ));
-    }
-    let mag: i64 = if int_part.is_empty() { 0 } else { int_part.parse().map_err(|_| "numeric literal".to_string())? };
-    Ok(if d.neg { -mag } else { mag })
-}
 
 // ---------------------------------------------------------------------------
 // CST helpers
@@ -1449,12 +1411,28 @@ mod tests {
     }
 
     #[test]
-    fn scaled_multiply_divide_still_deferred() {
-        // MULTIPLY/DIVIDE on a V operand, and their ROUNDED, remain a later rung.
+    fn scaled_multiply_divide_now_compile() {
+        // MULTIPLY/DIVIDE on a V operand, and their ROUNDED, are supported (PR3b).
         for body in ["MULTIPLY 2.5 BY R.", "DIVIDE 2 INTO R ROUNDED."] {
-            let err = compile_source(
+            let module = compile_source(
                 &wrap(&["01  R  PIC 9(2)V9 VALUE 1."], &[body, "STOP RUN."]),
                 "md",
+            )
+            .unwrap();
+            assert!(module.validate().is_empty(), "{body}: {:?}", module.validate());
+        }
+    }
+
+    #[test]
+    fn multiply_divide_on_size_error_still_deferred() {
+        // ON SIZE ERROR still needs the branch machinery of a later rung.
+        for body in [
+            "MULTIPLY 2 BY R ON SIZE ERROR DISPLAY \"O\".",
+            "DIVIDE 2 INTO R ON SIZE ERROR DISPLAY \"O\".",
+        ] {
+            let err = compile_source(
+                &wrap(&["01  R  PIC 9(3) VALUE 1."], &[body, "STOP RUN."]),
+                "se",
             )
             .unwrap_err();
             assert!(matches!(err, CompileError::Unsupported(_)), "{body}: got {err:?}");

--- a/code/packages/rust/cobol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/cobol-iir-compiler/tests/backend_compat.rs
@@ -147,3 +147,25 @@ fn if_else_program_accepted_by_print_backends() {
     let m = compile_source(&src, "if").unwrap();
     assert_accepted_by_print_backends(&m, "if/else branch");
 }
+
+#[test]
+fn scaled_multiply_divide_program_accepted_by_print_backends() {
+    // Scaled MULTIPLY and DIVIDE (with ROUNDED) exercise the dividend up-scale
+    // (mul by 10^e), the div, and the store rescale/rounding branches. Every
+    // print backend must accept the emitted IIR.
+    let src = program(&[
+        "IDENTIFICATION DIVISION.",
+        "PROGRAM-ID. P.",
+        "DATA DIVISION.",
+        "WORKING-STORAGE SECTION.",
+        "01  R  PIC 9(2)V99 VALUE 0.",
+        "PROCEDURE DIVISION.",
+        "MAIN.",
+        "    MULTIPLY 2.5 BY 2.5 GIVING R.",
+        "    DIVIDE 3 INTO 20 GIVING R ROUNDED.",
+        "    DISPLAY R.",
+        "    STOP RUN.",
+    ]);
+    let m = compile_source(&src, "muldiv").unwrap();
+    assert_accepted_by_print_backends(&m, "scaled multiply/divide");
+}

--- a/code/packages/rust/cobol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/cobol-iir-compiler/tests/jit_e2e.rs
@@ -397,6 +397,100 @@ fn item_to_item_move_rescales_the_implied_point() {
     assert_eq!(down, "123\n");
 }
 
+// -------------------------------------------------------------------------
+// Scaled-decimal MULTIPLY / DIVIDE (PR3b) — vs the oracle.
+// -------------------------------------------------------------------------
+
+#[test]
+fn multiply_fixed_point_truncates_into_receiver() {
+    // 2.5 * 2.5 = 6.25 → into 9(3)V9 truncates to "0062".
+    let out = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(3)V9."],
+        &["MULTIPLY 2.5 BY 2.5 GIVING R.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(out, "0062\n");
+}
+
+#[test]
+fn multiply_giving_rounded() {
+    // 6.25 into 9(2)V9: truncated 6.2, ROUNDED 6.3 (second place is 5).
+    let trunc = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(2)V9 VALUE 0."],
+        &["MULTIPLY 2.5 BY 2.5 GIVING R.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(trunc, "062\n");
+    let round = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(2)V9 VALUE 0."],
+        &["MULTIPLY 2.5 BY 2.5 GIVING R ROUNDED.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(round, "063\n");
+}
+
+#[test]
+fn multiply_by_field_updates_the_by_field() {
+    // MOVE 6 TO R; MULTIPLY 7 BY R → 42.
+    let out = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(3) VALUE 6."],
+        &["MULTIPLY 7 BY R.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(out, "042\n");
+}
+
+#[test]
+fn divide_into_giving_truncates_to_receiver_decimals() {
+    // 10 / 3 = 3.333… → into 9(3)V99 truncates to 3.33 → "00333".
+    let a = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(3)V99."],
+        &["DIVIDE 3 INTO 10 GIVING R.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(a, "00333\n");
+    // 10 / 4 = 2.5 → into 9(3) (no decimals) truncates to 2 → "002".
+    let b = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(3)."],
+        &["DIVIDE 4 INTO 10 GIVING R.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(b, "002\n");
+}
+
+#[test]
+fn divide_giving_rounded() {
+    // 20 / 3 = 6.666… → into V99: truncated 6.66, ROUNDED 6.67.
+    let trunc = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(2)V99 VALUE 0."],
+        &["DIVIDE 3 INTO 20 GIVING R.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(trunc, "0666\n");
+    let round = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(2)V99 VALUE 0."],
+        &["DIVIDE 3 INTO 20 GIVING R ROUNDED.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(round, "0667\n");
+}
+
+#[test]
+fn divide_into_without_giving_updates_the_dividend() {
+    // MOVE 20 TO R; DIVIDE 5 INTO R → 4.
+    let out = assert_matches_oracle(&wrap(
+        &["01  R  PIC 9(3) VALUE 20."],
+        &["DIVIDE 5 INTO R.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(out, "004\n");
+}
+
+#[test]
+fn multiply_decimal_field_operands() {
+    // A=1.5 (9(2)V9), B=2.0 (9(2)V9); MULTIPLY A BY B GIVING R(9(3)V99) = 3.00.
+    let out = assert_matches_oracle(&wrap(
+        &[
+            "01  A  PIC 9(2)V9 VALUE 1.5.",
+            "01  B  PIC 9(2)V9 VALUE 2.",
+            "01  R  PIC 9(3)V99.",
+        ],
+        &["MULTIPLY A BY B GIVING R.", "DISPLAY R.", "STOP RUN."],
+    ));
+    assert_eq!(out, "00300\n");
+}
+
 #[test]
 fn arithmetic_chains_through_the_field() {
     // Successive ops read the field back, proving the i64 slot round-trips:

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -2954,6 +2954,27 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("BIG"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // COBOL-60 — scaled DIVIDE with ROUNDED (PL09 step 4, PR3b). `20 / 3 =
+    // 6.666…`; carried to one guard digit past the `V99` receiver then rounded
+    // half away from zero → `6.67`, rendered as the four-digit field `0667`. This
+    // proves the dividend up-scale, integer division, and sign-aware rounding
+    // bias all lower to plain `i64` ops on every backend.
+    Prog {
+        lang: Language::Cobol60,
+        ext: "cob",
+        src: "000000 IDENTIFICATION DIVISION.\n\
+               000000 PROGRAM-ID. P.\n\
+               000000 DATA DIVISION.\n\
+               000000 WORKING-STORAGE SECTION.\n\
+               000000 01  R  PIC 9(2)V99 VALUE 0.\n\
+               000000 PROCEDURE DIVISION.\n\
+               000000 MAIN.\n\
+               000000     DIVIDE 3 INTO 20 GIVING R ROUNDED.\n\
+               000000     DISPLAY R.\n\
+               000000     STOP RUN.",
+        expect: Expect::Stdout("0667"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
 ];
 
 /// Is a usable native linker present on this host? On Linux/macOS the AOT path uses


### PR DESCRIPTION
## What

Completes COBOL **fixed-point arithmetic**: `MULTIPLY`/`DIVIDE` now honour the implied decimal point (`PIC …V…`), matching the `cobol-runtime` oracle byte-for-byte. Follows [#8474](https://github.com/adhithyan15/coding-adventures/pull/8474) (IF/ELSE).

## The slice

- **Scaled `MULTIPLY`** — the raw product of the two scaled `i64` slots carries scale `sa + sb`; `store_scaled` rounds/truncates it to the receiver's scale. Operands are ≤ 9 digits, so the product is `< 10^18` and never overflows `i64`.
- **Scaled `DIVIDE`** — the quotient is computed at working scale `w` = the receiver's `dec_digits` (plus one guard digit when `ROUNDED`) by scaling the dividend up before the truncating integer division: `floor(B·10^(sa+w−sb) / A)`, then `store_scaled` truncates or rounds `w → dec_digits`. **One guard digit exactly matches the oracle's `round()`**, which inspects only the first dropped digit (half away from zero).
- **`ROUNDED`** honoured on both via the shared `store_scaled` bias-rounding.

The now-redundant integer-only operand path (`int_operand`, `integer_decimal`, …) is removed — every arithmetic verb shares the scaled `Term` machinery and `store_scaled`.

## Overflow safety (security-reviewed)

`DIVIDE` rejects a dividend with more fractional digits than the result precision, and any intermediate whose digit width would exceed 18 (`b_int + sa + w > 18`) — a clean `Unsupported`. The reviewer independently verified every `pow` exponent ≤ 18, numerator and product `< 10^18`, that `store_scaled`'s up-scale guard still covers `MULTIPLY` into a wide-`V` receiver, and that `DIVIDE` only down-scales (so needs no up-scale guard). Divide-by-zero faults at runtime like the oracle's handler-less `DivideByZero`.

## Still deferred

`ON SIZE ERROR` on the arithmetic verbs (needs the `IF` rung's branch machinery).

## Testing
- **16 unit tests** — new capability + the retained `ON SIZE ERROR` boundary.
- **`jit_e2e.rs` (36 tests)** — seven new scaled MUL/DIV cases (fixed-point multiply truncate/round, BY-field update, divide truncate-to-receiver-decimals, divide rounded, dividend update, decimal-field multiply) each **byte-identical to the oracle**, plus all prior cases.
- **`backend_compat.rs`** — a scaled multiply/divide program accepted by the wasm/jvm/clr validators.
- **`lang_matrix.rs`** — a scaled DIVIDE-ROUNDED row (`20 / 3` in `V99` → `0667`).

> As before, the full `lang_matrix` native-AOT/JVM columns fail *locally* on a pre-existing Twig toolchain breakage (reproduced on pristine `main`); the COBOL VM/JIT paths are proven by `jit_e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)