### PR TITLE
fix(sir23): stale JS-backend-rejection tests in wolfram/macsyma-to-semantic-ir

### DIFF
--- a/code/packages/rust/macsyma-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/macsyma-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`tests/test_validator.rs` asserted the JS backend rejects every module
+  this frontend produces — stale since `semantic-ir-to-javascript` gained
+  real SIR23 codegen.** All 7 tests in that file were failing on
+  `origin/main` with "expected the JS backend to reject a module using
+  SIR23 features" even though the backend now accepts them. Fixed by
+  inverting the assertion (`assert_js_backend_accepts`, checking
+  `check_module` returns no errors) and updating the module doc comment.
+- Added `tests/e2e_node.rs`: actually compiles and runs representative
+  Macsyma programs (arithmetic, a function definition+call, assignment,
+  control-flow constructs, a multi-statement program) through `node`,
+  proving the SIR23 codegen path is genuinely executable, not just
+  statically accepted.
+
 ## [0.1.0] - 2026-07-13
 
 ### Added

--- a/code/packages/rust/macsyma-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/macsyma-to-semantic-ir/Cargo.toml
@@ -17,9 +17,7 @@ parser = { path = "../parser" }
 lexer = { path = "../lexer" }
 
 [dev-dependencies]
-# Used only by the capability-rejection tests: every module this frontend
-# produces uses SIR23 nodes, and this backend does not implement SIR23
-# codegen yet, so these tests confirm the *gate* rejects every module (see
-# tests/test_validator.rs's module doc comment — there is no e2e
-# `node`-execution test in this crate, unlike `matlab-to-semantic-ir`).
+# Used by tests/test_validator.rs (confirms the JS backend now accepts
+# every module this frontend produces, all of which use SIR23 nodes) and
+# tests/e2e_node.rs (actually runs the compiled JS through `node`).
 semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/macsyma-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/macsyma-to-semantic-ir/tests/e2e_node.rs
@@ -1,0 +1,127 @@
+//! End-to-end round-trip: Macsyma → SIR → JavaScript → `node`.
+//!
+//! Mirrors `wolfram-to-semantic-ir`'s own `tests/e2e_node.rs` harness
+//! (itself modeled on `matlab-to-semantic-ir`'s): lower a Macsyma program
+//! to SIR with this crate, validate the module, emit JavaScript with the
+//! merged `semantic-ir-to-javascript` backend (a dev-dependency), write it
+//! to a temp file, and **execute it with `node`**.
+//!
+//! # Why these tests check "runs cleanly", not a printed value
+//!
+//! See `wolfram-to-semantic-ir/tests/e2e_node.rs`'s own module doc comment
+//! for the full explanation — the same "everything is symbolic data"
+//! design applies here (`lower.rs`'s module doc comment): a Macsyma
+//! program never produces a host-language computed value through this
+//! pipeline, so there is no `disp`-equivalent stdout to assert on. These
+//! tests prove instead that every one of these programs compiles to
+//! JavaScript that `node` actually executes without throwing — genuine,
+//! executable confirmation that the SIR23 codegen `semantic-ir-to-javascript`
+//! implements handles the shapes this frontend emits (this grammar has no
+//! pattern-matching syntax at all, per `tests/test_validator.rs`'s own
+//! disclosure, so only arithmetic/assignment/control-flow/function-call
+//! shapes are exercised here — no rule/replace forms, unlike Wolfram's).
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use macsyma_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_via_node(name: &str, src: &str) {
+    let module = compile_source(src, "prog").expect("lowering should succeed");
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    let artifact =
+        semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("macsyma_sir_e2e_{name}_{}.js", std::process::id()));
+    // See `matlab-to-semantic-ir`'s identical helper for why `create_new`
+    // (not `std::fs::write`) is used here: it fails loudly on an existing
+    // path (including a symlink) instead of silently following/truncating
+    // through it. Each test uses a unique name+PID, so this should never
+    // legitimately collide.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes())
+        .expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn plain_arithmetic_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping plain_arithmetic_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("arithmetic", "1 + 2 * 3$\n");
+}
+
+#[test]
+fn a_function_definition_and_call_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_function_definition_and_call_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node("function_call", "f(x) := x^2$\nf(3)$\n");
+}
+
+#[test]
+fn assignment_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping assignment_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("assignment", "x : 5$\ny : x + 1$\n");
+}
+
+#[test]
+fn control_flow_constructs_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping control_flow_constructs_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node(
+        "control_flow",
+        "if x > 0 then 1 else -1$\nwhile x do x : x - 1$\nfor i in [1, 2, 3] do i$\n\
+         block([total : 0], total)$\nreturn(5)$\n",
+    );
+}
+
+#[test]
+fn a_complex_multi_statement_program_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping a_complex_multi_statement_program_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    run_via_node(
+        "complex",
+        "f(x) := x^2$\ng(x) := f(x) + 1$\nresult : g(3)$\n[result, f(2)]$\n",
+    );
+}

--- a/code/packages/rust/macsyma-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/macsyma-to-semantic-ir/tests/test_validator.rs
@@ -2,21 +2,36 @@
 //! produces must pass the shared SIR validator (confirming the manifest
 //! declares exactly the SIR23 features the module actually uses — the same
 //! ground truth `semantic-ir/src/validator.rs`'s `check_expr` enforces node
-//! kind for node kind), and every module must currently be *rejected* by
-//! the JS backend — mirroring `wolfram-to-semantic-ir`'s own
-//! `tests/test_validator.rs`, which established this pattern for SIR23.
+//! kind for node kind), and every module must be **accepted** by the JS
+//! backend.
 //!
-//! Like `wolfram-to-semantic-ir` (and unlike `matlab-to-semantic-ir`, which
-//! has one purely-literal subset that *is* accepted, since scalar-only
-//! MATLAB arithmetic never touches SIR22 at all), **every** test below is
-//! expected to be rejected: this frontend retargets `macsyma-compiler`'s
-//! own "everything is symbolic data" design (see `lower.rs`'s module doc
+//! # This file's assertions used to say the opposite — and that was a bug
+//!
+//! Until this crate's `semantic-ir-to-javascript` dependency gained real
+//! SIR23 codegen (`SymApply`/`SymPatternBlank`/`SymPatternNamed`/`SymRule`/
+//! `SymReplaceAll` all lower to calls into the inlined `__Sir.Symbolic.*`
+//! runtime, ported from `sir-runtime-symbolic` — HML01 Stream B rollout
+//! item 7), every module this frontend produced was necessarily *rejected*
+//! by that backend, since this frontend retargets `macsyma-compiler`'s own
+//! "everything is symbolic data" design (see `lower.rs`'s module doc
 //! comment) — even the most trivial literal arithmetic (`1 + 2`) emits at
-//! least one `SymApply` node, and `semantic-ir-to-javascript` does not
-//! implement SIR23 codegen at all yet (`sir-runtime-symbolic`, the runtime
-//! library it would depend on, is future work — HML01 Stream B rollout
-//! item 6). There is therefore no e2e `node`-execution test in this crate
-//! at all; see `lower.rs`'s module doc comment for the full disclosure.
+//! least one `SymApply` node. This file's tests asserted exactly that
+//! rejection, mirroring `wolfram-to-semantic-ir`'s own (now similarly
+//! fixed) `tests/test_validator.rs`, which originally established the
+//! pattern for SIR23.
+//!
+//! Once `sir-runtime-symbolic` and its JS-backend codegen landed, that
+//! assertion became **false** for every test below — the JS backend now
+//! successfully compiles every one of these modules — but nobody had
+//! updated this file to match, so all seven tests here started failing on
+//! `origin/main` (confirmed directly: `cargo test -p macsyma-to-semantic-ir`
+//! failed 7/7 in `test_validator.rs` before this fix, each with
+//! `expected the JS backend to reject a module using SIR23 features`).
+//! This file corrects that stale assumption: `assert_js_backend_accepts`
+//! now asserts `check_module` returns *no* errors, and `tests/e2e_node.rs`
+//! (new, this same fix) goes one step further and actually runs the
+//! compiled JS through `node`, proving the generated code is not just
+//! statically accepted but genuinely executable.
 
 use semantic_ir::backend::Backend;
 use semantic_ir::Feature;
@@ -34,13 +49,13 @@ fn assert_valid(src: &str) -> semantic_ir::Module {
     module
 }
 
-fn assert_js_backend_rejects(module: &semantic_ir::Module) {
+fn assert_js_backend_accepts(module: &semantic_ir::Module) {
     let backend = JavaScriptBackend;
     let errors = backend.check_module(module);
     assert!(
-        !errors.is_empty(),
-        "expected the JS backend to reject a module using SIR23 features \
-         (codegen for them isn't implemented there yet)"
+        errors.is_empty(),
+        "expected the JS backend to accept a module using only SIR23 features \
+         (codegen for them has been implemented since HML01 Stream B rollout item 7): {errors:?}"
     );
 }
 
@@ -49,14 +64,14 @@ fn bare_arithmetic_validates_and_declares_symbolic_expr() {
     let module = assert_valid("1 + 2$\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
     assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn a_bare_symbol_alone_validates_and_declares_symbolic_expr() {
     let module = assert_valid("x$\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
@@ -67,14 +82,14 @@ fn a_function_definition_and_call_validates() {
     // exists in this grammar at all, so this feature is never observed,
     // even for a "function definition" construct.
     assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn assignment_is_pure_data_and_still_validates() {
     let module = assert_valid("x : 5$\ny : x + 1$\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
@@ -84,22 +99,22 @@ fn control_flow_constructs_validate_as_symbolic_data() {
          block([total : 0], total)$\nreturn(5)$\n",
     );
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn a_float_literal_module_validates_and_declares_floats() {
     // A BARE float literal alone (no arithmetic wrapping it) emits no
     // SIR23 node at all -- it is just a plain SIR16 `FloatLit`, which the
-    // JS backend fully supports today, so it alone would NOT be rejected
-    // (unlike every other module in this file). Pairing it with a genuine
-    // symbolic construct keeps this test consistent with the rest of the
-    // file (checking that the module IS rejected once it uses an actual
-    // SIR23 node) while still confirming `Feature::Floats` is declared.
+    // JS backend has always accepted on its own, so it alone wouldn't
+    // exercise the `Feature::SymbolicExpr` manifest assertion this test
+    // also makes. Pairing it with a genuine symbolic construct keeps this
+    // test consistent with the rest of the file while still confirming
+    // `Feature::Floats` is declared.
     let module = assert_valid("1.5$\nx + 1$\n");
     assert!(module.manifest.iter().any(|f| f == Feature::Floats));
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
@@ -109,5 +124,5 @@ fn a_complex_multi_statement_program_validates_end_to_end() {
     );
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
     assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Fixed
 
+- **`tests/test_validator.rs` asserted the JS backend rejects every module
+  this frontend produces — stale since `semantic-ir-to-javascript` gained
+  real SIR23 codegen.** All 10 tests in that file were failing on
+  `origin/main` with "expected the JS backend to reject a module using
+  SIR23 features" even though the backend now accepts them. Fixed by
+  inverting the assertion (`assert_js_backend_accepts`, checking
+  `check_module` returns no errors) and updating the module doc comment.
+- Added `tests/e2e_node.rs`: actually compiles and runs representative
+  Wolfram programs (arithmetic, a pattern+call, `/.`, `//.`, a multi-statement
+  program) through `node`, proving the SIR23 codegen path is genuinely
+  executable, not just statically accepted.
+
 - **Correctness: `Feature::Floats` was never observed for a `FloatLit`.**
   `number_literal_expr` was a free function with no access to the
   lowerer's feature-tracking state, so a module containing a float

--- a/code/packages/rust/wolfram-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/wolfram-to-semantic-ir/Cargo.toml
@@ -17,9 +17,7 @@ parser = { path = "../parser" }
 lexer = { path = "../lexer" }
 
 [dev-dependencies]
-# Used only by the capability-rejection tests: every module this frontend
-# produces uses SIR23 nodes, and this backend does not implement SIR23
-# codegen yet, so these tests confirm the *gate* rejects every module (see
-# tests/test_validator.rs's module doc comment — there is no e2e
-# `node`-execution test in this crate, unlike `matlab-to-semantic-ir`).
+# Used by tests/test_validator.rs (confirms the JS backend now accepts
+# every module this frontend produces, all of which use SIR23 nodes) and
+# tests/e2e_node.rs (actually runs the compiled JS through `node`).
 semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
@@ -34,10 +34,14 @@
 //! expression is a pattern-matched template" without special-casing.
 //! Evaluating that data (binding `Set`/`SetDelayed`, running the matcher
 //! for `SymReplaceAll`) is deliberately left to a **backend runtime**
-//! library (`sir-runtime-symbolic`, not yet built — SIR23 spec, "Backend
-//! impact"; Stream B rollout item 6) — mirroring the SIR23 spec's own
-//! explicit "session state isn't SIR" boundary (the same boundary that lets
-//! Macsyma's `assume`/`kill` stay out of the IR entirely).
+//! library (`sir-runtime-symbolic`, published and wired into the JS/TS
+//! backends' codegen — SIR23 spec, "Backend impact"; Stream B rollout
+//! items 6-7) — mirroring the SIR23 spec's own explicit "session state
+//! isn't SIR" boundary (the same boundary that lets Macsyma's
+//! `assume`/`kill` stay out of the IR entirely). See
+//! `tests/e2e_node.rs`'s own module doc comment for exactly what that
+//! evaluation boundary means for what a compiled program actually does
+//! (and doesn't do) at runtime.
 //!
 //! # Scope (v0.1.0)
 //!

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/e2e_node.rs
@@ -1,0 +1,132 @@
+//! End-to-end round-trip: Wolfram → SIR → JavaScript → `node`.
+//!
+//! Mirrors `matlab-to-semantic-ir`'s own `tests/e2e_node.rs` harness: lower
+//! a Wolfram program to SIR with this crate, validate the module, emit
+//! JavaScript with the merged `semantic-ir-to-javascript` backend (a
+//! dev-dependency), write it to a temp file, and **execute it with
+//! `node`**.
+//!
+//! # Why these tests check "runs cleanly", not a printed value
+//!
+//! Under this frontend's "everything is data" design (see `lower.rs`'s
+//! module doc comment), a Wolfram program never produces a host-language
+//! computed value — `1 + 2` lowers to an *unevaluated* `SymApply` term
+//! tree (`apply(sym("Add"), [int(1), int(2)])`), and the compiled JS's
+//! `main()` evaluates that expression only for its (non-existent) side
+//! effects before returning `null`; nothing is ever printed. Evaluating
+//! symbolic data — actually reducing `Add(1, 2)` to `3`, or running the
+//! pattern matcher — is `sir-runtime-symbolic`'s own job (a runtime
+//! *library*, invoked separately, not something this compiled-`main`
+//! shape triggers automatically), not something the compiled entry point
+//! does on its own. So there is no `disp`-equivalent output to assert on
+//! here the way `matlab-to-semantic-ir`'s tests assert `stdout`.
+//!
+//! What these tests DO prove, and what matters most given this crate's
+//! history: every one of these programs compiles to JavaScript that
+//! `node` actually executes without throwing — a genuine, executable
+//! proof (not just `check_module` returning no errors) that the SIR23
+//! codegen `semantic-ir-to-javascript` implements for `SymApply`/
+//! `SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll` handles
+//! the full range of shapes this frontend emits: plain arithmetic,
+//! patterns, rules, and both `/.`/`//.` replacement forms.
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use wolfram_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_via_node(name: &str, src: &str) {
+    let module = compile_source(src, "prog").expect("lowering should succeed");
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    let artifact =
+        semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("wolfram_sir_e2e_{name}_{}.js", std::process::id()));
+    // See `matlab-to-semantic-ir`'s identical helper for why `create_new`
+    // (not `std::fs::write`) is used here: it fails loudly on an existing
+    // path (including a symlink) instead of silently following/truncating
+    // through it. Each test uses a unique name+PID, so this should never
+    // legitimately collide.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes())
+        .expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn plain_arithmetic_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping plain_arithmetic_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("arithmetic", "1 + 2 * 3\n");
+}
+
+#[test]
+fn a_pattern_and_function_call_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_pattern_and_function_call_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node("pattern_call", "f[x_] := x^2\nf[3]\n");
+}
+
+#[test]
+fn a_replaceall_program_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_replaceall_program_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("replaceall", "{1, 2, 3} /. a_ -> a + 1\n");
+}
+
+#[test]
+fn a_replacerepeated_program_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_replacerepeated_program_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("replacerepeated", "x //. a -> b\n");
+}
+
+#[test]
+fn a_complex_multi_statement_program_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping a_complex_multi_statement_program_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    run_via_node(
+        "complex",
+        "f[x_] := x^2\ng[x_] := f[x] + 1\nresult = g[3] /. Null -> 0\n{result, f[2]}\n",
+    );
+}

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/test_validator.rs
@@ -2,20 +2,33 @@
 //! produces must pass the shared SIR validator (confirming the manifest
 //! declares exactly the SIR23 features the module actually uses — the same
 //! ground truth `semantic-ir/src/validator.rs`'s `check_expr` enforces node
-//! kind for node kind), and every module must currently be *rejected* by
-//! the JS backend — mirroring the capability-rejection verification
-//! pattern used to land SIR22/SIR23 themselves and `matlab-to-semantic-ir`.
+//! kind for node kind), and every module must be **accepted** by the JS
+//! backend.
 //!
-//! Unlike `matlab-to-semantic-ir` (which has one purely-literal subset that
-//! *is* accepted, since scalar-only MATLAB arithmetic never touches SIR22
-//! at all), **every** test below is expected to be rejected: under this
-//! frontend's "everything is data" design (see `lower.rs`'s module doc
-//! comment), even the most trivial literal arithmetic (`1 + 2`) emits at
-//! least one `SymApply` node, and `semantic-ir-to-javascript` does not
-//! implement SIR23 codegen at all yet (`sir-runtime-symbolic`, the runtime
-//! library it would depend on, is future work — Stream B rollout item 6).
-//! There is therefore no e2e `node`-execution test in this crate at all;
-//! see `lower.rs`'s module doc comment for the full disclosure.
+//! # This file's assertions used to say the opposite — and that was a bug
+//!
+//! Until this crate's `semantic-ir-to-javascript` dependency gained real
+//! SIR23 codegen (`SymApply`/`SymPatternBlank`/`SymPatternNamed`/`SymRule`/
+//! `SymReplaceAll` all lower to calls into the inlined `__Sir.Symbolic.*`
+//! runtime, ported from `sir-runtime-symbolic` — Stream B rollout item 7),
+//! every module this frontend produced was necessarily *rejected* by that
+//! backend, since under this frontend's "everything is data" design (see
+//! `lower.rs`'s module doc comment) even the most trivial literal
+//! arithmetic (`1 + 2`) emits at least one `SymApply` node. This file's
+//! tests asserted exactly that rejection.
+//!
+//! Once `sir-runtime-symbolic` and its JS-backend codegen landed, that
+//! assertion became **false** for every test below — the JS backend now
+//! successfully compiles every one of these modules — but nobody had
+//! updated this file to match, so all ten tests here started failing on
+//! `origin/main` (confirmed directly: `cargo test -p wolfram-to-semantic-ir`
+//! failed 10/10 in `test_validator.rs` before this fix, each with
+//! `expected the JS backend to reject a module using SIR23 features`).
+//! This file corrects that stale assumption: `assert_js_backend_accepts`
+//! now asserts `check_module` returns *no* errors, and `tests/e2e_node.rs`
+//! (new, this same fix) goes one step further and actually runs the
+//! compiled JS through `node`, proving the generated code is not just
+//! statically accepted but genuinely executable.
 
 use semantic_ir::backend::Backend;
 use semantic_ir::Feature;
@@ -33,13 +46,13 @@ fn assert_valid(src: &str) -> semantic_ir::Module {
     module
 }
 
-fn assert_js_backend_rejects(module: &semantic_ir::Module) {
+fn assert_js_backend_accepts(module: &semantic_ir::Module) {
     let backend = JavaScriptBackend;
     let errors = backend.check_module(module);
     assert!(
-        !errors.is_empty(),
-        "expected the JS backend to reject a module using SIR23 features \
-         (codegen for them isn't implemented there yet)"
+        errors.is_empty(),
+        "expected the JS backend to accept a module using only SIR23 features \
+         (codegen for them has been implemented since Stream B rollout item 7): {errors:?}"
     );
 }
 
@@ -48,7 +61,7 @@ fn bare_arithmetic_validates_and_declares_symbolic_expr() {
     let module = assert_valid("1 + 2\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
     assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
@@ -63,18 +76,18 @@ fn a_float_literal_module_validates_and_declares_floats() {
     //
     // Paired with `x +` (a genuine `SymApply`) rather than a bare `1.5`
     // alone: a bare float literal is a plain SIR16 node the JS backend
-    // already accepts, so it wouldn't exercise this file's own "every
-    // module is rejected" capability-gate assertion below.
+    // already accepts on its own, so it wouldn't exercise this file's
+    // `Feature::SymbolicExpr` manifest assertion below.
     let module = assert_valid("x + 1.5\n");
     assert!(module.manifest.iter().any(|f| f == Feature::Floats));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn a_bare_symbol_alone_validates_and_declares_symbolic_expr() {
     let module = assert_valid("x\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
@@ -82,42 +95,42 @@ fn a_pattern_program_validates_and_declares_pattern_matching() {
     let module = assert_valid("f[x_] := x^2\nf[3]\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
     assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn a_replaceall_program_validates_and_declares_pattern_matching() {
     let module = assert_valid("{1, 2, 3} /. a_ -> a + 1\n");
     assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn a_replacerepeated_program_validates() {
     let module = assert_valid("x //. a -> b\n");
     assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn a_condition_alternatives_patterntest_program_validates() {
     let module = assert_valid("x_ /; x > 2\n_?IntegerQ\na | b\n");
     assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn a_pure_function_program_validates() {
     let module = assert_valid("Map[#^2 &, {1, 2, 3}]\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
 fn assignment_is_pure_data_and_still_validates() {
     let module = assert_valid("x = 5\ny = x + 1\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }
 
 #[test]
@@ -127,5 +140,5 @@ fn a_complex_multi_statement_program_validates_end_to_end() {
     );
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
     assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
-    assert_js_backend_rejects(&module);
+    assert_js_backend_accepts(&module);
 }

--- a/code/specs/HML01-math-to-semantic-ir.md
+++ b/code/specs/HML01-math-to-semantic-ir.md
@@ -135,18 +135,31 @@ pub fn compile_source(source: &str, module_name: &str)
   module doc comment for why this is necessary, not just convenient, to
   compile an *uncomputed* function body like `f[x_] := x + 1`). One
   consequence: because every Wolfram program, even bare literal arithmetic,
-  therefore emits at least one SIR23 node, no lowered module currently
-  executes end-to-end through any backend (`sir-runtime-symbolic` does not
-  exist yet) — unlike `matlab-to-semantic-ir`'s purely-literal subset, which
-  can. Covers the full grammar `wolfram-parser` accepts (the W-6/W-11/W-21
+  therefore emits at least one SIR23 node, no lowered module executed
+  end-to-end through any backend until `sir-runtime-symbolic` and its JS/TS
+  codegen shipped (Stream B rollout items 6-7, below) — unlike
+  `matlab-to-semantic-ir`'s purely-literal subset, which could from the
+  start. Both now round-trip through `node`; see `tests/e2e_node.rs`.
+  Covers the full grammar `wolfram-parser` accepts (the W-6/W-11/W-21
   operator sugar included), since nothing here forces a MATLAB-style
   narrower cut.
-- **`macsyma-to-semantic-ir`** — walks the `macsyma-parser` CST using the
-  same rule-name dispatch already proven in `macsyma-compiler` (`"assign"`,
-  `"additive"`, `"postfix"`, …), emits SIR23 nodes.
-- **`maxima-to-semantic-ir`** — a thin alias reusing
+- **`macsyma-to-semantic-ir`** (✅ v0.1.0 shipped) — walks the
+  `macsyma-parser` CST using the same rule-name dispatch already proven in
+  `macsyma-compiler` (`"assign"`, `"additive"`, `"postfix"`, …), emits SIR23
+  nodes. Same "everything is symbolic data" design as
+  `wolfram-to-semantic-ir` (this grammar has no pattern-matching syntax at
+  all, so only the arithmetic/assignment/control-flow/function-call SIR23
+  shapes are exercised); also round-trips through `node`.
+- **`maxima-to-semantic-ir`** (✅ v0.1.0 shipped) — a thin alias reusing
   `macsyma-to-semantic-ir` wholesale, mirroring Maxima's existing reuse of
   `macsyma-runtime`.
+- **`apl-to-semantic-ir`** (✅ v0.1.0 shipped, MA-4f) — the first Stream A
+  frontend beyond MATLAB/Octave, confirming the array/matrix domain
+  generalizes past the language it was designed against; emits SIR22 nodes
+  plus the APL-primitive `Expr`/`ElementwiseOpKind` additions (SIR22
+  addendum).
+- **`j-to-semantic-ir`** — the second array-family frontend beyond
+  MATLAB/Octave/APL, sharing the same SIR22 vocabulary.
 
 ## §4 Backend recipe: extend the existing JS/TS backends, don't fork
 
@@ -178,15 +191,21 @@ without any change to the IR or the frontends.
 
 ## §5 Rollout — two parallel streams, one shared serialization point
 
-**Stream A (array/matrix, backs MATLAB/Octave and future APL/J/Scilab/IDL):**
+**Stream A (array/matrix, backs MATLAB/Octave/APL and future J/Scilab/IDL):**
 `SIR22` spec → `semantic-ir` core additions → `matlab-to-semantic-ir` →
 `octave-to-semantic-ir` → `sir-runtime-array` → JS/TS backend codegen →
-golden/oracle tests.
+`apl-to-semantic-ir` (SIR22 addendum for APL primitives) →
+`j-to-semantic-ir` → golden/oracle tests (in progress).
+All items through JS/TS backend codegen are shipped.
 
 **Stream B (symbolic/CAS, backs Wolfram/Macsyma/Maxima and future
 Reduce/Derive/Maple):** `SIR23` spec → `semantic-ir` core additions →
 `wolfram-to-semantic-ir` → `macsyma-to-semantic-ir` → `maxima-to-semantic-ir`
-→ `sir-runtime-symbolic` → JS/TS backend codegen → golden/oracle tests.
+→ `sir-runtime-symbolic` → JS/TS backend codegen → golden/oracle tests
+(in progress — real `node`-execution proof shipped for `wolfram-to-semantic-ir`
+and `macsyma-to-semantic-ir` via each crate's `tests/e2e_node.rs`; a true
+oracle diff against each language's native runtime remains open).
+All items through JS/TS backend codegen are shipped.
 
 The streams touch disjoint crates except `semantic-ir` core and the two JS
 backends — a short serialization point, not a merge of the whole effort.


### PR DESCRIPTION
## Summary

Overnight consolidated PR for the "Semantic IR" front (HML01) of the
three-front rotation. **Separate from** #8532 (the parser recursion-depth-cap
PR from tonight, a different subsystem) — kept apart per this repo's own
"don't cram unrelated subsystems into one PR" guidance, even though both are
overnight work meant for the same morning review sitting.

While investigating the next well-scoped item for HML01 (the effort to make
math-language frontends compile to JS/TS via the shared Semantic IR), I
found a **confirmed, currently-failing regression on `origin/main`**: both
`wolfram-to-semantic-ir` and `macsyma-to-semantic-ir` have a
`tests/test_validator.rs` that asserts the JS backend *rejects* every module
these frontends produce. That assertion was true when the file was written,
before `semantic-ir-to-javascript` implemented real SIR23 codegen (a prior,
separate PR). Once that codegen landed, the assertion became false for
every test in both files, but nobody updated them to match:

```
cargo test -p wolfram-to-semantic-ir --test test_validator   # 10/10 FAILED on origin/main
cargo test -p macsyma-to-semantic-ir --test test_validator   #  7/7 FAILED on origin/main
```

## What this PR does

1. Inverts the stale assertion in both files (`assert_js_backend_accepts`,
   checking `check_module` returns no errors) and rewrites the module doc
   comments to explain what changed and why (independently re-verified: the
   JS backend's `ACCEPTED_FEATURES` list and its inlined `Symbolic.*`
   runtime genuinely implement `SymApply`/`SymPatternBlank`/
   `SymPatternNamed`/`SymRule`/`SymReplaceAll` codegen today).
2. Adds `tests/e2e_node.rs` to both crates: actually compiles representative
   programs (arithmetic, patterns, rules, `/.`/`//.`, multi-statement) and
   executes the result via a spawned `node` subprocess — genuine proof the
   codegen path is executable, not just statically accepted. (These tests
   check "runs cleanly", not a printed value — each frontend's "everything
   is data" design means a compiled Wolfram/Macsyma program never produces
   a host-language computed value; see each file's own module doc comment.)
3. Fixes the now-stale `Cargo.toml` dev-dependency comments and
   `wolfram-to-semantic-ir/src/lower.rs`'s doc comment, which both still
   described `sir-runtime-symbolic`/SIR23 codegen as "future work."
4. Syncs `code/specs/HML01-math-to-semantic-ir.md`: the Wolfram bullet still
   claimed "no lowered module currently executes end-to-end... (does not
   exist yet)" — also stale. Added missing shipped-status markers for
   `macsyma-to-semantic-ir`/`maxima-to-semantic-ir`, and missing
   `apl-to-semantic-ir`/`j-to-semantic-ir` bullets (both shipped, never
   mentioned in this spec before).
5. CHANGELOG.md updated for both crates.

## Test plan

- [x] `cargo test -p wolfram-to-semantic-ir -p macsyma-to-semantic-ir -p maxima-to-semantic-ir -p semantic-ir-to-javascript` — all pass (18 test binaries, 0 failures)
- [x] Confirmed the 17 originally-failing tests now pass
- [x] `/security-review` run on the full diff — passed clean (verified the
      temp-file/subprocess handling in the new `e2e_node.rs` files uses
      `create_new(true)` against symlink attacks, and independently
      confirmed the capability-acceptance claim against the JS backend's
      actual source rather than trusting the diff's own comments)
- [x] No merge conflicts with `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)