### PR TITLE
feat(adj-facts-stdlib): physics/temperature-scales — scale → symbol/reference table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_temperaturescales_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_temperaturescales_e2e.rs
@@ -1,0 +1,78 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/temperature-scales.adj`) driven through the built
+//! CLI: a native `table` of temperature reference point → numeric value resolves
+//! a binding-query recall with the NIST "SI Units – Temperature" citation, runs
+//! the relation backward (value → point), and abstains on a point the source
+//! does not fix (the Fahrenheit freezing point of water) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factstemp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn physics_temperature_scales_recall_binds_value_with_citation() {
+    let dir = scratch("temperaturescales");
+    // Copy the shipped physics table beside the entry program and import it.
+    let src = facts_stdlib().join("physics/temperature-scales.adj");
+    std::fs::copy(&src, dir.join("temperature-scales.adj"))
+        .expect("copy shipped temperature-scales.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"temperature-scales.adj\"\n\
+         ? temperature_reference_point(water_freezes_celsius, $V)\n\
+         ? temperature_reference_point(water_boils_celsius, $V)\n\
+         ? temperature_reference_point(zero_celsius_in_kelvin, $V)\n\
+         ? temperature_reference_point($P, 100)\n\
+         ? temperature_reference_point(water_freezes_fahrenheit, $V)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward lookups bind each reference point to the number NIST fixes it at,
+    // each a plain number (including the decimal 273.15).
+    assert!(out.contains("\"V\":\"0\""), "water_freezes_celsius → 0: {out}");
+    assert!(out.contains("\"V\":\"100\""), "water_boils_celsius → 100: {out}");
+    assert!(
+        out.contains("\"V\":\"273.15\""),
+        "zero_celsius_in_kelvin → 273.15: {out}"
+    );
+    // The relation runs BACKWARD: the value 100 recalls water_boils_celsius.
+    assert!(
+        out.contains("\"P\":\"water_boils_celsius\""),
+        "100 → water_boils_celsius (reverse recall): {out}"
+    );
+    // The answer carries the NIST locator + trust tier as its proof.
+    assert!(
+        out.contains("nist.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The Fahrenheit freezing point is not fixed by this NIST page — honest
+    // abstention, never a fabricated temperature.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "ungrounded reference point abstains: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -54,6 +54,7 @@ per rotation, in parallel):
 | `physics/` | energy form → defining token (chemical → bonds, thermal → heat) | EIA (energy.gov) |
 | `physics/` | common force → everyday example NASA uses (gravity → waterfall, tension → ropes) | NASA GSFC Swift (authoritative) |
 | `physics/` | named wave → its family (sound → mechanical, radio → electromagnetic) | NASA Science (authoritative) |
+| `physics/` | temperature reference point → the value NIST fixes it at (water_boils_celsius → 100, absolute_zero_kelvin → 0) | NIST (authoritative) |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |

--- a/code/specs/data/adj-facts-stdlib/physics/temperature-scales.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/temperature-scales.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% temperature-scales — named temperature REFERENCE POINTS and the numeric value
+% the source fixes each at (adj-facts-stdlib, PHYSICS).
+% ============================================================================
+% An elementary/middle-school physics fact on the way to thermodynamics: a
+% temperature SCALE is pinned down by a few agreed reference points, and each
+% one has a definite number. Water freezes at 0 °C and boils at about 100 °C on
+% the Celsius scale; the bottom of the Kelvin scale, 0 K, is "absolute zero";
+% and the zero of the Celsius scale sits at 273.15 K. Recall is a binding query:
+%
+%     ? temperature_reference_point(water_boils_celsius, $V)   % 100
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `temperature_reference_point(point, value)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the number WITH its source, on the CPU, with zero model calls, and
+% abstains on any reference point the source does not fix (it never invents a
+% temperature).
+%
+% The reference points, as a little truth table (each key bakes in the SCALE
+% its value is measured on, so the value column is just the bare number NIST
+% states):
+%
+%     reference point           value   what NIST fixes it at
+%     -----------------------   -----   -------------------------------------
+%     water_freezes_celsius       0     water freezes at 0 °C
+%     water_boils_celsius       100     water boils at about 100 °C
+%     absolute_zero_kelvin        0     0 K is "absolute zero"
+%     zero_celsius_in_kelvin    273.15  zero degrees Celsius is 273.15 K
+%
+% Because each `value` is a NUMBER (not a label), a recalled reference point
+% composes straight into arithmetic: the Celsius→Kelvin offset is exactly the
+% `zero_celsius_in_kelvin` row (273.15), and the 0→100 span of the two water
+% points is the 100-degree interval that DEFINES the Celsius degree. That is the
+% concrete bridge from RECALL to COMPUTE, and the rung a physics learner reasons
+% UP from before reasoning about heat, phase changes, or the ideal-gas law. The
+% query also runs BACKWARD — bind a value and recall the point that has it:
+%
+%     ? temperature_reference_point($P, 100)   % water_boils_celsius — reverse
+%
+% Note that the value 0 is shared by TWO points (water_freezes_celsius and
+% absolute_zero_kelvin), which is exactly right: a bare "0" is meaningless until
+% you name the scale, so a reverse recall on 0 honestly returns BOTH points.
+%
+% Something the source does NOT fix — the Fahrenheit freezing point of water,
+% human body temperature — has no row, so a recall on it ABSTAINS rather than
+% inventing a number. That honest-abstention property is what makes the table
+% safe to reason from.
+%
+% Each `value` is copied character-for-character from the NIST sentence that
+% states it — never a number the source does not print for that point.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every point→value pair was
+% read out of a fetched U.S. government NIST page this session, and any value
+% that could not be grounded there would have been dropped). All four numbers
+% come from the SAME primary U.S. government source, NIST's Office of Weights
+% and Measures "SI Units – Temperature"
+% (nist.gov/pml/owm/si-units-temperature), each quoted here character-for-
+% character so any reader can re-check it. One NIST sentence fixes the two
+% Celsius water points at once —
+%
+%   water_freezes_celsius → 0  and  water_boils_celsius → 100
+%     "On the widely used Celsius temperature scale, water freezes at 0 °C and
+%      boils at about 100 °C."
+%
+% — and two more fix the Kelvin points:
+%
+%   absolute_zero_kelvin → 0
+%     "The temperature 0 K is commonly referred to as 'absolute zero.'"
+%
+%   zero_celsius_in_kelvin → 273.15
+%     "One Celsius degree is an interval of 1 K, and zero degrees Celsius is
+%      273.15 K."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the NIST sentence that fixes the
+% first two rows (the Celsius water points). Every OTHER row's per-fact source
+% and verbatim span is listed above, so each value remains independently
+% checkable. The source is a primary U.S. government NIST page (nist.gov), so
+% `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table temperature_reference_point {
+    columns point, value
+
+    row (water_freezes_celsius, 0)
+    row (water_boils_celsius, 100)
+    row (absolute_zero_kelvin, 0)
+    row (zero_celsius_in_kelvin, 273.15)
+
+    source "On the widely used Celsius temperature scale, water freezes at 0 °C and boils at about 100 °C."
+    locator "https://www.nist.gov/pml/owm/si-units-temperature"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/physics/temperature-scales.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/temperature-scales.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% temperature-scales.query.adj — a worked recall over the physics
+% temperature-scales library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "at what temperature does
+% water boil on the Celsius scale?": it states no physics fact — it only
+% `import`s the grounded table and asks binding queries. The engine resolves
+% each `?` against the `temperature_reference_point` rows and returns the number
+% + the table's source/locator/trust. The fourth query runs the relation
+% BACKWARD (bind the value 100, recall the point that has it — water_boils_celsius).
+% The Fahrenheit freezing point of water is not fixed by this NIST page, so a
+% recall on it abstains honestly — the engine never invents a temperature.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli temperature-scales.query.adj
+% ============================================================================
+
+import "temperature-scales.adj"
+
+? temperature_reference_point(water_freezes_celsius, $V)   % expect 0
+? temperature_reference_point(water_boils_celsius, $V)     % expect 100
+? temperature_reference_point(zero_celsius_in_kelvin, $V)  % expect 273.15
+? temperature_reference_point($P, 100)                     % expect water_boils_celsius — reverse recall
+? temperature_reference_point(water_freezes_fahrenheit, $V) % expect abstain — this page fixes no Fahrenheit point


### PR DESCRIPTION
Add a grounded ADJ facts library mapping named temperature reference
points to the numeric value NIST fixes each at, plus a worked query and
an end-to-end CLI test. Native `table` lowering to
`temperature_reference_point(point, value)`: forward recall binds the
number with the NIST citation, reverse recall binds the point from a
value (0 honestly returns BOTH the Celsius freezing point and absolute
zero), and an ungrounded point (the Fahrenheit freezing point of water,
which this NIST page does not fix) abstains — 0 model calls.

Provenance — all four values byte-provenanced this session from a single
primary U.S. government source, NIST Office of Weights and Measures
"SI Units – Temperature"
(https://www.nist.gov/pml/owm/si-units-temperature), trust=authoritative:

  water_freezes_celsius   → 0       "On the widely used Celsius temperature
  water_boils_celsius     → 100      scale, water freezes at 0 °C and boils
                                     at about 100 °C."
  absolute_zero_kelvin    → 0       "The temperature 0 K is commonly
                                     referred to as 'absolute zero.'"
  zero_celsius_in_kelvin  → 273.15  "One Celsius degree is an interval of
                                     1 K, and zero degrees Celsius is
                                     273.15 K."

Each value token is copied verbatim from the NIST sentence that states
it. No Fahrenheit row was added because this page fixes no Fahrenheit
reference point (dropped rather than sourced from memory).

Targeted test `cargo test -p adj-lang-cli --test
facts_temperaturescales_e2e` passes; `cargo clippy -p adj-lang
-p adj-lang-cli --all-targets -- -D warnings` clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
