### PR TITLE
feat(block-ram): add C# and F# ports

### DIFF
--- a/code/packages/csharp/block-ram/BUILD
+++ b/code/packages/csharp/block-ram/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BlockRam.Tests/CodingAdventures.BlockRam.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.BlockRam]*"

--- a/code/packages/csharp/block-ram/BUILD_windows
+++ b/code/packages/csharp/block-ram/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BlockRam.Tests/CodingAdventures.BlockRam.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.BlockRam]*"

--- a/code/packages/csharp/block-ram/BlockRam.cs
+++ b/code/packages/csharp/block-ram/BlockRam.cs
@@ -1,0 +1,373 @@
+namespace CodingAdventures.BlockRam;
+
+internal static class BitValidation
+{
+    internal static void Validate(int value, string name)
+    {
+        if (value is not (0 or 1))
+        {
+            throw new ArgumentOutOfRangeException(name, value, $"{name} must be 0 or 1");
+        }
+    }
+
+    internal static int[] CopyAndValidate(IReadOnlyList<int> data, int width, string name)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Count != width)
+        {
+            throw new ArgumentException($"{name} length {data.Count} does not match width {width}", name);
+        }
+
+        var result = new int[width];
+        for (var index = 0; index < width; index++)
+        {
+            Validate(data[index], $"{name}[{index}]");
+            result[index] = data[index];
+        }
+
+        return result;
+    }
+}
+
+/// <summary>A single-bit static RAM cell.</summary>
+public sealed class SRAMCell
+{
+    /// <summary>The bit currently stored in the cell.</summary>
+    public int Value { get; private set; }
+
+    /// <summary>Reads the cell when its word line is asserted.</summary>
+    public int? Read(int wordLine)
+    {
+        BitValidation.Validate(wordLine, nameof(wordLine));
+        return wordLine == 1 ? Value : null;
+    }
+
+    /// <summary>Writes the cell when its word line is asserted.</summary>
+    public void Write(int wordLine, int bitLine)
+    {
+        BitValidation.Validate(wordLine, nameof(wordLine));
+        BitValidation.Validate(bitLine, nameof(bitLine));
+        if (wordLine == 1)
+        {
+            Value = bitLine;
+        }
+    }
+}
+
+/// <summary>A rectangular zero-initialized array of SRAM cells.</summary>
+public sealed class SRAMArray
+{
+    private readonly SRAMCell[][] _cells;
+
+    public SRAMArray(int rows, int cols)
+    {
+        if (rows < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rows), rows, "rows must be >= 1");
+        }
+
+        if (cols < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(cols), cols, "cols must be >= 1");
+        }
+
+        Rows = rows;
+        Cols = cols;
+        _cells = Enumerable.Range(0, rows)
+            .Select(_ => Enumerable.Range(0, cols).Select(_ => new SRAMCell()).ToArray())
+            .ToArray();
+    }
+
+    public int Rows { get; }
+    public int Cols { get; }
+    public (int Rows, int Cols) Shape => (Rows, Cols);
+
+    public int[] Read(int row)
+    {
+        ValidateRow(row);
+        return _cells[row].Select(cell => cell.Read(1)!.Value).ToArray();
+    }
+
+    public void Write(int row, IReadOnlyList<int> data)
+    {
+        ValidateRow(row);
+        var bits = BitValidation.CopyAndValidate(data, Cols, nameof(data));
+        for (var column = 0; column < Cols; column++)
+        {
+            _cells[row][column].Write(1, bits[column]);
+        }
+    }
+
+    private void ValidateRow(int row)
+    {
+        if (row < 0 || row >= Rows)
+        {
+            throw new ArgumentOutOfRangeException(nameof(row), row, $"row {row} out of range [0, {Rows - 1}]");
+        }
+    }
+}
+
+/// <summary>Controls the value exposed by a RAM port during writes.</summary>
+public enum ReadMode
+{
+    ReadFirst,
+    WriteFirst,
+    NoChange,
+}
+
+/// <summary>Raised when both ports write the same address on one rising edge.</summary>
+public sealed class WriteCollisionException : InvalidOperationException
+{
+    public WriteCollisionException(int address)
+        : base($"Write collision: both ports writing to address {address}")
+    {
+        Address = address;
+    }
+
+    public int Address { get; }
+}
+
+/// <summary>A synchronous single-port RAM.</summary>
+public sealed class SinglePortRAM
+{
+    private readonly SRAMArray _array;
+    private readonly ReadMode _readMode;
+    private int _previousClock;
+    private int[] _lastRead;
+
+    public SinglePortRAM(int depth, int width, ReadMode readMode = ReadMode.ReadFirst)
+    {
+        if (depth < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(depth), depth, "depth must be >= 1");
+        }
+
+        if (width < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), width, "width must be >= 1");
+        }
+
+        Depth = depth;
+        Width = width;
+        _readMode = readMode;
+        _array = new SRAMArray(depth, width);
+        _lastRead = new int[width];
+    }
+
+    public int Depth { get; }
+    public int Width { get; }
+
+    public int[] Tick(int clock, int address, IReadOnlyList<int> dataIn, int writeEnable)
+    {
+        BitValidation.Validate(clock, nameof(clock));
+        BitValidation.Validate(writeEnable, nameof(writeEnable));
+        ValidateAddress(address, nameof(address));
+        var data = BitValidation.CopyAndValidate(dataIn, Width, nameof(dataIn));
+
+        var risingEdge = _previousClock == 0 && clock == 1;
+        _previousClock = clock;
+        if (!risingEdge)
+        {
+            return [.. _lastRead];
+        }
+
+        if (writeEnable == 0)
+        {
+            _lastRead = _array.Read(address);
+            return [.. _lastRead];
+        }
+
+        switch (_readMode)
+        {
+            case ReadMode.ReadFirst:
+                _lastRead = _array.Read(address);
+                _array.Write(address, data);
+                break;
+            case ReadMode.WriteFirst:
+                _array.Write(address, data);
+                _lastRead = data;
+                break;
+            case ReadMode.NoChange:
+                _array.Write(address, data);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported read mode: {_readMode}");
+        }
+
+        return [.. _lastRead];
+    }
+
+    public int[][] Dump() => Enumerable.Range(0, Depth).Select(_array.Read).ToArray();
+
+    private void ValidateAddress(int address, string name)
+    {
+        if (address < 0 || address >= Depth)
+        {
+            throw new ArgumentOutOfRangeException(name, address, $"address {address} out of range [0, {Depth - 1}]");
+        }
+    }
+}
+
+/// <summary>A synchronous true dual-port RAM with collision detection.</summary>
+public sealed class DualPortRAM
+{
+    private readonly SRAMArray _array;
+    private readonly ReadMode _readModeA;
+    private readonly ReadMode _readModeB;
+    private int _previousClock;
+    private int[] _lastReadA;
+    private int[] _lastReadB;
+
+    public DualPortRAM(
+        int depth,
+        int width,
+        ReadMode readModeA = ReadMode.ReadFirst,
+        ReadMode readModeB = ReadMode.ReadFirst)
+    {
+        if (depth < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(depth), depth, "depth must be >= 1");
+        }
+
+        if (width < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), width, "width must be >= 1");
+        }
+
+        Depth = depth;
+        Width = width;
+        _readModeA = readModeA;
+        _readModeB = readModeB;
+        _array = new SRAMArray(depth, width);
+        _lastReadA = new int[width];
+        _lastReadB = new int[width];
+    }
+
+    public int Depth { get; }
+    public int Width { get; }
+
+    public (int[] DataOutA, int[] DataOutB) Tick(
+        int clock,
+        int addressA,
+        IReadOnlyList<int> dataInA,
+        int writeEnableA,
+        int addressB,
+        IReadOnlyList<int> dataInB,
+        int writeEnableB)
+    {
+        BitValidation.Validate(clock, nameof(clock));
+        BitValidation.Validate(writeEnableA, nameof(writeEnableA));
+        BitValidation.Validate(writeEnableB, nameof(writeEnableB));
+        ValidateAddress(addressA, nameof(addressA));
+        ValidateAddress(addressB, nameof(addressB));
+        var dataA = BitValidation.CopyAndValidate(dataInA, Width, nameof(dataInA));
+        var dataB = BitValidation.CopyAndValidate(dataInB, Width, nameof(dataInB));
+
+        var risingEdge = _previousClock == 0 && clock == 1;
+        _previousClock = clock;
+        if (!risingEdge)
+        {
+            return ([.. _lastReadA], [.. _lastReadB]);
+        }
+
+        if (writeEnableA == 1 && writeEnableB == 1 && addressA == addressB)
+        {
+            throw new WriteCollisionException(addressA);
+        }
+
+        _lastReadA = ProcessPort(addressA, dataA, writeEnableA, _readModeA, _lastReadA);
+        _lastReadB = ProcessPort(addressB, dataB, writeEnableB, _readModeB, _lastReadB);
+        return ([.. _lastReadA], [.. _lastReadB]);
+    }
+
+    private int[] ProcessPort(int address, int[] data, int writeEnable, ReadMode mode, int[] lastRead)
+    {
+        if (writeEnable == 0)
+        {
+            return _array.Read(address);
+        }
+
+        switch (mode)
+        {
+            case ReadMode.ReadFirst:
+                var oldData = _array.Read(address);
+                _array.Write(address, data);
+                return oldData;
+            case ReadMode.WriteFirst:
+                _array.Write(address, data);
+                return data;
+            case ReadMode.NoChange:
+                _array.Write(address, data);
+                return [.. lastRead];
+            default:
+                throw new InvalidOperationException($"Unsupported read mode: {mode}");
+        }
+    }
+
+    private void ValidateAddress(int address, string name)
+    {
+        if (address < 0 || address >= Depth)
+        {
+            throw new ArgumentOutOfRangeException(name, address, $"address {address} out of range [0, {Depth - 1}]");
+        }
+    }
+}
+
+/// <summary>An FPGA-style dual-port block RAM with configurable aspect ratio.</summary>
+public sealed class ConfigurableBRAM
+{
+    private DualPortRAM _ram;
+
+    public ConfigurableBRAM(int totalBits = 18_432, int width = 8)
+    {
+        ValidateConfiguration(totalBits, width);
+        TotalBits = totalBits;
+        Width = width;
+        Depth = totalBits / width;
+        _ram = NewRam();
+    }
+
+    public int TotalBits { get; }
+    public int Width { get; private set; }
+    public int Depth { get; private set; }
+
+    public void Reconfigure(int width)
+    {
+        ValidateConfiguration(TotalBits, width);
+        Width = width;
+        Depth = TotalBits / width;
+        _ram = NewRam();
+    }
+
+    public int[] TickA(int clock, int address, IReadOnlyList<int> dataIn, int writeEnable)
+    {
+        var result = _ram.Tick(clock, address, dataIn, writeEnable, 0, new int[Width], 0);
+        return result.DataOutA;
+    }
+
+    public int[] TickB(int clock, int address, IReadOnlyList<int> dataIn, int writeEnable)
+    {
+        var result = _ram.Tick(clock, 0, new int[Width], 0, address, dataIn, writeEnable);
+        return result.DataOutB;
+    }
+
+    private DualPortRAM NewRam() => new(Depth, Width, ReadMode.ReadFirst, ReadMode.ReadFirst);
+
+    private static void ValidateConfiguration(int totalBits, int width)
+    {
+        if (totalBits < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(totalBits), totalBits, "totalBits must be >= 1");
+        }
+
+        if (width < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), width, "width must be >= 1");
+        }
+
+        if (totalBits % width != 0)
+        {
+            throw new ArgumentException($"width {width} does not evenly divide totalBits {totalBits}", nameof(width));
+        }
+    }
+}

--- a/code/packages/csharp/block-ram/CHANGELOG.md
+++ b/code/packages/csharp/block-ram/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add SRAM cells and rectangular zero-initialized arrays.
+- Add rising-edge single-port and true dual-port RAM with all three read modes.
+- Add collision detection and reconfigurable FPGA-style Block RAM.

--- a/code/packages/csharp/block-ram/CodingAdventures.BlockRam.csproj
+++ b/code/packages/csharp/block-ram/CodingAdventures.BlockRam.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.BlockRam.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SRAM cells and synchronous configurable block RAM for C#</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/block-ram/README.md
+++ b/code/packages/csharp/block-ram/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.BlockRam
+
+A pure C# model of the memory hierarchy used by FPGA simulations: individual
+SRAM cells, row-addressed arrays, synchronous single- and dual-port RAM, and a
+Block RAM whose fixed capacity can be reconfigured into different width/depth
+aspect ratios.
+
+```csharp
+using CodingAdventures.BlockRam;
+
+var ram = new SinglePortRAM(256, 8, ReadMode.ReadFirst);
+ram.Tick(0, 0, new[] { 1, 0, 1, 0, 1, 0, 1, 0 }, 1);
+ram.Tick(1, 0, new[] { 1, 0, 1, 0, 1, 0, 1, 0 }, 1);
+```
+
+All operations are deterministic and in memory. RAM operations occur only on
+the rising clock edge; dual-port writes to the same address are rejected.

--- a/code/packages/csharp/block-ram/required_capabilities.json
+++ b/code/packages/csharp/block-ram/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/block-ram",
+  "capabilities": [],
+  "justification": "Pure in-memory digital storage simulation using only the .NET standard library."
+}

--- a/code/packages/csharp/block-ram/tests/CodingAdventures.BlockRam.Tests/BlockRamTests.cs
+++ b/code/packages/csharp/block-ram/tests/CodingAdventures.BlockRam.Tests/BlockRamTests.cs
@@ -1,0 +1,243 @@
+using CodingAdventures.BlockRam;
+
+public sealed class SRAMTests
+{
+    [Fact]
+    public void CellHoldsReadsAndWritesOneBit()
+    {
+        var cell = new SRAMCell();
+        Assert.Equal(0, cell.Value);
+        Assert.Null(cell.Read(0));
+        cell.Write(0, 1);
+        Assert.Equal(0, cell.Value);
+        cell.Write(1, 1);
+        Assert.Equal(1, cell.Read(1));
+        cell.Write(1, 0);
+        Assert.Equal(0, cell.Value);
+    }
+
+    [Fact]
+    public void CellRejectsNonBits()
+    {
+        var cell = new SRAMCell();
+        Assert.Throws<ArgumentOutOfRangeException>(() => cell.Read(2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => cell.Write(1, -1));
+    }
+
+    [Fact]
+    public void ArrayStoresIndependentRows()
+    {
+        var memory = new SRAMArray(3, 4);
+        Assert.Equal((3, 4), memory.Shape);
+        memory.Write(0, [1, 0, 1, 0]);
+        memory.Write(2, [0, 1, 0, 1]);
+        Assert.Equal([1, 0, 1, 0], memory.Read(0));
+        Assert.Equal([0, 0, 0, 0], memory.Read(1));
+        Assert.Equal([0, 1, 0, 1], memory.Read(2));
+    }
+
+    [Fact]
+    public void ArrayValidatesShapeAddressAndData()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SRAMArray(0, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SRAMArray(1, 0));
+        var memory = new SRAMArray(2, 2);
+        Assert.Throws<ArgumentOutOfRangeException>(() => memory.Read(2));
+        Assert.Throws<ArgumentException>(() => memory.Write(0, [1]));
+        Assert.Throws<ArgumentNullException>(() => memory.Write(0, null!));
+        Assert.Throws<ArgumentOutOfRangeException>(() => memory.Write(0, [0, 2]));
+    }
+}
+
+public sealed class SinglePortRAMTests
+{
+    [Fact]
+    public void ReadFirstReturnsOldValueAndWritesNewValue()
+    {
+        var ram = new SinglePortRAM(4, 4);
+        Write(ram, 0, [1, 0, 1, 0]);
+        Assert.Equal([1, 0, 1, 0], Write(ram, 0, [0, 1, 0, 1]));
+        Assert.Equal([0, 1, 0, 1], Read(ram, 0));
+        Assert.Equal(4, ram.Depth);
+        Assert.Equal(4, ram.Width);
+    }
+
+    [Fact]
+    public void WriteFirstReturnsNewValue()
+    {
+        var ram = new SinglePortRAM(2, 2, ReadMode.WriteFirst);
+        Assert.Equal([1, 1], Write(ram, 0, [1, 1]));
+    }
+
+    [Fact]
+    public void NoChangeRetainsOutputDuringWrite()
+    {
+        var ram = new SinglePortRAM(2, 2, ReadMode.NoChange);
+        Assert.Equal([0, 0], Read(ram, 0));
+        Assert.Equal([0, 0], Write(ram, 0, [1, 1]));
+        Assert.Equal([1, 1], Read(ram, 0));
+    }
+
+    [Fact]
+    public void OnlyRisingEdgePerformsOperationAndResultsAreCopies()
+    {
+        var ram = new SinglePortRAM(2, 2, ReadMode.WriteFirst);
+        var low = ram.Tick(0, 0, new[] { 1, 0 }, 1);
+        Assert.Equal([0, 0], low);
+        var high = ram.Tick(1, 0, new[] { 1, 0 }, 1);
+        high[0] = 0;
+        Assert.Equal([1, 0], ram.Tick(1, 0, new[] { 0, 0 }, 0));
+        Assert.Equal([1, 0], Read(ram, 0));
+    }
+
+    [Fact]
+    public void DumpReturnsAllRows()
+    {
+        var ram = new SinglePortRAM(3, 2);
+        Write(ram, 1, [1, 0]);
+        var dump = ram.Dump();
+        Assert.Equal(3, dump.Length);
+        Assert.Equal([0, 0], dump[0]);
+        Assert.Equal([1, 0], dump[1]);
+    }
+
+    [Fact]
+    public void ValidatesConstructorAndSignals()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SinglePortRAM(0, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SinglePortRAM(1, 0));
+        var ram = new SinglePortRAM(2, 2);
+        Assert.Throws<ArgumentOutOfRangeException>(() => ram.Tick(2, 0, [0, 0], 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ram.Tick(1, 0, [0, 0], 2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ram.Tick(1, 2, [0, 0], 0));
+        Assert.Throws<ArgumentException>(() => ram.Tick(1, 0, [0], 0));
+    }
+
+    private static int[] Write(SinglePortRAM ram, int address, int[] data)
+    {
+        ram.Tick(0, address, data, 1);
+        return ram.Tick(1, address, data, 1);
+    }
+
+    private static int[] Read(SinglePortRAM ram, int address)
+    {
+        var zeros = new int[ram.Width];
+        ram.Tick(0, address, zeros, 0);
+        return ram.Tick(1, address, zeros, 0);
+    }
+}
+
+public sealed class DualPortRAMTests
+{
+    [Fact]
+    public void PortsReadAndWriteDifferentAddressesTogether()
+    {
+        var ram = new DualPortRAM(4, 4);
+        ram.Tick(0, 0, new[] { 1, 0, 0, 0 }, 1, 1, new[] { 0, 1, 0, 0 }, 1);
+        ram.Tick(1, 0, new[] { 1, 0, 0, 0 }, 1, 1, new[] { 0, 1, 0, 0 }, 1);
+        ram.Tick(0, 0, new int[4], 0, 1, new int[4], 0);
+        var result = ram.Tick(1, 0, new int[4], 0, 1, new int[4], 0);
+        Assert.Equal([1, 0, 0, 0], result.DataOutA);
+        Assert.Equal([0, 1, 0, 0], result.DataOutB);
+        Assert.Equal(4, ram.Depth);
+        Assert.Equal(4, ram.Width);
+    }
+
+    [Fact]
+    public void CollisionReportsAddressWithoutWriting()
+    {
+        var ram = new DualPortRAM(2, 2);
+        ram.Tick(0, 0, new[] { 1, 0 }, 1, 0, new[] { 0, 1 }, 1);
+        var error = Assert.Throws<WriteCollisionException>(() =>
+            ram.Tick(1, 0, new[] { 1, 0 }, 1, 0, new[] { 0, 1 }, 1));
+        Assert.Equal(0, error.Address);
+        Assert.Contains("address 0", error.Message);
+    }
+
+    [Fact]
+    public void PerPortReadModesAreIndependent()
+    {
+        var ram = new DualPortRAM(4, 2, ReadMode.NoChange, ReadMode.WriteFirst);
+        ram.Tick(0, 0, new[] { 1, 1 }, 1, 1, new[] { 1, 0 }, 1);
+        var result = ram.Tick(1, 0, new[] { 1, 1 }, 1, 1, new[] { 1, 0 }, 1);
+        Assert.Equal([0, 0], result.DataOutA);
+        Assert.Equal([1, 0], result.DataOutB);
+
+        ram.Tick(0, 0, new[] { 0, 0 }, 0, 1, new[] { 0, 1 }, 1);
+        result = ram.Tick(1, 0, new[] { 0, 0 }, 0, 1, new[] { 0, 1 }, 1);
+        Assert.Equal([1, 1], result.DataOutA);
+        Assert.Equal([0, 1], result.DataOutB);
+    }
+
+    [Fact]
+    public void ReadFirstPortReturnsOldData()
+    {
+        var ram = new DualPortRAM(2, 2);
+        ram.Tick(0, 0, new[] { 1, 1 }, 1, 1, new int[2], 0);
+        ram.Tick(1, 0, new[] { 1, 1 }, 1, 1, new int[2], 0);
+        ram.Tick(0, 0, new[] { 0, 0 }, 1, 1, new int[2], 0);
+        var result = ram.Tick(1, 0, new[] { 0, 0 }, 1, 1, new int[2], 0);
+        Assert.Equal([1, 1], result.DataOutA);
+    }
+
+    [Fact]
+    public void ValidatesConstructorAndPortInputs()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DualPortRAM(0, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new DualPortRAM(1, 0));
+        var ram = new DualPortRAM(2, 2);
+        Assert.Throws<ArgumentOutOfRangeException>(() => ram.Tick(2, 0, [0, 0], 0, 0, [0, 0], 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ram.Tick(1, 0, [0, 0], 2, 0, [0, 0], 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ram.Tick(1, 0, [0, 0], 0, 0, [0, 0], -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ram.Tick(1, -1, [0, 0], 0, 0, [0, 0], 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => ram.Tick(1, 0, [0, 0], 0, 2, [0, 0], 0));
+        Assert.Throws<ArgumentException>(() => ram.Tick(1, 0, [0], 0, 0, [0, 0], 0));
+        Assert.Throws<ArgumentException>(() => ram.Tick(1, 0, [0, 0], 0, 0, [0], 0));
+    }
+}
+
+public sealed class ConfigurableBRAMTests
+{
+    [Fact]
+    public void DefaultsToAnEighteenKilobitEightWideBlock()
+    {
+        var bram = new ConfigurableBRAM();
+        Assert.Equal(18_432, bram.TotalBits);
+        Assert.Equal(8, bram.Width);
+        Assert.Equal(2_304, bram.Depth);
+    }
+
+    [Fact]
+    public void PortsShareStorage()
+    {
+        var bram = new ConfigurableBRAM(64, 4);
+        bram.TickA(0, 3, new[] { 1, 0, 1, 1 }, 1);
+        bram.TickA(1, 3, new[] { 1, 0, 1, 1 }, 1);
+        bram.TickB(0, 3, new int[4], 0);
+        Assert.Equal([1, 0, 1, 1], bram.TickB(1, 3, new int[4], 0));
+    }
+
+    [Fact]
+    public void ReconfigureChangesShapeAndClearsStorage()
+    {
+        var bram = new ConfigurableBRAM(64, 4);
+        bram.TickB(0, 0, new[] { 1, 1, 1, 1 }, 1);
+        bram.TickB(1, 0, new[] { 1, 1, 1, 1 }, 1);
+        bram.Reconfigure(8);
+        Assert.Equal(8, bram.Width);
+        Assert.Equal(8, bram.Depth);
+        bram.TickA(0, 0, new int[8], 0);
+        Assert.Equal(new int[8], bram.TickA(1, 0, new int[8], 0));
+    }
+
+    [Fact]
+    public void ValidatesConfigurations()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConfigurableBRAM(0, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConfigurableBRAM(8, 0));
+        Assert.Throws<ArgumentException>(() => new ConfigurableBRAM(8, 3));
+        var bram = new ConfigurableBRAM(8, 2);
+        Assert.Throws<ArgumentOutOfRangeException>(() => bram.Reconfigure(0));
+        Assert.Throws<ArgumentException>(() => bram.Reconfigure(3));
+    }
+}

--- a/code/packages/csharp/block-ram/tests/CodingAdventures.BlockRam.Tests/CodingAdventures.BlockRam.Tests.csproj
+++ b/code/packages/csharp/block-ram/tests/CodingAdventures.BlockRam.Tests/CodingAdventures.BlockRam.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.BlockRam.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/block-ram/BUILD
+++ b/code/packages/fsharp/block-ram/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BlockRam.Tests/CodingAdventures.BlockRam.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.BlockRam.FSharp]*"

--- a/code/packages/fsharp/block-ram/BUILD_windows
+++ b/code/packages/fsharp/block-ram/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.BlockRam.Tests/CodingAdventures.BlockRam.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.BlockRam.FSharp]*"

--- a/code/packages/fsharp/block-ram/BlockRam.fs
+++ b/code/packages/fsharp/block-ram/BlockRam.fs
@@ -1,0 +1,230 @@
+namespace CodingAdventures.BlockRam.FSharp
+
+open System
+
+module internal Validation =
+    let bit name value =
+        if value <> 0 && value <> 1 then
+            raise (ArgumentOutOfRangeException(name, value, $"{name} must be 0 or 1"))
+
+    let data name width (values: int array) =
+        if isNull values then
+            nullArg name
+
+        if values.Length <> width then
+            raise (ArgumentException($"{name} length {values.Length} does not match width {width}", name))
+
+        values
+        |> Array.iteri (fun index value -> bit $"{name}[{index}]" value)
+
+        Array.copy values
+
+/// A single-bit static RAM cell.
+type SRAMCell() =
+    let mutable value = 0
+
+    member _.Value = value
+
+    member _.Read(wordLine: int) =
+        Validation.bit "wordLine" wordLine
+        if wordLine = 1 then Some value else None
+
+    member _.Write(wordLine: int, bitLine: int) =
+        Validation.bit "wordLine" wordLine
+        Validation.bit "bitLine" bitLine
+
+        if wordLine = 1 then
+            value <- bitLine
+
+/// A rectangular zero-initialized array of SRAM cells.
+type SRAMArray(rows: int, cols: int) =
+    do
+        if rows < 1 then
+            raise (ArgumentOutOfRangeException("rows", rows, "rows must be >= 1"))
+
+        if cols < 1 then
+            raise (ArgumentOutOfRangeException("cols", cols, "cols must be >= 1"))
+
+    let cells = Array.init rows (fun _ -> Array.init cols (fun _ -> SRAMCell()))
+
+    let validateRow row =
+        if row < 0 || row >= rows then
+            raise (ArgumentOutOfRangeException("row", row, $"row {row} out of range [0, {rows - 1}]"))
+
+    member _.Rows = rows
+    member _.Cols = cols
+    member _.Shape = rows, cols
+
+    member _.Read(row: int) =
+        validateRow row
+
+        cells[row]
+        |> Array.map (fun cell -> cell.Read(1) |> Option.get)
+
+    member _.Write(row: int, data: int array) =
+        validateRow row
+        let bits = Validation.data "data" cols data
+        Array.iter2 (fun (cell: SRAMCell) bit -> cell.Write(1, bit)) cells[row] bits
+
+/// Controls the value exposed by a RAM port during writes.
+type ReadMode =
+    | ReadFirst
+    | WriteFirst
+    | NoChange
+
+/// Raised when both ports write the same address on one rising edge.
+type WriteCollisionException(address: int) =
+    inherit InvalidOperationException($"Write collision: both ports writing to address {address}")
+    member _.Address = address
+
+/// A synchronous single-port RAM.
+type SinglePortRAM(depth: int, width: int, ?readMode: ReadMode) =
+    do
+        if depth < 1 then
+            raise (ArgumentOutOfRangeException("depth", depth, "depth must be >= 1"))
+
+        if width < 1 then
+            raise (ArgumentOutOfRangeException("width", width, "width must be >= 1"))
+
+    let readMode = defaultArg readMode ReadFirst
+    let memory = SRAMArray(depth, width)
+    let mutable previousClock = 0
+    let mutable lastRead = Array.zeroCreate width
+
+    let validateAddress address =
+        if address < 0 || address >= depth then
+            raise (ArgumentOutOfRangeException("address", address, $"address {address} out of range [0, {depth - 1}]"))
+
+    member _.Depth = depth
+    member _.Width = width
+
+    member _.Tick(clock: int, address: int, dataIn: int array, writeEnable: int) =
+        Validation.bit "clock" clock
+        Validation.bit "writeEnable" writeEnable
+        validateAddress address
+        let data = Validation.data "dataIn" width dataIn
+        let risingEdge = previousClock = 0 && clock = 1
+        previousClock <- clock
+
+        if risingEdge then
+            if writeEnable = 0 then
+                lastRead <- memory.Read address
+            else
+                match readMode with
+                | ReadFirst ->
+                    lastRead <- memory.Read address
+                    memory.Write(address, data)
+                | WriteFirst ->
+                    memory.Write(address, data)
+                    lastRead <- data
+                | NoChange -> memory.Write(address, data)
+
+        Array.copy lastRead
+
+    member _.Dump() =
+        Array.init depth memory.Read
+
+/// A synchronous true dual-port RAM with collision detection.
+type DualPortRAM(depth: int, width: int, ?readModeA: ReadMode, ?readModeB: ReadMode) =
+    do
+        if depth < 1 then
+            raise (ArgumentOutOfRangeException("depth", depth, "depth must be >= 1"))
+
+        if width < 1 then
+            raise (ArgumentOutOfRangeException("width", width, "width must be >= 1"))
+
+    let readModeA = defaultArg readModeA ReadFirst
+    let readModeB = defaultArg readModeB ReadFirst
+    let memory = SRAMArray(depth, width)
+    let mutable previousClock = 0
+    let mutable lastReadA = Array.zeroCreate width
+    let mutable lastReadB = Array.zeroCreate width
+
+    let validateAddress name address =
+        if address < 0 || address >= depth then
+            raise (ArgumentOutOfRangeException(name, address, $"address {address} out of range [0, {depth - 1}]"))
+
+    let processPort address data writeEnable mode lastRead =
+        if writeEnable = 0 then
+            memory.Read address
+        else
+            match mode with
+            | ReadFirst ->
+                let oldData = memory.Read address
+                memory.Write(address, data)
+                oldData
+            | WriteFirst ->
+                memory.Write(address, data)
+                data
+            | NoChange ->
+                memory.Write(address, data)
+                Array.copy lastRead
+
+    member _.Depth = depth
+    member _.Width = width
+
+    member _.Tick(
+        clock: int,
+        addressA: int,
+        dataInA: int array,
+        writeEnableA: int,
+        addressB: int,
+        dataInB: int array,
+        writeEnableB: int
+    ) =
+        Validation.bit "clock" clock
+        Validation.bit "writeEnableA" writeEnableA
+        Validation.bit "writeEnableB" writeEnableB
+        validateAddress "addressA" addressA
+        validateAddress "addressB" addressB
+        let dataA = Validation.data "dataInA" width dataInA
+        let dataB = Validation.data "dataInB" width dataInB
+        let risingEdge = previousClock = 0 && clock = 1
+        previousClock <- clock
+
+        if risingEdge then
+            if writeEnableA = 1 && writeEnableB = 1 && addressA = addressB then
+                raise (WriteCollisionException(addressA))
+
+            lastReadA <- processPort addressA dataA writeEnableA readModeA lastReadA
+            lastReadB <- processPort addressB dataB writeEnableB readModeB lastReadB
+
+        Array.copy lastReadA, Array.copy lastReadB
+
+/// An FPGA-style dual-port block RAM with configurable aspect ratio.
+type ConfigurableBRAM(?totalBits: int, ?width: int) =
+    let totalBits = defaultArg totalBits 18_432
+    let mutable width = defaultArg width 8
+
+    let validateConfiguration width =
+        if totalBits < 1 then
+            raise (ArgumentOutOfRangeException("totalBits", totalBits, "totalBits must be >= 1"))
+
+        if width < 1 then
+            raise (ArgumentOutOfRangeException("width", width, "width must be >= 1"))
+
+        if totalBits % width <> 0 then
+            raise (ArgumentException($"width {width} does not evenly divide totalBits {totalBits}", "width"))
+
+    do validateConfiguration width
+
+    let mutable depth = totalBits / width
+    let mutable ram = DualPortRAM(depth, width)
+
+    member _.TotalBits = totalBits
+    member _.Width = width
+    member _.Depth = depth
+
+    member _.Reconfigure(newWidth: int) =
+        validateConfiguration newWidth
+        width <- newWidth
+        depth <- totalBits / width
+        ram <- DualPortRAM(depth, width)
+
+    member _.TickA(clock: int, address: int, dataIn: int array, writeEnable: int) =
+        let dataOutA, _ = ram.Tick(clock, address, dataIn, writeEnable, 0, Array.zeroCreate width, 0)
+        dataOutA
+
+    member _.TickB(clock: int, address: int, dataIn: int array, writeEnable: int) =
+        let _, dataOutB = ram.Tick(clock, 0, Array.zeroCreate width, 0, address, dataIn, writeEnable)
+        dataOutB

--- a/code/packages/fsharp/block-ram/CHANGELOG.md
+++ b/code/packages/fsharp/block-ram/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add SRAM cells and rectangular zero-initialized arrays.
+- Add rising-edge single-port and true dual-port RAM with all three read modes.
+- Add collision detection and reconfigurable FPGA-style Block RAM.

--- a/code/packages/fsharp/block-ram/CodingAdventures.BlockRam.fsproj
+++ b/code/packages/fsharp/block-ram/CodingAdventures.BlockRam.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.BlockRam.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.BlockRam.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>SRAM cells and synchronous configurable block RAM for F#</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="BlockRam.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/block-ram/README.md
+++ b/code/packages/fsharp/block-ram/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.BlockRam.FSharp
+
+A pure F# model of the memory hierarchy used by FPGA simulations: individual
+SRAM cells, row-addressed arrays, synchronous single- and dual-port RAM, and a
+Block RAM whose fixed capacity can be reconfigured into different width/depth
+aspect ratios.
+
+```fsharp
+open CodingAdventures.BlockRam.FSharp
+
+let ram = SinglePortRAM(256, 8, readMode = ReadFirst)
+ram.Tick(0, 0, [| 1; 0; 1; 0; 1; 0; 1; 0 |], 1) |> ignore
+ram.Tick(1, 0, [| 1; 0; 1; 0; 1; 0; 1; 0 |], 1) |> ignore
+```
+
+All operations are deterministic and in memory. RAM operations occur only on
+the rising clock edge; dual-port writes to the same address are rejected.

--- a/code/packages/fsharp/block-ram/required_capabilities.json
+++ b/code/packages/fsharp/block-ram/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/block-ram",
+  "capabilities": [],
+  "justification": "Pure in-memory digital storage simulation using only the .NET standard library."
+}

--- a/code/packages/fsharp/block-ram/tests/CodingAdventures.BlockRam.Tests/BlockRamTests.fs
+++ b/code/packages/fsharp/block-ram/tests/CodingAdventures.BlockRam.Tests/BlockRamTests.fs
@@ -1,0 +1,197 @@
+namespace CodingAdventures.BlockRam.FSharp.Tests
+
+open System
+open Xunit
+open CodingAdventures.BlockRam.FSharp
+
+module Helpers =
+    let write (ram: SinglePortRAM) address data =
+        ram.Tick(0, address, data, 1) |> ignore
+        ram.Tick(1, address, data, 1)
+
+    let read (ram: SinglePortRAM) address =
+        let zeros = Array.zeroCreate ram.Width
+        ram.Tick(0, address, zeros, 0) |> ignore
+        ram.Tick(1, address, zeros, 0)
+
+type SRAMTests() =
+    [<Fact>]
+    member _.``cell holds reads and writes one bit``() =
+        let cell = SRAMCell()
+        Assert.Equal(0, cell.Value)
+        Assert.Equal(None, cell.Read 0)
+        cell.Write(0, 1)
+        Assert.Equal(0, cell.Value)
+        cell.Write(1, 1)
+        Assert.Equal(Some 1, cell.Read 1)
+        cell.Write(1, 0)
+        Assert.Equal(0, cell.Value)
+
+    [<Fact>]
+    member _.``cell rejects non bits``() =
+        let cell = SRAMCell()
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> cell.Read 2 |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> cell.Write(1, -1)) |> ignore
+
+    [<Fact>]
+    member _.``array stores independent rows``() =
+        let memory = SRAMArray(3, 4)
+        Assert.Equal((3, 4), memory.Shape)
+        memory.Write(0, [| 1; 0; 1; 0 |])
+        memory.Write(2, [| 0; 1; 0; 1 |])
+        Assert.Equal<int>([| 1; 0; 1; 0 |], memory.Read 0)
+        Assert.Equal<int>([| 0; 0; 0; 0 |], memory.Read 1)
+        Assert.Equal<int>([| 0; 1; 0; 1 |], memory.Read 2)
+
+    [<Fact>]
+    member _.``array validates shape address and data``() =
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> SRAMArray(0, 1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> SRAMArray(1, 0) |> ignore) |> ignore
+        let memory = SRAMArray(2, 2)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> memory.Read 2 |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> memory.Write(0, [| 1 |])) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> memory.Write(0, null)) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> memory.Write(0, [| 0; 2 |])) |> ignore
+
+type SinglePortRAMTests() =
+    [<Fact>]
+    member _.``read first returns old value and writes new value``() =
+        let ram = SinglePortRAM(4, 4)
+        Helpers.write ram 0 [| 1; 0; 1; 0 |] |> ignore
+        Assert.Equal<int>([| 1; 0; 1; 0 |], Helpers.write ram 0 [| 0; 1; 0; 1 |])
+        Assert.Equal<int>([| 0; 1; 0; 1 |], Helpers.read ram 0)
+        Assert.Equal(4, ram.Depth)
+        Assert.Equal(4, ram.Width)
+
+    [<Fact>]
+    member _.``write first returns new value``() =
+        let ram = SinglePortRAM(2, 2, readMode = WriteFirst)
+        Assert.Equal<int>([| 1; 1 |], Helpers.write ram 0 [| 1; 1 |])
+
+    [<Fact>]
+    member _.``no change retains output during write``() =
+        let ram = SinglePortRAM(2, 2, readMode = NoChange)
+        Assert.Equal<int>([| 0; 0 |], Helpers.read ram 0)
+        Assert.Equal<int>([| 0; 0 |], Helpers.write ram 0 [| 1; 1 |])
+        Assert.Equal<int>([| 1; 1 |], Helpers.read ram 0)
+
+    [<Fact>]
+    member _.``only rising edge operates and results are copies``() =
+        let ram = SinglePortRAM(2, 2, readMode = WriteFirst)
+        Assert.Equal<int>([| 0; 0 |], ram.Tick(0, 0, [| 1; 0 |], 1))
+        let high = ram.Tick(1, 0, [| 1; 0 |], 1)
+        high[0] <- 0
+        Assert.Equal<int>([| 1; 0 |], ram.Tick(1, 0, [| 0; 0 |], 0))
+        Assert.Equal<int>([| 1; 0 |], Helpers.read ram 0)
+
+    [<Fact>]
+    member _.``dump returns all rows``() =
+        let ram = SinglePortRAM(3, 2)
+        Helpers.write ram 1 [| 1; 0 |] |> ignore
+        let dump = ram.Dump()
+        Assert.Equal(3, dump.Length)
+        Assert.Equal<int>([| 0; 0 |], dump[0])
+        Assert.Equal<int>([| 1; 0 |], dump[1])
+
+    [<Fact>]
+    member _.``validates constructor and signals``() =
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> SinglePortRAM(0, 1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> SinglePortRAM(1, 0) |> ignore) |> ignore
+        let ram = SinglePortRAM(2, 2)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ram.Tick(2, 0, [| 0; 0 |], 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ram.Tick(1, 0, [| 0; 0 |], 2) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ram.Tick(1, 2, [| 0; 0 |], 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> ram.Tick(1, 0, [| 0 |], 0) |> ignore) |> ignore
+
+type DualPortRAMTests() =
+    [<Fact>]
+    member _.``ports read and write different addresses together``() =
+        let ram = DualPortRAM(4, 4)
+        ram.Tick(0, 0, [| 1; 0; 0; 0 |], 1, 1, [| 0; 1; 0; 0 |], 1) |> ignore
+        ram.Tick(1, 0, [| 1; 0; 0; 0 |], 1, 1, [| 0; 1; 0; 0 |], 1) |> ignore
+        ram.Tick(0, 0, Array.zeroCreate 4, 0, 1, Array.zeroCreate 4, 0) |> ignore
+        let dataA, dataB = ram.Tick(1, 0, Array.zeroCreate 4, 0, 1, Array.zeroCreate 4, 0)
+        Assert.Equal<int>([| 1; 0; 0; 0 |], dataA)
+        Assert.Equal<int>([| 0; 1; 0; 0 |], dataB)
+        Assert.Equal(4, ram.Depth)
+        Assert.Equal(4, ram.Width)
+
+    [<Fact>]
+    member _.``collision reports address``() =
+        let ram = DualPortRAM(2, 2)
+        ram.Tick(0, 0, [| 1; 0 |], 1, 0, [| 0; 1 |], 1) |> ignore
+        let error =
+            Assert.Throws<WriteCollisionException>(fun () ->
+                ram.Tick(1, 0, [| 1; 0 |], 1, 0, [| 0; 1 |], 1) |> ignore)
+        Assert.Equal(0, error.Address)
+        Assert.Contains("address 0", error.Message)
+
+    [<Fact>]
+    member _.``per port read modes are independent``() =
+        let ram = DualPortRAM(4, 2, readModeA = NoChange, readModeB = WriteFirst)
+        ram.Tick(0, 0, [| 1; 1 |], 1, 1, [| 1; 0 |], 1) |> ignore
+        let dataA, dataB = ram.Tick(1, 0, [| 1; 1 |], 1, 1, [| 1; 0 |], 1)
+        Assert.Equal<int>([| 0; 0 |], dataA)
+        Assert.Equal<int>([| 1; 0 |], dataB)
+        ram.Tick(0, 0, [| 0; 0 |], 0, 1, [| 0; 1 |], 1) |> ignore
+        let dataA, dataB = ram.Tick(1, 0, [| 0; 0 |], 0, 1, [| 0; 1 |], 1)
+        Assert.Equal<int>([| 1; 1 |], dataA)
+        Assert.Equal<int>([| 0; 1 |], dataB)
+
+    [<Fact>]
+    member _.``read first port returns old data``() =
+        let ram = DualPortRAM(2, 2)
+        ram.Tick(0, 0, [| 1; 1 |], 1, 1, Array.zeroCreate 2, 0) |> ignore
+        ram.Tick(1, 0, [| 1; 1 |], 1, 1, Array.zeroCreate 2, 0) |> ignore
+        ram.Tick(0, 0, [| 0; 0 |], 1, 1, Array.zeroCreate 2, 0) |> ignore
+        let dataA, _ = ram.Tick(1, 0, [| 0; 0 |], 1, 1, Array.zeroCreate 2, 0)
+        Assert.Equal<int>([| 1; 1 |], dataA)
+
+    [<Fact>]
+    member _.``validates constructor and port inputs``() =
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> DualPortRAM(0, 1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> DualPortRAM(1, 0) |> ignore) |> ignore
+        let ram = DualPortRAM(2, 2)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ram.Tick(2, 0, [| 0; 0 |], 0, 0, [| 0; 0 |], 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ram.Tick(1, 0, [| 0; 0 |], 2, 0, [| 0; 0 |], 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ram.Tick(1, 0, [| 0; 0 |], 0, 0, [| 0; 0 |], -1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ram.Tick(1, -1, [| 0; 0 |], 0, 0, [| 0; 0 |], 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ram.Tick(1, 0, [| 0; 0 |], 0, 2, [| 0; 0 |], 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> ram.Tick(1, 0, [| 0 |], 0, 0, [| 0; 0 |], 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> ram.Tick(1, 0, [| 0; 0 |], 0, 0, [| 0 |], 0) |> ignore) |> ignore
+
+type ConfigurableBRAMTests() =
+    [<Fact>]
+    member _.``defaults to an eighteen kilobit eight wide block``() =
+        let bram = ConfigurableBRAM()
+        Assert.Equal(18_432, bram.TotalBits)
+        Assert.Equal(8, bram.Width)
+        Assert.Equal(2_304, bram.Depth)
+
+    [<Fact>]
+    member _.``ports share storage``() =
+        let bram = ConfigurableBRAM(totalBits = 64, width = 4)
+        bram.TickA(0, 3, [| 1; 0; 1; 1 |], 1) |> ignore
+        bram.TickA(1, 3, [| 1; 0; 1; 1 |], 1) |> ignore
+        bram.TickB(0, 3, Array.zeroCreate 4, 0) |> ignore
+        Assert.Equal<int>([| 1; 0; 1; 1 |], bram.TickB(1, 3, Array.zeroCreate 4, 0))
+
+    [<Fact>]
+    member _.``reconfigure changes shape and clears storage``() =
+        let bram = ConfigurableBRAM(totalBits = 64, width = 4)
+        bram.TickB(0, 0, [| 1; 1; 1; 1 |], 1) |> ignore
+        bram.TickB(1, 0, [| 1; 1; 1; 1 |], 1) |> ignore
+        bram.Reconfigure 8
+        Assert.Equal(8, bram.Width)
+        Assert.Equal(8, bram.Depth)
+        bram.TickA(0, 0, Array.zeroCreate 8, 0) |> ignore
+        Assert.Equal<int>(Array.zeroCreate 8, bram.TickA(1, 0, Array.zeroCreate 8, 0))
+
+    [<Fact>]
+    member _.``validates configurations``() =
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ConfigurableBRAM(totalBits = 0, width = 1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> ConfigurableBRAM(totalBits = 8, width = 0) |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> ConfigurableBRAM(totalBits = 8, width = 3) |> ignore) |> ignore
+        let bram = ConfigurableBRAM(totalBits = 8, width = 2)
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> bram.Reconfigure 0) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> bram.Reconfigure 3) |> ignore

--- a/code/packages/fsharp/block-ram/tests/CodingAdventures.BlockRam.Tests/CodingAdventures.BlockRam.Tests.fsproj
+++ b/code/packages/fsharp/block-ram/tests/CodingAdventures.BlockRam.Tests/CodingAdventures.BlockRam.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.BlockRam.fsproj" />
+    <Compile Include="BlockRamTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -112,16 +112,17 @@ the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
 and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
 `x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
-ports, and the paired C#/F# `chacha20-poly1305` and `xml-lexer` ports:
+ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, and `block-ram`
+ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 327 |
+| Present in 10-15 languages | 172 | 325 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 699 | 9,786 |
+| Present in one language | 701 | 9,814 |
 
-The loop must not start by attempting 9,786 singleton ports. It should finish
+The loop must not start by attempting 9,814 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -171,8 +172,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 9 | Move with F# |
-| F# | 9 | Move with C# |
+| C# | 8 | Move with F# |
+| F# | 8 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -291,6 +292,15 @@ namespaces, quoted attributes, entity and character references, significant
 whitespace, token positions, malformed input, and EOF behavior. The package
 now spans 12 implementation lanes, reduces the high-consensus backlog to 327
 slots, and leaves 9 paired gaps in each lane.
+
+The ninth paired C#/F# slice is complete: `block-ram` now models SRAM cells,
+row-addressed arrays, rising-edge single-port and true dual-port RAM, all three
+read-during-write modes, same-address collision detection, and configurable
+FPGA-style width/depth aspect ratios in both lanes. Package-native tests cover
+cross-port visibility, edge behavior, reconfiguration clearing, defensive
+copies, and invalid signals and dimensions. The package now spans 12 target
+implementation lanes, reduces the high-consensus backlog to 325 slots, and
+leaves 8 paired gaps in each lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add native, dependency-free C# and F# `block-ram` packages
- model SRAM cells/arrays, rising-edge single- and dual-port RAM, all read-during-write modes, write-collision detection, and configurable FPGA-style Block RAM
- add package metadata, capability declarations, build recipes, documentation, and 19 tests per language
- refresh the package-parity roadmap from the live inventory

## Why this slice is next

Priority 1 is complete. `block-ram` was the smallest remaining dependency-free leaf in the paired C#/F# high-consensus backlog, ahead of parser, crypto, compression, FPGA, and compiler families. This reduces the high-consensus backlog from 327 to 325 slots and the paired C#/F# gaps from nine to eight each.

## Validation

- C#: 19/19 tests; 99.07% line, 94.28% branch, 100% method coverage
- F#: 19/19 tests; 98.4% line, 93.02% branch, 94.28% method coverage
- `python code/scripts/tests/test_package_parity_report.py -v` (6/6)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions; 325 high-consensus missing slots; 8 C# and 8 F# gaps)
- `dotnet format code/packages/csharp/block-ram/CodingAdventures.BlockRam.csproj --verify-no-changes --no-restore`
- `git diff --check`