### PR TITLE
feat(dartmouth-basic-parser): add C# and F# ports

### DIFF
--- a/code/packages/csharp/dartmouth-basic-parser/BUILD
+++ b/code/packages/csharp/dartmouth-basic-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.DartmouthBasicParser.Tests/CodingAdventures.DartmouthBasicParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.DartmouthBasicParser]*"

--- a/code/packages/csharp/dartmouth-basic-parser/BUILD_windows
+++ b/code/packages/csharp/dartmouth-basic-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.DartmouthBasicParser.Tests/CodingAdventures.DartmouthBasicParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.DartmouthBasicParser]*"

--- a/code/packages/csharp/dartmouth-basic-parser/CHANGELOG.md
+++ b/code/packages/csharp/dartmouth-basic-parser/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a grammar-driven Dartmouth BASIC parser.
+- Provide one-shot and configured-parser APIs.
+- Require complete token-stream consumption for syntax errors.

--- a/code/packages/csharp/dartmouth-basic-parser/CodingAdventures.DartmouthBasicParser.csproj
+++ b/code/packages/csharp/dartmouth-basic-parser/CodingAdventures.DartmouthBasicParser.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.DartmouthBasicParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Grammar-driven parser for the original 1964 Dartmouth BASIC language</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/dartmouth_basic/dartmouth_basic.grammar" LogicalName="dartmouth_basic.grammar" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.csproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.csproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.csproj" />
+    <ProjectReference Include="../dartmouth-basic-lexer/CodingAdventures.DartmouthBasicLexer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/dartmouth-basic-parser/DartmouthBasicParser.cs
+++ b/code/packages/csharp/dartmouth-basic-parser/DartmouthBasicParser.cs
@@ -1,0 +1,89 @@
+using System.Text;
+using CodingAdventures.GrammarTools;
+using CodingAdventures.Lexer;
+using CodingAdventures.Parser;
+
+namespace CodingAdventures.DartmouthBasicParser;
+
+/// <summary>
+/// Parses original 1964 Dartmouth BASIC source into a grammar-shaped AST.
+/// </summary>
+public sealed class DartmouthBasicParser
+{
+    private const string GrammarResource = "dartmouth_basic.grammar";
+    private static readonly Lazy<ParserGrammar> ParserGrammar = new(ParseParserGrammar);
+    private readonly IReadOnlyList<Token> _tokens;
+
+    private DartmouthBasicParser(IReadOnlyList<Token> tokens) => _tokens = tokens;
+
+    /// <summary>Tokenizes <paramref name="source"/> and creates a configured parser.</summary>
+    public static DartmouthBasicParser CreateDartmouthBasicParser(string source) =>
+        new(CodingAdventures.DartmouthBasicLexer.DartmouthBasicLexer.TokenizeDartmouthBasic(source));
+
+    /// <summary>Parses an existing Dartmouth BASIC token stream.</summary>
+    public static ASTNode ParseTokens(IReadOnlyList<Token> tokens)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+        return new DartmouthBasicParser(tokens).Parse();
+    }
+
+    /// <summary>Tokenizes and parses <paramref name="source"/> in one call.</summary>
+    public static ASTNode ParseDartmouthBasic(string source) =>
+        CreateDartmouthBasicParser(source).Parse();
+
+    /// <summary>Parses the configured token stream and requires complete input consumption.</summary>
+    public ASTNode Parse()
+    {
+        try
+        {
+            var ast = new GrammarParser(ParserGrammar.Value).Parse(_tokens);
+            EnsureCompleteParse(ast);
+            return ast;
+        }
+        catch (GrammarParseError error)
+        {
+            throw new ArgumentException("Dartmouth BASIC parse failed: " + error.Message, "source", error);
+        }
+    }
+
+    private void EnsureCompleteParse(ASTNode ast)
+    {
+        if (_tokens.Count == 0 || _tokens[^1].EffectiveTypeName != "EOF")
+        {
+            var finalToken = _tokens.Count > 0 ? _tokens[^1] : null;
+            throw new GrammarParseError("Token stream must end with EOF", finalToken);
+        }
+
+        var eofIndex = _tokens.Count - 1;
+        var parsedTokenCount = CountTokens(ast);
+        if (parsedTokenCount != eofIndex)
+        {
+            var token = parsedTokenCount < _tokens.Count ? _tokens[parsedTokenCount] : null;
+            throw new GrammarParseError("Unexpected token while parsing program", token);
+        }
+    }
+
+    private static int CountTokens(ASTNode node) =>
+        node.Children.Sum(child => child switch
+        {
+            Token => 1,
+            ASTNode nested => CountTokens(nested),
+            _ => 0,
+        });
+
+    private static ParserGrammar ParseParserGrammar()
+    {
+        try
+        {
+            var assembly = typeof(DartmouthBasicParser).Assembly;
+            using var stream = assembly.GetManifestResourceStream(GrammarResource)
+                ?? throw new InvalidOperationException("Missing bundled resource: " + GrammarResource);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return ParserGrammarParser.Parse(reader.ReadToEnd());
+        }
+        catch (ParserGrammarError error)
+        {
+            throw new InvalidOperationException("Failed to parse bundled Dartmouth BASIC grammar", error);
+        }
+    }
+}

--- a/code/packages/csharp/dartmouth-basic-parser/README.md
+++ b/code/packages/csharp/dartmouth-basic-parser/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.DartmouthBasicParser
+
+A pure C# parser for the original 1964 Dartmouth BASIC language. It tokenizes
+source with `DartmouthBasicLexer`, loads the shared `dartmouth_basic.grammar`
+from an embedded resource, and produces the generic grammar-parser `ASTNode`.
+
+```csharp
+var ast = DartmouthBasicParser.ParseDartmouthBasic(
+    "10 LET X = 5\n20 PRINT X\n30 END\n");
+Console.WriteLine(ast.RuleName); // program
+```
+
+`CreateDartmouthBasicParser` provides the two-step API, while `ParseTokens`
+accepts an existing lexer token stream. Parsing requires every non-EOF token to
+be consumed, so incomplete or malformed statements are rejected rather than
+treated as a shorter program. No filesystem or network access is required at
+runtime.

--- a/code/packages/csharp/dartmouth-basic-parser/required_capabilities.json
+++ b/code/packages/csharp/dartmouth-basic-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/dartmouth-basic-parser",
+  "capabilities": [],
+  "justification": "Parsing is pure and uses a bundled grammar resource."
+}

--- a/code/packages/csharp/dartmouth-basic-parser/tests/CodingAdventures.DartmouthBasicParser.Tests/CodingAdventures.DartmouthBasicParser.Tests.csproj
+++ b/code/packages/csharp/dartmouth-basic-parser/tests/CodingAdventures.DartmouthBasicParser.Tests/CodingAdventures.DartmouthBasicParser.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.DartmouthBasicParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/dartmouth-basic-parser/tests/CodingAdventures.DartmouthBasicParser.Tests/DartmouthBasicParserTests.cs
+++ b/code/packages/csharp/dartmouth-basic-parser/tests/CodingAdventures.DartmouthBasicParser.Tests/DartmouthBasicParserTests.cs
@@ -1,0 +1,90 @@
+using CodingAdventures.Parser;
+using BasicLexer = CodingAdventures.DartmouthBasicLexer.DartmouthBasicLexer;
+using BasicParser = CodingAdventures.DartmouthBasicParser.DartmouthBasicParser;
+
+namespace CodingAdventures.DartmouthBasicParser.Tests;
+
+public sealed class DartmouthBasicParserTests
+{
+    [Fact]
+    public void ParsesTheCompleteStatementAndExpressionSurface()
+    {
+        const string source = """
+            10 LET X = FNA(SIN(-X)) ^ 2 + A(1) / 3
+            20 PRINT "HELLO", X;
+            30 INPUT A, B
+            40 IF X >= 0 THEN 100
+            50 GOTO 100
+            60 GOSUB 200
+            70 RETURN
+            80 FOR I = 1 TO 10 STEP 2
+            90 NEXT I
+            100 STOP
+            110 REM THIS BODY IS IGNORED @@@
+            120 READ A, B
+            130 DATA 1, 2, 3
+            140 RESTORE
+            150 DIM A(10), B(2, 3)
+            160 DEF FNA(T) = T * T
+            170 END
+            """ + "\n";
+
+        var ast = BasicParser.ParseDartmouthBasic(source);
+        var rules = Descendants(ast).Select(node => node.RuleName).ToHashSet();
+
+        Assert.Equal("program", ast.RuleName);
+        Assert.True(ast.DescendantCount() > 100);
+        Assert.Contains("let_stmt", rules);
+        Assert.Contains("print_stmt", rules);
+        Assert.Contains("if_stmt", rules);
+        Assert.Contains("for_stmt", rules);
+        Assert.Contains("data_stmt", rules);
+        Assert.Contains("dim_stmt", rules);
+        Assert.Contains("def_stmt", rules);
+    }
+
+    [Fact]
+    public void ConfiguredParserParsesBareAndEmptyPrograms()
+    {
+        Assert.Equal("program", BasicParser.CreateDartmouthBasicParser("10\n").Parse().RuleName);
+        Assert.Equal("program", BasicParser.ParseDartmouthBasic(string.Empty).RuleName);
+        Assert.Equal("program", BasicParser.ParseTokens(BasicLexer.TokenizeDartmouthBasic("20 END\n")).RuleName);
+    }
+
+    [Theory]
+    [InlineData("10 LET X 5\n")]
+    [InlineData("10 IF X > 0 100\n")]
+    [InlineData("10 FOR I = 1\n")]
+    [InlineData("10 END @\n")]
+    public void RejectsMalformedOrUnconsumedInput(string source)
+    {
+        var error = Assert.Throws<ArgumentException>(() => BasicParser.ParseDartmouthBasic(source));
+        Assert.Contains("Dartmouth BASIC parse failed", error.Message);
+    }
+
+    [Fact]
+    public void RejectsNullSource() =>
+        Assert.Multiple(
+            () => Assert.Throws<ArgumentNullException>(() => BasicParser.CreateDartmouthBasicParser(null!)),
+            () => Assert.Throws<ArgumentNullException>(() => BasicParser.ParseTokens(null!)));
+
+    [Fact]
+    public void TokenApiRequiresFinalEof()
+    {
+        var tokens = BasicLexer.TokenizeDartmouthBasic("20 END\n").SkipLast(1).ToArray();
+        Assert.Throws<ArgumentException>(() => BasicParser.ParseTokens(tokens));
+        Assert.Throws<ArgumentException>(() => BasicParser.ParseTokens([]));
+    }
+
+    private static IEnumerable<ASTNode> Descendants(ASTNode node)
+    {
+        yield return node;
+        foreach (var child in node.Children.OfType<ASTNode>())
+        {
+            foreach (var descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/code/packages/fsharp/dartmouth-basic-parser/BUILD
+++ b/code/packages/fsharp/dartmouth-basic-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.DartmouthBasicParser.Tests/CodingAdventures.DartmouthBasicParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.DartmouthBasicParser.FSharp]*"

--- a/code/packages/fsharp/dartmouth-basic-parser/BUILD_windows
+++ b/code/packages/fsharp/dartmouth-basic-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.DartmouthBasicParser.Tests/CodingAdventures.DartmouthBasicParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.DartmouthBasicParser.FSharp]*"

--- a/code/packages/fsharp/dartmouth-basic-parser/CHANGELOG.md
+++ b/code/packages/fsharp/dartmouth-basic-parser/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add a grammar-driven Dartmouth BASIC parser.
+- Provide one-shot and configured-parser APIs.
+- Require complete token-stream consumption for syntax errors.

--- a/code/packages/fsharp/dartmouth-basic-parser/CodingAdventures.DartmouthBasicParser.fsproj
+++ b/code/packages/fsharp/dartmouth-basic-parser/CodingAdventures.DartmouthBasicParser.fsproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.DartmouthBasicParser.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.DartmouthBasicParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Grammar-driven parser for the original 1964 Dartmouth BASIC language</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="DartmouthBasicParser.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="../../../grammars/dartmouth_basic/dartmouth_basic.grammar" LogicalName="dartmouth_basic.grammar" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../grammar-tools/CodingAdventures.GrammarTools.fsproj" />
+    <ProjectReference Include="../lexer/CodingAdventures.Lexer.fsproj" />
+    <ProjectReference Include="../parser/CodingAdventures.Parser.fsproj" />
+    <ProjectReference Include="../dartmouth-basic-lexer/CodingAdventures.DartmouthBasicLexer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/dartmouth-basic-parser/DartmouthBasicParser.fs
+++ b/code/packages/fsharp/dartmouth-basic-parser/DartmouthBasicParser.fs
@@ -1,0 +1,74 @@
+namespace CodingAdventures.DartmouthBasicParser.FSharp
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Reflection
+open System.Text
+open CodingAdventures.GrammarTools.FSharp
+open CodingAdventures.Lexer.FSharp
+open CodingAdventures.Parser.FSharp
+open CodingAdventures.DartmouthBasicLexer.FSharp
+
+module private Implementation =
+    let grammarResource = "dartmouth_basic.grammar"
+
+    let parserGrammar =
+        lazy
+            try
+                let assembly = Assembly.GetExecutingAssembly()
+                use stream = assembly.GetManifestResourceStream(grammarResource)
+                if isNull stream then
+                    invalidOp ("Missing bundled resource: " + grammarResource)
+                use reader = new StreamReader(stream, Encoding.UTF8)
+                ParserGrammarParser.Parse(reader.ReadToEnd())
+            with
+            | :? ParserGrammarError as error ->
+                raise (InvalidOperationException("Failed to parse bundled Dartmouth BASIC grammar", error))
+
+    let rec countTokens (node: ASTNode) =
+        node.Children
+        |> Seq.sumBy (fun child ->
+            match child with
+            | :? Token -> 1
+            | :? ASTNode as nested -> countTokens nested
+            | _ -> 0)
+
+/// Parses original 1964 Dartmouth BASIC source into a grammar-shaped AST.
+type DartmouthBasicParser private (tokens: IReadOnlyList<Token>) =
+    /// Parses the configured token stream and requires complete input consumption.
+    member _.Parse() =
+        try
+            let ast = GrammarParser(Implementation.parserGrammar.Value).Parse(tokens)
+            if tokens.Count = 0 then
+                raise (GrammarParseError("Token stream must end with EOF"))
+            elif tokens.[tokens.Count - 1].EffectiveTypeName <> "EOF" then
+                raise (GrammarParseError("Token stream must end with EOF", tokens.[tokens.Count - 1]))
+
+            let eofIndex = tokens.Count - 1
+            let parsedTokenCount = Implementation.countTokens ast
+
+            if parsedTokenCount <> eofIndex then
+                let token =
+                    if parsedTokenCount < tokens.Count then tokens.[parsedTokenCount]
+                    else Unchecked.defaultof<Token>
+                raise (GrammarParseError("Unexpected token while parsing program", token))
+
+            ast
+        with
+        | :? GrammarParseError as error ->
+            raise (ArgumentException("Dartmouth BASIC parse failed: " + error.Message, "source", error))
+
+    /// Tokenizes source and creates a configured parser.
+    static member CreateDartmouthBasicParser(source: string) =
+        DartmouthBasicLexer.TokenizeDartmouthBasic(source)
+        |> DartmouthBasicParser
+
+    /// Parses an existing Dartmouth BASIC token stream.
+    static member ParseTokens(tokens: IReadOnlyList<Token>) =
+        if isNull tokens then nullArg "tokens"
+        DartmouthBasicParser(tokens).Parse()
+
+    /// Tokenizes and parses source in one call.
+    static member ParseDartmouthBasic(source: string) =
+        DartmouthBasicParser.CreateDartmouthBasicParser(source).Parse()

--- a/code/packages/fsharp/dartmouth-basic-parser/README.md
+++ b/code/packages/fsharp/dartmouth-basic-parser/README.md
@@ -1,0 +1,17 @@
+# CodingAdventures.DartmouthBasicParser.FSharp
+
+A pure F# parser for the original 1964 Dartmouth BASIC language. It composes
+the native `DartmouthBasicLexer` with the generic grammar parser and embeds the
+shared `dartmouth_basic.grammar` resource.
+
+```fsharp
+let ast =
+    DartmouthBasicParser.ParseDartmouthBasic(
+        "10 LET X = 5\n20 PRINT X\n30 END\n")
+printfn "%s" ast.RuleName // program
+```
+
+The configured-parser API supports two-stage use, while `ParseTokens` accepts
+an existing lexer stream. Complete token-stream consumption rejects malformed
+or incomplete statements. Parsing is fully in memory and needs no filesystem
+or network capability.

--- a/code/packages/fsharp/dartmouth-basic-parser/required_capabilities.json
+++ b/code/packages/fsharp/dartmouth-basic-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/dartmouth-basic-parser",
+  "capabilities": [],
+  "justification": "Parsing is pure and uses a bundled grammar resource."
+}

--- a/code/packages/fsharp/dartmouth-basic-parser/tests/CodingAdventures.DartmouthBasicParser.Tests/CodingAdventures.DartmouthBasicParser.Tests.fsproj
+++ b/code/packages/fsharp/dartmouth-basic-parser/tests/CodingAdventures.DartmouthBasicParser.Tests/CodingAdventures.DartmouthBasicParser.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Include>[CodingAdventures.DartmouthBasicParser.FSharp]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.DartmouthBasicParser.fsproj" />
+    <Compile Include="DartmouthBasicParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/dartmouth-basic-parser/tests/CodingAdventures.DartmouthBasicParser.Tests/DartmouthBasicParserTests.fs
+++ b/code/packages/fsharp/dartmouth-basic-parser/tests/CodingAdventures.DartmouthBasicParser.Tests/DartmouthBasicParserTests.fs
@@ -1,0 +1,84 @@
+namespace CodingAdventures.DartmouthBasicParser.Tests
+
+open System
+open CodingAdventures.DartmouthBasicParser.FSharp
+open CodingAdventures.DartmouthBasicLexer.FSharp
+open CodingAdventures.Parser.FSharp
+open Xunit
+
+module DartmouthBasicParserTests =
+    let rec descendants (node: ASTNode) =
+        seq {
+            yield node
+            for child in node.Children do
+                match child with
+                | :? ASTNode as nested -> yield! descendants nested
+                | _ -> ()
+        }
+
+    [<Fact>]
+    let parsesTheCompleteStatementAndExpressionSurface () =
+        let source =
+            "10 LET X = FNA(SIN(-X)) ^ 2 + A(1) / 3\n" +
+            "20 PRINT \"HELLO\", X;\n" +
+            "30 INPUT A, B\n" +
+            "40 IF X >= 0 THEN 100\n" +
+            "50 GOTO 100\n" +
+            "60 GOSUB 200\n" +
+            "70 RETURN\n" +
+            "80 FOR I = 1 TO 10 STEP 2\n" +
+            "90 NEXT I\n" +
+            "100 STOP\n" +
+            "110 REM THIS BODY IS IGNORED @@@\n" +
+            "120 READ A, B\n" +
+            "130 DATA 1, 2, 3\n" +
+            "140 RESTORE\n" +
+            "150 DIM A(10), B(2, 3)\n" +
+            "160 DEF FNA(T) = T * T\n" +
+            "170 END\n"
+
+        let ast = DartmouthBasicParser.ParseDartmouthBasic(source)
+        let rules = descendants ast |> Seq.map (fun node -> node.RuleName) |> Set.ofSeq
+
+        Assert.Equal("program", ast.RuleName)
+        Assert.True(ast.DescendantCount() > 100)
+        Assert.Contains("let_stmt", rules)
+        Assert.Contains("print_stmt", rules)
+        Assert.Contains("if_stmt", rules)
+        Assert.Contains("for_stmt", rules)
+        Assert.Contains("data_stmt", rules)
+        Assert.Contains("dim_stmt", rules)
+        Assert.Contains("def_stmt", rules)
+
+    [<Fact>]
+    let configuredParserParsesBareAndEmptyPrograms () =
+        Assert.Equal("program", DartmouthBasicParser.CreateDartmouthBasicParser("10\n").Parse().RuleName)
+        Assert.Equal("program", DartmouthBasicParser.ParseDartmouthBasic(String.Empty).RuleName)
+        Assert.Equal("program", DartmouthBasicParser.ParseTokens(DartmouthBasicLexer.TokenizeDartmouthBasic("20 END\n")).RuleName)
+
+    [<Theory>]
+    [<InlineData("10 LET X 5\n")>]
+    [<InlineData("10 IF X > 0 100\n")>]
+    [<InlineData("10 FOR I = 1\n")>]
+    [<InlineData("10 END @\n")>]
+    let rejectsMalformedOrUnconsumedInput (source: string) =
+        let error = Assert.Throws<ArgumentException>(fun () -> DartmouthBasicParser.ParseDartmouthBasic(source) |> ignore)
+        Assert.Contains("Dartmouth BASIC parse failed", error.Message)
+
+    [<Fact>]
+    let rejectsNullSource () =
+        Assert.Throws<ArgumentNullException>(fun () -> DartmouthBasicParser.CreateDartmouthBasicParser(null) |> ignore)
+        |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> DartmouthBasicParser.ParseTokens(null) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let tokenApiRequiresFinalEof () =
+        let tokens =
+            DartmouthBasicLexer.TokenizeDartmouthBasic("20 END\n")
+            |> Seq.take 3
+            |> Seq.toArray
+        Assert.Throws<ArgumentException>(fun () -> DartmouthBasicParser.ParseTokens(tokens) |> ignore)
+        |> ignore
+        Assert.Throws<ArgumentException>(fun () -> DartmouthBasicParser.ParseTokens(Array.empty) |> ignore)
+        |> ignore

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -113,11 +113,12 @@ and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
 `x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
 ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
-`nib-wasm-compiler`, and `dartmouth-basic-lexer` ports:
+`nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
+ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 321 |
+| Present in 10-15 languages | 172 | 319 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 701 | 9,814 |
@@ -163,7 +164,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 321
+The 172 packages present in at least ten implementation languages need 319
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -172,8 +173,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 6 | Move with F# |
-| F# | 6 | Move with C# |
+| C# | 5 | Move with F# |
+| F# | 5 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -321,6 +322,16 @@ operators, numeric formats, functions, unknown input, CRLF positions, blank
 lines, and multi-line remark recovery. The package now spans 12 implementation
 lanes, reduces the high-consensus backlog to 321 slots, leaves 6 paired gaps in
 each lane, and unlocks the dependency-safe `dartmouth-basic-parser` slice.
+
+The twelfth paired C#/F# slice is complete: `dartmouth-basic-parser` now
+combines those native lexers with each lane's grammar-driven parser and the
+shared BASIC grammar embedded as a package resource. The adapters enforce
+complete non-EOF token consumption so malformed statements cannot collapse to
+the grammar's valid empty program, while package-native tests exercise all 17
+statement forms, expression precedence, configured and one-shot APIs, empty
+and bare-line programs, and syntax failures. The package now spans 12
+implementation lanes, reduces the high-consensus backlog to 319 slots, and
+leaves 5 paired gaps in each lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add pure C# and F# Dartmouth BASIC parser packages backed by the shared grammar
- expose source, configured-parser, and token-stream APIs with strict complete-input validation
- cover all 17 statement forms, expression parsing, empty/bare programs, malformed input, and EOF contracts
- update the parity roadmap from 321 to 319 high-consensus missing slots and from 6 to 5 gaps in each lane

## Validation
- `dotnet test` C# package with 80% line threshold: 8 passed, 91.42% line coverage
- `dotnet test` F# package with 80% line threshold: 8 passed, 92.68% line coverage
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: 319 high-consensus missing slots, 5 C# gaps, 5 F# gaps, 0 collisions
- `git diff --check`