### PR TITLE
feat(adj-facts-stdlib): biology/leaf-parts — leaf part → function table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_leafparts_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_leafparts_e2e.rs
@@ -1,0 +1,87 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/leaf-parts.adj`) driven through the built CLI:
+//! a native `table` of leaf parts → the defining token / function the source
+//! states resolves binding-query recalls (forward AND backward) with the
+//! source's Colorado State University Extension citation, and abstains on a word
+//! that is not one of these leaf parts (the root) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factlp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_leaf_parts_recall_binds_role_with_citation() {
+    let dir = scratch("leafparts");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/leaf-parts.adj");
+    std::fs::copy(&src, dir.join("leaf-parts.adj")).expect("copy shipped leaf-parts.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"leaf-parts.adj\"\n\
+         ? leaf_part_role(blade, $Role)\n\
+         ? leaf_part_role(stomata, $Role)\n\
+         ? leaf_part_role(cuticle, $Role)\n\
+         ? leaf_part_role(veins, $Role)\n\
+         ? leaf_part_role($Part, stalk)\n\
+         ? leaf_part_role(root, $Role)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The blade is the flattened part, the stomata are for gas exchange, the
+    // cuticle prevents water loss, the veins are xylem and phloem — the recalled
+    // roles (forward binds).
+    assert!(
+        out.contains("\"Role\":\"flattened\""),
+        "blade → flattened: {out}"
+    );
+    assert!(
+        out.contains("\"Role\":\"gas_exchange\""),
+        "stomata → gas_exchange: {out}"
+    );
+    assert!(
+        out.contains("\"Role\":\"prevents_water_loss\""),
+        "cuticle → prevents_water_loss: {out}"
+    );
+    assert!(
+        out.contains("\"Role\":\"xylem_and_phloem\""),
+        "veins → xylem_and_phloem: {out}"
+    );
+    // The relation runs BACKWARD: bind the role `stalk`, recall its leaf part.
+    assert!(
+        out.contains("\"Part\":\"petiole\""),
+        "stalk → petiole (reverse recall): {out}"
+    );
+    // The answer carries the CSU Extension citation as its proof, at the
+    // `authoritative` trust tier for a .edu-primary botany/extension source.
+    assert!(
+        out.contains("cmg.extension.colostate.edu") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The root is a plant part, not a part of the leaf — honest abstention,
+    // never a fabricated role.
+    assert!(out.contains("\"abstained\":true"), "root abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -47,6 +47,7 @@ per rotation, in parallel):
 | `biology/` | blood-vessel type → defining function (artery → away from heart) | NCI SEER Training |
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
+| `biology/` | leaf part → defining token / function (blade → flattened, stomata → gas_exchange) | Colorado State University Extension (authoritative) |
 | `physics/` | simple machine → everyday example | NASA |
 | `physics/` | phase change → its name (melting, freezing, …) | LibreTexts (consensus) |
 | `physics/` | energy form → defining token (chemical → bonds, thermal → heat) | EIA (energy.gov) |

--- a/code/specs/data/adj-facts-stdlib/biology/leaf-parts.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/leaf-parts.adj
@@ -1,0 +1,104 @@
+% ============================================================================
+% leaf-parts — the parts of a leaf and the defining token / function the
+% source states for each one (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A leaf is not one undifferentiated green flap: it is an assembly of named
+% parts, and a botany key names each part by the ONE thing it is or does. "The
+% blade is the flattened part; the petiole is the leaf stalk; the veins are the
+% xylem-and-phloem tissue; the stomata are the openings for gas exchange; the
+% cuticle prevents water loss; the epidermis is the outer layer." Before you can
+% reason about a leaf — identify it, diagnose it, or teach it — you must first
+% know WHICH part you are looking at and what that part is FOR. Recall is a
+% binding query:
+%
+%     ? leaf_part_role(stomata, $Role)      % gas_exchange
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `leaf_part_role(part, role)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the role
+% WITH its source, on the CPU, with zero model calls, and abstains on a word
+% that is not one of these leaf parts (it never invents a role).
+%
+% Each leaf part and the defining token / function the source states for it, as
+% a little truth table:
+%
+%     leaf part   defining token / function      a beginner's cue
+%     ---------   -------------------------      -----------------------------
+%     blade       flattened                      the flat green sheet of the leaf
+%     petiole     stalk                          the little stem that holds the leaf
+%     veins       xylem_and_phloem               the plumbing that runs through it
+%     stomata     gas_exchange                   pores that breathe in/out
+%     cuticle     prevents_water_loss            the waxy skin that seals it
+%     epidermis   outer                          the outermost layer of cells
+%
+% The query also runs BACKWARD — bind a role and recall the leaf part:
+%
+%     ? leaf_part_role($Part, stalk)   % petiole
+%
+% A word that is NOT one of these leaf parts — `root`, `flower`, `seed` — is
+% deliberately NOT a row, so a leaf-part recall ABSTAINS on it rather than
+% inventing a role. (The root is a plant part, but not a part of the LEAF.) That
+% honest-abstention property is what makes the table safe to build a reasoner
+% on: it answers exactly the part→role pairs it can ground, and only those.
+%
+% The `role` value of every row is a SINGLE lowercase atom, chosen to be a word
+% the source EXPLICITLY uses for that part — never one the source does not
+% support. Where the source's phrase is more than one word (the cuticle
+% "prevents water loss"; the veins are "xylem and phloem" tissue), the atom
+% joins the source's own words with underscores, so every value stays literally
+% checkable against the quoted span.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every part→role pair below
+% was read out of a single fetched Colorado State University Extension page, and
+% any pair whose role could not be verified there was dropped). Each pair, with
+% the verbatim span that states it, from CMG GardenNotes #134, "Plant
+% Structures: Leaves" (Colorado State University Extension, a land-grant .edu
+% cooperating with the U.S. Department of Agriculture):
+%   https://cmg.extension.colostate.edu/Gardennotes/134.pdf
+%
+%   blade → flattened
+%     "Leaf Blade – Flattened part of the leaf."
+%
+%   petiole → stalk
+%     "Petiole – Leaf stalk."
+%
+%   veins → xylem_and_phloem
+%     "Vascular bundle – Xylem and phloem tissues comprising the leaf veins."
+%
+%   stomata → gas_exchange
+%     "Stomates (Stomata) – Natural openings in leaves and herbaceous stems
+%      that allow for gas exchange (water vapor, carbon dioxide and oxygen) and
+%      plant cooling."
+%
+%   cuticle → prevents_water_loss
+%     "Cuticle – Waxy protective outer layer of epidermis that prevents water
+%      loss from leaves, green stems, and fruits."
+%
+%   epidermis → outer
+%     "Epidermis – Outer layer of cells"
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the CSU Extension statement that
+% fixes the first row (blade → flattened). Every OTHER row's verbatim span is
+% listed above, so each role remains independently checkable. The source is a
+% Colorado State University Extension botany teaching page (a .edu-primary
+% extension resource), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table leaf_part_role {
+    columns part, role
+
+    row (blade, flattened)
+    row (petiole, stalk)
+    row (veins, xylem_and_phloem)
+    row (stomata, gas_exchange)
+    row (cuticle, prevents_water_loss)
+    row (epidermis, outer)
+
+    source "Leaf Blade – Flattened part of the leaf."
+    locator "https://cmg.extension.colostate.edu/Gardennotes/134.pdf"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/leaf-parts.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/leaf-parts.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% leaf-parts.query.adj — a worked recall over the biology leaf-parts library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the petiole?" or
+% "what do the stomata do?": it states no botany fact of its own — it only
+% `import`s the grounded table and asks binding queries. The engine resolves
+% each `?` against the `leaf_part_role` rows and returns the role + the table's
+% source/locator/trust. The fifth query runs the relation BACKWARD (bind the
+% role `stalk`, recall its leaf part — petiole). A word that is not one of these
+% leaf parts abstains honestly — the engine never invents a role.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli leaf-parts.query.adj
+% ============================================================================
+
+import "leaf-parts.adj"
+
+? leaf_part_role(blade, $Role)      % expect flattened
+? leaf_part_role(stomata, $Role)    % expect gas_exchange
+? leaf_part_role(cuticle, $Role)    % expect prevents_water_loss
+? leaf_part_role(veins, $Role)      % expect xylem_and_phloem
+? leaf_part_role($Part, stalk)      % reverse bind — expect petiole
+? leaf_part_role(root, $Role)       % expect abstain — the root is a plant part, not a part of the leaf


### PR DESCRIPTION
Add a native ADJ `table` mapping each part of a leaf to the defining token /
function the source states for it, plus a worked `.query.adj` recall (forward,
reverse, and honest abstain) and an adj-lang-cli e2e test. Adds a biology
subject-index row to the adj-facts-stdlib README (all existing rows kept).

Single source, single axis, every value token verbatim from the source
sentence. Rows only where the source explicitly states the pair.

Provenance — Colorado State University Extension, CMG GardenNotes #134,
"Plant Structures: Leaves" (a .edu-primary land-grant extension botany page
cooperating with the USDA; trust: authoritative):
  https://cmg.extension.colostate.edu/Gardennotes/134.pdf

  blade    → flattened            "Leaf Blade – Flattened part of the leaf."
  petiole  → stalk                "Petiole – Leaf stalk."
  veins    → xylem_and_phloem     "Vascular bundle – Xylem and phloem tissues
                                   comprising the leaf veins."
  stomata  → gas_exchange         "Stomates (Stomata) – Natural openings ...
                                   that allow for gas exchange ... and plant
                                   cooling."
  cuticle  → prevents_water_loss  "Cuticle – Waxy protective outer layer of
                                   epidermis that prevents water loss ..."
  epidermis → outer               "Epidermis – Outer layer of cells"

Dropped: midrib (source gives no verbatim "central" token) and margin (source
never cleanly equates the margin with the edge) — could not be grounded.

Targeted e2e (cargo test -p adj-lang-cli --test facts_leafparts_e2e) passes;
clippy -p adj-lang -p adj-lang-cli --all-targets -D warnings clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
