### PR TITLE
feat(hl): how-are-you chapter — Italian & Portuguese (completes the 5-language set)

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -171,6 +171,7 @@
       "ES-SE-LLAMA": "se llama — 'he/she calls himself' (3rd-person of llamar)",
       "ES-WORD-MUCHO": "mucho — 'much / a lot'",
       "ES-VERB-ESTAR": "estar — 'to be' (temporary state / location; ← Latin stare 'to stand')",
+      "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -175,7 +175,8 @@
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
-      "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'"
+      "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
+      "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Chapter 2 — "Come stai?" (the how-are-you chapter)
+
+- **Chapter 2 authored** (`IT-C02-prego`, `-come`, `-stare`, `-come-stai`,
+  `-cosi-cosi`, `-practice`): the "how are you?" exchange, atom-first, reviewing
+  Chapter 1. Fourth track in the PR's cross-language how-are-you set, reusing the
+  canonical concepts `STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`, `WORD-SOSO`.
+  Register (tu/Lei) and the question word (come) are introduced inline, since the
+  track had no separate introductions chapter yet.
+- **Italian sits between the two metaphors**: it asks *Come stai?* on **stare**
+  (← Latin *stāre* "to stand" — literally Spanish *estar* with the propping *e-*
+  removed) **and** *Come va?* on **andare** ("to go") — so it bridges the
+  Spanish "stand" and the French/German "go."
+- **Etymology hooks**: *prego* ← *pregare* "to pray" (→ pray/precarious/deprecate),
+  behaving like German *bitte*; *come* ← *quōmodo* (sibling of *cómo*/*comment*);
+  *così così* ← *(ec)cum sīc* "thus" (the *[sic]* English still writes) — and
+  English "so-so" is a loan translation of it.
+- Taxonomy: namespaced `IT-VERB-STARE` documented.
+
 ## Chapter 1 — Greetings (track bootstrapped)
 
 - New Italian track on the HL00 framework: one word per lesson, slug ids,

--- a/code/learning/human-languages/italian/lessons/IT-C02-come-stai.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come-stai.md
@@ -1,0 +1,67 @@
+---
+id: IT-C02-come-stai
+chapter: 2
+type: phrase
+headword: Come stai?
+gloss: how are you? (informal); formal Come sta?; also Come va?
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [IT-C02-stare, IT-C02-come]
+sounds: [ai-glide]
+roots: [stare-latin, andare-latin]
+etymology_hook: "come (← quōmodo) + stai (stare 'to stand'); or Come va? — va from andare 'to go'"
+est_minutes: 4
+reviews_of: [IT-C02-stare, IT-C02-come]
+---
+
+# Come stai? — "how are you?"
+
+## Warm-up
+
+[PAUSE 2s] Both pieces are ready: **come** ("how") and **stare / stai** ("to
+be," from *stand*). Assemble Italian's everyday check-in — and meet its formal
+partner and a "go" cousin.
+
+## The phrase, taken apart
+
+> **Come stai?** = "How are you?" (informal)
+> literally: **"How do you stand?"**
+
+- **come** = "how" · **stai** = "you are/stand" (the *tu* form of *stare*).
+
+Italian, like Spanish, splits formal from informal — and here it also offers a
+"go" version, so you get **three** everyday forms:
+
+| register | question | verb → picture |
+|---|---|---|
+| **informal** (friend) | **Come stai?** | *stare* → "how do you **stand**?" |
+| **formal** (stranger, elder) | **Come sta?** | *stare*, *Lei* form |
+| **either, very common** | **Come va?** | *andare* → "how does it **go**?" |
+
+- **Lei** is the formal "you" — literally "she" (capitalized), a politeness that
+  addresses you in the third person, cousin to Spanish *usted* and German *Sie*.
+- **Come va?** uses **va**, from **andare** ("to go") — so Italian can ask it
+  *both* ways: standing (*stai*) **and** going (*va*). It sits right between the
+  Spanish "stand" and the French/German "go."
+
+## Where the five tracks land
+
+You've now seen the whole spread — same question, two metaphors:
+
+- **Stand:** Spanish *¿cómo estás?* · Italian *come stai?*
+- **Go:** French *comment ça va?* · German *wie geht's?* · Italian *come va?* (both!)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Come stai?" — informal, for a friend]
+- [YOU SAY: "Come sta?" — formal, for a stranger (Lei)]
+- [YOU SAY: "Come va?" — the "how's it going?" version]
+
+[REPEAT x2] "Come stai? — Sto bene, grazie." ("How are you? — I'm well, thanks.")
+
+## Wrap-up Recall
+
+[PAUSE 3s] *Come stai?* literally asks what? ("How do you **stand**?") What's the
+formal form, and what pronoun does it use? (*Come sta?*, with *Lei*, "she" as
+politeness.) Which verb is *Come va?* built on, and what does it mean? (*andare*,
+"to go" — "how does it go?") Next: the shrug — **così così**.

--- a/code/learning/human-languages/italian/lessons/IT-C02-come.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-come.md
@@ -1,0 +1,58 @@
+---
+id: IT-C02-come
+chapter: 2
+type: word
+headword: come
+gloss: how / like, as
+concept_tag: QUESTION-HOW
+prerequisites: [IT-C01-ciao]
+sounds: [soft-c]
+roots: [quomodo-latin]
+etymology_hook: "come ← Latin quōmodo 'in what manner' — the same root as Spanish cómo and French comment"
+est_minutes: 3
+reviews_of: [IT-C02-prego]
+---
+
+# come — "how," the third *quomodo* cousin
+
+## Warm-up
+
+[PAUSE 2s] To ask *how are you?* you need "how." In Italian it's **come** — and
+if you've seen the Spanish or French tracks, you already know its family.
+
+## Sounds you'll need
+
+- `soft-c` — **come** = *KOH-meh*. Here *c* is before *o*, so it's a **hard** *k*
+  (Italian *c* only softens to *ch* before *e/i*). Final *-e* is sounded:
+  *KOH-meh*.
+
+## The word, taken apart
+
+**come** = "how / like / as." Root: Latin **quōmodo**, "in what manner" — two
+words (*quō* "in what way" + *modo* "manner") fused and worn down. It is the
+**same source** as:
+
+- Spanish **cómo** ("how")
+- French **comment** ("how")
+- and, doubling as "like/as," it matches Spanish **como** and French **comme**.
+
+So one Latin *quōmodo* became the "how" word in all three Romance sisters. The
+*modo* piece ("manner, measure") also lives in English **mode**, **mod**el,
+**mod**erate — all about the *way* something is done.
+
+Note Italian *come* covers **both** jobs at once, and the written accent tells
+them apart only by context, not spelling: *Come stai?* ("**How** are you?") vs
+*bianco come la neve* ("white **as** snow").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "come" — *KOH-meh*]
+- [YOU SAY: come / cómo / comment — the three *quomodo* siblings]
+- [YOU SAY: English *mode, model* share the *modo* piece]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word gives *come*, and which Spanish and French words are
+its siblings? (*quōmodo* → *cómo*, *comment*.) What two jobs does *come* do?
+("How?" and "like/as.") Next: the verb it pairs with — **stare**.

--- a/code/learning/human-languages/italian/lessons/IT-C02-cosi-cosi.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-cosi-cosi.md
@@ -1,0 +1,70 @@
+---
+id: IT-C02-cosi-cosi
+chapter: 2
+type: word
+headword: così così
+gloss: so-so (literally "thus, thus" — "this way, that way")
+concept_tag: WORD-SOSO
+prerequisites: [IT-C02-come-stai]
+sounds: [soft-c, s-voiced]
+roots: [eccum-sic-latin]
+etymology_hook: "così ← Latin (ec)cum sīc 'thus, so'; sīc is the 'sic' English still writes"
+est_minutes: 3
+reviews_of: [IT-C01-buono, IT-C02-come-stai]
+---
+
+# così così — the original "so-so"
+
+## Warm-up
+
+[PAUSE 2s] English "so-so" is a **loan translation of the Italian** *così così*.
+Someone asks *Come stai?*; you're middling; you wobble a hand and say *così
+così* — "thus and thus," this way and that.
+
+## Sounds you'll need
+
+- `soft-c` — **così** = *koh-ZEE*: the *c* is before *o* (hard *k*), and the
+  single *s* between vowels is **voiced**, a *z* sound: *koh-**ZEE***. Stress the
+  end (that's what the accent on *ì* marks).
+
+## The word, taken apart
+
+**così** = "thus, so, in this way," from Latin **(ec)cum sīc**, "(behold) so."
+Doubled — *così così* — it means "**so** and **so**," neither up nor down: a
+verbal shrug.
+
+The core piece **sīc** ("thus, so") is one you already write in English:
+
+- **sic** — the *[sic]* you put after a quoted mistake means "**thus** it was
+  written."
+- It's also the Latin behind Spanish/French/Italian **sì / si / sì** ("yes" —
+  "it is *so*"), and the *-si* inside French **ain-si** ("thus").
+
+So *così così* is literally **"so, so"** — and English simply borrowed the shrug
+whole.
+
+## Grammar Lens: your answer ladder for *Come stai?*
+
+| answer | sense |
+|---|---|
+| **(Molto) bene, grazie** | (very) well, thanks |
+| **Così così** | so-so |
+| **Non c'è male** | "not bad" (lit. "there isn't bad") |
+
+The cross-track shrug set, now five deep: Italian **così così** ("so, so"),
+French **comme ci comme ça** ("like this, like that"), Spanish **más o menos**
+("more or less"), German **es geht** ("it goes").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "così così" — *koh-ZEE koh-ZEE*, with a hand-wobble]
+- [YOU SAY: answer "Come stai?" three ways — "Bene" / "Così così" / "Non c'è male"]
+- [YOU SAY: "sic" in English — "thus" — the same *sīc*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *così così* literally mean? ("Thus, thus / so, so.") What
+Latin word for "so" is inside it, and where do you still write it in English?
+(*sīc* → *[sic]*.) English "so-so" came from — which language? (Italian *così
+così*.) Next: put the exchange together.

--- a/code/learning/human-languages/italian/lessons/IT-C02-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-practice.md
@@ -1,0 +1,66 @@
+---
+id: IT-C02-practice
+chapter: 2
+type: practice-mix
+headword: (practice)
+gloss: the full "Come stai?" exchange, formal and informal
+concept_tag: CH2-PRACTICE
+prerequisites: [IT-C02-prego, IT-C02-come, IT-C02-stare, IT-C02-come-stai, IT-C02-cosi-cosi]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [IT-C02-prego, IT-C02-come-stai, IT-C02-cosi-cosi, IT-C01-practice]
+---
+
+# Practice — "Come stai?", start to finish
+
+## Warm-up
+
+[PAUSE 2s] No new words. This chapter's atoms — *prego, come, stare, come stai?,
+così così* — assemble into a real exchange, formal and informal. It picks up from
+the Chapter 1 greetings.
+
+## The exchange
+
+**Formal** (a stranger, an elder — *Lei*):
+
+> — Buongiorno. **Come sta?**
+> — **Bene, grazie.** E Lei?
+> — **Così così.**
+> — [after a small favour] — Grazie! — **Prego.**
+
+**Informal** (a friend — *tu*):
+
+> — Ciao! **Come stai?**
+> — **Sto bene, e tu?**
+> — Non c'è male.
+
+The glue is **e Lei? / e tu?** — "and you?" (*e* = "and," Latin *et*) — the
+Italian twin of Spanish *¿y usted?* and French *et toi?*.
+
+## What you've built this chapter
+
+- **prego** — you're welcome / please (← *pregare*, "to pray"; English
+  *precarious*).
+- **come** — how (← *quōmodo*; sibling of *cómo* / *comment*).
+- **stare** — "to be" from *stand* (= Spanish *estar*); vs *essere* (identity).
+- **Come stai? / sta? / va?** — informal, formal, and the "how's it going?"
+  form (*va* ← *andare*, "to go").
+- **così così** — so-so (English "so-so" borrowed it whole).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full *formal* exchange, both voices]
+- [YOU SAY: the same *informally* — *sta → stai*, *Lei → tu*]
+- [YOU SAY: all three questions — Come stai? / Come sta? / Come va?]
+
+[REPEAT x2] "Come stai? — Sto bene, grazie, e tu?" until it's reflex.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which verb carries *Come stai?*, and what does it literally ask?
+(*stare*, "to stand" — "how do you stand?") What does *prego* answer, and from
+what root? (*grazie*; ← *pregare*, "to pray.") Italian can ask "how are you" two
+ways — which verbs? (*stare*, stand; *andare* → *va*, go.) Next chapter:
+**introducing yourself** — mi chiamo, come ti chiami.

--- a/code/learning/human-languages/italian/lessons/IT-C02-prego.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-prego.md
@@ -1,0 +1,64 @@
+---
+id: IT-C02-prego
+chapter: 2
+type: word
+headword: prego
+gloss: you're welcome (and please, go ahead, after you)
+concept_tag: COURTESY-YOUREWELCOME
+prerequisites: [IT-C01-grazie]
+sounds: [hard-g-before-o]
+roots: [precari-latin]
+etymology_hook: "prego ← pregare 'to pray' (← Latin precārī) → English pray, precarious, deprecate"
+est_minutes: 3
+reviews_of: [IT-C01-grazie]
+---
+
+# prego — "you're welcome," literally "I pray"
+
+## Warm-up
+
+[PAUSE 2s] The *grazie* lesson already promised you this word. Someone says
+**grazie**; you reply **prego**. Like German *bitte*, it's a small word that does
+several jobs — and it comes straight from **praying**.
+
+## Sounds you'll need
+
+- `hard-g-before-o` — **prego** = *PREH-go* with a **hard** g. (Italian g is soft
+  only before *e/i*; here the g is followed by *o*, so it stays hard.)
+
+## The word, taken apart
+
+**prego** is "I pray" — the *io* ("I") form of **pregare**, "to pray, to beg,"
+from Latin **precārī**. When you answer *grazie* with *prego*, you're softly
+saying *"I pray (it was nothing) / please, don't mention it."*
+
+That root **prec-** ("pray, entreat") gives English a surprising family:
+
+- **pray**, **prayer** — the direct line.
+- **precarious** — literally "held by *prayer*," i.e. depending on someone's
+  goodwill, therefore unstable.
+- **deprecate** ("pray *away*, ward off") and **imprecation** ("a prayer
+  *against* — a curse").
+
+Like German **bitte**, *prego* stretches across situations, all of them a form
+of "I pray you":
+
+| you say *prego* when… | it means |
+|---|---|
+| answering *grazie* | **you're welcome** |
+| offering a seat / letting someone pass | **please, go ahead / after you** |
+| handing something over | **here you are** |
+| you didn't catch it | **sorry, come again?** |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "grazie" … "prego" — the full exchange]
+- [YOU SAY: "prego" then English "pray, precarious" — one family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What verb is *prego* the "I" form of? (*pregare*, "to pray.") What
+English word means "held by prayer" and so "unstable"? (*Precarious*.) Which
+German word does *prego* behave like? (*bitte* — one word, many courtesies.)
+Next: **come**, "how."

--- a/code/learning/human-languages/italian/lessons/IT-C02-stare.md
+++ b/code/learning/human-languages/italian/lessons/IT-C02-stare.md
@@ -1,0 +1,64 @@
+---
+id: IT-C02-stare
+chapter: 2
+type: word
+headword: stare
+gloss: to be (a state — how you're doing); literally "to stay/stand"
+concept_tag: IT-VERB-STARE
+prerequisites: []
+sounds: [st-clean]
+roots: [stare-latin]
+etymology_hook: "stare ← Latin stāre 'to stand' — the SAME verb as Spanish estar; come stai? = 'how do you stand?'"
+est_minutes: 4
+reviews_of: [IT-C02-come]
+---
+
+# stare — "to be," the standing kind (Spanish's estar, undressed)
+
+## Warm-up
+
+[PAUSE 2s] Like Spanish, Italian has **two** verbs for "to be" — **essere**
+(identity) and **stare** (state). "How are you?" runs on **stare**. And if you
+did the Spanish track, this is *estar* with its front *e* taken off.
+
+## Sounds you'll need
+
+- `st-clean` — Italian, unlike Spanish, is happy to start a word with *st-*: no
+  propping *e*. **stare** = *STAH-reh*, clean *st*, final *-e* sounded.
+
+## The word, taken apart
+
+**stare** comes straight from Latin **stāre**, *"to stand."* Spanish grew the
+same verb into **estar** (with a propping *e-*); Italian kept it bare as
+**stare**. Same Latin root, same job: the *temporary state* be-verb — how you
+*stand* right now.
+
+That **stā-** root stands behind a wall of English words: **stay**, **stand**,
+**state**, **status**, **stable**, **station**, **stance**, **e-state**,
+**con-stant**, **circum-stance**. So *Come stai?* is, at the root, **"how do you
+stand?"** — the very same picture as Spanish *¿Cómo estás?*.
+
+## Grammar Lens: essere vs stare, and the two forms you need
+
+| verb | from | job |
+|---|---|---|
+| **essere** | Latin *esse* | identity — *sono Marco*, "I am Marco" |
+| **stare** | Latin *stāre* | state / how you are — *sto bene*, "I'm well" |
+
+For this chapter, just two forms of *stare*:
+
+- **stai** — "you are" (informal, *tu*)
+- **sta** — "you are" (formal, *Lei*) / "he/she is"
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "stare" — *STAH-reh*, clean *st*]
+- [YOU SAY: "stai" … "sta" — the two forms you'll ask with]
+- [YOU SAY: Italian *stare* = Spanish *estar*, same Latin *stāre* "to stand"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *stare*, and which Spanish verb is its twin?
+("To stand," *stāre* — Spanish *estar*.) Which Italian be-verb is for how you
+feel — *essere* or *stare*? (*stare*.) Next: ask it — **Come stai?**

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -14,13 +14,17 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
 
 - **Ch. 1 — Greetings**: ciao → buono → **il/la/lo** (gender) → giorno →
   **buongiorno** → sera/buonasera → notte/buonanotte → grazie → practice.
+- **Ch. 2 — "Come stai?"**: prego (← *pregare* "to pray") → come (← *quōmodo*) →
+  **stare** ("to be" from *stand* = Spanish *estar*; vs *essere*) → come stai /
+  sta / **va** (also *andare* "to go") → così così → practice. **Authored.**
+  *(Reordered ahead of introductions to widen the cross-language how-are-you set;
+  register tu/Lei introduced inline.)*
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *mi chiamo*, **tu / Lei** (informal vs formal "you"), come, piacere |
-| 3 | Responding: come stai / come sta, bene, e tu / e Lei |
+| 3 | Introducing yourself: *mi chiamo*, come ti chiami, piacere |
 | 4 | Farewells: arrivederci, a presto, a domani |
 | 5+ | Numbers, time, days & months, family, food — following the shared theme order |
 

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter 2 — "Tudo bem?" (the how-are-you chapter)
+
+- **Chapter 2 authored** (`PT-C02-de-nada`, `-como`, `-tudo`, `-tudo-bem`,
+  `-mais-ou-menos`, `-practice`): the "how are you?" exchange, atom-first,
+  reviewing Chapter 1. Fifth and final track in the PR's cross-language
+  how-are-you set, reusing `STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`,
+  `WORD-SOSO`. Reordered ahead of introductions to widen the set (register
+  você / o senhor introduced inline).
+- **Portuguese's distinctive move — the verb-free greeting**: *Tudo bem?*
+  ("everything well?") uses **no pronoun and no verb**, dodging the
+  você/tu/senhor tangle; built on **tudo** ← Latin *tōtus* "whole" (→ total/
+  teetotal) + **bem** ← *bene*. It also does *Como vai?* (*ir*, "to go" — with
+  French/German) **and** *Como está?* (*estar*, "to stand" — with Spanish/
+  Italian), so Portuguese spans all three patterns.
+- **Etymology hooks**: *de nada* ← *nāta* "born thing" (exact twin of Spanish);
+  *como* ← *quōmodo*; *mais ou menos* ← *magis* + *minus* (twin of Spanish *más
+  o menos*); and *você* ← *vossa mercê* "your mercy" — the same "your grace"
+  origin as Spanish *usted*.
+- Taxonomy: namespaced `PT-WORD-TUDO` documented.
+
 ## Chapter 1 — Greetings (track bootstrapped)
 
 - New Portuguese track on the HL00 framework: one word per lesson, slug ids,

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-como.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-como.md
@@ -1,0 +1,63 @@
+---
+id: PT-C02-como
+chapter: 2
+type: word
+headword: como
+gloss: how / like, as
+concept_tag: QUESTION-HOW
+prerequisites: [PT-C01-ola]
+sounds: [final-o-is-u]
+roots: [quomodo-latin]
+etymology_hook: "como ← Latin quōmodo 'in what manner' — the same root as Spanish cómo, Italian come"
+est_minutes: 3
+reviews_of: [PT-C02-de-nada]
+---
+
+# como — "how," the fourth *quomodo* cousin
+
+## Warm-up
+
+[PAUSE 2s] One of two everyday ways to ask *how are you?* in Portuguese starts
+with **como**, "how." It's the same word you've met (or will meet) across the
+Romance family.
+
+## Sounds you'll need
+
+- `final-o-is-u` — **como** = *KOH-moo*: the final unstressed *-o* is said like
+  *u*. (Portuguese does this to nearly every final *-o*: *obrigado* → *-doo*.)
+
+## The word, taken apart
+
+**como** = "how / like / as." Root: Latin **quōmodo**, "in what manner" — *quō*
+("in what way") + *modo* ("manner"). It is the **same source** as its siblings:
+
+- Spanish **cómo**, Italian **come**, French **comment** — all "how."
+- Doubling as "like/as," it matches Spanish *como*, Italian *come*.
+
+Notice Portuguese and Spanish look almost identical here — *como* vs *cómo* — the
+only visible difference is the Spanish written accent that marks the *question*.
+Portuguese leans on context and the question mark instead. The *modo* piece
+lives on in English **mode**, **mod**el, **mod**erate.
+
+## Grammar Lens: the two Portuguese "how are you"s
+
+Portuguese asks after you **two** ways, and you'll assemble both next lesson:
+
+- **Como vai?** — "how do you **go**?" (verb *ir*, "to go" — like French/German).
+- **Como está?** — "how do you **stand/are**?" (verb *estar* — like Spanish).
+
+Plus a third, verb-free favourite — **Tudo bem?** — coming up.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "como" — *KOH-moo*]
+- [YOU SAY: como / cómo / come / comment — the four *quomodo* siblings]
+- [YOU SAY: "Como vai?" and "Como está?" — go, and stand]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word gives *como*, and name two siblings. (*quōmodo* →
+*cómo*, *come*, *comment*.) What's the only written difference between Portuguese
+*como* and Spanish *cómo*? (The Spanish accent that marks a question.) Next: the
+word behind Portuguese's favourite greeting — **tudo**.

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-de-nada.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-de-nada.md
@@ -1,0 +1,60 @@
+---
+id: PT-C02-de-nada
+chapter: 2
+type: phrase
+headword: de nada
+gloss: you're welcome (literally "of nothing")
+concept_tag: COURTESY-YOUREWELCOME
+prerequisites: [PT-C01-obrigado]
+sounds: [final-a-reduces]
+roots: [de-latin, nata-latin]
+etymology_hook: "nada ← Latin (rem) nāta 'a born thing' → 'nothing' — the same word as Spanish nada"
+est_minutes: 3
+reviews_of: [PT-C01-obrigado]
+---
+
+# de nada — "you're welcome," or "it was nothing"
+
+## Warm-up
+
+[PAUSE 2s] You already say **obrigado / obrigada** ("I am obliged"). The reply
+that closes the exchange is **de nada** — "of nothing" — the very same phrase,
+word for word, as Spanish.
+
+## Sounds you'll need
+
+- `final-a-reduces` — **de nada** ≈ *dee NAH-duh*: unstressed final *-a* softens
+  toward *uh*; the *d* is soft.
+
+## The phrase, taken apart
+
+- **de** = "of / from" (Latin **dē**).
+- **nada** = "nothing" — and it has the same buried story as its Spanish twin.
+
+**nada** comes from Latin **(rēs) nāta**, *"a born thing"* — from *nāscī*, "to be
+born" (English **nat**ive, **nat**ure, **nat**al, re-**nais-sance**). Latin
+*nōn … rēs nāta*, "not a single born thing," wore down until the "born thing"
+word, **nada**, came to mean **nothing** by itself.
+
+Portuguese and Spanish inherited the identical word and the identical courtesy:
+
+| language | "you're welcome" | the "nothing" word |
+|---|---|---|
+| **Portuguese** | *de nada* | *nada* ← *nāta*, "a born thing" |
+| **Spanish** | *de nada* | *nada* ← *nāta*, "a born thing" |
+| **French** | *de rien* | *rien* ← *rem*, "a thing" |
+
+So Iberia says "of no *born-thing*"; France says "of no *thing*." Same shrug of
+the shoulders, one Latin idea.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "obrigado / obrigada" … "de nada" — the full exchange]
+- [YOU SAY: "de nada" then English "native, nature" — nada's true family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did *nada* originally mean in Latin? (A *born thing* — *nāta*.)
+Which language shares *de nada* exactly, and which uses *de rien* instead?
+(Spanish; French.) Next: **como**, "how."

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-mais-ou-menos.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-mais-ou-menos.md
@@ -1,0 +1,68 @@
+---
+id: PT-C02-mais-ou-menos
+chapter: 2
+type: word
+headword: mais ou menos
+gloss: so-so (literally "more or less")
+concept_tag: WORD-SOSO
+prerequisites: [PT-C02-tudo-bem]
+sounds: [nasal-ai, final-o-is-u]
+roots: [magis-latin, minus-latin]
+etymology_hook: "mais ← Latin magis 'more'; menos ← minus 'less' — the same shrug as Spanish más o menos"
+est_minutes: 3
+reviews_of: [PT-C02-tudo, PT-C02-tudo-bem]
+---
+
+# mais ou menos — the "more or less" shrug
+
+## Warm-up
+
+[PAUSE 2s] Someone asks *Tudo bem?* You're okay-ish. The Portuguese shrug is
+**mais ou menos** — "more or less" — the same words, root for root, that Spanish
+uses.
+
+## Sounds you'll need
+
+- `nasal-ai` — **mais** ≈ *mais* with a nasal glide (*maish* in Brazil, the *s*
+  a soft *sh*).
+- `final-o-is-u` — **menos** ≈ *MEH-noos*; **ou** = a closed *oh*.
+
+## The word, taken apart
+
+**mais ou menos** = literally **"more or less."** Every piece is Latin at heart:
+
+- **mais** = "more," from Latin **magis** ("more") — cousin of *major*, *master*,
+  *maximum*, *mayor*.
+- **ou** = "or," from Latin **aut**.
+- **menos** = "less," from Latin **minus** — the very word English borrowed for
+  *minus*, *minor*, *minimum*, *minus*cule.
+
+So *mais ou menos* is a **word-for-word twin of Spanish *más o menos*** — Iberia's
+shared shrug. (Portuguese *mais* and Spanish *más* are the same *magis*; the
+nasal *-ais* is just Portuguese's accent.)
+
+## Grammar Lens: your answer ladder for *Tudo bem?*
+
+| answer | sense |
+|---|---|
+| **Tudo bem / Tudo ótimo** | all well / all great |
+| **Mais ou menos** | so-so |
+| **Mais ou menos** + a hand-wobble | "eh, could be better" |
+
+The five-language shrug set is now complete: Portuguese/Spanish **mais/más o
+menos** ("more or less"), Italian **così così** ("so, so"), French **comme ci
+comme ça** ("like this, like that"), German **es geht** ("it goes").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mais ou menos" — with a little wobble]
+- [YOU SAY: answer "Tudo bem?" two ways — "Tudo bem!" / "Mais ou menos"]
+- [YOU SAY: Portuguese *mais ou menos* = Spanish *más o menos*, same Latin *magis*/*minus*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *mais ou menos* literally mean? ("More or less.") What Latin
+words are *mais* and *menos* from, and their English cousins? (*magis* → major/
+maximum; *minus* → minor/minus.) Which language's shrug is its exact twin?
+(Spanish *más o menos*.) Next: put the whole exchange together.

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-practice.md
@@ -1,0 +1,65 @@
+---
+id: PT-C02-practice
+chapter: 2
+type: practice-mix
+headword: (practice)
+gloss: the full "Tudo bem?" exchange, casual and formal
+concept_tag: CH2-PRACTICE
+prerequisites: [PT-C02-de-nada, PT-C02-como, PT-C02-tudo, PT-C02-tudo-bem, PT-C02-mais-ou-menos]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [PT-C02-de-nada, PT-C02-tudo-bem, PT-C02-mais-ou-menos, PT-C01-practice]
+---
+
+# Practice — "Tudo bem?", start to finish
+
+## Warm-up
+
+[PAUSE 2s] No new words. This chapter's atoms — *de nada, como, tudo, tudo bem?,
+mais ou menos* — assemble into a real exchange. It picks up from the Chapter 1
+greetings.
+
+## The exchange
+
+**Casual** (anyone — the verb-free favourite):
+
+> — Olá! **Tudo bem?**
+> — **Tudo bem, e você?**
+> — **Mais ou menos.**
+> — [after a small favour] — Obrigado! — **De nada.**
+
+**A touch more formal** (with a verb):
+
+> — Bom dia. **Como está o senhor?**
+> — **Bem, obrigado.** E o senhor?
+> — Tudo bem.
+
+The glue is **e você? / e o senhor?** — "and you?" (*e* = "and," Latin *et*), the
+Portuguese twin of Spanish *¿y usted?* and Italian *e Lei?*.
+
+## What you've built this chapter
+
+- **de nada** — you're welcome (← *nāta*, "born thing" → "nothing"; = Spanish).
+- **como** — how (← *quōmodo*; sibling of *cómo* / *come* / *comment*).
+- **tudo** — everything (← *tōtus*; English *total*), the heart of *Tudo bem?*.
+- **Tudo bem? / Como vai? / Como está?** — the verb-free, the "go," and the
+  "stand" questions.
+- **mais ou menos** — so-so (twin of Spanish *más o menos*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full *casual* exchange, both voices]
+- [YOU SAY: the more formal version with *Como está o senhor?*]
+- [YOU SAY: all three questions — Tudo bem? / Como vai? / Como está?]
+
+[REPEAT x2] "Tudo bem? — Tudo bem, e você?" until it's reflex.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is *Tudo bem?* the easiest greeting? (No pronoun or verb — skips
+register.) *Como vai?* vs *Como está?* — which metaphors? (Go, *ir*; stand,
+*estar*.) What does *de nada* literally say, and which language shares it
+exactly? ("Of nothing"; Spanish.) Next chapter: **introducing yourself** — meu
+nome é, como se chama.

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-tudo-bem.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-tudo-bem.md
@@ -1,0 +1,68 @@
+---
+id: PT-C02-tudo-bem
+chapter: 2
+type: phrase
+headword: Tudo bem?
+gloss: how are you? (also Como vai? / Como está?)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [PT-C02-tudo, PT-C02-como]
+sounds: [nasal-em]
+roots: [totus-latin, ire-latin, stare-latin]
+etymology_hook: "Tudo bem? = 'everything well?' (no verb); Como vai? (ir 'to go') / Como está? (estar 'to stand')"
+est_minutes: 4
+reviews_of: [PT-C02-tudo, PT-C02-como]
+---
+
+# Tudo bem? — "how are you?", three ways
+
+## Warm-up
+
+[PAUSE 2s] Portuguese gives you three everyday ways to ask *how are you?* — one
+with no verb at all, one on "to go," one on "to stand." All three pieces are
+already yours.
+
+## The three forms
+
+| form | literally | verb |
+|---|---|---|
+| **Tudo bem?** (also *Tudo bom?*) | "everything well?" | *(none — tudo + bem)* |
+| **Como vai?** | "how do you **go**?" | *ir*, "to go" (vai = "goes") |
+| **Como está?** | "how are you / **stand**?" | *estar*, "to be/stand" |
+
+- **Tudo bem?** is the friendly default — **no pronoun, no verb**, so it dodges
+  the register question entirely. Answer with the same words: *Tudo bem.*
+- **Como vai?** puts Portuguese with **French and German** (state as *going* —
+  *vai* is from **ir**, "to go," ← Latin *īre*, English *exit/transit*).
+- **Como está?** puts it with **Spanish and Italian** (state as *standing* —
+  *está* is from **estar**, ← Latin *stāre*). Portuguese, like Italian, does
+  **both.**
+
+## Grammar Lens: the "you" you're skipping
+
+When you *do* want a pronoun, everyday Portuguese uses **você** ("you," worn down
+from *vossa mercê*, "your mercy" — the very same "your grace" origin as Spanish
+*usted*!). For respect, **o senhor / a senhora** ("the gentleman / the lady").
+But *Tudo bem?* lets you greet anyone without choosing — which is exactly why
+it's everywhere.
+
+## The full five-language map (this PR)
+
+- **Stand** (*estar/stare*): Spanish, Italian, Portuguese (*Como está?*)
+- **Go** (*aller/gehen/ir*): French, German, Portuguese (*Como vai?*), Italian (*Come va?*)
+- **Neither** — just "everything well?": Portuguese *Tudo bem?*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Tudo bem?" — the no-pronoun favourite]
+- [YOU SAY: "Como vai?" (go) and "Como está?" (stand)]
+- [YOU SAY: "Tudo bem? — Tudo bem, e você?" — bounce it back with *e você?*]
+
+[REPEAT x2] "Tudo bem? — Tudo bem!" question and answer, same two words.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is *Tudo bem?* so handy? (No pronoun/verb — skips the register
+choice.) *Como vai?* and *Como está?* use which two verbs, and which metaphors?
+(*ir* = go; *estar* = stand.) Where does *você* come from? (*vossa mercê*, "your
+mercy" — like Spanish *usted*.) Next: the so-so answer, **mais ou menos**.

--- a/code/learning/human-languages/portuguese/lessons/PT-C02-tudo.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C02-tudo.md
@@ -1,0 +1,64 @@
+---
+id: PT-C02-tudo
+chapter: 2
+type: word
+headword: tudo
+gloss: everything / all
+concept_tag: PT-WORD-TUDO
+prerequisites: []
+sounds: [final-o-is-u]
+roots: [totus-latin]
+etymology_hook: "tudo ← Latin tōtus 'whole, entire' → English total, totally, teetotal"
+est_minutes: 3
+reviews_of: [PT-C02-como]
+---
+
+# tudo — "everything," the heart of *Tudo bem?*
+
+## Warm-up
+
+[PAUSE 2s] The most Brazilian way to greet someone doesn't use a "you" or a
+"to be" at all — it just asks **Tudo bem?**, "everything well?" To own it, learn
+its first word: **tudo**, "everything."
+
+## Sounds you'll need
+
+- `final-o-is-u` — **tudo** = *TOO-doo*: final *-o* → *u*, and the *d* is soft.
+
+## The word, taken apart
+
+**tudo** = "everything, all," from Latin **tōtus**, *"whole, entire."* You ask
+whether the **whole** of someone's life is going well — *is everything OK?*
+
+That root **tōtus** is completely at home in English:
+
+- **total**, **totally**, **totality** — the whole amount.
+- **teetotal** — "**total**ly" abstaining (a playful reduplication of *total*).
+- Italian **tutto**, Spanish **todo**, French **tout** — the same *tōtus* across
+  the family (you'll hear Spanish *todo* echoing this).
+
+## Grammar Lens: pairing it with "well"
+
+Portuguese "well" is **bem** (← Latin *bene*, "well" — the *bene* of *bene*fit,
+*bene*volent; cousin of Spanish *bien*, French *bien*). Put them together:
+
+> **Tudo bem?** = "Everything well?" → "How are you? / You OK?"
+
+The magic: **no pronoun, no verb.** You skip the whole *você / tu / o senhor*
+tangle. That's why *Tudo bem?* is the friendliest, safest opener in Brazilian
+Portuguese — and you can answer with the very same two words: **Tudo bem.**
+("Everything's well.") Or just **Tudo bom.**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tudo" — *TOO-doo*]
+- [YOU SAY: "Tudo bem?" — everything well?]
+- [YOU SAY: "tudo" then English "total, totally" — one family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word gives *tudo*, and its English cousins? (*tōtus* →
+total, totally, teetotal.) Why is *Tudo bem?* so easy to use? (No pronoun, no
+verb — it dodges the *você/tu/senhor* choice.) What's Portuguese for "well"?
+(*bem* ← *bene*.) Next: assemble all three "how are you"s.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -15,13 +15,17 @@ French.
 
 - **Ch. 1 — Greetings**: olá → bom/boa → **o/a** (gender) → dia → **bom dia** →
   tarde/boa tarde → noite/boa noite → obrigado/obrigada → practice.
+- **Ch. 2 — "Tudo bem?"**: de nada (← *nāta*) → como (← *quōmodo*) → **tudo**
+  (← *tōtus* "whole") → tudo bem? / como vai? (*ir*, go) / como está? (*estar*,
+  stand) → mais ou menos → practice. **Authored** — the verb-free *Tudo bem?* is
+  the distinctive Portuguese move; reordered ahead of introductions, register
+  você/o senhor inline.
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *chamo-me / o meu nome é*, **tu / você** (familiar vs polite "you"), como, prazer |
-| 3 | Responding: como está / tudo bem, bem, e você |
+| 3 | Introducing yourself: *chamo-me / o meu nome é*, como se chama, prazer |
 | 4 | Farewells: adeus, até logo, até amanhã |
 | 5+ | Numbers, time, days & months, family, food — following the shared theme order |
 


### PR DESCRIPTION
## How-are-you, Italian + Portuguese — completing the five-language set

Follow-on to the merged #8528. That PR built the "how are you?" chapter in
parallel across Spanish / French / German; this adds **Italian** and
**Portuguese**, so the same chapter — and the same three canonical concepts
(`STATE-HOW-ARE-YOU`, `COURTESY-YOUREWELCOME`, `WORD-SOSO`) — now spans five
languages for cross-language interleaving. Both tracks were still at Chapter 1
(greetings), so each how-are-you chapter is **self-contained**: the "how" word
and the formal/informal register are introduced inline (I reordered it ahead of
the introductions chapter and updated each roadmap — noted in the commits).

### The completed metaphor map

| pattern | languages |
|---|---|
| **stand** (*estar / stare*) | Spanish *¿cómo estás?*, **Italian *come stai?***, **Portuguese *como está?*** |
| **go** (*aller / gehen / ir / andare*) | French, German, **Italian *come va?***, **Portuguese *como vai?*** |
| **neither** (verb-free) | **Portuguese *Tudo bem?*** ("everything well?") |

Italian bridges both (*come stai?* stand + *come va?* go); Portuguese does all
three, and its signature **Tudo bem?** uses no pronoun and no verb — dodging the
*você / tu / senhor* tangle entirely.

### Commits
1. **`99d5857` Italian Ch. 2 — *Come stai?*** — prego (← *pregare* "to pray";
   like German *bitte*), come (← *quōmodo*), stare (← *stāre* = Spanish *estar*),
   come stai/sta/va, così così (← *sīc* "thus" — the *[sic]* we write; English
   "so-so" is a loan translation).
2. **`48cfbb2` Portuguese Ch. 2 — *Tudo bem?*** — de nada (← *nāta*, twin of
   Spanish), como (← *quōmodo*), tudo (← *tōtus* "whole" → total), Tudo bem? /
   Como vai? / Como está?, mais ou menos (twin of *más o menos*). *você* ← *vossa
   mercê* "your mercy" (same origin as Spanish *usted*).

### Checks
- 38 data-package tests pass; validator clean.
- Security review: **passed**, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
