### PR TITLE
feat(hl): overnight curriculum build — the how-are-you chapter across ES/FR/DE + Spanish writing nuances

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -140,6 +140,28 @@
       "core": false,
       "retires": ["ARTICLES-EL-LA", "ARTICLES-LE-LA", "ARTICLES-DER-DIE-DAS", "ARTICLE-GENDER", "ARTICLE"],
       "notes": "One join key for 'the'; the realization holds each language's specific forms (el/la, der/die/das, il/la/lo, o/a, al-)."
+    },
+
+    "COURTESY-YOUREWELCOME": {
+      "family": "COURTESY",
+      "gloss": "you're welcome (the standard reply to thanks)",
+      "core": false,
+      "retires": ["YOURE-WELCOME", "WELCOME-REPLY"],
+      "notes": "The reply that closes a thanks exchange (de nada, prego, bitte, не за что). Distinct from GREETING-WELCOME (svāgatam), which welcomes an arrival."
+    },
+    "STATE-HOW-ARE-YOU": {
+      "family": "STATE",
+      "gloss": "how are you? (asking after someone's state)",
+      "core": false,
+      "retires": ["HOW-ARE-YOU", "HOWAREYOU"],
+      "notes": "The realization holds each language's phrasing and register split (¿cómo está usted? / ¿cómo estás?). Builds on QUESTION-HOW plus the state verb."
+    },
+    "WORD-SOSO": {
+      "family": "WORD",
+      "gloss": "so-so / not bad (a middling answer to 'how are you?')",
+      "core": false,
+      "retires": ["SO-SO", "SOSO"],
+      "notes": "The neither-good-nor-bad reply (regular / más o menos, così così, comme ci comme ça)."
     }
   },
   "namespaced": {
@@ -148,11 +170,12 @@
       "ES-VERB-LLAMAR": "llamar — 'to call' (the Spanish naming verb)",
       "ES-SE-LLAMA": "se llama — 'he/she calls himself' (3rd-person of llamar)",
       "ES-WORD-MUCHO": "mucho — 'much / a lot'",
+      "ES-VERB-ESTAR": "estar — 'to be' (temporary state / location; ← Latin stare 'to stand')",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "DE-VERB-HEISSEN": "heißen — 'to be called'"
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix) carry a session label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -173,7 +173,8 @@
       "ES-VERB-ESTAR": "estar — 'to be' (temporary state / location; ← Latin stare 'to stand')",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
-      "DE-VERB-HEISSEN": "heißen — 'to be called'"
+      "DE-VERB-HEISSEN": "heißen — 'to be called'",
+      "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -172,6 +172,7 @@
       "ES-WORD-MUCHO": "mucho — 'much / a lot'",
       "ES-VERB-ESTAR": "estar — 'to be' (temporary state / location; ← Latin stare 'to stand')",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
+      "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "DE-VERB-HEISSEN": "heißen — 'to be called'"
     }
   },

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter 3 — "Comment ça va ?" (the parallel of Spanish Ch. 4)
+
+- **Chapter 3 authored** (`FR-C03-merci`, `-de-rien`, `-aller`,
+  `-comment-ca-va`, `-comme-ci-comme-ca`, `-practice`): the "how are you?"
+  exchange, atom-first, reviewing Chapter 2 throughout. Built deliberately as the
+  cross-language mirror of the Spanish Chapter 4 shipped in the same PR — same
+  canonical concepts (`STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`, `WORD-SOSO`),
+  so the interleaving method has real parallel material.
+- **Etymology contrasts made explicit** (the point of the curriculum):
+  - *merci* ← *mercēs* "reward / wages" (→ mercy/merchant/commerce) — set against
+    Spanish *gracias* ← *grātia* "grace" and Portuguese *obrigado* ← "obliged".
+  - *de rien* ← *rem* "a thing" → "nothing" — the exact twin of Spanish *de nada*
+    ← *nāta* "a born thing" (a callback the Spanish lesson already forward-references).
+  - *aller* "to go" as the state-verb ("how does it *go*?") — contrasted with
+    Spanish *estar* "to stand"; its suppletive paradigm traced to *ambulāre*
+    (amble/ambulance), *vādere* (invade/evade), *īre* (exit/transit).
+  - *comme ci, comme ça* — *comme* shares *quōmodo* with *comment*; the shrug set
+    against Spanish *más o menos* and Italian *così così*.
+- Taxonomy: namespaced `FR-VERB-ALLER` documented in the examples list.
+
 ## Chapter 2 — Introducing Yourself
 
 - New chapter built around the introduction dialogue (*Je m'appelle Susanne. /

--- a/code/learning/human-languages/french/lessons/FR-C03-aller.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-aller.md
@@ -1,0 +1,69 @@
+---
+id: FR-C03-aller
+chapter: 3
+type: word
+headword: aller
+gloss: to go (and, oddly, "to be" in "how are you?")
+concept_tag: FR-VERB-ALLER
+prerequisites: []
+sounds: [er-ending, r-uvular]
+roots: [ambulare-latin, vadere-latin, ire-latin]
+etymology_hook: "aller ← Latin ambulāre 'to walk' (→ amble, ambulance); its je vais ← vādere 'to go' (→ invade)"
+est_minutes: 4
+reviews_of: [FR-C03-merci]
+---
+
+# aller — "to go," the verb behind "how are you?"
+
+## Warm-up
+
+[PAUSE 2s] Spanish asks *how are you* with **estar**, "to *stand*." French asks
+it with **aller**, "to **go**" — *how does it go?* Same question, a different
+picture of a life: one language stands, the other walks. Meet **aller**.
+
+## Sounds you'll need
+
+- `er-ending` — the infinitive **-er** is a clean *ay*: **aller** = *ah-LAY*
+  (the double *l* is just one *l* sound; the *r* is silent here).
+
+## The word, taken apart
+
+**aller** means "to go." Its origin is one of the great messes of French — it is
+**suppletive**, meaning it was stitched together from **three** different Latin
+verbs, and you can still see the seams in its everyday forms:
+
+- **je vais** ("I go") ← Latin **vādere**, "to go, to rush" → English **invade**,
+  **evade**, **wade** (all "going" words).
+- **nous allons** ("we go"), and the infinitive **aller** ← Latin **ambulāre**,
+  "to walk" → English **amble**, **ambulance** (a walking hospital),
+  **preamble**, **perambulate**.
+- **j'irai** ("I will go") ← Latin **īre**, "to go" → English **exit** (*ex-it*,
+  "he goes out"), **transit**, **initial**.
+
+So a single French verb carries **three** Latin roots for motion. You don't need
+to conjugate it yet — just recognize one form for the next lesson:
+
+- **ça va** = "it goes" (the *va* is from *vādere*) — the beating heart of
+  French small talk.
+
+## Grammar Lens: "going" as "being"
+
+Lots of languages borrow a motion verb to talk about *state*: English says "how
+are you **getting on**? / how's it **going**?" French made that the standard:
+*Comment ça va?* = "How does it **go**?" Hold the metaphor — it makes the next
+lesson obvious.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "aller" — *ah-LAY*]
+- [YOU SAY: "ça va" — *sa VA*, "it goes"]
+- [YOU SAY: English "amble, ambulance" (walk) and "invade, evade" (go) — aller's
+  two big families]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *aller* literally mean, and how many Latin verbs is it
+stitched from? (To *go*; three — *ambulāre, vādere, īre*.) Which everyday form
+means "it goes"? (*ça va*.) So *Comment ça va?* literally asks — what? ("How does
+it *go*?") Next: ask it for real.

--- a/code/learning/human-languages/french/lessons/FR-C03-comme-ci-comme-ca.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-comme-ci-comme-ca.md
@@ -1,0 +1,71 @@
+---
+id: FR-C03-comme-ci-comme-ca
+chapter: 3
+type: word
+headword: comme ci, comme ça
+gloss: so-so (literally "like this, like that")
+concept_tag: WORD-SOSO
+prerequisites: [FR-C03-comment-ca-va]
+sounds: []
+roots: [quomodo-latin, ecce-hic-latin, ecce-hoc-latin]
+etymology_hook: "comme (← quōmodo, like comment) + ci/ça (← ecce hic / ecce hoc) — 'like this, like that'"
+est_minutes: 3
+reviews_of: [FR-C01-bien, FR-C03-comment-ca-va]
+---
+
+# comme ci, comme ça — the classic French shrug
+
+## Warm-up
+
+[PAUSE 2s] Someone asks *Ça va?* You're not great, not bad. The perfect,
+gloriously French answer — a phrase English borrowed whole — is **comme ci,
+comme ça**: "like this, like that." A verbal shrug of the shoulders.
+
+## Review first (20 seconds)
+
+[PAUSE 2s] From Chapter 1: **bien** — "well" (← Latin *bene*). So *Ça va bien*
+= "It's going well." Now the answer for when it's only *going*.
+
+## The phrase, taken apart
+
+**comme ci, comme ça** — literally **"like this, like that."** Every piece is an
+old friend:
+
+- **comme** = "like, as" — from Latin **quōmodo**, "in what manner." That's the
+  **same root as *comment*** ("how") from last lesson! *comment* = "in what
+  manner (as a question)"; *comme* = "in the manner of, like." One Latin word,
+  two French children.
+- **ci** = "here / this" ← Latin **ecce hic**, "behold here."
+- **ça** = "there / that" ← Latin **ecce hoc**, "behold this" — the same *ça*
+  from *Ça va?*.
+
+So you're literally waving a hand: *a bit like this way, a bit like that way* —
+neither up nor down.
+
+## Grammar Lens: your answer set for *Ça va?*
+
+| answer | sense |
+|---|---|
+| **(Très) bien, merci** | (very) well, thank you |
+| **Ça va** | fine / okay ("it goes") |
+| **Comme ci, comme ça** | so-so |
+| **Pas mal** | not bad |
+
+Compare across the family — every language has its shrug: Spanish **más o
+menos** ("more or less") / **regular**, Italian **così così** ("so so"), and
+French **comme ci, comme ça** ("like this, like that"). Same shrug, different
+picture.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "comme ci, comme ça" — with a little hand-wobble in the voice]
+- [YOU SAY: answer "Ça va?" three ways — "Bien" / "Ça va" / "Comme ci, comme ça"]
+- [YOU SAY: notice *comme* and *comment* share a root — *quōmodo*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *comme ci, comme ça* literally mean? ("Like this, like
+that.") What "how"-word shares *comme*'s root? (*comment* — both from *quōmodo*.)
+What's the Spanish equivalent shrug? (*más o menos* / *regular*.) Next: put the
+whole exchange together.

--- a/code/learning/human-languages/french/lessons/FR-C03-comment-ca-va.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-comment-ca-va.md
@@ -1,0 +1,69 @@
+---
+id: FR-C03-comment-ca-va
+chapter: 3
+type: phrase
+headword: comment ça va ?
+gloss: how are you? (neutral); formal Comment allez-vous?
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [FR-C03-aller, FR-C02-comment, FR-C02-tu-vous]
+sounds: [nasal-an]
+roots: [quomodo-latin, ecce-hoc-latin, ambulare-latin]
+etymology_hook: "comment (← quōmodo) + ça (← ecce hoc 'behold this') + va (aller) — 'how does this go?'"
+est_minutes: 4
+reviews_of: [FR-C03-aller, FR-C02-comment, FR-C02-tu-vous]
+---
+
+# comment ça va ? — "how are you?"
+
+## Warm-up
+
+[PAUSE 2s] All three pieces are in your hands: **comment** ("how," Chapter 2),
+the **tu / vous** choice (Chapter 2), and **aller / ça va** (last lesson).
+Assemble the single most useful question in spoken French.
+
+## Review first (30 seconds)
+
+[PAUSE 2s] No peeking:
+
+- **comment** — "how," from Latin *quōmodo* ("in what manner") — the very same
+  root as Spanish *cómo*.
+- **tu** vs **vous** — the informal vs formal (or plural) "you." *tu* to a
+  friend; *vous* to a stranger, an elder, or a group.
+
+Got them? Assemble.
+
+## The phrase, three registers
+
+French has a neat three-step ladder from casual to formal:
+
+| register | question | literally |
+|---|---|---|
+| **casual / universal** | **Comment ça va ?** (or just *Ça va ?*) | "How does **it** go?" |
+| **informal, to one friend** | **Comment vas-tu ?** | "How go **you**?" |
+| **formal / plural** | **Comment allez-vous ?** | "How go **you** (vous)?" |
+
+- **ça** = "it / this," worn down from Latin **ecce hoc**, "behold this" — the
+  same *hoc* that gives Spanish *ça*-less cousins. *Ça va?* — "It goes?" — is the
+  one everyone actually says; you can answer it with the same two words: **Ça
+  va.** ("It goes." = "I'm fine.")
+- **allez** / **vas** are just the *vous* and *tu* forms of **aller** you
+  previewed.
+
+Note *comment*'s nasal ending (`nasal-an`): *ko-**mahn***, the *t* silent —
+until **liaison** glues it onto a vowel in *Comment_allez-vous* (*ko-mahn-ta-lay-VOO*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Ça va ?" — the two-word version everybody uses]
+- [YOU SAY: "Comment allez-vous ?" — formal, hear the *t* liaison]
+- [YOU SAY: for your boss, then your best friend — *vous* or *tu*?]
+
+[REPEAT x2] "Ça va ? — Ça va." Question and answer, same two words.
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *Comment ça va?* literally ask? ("How does it *go*?") Which
+verb is *va* from, and how does that differ from Spanish's choice? (*aller*, "to
+go" — Spanish uses *estar*, "to stand.") Which form for a stranger — *vas-tu* or
+*allez-vous*? (*allez-vous*.) Next: the "so-so" answer.

--- a/code/learning/human-languages/french/lessons/FR-C03-de-rien.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-de-rien.md
@@ -1,0 +1,65 @@
+---
+id: FR-C03-de-rien
+chapter: 3
+type: phrase
+headword: de rien
+gloss: you're welcome (literally "of nothing")
+concept_tag: COURTESY-YOUREWELCOME
+prerequisites: [FR-C03-merci]
+sounds: [nasal-in, r-uvular]
+roots: [de-latin, rem-res-latin]
+etymology_hook: "rien ← Latin rem 'a thing' → drifted to 'nothing' — the exact mirror of Spanish nada ← nāta"
+est_minutes: 3
+reviews_of: [FR-C03-merci]
+---
+
+# de rien — "you're welcome," or "it was nothing"
+
+## Warm-up
+
+[PAUSE 2s] Someone says **merci**. The easy reply: **de rien** — literally *"of
+nothing."* You wave the favour off as no trouble — and if you did the Spanish
+track, you've *already met this exact trick.*
+
+## Sounds you'll need
+
+- `nasal-in` — **rien** = *ryɛ̃*, a nasal ending (air through the nose, no hard
+  *n*): *duh RYAN* → more like *duh ryɛ̃*.
+- `r-uvular` — that guttural French *r* again, at the back of the throat.
+
+## The phrase, taken apart
+
+- **de** = "of / from" (Latin **dē**).
+- **rien** = "nothing." And here is the beautiful part.
+
+**rien** comes from Latin **rem** — the accusative of **rēs**, *"a thing."* In
+Latin *rem* meant a **thing**, something real. But French kept using it inside
+negations — *ne … rien*, "not … a thing" — until the *thing* word absorbed the
+"nothing" and **rien came to mean 'nothing' all by itself.**
+
+If that sounds familiar, it should: **Spanish did the identical thing with
+nada** (← Latin *nāta*, "a born thing" → "nothing"). Two sister languages, the
+same move — the word for **thing** collapses into the word for **nothing**:
+
+| language | "you're welcome" | the "nothing" word, from Latin |
+|---|---|---|
+| **French** | *de rien* | *rien* ← *rem*, "a thing" |
+| **Spanish** | *de nada* | *nada* ← *nāta*, "a born thing" |
+
+Latin *rēs* also gives English **real**, **re**public (*rēs pūblica*, "the public
+thing"), and **rebus**. So *rien* is, at the root, a **real thing** that learned
+to mean nothing at all.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "merci" … "de rien" — the full exchange, both voices]
+- [YOU SAY: French *de rien* and Spanish *de nada* back to back — same idea, two
+  "thing → nothing" words]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did *rien* ("nothing") originally mean in Latin? (*rem* — a
+*thing*.) What Spanish word pulled the same trick, and from what? (*nada* ←
+*nāta*, "a born thing.") Next: the verb French uses for "how are you?" — and it's
+not "to stand" like Spanish, but **to go**.

--- a/code/learning/human-languages/french/lessons/FR-C03-merci.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-merci.md
@@ -1,0 +1,72 @@
+---
+id: FR-C03-merci
+chapter: 3
+type: word
+headword: merci
+gloss: thank you
+concept_tag: COURTESY-THANKS
+prerequisites: []
+sounds: [r-uvular]
+roots: [merces-latin]
+etymology_hook: "merci ← Latin mercēs 'wages, reward, price' → English mercy, mercenary, merchant, commerce"
+est_minutes: 3
+reviews_of: [FR-C02-practice]
+---
+
+# merci — "thank you," and it means *mercy*
+
+## Warm-up
+
+[PAUSE 2s] You can introduce yourself in French. Next you'll ask *how are you?*
+— and every polite answer needs **merci** first. It hides a word you already
+know: *mercy*.
+
+## Sounds you'll need
+
+- `r-uvular` — **merci** = *mehr-SEE*, with the soft guttural French *r* at the
+  back of the throat (never the Spanish tap). Stress the end: *mehr-**SEE***.
+
+## The word, taken apart
+
+**merci** — "thank you." Root: Latin **mercēs**, *"wages, reward, price, that
+which is earned."* Saying *merci* originally invoked a **reward** owed for a
+kindness — and, in old religious use, a plea for divine **mercy** (a reward you
+haven't earned).
+
+That one root **merc-** ("pay, trade, reward") pays out a huge English family:
+
+- **mercy**, **merciful** — the reward/pity sense.
+- **mercenary** — a soldier who fights for *wages*.
+- **merchant**, **commerce**, **market**, **mercantile** — buying and selling,
+  the *price* sense (Latin *mercārī*, "to trade").
+- Even **Mercury** — the Roman god of merchants.
+
+## Across the family — thanks, two different metaphors
+
+Here's a lovely contrast to lock in:
+
+| language | "thank you" | literal root |
+|---|---|---|
+| **French** | *merci* | *mercēs* — **reward / mercy** |
+| **Spanish** | *gracias* | *grātia* — **grace / favour** |
+| **Portuguese** | *obrigado* | *obligātus* — "I am **obliged**" |
+
+Three Romance sisters, three different pictures of gratitude: French hands you a
+**reward**, Spanish hands you **grace**, Portuguese declares itself **obliged**.
+Same feeling, three metaphors — this is exactly the kind of thing the curriculum
+wants you to *notice*, not just memorize.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "merci" — *mehr-SEE*, guttural *r*]
+- [YOU SAY: "merci" then English "mercy, merchant, commerce" — one family]
+- [YOU SAY: French *merci* (reward) vs Spanish *gracias* (grace) — feel the
+  difference]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What everyday English word is *merci* a cousin of? (*Mercy*.) And its
+"trade" cousins? (Merchant, commerce, market, mercenary.) How does its metaphor
+differ from Spanish *gracias*? (*merci* = reward/mercy; *gracias* = grace.) Next:
+the reply — **de rien**.

--- a/code/learning/human-languages/french/lessons/FR-C03-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C03-practice.md
@@ -1,0 +1,67 @@
+---
+id: FR-C03-practice
+chapter: 3
+type: practice-mix
+headword: (practice)
+gloss: the full "how are you?" exchange, formal and informal
+concept_tag: CH3-PRACTICE
+prerequisites: [FR-C03-merci, FR-C03-de-rien, FR-C03-aller, FR-C03-comment-ca-va, FR-C03-comme-ci-comme-ca]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [FR-C03-merci, FR-C03-de-rien, FR-C03-comment-ca-va, FR-C03-comme-ci-comme-ca, FR-C02-practice]
+---
+
+# Practice — "comment ça va ?", start to finish
+
+## Warm-up
+
+[PAUSE 2s] No new words. This chapter's atoms — *merci, de rien, aller, ça va,
+comme ci comme ça* — assemble into a real exchange, run formally and informally.
+It picks up right where the Chapter 2 introduction left off.
+
+## The exchange
+
+**Formal** (a stranger, an elder):
+
+> — Bonjour. **Comment allez-vous ?**
+> — **Très bien, merci.** Et vous ?
+> — **Comme ci, comme ça.**
+> — [later, after a small favour] — Merci ! — **De rien.**
+
+**Informal** (a friend):
+
+> — Salut ! **Ça va ?**
+> — **Ça va, et toi ?**
+> — Comme ci, comme ça.
+
+The glue word is **et vous ? / et toi ?** — "and you?" (*et* = "and," Latin
+*et*; *toi* is the stressed "you"). It bounces the question back — exactly like
+Spanish *¿y usted? / ¿y tú?*
+
+## What you've built this chapter
+
+- **merci** — thank you (← *mercēs*, "reward / mercy").
+- **de rien** — you're welcome (← *rem*, "a thing" → "nothing"; twin of Spanish
+  *de nada*).
+- **aller / ça va** — "to go," the verb French uses for *how are you* (vs
+  Spanish *estar*, "to stand").
+- **Comment ça va ? / allez-vous ? / vas-tu ?** — the casual, formal, and
+  informal question.
+- **bien / ça va / comme ci comme ça / pas mal** — the answer ladder.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full *formal* exchange, both voices]
+- [YOU SAY: the same *informally* — *allez-vous → ça va*, *vous → toi*]
+- [YOU SAY: chain Chapter 2 + 3 — "Je m'appelle … Comment allez-vous ?"]
+
+[REPEAT x2] "Ça va ? — Ça va, et toi ?" until it's reflex.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which verb carries French "how are you?", and how does its metaphor
+differ from Spanish's? (*aller*, "to go" — *how does it go?* — vs *estar*, "to
+stand.") What does *de rien* literally say, and its Spanish twin? ("Of nothing";
+*de nada*.) Next chapter: **farewells** — au revoir, à bientôt, bonne journée.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -18,12 +18,16 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   m'appelle** ("my name is") → **tu / vous** → comment → **comment vous
   appelez-vous?** → enchanté(e) → practice. (Every atom traced, *me* ← *mē*
   included.)
+- **Ch. 3 — "Comment ça va ?"**: merci (← *mercēs* "reward") → de rien (← *rem*
+  "thing" → "nothing"; twin of Spanish *de nada*) → **aller** ("to go," the
+  state-verb — vs Spanish *estar* "to stand") → comment ça va / allez-vous /
+  vas-tu → comme ci, comme ça → practice. **Authored** — the deliberate mirror of
+  Spanish Ch. 4.
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 3 | Responding: ça va, très bien, merci, et vous/et toi |
 | 4 | Farewells: au revoir, à bientôt, à demain |
 | 5+ | Numbers, time, days & months, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
 

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 3 — "Wie geht's?" (completes the how-are-you trilogy)
+
+- **Chapter 3 authored** (`GE-C03-danke`, `-bitte`, `-gehen`, `-wie-geht-es`,
+  `-es-geht`, `-practice`): the "how are you?" exchange, atom-first, reviewing
+  Chapter 2. Third of a deliberate cross-language trilogy in this PR (Spanish
+  Ch.4 / French Ch.3 / German Ch.3), all sharing the canonical concepts
+  `STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`, `WORD-SOSO`.
+- **The etymologies English speakers already own**:
+  - *danke* ← *denken* "to think" — and English *thank* IS *think* (both from
+    Old English *þancian*/*þencan*), set against *merci* (reward) and *gracias*
+    (grace).
+  - *bitte* ← *bitten* "to ask/pray" — cognate of English *bid* and *bead* (a
+    bead was a prayer); the one word doing please / you're-welcome / here-you-go
+    / pardon.
+  - *gehen* IS English *go* (straight Germanic cognate); *es geht mir gut* = "it
+    goes well *to me*" — gently introduces the **dative** (*mir/dir/Ihnen*).
+  - *es geht* ("it goes," nothing added) as the understated shrug for "so-so."
+- **The trilogy's payoff**, stated in-lesson: German and French say wellbeing as
+  motion ("how does it **go**?"), Spanish as posture ("how are you
+  **standing**?" — *estar*).
+- Taxonomy: namespaced `DE-VERB-GEHEN` documented.
+
 ## Chapter 2 — Introducing Yourself
 
 - New chapter built around the introduction dialogue (*Ich heiße Susanne. / Wie

--- a/code/learning/human-languages/german/lessons/GE-C03-bitte.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-bitte.md
@@ -1,0 +1,66 @@
+---
+id: GE-C03-bitte
+chapter: 3
+type: word
+headword: bitte
+gloss: please — and also "you're welcome" (and "here you go," and "pardon?")
+concept_tag: COURTESY-YOUREWELCOME
+prerequisites: [GE-C03-danke]
+sounds: []
+roots: [bitten-german]
+etymology_hook: "bitte ← bitten 'to ask, to pray' — cognate of English bid and bead (prayer-beads)"
+est_minutes: 3
+reviews_of: [GE-C03-danke]
+---
+
+# bitte — the Swiss-army word: please *and* you're welcome
+
+## Warm-up
+
+[PAUSE 2s] If German gives you one word to overwork, it's **bitte**. It's
+"please." It's also "you're welcome." Also "here you go," and even "pardon?"
+One word, and it comes straight from **asking**.
+
+## Sounds you'll need
+
+- **bitte** = *BIT-tuh* — short crisp *i*, a clear double-*t*, soft *-uh* end.
+
+## The word, taken apart
+
+**bitte** is the plea-form of **bitten**, *"to ask, to request, to pray."* When
+you say *bitte* you are, at root, **making a request** — "I ask (this of you)."
+
+That verb **bitten** is a close cousin of two English words:
+
+- **bid** — as in "I *bid* you welcome," "do as you're *bidden*" — to ask/command.
+- **bead** — astonishingly, yes: a *bead* was originally a **prayer**. People
+  counted their *prayers* (Old English *gebed*) on a string, and the *name of
+  the prayer* slid onto the little ball you counted it with. So a rosary
+  **bead** is a frozen **request** — exactly what *bitte* still is.
+
+### How one word covers so much
+
+| you say *bitte* when… | it means | why (it's all "I ask") |
+|---|---|---|
+| making a request | **please** | "I ask you…" |
+| answering *danke* | **you're welcome** | "(don't mention it,) I ask nothing back" |
+| handing something over | **here you go** | "I offer, at your request" |
+| you didn't hear | **pardon?** | "I ask you to repeat" |
+
+For this chapter, the key pairing is the courtesy loop: **Danke. — Bitte.**
+("Thanks." — "You're welcome.") — the German twin of *de nada* / *de rien*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "danke" … "bitte" — the full thanks/you're-welcome exchange]
+- [YOU SAY: "bitte" as *please*, then as *you're welcome* — same word, tone does
+  the work]
+- [YOU SAY: German *bitte* ↔ English *bid* / *bead* — a prayer you can hold]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What verb is *bitte* from? (*bitten*, "to ask / to pray.") What two
+English words are its cousins? (*Bid* and *bead* — a bead was a prayer.) Name two
+different jobs *bitte* does. (please; you're welcome; here-you-go; pardon.) Next:
+the verb behind "how are you?" — and like French, it's **to go**.

--- a/code/learning/human-languages/german/lessons/GE-C03-danke.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-danke.md
@@ -1,0 +1,69 @@
+---
+id: GE-C03-danke
+chapter: 3
+type: word
+headword: danke
+gloss: thank you
+concept_tag: COURTESY-THANKS
+prerequisites: []
+sounds: [vowel-a-german]
+roots: [denken-german]
+etymology_hook: "danke ← denken 'to think' — 'I think of you' (with gratitude); English thank IS think"
+est_minutes: 3
+reviews_of: [GE-C02-practice]
+---
+
+# danke — "thank you," which is really "I think of you"
+
+## Warm-up
+
+[PAUSE 2s] You can introduce yourself in German. Next, *how are you?* — and its
+answers all lean on **danke**. It hides a secret that English shares but hides
+too: **to thank is to think.**
+
+## Sounds you'll need
+
+- `vowel-a-german` — **danke** = *DAHN-kuh*, a pure open *ah*, final *-e* a soft
+  *uh*. Stress the front: *DAHN-kuh*.
+
+## The word, taken apart
+
+**danke** comes from **denken**, *"to think."* The old idea: to thank someone is
+to **keep them in mind** — *"I think of you"* / *"you are in my thoughts."*
+German *Dank* ("thanks") and *Gedanke* ("a thought") are the same root wearing
+two coats.
+
+And here is the payoff for an English speaker: **English "thank" and "think" are
+the same word too.** Old English *þancian* ("thank") and *þencan* ("think")
+split from one root — to thank was to *hold in thought*. So German *danke* isn't
+foreign at all; it's English *thank* with the *think* still visible inside it.
+
+Across the family, three different pictures of gratitude — worth holding side by
+side:
+
+| language | "thanks" | literal idea |
+|---|---|---|
+| **German** | *danke* | "I **think** of you" |
+| **French** | *merci* | a **reward / mercy** |
+| **Spanish** | *gracias* | **grace / favour** |
+
+## Grammar Lens: dressing it up
+
+- **danke schön** — "thank you *nicely*" (*schön* = beautiful/nice) → "thank you
+  very much."
+- **danke sehr** — "thanks *very*."
+- **vielen Dank** — "many thanks" (you'll meet *viel*, "much," later).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "danke" — *DAHN-kuh*]
+- [YOU SAY: "danke schön" — thank you very much]
+- [YOU SAY: German *danke* ↔ English *think/thank* — one root]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What everyday verb is *danke* built from? (*denken*, "to think" — to
+thank is to think of someone.) What two English words share that same split?
+(*Thank* and *think*.) Next: the word that means both "please" **and** "you're
+welcome" — **bitte**.

--- a/code/learning/human-languages/german/lessons/GE-C03-es-geht.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-es-geht.md
@@ -1,0 +1,65 @@
+---
+id: GE-C03-es-geht
+chapter: 3
+type: word
+headword: es geht
+gloss: so-so / okay (literally "it goes"); also "so lala"
+concept_tag: WORD-SOSO
+prerequisites: [GE-C03-wie-geht-es]
+sounds: []
+roots: [gehen-german]
+etymology_hook: "es geht = 'it goes' — the bare 'it goes' (nothing added) is the German shrug for 'so-so'"
+est_minutes: 3
+reviews_of: [GE-C01-gut, GE-C03-wie-geht-es]
+---
+
+# es geht — the German shrug: "it goes"
+
+## Warm-up
+
+[PAUSE 2s] Someone asks *Wie geht's?* You're neither great nor terrible. German's
+answer is beautifully understated: **es geht** — just *"it goes."* Not *well*,
+not *badly* — it simply *goes*. That bareness **is** the shrug.
+
+## Review first (20 seconds)
+
+[PAUSE 2s] From Chapter 1: **gut** — "well / good" (cognate of English *good*). So
+*Es geht mir gut* = "it goes well for me." Now drop the *gut*, and watch what
+happens to the meaning.
+
+## The word, taken apart
+
+**es geht** = literally **"it goes."** In the last lesson you added *gut* to make
+it positive. Say it with **nothing added** — *"es geht"* — and the very absence
+of a "well" or "badly" makes it mean **"eh, so-so, it's going, I'm getting by."**
+The understatement carries the whole meaning.
+
+Your German answer ladder for *Wie geht's?*:
+
+| answer | sense |
+|---|---|
+| **Sehr gut!** / **Gut, danke** | very well / well, thanks |
+| **Es geht** | so-so, okay-ish |
+| **So lala** | so-so (a sing-song "meh"; *lala* is just a filler singsong) |
+| **Nicht so gut** | not so well |
+
+And the cross-track shrug collection, now four deep:
+
+- German **es geht** ("it goes") · French **comme ci, comme ça** ("like this,
+  like that") · Spanish **más o menos** ("more or less") / **regular** · Italian
+  **così così** ("so so").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "es geht" — flat, understated, a shrug in the voice]
+- [YOU SAY: answer "Wie geht's?" three ways — "Gut!" / "Es geht" / "So lala"]
+- [YOU SAY: the four shrugs — es geht / comme ci comme ça / más o menos / così
+  così]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does bare *es geht* ("it goes") mean "so-so"? (Because it adds no
+*well* or *badly* — the understatement is the shrug.) What do you add to make it
+positive? (*gut* → *es geht mir gut*.) Next chapter: **farewells** — auf
+Wiedersehen, tschüss, bis bald.

--- a/code/learning/human-languages/german/lessons/GE-C03-gehen.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-gehen.md
@@ -1,0 +1,66 @@
+---
+id: GE-C03-gehen
+chapter: 3
+type: word
+headword: gehen
+gloss: to go — and the verb German uses for "how are you?"
+concept_tag: DE-VERB-GEHEN
+prerequisites: []
+sounds: [h-pronounced]
+roots: [gehen-german]
+etymology_hook: "gehen IS English 'go' (both from Germanic *gān); es geht mir gut = 'it goes well for me'"
+est_minutes: 4
+reviews_of: [GE-C03-danke]
+---
+
+# gehen — "to go," and it's just English *go*
+
+## Warm-up
+
+[PAUSE 2s] Spanish asks *how are you?* with **estar** ("to stand"). French and
+German both ask it with **"to go"** — *how does it go?* You already own the
+German verb without studying it, because it **is** English *go*.
+
+## Sounds you'll need
+
+- `h-pronounced` — in **gehen** the *h* just **lengthens** the vowel (it isn't a
+  breathy English h): *GAY-en*. The form you need most is **geht** = *gayt*.
+
+## The word, taken apart
+
+**gehen** = "to go." It and English **go** descend from the *same* Germanic verb
+(*gān / gehen*) — no Latin detour, no false friend, a straight cognate. When you
+say *geht*, you're saying *goes*.
+
+German states its wellbeing as **motion**, exactly like French *ça va*:
+
+> **Es geht mir gut.** = literally *"It goes for-me well."* → "I'm doing well."
+
+- **es** = "it" (cognate of English *it*).
+- **geht** = "goes."
+- **mir** = "to/for me" (the **dative** — the "to-whom" form; you'll meet its
+  partner *dir*, "to you," next lesson).
+- **gut** = "well" (Chapter 1 — cognate of English *good*).
+
+So German literally says **"it goes well *to me*."** Wellbeing is something that
+*goes*, and it goes *to* a person.
+
+## Grammar Lens: the dative, gently
+
+German marks *the person something happens to* with a special form: *ich* ("I")
+→ *mir* ("to me"); *du* ("you") → *dir* ("to you"). "How are you?" will use *dir*
+/ *Ihnen* — "how does it go **to you**?" Just recognize *mir* = "to me" for now.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "gehen" (*GAY-en*), then "geht" (*gayt*) = goes]
+- [YOU SAY: "Es geht mir gut" — *it goes well to me*]
+- [YOU SAY: German *gehen* = English *go*, same word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What English word is *gehen*, at the root? (*Go* — a straight
+cognate.) *Es geht mir gut* literally says what? ("It goes well *to me*.") German
+and French use "to go" for wellbeing — which verb does Spanish use instead?
+(*estar*, "to stand.") Next: ask it — **Wie geht es dir?**

--- a/code/learning/human-languages/german/lessons/GE-C03-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-practice.md
@@ -1,0 +1,68 @@
+---
+id: GE-C03-practice
+chapter: 3
+type: practice-mix
+headword: (practice)
+gloss: the full "Wie geht's?" exchange, formal and informal
+concept_tag: CH3-PRACTICE
+prerequisites: [GE-C03-danke, GE-C03-bitte, GE-C03-gehen, GE-C03-wie-geht-es, GE-C03-es-geht]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [GE-C03-danke, GE-C03-bitte, GE-C03-wie-geht-es, GE-C03-es-geht, GE-C02-practice]
+---
+
+# Practice — "Wie geht's?", start to finish
+
+## Warm-up
+
+[PAUSE 2s] No new words. This chapter's atoms — *danke, bitte, gehen, wie geht's,
+es geht* — assemble into a real exchange, formal and informal. It picks up right
+where the Chapter 2 introduction left off.
+
+## The exchange
+
+**Formal** (a stranger, an elder):
+
+> — Guten Tag. **Wie geht es Ihnen?**
+> — **Danke, gut.** Und Ihnen?
+> — **Es geht.**
+> — [after a small favour] — Danke! — **Bitte.**
+
+**Informal** (a friend):
+
+> — Hallo! **Wie geht's?**
+> — **Gut, danke, und dir?**
+> — So lala.
+
+The glue is **und dir? / und Ihnen?** — "and you?" (*und* = "and," cognate of
+English *and*), the German twin of Spanish *¿y tú?* and French *et toi?*. Note it
+takes the **dative** (*dir / Ihnen*), because it's short for "how goes it *to
+you*?"
+
+## What you've built this chapter
+
+- **danke** — thanks (← *denken*, "to think"; English *thank* = *think*).
+- **bitte** — please / you're welcome (← *bitten*, "to ask/pray"; English *bid*,
+  *bead*).
+- **gehen / geht** — "to go," the state-verb (= English *go*; like French, unlike
+  Spanish *estar*).
+- **Wie geht es dir? / Ihnen?** — how are you, informal / formal.
+- **gut / es geht / so lala / nicht so gut** — the answer ladder.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full *formal* exchange, both voices]
+- [YOU SAY: the same *informally* — *Ihnen → dir*, *Wie geht es → Wie geht's*]
+- [YOU SAY: chain Chapter 2 + 3 — "Ich heiße … Wie geht es Ihnen?"]
+
+[REPEAT x2] "Wie geht's? — Gut, danke, und dir?" until it's reflex.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which verb carries German "how are you?", and what English word is it?
+(*gehen* = *go*.) What does *danke* literally mean, and *bitte*? ("I *think* of
+you"; "I *ask*" → please/you're-welcome.) Which two of our three tracks use "to
+go," and which uses "to stand"? (Go: German, French; stand: Spanish.) Next
+chapter: **farewells** — auf Wiedersehen, tschüss, bis bald.

--- a/code/learning/human-languages/german/lessons/GE-C03-wie-geht-es.md
+++ b/code/learning/human-languages/german/lessons/GE-C03-wie-geht-es.md
@@ -1,0 +1,74 @@
+---
+id: GE-C03-wie-geht-es
+chapter: 3
+type: phrase
+headword: Wie geht es dir?
+gloss: how are you? (informal); formal Wie geht es Ihnen?
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [GE-C03-gehen, GE-C02-wie, GE-C02-du-sie]
+sounds: [w-is-v, ie-long-ee]
+roots: [gehen-german]
+etymology_hook: "Wie (how) + geht (goes) + es (it) + dir (to you) — 'how goes it to you?'"
+est_minutes: 4
+reviews_of: [GE-C03-gehen, GE-C02-wie, GE-C02-du-sie]
+---
+
+# Wie geht es dir? — "how are you?"
+
+## Warm-up
+
+[PAUSE 2s] Every piece is already yours: **wie** ("how," Chapter 2), the **du /
+Sie** choice (Chapter 2), and **gehen / geht** ("to go," last lesson). Snap them
+together into the question Germans actually ask.
+
+## Review first (30 seconds)
+
+[PAUSE 2s] No peeking:
+
+- **wie** — "how." (*w* says *v*: *vee*.) Cognate with English *how*'s cousin;
+  used for manner and degree.
+- **du** vs **Sie** — informal vs formal "you." *du* to a friend; capital-S
+  *Sie* to a stranger or elder (it's literally "they," borrowed as respect).
+
+## The phrase, taken apart
+
+> **Wie geht es dir?** = "How are you?" (informal)
+> literally: **"How goes it to you?"**
+
+- **wie** = "how" · **geht** = "goes" · **es** = "it" · **dir** = "to you"
+  (the dative of *du* — the *mir* → *dir* pair from last lesson).
+
+Two registers, and only the "you" changes — the same move as the *du/Sie* split:
+
+| register | question |
+|---|---|
+| **informal** (friend, family) | **Wie geht es dir?** (spoken: **Wie geht's dir?** / just **Wie geht's?**) |
+| **formal** (stranger, elder) | **Wie geht es Ihnen?** |
+
+*es* + *dir* often crush together in speech into **geht's** — *Wie geht's?* is
+the everyday form, and you can answer it with the **gut** you already know:
+*Danke, gut!* ("Thanks, well!").
+
+Compare the three tracks in this PR — same question, three metaphors:
+
+| | verb | literal |
+|---|---|---|
+| **German** | *gehen* (go) | "how **goes** it to you?" |
+| **French** | *aller* (go) | "how does it **go**?" |
+| **Spanish** | *estar* (stand) | "how are you **standing**?" |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Wie geht's?" — the everyday short form]
+- [YOU SAY: "Wie geht es Ihnen?" — formal, for a stranger]
+- [YOU SAY: "Danke, gut! Und dir?" — answer + bounce it back]
+
+[REPEAT x2] "Wie geht's? — Danke, gut!" until it's automatic.
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *Wie geht es dir?* literally ask? ("How goes it *to* you?")
+Which form of "you" for a stranger — *dir* or *Ihnen*? (*Ihnen*.) All three
+languages here use one of two metaphors for "how are you" — which two? (To *go*:
+German/French; to *stand*: Spanish.) Next: the "so-so" answer, **es geht**.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -17,12 +17,16 @@ Spanish and French where a contrast helps. The recurring decoder is the
   **Gute Nacht** → practice.
 - **Ch. 2 — Introducing Yourself**: ich → heißen → **ich heiße** ("my name
   is") → **du / Sie** → wie → **wie heißen Sie?** → freut mich → practice.
+- **Ch. 3 — "Wie geht's?"**: danke (← *denken* "think"; Eng *thank*=*think*) →
+  bitte (← *bitten* "ask/pray"; Eng *bid*/*bead*) → **gehen** ("to go" = Eng
+  *go*; the state-verb, w/ a first taste of the **dative** *mir/dir*) → wie geht
+  es dir/Ihnen → es geht (so-so) → practice. **Authored** — completes the
+  Spanish/French/German how-are-you trilogy.
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 3 | Responding: wie geht's, gut danke, und dir/Ihnen |
 | 4 | Farewells: tschüss, auf Wiedersehen, bis morgen |
 | 5+ | Numbers, cases (der→den→dem), family, food — following the shared theme order |
 

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Writing nuances — the accent, the ñ, the inverted marks
+
+- **First `writing`-type lessons** (`ES-W01-acento`, `ES-W02-enye`,
+  `ES-W03-inverted`): orthography taught the same etymology-first way as the
+  vocabulary, once enough accented words have accumulated to make it concrete.
+  Each names the mark, explains *why* it exists, and says how to draw it.
+- **The acute accent** (`á é í ó ú`): Spanish's only accent mark, its two jobs
+  (irregular-stress marker + the diacrítica that splits *tu/tú, el/él, si/sí,
+  se/sé, mas/más, como/cómo, que/qué*), and the rule that question words carry it.
+- **ñ**: the tilde as a frozen medieval shorthand for a doubled *nn* (Latin
+  *annus* → *año*, cousin of *annual/anniversary*); ñ as a distinct letter, not
+  an accented n.
+- **¿ ¡**: why Spanish opens a question/exclamation (word order often doesn't
+  change, so the reader needs an early intonation cue — Royal Academy, 1754),
+  and that they bracket the *question*, not necessarily the sentence.
+- These use the new `writing` lesson type in `@coding-adventures/human-language-data`
+  (0.3.0) — exempt from the concept join, no `concept_tag`.
+
 ## Chapter 4 — Responding to "¿cómo está usted?"
 
 - **Chapter 4 authored** (`ES-C04-gracias`, `-de-nada`, `-estar`, `-como-esta`,

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Chapter 4 — Responding to "¿cómo está usted?"
+
+- **Chapter 4 authored** (`ES-C04-gracias`, `-de-nada`, `-estar`, `-como-esta`,
+  `-regular`, `-practice`): the "how are you?" exchange, built atom-first and
+  reviewing Chapter 3 throughout. Each lesson stays 3–5 minutes and folds prior
+  words back in via `reviews_of`.
+- **The two "to be" verbs.** *estar* is introduced as the *temporary* be-verb
+  (← Latin *stāre*, "to stand" → stay/state/status/estate) and explicitly
+  contrasted with *ser* (identity). "How are you?" is framed as *estar* because
+  it asks about your current state.
+- **Deep etymology hooks**, per the curriculum's method: *gracias* ← *grātia*
+  (grace/grateful/gratis/congratulate); *de nada* ← *(rēs) nāta* "a born thing"
+  → "nothing" (cousin of native/nature/natal, mirroring French *rien* ← *rem*);
+  *regular* ← *rēgula* "straight rod" (rule/ruler/regulate/rail) and flagged as
+  a false friend (so-so, not "normal"); *más o menos* ← *magis* + *minus*.
+- **Taxonomy additions**: canonical `COURTESY-YOUREWELCOME`, `STATE-HOW-ARE-YOU`,
+  `WORD-SOSO` (all `core:false`), plus namespaced `ES-VERB-ESTAR` documented in
+  the examples list, and `CH4-PRACTICE` added to the practice-tag note.
+
 ## Slug-based lesson ids + el/la before día
 
 - **Stopped numbering lessons.** Ordinal ids (`ES-C01-L03`) forced a

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
@@ -1,0 +1,71 @@
+---
+id: ES-C04-como-esta
+chapter: 4
+type: phrase
+headword: ¿cómo está usted?
+gloss: how are you? (formal); informal ¿cómo estás?
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [ES-C04-estar, ES-C03-como, ES-C03-tu-usted]
+sounds: [vowel-o, r-tap]
+roots: [quomodo-latin, stare-latin]
+etymology_hook: "cómo (← Latin quōmodo 'in what manner') + está (estar) — 'in what manner are you standing?'"
+est_minutes: 4
+reviews_of: [ES-C04-estar, ES-C03-como, ES-C03-tu-usted]
+---
+
+# ¿cómo está usted? — "how are you?"
+
+## Warm-up
+
+[PAUSE 2s] Everything you've built this chapter now snaps together into one
+question. You already met **cómo** ("how") and the **tú / usted** choice back in
+Chapter 3; you just learned **estar**. Assemble them.
+
+## Review first (30 seconds)
+
+[PAUSE 2s] Before the new phrase, recall the pieces — no peeking:
+
+- **cómo** — "how." From Latin *quōmodo*, "in what manner." (Its cousin? English
+  *how* is Germanic, but *cómo* is the *qu-* question family: *qué, quién, cuándo*.)
+- **usted** vs **tú** — the formal vs informal "you." *usted* is worn down from
+  *vuestra merced*, "your grace"; *tú* is the old intimate "thou."
+
+Got them? Good — now the assembly.
+
+## The phrase, taken apart
+
+> **¿Cómo está usted?** = "How are you?" (formal)
+> literally: **"In what manner are you standing?"**
+
+- **cómo** = "how / in what manner"
+- **está** = "you are" (the *usted*/he-she form of **estar** — state, not identity)
+- **usted** = the formal "you"
+
+Two registers, and only the verb ending + pronoun change — exactly the *se
+llama* / *te llamas* split you already drilled:
+
+| register | question |
+|---|---|
+| **formal** (stranger, elder, customer) | **¿Cómo está usted?** |
+| **informal** (friend, peer, child) | **¿Cómo estás?** |
+
+Note the **¿** — Spanish opens a question with an upside-down mark so you know
+the melody is coming before you start reading aloud. (We take that mark apart in
+a dedicated writing lesson.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "¿Cómo está usted?" — formal, for a stranger]
+- [YOU SAY: "¿Cómo estás?" — informal, for a friend]
+- [YOU SAY: for a doctor you just met, then your cousin — which form for each?]
+
+[REPEAT x2] Ask both versions back to back until the *está / estás* swap is
+automatic.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which be-verb does "how are you?" use — *ser* or *estar*, and why?
+(*estar* — it's about your current state.) What changes between formal and
+informal? (The verb ending *está → estás*, and you drop *usted*.) Next: how to
+answer — **bien, regular, más o menos.**

--- a/code/learning/human-languages/spanish/lessons/ES-C04-de-nada.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-de-nada.md
@@ -1,0 +1,65 @@
+---
+id: ES-C04-de-nada
+chapter: 4
+type: phrase
+headword: de nada
+gloss: you're welcome (literally "of nothing")
+concept_tag: COURTESY-YOUREWELCOME
+prerequisites: [ES-C04-gracias]
+sounds: [vowel-a, d-soft]
+roots: [de-latin, nada-nata-latin]
+etymology_hook: "nada ← Latin (rem) nata '(thing) born' → 'nothing'; the reply waves the favour away"
+est_minutes: 3
+reviews_of: [ES-C04-gracias]
+---
+
+# de nada — "you're welcome," or "it was nothing"
+
+## Warm-up
+
+[PAUSE 2s] Someone says **gracias**. You need the reply that closes the loop:
+**de nada** — literally *"of nothing."* You're waving the favour off as no
+trouble at all — the same move English makes with *"it's nothing"* / *"no
+problem."*
+
+## Sounds you'll need
+
+- `d-soft` — the *d* in *nada* is soft, almost the *th* of *this* (**NAH-thah**),
+  not a hard English *d*. Spanish *d* between vowels always softens.
+- `vowel-a` — three clean *ah* sounds: *deh NAH-thah*.
+
+## The phrase, taken apart
+
+- **de** = "of / from" (Latin **dē**) — the same *de* hiding in English
+  **de**part, **de**duct, **de**scend.
+- **nada** = "nothing." And this is the beautiful part.
+
+**nada** comes from Latin **(rēs) nāta** — "(a thing) *born*." From *nāscī*, "to
+be born," the same root as English **nat**ive, **nat**ure, **nat**al,
+**re-nais-sance** (re-birth). Latin speakers said *nōn est rēs nāta*, "there is
+not a born thing" — *not a single thing that ever came into being* — and over
+centuries the emphatic *nāta* ("born thing") wore down until **the word for
+'born thing' became the word for 'nothing' itself.**
+
+So the reply *de nada* literally says **"of [a] born-thing"** → "of nothing at
+all." French did the identical trick with **rien** ("nothing") — which is Latin
+**rem**, "a thing." Two languages, same move: the word for *thing* collapses
+into the word for *nothing*.
+
+## Grammar Lens: the courtesy pair
+
+*gracias* → *de nada* is a fixed **adjacency pair**: one turn expects the other.
+Learn them as a unit, the way English glues *thank you* → *you're welcome*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "gracias" … "de nada" — the full exchange, both voices]
+- [YOU SAY: "de nada" then English "native, nature, natal" — nada's true family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] *nada* ("nothing") started life as the Latin word for a *born* —
+what? (A *thing* — *rēs nāta*, a born thing.) What English words share that
+"born" root? (Native, nature, natal, renaissance.) Next: the verb the whole
+"how are you?" question turns on — **estar**.

--- a/code/learning/human-languages/spanish/lessons/ES-C04-estar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-estar.md
@@ -1,0 +1,78 @@
+---
+id: ES-C04-estar
+chapter: 4
+type: word
+headword: estar
+gloss: to be (a state or location — temporary)
+concept_tag: ES-VERB-ESTAR
+prerequisites: []
+sounds: [vowel-e, r-tap, st-no-e]
+roots: [stare-latin]
+etymology_hook: "estar ← Latin stare 'to stand' → English stay, state, status, stable, stance, estate"
+est_minutes: 4
+reviews_of: [ES-C04-gracias]
+---
+
+# estar — "to be," the *standing* kind
+
+## Warm-up
+
+[PAUSE 2s] To ask *how are you?* Spanish needs a verb for **being** — but
+Spanish has **two**, and the split is one of the language's signatures. Today:
+**estar**, the *temporary* one — how you *are right now*, and *where* you are.
+
+## Sounds you'll need
+
+- `st-no-e` — Spanish never starts a word with a bare *st-*; it props it up with
+  an *e*: *es-TAR*. (That reflex is why Spanish speakers say *e-Spain*,
+  *e-student* — the same *e* that Latin *stare* grew to become *estar*.)
+- `r-tap` — the final *r* is one soft tap: *es-TAR*.
+
+## The word, taken apart
+
+**estar** comes straight from Latin **stāre**, *"to stand."* And "to stand" is
+exactly the right picture for the *temporary* be-verb: how you are *standing* at
+this moment — well, tired, here, there — not what you permanently *are*.
+
+That root **stā-/sta-** ("stand") is one of the most productive in English.
+*estar* hands you a huge family:
+
+- **stay**, **stand**, **stance**, **station**, **stable**, **stationary** — to
+  stand / stay put.
+- **state**, **status**, **statue**, **estate**, **e-state → estate** — a way of
+  *standing* (your state = how you stand).
+- **constant**, **circumstance**, **substance** — "standing with / around /
+  under."
+
+So *¿cómo estás?* is, at the root, **"how are you standing?"** — a snapshot of
+right now.
+
+## Grammar Lens: estar vs. ser (the famous split)
+
+Spanish has **two** verbs for "to be":
+
+| verb | from | used for |
+|---|---|---|
+| **ser** | Latin *esse* ("to be") | permanent identity — *soy David*, "I am David" |
+| **estar** | Latin *stāre* ("to stand") | temporary state & location — *estoy bien*, "I am well (now)"; *estoy aquí*, "I am here" |
+
+Rule of thumb: **how you feel and where you are → estar.** Who you *are* → ser.
+"How are you?" is about your current state, so it always takes **estar**.
+
+You only need two forms of it this chapter:
+
+- **estás** — "you are" (informal *tú*)
+- **está** — "you are" (formal *usted*) / "he/she is"
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "estar" — *es-TAR*, with the little propping *e*]
+- [YOU SAY: "estás" … "está" — the two forms you'll ask with]
+- [YOU SAY: "estar" then English "stay, state, status, stable" — all *standing*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which Latin verb is *estar* — "to be" or "to stand"? (To *stand* —
+*stāre*.) Which be-verb do you use for how you feel right now, *ser* or *estar*?
+(*estar*.) Next lesson, you finally ask it: **¿cómo está usted?**

--- a/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
@@ -1,0 +1,62 @@
+---
+id: ES-C04-gracias
+chapter: 4
+type: word
+headword: gracias
+gloss: thank you
+concept_tag: COURTESY-THANKS
+prerequisites: []
+sounds: [vowel-a, r-tap, ci-th-s]
+roots: [gratia-latin]
+etymology_hook: "gracias ← Latin gratia 'favour, grace' → English grace, grateful, gratis, congratulate"
+est_minutes: 3
+reviews_of: [ES-C03-practice]
+---
+
+# gracias — "thank you," and a whole family of English words
+
+## Warm-up
+
+[PAUSE 2s] You can now introduce yourself. The next exchange is *how are you?* —
+but every answer ends the same polite way, so we learn the courtesy word first:
+**gracias**.
+
+## Sounds you'll need
+
+- `vowel-a` — the clean *ah* of *father*, twice.
+- `r-tap` — a single flicked *r* (not the English one, and not yet the rolled
+  *rr*): the tongue taps once, like the middle of American *butter*.
+- `ci-th-s` — the *ci* is a soft *s* in Latin America (**GRAH-syahs**) and a
+  soft *th* in most of Spain (**GRAH-thyahs**). Either is correct — pick one.
+
+## The word, taken apart
+
+**gracias** is the plural of **gracia** ("grace, favour"), from Latin **grātia**
+— *favour freely given*. Saying *gracias* literally offers someone "graces,"
+i.e. good will in return for theirs.
+
+That one Latin root **grātia** fans out across English — once you see it, you
+get a fistful of words for free:
+
+- **grace**, **gracious**, **graceful** — the direct borrowings.
+- **grateful**, **gratitude** — being *full of* grātia.
+- **gratis**, **gratuity** — something given as a *favour* (for free, or a tip).
+- **congratulate** — literally "to wish grace *together with* someone."
+- Italian **grazie**, French **grâce/merci-less** *grâces*, Portuguese
+  **obrigado**'s cousin *graças* — the whole Romance family keeps grātia.
+
+So *gracias* is not a word to memorize cold: it is **grace**, made plural and
+handed to another person.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "gracias" — *GRAH-syahs*, one soft tap on the *r*]
+- [YOU SAY: "gracias" then English "grace, grateful, gratitude" — one family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What everyday English word is *gracias* the plural of, at the root?
+(*Grace*.) So when you thank someone in Spanish, you are literally handing them
+— what? (Graces / favours.) Next: the little reply that closes the exchange,
+**de nada**.

--- a/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
@@ -1,0 +1,65 @@
+---
+id: ES-C04-practice
+chapter: 4
+type: practice-mix
+headword: (practice)
+gloss: the full "how are you?" exchange, formal and informal
+concept_tag: CH4-PRACTICE
+prerequisites: [ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-como-esta, ES-C04-regular]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C04-gracias, ES-C04-de-nada, ES-C04-como-esta, ES-C04-regular, ES-C03-practice]
+---
+
+# Practice — "how are you?", start to finish
+
+## Warm-up
+
+[PAUSE 2s] No new words. This chapter's atoms — *gracias, de nada, estar, ¿cómo
+está?, regular* — now assemble into a real exchange, run formally and informally
+until the register swap is automatic. It picks up right where the Chapter 3
+introduction left off.
+
+## The exchange
+
+**Formal** (a stranger, an elder, a customer):
+
+> — Buenos días. ¿**Cómo está usted**?
+> — **Bien, gracias.** ¿Y usted?
+> — **Más o menos.**
+> — [reply to a thanks, later in the chat] **De nada.**
+
+**Informal** (a friend, a peer) — only the verb + pronoun change:
+
+> — ¡Hola! ¿**Cómo estás**?
+> — **Regular.** ¿Y tú?
+> — Bien, gracias.
+
+The one new glue word here is **¿y usted? / ¿y tú?** — "and you?" (*y* = "and,"
+from Latin *et*). It bounces the question back.
+
+## What you've built this chapter
+
+- **gracias** — thank you (← *grātia*, "grace").
+- **de nada** — you're welcome (← "of a born-thing" → "of nothing").
+- **estar** — the *temporary* to-be (← *stāre*, "to stand"); vs *ser* (identity).
+- **¿cómo está usted? / ¿cómo estás?** — how are you, formal / informal.
+- **bien / regular / más o menos** — well / so-so / more-or-less.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full *formal* exchange, both voices]
+- [YOU SAY: the same exchange *informally* — catch *está → estás*, *usted → tú*]
+- [YOU SAY: chain Chapter 3 + 4 — introduce yourself *and* ask how they are:
+  "Me llamo … ¿Cómo está usted?"]
+
+[REPEAT x2] Run the formal exchange, greeting to answer, without stopping.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which be-verb carries "how are you?" and why? (*estar* — current
+state.) Two words swap between formal and informal — which? (*está → estás*, and
+*usted → tú*.) What does *de nada* literally say? ("Of nothing.") Next chapter:
+**farewells** — hasta luego, hasta mañana, adiós.

--- a/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
@@ -1,0 +1,74 @@
+---
+id: ES-C04-regular
+chapter: 4
+type: word
+headword: regular
+gloss: so-so / not great (also "más o menos")
+concept_tag: WORD-SOSO
+prerequisites: [ES-C04-como-esta]
+sounds: [vowel-e, r-tap, l-clear]
+roots: [regula-latin, magis-minus-latin]
+etymology_hook: "regular ← Latin regula 'straight rod, rule'; the middling answer — 'on the rule / average'"
+est_minutes: 4
+reviews_of: [ES-C01-bien, ES-C04-como-esta]
+---
+
+# regular / más o menos — the honest "so-so"
+
+## Warm-up
+
+[PAUSE 2s] You asked *¿cómo estás?* Now you can answer three ways: great,
+middling, or a wave of the hand. You already have **bien** ("well," Chapter 1).
+Today, the *middling* answers — because nobody is *bien* every day.
+
+## Review first (20 seconds)
+
+[PAUSE 2s] Recall from Chapter 1: **bien** — "well." Root? (Latin *bene*, "well"
+— same as *bene*fit, *bene*volent.) So *estoy bien* = "I'm well." Now the answer
+for when you're *not* quite bien.
+
+## The words, taken apart
+
+**regular** — as an answer to "how are you?", it means **"so-so, average, not
+great."** (A famous false-friend trap: it does **not** mean English "regular /
+normal / usual" here.) From Latin **rēgula**, a *straight rod* a builder used to
+check a line — the **ruler**. So *regular* is "on the rule, on the average line"
+→ middling.
+
+That *rēgula* rod is everywhere in English: **rule**, **ruler**, **regulate**,
+**regular**, **regiment**, and even **rail** (a straight rod). All the same
+straight stick.
+
+**más o menos** — "more or less," the shrug-answer:
+
+- **más** = "more," from Latin **magis** ("more") — cousin of *major*, *master*,
+  *maximum*.
+- **menos** = "less," from Latin **minus** — the very word English borrowed for
+  *minus*, *minor*, *minimum*, *minus*cule.
+
+So *más o menos* is literally **"more or less"** — the exact phrase, root for
+root, that English uses for the same shrug.
+
+## Grammar Lens: a small answer set
+
+You now have a scale to answer *¿cómo estás?*:
+
+| answer | sense |
+|---|---|
+| **(muy) bien** | (very) well |
+| **regular** | so-so |
+| **más o menos** | more or less / meh |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "regular" — *reh-goo-LAR*, soft tap on both *r*'s]
+- [YOU SAY: "más o menos" — a little shrug in the voice]
+- [YOU SAY: answer "¿cómo estás?" three ways — bien / regular / más o menos]
+
+## Wrap-up Recall
+
+[PAUSE 3s] As an answer, does *regular* mean "normal" or "so-so"? (So-so — the
+false-friend trap.) What straight-rod Latin word is it from, and what English
+"rod" words share it? (*rēgula* → rule, ruler, regulate, rail.) Next: put the
+whole exchange together.

--- a/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
@@ -1,0 +1,79 @@
+---
+id: ES-W01-acento
+chapter: 4
+type: writing
+headword: "á é í ó ú"
+gloss: the acute accent (el acento / la tilde) — Spanish's one and only accent mark
+prerequisites: [ES-C03-como, ES-C03-tu-usted, ES-C04-como-esta]
+sounds: [stress]
+roots: []
+est_minutes: 4
+reviews_of: [ES-C03-como, ES-C04-regular]
+---
+
+# á é í ó ú — the acute accent, and the two jobs it does
+
+## Warm-up
+
+[PAUSE 2s] You've been reading accented words since your very first noun —
+**dí**a, **có**mo, es**tá**, **má**s. Time to make that little stroke make
+sense. Spanish has exactly **one** accent mark — the *acute* accent, `´`,
+leaning right — and it does just **two** jobs. Learn both and you can read any
+Spanish word aloud correctly, first try.
+
+## What it looks like, and how to write it
+
+A short stroke rising **left-to-right**, sitting on top of a vowel:
+**á é í ó ú**. (On the *í*, it replaces the dot.) One clean up-stroke — the
+opposite lean from the French *grave* accent `à`. Spanish never uses grave or
+circumflex; if it leans the wrong way, it isn't Spanish.
+
+## Job 1 — it tells you where to shout
+
+Spanish stress is regular, so most words need **no** mark. The default:
+
+- word ends in a **vowel, -n, or -s** → stress the **second-to-last** syllable
+  (*ca-**sa***, *jo-ven*, *lla-mo*).
+- word ends in **any other consonant** → stress the **last** syllable
+  (*us-**ted***, *re-gu-**lar***, *ha-blar*).
+
+The accent appears **only when a word breaks that rule** — it marks the
+exception. *está* ends in a vowel, so the rule wants *ES-ta*; the accent
+overrides it to *es-**TÁ***. *cómo* ends in a vowel (rule wants *co-**MO***) but
+is stressed *CÓ-mo*, so it gets the mark. The accent is a **spoken stress you
+can see** — it never changes the vowel's sound, only which syllable you hit.
+
+## Job 2 — it splits look-alike words (la tilde diacrítica)
+
+The same mark pulls apart pairs that are spelled identically but do different
+jobs. This is the one you *must* know — you've already met most of them:
+
+| no accent | with accent |
+|---|---|
+| **tu** = your | **tú** = you (Ch. 3) |
+| **el** = the | **él** = he |
+| **si** = if | **sí** = yes |
+| **se** = (reflexive *se*, Ch. 3) | **sé** = I know |
+| **mas** = but (literary) | **más** = more (Ch. 4) |
+| **como** = like/as | **cómo** = how? (Ch. 3) |
+| **que** = that | **qué** = what? |
+
+Notice the pattern in the bottom rows: **question words wear the accent**
+(*qué, cómo, cuándo, dónde, quién*) — the mark is how writing shows the rising
+"I'm asking" stress. That's why *¿**Có**mo está?* has the accent but *tan
+**co**mo* would not.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tu" vs "tú", "el" vs "él", "si" vs "sí" — same spelling, the accent
+  is the only difference, and it changes the meaning entirely]
+- [YOU SAY: "cómo" as a question, then "como" as "like" — hear the accent land]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How many accent marks does Spanish have, and which way does it lean?
+(One — the acute, `´`, rising left-to-right.) Its two jobs? (Mark irregular
+stress; split look-alike words like *tu/tú*, *si/sí*.) Which class of words
+almost always carries it? (Question words — *qué, cómo, dónde*.) Next writing
+lesson: the letter that is a *tilde* wearing a hat — **ñ**.

--- a/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
@@ -1,0 +1,67 @@
+---
+id: ES-W02-enye
+chapter: 4
+type: writing
+headword: "ñ"
+gloss: the letter eñe — a tiny second n riding on the first
+prerequisites: [ES-W01-acento]
+sounds: [ny-palatal]
+roots: [annus-latin]
+est_minutes: 3
+reviews_of: [ES-W01-acento]
+---
+
+# ñ — the letter that remembers a doubled n
+
+## Warm-up
+
+[PAUSE 2s] **ñ** is the one letter English doesn't have — and it has the best
+origin story in the alphabet. That wavy hat (`~`, a *tilde*) is not decoration.
+It is **a tiny second *n*, written on top to save space.** Once you know that,
+you know both how to write it *and* why it sounds the way it does.
+
+## The sound
+
+**ñ** = the *ny* in "ca**ny**on" or "o**ni**on" — one squished sound, tongue
+flat against the roof of the mouth. English *canyon* is, in fact, Spanish
+**cañón** with the *ñ* spelled out as *ny*. Say "onion," freeze on the middle:
+that's ñ.
+
+## How to write it, and where the hat came from
+
+Write a normal **n**, then a small wavy **~** floating above it. That wave is a
+**medieval shorthand**. Scribes copying Latin were forever writing double
+letters, so they saved a stroke by writing the letter **once** and putting a
+little mark above to mean *"...and one more of these."* A bar/wave over a vowel
+meant a dropped *n* or *m* (Latin *tantum* → *tãtum*); a wave over an *n* meant
+**nn**.
+
+Spanish is full of words where a Latin **-nn-** did exactly this:
+
+- Latin **annus** ("year") → *anno* → **año** — the *nn* collapsed into *ñ*.
+  (That same *annus* gives English **ann**ual, **ann**iversary, bi-**enn**ial.)
+- Latin **cannon** → *caña* → **cañón**; Latin *domina* line → *doña*.
+
+So the tilde on **ñ** is a **frozen abbreviation**: a thousand-year-old note
+that says "there used to be two *n*'s here." You are writing a scribe's
+shortcut.
+
+> ⚠️ Careful: **ñ is its own letter**, not "n with an accent." *año* ("year")
+> and *ano* (a rather different word) are completely different words — the tilde
+> is not optional flourish, it's a distinct letter of the alphabet.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "año" — *AH-nyo*, one squished *ny*; then English "annual" — same
+  Latin *annus*]
+- [YOU SAY: "señor", "mañana", "España" — the ñ in three everyday words you'll
+  meet soon]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the tilde on *ñ*, really? (A tiny second *n* — a scribe's
+shorthand for a doubled *nn*.) What Latin word gives *año*, and what English
+words share it? (*annus* → annual, anniversary.) Is *ñ* a separate letter or
+just an accented *n*? (A separate letter.) Next writing lesson: the upside-down
+marks **¿ ¡**.

--- a/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
@@ -1,0 +1,69 @@
+---
+id: ES-W03-inverted
+chapter: 4
+type: writing
+headword: "¿ ¡"
+gloss: the inverted opening marks — Spanish brackets a question or exclamation at both ends
+prerequisites: [ES-C04-como-esta]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [ES-C04-como-esta, ES-W01-acento]
+---
+
+# ¿ ¡ — the marks that open a question
+
+## Warm-up
+
+[PAUSE 2s] You've been writing them since *¿cómo está usted?* Spanish is the one
+major language that puts an **upside-down** question or exclamation mark at the
+**start** of the sentence, as well as the normal one at the end. It looks exotic;
+the reason is purely practical.
+
+## What they are
+
+- **¿ … ?** wraps a question: *¿Cómo estás?*
+- **¡ … !** wraps an exclamation: *¡Hola!* *¡Gracias!*
+
+The opening mark is just the closing mark **flipped 180°** — turned upside down
+*and* left-right. To write **¿**, draw a normal *?* and rotate it half a turn:
+the hook ends up at the bottom, the dot on top.
+
+## Why open a question at all?
+
+English lets you read most of a sentence before the final **?** reveals it was a
+question — fine, because English usually flags a question early with word order
+("*Are* you…", "*Do* you…"). Spanish often **doesn't reorder words**: *Tienes
+hambre.* ("You're hungry.") and *¿Tienes hambre?* ("Are you hungry?") are the
+**same words** — only punctuation and the spoken rising tone tell them apart.
+
+So the Spanish Royal Academy, in **1754**, made the opening **¿** official: it
+warns the reader *"a question is starting — read this with rising intonation from
+the very first word."* It's a **melody cue placed before the melody**, the exact
+same instinct as the written accent marking stress you can't otherwise see. For
+a language read aloud, it's genuinely useful.
+
+## A nuance: they don't have to hug the capital
+
+The opening mark goes where the *question* starts, not where the sentence
+starts:
+
+> Roberto, ¿cómo estás?
+
+The *¿* opens only the question part. Same for *¡*: *Roberto, ¡buenos días!*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: read "¿Cómo estás?" — start the rising *question* melody from the
+  very first word, the way the ¿ tells you to]
+- [YOU SAY: "¡Hola!" then "¡Gracias!" — the ¡ warns you to land them with energy]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does Spanish open a question with **¿**? (Because word order often
+doesn't change, so the reader needs an early warning to use question
+intonation.) How do you write it? (A normal *?* rotated 180°.) Does it always
+sit at the sentence's start? (No — at the *question's* start: *Roberto, ¿cómo
+estás?*) That's the full writing toolkit for Latin-script Spanish: **the acute
+accent, ñ, and ¿ ¡**.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -27,10 +27,15 @@ with grammar introduced exactly where a word needs it
 (Lessons are identified by stable **slug** ids, not numbers — see `HL00`;
 order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
 
-Next: **Ch. 4** — responding to *¿cómo está usted?* (bien, gracias, regular,
-más o menos); then **farewells** (hasta luego/mañana/pronto, adiós). Sentences
-grow as grammar accumulates piece by piece. The theme skeleton below plans the
-wider road ahead.
+- **Ch. 4 — Responding to *¿cómo está usted?***: gracias (← *grātia*) → de nada
+  (← *nāta*, "born thing" → "nothing") → **estar** (the *temporary* to-be, ←
+  *stāre* "to stand"; vs *ser*) → ¿cómo está usted? / ¿cómo estás? (assembled;
+  formal vs informal) → regular / más o menos ("so-so") → practice. **Authored.**
+
+Next: **Ch. 5** — **farewells** (hasta luego / hasta mañana / hasta pronto,
+adiós — and *hasta* ← Arabic *ḥattā*, the first of the Arabic-loanword deep
+dives). Sentences grow as grammar accumulates piece by piece. The theme skeleton
+below plans the wider road ahead.
 
 ## Theme Skeleton (planning only)
 

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@coding-adventures/human-language-data` are documented here.
 
+## [0.3.0] - 2026-07-18
+
+### Added — `writing` lesson type (orthography / writing nuances)
+- **New exempt lesson type `writing`** for lessons that teach a *writing-system*
+  nuance — an accent mark, a diacritic, an inverted punctuation mark — rather
+  than a vocabulary word. Its `headword` is the mark itself and it carries **no
+  `concept_tag`** (a mark does not join across languages), so it is exempt from
+  the cross-language concept join, exactly like `practice`/`review`.
+- Validator now accepts `writing` without flagging `unknown-type` or requiring a
+  concept; added a test covering it. Supports the curriculum's "teach the
+  accent marks and other writing nuances" goal (HL00) and gives HL02's
+  hand-writing practice a lesson type to draw from.
+
 ## [0.2.0] - 2026-07-18
 
 ### Changed — general script model (teach any writing system)

--- a/code/packages/typescript/human-language-data/package.json
+++ b/code/packages/typescript/human-language-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/human-language-data",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Cross-language concept dataset + validator derived from the Human Languages curriculum (spec HL01)",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/human-language-data/src/constants.ts
+++ b/code/packages/typescript/human-language-data/src/constants.ts
@@ -29,8 +29,25 @@ export const LANGUAGE_SCRIPT: Record<string, Script> = {
 /** Lesson types that teach a real concept and take part in the cross-language join. */
 export const CONTENT_TYPES = new Set(["word", "phrase"]);
 
-/** Lesson types that are session labels (review/recap) — exempt from the join. */
-export const EXEMPT_TYPES = new Set(["practice", "practice-mix", "review"]);
+/**
+ * Lesson types that carry a session/orthography label, not a cross-language
+ * concept — exempt from the join.
+ *
+ * - `practice` / `practice-mix` / `review` — recap sessions that re-assemble
+ *   already-taught words.
+ * - `writing` — an orthography lesson that teaches a *writing-system* nuance
+ *   (an accent mark, a diacritic, the direction of a stroke) rather than a
+ *   vocabulary item. Its `headword` is the mark itself (e.g. "◌́" for the acute
+ *   accent) and its `gloss` names it; it takes no `concept_tag`, because a mark
+ *   is not a word that joins across languages. See HL00 "writing nuances" and
+ *   HL02 (the app renders these for hand-writing practice).
+ */
+export const EXEMPT_TYPES = new Set([
+  "practice",
+  "practice-mix",
+  "review",
+  "writing",
+]);
 
 /** A language-local concept id: two-letter lang prefix + SCREAMING-KEBAB name. */
 export const NAMESPACED_TAG = /^[A-Z]{2}-[A-Z0-9-]+$/;

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -44,7 +44,7 @@ export interface Realization {
   language: string; // track slug: "spanish", "telugu", …
   lessonId: string; // e.g. ES-C01-dia
   chapter: number;
-  type: string; // word | phrase | practice | practice-mix | review
+  type: string; // word | phrase | practice | practice-mix | review | writing
   headword: string; // "día" / "నమస్కారం"
   gloss: string; // "day (el día — masculine)"
   romanization: string; // "DEE-ah"; = headword for Latin script; "" if unknown

--- a/code/packages/typescript/human-language-data/tests/validate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/validate.test.ts
@@ -84,6 +84,20 @@ describe("validate", () => {
     expect(issues.some((i) => i.code === "unknown-type")).toBe(true); // quiz flagged
   });
 
+  it("accepts a `writing` (orthography) lesson with no concept_tag", () => {
+    // A writing-nuance lesson teaches a mark, not a word: its headword is the
+    // mark itself and it carries no concept_tag, so it must be exempt from the
+    // concept join and must NOT be flagged as an unknown type.
+    const acento = parseLesson(
+      lesson({ id: "ES-W01-acento", chapter: "1", type: "writing", headword: "◌́", gloss: "the acute accent", concept_tag: "" }),
+      "spanish",
+    );
+    const issues = validate({ taxonomy, lessons: [acento] });
+    expect(issues.some((i) => i.code === "unknown-type")).toBe(false); // writing is known
+    expect(issues.some((i) => i.code === "missing-concept")).toBe(false); // no concept required
+    expect(issues.some((i) => i.code === "unresolved-concept")).toBe(false);
+  });
+
   it("treats missing core coverage as info, but as error for parity-complete tracks", () => {
     const lessons = [good("spanish", "ES1", "GREETING-HELLO")]; // missing COURTESY-THANKS
     const infoIssues = validate({ taxonomy, lessons });


### PR DESCRIPTION
## Overnight curriculum build — one PR to review in the morning

The **single accumulator PR** for the overnight human-languages work. Each commit
is one reviewable unit (a chapter, a data-layer change, a writing thread), so the
diff reads piece by piece. It builds toward an *Easy Spanish Step By Step* that
goes **etymology-deep**, rises slowly in complexity, teaches **writing nuances**
(accent marks and the like), and — for non-Latin scripts — introduces the script
inline then breaks it apart for hand-writing. Lessons stay small (3–5 min),
**build on** prior lessons, and **review** them via `reviews_of`.

*(The first Cyrillic/Russian track, #8525, merged while this was in flight; this
PR is based on top of it.)*

### The centrepiece: one chapter, three languages, three metaphors

I built the **"how are you?" chapter in parallel across Spanish, French, and
German** — deliberately, so the cross-language interleaving method has real
material and the shared taxonomy is *proven* to join across languages (all three
reuse the same new canonical concepts `STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`,
`WORD-SOSO`). The payoff is stated inside the lessons:

| | verb for "how are you?" | literal picture |
|---|---|---|
| **Spanish** (`estar`) | to **stand** | "how are you *standing*?" |
| **French** (`aller`) | to **go** | "how does it *go*?" |
| **German** (`gehen`) | to **go** | "how *goes* it to you?" |

And the courtesy words, each a different metaphor an English speaker already owns:
*gracias* ← *grātia* (grace) · *merci* ← *mercēs* (reward/mercy) · *danke* ←
*denken* (**thank IS think**); with the "you're welcome / of nothing" twins
*de nada* ← *nāta* and *de rien* ← *rem* (both "a thing" → "nothing"), and German
*bitte* ← *bitten* (**bid**/**bead** — a bead was a prayer).

### Commit by commit

1. **`afd16b1` Spanish Ch. 4 — *¿cómo está usted?*** — gracias, de nada, estar
   (← *stāre* "to stand"; the ser/estar split), ¿cómo está?, regular / más o
   menos, practice. Adds the three canonical concepts.
2. **`74270cd` data layer: `writing` lesson type** (`human-language-data` 0.3.0)
   — a lesson that teaches a *mark* (accent, diacritic, ¿¡) not a word: no
   `concept_tag`, exempt from the join. Validator + test.
3. **`744641` Spanish writing nuances** — acute accent `á é í ó ú` (stress +
   *tu/tú* diacrítica), **ñ** (tilde = a scribe's doubled-*nn*; *annus* → *año*),
   **¿ ¡** (why Spanish opens a question; RAE 1754).
4. **`d174f08` French Ch. 3 — *Comment ça va ?*** — merci, de rien, aller (the
   suppletive "to go"), comment ça va / allez-vous, comme ci comme ça, practice.
5. **`543d2af` German Ch. 3 — *Wie geht's?*** — danke, bitte, gehen (= English
   *go*), wie geht es dir/Ihnen (first taste of the **dative**), es geht, practice.

### Spot-check worth doing
The etymology hooks are the teaching method, so they're the thing to verify:
*estar* ← *stāre*; *nada* ← *nāta* / *rien* ← *rem*; *merci* ← *mercēs*; *danke*
← *denken* (thank=think); *bitte* ← *bitten* (bid/bead); *gehen* = go; *ñ* ←
doubled-*nn*/*annus*; the 1754 RAE date.

### Checks
- `@coding-adventures/human-language-data`: **38 tests pass**, validator clean.
- Security review: **passed** on every batch, no findings.

### Deliberately *not* done overnight (flagged for your call)
The **companion web app** that renders "break the script apart and write it."
The per-letter decomposition **data** it needs (`components`, `strokeOrder` per
glyph) already exists for every non-Latin script (Cyrillic, Hebrew, Chinese,
Arabic, Devanagari) — but the app itself (HL02) is an architecture decision worth
your input before I build it unreviewed. Ready to start it on your say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
