### PR TITLE
feat(adj-facts-stdlib): biology/flower-parts — flower part → function table

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_flowerparts_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_flowerparts_e2e.rs
@@ -1,0 +1,88 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/flower-parts.adj`) driven through the built CLI:
+//! a native `table` of flower parts → the function / role the source states
+//! resolves binding-query recalls (forward AND backward) with the source's
+//! University of Illinois Extension citation, and abstains on a word that is not
+//! one of these flower parts (the leaf) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factfp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_flower_parts_recall_binds_function_with_citation() {
+    let dir = scratch("flowerparts");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/flower-parts.adj");
+    std::fs::copy(&src, dir.join("flower-parts.adj")).expect("copy shipped flower-parts.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"flower-parts.adj\"\n\
+         ? flower_part_function(petal, $Function)\n\
+         ? flower_part_function(anther, $Function)\n\
+         ? flower_part_function(ovary, $Function)\n\
+         ? flower_part_function(stigma, $Function)\n\
+         ? flower_part_function($Part, male)\n\
+         ? flower_part_function(leaf, $Function)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The petals attract pollinators, the anthers carry the pollen, the ovary
+    // contains the ovules, the stigma traps the pollen — the recalled functions
+    // (forward binds).
+    assert!(
+        out.contains("\"Function\":\"attract_pollinators\""),
+        "petal → attract_pollinators: {out}"
+    );
+    assert!(
+        out.contains("\"Function\":\"carry_pollen\""),
+        "anther → carry_pollen: {out}"
+    );
+    assert!(
+        out.contains("\"Function\":\"contains_ovules\""),
+        "ovary → contains_ovules: {out}"
+    );
+    assert!(
+        out.contains("\"Function\":\"traps_pollen\""),
+        "stigma → traps_pollen: {out}"
+    );
+    // The relation runs BACKWARD: bind the function `male`, recall its flower part.
+    assert!(
+        out.contains("\"Part\":\"stamen\""),
+        "male → stamen (reverse recall): {out}"
+    );
+    // The answer carries the Illinois Extension citation as its proof, at the
+    // `authoritative` trust tier for a .edu-primary botany/extension source.
+    assert!(
+        out.contains("web.extension.illinois.edu")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // The leaf is a plant part, not a part of the flower — honest abstention,
+    // never a fabricated function.
+    assert!(out.contains("\"abstained\":true"), "leaf abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -50,6 +50,7 @@ per rotation, in parallel):
 | `biology/` | hormone → endocrine gland that secretes it | NCI SEER Training / NIH MedlinePlus |
 | `biology/` | vitamin → deficiency disease it prevents | NIH Office of Dietary Supplements |
 | `biology/` | leaf part → defining token / function (blade → flattened, stomata → gas_exchange) | Colorado State University Extension (authoritative) |
+| `biology/` | flower part → function / role (petal → attract_pollinators, stamen → male, ovary → contains_ovules) | University of Illinois Extension (authoritative) |
 | `physics/` | simple machine → everyday example | NASA |
 | `physics/` | phase change → its name (melting, freezing, …) | LibreTexts (consensus) |
 | `physics/` | energy form → defining token (chemical → bonds, thermal → heat) | EIA (energy.gov) |

--- a/code/specs/data/adj-facts-stdlib/biology/flower-parts.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/flower-parts.adj
@@ -1,0 +1,110 @@
+% ============================================================================
+% flower-parts — the parts of a flower and the function / role the source
+% states for each one (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A flower is not one undifferentiated bloom: it is an assembly of named parts,
+% and an elementary botany key names each part by the ONE thing it does. "The
+% petals attract pollinators; the sepals protect the bud; the stamen is the male
+% part; the pistil is the female part; the anthers carry the pollen; the stigma
+% traps the pollen; the ovary contains the ovules." Before you can reason about a
+% flower — identify it, pollinate it, or teach it — you must first know WHICH
+% part you are looking at and what that part is FOR. Recall is a binding query:
+%
+%     ? flower_part_function(petal, $Function)      % attract_pollinators
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `flower_part_function(part, function)` carrying the table's citation,
+% so the lookup above is the ordinary SLD binding query — the engine returns the
+% function WITH its source, on the CPU, with zero model calls, and abstains on a
+% word that is not one of these flower parts (it never invents a function).
+%
+% Each flower part and the function / role the source states for it, as a little
+% truth table:
+%
+%     flower part   function / role the source states   a beginner's cue
+%     -----------   ---------------------------------   ---------------------------
+%     petal         attract_pollinators                 the bright part that lures bees
+%     sepal         protect                             the green leaf that guards the bud
+%     stamen        male                                the male reproductive part
+%     pistil        female                              the female reproductive part
+%     anther        carry_pollen                        the tip of the stamen, full of pollen
+%     stigma        traps_pollen                        the sticky top that catches pollen
+%     ovary         contains_ovules                     the base that holds the future seeds
+%
+% The query also runs BACKWARD — bind a function and recall the flower part:
+%
+%     ? flower_part_function($Part, male)   % stamen
+%
+% A word that is NOT one of these flower parts — `leaf`, `root`, `stem` — is
+% deliberately NOT a row, so a flower-part recall ABSTAINS on it rather than
+% inventing a function. (The leaf is a plant part, but not a part of the FLOWER.)
+% That honest-abstention property is what makes the table safe to build a
+% reasoner on: it answers exactly the part→function pairs it can ground, and only
+% those.
+%
+% The `function` value of every row is a SINGLE lowercase atom, chosen to be a
+% word the source EXPLICITLY uses for that part — never one the source does not
+% support. Where the source's phrase is more than one word (the petals "attract
+% pollinators"; the anthers "carry the pollen"; the ovary "contains the ovules"),
+% the atom joins the source's own words with underscores, so every value stays
+% literally checkable against the quoted span.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every part→function pair
+% below was read out of a single fetched University of Illinois Extension page,
+% and any pair whose function could not be verified there was dropped). Each
+% pair, with the verbatim span that states it, from "The Great Plant Escape"
+% (University of Illinois Extension, a land-grant .edu-primary Cooperative
+% Extension botany teaching resource):
+%   https://web.extension.illinois.edu/gpe/case4/c4facts1a.html
+%
+%   petal → attract_pollinators
+%     "Petals attract pollinators and are usually the reason why we buy and
+%      enjoy flowers."
+%
+%   sepal → protect
+%     "Sepals help protect the developing bud."
+%
+%   stamen → male
+%     "The main flower parts are the male part called the stamen and the female
+%      part called the pistil."
+%
+%   pistil → female
+%     "The main flower parts are the male part called the stamen and the female
+%      part called the pistil."
+%
+%   anther → carry_pollen
+%     "The anthers carry the pollen."
+%
+%   stigma → traps_pollen
+%     "The stigma is the sticky surface at the top of the pistil; it traps and
+%      holds the pollen."
+%
+%   ovary → contains_ovules
+%     "The style leads down to the ovary that contains the ovules."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the Illinois Extension statement
+% that fixes the first row (petal → attract_pollinators). Every OTHER row's
+% verbatim span is listed above, so each function remains independently
+% checkable. The source is a University of Illinois Extension botany teaching
+% page (a .edu-primary Cooperative Extension resource), so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table flower_part_function {
+    columns part, function
+
+    row (petal, attract_pollinators)
+    row (sepal, protect)
+    row (stamen, male)
+    row (pistil, female)
+    row (anther, carry_pollen)
+    row (stigma, traps_pollen)
+    row (ovary, contains_ovules)
+
+    source "Petals attract pollinators and are usually the reason why we buy and enjoy flowers."
+    locator "https://web.extension.illinois.edu/gpe/case4/c4facts1a.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/flower-parts.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/flower-parts.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% flower-parts.query.adj — a worked recall over the biology flower-parts library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the petal do?":
+% it states no botany fact of its own — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `flower_part_function` rows and returns the function + the table's source/
+% locator/trust. The fifth query runs the relation BACKWARD (bind the function
+% `male`, recall its flower part — stamen). A word that is not one of these
+% flower parts abstains honestly — the engine never invents a function.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli flower-parts.query.adj
+% ============================================================================
+
+import "flower-parts.adj"
+
+? flower_part_function(petal, $Function)    % expect attract_pollinators
+? flower_part_function(anther, $Function)   % expect carry_pollen
+? flower_part_function(ovary, $Function)    % expect contains_ovules
+? flower_part_function(stigma, $Function)   % expect traps_pollen
+? flower_part_function($Part, male)         % reverse bind — expect stamen
+? flower_part_function(leaf, $Function)     % expect abstain — the leaf is a plant part, not one of these flower parts


### PR DESCRIPTION
Add a native `table` mapping each flower part to the function / role the
source explicitly states for it, plus a worked `.query.adj` recall (forward
+ reverse + honest abstain) and a CLI e2e test.

Single source, single clean axis (flower_part → function), each value token
verbatim from the source sentence. Every pair byte-provenanced from one
fetched page — "The Great Plant Escape" (University of Illinois Extension, a
land-grant .edu-primary Cooperative Extension botany teaching resource):
  https://web.extension.illinois.edu/gpe/case4/c4facts1a.html

  petal  → attract_pollinators
    "Petals attract pollinators and are usually the reason why we buy and
     enjoy flowers."
  sepal  → protect
    "Sepals help protect the developing bud."
  stamen → male
    "The main flower parts are the male part called the stamen and the
     female part called the pistil."
  pistil → female
    (same sentence as stamen)
  anther → carry_pollen
    "The anthers carry the pollen."
  stigma → traps_pollen
    "The stigma is the sticky surface at the top of the pistil; it traps and
     holds the pollen."
  ovary  → contains_ovules
    "The style leads down to the ovary that contains the ovules."

Trust tier `authoritative` — University of Illinois Extension is a
.edu-primary Cooperative Extension botany page. The `table` carries one
provenance envelope holding the cleanest span (petal → attract_pollinators);
every other row's verbatim span is listed inline so each value stays
independently checkable. A word that is not a flower part (leaf) abstains.

Added README biology subject-index row (all existing rows kept).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
