### PR TITLE
feat(gc-core): precise interior tracing via reference-field maps (#119)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this crate are documented here.
 
+## [0.7.0] — 2026-07-17
+
+### Added
+
+- **`__gc_register_kind(field_offsets, count) -> i64`** — C ABI over
+  `FlatHeap::register_kind`. Registers a reference-field map (the byte offsets of
+  an object layout's `ref`-typed fields) and returns a 1-based `kind` id to pass
+  to `__gc_alloc_kind`. Objects of that kind are traced **precisely** — only the
+  mapped offsets are followed during marking — so a look-alike-pointer integer in
+  a non-reference field can't keep a dead object alive. This is the seam a native
+  runtime / language frontend uses to teach the collector its object layouts
+  (records, tuples, Ruby/Python/JS objects). Negative offsets are ignored; a null
+  list / `count <= 0` registers a no-ref-field (opaque) kind. Host test proves a
+  precise collect reclaims a pointee referenced only via a non-ref field.
+
 ## [0.6.0] — 2026-07-17
 
 ### Changed

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/README.md
+++ b/code/packages/rust/gc-core-capi/README.md
@@ -35,7 +35,8 @@ The interpreters use `gc-core`'s managed-object collector; native output uses
 | Symbol | Meaning |
 |---|---|
 | `int64_t __gc_alloc(int64_t n)` | allocate `n` zeroed bytes; returns a real pointer (as `int64`), `0` on failure/`n<=0` |
-| `int64_t __gc_alloc_kind(int64_t n, uint16_t kind)` | as above, tagging the object with a `HeapKind` id (for later precise tracing) |
+| `int64_t __gc_alloc_kind(int64_t n, uint16_t kind)` | as above, tagging the object with a registered `kind` id → precise interior tracing (`0` = conservative) |
+| `int64_t __gc_register_kind(const int64_t *field_offsets, int64_t count)` | register a ref-field map, returns a 1-based `kind` id for `__gc_alloc_kind` (precise tracing) |
 | `int64_t __gc_collect_roots(const int64_t *roots, int64_t count)` | mark from `count` root words, sweep; returns objects freed |
 | `int64_t __gc_collect_region(const uint8_t *base, int64_t len)` | mark from every candidate pointer in a raw region, sweep; returns objects freed |
 | `int64_t __gc_collect(void)` | conservative collection rooted at this thread's live stack + callee-saved registers (no caller roots); returns objects freed |
@@ -87,12 +88,18 @@ The archive also exports **twig-compat aliases** — `__twig_gc_alloc` /
 `twig_gc.c` exported; these aliases let this archive satisfy them so `twig_gc.c`
 can be retired without changing the emitters.
 
-Still to come (own PRs):
+**Precise interior tracing** is now available: `__gc_register_kind` records an
+object layout's ref-field offsets and returns a `kind` id for `__gc_alloc_kind`,
+so typed objects are traced exactly (only their ref fields) rather than
+conservatively — the first rung of the precision ladder, and what lets the
+collector serve typed-object languages.
 
-- Wire `twig-aot`'s `build.rs` to link this archive instead of compiling
-  `twig_gc.c`, and retire `twig_gc.c` (golden / `*_smoke.rs` parity).
-- **Precise** roots (stack maps) and interior tracing (`HeapKind` field maps),
-  then moving / generational — all as `gc-core` algorithms.
+Still to come (own PRs) — the rest of the ladder, all as `gc-core` algorithms:
+
+- **Precise roots** (stack maps: the backend emits a live-ref-slot map at each
+  safepoint so the *stack* scan is exact, not just interiors).
+- **Generational** (nursery + write barrier — the biggest win for high-churn
+  object allocation), then **moving / compacting**, then **incremental**.
 
 ## Build & test
 

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -38,9 +38,18 @@ extern "C" {
  * n <= 0, size overflow, or allocator failure. */
 int64_t __gc_alloc(int64_t n);
 
-/* As __gc_alloc, tagging the object with a HeapKind id (for later precise
- * interior tracing; 0 = opaque / trace conservatively). */
+/* As __gc_alloc, tagging the object with a HeapKind id (0 = opaque / trace
+ * conservatively; a registered kind id enables precise interior tracing). */
 int64_t __gc_alloc_kind(int64_t n, uint16_t kind);
+
+/* Register a reference-field map (the byte offsets of an object layout's ref
+ * fields) and return a 1-based kind id to pass to __gc_alloc_kind. Objects of
+ * that kind are traced PRECISELY — only the mapped offsets are followed — so a
+ * look-alike-pointer integer in a non-reference field cannot pin a phantom
+ * child. A null list or count <= 0 registers an opaque (no-ref-field) kind;
+ * negative offsets are ignored. This is how a frontend teaches the collector
+ * its object layouts (records, tuples, Ruby/Python/JS objects). */
+int64_t __gc_register_kind(const int64_t *field_offsets, int64_t count);
 
 /* Mark from `count` root words at `roots`, then sweep. Returns objects freed.
  * A null `roots` or count <= 0 means "no roots". */

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -107,6 +107,34 @@ pub extern "C" fn __gc_alloc_kind(n: i64, kind: u16) -> i64 {
     with_heap(|h| h.alloc(n as usize, kind) as i64)
 }
 
+/// Register a **reference-field map** for one class of object and return the
+/// `kind` id (≥ 1) to pass to [`__gc_alloc_kind`]. Objects allocated with that id
+/// are traced **precisely** — only the `count` byte offsets at `field_offsets`
+/// (the object's `ref`-typed fields) are followed during marking, instead of
+/// scanning every payload word conservatively.
+///
+/// This is the C-ABI seam a native runtime / language frontend uses to teach the
+/// collector its object layouts (records, tuples, Ruby/Python/JS objects) so a
+/// look-alike-pointer integer in a non-reference field can't pin a phantom child.
+/// Registering nothing (`field_offsets` null or `count <= 0`) yields a kind whose
+/// objects have no ref fields — traced as fully opaque.
+///
+/// # Safety
+///
+/// `field_offsets` must point to `count` readable `int64` words (or be null with
+/// `count <= 0`). Negative offsets are ignored. Standard C-array contract.
+#[no_mangle]
+pub unsafe extern "C" fn __gc_register_kind(field_offsets: *const i64, count: i64) -> i64 {
+    let offsets: Vec<usize> = if field_offsets.is_null() || count <= 0 {
+        Vec::new()
+    } else {
+        // SAFETY: caller guarantees `field_offsets` covers `count` readable words.
+        let slice = std::slice::from_raw_parts(field_offsets, count as usize);
+        slice.iter().filter(|&&o| o >= 0).map(|&o| o as usize).collect()
+    };
+    with_heap(|h| h.register_kind(&offsets) as i64)
+}
+
 /// Mark from the `count` root words at `roots`, then sweep.  Returns the number
 /// of objects reclaimed.  A null `roots` or `count <= 0` means "no roots" — a
 /// full collection that frees everything not otherwise reachable (here, since
@@ -245,5 +273,38 @@ mod tests {
         __gc_reset();
         assert_eq!(__gc_live_bytes(), 0);
         assert_eq!(__gc_collection_count(), 0);
+    }
+
+    /// `__gc_register_kind` + `__gc_alloc_kind` give **precise** interior tracing
+    /// through the C ABI: a heap pointer in a non-reference field of a typed
+    /// object is not followed, so its pointee is reclaimed.
+    #[test]
+    fn c_abi_register_kind_precise_trace() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+
+        // A kind whose only ref field is at byte offset 0.
+        let offsets = [0i64];
+        let rec = unsafe { __gc_register_kind(offsets.as_ptr(), 1) };
+        assert!(rec >= 1, "kind ids are 1-based");
+
+        let target = __gc_alloc(16); // opaque pointee
+        let container = __gc_alloc_kind(16, rec as u16);
+        assert!(target != 0 && container != 0);
+        unsafe {
+            *(container as *mut i64) = 0; // field@0 (ref) = null
+            *((container as usize + 8) as *mut i64) = target; // field@8 (non-ref) = phantom
+        }
+        assert_eq!(__gc_live_bytes(), 32);
+
+        // Root only the container; precise tracing follows offset 0 only.
+        let roots = [container];
+        let freed = unsafe { __gc_collect_roots(roots.as_ptr(), 1) };
+        assert_eq!(freed, 1, "the non-ref-field pointee is reclaimed precisely");
+        assert_eq!(__gc_live_bytes(), 16, "the container survives");
+        // Container memory is still valid.
+        assert_eq!(unsafe { *(container as *const i64) }, 0);
+
+        __gc_reset();
     }
 }

--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — gc-core
 
+## 0.5.0 — 2026-07-17
+
+### Added
+
+- **`FlatHeap` precise interior tracing via reference-field maps** — the first
+  rung of the precision ladder (conservative → precise) and the step that lets
+  the collector serve typed-object languages. `register_kind(field_offsets) ->
+  u16` records the ref-field byte offsets for one object layout and returns a
+  1-based `kind` id; `scan_payload` now follows **only** those offsets for objects
+  allocated with that kind (via `alloc(n, kind)`), instead of scanning every
+  payload word conservatively. So a look-alike-pointer integer sitting in a
+  non-reference field no longer pins a phantom child. Kind id `0` stays reserved
+  for "opaque / trace conservatively", so existing `alloc(n, 0)` behaviour is
+  unchanged; an unregistered kind id or an offset that runs past an object's
+  payload safely falls back / is skipped (never an out-of-bounds read, never
+  under-traces). New `registered_kinds()`. 6 unit tests, including the headline
+  precise-reclaims-phantom vs. conservative-retains-phantom contrast.
+
 ## 0.4.0 — 2026-07-17
 
 ### Added

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "LANG16 — adaptive GC adapter layer wiring garbage-collector into the LANG VM pipeline."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/flat_heap.rs
+++ b/code/packages/rust/gc-core/src/flat_heap.rs
@@ -120,6 +120,15 @@ pub struct FlatHeap {
     collect_threshold: usize,
     /// Adaptive-policy profile shared with the rest of `gc-core`.
     profile: GcProfile,
+    /// Per-kind **reference-field maps** for *precise* interior tracing, indexed
+    /// by `kind_id - 1` (see [`Self::register_kind`]). Entry *k* is the byte
+    /// offsets of the `ref`-typed fields in an object of kind `k + 1`. When an
+    /// object carries a registered kind, [`Self::scan_payload`] follows *only*
+    /// those offsets instead of scanning every payload word conservatively — so
+    /// a look-alike-pointer integer sitting in a non-reference field no longer
+    /// pins a phantom child. Kind id `0` is reserved for "opaque / trace
+    /// conservatively" and never appears here.
+    field_maps: Vec<Box<[usize]>>,
 }
 
 /// Initial collection threshold, and the floor `adapt_threshold` never drops
@@ -156,6 +165,7 @@ impl FlatHeap {
             collection_count: 0,
             collect_threshold: INITIAL_THRESHOLD,
             profile: GcProfile::default(),
+            field_maps: Vec::new(),
         }
     }
 
@@ -226,6 +236,42 @@ impl FlatHeap {
     /// The current collection threshold in bytes (see [`INITIAL_THRESHOLD`]).
     pub fn collect_threshold(&self) -> usize {
         self.collect_threshold
+    }
+
+    /// Register a **reference-field map** for one class of object and return the
+    /// `kind` id to allocate it with. Objects allocated with that id are traced
+    /// **precisely**: [`Self::scan_payload`] follows only the byte offsets in
+    /// `field_offsets` (the object's `ref`-typed fields) instead of scanning every
+    /// payload word conservatively.
+    ///
+    /// This is what makes the flat collector serve **typed-object languages**
+    /// (Ruby/Python/JS objects, records, tuples): a frontend registers each
+    /// object layout's ref-field offsets once at startup, then a look-alike
+    /// pointer sitting in an integer field can no longer keep a dead object alive.
+    ///
+    /// Ids are assigned from **1**; id `0` stays reserved for "opaque / trace
+    /// conservatively", so `alloc(n, 0)` (the default) keeps the exact conservative
+    /// behaviour. Offsets are taken as-is; an offset whose 8-byte word would run
+    /// past an object's payload is skipped at trace time (a malformed map can never
+    /// cause an out-of-bounds read).
+    ///
+    /// # Panics
+    ///
+    /// Panics only if more than `u16::MAX - 1` kinds are registered — far beyond
+    /// any real program.
+    pub fn register_kind(&mut self, field_offsets: &[usize]) -> u16 {
+        let id = self.field_maps.len() + 1;
+        assert!(
+            id <= u16::MAX as usize,
+            "flat-heap kind registry overflow: more than 65534 kinds registered"
+        );
+        self.field_maps.push(field_offsets.into());
+        id as u16
+    }
+
+    /// Number of registered precise kinds (0 = none; ids run 1..=len).
+    pub fn registered_kinds(&self) -> usize {
+        self.field_maps.len()
     }
 
     /// Whether the live set has reached the threshold — i.e. a collection is due.
@@ -423,13 +469,43 @@ impl FlatHeap {
         }
     }
 
-    /// Conservatively scan `h`'s payload for further candidate pointers.
+    /// Scan `h`'s payload for further candidate pointers.
+    ///
+    /// If the object carries a **registered kind** (`kind != 0` with a field map
+    /// from [`Self::register_kind`]), only that kind's `ref`-field offsets are
+    /// followed — **precise** interior tracing, so a look-alike-pointer integer in
+    /// a non-reference field pins nothing. Otherwise the whole payload is scanned
+    /// **conservatively** (kind `0`, or a kind id with no map — a safe fallback
+    /// that never under-traces).
     fn scan_payload(&self, h: *mut FlatHeader, work: &mut Vec<*mut FlatHeader>) {
         // SAFETY: `h` is a live block; its payload is `size` bytes at `h + 32`.
-        let (base, size) = unsafe {
+        let (base, size, kind) = unsafe {
             let payload = (h.add(1)) as *const u8;
-            (payload, (*h).size)
+            (payload, (*h).size, (*h).kind)
         };
+
+        // Precise path: an object of a registered kind is traced through exactly
+        // its ref-field offsets. `kind` ids are 1-based (`0` = conservative).
+        if kind != 0 {
+            if let Some(offsets) = self.field_maps.get((kind - 1) as usize) {
+                for &off in offsets.iter() {
+                    // A malformed map (offset past the payload) is skipped, never
+                    // read out of bounds. Written as `off <= size - 8` (not
+                    // `off + 8 <= size`) so a near-`usize::MAX` offset from a bad
+                    // map can't wrap the add and slip past the guard.
+                    if size >= 8 && off <= size - 8 {
+                        // SAFETY: `off + 8 <= size` keeps the 8-byte read inside
+                        // the payload; `read_unaligned` tolerates sub-alignment.
+                        let word =
+                            unsafe { ptr::read_unaligned(base.add(off) as *const usize) };
+                        self.mark_word(word, work);
+                    }
+                }
+                return;
+            }
+        }
+
+        // Conservative fallback: scan every aligned word of the payload.
         let mut off = 0usize;
         while off + 8 <= size {
             // SAFETY: `off + 8 <= size`, so the 8-byte read stays inside the
@@ -788,5 +864,134 @@ mod tests {
         heap.alloc(64, 0); // unrooted → freed by the collect below
         let _ = heap.collect(&[]); // 0 survive ≤ prev/2 → halve
         assert_eq!(heap.collect_threshold(), 2 * INITIAL_THRESHOLD);
+    }
+
+    // ── Precise interior tracing (HeapKind field maps) ─────────────────────────
+
+    /// Kind ids are assigned from 1 (0 stays reserved for conservative tracing).
+    #[test]
+    fn register_kind_ids_are_one_based() {
+        let mut heap = FlatHeap::new();
+        assert_eq!(heap.registered_kinds(), 0);
+        assert_eq!(heap.register_kind(&[0]), 1);
+        assert_eq!(heap.register_kind(&[0, 8]), 2);
+        assert_eq!(heap.registered_kinds(), 2);
+    }
+
+    /// The headline property: with a precise kind whose only ref field is at
+    /// offset 0, a heap pointer stored in a **non-reference** field (offset 8) is
+    /// NOT followed, so the pointee is reclaimed — no phantom retention.
+    #[test]
+    fn precise_tracing_reclaims_phantom_in_nonref_field() {
+        let mut heap = FlatHeap::new();
+        // Kind 1: a 16-byte object whose only ref field is at offset 0.
+        let rec = heap.register_kind(&[0]);
+        let target = heap.alloc(16, 0) as usize; // opaque pointee
+        let container = heap.alloc(16, rec) as usize;
+        unsafe {
+            *(container as *mut usize) = 0; // field@0 (ref) = null
+            *((container + 8) as *mut usize) = target; // field@8 (non-ref) = look-alike ptr
+        }
+        // Root only the container.
+        let stats = heap.collect(&[container]);
+        // Precise tracing follows offset 0 only → `target` is unreachable → freed.
+        assert!(
+            heap.find_header(target).is_null(),
+            "precise tracing must reclaim a pointee referenced only via a non-ref field"
+        );
+        assert!(!heap.find_header(container).is_null(), "container is rooted");
+        assert_eq!(stats.freed, 1, "exactly the phantom pointee is freed");
+    }
+
+    /// Baseline contrast: the *same* memory layout under conservative tracing
+    /// (kind 0) DOES retain the phantom — proving the precise path is what closes
+    /// the gap, not something else.
+    #[test]
+    fn conservative_retains_phantom_baseline() {
+        let mut heap = FlatHeap::new();
+        let target = heap.alloc(16, 0) as usize;
+        let container = heap.alloc(16, 0) as usize; // kind 0 → conservative
+        unsafe {
+            *(container as *mut usize) = 0;
+            *((container + 8) as *mut usize) = target; // phantom in payload
+        }
+        let stats = heap.collect(&[container]);
+        assert!(
+            !heap.find_header(target).is_null(),
+            "conservative tracing retains the look-alike pointer's pointee"
+        );
+        assert_eq!(stats.freed, 0, "nothing freed — both survive conservatively");
+    }
+
+    /// A pointer in a real **ref** field is still followed under precise tracing.
+    #[test]
+    fn precise_tracing_follows_real_ref_field() {
+        let mut heap = FlatHeap::new();
+        let rec = heap.register_kind(&[0]); // ref field at offset 0
+        let target = heap.alloc(16, 0) as usize;
+        let container = heap.alloc(16, rec) as usize;
+        unsafe {
+            *(container as *mut usize) = target; // field@0 (ref) = target
+            *((container + 8) as *mut usize) = 0;
+        }
+        let stats = heap.collect(&[container]);
+        assert!(
+            !heap.find_header(target).is_null(),
+            "a real ref field must keep its pointee alive"
+        );
+        assert_eq!(stats.freed, 0);
+    }
+
+    /// An object carrying a kind id with no registered map falls back to a
+    /// conservative full-payload scan — a safe default that never under-traces.
+    #[test]
+    fn unregistered_kind_falls_back_to_conservative() {
+        let mut heap = FlatHeap::new();
+        let target = heap.alloc(16, 0) as usize;
+        // kind 99 was never registered → treated conservatively.
+        let container = heap.alloc(16, 99) as usize;
+        unsafe {
+            *((container + 8) as *mut usize) = target;
+        }
+        let _ = heap.collect(&[container]);
+        assert!(
+            !heap.find_header(target).is_null(),
+            "unregistered kind traces conservatively (safe fallback)"
+        );
+    }
+
+    /// A field offset that would run past the payload is skipped, never read out
+    /// of bounds — a malformed map cannot corrupt memory.
+    #[test]
+    fn precise_out_of_range_offset_is_skipped() {
+        let mut heap = FlatHeap::new();
+        // Ref field claimed at offset 16, but the object is only 16 bytes: the
+        // 8-byte read at 16 would end at 24 > 16, so it must be skipped.
+        let rec = heap.register_kind(&[16]);
+        let target = heap.alloc(16, 0) as usize;
+        let container = heap.alloc(16, rec) as usize;
+        unsafe {
+            *(container as *mut usize) = target; // in-bounds but NOT a mapped field
+        }
+        // No mapped offset is in range → nothing traced from container → target freed.
+        let stats = heap.collect(&[container]);
+        assert!(heap.find_header(target).is_null());
+        assert_eq!(stats.freed, 1);
+    }
+
+    /// A pathological offset near `usize::MAX` must not wrap the bounds check and
+    /// trigger an out-of-bounds read — it is simply skipped. (The guard is written
+    /// `off <= size - 8`, not `off + 8 <= size`, precisely to avoid the wrap.)
+    #[test]
+    fn precise_huge_offset_does_not_overflow_the_guard() {
+        let mut heap = FlatHeap::new();
+        let rec = heap.register_kind(&[usize::MAX, usize::MAX - 3]);
+        let container = heap.alloc(16, rec) as usize;
+        unsafe {
+            *(container as *mut usize) = 0;
+        }
+        // Must not read out of bounds; container is rooted so it survives cleanly.
+        let _ = heap.collect(&[container]);
+        assert!(!heap.find_header(container).is_null());
     }
 }


### PR DESCRIPTION
## What — the first rung of the GC precision ladder

The generic collector could only trace **conservatively** (scan every payload word, treat pointer-shaped ints as roots). This wires the `HeapKind`-style **reference-field map** that the design always anticipated, so objects of a known layout are traced **precisely** — only their real ref fields. It's the concrete step that lets one generic collector serve **typed-object languages** (records, tuples, Ruby/Python/JS objects all have known layouts).

## Change

**gc-core (`FlatHeap`)**
- `register_kind(field_offsets) -> u16` records an object layout's ref-field byte offsets and returns a **1-based** `kind` id. `scan_payload`, for an object allocated with that kind, follows **only** those offsets during marking. A look-alike-pointer integer in a non-reference field no longer pins a phantom child.
- Kind id **0** stays reserved for "opaque / conservative" (existing `alloc(n, 0)` unchanged); an **unregistered** kind id falls back to the conservative full scan — a safe default that never under-traces. New `registered_kinds()`.

**gc-core-capi**
- `__gc_register_kind(field_offsets, count) -> i64` — the C-ABI seam a native runtime / frontend uses to teach the collector its object layouts.

## Proof (7 new tests)

The headline `precise_tracing_reclaims_phantom_in_nonref_field` reclaims a pointee referenced **only** via a non-ref field; the `conservative_retains_phantom_baseline` contrast shows the *same* layout under kind 0 retains it — **precise < conservative retention, demonstrated**. Plus: real-ref field still traced, unregistered-kind conservative fallback, out-of-range/`usize::MAX`-offset maps safely skipped, and C-ABI precise reclaim end-to-end. Runtime-validated on aarch64 + x86-64 SysV.

## Security review — PASSED (after one fix)

The review found the precise-path bounds check `off + 8 <= size` could **wrap** for an offset near `usize::MAX` from a malformed map (reachable via the safe Rust API and on 32-bit FFI), slipping past the guard into an OOB read. Fixed to the overflow-free `size >= 8 && off <= size - 8`, with a `usize::MAX`-offset regression test. Under-trace/UAF paths, kind-id arithmetic, and the FFI array read all verified clean.

## Details

- gc-core 0.4.0 → 0.5.0; gc-core-capi 0.6.0 → 0.7.0. Header/README/CHANGELOGs updated.
- **Next rungs** (own PRs): precise **stack-map roots** (backend emits live-ref slots at safepoints), then **generational** (nursery + write barrier — the biggest win for high-churn object allocation), then moving/compacting, then incremental. Each frontend registers its object layouts via `__gc_register_kind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)