### PR TITLE
feat(nib-wasm-compiler): add C# and F# ports

### DIFF
--- a/code/packages/csharp/nib-wasm-compiler/BUILD
+++ b/code/packages/csharp/nib-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.NibWasmCompiler.Tests/CodingAdventures.NibWasmCompiler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.NibWasmCompiler]*"

--- a/code/packages/csharp/nib-wasm-compiler/BUILD_windows
+++ b/code/packages/csharp/nib-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.NibWasmCompiler.Tests/CodingAdventures.NibWasmCompiler.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.NibWasmCompiler]*"

--- a/code/packages/csharp/nib-wasm-compiler/CHANGELOG.md
+++ b/code/packages/csharp/nib-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native Nib `u4` function and expression parser.
+- Compile literals, parameters, calls, and wrapping addition to WebAssembly.
+- Export every declared function and support optional `.wasm` file output.

--- a/code/packages/csharp/nib-wasm-compiler/CodingAdventures.NibWasmCompiler.csproj
+++ b/code/packages/csharp/nib-wasm-compiler/CodingAdventures.NibWasmCompiler.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.NibWasmCompiler.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# Nib u4 expression compiler targeting WebAssembly</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../wasm-leb128/CodingAdventures.WasmLeb128.csproj" />
+    <ProjectReference Include="../wasm-module-encoder/CodingAdventures.WasmModuleEncoder.csproj" />
+    <ProjectReference Include="../wasm-types/CodingAdventures.WasmTypes.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/nib-wasm-compiler/NibWasmCompiler.cs
+++ b/code/packages/csharp/nib-wasm-compiler/NibWasmCompiler.cs
@@ -1,0 +1,318 @@
+using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
+using CodingAdventures.WasmLeb128;
+using CodingAdventures.WasmTypes;
+using WasmValueType = CodingAdventures.WasmTypes.ValueType;
+
+namespace CodingAdventures.NibWasmCompiler;
+
+public static class NibWasmCompilerVersion
+{
+    public const string VERSION = "0.1.0";
+}
+
+public sealed class PackageError : Exception
+{
+    public PackageError(string stage, string message) : base(message)
+    {
+        Stage = stage;
+    }
+
+    public string Stage { get; }
+
+    public override string ToString() => $"[{Stage}] {Message}";
+}
+
+public sealed class NibFunction
+{
+    internal NibFunction(string name, IEnumerable<string> parameters, string expression)
+    {
+        Name = name;
+        Parameters = Array.AsReadOnly(parameters.ToArray());
+        Expression = expression.Trim();
+    }
+
+    public string Name { get; }
+    public IReadOnlyList<string> Parameters { get; }
+    public string Expression { get; }
+}
+
+public sealed class PackageResult
+{
+    private readonly byte[] _wasmBytes;
+
+    internal PackageResult(string source, IEnumerable<NibFunction> functions, byte[] wasmBytes, string? wasmPath)
+    {
+        Source = source;
+        Functions = new ReadOnlyCollection<NibFunction>(functions.ToArray());
+        _wasmBytes = wasmBytes.ToArray();
+        WasmPath = wasmPath;
+    }
+
+    public string Source { get; }
+    public IReadOnlyList<NibFunction> Functions { get; }
+    public byte[] WasmBytes => _wasmBytes.ToArray();
+    public string? WasmPath { get; }
+}
+
+public static class NibWasmCompiler
+{
+    private const int MaxSourceLength = 1_000_000;
+    private const int MaxExpressionNesting = 256;
+    private static readonly Regex FunctionPattern = new(
+        @"fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*->\s*u4\s*\{\s*return\s+([^;]+);\s*\}",
+        RegexOptions.Singleline | RegexOptions.CultureInvariant);
+    private static readonly Regex IdentifierPattern = new(
+        @"\A[A-Za-z_][A-Za-z0-9_]*\z",
+        RegexOptions.CultureInvariant);
+    private static readonly Regex CallPattern = new(
+        @"\A([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\z",
+        RegexOptions.Singleline | RegexOptions.CultureInvariant);
+
+    public static PackageResult CompileSource(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var functions = Parse(source);
+        var index = IndexFunctions(functions);
+        foreach (var function in functions)
+        {
+            EmitExpression([], function.Expression, index, ParameterMap(function), false, 0);
+        }
+
+        return new PackageResult(source, functions, EmitModule(functions, index), null);
+    }
+
+    public static PackageResult PackSource(string source) => CompileSource(source);
+
+    public static PackageResult WriteWasmFile(string source, string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        var result = CompileSource(source);
+        try
+        {
+            File.WriteAllBytes(path, result.WasmBytes);
+        }
+        catch (Exception error) when (error is IOException or UnauthorizedAccessException)
+        {
+            throw new PackageError("write", error.Message);
+        }
+
+        return new PackageResult(result.Source, result.Functions, result.WasmBytes, path);
+    }
+
+    private static IReadOnlyList<NibFunction> Parse(string source)
+    {
+        if (source.Length > MaxSourceLength)
+        {
+            throw new PackageError("parse", $"source exceeds {MaxSourceLength} characters");
+        }
+
+        var functions = new List<NibFunction>();
+        var cursor = 0;
+        foreach (Match match in FunctionPattern.Matches(source))
+        {
+            if (!string.IsNullOrWhiteSpace(source[cursor..match.Index]))
+            {
+                throw new PackageError("parse", "unexpected text before function");
+            }
+
+            functions.Add(new NibFunction(match.Groups[1].Value, ParseParameters(match.Groups[2].Value), match.Groups[3].Value));
+            cursor = match.Index + match.Length;
+        }
+
+        if (functions.Count == 0 || !string.IsNullOrWhiteSpace(source[cursor..]))
+        {
+            throw new PackageError("parse", "expected one or more Nib functions");
+        }
+
+        return functions;
+    }
+
+    private static IReadOnlyList<string> ParseParameters(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return [];
+        }
+
+        var parameters = new List<string>();
+        foreach (var piece in text.Split(','))
+        {
+            var parts = Regex.Split(piece.Trim(), @"\s*:\s*");
+            if (parts.Length != 2 || parts[1] != "u4" || !IdentifierPattern.IsMatch(parts[0]))
+            {
+                throw new PackageError("parse", "parameters must be `name: u4`");
+            }
+
+            if (parameters.Contains(parts[0], StringComparer.Ordinal))
+            {
+                throw new PackageError("validate", $"duplicate parameter `{parts[0]}`");
+            }
+
+            parameters.Add(parts[0]);
+        }
+
+        return parameters;
+    }
+
+    private static IReadOnlyDictionary<string, (NibFunction Function, int Index)> IndexFunctions(IReadOnlyList<NibFunction> functions)
+    {
+        var result = new Dictionary<string, (NibFunction, int)>(StringComparer.Ordinal);
+        for (var index = 0; index < functions.Count; index++)
+        {
+            if (!result.TryAdd(functions[index].Name, (functions[index], index)))
+            {
+                throw new PackageError("validate", $"duplicate function `{functions[index].Name}`");
+            }
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyDictionary<string, int> ParameterMap(NibFunction function) =>
+        function.Parameters.Select((name, index) => (name, index)).ToDictionary(item => item.name, item => item.index, StringComparer.Ordinal);
+
+    private static byte[] EmitModule(
+        IReadOnlyList<NibFunction> functions,
+        IReadOnlyDictionary<string, (NibFunction Function, int Index)> index)
+    {
+        var module = new WasmModule();
+        for (var functionIndex = 0; functionIndex < functions.Count; functionIndex++)
+        {
+            var function = functions[functionIndex];
+            module.Types.Add(new FuncType(
+                Enumerable.Repeat(WasmValueType.I32, function.Parameters.Count),
+                [WasmValueType.I32]));
+            module.Functions.Add(functionIndex);
+            module.Exports.Add(new Export(function.Name, ExternalKind.FUNCTION, functionIndex));
+
+            var body = new List<byte>();
+            EmitExpression(body, function.Expression, index, ParameterMap(function), true, 0);
+            body.Add(0x0B);
+            module.Code.Add(new FunctionBody([], body.ToArray()));
+        }
+
+        return WasmModuleEncoder.WasmModuleEncoder.EncodeModule(module);
+    }
+
+    private static void EmitExpression(
+        List<byte> output,
+        string expression,
+        IReadOnlyDictionary<string, (NibFunction Function, int Index)> functions,
+        IReadOnlyDictionary<string, int> parameters,
+        bool emit,
+        int depth)
+    {
+        if (depth > MaxExpressionNesting)
+        {
+            throw new PackageError("validate", $"expression nesting exceeds {MaxExpressionNesting}");
+        }
+
+        var addition = SplitTopLevel(expression, "+%");
+        if (addition.Count > 1)
+        {
+            EmitExpression(output, addition[0], functions, parameters, emit, depth + 1);
+            foreach (var part in addition.Skip(1))
+            {
+                EmitExpression(output, part, functions, parameters, emit, depth + 1);
+                if (emit)
+                {
+                    output.Add(0x6A);
+                    I32(output, 15);
+                    output.Add(0x71);
+                }
+            }
+
+            return;
+        }
+
+        var trimmed = expression.Trim();
+        if (int.TryParse(trimmed, out var literal))
+        {
+            if (literal is < 0 or > 15)
+            {
+                throw new PackageError("validate", $"u4 literal out of range: {literal}");
+            }
+
+            if (emit)
+            {
+                I32(output, literal);
+            }
+
+            return;
+        }
+
+        var call = CallPattern.Match(trimmed);
+        if (call.Success)
+        {
+            if (!functions.TryGetValue(call.Groups[1].Value, out var target))
+            {
+                throw new PackageError("validate", $"unknown function `{call.Groups[1].Value}`");
+            }
+
+            var arguments = SplitArguments(call.Groups[2].Value);
+            if (arguments.Count != target.Function.Parameters.Count)
+            {
+                throw new PackageError("validate", $"wrong arity for `{target.Function.Name}`");
+            }
+
+            foreach (var argument in arguments)
+            {
+                EmitExpression(output, argument, functions, parameters, emit, depth + 1);
+            }
+
+            if (emit)
+            {
+                output.Add(0x10);
+                U32(output, target.Index);
+            }
+
+            return;
+        }
+
+        if (parameters.TryGetValue(trimmed, out var parameterIndex))
+        {
+            if (emit)
+            {
+                output.Add(0x20);
+                U32(output, parameterIndex);
+            }
+
+            return;
+        }
+
+        throw new PackageError("validate", $"unsupported expression `{expression}`");
+    }
+
+    private static IReadOnlyList<string> SplitArguments(string text) =>
+        string.IsNullOrWhiteSpace(text) ? [] : SplitTopLevel(text, ",");
+
+    private static IReadOnlyList<string> SplitTopLevel(string text, string delimiter)
+    {
+        var parts = new List<string>();
+        var nesting = 0;
+        var start = 0;
+        for (var index = 0; index < text.Length; index++)
+        {
+            nesting += text[index] switch { '(' => 1, ')' => -1, _ => 0 };
+            if (nesting == 0 && text.AsSpan(index).StartsWith(delimiter, StringComparison.Ordinal))
+            {
+                parts.Add(text[start..index].Trim());
+                index += delimiter.Length - 1;
+                start = index + 1;
+            }
+        }
+
+        parts.Add(text[start..].Trim());
+        return parts;
+    }
+
+    private static void I32(List<byte> output, int value)
+    {
+        output.Add(0x41);
+        output.AddRange(WasmLeb128.WasmLeb128.EncodeSigned(value));
+    }
+
+    private static void U32(List<byte> output, int value) =>
+        output.AddRange(WasmLeb128.WasmLeb128.EncodeUnsigned(value));
+}

--- a/code/packages/csharp/nib-wasm-compiler/README.md
+++ b/code/packages/csharp/nib-wasm-compiler/README.md
@@ -1,0 +1,14 @@
+# CodingAdventures.NibWasmCompiler
+
+A pure C# compiler for the portable Nib `u4` function subset. It accepts typed
+function declarations whose return expressions contain `u4` literals,
+parameters, function calls, and wrapping `+%` addition, then emits a validated
+WebAssembly-shaped module through the native `wasm-module-encoder` package.
+
+```csharp
+var result = NibWasmCompiler.CompileSource(
+    "fn add(a: u4, b: u4) -> u4 { return a +% b; }");
+```
+
+Each Nib function is exported under its source name. Compilation is in memory;
+`WriteWasmFile` is the optional filesystem boundary.

--- a/code/packages/csharp/nib-wasm-compiler/required_capabilities.json
+++ b/code/packages/csharp/nib-wasm-compiler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/nib-wasm-compiler",
+  "capabilities": ["filesystem_write"],
+  "justification": "Compilation is pure and in memory; the optional write helper persists the emitted WebAssembly module."
+}

--- a/code/packages/csharp/nib-wasm-compiler/tests/CodingAdventures.NibWasmCompiler.Tests/CodingAdventures.NibWasmCompiler.Tests.csproj
+++ b/code/packages/csharp/nib-wasm-compiler/tests/CodingAdventures.NibWasmCompiler.Tests/CodingAdventures.NibWasmCompiler.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.NibWasmCompiler.csproj" />
+    <ProjectReference Include="../../../wasm-runtime/CodingAdventures.WasmRuntime.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/nib-wasm-compiler/tests/CodingAdventures.NibWasmCompiler.Tests/NibWasmCompilerTests.cs
+++ b/code/packages/csharp/nib-wasm-compiler/tests/CodingAdventures.NibWasmCompiler.Tests/NibWasmCompilerTests.cs
@@ -1,0 +1,119 @@
+using CodingAdventures.NibWasmCompiler;
+using CodingAdventures.WasmRuntime;
+
+public sealed class NibWasmCompilerTests
+{
+    [Fact]
+    public void CompilesAndRunsLiteralFunction()
+    {
+        var result = NibWasmCompiler.CompileSource("fn answer() -> u4 { return 7; }");
+
+        Assert.Equal("answer", result.Functions.Single().Name);
+        Assert.Equal("7", result.Functions.Single().Expression);
+        Assert.Equal([0x00, 0x61, 0x73, 0x6D], result.WasmBytes[..4]);
+        Assert.Null(result.WasmPath);
+        Assert.Equal([7], new WasmRuntime().LoadAndRun(result.WasmBytes, "answer"));
+    }
+
+    [Fact]
+    public void CompilesParametersAndWrappingAddition()
+    {
+        const string source = "fn add(a: u4, b: u4) -> u4 { return a +% b; }";
+        var result = NibWasmCompiler.CompileSource(source);
+        var runtime = new WasmRuntime();
+        var module = runtime.Load(result.WasmBytes);
+
+        Assert.Equal(["a", "b"], result.Functions.Single().Parameters);
+        runtime.Validate(module);
+        Assert.Contains((byte)0x6A, result.WasmBytes);
+        Assert.Contains((byte)0x71, result.WasmBytes);
+    }
+
+    [Fact]
+    public void CompilesNestedCallsAndExportsEveryFunction()
+    {
+        const string source = "fn id(x: u4) -> u4 { return x; }\nfn twice(x: u4) -> u4 { return id(id(x)); }";
+        var result = NibWasmCompiler.CompileSource(source);
+        var runtime = new WasmRuntime();
+        var module = runtime.Load(result.WasmBytes);
+
+        Assert.Equal(["id", "twice"], module.Exports.Select(item => item.Name));
+        Assert.Equal([15], runtime.LoadAndRun(result.WasmBytes, "twice", 15));
+    }
+
+    [Fact]
+    public void PackIsAliasAndResultDefendsBytes()
+    {
+        var result = NibWasmCompiler.PackSource("fn answer() -> u4 { return 7; }");
+        var bytes = result.WasmBytes;
+        bytes[0] = 0xFF;
+
+        Assert.Equal((byte)0, result.WasmBytes[0]);
+        Assert.Equal("0.1.0", NibWasmCompilerVersion.VERSION);
+    }
+
+    [Fact]
+    public void WritesWasmFileAndRecordsPath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nib-wasm-{Guid.NewGuid():N}.wasm");
+        try
+        {
+            var result = NibWasmCompiler.WriteWasmFile("fn answer() -> u4 { return 7; }", path);
+            Assert.Equal(path, result.WasmPath);
+            Assert.Equal(result.WasmBytes, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WrapsWriteErrors()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "x.wasm");
+        var error = Assert.Throws<PackageError>(() => NibWasmCompiler.WriteWasmFile("fn answer() -> u4 { return 7; }", path));
+        Assert.Equal("write", error.Stage);
+    }
+
+    [Theory]
+    [InlineData("", "parse")]
+    [InlineData("garbage fn answer() -> u4 { return 7; }", "parse")]
+    [InlineData("fn bad(x: u8) -> u4 { return 1; }", "parse")]
+    [InlineData("fn bad(x: u4, x: u4) -> u4 { return x; }", "validate")]
+    [InlineData("fn same() -> u4 { return 1; } fn same() -> u4 { return 2; }", "validate")]
+    [InlineData("fn bad() -> u4 { return 16; }", "validate")]
+    [InlineData("fn bad() -> u4 { return missing(); }", "validate")]
+    [InlineData("fn one(x: u4) -> u4 { return x; } fn bad() -> u4 { return one(); }", "validate")]
+    [InlineData("fn bad() -> u4 { return nope; }", "validate")]
+    public void ReportsInvalidNibByStage(string source, string stage)
+    {
+        var error = Assert.Throws<PackageError>(() => NibWasmCompiler.CompileSource(source));
+        Assert.Equal(stage, error.Stage);
+        Assert.StartsWith($"[{stage}]", error.ToString());
+    }
+
+    [Fact]
+    public void RejectsExcessiveExpressionNesting()
+    {
+        var expression = "0";
+        for (var index = 0; index < 258; index++)
+        {
+            expression = $"id({expression})";
+        }
+
+        var source = $"fn id(x: u4) -> u4 {{ return x; }} fn main() -> u4 {{ return {expression}; }}";
+        var error = Assert.Throws<PackageError>(() => NibWasmCompiler.CompileSource(source));
+        Assert.Equal("validate", error.Stage);
+        Assert.Contains("nesting", error.Message);
+    }
+
+    [Fact]
+    public void RejectsExcessiveSourceLengthAndNulls()
+    {
+        var error = Assert.Throws<PackageError>(() => NibWasmCompiler.CompileSource(new string(' ', 1_000_001)));
+        Assert.Equal("parse", error.Stage);
+        Assert.Throws<ArgumentNullException>(() => NibWasmCompiler.CompileSource(null!));
+        Assert.Throws<ArgumentNullException>(() => NibWasmCompiler.WriteWasmFile("fn x() -> u4 { return 0; }", null!));
+    }
+}

--- a/code/packages/fsharp/nib-wasm-compiler/BUILD
+++ b/code/packages/fsharp/nib-wasm-compiler/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.NibWasmCompiler.Tests/CodingAdventures.NibWasmCompiler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.NibWasmCompiler.FSharp]*"

--- a/code/packages/fsharp/nib-wasm-compiler/BUILD_windows
+++ b/code/packages/fsharp/nib-wasm-compiler/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.NibWasmCompiler.Tests/CodingAdventures.NibWasmCompiler.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.NibWasmCompiler.FSharp]*"

--- a/code/packages/fsharp/nib-wasm-compiler/CHANGELOG.md
+++ b/code/packages/fsharp/nib-wasm-compiler/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a native Nib `u4` function and expression parser.
+- Compile literals, parameters, calls, and wrapping addition to WebAssembly.
+- Export every declared function and support optional `.wasm` file output.

--- a/code/packages/fsharp/nib-wasm-compiler/CodingAdventures.NibWasmCompiler.fsproj
+++ b/code/packages/fsharp/nib-wasm-compiler/CodingAdventures.NibWasmCompiler.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.NibWasmCompiler.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.NibWasmCompiler.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# Nib u4 expression compiler targeting WebAssembly</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="NibWasmCompiler.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../wasm-leb128/CodingAdventures.WasmLeb128.fsproj" />
+    <ProjectReference Include="../wasm-module-encoder/CodingAdventures.WasmModuleEncoder.fsproj" />
+    <ProjectReference Include="../wasm-types/CodingAdventures.WasmTypes.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/nib-wasm-compiler/NibWasmCompiler.fs
+++ b/code/packages/fsharp/nib-wasm-compiler/NibWasmCompiler.fs
@@ -1,0 +1,222 @@
+namespace CodingAdventures.NibWasmCompiler.FSharp
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text.RegularExpressions
+open CodingAdventures.WasmLeb128.FSharp
+open CodingAdventures.WasmModuleEncoder.FSharp
+open CodingAdventures.WasmTypes.FSharp
+
+module Version =
+    [<Literal>]
+    let VERSION = "0.1.0"
+
+type PackageError(stage: string, message: string) =
+    inherit Exception(message)
+    member _.Stage = stage
+    override _.ToString() = $"[{stage}] {message}"
+
+type NibFunction(name: string, parameters: string list, expression: string) =
+    member _.Name = name
+    member _.Parameters = parameters
+    member _.Expression = expression.Trim()
+
+type PackageResult(source: string, functions: NibFunction list, wasmBytes: byte array, wasmPath: string option) =
+    let copiedBytes = Array.copy wasmBytes
+
+    member _.Source = source
+    member _.Functions = functions
+    member _.WasmBytes = Array.copy copiedBytes
+    member _.WasmPath = wasmPath
+
+[<RequireQualifiedAccess>]
+module NibWasmCompiler =
+    let private maxSourceLength = 1_000_000
+    let private maxExpressionNesting = 256
+    let private functionPattern =
+        Regex(
+            """fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*->\s*u4\s*\{\s*return\s+([^;]+);\s*\}""",
+            RegexOptions.Singleline ||| RegexOptions.CultureInvariant
+        )
+    let private identifierPattern = Regex("""\A[A-Za-z_][A-Za-z0-9_]*\z""", RegexOptions.CultureInvariant)
+    let private callPattern =
+        Regex("""\A([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\z""", RegexOptions.Singleline ||| RegexOptions.CultureInvariant)
+
+    let private parseParameters text =
+        if String.IsNullOrWhiteSpace text then
+            []
+        else
+            let parameters =
+                text.Split(',')
+                |> Array.map (fun piece ->
+                    let parts = Regex.Split(piece.Trim(), """\s*:\s*""")
+                    if parts.Length <> 2 || parts[1] <> "u4" || not (identifierPattern.IsMatch parts[0]) then
+                        raise (PackageError("parse", "parameters must be `name: u4`"))
+                    parts[0])
+                |> Array.toList
+
+            if (parameters |> List.distinct).Length <> parameters.Length then
+                raise (PackageError("validate", "duplicate parameter"))
+
+            parameters
+
+    let private parse (source: string) =
+        if source.Length > maxSourceLength then
+            raise (PackageError("parse", $"source exceeds {maxSourceLength} characters"))
+
+        let functions = ResizeArray<NibFunction>()
+        let mutable cursor = 0
+        for matched in functionPattern.Matches(source) |> Seq.cast<Match> do
+            if not (String.IsNullOrWhiteSpace(source.Substring(cursor, matched.Index - cursor))) then
+                raise (PackageError("parse", "unexpected text before function"))
+
+            functions.Add(
+                NibFunction(
+                    matched.Groups[1].Value,
+                    parseParameters matched.Groups[2].Value,
+                    matched.Groups[3].Value
+                )
+            )
+            cursor <- matched.Index + matched.Length
+
+        if functions.Count = 0 || not (String.IsNullOrWhiteSpace(source[cursor..])) then
+            raise (PackageError("parse", "expected one or more Nib functions"))
+
+        functions |> Seq.toList
+
+    let private indexFunctions (functions: NibFunction list) =
+        let indexed = Dictionary<string, NibFunction * int>(StringComparer.Ordinal)
+        functions
+        |> List.iteri (fun index functionValue ->
+            if not (indexed.TryAdd(functionValue.Name, (functionValue, index))) then
+                raise (PackageError("validate", $"duplicate function `{functionValue.Name}`")))
+        indexed
+
+    let private parameterMap (functionValue: NibFunction) =
+        functionValue.Parameters
+        |> List.mapi (fun index name -> name, index)
+        |> Map.ofList
+
+    let private append (target: ResizeArray<byte>) (bytes: seq<byte>) =
+        target.AddRange(bytes)
+
+    let private u32 (target: ResizeArray<byte>) value =
+        append target (WasmLeb128.encodeUnsignedInt value)
+
+    let private i32 (target: ResizeArray<byte>) value =
+        target.Add(0x41uy)
+        append target (WasmLeb128.encodeSigned value)
+
+    let private splitTopLevel (text: string) (delimiter: string) =
+        let parts = ResizeArray<string>()
+        let mutable nesting = 0
+        let mutable start = 0
+        let mutable index = 0
+        while index < text.Length do
+            match text[index] with
+            | '(' -> nesting <- nesting + 1
+            | ')' -> nesting <- nesting - 1
+            | _ -> ()
+
+            if nesting = 0 && index + delimiter.Length <= text.Length && text.Substring(index, delimiter.Length) = delimiter then
+                parts.Add(text.Substring(start, index - start).Trim())
+                index <- index + delimiter.Length
+                start <- index
+            else
+                index <- index + 1
+
+        parts.Add(text[start..].Trim())
+        parts |> Seq.toList
+
+    let private splitArguments text =
+        if String.IsNullOrWhiteSpace text then [] else splitTopLevel text ","
+
+    let rec private emitExpression
+        (target: ResizeArray<byte>)
+        expression
+        (functions: IReadOnlyDictionary<string, NibFunction * int>)
+        (parameters: Map<string, int>)
+        emit
+        depth
+        =
+        if depth > maxExpressionNesting then
+            raise (PackageError("validate", $"expression nesting exceeds {maxExpressionNesting}"))
+
+        let addition = splitTopLevel expression "+%"
+        if addition.Length > 1 then
+            emitExpression target addition.Head functions parameters emit (depth + 1)
+            for part in addition.Tail do
+                emitExpression target part functions parameters emit (depth + 1)
+                if emit then
+                    target.Add(0x6Auy)
+                    i32 target 15
+                    target.Add(0x71uy)
+        else
+            let trimmed = expression.Trim()
+            let mutable literal = 0
+            if Int32.TryParse(trimmed, &literal) then
+                if literal < 0 || literal > 15 then
+                    raise (PackageError("validate", $"u4 literal out of range: {literal}"))
+                if emit then i32 target literal
+            else
+                let call = callPattern.Match trimmed
+                if call.Success then
+                    let name = call.Groups[1].Value
+                    match functions.TryGetValue name with
+                    | false, _ -> raise (PackageError("validate", $"unknown function `{name}`"))
+                    | true, (calledFunction, functionIndex) ->
+                        let arguments = splitArguments call.Groups[2].Value
+                        if arguments.Length <> calledFunction.Parameters.Length then
+                            raise (PackageError("validate", $"wrong arity for `{calledFunction.Name}`"))
+                        for argument in arguments do
+                            emitExpression target argument functions parameters emit (depth + 1)
+                        if emit then
+                            target.Add(0x10uy)
+                            u32 target functionIndex
+                else
+                    match parameters.TryFind trimmed with
+                    | Some parameterIndex ->
+                        if emit then
+                            target.Add(0x20uy)
+                            u32 target parameterIndex
+                    | None -> raise (PackageError("validate", $"unsupported expression `{expression}`"))
+
+    let private emitModule (functions: NibFunction list) (indexed: IReadOnlyDictionary<string, NibFunction * int>) =
+        let moduleValue = WasmModule()
+        functions
+        |> List.iteri (fun functionIndex (functionValue: NibFunction) ->
+            moduleValue.Types.Add(
+                WasmTypes.makeFuncType
+                    (List.replicate functionValue.Parameters.Length ValueType.I32)
+                    [ ValueType.I32 ]
+            )
+            moduleValue.Functions.Add(functionIndex)
+            moduleValue.Exports.Add(
+                { Name = functionValue.Name; Kind = ExternalKind.FUNCTION; Index = functionIndex }
+            )
+            let body = ResizeArray<byte>()
+            emitExpression body functionValue.Expression indexed (parameterMap functionValue) true 0
+            body.Add(0x0Buy)
+            moduleValue.Code.Add(FunctionBody([], body.ToArray())))
+        WasmModuleEncoder.encodeModule moduleValue
+
+    let compileSource (source: string) =
+        if isNull source then nullArg "source"
+        let functions = parse source
+        let indexed = indexFunctions functions
+        for functionValue in functions do
+            emitExpression (ResizeArray<byte>()) functionValue.Expression indexed (parameterMap functionValue) false 0
+        PackageResult(source, functions, emitModule functions indexed, None)
+
+    let packSource source = compileSource source
+
+    let writeWasmFile source path =
+        if isNull path then nullArg "path"
+        let result = compileSource source
+        try
+            File.WriteAllBytes(path, result.WasmBytes)
+        with
+        | :? IOException as error -> raise (PackageError("write", error.Message))
+        | :? UnauthorizedAccessException as error -> raise (PackageError("write", error.Message))
+        PackageResult(result.Source, result.Functions, result.WasmBytes, Some path)

--- a/code/packages/fsharp/nib-wasm-compiler/README.md
+++ b/code/packages/fsharp/nib-wasm-compiler/README.md
@@ -1,0 +1,15 @@
+# CodingAdventures.NibWasmCompiler.FSharp
+
+A pure F# compiler for the portable Nib `u4` function subset. It accepts typed
+function declarations whose return expressions contain `u4` literals,
+parameters, function calls, and wrapping `+%` addition, then emits a validated
+WebAssembly-shaped module through the native `wasm-module-encoder` package.
+
+```fsharp
+let result =
+    NibWasmCompiler.compileSource
+        "fn add(a: u4, b: u4) -> u4 { return a +% b; }"
+```
+
+Each Nib function is exported under its source name. Compilation is in memory;
+`writeWasmFile` is the optional filesystem boundary.

--- a/code/packages/fsharp/nib-wasm-compiler/required_capabilities.json
+++ b/code/packages/fsharp/nib-wasm-compiler/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/nib-wasm-compiler",
+  "capabilities": ["filesystem_write"],
+  "justification": "Compilation is pure and in memory; the optional write helper persists the emitted WebAssembly module."
+}

--- a/code/packages/fsharp/nib-wasm-compiler/tests/CodingAdventures.NibWasmCompiler.Tests/CodingAdventures.NibWasmCompiler.Tests.fsproj
+++ b/code/packages/fsharp/nib-wasm-compiler/tests/CodingAdventures.NibWasmCompiler.Tests/CodingAdventures.NibWasmCompiler.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.NibWasmCompiler.fsproj" />
+    <ProjectReference Include="../../../wasm-runtime/CodingAdventures.WasmRuntime.fsproj" />
+    <Compile Include="NibWasmCompilerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/nib-wasm-compiler/tests/CodingAdventures.NibWasmCompiler.Tests/NibWasmCompilerTests.fs
+++ b/code/packages/fsharp/nib-wasm-compiler/tests/CodingAdventures.NibWasmCompiler.Tests/NibWasmCompilerTests.fs
@@ -1,0 +1,97 @@
+namespace CodingAdventures.NibWasmCompiler.FSharp.Tests
+
+open System
+open System.IO
+open CodingAdventures.NibWasmCompiler.FSharp
+open CodingAdventures.WasmRuntime.FSharp
+open Xunit
+
+module NibWasmCompilerTests =
+    [<Fact>]
+    let ``compiles and runs literal function`` () =
+        let result = NibWasmCompiler.compileSource "fn answer() -> u4 { return 7; }"
+        Assert.Equal("answer", result.Functions.Head.Name)
+        Assert.Equal("7", result.Functions.Head.Expression)
+        Assert.Equal<byte array>([| 0x00uy; 0x61uy; 0x73uy; 0x6Duy |], result.WasmBytes[..3])
+        Assert.Equal(None, result.WasmPath)
+        Assert.Equal<obj list>([ box 7 ], WasmRuntime().LoadAndRun(result.WasmBytes, "answer", [||]))
+
+    [<Fact>]
+    let ``compiles parameters and wrapping addition`` () =
+        let result = NibWasmCompiler.compileSource "fn add(a: u4, b: u4) -> u4 { return a +% b; }"
+        let runtime = WasmRuntime()
+        let moduleValue = runtime.Load(result.WasmBytes)
+        Assert.Equal<string list>([ "a"; "b" ], result.Functions.Head.Parameters)
+        runtime.Validate(moduleValue) |> ignore
+        Assert.Contains(0x6Auy, result.WasmBytes)
+        Assert.Contains(0x71uy, result.WasmBytes)
+
+    [<Fact>]
+    let ``compiles nested calls and exports every function`` () =
+        let source = "fn id(x: u4) -> u4 { return x; }\nfn twice(x: u4) -> u4 { return id(id(x)); }"
+        let result = NibWasmCompiler.compileSource source
+        let runtime = WasmRuntime()
+        let moduleValue = runtime.Load(result.WasmBytes)
+        Assert.Equal<string list>([ "id"; "twice" ], moduleValue.Exports |> Seq.map _.Name |> Seq.toList)
+        Assert.Equal<obj list>([ box 15 ], runtime.LoadAndRun(result.WasmBytes, "twice", [| 15 |]))
+
+    [<Fact>]
+    let ``pack is alias and result defends bytes`` () =
+        let result = NibWasmCompiler.packSource "fn answer() -> u4 { return 7; }"
+        let bytes = result.WasmBytes
+        bytes[0] <- 0xFFuy
+        Assert.Equal(0x00uy, result.WasmBytes[0])
+        Assert.Equal("0.1.0", Version.VERSION)
+
+    [<Fact>]
+    let ``writes wasm file and records path`` () =
+        let path = Path.Combine(Path.GetTempPath(), $"nib-wasm-{Guid.NewGuid():N}.wasm")
+        try
+            let result = NibWasmCompiler.writeWasmFile "fn answer() -> u4 { return 7; }" path
+            Assert.Equal(Some path, result.WasmPath)
+            Assert.Equal<byte array>(result.WasmBytes, File.ReadAllBytes path)
+        finally
+            File.Delete path
+
+    [<Fact>]
+    let ``wraps write errors`` () =
+        let path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "x.wasm")
+        let error = Assert.Throws<PackageError>(fun () -> NibWasmCompiler.writeWasmFile "fn answer() -> u4 { return 7; }" path |> ignore)
+        Assert.Equal("write", error.Stage)
+
+    [<Fact>]
+    let ``reports invalid nib by stage`` () =
+        let cases =
+            [
+                "", "parse"
+                "garbage fn answer() -> u4 { return 7; }", "parse"
+                "fn bad(x: u8) -> u4 { return 1; }", "parse"
+                "fn bad(x: u4, x: u4) -> u4 { return x; }", "validate"
+                "fn same() -> u4 { return 1; } fn same() -> u4 { return 2; }", "validate"
+                "fn bad() -> u4 { return 16; }", "validate"
+                "fn bad() -> u4 { return missing(); }", "validate"
+                "fn one(x: u4) -> u4 { return x; } fn bad() -> u4 { return one(); }", "validate"
+                "fn bad() -> u4 { return nope; }", "validate"
+            ]
+
+        for source, stage in cases do
+            let error = Assert.Throws<PackageError>(fun () -> NibWasmCompiler.compileSource source |> ignore)
+            Assert.Equal(stage, error.Stage)
+            Assert.StartsWith($"[{stage}]", error.ToString())
+
+    [<Fact>]
+    let ``rejects excessive expression nesting`` () =
+        let mutable expression = "0"
+        for _ = 0 to 257 do
+            expression <- $"id({expression})"
+        let source = $"fn id(x: u4) -> u4 {{ return x; }} fn main() -> u4 {{ return {expression}; }}"
+        let error = Assert.Throws<PackageError>(fun () -> NibWasmCompiler.compileSource source |> ignore)
+        Assert.Equal("validate", error.Stage)
+        Assert.Contains("nesting", error.Message)
+
+    [<Fact>]
+    let ``rejects excessive source length and nulls`` () =
+        let error = Assert.Throws<PackageError>(fun () -> NibWasmCompiler.compileSource (String(' ', 1_000_001)) |> ignore)
+        Assert.Equal("parse", error.Stage)
+        Assert.Throws<ArgumentNullException>(fun () -> NibWasmCompiler.compileSource null |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> NibWasmCompiler.writeWasmFile "fn x() -> u4 { return 0; }" null |> ignore) |> ignore

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -112,12 +112,12 @@ the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
 and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
 `x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
-ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, and `block-ram`
-ports:
+ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`, and
+`nib-wasm-compiler` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 325 |
+| Present in 10-15 languages | 172 | 323 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 701 | 9,814 |
@@ -301,6 +301,16 @@ cross-port visibility, edge behavior, reconfiguration clearing, defensive
 copies, and invalid signals and dimensions. The package now spans 12 target
 implementation lanes, reduces the high-consensus backlog to 325 slots, and
 leaves 8 paired gaps in each lane.
+
+The tenth paired C#/F# slice is complete: `nib-wasm-compiler` now compiles the
+portable typed Nib `u4` function subset in both lanes. Native parsers cover
+literals, parameters, nested calls, and wrapping `+%` addition, while the
+existing `wasm-module-encoder`, `wasm-types`, and `wasm-leb128` packages produce
+validated modules that export every declared function. Package-native tests
+cover executable literals and calls, wrapping-opcode validation, malformed
+source, depth and size limits, defensive results, and optional file output. The
+package now spans 13 implementation lanes, reduces the high-consensus backlog
+to 323 slots, and leaves 7 paired gaps in each lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add pure C# and F# ports of the portable typed Nib `u4` compiler subset
- compile literals, parameters, nested calls, and wrapping `+%` addition through the native WebAssembly encoders
- add package metadata, build gates, defensive file-output helpers, package-native tests, and roadmap measurements

## Why this item
`nib-wasm-compiler` was the smallest remaining paired C#/F# high-consensus gap and was already dependency-safe after the native `wasm-module-encoder` ports landed.

## Validation
- C#: 17 tests; 100% line, branch, and method coverage
- F#: 9 tests; 99.33% line, 85.04% branch, and 100% method coverage
- C# `dotnet format --verify-no-changes`
- package-parity reporter: 6 tests passed; 323 broad missing slots; 7 paired C#/F# gaps; 0 identity collisions
- both focused suites rerun after rebasing onto current `origin/main`

The repository's educational C#/F# execution engines do not yet execute `i32.and`, so the wrapping-addition tests validate the canonical `i32.add`/`i32.const 15`/`i32.and` instruction sequence structurally while executable runtime tests cover literals and nested calls.