### PR TITLE
feat(sir): close the division frontier — floor Integer# division on Rust/Go/JS + neg (SIR21 §E3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.34.0 — Ruby `Integer#/` floors toward −∞ (SIR21 §E3)
+
+The inline `__sir` runtime's `_sir_divide` truncated integer division toward
+zero (`acc /= d`), so `-7 / 2` gave `-3` instead of Ruby's floored `-4`. The
+integer path now floors toward −∞ — the truncated quotient minus one exactly
+when the remainder is non-zero and its sign differs from the divisor's —
+matching the SIR21 §E3 oracle `DivOp::Floor` on every sign combination. The float
+path (`_sir_any_float`) is unchanged and already true-divides (Ruby `Float#/`);
+typed division-by-zero is unchanged.
+
+### Fixed — unary minus (`neg`) was unimplemented (any negative literal crashed)
+
+Closing the division frontier surfaced a second, unrelated gap: the Ruby
+frontend lowers unary minus (`-x`) to `BuiltinCall("neg", [x])`, but
+`_sir_call_builtin_by_name` had **no `neg` case**, so *every* negative literal
+(`-7`, not just division) panicked at runtime with `unknown builtin: neg`. The
+JavaScript and Python runtimes already implemented it; the Go backend now does
+too (`_sir_neg`), tag-preservingly (a `float64` stays a `float64`, otherwise
+negate as `int64`). This is what lets the division frontier's negative cases run
+at all.
+
+Together these close the **Go arm** of the division frontier
+(`sir-conformance/tests/division.rs`).
+
 ## 0.33.0 — Array `cycle(n)`
 
 Mirrors the Python reference (PR #8117) into the Go backend's inline `__sir`

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -395,6 +395,21 @@ func _sir_times(args []Value) Value {
 	return acc
 }
 
+// _sir_neg implements Ruby unary minus (`-x`), which the frontend lowers to
+// `BuiltinCall("neg", [x])`.  It was UNIMPLEMENTED, so any negative literal
+// panicked with "unknown builtin: neg" (the JS/Python runtimes already had it).
+// Negate tag-preservingly: a float64 stays a float64; anything else negates as
+// an int64 (the coercion the rest of the arithmetic helpers use).
+func _sir_neg(args []Value) Value {
+	if len(args) == 0 {
+		return int64(0)
+	}
+	if f, ok := args[0].(float64); ok {
+		return -f
+	}
+	return -_sir_as_int(args[0])
+}
+
 func _sir_divide(args []Value) Value {
 	if len(args) == 0 {
 		return int64(0)
@@ -424,7 +439,19 @@ func _sir_divide(args []Value) Value {
 		if d == 0 {
 			panic(_sir_new_error("ZeroDivisionError", Value("divided by 0")))
 		}
-		acc /= d
+		// Ruby `Integer#/` FLOORS toward −∞ (`-7 / 2 == -4`), unlike Go's `/`
+		// which truncates toward zero (`-3`). The floored quotient is the
+		// truncated one minus one exactly when the remainder is non-zero and
+		// its sign differs from the divisor's — when a real division would land
+		// between two integers on the negative side. Matches the SIR21 §E3
+		// oracle `DivOp::Floor` on every sign combination. (Float operands take
+		// the `_sir_any_float` branch above, which true-divides — Ruby `Float#/`.)
+		q := acc / d
+		r := acc % d
+		if r != 0 && (r < 0) != (d < 0) {
+			q--
+		}
+		acc = q
 	}
 	return acc
 }
@@ -1126,6 +1153,8 @@ func _sir_call_builtin_by_name(name string, args []Value) Value {
 		return _sir_times(args)
 	case "/":
 		return _sir_divide(args)
+	case "neg":
+		return _sir_neg(args)
 	case "=":
 		return _sir_eq(args)
 	case "case_eq":

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.37.0 — Ruby `Integer#/` floors toward −∞ (SIR21 §E3)
+
+The runtime `divide` returned a bare `a / b` — JavaScript float division — so
+integer division was wrong: `7 / 2` gave `3.5`, `-7 / 2` gave `-3.5`, never
+Ruby's floored integer result. `divide` now floors via `Math.floor(a / b)` when
+**both** operands are integer-valued (`Number.isInteger`), matching the SIR21 §E3
+oracle `DivOp::Floor` on every sign combination, and true-divides otherwise.
+Typed division-by-zero is unchanged. Closes the **JavaScript arm** of the
+division frontier.
+
+**Known limitation (needs type-flow, not a runtime fix):** JavaScript numbers are
+all `f64`, so a Ruby `Float` that is integral (`7.0`) is indistinguishable from
+the `Integer` `7`; `divide(7.0, 2)` therefore floors to `3` rather than Ruby's
+`3.5`. Faithful float division requires the `SirType` to reach the emitter (a
+`div_true` op), tracked separately. The common, corpus-exercised case — integer
+division — is now correct.
+
 ## 0.36.0 — SIR22 array/matrix base-cut codegen (HML01 Stream A)
 
 Real codegen for the SIR22 array/matrix domain's *base cut* — `ArrayLit`,

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -421,6 +421,22 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     if (b === 0) {
       raiseError("ZeroDivisionError", "divided by 0");
     }
+    // Ruby's `/` is polymorphic: `Integer#/` FLOORS toward −∞ (`-7 / 2 == -4`),
+    // while `Float#/` true-divides (`7.0 / 2 == 3.5`). A bare `a / b` gives
+    // JavaScript's float division, so integer division was wrong (`7 / 2` gave
+    // `3.5`, not `3`). We floor via `Math.floor` when BOTH operands are
+    // integer-valued — matching the SIR21 §E3 oracle `DivOp::Floor` on every
+    // sign combination — and otherwise true-divide.
+    //
+    // KNOWN LIMITATION (needs type-flow, not a runtime fix): JavaScript numbers
+    // are all f64, so a Ruby `Float` that happens to be integral (`7.0`) is
+    // indistinguishable from the `Integer` `7`; `divide(7.0, 2)` therefore
+    // floors to `3` rather than Ruby's `3.5`. Faithful float division requires
+    // the SirType to reach the emitter (a `div_true` op), tracked separately.
+    // The common, corpus-exercised case — integer division — is now correct.
+    if (Number.isInteger(a) && Number.isInteger(b)) {
+      return Math.floor(a / b);
+    }
     return a / b;
   }
 

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.36.0 — Ruby `Integer#/` floors toward −∞ (SIR21 §E3)
+
+The inline `__sir` runtime's `divide` truncated integer division toward zero
+(`acc /= d`), so `-7 / 2` gave `-3` instead of Ruby's floored `-4`. The integer
+path now floors toward −∞ — the truncated quotient minus one exactly when the
+remainder is non-zero and its sign differs from the divisor's — matching the
+SIR21 §E3 oracle `DivOp::Floor` on every sign combination. The float path
+(`any_float`) is unchanged and already true-divides (Ruby `Float#/`); typed
+division-by-zero is unchanged.
+
+### Fixed — unary minus (`neg`) was unimplemented (any negative literal crashed)
+
+Closing the division frontier surfaced a second, unrelated gap: the Ruby
+frontend lowers unary minus (`-x`) to `BuiltinCall("neg", [x])`, but
+`call_builtin_by_name` had **no `neg` arm**, so *every* negative literal
+(`-7`, not just division) panicked at runtime with `unknown builtin: neg`. The
+JavaScript and Python runtimes already implemented it; the Rust backend now
+does too — tag-preservingly (a `Float` stays a `Float`, otherwise negate as
+`Int`). This is what lets the division frontier's negative cases run at all.
+
+Together these close the **Rust arm** of the division frontier
+(`sir-conformance/tests/division.rs`), now a live non-ignored assertion.
+
 ## 0.35.0 — Array `cycle(n)`
 
 Mirrors the Python reference (PR #8117) and the Go backend (PR #8123) into the

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -443,7 +443,17 @@ pub const RUNTIME: &str = r##"mod __sir {
                 // so `rescue ZeroDivisionError` catches it — Ruby parity.
                 raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
             }
-            acc /= d;
+            // Ruby `Integer#/` FLOORS toward −∞ (`-7 / 2 == -4`), unlike Rust's
+            // `/` which truncates toward zero (`-3`). The floored quotient is
+            // the truncated one minus one *exactly* when the remainder is
+            // non-zero and its sign differs from the divisor's — i.e. when a
+            // real division would land between two integers on the negative
+            // side. Matches the SIR21 §E3 oracle `DivOp::Floor` on every sign
+            // combination. (Float operands take the `any_float` branch above,
+            // which correctly true-divides — Ruby `Float#/`.)
+            let q = acc / d;
+            let r = acc % d;
+            acc = if r != 0 && ((r < 0) != (d < 0)) { q - 1 } else { q };
         }
         Value::Int(acc)
     }
@@ -1107,6 +1117,16 @@ pub const RUNTIME: &str = r##"mod __sir {
             "-" => minus(args),
             "*" => times(args),
             "/" => divide(args),
+            // Ruby unary minus (`-x`) lowers to `BuiltinCall("neg", [x])`. It
+            // was UNIMPLEMENTED here, so any negative literal panicked with
+            // "unknown builtin: neg" (the JS/Python runtimes already had it).
+            // Negate tag-preservingly — a `Float` stays a `Float`; anything
+            // else negates as an `Int` (the same coercion `subtract` uses for
+            // its single-argument negation).
+            "neg" => match args.into_iter().next().unwrap_or(Value::Int(0)) {
+                Value::Float(f) => Value::Float(-f),
+                other => Value::Int(-as_i64(&other)),
+            },
             "=" => {
                 let mut it = args.into_iter();
                 eq(it.next().unwrap_or(Value::Nil), it.next().unwrap_or(Value::Nil))

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.13.0] - Division frontier CLOSED on every backend (SIR21 §E3)
+
+With Rust, Go and JavaScript now flooring integer division (their runtime
+`divide` helpers, this release's sibling backend bumps) alongside Python — and
+Ruby flooring natively (it transpiles to Ruby) and C already flooring
+(`_sir_ifloordiv`) — `division_matches_ruby_floor_on_every_backend` is **no
+longer `#[ignore]`d**. It is a live conformance assertion that emits
+`puts(lhs / rhs)`, runs it through every backend's real toolchain, and asserts
+the output equals the oracle's `DivOp::Floor` on all sign combinations. It fails
+(naming the backend) if any backend regresses to truncation or true-division on
+integer operands. `Skipped` outcomes are not asserted: the C *emitter* does not
+yet lower unary `neg`, so its negative cases skip (positive division is
+asserted), and Ruby skips without a `ruby` toolchain. Verified locally: Python,
+JavaScript, Go, Rust and Ruby all floor every sign combination; C floors the
+positive cases.
+`python_division_is_ruby_floor_faithful` remains as a granular per-backend guard;
+module docs updated to record all four arms closed.
+
+Un-ignoring the frontier also surfaced (and this release's Go/Rust bumps fixed)
+a second bug: the negative test cases (`-7 / 2`) crashed Go and Rust with
+`unknown builtin: neg` — unary minus (`-x`) lowers to a `neg` builtin those two
+runtimes never implemented. That is the "Go/Rust crash on negatives" the
+frontier doc long recorded; it was never a division bug at all. The frontier is
+what forced it to the surface, since floor and truncation only *differ* on
+negative operands.
+
 ## [0.11.0] - Division frontier: Python arm closed (SIR21 §E3)
 
 ### Added — `python_division_is_ruby_floor_faithful` (non-ignored)

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/tests/division.rs
+++ b/code/packages/rust/sir-conformance/tests/division.rs
@@ -5,35 +5,49 @@
 //! ([`sir_conformance::oracle::DivOp::Floor`]) prescribes, and what a faithful
 //! transpile of Ruby must reproduce on every backend.
 //!
-//! Probing the pipeline surfaced a real, multi-way divergence — the textbook
-//! "one overloaded `divide` that does the Ruby thing on Tuesdays" bug SIR21 §E3
-//! exists to kill:
+//! Probing the pipeline once surfaced a real, multi-way divergence — the
+//! textbook "one overloaded `divide` that does the Ruby thing on Tuesdays" bug
+//! SIR21 §E3 exists to kill. **It is now closed:** every backend that runs the
+//! negative cases reproduces Ruby's floor.
 //!
-//! | `-7 / 2` (Ruby floor = **−4**) | backend |
-//! |-------------------------------|---------------|
-//! | Python — **now −4** ✅         | `Integer#/` floors, `Float#/` true-divides (SIR21 §E3) |
-//! | JavaScript `-3.5`             | true (float) division, not integer at all |
-//! | Go / Rust — **crash**         | native `/` panics / errors on the path |
+//! | `-7 / 2` (Ruby floor = **−4**) | was | now |
+//! |-------------------------------|-----|-----|
+//! | Python     | `-3` (truncated)   | ✅ `-4` — `//` on two ints; `Float#/` true-divides |
+//! | Rust       | `-3` (truncated)   | ✅ `-4` — floored int path in `__sir::divide` |
+//! | Go         | `-3` (truncated)   | ✅ `-4` — floored int path in `_sir_divide` |
+//! | JavaScript | `-3.5` (float `/`) | ✅ `-4` — `Math.floor` when both operands integral |
+//! | Ruby       | (native)           | ✅ `-4` — emits Ruby, whose `/` floors natively |
+//! | C          | (crashed)          | ✅ `-4` on positives; **negatives skip** (see below) |
 //!
-//! Even *positive* division diverges elsewhere: `7 / 2` prints `3.5` on
-//! JavaScript.
+//! The int-path fixes live in each backend's runtime `divide` helper and mirror
+//! the oracle's [`DivOp::Floor`]: the floored quotient is the truncated one
+//! minus one exactly when the remainder is non-zero and its sign differs from
+//! the divisor's. Python, Rust, Go and C carry tagged values, so they dispatch
+//! `Integer#/` (floor) vs `Float#/` (true-divide) faithfully; the C runtime
+//! already floored (`_sir_ifloordiv`). JavaScript numbers are all `f64`, so it
+//! floors when both operands are integer-valued (`Number.isInteger`) — correct
+//! for every integer-division case the frontier asserts; a Ruby `Float` that is
+//! integral (`7.0`) still needs the typed pipeline to true-divide, tracked
+//! separately. Ruby transpiles to Ruby, so its `/` is already floor.
 //!
-//! **The Python arm is closed.** The runtime `div` (in
-//! `coding-adventures-sir-runtime-core`) used to be `int(a / b)` — truncating
-//! toward zero, and (a latent bug) flooring float division to an `int`. It now
-//! dispatches on operand type: two ints floor via `//` (matching the oracle's
-//! [`DivOp::Floor`]); anything with a float true-divides — exactly Ruby's
-//! polymorphic `/`. [`python_division_is_ruby_floor_faithful`] is the
-//! non-ignored regression guard that proves it end-to-end. The resolution of the
-//! "deliberate conflict" (flip vs. split) went the additive way: the oracle
-//! already carries *both* honest ops (`div_floor`, `div_trunc`), and the Python
-//! backend maps `Integer#/` onto floor — no overloaded runtime `divide`.
+//! **Two gaps this frontier forced to the surface — both fixed here except one
+//! narrow emitter case:** Ruby lowers unary minus (`-x`) to a `neg` builtin, and
+//! the Go and Rust *runtimes* had no `neg` — so every negative literal (not just
+//! division) crashed with `unknown builtin: neg`. That is the "Go/Rust crash on
+//! negatives" this doc long recorded; it was never a division bug. Both now
+//! implement `neg`. The **C backend's emitter** does not yet lower `neg`, so its
+//! negative cases are reported [`RunOutcome::Skipped`] (not `Failed`) and the
+//! frontier does not assert them — C is closed for positive division and tracked
+//! for negative-literal emit. Ruby needs the `ruby` toolchain present to run;
+//! absent it, it skips.
 //!
-//! JavaScript, Go and Rust still diverge, so the *all-backend* frontier below
-//! stays `#[ignore]`d (it flips green the day those three are floor-faithful
-//! too). This file **captures** the frontier so it is tracked and oracle-judged,
-//! the way the `10²⁴` bignum frontier is captured in `arithmetic.rs`. The
-//! toolchain-free control below always runs.
+//! The resolution of the original "deliberate conflict" (flip vs. split) went
+//! the additive way: the oracle already carries *both* honest ops (`div_floor`,
+//! `div_trunc`), and each backend maps `Integer#/` onto floor — no overloaded
+//! runtime `divide`. [`division_matches_ruby_floor_on_every_backend`] is now a
+//! live (non-ignored) assertion; [`python_division_is_ruby_floor_faithful`]
+//! remains as a granular per-backend guard. The toolchain-free control below
+//! always runs.
 
 use sir_conformance::oracle::{DivOp, Outcome};
 use sir_conformance::{run_source, RunOutcome, Target};
@@ -69,14 +83,16 @@ fn oracle_floor_matches_ruby_integer_division() {
     assert_eq!(floor_expected(-6, 2), "-3");
 }
 
-/// The frontier itself: *every* backend must reproduce Ruby's floor `/`. Still
-/// ignored — Python is now floor-faithful (see
-/// [`python_division_is_ruby_floor_faithful`]), but JS true-divides and Go/Rust
-/// crash on the negative path. Run with `cargo test -- --ignored` to watch it;
-/// it becomes a passing assertion once those three are closed too.
+/// The frontier itself, now **closed and live**: every backend that *runs* a
+/// case must reproduce Ruby's floor `/` for it. Each backend's runtime `divide`
+/// floors integer division (SIR21 §E3), so this is no longer `#[ignore]`d — it
+/// is a first-class conformance assertion. It asserts on `Ran` outcomes and
+/// fails (naming the offending backend) the day one regresses to truncation or
+/// true-division on integer operands; `Skipped` cases are not asserted (the C
+/// emitter does not yet lower unary `neg`, so its negative cases skip, and Ruby
+/// skips without a `ruby` toolchain). Verified locally across Python, JavaScript,
+/// Go, Rust and Ruby (all flooring) with C flooring the positive cases.
 #[test]
-#[ignore = "division frontier (SIR21 §E3): Python now floors ✅, but JS true-divides and \
-            Go/Rust crash on negatives. Flips green when all four are floor-faithful."]
 fn division_matches_ruby_floor_on_every_backend() {
     let mut ran = 0usize;
     for &(lhs, rhs) in CASES {


### PR DESCRIPTION
## What

Completes the SIR21 §E3 division frontier that PR #7783 opened (Python). Ruby's integer `/` **floors** toward −∞ (`-7 / 2 == -4`), but the backends didn't: Rust and Go **truncated** toward zero (`-3`), JavaScript **true-divided** (`-3.5`). Each backend's runtime `divide` helper now floors the integer path to match the oracle's `DivOp::Floor` on every sign combination.

The `sir-conformance` all-backend frontier test `division_matches_ruby_floor_on_every_backend` is **no longer `#[ignore]`d** — it's now a live conformance assertion.

## Per backend

| Backend | Before | After |
|---|---|---|
| Rust | `-3` (truncated) | ✅ floored int path in `__sir::divide` (tagged values → faithful) |
| Go | `-3` (truncated) | ✅ floored int path in `_sir_divide` (tagged values → faithful) |
| JavaScript | `-3.5` (float `/`) | ✅ `Math.floor(a/b)` when both operands integral |
| Python | (done in #7783) | ✅ floors |
| Ruby | (native) | ✅ transpiles to Ruby, whose `/` floors natively |
| C | (crashed) | ✅ already floors (`_sir_ifloordiv`) on positives; negatives skip — see below |

Rust/Go/C/Python carry tagged values, so they dispatch `Integer#/` (floor) vs `Float#/` (true-divide) faithfully. JavaScript numbers are all f64, so it floors when both operands are integer-valued; an integral Ruby `Float` (`7.0`) still needs the typed pipeline to true-divide (tracked, documented in-code).

## The `neg` gap this surfaced (and fixes)

Closing the frontier's **negative** cases exposed a second, unrelated bug: Ruby lowers unary minus (`-x`) to a `neg` builtin, but the **Go and Rust runtimes never implemented it** — so *every* negative literal (not just division) crashed with `unknown builtin: neg`. That's the long-recorded "Go/Rust crash on negatives"; it was never a division bug. Both runtimes now implement `neg` tag-preservingly (a `Float` stays a `Float`; else negate as `Int`). JS and Python already had it.

The **C emitter** does not yet lower `neg`, so C's negative cases are `Skipped` (not `Failed`) and the frontier does not assert them — C is closed for positive division and tracked for negative-literal emit.

## Verification

- **Frontier test green**: verified locally across Python, JavaScript, Go, Rust and Ruby — all floor every sign combination (`7/2→3`, `-7/2→-4`, `7/-2→-4`, `-7/-2→3`, `6/3→2`, `-6/2→-3`); C floors the positive cases.
- Full `semantic-ir-to-{rust,go,javascript}` + `sir-conformance` suites pass (no fixture drift from `neg`).
- Security-reviewed: clean (overflow is pre-existing/benign wraparound, div-by-zero unchanged, no injection/eval/reflection).

## Versions
`semantic-ir-to-rust` 0.36.0 · `semantic-ir-to-go` 0.34.0 · `semantic-ir-to-javascript` 0.37.0 · `sir-conformance` 0.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)