### PR TITLE
feat(adj-facts-stdlib): chemistry/mixture-types — mixture type → example table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_mixturetypes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_mixturetypes_e2e.rs
@@ -1,0 +1,73 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/mixture-types.adj`) driven through the built
+//! CLI: a native `table` of mixture kind → the everyday example the source names
+//! resolves binding-query recalls (forward and backward) with the source's
+//! LibreTexts citation, and abstains on a kind not in the table (alloy) — 0
+//! model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsmix_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_mixture_example_recall_binds_example_with_citation() {
+    let dir = scratch("mixturetypes");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/mixture-types.adj");
+    std::fs::copy(&src, dir.join("mixture-types.adj")).expect("copy shipped mixture-types.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mixture-types.adj\"\n\
+         ? mixture_example(colloid, $Example)\n\
+         ? mixture_example(suspension, $Example)\n\
+         ? mixture_example($Kind, vegetable_soup)\n\
+         ? mixture_example(alloy, $Example)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A colloid's everyday example is milk; a suspension's is salad dressing —
+    // the recalled example values (forward binds).
+    assert!(out.contains("\"Example\":\"milk\""), "colloid -> milk: {out}");
+    assert!(
+        out.contains("\"Example\":\"salad_dressing\""),
+        "suspension -> salad_dressing: {out}"
+    );
+    // The relation runs BACKWARD: bind the example vegetable_soup, recall the
+    // kind the source classifies it as — heterogeneous.
+    assert!(
+        out.contains("\"Kind\":\"heterogeneous\""),
+        "vegetable_soup -> heterogeneous (reverse recall): {out}"
+    );
+    // The answer carries the LibreTexts citation as its proof, at consensus trust
+    // (a secondary teaching reference, honestly tiered).
+    assert!(
+        out.contains("chem.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation at consensus trust: {out}"
+    );
+    // "alloy" is not in the table — honest abstention, never a fabricated example.
+    assert!(out.contains("\"abstained\":true"), "alloy abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -33,6 +33,7 @@ per rotation, in parallel):
 | `chemistry/` | common chemical → acid or base | LibreTexts (consensus) |
 | `chemistry/` | subatomic particle → electric charge (proton → positive) | DOE "Explains…Nuclei" (authoritative) |
 | `chemistry/` | chemical bond type → defining token (ionic → transfer) | LibreTexts (consensus) |
+| `chemistry/` | mixture kind → the everyday example the source names (colloid → milk) | LibreTexts (consensus) |
 | `metrology/` | SI prefix → power of ten | NIST |
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |

--- a/code/specs/data/adj-facts-stdlib/chemistry/mixture-types.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/mixture-types.adj
@@ -1,0 +1,95 @@
+% ============================================================================
+% mixture_example — each kind of mixture and the everyday example the source
+% names for it (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% An early-chemistry fact set: matter that is not a pure substance is a MIXTURE,
+% and a first chemistry course sorts mixtures into a few named kinds — is it
+% evenly blended (homogeneous) or visibly patchy (heterogeneous)? does the stuff
+% dissolve (a solution), settle out on standing (a suspension), or stay cloudy
+% and suspended forever (a colloid)? The easiest way to learn the kinds is by the
+% one everyday example a textbook points at for each. That is exactly what this
+% table records: a mixture kind → the sample the source names for it. Recall is a
+% binding query:
+%
+%     ? mixture_example(colloid, $Example)     % milk
+%
+% Like every FACTS library this is a native `table` (ADJ-TABLES RS-5): each `row`
+% lowers to a ground relation `mixture_example(mixture_type, example)` carrying
+% the table's citation, so the lookup above is the ordinary SLD binding query —
+% the engine returns the example WITH its source, on the CPU, with zero model
+% calls, and abstains on a kind that is not in the table. It also runs BACKWARD
+% (bind an example, recall the kind the source classifies it as):
+%
+%     ? mixture_example($Kind, vegetable_soup)  % heterogeneous
+%
+% The five rows, as a little truth table (follow each kind to the sample the
+% source names — the phrase the example word is copied out of):
+%
+%     mixture_type    example          what the source says
+%     -------------   --------------   -------------------------------------
+%     homogeneous     salt_water       "The salt water ... is homogeneous"
+%     solution        salt_water       salt mixed into water "will form a
+%                                       solution"
+%     heterogeneous   vegetable_soup   "Vegetable soup is a heterogeneous
+%                                       mixture."
+%     suspension      salad_dressing   "The salad dressing ... is a suspension."
+%     colloid         milk             "Homogenized milk is a colloid."
+%
+% Note that `salt_water` appears TWICE — as the example for both `homogeneous`
+% and `solution`. That is not a mistake but the source's own point: a solution IS
+% a homogeneous mixture (the page states "All solutions would be considered
+% homogeneous"), so its salt-water example is the natural witness for BOTH kinds.
+% A reverse recall on `salt_water` therefore honestly returns both rows; a reverse
+% recall on a value the source names only once (vegetable_soup, salad_dressing,
+% milk) binds a single kind.
+%
+% A mixture kind the source does not name an example for here — an `alloy`, an
+% `emulsion` — has no row, so a recall on it ABSTAINS rather than inventing an
+% example. That honest-abstention property is what makes the table safe to reason
+% from.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every mixture_type→example
+% pair was read out of a fetched teaching-reference page, and any pair whose
+% example word could not be copied verbatim from the source sentence was dropped).
+% All five rows come from the SAME source: the LibreTexts Chemistry page
+% "9.1: Mixtures" (chem.libretexts.org, Mendocino College "Introduction to
+% Chemistry (CHM 200)", §9.01). Each example word is copied character-for-
+% character out of that page's own sentence:
+%
+%   homogeneous → salt water
+%       "The salt water described above is homogeneous because the dissolved
+%        salt is evenly distributed throughout the entire salt water sample."
+%   solution → salt water
+%       "When the salt is thoroughly mixed into the water in this glass, it will
+%        form a solution."
+%   heterogeneous → vegetable soup
+%       "Vegetable soup is a heterogeneous mixture."
+%   suspension → salad dressing
+%       "The salad dressing in this bottle is a suspension."
+%   colloid → milk
+%       "Homogenized milk is a colloid."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source` below holds the
+% five verbatim example sentences (joined with " … "), the `locator` the page
+% URL, and `trust`. Every example word above therefore remains independently
+% checkable against the quoted sentence it was copied from. LibreTexts is a
+% SECONDARY teaching reference (a college course text, not a primary standards
+% body), so `trust consensus` — the honest tier for a teaching summary, per the
+% standard-library trust convention. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table mixture_example {
+    columns mixture_type, example
+
+    row (homogeneous, salt_water)
+    row (solution, salt_water)
+    row (heterogeneous, vegetable_soup)
+    row (suspension, salad_dressing)
+    row (colloid, milk)
+
+    source "The salt water described above is homogeneous because the dissolved salt is evenly distributed throughout the entire salt water sample. … When the salt is thoroughly mixed into the water in this glass, it will form a solution. … Vegetable soup is a heterogeneous mixture. … The salad dressing in this bottle is a suspension. … Homogenized milk is a colloid."
+    locator "https://chem.libretexts.org/Courses/Mendocino_College/Introduction_to_Chemistry_(CHM_200)/09:_Solutions_and_Aqueous_Mixtures/9.01:_Mixtures"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/mixture-types.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/mixture-types.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% mixture-types.query.adj — a worked recall over the chemistry mixture-types
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what's an example of a
+% colloid?": it states no chemistry fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `mixture_example` rows and returns the example + the table's source/locator/
+% trust. The fourth query runs the relation BACKWARD (bind the example
+% vegetable_soup, recall the kind the source classifies it as — heterogeneous).
+% An `alloy` is not in the table, so a recall on it abstains honestly — the
+% engine never invents an example.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli mixture-types.query.adj
+% ============================================================================
+
+import "mixture-types.adj"
+
+? mixture_example(colloid, $Example)        % expect milk
+? mixture_example(suspension, $Example)     % expect salad_dressing
+? mixture_example(heterogeneous, $Example)  % expect vegetable_soup
+? mixture_example($Kind, vegetable_soup)    % expect heterogeneous — reverse recall
+? mixture_example(alloy, $Example)          % expect abstain — alloy is not in the table


### PR DESCRIPTION
Add a grounded chemistry FACTS library mapping each kind of mixture to the
everyday example the source names for it, plus a worked recall query, an e2e
CLI test, and a chemistry subject-index README row.

Native `table` mixture_example(mixture_type, example); recall is a binding
query resolved on the CPU with 0 model calls, carrying the source citation,
running forward and backward, and abstaining on a kind not in the table (alloy).

Five rows, single axis, single source. Each example word copied verbatim from
its own sentence on the LibreTexts page "9.1: Mixtures" (Mendocino College,
Introduction to Chemistry CHM 200, §9.01):

  homogeneous   → salt_water      "The salt water described above is homogeneous..."
  solution      → salt_water      salt mixed into water "will form a solution"
  heterogeneous → vegetable_soup  "Vegetable soup is a heterogeneous mixture."
  suspension    → salad_dressing  "The salad dressing in this bottle is a suspension."
  colloid       → milk            "Homogenized milk is a colloid."

salt_water witnesses both homogeneous and solution because the source states a
solution IS homogeneous ("All solutions would be considered homogeneous"); this
is recorded honestly rather than deduplicated. LibreTexts is a secondary
teaching reference → trust consensus. Nothing asserted from memory; every value
byte-provenanced from the fetched page.

locator: https://chem.libretexts.org/Courses/Mendocino_College/Introduction_to_Chemistry_(CHM_200)/09:_Solutions_and_Aqueous_Mixtures/9.01:_Mixtures

Targeted test green: cargo test -p adj-lang-cli --test facts_mixturetypes_e2e.
Clippy clean: cargo clippy -p adj-lang -p adj-lang-cli --all-targets -D warnings.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
