### PR TITLE
feat(adj-facts-stdlib): anatomy/ear-parts — ear structure → region/function table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_earparts_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_earparts_e2e.rs
@@ -1,0 +1,79 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/ear-parts.adj`) driven through the built CLI:
+//! a native `table` of ear structure → ear region resolves binding-query
+//! recalls with the source's NIDCD "How Do We Hear?" citation, runs the
+//! relation backward (region → structure, recalling the three middle-ear
+//! ossicles), and abstains on a non-listed structure (the pinna) — 0 model
+//! calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsear_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_ear_parts_recall_binds_region_with_citation() {
+    let dir = scratch("earparts");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/ear-parts.adj");
+    std::fs::copy(&src, dir.join("ear-parts.adj")).expect("copy shipped ear-parts.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ear-parts.adj\"\n\
+         ? ear_structure_region(cochlea, $R)\n\
+         ? ear_structure_region(malleus, $R)\n\
+         ? ear_structure_region(ear_canal, $R)\n\
+         ? ear_structure_region($S, middle_ear)\n\
+         ? ear_structure_region(pinna, $R)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The cochlea sits in the inner ear; the malleus (an ossicle) in the middle
+    // ear; the ear canal in the outer ear — the recalled regions, each a plain
+    // token verbatim from the NIDCD path-of-sound description.
+    assert!(out.contains("\"R\":\"inner_ear\""), "cochlea → inner_ear: {out}");
+    assert!(out.contains("\"R\":\"middle_ear\""), "malleus → middle_ear: {out}");
+    assert!(out.contains("\"R\":\"outer_ear\""), "ear_canal → outer_ear: {out}");
+    // The relation runs backward: the region middle_ear recalls the three tiny
+    // bones — malleus, incus, and stapes.
+    assert!(
+        out.contains("\"S\":\"malleus\"")
+            && out.contains("\"S\":\"incus\"")
+            && out.contains("\"S\":\"stapes\""),
+        "middle_ear → malleus/incus/stapes (reverse recall): {out}"
+    );
+    // The answer carries the NIDCD citation as its proof.
+    assert!(
+        out.contains("nidcd.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The pinna is not a listed structure — honest abstention, never a
+    // fabricated region.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "unknown structure abstains: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -59,6 +59,7 @@ per rotation, in parallel):
 | `anatomy/` | digestive organ → primary function it performs | NIH NIDDK / NCI SEER Training |
 | `anatomy/` | synovial joint type → representative example (hinge → elbow) | NIH / NLM StatPearls |
 | `anatomy/` | skin layer → defining descriptor (epidermis → outermost, subcutaneous → fat) | NIH / NCI SEER Training |
+| `anatomy/` | ear structure → ear region it sits in (cochlea → inner, malleus → middle, ear canal → outer) | NIH NIDCD (authoritative) |
 | … | *geography, physical constants, …* | *(expanding)* |
 
 Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown

--- a/code/specs/data/adj-facts-stdlib/anatomy/ear-parts.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/ear-parts.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% ear-parts — which region of the ear each structure belongs to
+% (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% A hearing-anatomy fact on the way to medicine: the ear is built in three
+% regions, and sound passes through them in order. The OUTER ear catches sound
+% and funnels it inward; the MIDDLE ear turns the air-pressure wave into a
+% mechanical push through three tiny bones; the INNER ear turns that mechanical
+% push into the fluid wave the nerve can read. Recall is a binding query:
+%
+%     ? ear_structure_region(cochlea, $R)     % inner_ear
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `ear_structure_region(structure, region)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the region WITH its source, on the CPU, with zero model calls, and
+% abstains on anything that is not one of the listed structures (it never
+% invents a region).
+%
+% The path of sound, as a little truth table (structure → region it sits in):
+%
+%     structure     region        role on the path of sound
+%     -----------   -----------   -------------------------------------------
+%     ear_canal     outer_ear     narrow passageway sound travels down
+%     malleus       middle_ear    first of the three tiny bones (the "hammer")
+%     incus         middle_ear    second bone (the "anvil")
+%     stapes        middle_ear    third bone (the "stirrup")
+%     cochlea       inner_ear     snail-shaped, fluid-filled hearing organ
+%
+% Because each `region` is a stable token, a recalled region composes straight
+% into checks: a note describing a "middle-ear cochlea" is suspect precisely
+% because the cochlea is an inner-ear structure; a "malleus" placed in the inner
+% ear contradicts this table. That is the concrete bridge from anatomy RECALL to
+% reasoning, and the rung a medicine agent climbs UP from before it can reason
+% about conductive vs. sensorineural hearing loss (a broken ossicle is a
+% MIDDLE-ear, conductive problem; a damaged cochlea is an INNER-ear,
+% sensorineural one). The query also runs BACKWARD — bind a region and recall a
+% structure that lives there:
+%
+%     ? ear_structure_region($S, middle_ear)  % malleus / incus / stapes
+%
+% Something that is not one of the listed structures — the pinna, the eardrum,
+% the auditory nerve — has no row, so a recall on it ABSTAINS rather than
+% inventing a region. That honest-abstention property is what makes the table
+% safe to reason from.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every structure→region pair
+% was read out of a single fetched U.S. government page this session, and any
+% pair that could not be grounded there would have been dropped). The single
+% source is the primary U.S. National Institutes of Health reference, the
+% National Institute on Deafness and Other Communication Disorders (NIDCD),
+% "How Do We Hear?" (nidcd.nih.gov/health/how-do-we-hear), whose step-by-step
+% description of the path of sound places each structure in its region. Each
+% span is quoted here character-for-character so any reader can re-check it:
+%
+%   ear_canal → outer_ear
+%     "Sound waves enter the outer ear and travel through a narrow passageway
+%      called the ear canal, which leads to the eardrum."
+%
+%   malleus, incus, stapes → middle_ear
+%     "The eardrum vibrates from the incoming sound waves and sends these
+%      vibrations to three tiny bones in the middle ear. These bones are called
+%      the malleus, incus, and stapes."
+%
+%   cochlea → inner_ear
+%     "The bones in the middle ear amplify, or increase, the sound vibrations
+%      and send them to the cochlea, a snail-shaped structure filled with fluid,
+%      in the inner ear."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the NIDCD sentence that fixes
+% the cochlea → inner_ear row ("... send them to the cochlea, ... in the inner
+% ear."). The other rows' per-fact source spans are listed above, so each pair
+% remains independently checkable. NIDCD is a primary U.S. government NIH
+% institute, so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table ear_structure_region {
+    columns structure, region
+
+    row (ear_canal, outer_ear)
+    row (malleus, middle_ear)
+    row (incus, middle_ear)
+    row (stapes, middle_ear)
+    row (cochlea, inner_ear)
+
+    source "The bones in the middle ear amplify, or increase, the sound vibrations and send them to the cochlea, a snail-shaped structure filled with fluid, in the inner ear."
+    locator "https://www.nidcd.nih.gov/health/how-do-we-hear"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/ear-parts.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/ear-parts.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% ear-parts.query.adj — a worked recall over the anatomy ear-parts library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which region of the ear is
+% the cochlea in?": it states no anatomy fact — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `ear_structure_region` rows and returns the region + the table's
+% source/locator/trust. The fourth query runs the relation BACKWARD (bind the
+% region middle_ear, recall a structure that lives there — one of the three
+% ossicles). The pinna has no grounded row here, so a recall on it abstains
+% honestly — the engine never invents a region.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ear-parts.query.adj
+% ============================================================================
+
+import "ear-parts.adj"
+
+? ear_structure_region(cochlea, $R)     % expect inner_ear
+? ear_structure_region(malleus, $R)     % expect middle_ear
+? ear_structure_region(ear_canal, $R)   % expect outer_ear
+? ear_structure_region($S, middle_ear)  % expect malleus/incus/stapes — reverse recall
+? ear_structure_region(pinna, $R)       % expect abstain — pinna has no row


### PR DESCRIPTION
Add a grounded ADJ facts library mapping each ear structure to the ear
region it sits in, on the path of sound: ear_canal → outer_ear;
malleus, incus, stapes → middle_ear; cochlea → inner_ear. Native `table`
(ADJ-TABLES RS-5): each row lowers to a ground relation
ear_structure_region(structure, region), so recall is an SLD binding
query resolved on the CPU with zero model calls, running forward
(structure → region) and backward (region → structure, recalling the
three ossicles for middle_ear), and abstaining on any non-listed
structure (the pinna) rather than inventing a region.

Single source, single clean axis. Every structure→region pair is
byte-provenanced to a single primary U.S. government NIH page fetched
this session — the National Institute on Deafness and Other
Communication Disorders (NIDCD), "How Do We Hear?"
(https://www.nidcd.nih.gov/health/how-do-we-hear) — so trust
authoritative. Verbatim spans:

  ear_canal → outer_ear
    "Sound waves enter the outer ear and travel through a narrow
     passageway called the ear canal, which leads to the eardrum."

  malleus, incus, stapes → middle_ear
    "The eardrum vibrates from the incoming sound waves and sends these
     vibrations to three tiny bones in the middle ear. These bones are
     called the malleus, incus, and stapes."

  cochlea → inner_ear
    "The bones in the middle ear amplify, or increase, the sound
     vibrations and send them to the cochlea, a snail-shaped structure
     filled with fluid, in the inner ear."

The table's single provenance envelope carries the strongest span (the
cochlea → inner_ear sentence); the other per-row spans are documented in
the header comment so each pair stays independently checkable. Nothing
asserted from memory; any pair that could not be grounded on this page
was dropped (pinna, eardrum, auditory nerve — no clean region placement
in the source prose).

Adds ear-parts.query.adj (worked forward + reverse + abstain recall) and
facts_earparts_e2e.rs driving the shipped table through the built CLI,
plus an anatomy subject-index row in the stdlib README.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
