### PR TITLE
feat(human-language-data): HL01 cross-language data layer + validator

### DIFF
--- a/code/packages/typescript/human-language-data/BUILD
+++ b/code/packages/typescript/human-language-data/BUILD
@@ -1,0 +1,2 @@
+npm ci --quiet
+npx vitest run --coverage

--- a/code/packages/typescript/human-language-data/BUILD_windows
+++ b/code/packages/typescript/human-language-data/BUILD_windows
@@ -1,0 +1,2 @@
+npm ci --quiet
+npx vitest run --coverage

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to `@coding-adventures/human-language-data` are documented here.
+
+## [0.1.0] - 2026-07-17
+
+### Added
+- Initial release — the HL01 data layer over the Human Languages curriculum.
+- **Types** (`types.ts`): `Concept`, `Realization`, `Dataset`, `Taxonomy`,
+  `ScriptData`/`Glyph`/`VowelSign`, `Issue`.
+- **Frontmatter reader** (`frontmatter.ts`): a tiny zero-dependency parser for the
+  `key: value` / `[list]` frontmatter shape the lesson schema uses (BOM- and
+  CRLF-tolerant, quote-stripping, comment-skipping).
+- **Parser** (`parse.ts`): `parseLesson` derives a `Realization` from lesson
+  frontmatter (romanization defaults to headword for Latin scripts; gender sniffed
+  from the gloss when unfielded); `buildDataset` joins content lessons through the
+  taxonomy into concepts + per-language indexes.
+- **Validator** (`validate.ts`): the round-trip consistency gate — resolves every
+  concept tag, forbids duplicate realizations per language, checks required fields
+  and field shapes, script-glyph coverage, and core-concept coverage. Errors fail
+  CI; warnings/info are tolerated.
+- **Queries** (`queries.ts`): `allConcepts`, `conceptsByLanguage`,
+  `languagesForConcept`, `coverageByLanguage`.
+- **Loader + CLI** (`loader.ts`, `cli.ts`): the filesystem boundary — reads the
+  curriculum and runs `validate`. Declared `fs:read`/`fs:list` capabilities.
+- Tests for the pure core (frontmatter, parse, validate, queries) plus an
+  integration test that validates the **real** curriculum in CI and asserts the
+  cross-language joins (e.g. `GREETING-HELLO` across all 16 tracks).
+
+### Notes
+- `data/scripts/*.json` character-breakdown data is authored incrementally in
+  follow-up work; the package degrades gracefully when it is absent.

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -1,0 +1,74 @@
+# @coding-adventures/human-language-data
+
+The machine-readable bridge from the **Human Languages** curriculum (spec
+[`HL00`](../../../specs/HL00-human-language-curriculum-framework.md)) to the
+cross-language dataset that downstream tools — the Engram practice deck
+([`HL02`](../../../specs/HL02-companion-practice-app.md)) and anything later —
+consume. It implements [`HL01`](../../../specs/HL01-concept-taxonomy-and-data-layer.md).
+
+## What it does
+
+The curriculum is a pile of per-language Markdown lessons. This package parses
+their frontmatter, joins them through the canonical **concept taxonomy**
+(`concepts/taxonomy.json`), and exposes the result as a queryable dataset —
+plus a **validator** that keeps the lessons and the taxonomy from drifting apart.
+
+```
+lessons/*.md frontmatter  ─┐
+concepts/taxonomy.json     ─┼─►  Dataset { concepts, byLanguage, languages }
+data/scripts/*.json        ─┘         + validate() → Issue[]
+```
+
+The core is the **concept**: a language-independent idea (`GREETING-HELLO`). Each
+language's word for it is a **realization** (Spanish *hola*, Telugu *నమస్కారం*).
+That join is what lets a study app say "here is *hello* in every language you're
+learning."
+
+## Usage
+
+```ts
+import { loadEverything, languagesForConcept, validate } from "@coding-adventures/human-language-data";
+
+const { dataset, taxonomy, lessons, scripts } = loadEverything();
+
+// The cross-language join:
+languagesForConcept(dataset, "GREETING-HELLO");
+//  → [{ language: "spanish", headword: "hola", … }, { language: "telugu", … }, …]
+
+// The consistency gate:
+const issues = validate({ taxonomy, lessons, scripts });
+```
+
+### Architecture — a pure core with a thin fs shell
+
+| Module | Role | Pure? |
+|---|---|---|
+| `frontmatter.ts` | tiny zero-dep YAML-frontmatter reader | ✅ |
+| `parse.ts` | frontmatter → `Realization`; realizations → `Dataset` | ✅ |
+| `validate.ts` | the round-trip validator (errors fail CI; warnings tolerated) | ✅ |
+| `queries.ts` | `allConcepts` / `conceptsByLanguage` / `languagesForConcept` / `coverageByLanguage` | ✅ |
+| `loader.ts` | reads the curriculum off disk | ⛔ (fs) |
+| `cli.ts` | `validate` command + report | ⛔ (fs) |
+
+Only `loader.ts`/`cli.ts` touch the filesystem (declared in
+`required_capabilities.json`); everything the app relies on is pure and unit-tested
+against inline fixtures.
+
+## Validation rules (the CI gate)
+
+`validate()` returns a list of issues. **Errors** fail the build; **warnings** and
+**info** are reported but tolerated (some fields — `romanization`, `etymology_hook`
+— and the `data/scripts/*.json` character data are still being authored track by
+track). It checks: every content lesson's `concept_tag` resolves (canonical or
+namespaced), one realization per (concept, language), required fields present,
+field shapes, script-glyph coverage (where script data exists), and core-concept
+coverage (enforced only for tracks that declare `parity: complete`). The
+integration test runs it against the real curriculum, so drift breaks CI.
+
+## Scope note
+
+Script/character-breakdown data (`data/scripts/*.json`, the "learn to write, piece
+by piece" source) is authored incrementally, one script at a time, starting with
+Telugu/Kannada/Malayalam/Gurmukhi. This package reads whatever is present and
+degrades gracefully (coverage checks become warnings, then errors once a script
+file declares itself complete).

--- a/code/packages/typescript/human-language-data/package-lock.json
+++ b/code/packages/typescript/human-language-data/package-lock.json
@@ -1,0 +1,1570 @@
+{
+  "name": "@coding-adventures/human-language-data",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/human-language-data",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/human-language-data/package.json
+++ b/code/packages/typescript/human-language-data/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@coding-adventures/human-language-data",
+  "version": "0.1.0",
+  "description": "Cross-language concept dataset + validator derived from the Human Languages curriculum (spec HL01)",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "validate": "node --experimental-strip-types src/cli.ts validate",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "license": "MIT",
+  "author": "Adhithya Rajasekaran",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/human-language-data/required_capabilities.json
+++ b/code/packages/typescript/human-language-data/required_capabilities.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/human-language-data",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "../../learning/human-languages/**",
+      "justification": "The loader/CLI read the curriculum's lesson Markdown, concept taxonomy, and script JSON from the repo working tree to build and validate the cross-language dataset."
+    },
+    {
+      "category": "fs",
+      "action": "list",
+      "target": "../../learning/human-languages/**",
+      "justification": "The loader enumerates each track's lessons/ directory and data/scripts/ to discover files to parse."
+    }
+  ],
+  "justification": "Read-only filesystem access to the Human Languages curriculum directory. The parse/build/validate/query core is pure; only loader.ts and cli.ts touch the filesystem. No write, network, or process access needed."
+}

--- a/code/packages/typescript/human-language-data/src/cli.ts
+++ b/code/packages/typescript/human-language-data/src/cli.ts
@@ -1,0 +1,35 @@
+// CLI: `human-language-data validate` — the CI-facing entry point.
+// Loads the real curriculum, runs the validator, prints a report, and exits
+// non-zero if there are any errors.
+
+import { loadEverything } from "./loader.js";
+import { validate, hasErrors, summarize } from "./validate.js";
+import { coverageByLanguage } from "./queries.js";
+
+export function runValidate(root?: string): number {
+  const { taxonomy, lessons, scripts, dataset } = loadEverything(root);
+  const issues = validate({ taxonomy, lessons, scripts });
+
+  for (const issue of issues) {
+    const tag = issue.level.toUpperCase().padEnd(7);
+    process.stdout.write(`${tag} [${issue.code}] ${issue.message}\n`);
+  }
+
+  process.stdout.write(`\n${dataset.concepts.length} concepts, ${dataset.languages.length} languages\n`);
+  const cov = coverageByLanguage(dataset);
+  for (const lang of dataset.languages) {
+    process.stdout.write(`  ${lang.padEnd(12)} ${cov[lang].core} core / ${cov[lang].total} total\n`);
+  }
+  process.stdout.write(`\n${summarize(issues)}\n`);
+  return hasErrors(issues) ? 1 : 0;
+}
+
+// Run when invoked directly (node/tsx src/cli.ts validate).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const cmd = process.argv[2] ?? "validate";
+  if (cmd !== "validate") {
+    process.stderr.write(`unknown command '${cmd}'\n`);
+    process.exit(2);
+  }
+  process.exit(runValidate());
+}

--- a/code/packages/typescript/human-language-data/src/constants.ts
+++ b/code/packages/typescript/human-language-data/src/constants.ts
@@ -1,0 +1,39 @@
+// Fixed facts about the curriculum that the parser and validator lean on.
+import type { Script } from "./types.js";
+
+/**
+ * Which script each track is written in. HL01 imagines each track eventually
+ * declaring this itself (a `track.json`); until then this map is the single
+ * source of truth, kept here where it's easy to find and easy to extend when a
+ * new track (e.g. Gujarati) is added.
+ */
+export const LANGUAGE_SCRIPT: Record<string, Script> = {
+  spanish: "latin",
+  french: "latin",
+  german: "latin",
+  italian: "latin",
+  portuguese: "latin",
+  latin: "latin",
+  hindi: "devanagari",
+  marathi: "devanagari",
+  sanskrit: "devanagari",
+  punjabi: "gurmukhi",
+  bengali: "bengali",
+  tamil: "tamil",
+  kannada: "kannada",
+  telugu: "telugu",
+  malayalam: "malayalam",
+  arabic: "arabic",
+};
+
+/** Lesson types that teach a real concept and take part in the cross-language join. */
+export const CONTENT_TYPES = new Set(["word", "phrase"]);
+
+/** Lesson types that are session labels (review/recap) — exempt from the join. */
+export const EXEMPT_TYPES = new Set(["practice", "practice-mix", "review"]);
+
+/** A language-local concept id: two-letter lang prefix + SCREAMING-KEBAB name. */
+export const NAMESPACED_TAG = /^[A-Z]{2}-[A-Z0-9-]+$/;
+
+/** Longest an authored etymology hook may be (HL01). */
+export const MAX_ETYMOLOGY_HOOK = 120;

--- a/code/packages/typescript/human-language-data/src/constants.ts
+++ b/code/packages/typescript/human-language-data/src/constants.ts
@@ -37,3 +37,12 @@ export const NAMESPACED_TAG = /^[A-Z]{2}-[A-Z0-9-]+$/;
 
 /** Longest an authored etymology hook may be (HL01). */
 export const MAX_ETYMOLOGY_HOOK = 120;
+
+/**
+ * Own-property check that ignores the prototype chain. Lesson content controls
+ * concept ids, so a tag like `constructor` or `toString` must NOT resolve to an
+ * inherited Object member and sneak past validation as "canonical".
+ */
+export function hasOwn(obj: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}

--- a/code/packages/typescript/human-language-data/src/frontmatter.ts
+++ b/code/packages/typescript/human-language-data/src/frontmatter.ts
@@ -1,0 +1,67 @@
+// A deliberately tiny YAML-frontmatter reader.
+//
+// Lesson frontmatter is a flat block of `key: value` lines between two `---`
+// fences, where a value is a scalar or a simple `[a, b, c]` list. That's all the
+// schema uses, so a full YAML parser (and a third-party dependency, which this
+// repo forbids) would be overkill. This handles exactly that shape and nothing
+// more — which is a feature, not a limitation: it can't silently mis-parse
+// something clever because there's nothing clever to parse.
+
+export type FrontmatterValue = string | string[];
+
+export interface Frontmatter {
+  [key: string]: FrontmatterValue;
+}
+
+/**
+ * Split a document into its frontmatter block and body. Returns `null` for
+ * frontmatter if the document doesn't open with a `---` fence.
+ */
+export function splitFrontmatter(source: string): {
+  frontmatter: Frontmatter | null;
+  body: string;
+} {
+  // The block must be the very first thing in the file (after an optional BOM).
+  const text = source.replace(/^﻿/, "");
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(text);
+  if (!match) return { frontmatter: null, body: text };
+  return { frontmatter: parseBlock(match[1]), body: match[2] };
+}
+
+function parseBlock(block: string): Frontmatter {
+  const out: Frontmatter = {};
+  for (const raw of block.split(/\r?\n/)) {
+    const line = raw.trimEnd();
+    // Skip blanks and whole-line comments.
+    if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
+    const colon = line.indexOf(":");
+    if (colon === -1) continue; // not a key: value line — ignore
+    const key = line.slice(0, colon).trim();
+    if (key === "") continue;
+    out[key] = parseValue(line.slice(colon + 1).trim());
+  }
+  return out;
+}
+
+function parseValue(value: string): FrontmatterValue {
+  // A `[ ... ]` list — split on commas, trim, drop empties (so `[]` → `[]`).
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return value
+      .slice(1, -1)
+      .split(",")
+      .map((v) => unquote(v.trim()))
+      .filter((v) => v !== "");
+  }
+  return unquote(value);
+}
+
+function unquote(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -1,0 +1,25 @@
+// @coding-adventures/human-language-data
+//
+// The machine-readable bridge from the Human Languages curriculum (Markdown
+// lessons + concept taxonomy) to the cross-language dataset the Engram deck
+// generator and companion app consume. See code/specs/HL01-*.
+
+export * from "./types.js";
+export * from "./constants.js";
+export { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
+export { parseLesson, buildDataset, type ParsedLesson } from "./parse.js";
+export {
+  allConcepts,
+  conceptsByLanguage,
+  languagesForConcept,
+  coverageByLanguage,
+} from "./queries.js";
+export { validate, hasErrors, summarize, type ValidateInput } from "./validate.js";
+export {
+  defaultCurriculumRoot,
+  loadTaxonomy,
+  loadLessons,
+  loadScripts,
+  loadEverything,
+} from "./loader.js";
+export { runValidate } from "./cli.js";

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -1,0 +1,63 @@
+// The filesystem boundary. Everything impure lives here: it reads the curriculum
+// directory off disk and hands strings to the pure parse/build/validate core.
+// This is the only module that needs the `filesystem` capability.
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildDataset, parseLesson, type ParsedLesson } from "./parse.js";
+import type { Dataset, ScriptData, Taxonomy } from "./types.js";
+
+/** Default curriculum root: code/learning/human-languages, relative to this package. */
+export function defaultCurriculumRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // src/ -> human-language-data -> typescript -> packages -> code
+  return join(here, "..", "..", "..", "..", "learning", "human-languages");
+}
+
+export function loadTaxonomy(root = defaultCurriculumRoot()): Taxonomy {
+  const raw = JSON.parse(readFileSync(join(root, "concepts", "taxonomy.json"), "utf8"));
+  return { version: raw.version ?? 1, concepts: raw.concepts ?? {} };
+}
+
+/** Read every track's lessons/*.md into parsed lessons. */
+export function loadLessons(root = defaultCurriculumRoot()): ParsedLesson[] {
+  const out: ParsedLesson[] = [];
+  for (const track of readdirSync(root, { withFileTypes: true })) {
+    if (!track.isDirectory()) continue;
+    const lessonsDir = join(root, track.name, "lessons");
+    if (!existsSync(lessonsDir)) continue;
+    for (const file of readdirSync(lessonsDir)) {
+      if (!file.endsWith(".md")) continue;
+      const source = readFileSync(join(lessonsDir, file), "utf8");
+      out.push(parseLesson(source, track.name));
+    }
+  }
+  return out;
+}
+
+/** Read data/scripts/*.json (may be empty while scripts are still being authored). */
+export function loadScripts(root = defaultCurriculumRoot()): Record<string, ScriptData> {
+  const dir = join(root, "data", "scripts");
+  const out: Record<string, ScriptData> = {};
+  if (!existsSync(dir)) return out;
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".json")) continue;
+    const sd = JSON.parse(readFileSync(join(dir, file), "utf8")) as ScriptData;
+    out[sd.script] = sd;
+  }
+  return out;
+}
+
+/** Load and build everything from disk in one call. */
+export function loadEverything(root = defaultCurriculumRoot()): {
+  taxonomy: Taxonomy;
+  lessons: ParsedLesson[];
+  scripts: Record<string, ScriptData>;
+  dataset: Dataset;
+} {
+  const taxonomy = loadTaxonomy(root);
+  const lessons = loadLessons(root);
+  const scripts = loadScripts(root);
+  return { taxonomy, lessons, scripts, dataset: buildDataset(taxonomy, lessons) };
+}

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -4,7 +4,7 @@
 // lives in loader.ts.
 
 import { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
-import { LANGUAGE_SCRIPT, CONTENT_TYPES } from "./constants.js";
+import { LANGUAGE_SCRIPT, CONTENT_TYPES, hasOwn } from "./constants.js";
 import type {
   Concept,
   Dataset,
@@ -84,8 +84,10 @@ export function parseLesson(source: string, language: string): ParsedLesson {
 export function buildDataset(taxonomy: Taxonomy, lessons: ParsedLesson[]): Dataset {
   const content = lessons.filter((l) => CONTENT_TYPES.has(l.realization.type));
 
+  // null-prototype maps so a stray `__proto__`/`constructor` key from a
+  // filename-derived language or a concept tag can't collide with inherited members.
   const byConcept = new Map<string, Realization[]>();
-  const byLanguage: Record<string, Realization[]> = {};
+  const byLanguage: Record<string, Realization[]> = Object.create(null);
   for (const { realization } of content) {
     if (realization.concept === "") continue;
     (byConcept.get(realization.concept) ?? setGet(byConcept, realization.concept)).push(
@@ -96,7 +98,7 @@ export function buildDataset(taxonomy: Taxonomy, lessons: ParsedLesson[]): Datas
 
   const concepts: Concept[] = [];
   for (const [id, realizations] of byConcept) {
-    const canon = taxonomy.concepts[id];
+    const canon = hasOwn(taxonomy.concepts, id) ? taxonomy.concepts[id] : undefined;
     concepts.push({
       id,
       family: canon?.family ?? "(namespaced)",

--- a/code/packages/typescript/human-language-data/src/parse.ts
+++ b/code/packages/typescript/human-language-data/src/parse.ts
@@ -1,0 +1,124 @@
+// Turn lesson frontmatter into realizations, and realizations into a dataset.
+// Pure functions only — they take strings/objects in and return data out, with
+// no filesystem access, so they're trivially unit-testable. The fs boundary
+// lives in loader.ts.
+
+import { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
+import { LANGUAGE_SCRIPT, CONTENT_TYPES } from "./constants.js";
+import type {
+  Concept,
+  Dataset,
+  Gender,
+  Realization,
+  Script,
+  Taxonomy,
+} from "./types.js";
+
+/** A lesson after parsing: its raw frontmatter kept alongside the derived row. */
+export interface ParsedLesson {
+  language: string;
+  script: Script;
+  frontmatter: Frontmatter;
+  realization: Realization;
+}
+
+function arrayify(value: Frontmatter[string] | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") return [value];
+  return [];
+}
+
+function str(value: Frontmatter[string] | undefined): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** Gender: prefer an explicit field, else sniff the gloss, else none. */
+function deriveGender(fm: Frontmatter, gloss: string): Gender {
+  const explicit = str(fm.gender).toLowerCase();
+  if (explicit === "masc" || explicit === "masculine") return "masc";
+  if (explicit === "fem" || explicit === "feminine") return "fem";
+  if (explicit === "neut" || explicit === "neuter") return "neut";
+  if (/\bmasc/i.test(gloss)) return "masc";
+  if (/\bfem/i.test(gloss)) return "fem";
+  if (/\bneut/i.test(gloss)) return "neut";
+  return null;
+}
+
+/**
+ * Parse one lesson file's text into a ParsedLesson. `language` is the track slug
+ * (the lessons/ directory's parent). Missing fields are left empty/zero here and
+ * flagged later by the validator, so parsing never throws on imperfect input.
+ */
+export function parseLesson(source: string, language: string): ParsedLesson {
+  const { frontmatter } = splitFrontmatter(source);
+  const fm = frontmatter ?? {};
+  const script = LANGUAGE_SCRIPT[language] ?? "latin";
+  const headword = str(fm.headword);
+  const gloss = str(fm.gloss);
+  const chapterRaw = str(fm.chapter);
+  const romanization = str(fm.romanization) || (script === "latin" ? headword : "");
+
+  const realization: Realization = {
+    concept: str(fm.concept_tag),
+    language,
+    lessonId: str(fm.id),
+    chapter: chapterRaw === "" ? NaN : Number(chapterRaw),
+    type: str(fm.type) || "word",
+    headword,
+    gloss,
+    romanization,
+    script,
+    gender: deriveGender(fm, gloss),
+    sounds: arrayify(fm.sounds),
+    roots: arrayify(fm.roots),
+    etymologyHook: str(fm.etymology_hook),
+  };
+  return { language, script, frontmatter: fm, realization };
+}
+
+/**
+ * Assemble parsed lessons + the taxonomy into the queryable Dataset. Only
+ * content lessons (word/phrase) become concepts/realizations — practice and
+ * review lessons are session labels, not concepts.
+ */
+export function buildDataset(taxonomy: Taxonomy, lessons: ParsedLesson[]): Dataset {
+  const content = lessons.filter((l) => CONTENT_TYPES.has(l.realization.type));
+
+  const byConcept = new Map<string, Realization[]>();
+  const byLanguage: Record<string, Realization[]> = {};
+  for (const { realization } of content) {
+    if (realization.concept === "") continue;
+    (byConcept.get(realization.concept) ?? setGet(byConcept, realization.concept)).push(
+      realization,
+    );
+    (byLanguage[realization.language] ??= []).push(realization);
+  }
+
+  const concepts: Concept[] = [];
+  for (const [id, realizations] of byConcept) {
+    const canon = taxonomy.concepts[id];
+    concepts.push({
+      id,
+      family: canon?.family ?? "(namespaced)",
+      gloss: canon?.gloss ?? realizations[0]?.gloss ?? "",
+      core: canon?.core ?? false,
+      namespaced: canon === undefined,
+      realizations,
+    });
+  }
+  concepts.sort((a, b) => a.id.localeCompare(b.id));
+
+  return {
+    taxonomy,
+    concepts,
+    byLanguage,
+    languages: Object.keys(byLanguage).sort(),
+  };
+}
+
+// Small helper: get-or-create a bucket in a Map.
+function setGet<K, V>(map: Map<K, V[]>, key: K): V[] {
+  const fresh: V[] = [];
+  map.set(key, fresh);
+  return fresh;
+}

--- a/code/packages/typescript/human-language-data/src/queries.ts
+++ b/code/packages/typescript/human-language-data/src/queries.ts
@@ -1,0 +1,42 @@
+// The typed accessors HL01 promises. Thin, pure lookups over a built Dataset —
+// these are what the Engram deck generator and the companion app call.
+
+import type { Concept, Dataset, Realization } from "./types.js";
+
+/** Every concept (canonical + namespaced), id-sorted. */
+export function allConcepts(dataset: Dataset): Concept[] {
+  return dataset.concepts;
+}
+
+/** Every concept a given language realizes. */
+export function conceptsByLanguage(dataset: Dataset, language: string): Concept[] {
+  return dataset.concepts.filter((c) =>
+    c.realizations.some((r) => r.language === language),
+  );
+}
+
+/**
+ * Every language's realization of a concept — the cross-language join that
+ * powers "the same word in Spanish, French, German." Empty if unknown.
+ */
+export function languagesForConcept(dataset: Dataset, concept: string): Realization[] {
+  return dataset.concepts.find((c) => c.id === concept)?.realizations ?? [];
+}
+
+/** How many `core` concepts each language realizes — the parity dashboard. */
+export function coverageByLanguage(
+  dataset: Dataset,
+): Record<string, { core: number; total: number }> {
+  const coreIds = new Set(
+    dataset.concepts.filter((c) => c.core).map((c) => c.id),
+  );
+  const out: Record<string, { core: number; total: number }> = {};
+  for (const lang of dataset.languages) {
+    const concepts = conceptsByLanguage(dataset, lang);
+    out[lang] = {
+      total: concepts.length,
+      core: concepts.filter((c) => coreIds.has(c.id)).length,
+    };
+  }
+  return out;
+}

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -1,0 +1,118 @@
+// Data model for the Human Languages data layer (spec: code/specs/HL01-*).
+//
+// The whole point of this package is to turn the curriculum's Markdown lessons
+// into something a program can reason about *across* languages. The unit of that
+// reasoning is the CONCEPT — a language-independent idea ("the greeting you say
+// on meeting someone") — and each language's word for it is a REALIZATION. These
+// types are that model.
+
+/** A writing system. Every track uses exactly one; `latin` needs no script data. */
+export type Script =
+  | "latin"
+  | "devanagari"
+  | "bengali"
+  | "gurmukhi"
+  | "tamil"
+  | "telugu"
+  | "kannada"
+  | "malayalam"
+  | "arabic";
+
+/** Grammatical gender tag on a noun. `null` when the language/word carries none. */
+export type Gender = "masc" | "fem" | "neut" | null;
+
+/** One entry in `concepts/taxonomy.json` — a canonical universal concept. */
+export interface TaxonomyConcept {
+  family: string;
+  gloss: string;
+  /** Expected in every track once it declares parity. */
+  core: boolean;
+  /** Pre-canonical tags this id replaced, for traceability. */
+  retires?: string[];
+  notes?: string;
+}
+
+export interface Taxonomy {
+  version: number;
+  concepts: Record<string, TaxonomyConcept>;
+}
+
+/**
+ * One language's realization of a concept — the row the app turns into a card.
+ * Derived from a single lesson's frontmatter (plus a couple of best-effort
+ * heuristics where the field isn't authored yet).
+ */
+export interface Realization {
+  concept: string; // canonical or namespaced concept id
+  language: string; // track slug: "spanish", "telugu", …
+  lessonId: string; // e.g. ES-C01-dia
+  chapter: number;
+  type: string; // word | phrase | practice | practice-mix | review
+  headword: string; // "día" / "నమస్కారం"
+  gloss: string; // "day (el día — masculine)"
+  romanization: string; // "DEE-ah"; = headword for Latin script; "" if unknown
+  script: Script;
+  gender: Gender;
+  sounds: string[]; // ids into pronunciation-reference.md
+  roots: string[]; // etymological roots, for indexing
+  etymologyHook: string; // ≤120-char memory anchor; "" if not authored yet
+}
+
+/** A concept plus every language that realizes it — the cross-language join. */
+export interface Concept {
+  id: string;
+  family: string;
+  gloss: string;
+  core: boolean;
+  /** True when language-local (namespaced id, not in the taxonomy). */
+  namespaced: boolean;
+  realizations: Realization[];
+}
+
+/** The whole parsed curriculum, ready for querying. */
+export interface Dataset {
+  taxonomy: Taxonomy;
+  concepts: Concept[];
+  byLanguage: Record<string, Realization[]>;
+  languages: string[];
+}
+
+// ---- Script / character-breakdown data (data/scripts/<script>.json) ----
+
+export interface Glyph {
+  glyph: string;
+  sound: string;
+  type: "consonant" | "vowel" | "sign" | "conjunct" | "other";
+  inherentVowel?: string;
+  /** The literal "pieces" of the character, for paper practice. */
+  components: string[];
+  /** Typical handwriting order — conventional, not canonical. */
+  strokeOrder: string[];
+  strokeOrderNote: string;
+  notes?: string;
+}
+
+export interface VowelSign {
+  sign: string;
+  sound: string;
+  attachesAs: string;
+  example?: { base: string; combined: string; sound: string };
+}
+
+export interface ScriptData {
+  script: Script;
+  font: string;
+  abugida: boolean;
+  glyphs: Glyph[];
+  vowelSigns: VowelSign[];
+  conjunctRule?: string;
+}
+
+// ---- Validation ----
+
+export interface Issue {
+  level: "error" | "warning" | "info";
+  code: string;
+  message: string;
+  lessonId?: string;
+}

--- a/code/packages/typescript/human-language-data/src/validate.ts
+++ b/code/packages/typescript/human-language-data/src/validate.ts
@@ -1,0 +1,149 @@
+// The round-trip validator (HL01 §"The round-trip validator").
+//
+// This is the guard that keeps the lessons and the taxonomy from drifting apart.
+// It runs in CI (via a test that loads the real curriculum). ERRORS fail the
+// build; WARNINGS and INFO are reported but tolerated, because some things
+// (romanization fields, script data) are still being authored track by track.
+
+import {
+  CONTENT_TYPES,
+  EXEMPT_TYPES,
+  MAX_ETYMOLOGY_HOOK,
+  NAMESPACED_TAG,
+} from "./constants.js";
+import type { Issue, ScriptData, Taxonomy } from "./types.js";
+import type { ParsedLesson } from "./parse.js";
+
+export interface ValidateInput {
+  taxonomy: Taxonomy;
+  lessons: ParsedLesson[];
+  /** Optional per-script character data, keyed by script name. */
+  scripts?: Record<string, ScriptData>;
+  /** Tracks that declare parity:complete — core coverage is enforced for these. */
+  completeTracks?: Set<string>;
+}
+
+export function validate(input: ValidateInput): Issue[] {
+  const { taxonomy, lessons, scripts = {}, completeTracks = new Set() } = input;
+  const issues: Issue[] = [];
+  const err = (code: string, message: string, lessonId?: string) =>
+    issues.push({ level: "error", code, message, lessonId });
+  const warn = (code: string, message: string, lessonId?: string) =>
+    issues.push({ level: "warning", code, message, lessonId });
+  const info = (code: string, message: string, lessonId?: string) =>
+    issues.push({ level: "info", code, message, lessonId });
+
+  // Per-(language) content-concept ledger, to catch duplicate realizations.
+  const seen = new Map<string, string>(); // `${lang}|${concept}` -> lessonId
+
+  for (const { realization: r } of lessons) {
+    const id = r.lessonId || "(no id)";
+    const isContent = CONTENT_TYPES.has(r.type);
+    const isExempt = EXEMPT_TYPES.has(r.type);
+
+    // (3) Required fields — every lesson.
+    if (r.headword === "") err("missing-headword", `${id}: no headword`, id);
+    if (r.gloss === "") err("missing-gloss", `${id}: no gloss`, id);
+    if (Number.isNaN(r.chapter)) err("missing-chapter", `${id}: no/invalid chapter`, id);
+    if (!isContent && !isExempt) {
+      warn("unknown-type", `${id}: unrecognized type '${r.type}'`, id);
+    }
+
+    if (!isContent) continue; // only content lessons join the taxonomy
+
+    // (1) The concept tag must resolve.
+    if (r.concept === "") {
+      err("missing-concept", `${id}: content lesson has no concept_tag`, id);
+    } else if (!(r.concept in taxonomy.concepts) && !NAMESPACED_TAG.test(r.concept)) {
+      err(
+        "unresolved-concept",
+        `${id}: concept_tag '${r.concept}' is neither canonical nor namespaced`,
+        id,
+      );
+    }
+
+    // (2) One realization per (concept, language).
+    if (r.concept !== "") {
+      const key = `${r.language}|${r.concept}`;
+      const prev = seen.get(key);
+      if (prev) {
+        err(
+          "duplicate-realization",
+          `${r.language}: concept '${r.concept}' realized twice (${prev} and ${id})`,
+          id,
+        );
+      } else {
+        seen.set(key, id);
+      }
+    }
+
+    // (6) Field shapes.
+    if (r.script !== "latin" && r.romanization === "") {
+      warn("missing-romanization", `${id}: non-Latin lesson missing romanization`, id);
+    }
+    if (r.etymologyHook.length > MAX_ETYMOLOGY_HOOK) {
+      warn(
+        "long-etymology-hook",
+        `${id}: etymology_hook is ${r.etymologyHook.length} chars (max ${MAX_ETYMOLOGY_HOOK})`,
+        id,
+      );
+    }
+
+    // (4) Script glyph references resolve (only where we have the script data).
+    const sd = scripts[r.script];
+    if (sd) {
+      const uncovered = uncoveredGlyphs(r.headword, sd);
+      if (uncovered.length > 0) {
+        warn(
+          "uncovered-glyphs",
+          `${id}: characters not yet in ${r.script}.json: ${uncovered.join(" ")}`,
+          id,
+        );
+      }
+    }
+  }
+
+  // (5) Core-concept coverage — enforced only for parity-complete tracks.
+  const languages = [...new Set(lessons.map((l) => l.language))];
+  const coreConcepts = Object.entries(taxonomy.concepts)
+    .filter(([, c]) => c.core)
+    .map(([id]) => id);
+  for (const lang of languages) {
+    const realized = new Set(
+      lessons
+        .filter((l) => l.language === lang && CONTENT_TYPES.has(l.realization.type))
+        .map((l) => l.realization.concept),
+    );
+    const missing = coreConcepts.filter((c) => !realized.has(c));
+    if (missing.length === 0) continue;
+    const msg = `${lang}: missing ${missing.length} core concept(s): ${missing.join(", ")}`;
+    if (completeTracks.has(lang)) err("core-coverage", msg);
+    else info("core-coverage", msg);
+  }
+
+  return issues;
+}
+
+/** Characters of a headword not represented anywhere in the script data. */
+function uncoveredGlyphs(headword: string, sd: ScriptData): string[] {
+  const covered = new Set<string>();
+  for (const g of sd.glyphs) for (const ch of g.glyph) covered.add(ch);
+  for (const v of sd.vowelSigns) for (const ch of v.sign) covered.add(ch);
+  const skip = /[\s\p{P}‌‍]/u; // spaces, punctuation, ZWNJ/ZWJ
+  const out: string[] = [];
+  for (const ch of headword) {
+    if (skip.test(ch)) continue;
+    if (!covered.has(ch) && !out.includes(ch)) out.push(ch);
+  }
+  return out;
+}
+
+export function hasErrors(issues: Issue[]): boolean {
+  return issues.some((i) => i.level === "error");
+}
+
+/** A one-line-per-level tally, handy for CLI/test output. */
+export function summarize(issues: Issue[]): string {
+  const n = (lvl: string) => issues.filter((i) => i.level === lvl).length;
+  return `${n("error")} error(s), ${n("warning")} warning(s), ${n("info")} info`;
+}

--- a/code/packages/typescript/human-language-data/src/validate.ts
+++ b/code/packages/typescript/human-language-data/src/validate.ts
@@ -8,6 +8,7 @@
 import {
   CONTENT_TYPES,
   EXEMPT_TYPES,
+  hasOwn,
   MAX_ETYMOLOGY_HOOK,
   NAMESPACED_TAG,
 } from "./constants.js";
@@ -54,7 +55,7 @@ export function validate(input: ValidateInput): Issue[] {
     // (1) The concept tag must resolve.
     if (r.concept === "") {
       err("missing-concept", `${id}: content lesson has no concept_tag`, id);
-    } else if (!(r.concept in taxonomy.concepts) && !NAMESPACED_TAG.test(r.concept)) {
+    } else if (!hasOwn(taxonomy.concepts, r.concept) && !NAMESPACED_TAG.test(r.concept)) {
       err(
         "unresolved-concept",
         `${id}: concept_tag '${r.concept}' is neither canonical nor namespaced`,

--- a/code/packages/typescript/human-language-data/tests/cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/cli.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from "vitest";
+import { runValidate } from "../src/cli.js";
+
+describe("runValidate", () => {
+  it("returns 0 (no errors) on the real curriculum and prints a report", () => {
+    const out = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const code = runValidate();
+    const printed = out.mock.calls.map((c) => String(c[0])).join("");
+    out.mockRestore();
+
+    expect(code).toBe(0);
+    expect(printed).toMatch(/concepts, \d+ languages/);
+    expect(printed).toMatch(/error\(s\)/);
+    expect(printed).toContain("spanish");
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/frontmatter.test.ts
+++ b/code/packages/typescript/human-language-data/tests/frontmatter.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { splitFrontmatter } from "../src/frontmatter.js";
+
+describe("splitFrontmatter", () => {
+  it("parses scalars, lists, and the body", () => {
+    const src = [
+      "---",
+      "id: ES-C01-dia",
+      "chapter: 1",
+      "type: word",
+      "headword: día",
+      "prerequisites: [ES-C01-el-la, ES-C01-hola]",
+      "reviews_of: []",
+      "---",
+      "# Body starts here",
+      "text",
+    ].join("\n");
+    const { frontmatter, body } = splitFrontmatter(src);
+    expect(frontmatter).toMatchObject({
+      id: "ES-C01-dia",
+      chapter: "1",
+      type: "word",
+      headword: "día",
+      prerequisites: ["ES-C01-el-la", "ES-C01-hola"],
+      reviews_of: [],
+    });
+    expect(body.trim().startsWith("# Body")).toBe(true);
+  });
+
+  it("strips single and double quotes from values", () => {
+    const { frontmatter } = splitFrontmatter(
+      ['---', 'etymology_hook: "día ← dies"', "gloss: 'day'", "---", ""].join("\n"),
+    );
+    expect(frontmatter?.etymology_hook).toBe("día ← dies");
+    expect(frontmatter?.gloss).toBe("day");
+  });
+
+  it("ignores blank lines and comment lines inside the block", () => {
+    const { frontmatter } = splitFrontmatter(
+      ["---", "# a comment", "", "id: X", "---", ""].join("\n"),
+    );
+    expect(frontmatter).toEqual({ id: "X" });
+  });
+
+  it("returns null frontmatter when there is no fence", () => {
+    const { frontmatter, body } = splitFrontmatter("no frontmatter here");
+    expect(frontmatter).toBeNull();
+    expect(body).toBe("no frontmatter here");
+  });
+
+  it("tolerates a leading BOM and CRLF line endings", () => {
+    const { frontmatter } = splitFrontmatter("﻿---\r\nid: X\r\n---\r\nbody");
+    expect(frontmatter).toEqual({ id: "X" });
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -1,0 +1,45 @@
+// The CI gate: load the *real* curriculum off disk and assert it stays
+// consistent with the taxonomy. If a future lesson drifts (an unknown tag, a
+// duplicate realization, a missing required field), this test fails the build.
+
+import { describe, it, expect } from "vitest";
+import { loadEverything } from "../src/loader.js";
+import { validate, hasErrors } from "../src/validate.js";
+import { languagesForConcept } from "../src/queries.js";
+
+const { taxonomy, lessons, scripts, dataset } = loadEverything();
+
+describe("real curriculum", () => {
+  it("has zero validation errors", () => {
+    const issues = validate({ taxonomy, lessons, scripts });
+    const errors = issues.filter((i) => i.level === "error");
+    // Surface any error messages so a failure is self-explaining.
+    expect(errors.map((e) => e.message)).toEqual([]);
+    expect(hasErrors(issues)).toBe(false);
+  });
+
+  it("loaded all 16 tracks", () => {
+    expect(dataset.languages.length).toBe(16);
+    expect(dataset.languages).toContain("spanish");
+    expect(dataset.languages).toContain("telugu");
+    expect(dataset.languages).toContain("arabic");
+  });
+
+  it("GREETING-HELLO joins every track (the normalization payoff)", () => {
+    const langs = languagesForConcept(dataset, "GREETING-HELLO").map((r) => r.language);
+    expect(new Set(langs).size).toBe(16);
+  });
+
+  it("the self-introduction concepts join many languages", () => {
+    expect(languagesForConcept(dataset, "INTRO-MY-NAME-IS").length).toBeGreaterThanOrEqual(8);
+    expect(languagesForConcept(dataset, "INTRO-WHATS-YOUR-NAME").length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("every concept id is canonical or namespaced", () => {
+    const NS = /^[A-Z]{2}-[A-Z0-9-]+$/;
+    for (const c of dataset.concepts) {
+      const ok = c.id in taxonomy.concepts || NS.test(c.id);
+      expect(ok, `bad concept id: ${c.id}`).toBe(true);
+    }
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/parse.test.ts
+++ b/code/packages/typescript/human-language-data/tests/parse.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { parseLesson, buildDataset } from "../src/parse.js";
+import type { Taxonomy } from "../src/types.js";
+
+const lesson = (fields: Record<string, string>) =>
+  ["---", ...Object.entries(fields).map(([k, v]) => `${k}: ${v}`), "---", "body"].join("\n");
+
+const taxonomy: Taxonomy = {
+  version: 1,
+  concepts: {
+    "GREETING-HELLO": { family: "GREETING", gloss: "hello", core: true },
+    "TIME-DAY": { family: "TIME", gloss: "day", core: false },
+  },
+};
+
+describe("parseLesson", () => {
+  it("derives romanization from headword for Latin scripts", () => {
+    const p = parseLesson(
+      lesson({ id: "ES-C01-hola", chapter: "1", type: "word", headword: "hola", gloss: "hello", concept_tag: "GREETING-HELLO" }),
+      "spanish",
+    );
+    expect(p.script).toBe("latin");
+    expect(p.realization.romanization).toBe("hola");
+    expect(p.realization.concept).toBe("GREETING-HELLO");
+  });
+
+  it("keeps romanization empty for a non-Latin lesson that omits it", () => {
+    const p = parseLesson(
+      lesson({ id: "TE-C01-hi", chapter: "1", type: "word", headword: "నమస్కారం", gloss: "hello", concept_tag: "GREETING-HELLO" }),
+      "telugu",
+    );
+    expect(p.script).toBe("telugu");
+    expect(p.realization.romanization).toBe("");
+  });
+
+  it("prefers an explicit romanization field", () => {
+    const p = parseLesson(
+      lesson({ id: "TE-C01-hi", chapter: "1", type: "word", headword: "నమస్కారం", gloss: "hello", concept_tag: "GREETING-HELLO", romanization: "namaskāram" }),
+      "telugu",
+    );
+    expect(p.realization.romanization).toBe("namaskāram");
+  });
+
+  it("sniffs gender from the gloss when no field is present", () => {
+    const masc = parseLesson(lesson({ id: "x", chapter: "1", type: "word", headword: "día", gloss: "day (el día — masculine)", concept_tag: "TIME-DAY" }), "spanish");
+    expect(masc.realization.gender).toBe("masc");
+    const fem = parseLesson(lesson({ id: "y", chapter: "1", type: "word", headword: "noche", gloss: "night (feminine)", concept_tag: "TIME-NIGHT" }), "spanish");
+    expect(fem.realization.gender).toBe("fem");
+    const none = parseLesson(lesson({ id: "z", chapter: "1", type: "word", headword: "hola", gloss: "hello", concept_tag: "GREETING-HELLO" }), "spanish");
+    expect(none.realization.gender).toBeNull();
+  });
+
+  it("marks chapter NaN when missing", () => {
+    const p = parseLesson(lesson({ id: "x", type: "word", headword: "h", gloss: "g", concept_tag: "GREETING-HELLO" }), "spanish");
+    expect(Number.isNaN(p.realization.chapter)).toBe(true);
+  });
+
+  it("defaults unknown languages to the latin script", () => {
+    const p = parseLesson(lesson({ id: "x", chapter: "1", type: "word", headword: "h", gloss: "g", concept_tag: "GREETING-HELLO" }), "esperanto");
+    expect(p.script).toBe("latin");
+  });
+});
+
+describe("buildDataset", () => {
+  it("joins the same concept across languages and excludes practice lessons", () => {
+    const lessons = [
+      parseLesson(lesson({ id: "ES", chapter: "1", type: "word", headword: "hola", gloss: "hello", concept_tag: "GREETING-HELLO" }), "spanish"),
+      parseLesson(lesson({ id: "DE", chapter: "1", type: "word", headword: "hallo", gloss: "hello", concept_tag: "GREETING-HELLO" }), "german"),
+      parseLesson(lesson({ id: "ES-P", chapter: "1", type: "practice-mix", headword: "(practice)", gloss: "recap", concept_tag: "CH1-PRACTICE" }), "spanish"),
+      parseLesson(lesson({ id: "ES-DIA", chapter: "1", type: "word", headword: "día", gloss: "day", concept_tag: "ES-WORD-DIA" }), "spanish"),
+    ];
+    const ds = buildDataset(taxonomy, lessons);
+
+    const hello = ds.concepts.find((c) => c.id === "GREETING-HELLO");
+    expect(hello?.realizations.map((r) => r.language).sort()).toEqual(["german", "spanish"]);
+    expect(hello?.namespaced).toBe(false);
+    expect(hello?.core).toBe(true);
+
+    const dia = ds.concepts.find((c) => c.id === "ES-WORD-DIA");
+    expect(dia?.namespaced).toBe(true);
+    expect(dia?.family).toBe("(namespaced)");
+
+    // The practice lesson contributes no concept.
+    expect(ds.concepts.some((c) => c.id === "CH1-PRACTICE")).toBe(false);
+    expect(ds.languages).toEqual(["german", "spanish"]);
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/queries.test.ts
+++ b/code/packages/typescript/human-language-data/tests/queries.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { parseLesson, buildDataset } from "../src/parse.js";
+import {
+  allConcepts,
+  conceptsByLanguage,
+  languagesForConcept,
+  coverageByLanguage,
+} from "../src/queries.js";
+import type { Taxonomy } from "../src/types.js";
+
+const lesson = (fields: Record<string, string>) =>
+  ["---", ...Object.entries(fields).map(([k, v]) => `${k}: ${v}`), "---", "b"].join("\n");
+
+const taxonomy: Taxonomy = {
+  version: 1,
+  concepts: {
+    "GREETING-HELLO": { family: "GREETING", gloss: "hello", core: true },
+    "COURTESY-THANKS": { family: "COURTESY", gloss: "thanks", core: true },
+    "TIME-DAY": { family: "TIME", gloss: "day", core: false },
+  },
+};
+
+const ds = buildDataset(taxonomy, [
+  parseLesson(lesson({ id: "ES1", chapter: "1", type: "word", headword: "hola", gloss: "hello", concept_tag: "GREETING-HELLO" }), "spanish"),
+  parseLesson(lesson({ id: "DE1", chapter: "1", type: "word", headword: "hallo", gloss: "hello", concept_tag: "GREETING-HELLO" }), "german"),
+  parseLesson(lesson({ id: "ES2", chapter: "1", type: "word", headword: "gracias", gloss: "thanks", concept_tag: "COURTESY-THANKS" }), "spanish"),
+  parseLesson(lesson({ id: "ES3", chapter: "1", type: "word", headword: "día", gloss: "day", concept_tag: "TIME-DAY" }), "spanish"),
+]);
+
+describe("queries", () => {
+  it("allConcepts is id-sorted", () => {
+    expect(allConcepts(ds).map((c) => c.id)).toEqual(["COURTESY-THANKS", "GREETING-HELLO", "TIME-DAY"]);
+  });
+
+  it("conceptsByLanguage filters to a track", () => {
+    expect(conceptsByLanguage(ds, "german").map((c) => c.id)).toEqual(["GREETING-HELLO"]);
+    expect(conceptsByLanguage(ds, "spanish").length).toBe(3);
+  });
+
+  it("languagesForConcept returns the cross-language join", () => {
+    expect(languagesForConcept(ds, "GREETING-HELLO").map((r) => r.language).sort()).toEqual(["german", "spanish"]);
+    expect(languagesForConcept(ds, "NOPE")).toEqual([]);
+  });
+
+  it("coverageByLanguage counts core vs total", () => {
+    const cov = coverageByLanguage(ds);
+    expect(cov.spanish).toEqual({ core: 2, total: 3 }); // hello+thanks core, day not
+    expect(cov.german).toEqual({ core: 1, total: 1 });
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/validate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/validate.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { parseLesson } from "../src/parse.js";
+import { validate, hasErrors, summarize } from "../src/validate.js";
+import type { ScriptData, Taxonomy } from "../src/types.js";
+
+const lesson = (fields: Record<string, string>) =>
+  ["---", ...Object.entries(fields).map(([k, v]) => `${k}: ${v}`), "---", "body"].join("\n");
+
+const taxonomy: Taxonomy = {
+  version: 1,
+  concepts: {
+    "GREETING-HELLO": { family: "GREETING", gloss: "hello", core: true },
+    "COURTESY-THANKS": { family: "COURTESY", gloss: "thanks", core: true },
+  },
+};
+
+const good = (lang: string, id: string, concept: string, extra: Record<string, string> = {}) =>
+  parseLesson(lesson({ id, chapter: "1", type: "word", headword: "w", gloss: "g", concept_tag: concept, ...extra }), lang);
+
+describe("validate", () => {
+  it("passes a clean set with no errors", () => {
+    const issues = validate({
+      taxonomy,
+      lessons: [good("spanish", "ES1", "GREETING-HELLO"), good("german", "DE1", "GREETING-HELLO")],
+    });
+    expect(hasErrors(issues)).toBe(false);
+  });
+
+  it("errors on an unresolved concept tag", () => {
+    const issues = validate({ taxonomy, lessons: [good("spanish", "ES1", "NOT-A-REAL-TAG-lowercase!")] });
+    expect(issues.some((i) => i.code === "unresolved-concept" && i.level === "error")).toBe(true);
+  });
+
+  it("accepts a namespaced tag without complaint", () => {
+    const issues = validate({ taxonomy, lessons: [good("spanish", "ES1", "ES-WORD-DIA")] });
+    expect(issues.some((i) => i.code === "unresolved-concept")).toBe(false);
+  });
+
+  it("errors on a duplicate realization within a language", () => {
+    const issues = validate({
+      taxonomy,
+      lessons: [good("spanish", "ES1", "GREETING-HELLO"), good("spanish", "ES2", "GREETING-HELLO")],
+    });
+    expect(issues.some((i) => i.code === "duplicate-realization" && i.level === "error")).toBe(true);
+  });
+
+  it("errors on missing required fields", () => {
+    const bare = parseLesson(lesson({ type: "word", concept_tag: "GREETING-HELLO" }), "spanish");
+    const issues = validate({ taxonomy, lessons: [bare] });
+    for (const code of ["missing-headword", "missing-gloss", "missing-chapter"]) {
+      expect(issues.some((i) => i.code === code)).toBe(true);
+    }
+  });
+
+  it("warns (not errors) on a non-Latin lesson missing romanization", () => {
+    const issues = validate({ taxonomy, lessons: [good("telugu", "TE1", "GREETING-HELLO")] });
+    expect(issues.some((i) => i.code === "missing-romanization" && i.level === "warning")).toBe(true);
+    expect(hasErrors(issues)).toBe(false);
+  });
+
+  it("warns on an over-length etymology hook", () => {
+    const long = "x".repeat(200);
+    const issues = validate({ taxonomy, lessons: [good("spanish", "ES1", "GREETING-HELLO", { etymology_hook: long })] });
+    expect(issues.some((i) => i.code === "long-etymology-hook")).toBe(true);
+  });
+
+  it("exempts practice lessons from the concept checks but flags unknown types", () => {
+    const practice = parseLesson(lesson({ id: "P", chapter: "1", type: "practice-mix", headword: "(p)", gloss: "recap", concept_tag: "CH1-PRACTICE" }), "spanish");
+    const weird = parseLesson(lesson({ id: "W", chapter: "1", type: "quiz", headword: "w", gloss: "g", concept_tag: "GREETING-HELLO" }), "spanish");
+    const issues = validate({ taxonomy, lessons: [practice, weird] });
+    expect(issues.some((i) => i.code === "unresolved-concept")).toBe(false); // practice exempt
+    expect(issues.some((i) => i.code === "unknown-type")).toBe(true); // quiz flagged
+  });
+
+  it("treats missing core coverage as info, but as error for parity-complete tracks", () => {
+    const lessons = [good("spanish", "ES1", "GREETING-HELLO")]; // missing COURTESY-THANKS
+    const infoIssues = validate({ taxonomy, lessons });
+    expect(infoIssues.some((i) => i.code === "core-coverage" && i.level === "info")).toBe(true);
+    const errIssues = validate({ taxonomy, lessons, completeTracks: new Set(["spanish"]) });
+    expect(errIssues.some((i) => i.code === "core-coverage" && i.level === "error")).toBe(true);
+  });
+
+  it("warns about headword characters missing from script data", () => {
+    const scripts: Record<string, ScriptData> = {
+      telugu: { script: "telugu", font: "f", abugida: true, glyphs: [{ glyph: "క", sound: "ka", type: "consonant", components: [], strokeOrder: [], strokeOrderNote: "" }], vowelSigns: [] },
+    };
+    const l = good("telugu", "TE1", "GREETING-HELLO", { headword: "కమ", romanization: "kama" });
+    const issues = validate({ taxonomy, lessons: [l], scripts });
+    expect(issues.some((i) => i.code === "uncovered-glyphs")).toBe(true); // మ not covered
+  });
+
+  it("summarize counts levels", () => {
+    const issues = validate({ taxonomy, lessons: [good("spanish", "ES1", "bad!")] });
+    expect(summarize(issues)).toMatch(/error\(s\)/);
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/validate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/validate.test.ts
@@ -31,6 +31,18 @@ describe("validate", () => {
     expect(issues.some((i) => i.code === "unresolved-concept" && i.level === "error")).toBe(true);
   });
 
+  it("rejects a concept tag that collides with an Object prototype member", () => {
+    // Without an own-property check, `constructor`/`toString` would resolve via
+    // the prototype chain and spuriously validate as canonical.
+    for (const evil of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
+      const issues = validate({ taxonomy, lessons: [good("spanish", "ES1", evil)] });
+      expect(
+        issues.some((i) => i.code === "unresolved-concept" && i.level === "error"),
+        `${evil} should not validate`,
+      ).toBe(true);
+    }
+  });
+
   it("accepts a namespaced tag without complaint", () => {
     const issues = validate({ taxonomy, lessons: [good("spanish", "ES1", "ES-WORD-DIA")] });
     expect(issues.some((i) => i.code === "unresolved-concept")).toBe(false);

--- a/code/packages/typescript/human-language-data/tsconfig.json
+++ b/code/packages/typescript/human-language-data/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests", "dist", "node_modules", "vitest.config.ts"]
+}

--- a/code/packages/typescript/human-language-data/vitest.config.ts
+++ b/code/packages/typescript/human-language-data/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      // The direct-invoke guard in cli.ts only runs as a standalone process.
+      exclude: ["src/index.ts"],
+      thresholds: {
+        lines: 85,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## What & why

Implements the **HL01** data layer — the machine-readable bridge from the Human Languages curriculum (Markdown lessons + the canonical concept taxonomy, both already on `main`) to the cross-language dataset the Engram practice deck (**HL02**) and future tooling consume. Also lands the **validator** that becomes a standing CI gate so lessons can't drift out of the taxonomy again.

## Design — a pure core with a thin fs shell

| Module | Role | Pure? |
|---|---|---|
| `frontmatter.ts` | tiny zero-dep YAML-frontmatter reader (BOM/CRLF-tolerant) | ✅ |
| `parse.ts` | `parseLesson` (frontmatter → `Realization`) + `buildDataset` (join through taxonomy) | ✅ |
| `validate.ts` | round-trip consistency gate (errors fail CI; warnings/info tolerated) | ✅ |
| `queries.ts` | `allConcepts` / `conceptsByLanguage` / `languagesForConcept` / `coverageByLanguage` | ✅ |
| `loader.ts` + `cli.ts` | the only fs-touching modules (declared `fs:read`/`fs:list` in `required_capabilities.json`) | ⛔ |

The pure core is unit-tested against inline fixtures; the **integration test loads the real curriculum in CI** and asserts zero validation errors + the cross-language joins (`GREETING-HELLO` across all 16 tracks, the self-introduction concepts across 9).

## Validator rules (the CI gate)
Every content lesson's `concept_tag` resolves (canonical or namespaced), one realization per (concept, language), required fields + field shapes, script-glyph coverage (where script data exists), and core-concept coverage (enforced only for `parity: complete` tracks). Errors fail the build; warnings/info are tolerated while `romanization`/`etymology_hook` fields and `data/scripts/*.json` are still being authored.

## Quality
- **34 tests pass**, **94% line / 100% function coverage**, `tsc` clean.
- Ran `/security-review` (senior-TS-engineer sub-agent) → **passed**. Its two INFO hardening notes (prototype-chain lookups on content-derived keys) are fixed in `fix(security)`: tag resolution now uses own-property checks, so `concept_tag: constructor` is correctly rejected.
- Zero third-party deps (hand-rolled frontmatter reader); only `@types/node` + vitest/tsc dev deps.

## Scope
`data/scripts/*.json` character-breakdown data (the "learn to write, piece by piece" source) is authored incrementally in follow-up PRs, Telugu/Kannada/Malayalam/Gurmukhi first; the loader/validator degrade gracefully when it's absent.

Builds on HL01 spec + taxonomy (both merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)