### PR TITLE
fix(security): add MAX_RULE_DEPTH guards to css/toml/jsdoc parsers

### DIFF
--- a/code/packages/rust/css-parser/CHANGELOG.md
+++ b/code/packages/rust/css-parser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `coding-adventures-css-parser` crate will be documented in this file.
 
+## [0.1.1] - 2026-07-18
+
+### Fixed
+- **Security hardening**: `create_css_parser` never called `GrammarParser::with_max_depth`, leaving every caller (including this crate's own `parse_css`) exposed to a native-stack-overflow DoS from adversarial deeply-nested input. Added a `MAX_RULE_DEPTH = 170` cap, derived from independently measuring `css.grammar`'s five distinct self-referential recursion shapes (nested qualified-rule blocks, nested `@media` at-rules, nested `@supports`/paren conditions, nested `calc()` calls, nested `:not()` pseudo-class args) — binary search over candidate `with_max_depth` values against a 5000-deep adversarial input per shape. Binding floor: nested `@media` at 247/248 (safe/crash). Cap sits ~31% below that. 3 new depth-guard regression tests.
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/code/packages/rust/css-parser/Cargo.toml
+++ b/code/packages/rust/css-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-css-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "CSS parser — parses CSS source code into an AST using the grammar-driven parser and the css.grammar file"
 

--- a/code/packages/rust/css-parser/src/lib.rs
+++ b/code/packages/rust/css-parser/src/lib.rs
@@ -5,10 +5,71 @@ use parser::grammar_parser::{GrammarASTNode, GrammarParser};
 
 mod _grammar;
 
+/// Recursion-depth cap for the CSS [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own callers ever get a chance to report anything). Before this
+/// constant was added, `create_css_parser` never called `with_max_depth` at
+/// all, leaving every caller (including this crate's own `parse_css`)
+/// exposed to a native-stack-overflow DoS from adversarial input.
+///
+/// # Five recursion shapes, measured independently
+///
+/// `css.grammar` has five distinct self-referential productions (each one
+/// a genuine cycle of rule calls, not an EBNF `{ x }` repetition — those
+/// cost zero native stack regardless of width, confirmed in
+/// `reduce-parser`'s own `MAX_RULE_DEPTH` doc comment via a throwaway
+/// probe grammar). Each was measured with the same methodology every
+/// sibling `*-parser` crate uses: binary search directly over candidate
+/// `with_max_depth` values against a fixed 5000-level/link adversarial
+/// input of that shape (deep enough that the *cap itself*, not the input's
+/// finite length, is what triggers first) on a default-~2MiB-stack worker
+/// thread in a debug build — this single measurement directly yields the
+/// rule-frame floor `MAX_RULE_DEPTH` needs to respect, without a separate
+/// nesting-count-to-frame-count conversion step.
+///
+/// 1. **Nested qualified-rule blocks** (CSS Nesting), `.a{.a{.a{...}}}` —
+///    `block -> block_contents -> block_item -> declaration_or_nested ->
+///    qualified_rule -> block -> …`. Safe at **289**, crashes at **290**.
+/// 2. **Nested `@supports`/`@media` parenthesised conditions**,
+///    `@supports (((...)))` — `at_prelude_token -> paren_block ->
+///    at_prelude_tokens -> at_prelude_token -> …`. Safe at **289**, crashes
+///    at **290**.
+/// 3. **Nested `calc()`/function calls in a value**, `calc(calc(calc(...)))`
+///    — `function_args -> function_arg -> FUNCTION function_args RPAREN ->
+///    …`. Safe at **248**, crashes at **249**.
+/// 4. **Nested `:not()` pseudo-class arguments**, `:not(:not(:not(...)))`
+///    — `pseudo_class_args -> pseudo_class_arg -> FUNCTION
+///    pseudo_class_args RPAREN -> …`. Safe at **248**, crashes at **249**.
+/// 5. **Nested `@media` at-rule blocks**, `@media{@media{@media{...}}}` —
+///    `at_rule -> block -> block_contents -> block_item -> at_rule -> …`
+///    — the **binding** shape. Safe at **247**, crashes at **248**.
+///
+/// `MAX_RULE_DEPTH` is set to **170** — about 31% below the binding
+/// nested-`@media` floor of 247 (comparable margin to `apl-parser`'s own
+/// ~26.5%, `j-parser`'s ~30%, `reduce-parser`'s ~28.5%), and therefore
+/// safely below all four other floors (248, 248, 289, 289) as well.
+///
+/// Measured real-input headroom at `170` (using the CAPPED parser, so no
+/// crash risk at all — confirmed directly, not extrapolated from the
+/// floors above, since different shapes cost different amounts of native
+/// stack per rule-frame and headroom does not scale uniformly with the
+/// floor ratios): nested qualified rules parse cleanly to 33 levels (34
+/// trips); nested `@media` at-rules parse cleanly to 39 levels (40 trips);
+/// `@supports` paren nesting parses cleanly to 55 levels (56 trips);
+/// `calc()` nesting parses cleanly to 79 levels (80 trips); `:not()`
+/// nesting parses cleanly to 81 levels (82 trips) — all comfortably
+/// beyond anything a hand-written stylesheet needs, and all five
+/// independently confirmed not to crash a default-stack thread even
+/// thousands of levels/links past the cap (see this crate's tests).
+const MAX_RULE_DEPTH: usize = 170;
+
 pub fn create_css_parser(source: &str) -> GrammarParser {
     let tokens = tokenize_css(source);
     let grammar = _grammar::parser_grammar();
-    GrammarParser::new(tokens, grammar)
+    GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH)
 }
 
 pub fn parse_css(source: &str) -> GrammarASTNode {
@@ -177,6 +238,145 @@ mod tests {
         let ast = parse_css(prettified);
         assert_stylesheet_root(&ast);
         assert!(!ast.children.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- exercises all five
+    // independently-measured shapes documented on `MAX_RULE_DEPTH`.
+    // -----------------------------------------------------------------------
+
+    fn nested_qualified_rule_source(n: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str(".a{");
+        }
+        s.push_str("color:red;");
+        for _ in 0..n {
+            s.push('}');
+        }
+        s
+    }
+
+    fn nested_at_rule_source(n: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str("@media{");
+        }
+        s.push_str("a{color:red;}");
+        for _ in 0..n {
+            s.push('}');
+        }
+        s
+    }
+
+    fn nested_calc_source(n: usize) -> String {
+        let mut s = String::from("a{width:");
+        for _ in 0..n {
+            s.push_str("calc(");
+        }
+        s.push('1');
+        for _ in 0..n {
+            s.push(')');
+        }
+        s.push_str(";}");
+        s
+    }
+
+    fn nested_not_source(n: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str(":not(");
+        }
+        s.push('a');
+        for _ in 0..n {
+            s.push(')');
+        }
+        s.push_str("{color:red;}");
+        s
+    }
+
+    fn nested_supports_paren_source(n: usize) -> String {
+        let mut s = String::from("@supports ");
+        for _ in 0..n {
+            s.push('(');
+        }
+        s.push_str("a:1");
+        for _ in 0..n {
+            s.push(')');
+        }
+        s.push_str("{a{color:red;}}");
+        s
+    }
+
+    fn try_parse(src: &str) -> Result<GrammarASTNode, String> {
+        create_css_parser(src).parse().map_err(|e| e.to_string())
+    }
+
+    /// Deeply-nested input, for every measured shape, must produce a
+    /// recoverable error, not overflow the native stack. Parses 5000
+    /// levels/links -- far past `MAX_RULE_DEPTH` -- on a worker thread
+    /// with a generous 32 MiB stack, so the *guard* is what stops the
+    /// recursion, not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow_for_every_shape() {
+        let sources = vec![
+            nested_qualified_rule_source(5000),
+            nested_at_rule_source(5000),
+            nested_calc_source(5000),
+            nested_not_source(5000),
+            nested_supports_paren_source(5000),
+        ];
+        let handle = std::thread::Builder::new()
+            .name("css-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                for src in sources {
+                    assert!(
+                        try_parse(&src).is_err(),
+                        "deeply-nested input must fail with an error, not parse or crash"
+                    );
+                }
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. Parses far-too-deep input, for every
+    /// shape, on a worker thread with **no** `stack_size` override (the
+    /// same ~2 MiB a default thread gets).
+    #[test]
+    fn test_cap_trips_before_overflow_on_default_stack_for_every_shape() {
+        let sources = vec![
+            nested_qualified_rule_source(5000),
+            nested_at_rule_source(5000),
+            nested_calc_source(5000),
+            nested_not_source(5000),
+            nested_supports_paren_source(5000),
+        ];
+        let handle = std::thread::spawn(move || {
+            for src in sources {
+                assert!(try_parse(&src).is_err(), "deeply-nested input must error, not crash");
+            }
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// Reasonable, hand-writable nesting for every shape stays well under
+    /// the cap.
+    #[test]
+    fn test_reasonable_nesting_stays_under_the_cap_for_every_shape() {
+        assert!(try_parse(&nested_qualified_rule_source(10)).is_ok());
+        assert!(try_parse(&nested_at_rule_source(10)).is_ok());
+        assert!(try_parse(&nested_calc_source(10)).is_ok());
+        assert!(try_parse(&nested_not_source(10)).is_ok());
+        assert!(try_parse(&nested_supports_paren_source(10)).is_ok());
     }
 }
 

--- a/code/packages/rust/jsdoc-parser/CHANGELOG.md
+++ b/code/packages/rust/jsdoc-parser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `coding-adventures-jsdoc-parser` crate will be documented in this file.
 
+## [0.1.1] - 2026-07-18
+
+### Fixed
+- **Security hardening**: `create_jsdoc_parser` never called `GrammarParser::with_max_depth`, leaving every caller exposed to a native-stack-overflow DoS from an adversarial `@type {(((...)))}` payload. Added a `MAX_RULE_DEPTH = 200` cap, derived from measuring `jsdoc.grammar`'s one self-referential recursion shape (nested parenthesised type expressions) — safe at 289, crashes at 290. Cap sits ~31% below that. Notable surprise: exceeding the cap does not produce a parse error — `jsdoc.grammar`'s own `unknown_tag` catch-all (documented as a deliberate "unknown tags survive and round-trip" fallback) absorbs the too-deep payload as an unstructured tag instead, so the overall parse still succeeds, just with a different (degraded but harmless) tree shape. 3 new depth-guard regression tests assert "does not crash" rather than "returns Err" for this reason.
+
 ## [0.1.0] - 2026-05-22
 
 ### Added

--- a/code/packages/rust/jsdoc-parser/Cargo.toml
+++ b/code/packages/rust/jsdoc-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-jsdoc-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "JSDoc parser — parses the interior of a /** ... */ block comment into a tag tree using the grammar-driven parser. Per CLOC05."
 

--- a/code/packages/rust/jsdoc-parser/src/lib.rs
+++ b/code/packages/rust/jsdoc-parser/src/lib.rs
@@ -15,13 +15,65 @@ use parser::grammar_parser::{GrammarASTNode, GrammarParser};
 
 mod _grammar;
 
+/// Recursion-depth cap for the JSDoc [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own callers ever get a chance to report anything). Before this
+/// constant was added, `create_jsdoc_parser` never called `with_max_depth`
+/// at all, leaving every caller exposed to a native-stack-overflow DoS from
+/// an adversarial `@type {(((...)))}` payload.
+///
+/// # One recursion shape — and a graceful-degradation surprise
+///
+/// `jsdoc.grammar` has exactly one self-referential production: nested
+/// parenthesised type expressions, `@type {(((Foo)))}` — `type ->
+/// primary_type -> parenthesized_type -> type -> …`. Measured directly:
+/// binary search over candidate `with_max_depth` values against a fixed
+/// 5000-level adversarial input, on a default-~2MiB-stack worker thread in
+/// a debug build. Safe at **289**, crashes at **290**.
+///
+/// `MAX_RULE_DEPTH` is set to **200** — about 31% below the 289 floor
+/// (comparable margin to `apl-parser`'s own ~26.5%, `j-parser`'s ~30%,
+/// `reduce-parser`'s ~28.5%).
+///
+/// The surprise: unlike every other `*-parser` crate audited alongside this
+/// one, exceeding the cap here does **not** produce a parse *error*.
+/// `tag = type_tag | param_tag | returns_tag | unknown_tag` — and
+/// `unknown_tag = AT_TAG { tag_payload_token } NEWLINE` is a deliberate,
+/// non-recursive catch-all (documented in `jsdoc.grammar`'s own header:
+/// "unknown tags survive and round-trip") that sweeps up *any* sequence of
+/// tokens up to the next `NEWLINE`, parens included. So once the depth cap
+/// refuses `type_tag`'s attempt at a properly-nested `type_expression`,
+/// the PEG ordered-choice in `tag` does not fail outright — it falls
+/// through to `unknown_tag`, which happily accepts the same (still
+/// well-formed, just too-deep) token sequence as an opaque, unstructured
+/// payload. The overall parse still succeeds (`Ok`), just with a
+/// *different* — degraded but harmless — tree shape than the "real" nested
+/// type expression would have produced. This is arguably a *better*
+/// outcome than a hard error (graceful degradation instead of rejection),
+/// but it means this crate's own depth-guard regression tests assert "no
+/// crash" rather than "returns `Err`", unlike every sibling `*-parser`
+/// crate's identically-named tests.
+///
+/// Measured real-input headroom at `200` (using the CAPPED parser, so no
+/// crash risk at all, and checking the resulting tree shape rather than
+/// just success/failure): parenthesised-type nesting parses as a *genuine*
+/// `parenthesized_type` node up to 48 levels; at 49 levels the tree
+/// contains `unknown_tag` instead — comfortably beyond anything a
+/// hand-written JSDoc comment needs, and confirmed not to crash a
+/// default-stack thread even thousands of levels past the cap (see this
+/// crate's tests).
+const MAX_RULE_DEPTH: usize = 200;
+
 /// Construct a JSDoc [`GrammarParser`] over `source`. The caller is
 /// responsible for stripping the surrounding `/** */` markers; see the
 /// crate-level docs.
 pub fn create_jsdoc_parser(source: &str) -> GrammarParser {
     let tokens = tokenize_jsdoc(source);
     let grammar = _grammar::parser_grammar();
-    GrammarParser::new(tokens, grammar)
+    GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH)
 }
 
 /// Parse `source` into a [`GrammarASTNode`] rooted at the `document`
@@ -110,5 +162,84 @@ mod tests {
         let mut parser = create_jsdoc_parser("@type {string}\n");
         let ast = parser.parse().expect("parse should succeed");
         assert_eq!(ast.rule_name, "document");
+    }
+
+    // -----------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- see `MAX_RULE_DEPTH`'s own
+    // doc comment for why these assert "does not crash" rather than
+    // "returns Err", unlike every sibling `*-parser` crate's identically
+    // named tests: `unknown_tag`'s deliberate catch-all fallback means an
+    // over-cap `@type {(((...)))}` still parses successfully overall (as
+    // an unstructured unknown tag), just with a different tree shape.
+    // -----------------------------------------------------------------------
+
+    fn nested_paren_type_source(n: usize) -> String {
+        let mut s = String::from("@type {");
+        for _ in 0..n {
+            s.push('(');
+        }
+        s.push_str("Foo");
+        for _ in 0..n {
+            s.push(')');
+        }
+        s.push_str("}\n");
+        s
+    }
+
+    /// Deeply-nested input must not overflow the native stack, regardless
+    /// of whether the eventual parse result is `Ok` (via the `unknown_tag`
+    /// fallback) or `Err`. Parses 5000 levels -- far past `MAX_RULE_DEPTH`
+    /// -- on a worker thread with a generous 32 MiB stack, so the *guard*
+    /// is what stops the recursion, not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_does_not_overflow() {
+        let src = nested_paren_type_source(5000);
+        let handle = std::thread::Builder::new()
+            .name("jsdoc-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                let _ = create_jsdoc_parser(&src).parse();
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. Parses far-too-deep input on a worker
+    /// thread with **no** `stack_size` override (the same ~2 MiB a default
+    /// thread gets).
+    #[test]
+    fn test_cap_trips_before_overflow_on_default_stack() {
+        let src = nested_paren_type_source(5000);
+        let handle = std::thread::spawn(move || {
+            let _ = create_jsdoc_parser(&src).parse();
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// Reasonable, hand-writable nesting stays well under the cap and
+    /// still produces a genuine `parenthesized_type` node, not the
+    /// `unknown_tag` fallback.
+    #[test]
+    fn test_reasonable_nesting_stays_under_the_cap() {
+        let ast = create_jsdoc_parser(&nested_paren_type_source(10))
+            .parse()
+            .expect("reasonable nesting should parse");
+
+        fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+            use parser::grammar_parser::ASTNodeOrToken;
+            node.rule_name == name
+                || node.children.iter().any(|c| match c {
+                    ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                    ASTNodeOrToken::Token(_) => false,
+                })
+        }
+        assert!(contains_rule(&ast, "parenthesized_type"));
     }
 }

--- a/code/packages/rust/toml-parser/CHANGELOG.md
+++ b/code/packages/rust/toml-parser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-07-18
+
+### Fixed
+- **Security hardening**: `create_toml_parser` never called `GrammarParser::with_max_depth`, leaving every caller (including this crate's own `parse_toml`) exposed to a native-stack-overflow DoS from adversarial deeply-nested input. Added a `MAX_RULE_DEPTH = 165` cap, derived from independently measuring `toml.grammar`'s two distinct self-referential recursion shapes (nested arrays, nested inline tables) — binary search over candidate `with_max_depth` values against a 5000-deep adversarial input per shape. Both shapes land on the identical floor (236 safe / 237 crash). Cap sits ~30% below that. 3 new depth-guard regression tests.
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/code/packages/rust/toml-parser/Cargo.toml
+++ b/code/packages/rust/toml-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-toml-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "TOML parser — parses TOML source text into an AST using the grammar-driven parser and the toml.grammar file"
 

--- a/code/packages/rust/toml-parser/src/lib.rs
+++ b/code/packages/rust/toml-parser/src/lib.rs
@@ -5,10 +5,51 @@ use parser::grammar_parser::{GrammarASTNode, GrammarParser};
 
 mod _grammar;
 
+/// Recursion-depth cap for the TOML [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own callers ever get a chance to report anything). Before this
+/// constant was added, `create_toml_parser` never called `with_max_depth`
+/// at all, leaving every caller (including this crate's own `parse_toml`)
+/// exposed to a native-stack-overflow DoS from adversarial input.
+///
+/// # Two recursion shapes, measured independently
+///
+/// `toml.grammar` has two distinct self-referential productions (each a
+/// genuine cycle of rule calls through `value`, not an EBNF `{ x }`
+/// repetition — those cost zero native stack regardless of width,
+/// confirmed in `reduce-parser`'s own `MAX_RULE_DEPTH` doc comment via a
+/// throwaway probe grammar). Each was measured directly: binary search
+/// over candidate `with_max_depth` values against a fixed 5000-level
+/// adversarial input of that shape (deep enough that the *cap itself*,
+/// not the input's finite length, is what triggers first) on a
+/// default-~2MiB-stack worker thread in a debug build.
+///
+/// 1. **Nested arrays**, `a = [[[[1]]]]` — `value -> array ->
+///    array_values -> value -> …`. Safe at **236**, crashes at **237**.
+/// 2. **Nested inline tables**, `a = { b = { c = { d = 1 } } }` —
+///    `value -> inline_table -> keyval -> value -> …`. Safe at **236**,
+///    crashes at **237**.
+///
+/// Both shapes land on the identical floor (236/237) — they cycle through
+/// `value` with near-identical per-level rule-frame cost.
+///
+/// `MAX_RULE_DEPTH` is set to **165** — about 30% below the 236 floor
+/// (comparable margin to `apl-parser`'s own ~26.5%, `j-parser`'s ~30%,
+/// `reduce-parser`'s ~28.5%). Measured real-input headroom at `165` (using
+/// the CAPPED parser, so no crash risk at all): both nested arrays and
+/// nested inline tables parse cleanly to 53 levels (54 trips) — comfortably
+/// beyond anything a hand-written TOML document needs, and both
+/// independently confirmed not to crash a default-stack thread even
+/// thousands of levels past the cap (see this crate's tests).
+const MAX_RULE_DEPTH: usize = 165;
+
 pub fn create_toml_parser(source: &str) -> GrammarParser {
     let tokens = tokenize_toml(source);
     let grammar = _grammar::parser_grammar();
-    GrammarParser::new(tokens, grammar)
+    GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH)
 }
 
 pub fn parse_toml(source: &str) -> GrammarASTNode {
@@ -399,6 +440,94 @@ role = \"user\"
 
         let has_table_header = find_rule(&ast, "table_header");
         assert!(has_table_header, "Expected 'table_header' rule in AST");
+    }
+
+    // -----------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- exercises both
+    // independently-measured shapes documented on `MAX_RULE_DEPTH`.
+    // -----------------------------------------------------------------------
+
+    fn nested_array_source(n: usize) -> String {
+        let mut s = String::from("a = ");
+        for _ in 0..n {
+            s.push('[');
+        }
+        s.push('1');
+        for _ in 0..n {
+            s.push(']');
+        }
+        s
+    }
+
+    fn nested_inline_table_source(n: usize) -> String {
+        let mut s = String::from("a = ");
+        for i in 0..n {
+            if i > 0 {
+                s.push_str("b = ");
+            }
+            s.push_str("{ ");
+        }
+        s.push_str("c = 1");
+        for _ in 0..n {
+            s.push_str(" }");
+        }
+        s
+    }
+
+    fn try_parse(src: &str) -> Result<GrammarASTNode, String> {
+        create_toml_parser(src).parse().map_err(|e| e.to_string())
+    }
+
+    /// Deeply-nested input, for both measured shapes, must produce a
+    /// recoverable error, not overflow the native stack. Parses 5000
+    /// levels -- far past `MAX_RULE_DEPTH` -- on a worker thread with a
+    /// generous 32 MiB stack, so the *guard* is what stops the recursion,
+    /// not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow_for_every_shape() {
+        let sources = vec![nested_array_source(5000), nested_inline_table_source(5000)];
+        let handle = std::thread::Builder::new()
+            .name("toml-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                for src in sources {
+                    assert!(
+                        try_parse(&src).is_err(),
+                        "deeply-nested input must fail with an error, not parse or crash"
+                    );
+                }
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. Parses far-too-deep input, for both
+    /// shapes, on a worker thread with **no** `stack_size` override (the
+    /// same ~2 MiB a default thread gets).
+    #[test]
+    fn test_cap_trips_before_overflow_on_default_stack_for_every_shape() {
+        let sources = vec![nested_array_source(5000), nested_inline_table_source(5000)];
+        let handle = std::thread::spawn(move || {
+            for src in sources {
+                assert!(try_parse(&src).is_err(), "deeply-nested input must error, not crash");
+            }
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// Reasonable, hand-writable nesting for both shapes stays well under
+    /// the cap.
+    #[test]
+    fn test_reasonable_nesting_stays_under_the_cap_for_every_shape() {
+        assert!(try_parse(&nested_array_source(10)).is_ok());
+        assert!(try_parse(&nested_inline_table_source(10)).is_ok());
     }
 }
 


### PR DESCRIPTION
## Summary
- `css-parser`, `toml-parser`, and `jsdoc-parser` each constructed `GrammarParser` without ever calling `.with_max_depth(...)`, leaving every caller (including their own panic-based `parse_*` entry points) exposed to a native-stack-overflow DoS from adversarial deeply-nested/deeply-chained input. Found via an Explore audit of every `*-parser`/`*-compiler` crate wrapping the shared `GrammarParser` engine (20 crates total flagged unhardened; this is the first, narrowest batch of a larger remediation — see follow-up tasks for the rest).
- Each crate's distinct self-referential recursion shapes were measured independently (binary search over candidate `with_max_depth` values against a 5000-deep adversarial input per shape, on a default-stack worker thread, debug build) rather than assuming a value transfers between crates or shapes:
  - `css.grammar`: 5 shapes (nested qualified-rule blocks, nested `@media`, nested `@supports` parens, nested `calc()`, nested `:not()`). Binding floor 247 (nested `@media`) → cap **170**.
  - `toml.grammar`: 2 shapes (nested arrays, nested inline tables), both landing on floor 236 → cap **165**.
  - `jsdoc.grammar`: 1 shape (nested parenthesised types), floor 289 → cap **200**. Genuine surprise: exceeding the cap doesn't error — jsdoc's own `unknown_tag` catch-all (a deliberate "unknown tags survive and round-trip" fallback) absorbs the too-deep payload as an unstructured tag instead, so the parse still succeeds with a different, harmless tree shape. That crate's tests assert "does not crash" rather than "returns Err" for this reason.
- `starlark-parser` and `lattice-parser` were found in the same audit but turned out to have full general-purpose-language-complexity grammars (~10-11 and ~5 distinct recursion shapes respectively) rather than simple config/markup grammars — split into a separate follow-up task instead of bundled here.
- 9 new depth-guard regression tests total. `/security-review` passed clean (no findings).

## Test plan
- [x] `cargo test -p coding-adventures-css-parser -p coding-adventures-toml-parser -p coding-adventures-jsdoc-parser` — all pass (13 + 24 + 13 tests)
- [x] `cargo clippy --all-targets` on all three crates — clean
- [x] Depth-guard regression tests exercise every measured shape on both enlarged-stack and default-stack worker threads
- [x] `/security-review` — SECURITY REVIEW PASSED, no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)