### PR TITLE
feat(sir-c): lower unary minus (neg) — closes the C arm of the division frontier (SIR21 §E3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.3.0 — lower unary minus (`neg` builtin) — negative literals no longer skip
+
+Ruby lowers unary minus (`-x`) to `BuiltinCall("neg", [x])`, but the v0 C
+emitter had no lowering for `neg`, so `first_unsupported_builtin` rejected it and
+the whole program was reported `UnsupportedFeature` (i.e. **skipped**) — meaning
+ANY negative literal, not just division, was unrunnable on the C backend.
+
+Unary minus IS single-argument subtraction, and the runtime's `_sir_minus_v`
+already negates a single argument tag-preservingly (a `SIR_FLOAT` stays float,
+otherwise int). So `neg` now lowers to `_sir_minus(1, x)` via `variadic_helper`
+— no new runtime code — matching the Go/Rust/Python runtimes that gained `neg`
+in SIR21 §E3. New `unary_minus` exec-proof in `tests/compile_and_run.rs`
+(`puts(-7)` → `-7`, `puts(-7 / 2)` → `-4` floored, `puts(-(3 * 2))` → `-6`),
+compiled and run through a real C compiler.
+
+This closes the **C arm** of the division frontier: with the runtime already
+flooring (`_sir_ifloordiv`), C now reproduces Ruby's floor `/` on negative
+dividends too, so `sir-conformance`'s `division_matches_ruby_floor_on_every_backend`
+asserts (rather than skips) C's negative cases.
+
 ## 0.2.0 — render SIR26 integer conversions
 
 Accepts `Feature::Conversions` (plus the SIR21 type-implied `SizedIntegers`,

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -712,6 +712,14 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
         "-" => "_sir_minus",
         "*" => "_sir_times",
         "/" => "_sir_divide",
+        // Ruby unary minus (`-x`) lowers to `BuiltinCall("neg", [x])`. It was
+        // UNIMPLEMENTED here, so any negative literal made the C backend report
+        // an unsupported builtin and skip. Unary minus IS single-argument
+        // subtraction, and `_sir_minus_v` already negates its single argument
+        // tag-preservingly (a `SIR_FLOAT` stays float, else int) — so `neg`
+        // lowers to `_sir_minus(1, x)` with no new runtime code, matching the
+        // Go/Rust/Python runtimes that gained `neg` in SIR21 §E3.
+        "neg" => "_sir_minus",
         "print" => "_sir_print",
         "puts" => "_sir_puts",
         _ => return None,

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run.rs
@@ -143,6 +143,18 @@ const CORPUS: &[Case] = &[
         source: "(define (adder n) (lambda (x) (+ x n))) (define a (adder 5)) (print (a 3))",
         expected: "8",
     },
+    Case {
+        // Unary minus (`-x`) lowers to the `neg` builtin, which the C backend
+        // now lowers (SIR21 §E3). Before, ANY negative literal made the C
+        // backend report an unsupported builtin and skip. `neg` reuses the
+        // single-argument `_sir_minus` path (which negates tag-preservingly),
+        // so this also confirms floored `Integer#/` on a negative dividend
+        // (`-7 / 2 == -4`, not the truncating `-3`).
+        name: "unary_minus",
+        lang: "ruby",
+        source: "puts(-7)\nputs(-7 / 2)\nputs(-(3 * 2))",
+        expected: "-7\n-4\n-6\n",
+    },
 ];
 
 fn lower(case: &Case) -> semantic_ir::Module {

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.14.0] - Division frontier: C arm fully closed (SIR21 §E3)
+
+The C backend now lowers the unary-minus `neg` builtin (semantic-ir-to-c 0.3.0),
+so `division_matches_ruby_floor_on_every_backend` now **asserts** C's negative
+cases instead of skipping them — the C emitter previously reported `neg` as an
+unsupported builtin, so `run_c` returned `Skipped` for every negative literal.
+All six backends (Python, JavaScript, Go, Rust, Ruby, C) now floor every sign
+combination end-to-end. Module docs and the test doc-comment updated to record
+the C arm as closed rather than tracked.
+
 ## [0.13.0] - Division frontier CLOSED on every backend (SIR21 §E3)
 
 With Rust, Go and JavaScript now flooring integer division (their runtime

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/tests/division.rs
+++ b/code/packages/rust/sir-conformance/tests/division.rs
@@ -17,7 +17,7 @@
 //! | Go         | `-3` (truncated)   | ✅ `-4` — floored int path in `_sir_divide` |
 //! | JavaScript | `-3.5` (float `/`) | ✅ `-4` — `Math.floor` when both operands integral |
 //! | Ruby       | (native)           | ✅ `-4` — emits Ruby, whose `/` floors natively |
-//! | C          | (crashed)          | ✅ `-4` on positives; **negatives skip** (see below) |
+//! | C          | (crashed)          | ✅ `-4` — runtime already floored; emitter now lowers `neg` |
 //!
 //! The int-path fixes live in each backend's runtime `divide` helper and mirror
 //! the oracle's [`DivOp::Floor`]: the floored quotient is the truncated one
@@ -30,16 +30,15 @@
 //! integral (`7.0`) still needs the typed pipeline to true-divide, tracked
 //! separately. Ruby transpiles to Ruby, so its `/` is already floor.
 //!
-//! **Two gaps this frontier forced to the surface — both fixed here except one
-//! narrow emitter case:** Ruby lowers unary minus (`-x`) to a `neg` builtin, and
-//! the Go and Rust *runtimes* had no `neg` — so every negative literal (not just
-//! division) crashed with `unknown builtin: neg`. That is the "Go/Rust crash on
-//! negatives" this doc long recorded; it was never a division bug. Both now
-//! implement `neg`. The **C backend's emitter** does not yet lower `neg`, so its
-//! negative cases are reported [`RunOutcome::Skipped`] (not `Failed`) and the
-//! frontier does not assert them — C is closed for positive division and tracked
-//! for negative-literal emit. Ruby needs the `ruby` toolchain present to run;
-//! absent it, it skips.
+//! **A gap this frontier forced to the surface — now fixed everywhere:** Ruby
+//! lowers unary minus (`-x`) to a `neg` builtin, and the Go and Rust *runtimes*
+//! had no `neg` — so every negative literal (not just division) crashed with
+//! `unknown builtin: neg`. That is the "Go/Rust crash on negatives" this doc
+//! long recorded; it was never a division bug. Both runtimes now implement it,
+//! and the **C backend's emitter** now lowers `neg` too (to its single-argument
+//! `_sir_minus`, which negates tag-preservingly), so C's negative cases run and
+//! are asserted rather than skipped. Ruby needs the `ruby` toolchain present to
+//! run; absent it, it skips.
 //!
 //! The resolution of the original "deliberate conflict" (flip vs. split) went
 //! the additive way: the oracle already carries *both* honest ops (`div_floor`,
@@ -88,10 +87,10 @@ fn oracle_floor_matches_ruby_integer_division() {
 /// floors integer division (SIR21 §E3), so this is no longer `#[ignore]`d — it
 /// is a first-class conformance assertion. It asserts on `Ran` outcomes and
 /// fails (naming the offending backend) the day one regresses to truncation or
-/// true-division on integer operands; `Skipped` cases are not asserted (the C
-/// emitter does not yet lower unary `neg`, so its negative cases skip, and Ruby
-/// skips without a `ruby` toolchain). Verified locally across Python, JavaScript,
-/// Go, Rust and Ruby (all flooring) with C flooring the positive cases.
+/// true-division on integer operands; `Skipped` cases are not asserted (Ruby
+/// skips without a `ruby` toolchain, and any backend skips without its
+/// compiler). Verified locally across all six backends — Python, JavaScript,
+/// Go, Rust, Ruby and C — flooring every sign combination.
 #[test]
 fn division_matches_ruby_floor_on_every_backend() {
     let mut ran = 0usize;


### PR DESCRIPTION
## What

Teaches the C backend to lower Ruby's unary-minus `neg` builtin, **closing the last arm of the SIR21 §E3 division frontier**. All six backends (Python, JavaScript, Go, Rust, Ruby, **C**) now floor integer division on every sign combination end-to-end.

## The gap

Ruby lowers `-x` to `BuiltinCall("neg", [x])`, but the v0 C emitter had no lowering for `neg`. So `first_unsupported_builtin` rejected it and the whole program was reported `UnsupportedFeature` → **skipped**. This meant *any* negative literal — not just division — was unrunnable on the C backend. (That's the "C negatives skip" caveat noted when the rest of the frontier landed.)

## The fix (no new runtime code)

Unary minus **is** single-argument subtraction, and the C runtime's `_sir_minus_v` already negates a single argument tag-preservingly:
```c
if (n == 1) {
    if (xs[0].tag == SIR_FLOAT) return _sir_float(-xs[0].as.f);
    return _sir_int(-xs[0].as.i);
}
```
So `neg` now maps to `_sir_minus` in `variadic_helper` — `BuiltinCall("neg",[x])` emits `_sir_minus(1, x)`. One 8-line change, mirroring the `neg` the Go/Rust/Python runtimes gained in SIR21 §E3.

## Result

With the C runtime already flooring (`_sir_ifloordiv`), C now reproduces Ruby's floor `/` on negative dividends. `sir-conformance`'s `division_matches_ruby_floor_on_every_backend` now **asserts** (rather than skips) C's negative cases.

## Verification

- New `unary_minus` exec-proof in `semantic-ir-to-c/tests/compile_and_run.rs` — compiles & runs `puts(-7)` → `-7`, `puts(-7 / 2)` → `-4` (floored), `puts(-(3 * 2))` → `-6` through a real C compiler.
- Confirmed C now floors every sign combination (`7/2→3`, `-7/2→-4`, `7/-2→-4`, `-7/-2→3`, `6/3→2`, `-6/2→-3`).
- Full `semantic-ir-to-c` + `sir-conformance` suites pass.
- Security-reviewed clean (`neg` inherits the identical, already-reachable single-arg `-` path — no new exposure).

## Versions
`semantic-ir-to-c` 0.2.0 → **0.3.0** · `sir-conformance` 0.13.0 → **0.14.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)