### PR TITLE
feat(adj-facts-stdlib): biology/animal-diets — diet category → food table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_animaldiets_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_animaldiets_e2e.rs
@@ -1,0 +1,69 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/animal-diets.adj`) driven through the built CLI:
+//! a native `table` of diet category → food resolves a binding-query recall with
+//! the source's citation, runs backward, and abstains on a non-category — with
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_animal_diets_recall_binds_food_with_citation() {
+    let dir = scratch("animaldiets");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/animal-diets.adj");
+    std::fs::copy(&src, dir.join("animal-diets.adj")).expect("copy shipped animal-diets.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"animal-diets.adj\"\n\
+         ? diet_food(herbivore, $Food)\n\
+         ? diet_food(carnivore, $Food)\n\
+         ? diet_food(omnivore, $Food)\n\
+         ? diet_food($Category, plants)\n\
+         ? diet_food(detritivore, $Food)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A herbivore eats plants; a carnivore eats animals; an omnivore eats anything.
+    assert!(out.contains("\"Food\":\"plants\""), "herbivore → plants: {out}");
+    assert!(out.contains("\"Food\":\"animals\""), "carnivore → animals: {out}");
+    assert!(out.contains("\"Food\":\"anything\""), "omnivore → anything: {out}");
+    // Reverse bind: the food `plants` recalls its diet category, herbivore.
+    assert!(
+        out.contains("\"Category\":\"herbivore\""),
+        "plants → herbivore (reverse): {out}"
+    );
+    // The answer carries the U.S. National Park Service citation (locator + trust).
+    assert!(
+        out.contains("nps.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A detritivore is not one of the three diet categories the source defines —
+    // honest abstention, never a fabricated food.
+    assert!(out.contains("\"abstained\":true"), "detritivore abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -49,6 +49,7 @@ per rotation, in parallel):
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
 | `biology/` | leaf part → defining token / function (blade → flattened, stomata → gas_exchange) | Colorado State University Extension (authoritative) |
+| `biology/` | diet category → food it eats (herbivore → plants, carnivore → animals, omnivore → anything) | U.S. National Park Service (authoritative) |
 | `physics/` | simple machine → everyday example | NASA |
 | `physics/` | phase change → its name (melting, freezing, …) | LibreTexts (consensus) |
 | `physics/` | energy form → defining token (chemical → bonds, thermal → heat) | EIA (energy.gov) |

--- a/code/specs/data/adj-facts-stdlib/biology/animal-diets.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/animal-diets.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% animal-diets — the three basic animal diet categories and the food each
+% kind of animal eats (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% One of the very first sorting rules of elementary biology, and a rung an
+% ecology or MEDICINE agent reasons UP from: every animal can be sorted by WHAT
+% it eats into one of three basic diet categories. "A herbivore eats only
+% plants; a carnivore eats other animals; an omnivore eats anything." Before you
+% can reason about a food chain, a food web, or a predator/prey balance you must
+% first know WHICH diet category an animal belongs to. Recall is a binding
+% query:
+%
+%     ? diet_food(herbivore, $Food)      % plants
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `diet_food(category, food)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the food
+% WITH its source, on the CPU, with zero model calls, and abstains on a word
+% that is not one of these three diet categories (it never invents a food).
+%
+% Each of the three basic diet categories and the food the source states that
+% kind of animal eats, as a little truth table:
+%
+%     diet category   food it eats   a beginner's cue
+%     -------------   ------------   ------------------------------------------
+%     herbivore       plants         a plant-eater: eats only plants
+%     carnivore       animals        a meat-eater: eats (almost exclusively)
+%                                     other animals
+%     omnivore        anything       a generalist: eats anything (plants AND
+%                                     animals)
+%
+% The query also runs BACKWARD — bind the food and recall its diet category:
+%
+%     ? diet_food($Category, plants)     % herbivore
+%
+% A word that is NOT one of these three basic diet categories — `detritivore`,
+% `frugivore`, `rock` — is deliberately NOT a row, so a diet recall ABSTAINS on
+% it rather than inventing a food. That honest-abstention property is what makes
+% the table safe to build a reasoner on: it answers exactly the category→food
+% pairs it can ground, and only those.
+%
+% The `food` value of every row is a SINGLE lowercase atom, chosen to be the
+% food the source EXPLICITLY states that kind of animal eats — never one the
+% source does not support. (Where the everyday word differs from the source's
+% word — a carnivore is a "meat-eater", but the source's own noun for what it
+% eats is "animals", not "meat" — the atom uses the source's own word, so every
+% value stays literally checkable against the quoted span.)
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every category→food pair
+% below was read out of a single fetched U.S. National Park Service teacher
+% lesson-plan page, and any pair whose food could not be verified there would
+% have been dropped). All three definitions are three parallel sentences on the
+% SAME page ("Explain that X refers to living things that ..."). Each pair, with
+% the primary source it was copied from and the verbatim span that states it:
+%
+%   herbivore → plants
+%     https://www.nps.gov/teachers/classrooms/carnivores-herbivores-omnivores.htm
+%     (U.S. National Park Service — Teachers / Lesson Plans)
+%     "Explain that herbivore refers to living things that eat only plants."
+%
+%   carnivore → animals
+%     https://www.nps.gov/teachers/classrooms/carnivores-herbivores-omnivores.htm
+%     (U.S. National Park Service — Teachers / Lesson Plans)
+%     "Explain that carnivore refers to living things that eat almost
+%      exclusively other animals."
+%
+%   omnivore → anything
+%     https://www.nps.gov/teachers/classrooms/carnivores-herbivores-omnivores.htm
+%     (U.S. National Park Service — Teachers / Lesson Plans)
+%     "Explain that omnivore refers to living things that eats anything."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the NPS statement that fixes the
+% first row (herbivore → plants). Every OTHER row's per-fact source and verbatim
+% span is listed above, so each food remains independently checkable. The source
+% is the U.S. National Park Service, a primary U.S. government teaching resource,
+% so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table diet_food {
+    columns category, food
+
+    row (herbivore, plants)
+    row (carnivore, animals)
+    row (omnivore, anything)
+
+    source "Explain that herbivore refers to living things that eat only plants."
+    locator "https://www.nps.gov/teachers/classrooms/carnivores-herbivores-omnivores.htm"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/animal-diets.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/animal-diets.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% animal-diets.query.adj — a worked recall over the biology animal-diets library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does a herbivore
+% eat?": it states no biology fact of its own — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `diet_food` rows and returns the food + the table's source/locator/trust. The
+% fourth query runs the relation BACKWARD (bind the food `plants`, recall its
+% diet category — herbivore). A word that is not one of the three basic diet
+% categories abstains honestly — the engine never invents a food.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli animal-diets.query.adj
+% ============================================================================
+
+import "animal-diets.adj"
+
+? diet_food(herbivore, $Food)      % expect plants
+? diet_food(carnivore, $Food)      % expect animals
+? diet_food(omnivore, $Food)       % expect anything
+? diet_food($Category, plants)     % reverse bind — expect herbivore
+? diet_food(detritivore, $Food)    % expect abstain — a detritivore (a detritus-eater) is a real diet category, but not one of the three this source defines


### PR DESCRIPTION
A native ADJ `table` mapping each of the three basic animal diet categories
to the food that kind of animal eats, plus its worked recall query and an
end-to-end CLI test. Mirrors biology/tissue-types exactly (table + .query +
facts_*_e2e.rs + README subject-index row).

Recall is an ordinary SLD binding query resolved on the CPU with zero model
calls; it runs forward (category → food) and backward (food → category), and
abstains honestly on a word that is not one of the three categories.

Provenance — every pair byte-provenanced this session from a single fetched
U.S. National Park Service teacher lesson-plan page (three parallel "Explain
that X refers to living things that ..." sentences). trust: authoritative
(primary U.S. government teaching resource). Nothing asserted from memory.

  herbivore → plants
    "Explain that herbivore refers to living things that eat only plants."
  carnivore → animals
    "Explain that carnivore refers to living things that eat almost
     exclusively other animals."
  omnivore → anything
    "Explain that omnivore refers to living things that eats anything."

  https://www.nps.gov/teachers/classrooms/carnivores-herbivores-omnivores.htm

Targeted test `cargo test -p adj-lang-cli --test facts_animaldiets_e2e` passes
and `cargo clippy -p adj-lang -p adj-lang-cli --all-targets -- -D warnings` is
clean. Collision-checked: animal-diets.adj was absent from origin/main.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
