### PR TITLE
feat(sql): IN uses numeric equality and three-valued NULL logic

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.47 — IN uses numeric equality + three-valued NULL
+
+`1 IN (1.0)` now returns 1 (true) instead of 0: `IN` membership uses the same
+equality as `=`, so INTEGER and REAL compare numerically (`'1' IN (1)` stays
+false — text vs integer). `IN` is also now correctly three-valued for NULL: a
+NULL list element makes an otherwise-non-matching test NULL (`1 IN (NULL,2)` →
+NULL), while a real match still wins (`1 IN (NULL,1)` → 1); `NOT IN` inverts.
+Two new differential-oracle cases; sql-vm 0.4.25. The IN-collation folding
+(0.5.44) is unaffected.
+
 ## 0.5.46 — `||` concatenates blobs as raw bytes
 
 `X'41' || 'B'` now returns `'AB'` (0x41 = 'A'), not `"x'41'B"`. The `||` operator

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.46"
+version = "0.5.47"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1190,6 +1190,24 @@ const CASES: &[Case] = &[
     // operator), so that override is a separate grammar follow-up, not covered
     // here. The `is_collate_call` guard in `collate_comparisons` already handles
     // it once the syntax parses.)
+    // IN membership uses the same equality as `=`: numeric across INTEGER/REAL,
+    // and it is three-valued for NULL. `1 IN (1.0)` and `1.0 IN (1)` are true
+    // (numeric), `'1' IN (1)` is false (text vs int, no affinity), and a list
+    // element `1.0` matches `1`. Previously IN used exact same-variant equality,
+    // so `1 IN (1.0)` wrongly returned false.
+    Case {
+        id: "in_numeric_equality",
+        setup: &[],
+        query: "SELECT 1 IN (1.0) AS a, 1.0 IN (1) AS b, '1' IN (1) AS c, 1 IN (2,1.0,3) AS d, 5 IN (1,2) AS e",
+    },
+    // IN is three-valued: a NULL element makes an otherwise-non-matching test
+    // NULL (`1 IN (NULL,2)` → NULL), but a real match wins over a NULL element
+    // (`1 IN (NULL,1)` → 1). `NOT IN` inverts, so `5 NOT IN (NULL,2)` is NULL.
+    Case {
+        id: "in_null_three_valued",
+        setup: &[],
+        query: "SELECT (1 IN (NULL,2)) IS NULL AS a, 1 IN (NULL,1) AS b, (5 IN (NULL,2)) IS NULL AS c, 5 NOT IN (1,2) AS d, (5 NOT IN (NULL,2)) IS NULL AS e",
+    },
     // A column WITHOUT a declared collation keeps BINARY comparison — only the
     // exact-case match qualifies. Guards against over-applying the fold.
     Case {

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.25] - Unreleased
+
+### Fixed
+
+- **`IN` now uses `=` equality and three-valued NULL logic.** The `InList`
+  instruction tested membership with same-variant equality, so `1 IN (1.0)`
+  wrongly returned false and a NULL list element was ignored. It now uses
+  `sql_eq` (INTEGER/REAL compare numerically; text vs integer do not match) and
+  follows SQLite's three-valued rule: a match → true (even alongside NULLs); no
+  match with a NULL element present → NULL (`1 IN (NULL,2)`); otherwise false.
+  `NOT IN` inherits this, so `5 NOT IN (NULL,2)` is NULL. Collation-wrapped
+  operands (0.2.21's IN-collation) still fold correctly since both sides are
+  canonicalised before the compare.
+
 ## [0.4.24] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -443,9 +443,37 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
                     .map(|_| pop(&mut stack))
                     .collect::<Result<_, _>>()?;
                 let val = pop(&mut stack)?;
+                // SQLite IN is three-valued and uses the same equality as `=`:
+                //   • test value NULL            → NULL
+                //   • any element `=` the value  → 1 (true), even if NULLs present
+                //   • else if any element is NULL → NULL (the value *might* equal
+                //     the unknown), matching `1 IN (NULL,2)` → NULL
+                //   • else                        → 0 (false)
+                // `sql_eq` compares by storage class, so `1 IN (1.0)` is true
+                // (Int/Float compare numerically) while `'1' IN (1)` is false
+                // (text vs integer). This supersedes the old derived-`PartialEq`
+                // membership, which missed both numeric equality and NULL logic.
                 let result = match val {
                     SqlValue::Null => SqlValue::Null,
-                    v => SqlValue::Bool(items.contains(&v)),
+                    v => {
+                        let mut saw_null = false;
+                        let mut matched = false;
+                        for item in &items {
+                            if matches!(item, SqlValue::Null) {
+                                saw_null = true;
+                            } else if sql_eq(&v, item) {
+                                matched = true;
+                                break;
+                            }
+                        }
+                        if matched {
+                            SqlValue::Bool(true)
+                        } else if saw_null {
+                            SqlValue::Null
+                        } else {
+                            SqlValue::Bool(false)
+                        }
+                    }
                 };
                 stack.push(result);
             }
@@ -3974,6 +4002,53 @@ mod tests {
             Instruction::Halt,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![null()]]);
+    }
+
+    #[test]
+    fn test_in_list_numeric_equality() {
+        // `1 IN (1.0)` is TRUE — IN uses `=` equality, which compares INTEGER and
+        // REAL numerically (not by same-variant identity).
+        let run = |val: SqlValue, items: Vec<SqlValue>| {
+            let mut b = InMemoryBackend::new();
+            let n = items.len();
+            let mut prog_v = vec![Instruction::BeginRow, Instruction::LoadConst(val)];
+            for it in items {
+                prog_v.push(Instruction::LoadConst(it));
+            }
+            prog_v.push(Instruction::InList(n));
+            prog_v.push(Instruction::EmitColumn("r".to_string()));
+            prog_v.push(Instruction::EmitRow);
+            prog_v.push(Instruction::Halt);
+            execute(&prog(prog_v), &mut b).unwrap().rows[0][0].clone()
+        };
+        assert_eq!(run(int(1), vec![float(1.0)]), bool_val(true));
+        assert_eq!(run(float(1.0), vec![int(1)]), bool_val(true));
+        assert_eq!(run(int(1), vec![int(2), float(1.0), int(3)]), bool_val(true));
+        // Text vs integer do NOT match (no affinity in IN).
+        assert_eq!(run(SqlValue::Text("1".into()), vec![int(1)]), bool_val(false));
+    }
+
+    #[test]
+    fn test_in_list_null_three_valued() {
+        let run = |val: SqlValue, items: Vec<SqlValue>| {
+            let mut b = InMemoryBackend::new();
+            let n = items.len();
+            let mut prog_v = vec![Instruction::BeginRow, Instruction::LoadConst(val)];
+            for it in items {
+                prog_v.push(Instruction::LoadConst(it));
+            }
+            prog_v.push(Instruction::InList(n));
+            prog_v.push(Instruction::EmitColumn("r".to_string()));
+            prog_v.push(Instruction::EmitRow);
+            prog_v.push(Instruction::Halt);
+            execute(&prog(prog_v), &mut b).unwrap().rows[0][0].clone()
+        };
+        // No match but a NULL element present → NULL.
+        assert_eq!(run(int(5), vec![null(), int(2)]), null());
+        // A real match wins even with a NULL element present → true.
+        assert_eq!(run(int(1), vec![null(), int(1)]), bool_val(true));
+        // No match, no NULL element → false.
+        assert_eq!(run(int(5), vec![int(1), int(2)]), bool_val(false));
     }
 
     // ── 10. Scan / LoadColumn ─────────────────────────────────────────────────


### PR DESCRIPTION
## What

`1 IN (1.0)` now returns `1` (true), not `0`. The `InList` VM instruction tested membership with same-variant equality (`items.contains`), so INTEGER never matched REAL and a NULL list element was ignored.

Lane-2/3 increment in the mini-sqlite conformance rotation. This is the numeric-equality half of a chip alongside the (already-merged) blob-`||` fix.

## Change

`sql-vm` 0.4.25 — `InList` now:
- compares with **`sql_eq`** (INTEGER/REAL numerically; `'1' IN (1)` stays **false** — text vs integer, no affinity);
- follows SQLite's **three-valued** rule: a match → true (even alongside NULLs); no match with a NULL element present → **NULL** (`1 IN (NULL,2)`); otherwise false.

`NOT IN` inherits this correctly: `eval_unary`'s outer NULL guard propagates NULL, so `5 NOT IN (NULL,2)` is NULL — **verified directly against sqlite3 3.51.0**. `mini-sqlite` 0.5.47.

## Tests

- 2 differential-oracle cases (numeric equality; NULL three-valued incl. NOT IN) match real sqlite3.
- 5 sql-vm InList unit tests (match / no-match / null-val / numeric / null-three-valued).
- **Full suites green** — no regression, incl. the IN-collation cases from 0.5.44 (collation-wrapped operands reach `InList` already canonicalised and compare equal under `sql_eq`). sql-vm 106, mini-sqlite 45 + oracle. Downstream consumers build.
- Inline security review clean: loop bounded (`n ≤ 65_536`), no panic/overflow/DoS, three-valued logic verified (match dominates NULL; `break` on first match is correct).

## Pre-existing edge (not changed, out of scope)

`NULL IN ()` (empty list) → NULL here vs SQLite's `false`; requires empty IN lists and predates this change.

## Notes

Never self-merge — queued for review. No `_grammar.rs` touched (pure VM change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
