### PR TITLE
feat(adj-facts-stdlib): physics/magnet-poles — pole interaction → outcome table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_magnetpoles_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_magnetpoles_e2e.rs
@@ -1,0 +1,80 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/magnet-poles.adj`) driven through the built CLI:
+//! a native `table` of magnetic pole pairing → interaction outcome resolves a
+//! binding query recall with the NASA citation, runs backward (outcome →
+//! pairing), and abstains on something that is not a pole pairing the source
+//! names — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsmp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn physics_magnet_poles_recall_binds_outcome_with_citation() {
+    let dir = scratch("magnetpoles");
+    // Copy the shipped physics table beside the entry program and import it.
+    let src = facts_stdlib().join("physics/magnet-poles.adj");
+    std::fs::copy(&src, dir.join("magnet-poles.adj")).expect("copy shipped magnet-poles.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"magnet-poles.adj\"\n\
+         ? magnet_pole_interaction(like_poles, $Out)\n\
+         ? magnet_pole_interaction(opposite_poles, $Out)\n\
+         ? magnet_pole_interaction(north_to_north, $Out)\n\
+         ? magnet_pole_interaction($P, attract)\n\
+         ? magnet_pole_interaction(single_pole, $Out)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward lookups bind each pairing to the outcome NASA states.
+    assert!(out.contains("\"Out\":\"repel\""), "like_poles binds to repel: {out}");
+    assert!(out.contains("\"Out\":\"attract\""), "opposite_poles binds to attract: {out}");
+    assert!(
+        out.contains("magnet_pole_interaction(like_poles, repel)"),
+        "like_poles is governing-bound to repel: {out}"
+    );
+    assert!(
+        out.contains("magnet_pole_interaction(opposite_poles, attract)"),
+        "opposite_poles is governing-bound to attract: {out}"
+    );
+    assert!(
+        out.contains("magnet_pole_interaction(north_to_north, repel)"),
+        "north_to_north is governing-bound to repel: {out}"
+    );
+    // The relation runs BACKWARD: bind the outcome, recall a pairing.
+    assert!(
+        out.contains("\"P\":\"opposite_poles\""),
+        "reverse recall binds P=opposite_poles from attract: {out}"
+    );
+    // The answer carries the NASA locator + trust tier as its proof.
+    assert!(
+        out.contains("nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A single pole is NOT a pole pairing the source names — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "single_pole abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -55,6 +55,7 @@ per rotation, in parallel):
 | `physics/` | common force → everyday example NASA uses (gravity → waterfall, tension → ropes) | NASA GSFC Swift (authoritative) |
 | `physics/` | named wave → its family (sound → mechanical, radio → electromagnetic) | NASA Science (authoritative) |
 | `physics/` | temperature reference point → the value NIST fixes it at (water_boils_celsius → 100, absolute_zero_kelvin → 0) | NIST (authoritative) |
+| `physics/` | magnetic pole pairing → interaction (like_poles → repel, opposite_poles → attract) | NASA Heliophysics Education (authoritative) |
 | `anatomy/` | lung → number of lobes (right 3, left 2) | NIH / NCI SEER Training |
 | `anatomy/` | brain part → primary function it controls | NIH / NCI SEER Training + StatPearls |
 | `anatomy/` | skeletal muscle → body region it is located in | Wikipedia (consensus) |

--- a/code/specs/data/adj-facts-stdlib/physics/magnet-poles.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/magnet-poles.adj
@@ -1,0 +1,84 @@
+% ============================================================================
+% magnet-poles — how a pair of magnetic poles INTERACTS: like poles repel,
+% opposite poles attract (adj-facts-stdlib, PHYSICS).
+% ============================================================================
+% The very first fact a child learns about magnetism, on the way to fields,
+% forces, and electromagnetism: two magnetic poles either PUSH apart or PULL
+% together, and which one happens depends only on whether the poles are the
+% SAME kind or OPPOSITE kinds. Recall is a binding query:
+%
+%     ? magnet_pole_interaction(like_poles, $Out)   % repel
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `magnet_pole_interaction(pairing, outcome)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the outcome WITH its source, on the CPU, with zero model calls, and
+% abstains on anything that is not a pole pairing the source names.
+%
+% The rule of magnetic poles, as a little truth table (a pair of poles → what
+% the two poles DO, in the word the source uses):
+%
+%     pairing          the two poles are…          they…      (NASA)
+%     --------------   -------------------------    ---------
+%     like_poles       the SAME kind (N & N)        repel
+%     opposite_poles   OPPOSITE kinds (N & S)       attract
+%     north_to_north   N brought toward N           repel
+%     north_to_south   N brought toward S           attract
+%
+% "like_poles"/"opposite_poles" are the general rule; "north_to_north"/
+% "north_to_south" are the SAME rule stated for the concrete pole pairs the
+% source names in its own parenthetical — every key and every outcome token
+% appears verbatim in the one NASA sentence quoted below. This is the concrete
+% rung a physics learner reasons UP from: before reasoning about field lines,
+% flux, or the right-hand rule, a student first learns that same-pole → push,
+% opposite-pole → pull.
+%
+% The query also runs BACKWARD — bind the outcome and recall a pairing that
+% produces it:
+%
+%     ? magnet_pole_interaction($P, attract)   % opposite_poles — reverse recall
+%
+% Something that is not a pole pairing the source states — a single pole, a
+% pole and a piece of unmagnetized iron — has no row, so a recall on it
+% ABSTAINS rather than inventing an interaction. That honest-abstention
+% property is what makes the table safe to reason from.
+%
+% Each `pairing` and each `outcome` value is a SINGLE lowercase snake_case atom,
+% chosen to be a faithful short paraphrase of the pole pairing and outcome the
+% source explicitly states — never an interaction the source does not name.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every pairing→outcome pair
+% was read out of a fetched NASA education page this session, and any pairing
+% that could not be grounded there would have been dropped). All four rows come
+% from ONE sentence in the SAME primary U.S. government source, NASA's
+% Heliophysics Education "Introductory Activities in Magnetism with Smart
+% Devices" educator guide
+% (assets.science.nasa.gov/.../NASAMagnetism-Introduction_FINAL.pdf), quoted
+% here character-for-character so any reader can re-check it:
+%
+%   "Elementary School Experiments (Grades 3-5) have observed how like poles
+%    (North to North) repel and opposite poles (North to South) attract."
+%
+% That single sentence fixes all four rows: it states that LIKE poles — which
+% it glosses as "North to North" — REPEL, and that OPPOSITE poles — which it
+% glosses as "North to South" — ATTRACT. An ADJ `table` carries ONE provenance
+% envelope, so the `source`/`locator`/`trust` below hold that span, and every
+% row is a token drawn straight from it. The source is a primary U.S.
+% government NASA science-education page (nasa.gov), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table magnet_pole_interaction {
+    columns pairing, outcome
+
+    row (like_poles, repel)
+    row (opposite_poles, attract)
+    row (north_to_north, repel)
+    row (north_to_south, attract)
+
+    source "Elementary School Experiments (Grades 3-5) have observed how like poles (North to North) repel and opposite poles (North to South) attract."
+    locator "https://assets.science.nasa.gov/content/dam/science/hpd/heat/sten-guides/sten-guides-pdfs/NASAMagnetism-Introduction_FINAL.pdf"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/physics/magnet-poles.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/magnet-poles.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% magnet-poles.query.adj — a worked recall over the physics magnet-poles library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what do two like poles
+% do?": it states no physics fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `magnet_pole_interaction` rows and returns the outcome + the table's
+% source/locator/trust. The fifth query runs the relation BACKWARD (bind the
+% outcome `attract`, recall a pairing that produces it — opposite poles). A
+% single pole is not a pole PAIRING, so a recall on it abstains honestly — the
+% engine never invents an interaction.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli magnet-poles.query.adj
+% ============================================================================
+
+import "magnet-poles.adj"
+
+? magnet_pole_interaction(like_poles, $Out)      % expect repel
+? magnet_pole_interaction(opposite_poles, $Out)  % expect attract
+? magnet_pole_interaction(north_to_north, $Out)  % expect repel
+? magnet_pole_interaction(north_to_south, $Out)  % expect attract
+? magnet_pole_interaction($P, attract)           % expect opposite_poles — reverse recall
+? magnet_pole_interaction(single_pole, $Out)     % expect abstain — not a pole pairing


### PR DESCRIPTION
Add a grounded PHYSICS facts library mapping a magnetic pole pairing to the
interaction it produces (like_poles → repel, opposite_poles → attract), as a
native ADJ `table` resolved by binding query with zero model calls.

Rows (single axis: pole pairing → interaction outcome), all four tokens drawn
verbatim from ONE NASA sentence:
  like_poles     → repel
  opposite_poles → attract
  north_to_north → repel      (source's own gloss of "like poles")
  north_to_south → attract    (source's own gloss of "opposite poles")

Provenance — single primary U.S. government source, NASA Heliophysics
Education "Introductory Activities in Magnetism with Smart Devices" educator
guide (trust authoritative), fetched this session and quoted character-for-
character in the table's `source` envelope:

  "Elementary School Experiments (Grades 3-5) have observed how like poles
   (North to North) repel and opposite poles (North to South) attract."
  https://assets.science.nasa.gov/content/dam/science/hpd/heat/sten-guides/sten-guides-pdfs/NASAMagnetism-Introduction_FINAL.pdf

Nothing asserted from memory; every pairing→outcome pair read out of that
fetched page. Recall runs forward and backward (outcome → pairing) and
abstains honestly on anything that is not a pole pairing the source names
(e.g. single_pole).

Adds magnet-poles.adj + magnet-poles.query.adj, a physics README subject-index
row (all existing rows kept), and facts_magnetpoles_e2e.rs. Targeted e2e test
and clippy (adj-lang, adj-lang-cli) green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
