### PR TITLE
feat(adj-facts-stdlib): chemistry/lab-equipment — equipment → use table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_labequipment_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_labequipment_e2e.rs
@@ -1,0 +1,69 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/lab-equipment.adj`) driven through the built
+//! CLI: a native `table` of common lab equipment → its use resolves
+//! binding-query recalls (forward and backward) with the source's LibreTexts
+//! citation, and abstains on a tool not in the table (stir rod) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factslabeq_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_equipment_use_recall_binds_use_with_citation() {
+    let dir = scratch("labequipment");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/lab-equipment.adj");
+    std::fs::copy(&src, dir.join("lab-equipment.adj")).expect("copy shipped lab-equipment.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"lab-equipment.adj\"\n\
+         ? equipment_use(beaker, $U)\n\
+         ? equipment_use(funnel, $U)\n\
+         ? equipment_use($E, heat)\n\
+         ? equipment_use(stir_rod, $U)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A beaker holds liquid; a funnel transfers it — the recalled use verbs
+    // (forward binds), each copied verbatim from the source sentence.
+    assert!(out.contains("\"U\":\"hold\""), "beaker -> hold: {out}");
+    assert!(out.contains("\"U\":\"transfer\""), "funnel -> transfer: {out}");
+    // The relation runs BACKWARD: bind the use `heat`, recall the tool — the
+    // Bunsen burner, the open-flame heat source.
+    assert!(
+        out.contains("\"E\":\"bunsen_burner\""),
+        "heat -> bunsen_burner (reverse recall to the heat source): {out}"
+    );
+    // The answer carries the LibreTexts citation as its proof, at consensus trust
+    // (a secondary teaching reference, honestly tiered).
+    assert!(
+        out.contains("chem.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation at consensus trust: {out}"
+    );
+    // "stir_rod" is not in the table — honest abstention, never a fabricated use.
+    assert!(out.contains("\"abstained\":true"), "stir_rod abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -34,6 +34,7 @@ per rotation, in parallel):
 | `chemistry/` | subatomic particle → electric charge (proton → positive) | DOE "Explains…Nuclei" (authoritative) |
 | `chemistry/` | chemical bond type → defining token (ionic → transfer) | LibreTexts (consensus) |
 | `chemistry/` | mixture kind → the everyday example the source names (colloid → milk) | LibreTexts (consensus) |
+| `chemistry/` | lab equipment → its use (beaker → hold, bunsen_burner → heat) | LibreTexts (consensus) |
 | `metrology/` | SI prefix → power of ten | NIST |
 | `mathematics/` | Roman numeral → value | (consensus) |
 | `calendar/` | day / month → number | ISO 8601 |

--- a/code/specs/data/adj-facts-stdlib/chemistry/lab-equipment.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/lab-equipment.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% equipment_use — what each common piece of chemistry-lab glassware/apparatus
+% is FOR (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% A middle/high-school chemistry-lab fact set: the first day in the lab you are
+% handed a bench full of glassware and asked "what is this one for?" This table
+% answers exactly that — it maps a piece of lab equipment to the ONE verb the
+% source uses for its job. Recall is a binding query:
+%
+%     ? equipment_use(beaker, $U)          % hold
+%
+% Like every FACTS library this is a native `table` (ADJ-TABLES RS-5): each
+% `row` lowers to a ground relation `equipment_use(equipment, purpose)` carrying
+% the table's citation, so the lookup above is the ordinary SLD binding query —
+% the engine returns the use WITH its source, on the CPU, with zero model calls,
+% and abstains on a tool that is not in the table. It also runs BACKWARD (bind a
+% use, recall the tool that has it):
+%
+%     ? equipment_use($E, heat)            % bunsen_burner — the heat source
+%
+% The value is an ATOM (a single verb copied out of the source sentence), not a
+% number, because "what is it for" is a categorical fact, not a measured
+% quantity. That keeps the axis clean: ONE tool, ONE use-verb, verbatim.
+%
+% The seven pieces of equipment, each with the verb its description uses (a
+% little truth table — read tool → what you do with it):
+%
+%     equipment            use          the job in one word
+%     ------------------   ----------   ----------------------------------
+%     beaker               hold         holds varying volumes of liquid
+%     graduated_cylinder   measuring    measures many different volumes
+%     bunsen_burner        heat         heats things (the open-flame source)
+%     test_tube            mix          holds AND mixes small samples
+%     funnel               transfer     aids the transfer of liquids
+%     buret                dispensing   dispenses specific volumes (titrations)
+%     watch_glass          evaporate    evaporates a liquid / heats a portion
+%
+% A tool that is not one of these seven — a stir rod, a ring stand, a crucible —
+% has no row, so a recall on it ABSTAINS rather than inventing a use. That
+% honest-abstention property is what makes the table safe to reason from.
+%
+% Note the two "measure-like" tools carry DISTINCT verbs, each verbatim from its
+% own sentence: the graduated cylinder is for `measuring` volumes, while the
+% buret's sentence is about `dispensing` specific volumes — the source's own
+% words, not a paraphrase collapsing them together.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every equipment→use pair was
+% read out of a fetched teaching-lab page, and any tool whose use could not be
+% copied verbatim from its sentence was dropped). All seven rows come from the
+% SAME source: the LibreTexts "Lab Equipment" page for Bethune-Cookman University
+% CHL-141 "General Chemistry 1 Lab", Laboratory 1: Basic Lab Techniques
+% (chem.libretexts.org). Each use-verb is copied character-for-character out of
+% that page's description sentence for the tool:
+%
+%   Beaker              → "Used to hold varying volumes of liquid"          → hold
+%   Graduated cylinder  → "Used for measuring many different volumes"       → measuring
+%   Bunsen burner       → "Used to heat things"                             → heat
+%   Test tube           → "Used to hold and mix small samples"             → mix
+%   Funnel              → "Used to aide in the transfer of liquids"        → transfer
+%   Buret               → "Often used for titrations or dispensing
+%                          specific volumes of liquids"                    → dispensing
+%   Watch glass         → "Used to evaporate a liquid, to heat small
+%                          portions of a substance"                        → evaporate
+%
+% (The Erlenmeyer flask, volumetric flask, pipet, and wash bottle appear on the
+% same page but were dropped: the flask's lead sentence is about stirring rather
+% than a single clean use, and pipet/wash-bottle duplicate the measuring /
+% dispensing verbs already covered — so they are omitted to keep one distinct
+% verb per row rather than padded in.)
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold that single page's title and three representative verbatim
+% sentences; every other row's verbatim span is listed above, so each use-verb
+% remains independently checkable. LibreTexts is a SECONDARY teaching reference
+% (a college course lab text, not a primary standards body), so `trust
+% consensus` — the honest tier for a teaching summary, per the standard-library
+% trust convention. (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table equipment_use {
+    columns equipment, purpose
+
+    row (beaker, hold)
+    row (graduated_cylinder, measuring)
+    row (bunsen_burner, heat)
+    row (test_tube, mix)
+    row (funnel, transfer)
+    row (buret, dispensing)
+    row (watch_glass, evaporate)
+
+    source "Lab Equipment (Bethune-Cookman University CHL-141 General Chemistry 1 Lab, Laboratory 1: Basic Lab Techniques) — Beaker: \"Used to hold varying volumes of liquid\" … Bunsen burner: \"Used to heat things\" … Funnel: \"Used to aide in the transfer of liquids\""
+    locator "https://chem.libretexts.org/Courses/BethuneCookman_University/B-CU:_CHL-141_General_Chemistry_1_Lab/Labs/Laboratory_1:_Basic_Lab_Techniques/Lab_Equipment"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/lab-equipment.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/lab-equipment.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% lab-equipment.query.adj — a worked recall over the chemistry lab-equipment
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is a beaker for?": it
+% states no chemistry fact — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `equipment_use` rows
+% and returns the use + the table's source/locator/trust. The fourth query runs
+% the relation BACKWARD (bind the use `heat`, recall the tool that has it — the
+% Bunsen burner, the open-flame heat source). A stir rod is not in the table, so
+% a recall on it abstains honestly — the engine never invents a use.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli lab-equipment.query.adj
+% ============================================================================
+
+import "lab-equipment.adj"
+
+? equipment_use(beaker, $U)             % expect hold       — holds varying volumes of liquid
+? equipment_use(graduated_cylinder, $U) % expect measuring  — measures many different volumes
+? equipment_use(funnel, $U)             % expect transfer   — aids the transfer of liquids
+? equipment_use($E, heat)               % expect bunsen_burner — reverse recall to the heat source
+? equipment_use(stir_rod, $U)           % expect abstain    — a stir rod is not in the table


### PR DESCRIPTION
A middle/high-school chemistry-lab FACTS library: a native `table`
`equipment_use(equipment, purpose)` mapping seven common pieces of lab
apparatus to the ONE use-verb the source states for each. Recall runs
forward (beaker → hold), backward (heat → bunsen_burner), and abstains
on a tool not in the table (stir_rod) — 0 model calls, on the CPU, each
answer carrying the source citation as its proof.

Adds the table, a worked .query.adj (forward + reverse + abstain), a CLI
e2e test (facts_labequipment_e2e), and a chemistry subject-index row in
the stdlib README.

Provenance — nothing from memory. All seven rows byte-provenanced from a
SINGLE source fetched this session, each use-verb copied character-for-
character from the tool's own description sentence:

  Lab Equipment — Bethune-Cookman University CHL-141 "General Chemistry 1
  Lab", Laboratory 1: Basic Lab Techniques (chem.libretexts.org)
  https://chem.libretexts.org/Courses/BethuneCookman_University/B-CU:_CHL-141_General_Chemistry_1_Lab/Labs/Laboratory_1:_Basic_Lab_Techniques/Lab_Equipment

    beaker              "Used to hold varying volumes of liquid"        → hold
    graduated_cylinder  "Used for measuring many different volumes"     → measuring
    bunsen_burner       "Used to heat things"                           → heat
    test_tube           "Used to hold and mix small samples"            → mix
    funnel              "Used to aide in the transfer of liquids"       → transfer
    buret               "Often used for titrations or dispensing
                         specific volumes of liquids"                   → dispensing
    watch_glass         "Used to evaporate a liquid, to heat small
                         portions of a substance"                       → evaporate

LibreTexts is a secondary teaching reference (a college course lab text,
not a primary standards body), so trust=consensus — the honest tier, per
the standard-library trust convention and the chemistry/ph-scale
precedent.

Dropped rows (could not be cleanly grounded on one distinct verb):
Erlenmeyer flask (lead sentence is about stirring, not a single use),
pipet and wash bottle (duplicate the measuring / dispensing verbs).

Targeted test `cargo test -p adj-lang-cli --test facts_labequipment_e2e`
passes; `cargo clippy -p adj-lang -p adj-lang-cli --all-targets -D
warnings` clean. Data-only diff plus its e2e test.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
