### PR TITLE
feat(reduce): reduce-runtime + reduce-repl — MA08 R-4 (front2, Wave 5)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -261,6 +261,8 @@ members = [
     "j-to-semantic-ir",
     "reduce-lexer",
     "reduce-parser",
+    "reduce-runtime",
+    "reduce-repl",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/reduce-repl/BUILD
+++ b/code/packages/rust/reduce-repl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-reduce-repl -- --nocapture

--- a/code/packages/rust/reduce-repl/BUILD_windows
+++ b/code/packages/rust/reduce-repl/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-reduce-repl -- --nocapture

--- a/code/packages/rust/reduce-repl/CHANGELOG.md
+++ b/code/packages/rust/reduce-repl/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## [0.1.0] - 2026-07-18
+
+### Added
+
+- Initial `reduce-repl` crate (MA08 R-4, front2 Wave 5): an interactive
+  Read-Eval-Print loop and the `reduce` binary, wrapping a persistent
+  `ReduceSession` (`reduce-runtime`) — mirroring `derive-repl`'s driver,
+  per MA08 §2/§5's explicit template pointer.
+- A **plain, non-numbered** prompt (`"> "`, continuation `"... "`) — MA08
+  §2/§5 are explicit that Reduce's own session transcript has no
+  numbered-input convention the way Derive's `#n:` or Wolfram's `In[n]:=`
+  do, so (unlike `derive-repl`) no result is ever prefixed with an index.
+- `(`/`)`-, `{`/`}`- (Reduce's list braces, MA08 §3 — not Derive's `[`/`]`),
+  and `<<`/`>>`-aware (Reduce's group-statement delimiters, MA08 §3)
+  bracket-depth line continuation, with the `<<`/`>>` two-character pair
+  matched by explicit lookahead so a bare comparison `<`/`>` never falsely
+  triggers continuation — the one genuinely new tracking case relative to
+  `derive-repl`'s simpler `(`/`[` pair.
+- Case-insensitive `QUIT`/`EXIT` to end the session, carried forward as a
+  REPL-level convenience (not a language feature — real REDUCE's own exit
+  command is the semicolon-terminated procedure call `quit;`).
+- Bounded single-physical-line reads (`read_bounded_line`, 64 KiB cap),
+  carrying forward the `derive-repl`/`j-repl`/`apl-repl` `/security-review`
+  fix ("cap unbounded single-line read before continuation-buffer check")
+  rather than reintroducing the same gap in a new REPL.
+- 21 tests: prompt/continuation behaviour (parens, braces, group-statement
+  delimiters, and the `<<`/`>>`-vs-bare-comparison disambiguation), quit
+  words, error recovery, persistent bindings, an end-to-end Reduce
+  program, and the full `read_bounded_line` regression suite (oversized
+  line, exact-cap boundary, multi-chunk overflow drain, multibyte-character
+  straddle).

--- a/code/packages/rust/reduce-repl/Cargo.toml
+++ b/code/packages/rust/reduce-repl/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-reduce-repl"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive REPL and `reduce` binary for Reduce (a subset)"
+license = "MIT"
+
+[dependencies]
+coding-adventures-reduce-runtime = { path = "../reduce-runtime" }
+
+[[bin]]
+name = "reduce"
+path = "src/main.rs"

--- a/code/packages/rust/reduce-repl/README.md
+++ b/code/packages/rust/reduce-repl/README.md
@@ -1,0 +1,66 @@
+# coding-adventures-reduce-repl
+
+An interactive Read-Eval-Print loop and the `reduce` binary for Reduce (a
+subset). Wraps a persistent
+[`coding_adventures_reduce_runtime::ReduceSession`](../reduce-runtime) and
+adds the console behaviours an interactive Reduce user expects. See
+[`code/specs/MA08-reduce-language.md`](../../../specs/MA08-reduce-language.md).
+
+## Usage
+
+```sh
+cargo run -p coding-adventures-reduce-repl --bin reduce
+```
+
+```text
+Reduce (on the shared symbolic stack) — one statement per line, type QUIT to exit.
+> x := 5;
+5
+> x + 1;
+6
+> h(l, m) := l + m;
+h
+> h(2, 3);
+5
+> QUIT
+```
+
+## Behaviour
+
+- **A plain, non-numbered prompt (`> `)** — MA08 §2/§5 are explicit that
+  Reduce's own session transcript has no numbered-input convention the way
+  Derive's `#n:` or Wolfram's `In[n]:=` do (even though *real* REDUCE's own
+  interactive prompt actually is numbered, `1: `, `2: `, …) — so, unlike
+  `derive-repl`, results here are never prefixed at all.
+- **Line continuation** — a statement is complete once `(`/`)`, `{`/`}`
+  (Reduce's list braces, MA08 §3 — NOT Derive's `[`/`]`), and `<<`/`>>`
+  (group-statement delimiters, matched as a genuine two-character pair, so
+  a bare comparison `<`/`>` never falsely triggers it) are all balanced;
+  like `derive-repl` there is no string/comment state to track (this
+  subset has neither — MA08 §4).
+- **`QUIT`/`EXIT`** (case-insensitive) or Ctrl-D ends the session.
+- **Non-fatal errors** — a surface error (parse failure, a malformed
+  `Assign` LHS, …) prints and the session keeps working.
+
+## Security: bounded line reads
+
+`run` reads each physical line through a byte-oriented, cap-bounded
+`read_bounded_line` (64 KiB) rather than `BufRead::read_line` directly —
+carrying forward the exact fix `derive-repl`/`j-repl`/`apl-repl` needed
+after their own `/security-review`: `read_line` has no length bound of its
+own, so a single, arbitrarily long line (no embedded newline) would be
+fully buffered in memory before `ReduceRepl::feed`'s own size check ever
+ran. See the module doc comment for the full rationale (including the
+multibyte-character/cap-boundary edge case this fix also closes).
+
+## Tests
+
+```sh
+cargo test -p coding-adventures-reduce-repl
+```
+
+Prompt/continuation behaviour (including the `<<`/`>>` vs bare `<`/`>`
+disambiguation), quit words, error recovery, persistent bindings, an
+end-to-end Reduce program, and the full `read_bounded_line` regression
+suite (oversized single line, exact-cap boundary, multi-chunk overflow
+drain, multibyte-character straddle).

--- a/code/packages/rust/reduce-repl/required_capabilities.json
+++ b/code/packages/rust/reduce-repl/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/reduce-repl",
+  "capabilities": ["stdio"],
+  "justification": "An interactive console: the `reduce` binary reads Reduce source from stdin and writes results to stdout. No filesystem, network, or process access beyond standard streams."
+}

--- a/code/packages/rust/reduce-repl/src/lib.rs
+++ b/code/packages/rust/reduce-repl/src/lib.rs
@@ -1,0 +1,498 @@
+//! # Reduce REPL — an interactive Read-Eval-Print loop for Reduce (a subset).
+//!
+//! [`ReduceRepl`] wraps a persistent [`ReduceSession`] (which reuses the
+//! entire shared symbolic stack) and adds the console behaviours an
+//! interactive Reduce user expects. Mirrors `derive-repl`'s driver almost
+//! exactly (MA08 §2/§5 call it out as the template), with one deliberate
+//! difference:
+//!
+//! * **No numbered prompt.** Real REDUCE's own interactive session prompt
+//!   actually *is* numbered (`1: `, `2: `, …) — but MA08 §2/§5 are explicit
+//!   that this subset's `reduce-repl` is "a plain read-eval-print loop, no
+//!   numbering", the same way [`ReduceSession::feed`] (unlike
+//!   `DeriveSession::feed`'s `#n:` lines) never prefixes a result. So the
+//!   prompt here is a fixed `"> "` (continuation: `"... "`, identical to
+//!   `derive-repl`'s spelling), not `#n:`/`In[n]:=`.
+//! * **Line continuation** tracks `(`/`)` **and** `{`/`}` (Reduce's list
+//!   braces, MA08 §3 — NOT Derive's `[`/`]`) **and** the two-character
+//!   `<<`/`>>` group-statement delimiters (MA08 §3), distinguished from the
+//!   single-character `<`/`>` comparison operators by looking one
+//!   character ahead — naively counting every bare `<`/`>` would
+//!   miscount `a < b` as an opening/closing group delimiter. Reduce has no
+//!   strings or comments in this subset (MA08 §4), so — like `derive-repl`
+//!   — there is no quote/comment state to track either.
+//! * **Quit / EOF** — `QUIT`, `EXIT` (case-insensitive convenience, mirroring
+//!   `derive-repl`'s identical convenience even though real REDUCE's own
+//!   exit command is the semicolon-terminated procedure call `quit;`), or
+//!   Ctrl-D end the session.
+//! * **Non-fatal errors** — a surface error prints and the session continues.
+//!
+//! This mirrors `derive-repl`'s single-threaded driver, carrying forward its
+//! `read_bounded_line` fix verbatim: [`run`] reads each physical line
+//! through [`read_bounded_line`] (capped at [`MAX_LINE_LEN`]) rather than
+//! `BufRead::read_line` directly — see that function's own doc comment for
+//! the full rationale (unbounded `read_line`, and the multibyte-character/
+//! cap-boundary edge case).
+
+use coding_adventures_reduce_runtime::{ReduceSession, MAX_INPUT_LEN};
+use std::io::{BufRead, Write};
+
+/// What the REPL should do after being fed one physical line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplResponse {
+    /// A complete statement (or batch) was evaluated; here is its echo.
+    Output(String),
+    /// The buffer is not yet a complete statement — read another line.
+    NeedMore,
+    /// The user asked to leave.
+    Quit,
+}
+
+/// A persistent interactive Reduce session.
+pub struct ReduceRepl {
+    session: ReduceSession,
+    buffer: String,
+}
+
+impl Default for ReduceRepl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReduceRepl {
+    pub fn new() -> Self {
+        ReduceRepl {
+            session: ReduceSession::new(),
+            buffer: String::new(),
+        }
+    }
+
+    /// The prompt to print before reading the next physical line.
+    ///
+    /// A plain, non-numbered prompt (MA08 §2/§5 — see the module doc
+    /// comment) — `"> "` for a fresh statement, `"... "` while one spans
+    /// multiple physical lines.
+    pub fn prompt(&self) -> String {
+        if self.buffer.is_empty() {
+            "> ".to_string()
+        } else {
+            "... ".to_string()
+        }
+    }
+
+    /// Feed one physical input line (without its trailing newline).
+    pub fn feed(&mut self, line: &str) -> ReplResponse {
+        // Quit words are only recognised at the start of a fresh statement,
+        // so an identifier named `QUIT`/`EXIT` mid-expression is never
+        // hijacked.
+        if self.buffer.is_empty() {
+            match line.trim() {
+                "QUIT" | "quit" | "Quit" | "EXIT" | "exit" | "Exit" => return ReplResponse::Quit,
+                _ => {}
+            }
+        }
+        self.buffer.push_str(line);
+        self.buffer.push('\n');
+
+        // Bound the accumulation buffer: a stream that never balances (an
+        // endless run of open brackets) must not buffer unbounded memory.
+        // Once over the size the session would reject anyway, submit so
+        // `feed` returns the clean "too large" error and resets.
+        if self.buffer.len() <= MAX_INPUT_LEN && is_incomplete(&self.buffer) {
+            return ReplResponse::NeedMore;
+        }
+
+        let src = std::mem::take(&mut self.buffer);
+        if src.trim().is_empty() {
+            return ReplResponse::Output(String::new());
+        }
+        match self.session.feed(&src) {
+            Ok(text) => ReplResponse::Output(text),
+            Err(e) => ReplResponse::Output(format!("Error: {e}\n")),
+        }
+    }
+
+    /// Is a statement currently spanning multiple lines?
+    pub fn is_continuing(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}
+
+/// Upper bound on a single *physical* line read from the input stream,
+/// applied in [`read_bounded_line`] before [`ReduceRepl::feed`]'s own
+/// `MAX_INPUT_LEN` check ever runs. `BufRead::read_line` has no length bound
+/// of its own — it grows its buffer until it sees a `\n` or EOF — so without
+/// this, a single, arbitrarily long physical line (no embedded newline at
+/// all) is fully buffered in memory before `feed` ever gets a chance to
+/// reject anything. Mirrors `derive-repl`/`j-repl`/`apl-repl`'s own
+/// `MAX_LINE_LEN` fix exactly (same value, same rationale).
+const MAX_LINE_LEN: u64 = 64 * 1024;
+
+/// Read one physical line, bounded to [`MAX_LINE_LEN`] bytes.
+///
+/// - `Ok(None)` — genuine end of input.
+/// - `Ok(Some(Ok(line)))` — an ordinary line. Includes a final, newline-less
+///   line at genuine EOF (same as `BufRead::read_line`'s own contract).
+/// - `Ok(Some(Err(())))` — a single physical line's true length exceeds the
+///   cap; the oversized remainder is fully drained and discarded so the next
+///   read always starts at a genuine line boundary.
+///
+/// Reads raw **bytes** (`read_until(b'\n', ..)`), not `BufRead::read_line`
+/// directly, deciding "oversized?" on the byte run *before* attempting UTF-8
+/// decoding — `Take` stops at an arbitrary byte offset with no notion of a
+/// character boundary, so a valid UTF-8 line whose true length only slightly
+/// exceeds the cap could have a multi-byte character straddle that exact
+/// offset, and validating on the byte run through `read_line` alone would
+/// misreport that as a decoding failure rather than an oversized line.
+/// Mirrors `derive-repl::read_bounded_line`/`j-repl::read_bounded_line`
+/// exactly.
+fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
+    let mut buf: Vec<u8> = Vec::new();
+    // Explicit UFCS + an explicit reborrow (`&mut *reader`): `Read`/`BufRead`
+    // are implemented both for `R` itself and for `&mut R`, and ordinary
+    // autoref method resolution prefers the by-value `R` candidate even when
+    // the receiver is already a reference — silently trying to MOVE
+    // `*reader` instead of taking a bounded view of it. Naming the trait and
+    // the exact `&mut R` receiver explicitly removes that ambiguity.
+    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+    let read = limited.read_until(b'\n', &mut buf)?;
+    if read == 0 {
+        return Ok(None);
+    }
+    let hit_cap = buf.len() as u64 == MAX_LINE_LEN && buf.last() != Some(&b'\n');
+    if hit_cap {
+        // The initial capped read filled up with no newline in sight — keep
+        // reading further capped chunks (discarding them) until either a
+        // real `\n` is found (genuinely oversized) or a chunk comes back
+        // empty (a maximal-but-not-oversized line at genuine EOF).
+        let mut saw_more_data = false;
+        loop {
+            let mut chunk: Vec<u8> = Vec::new();
+            let mut limited: std::io::Take<&mut R> =
+                std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+            let n = limited.read_until(b'\n', &mut chunk)?;
+            if n == 0 {
+                if !saw_more_data {
+                    return match String::from_utf8(buf) {
+                        Ok(line) => Ok(Some(Ok(line))),
+                        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+                    };
+                }
+                break; // true EOF reached while draining real overflow
+            }
+            saw_more_data = true;
+            if chunk.last() == Some(&b'\n') {
+                break; // found the oversized line's real end
+            }
+        }
+        return Ok(Some(Err(())));
+    }
+    match String::from_utf8(buf) {
+        Ok(line) => Ok(Some(Ok(line))),
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+    }
+}
+
+/// Is the accumulated source *incomplete* — i.e. should the REPL keep
+/// reading?
+///
+/// A Reduce statement (unlike Derive's, whose separator IS the newline) is
+/// terminated by `;`/`$`, and this subset's grammar tolerates a final
+/// statement with no terminator at all (`reduce-parser`'s own
+/// `bare_trailing_statement_with_no_terminator_parses` test) — so this
+/// heuristic tracks bracket balance, not terminators, exactly mirroring
+/// `derive-repl::is_incomplete`'s identical "wait for balance, then submit
+/// the whole buffer" shape, just over Reduce's own bracket vocabulary:
+/// `(`/`)` (grouping and calls), `{`/`}` (list literals — MA08 §3, NOT
+/// Derive's `[`/`]`), and the two-character `<<`/`>>` group-statement
+/// delimiters, which must be matched as a *pair* — a bare single `<` or `>`
+/// is an ordinary comparison operator (MA08 §3) and must NOT perturb the
+/// depth count.
+///
+/// This is only a continuation *heuristic*: whatever is submitted still
+/// passes through [`ReduceSession::feed`], which re-lexes with the real
+/// lexer and applies the size/complexity guards, so a mismatch can never
+/// crash — at worst it submits early (e.g. a statement deliberately split
+/// across lines with no open bracket at all, like `x :=\n5;`) or asks for
+/// one more line.
+fn is_incomplete(src: &str) -> bool {
+    let chars: Vec<char> = src.chars().collect();
+    let mut depth: i32 = 0;
+    let mut i = 0;
+    while i < chars.len() {
+        match (chars[i], chars.get(i + 1)) {
+            ('<', Some('<')) => {
+                depth += 1;
+                i += 2;
+                continue;
+            }
+            ('>', Some('>')) => {
+                depth -= 1;
+                i += 2;
+                continue;
+            }
+            ('(', _) | ('{', _) => depth += 1,
+            (')', _) | ('}', _) => depth -= 1,
+            _ => {}
+        }
+        i += 1;
+    }
+    depth > 0
+}
+
+/// Drive a full interactive Reduce session over the given reader and writer.
+pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Result<()> {
+    let mut repl = ReduceRepl::new();
+    writeln!(
+        writer,
+        "Reduce (on the shared symbolic stack) — one statement per line, type QUIT to exit."
+    )?;
+
+    loop {
+        write!(writer, "{}", repl.prompt())?;
+        writer.flush()?;
+
+        let line = match read_bounded_line(&mut reader)? {
+            None => {
+                writeln!(writer)?;
+                break;
+            }
+            Some(Err(())) => {
+                writeln!(
+                    writer,
+                    "Error: line exceeds the {MAX_LINE_LEN}-byte limit; discarded"
+                )?;
+                writer.flush()?;
+                continue;
+            }
+            Some(Ok(line)) => line,
+        };
+        let line = line.strip_suffix('\n').unwrap_or(&line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        match repl.feed(line) {
+            ReplResponse::Output(text) => {
+                write!(writer, "{text}")?;
+                writer.flush()?;
+            }
+            ReplResponse::NeedMore => {}
+            ReplResponse::Quit => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_single_line_statement_evaluates_immediately() {
+        let mut r = ReduceRepl::new();
+        assert!(matches!(r.feed("1 + 2*3;"), ReplResponse::Output(t) if t.contains('7')));
+    }
+
+    #[test]
+    fn continues_while_a_paren_is_open() {
+        let mut r = ReduceRepl::new();
+        assert_eq!(r.feed("h(1,"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("2);"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn continues_while_a_brace_is_open() {
+        // A list literal spanning lines — buffers until the closing `}`.
+        let mut r = ReduceRepl::new();
+        assert_eq!(r.feed("{1,"), ReplResponse::NeedMore);
+        assert!(matches!(
+            r.feed("2, 3};"),
+            ReplResponse::Output(t) if t.contains("{1, 2, 3}")
+        ));
+    }
+
+    #[test]
+    fn continues_while_a_group_statement_is_open() {
+        // `<<`/`>>` group-statement delimiters, not bare `<`/`>`.
+        let mut r = ReduceRepl::new();
+        assert_eq!(r.feed("<< a := 1;"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("a + 1 >>;"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn a_bare_comparison_does_not_trigger_group_statement_continuation() {
+        // `a < b` must NOT be mistaken for a half-open `<<` group delimiter.
+        let mut r = ReduceRepl::new();
+        assert!(matches!(r.feed("1 < 2;"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn prompts_switch_between_input_and_continuation_with_no_numbering() {
+        let mut r = ReduceRepl::new();
+        assert_eq!(r.prompt(), "> ");
+        assert_eq!(r.feed("h("), ReplResponse::NeedMore);
+        assert_eq!(r.prompt(), "... ", "continuation prompt while open");
+        assert!(r.is_continuing());
+        assert!(matches!(r.feed("0);"), ReplResponse::Output(_)));
+        assert_eq!(
+            r.prompt(),
+            "> ",
+            "prompt returns to the plain, non-numbered form"
+        );
+    }
+
+    #[test]
+    fn quit_words_leave_the_session() {
+        assert_eq!(ReduceRepl::new().feed("QUIT"), ReplResponse::Quit);
+        assert_eq!(ReduceRepl::new().feed("quit"), ReplResponse::Quit);
+        assert_eq!(ReduceRepl::new().feed("EXIT"), ReplResponse::Quit);
+        assert_eq!(ReduceRepl::new().feed("exit"), ReplResponse::Quit);
+    }
+
+    #[test]
+    fn an_error_is_printed_and_the_session_survives() {
+        let mut r = ReduceRepl::new();
+        assert!(matches!(r.feed("1 +"), ReplResponse::Output(t) if t.contains("Error")));
+        assert!(matches!(r.feed("1 + 1;"), ReplResponse::Output(t) if t.contains('2')));
+    }
+
+    #[test]
+    fn bindings_persist_across_lines() {
+        let mut r = ReduceRepl::new();
+        assert!(matches!(r.feed("x := 5;"), ReplResponse::Output(_)));
+        assert!(matches!(r.feed("x + 1;"), ReplResponse::Output(t) if t.contains('6')));
+    }
+
+    #[test]
+    fn an_unterminated_buffer_is_submitted_once_over_the_size_cap() {
+        let mut r = ReduceRepl::new();
+        let big = "(".repeat(MAX_INPUT_LEN + 16);
+        match r.feed(&big) {
+            ReplResponse::Output(t) => assert!(t.contains("too large"), "got {t:?}"),
+            other => panic!("expected an over-size submission, got {other:?}"),
+        }
+        assert_eq!(r.prompt(), "> ");
+    }
+
+    #[test]
+    fn run_drives_a_session_to_eof() {
+        let input = b"1 + 2*3;\nQUIT\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains('7'), "expected 7 in session: {text:?}");
+        assert!(text.contains("> "), "expected the plain prompt: {text:?}");
+    }
+
+    #[test]
+    fn run_handles_bare_eof_without_quit() {
+        let input = b"2 + 2;\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        assert!(String::from_utf8(output).unwrap().contains('4'));
+    }
+
+    #[test]
+    fn blank_lines_are_harmless() {
+        let mut r = ReduceRepl::new();
+        assert_eq!(r.feed(""), ReplResponse::Output(String::new()));
+        assert_eq!(r.prompt(), "> ", "a blank line does not change the prompt");
+    }
+
+    #[test]
+    fn a_reduce_program_evaluates_end_to_end() {
+        let mut r = ReduceRepl::new();
+        assert!(matches!(r.feed("h(x) := x*x;"), ReplResponse::Output(_)));
+        assert!(matches!(
+            r.feed("h(5);"),
+            ReplResponse::Output(t) if t.contains("25")
+        ));
+    }
+
+    // --- read_bounded_line: carried forward from derive-repl/j-repl/apl-repl
+    //     (the /security-review fix, task #32) --------------------------
+
+    #[test]
+    fn read_bounded_line_rejects_a_line_exceeding_the_cap_without_buffering_it_whole() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 3);
+        let mut input = oversized.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        let _ = read_bounded_line(&mut input);
+    }
+
+    #[test]
+    fn read_bounded_line_at_exactly_the_cap_with_a_trailing_newline_is_not_oversized() {
+        let mut line = "+".repeat(MAX_LINE_LEN as usize - 1);
+        line.push('\n');
+        assert_eq!(line.len() as u64, MAX_LINE_LEN);
+        let mut input = line.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Ok(line)));
+    }
+
+    #[test]
+    fn read_bounded_line_treats_an_exactly_cap_sized_final_line_as_ordinary_not_oversized() {
+        let line = "+".repeat(MAX_LINE_LEN as usize);
+        let mut input = line.as_bytes();
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok(line.clone()))
+        );
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn read_bounded_line_fully_drains_a_line_spanning_multiple_cap_chunks() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1;\n");
+        let mut input = input.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("1+1;\n".to_string()))
+        );
+    }
+
+    #[test]
+    fn read_bounded_line_handles_a_multibyte_char_straddling_the_cap_boundary() {
+        let mut oversized: Vec<u8> = vec![b'a'; MAX_LINE_LEN as usize - 1];
+        oversized.extend_from_slice("é".as_bytes()); // 2-byte char, straddles the cap
+        oversized.push(b'\n');
+        let mut input = oversized.as_slice();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+    }
+
+    #[test]
+    fn run_reports_an_oversized_line_cleanly_and_keeps_the_session_alive() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 2);
+        let input = format!("{oversized}\n1+1;\nQUIT\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            text.contains("exceeds"),
+            "expected an oversized-line error, got: {text}"
+        );
+        assert!(
+            text.contains('2'),
+            "session must keep working after an oversized line, got: {text}"
+        );
+    }
+
+    #[test]
+    fn run_executes_the_correct_follow_up_statement_after_a_multi_chunk_oversized_line() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1;\nQUIT\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            text.contains("exceeds"),
+            "expected an oversized-line error, got: {text}"
+        );
+        assert!(
+            text.contains('2'),
+            "the real follow-up statement (1+1), not a fragment of the \
+             discarded line, must be what gets evaluated, got: {text}"
+        );
+    }
+}

--- a/code/packages/rust/reduce-repl/src/main.rs
+++ b/code/packages/rust/reduce-repl/src/main.rs
@@ -1,0 +1,19 @@
+//! The `reduce` binary — an interactive prompt for Reduce (a subset).
+//!
+//! Reads one physical line at a time (continuing across an open `(`/`)`,
+//! `{`/`}`, or `<<`/`>>` until balanced), evaluates over the reused shared
+//! symbolic stack, and echoes each result — a plain, non-numbered
+//! read-eval-print loop (MA08 §2/§5; unlike `derive`'s `#n:` worksheet
+//! convention). Type `QUIT`/`EXIT` (or Ctrl-D) to leave. All logic lives in
+//! [`coding_adventures_reduce_repl::run`].
+
+use std::io;
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if let Err(e) = coding_adventures_reduce_repl::run(stdin.lock(), stdout.lock()) {
+        eprintln!("reduce: I/O error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/reduce-runtime/BUILD
+++ b/code/packages/rust/reduce-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-reduce-runtime -- --nocapture

--- a/code/packages/rust/reduce-runtime/BUILD_windows
+++ b/code/packages/rust/reduce-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-reduce-runtime -- --nocapture

--- a/code/packages/rust/reduce-runtime/CHANGELOG.md
+++ b/code/packages/rust/reduce-runtime/CHANGELOG.md
@@ -37,14 +37,23 @@
   (grammar repetitions, not recursive rule calls, aren't bounded by that
   cap). Unlike `derive-runtime`'s identical-in-spirit guard (reset on a
   significant `NEWLINE`), this crate resets on Reduce's own real
-  terminators, `SEMI`/`DOLLAR`, including ones lexically inside a
-  `<< ... >>` group statement (safe, since `group_expr` lowers to a *flat*
-  `CompoundExpression`, never nested sub-statements). Two shapes are
+  terminators, `SEMI`/`DOLLAR` — but **only at bracket depth 0** (tracked
+  over `LPAREN`/`RPAREN`, `LBRACE`/`RBRACE`, `GROUP_OPEN`/`GROUP_CLOSE`),
+  a `/security-review` fix over resetting unconditionally: a `;`/`$`
+  lexically inside a *parenthesized* `<< ... >>` group construct that is
+  itself embedded as one operand of a much larger enclosing chain
+  (`1 + 1 + (<<0;0>>) + 1 + 1 + ...`) previously reset the outer chain's
+  own count too, even though the outer chain still folds every operand
+  into one deeply nested tree regardless — empirically, a chain 16× the
+  documented cap sailed through undetected before this fix. Two shapes are
   guarded: the additive/multiplicative left-fold chain (shared with
   Derive's identical vector) and, new here, a chained postfix call
   `f(x)(x)(x)…` (`postfix`'s own call-chaining loop folds the same way).
   Evaluation runs on a 512 MiB-stack worker thread inside `catch_unwind`,
-  rebuilding the session after any caught panic.
+  rebuilding the session after any caught panic; a thread-spawn failure
+  itself (a second `/security-review` fix, over an earlier `.expect()`
+  that panicked on the *calling* thread, outside that boundary) is now
+  folded into the same ordinary `Err` path instead.
 - **Disclosed spec/reality gap** (documented in `crate::lower`'s module
   doc comment, this crate's README, and MA08 itself — see that spec's own
   R-4 status note): grepping `symbolic-vm::handlers::build_handler_table`
@@ -64,9 +73,10 @@
   already-reused heads instead — `Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`,
   exactly what `derive-runtime`/`macsyma-compiler` already lower to — so
   Reduce agrees with its CAS-family siblings on every arithmetic result.
-- 84 tests total: `lower`/`printer` unit tests covering every row of MA08
+- 85 tests total: `lower`/`printer` unit tests covering every row of MA08
   §3's surface table, plus end-to-end session tests (arithmetic, persistent
   bindings/procedures, `if` with/without `else`, lists and cons-folding,
-  both robustness guards including the group-statement-nested case, panic
-  recovery, and the disclosed `CompoundExpression`/list-accessor gap), plus
-  a doctest on `ReduceSession::feed`.
+  both robustness guards including the group-statement-nested case and the
+  embedded-group-inside-a-larger-chain regression, panic recovery, and the
+  disclosed `CompoundExpression`/list-accessor gap), plus a doctest on
+  `ReduceSession::feed`.

--- a/code/packages/rust/reduce-runtime/CHANGELOG.md
+++ b/code/packages/rust/reduce-runtime/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+## [0.1.0] - 2026-07-18
+
+### Added
+
+- Initial `reduce-runtime` crate (MA08 R-4, front2 Wave 5): lowers the
+  `reduce-parser` (R-3) `GrammarASTNode` CST into `symbolic_ir::IRNode` and
+  evaluates it via `symbolic_vm::VM` over the shared `SymbolicBackend` —
+  unchanged, no custom `Backend` — mirroring `derive-runtime`'s identical
+  reuse story for the other Wave-5 CAS-family language.
+- `lower` module: the full precedence-cascade lowering (`assignment`
+  through `atom`, plus `if_expr`/`group_expr`/`cons`/`list_literal`), the
+  lowercase-surface→canonical head bridge (`list`→`List`, `first`→`First`,
+  `second`→`Second`, `third`→`Third`, `rest`→`Rest`, `part`→`Part`,
+  `append`→`Append`, `reverse`→`Reverse`), `:=` assignment-vs-procedure-
+  definition disambiguation by LHS shape (Reduce, like Derive, has only one
+  assignment token), and the cons-onto-a-literal-list fold MA08 §3
+  documents (`a . {b, c}` → `List[a, b, c]`, not a standalone `Cons` node;
+  right-associative, so `a . b . {c}` folds through every link).
+- `printer` module: the inverse — canonical heads back to Reduce surface
+  notation (infix arithmetic/comparison/logic, curly-brace `{a, b, c}`
+  lists, `if ... then [... else ...]`, `<< s1; s2; ... >>`), with its own
+  precedence ladder mirroring `reduce.grammar`'s cascade (one tier more
+  than `derive-runtime::printer`'s table, for the `cons` tier Derive has no
+  analogue of).
+- `ReduceSession`/`eval`: a string-in/string-out facade mirroring
+  `derive-runtime`'s session pattern, **without** a numbered-worksheet
+  prefix — MA08 §2/§5 are explicit that Reduce's own session transcript has
+  no numbered-input convention the way Derive's `#n:` or Wolfram's
+  `In[n]:=` do, so `Output` here carries only rendered text and `feed`
+  never prints a prefix.
+- Robustness: `MAX_INPUT_LEN` (64 KiB) bounds total input;
+  `MAX_STATEMENT_TOKENS` (2000, measured against the real `reduce-lexer`
+  token stream) closes the "long flat chain folds into a deep lowered
+  tree" vector that `reduce-parser`'s own `MAX_RULE_DEPTH` cannot cover
+  (grammar repetitions, not recursive rule calls, aren't bounded by that
+  cap). Unlike `derive-runtime`'s identical-in-spirit guard (reset on a
+  significant `NEWLINE`), this crate resets on Reduce's own real
+  terminators, `SEMI`/`DOLLAR`, including ones lexically inside a
+  `<< ... >>` group statement (safe, since `group_expr` lowers to a *flat*
+  `CompoundExpression`, never nested sub-statements). Two shapes are
+  guarded: the additive/multiplicative left-fold chain (shared with
+  Derive's identical vector) and, new here, a chained postfix call
+  `f(x)(x)(x)…` (`postfix`'s own call-chaining loop folds the same way).
+  Evaluation runs on a 512 MiB-stack worker thread inside `catch_unwind`,
+  rebuilding the session after any caught panic.
+- **Disclosed spec/reality gap** (documented in `crate::lower`'s module
+  doc comment, this crate's README, and MA08 itself — see that spec's own
+  R-4 status note): grepping `symbolic-vm::handlers::build_handler_table`
+  confirms **no** handler exists for `CompoundExpression`, `First`/
+  `Second`/`Third`/`Rest`/`Part`/`Append`/`Reverse`, or `Cons` — MA08 §5's
+  claim that these are "already implemented for Macsyma/Wolfram/Derive" is
+  true only via a *bespoke* `Backend` specific to each of those languages,
+  not the shared `SymbolicBackend` R-4 is required to reuse unchanged. This
+  crate still lowers to the structurally-correct heads MA08 §3 documents
+  (arguments evaluate, including any `Assign`/`Define` side effects, in
+  order), but the calls themselves stay unevaluated rather than performing
+  the operation — the same "no handler, no crash" contract an undefined
+  user function already has. Also disclosed: MA08 §3's own prose describes
+  the arithmetic heads as `Plus`/`Subtract`/`Times`/`Power` (with `/`
+  and unary `-` expanded into `Times`/`Power` applications); none of those
+  spellings exist in `symbolic-ir` at all. This crate uses the real,
+  already-reused heads instead — `Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`,
+  exactly what `derive-runtime`/`macsyma-compiler` already lower to — so
+  Reduce agrees with its CAS-family siblings on every arithmetic result.
+- 84 tests total: `lower`/`printer` unit tests covering every row of MA08
+  §3's surface table, plus end-to-end session tests (arithmetic, persistent
+  bindings/procedures, `if` with/without `else`, lists and cons-folding,
+  both robustness guards including the group-statement-nested case, panic
+  recovery, and the disclosed `CompoundExpression`/list-accessor gap), plus
+  a doctest on `ReduceSession::feed`.

--- a/code/packages/rust/reduce-runtime/Cargo.toml
+++ b/code/packages/rust/reduce-runtime/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "coding-adventures-reduce-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Reduce runtime — lowers Reduce syntax to symbolic-ir and evaluates via symbolic-vm (R-4)"
+license = "MIT"
+
+[dependencies]
+# The R-3 frontend: parses Reduce source into a generic GrammarASTNode that
+# this crate lowers to symbolic-ir.
+coding-adventures-reduce-parser = { path = "../reduce-parser" }
+# The R-2 lexer. Tokenized once up front (the lexer is iterative, so unlike
+# the parser it cannot stack-overflow) to measure per-statement token counts
+# from the *real* token stream, mirroring derive-runtime/wolfram-runtime's
+# identical guard against a long flat operator chain folding into a deeply
+# nested lowered tree (see MAX_STATEMENT_TOKENS's doc comment).
+coding-adventures-reduce-lexer = { path = "../reduce-lexer" }
+# The shared symbolic substrate: the term IR everything lowers to and the VM
+# that rewrites it.
+symbolic-ir = { path = "../symbolic-ir" }
+symbolic-vm = { path = "../symbolic-vm" }
+# The generic parser AST types (GrammarASTNode / ASTNodeOrToken) and the lexer
+# Token type the lowering walks.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/reduce-runtime/README.md
+++ b/code/packages/rust/reduce-runtime/README.md
@@ -1,0 +1,142 @@
+# coding-adventures-reduce-runtime
+
+Evaluates Reduce (a subset) by lowering the `reduce-parser` (R-3) CST into
+[`symbolic-ir`](../symbolic-ir) and running it through
+[`symbolic-vm`](../symbolic-vm)'s shared `SymbolicBackend` — the *same*
+rewrite engine Wolfram, Macsyma, and Derive already drive, unchanged. See
+[`code/specs/MA08-reduce-language.md`](../../../specs/MA08-reduce-language.md).
+
+## Where this fits
+
+`reduce-runtime` is R-4 of the Reduce frontend/runtime pipeline:
+
+```
+reduce.tokens + reduce-lexer   (R-2)
+        │
+reduce.grammar + reduce-parser (R-3)
+        │
+reduce-runtime                 (R-4, this crate) ── crate::lower ──► symbolic_ir::IRNode
+        │                                              │
+        │                                       symbolic_vm::VM (SymbolicBackend)
+        │                                              │
+reduce-repl                     (R-4)  ◄── crate::printer ─┘
+```
+
+## No custom `Backend` — and what that costs
+
+`SymbolicBackend` (built with `simplify: true`) already provides arithmetic
+(`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`), comparison (`Equal`/`Less`/`Greater`/
+`LessEqual`/`GreaterEqual`/`NotEqual`), logic (`And`/`Or`/`Not`), the held
+`Assign`/`Define`/`If` forms, and `List` — so this crate adds **no new
+evaluation code**, only:
+
+- **`lower`** — Reduce's surface `GrammarASTNode` (`assignment`, `if_expr`,
+  `group_expr`, `additive`, `cons`, `postfix`, `atom`, …) → the canonical
+  `IRNode` heads the VM dispatches, including the lowercase-surface→canonical
+  head bridge (`list`→`List`, `first`→`First`, `rest`→`Rest`, …), the `:=`
+  assignment-vs-definition disambiguation by LHS shape (mirroring
+  `derive-runtime`'s identical trick — Reduce, like Derive, has only one
+  assignment token), and the `cons` (`.`)-onto-a-literal-list fold (MA08
+  §3: `a . {b, c}` → `List[a, b, c]`, not a standalone `Cons` node).
+- **`printer`** — the inverse: canonical `IRNode` → Reduce surface notation
+  (infix `+`/`-`/`*`/`/`/`^`, `and`/`or`/`not`, curly-brace `{a, b, c}`
+  lists, `if ... then ... else ...`, `<< s1; s2; ... >>`).
+
+**A real gap, disclosed rather than papered over:** grepping
+`symbolic-vm::handlers::build_handler_table` turns up **no** handler for
+`CompoundExpression` (Reduce's `<< ... >>`), `First`/`Second`/`Third`/
+`Rest`/`Part`/`Append`/`Reverse` (the list accessors/constructors), or
+`Cons` — MA08 §5's claim that these are "already implemented for Macsyma/
+Wolfram/Derive" does not hold for the *shared*, unchanged `SymbolicBackend`
+this crate is required to reuse: Macsyma's list functions and Wolfram's
+`CompoundExpression` are each wired through a **bespoke `Backend`**
+specific to that language, which is exactly what R-4 is not supposed to
+build. This crate still lowers to the structurally-correct heads MA08 §3
+documents, so a future item adding real handlers needs no lowering change
+— but evaluating one of these calls today does not perform the operation:
+arguments evaluate (so `Assign`/`Define` side effects inside a
+`<< ... >>` genuinely happen, in order), the call itself just stays
+unevaluated, exactly like calling an undefined user function:
+
+```rust
+use coding_adventures_reduce_runtime::ReduceSession;
+
+let mut s = ReduceSession::new();
+// The Assign inside really fires (and persists!) -- but the group's own
+// result is the unevaluated CompoundExpression(1, 2), not just `2`.
+assert_eq!(s.feed("<< a := 1; a + 1 >>;\n").unwrap(), "<< 1; 2 >>\n");
+assert_eq!(s.feed("a;\n").unwrap(), "1\n");
+
+// first(...) evaluates its argument but the call itself stays unevaluated.
+assert_eq!(
+    coding_adventures_reduce_runtime::eval("first({1, 2, 3});\n").unwrap(),
+    "first({1, 2, 3})\n"
+);
+```
+
+Also disclosed: MA08 §3's own prose describes the arithmetic "Lowers to"
+column as `Plus`/`Subtract`/`Times`/`Power` (and even expands `a / b` to
+`Times[a, Power[b, -1]]` and `-a` to `Times[-1, a]`) — none of those
+spellings exist in `symbolic-ir` (`grep -n '"Plus"\|"Subtract"\|"Times"'
+symbolic-ir/src/lib.rs` returns nothing). The real, already-reused heads
+are `Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg` — what `derive-runtime`/
+`macsyma-compiler` already lower `+`/`-`/`*`/`/`/`^`/unary-`-` to, and what
+this crate lowers to as well, so all four CAS-family languages keep
+agreeing on every arithmetic result. The spec has been corrected to match
+(see MA08's own changelog note); this README and `crate::lower`'s module
+doc comment carry the full reasoning.
+
+## Usage
+
+```rust
+use coding_adventures_reduce_runtime::ReduceSession;
+
+let mut s = ReduceSession::new();
+assert_eq!(s.feed("x := 5;\n").unwrap(), "5\n");
+assert_eq!(s.feed("x + 1;\n").unwrap(), "6\n");
+// A procedure definition's own result is just the defined name (`h`) --
+// like `derive-runtime`'s `Define`, the body is stored, not evaluated yet.
+assert_eq!(s.feed("h(x) := x*x;\n").unwrap(), "h\n");
+assert_eq!(s.feed("h(5);\n").unwrap(), "25\n");
+```
+
+`coding_adventures_reduce_runtime::eval(src)` is a one-shot convenience for
+callers that don't need a persistent session. Unlike `derive-runtime`'s
+`#n:`-numbered `Output`, Reduce's own session transcript has no numbered-
+input convention (MA08 §2/§5), so every result line here is unprefixed
+plain text.
+
+## Robustness
+
+`feed`/`eval_to_outputs` are the trust boundary for arbitrary Reduce source.
+Two independent deep-recursion vectors are closed (see the crate doc
+comment for the full rationale):
+
+1. **Deeply nested source** (parenthesised, or a right-recursive
+   `:=`/`if`-`else`/cons/power chain) — already rejected by
+   `reduce-parser`'s own `MAX_RULE_DEPTH`.
+2. **A long flat chain** (`1+1+1+…`, or a chained call `f(x)(x)(x)…`) that
+   folds into a deeply *nested* lowered tree — grammar repetitions aren't
+   bounded by `MAX_RULE_DEPTH`, so `MAX_STATEMENT_TOKENS` (measured against
+   the real lexer token stream, reset on Reduce's own `SEMI`/`DOLLAR`
+   statement separators — including ones lexically inside a `<< ... >>`
+   group statement) closes this separately.
+
+Evaluation itself runs on a worker thread with a large bounded stack inside
+`catch_unwind`, so a reused-handler panic (e.g. a malformed `Assign` LHS)
+becomes a clean `Err` and the session is rebuilt rather than left corrupted.
+
+## Tests
+
+```sh
+cargo test -p coding-adventures-reduce-runtime
+```
+
+Unit tests for every `lower`/`printer` construct in MA08 §3's table
+(arithmetic, comparison, logic, `if`/`<< ... >>`, lists, cons-folding,
+assignment/definition), plus end-to-end session tests: arithmetic,
+persistent assignment/user-defined operators, `if` with and without
+`else`, both robustness guards (including the chained-call-postfix and
+inside-a-group-statement variants), panic recovery, and the disclosed
+list-accessor/`CompoundExpression` gap (evaluates without crashing, stays
+structurally unevaluated).

--- a/code/packages/rust/reduce-runtime/README.md
+++ b/code/packages/rust/reduce-runtime/README.md
@@ -119,12 +119,20 @@ comment for the full rationale):
    folds into a deeply *nested* lowered tree — grammar repetitions aren't
    bounded by `MAX_RULE_DEPTH`, so `MAX_STATEMENT_TOKENS` (measured against
    the real lexer token stream, reset on Reduce's own `SEMI`/`DOLLAR`
-   statement separators — including ones lexically inside a `<< ... >>`
-   group statement) closes this separately.
+   statement separators — but only at bracket depth 0, i.e. genuine
+   top-level statement boundaries) closes this separately. A `/security-
+   review` finding caught a bypass in an earlier version that reset
+   unconditionally, including on a `;`/`$` lexically inside a `<< ... >>`
+   group statement embedded as one operand of a much larger enclosing
+   chain (`1 + 1 + (<<0;0>>) + 1 + 1 + ...`) — see `check_statement_token_
+   counts`'s doc comment for the full accounting.
 
 Evaluation itself runs on a worker thread with a large bounded stack inside
 `catch_unwind`, so a reused-handler panic (e.g. a malformed `Assign` LHS)
 becomes a clean `Err` and the session is rebuilt rather than left corrupted.
+A thread-spawn failure itself (OS thread-count/memory pressure) is also
+handled as an ordinary `Err`, not a caller-thread panic — a second
+`/security-review` finding against an earlier `.expect()`-based version.
 
 ## Tests
 

--- a/code/packages/rust/reduce-runtime/required_capabilities.json
+++ b/code/packages/rust/reduce-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/reduce-runtime",
+  "capabilities": [],
+  "justification": "Pure computation: parses Reduce source, lowers it to symbolic-ir, evaluates with symbolic-vm, and formats the result string. No filesystem, network, or process access. (A bounded worker thread with a large stack is spawned per evaluation to contain deep-recursion stack overflows; this is in-process compute, not OS-level process spawning.)"
+}

--- a/code/packages/rust/reduce-runtime/src/lib.rs
+++ b/code/packages/rust/reduce-runtime/src/lib.rs
@@ -1,0 +1,553 @@
+//! # Reduce runtime — lower Reduce syntax to `symbolic-ir`, evaluate via `symbolic-vm`.
+//!
+//! This is the **R-4** deliverable of the Reduce-language lane (MA08 §2). R-1
+//! through R-3 gave us a spec, a lexer, and a parser; this crate is the
+//! *runtime* that finally **evaluates** Reduce source — by **reusing the
+//! shared symbolic substrate** rather than writing a bespoke interpreter,
+//! exactly the reuse story [`derive-runtime`](../derive-runtime) already
+//! demonstrated for the other Wave-5 CAS-family language:
+//!
+//! ```text
+//!   Reduce source
+//!        │
+//!        ▼  coding_adventures_reduce_parser::try_parse_reduce  (R-3)
+//!   GrammarASTNode  (surface tree: assignment, if_expr, additive, postfix, …)
+//!        │
+//!        ▼  crate::lower                                        (this crate)
+//!   symbolic_ir::IRNode   (Add, Mul, Pow, Assign, Define, If, List, …)
+//!        │
+//!        ▼  symbolic_vm::VM over SymbolicBackend, UNCHANGED
+//!   symbolic_ir::IRNode   (evaluated)
+//!        │
+//!        ▼  crate::printer
+//!   Reduce surface string  (infix, {a,b,c}, and/or/not, if...then...else)
+//! ```
+//!
+//! ## No custom `Backend` needed — and what that costs (MA08 §5)
+//!
+//! Per MA08 §2/§5, R-4 reuses [`symbolic_vm::SymbolicBackend`] *unchanged* —
+//! no bespoke `Backend` the way `wolfram-runtime`/`macsyma-runtime` each
+//! layer their own list/string built-ins onto. `SymbolicBackend` (built
+//! with `simplify: true`) already provides everything MA08 §3 needs for
+//! arithmetic (`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`), comparison (`Equal`/
+//! `Less`/`Greater`/`LessEqual`/`GreaterEqual`/`NotEqual`), logic (`And`/
+//! `Or`/`Not`), the held `Assign`/`Define`/`If` forms, and `List` — so this
+//! crate's entire Reduce-specific contribution is the **lowering**
+//! (surface syntax → canonical heads, [`lower`]) and the **printer**
+//! (canonical heads → surface syntax, [`printer`]); the evaluation engine
+//! itself is reused completely unchanged.
+//!
+//! What MA08 §5 gets *wrong*, confirmed by grepping the actual crates
+//! (see [`lower`]'s module doc comment for the full accounting): the
+//! *shared* handler table has **no** handler at all for `CompoundExpression`
+//! (Reduce's `<< ... >>`), `First`/`Second`/`Third`/`Rest`/`Part`/`Append`/
+//! `Reverse` (the list accessors/constructors), or `Cons` — Macsyma's list
+//! functions and Wolfram's `CompoundExpression` are real, but wired through
+//! a *bespoke* `Backend` specific to that language, which is exactly what
+//! R-4 is not supposed to build. This crate still lowers to the
+//! structurally-correct heads MA08 §3 documents (so a future item that adds
+//! real handlers needs no lowering changes), but evaluating one of these
+//! calls does not perform the operation — arguments evaluate (so `Assign`/
+//! `Define` side effects inside a `<< ... >>` still happen, in order), the
+//! call itself just stays unevaluated, exactly like an undefined user
+//! function. Also disclosed: MA08 §3's own prose describes the arithmetic
+//! heads as `Plus`/`Subtract`/`Times`/`Power` (and even expands `/`/unary
+//! `-` into `Times`/`Power` applications) — none of those spellings exist
+//! in `symbolic-ir` either; the real, already-reused heads are `Add`/`Sub`/
+//! `Mul`/`Div`/`Pow`/`Neg`, which is what this crate actually lowers to.
+//!
+//! ## Public contract
+//!
+//! [`ReduceSession::feed`] is string-in / string-out. It evaluates a chunk
+//! of source (one or more `;`/`$`-terminated statements) and returns the
+//! surface rendering of each result, one per line. Unlike
+//! [`derive-runtime`](../derive-runtime) or Wolfram's `In[n]:=`/`Out[n]=`,
+//! **Reduce's own session transcript has no numbered-input convention**
+//! (MA08 §2/§5) — so, unlike [`derive_runtime::Output`]'s `#n` index,
+//! [`Output`] here carries only the rendered text, and `feed` never prints
+//! any prefix. Bindings persist across calls, so an interactive `x := 5`
+//! then `x + 1` works.
+//!
+//! [`derive_runtime::Output`]: https://docs.rs/coding-adventures-derive-runtime
+//!
+//! ## Robustness at the trust boundary
+//!
+//! `feed` takes arbitrary user text, so — exactly as in
+//! `derive-runtime`/`wolfram-runtime`/`maxima-runtime` — it is the trust
+//! boundary for the whole reused stack. Two layered guards close the two
+//! independent deep-recursion vectors (per the "depth caps don't compose
+//! across boundaries" lesson: a cap on one recursive walk does not protect
+//! a *different* recursive walk over the same or a derived tree):
+//!
+//! 1. **Deeply *nested* source**, whether parenthesised (`((((…))))`),
+//!    right-recursive assignment/`if`-`else`/cons/power chains, or any
+//!    other shape `reduce-parser`'s own `MAX_RULE_DEPTH` measures — this
+//!    vector is already closed by the *parser*, before this crate's
+//!    lowering/printing recursion (which walks the *same* already-shallow
+//!    tree the parser handed back) ever runs.
+//! 2. **A long *flat* chain that folds into a deeply *nested* lowered
+//!    tree.** `reduce-parser`'s own `MAX_RULE_DEPTH` doc comment proves,
+//!    with a throwaway probe grammar, that its EBNF `{ x }`-repetition
+//!    productions (`additive`, `multiplicative`, a chained `postfix` call
+//!    `f(x)(y)(z)…`, `logical_or`/`logical_and`, `arglist`) cost the parser
+//!    *zero* native stack regardless of width — so `MAX_RULE_DEPTH` does not
+//!    (and structurally cannot) bound a flat chain's length. Of those,
+//!    [`lower::lower_binary_chain`] (additive/multiplicative) and
+//!    [`lower::lower_postfix`]'s call-chaining loop both left-fold an
+//!    N-repetition into an N-1-deep *nested* `Apply` tree — `logical_or`/
+//!    `logical_and`/`arglist` do not (they fold flat/n-ary, or lower each
+//!    element independently — see their own doc comments), so they need no
+//!    guarding here. [`MAX_STATEMENT_TOKENS`], measured against the
+//!    **real** lexer token stream (so there is no separately-maintained
+//!    lexical model to diverge from and bypass), closes this vector — a
+//!    statement's resulting tree depth is bounded above by its token count,
+//!    since every node consumes at least one token. Unlike
+//!    `derive-runtime`'s identical-in-spirit guard (which resets its
+//!    running count on a `NEWLINE` token, since Derive's statement
+//!    separator IS the newline), this crate resets on Reduce's own real
+//!    separators, `SEMI`/`DOLLAR` (`;`/`$`) — including ones lexically
+//!    inside a `<< ... >>` group statement, which is fine: `group_expr`'s
+//!    own statements lower to a *flat* `CompoundExpression(s1, s2, …)`
+//!    (see [`lower::lower_group_expr`]), never nested onto each other, so
+//!    bounding each `s_i`'s own token run independently is exactly the
+//!    right (and no more permissive) boundary.
+//! 3. **Unwinding panics** (a malformed `Assign`/`Define` LHS, or any other
+//!    reused-handler panic on a surprising shape). Evaluation runs inside
+//!    [`catch_unwind`] on a worker thread with a large bounded stack, and any
+//!    panic becomes a clean `Err(String)`; the session is rebuilt afterward
+//!    (trading lost bindings for a guaranteed-usable session next call), so
+//!    one crafted statement can never abort the process or wedge a session.
+
+mod lower;
+mod printer;
+
+pub use lower::LowerError;
+pub use printer::print_reduce;
+
+use coding_adventures_reduce_lexer::try_tokenize_reduce;
+use coding_adventures_reduce_parser::try_parse_reduce;
+use lower::lower_program;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use symbolic_vm::{SymbolicBackend, VM};
+
+/// Maximum length, in bytes, of a single source chunk handed to
+/// [`ReduceSession::feed`].
+///
+/// A cheap first gate bounding per-call memory/time. 64 KiB is far beyond
+/// any realistic interactive submission.
+pub const MAX_INPUT_LEN: usize = 64 * 1024;
+
+/// Maximum number of lexer tokens allowed in any single statement (a run of
+/// tokens between two `SEMI`/`DOLLAR` separators, or between a separator and
+/// the start/end of input).
+///
+/// See the module doc comment's "Robustness" point 2 — this closes the
+/// long-flat-chain vector `reduce-parser`'s own `MAX_RULE_DEPTH` does not
+/// (and cannot) cover. 2000 tokens in one statement is already absurd for a
+/// hand-written Reduce program line, matching `derive-runtime`'s identical
+/// choice of cap.
+pub const MAX_STATEMENT_TOKENS: usize = 2000;
+
+/// Stack size of the worker thread that runs evaluation and printing.
+///
+/// With the per-statement complexity cap bounding tree depth, this is
+/// generous headroom so the bounded-but-still-deep trees are built,
+/// evaluated, printed, and dropped well clear of any overflow, regardless of
+/// the caller's own stack.
+const EVAL_STACK_SIZE: usize = 512 * 1024 * 1024;
+
+/// A persistent Reduce session.
+///
+/// Owns the [`VM`] (and through it the [`SymbolicBackend`] environment), so
+/// variable bindings (`x := 5`) and user-defined operators (`h(l, m) := l +
+/// m`) persist across calls to [`feed`](ReduceSession::feed), exactly as in
+/// an interactive Reduce session.
+pub struct ReduceSession {
+    vm: VM,
+}
+
+impl Default for ReduceSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One displayed result line from a [`ReduceSession::feed`] call.
+///
+/// Reduce's own session transcript has no numbered-input convention (MA08
+/// §2/§5, unlike Derive's `#n:` or Wolfram's `In[n]:=`), so — unlike
+/// `derive-runtime::Output` — this carries only the rendered text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Output {
+    /// The result rendered in Reduce surface notation.
+    pub text: String,
+}
+
+impl ReduceSession {
+    /// Create a fresh session with an empty environment.
+    pub fn new() -> Self {
+        ReduceSession {
+            vm: VM::new(Box::new(SymbolicBackend::new())),
+        }
+    }
+
+    /// Evaluate a chunk of Reduce source and return the concatenated echo.
+    ///
+    /// Every statement produces one plain output line (no numbering — see
+    /// the module/[`Output`] doc comments); the lines are concatenated in
+    /// evaluation order, each ending in a newline. A parse or lowering error
+    /// is returned as `Err` with the message.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use coding_adventures_reduce_runtime::ReduceSession;
+    /// let mut s = ReduceSession::new();
+    /// assert_eq!(s.feed("1 + 2*3;\n").unwrap(), "7\n");
+    /// ```
+    pub fn feed(&mut self, src: &str) -> Result<String, String> {
+        let outputs = self.eval_to_outputs(src)?;
+        let mut out = String::new();
+        for o in outputs {
+            out.push_str(&o.text);
+            out.push('\n');
+        }
+        Ok(out)
+    }
+
+    /// Evaluate `src` and return the structured list of displayed [`Output`]s.
+    ///
+    /// The lower-level cousin of [`feed`](ReduceSession::feed) — a REPL that
+    /// wants to format its own prompt uses this and renders each `Output`.
+    pub fn eval_to_outputs(&mut self, src: &str) -> Result<Vec<Output>, String> {
+        // Guard 1: bound total input size (cheap memory/time gate).
+        if src.len() > MAX_INPUT_LEN {
+            return Err(format!(
+                "input too large: {} bytes exceeds the {}-byte limit",
+                src.len(),
+                MAX_INPUT_LEN
+            ));
+        }
+        // Guard 2: reject a long flat chain before it can fold into a
+        // stack-overflowing lowered tree (see the module "Robustness" note,
+        // point 2 — deeply *nested* source is already rejected by
+        // `reduce-parser`'s own `MAX_RULE_DEPTH`, a *different* vector this
+        // guard does not need to re-cover).
+        check_statement_token_counts(src)?;
+
+        // Guard 3 + panics: the lowering, the VM evaluation, and the printer
+        // all run on a worker thread with a large bounded stack, and any
+        // unwinding panic from the reused symbolic stack is caught.
+        let vm = &mut self.vm;
+        let src_owned = src.to_string();
+        let outcome = std::thread::scope(|scope| {
+            std::thread::Builder::new()
+                .stack_size(EVAL_STACK_SIZE)
+                .spawn_scoped(scope, || {
+                    catch_unwind(AssertUnwindSafe(|| eval_source(vm, &src_owned)))
+                })
+                .expect("failed to spawn reduce evaluation thread")
+                .join()
+        });
+
+        match outcome {
+            // Normal path: the worker produced the outputs (or a surface error).
+            Ok(Ok(Ok(outputs))) => Ok(outputs),
+            Ok(Ok(Err(message))) => Err(message),
+            // A panic the worker caught, or one that escaped and unwound the
+            // join. Either way the env may be inconsistent, so rebuild.
+            Ok(Err(payload)) | Err(payload) => {
+                self.vm = VM::new(Box::new(SymbolicBackend::new()));
+                Err(panic_message(payload))
+            }
+        }
+    }
+}
+
+/// Evaluate every statement in `src`, returning the displayed outputs. Runs
+/// on the worker thread.
+fn eval_source(vm: &mut VM, src: &str) -> Result<Vec<Output>, String> {
+    // The parser's error string already carries a user-readable message, so
+    // we forward it as-is.
+    let ast = try_parse_reduce(src)?;
+    let statements = lower_program(&ast).map_err(|e| e.to_string())?;
+
+    let mut outputs = Vec::new();
+    for stmt in statements {
+        let result = vm.eval(stmt);
+        outputs.push(Output {
+            text: print_reduce(&result),
+        });
+    }
+    Ok(outputs)
+}
+
+/// Reject input where any single statement lexes to too many tokens.
+///
+/// The count is taken from the **real** Reduce lexer, the very one the
+/// parser consumes, so there is no separately-maintained lexical model to
+/// diverge from: a `SEMI`/`DOLLAR` token (`;`/`$`, Reduce's own
+/// interchangeable statement terminators — manual §5.1, unlike
+/// `derive-runtime`'s significant-`NEWLINE` reset) marks a statement
+/// boundary and resets the running count, including one lexically inside a
+/// `<< ... >>` group statement — see the module doc comment's "Robustness"
+/// point 2 for why that's the correct, and not overly permissive, boundary.
+///
+/// If the lexer itself errors (an untokenizable character), we return
+/// `Ok(())` and let the parser surface the error uniformly — we never
+/// reject solely because the *checker* could not lex something.
+fn check_statement_token_counts(src: &str) -> Result<(), String> {
+    let tokens = match try_tokenize_reduce(src) {
+        Ok(tokens) => tokens,
+        Err(_) => return Ok(()), // unlexable — let the parser surface it
+    };
+
+    let mut count: usize = 0;
+    for token in &tokens {
+        if matches!(token.effective_type_name(), "SEMI" | "DOLLAR") {
+            count = 0;
+            continue;
+        }
+        count += 1;
+        if count > MAX_STATEMENT_TOKENS {
+            return Err(format!(
+                "statement too complex: more than {MAX_STATEMENT_TOKENS} tokens in one statement"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Evaluate `src` once on a fresh [`ReduceSession`] and return its echo.
+///
+/// Convenience for callers that do not need persistent state.
+pub fn eval(src: &str) -> Result<String, String> {
+    ReduceSession::new().feed(src)
+}
+
+/// Recover a human-readable message from a caught panic payload.
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        "Reduce could not evaluate that input".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arithmetic_folds_to_an_integer() {
+        assert_eq!(eval("1 + 2*3;\n").unwrap(), "7\n");
+    }
+
+    #[test]
+    fn power_and_division() {
+        assert_eq!(eval("2^10;\n").unwrap(), "1024\n");
+        assert_eq!(eval("10 / 2;\n").unwrap(), "5\n");
+        assert_eq!(eval("2**10;\n").unwrap(), "1024\n");
+    }
+
+    #[test]
+    fn free_symbols_stay_symbolic() {
+        assert_eq!(eval("x + 0;\n").unwrap(), "x\n");
+    }
+
+    #[test]
+    fn assignment_persists_across_calls() {
+        let mut s = ReduceSession::new();
+        assert_eq!(s.feed("x := 5;\n").unwrap(), "5\n");
+        assert_eq!(s.feed("x + 1;\n").unwrap(), "6\n");
+    }
+
+    #[test]
+    fn user_defined_operator_end_to_end() {
+        let mut s = ReduceSession::new();
+        s.feed("h(x) := x*x;\n").unwrap();
+        assert_eq!(s.feed("h(5);\n").unwrap(), "25\n");
+    }
+
+    #[test]
+    fn if_selects_a_branch_via_the_held_handler() {
+        assert_eq!(eval("if 1 > 0 then 42 else 0;\n").unwrap(), "42\n");
+        assert_eq!(eval("if 0 > 1 then 42 else 7;\n").unwrap(), "7\n");
+    }
+
+    #[test]
+    fn if_with_no_else_returns_false_on_a_failing_condition() {
+        assert_eq!(eval("if 0 > 1 then 42;\n").unwrap(), "False\n");
+    }
+
+    #[test]
+    fn equation_stays_unevaluated_not_assignment() {
+        // `x = 4` is Equal, not Assign — it does not bind x.
+        let mut s = ReduceSession::new();
+        assert_eq!(s.feed("x = 4;\n").unwrap(), "x = 4\n");
+        assert_eq!(s.feed("x + 1;\n").unwrap(), "x + 1\n");
+    }
+
+    #[test]
+    fn multiple_statements_in_one_feed() {
+        let out = eval("1 + 1; 2 + 2; 3 + 3;\n").unwrap();
+        assert_eq!(out, "2\n4\n6\n");
+    }
+
+    #[test]
+    fn semi_and_dollar_terminators_are_interchangeable() {
+        let out = eval("1 + 1$ 2 + 2;\n").unwrap();
+        assert_eq!(out, "2\n4\n");
+    }
+
+    #[test]
+    fn list_literal_evaluates_elementwise() {
+        assert_eq!(
+            eval("{1 + 1, 2*3, 2^3};\n").unwrap(),
+            "{2, 6, 8}\n"
+        );
+    }
+
+    #[test]
+    fn list_assignment_persists_across_calls() {
+        let mut s = ReduceSession::new();
+        assert_eq!(s.feed("v := {1, 2, 3};\n").unwrap(), "{1, 2, 3}\n");
+        assert_eq!(s.feed("v;\n").unwrap(), "{1, 2, 3}\n");
+    }
+
+    #[test]
+    fn cons_onto_a_literal_list_folds_and_evaluates() {
+        assert_eq!(eval("1 . {2, 3};\n").unwrap(), "{1, 2, 3}\n");
+    }
+
+    #[test]
+    fn boolean_logic_evaluates() {
+        assert_eq!(eval("1 > 0 and 2 > 1;\n").unwrap(), "True\n");
+        assert_eq!(eval("not (1 > 2);\n").unwrap(), "True\n");
+    }
+
+    #[test]
+    fn a_parse_error_is_returned_not_panicked() {
+        let err = eval("1 +\n");
+        assert!(err.is_err(), "expected a clean Err, got {err:?}");
+    }
+
+    #[test]
+    fn session_recovers_after_a_parse_error() {
+        let mut s = ReduceSession::new();
+        let _ = s.feed("1 +\n");
+        assert_eq!(s.feed("3 + 4;\n").unwrap(), "7\n");
+    }
+
+    #[test]
+    fn oversized_input_is_rejected_before_evaluation() {
+        let huge = format!("{}1;\n", "1+".repeat(MAX_INPUT_LEN));
+        assert!(huge.len() > MAX_INPUT_LEN);
+        let err = eval(&huge).unwrap_err();
+        assert!(err.contains("too large"), "got {err:?}");
+    }
+
+    #[test]
+    fn deeply_nested_parens_are_rejected_by_the_parsers_own_cap() {
+        // reduce-parser's own MAX_RULE_DEPTH rejects this before the runtime
+        // ever sees a tree — this test proves the session surfaces that as a
+        // clean Err (not a crash), not that this crate re-implements the cap.
+        let depth = 5000;
+        let src = format!("{}1{};\n", "(".repeat(depth), ")".repeat(depth));
+        assert!(src.len() <= MAX_INPUT_LEN, "stays under the length cap");
+        assert!(eval(&src).is_err());
+    }
+
+    #[test]
+    fn long_flat_additive_chain_is_rejected_by_the_statement_token_cap() {
+        // additive/multiplicative are grammar REPETITIONS, not recursive
+        // rule calls, so reduce-parser's MAX_RULE_DEPTH does not bound
+        // chain length — this is the vector MAX_STATEMENT_TOKENS closes.
+        let src = format!("{}1;\n", "1+".repeat(5_000));
+        assert!(src.len() <= MAX_INPUT_LEN);
+        assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn long_flat_postfix_call_chain_is_rejected_by_the_statement_token_cap() {
+        // f(x)(x)(x)... -- `postfix`'s own call-chaining loop folds each
+        // successive call into a nested Apply, another repetition-driven
+        // (not recursion-driven) vector MAX_RULE_DEPTH does not bound.
+        let src = format!("f{};\n", "(x)".repeat(5_000));
+        assert!(src.len() <= MAX_INPUT_LEN);
+        assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn a_long_chain_inside_a_group_statement_is_still_capped() {
+        // The token-count reset on SEMI/DOLLAR happens even lexically
+        // inside `<< ... >>` (see the module doc comment) -- this proves a
+        // dangerous chain hidden as one of a group statement's own
+        // sub-statements is still caught.
+        let src = format!("<< 1; {}1 >>;\n", "1+".repeat(5_000));
+        assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn moderate_chain_still_evaluates() {
+        let src = format!("{}1;\n", "1+".repeat(50));
+        assert_eq!(eval(&src).unwrap(), "51\n");
+    }
+
+    #[test]
+    fn a_malformed_assign_lhs_is_caught_not_aborted() {
+        // `5 := 3` lowers to Assign(5, 3). The reused VM's assign_handler
+        // *panics* when the lhs is not a symbol — the worker-thread
+        // `catch_unwind` must convert that panic into a clean `Err`, and the
+        // session must remain usable afterward (the env is rebuilt).
+        let mut s = ReduceSession::new();
+        assert!(
+            s.feed("5 := 3;\n").is_err(),
+            "a non-symbol Assign lhs must return Err, never abort"
+        );
+        assert_eq!(s.feed("2 + 2;\n").unwrap(), "4\n");
+    }
+
+    #[test]
+    fn the_one_shot_eval_helper_matches_a_session() {
+        let one = eval("2 + 3;\n").unwrap();
+        let two = ReduceSession::new().feed("2 + 3;\n").unwrap();
+        assert_eq!(one, two);
+    }
+
+    #[test]
+    fn empty_and_whitespace_input_yields_nothing() {
+        assert_eq!(eval("\n").unwrap(), "");
+    }
+
+    #[test]
+    fn a_small_reduce_program_evaluates_end_to_end() {
+        let mut s = ReduceSession::new();
+        s.feed("h(x) := x - 2*x;\n").unwrap();
+        let out = s.feed("h(5);\n").unwrap();
+        assert_eq!(out, "-5\n");
+    }
+
+    #[test]
+    fn group_statement_executes_side_effects_in_order() {
+        // MA08 §5 gap (see the module/`lower` doc comments): the group's
+        // OWN result stays the unevaluated CompoundExpression(1, 2) rather
+        // than collapsing to just `2`, since the shared handler table has
+        // no handler for that head -- but the ASSIGN side effect inside it
+        // genuinely fires, in order, since arguments are still evaluated.
+        let mut s = ReduceSession::new();
+        let out = s.feed("<< a := 1; a + 1 >>;\n").unwrap();
+        assert_eq!(out, "<< 1; 2 >>\n");
+        assert_eq!(s.feed("a;\n").unwrap(), "1\n");
+    }
+
+    #[test]
+    fn list_accessor_calls_do_not_crash_even_though_unwired() {
+        // See the crate/`lower` doc comments' disclosed gap: no shared
+        // handler exists yet, so this evaluates the argument and leaves the
+        // call itself unevaluated -- it must not panic or hang.
+        assert_eq!(eval("first({1, 2, 3});\n").unwrap(), "first({1, 2, 3})\n");
+    }
+}

--- a/code/packages/rust/reduce-runtime/src/lib.rs
+++ b/code/packages/rust/reduce-runtime/src/lib.rs
@@ -105,18 +105,34 @@
 //!    `derive-runtime`'s identical-in-spirit guard (which resets its
 //!    running count on a `NEWLINE` token, since Derive's statement
 //!    separator IS the newline), this crate resets on Reduce's own real
-//!    separators, `SEMI`/`DOLLAR` (`;`/`$`) — including ones lexically
-//!    inside a `<< ... >>` group statement, which is fine: `group_expr`'s
-//!    own statements lower to a *flat* `CompoundExpression(s1, s2, …)`
-//!    (see [`lower::lower_group_expr`]), never nested onto each other, so
-//!    bounding each `s_i`'s own token run independently is exactly the
-//!    right (and no more permissive) boundary.
+//!    separators, `SEMI`/`DOLLAR` (`;`/`$`) — but **only when they mark a
+//!    genuine top-level statement boundary**, i.e. at bracket depth 0. An
+//!    earlier version reset unconditionally, including on a `;`/`$`
+//!    lexically inside a `<< ... >>` group statement, reasoning that
+//!    `group_expr`'s own statements lower flat ([`lower::lower_group_expr`])
+//!    so bounding each sub-statement's own token run independently was fine
+//!    — but a `/security-review` finding caught the gap that reasoning
+//!    missed: a *parenthesized* group construct can itself be embedded as
+//!    just **one operand** of a much larger enclosing additive/
+//!    multiplicative/postfix chain (`1 + 1 + (<<0;0>>) + 1 + 1 + ...`), and
+//!    the `;` inside it reset the counter for that *outer* chain too, even
+//!    though the outer chain still folds every operand into one deeply
+//!    nested tree regardless. [`check_statement_token_counts`] now tracks
+//!    bracket nesting (`LPAREN`/`RPAREN`, `LBRACE`/`RBRACE`, `GROUP_OPEN`/
+//!    `GROUP_CLOSE`) and only resets at depth 0 — see that function's own
+//!    doc comment for the full accounting, including the deliberate (and
+//!    safe) trade-off of being slightly more conservative than the strict
+//!    minimum in one unusual case.
 //! 3. **Unwinding panics** (a malformed `Assign`/`Define` LHS, or any other
 //!    reused-handler panic on a surprising shape). Evaluation runs inside
 //!    [`catch_unwind`] on a worker thread with a large bounded stack, and any
 //!    panic becomes a clean `Err(String)`; the session is rebuilt afterward
 //!    (trading lost bindings for a guaranteed-usable session next call), so
 //!    one crafted statement can never abort the process or wedge a session.
+//!    (A thread-spawn failure itself — OS thread-count/memory pressure — is
+//!    handled as an ordinary `Err` too, not a caller-thread panic; an
+//!    earlier version `.expect()`-unwrapped that outside this boundary,
+//!    another `/security-review` finding.)
 
 mod lower;
 mod printer;
@@ -238,29 +254,57 @@ impl ReduceSession {
         // Guard 3 + panics: the lowering, the VM evaluation, and the printer
         // all run on a worker thread with a large bounded stack, and any
         // unwinding panic from the reused symbolic stack is caught.
+        //
+        // `spawn_scoped` itself can fail (OS thread-count/memory pressure —
+        // exactly the kind of adversarial-load condition this crate's own
+        // "trust boundary" doc anticipates) — a previous version unwrapped
+        // that with `.expect(...)`, panicking on the *calling* thread,
+        // entirely outside the `catch_unwind` below (a `/security-review`
+        // finding). Resolved to a plain `Result<Vec<Output>, String>`
+        // *inside* the scoped closure instead (a `ScopedJoinHandle` can't
+        // outlive it), with `panicked` — mutated only on this, the calling,
+        // thread, never touched from the spawned one — flagging whether
+        // `self.vm` needs rebuilding after the scope returns.
         let vm = &mut self.vm;
         let src_owned = src.to_string();
-        let outcome = std::thread::scope(|scope| {
-            std::thread::Builder::new()
+        let mut panicked = false;
+        let result: Result<Vec<Output>, String> = std::thread::scope(|scope| {
+            let handle = match std::thread::Builder::new()
                 .stack_size(EVAL_STACK_SIZE)
                 .spawn_scoped(scope, || {
                     catch_unwind(AssertUnwindSafe(|| eval_source(vm, &src_owned)))
-                })
-                .expect("failed to spawn reduce evaluation thread")
-                .join()
+                }) {
+                Ok(handle) => handle,
+                Err(io_err) => {
+                    // Nothing ran on another thread at all, so there is no
+                    // VM state to rebuild.
+                    return Err(format!(
+                        "failed to spawn the Reduce evaluation thread: {io_err}"
+                    ));
+                }
+            };
+            // `handle.join()`'s outer `Result` is join's own (a panic that
+            // somehow escaped the `catch_unwind` below); its `Ok` carries
+            // `catch_unwind`'s own `Result` (a panic it *did* catch); *that*
+            // `Ok` finally carries `eval_source`'s own `Result<Vec<Output>,
+            // String>` (an ordinary surface error, not a panic at all).
+            match handle.join() {
+                Ok(Ok(Ok(outputs))) => Ok(outputs),
+                Ok(Ok(Err(message))) => Err(message),
+                // A panic the worker caught, or one that escaped and unwound
+                // the join. Either way the env may be inconsistent, so flag
+                // it for a rebuild once we're back on this thread.
+                Ok(Err(payload)) | Err(payload) => {
+                    panicked = true;
+                    Err(panic_message(payload))
+                }
+            }
         });
 
-        match outcome {
-            // Normal path: the worker produced the outputs (or a surface error).
-            Ok(Ok(Ok(outputs))) => Ok(outputs),
-            Ok(Ok(Err(message))) => Err(message),
-            // A panic the worker caught, or one that escaped and unwound the
-            // join. Either way the env may be inconsistent, so rebuild.
-            Ok(Err(payload)) | Err(payload) => {
-                self.vm = VM::new(Box::new(SymbolicBackend::new()));
-                Err(panic_message(payload))
-            }
+        if panicked {
+            self.vm = VM::new(Box::new(SymbolicBackend::new()));
         }
+        result
     }
 }
 
@@ -289,9 +333,38 @@ fn eval_source(vm: &mut VM, src: &str) -> Result<Vec<Output>, String> {
 /// diverge from: a `SEMI`/`DOLLAR` token (`;`/`$`, Reduce's own
 /// interchangeable statement terminators — manual §5.1, unlike
 /// `derive-runtime`'s significant-`NEWLINE` reset) marks a statement
-/// boundary and resets the running count, including one lexically inside a
-/// `<< ... >>` group statement — see the module doc comment's "Robustness"
-/// point 2 for why that's the correct, and not overly permissive, boundary.
+/// boundary and resets the running count.
+///
+/// **Only at bracket depth 0**, though — a `/security-review` finding caught
+/// a bypass in an earlier version of this guard that reset unconditionally,
+/// including on a `;`/`$` lexically inside a `<< ... >>` group statement.
+/// `lower_group_expr` does lower a group's *own* statements flat, but a
+/// group construct can itself be parenthesized and embedded as **one
+/// operand inside a much larger enclosing `additive`/`multiplicative`/
+/// `postfix` chain** (`reduce.grammar`'s `atom = ... | group`, `group =
+/// LPAREN expr RPAREN`) — e.g. `1 + 1 + (<<0;0>>) + 1 + 1 + ...`. The `;`
+/// inside `(<<0;0>>)` would reset the counter for the *outer* chain too,
+/// even though [`lower::lower_binary_chain`] still left-folds every operand
+/// of that outer chain — before, at, and after the embedded reset point —
+/// into one single nested `Apply` tree, since it is one contiguous grammar
+/// repetition with no true top-level statement boundary at each reset
+/// point. Empirically, a 32,000-term `+` chain with a trivial `+(<<0;0>>)`
+/// spliced in every 900 terms sailed through with no error at all, while a
+/// plain uninterrupted chain of the same length was correctly rejected —
+/// 16× the documented cap, undetected.
+///
+/// The fix: track nesting depth over `LPAREN`/`RPAREN`, `LBRACE`/`RBRACE`,
+/// and `GROUP_OPEN`/`GROUP_CLOSE` (every bracket-like construct this
+/// grammar has), and only treat a `SEMI`/`DOLLAR` as a genuine reset point
+/// when depth is back to 0. This is slightly more conservative than
+/// strictly necessary — a single *top-level* `<< s1; s2; ...; sN >>` with
+/// many short, independently-flat sub-statements no longer resets between
+/// them either, since depth stays 1 throughout the group — but that only
+/// means such an (unusual) statement hits the cap sooner than the absolute
+/// minimum required, never that a genuinely deep-folding chain slips
+/// through uncounted. A negative depth from malformed/unbalanced brackets
+/// (which the real parser will separately reject) only makes future
+/// `;`/`$` tokens *not* reset, i.e. more conservative still — never less.
 ///
 /// If the lexer itself errors (an untokenizable character), we return
 /// `Ok(())` and let the parser surface the error uniformly — we never
@@ -303,10 +376,16 @@ fn check_statement_token_counts(src: &str) -> Result<(), String> {
     };
 
     let mut count: usize = 0;
+    let mut depth: i32 = 0;
     for token in &tokens {
-        if matches!(token.effective_type_name(), "SEMI" | "DOLLAR") {
-            count = 0;
-            continue;
+        match token.effective_type_name() {
+            "LPAREN" | "LBRACE" | "GROUP_OPEN" => depth += 1,
+            "RPAREN" | "RBRACE" | "GROUP_CLOSE" => depth -= 1,
+            "SEMI" | "DOLLAR" if depth == 0 => {
+                count = 0;
+                continue;
+            }
+            _ => {}
         }
         count += 1;
         if count > MAX_STATEMENT_TOKENS {
@@ -488,6 +567,41 @@ mod tests {
         // sub-statements is still caught.
         let src = format!("<< 1; {}1 >>;\n", "1+".repeat(5_000));
         assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn a_group_statement_embedded_inside_a_larger_chain_cannot_hide_the_chains_true_length() {
+        // `/security-review` finding: resetting on ANY `;`/`$` regardless of
+        // bracket nesting let a `;` lexically inside a *parenthesized* group
+        // construct — itself just one operand of a much larger enclosing
+        // additive chain — reset the counter for that outer chain too, even
+        // though `lower_binary_chain` still folds every operand (before, at,
+        // and after the embedded reset point) into one single nested `Apply`
+        // tree, since the whole thing is one contiguous grammar repetition
+        // with no true top-level statement boundary at each reset point.
+        // Splicing a trivial `(<<0;0>>)` into an otherwise-uninterrupted
+        // chain every 900 terms previously let a chain 16x the documented
+        // cap sail through with no error at all; the fix tracks bracket
+        // depth and only resets at depth 0, so the true (much longer than
+        // MAX_STATEMENT_TOKENS) chain length must still be rejected.
+        let mut src = String::new();
+        for i in 0..32_000 {
+            if i > 0 && i % 900 == 0 {
+                src.push_str("+(<<0;0>>)");
+            }
+            src.push_str("+1");
+        }
+        src.push_str(";\n");
+        assert!(
+            src.len() <= MAX_INPUT_LEN,
+            "the PoC must fit under the input-size cap on its own, so only \
+             the statement-token-count guard is what's actually being tested"
+        );
+        assert!(
+            eval(&src).unwrap_err().contains("too complex"),
+            "a chain far longer than MAX_STATEMENT_TOKENS must not be hidden \
+             by an embedded group statement's own internal reset"
+        );
     }
 
     #[test]

--- a/code/packages/rust/reduce-runtime/src/lower.rs
+++ b/code/packages/rust/reduce-runtime/src/lower.rs
@@ -1,0 +1,1207 @@
+//! # Lowering — Reduce syntax tree → `symbolic-ir`
+//!
+//! The R-3 [`reduce-parser`](coding_adventures_reduce_parser) hands us a
+//! *generic* [`GrammarASTNode`] tree whose `rule_name`s mirror
+//! `reduce.grammar` (`assignment`, `additive`, `multiplicative`, `power`,
+//! `postfix`, `atom`, `if_expr`, `group_expr`, …). The parser deliberately
+//! does **no** semantic work — it just records which rule matched. This
+//! module is where Reduce's *meaning* is assigned: every surface construct
+//! is **desugared** into the canonical [`symbolic_ir::IRNode`] head
+//! [`symbolic-vm`](symbolic_vm) already knows how to evaluate, per MA08 §3's
+//! table.
+//!
+//! ## Much of this is a direct copy of `derive-runtime::lower`'s shape
+//!
+//! Reduce (MA08 §1) is, like Derive, a "surface operators + `head(args)`
+//! calls" language with no `f[x]`-universal-application syntax and no
+//! pattern/rewrite-rule vocabulary in this subset (MA08 §4 defers `let`
+//! rules) — so this module needs none of Wolfram's pattern-lowering or
+//! `ReplaceAll` machinery, just arithmetic, comparison, logic, assignment/
+//! definition, function application, and (new relative to Derive) lists,
+//! cons, and two expression-shaped control-flow forms (`if`, `<< ... >>`).
+//!
+//! ## A REAL divergence from MA08 §3's own prose: arithmetic head *names*
+//!
+//! MA08 §3's table spells the "Lowers to" column for arithmetic as `Plus`/
+//! `Subtract`/`Times`/`Power`, and even expands `a / b` to
+//! `Times[a, Power[b, -1]]` and `-a` to `Times[-1, a]`. **None of those
+//! spellings exist in `symbolic-ir`** — grep it yourself:
+//! `grep -n '"Plus"\|"Subtract"\|"Times"\|"Power"' symbolic-ir/src/lib.rs`
+//! returns nothing. What actually exists, and what
+//! `symbolic_vm::handlers::build_handler_table` actually wires handlers for,
+//! is [`ADD`]/[`SUB`]/[`MUL`]/[`DIV`]/[`POW`]/[`NEG`] — the *exact* heads
+//! `derive-runtime::lower` and `macsyma-compiler` already lower `+`/`-`/`*`/
+//! `/`/`^`/unary-`-` to. Using the shared `Div`/`Neg` handlers directly
+//! (rather than literally expanding division/negation into `Times`/`Power`
+//! applications, which would sidestep the very handlers MA08 §5 says this
+//! milestone reuses, and would make Reduce's `1/2` print/compare
+//! differently from Derive's or Macsyma's identical expression) is *more*
+//! faithful to "the exact same functions, so all four languages agree on
+//! every result" (MA08 §5) than following the spec prose literally would
+//! have been. This is a disclosed, deliberate divergence — MA08 §3's table
+//! has been corrected to match (see the spec's own changelog-style note),
+//! and is called out in R-4's commit message.
+//!
+//! ## A REAL gap: several MA08 §3 heads have no handler in `symbolic-vm` at all
+//!
+//! Unlike the arithmetic renaming above (a naming mismatch with a working
+//! handler underneath), grepping `symbolic-vm::handlers::build_handler_table`
+//! for `CompoundExpression`, `First`, `Second`, `Third`, `Rest`, `Part`,
+//! `Append`, and `Reverse` turns up **nothing** — no handler is registered
+//! for any of them. MA08 §5's claim that these are "already implemented for
+//! Macsyma/Wolfram/Derive — the exact same functions" does not hold for the
+//! *shared* `SymbolicBackend`/`build_handler_table` this crate is required
+//! to reuse *unchanged*: Macsyma's `first`/`rest`/`append`/`reverse` are
+//! real (`cas-list-operations`), and Wolfram's `CompoundExpression` is real,
+//! but both are wired through a **bespoke `Backend`** specific to that
+//! language (`macsyma-runtime`/`wolfram-runtime`'s own `builtins.rs`), which
+//! is precisely the thing MA08 §2/§5 says R-4 must *not* build ("reused
+//! *unchanged*, with no custom `Backend` at all"). Per this crate's own
+//! marching orders ("if any is missing, that's a real gap to flag ...  not
+//! something to invent new engine code for beyond what's needed"), this
+//! lowering still produces the structurally-correct heads MA08 §3
+//! documents (so the parsed *shape* is right, and a future item that adds a
+//! `cas-list-operations`-backed handler — or a documented, narrow custom
+//! `Backend` — to the shared table needs no lowering changes at all), but
+//! evaluating one of these calls does **not** perform the list operation:
+//! the arguments evaluate (so side effects inside them, e.g. an `Assign`,
+//! still happen), and [`Backend::on_unknown_head`]'s default fallback
+//! leaves the call itself unevaluated, exactly like calling an
+//! undefined user function. `Cons` is the same story for the one shape MA08
+//! §3 does *not* say to fold away (see [`fold_cons`]).
+//!
+//! [`Backend::on_unknown_head`]: symbolic_vm::backend::Backend::on_unknown_head
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use symbolic_ir::{
+    apply, flt, int, sym, IRNode, ADD, AND, ASSIGN, DEFINE, DIV, EQUAL, GREATER, GREATER_EQUAL, IF,
+    LESS, LESS_EQUAL, LIST, MUL, NEG, NOT, NOT_EQUAL, OR, POW, SUB,
+};
+
+/// The canonical head for a `<< s1; s2; ... >>` group statement (MA08 §3).
+///
+/// Not exported by `symbolic-ir` (see the module doc comment's "REAL gap"
+/// section) — defined locally so the one place this crate needs the
+/// spelling has a name, not a repeated string literal.
+pub const COMPOUND_EXPRESSION: &str = "CompoundExpression";
+
+/// The canonical head for a non-foldable `a . b` cons (MA08 §3). See
+/// [`fold_cons`] — this head is only ever produced when the right-hand side
+/// isn't structurally a literal `List`, the one case MA08 §3 does not
+/// document a fold for.
+pub const CONS: &str = "Cons";
+
+/// The canonical heads for Reduce's list accessors/constructors (MA08 §3).
+/// Spelled to match `cas-list-operations`' own `FIRST`/`REST`/`APPEND`/
+/// `REVERSE`/`PART` constants (that crate is not a dependency here — see
+/// the module doc comment — but the *spelling* is kept identical on
+/// purpose, so a future handler wiring either crate's constants into the
+/// shared table needs no change on this crate's side).
+pub const FIRST: &str = "First";
+pub const SECOND: &str = "Second";
+pub const THIRD: &str = "Third";
+pub const REST: &str = "Rest";
+pub const PART: &str = "Part";
+pub const APPEND: &str = "Append";
+pub const REVERSE: &str = "Reverse";
+
+/// A failure while lowering the surface tree to IR. These are *structural*
+/// errors — a node shape the lowering did not expect, or a construct
+/// deliberately deferred to a later item — not user syntax errors (those are
+/// caught earlier by the parser).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LowerError {
+    message: String,
+}
+
+impl LowerError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// The human-readable message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl std::fmt::Display for LowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for LowerError {}
+
+/// Lower a parsed `program` node into one IR statement per source statement.
+///
+/// `reduce.grammar`'s root is `program = { statement_line } [ statement ]`:
+/// zero or more `;`/`$`-terminated `statement_line`s, plus an optional final
+/// bare `statement` with no terminator (so a source file need not end with
+/// one). Both shapes contribute exactly one lowered statement each.
+pub fn lower_program(root: &GrammarASTNode) -> Result<Vec<IRNode>, LowerError> {
+    if root.rule_name != "program" {
+        return Err(LowerError::new(format!(
+            "expected `program` root, got `{}`",
+            root.rule_name
+        )));
+    }
+    let mut statements = Vec::new();
+    for child in child_nodes(root) {
+        match child.rule_name.as_str() {
+            "statement_line" => {
+                if let Some(statement) = child_nodes(child).find(|n| n.rule_name == "statement") {
+                    statements.push(lower_node(statement)?);
+                }
+            }
+            "statement" => statements.push(lower_node(child)?),
+            _ => {}
+        }
+    }
+    Ok(statements)
+}
+
+/// Lower a single arbitrary node.
+///
+/// Most grammar rules are "transparent wrappers" — a `statement` is just an
+/// `expr`, an `expr` is just whichever of `if_expr`/`group_expr`/
+/// `assignment` matched, and when a precedence level did not actually apply
+/// its operator the parser still emits the level's node with a single
+/// child. [`unwrap_single`] peels those away so we dispatch on the first
+/// rule that genuinely shapes the tree.
+fn lower_node(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    match unwrap_single(node) {
+        Unwrapped::Token(token) => lower_token(token),
+        Unwrapped::Node(node) => match node.rule_name.as_str() {
+            "program" => Err(LowerError::new("nested program node is not an expression")),
+            "statement_line" | "statement" | "expr" => lower_first_node(node),
+            "if_expr" => lower_if(node),
+            "group_expr" => lower_group_expr(node),
+            "assignment" => lower_assignment(node),
+            "logical_or" => lower_logical_chain(node, OR),
+            "logical_and" => lower_logical_chain(node, AND),
+            "logical_not" => lower_logical_not(node),
+            "comparison" => lower_comparison(node),
+            "cons" => lower_cons(node),
+            "additive" | "multiplicative" => lower_binary_chain(node),
+            "unary" => lower_unary(node),
+            "power" => lower_power(node),
+            "postfix" => lower_postfix(node),
+            "atom" => lower_atom(node),
+            "list_literal" => lower_list_literal(node),
+            "arglist" => Err(LowerError::new(
+                "an arglist cannot be lowered as a scalar expression",
+            )),
+            "group" => lower_group(node),
+            other => Err(LowerError::new(format!("no lowering for rule `{other}`"))),
+        },
+    }
+}
+
+/// Lower a raw token (a literal or a bare symbol).
+fn lower_token(token: &Token) -> Result<IRNode, LowerError> {
+    match token_type(token) {
+        "NUMBER" => lower_number(&token.value),
+        "NAME" => Ok(sym(&token.value)),
+        other => Err(LowerError::new(format!(
+            "unexpected token `{other}` = {:?}",
+            token.value
+        ))),
+    }
+}
+
+/// Parse a `NUMBER` lexeme into an `Integer` or `Float` IR literal.
+///
+/// The R-2 lexer's `NUMBER` regex is `[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?`
+/// (identical to Derive's/Macsyma's own), so a `.`, `e`, or `E` means it is
+/// a real; otherwise it is an integer. We reject an integer that overflows
+/// `i64` (the IR's integer width) rather than silently wrapping.
+fn lower_number(text: &str) -> Result<IRNode, LowerError> {
+    if text.contains('.') || text.contains('e') || text.contains('E') {
+        text.parse::<f64>()
+            .map(flt)
+            .map_err(|e| LowerError::new(format!("invalid real literal {text:?}: {e}")))
+    } else {
+        text.parse::<i64>()
+            .map(int)
+            .map_err(|e| LowerError::new(format!("invalid integer literal {text:?}: {e}")))
+    }
+}
+
+/// `if_expr = "if" expr "then" expr [ "else" expr ]` — MA08 §3: `If[b, s1,
+/// s2]`, or (no `else`) `If[b, s1]`, which `symbolic_vm::handlers`' own
+/// `if_handler` already accepts (2 *or* 3 args — the 2-arg case returns the
+/// `False` symbol when the condition doesn't hold, since there is no
+/// `else`-branch value to produce), so this needs no special-casing beyond
+/// counting how many `expr` children were parsed.
+fn lower_if(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let branches: Vec<&GrammarASTNode> = child_nodes(node).collect();
+    match branches.len() {
+        2 => Ok(apply(
+            sym(IF),
+            vec![lower_node(branches[0])?, lower_node(branches[1])?],
+        )),
+        3 => Ok(apply(
+            sym(IF),
+            vec![
+                lower_node(branches[0])?,
+                lower_node(branches[1])?,
+                lower_node(branches[2])?,
+            ],
+        )),
+        n => Err(LowerError::new(format!(
+            "if_expr expected 2 or 3 `expr` children (cond/then[/else]), got {n}"
+        ))),
+    }
+}
+
+/// `group_expr = GROUP_OPEN expr { ( SEMI | DOLLAR ) expr } GROUP_CLOSE` —
+/// MA08 §3's `<< s1; s2; ... >>`, lowered to `CompoundExpression[s1, s2,
+/// ...]`. See the module doc comment's "REAL gap" section: `symbolic-vm`'s
+/// shared handler table has no handler for this head, so — while each
+/// `s_i` still evaluates in order (the VM evaluates every argument of an
+/// unheld `Apply` before dispatching, and `CompoundExpression` is not in
+/// `BaseBackend`'s held-head set), so `<< x := 1; x + 1 >>` really does bind
+/// `x` and really does compute `2` for its second statement — the
+/// *overall* result is the unevaluated `CompoundExpression(1, 2)`, not bare
+/// `2`, because there is no handler to collapse it to "the last statement's
+/// value" the way MA08 §3 describes. A disclosed gap, not a silent bug.
+fn lower_group_expr(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let exprs: Vec<&GrammarASTNode> = child_nodes(node).collect();
+    if exprs.is_empty() {
+        return Err(LowerError::new("empty group statement `<< >>`"));
+    }
+    let lowered = exprs
+        .into_iter()
+        .map(lower_node)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(apply(sym(COMPOUND_EXPRESSION), lowered))
+}
+
+/// `assignment = logical_or [ ASSIGN expr ]` — right-associative (manual
+/// §2.7: "a:=b:=c evaluates as a:=(b:=c)"), disambiguated purely by the
+/// lowered LHS's *shape* since — exactly like Derive (see
+/// `derive-runtime::lower`'s identical note) — Reduce's grammar has only
+/// ONE assignment token reaching this rule: `Apply(Symbol(_), _)` → a
+/// `h(l, m) := e` procedure definition (`Define`); anything else → an
+/// ordinary `x := e` variable assignment (`Assign`).
+///
+/// Unlike `derive.grammar`'s `assignment = logical_or [ ASSIGN assignment
+/// ]` (whose RHS recurses back into `assignment` itself),
+/// `reduce.grammar`'s RHS is the wider `expr` — so `x := if a>0 then 1 else
+/// -1` and `x := << a:=1; a+1 >>` parse (and lower) directly, since
+/// Reduce's `if`/`<< ... >>` are genuinely usable as expressions (MA08 §3),
+/// unlike anything in Derive's grammar.
+fn lower_assignment(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let Some(op_index) = node
+        .children
+        .iter()
+        .position(|c| as_token(c).is_some_and(|t| token_type(t) == "ASSIGN"))
+    else {
+        return lower_first_node(node);
+    };
+    if op_index == 0 || op_index + 1 >= node.children.len() {
+        return Err(LowerError::new("malformed assignment node"));
+    }
+    let lhs = lower_child(&node.children[op_index - 1])?;
+    let rhs = lower_child(&node.children[op_index + 1])?;
+
+    if let IRNode::Apply(app) = &lhs {
+        if matches!(&app.head, IRNode::Symbol(_)) {
+            // h(l, m) := e — a procedure definition. Reduce has no pattern
+            // syntax either, so each parameter already lowered to a plain
+            // `Symbol` (or, for a malformed definition like `h(1) := e`,
+            // whatever the caller wrote — `define_handler` and the VM's
+            // parameter binder own validating that, not this lowering).
+            return Ok(apply(
+                sym(DEFINE),
+                vec![app.head.clone(), apply(sym(LIST), app.args.clone()), rhs],
+            ));
+        }
+    }
+    // x := e — variable assignment.
+    Ok(apply(sym(ASSIGN), vec![lhs, rhs]))
+}
+
+/// `logical_or`/`logical_and` — fold the operands into an n-ary `Or`/`And`.
+/// Safe to fold n-ary (unlike `additive`/`multiplicative`) because every
+/// step in one chain shares the SAME operator (`logical_or = logical_and {
+/// "or" logical_and }` never mixes `or` and `and`). A single operand (no
+/// operator present) is a transparent wrapper.
+fn lower_logical_chain(node: &GrammarASTNode, head: &str) -> Result<IRNode, LowerError> {
+    let operands = child_nodes(node)
+        .map(lower_node)
+        .collect::<Result<Vec<_>, _>>()?;
+    match operands.len() {
+        0 => Err(LowerError::new("empty logical chain")),
+        1 => Ok(operands.into_iter().next().unwrap()),
+        _ => Ok(apply(sym(head), operands)),
+    }
+}
+
+/// `logical_not = "not" logical_not | comparison`. A leading `not` wraps the
+/// operand; otherwise it is the inner comparison.
+///
+/// `and`/`or`/`not`/`neq`/`if`/`then`/`else` are all matched in the grammar
+/// as `reduce.tokens`' own `KEYWORD` token type (promoted from `NAME` by
+/// exact lowercase spelling — see `reduce.tokens`'s header), so — mirroring
+/// `derive-runtime::lower_logical_not`'s identical check for its own
+/// `Literal`-matched `"NOT"` — this checks the token's literal *value*, not
+/// `effective_type_name()` alone (every keyword shares that same type
+/// name).
+fn lower_logical_not(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let has_not = node
+        .children
+        .iter()
+        .any(|c| as_token(c).is_some_and(|t| t.value == "not"));
+    if !has_not {
+        return lower_first_node(node);
+    }
+    let inner = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new("`not` with no operand"))?;
+    Ok(apply(sym(NOT), vec![lower_node(inner)?]))
+}
+
+/// `comparison = cons [ ( EQ | "neq" | LESS | GREATER | LE | GE ) cons ]` —
+/// a single (non-chained) comparison, per MA08 §3's own disclosed
+/// simplification ("this subset treats the whole group as one flat,
+/// non-chaining comparison tier"). `=` is Reduce's *equation* operator
+/// (`Equal`), never assignment — `:=` alone owns that role (MA08 §3,
+/// manual §3.4).
+fn lower_comparison(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let Some(op_index) = node
+        .children
+        .iter()
+        .position(|c| as_token(c).is_some_and(|t| comparison_head(t).is_some()))
+    else {
+        return lower_first_node(node);
+    };
+    if op_index == 0 || op_index + 1 >= node.children.len() {
+        return Err(LowerError::new("malformed comparison node"));
+    }
+    let head = comparison_head(as_token(&node.children[op_index]).unwrap()).unwrap();
+    Ok(apply(
+        sym(head),
+        vec![
+            lower_child(&node.children[op_index - 1])?,
+            lower_child(&node.children[op_index + 1])?,
+        ],
+    ))
+}
+
+/// `cons = additive [ DOT cons ] ` — right-associative (`cons`'s own
+/// optional continuation references itself: `a . b . {c}` is `a . (b .
+/// {c})`, so lowering the RHS recursively folds inside-out before this
+/// call ever sees it — see [`fold_cons`]).
+fn lower_cons(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let Some(dot_index) = node
+        .children
+        .iter()
+        .position(|c| as_token(c).is_some_and(|t| token_type(t) == "DOT"))
+    else {
+        return lower_first_node(node);
+    };
+    if dot_index == 0 || dot_index + 1 >= node.children.len() {
+        return Err(LowerError::new("malformed cons node"));
+    }
+    let lhs = lower_child(&node.children[dot_index - 1])?;
+    let rhs = lower_child(&node.children[dot_index + 1])?;
+    Ok(fold_cons(lhs, rhs))
+}
+
+/// Fold `a . rhs` — MA08 §3's own words: "R-4 folds a `Cons` onto a literal
+/// `List` immediately into one `List`". When `rhs` lowered to a
+/// *structurally* literal `List(...)` application, prepend `lhs` directly
+/// into a new flat `List` — no `Cons` head is ever produced for this case,
+/// so it needs no VM handler at all (`List`'s own handler, already shared
+/// and reused, does all the work). This is the ONLY shape MA08 §3's table
+/// documents a lowering for.
+///
+/// A right-hand side that ISN'T structurally a `List` at lowering time
+/// (`a . b`, where `b` is a bound variable, a function call, or another
+/// not-yet-resolved expression — lowering runs once, before any VM
+/// evaluation, so it cannot know what `b` will turn out to be) has no such
+/// fold available; MA08 §3's table is silent on this case. Rather than
+/// reject it outright, it lowers to a plain `Cons[a, b]` application — the
+/// same "structurally correct, but no handler evaluates it further" gap as
+/// `First`/`Rest`/etc (see the module doc comment).
+fn fold_cons(lhs: IRNode, rhs: IRNode) -> IRNode {
+    if let IRNode::Apply(app) = &rhs {
+        if matches!(&app.head, IRNode::Symbol(s) if s == LIST) {
+            let mut elems = vec![lhs];
+            elems.extend(app.args.iter().cloned());
+            return apply(sym(LIST), elems);
+        }
+    }
+    apply(sym(CONS), vec![lhs, rhs])
+}
+
+/// `additive`/`multiplicative` — a left-associative chain of `+`/`-` or
+/// `*`/`/`. Must fold pairwise (not n-ary, unlike the logical chains) since a
+/// single chain can mix operators: `a - b - c` folds left into
+/// `Sub(Sub(a, b), c)`; `a + b - c` into `Sub(Add(a, b), c)`.
+fn lower_binary_chain(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let mut children = node.children.iter();
+    let first = children
+        .next()
+        .ok_or_else(|| LowerError::new("empty binary chain"))?;
+    let mut result = lower_child(first)?;
+    while let Some(op_child) = children.next() {
+        let head = as_token(op_child)
+            .and_then(|t| binary_head(token_type(t)))
+            .ok_or_else(|| LowerError::new("expected a binary operator"))?;
+        let rhs = children
+            .next()
+            .ok_or_else(|| LowerError::new("binary operator with no right operand"))?;
+        result = apply(sym(head), vec![result, lower_child(rhs)?]);
+    }
+    Ok(result)
+}
+
+/// `unary = MINUS unary | power`. MA08 §3 lists only unary `-` (no unary
+/// `+`, matching `derive.grammar`'s identical asymmetry) — a leading `-` is
+/// `Neg`; otherwise it is the inner `power`.
+fn lower_unary(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    if node.children.len() == 1 {
+        return lower_child(&node.children[0]);
+    }
+    let operand = lower_child(
+        node.children
+            .get(1)
+            .ok_or_else(|| LowerError::new("unary `-` with no operand"))?,
+    )?;
+    Ok(apply(sym(NEG), vec![operand]))
+}
+
+/// `power = postfix [ ( CARET | POW ) unary ]` — right-associative `^`/`**`
+/// (MA08 §3: "manual §2.7's own precedence table lists them as one tier" —
+/// `reduce.tokens` keeps `CARET`/`POW` as two distinct *token* types, but
+/// this grammar tier already collapses both onto the one `power` production,
+/// so lowering just needs to accept either token type here).
+fn lower_power(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    match node.children.len() {
+        1 => lower_child(&node.children[0]),
+        3 => {
+            let is_power_op = as_token(&node.children[1])
+                .is_some_and(|t| matches!(token_type(t), "CARET" | "POW"));
+            if !is_power_op {
+                return Err(LowerError::new(
+                    "malformed power node: expected CARET or POW",
+                ));
+            }
+            Ok(apply(
+                sym(POW),
+                vec![
+                    lower_child(&node.children[0])?,
+                    lower_child(&node.children[2])?,
+                ],
+            ))
+        }
+        _ => Err(LowerError::new("malformed power node")),
+    }
+}
+
+/// `postfix = atom { LPAREN [arglist] RPAREN }` — function/procedure/
+/// array-subscript application, left-associative and chainable. MA08 §3's
+/// single call-shaped production covers `f(a, b)`, a `Define` LHS like
+/// `h(l, m)`, and `a(5)`/`b(i, q)` (array-subscript *reads* — array
+/// declaration/indexed *write* are out of scope, MA08 §4) all at once.
+///
+/// The head runs through [`canonical_head`] so a builtin surface name like
+/// `list`/`first`/`rest`/`append`/`reverse` becomes the IR head the VM
+/// dispatches (or, per the module doc comment's "REAL gap" section,
+/// structurally produces but cannot yet further evaluate); an unrecognised
+/// head (a user-defined operator/procedure) passes through unchanged.
+fn lower_postfix(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let mut result = lower_child(
+        node.children
+            .first()
+            .ok_or_else(|| LowerError::new("postfix has no base"))?,
+    )?;
+
+    let mut i = 1;
+    while i < node.children.len() {
+        let Some(token) = as_token(&node.children[i]) else {
+            i += 1;
+            continue;
+        };
+        if token_type(token) == "LPAREN" {
+            let args = node
+                .children
+                .get(i + 1)
+                .and_then(as_node)
+                .filter(|n| n.rule_name == "arglist")
+                .map(lower_arglist)
+                .transpose()?
+                .unwrap_or_default();
+            result = apply(canonical_head(result), args);
+        }
+        i += 1;
+    }
+    Ok(result)
+}
+
+/// `arglist = expr { COMMA expr }` — lower each comma-separated argument.
+fn lower_arglist(node: &GrammarASTNode) -> Result<Vec<IRNode>, LowerError> {
+    child_nodes(node).map(lower_node).collect()
+}
+
+/// `atom = NUMBER | NAME | list_literal | group`.
+fn lower_atom(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    if let Some(child) = child_nodes(node).next() {
+        if matches!(child.rule_name.as_str(), "list_literal" | "group") {
+            return lower_node(child);
+        }
+    }
+    let tokens: Vec<&Token> = node.children.iter().filter_map(as_token).collect();
+    match tokens.as_slice() {
+        [single] => lower_token(single),
+        _ => Err(LowerError::new(format!(
+            "unrecognised atom token shape: {:?}",
+            tokens.iter().map(|t| &t.value).collect::<Vec<_>>()
+        ))),
+    }
+}
+
+/// `list_literal = LBRACE [ arglist ] RBRACE` — MA08 §3's `{a, b, c}`
+/// (curly braces, NOT Derive's square brackets). Reduce's list is always
+/// flat here (no row/matrix shape — matrices are out of scope, MA08 §4), so
+/// this reuses [`lower_arglist`] directly, unlike `derive-runtime`'s
+/// row-counting `vector`/`row` split.
+fn lower_list_literal(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let args = child_nodes(node)
+        .find(|n| n.rule_name == "arglist")
+        .map(lower_arglist)
+        .transpose()?
+        .unwrap_or_default();
+    Ok(apply(sym(LIST), args))
+}
+
+/// `group = LPAREN expr RPAREN` — grouping only; lower the inner expression.
+fn lower_group(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let inner = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new("empty group `( )`"))?;
+    lower_node(inner)
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+fn lower_child(child: &ASTNodeOrToken) -> Result<IRNode, LowerError> {
+    match child {
+        ASTNodeOrToken::Node(node) => lower_node(node),
+        ASTNodeOrToken::Token(token) => lower_token(token),
+    }
+}
+
+/// Lower the first *node* child (ignoring tokens). Used by transparent-
+/// wrapper rules whose only meaningful content is a nested expression node.
+fn lower_first_node(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let child = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new(format!("`{}` has no expression child", node.rule_name)))?;
+    lower_node(child)
+}
+
+/// Map an arithmetic token type to its IR head. See the module doc
+/// comment's naming-divergence note: these are `Add`/`Sub`/`Mul`/`Div`, not
+/// MA08 §3's literal (and non-existent) `Plus`/`Subtract`/`Times`.
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a comparison token to its IR head. `neq` is a `KEYWORD`-typed token
+/// (see `lower_logical_not`'s identical note), matched by literal value
+/// alongside the four symbolic comparison token *types*.
+fn comparison_head(token: &Token) -> Option<&'static str> {
+    match token_type(token) {
+        "EQ" => Some(EQUAL),
+        "LESS" => Some(LESS),
+        "GREATER" => Some(GREATER),
+        "LE" => Some(LESS_EQUAL),
+        "GE" => Some(GREATER_EQUAL),
+        "KEYWORD" if token.value == "neq" => Some(NOT_EQUAL),
+        _ => None,
+    }
+}
+
+/// Bridge a Reduce *surface* builtin name (lowercase, per manual convention
+/// — `list`, `first`, `second`, `third`, `rest`, `part`, `append`,
+/// `reverse`) to the canonical IR head. A head not in this table (a
+/// user-defined operator/procedure, or a builtin spelled with different
+/// casing) is returned unchanged, so it evaluates through the VM's ordinary
+/// user-function path and an unrecognised spelling stays a harmless
+/// unevaluated symbolic call — exactly `derive-runtime::lower::canonical_head`'s
+/// same fallthrough contract.
+fn canonical_head(head: IRNode) -> IRNode {
+    if let IRNode::Symbol(name) = &head {
+        if let Some(canonical) = surface_head_to_ir(name) {
+            return sym(canonical);
+        }
+    }
+    head
+}
+
+/// The surface→IR head dictionary for R-4's scope (MA08 §3): the
+/// function-call spelling of a list literal (`list(...)` → `List`) and the
+/// list accessors/constructors. Every one of these except `List` has no
+/// handler in the shared `symbolic-vm` table (see the module doc comment's
+/// "REAL gap" section) — they are bridged here anyway so the lowered
+/// *shape* is exactly what MA08 §3's table says, ready for a future item
+/// that wires the handlers without touching this lowering at all.
+fn surface_head_to_ir(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "list" => LIST,
+        "first" => FIRST,
+        "second" => SECOND,
+        "third" => THIRD,
+        "rest" => REST,
+        "part" => PART,
+        "append" => APPEND,
+        "reverse" => REVERSE,
+        _ => return None,
+    })
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+/// Iterate a node's direct *node* children (skipping tokens).
+fn child_nodes(node: &GrammarASTNode) -> impl Iterator<Item = &GrammarASTNode> {
+    node.children.iter().filter_map(as_node)
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with structure
+/// (or a leaf token). A precedence-cascade rule that did not apply its
+/// operator still emits its own node with exactly one child, and so does an
+/// ordered-choice rule like `expr = if_expr | group_expr | assignment` once
+/// it has committed to one alternative — `unwrap_single` skips straight to
+/// the rule that actually matters.
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_reduce_parser::parse_reduce;
+
+    /// Lower a single-statement source to its one IR node.
+    fn lower_one(src: &str) -> IRNode {
+        let ast = parse_reduce(src);
+        let mut stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 1, "expected exactly one statement for {src:?}");
+        stmts.pop().unwrap()
+    }
+
+    #[test]
+    fn integer_and_real_literals() {
+        assert_eq!(lower_one("42;\n"), int(42));
+        assert_eq!(lower_one("1.5;\n"), flt(1.5));
+    }
+
+    #[test]
+    fn bare_symbol() {
+        assert_eq!(lower_one("foo;\n"), sym("foo"));
+    }
+
+    #[test]
+    fn bare_trailing_statement_with_no_terminator_lowers() {
+        assert_eq!(lower_one("42"), int(42));
+    }
+
+    // --- Arithmetic (MA08 §3 row: `a+b`,`a-b`->Plus/Subtract; `a*b`->Times;
+    //     `a/b`->Times[a,Power[b,-1]] -- this crate instead reuses Add/Sub/
+    //     Mul/Div directly; see the module doc comment's divergence note) --
+
+    #[test]
+    fn additive_lowers_to_add() {
+        assert_eq!(lower_one("1 + 2;\n"), apply(sym(ADD), vec![int(1), int(2)]));
+    }
+
+    #[test]
+    fn subtraction_lowers_to_sub_left_assoc() {
+        // a - b - c  ->  Sub(Sub(a, b), c)
+        assert_eq!(
+            lower_one("a - b - c;\n"),
+            apply(
+                sym(SUB),
+                vec![apply(sym(SUB), vec![sym("a"), sym("b")]), sym("c")]
+            )
+        );
+    }
+
+    #[test]
+    fn mixed_additive_chain_folds_left_by_operator() {
+        // a + b - c  ->  Sub(Add(a, b), c)
+        assert_eq!(
+            lower_one("a + b - c;\n"),
+            apply(
+                sym(SUB),
+                vec![apply(sym(ADD), vec![sym("a"), sym("b")]), sym("c")]
+            )
+        );
+    }
+
+    #[test]
+    fn multiplication_and_division_use_mul_and_div_directly() {
+        assert_eq!(
+            lower_one("a * b;\n"),
+            apply(sym(MUL), vec![sym("a"), sym("b")])
+        );
+        // NOT Times(a, Pow(b, -1)) -- see the module doc comment.
+        assert_eq!(
+            lower_one("a / b;\n"),
+            apply(sym(DIV), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn power_operator_and_double_star_both_lower_to_pow() {
+        assert_eq!(
+            lower_one("a ^ b;\n"),
+            apply(sym(POW), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a ** b;\n"),
+            apply(sym(POW), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn power_is_right_associative() {
+        // a ^ b ^ c  ->  Pow(a, Pow(b, c))
+        assert_eq!(
+            lower_one("a ^ b ^ c;\n"),
+            apply(
+                sym(POW),
+                vec![sym("a"), apply(sym(POW), vec![sym("b"), sym("c")])]
+            )
+        );
+    }
+
+    #[test]
+    fn unary_minus_lowers_to_neg_and_binds_looser_than_power() {
+        // -x^2  ->  Neg(Pow(x, 2)) -- NOT Times(-1, Pow(x, 2)).
+        assert_eq!(
+            lower_one("-x^2;\n"),
+            apply(sym(NEG), vec![apply(sym(POW), vec![sym("x"), int(2)])])
+        );
+    }
+
+    // --- Comparison / equation (MA08 §3) -----------------------------------
+
+    #[test]
+    fn eq_lowers_to_equal_not_assign() {
+        assert_eq!(
+            lower_one("x = 4;\n"),
+            apply(sym(EQUAL), vec![sym("x"), int(4)])
+        );
+    }
+
+    #[test]
+    fn every_comparison_operator_lowers_to_its_head() {
+        assert_eq!(
+            lower_one("a < b;\n"),
+            apply(sym(LESS), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a > b;\n"),
+            apply(sym(GREATER), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a <= b;\n"),
+            apply(sym(LESS_EQUAL), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a >= b;\n"),
+            apply(sym(GREATER_EQUAL), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a neq b;\n"),
+            apply(sym(NOT_EQUAL), vec![sym("a"), sym("b")])
+        );
+    }
+
+    // --- Logic (MA08 §3) ---------------------------------------------------
+
+    #[test]
+    fn boolean_keywords_lower_to_and_or_not() {
+        assert_eq!(
+            lower_one("a and b;\n"),
+            apply(sym(AND), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a or b;\n"),
+            apply(sym(OR), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(lower_one("not a;\n"), apply(sym(NOT), vec![sym("a")]));
+    }
+
+    #[test]
+    fn logical_or_chain_folds_n_ary() {
+        assert_eq!(
+            lower_one("a or b or c;\n"),
+            apply(sym(OR), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn uppercase_keyword_spellings_are_not_special_cased_here() {
+        // reduce.tokens' keywords are lowercase-only, so `AND` etc lex as a
+        // plain NAME at the R-2 layer already; this crate never sees an
+        // uppercase logical keyword to bridge (the mirror image of Derive's
+        // uppercase-only AND/OR/NOT).
+        assert_eq!(lower_one("AND;\n"), sym("AND"));
+    }
+
+    // --- Grouping ------------------------------------------------------------
+
+    #[test]
+    fn grouping_parens_lower_transparently() {
+        assert_eq!(
+            lower_one("(1 + 2) * 3;\n"),
+            apply(
+                sym(MUL),
+                vec![apply(sym(ADD), vec![int(1), int(2)]), int(3)]
+            )
+        );
+    }
+
+    // --- Function/procedure application (MA08 §3) --------------------------
+
+    #[test]
+    fn function_application_of_unknown_head_passes_through() {
+        assert_eq!(
+            lower_one("f(a, b);\n"),
+            apply(sym("f"), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn array_subscript_read_shares_the_call_production() {
+        // a(5) / b(i, q) -- MA08 §3: reads exactly like an ordinary call.
+        assert_eq!(lower_one("a(5);\n"), apply(sym("a"), vec![int(5)]));
+        assert_eq!(
+            lower_one("b(i, q);\n"),
+            apply(sym("b"), vec![sym("i"), sym("q")])
+        );
+    }
+
+    #[test]
+    fn nested_function_calls_lower_correctly() {
+        assert_eq!(
+            lower_one("log(exp(x));\n"),
+            apply(sym("log"), vec![apply(sym("exp"), vec![sym("x")])])
+        );
+    }
+
+    // --- Assignment / procedure definition (MA08 §3) -----------------------
+
+    #[test]
+    fn variable_assignment_lowers_to_assign() {
+        assert_eq!(
+            lower_one("x := 5;\n"),
+            apply(sym(ASSIGN), vec![sym("x"), int(5)])
+        );
+    }
+
+    #[test]
+    fn procedure_definition_lowers_to_define() {
+        // h(l, m) := l - 2*m  ->  Define(h, List(l, m), Sub(l, Mul(2, m)))
+        assert_eq!(
+            lower_one("h(l, m) := l - 2*m;\n"),
+            apply(
+                sym(DEFINE),
+                vec![
+                    sym("h"),
+                    apply(sym(LIST), vec![sym("l"), sym("m")]),
+                    apply(
+                        sym(SUB),
+                        vec![sym("l"), apply(sym(MUL), vec![int(2), sym("m")])]
+                    ),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn assign_vs_define_disambiguated_by_lhs_shape_not_operator() {
+        assert!(matches!(
+            lower_one("x := 5;\n"),
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == ASSIGN)
+        ));
+        assert!(matches!(
+            lower_one("h(x) := x;\n"),
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == DEFINE)
+        ));
+    }
+
+    #[test]
+    fn assignment_right_associates() {
+        // a := b := 5  ->  Assign(a, Assign(b, 5))
+        assert_eq!(
+            lower_one("a := b := 5;\n"),
+            apply(
+                sym(ASSIGN),
+                vec![sym("a"), apply(sym(ASSIGN), vec![sym("b"), int(5)])]
+            )
+        );
+    }
+
+    #[test]
+    fn if_is_usable_as_an_assignment_rhs() {
+        // x := if a>0 then 1 else -1
+        let lowered = lower_one("x := if a>0 then 1 else -1;\n");
+        assert!(matches!(
+            &lowered,
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == ASSIGN)
+        ));
+        if let IRNode::Apply(a) = lowered {
+            assert!(matches!(
+                &a.args[1],
+                IRNode::Apply(inner) if matches!(&inner.head, IRNode::Symbol(s) if s == IF)
+            ));
+        }
+    }
+
+    // --- `if` (MA08 §3) ------------------------------------------------------
+
+    #[test]
+    fn if_then_else_lowers_to_three_arg_if() {
+        assert_eq!(
+            lower_one("if a > b then a else b;\n"),
+            apply(
+                sym(IF),
+                vec![
+                    apply(sym(GREATER), vec![sym("a"), sym("b")]),
+                    sym("a"),
+                    sym("b"),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn if_then_with_no_else_lowers_to_two_arg_if() {
+        assert_eq!(
+            lower_one("if a then b;\n"),
+            apply(sym(IF), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn dangling_else_attaches_to_the_nearest_if() {
+        // if a then if b then c else d
+        //   -> If(a, If(b, c, d))          -- NOT If(If(a, If(b,c)), d)
+        assert_eq!(
+            lower_one("if a then if b then c else d;\n"),
+            apply(
+                sym(IF),
+                vec![sym("a"), apply(sym(IF), vec![sym("b"), sym("c"), sym("d")])]
+            )
+        );
+    }
+
+    // --- Group statement `<< ... >>` (MA08 §3) ------------------------------
+
+    #[test]
+    fn group_statement_lowers_to_compound_expression() {
+        assert_eq!(
+            lower_one("<< a := 1; a + 1 >>;\n"),
+            apply(
+                sym(COMPOUND_EXPRESSION),
+                vec![
+                    apply(sym(ASSIGN), vec![sym("a"), int(1)]),
+                    apply(sym(ADD), vec![sym("a"), int(1)]),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn group_statement_with_a_single_statement_lowers() {
+        assert_eq!(
+            lower_one("<< a + 1 >>;\n"),
+            apply(
+                sym(COMPOUND_EXPRESSION),
+                vec![apply(sym(ADD), vec![sym("a"), int(1)])]
+            )
+        );
+    }
+
+    #[test]
+    fn group_statement_is_usable_as_an_assignment_rhs() {
+        let lowered = lower_one("x := << a := 1; a + 1 >>;\n");
+        assert!(matches!(
+            &lowered,
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == ASSIGN)
+        ));
+    }
+
+    // --- Lists (MA08 §3) -----------------------------------------------------
+
+    #[test]
+    fn brace_list_literal_lowers_to_list() {
+        assert_eq!(
+            lower_one("{a, b, c};\n"),
+            apply(sym(LIST), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn empty_brace_list_literal_lowers_to_empty_list() {
+        assert_eq!(lower_one("{};\n"), apply(sym(LIST), vec![]));
+    }
+
+    #[test]
+    fn list_function_call_spelling_lowers_the_same_as_braces() {
+        assert_eq!(
+            lower_one("list(a, b, c);\n"),
+            apply(sym(LIST), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn list_accessor_and_constructor_calls_bridge_to_canonical_heads() {
+        assert_eq!(lower_one("first(l);\n"), apply(sym(FIRST), vec![sym("l")]));
+        assert_eq!(
+            lower_one("second(l);\n"),
+            apply(sym(SECOND), vec![sym("l")])
+        );
+        assert_eq!(lower_one("third(l);\n"), apply(sym(THIRD), vec![sym("l")]));
+        assert_eq!(lower_one("rest(l);\n"), apply(sym(REST), vec![sym("l")]));
+        assert_eq!(
+            lower_one("part(l, n);\n"),
+            apply(sym(PART), vec![sym("l"), sym("n")])
+        );
+        assert_eq!(
+            lower_one("append(l1, l2);\n"),
+            apply(sym(APPEND), vec![sym("l1"), sym("l2")])
+        );
+        assert_eq!(
+            lower_one("reverse(l);\n"),
+            apply(sym(REVERSE), vec![sym("l")])
+        );
+    }
+
+    // --- Cons (MA08 §3) ------------------------------------------------------
+
+    #[test]
+    fn cons_onto_a_literal_list_folds_into_one_list() {
+        // a . {b, c}  ->  List(a, b, c) -- NOT Cons(a, List(b, c)).
+        assert_eq!(
+            lower_one("a . {b, c};\n"),
+            apply(sym(LIST), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn cons_is_right_associative_and_folds_through_every_link() {
+        // a . b . {c}  ->  a . (b . {c}) -> a . List(b, c) -> List(a, b, c)
+        assert_eq!(
+            lower_one("a . b . {c};\n"),
+            apply(sym(LIST), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn cons_onto_a_non_list_lowers_to_a_bare_cons_head() {
+        // a . b  (b not structurally a literal list) -> Cons(a, b) -- a
+        // disclosed, documented gap (see the module doc comment); this does
+        // not crash, it just cannot be folded away at lowering time.
+        assert_eq!(
+            lower_one("a . b;\n"),
+            apply(sym(CONS), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn cons_binds_looser_than_additive_but_tighter_than_comparison() {
+        // 1+2 . {3,4} = 4  ->  Equal(List(Add(1,2), 3, 4), 4)
+        assert_eq!(
+            lower_one("1+2 . {3,4} = 4;\n"),
+            apply(
+                sym(EQUAL),
+                vec![
+                    apply(
+                        sym(LIST),
+                        vec![apply(sym(ADD), vec![int(1), int(2)]), int(3), int(4)]
+                    ),
+                    int(4),
+                ]
+            )
+        );
+    }
+
+    // --- Multi-statement programs -------------------------------------------
+
+    #[test]
+    fn multi_statement_program_lowers_each_line() {
+        let ast = parse_reduce("x := 1; y := 2; x + y;\n");
+        let stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 3);
+        assert_eq!(stmts[0], apply(sym(ASSIGN), vec![sym("x"), int(1)]));
+        assert_eq!(stmts[1], apply(sym(ASSIGN), vec![sym("y"), int(2)]));
+        assert_eq!(stmts[2], apply(sym(ADD), vec![sym("x"), sym("y")]));
+    }
+
+    #[test]
+    fn semi_and_dollar_terminated_statements_both_lower() {
+        let ast = parse_reduce("x := 1$ y := 2;\n");
+        let stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 2);
+    }
+
+    #[test]
+    fn a_small_reduce_program_lowers_end_to_end() {
+        let ast = parse_reduce("h(x) := x*x; h(5);\n");
+        let stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 2);
+        assert!(matches!(
+            &stmts[0],
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == DEFINE)
+        ));
+        assert_eq!(stmts[1], apply(sym("h"), vec![int(5)]));
+    }
+}

--- a/code/packages/rust/reduce-runtime/src/printer.rs
+++ b/code/packages/rust/reduce-runtime/src/printer.rs
@@ -1,0 +1,395 @@
+//! # Pretty-printing — `symbolic-ir` → Reduce surface notation
+//!
+//! After evaluation the result is a [`symbolic_ir::IRNode`] whose heads are
+//! the IR's canonical names (`Add`, `Equal`, `List`, …). A Reduce user
+//! expects to read it back in Reduce's own notation — infix `+`/`*`/`^`,
+//! `and`/`or`/`not`, curly-brace `{a, b, c}` lists, `f(…)` application — not
+//! the IR's default `Add(2, 3)` debug form. This module is the inverse of
+//! [`crate::lower`]: it walks the result tree and renders the surface
+//! string, reversing the same head bridges `crate::lower` applies going in
+//! (mirroring `derive-runtime::printer`'s identical role and shape).
+//!
+//! It is deliberately a **presentation** layer, not a re-parse: the output
+//! only needs to be readable and round-trippable for the heads this subset
+//! actually produces. Precedence is handled by parenthesising a child
+//! whenever its operator binds *looser* than the parent's.
+//!
+//! ## Precedence ladder (loosest → tightest, mirrors `reduce.grammar`'s own
+//! cascade — MA08 §3 — one tier more than `derive-runtime::printer`'s table,
+//! for the `cons` (`.`) tier Derive has no analogue of)
+//!
+//! | Level | Constructs |
+//! |-------|------------|
+//! | — | (`if`/`<< ... >>` are self-delimited by their own keywords/`<<`/`>>`,
+//! |   | so they never need surrounding parens — treated as atom-level) |
+//! | 0 | (unevaluated `Assign`/`Define` never reach the printer — see below) |
+//! | 1 | `or` |
+//! | 2 | `and` |
+//! | 3 | `not` (prefix) / comparisons `=` `neq` `<` `<=` `>` `>=` |
+//! | 4 | `Cons` (`.`, right-associative — only appears unresolved, MA08 §3) |
+//! | 5 | `Add` `Sub` |
+//! | 6 | `Mul` `Div` |
+//! | 7 | unary `Neg` |
+//! | 8 | `Pow` |
+//! | 9 | atoms, `f(…)`, `{…}` |
+//!
+//! `Assign`/`Define` never appear in a printed *result*: `assign_handler`
+//! returns the bound *value* (not an `Assign(...)` node), and
+//! `define_handler` returns `Symbol(name)` — see `symbolic-vm`'s own
+//! `handlers.rs`. So, unlike `derive-runtime::printer` (whose precedence
+//! table reserves a level for them anyway, for documentation symmetry),
+//! this module has no rendering case for either head at all.
+
+use symbolic_ir::{
+    IRApply, IRNode, ADD, AND, DIV, EQUAL, GREATER, GREATER_EQUAL, IF, LESS, LESS_EQUAL, LIST, MUL,
+    NEG, NOT, NOT_EQUAL, OR, POW, SUB,
+};
+
+use crate::lower::{APPEND, COMPOUND_EXPRESSION, CONS, FIRST, PART, REST, REVERSE, SECOND, THIRD};
+
+const PREC_LOWEST: u8 = 0;
+const PREC_OR: u8 = 1;
+const PREC_AND: u8 = 2;
+const PREC_NOT_CMP: u8 = 3;
+const PREC_CONS: u8 = 4;
+const PREC_ADD: u8 = 5;
+const PREC_MUL: u8 = 6;
+const PREC_NEG: u8 = 7;
+const PREC_POW: u8 = 8;
+const PREC_ATOM: u8 = 9;
+
+/// Render `node` as a Reduce surface string.
+pub fn print_reduce(node: &IRNode) -> String {
+    print_at(node, PREC_LOWEST)
+}
+
+/// Render `node`, wrapping it in parentheses if its own precedence is looser
+/// than `parent_prec` (so the surface string re-parses to the same tree).
+fn print_at(node: &IRNode, parent_prec: u8) -> String {
+    let (text, prec) = render(node);
+    if prec < parent_prec {
+        format!("({text})")
+    } else {
+        text
+    }
+}
+
+/// Render a node, returning its surface text and its own precedence level.
+fn render(node: &IRNode) -> (String, u8) {
+    match node {
+        IRNode::Integer(n) => (n.to_string(), PREC_ATOM),
+        IRNode::Float(v) => (format!("{v:?}"), PREC_ATOM),
+        IRNode::Rational(n, d) => (format!("{n}/{d}"), PREC_MUL),
+        IRNode::Str(s) => (format!("\"{s}\""), PREC_ATOM),
+        IRNode::Symbol(s) => (s.clone(), PREC_ATOM),
+        IRNode::Apply(app) => render_apply(app),
+    }
+}
+
+/// Render a compound `head(args)` node.
+fn render_apply(app: &IRApply) -> (String, u8) {
+    let head_name = match &app.head {
+        IRNode::Symbol(s) => Some(s.as_str()),
+        _ => None,
+    };
+    let args = &app.args;
+
+    if let Some(name) = head_name {
+        if let Some((op, prec)) = infix_binary(name) {
+            if args.len() == 2 {
+                let l = print_at(&args[0], prec);
+                let r = print_at(&args[1], prec);
+                return (format!("{l}{op}{r}"), prec);
+            }
+        }
+        // n-ary associative logic: And/Or flatten to a chain (mirrors how
+        // `lower_logical_chain` folds a homogeneous run flat rather than
+        // pairwise).
+        if let Some((op, prec)) = nary_logic(name) {
+            if args.len() >= 2 {
+                let parts: Vec<String> = args.iter().map(|a| print_at(a, prec)).collect();
+                return (parts.join(op), prec);
+            }
+            if args.len() == 1 {
+                return render(&args[0]);
+            }
+        }
+        match name {
+            POW if args.len() == 2 => {
+                // Right-associative and tighter than unary minus.
+                let base = print_at(&args[0], PREC_POW + 1);
+                let exp = print_at(&args[1], PREC_NEG);
+                return (format!("{base}^{exp}"), PREC_POW);
+            }
+            NEG if args.len() == 1 => {
+                let inner = print_at(&args[0], PREC_NEG);
+                return (format!("-{inner}"), PREC_NEG);
+            }
+            NOT if args.len() == 1 => {
+                let inner = print_at(&args[0], PREC_NOT_CMP);
+                return (format!("not {inner}"), PREC_NOT_CMP);
+            }
+            LIST => return (render_list(args), PREC_ATOM),
+            IF if args.len() == 2 => {
+                return (
+                    format!(
+                        "if {} then {}",
+                        print_reduce(&args[0]),
+                        print_reduce(&args[1])
+                    ),
+                    PREC_ATOM,
+                )
+            }
+            IF if args.len() == 3 => {
+                return (
+                    format!(
+                        "if {} then {} else {}",
+                        print_reduce(&args[0]),
+                        print_reduce(&args[1]),
+                        print_reduce(&args[2])
+                    ),
+                    PREC_ATOM,
+                )
+            }
+            // A group statement left unevaluated (MA08 §3's "last statement's
+            // value" collapse has no handler in the shared table yet — see
+            // `crate::lower`'s module doc comment). Rendered back with its
+            // real `<< s1; s2; ... >>` surface syntax, an honest reflection
+            // of what actually survived evaluation (each `s_i` already fully
+            // evaluated, just not collapsed to the last one).
+            COMPOUND_EXPRESSION if !args.is_empty() => {
+                let parts: Vec<String> = args.iter().map(print_reduce).collect();
+                return (format!("<< {} >>", parts.join("; ")), PREC_ATOM);
+            }
+            _ => {}
+        }
+
+        // Ordinary function application: `head(args…)`, bridging the
+        // canonical IR head back to Reduce's lowercase surface spelling
+        // (the reverse of `crate::lower::canonical_head`); an unrecognised
+        // head (a user-defined operator/procedure, or one of the
+        // no-handler-yet heads like `Cons`/`First`/… left structurally
+        // unevaluated) is rendered as-typed/bridged-back but otherwise
+        // unchanged.
+        let surface = ir_head_to_surface(name).unwrap_or(name);
+        let parts: Vec<String> = args.iter().map(print_reduce).collect();
+        return (format!("{surface}({})", parts.join(", ")), PREC_ATOM);
+    }
+
+    // A computed (non-symbol) head — render generically as `(head)(args…)`.
+    let head_text = print_at(&app.head, PREC_ATOM);
+    let parts: Vec<String> = args.iter().map(print_reduce).collect();
+    (format!("{head_text}({})", parts.join(", ")), PREC_ATOM)
+}
+
+/// Binary infix arithmetic/comparison/cons operators — `(surface,
+/// precedence)`. `Cons` only ever reaches here when its right-hand side
+/// wasn't structurally a literal `List` at lowering time (see
+/// `crate::lower::fold_cons`) — the one case MA08 §3 leaves as a bare,
+/// unevaluated `Cons[a, b]` application (no handler in the shared table).
+fn infix_binary(name: &str) -> Option<(&'static str, u8)> {
+    Some(match name {
+        ADD => (" + ", PREC_ADD),
+        SUB => (" - ", PREC_ADD),
+        MUL => ("*", PREC_MUL),
+        DIV => ("/", PREC_MUL),
+        EQUAL => (" = ", PREC_NOT_CMP),
+        NOT_EQUAL => (" neq ", PREC_NOT_CMP),
+        LESS => (" < ", PREC_NOT_CMP),
+        GREATER => (" > ", PREC_NOT_CMP),
+        LESS_EQUAL => (" <= ", PREC_NOT_CMP),
+        GREATER_EQUAL => (" >= ", PREC_NOT_CMP),
+        CONS => (" . ", PREC_CONS),
+        _ => return None,
+    })
+}
+
+/// n-ary logic operators — `(join-text, precedence)`.
+fn nary_logic(name: &str) -> Option<(&'static str, u8)> {
+    Some(match name {
+        AND => (" and ", PREC_AND),
+        OR => (" or ", PREC_OR),
+        _ => return None,
+    })
+}
+
+/// Render a `List(...)` node back to Reduce's curly-brace syntax — the
+/// exact reverse of `crate::lower::lower_list_literal`. Unlike
+/// `derive-runtime::printer::render_list`, there is no row/matrix
+/// distinction to make: Reduce's list is always flat (matrices are out of
+/// scope, MA08 §4), so every element just prints comma-separated.
+fn render_list(args: &[IRNode]) -> String {
+    let parts: Vec<String> = args.iter().map(print_reduce).collect();
+    format!("{{{}}}", parts.join(", "))
+}
+
+/// The IR→surface head dictionary — the exact reverse of
+/// [`crate::lower`]'s `surface_head_to_ir`, kept as its own table (rather
+/// than derived at runtime) so each direction reads as a simple, directly
+/// checkable list. `List` is handled specially above (curly-brace syntax,
+/// never the generic call form), so it has no entry here.
+fn ir_head_to_surface(name: &str) -> Option<&'static str> {
+    Some(match name {
+        FIRST => "first",
+        SECOND => "second",
+        THIRD => "third",
+        REST => "rest",
+        PART => "part",
+        APPEND => "append",
+        REVERSE => "reverse",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symbolic_ir::{apply, flt, int, rat, sym};
+
+    #[test]
+    fn atoms_print_bare() {
+        assert_eq!(print_reduce(&int(42)), "42");
+        assert_eq!(print_reduce(&flt(1.5)), "1.5");
+        assert_eq!(print_reduce(&rat(1, 3)), "1/3");
+        assert_eq!(print_reduce(&sym("x")), "x");
+    }
+
+    #[test]
+    fn arithmetic_prints_infix() {
+        assert_eq!(
+            print_reduce(&apply(sym(ADD), vec![sym("x"), int(1)])),
+            "x + 1"
+        );
+        assert_eq!(
+            print_reduce(&apply(sym(MUL), vec![sym("x"), int(2)])),
+            "x*2"
+        );
+        assert_eq!(
+            print_reduce(&apply(sym(DIV), vec![sym("x"), int(2)])),
+            "x/2"
+        );
+    }
+
+    #[test]
+    fn precedence_forces_parens_on_the_looser_child() {
+        // Mul(Add(a, b), c)  ->  "(a + b)*c" — never the ambiguous "a + b*c".
+        let e = apply(
+            sym(MUL),
+            vec![apply(sym(ADD), vec![sym("a"), sym("b")]), sym("c")],
+        );
+        assert_eq!(print_reduce(&e), "(a + b)*c");
+    }
+
+    #[test]
+    fn power_prints_caret_right_associative() {
+        let e = apply(
+            sym(POW),
+            vec![sym("a"), apply(sym(POW), vec![sym("b"), sym("c")])],
+        );
+        assert_eq!(print_reduce(&e), "a^b^c");
+    }
+
+    #[test]
+    fn negation_and_not_print_prefix() {
+        assert_eq!(print_reduce(&apply(sym(NEG), vec![sym("x")])), "-x");
+        assert_eq!(print_reduce(&apply(sym(NOT), vec![sym("a")])), "not a");
+    }
+
+    #[test]
+    fn logic_chain_prints_flat() {
+        let e = apply(sym(OR), vec![sym("a"), sym("b"), sym("c")]);
+        assert_eq!(print_reduce(&e), "a or b or c");
+    }
+
+    #[test]
+    fn comparisons_print_reduce_spelling() {
+        assert_eq!(
+            print_reduce(&apply(sym(EQUAL), vec![sym("x"), int(4)])),
+            "x = 4"
+        );
+        assert_eq!(
+            print_reduce(&apply(sym(NOT_EQUAL), vec![sym("x"), int(4)])),
+            "x neq 4"
+        );
+        assert_eq!(
+            print_reduce(&apply(sym(LESS_EQUAL), vec![sym("a"), sym("b")])),
+            "a <= b"
+        );
+    }
+
+    #[test]
+    fn user_function_call_prints_as_typed() {
+        assert_eq!(
+            print_reduce(&apply(sym("f"), vec![sym("x"), sym("y")])),
+            "f(x, y)"
+        );
+    }
+
+    #[test]
+    fn flat_list_prints_with_curly_braces() {
+        assert_eq!(
+            print_reduce(&apply(sym(LIST), vec![int(1), int(2), int(3)])),
+            "{1, 2, 3}"
+        );
+    }
+
+    #[test]
+    fn empty_list_prints_as_empty_braces() {
+        assert_eq!(print_reduce(&apply(sym(LIST), vec![])), "{}");
+    }
+
+    #[test]
+    fn list_of_expressions_prints_each_element() {
+        let e = apply(
+            sym(LIST),
+            vec![apply(sym(ADD), vec![sym("x"), int(1)]), sym("y")],
+        );
+        assert_eq!(print_reduce(&e), "{x + 1, y}");
+    }
+
+    #[test]
+    fn list_accessor_calls_print_bridged_back_to_lowercase() {
+        assert_eq!(print_reduce(&apply(sym(FIRST), vec![sym("l")])), "first(l)");
+        assert_eq!(print_reduce(&apply(sym(REST), vec![sym("l")])), "rest(l)");
+        assert_eq!(
+            print_reduce(&apply(sym(APPEND), vec![sym("l1"), sym("l2")])),
+            "append(l1, l2)"
+        );
+        assert_eq!(
+            print_reduce(&apply(sym(REVERSE), vec![sym("l")])),
+            "reverse(l)"
+        );
+        assert_eq!(
+            print_reduce(&apply(sym(PART), vec![sym("l"), int(2)])),
+            "part(l, 2)"
+        );
+    }
+
+    #[test]
+    fn unresolved_cons_prints_the_dot_operator() {
+        assert_eq!(
+            print_reduce(&apply(sym(CONS), vec![sym("a"), sym("b")])),
+            "a . b"
+        );
+    }
+
+    #[test]
+    fn unresolved_if_prints_if_then_else() {
+        assert_eq!(
+            print_reduce(&apply(sym(IF), vec![sym("a"), int(1), int(2)])),
+            "if a then 1 else 2"
+        );
+        assert_eq!(
+            print_reduce(&apply(sym(IF), vec![sym("a"), int(1)])),
+            "if a then 1"
+        );
+    }
+
+    #[test]
+    fn unresolved_compound_expression_prints_group_syntax() {
+        assert_eq!(
+            print_reduce(&apply(sym(COMPOUND_EXPRESSION), vec![int(1), int(2)])),
+            "<< 1; 2 >>"
+        );
+    }
+}

--- a/code/specs/MA08-reduce-language.md
+++ b/code/specs/MA08-reduce-language.md
@@ -75,19 +75,31 @@ follow-on. This PR is a **design-only** kickoff, with no grammar files yet:
   with an explicit `MAX_RULE_DEPTH` measured the same way `apl-parser`/
   `j-parser`/`derive-parser` measured theirs, not assumed (per
   [MA06](MA06-j-language.md) §6's precedent).
-- **R-4 — `reduce-runtime` + `reduce-repl`.** Lowers the parsed
+- **R-4 — `reduce-runtime` + `reduce-repl`.** (✅ done) Lowers the parsed
   `GrammarASTNode` into `symbolic-ir`, evaluates with `symbolic-vm`'s shared
   `SymbolicBackend` — reused *unchanged*, with no custom `Backend` at all,
   the same reuse `derive-runtime` already demonstrated: R-4's in-scope
   surface (§3) needs nothing the shared handler table doesn't already
-  provide (arithmetic, comparison, logic, the held `Assign`/`Define`/`If`
-  forms, and `List`/`first`/`rest`/`append`/`reverse`, all already
-  implemented for Macsyma/Wolfram/Derive — the *exact same* functions,
-  so all four languages agree on every result these handlers can
-  produce). Plus the interactive `reduce-repl` (Reduce's own session
-  transcript has no numbered-input convention the way Derive's `#n:` or
-  Wolfram's `In[n]:=` do — a plain read-eval-print loop, no numbering)
-  and the `reduce` binary.
+  provide for arithmetic, comparison, logic, and the held `Assign`/
+  `Define`/`If` forms. Plus the interactive `reduce-repl` (Reduce's own
+  session transcript has no numbered-input convention the way Derive's
+  `#n:` or Wolfram's `In[n]:=` do — a plain read-eval-print loop, no
+  numbering) and the `reduce` binary.
+  **Two things this line originally claimed turned out not to hold once
+  R-4 actually grepped `symbolic-vm` rather than assuming family
+  resemblance to Macsyma/Wolfram/Derive — see §3/§5's own corrected text
+  and `reduce-runtime`'s CHANGELOG for the full accounting:** (1) `List`/
+  `first`/`rest`/`append`/`reverse` are **not** "already implemented …
+  the exact same functions" for the *shared* `SymbolicBackend` — only
+  `List` has a handler there; Macsyma's list functions and Wolfram's
+  `CompoundExpression` are each wired through a bespoke `Backend` specific
+  to that language, which R-4 does not build, so `first`/`second`/`third`/
+  `rest`/`part`/`append`/`reverse`/`Cons`/`CompoundExpression` all lower to
+  the structurally-correct head but evaluate as an unresolved call (no
+  crash, just no reduction) until a follow-on item wires real handlers.
+  (2) the arithmetic heads are `Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg` (what
+  `derive-runtime` already reuses), not `Plus`/`Subtract`/`Times`/`Power`
+  (spellings that do not exist in `symbolic-ir` at all).
 
 ## §3 The supported surface (the grammar)
 
@@ -109,11 +121,11 @@ consulted. Everything is desugared to a `head(args)`-shaped
 | `a . {b, c}` | cons (prepend `a` onto list `{b,c}`) | `Cons[a, List[b, c]]` (R-4 folds a `Cons` onto a literal `List` immediately into one `List`) |
 | `first(l)`, `second(l)`, `third(l)`, `rest(l)`, `part(l, n)` | list accessors | `First`/`Second`/`Third`/`Rest`/`Part` |
 | `append(l1, l2)`, `reverse(l)` | list construction | `Append`/`Reverse` |
-| `a + b`, `a - b` | additive | `Plus` / `Subtract` |
-| `a * b` | multiply *(explicit `*` required — see §4)* | `Times` |
-| `a / b` | divide | `Times[a, Power[b, -1]]` |
-| `a ^ b`, `a ** b` | power (`^` and `**` are the same operator — manual §2.7's own precedence table lists them as one tier) | `Power` |
-| `-a` | negation | `Times[-1, a]` |
+| `a + b`, `a - b` | additive | `Add` / `Sub` |
+| `a * b` | multiply *(explicit `*` required — see §4)* | `Mul` |
+| `a / b` | divide | `Div` |
+| `a ^ b`, `a ** b` | power (`^` and `**` are the same operator — manual §2.7's own precedence table lists them as one tier) | `Pow` |
+| `-a` | negation | `Neg` |
 | `a = b` | equation (boolean-valued; distinct from `:=` — manual §3.4 confirms `=` never assigns, only `on evallhseqp` even evaluates its left side) | `Equal` |
 | `a < b`, `a > b`, `a <= b`, `a >= b`, `a neq b` | relational | `Less`/`Greater`/`LessEqual`/`GreaterEqual`/`NotEqual` |
 | `a and b`, `a or b`, `not a` | logical | `And` / `Or` / `Not` |
@@ -149,6 +161,30 @@ never `1 + (2 . {3,4})`), while still nesting inside an equation (`a . {b}
 spirit as this section's own comparison-tier note above, not a verified
 claim about real Reduce's exact grammar; see `reduce.grammar`'s own header
 comment for the full reasoning.
+
+**R-4 correction to this table** (added once `reduce-runtime` actually
+lowered against `symbolic-ir`/`symbolic-vm` rather than assuming their
+exact head spellings from family resemblance to Macsyma/Wolfram/Derive):
+the arithmetic/negation rows above originally read `Plus`/`Subtract`/
+`Times`/`Power`, with `a / b` and `-a` expanded to `Times[a, Power[b,
+-1]]` and `Times[-1, a]` respectively. None of `Plus`/`Subtract`/`Times`/
+`Power` exist as head names in `symbolic-ir` — `grep -n '"Plus"\|
+"Subtract"\|"Times"\|"Power"' symbolic-ir/src/lib.rs` returns nothing.
+The real, already-implemented-and-reused heads are `Add`/`Sub`/`Mul`/
+`Div`/`Pow`/`Neg` (exactly what `derive-runtime`/`macsyma-compiler`
+already lower `+`/`-`/`*`/`/`/`^`/unary-`-` to), which is what the table
+above now shows and what `reduce-runtime` actually lowers to — using the
+real heads is *more* faithful to this spec's own reuse promise (§5: "the
+exact same functions, so all four languages agree on every result") than
+literally expanding division/negation into `Times`/`Power` applications
+would have been, since that would have sidestepped the very `Div`/`Neg`
+handlers already shared with Derive and Macsyma.
+
+This table's `Cons`/`First`/`Second`/`Third`/`Rest`/`Part`/`Append`/
+`Reverse`/`CompoundExpression` entries remain accurate as *lowering
+targets* — `reduce-runtime` does produce exactly these heads — but §5's
+claim that they are "already implemented … the exact same functions" for
+the shared `SymbolicBackend` did not hold: see §5's own corrected text.
 
 Comments, Reduce's mode-switch mechanism (`on rounded;`, `on complex;`,
 …), and its symbolic (raw-Lisp) mode are not part of this grammar; see §4.
@@ -252,20 +288,42 @@ with the others.
 - **Frontend:** the grammar-tools framework, exactly as Macsyma/MATLAB/
   Wolfram/APL/J/Derive use it. `reduce.tokens`/`reduce.grammar` compile to
   committed `_grammar.rs` in `reduce-lexer`/`reduce-parser` (R-2/R-3).
-- **Lowering + engine (R-4):** the parsed tree lowers to
-  [`symbolic_ir::IRNode`](../packages/rust/symbolic-ir) (surface operators,
-  `:=`/equations, and list operations → canonical `Plus`/`Times`/`Power`/
-  `Assign`/`Define`/`If`/`CompoundExpression`/`List`/`First`/`Rest`/
-  `Append`/`Reverse` heads), evaluated by
-  [`symbolic_vm::VM`](../packages/rust/symbolic-vm) with a Reduce `Backend`
-  over the shared `build_handler_table` pattern — the same rewrite engine
-  Macsyma, Wolfram, and Derive already drive, unchanged. No new engine
-  code is needed for R-4's in-scope surface (§3): every head it lowers to
-  already has a handler, shared verbatim across all four symbolic-family
-  languages now in this repo.
-- **REPL (R-4):** a single-threaded driver mirroring `wolfram-repl`/
-  `maxima-repl`/`derive-repl`; a plain (non-numbered) read-eval-print
-  loop, matching real Reduce's own interactive session transcript style.
+- **Lowering + engine (R-4, ✅ done, `reduce-runtime`):** the parsed tree
+  lowers to [`symbolic_ir::IRNode`](../packages/rust/symbolic-ir) (surface
+  operators, `:=`/equations, and list operations → canonical `Add`/`Sub`/
+  `Mul`/`Div`/`Pow`/`Neg`/`Assign`/`Define`/`If`/`CompoundExpression`/
+  `List`/`First`/`Second`/`Third`/`Rest`/`Part`/`Append`/`Reverse`/`Cons`
+  heads), evaluated by [`symbolic_vm::VM`](../packages/rust/symbolic-vm)
+  over the *stock* [`SymbolicBackend`](../packages/rust/symbolic-vm) —
+  reused directly, unchanged, with **no** Reduce-specific `Backend` at
+  all (this spec's original wording, "a Reduce `Backend` over the shared
+  `build_handler_table` pattern," implied a per-language `Backend` the
+  way Macsyma/Wolfram each have their own; R-4 does not build one) — the
+  same rewrite engine Macsyma, Wolfram, and Derive already drive.
+  **Corrected once implemented, rather than left to quietly mismatch
+  reality:** this spec originally claimed "No new engine code is needed
+  for R-4's in-scope surface (§3): every head it lowers to already has a
+  handler, shared verbatim across all four symbolic-family languages" —
+  grepping `symbolic_vm::handlers::build_handler_table` shows that is
+  true only for the arithmetic/comparison/logic/`Assign`/`Define`/`If`/
+  `List` heads. `CompoundExpression`, `First`/`Second`/`Third`/`Rest`/
+  `Part`/`Append`/`Reverse`, and `Cons` have **no handler at all** in the
+  shared table — Macsyma's list functions and Wolfram's
+  `CompoundExpression` are each wired through a bespoke per-language
+  `Backend`, which is exactly what "no custom `Backend` at all" (above)
+  rules out building here. `reduce-runtime` still lowers to these exact
+  heads (so a later item that adds real handlers to the shared table, or
+  a narrowly-scoped Reduce `Backend` if that turns out to be the right
+  shape, needs no lowering change), but evaluating one of these calls
+  today does not perform the operation — arguments still evaluate (so
+  `Assign`/`Define` side effects inside a `<< ... >>` genuinely happen,
+  in order), the call itself just stays unevaluated, like calling an
+  undefined user function. See `reduce-runtime`'s own module doc comment
+  and CHANGELOG for the full accounting.
+- **REPL (R-4, ✅ done, `reduce-repl`):** a single-threaded driver
+  mirroring `wolfram-repl`/`maxima-repl`/`derive-repl`; a plain
+  (non-numbered) read-eval-print loop, matching real Reduce's own
+  interactive session transcript style.
 
 ## §6 References
 

--- a/lessons.md
+++ b/lessons.md
@@ -1591,3 +1591,41 @@ ubuntu CI.
 `"CompileError: Parse error: %.100s"` (128 − 27-char prefix − NUL = 100 usable).
 Truncating an over-long nested message inside a fixed error buffer is correct
 behaviour anyway. Do NOT silence the warning; cap the field.
+
+## An agent isolated in a `.claude/worktrees/<id>` worktree must NEVER `cd` to the repo's top-level absolute path — it silently lands in a DIFFERENT sibling checkout
+
+**Context:** Started a task already inside a dedicated worktree at
+`/Users/.../coding-adventures/.claude/worktrees/agent-<id>` (Bash's default cwd,
+confirmed by an early `pwd`). Ran a later command as
+`cd /Users/.../coding-adventures && git checkout -b <branch>` out of habit —
+`/Users/.../coding-adventures` LOOKS like "the repo root" and IS a valid git
+checkout, but it is the **main/shared checkout**, a sibling of the worktree, not
+an ancestor or the same directory. The `git checkout -b` succeeded there with no
+error (it's a completely valid repo), silently switching the SHARED checkout's
+active branch and leaving the actual worktree untouched and still on its
+original branch.
+
+**How it was caught:** The Write tool refused a subsequent absolute-path write
+under `/Users/.../coding-adventures/code/...` with: "This agent is isolated in
+the worktree .../.claude/worktrees/agent-<id>. Edit the worktree copy of this
+file instead of the shared-checkout path." — i.e. the write guard, not the git
+command, is what flags the mistake. `git`/`find`/`grep`/`Read` all succeed
+silently against the wrong checkout because it's a real, valid repo with
+(usually) identical file content at the same commit — there is no error to
+notice until a Write/Edit call is rejected, or until `git status`/`git log` is
+inspected side-by-side in both directories.
+
+**Fix:** In an isolated-worktree session, never `cd` to (or hardcode absolute
+paths rooted at) the plain top-level clone path — always use the cwd Bash
+already defaults to (the actual worktree path), or explicitly prefix every
+absolute path with the worktree's own directory. If a stray `cd` to the wrong
+checkout already happened: check `git branch --show-current` and `git status
+--short` in BOTH directories, restore the shared checkout's original branch
+(`git checkout main` or whatever it was), and delete any stray branch created
+there (safe with `git branch -d` if it has no unique commits — verify with `git
+log <stray> --oneline` first). Do all actual work (branch, commits, file
+writes) only inside the real worktree path. Cross-refs the existing
+`git worktree add inherits HEAD` and "default to a fresh worktree" lessons
+above — this is the write-side counterpart: even with a correctly-created
+worktree, a single absolute-path `cd` habit can still misdirect an entire
+session.


### PR DESCRIPTION
## Summary

MA08 R-4, the final piece of the Reduce (CAS) language frontend: `reduce-runtime` lowers `reduce-parser`'s (R-3) parsed tree into `symbolic_ir::IRNode` and evaluates it via `symbolic_vm`'s shared `SymbolicBackend`, reused completely unchanged — the same reuse story `derive-runtime` already demonstrated. `reduce-repl` adds the interactive plain (non-numbered) REPL and the `reduce` binary.

- **`reduce-runtime`**: full precedence-cascade lowering covering every row of [MA08 §3](code/specs/MA08-reduce-language.md)'s surface table, plus a printer for the inverse. 85 tests.
- **`reduce-repl`**: bracket-aware (`(`/`)`, `{`/`}`, `<<`/`>>`) line-continuation REPL, bounded single-line reads carried forward from `derive-repl`/`j-repl`/`apl-repl`'s own prior security fix. 21 tests.
- **Disclosed spec corrections** (verified against the real `symbolic-ir`/`symbolic-vm` source, not assumed from family resemblance): the arithmetic heads are `Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`, not `Plus`/`Subtract`/`Times`/`Power` as MA08 originally stated; and the shared `SymbolicBackend` has no handler for `CompoundExpression`/list accessors/`Cons` (those exist only via bespoke per-language backends Wolfram/Macsyma each built, which R-4 is explicitly not supposed to duplicate) — calls to these lower correctly but stay unevaluated rather than performing the operation, same as an undefined user function. Spec, README, and CHANGELOG all corrected to match reality.

## Security review (2 rounds)

Round 1 found and this PR fixes, before push:
- **HIGH**: `check_statement_token_counts`'s DoS guard reset unconditionally on any `;`/`$`, letting a `<< ... >>` group statement embedded as one operand of a larger enclosing chain (`1 + 1 + (<<0;0>>) + 1 + 1 + ...`) bypass the cap entirely — empirically, a chain 16x the documented 2000-token limit sailed through undetected. Fixed by tracking bracket-nesting depth and only resetting at depth 0; added a regression test reproducing the exact bypass.
- **MEDIUM**: a thread-spawn failure (`spawn_scoped(...).expect(...)`) panicked on the calling thread, outside the `catch_unwind` boundary the crate's own docs claim makes "one crafted statement can never abort the process" true. Folded into the ordinary `Err` path instead.

Round 2 confirmed both fixes sound with no new issues. One LOW/INFO carryover (a pre-lex guard pass runs outside the `catch_unwind` boundary, over an iterative/non-recursive lexer with no known panic path) is disclosed but non-blocking.

## Test plan

- [x] `cargo test -p coding-adventures-reduce-runtime -p coding-adventures-reduce-repl` — 106/106 passing
- [x] `cargo clippy -p coding-adventures-reduce-runtime -p coding-adventures-reduce-repl --all-targets` — clean
- [x] `cargo check --workspace` — 0 errors (purely additive: two new crates + two `Cargo.toml` member-list lines, no existing crate touched)
- [x] Two-round `/security-review` — passed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>