### PR TITLE
feat(adj-facts-stdlib): physics/wave-types — wave type → example/defining token table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_wavetypes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_wavetypes_e2e.rs
@@ -1,0 +1,83 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/wave-types.adj`) driven through the built CLI:
+//! a native `table` of named wave → wave family (mechanical / electromagnetic)
+//! resolves a binding query recall with the NASA citation, runs backward
+//! (family → wave), and abstains on a wave the source never classifies
+//! (a seismic wave) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factswt_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn physics_wave_types_recall_binds_family_with_citation() {
+    let dir = scratch("wavetypes");
+    // Copy the shipped physics table beside the entry program and import it.
+    let src = facts_stdlib().join("physics/wave-types.adj");
+    std::fs::copy(&src, dir.join("wave-types.adj")).expect("copy shipped wave-types.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"wave-types.adj\"\n\
+         ? wave_family(sound, $F)\n\
+         ? wave_family(radio, $F)\n\
+         ? wave_family(gamma, $F)\n\
+         ? wave_family($W, electromagnetic)\n\
+         ? wave_family(seismic, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward lookups bind each named wave to the family NASA sorts it into.
+    assert!(out.contains("\"F\":\"mechanical\""), "sound binds to mechanical: {out}");
+    assert!(
+        out.contains("\"F\":\"electromagnetic\""),
+        "radio binds to electromagnetic: {out}"
+    );
+    assert!(
+        out.contains("wave_family(sound, mechanical)"),
+        "sound is governing-bound to mechanical: {out}"
+    );
+    assert!(
+        out.contains("wave_family(radio, electromagnetic)"),
+        "radio is governing-bound to electromagnetic: {out}"
+    );
+    assert!(
+        out.contains("wave_family(gamma, electromagnetic)"),
+        "gamma is governing-bound to electromagnetic: {out}"
+    );
+    // The relation runs BACKWARD: bind the family, recall a wave that belongs to it.
+    assert!(
+        out.contains("\"W\":\"gamma\""),
+        "reverse recall binds W=gamma from electromagnetic: {out}"
+    );
+    // The answer carries the NASA locator + trust tier as its proof.
+    assert!(
+        out.contains("science.nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A seismic wave is never sorted into a family by the source — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "seismic abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -50,6 +50,7 @@ per rotation, in parallel):
 | `physics/` | phase change → its name (melting, freezing, …) | LibreTexts (consensus) |
 | `physics/` | energy form → defining token (chemical → bonds, thermal → heat) | EIA (energy.gov) |
 | `physics/` | common force → everyday example NASA uses (gravity → waterfall, tension → ropes) | NASA GSFC Swift (authoritative) |
+| `physics/` | named wave → its family (sound → mechanical, radio → electromagnetic) | NASA Science (authoritative) |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |

--- a/code/specs/data/adj-facts-stdlib/physics/wave-types.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/wave-types.adj
@@ -1,0 +1,99 @@
+% ============================================================================
+% wave-types — each of several named waves and the WAVE FAMILY it belongs to,
+% mechanical or electromagnetic (adj-facts-stdlib, PHYSICS).
+% ============================================================================
+% An elementary/middle-school physics fact on the way to waves and optics:
+% every wave you meet is one of two great families. A MECHANICAL wave carries
+% energy by shaking matter, so it needs a medium (water, air, a rope). An
+% ELECTROMAGNETIC wave carries energy in oscillating electric and magnetic
+% fields, so it needs no medium at all and can cross the vacuum of space. Recall
+% is a binding query:
+%
+%     ? wave_family(sound, $F)   % mechanical
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `wave_family(wave, family)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the family
+% WITH its source, on the CPU, with zero model calls, and abstains on anything
+% the source does not classify.
+%
+% The named waves, as a little truth table (wave → the family NASA places it in):
+%
+%     wave            family            why (which sentence names it)
+%     -------------   ---------------   -----------------------------------------
+%     water           mechanical        "…examples of mechanical waves."
+%     sound           mechanical        "…examples of mechanical waves."
+%     rope            mechanical        "…waves on a rope … mechanical waves."
+%     gamma           electromagnetic   "…all forms of electromagnetic radiation:
+%                                        gamma rays…"
+%     xray            electromagnetic   "…X-rays…"
+%     visible_light   electromagnetic   "…visible light…"
+%     radio           electromagnetic   "…radio waves."
+%
+% This is the concrete rung a physics learner reasons UP from: before reasoning
+% about wavelength, frequency, refraction, or the Doppler effect, a student first
+% learns to SORT a wave into its family. The query also runs BACKWARD — bind the
+% family and recall a wave that belongs to it:
+%
+%     ? wave_family($W, electromagnetic)   % radio (or another EM wave) — reverse
+%
+% Something the source never sorts into a family — a seismic wave, a gravitational
+% wave — has no row, so a recall on it ABSTAINS rather than inventing a family.
+% That honest-abstention property is what makes the table safe to reason from.
+%
+% Each `family` value is one of the two SINGLE lowercase atoms the source itself
+% uses to name the two families — `mechanical` and `electromagnetic` — copied
+% verbatim from the sentence that classifies each wave; never a family the source
+% does not assign. Each `wave` key is a faithful short snake_case paraphrase of a
+% wave the source explicitly names (gamma rays → gamma, X-rays → xray, radio
+% waves → radio, visible light → visible_light).
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every wave→family pair was
+% read out of a fetched NASA education page this session, and any wave that could
+% not be grounded there would have been dropped). All rows come from the SAME
+% primary U.S. government source, NASA Science's James Webb Space Telescope
+% education asset "Electromagnetic Wave (Light Wave) vs. Mechanical Wave"
+% (science.nasa.gov/asset/webb/electromagnetic-wave-light-wave-vs-mechanical-wave/),
+% quoted here character-for-character so any reader can re-check it.
+%
+% The mechanical family (water, sound, rope) is fixed by ONE sentence —
+%
+%   "Water waves, sound waves, and waves on a rope are all examples of
+%    mechanical waves."
+%
+% The electromagnetic family (gamma, xray, visible_light, radio) is fixed by
+% ONE sentence —
+%
+%   "Light waves include all forms of electromagnetic radiation: gamma rays,
+%    X-rays, ultraviolet light, visible light, infrared light, microwaves, and
+%    radio waves."
+%
+% (and the same page names light itself as electromagnetic: "Light waves, also
+% called electromagnetic waves, involve oscillations of electric and magnetic
+% fields rather than oscillations of matter.")
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the NASA sentence that fixes the
+% three mechanical rows. The OTHER (electromagnetic) span is listed above, so
+% each row's family stays independently checkable. The source is a primary U.S.
+% government NASA education page (science.nasa.gov), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table wave_family {
+    columns wave, family
+
+    row (water, mechanical)
+    row (sound, mechanical)
+    row (rope, mechanical)
+    row (gamma, electromagnetic)
+    row (xray, electromagnetic)
+    row (visible_light, electromagnetic)
+    row (radio, electromagnetic)
+
+    source "Water waves, sound waves, and waves on a rope are all examples of mechanical waves."
+    locator "https://science.nasa.gov/asset/webb/electromagnetic-wave-light-wave-vs-mechanical-wave/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/physics/wave-types.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/wave-types.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% wave-types.query.adj — a worked recall over the physics wave-types library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "is sound a mechanical or
+% electromagnetic wave?": it states no physics fact — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `wave_family` rows and returns the family + the table's source/locator/
+% trust. The fifth query runs the relation BACKWARD (bind the family
+% `electromagnetic`, recall a wave that belongs to it — radio). A seismic wave is
+% never sorted into a family by the source, so a recall on it abstains honestly —
+% the engine never invents a family.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli wave-types.query.adj
+% ============================================================================
+
+import "wave-types.adj"
+
+? wave_family(sound, $F)          % expect mechanical
+? wave_family(water, $F)          % expect mechanical
+? wave_family(radio, $F)          % expect electromagnetic
+? wave_family(gamma, $F)          % expect electromagnetic
+? wave_family($W, electromagnetic) % expect radio (or another EM wave) — reverse recall
+? wave_family(seismic, $F)        % expect abstain — the source never sorts a seismic wave


### PR DESCRIPTION
Add a grounded ADJ facts library sorting each named wave into its wave
family (mechanical vs electromagnetic) as a native `table`. Recall is an
ordinary SLD binding query resolved on the CPU with 0 model calls; it runs
forward (wave → family), backward (family → wave), and abstains on any wave
the source never classifies.

Rows (all from ONE primary U.S. government source, trust=authoritative,
NASA Science JWST education asset "Electromagnetic Wave (Light Wave) vs.
Mechanical Wave",
https://science.nasa.gov/asset/webb/electromagnetic-wave-light-wave-vs-mechanical-wave/):

  water          → mechanical
  sound          → mechanical
  rope           → mechanical
      grounded in verbatim span:
      "Water waves, sound waves, and waves on a rope are all examples of
       mechanical waves."

  gamma          → electromagnetic
  xray           → electromagnetic
  visible_light  → electromagnetic
  radio          → electromagnetic
      grounded in verbatim span:
      "Light waves include all forms of electromagnetic radiation: gamma
       rays, X-rays, ultraviolet light, visible light, infrared light,
       microwaves, and radio waves."

Each `family` value (mechanical / electromagnetic) is copied verbatim from
the classifying sentence; each `wave` key is a faithful short snake_case
paraphrase of a wave the source explicitly names. Nothing asserted from
memory — every pair was read from the fetched NASA page this session.

Files:
- physics/wave-types.adj          — the grounded table
- physics/wave-types.query.adj    — worked forward/reverse/abstain recall
- facts_wavetypes_e2e.rs          — CLI e2e: binding recall + citation + abstain
- README.md                       — physics subject-index row added

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
