### PR TITLE
feat(ed25519): add C# and F# ports

### DIFF
--- a/code/packages/csharp/ed25519/BUILD
+++ b/code/packages/csharp/ed25519/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Ed25519.Tests/CodingAdventures.Ed25519.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Ed25519]*"

--- a/code/packages/csharp/ed25519/BUILD_windows
+++ b/code/packages/csharp/ed25519/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Ed25519.Tests/CodingAdventures.Ed25519.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Ed25519]*"

--- a/code/packages/csharp/ed25519/CHANGELOG.md
+++ b/code/packages/csharp/ed25519/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add pure C# Ed25519 key generation, deterministic signing, and verification.
+- Compose the existing native SHA-512 implementation.
+- Validate key formats and reject malformed point and scalar encodings.
+- Add RFC 8032 conformance and tamper-rejection tests.

--- a/code/packages/csharp/ed25519/CodingAdventures.Ed25519.csproj
+++ b/code/packages/csharp/ed25519/CodingAdventures.Ed25519.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Ed25519.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# Ed25519 digital signatures from RFC 8032</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+    <ProjectReference Include="../sha512/CodingAdventures.Sha512.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ed25519/Ed25519.cs
+++ b/code/packages/csharp/ed25519/Ed25519.cs
@@ -1,0 +1,310 @@
+using System.Numerics;
+using CodingAdventures.Sha512;
+using Sha512Algorithm = CodingAdventures.Sha512.Sha512;
+
+namespace CodingAdventures.Ed25519;
+
+/// <summary>
+/// Ed25519 deterministic digital signatures from RFC 8032.
+/// </summary>
+/// <remarks>
+/// This educational implementation uses <see cref="BigInteger"/> field
+/// arithmetic. It is written for clarity and is not guaranteed to execute in
+/// constant time.
+/// </remarks>
+public static class Ed25519
+{
+    /// <summary>The encoded seed and public-key length.</summary>
+    public const int KeyLength = 32;
+
+    /// <summary>The secret-key and signature length.</summary>
+    public const int ExtendedLength = 64;
+
+    private static readonly BigInteger Prime = (BigInteger.One << 255) - 19;
+    private static readonly BigInteger GroupOrder =
+        (BigInteger.One << 252) + BigInteger.Parse("27742317777372353535851937790883648493");
+    private static readonly BigInteger D = Multiply(-121665, Invert(121666));
+    private static readonly BigInteger SqrtMinusOne =
+        BigInteger.ModPow(2, (Prime - 1) / 4, Prime);
+    private static readonly Point Identity =
+        new(BigInteger.Zero, BigInteger.One, BigInteger.One, BigInteger.Zero);
+    private static readonly Point BasePoint = CreateBasePoint();
+
+    /// <summary>
+    /// Generate a public key and 64-byte <c>seed || publicKey</c> secret key.
+    /// </summary>
+    public static (byte[] PublicKey, byte[] SecretKey) GenerateKeypair(byte[] seed)
+    {
+        ValidateLength(seed, KeyLength, nameof(seed), "seed");
+
+        var digest = Sha512Algorithm.Hash(seed);
+        var scalar = ClampScalar(digest.AsSpan(0, KeyLength));
+        var publicKey = EncodePoint(ScalarMultiply(scalar, BasePoint));
+        var secretKey = new byte[ExtendedLength];
+        seed.CopyTo(secretKey, 0);
+        publicKey.CopyTo(secretKey, KeyLength);
+        return (publicKey, secretKey);
+    }
+
+    /// <summary>Sign a message with a 64-byte <c>seed || publicKey</c> key.</summary>
+    public static byte[] Sign(byte[] message, byte[] secretKey)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ValidateLength(secretKey, ExtendedLength, nameof(secretKey), "secret key");
+
+        var seed = secretKey.AsSpan(0, KeyLength).ToArray();
+        var suppliedPublicKey = secretKey.AsSpan(KeyLength, KeyLength).ToArray();
+        var (_, reconstructedSecretKey) = GenerateKeypair(seed);
+        if (!secretKey.AsSpan().SequenceEqual(reconstructedSecretKey))
+        {
+            throw new ArgumentException(
+                "Ed25519 secret key must be seed || publicKey.", nameof(secretKey));
+        }
+
+        var digest = Sha512Algorithm.Hash(seed);
+        var scalar = ClampScalar(digest.AsSpan(0, KeyLength));
+        var prefix = digest.AsSpan(KeyLength, KeyLength).ToArray();
+        var nonce = ReduceScalar(HashParts(prefix, message));
+        var encodedR = EncodePoint(ScalarMultiply(nonce, BasePoint));
+        var challenge = ReduceScalar(HashParts(encodedR, suppliedPublicKey, message));
+        var scalarS = ModGroup(nonce + challenge * scalar);
+
+        var signature = new byte[ExtendedLength];
+        encodedR.CopyTo(signature, 0);
+        EncodeLittleEndian(scalarS).CopyTo(signature, KeyLength);
+        return signature;
+    }
+
+    /// <summary>
+    /// Verify a signature. Malformed signature and public-key encodings return
+    /// <see langword="false"/> rather than throwing.
+    /// </summary>
+    public static bool Verify(byte[] message, byte[]? signature, byte[]? publicKey)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (signature is null || signature.Length != ExtendedLength ||
+            publicKey is null || publicKey.Length != KeyLength)
+        {
+            return false;
+        }
+
+        var encodedR = signature.AsSpan(0, KeyLength).ToArray();
+        var scalarS = DecodeLittleEndian(signature.AsSpan(KeyLength, KeyLength));
+        if (scalarS >= GroupOrder ||
+            !TryDecodePoint(encodedR, out var pointR) ||
+            !TryDecodePoint(publicKey, out var pointA))
+        {
+            return false;
+        }
+
+        var challenge = ReduceScalar(HashParts(encodedR, publicKey, message));
+        var left = ScalarMultiply(scalarS, BasePoint);
+        var right = Add(pointR, ScalarMultiply(challenge, pointA));
+        return PointsEqual(left, right);
+    }
+
+    private static void ValidateLength(
+        byte[]? value,
+        int expectedLength,
+        string parameterName,
+        string description)
+    {
+        ArgumentNullException.ThrowIfNull(value, parameterName);
+        if (value.Length != expectedLength)
+        {
+            throw new ArgumentException(
+                $"Ed25519 {description} must be exactly {expectedLength} bytes.",
+                parameterName);
+        }
+    }
+
+    private static byte[] HashParts(params byte[][] parts)
+    {
+        var hasher = new Sha512Hasher();
+        foreach (var part in parts)
+        {
+            hasher.Update(part);
+        }
+
+        return hasher.Digest();
+    }
+
+    private static BigInteger ClampScalar(ReadOnlySpan<byte> digestPrefix)
+    {
+        var clamped = digestPrefix.ToArray();
+        clamped[0] &= 248;
+        clamped[31] &= 127;
+        clamped[31] |= 64;
+        return DecodeLittleEndian(clamped);
+    }
+
+    private static BigInteger ReduceScalar(ReadOnlySpan<byte> bytes) =>
+        DecodeLittleEndian(bytes) % GroupOrder;
+
+    private static Point CreateBasePoint()
+    {
+        var y = Multiply(4, Invert(5));
+        if (!TryRecoverX(y, 0, out var x))
+        {
+            throw new InvalidOperationException("Unable to construct the Ed25519 base point.");
+        }
+
+        return FromAffine(x, y);
+    }
+
+    private static Point FromAffine(BigInteger x, BigInteger y) =>
+        new(Mod(x), Mod(y), BigInteger.One, Multiply(x, y));
+
+    private static Point Add(Point left, Point right)
+    {
+        var a = Multiply(Subtract(left.Y, left.X), Subtract(right.Y, right.X));
+        var b = Multiply(Add(left.Y, left.X), Add(right.Y, right.X));
+        var c = Multiply(2 * D, Multiply(left.T, right.T));
+        var d = Multiply(2, Multiply(left.Z, right.Z));
+        var e = Subtract(b, a);
+        var f = Subtract(d, c);
+        var g = Add(d, c);
+        var h = Add(b, a);
+        return new Point(
+            Multiply(e, f),
+            Multiply(g, h),
+            Multiply(f, g),
+            Multiply(e, h));
+    }
+
+    private static Point Double(Point point)
+    {
+        var a = Square(point.X);
+        var b = Square(point.Y);
+        var c = Multiply(2, Square(point.Z));
+        var d = Mod(-a);
+        var e = Subtract(Subtract(Square(Add(point.X, point.Y)), a), b);
+        var g = Add(d, b);
+        var f = Subtract(g, c);
+        var h = Subtract(d, b);
+        return new Point(
+            Multiply(e, f),
+            Multiply(g, h),
+            Multiply(f, g),
+            Multiply(e, h));
+    }
+
+    private static Point ScalarMultiply(BigInteger scalar, Point point)
+    {
+        var result = Identity;
+        var addend = point;
+        var remaining = scalar;
+
+        while (remaining > 0)
+        {
+            if (!remaining.IsEven)
+            {
+                result = Add(result, addend);
+            }
+
+            addend = Double(addend);
+            remaining >>= 1;
+        }
+
+        return result;
+    }
+
+    private static byte[] EncodePoint(Point point)
+    {
+        var inverseZ = Invert(point.Z);
+        var x = Multiply(point.X, inverseZ);
+        var y = Multiply(point.Y, inverseZ);
+        var encoded = EncodeLittleEndian(y);
+        if (!x.IsEven)
+        {
+            encoded[31] |= 0x80;
+        }
+
+        return encoded;
+    }
+
+    private static bool TryDecodePoint(ReadOnlySpan<byte> encoded, out Point point)
+    {
+        point = Identity;
+        if (encoded.Length != KeyLength)
+        {
+            return false;
+        }
+
+        var sign = (encoded[31] >> 7) & 1;
+        var yBytes = encoded.ToArray();
+        yBytes[31] &= 0x7f;
+        var y = DecodeLittleEndian(yBytes);
+        if (y >= Prime || !TryRecoverX(y, sign, out var x))
+        {
+            return false;
+        }
+
+        point = FromAffine(x, y);
+        return true;
+    }
+
+    private static bool TryRecoverX(BigInteger y, int sign, out BigInteger x)
+    {
+        var ySquared = Square(y);
+        var xSquared = Multiply(Subtract(ySquared, 1), Invert(Add(Multiply(D, ySquared), 1)));
+        var candidate = BigInteger.ModPow(xSquared, (Prime + 3) / 8, Prime);
+        if (Square(candidate) != xSquared)
+        {
+            candidate = Multiply(candidate, SqrtMinusOne);
+        }
+
+        if (Square(candidate) != xSquared || (candidate.IsZero && sign == 1))
+        {
+            x = BigInteger.Zero;
+            return false;
+        }
+
+        x = ((int)(candidate & BigInteger.One)) == sign ? candidate : Mod(-candidate);
+        return true;
+    }
+
+    private static bool PointsEqual(Point left, Point right) =>
+        Multiply(left.X, right.Z) == Multiply(right.X, left.Z) &&
+        Multiply(left.Y, right.Z) == Multiply(right.Y, left.Z);
+
+    private static BigInteger DecodeLittleEndian(ReadOnlySpan<byte> bytes) =>
+        new(bytes, isUnsigned: true, isBigEndian: false);
+
+    private static byte[] EncodeLittleEndian(BigInteger value)
+    {
+        var encoded = value.ToByteArray(isUnsigned: true, isBigEndian: false);
+        var result = new byte[KeyLength];
+        encoded.CopyTo(result, 0);
+        return result;
+    }
+
+    private static BigInteger Add(BigInteger left, BigInteger right) => Mod(left + right);
+
+    private static BigInteger Subtract(BigInteger left, BigInteger right) => Mod(left - right);
+
+    private static BigInteger Multiply(BigInteger left, BigInteger right) => Mod(left * right);
+
+    private static BigInteger Square(BigInteger value) => Mod(value * value);
+
+    private static BigInteger Invert(BigInteger value) =>
+        BigInteger.ModPow(Mod(value), Prime - 2, Prime);
+
+    private static BigInteger ModGroup(BigInteger value)
+    {
+        var reduced = value % GroupOrder;
+        return reduced.Sign < 0 ? reduced + GroupOrder : reduced;
+    }
+
+    private static BigInteger Mod(BigInteger value)
+    {
+        var reduced = value % Prime;
+        return reduced.Sign < 0 ? reduced + Prime : reduced;
+    }
+
+    private readonly record struct Point(
+        BigInteger X,
+        BigInteger Y,
+        BigInteger Z,
+        BigInteger T);
+}

--- a/code/packages/csharp/ed25519/README.md
+++ b/code/packages/csharp/ed25519/README.md
@@ -1,0 +1,20 @@
+# CodingAdventures.Ed25519
+
+A pure C# implementation of Ed25519 deterministic digital signatures from
+RFC 8032. It composes the existing native SHA-512 package with extended
+Edwards-coordinate arithmetic over `2^255 - 19`.
+
+```csharp
+using CodingAdventures.Ed25519;
+
+var (publicKey, secretKey) = Ed25519.GenerateKeypair(seed);
+byte[] signature = Ed25519.Sign(message, secretKey);
+bool valid = Ed25519.Verify(message, signature, publicKey);
+```
+
+The 32-byte seed deterministically produces a 32-byte public key and a 64-byte
+`seed || publicKey` secret key. Signatures are 64-byte `R || S` values. The
+implementation rejects non-canonical scalars and point encodings.
+
+This package uses `BigInteger` for clarity. Its arithmetic is not guaranteed
+to be constant-time and should be treated as an educational implementation.

--- a/code/packages/csharp/ed25519/required_capabilities.json
+++ b/code/packages/csharp/ed25519/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/ed25519",
+  "capabilities": [],
+  "justification": "Pure in-memory RFC 8032 field arithmetic and hashing. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/csharp/ed25519/tests/CodingAdventures.Ed25519.Tests/CodingAdventures.Ed25519.Tests.csproj
+++ b/code/packages/csharp/ed25519/tests/CodingAdventures.Ed25519.Tests/CodingAdventures.Ed25519.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Ed25519.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/ed25519/tests/CodingAdventures.Ed25519.Tests/Ed25519Tests.cs
+++ b/code/packages/csharp/ed25519/tests/CodingAdventures.Ed25519.Tests/Ed25519Tests.cs
@@ -1,0 +1,122 @@
+using Ed25519Algorithm = CodingAdventures.Ed25519.Ed25519;
+
+namespace CodingAdventures.Ed25519.Tests;
+
+public sealed class Ed25519Tests
+{
+    [Theory]
+    [InlineData(
+        "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "",
+        "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b")]
+    [InlineData(
+        "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb",
+        "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "72",
+        "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00")]
+    [InlineData(
+        "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7",
+        "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "af82",
+        "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a")]
+    public void MatchesRfc8032Vectors(
+        string seedHex,
+        string publicKeyHex,
+        string messageHex,
+        string signatureHex)
+    {
+        var seed = Hex(seedHex);
+        var message = Hex(messageHex);
+        var expectedPublicKey = Hex(publicKeyHex);
+        var expectedSignature = Hex(signatureHex);
+
+        var (publicKey, secretKey) = Ed25519Algorithm.GenerateKeypair(seed);
+
+        Assert.Equal(expectedPublicKey, publicKey);
+        Assert.Equal(seed.Concat(publicKey), secretKey);
+        Assert.Equal(expectedSignature, Ed25519Algorithm.Sign(message, secretKey));
+        Assert.True(Ed25519Algorithm.Verify(message, expectedSignature, publicKey));
+    }
+
+    [Fact]
+    public void KeyGenerationAndSigningAreDeterministic()
+    {
+        var seed = Enumerable.Range(0, 32).Select(value => (byte)value).ToArray();
+        var message = "deterministic"u8.ToArray();
+        var first = Ed25519Algorithm.GenerateKeypair(seed);
+        var second = Ed25519Algorithm.GenerateKeypair(seed);
+
+        Assert.Equal(first.PublicKey, second.PublicKey);
+        Assert.Equal(first.SecretKey, second.SecretKey);
+        Assert.Equal(
+            Ed25519Algorithm.Sign(message, first.SecretKey),
+            Ed25519Algorithm.Sign(message, first.SecretKey));
+    }
+
+    [Fact]
+    public void VerificationRejectsTamperingWrongMessagesAndWrongKeys()
+    {
+        var seed = Enumerable.Range(0, 32).Select(value => (byte)value).ToArray();
+        var otherSeed = Enumerable.Range(32, 32).Select(value => (byte)value).ToArray();
+        var (publicKey, secretKey) = Ed25519Algorithm.GenerateKeypair(seed);
+        var (otherPublicKey, _) = Ed25519Algorithm.GenerateKeypair(otherSeed);
+        var message = "hello"u8.ToArray();
+        var signature = Ed25519Algorithm.Sign(message, secretKey);
+
+        var tamperedR = signature.ToArray();
+        tamperedR[0] ^= 1;
+        var tamperedS = signature.ToArray();
+        tamperedS[32] ^= 1;
+
+        Assert.False(Ed25519Algorithm.Verify("world"u8.ToArray(), signature, publicKey));
+        Assert.False(Ed25519Algorithm.Verify(message, signature, otherPublicKey));
+        Assert.False(Ed25519Algorithm.Verify(message, tamperedR, publicKey));
+        Assert.False(Ed25519Algorithm.Verify(message, tamperedS, publicKey));
+    }
+
+    [Fact]
+    public void VerificationRejectsMalformedScalarsPointsAndLengths()
+    {
+        var seed = new byte[32];
+        var (publicKey, secretKey) = Ed25519Algorithm.GenerateKeypair(seed);
+        var message = "hello"u8.ToArray();
+        var signature = Ed25519Algorithm.Sign(message, secretKey);
+
+        var outOfRangeS = signature.ToArray();
+        Hex("edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010")
+            .CopyTo(outOfRangeS, 32);
+        var invalidR = signature.ToArray();
+        Enumerable.Repeat((byte)0xff, 32).ToArray().CopyTo(invalidR, 0);
+        var negativeZeroR = signature.ToArray();
+        Array.Clear(negativeZeroR, 0, 32);
+        negativeZeroR[0] = 1;
+        negativeZeroR[31] = 0x80;
+
+        Assert.False(Ed25519Algorithm.Verify(message, outOfRangeS, publicKey));
+        Assert.False(Ed25519Algorithm.Verify(message, invalidR, publicKey));
+        Assert.False(Ed25519Algorithm.Verify(message, negativeZeroR, publicKey));
+        Assert.False(Ed25519Algorithm.Verify(message, signature, Enumerable.Repeat((byte)0xff, 32).ToArray()));
+        Assert.False(Ed25519Algorithm.Verify(message, null, publicKey));
+        Assert.False(Ed25519Algorithm.Verify(message, new byte[63], publicKey));
+        Assert.False(Ed25519Algorithm.Verify(message, signature, null));
+        Assert.False(Ed25519Algorithm.Verify(message, signature, new byte[31]));
+    }
+
+    [Fact]
+    public void PublicInputsAreValidatedAndSecretKeyMustMatchItsSeed()
+    {
+        Assert.Throws<ArgumentNullException>(() => Ed25519Algorithm.GenerateKeypair(null!));
+        Assert.Throws<ArgumentException>(() => Ed25519Algorithm.GenerateKeypair(new byte[31]));
+        Assert.Throws<ArgumentNullException>(() => Ed25519Algorithm.Sign(null!, new byte[64]));
+        Assert.Throws<ArgumentNullException>(() => Ed25519Algorithm.Sign([], null!));
+        Assert.Throws<ArgumentException>(() => Ed25519Algorithm.Sign([], new byte[63]));
+        Assert.Throws<ArgumentNullException>(() => Ed25519Algorithm.Verify(null!, new byte[64], new byte[32]));
+
+        var (_, secretKey) = Ed25519Algorithm.GenerateKeypair(new byte[32]);
+        secretKey[63] ^= 1;
+        Assert.Throws<ArgumentException>(() => Ed25519Algorithm.Sign([], secretKey));
+    }
+
+    private static byte[] Hex(string value) => Convert.FromHexString(value);
+}

--- a/code/packages/fsharp/ed25519/BUILD
+++ b/code/packages/fsharp/ed25519/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Ed25519.Tests/CodingAdventures.Ed25519.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Ed25519.FSharp]*"

--- a/code/packages/fsharp/ed25519/BUILD_windows
+++ b/code/packages/fsharp/ed25519/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Ed25519.Tests/CodingAdventures.Ed25519.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Ed25519.FSharp]*"

--- a/code/packages/fsharp/ed25519/CHANGELOG.md
+++ b/code/packages/fsharp/ed25519/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add pure F# Ed25519 key generation, deterministic signing, and verification.
+- Compose the existing native SHA-512 implementation.
+- Validate key formats and reject malformed point and scalar encodings.
+- Add RFC 8032 conformance and tamper-rejection tests.

--- a/code/packages/fsharp/ed25519/CodingAdventures.Ed25519.fsproj
+++ b/code/packages/fsharp/ed25519/CodingAdventures.Ed25519.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.Ed25519.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Ed25519.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# Ed25519 digital signatures from RFC 8032</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../sha512/CodingAdventures.Sha512.fsproj" />
+    <Compile Include="Ed25519.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ed25519/Ed25519.fs
+++ b/code/packages/fsharp/ed25519/Ed25519.fs
@@ -1,0 +1,255 @@
+namespace CodingAdventures.Ed25519.FSharp
+
+open System
+open System.Numerics
+open CodingAdventures.Sha512.FSharp
+
+/// Ed25519 deterministic digital signatures from RFC 8032.
+/// This educational implementation uses BigInteger field arithmetic, which is
+/// not guaranteed to execute in constant time.
+[<RequireQualifiedAccess>]
+module Ed25519 =
+    [<Literal>]
+    let KeyLength = 32
+
+    [<Literal>]
+    let ExtendedLength = 64
+
+    type private Point =
+        { X: bigint
+          Y: bigint
+          Z: bigint
+          T: bigint }
+
+    let private prime = (BigInteger.One <<< 255) - 19I
+
+    let private groupOrder =
+        (BigInteger.One <<< 252)
+        + BigInteger.Parse("27742317777372353535851937790883648493")
+
+    let private modulo value =
+        let reduced = value % prime
+        if reduced.Sign < 0 then reduced + prime else reduced
+
+    let private moduloGroup value =
+        let reduced = value % groupOrder
+        if reduced.Sign < 0 then reduced + groupOrder else reduced
+
+    let private add left right = modulo (left + right)
+    let private subtract left right = modulo (left - right)
+    let private multiply left right = modulo (left * right)
+    let private square value = modulo (value * value)
+    let private invert value = BigInteger.ModPow(modulo value, prime - 2I, prime)
+
+    let private d = multiply -121665I (invert 121666I)
+    let private sqrtMinusOne = BigInteger.ModPow(2I, (prime - 1I) / 4I, prime)
+
+    let private identity =
+        { X = BigInteger.Zero
+          Y = BigInteger.One
+          Z = BigInteger.One
+          T = BigInteger.Zero }
+
+    let private decodeLittleEndian (bytes: ReadOnlySpan<byte>) =
+        BigInteger(bytes, isUnsigned = true, isBigEndian = false)
+
+    let private encodeLittleEndian (value: bigint) =
+        let encoded = value.ToByteArray(isUnsigned = true, isBigEndian = false)
+        let result = Array.zeroCreate<byte> KeyLength
+        Array.Copy(encoded, result, encoded.Length)
+        result
+
+    let private fromAffine x y =
+        { X = modulo x
+          Y = modulo y
+          Z = BigInteger.One
+          T = multiply x y }
+
+    let private tryRecoverX y sign =
+        let ySquared = square y
+
+        let xSquared =
+            multiply (subtract ySquared 1I) (invert (add (multiply d ySquared) 1I))
+
+        let mutable candidate = BigInteger.ModPow(xSquared, (prime + 3I) / 8I, prime)
+
+        if square candidate <> xSquared then
+            candidate <- multiply candidate sqrtMinusOne
+
+        if square candidate <> xSquared || (candidate.IsZero && sign = 1) then
+            None
+        else
+            let x =
+                if int (candidate &&& BigInteger.One) = sign then
+                    candidate
+                else
+                    modulo -candidate
+
+            Some x
+
+    let private basePoint =
+        let y = multiply 4I (invert 5I)
+
+        match tryRecoverX y 0 with
+        | Some x -> fromAffine x y
+        | None -> invalidOp "Unable to construct the Ed25519 base point."
+
+    let private pointAdd left right =
+        let a = multiply (subtract left.Y left.X) (subtract right.Y right.X)
+        let b = multiply (add left.Y left.X) (add right.Y right.X)
+        let c = multiply (2I * d) (multiply left.T right.T)
+        let dValue = multiply 2I (multiply left.Z right.Z)
+        let e = subtract b a
+        let f = subtract dValue c
+        let g = add dValue c
+        let h = add b a
+
+        { X = multiply e f
+          Y = multiply g h
+          Z = multiply f g
+          T = multiply e h }
+
+    let private pointDouble point =
+        let a = square point.X
+        let b = square point.Y
+        let c = multiply 2I (square point.Z)
+        let dValue = modulo -a
+        let e = subtract (subtract (square (add point.X point.Y)) a) b
+        let g = add dValue b
+        let f = subtract g c
+        let h = subtract dValue b
+
+        { X = multiply e f
+          Y = multiply g h
+          Z = multiply f g
+          T = multiply e h }
+
+    let private scalarMultiply (scalar: bigint) point =
+        let mutable result = identity
+        let mutable addend = point
+        let mutable remaining = scalar
+
+        while remaining > BigInteger.Zero do
+            if not remaining.IsEven then
+                result <- pointAdd result addend
+
+            addend <- pointDouble addend
+            remaining <- remaining >>> 1
+
+        result
+
+    let private encodePoint point =
+        let inverseZ = invert point.Z
+        let x = multiply point.X inverseZ
+        let y = multiply point.Y inverseZ
+        let encoded = encodeLittleEndian y
+
+        if not x.IsEven then
+            encoded[31] <- encoded[31] ||| 0x80uy
+
+        encoded
+
+    let private tryDecodePoint (encoded: byte array) =
+        if isNull encoded || encoded.Length <> KeyLength then
+            None
+        else
+            let sign = int ((encoded[31] >>> 7) &&& 1uy)
+            let yBytes = Array.copy encoded
+            yBytes[31] <- yBytes[31] &&& 0x7fuy
+            let y = decodeLittleEndian (ReadOnlySpan<byte>(yBytes))
+
+            if y >= prime then
+                None
+            else
+                match tryRecoverX y sign with
+                | Some x -> Some(fromAffine x y)
+                | None -> None
+
+    let private pointsEqual left right =
+        multiply left.X right.Z = multiply right.X left.Z
+        && multiply left.Y right.Z = multiply right.Y left.Z
+
+    let private clampScalar (digestPrefix: byte array) =
+        let clamped = Array.copy digestPrefix
+        clamped[0] <- clamped[0] &&& 248uy
+        clamped[31] <- clamped[31] &&& 127uy
+        clamped[31] <- clamped[31] ||| 64uy
+        decodeLittleEndian (ReadOnlySpan<byte>(clamped))
+
+    let private reduceScalar (bytes: byte array) =
+        decodeLittleEndian (ReadOnlySpan<byte>(bytes)) % groupOrder
+
+    let private hashParts (parts: byte array list) =
+        parts |> Array.concat |> Sha512.hash
+
+    let private validateLength parameterName description expectedLength (value: byte array) =
+        if isNull value then
+            nullArg parameterName
+
+        if value.Length <> expectedLength then
+            invalidArg
+                parameterName
+                $"Ed25519 {description} must be exactly {expectedLength} bytes."
+
+    /// Generate a public key and 64-byte seed || publicKey secret key.
+    let generateKeypair (seed: byte array) =
+        validateLength "seed" "seed" KeyLength seed
+        let digest = Sha512.hash seed
+        let scalar = clampScalar digest[0 .. KeyLength - 1]
+        let publicKey = scalarMultiply scalar basePoint |> encodePoint
+        let secretKey = Array.append (Array.copy seed) publicKey
+        publicKey, secretKey
+
+    /// Sign a message with a 64-byte seed || publicKey key.
+    let sign (message: byte array) (secretKey: byte array) =
+        if isNull message then
+            nullArg "message"
+
+        validateLength "secretKey" "secret key" ExtendedLength secretKey
+        let seed = secretKey[0 .. KeyLength - 1]
+        let suppliedPublicKey = secretKey[KeyLength .. ExtendedLength - 1]
+        let _, reconstructedSecretKey = generateKeypair seed
+
+        if secretKey <> reconstructedSecretKey then
+            invalidArg "secretKey" "Ed25519 secret key must be seed || publicKey."
+
+        let digest = Sha512.hash seed
+        let scalar = clampScalar digest[0 .. KeyLength - 1]
+        let prefix = digest[KeyLength .. ExtendedLength - 1]
+        let nonce = hashParts [ prefix; message ] |> reduceScalar
+        let encodedR = scalarMultiply nonce basePoint |> encodePoint
+
+        let challenge =
+            hashParts [ encodedR; suppliedPublicKey; message ] |> reduceScalar
+
+        let scalarS = moduloGroup (nonce + challenge * scalar)
+        Array.append encodedR (encodeLittleEndian scalarS)
+
+    /// Verify a signature. Malformed encodings return false rather than throw.
+    let verify (message: byte array) (signature: byte array) (publicKey: byte array) =
+        if isNull message then
+            nullArg "message"
+
+        if isNull signature
+           || signature.Length <> ExtendedLength
+           || isNull publicKey
+           || publicKey.Length <> KeyLength then
+            false
+        else
+            let encodedR = signature[0 .. KeyLength - 1]
+
+            let scalarS =
+                decodeLittleEndian (ReadOnlySpan<byte>(signature, KeyLength, KeyLength))
+
+            if scalarS >= groupOrder then
+                false
+            else
+                match tryDecodePoint encodedR, tryDecodePoint publicKey with
+                | Some pointR, Some pointA ->
+                    let challenge =
+                        hashParts [ encodedR; publicKey; message ] |> reduceScalar
+
+                    let left = scalarMultiply scalarS basePoint
+                    let right = pointAdd pointR (scalarMultiply challenge pointA)
+                    pointsEqual left right
+                | _ -> false

--- a/code/packages/fsharp/ed25519/README.md
+++ b/code/packages/fsharp/ed25519/README.md
@@ -1,0 +1,20 @@
+# CodingAdventures.Ed25519
+
+A pure F# implementation of Ed25519 deterministic digital signatures from
+RFC 8032. It composes the existing native SHA-512 package with extended
+Edwards-coordinate arithmetic over `2^255 - 19`.
+
+```fsharp
+open CodingAdventures.Ed25519.FSharp
+
+let publicKey, secretKey = Ed25519.generateKeypair seed
+let signature = Ed25519.sign message secretKey
+let valid = Ed25519.verify message signature publicKey
+```
+
+The 32-byte seed deterministically produces a 32-byte public key and a 64-byte
+`seed || publicKey` secret key. Signatures are 64-byte `R || S` values. The
+implementation rejects non-canonical scalars and point encodings.
+
+This package uses `BigInteger` for clarity. Its arithmetic is not guaranteed
+to be constant-time and should be treated as an educational implementation.

--- a/code/packages/fsharp/ed25519/required_capabilities.json
+++ b/code/packages/fsharp/ed25519/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/ed25519",
+  "capabilities": [],
+  "justification": "Pure in-memory RFC 8032 field arithmetic and hashing. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/ed25519/tests/CodingAdventures.Ed25519.Tests/CodingAdventures.Ed25519.Tests.fsproj
+++ b/code/packages/fsharp/ed25519/tests/CodingAdventures.Ed25519.Tests/CodingAdventures.Ed25519.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Ed25519.fsproj" />
+    <Compile Include="Ed25519Tests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/ed25519/tests/CodingAdventures.Ed25519.Tests/Ed25519Tests.fs
+++ b/code/packages/fsharp/ed25519/tests/CodingAdventures.Ed25519.Tests/Ed25519Tests.fs
@@ -1,0 +1,121 @@
+namespace CodingAdventures.Ed25519.FSharp.Tests
+
+open System
+open Xunit
+open CodingAdventures.Ed25519.FSharp
+
+module Ed25519Tests =
+    let private hex (value: string) = Convert.FromHexString value
+
+    [<Theory>]
+    [<InlineData(
+        "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        "",
+        "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b")>]
+    [<InlineData(
+        "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb",
+        "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        "72",
+        "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00")>]
+    [<InlineData(
+        "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7",
+        "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+        "af82",
+        "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a")>]
+    let ``matches RFC 8032 vectors`` seedHex publicKeyHex messageHex signatureHex =
+        let seed = hex seedHex
+        let message = hex messageHex
+        let expectedPublicKey = hex publicKeyHex
+        let expectedSignature = hex signatureHex
+        let publicKey, secretKey = Ed25519.generateKeypair seed
+
+        Assert.Equal<byte array>(expectedPublicKey, publicKey)
+        Assert.Equal<byte array>(Array.append seed publicKey, secretKey)
+        Assert.Equal<byte array>(expectedSignature, Ed25519.sign message secretKey)
+        Assert.True(Ed25519.verify message expectedSignature publicKey)
+
+    [<Fact>]
+    let ``key generation and signing are deterministic`` () =
+        let seed = [| 0uy .. 31uy |]
+        let message = Text.Encoding.UTF8.GetBytes "deterministic"
+        let firstPublic, firstSecret = Ed25519.generateKeypair seed
+        let secondPublic, secondSecret = Ed25519.generateKeypair seed
+
+        Assert.Equal<byte array>(firstPublic, secondPublic)
+        Assert.Equal<byte array>(firstSecret, secondSecret)
+        Assert.Equal<byte array>(Ed25519.sign message firstSecret, Ed25519.sign message firstSecret)
+
+    [<Fact>]
+    let ``verification rejects tampering wrong messages and wrong keys`` () =
+        let seed = [| 0uy .. 31uy |]
+        let otherSeed = [| 32uy .. 63uy |]
+        let publicKey, secretKey = Ed25519.generateKeypair seed
+        let otherPublicKey, _ = Ed25519.generateKeypair otherSeed
+        let message = Text.Encoding.UTF8.GetBytes "hello"
+        let signature = Ed25519.sign message secretKey
+        let tamperedR = Array.copy signature
+        tamperedR[0] <- tamperedR[0] ^^^ 1uy
+        let tamperedS = Array.copy signature
+        tamperedS[32] <- tamperedS[32] ^^^ 1uy
+
+        Assert.False(Ed25519.verify (Text.Encoding.UTF8.GetBytes "world") signature publicKey)
+        Assert.False(Ed25519.verify message signature otherPublicKey)
+        Assert.False(Ed25519.verify message tamperedR publicKey)
+        Assert.False(Ed25519.verify message tamperedS publicKey)
+
+    [<Fact>]
+    let ``verification rejects malformed scalars points and lengths`` () =
+        let publicKey, secretKey = Ed25519.generateKeypair (Array.zeroCreate 32)
+        let message = Text.Encoding.UTF8.GetBytes "hello"
+        let signature = Ed25519.sign message secretKey
+        let outOfRangeS = Array.copy signature
+
+        Array.Copy(
+            hex "edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+            0,
+            outOfRangeS,
+            32,
+            32)
+
+        let invalidR = Array.copy signature
+        Array.Copy(Array.create 32 0xffuy, invalidR, 32)
+        let negativeZeroR = Array.copy signature
+        Array.Clear(negativeZeroR, 0, 32)
+        negativeZeroR[0] <- 1uy
+        negativeZeroR[31] <- 0x80uy
+
+        Assert.False(Ed25519.verify message outOfRangeS publicKey)
+        Assert.False(Ed25519.verify message invalidR publicKey)
+        Assert.False(Ed25519.verify message negativeZeroR publicKey)
+        Assert.False(Ed25519.verify message signature (Array.create 32 0xffuy))
+        Assert.False(Ed25519.verify message null publicKey)
+        Assert.False(Ed25519.verify message (Array.zeroCreate 63) publicKey)
+        Assert.False(Ed25519.verify message signature null)
+        Assert.False(Ed25519.verify message signature (Array.zeroCreate 31))
+
+    [<Fact>]
+    let ``public inputs are validated and secret key must match its seed`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> Ed25519.generateKeypair null |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentException>(fun () -> Ed25519.generateKeypair (Array.zeroCreate 31) |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () -> Ed25519.sign null (Array.zeroCreate 64) |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () -> Ed25519.sign [||] null |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentException>(fun () -> Ed25519.sign [||] (Array.zeroCreate 63) |> ignore)
+        |> ignore
+
+        Assert.Throws<ArgumentNullException>(fun () -> Ed25519.verify null (Array.zeroCreate 64) (Array.zeroCreate 32) |> ignore)
+        |> ignore
+
+        let _, secretKey = Ed25519.generateKeypair (Array.zeroCreate 32)
+        secretKey[63] <- secretKey[63] ^^^ 1uy
+
+        Assert.Throws<ArgumentException>(fun () -> Ed25519.sign [||] secretKey |> ignore)
+        |> ignore

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -118,7 +118,7 @@ ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 319 |
+| Present in 10-15 languages | 172 | 317 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 701 | 9,814 |
@@ -164,7 +164,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 319
+The 172 packages present in at least ten implementation languages need 317
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -173,8 +173,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 5 | Move with F# |
-| F# | 5 | Move with C# |
+| C# | 4 | Move with F# |
+| F# | 4 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -332,6 +332,16 @@ statement forms, expression precedence, configured and one-shot APIs, empty
 and bare-line programs, and syntax failures. The package now spans 12
 implementation lanes, reduces the high-consensus backlog to 319 slots, and
 leaves 5 paired gaps in each lane.
+
+The thirteenth paired C#/F# slice is complete: `ed25519` now provides native
+RFC 8032 key generation, deterministic signing, and verification in both
+lanes, composing their existing SHA-512 packages with extended Edwards
+coordinates over `2^255 - 19`. Package-native tests cover the first three RFC
+vectors, deterministic key and signature derivation, wrong messages and keys,
+tampered signature halves, non-canonical scalars, malformed point encodings,
+and strict seed and secret-key formats. The package now spans 12 implementation
+lanes, reduces the high-consensus backlog to 317 slots, and leaves 4 paired
+gaps in each lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add pure C# and F# Ed25519 implementations with native SHA-512 dependencies
- implement RFC 8032 seed-based key generation, deterministic signing, and verification with extended Edwards coordinates
- add package metadata, capability declarations, documentation, and conformance tests in both lanes
- update the package-parity roadmap and reduce the high-consensus backlog from 319 to 317 slots

## Why

Ed25519 was the smallest dependency-safe remaining paired C#/F# high-consensus gap. Both lanes already provide native SHA-512, so this closes two parity slots without external cryptography libraries or new capability requirements.

## Validation

- C#: 7 tests passed; 98.02% line coverage
- F#: 7 tests passed; 98.7% line coverage
- first three RFC 8032 vectors match for key generation, signing, and verification
- tampered signatures, wrong messages and keys, non-canonical scalars, malformed points, and invalid key formats are rejected
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` reports 317 high-consensus gaps and zero collisions
- `git diff --check`

## Impact

The `ed25519` package now spans 12 implementation lanes. The paired C#/F# high-consensus backlog falls from five packages per lane to four.
