### PR TITLE
feat(sql): binary arithmetic coerces text/blob operands via numeric affinity

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.48 — arithmetic coerces text/blob operands
+
+`'5' + 0` now returns 5 instead of erroring. Binary arithmetic (`+ - * / %`)
+applies SQLite numeric affinity to text/blob operands: `'abc' + 1` = 1, `'10' -
+'3'` = 7, `'5' * 2` = 10, `5 / '2'` = 2, `5 / '0'` = NULL, `'7' % 3` = 1. This is
+the binary analog of the unary-minus coercion (0.5.43). Comparison and bitwise
+operators are unaffected. Two new differential-oracle cases; sql-vm 0.4.26.
+Known edge (shared with unary minus): an integral real-syntax string `'9.0'`
+collapses to an integer, a float-affinity follow-up.
+
 ## 0.5.47 — IN uses numeric equality + three-valued NULL
 
 `1 IN (1.0)` now returns 1 (true) instead of 0: `IN` membership uses the same

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.47"
+version = "0.5.48"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1435,6 +1435,26 @@ const CASES: &[Case] = &[
         setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
         query: "SELECT (7 / 2) AS a, (-7 / 2) AS b, (7 % 3) AS c, (7.0 / 2) AS d FROM t",
     },
+    // Binary arithmetic applies NUMERIC affinity to text/blob operands, matching
+    // SQLite: `'5'+0` = 5 (integer), `'5.5'+0` = 5.5 (real), `'abc'+1` = 1 (no
+    // numeric prefix → 0), `'12abc'+0` = 12, and `'10'-'3'` = 7 (both coerced).
+    // Previously the engine errored on any text operand.
+    Case {
+        id: "arith_text_numeric_affinity",
+        setup: &[],
+        query: "SELECT '5'+0 AS a, '5.5'+0 AS b, 'abc'+1 AS c, '5'*2 AS d, '10'-'3' AS e, '12abc'+0 AS f",
+    },
+    // Division/modulo also coerce: `5 / '2'` = 2, `5 / '0'` = NULL (affinity makes
+    // '0' the integer zero, so the divide-by-zero → NULL rule fires), `'7' % 3` = 1.
+    // (Known edge left for later, shared with unary minus: an *integral* real-
+    // syntax string like `'9.0'` collapses to an integer here, so `'9.0' / 2` is
+    // 4 not SQLite's 4.5 — the float-affinity follow-up. Non-integral `'5.5'`
+    // is fine.)
+    Case {
+        id: "div_mod_text_affinity",
+        setup: &[],
+        query: "SELECT 5 / '2' AS a, (5 / '0') IS NULL AS b, '7' % 3 AS c, '5.5' * 2 AS d",
+    },
     // Unary minus applies NUMERIC affinity to a text/blob operand before
     // negating, matching SQLite: `-'5'` = -5, `-'12abc'` = -12 (leading numeric
     // prefix), `-'abc'` = 0 (no prefix → 0), `-'3.5'` = -3.5, and leading

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.26] - Unreleased
+
+### Fixed
+
+- **Binary arithmetic now applies numeric affinity to text/blob operands.**
+  `'5' + 0` errored ("cannot perform arithmetic on TEXT"); it now coerces via the
+  shared `coerce_arith`/`text_to_numeric` path and evaluates to 5, matching
+  SQLite. `'abc' + 1` = 1 (no numeric prefix → 0), `'10' - '3'` = 7, `'5' * 2` =
+  10; division and modulo coerce too (`5 / '2'` = 2, `5 / '0'` = NULL, `'7' % 3`
+  = 1). Bool operands use their integer value. Coercion is scoped to arithmetic
+  only — comparison and bitwise operators keep their own rules. Known edge shared
+  with unary minus: an integral real-syntax string (`'9.0'`) collapses to an
+  integer, so `'9.0' / 2` is 4 not SQLite's 4.5 (float-affinity follow-up).
+
 ## [0.4.25] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1991,6 +1991,9 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
             // `SELECT 5/0`, `5.0/0`, and `0/0` all yield NULL, never an error.
             // NULL operands were already short-circuited above, so a zero divisor
             // here is a genuine value. `*f == 0.0` also matches `-0.0`.
+            // Numeric affinity applies first, so `5 / '0'` is NULL and `5 / '2'`
+            // is 2, matching SQLite.
+            let (l, r) = (coerce_arith(l), coerce_arith(r));
             match (&l, &r) {
                 (_, SqlValue::Int(0)) => Ok(SqlValue::Null),
                 (_, SqlValue::Float(f)) if *f == 0.0 => Ok(SqlValue::Null),
@@ -2008,9 +2011,11 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
                 ))),
             }
         }
-        BinaryOp::Mod => match (&l, &r) {
-            // Like division, modulo by zero is NULL in SQLite (`5%0`, `5.5%0`,
-            // `5%0.0` → NULL), including a float-zero divisor — not an error.
+        BinaryOp::Mod => {
+          // Numeric affinity applies first (`'7' % 3` = 1); then modulo by zero
+          // is NULL in SQLite (`5%0`, `5.5%0`, `5%0.0`), not an error.
+          let (l, r) = (coerce_arith(l), coerce_arith(r));
+          match (&l, &r) {
             (_, SqlValue::Int(0)) => Ok(SqlValue::Null),
             (_, SqlValue::Float(f)) if *f == 0.0 => Ok(SqlValue::Null),
             (SqlValue::Int(a), SqlValue::Int(b)) => {
@@ -2024,7 +2029,8 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
             _ => Err(VmError::TypeMismatch(format!(
                 "cannot mod {:?} by {:?}", l.type_name(), r.type_name()
             ))),
-        },
+          }
+        }
 
         // ── Comparison ────────────────────────────────────────────────────────
         BinaryOp::Eq => Ok(SqlValue::Bool(sql_eq(&l, &r))),
@@ -2120,6 +2126,22 @@ fn sql_shift(value: i64, count: i64, left: bool) -> i64 {
 ///
 /// `int_op` is a checked variant (returns `Option<i64>`); `float_op` is unchecked
 /// (IEEE 754 overflow saturates to ±∞ which is the standard SQL behaviour).
+/// Apply SQLite numeric affinity to an arithmetic operand. Text/blob take their
+/// leading numeric prefix (`'5'`→5, `'5.5'`→5.5, `'12abc'`→12, `'abc'`→0, via
+/// [`text_to_numeric`]); a bool is its integer value; INTEGER/REAL pass through.
+/// NULL never reaches here — `eval_binary` short-circuits NULL operands before
+/// dispatching to arithmetic. Scoped to arithmetic only: comparison and bitwise
+/// operators apply their own (different) coercion rules.
+fn coerce_arith(v: SqlValue) -> SqlValue {
+    match v {
+        SqlValue::Int(_) | SqlValue::Float(_) => v,
+        SqlValue::Bool(b) => SqlValue::Int(b as i64),
+        SqlValue::Text(s) => text_to_numeric(&s),
+        SqlValue::Blob(b) => text_to_numeric(&String::from_utf8_lossy(&b)),
+        SqlValue::Null => SqlValue::Null,
+    }
+}
+
 fn checked_int_binop(
     l: SqlValue,
     r: SqlValue,
@@ -2127,6 +2149,8 @@ fn checked_int_binop(
     float_op: impl Fn(f64, f64) -> f64,
     op_name: &'static str,
 ) -> Result<SqlValue, VmError> {
+    // SQLite applies numeric affinity to arithmetic operands: `'5' + 0` = 5.
+    let (l, r) = (coerce_arith(l), coerce_arith(r));
     match (l, r) {
         (SqlValue::Int(a), SqlValue::Int(b)) => {
             int_op(a, b).map(SqlValue::Int).ok_or_else(|| {
@@ -3428,6 +3452,25 @@ mod tests {
             Instruction::Halt,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(7)]]);
+    }
+
+    #[test]
+    fn test_arith_text_numeric_affinity() {
+        // Binary arithmetic coerces text/blob operands via numeric affinity,
+        // matching SQLite: `'5' + 0` = 5, `'abc' + 1` = 1, `'10' - '3'` = 7.
+        let bin = |op: BinaryOp, l: SqlValue, r: SqlValue| eval_binary(&op, l, r).unwrap();
+        let t = |s: &str| SqlValue::Text(s.to_string());
+        assert_eq!(bin(BinaryOp::Add, t("5"), int(0)), int(5));
+        assert_eq!(bin(BinaryOp::Add, t("5.5"), int(0)), SqlValue::Float(5.5));
+        assert_eq!(bin(BinaryOp::Add, t("abc"), int(1)), int(1)); // no prefix → 0
+        assert_eq!(bin(BinaryOp::Mul, t("5"), int(2)), int(10));
+        assert_eq!(bin(BinaryOp::Sub, t("10"), t("3")), int(7));
+        // Division/modulo coerce too; `5 / '0'` → NULL (affinity → integer 0).
+        assert_eq!(bin(BinaryOp::Div, int(5), t("2")), int(2));
+        assert_eq!(bin(BinaryOp::Div, int(5), t("0")), null());
+        assert_eq!(bin(BinaryOp::Mod, t("7"), int(3)), int(1));
+        // NULL still short-circuits to NULL (handled before coercion).
+        assert_eq!(bin(BinaryOp::Add, t("5"), null()), null());
     }
 
     #[test]


### PR DESCRIPTION
## What

`'5' + 0` errored ("cannot perform arithmetic on TEXT"); it now evaluates to `5`, matching sqlite3 3.51.0. Binary arithmetic (`+ - * / %`) applies SQLite **numeric affinity** to text/blob operands — the binary analog of the unary-minus coercion (0.5.43).

Lane-1/2 increment in the mini-sqlite conformance rotation.

## Change

`sql-vm` 0.4.26 — a new `coerce_arith` helper (text/blob → `text_to_numeric`, bool → int, int/real pass through) is applied in `checked_int_binop` (Add/Sub/Mul) and at the top of the `Div`/`Mod` arms (before their divide-by-zero → NULL checks):

| Expr | Before | After / SQLite |
|------|--------|----------------|
| `'5' + 0` | error ❌ | `5` |
| `'abc' + 1` | error ❌ | `1` (no prefix → 0) |
| `'10' - '3'` | error ❌ | `7` |
| `'5' * 2` | error ❌ | `10` |
| `5 / '2'` | error ❌ | `2` |
| `5 / '0'` | error ❌ | `NULL` (affinity → int 0 → div-by-zero rule) |
| `'7' % 3` | error ❌ | `1` |

Coercion is **scoped to arithmetic** — comparison (`=`,`<`,…) and bitwise (`&`,`|`,`<<`) operators keep their own rules; NULL still short-circuits before coercion. `mini-sqlite` 0.5.48.

## Tests

- 2 differential-oracle cases (arithmetic + div/mod) match real sqlite3.
- sql-vm unit test (Add/Sub/Mul/Div/Mod on text, `5/'0'`→NULL, NULL short-circuit).
- **Full suites green, no regression** to Int/Float paths (sql-vm 107, mini-sqlite 45 + oracle). Downstream consumers build. Inline security review clean: checked overflow preserved (incl. `i64::MIN / -1`), `from_utf8_lossy` safe, comparison/bitwise arms confirmed untouched.

## Known edge (documented, out of scope)

An **integral real-syntax** string like `'9.0'` collapses to an integer, so `'9.0' / 2` is `4` not SQLite's `4.5` — the same float-affinity follow-up already noted for unary minus.

## Notes

Never self-merge — queued for review. No `_grammar.rs` touched (pure VM change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
