### PR TITLE
feat(dartmouth-basic-lexer): add C# and F# ports

### DIFF
--- a/code/packages/csharp/dartmouth-basic-lexer/BUILD
+++ b/code/packages/csharp/dartmouth-basic-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.DartmouthBasicLexer.Tests/CodingAdventures.DartmouthBasicLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.DartmouthBasicLexer]*"

--- a/code/packages/csharp/dartmouth-basic-lexer/BUILD_windows
+++ b/code/packages/csharp/dartmouth-basic-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.DartmouthBasicLexer.Tests/CodingAdventures.DartmouthBasicLexer.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.DartmouthBasicLexer]*"

--- a/code/packages/csharp/dartmouth-basic-lexer/CHANGELOG.md
+++ b/code/packages/csharp/dartmouth-basic-lexer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a grammar-driven Dartmouth BASIC lexer.
+- Relabel physical-line labels and suppress `REM` bodies.
+- Normalize parser-facing token values consistently with the Go port.

--- a/code/packages/csharp/dartmouth-basic-lexer/CodingAdventures.DartmouthBasicLexer.csproj
+++ b/code/packages/csharp/dartmouth-basic-lexer/CodingAdventures.DartmouthBasicLexer.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.DartmouthBasicLexer.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Grammar-driven lexer for the original 1964 Dartmouth BASIC language</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/dartmouth_basic/dartmouth_basic.tokens" LogicalName="dartmouth_basic.tokens" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/dartmouth-basic-lexer/DartmouthBasicLexer.cs
+++ b/code/packages/csharp/dartmouth-basic-lexer/DartmouthBasicLexer.cs
@@ -1,0 +1,145 @@
+using System.Text;
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Lexer;
+
+namespace CodingAdventures.DartmouthBasicLexer;
+
+/// <summary>
+/// Tokenizes the original 1964 Dartmouth BASIC language.
+/// </summary>
+public sealed class DartmouthBasicLexer
+{
+    private const string GrammarResource = "dartmouth_basic.tokens";
+    private static readonly Lazy<TokenGrammar> TokenGrammar = new(ParseTokenGrammar);
+    private readonly string _source;
+
+    private DartmouthBasicLexer(string source) => _source = source;
+
+    /// <summary>Creates a configured lexer for <paramref name="source"/>.</summary>
+    public static DartmouthBasicLexer CreateDartmouthBasicLexer(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return new DartmouthBasicLexer(source);
+    }
+
+    /// <summary>Tokenizes <paramref name="source"/> in one call.</summary>
+    public static IReadOnlyList<Token> TokenizeDartmouthBasic(string source) =>
+        CreateDartmouthBasicLexer(source).Tokenize();
+
+    /// <summary>Produces the normalized, parser-ready token stream.</summary>
+    public IReadOnlyList<Token> Tokenize()
+    {
+        try
+        {
+            return PostProcess(new GrammarLexer(TokenGrammar.Value).Tokenize(_source));
+        }
+        catch (LexerError error)
+        {
+            throw new ArgumentException("Dartmouth BASIC tokenization failed: " + error.Message, nameof(_source), error);
+        }
+    }
+
+    private static IReadOnlyList<Token> PostProcess(IReadOnlyList<Token> tokens)
+    {
+        var result = new List<Token>(tokens.Count);
+        var atLineStart = true;
+        var suppressingRemark = false;
+
+        foreach (var original in tokens)
+        {
+            var token = NormalizeValue(original);
+            if (atLineStart && token.EffectiveTypeName == "NUMBER")
+            {
+                token = token with { TypeName = "LINE_NUM" };
+            }
+
+            if (atLineStart)
+            {
+                atLineStart = false;
+            }
+
+            if (!suppressingRemark || token.EffectiveTypeName == "NEWLINE")
+            {
+                result.Add(token);
+            }
+
+            if (token.EffectiveTypeName == "KEYWORD" && token.Value == "REM")
+            {
+                suppressingRemark = true;
+            }
+            else if (token.EffectiveTypeName == "NEWLINE")
+            {
+                suppressingRemark = false;
+                atLineStart = true;
+            }
+        }
+
+        return result;
+    }
+
+    private static Token NormalizeValue(Token token)
+    {
+        var value = token.EffectiveTypeName switch
+        {
+            "KEYWORD" => token.Value.ToUpperInvariant(),
+            "BUILTIN_FN" or "USER_FN" or "NAME" or "NUMBER" or "LINE_NUM" => token.Value.ToLowerInvariant(),
+            "STRING" when token.Value.Length >= 2 && token.Value[0] == '"' && token.Value[^1] == '"' => token.Value[1..^1],
+            "NEWLINE" => "\\n",
+            _ => token.Value,
+        };
+        return token with { Value = value };
+    }
+
+    private static TokenGrammar ParseTokenGrammar()
+    {
+        try
+        {
+            var assembly = typeof(DartmouthBasicLexer).Assembly;
+            using var stream = assembly.GetManifestResourceStream(GrammarResource)
+                ?? throw new InvalidOperationException("Missing bundled resource: " + GrammarResource);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return TokenGrammarParser.Parse(PrepareGrammar(reader.ReadToEnd()));
+        }
+        catch (TokenGrammarError error)
+        {
+            throw new InvalidOperationException("Failed to parse bundled Dartmouth BASIC token grammar", error);
+        }
+    }
+
+    // The .NET grammar parser keeps consuming a keyword section until another
+    // named section appears. Move Dartmouth's mid-file keyword list to the end,
+    // and lowercase it for the parser's case-insensitive lookup convention.
+    private static string PrepareGrammar(string source)
+    {
+        var output = new List<string>();
+        var keywords = new List<string>();
+        var readingKeywords = false;
+
+        foreach (var rawLine in source.Replace("\r\n", "\n").Split('\n'))
+        {
+            var trimmed = rawLine.Trim();
+            if (trimmed == "keywords:")
+            {
+                readingKeywords = true;
+                continue;
+            }
+
+            if (readingKeywords && trimmed.Length > 0 && !trimmed.StartsWith('#') && char.IsWhiteSpace(rawLine[0]))
+            {
+                keywords.Add(trimmed.ToLowerInvariant());
+                continue;
+            }
+
+            if (readingKeywords && trimmed.Length > 0 && !trimmed.StartsWith('#'))
+            {
+                readingKeywords = false;
+            }
+
+            output.Add(rawLine);
+        }
+
+        output.Add("keywords:");
+        output.AddRange(keywords.Select(keyword => "  " + keyword));
+        return string.Join('\n', output);
+    }
+}

--- a/code/packages/csharp/dartmouth-basic-lexer/README.md
+++ b/code/packages/csharp/dartmouth-basic-lexer/README.md
@@ -1,0 +1,16 @@
+# CodingAdventures.DartmouthBasicLexer
+
+A pure C# lexer for the original 1964 Dartmouth BASIC language. It loads the
+shared `dartmouth_basic.tokens` grammar from an embedded resource, then applies
+the language's two context-sensitive rules: the first number on a physical line
+is a `LINE_NUM`, and `REM` discards everything through the end of that line.
+
+```csharp
+var tokens = DartmouthBasicLexer.TokenizeDartmouthBasic(
+    "10 LET X = 5\n20 PRINT X\n30 END\n");
+```
+
+Keywords are normalized to uppercase, names and function identifiers to
+lowercase, strings retain their original case without surrounding quotes, and
+every stream ends with `EOF`. The grammar is embedded, so tokenization performs
+no filesystem or network access.

--- a/code/packages/csharp/dartmouth-basic-lexer/required_capabilities.json
+++ b/code/packages/csharp/dartmouth-basic-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/dartmouth-basic-lexer",
+  "capabilities": [],
+  "justification": "Tokenization is pure and uses a bundled grammar resource."
+}

--- a/code/packages/csharp/dartmouth-basic-lexer/tests/CodingAdventures.DartmouthBasicLexer.Tests/CodingAdventures.DartmouthBasicLexer.Tests.csproj
+++ b/code/packages/csharp/dartmouth-basic-lexer/tests/CodingAdventures.DartmouthBasicLexer.Tests/CodingAdventures.DartmouthBasicLexer.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.DartmouthBasicLexer.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/dartmouth-basic-lexer/tests/CodingAdventures.DartmouthBasicLexer.Tests/DartmouthBasicLexerTests.cs
+++ b/code/packages/csharp/dartmouth-basic-lexer/tests/CodingAdventures.DartmouthBasicLexer.Tests/DartmouthBasicLexerTests.cs
@@ -1,0 +1,79 @@
+using CodingAdventures.Lexer;
+using BasicLexer = CodingAdventures.DartmouthBasicLexer.DartmouthBasicLexer;
+
+namespace CodingAdventures.DartmouthBasicLexer.Tests;
+
+public sealed class DartmouthBasicLexerTests
+{
+    [Fact]
+    public void TokenizesAndNormalizesAStatement()
+    {
+        var tokens = BasicLexer.TokenizeDartmouthBasic("10 let X = 1.5E3\r\n");
+
+        Assert.Equal(
+            ["LINE_NUM", "KEYWORD", "NAME", "EQ", "NUMBER", "NEWLINE", "EOF"],
+            tokens.Select(token => token.EffectiveTypeName));
+        Assert.Equal(["10", "LET", "x", "=", "1.5e3", "\\n", ""], tokens.Select(token => token.Value));
+        Assert.Equal((1, 1), (tokens[0].Line, tokens[0].Column));
+        Assert.Equal((2, 1), (tokens[^1].Line, tokens[^1].Column));
+    }
+
+    [Fact]
+    public void RelabelsOnlyTheFirstNumberOnEachPhysicalLine()
+    {
+        var tokens = BasicLexer.TokenizeDartmouthBasic("30 GOTO 10\n40 PRINT 20\n");
+        Assert.Equal(["LINE_NUM", "NUMBER", "LINE_NUM", "NUMBER"],
+            tokens.Where(token => token.EffectiveTypeName is "LINE_NUM" or "NUMBER").Select(token => token.EffectiveTypeName));
+    }
+
+    [Fact]
+    public void SuppressesRemarkBodyButRetainsItsNewline()
+    {
+        var tokens = BasicLexer.CreateDartmouthBasicLexer("10 rem GOTO 20 @ ignored\n20 END\n").Tokenize();
+        Assert.Equal(
+            ["LINE_NUM", "KEYWORD", "NEWLINE", "LINE_NUM", "KEYWORD", "NEWLINE", "EOF"],
+            tokens.Select(token => token.EffectiveTypeName));
+        Assert.Equal("REM", tokens[1].Value);
+    }
+
+    [Fact]
+    public void PreservesStringCaseWithoutQuotes()
+    {
+        var tokens = BasicLexer.TokenizeDartmouthBasic("10 PRINT \"Hello, World!\"\n");
+        var value = Assert.Single(tokens, token => token.EffectiveTypeName == "STRING").Value;
+        Assert.Equal("Hello, World!", value);
+    }
+
+    [Fact]
+    public void ClassifiesFunctionsNamesAndUnknownCharacters()
+    {
+        var tokens = BasicLexer.TokenizeDartmouthBasic("10 LET Result = SIN(FNA(X)) @\n");
+        Assert.Contains(tokens, token => token.EffectiveTypeName == "BUILTIN_FN" && token.Value == "sin");
+        Assert.Contains(tokens, token => token.EffectiveTypeName == "USER_FN" && token.Value == "fna");
+        Assert.Contains(tokens, token => token.EffectiveTypeName == "NAME" && token.Value == "result");
+        Assert.Contains(tokens, token => token.EffectiveTypeName == "UNKNOWN" && token.Value == "@");
+    }
+
+    [Theory]
+    [InlineData("<=", "LE")]
+    [InlineData(">=", "GE")]
+    [InlineData("<>", "NE")]
+    [InlineData("^", "CARET")]
+    [InlineData(";", "SEMICOLON")]
+    public void RecognizesOperators(string source, string expectedType)
+    {
+        Assert.Equal(expectedType, BasicLexer.TokenizeDartmouthBasic(source)[0].EffectiveTypeName);
+    }
+
+    [Fact]
+    public void ABlankLineDoesNotRelabelTheFollowingExpressionNumberIncorrectly()
+    {
+        var tokens = BasicLexer.TokenizeDartmouthBasic("\n10 END\n");
+        Assert.Equal("NEWLINE", tokens[0].EffectiveTypeName);
+        Assert.Equal("LINE_NUM", tokens[1].EffectiveTypeName);
+    }
+
+    [Fact]
+    public void RejectsNullSource() =>
+        Assert.Throws<ArgumentNullException>(() => BasicLexer.CreateDartmouthBasicLexer(null!));
+}

--- a/code/packages/fsharp/dartmouth-basic-lexer/BUILD
+++ b/code/packages/fsharp/dartmouth-basic-lexer/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.DartmouthBasicLexer.Tests/CodingAdventures.DartmouthBasicLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.DartmouthBasicLexer.FSharp]*"

--- a/code/packages/fsharp/dartmouth-basic-lexer/BUILD_windows
+++ b/code/packages/fsharp/dartmouth-basic-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.DartmouthBasicLexer.Tests/CodingAdventures.DartmouthBasicLexer.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.DartmouthBasicLexer.FSharp]*"

--- a/code/packages/fsharp/dartmouth-basic-lexer/CHANGELOG.md
+++ b/code/packages/fsharp/dartmouth-basic-lexer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a grammar-driven Dartmouth BASIC lexer.
+- Relabel physical-line labels and suppress `REM` bodies.
+- Normalize parser-facing token values consistently with the Go port.

--- a/code/packages/fsharp/dartmouth-basic-lexer/CodingAdventures.DartmouthBasicLexer.fsproj
+++ b/code/packages/fsharp/dartmouth-basic-lexer/CodingAdventures.DartmouthBasicLexer.fsproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.DartmouthBasicLexer.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.DartmouthBasicLexer.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Grammar-driven lexer for the original 1964 Dartmouth BASIC language</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="DartmouthBasicLexer.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/dartmouth_basic/dartmouth_basic.tokens" LogicalName="dartmouth_basic.tokens" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/dartmouth-basic-lexer/DartmouthBasicLexer.fs
+++ b/code/packages/fsharp/dartmouth-basic-lexer/DartmouthBasicLexer.fs
@@ -1,0 +1,103 @@
+namespace CodingAdventures.DartmouthBasicLexer.FSharp
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Reflection
+open System.Text
+open CodingAdventures.GrammarTools.FSharp
+open CodingAdventures.Lexer.FSharp
+
+module private Implementation =
+    let grammarResource = "dartmouth_basic.tokens"
+
+    let prepareGrammar (source: string) =
+        let output = ResizeArray<string>()
+        let keywords = ResizeArray<string>()
+        let mutable readingKeywords = false
+
+        for rawLine in source.Replace("\r\n", "\n").Split('\n') do
+            let trimmed = rawLine.Trim()
+            if trimmed = "keywords:" then
+                readingKeywords <- true
+            elif readingKeywords && trimmed.Length > 0 && not (trimmed.StartsWith('#')) && Char.IsWhiteSpace(rawLine.[0]) then
+                keywords.Add(trimmed.ToLowerInvariant())
+            else
+                if readingKeywords && trimmed.Length > 0 && not (trimmed.StartsWith('#')) then
+                    readingKeywords <- false
+                output.Add(rawLine)
+
+        output.Add("keywords:")
+        keywords |> Seq.map (fun keyword -> "  " + keyword) |> output.AddRange
+        String.Join("\n", output)
+
+    let tokenGrammar =
+        lazy
+            try
+                let assembly = Assembly.GetExecutingAssembly()
+                use stream = assembly.GetManifestResourceStream(grammarResource)
+                if isNull stream then
+                    invalidOp ("Missing bundled resource: " + grammarResource)
+                use reader = new StreamReader(stream, Encoding.UTF8)
+                TokenGrammarParser.Parse(prepareGrammar (reader.ReadToEnd()))
+            with
+            | :? TokenGrammarError as error ->
+                raise (InvalidOperationException("Failed to parse bundled Dartmouth BASIC token grammar", error))
+
+    let normalizeValue (token: Token) =
+        let value =
+            match token.EffectiveTypeName with
+            | "KEYWORD" -> token.Value.ToUpperInvariant()
+            | "BUILTIN_FN" | "USER_FN" | "NAME" | "NUMBER" | "LINE_NUM" -> token.Value.ToLowerInvariant()
+            | "STRING" when token.Value.Length >= 2 && token.Value.[0] = '"' && token.Value.[token.Value.Length - 1] = '"' ->
+                token.Value.Substring(1, token.Value.Length - 2)
+            | "NEWLINE" -> "\\n"
+            | _ -> token.Value
+        Token(token.Type, value, token.Line, token.Column, token.TypeName, token.Flags)
+
+    let postProcess (tokens: IReadOnlyList<Token>) =
+        let result = ResizeArray<Token>(tokens.Count)
+        let mutable atLineStart = true
+        let mutable suppressingRemark = false
+
+        for original in tokens do
+            let normalized = normalizeValue original
+            let token =
+                if atLineStart && normalized.EffectiveTypeName = "NUMBER" then
+                    Token(normalized.Type, normalized.Value, normalized.Line, normalized.Column, "LINE_NUM", normalized.Flags)
+                else
+                    normalized
+
+            if atLineStart then
+                atLineStart <- false
+
+            if not suppressingRemark || token.EffectiveTypeName = "NEWLINE" then
+                result.Add(token)
+
+            if token.EffectiveTypeName = "KEYWORD" && token.Value = "REM" then
+                suppressingRemark <- true
+            elif token.EffectiveTypeName = "NEWLINE" then
+                suppressingRemark <- false
+                atLineStart <- true
+
+        result |> Seq.toList :> IReadOnlyList<Token>
+
+/// Tokenizes the original 1964 Dartmouth BASIC language.
+type DartmouthBasicLexer private (source: string) =
+    /// Produces the normalized, parser-ready token stream.
+    member _.Tokenize() =
+        try
+            GrammarLexer(Implementation.tokenGrammar.Value).Tokenize(source)
+            |> fun tokens -> Implementation.postProcess (tokens :> IReadOnlyList<Token>)
+        with
+        | :? LexerError as error ->
+            raise (ArgumentException("Dartmouth BASIC tokenization failed: " + error.Message, "source", error))
+
+    /// Creates a configured lexer for source.
+    static member CreateDartmouthBasicLexer(source: string) =
+        if isNull source then nullArg "source"
+        DartmouthBasicLexer(source)
+
+    /// Tokenizes source in one call.
+    static member TokenizeDartmouthBasic(source: string) =
+        DartmouthBasicLexer.CreateDartmouthBasicLexer(source).Tokenize()

--- a/code/packages/fsharp/dartmouth-basic-lexer/README.md
+++ b/code/packages/fsharp/dartmouth-basic-lexer/README.md
@@ -1,0 +1,14 @@
+# CodingAdventures.DartmouthBasicLexer.FSharp
+
+A pure F# lexer for the original 1964 Dartmouth BASIC language. It embeds the
+shared `dartmouth_basic.tokens` grammar and applies the language's contextual
+line-label and `REM` rules after generic tokenization.
+
+```fsharp
+let tokens =
+    DartmouthBasicLexer.TokenizeDartmouthBasic(
+        "10 LET X = 5\n20 PRINT X\n30 END\n")
+```
+
+The normalized token contract matches the C# and Go ports. Tokenization is
+fully in memory and requires no filesystem or network capability.

--- a/code/packages/fsharp/dartmouth-basic-lexer/required_capabilities.json
+++ b/code/packages/fsharp/dartmouth-basic-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/dartmouth-basic-lexer",
+  "capabilities": [],
+  "justification": "Tokenization is pure and uses a bundled grammar resource."
+}

--- a/code/packages/fsharp/dartmouth-basic-lexer/tests/CodingAdventures.DartmouthBasicLexer.Tests/CodingAdventures.DartmouthBasicLexer.Tests.fsproj
+++ b/code/packages/fsharp/dartmouth-basic-lexer/tests/CodingAdventures.DartmouthBasicLexer.Tests/CodingAdventures.DartmouthBasicLexer.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.DartmouthBasicLexer.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.DartmouthBasicLexer.fsproj" />
+    <Compile Include="DartmouthBasicLexerTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/dartmouth-basic-lexer/tests/CodingAdventures.DartmouthBasicLexer.Tests/DartmouthBasicLexerTests.fs
+++ b/code/packages/fsharp/dartmouth-basic-lexer/tests/CodingAdventures.DartmouthBasicLexer.Tests/DartmouthBasicLexerTests.fs
@@ -1,0 +1,67 @@
+namespace CodingAdventures.DartmouthBasicLexer.Tests
+
+open System
+open CodingAdventures.DartmouthBasicLexer.FSharp
+open CodingAdventures.Lexer.FSharp
+open Xunit
+
+module DartmouthBasicLexerTests =
+    let types (tokens: seq<Token>) = tokens |> Seq.map (fun token -> token.EffectiveTypeName) |> Seq.toArray
+    let values (tokens: seq<Token>) = tokens |> Seq.map (fun token -> token.Value) |> Seq.toArray
+
+    [<Fact>]
+    let tokenizesAndNormalizesAStatement () =
+        let tokens = DartmouthBasicLexer.TokenizeDartmouthBasic("10 let X = 1.5E3\r\n")
+        Assert.Equal<string array>([| "LINE_NUM"; "KEYWORD"; "NAME"; "EQ"; "NUMBER"; "NEWLINE"; "EOF" |], types tokens)
+        Assert.Equal<string array>([| "10"; "LET"; "x"; "="; "1.5e3"; "\\n"; "" |], values tokens)
+        Assert.Equal((1, 1), (tokens.[0].Line, tokens.[0].Column))
+        Assert.Equal((2, 1), (tokens.[tokens.Count - 1].Line, tokens.[tokens.Count - 1].Column))
+
+    [<Fact>]
+    let relabelsOnlyTheFirstNumberOnEachPhysicalLine () =
+        let tokens = DartmouthBasicLexer.TokenizeDartmouthBasic("30 GOTO 10\n40 PRINT 20\n")
+        let numberTypes =
+            tokens
+            |> Seq.filter (fun token -> token.EffectiveTypeName = "LINE_NUM" || token.EffectiveTypeName = "NUMBER")
+            |> types
+        Assert.Equal<string array>([| "LINE_NUM"; "NUMBER"; "LINE_NUM"; "NUMBER" |], numberTypes)
+
+    [<Fact>]
+    let suppressesRemarkBodyButRetainsItsNewline () =
+        let tokens = DartmouthBasicLexer.CreateDartmouthBasicLexer("10 rem GOTO 20 @ ignored\n20 END\n").Tokenize()
+        Assert.Equal<string array>([| "LINE_NUM"; "KEYWORD"; "NEWLINE"; "LINE_NUM"; "KEYWORD"; "NEWLINE"; "EOF" |], types tokens)
+        Assert.Equal("REM", tokens.[1].Value)
+
+    [<Fact>]
+    let preservesStringCaseWithoutQuotes () =
+        let tokens = DartmouthBasicLexer.TokenizeDartmouthBasic("10 PRINT \"Hello, World!\"\n")
+        let stringToken = tokens |> Seq.find (fun token -> token.EffectiveTypeName = "STRING")
+        Assert.Equal("Hello, World!", stringToken.Value)
+
+    [<Fact>]
+    let classifiesFunctionsNamesAndUnknownCharacters () =
+        let tokens = DartmouthBasicLexer.TokenizeDartmouthBasic("10 LET Result = SIN(FNA(X)) @\n")
+        Assert.Contains(tokens, fun token -> token.EffectiveTypeName = "BUILTIN_FN" && token.Value = "sin")
+        Assert.Contains(tokens, fun token -> token.EffectiveTypeName = "USER_FN" && token.Value = "fna")
+        Assert.Contains(tokens, fun token -> token.EffectiveTypeName = "NAME" && token.Value = "result")
+        Assert.Contains(tokens, fun token -> token.EffectiveTypeName = "UNKNOWN" && token.Value = "@")
+
+    [<Theory>]
+    [<InlineData("<=", "LE")>]
+    [<InlineData(">=", "GE")>]
+    [<InlineData("<>", "NE")>]
+    [<InlineData("^", "CARET")>]
+    [<InlineData(";", "SEMICOLON")>]
+    let recognizesOperators (source: string) (expectedType: string) =
+        Assert.Equal(expectedType, DartmouthBasicLexer.TokenizeDartmouthBasic(source).[0].EffectiveTypeName)
+
+    [<Fact>]
+    let aBlankLineStillAllowsTheNextLineLabel () =
+        let tokens = DartmouthBasicLexer.TokenizeDartmouthBasic("\n10 END\n")
+        Assert.Equal("NEWLINE", tokens.[0].EffectiveTypeName)
+        Assert.Equal("LINE_NUM", tokens.[1].EffectiveTypeName)
+
+    [<Fact>]
+    let rejectsNullSource () =
+        Assert.Throws<ArgumentNullException>(fun () -> DartmouthBasicLexer.CreateDartmouthBasicLexer(null) |> ignore)
+        |> ignore

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -112,12 +112,12 @@ the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
 and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
 `x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
-ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`, and
-`nib-wasm-compiler` ports:
+ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
+`nib-wasm-compiler`, and `dartmouth-basic-lexer` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 323 |
+| Present in 10-15 languages | 172 | 321 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 701 | 9,814 |
@@ -163,7 +163,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 327
+The 172 packages present in at least ten implementation languages need 321
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -172,8 +172,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 8 | Move with F# |
-| F# | 8 | Move with C# |
+| C# | 6 | Move with F# |
+| F# | 6 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -311,6 +311,16 @@ cover executable literals and calls, wrapping-opcode validation, malformed
 source, depth and size limits, defensive results, and optional file output. The
 package now spans 13 implementation lanes, reduces the high-consensus backlog
 to 323 slots, and leaves 7 paired gaps in each lane.
+
+The eleventh paired C#/F# slice is complete: `dartmouth-basic-lexer` now loads
+the shared token grammar from an embedded resource in both lanes. The native
+wrappers normalize case-insensitive token values, relabel only physical-line
+labels as `LINE_NUM`, preserve string case without quotes, and suppress `REM`
+bodies while retaining their terminating newline. Package-native tests cover
+operators, numeric formats, functions, unknown input, CRLF positions, blank
+lines, and multi-line remark recovery. The package now spans 12 implementation
+lanes, reduces the high-consensus backlog to 321 slots, leaves 6 paired gaps in
+each lane, and unlocks the dependency-safe `dartmouth-basic-parser` slice.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add native, pure-language C# and F# ports of `dartmouth-basic-lexer`
- embed and adapt the shared Dartmouth BASIC token grammar for the .NET grammar parser
- normalize token values, relabel physical-line numbers, and suppress `REM` bodies while retaining newlines
- add package-native tests, metadata, capability manifests, build commands, and roadmap updates

## Validation

- C#: 12 tests passed; 93.47% line coverage
- F#: 12 tests passed; 92.18% line coverage
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (321 high-consensus slots; 6 C# gaps; 6 F# gaps; 0 collisions)
- `dotnet format CodingAdventures.DartmouthBasicLexer.csproj --verify-no-changes --no-restore`
- `git diff --check origin/main...HEAD`