### PR TITLE
feat(sql): text/blob truthiness takes numeric affinity

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.49 — text truthiness takes numeric affinity
+
+`NOT 'abc'` now returns 1 (not 0) and `WHERE <text>` keeps only rows whose text
+is numerically non-zero, matching SQLite. A text/blob in a boolean context takes
+numeric affinity: `'abc'`/`'0'`/`''` are false, `'5'`/`'5.5'` are true. This
+completes the type-affinity work — the boolean-context analog of the arithmetic
+(0.5.48) and unary-minus (0.5.43) coercion — and applies uniformly to WHERE,
+HAVING, AND/OR, NOT, IIF, and CASE WHEN. Two new differential-oracle cases;
+sql-vm 0.4.27.
+
 ## 0.5.48 — arithmetic coerces text/blob operands
 
 `'5' + 0` now returns 5 instead of erroring. Binary arithmetic (`+ - * / %`)

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.48"
+version = "0.5.49"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1455,6 +1455,24 @@ const CASES: &[Case] = &[
         setup: &[],
         query: "SELECT 5 / '2' AS a, (5 / '0') IS NULL AS b, '7' % 3 AS c, '5.5' * 2 AS d",
     },
+    // A text/blob in a BOOLEAN context takes numeric affinity, matching SQLite:
+    // `NOT 'abc'` = 1 ('abc'→0), `NOT '5'` = 0, `NOT '0'` = `NOT ''` = 1, and
+    // `'5' AND 1` = 1 while `'abc' AND 1` = 0. Previously all text was truthy.
+    Case {
+        id: "text_boolean_affinity",
+        setup: &[],
+        query: "SELECT NOT 'abc' AS a, NOT '5' AS b, NOT '0' AS c, 'abc' AND 1 AS d, '5' AND 1 AS e",
+    },
+    // The same rule drives WHERE and CASE: `WHERE <text>` keeps only rows whose
+    // text is numerically non-zero, and `CASE WHEN <text>` picks THEN only then.
+    Case {
+        id: "where_case_text_truthiness",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1,'abc'), (2,'5'), (3,'0'), (4,'')",
+        ],
+        query: "SELECT id, CASE WHEN s THEN 'y' ELSE 'n' END AS c FROM t WHERE s ORDER BY id",
+    },
     // Unary minus applies NUMERIC affinity to a text/blob operand before
     // negating, matching SQLite: `-'5'` = -5, `-'12abc'` = -12 (leading numeric
     // prefix), `-'abc'` = 0 (no prefix → 0), `-'3.5'` = -3.5, and leading

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.27] - Unreleased
+
+### Fixed
+
+- **Text/blob truthiness now takes numeric affinity.** `is_truthy` treated every
+  non-NULL text/blob as true, so `WHERE <text-column>` kept all rows and `NOT
+  'abc'` returned false. It now coerces via `cast_to_f64` and tests `!= 0`,
+  matching SQLite: `NOT 'abc'` = 1, `NOT '5'` = 0, `'5' AND 1` = 1, `'abc' AND 1`
+  = 0, and `WHERE s` / `CASE WHEN s` keep only numerically-non-zero text. This
+  affects every boolean context uniformly (WHERE, HAVING, AND/OR, NOT, IIF,
+  CASE WHEN) since they all route through `is_truthy`.
+
 ## [0.4.26] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1903,14 +1903,19 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
 /// | Int(n ≠ 0)  | true      |
 /// | Float(0.0)  | false     |
 /// | Float(f≠0)  | true      |
-/// | Text / Blob | true      |
+/// | Text / Blob | numeric affinity ≠ 0 (`'5'`→true, `'abc'`/`'0'`/`''`→false) |
 fn is_truthy(v: &SqlValue) -> bool {
     match v {
         SqlValue::Null => false,
         SqlValue::Bool(b) => *b,
         SqlValue::Int(n) => *n != 0,
         SqlValue::Float(f) => *f != 0.0,
-        SqlValue::Text(_) | SqlValue::Blob(_) => true,
+        // A text/blob in a boolean context takes NUMERIC AFFINITY first, exactly
+        // like SQLite: `WHERE 'abc'` is false (`'abc'`→0), `WHERE '5'` is true,
+        // `NOT 'abc'` = 1, `NOT '5'` = 0. Previously every non-NULL text/blob was
+        // truthy, which wrongly kept `WHERE <text-column>` rows and inverted
+        // `NOT`. `cast_to_f64` takes the leading numeric prefix (0 for non-numeric).
+        SqlValue::Text(_) | SqlValue::Blob(_) => cast_to_f64(v) != 0.0,
     }
 }
 
@@ -3882,6 +3887,23 @@ mod tests {
             Instruction::Halt,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![null()]]);
+    }
+
+    #[test]
+    fn test_is_truthy_text_numeric_affinity() {
+        // Text/blob truthiness takes numeric affinity, matching SQLite.
+        assert!(!is_truthy(&SqlValue::Text("abc".into()))); // → 0 → false
+        assert!(is_truthy(&SqlValue::Text("5".into()))); // → 5 → true
+        assert!(!is_truthy(&SqlValue::Text("0".into())));
+        assert!(!is_truthy(&SqlValue::Text("".into())));
+        assert!(is_truthy(&SqlValue::Text("5.5".into())));
+        assert!(is_truthy(&SqlValue::Text("12abc".into()))); // leading 12 → true
+        assert!(!is_truthy(&SqlValue::Blob(b"abc".to_vec())));
+        assert!(is_truthy(&SqlValue::Blob(b"9".to_vec())));
+        // Numeric/NULL/bool arms unchanged.
+        assert!(!is_truthy(&SqlValue::Int(0)));
+        assert!(is_truthy(&SqlValue::Int(3)));
+        assert!(!is_truthy(&SqlValue::Null));
     }
 
     // ── 7. LIKE ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`NOT 'abc'` returned `false` and `WHERE <text-column>` kept *every* row, because `is_truthy` treated all non-NULL text/blob as true. It now applies SQLite **numeric affinity** — a text/blob is truthy iff its numeric value is non-zero — matching sqlite3 3.51.0.

This completes the type-affinity arc: the **boolean-context** analog of the arithmetic (0.5.48) and unary-minus (0.5.43) coercion.

## Change (one line)

`sql-vm` 0.4.27 — `is_truthy`'s Text/Blob arm changes from `=> true` to `=> cast_to_f64(v) != 0.0`. It applies uniformly to every boolean context (WHERE, HAVING, AND/OR, NOT, IIF, CASE WHEN), which all route through `is_truthy`.

| Expr | Before | After / SQLite |
|------|--------|----------------|
| `NOT 'abc'` | `false` ❌ | `1` (`'abc'`→0) |
| `NOT '5'` | `false` ❌ | `0` |
| `'5' AND 1` | — | `1` |
| `'abc' AND 1` | `1` ❌ | `0` |
| `WHERE s` on `'abc','5','0',''` | all rows ❌ | only `'5'` |
| `CASE WHEN 'abc'` | THEN ❌ | ELSE |

`mini-sqlite` 0.5.49.

## Tests

- 2 differential-oracle cases (NOT/AND on text; WHERE + CASE truthiness) match real sqlite3.
- sql-vm unit test (text/blob/numeric/NULL truthiness).
- **FULL suites green with NO regression** — the 22s differential oracle runs *every* case against real SQLite, including all existing WHERE/AND/CASE cases (sql-vm 108, mini-sqlite 45 + oracle). Downstream consumers build. Inline security review clean: `cast_to_f64` is char-boundary-safe and cannot produce NaN; `-0.0` correctly falsy; no overflow/ReDoS/DoS.

## Notes

Never self-merge — queued for review. No `_grammar.rs` touched (pure VM change). This is a *bug fix* (the old behavior diverged from SQLite in a common WHERE/NOT scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
