### PR TITLE
feat(adj-tables): RS-5c — range/bracket lookup over a table read as a step function

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -141,7 +141,17 @@ context_order_decl = "context_order" LBRACE IDENT GT IDENT { COMMA IDENT GT IDEN
 # ----------------------------------------------------------------
 functional_decl  = "functional" term ;
 
-query_decl       = QUESTION term ;
+query_decl       = QUESTION ( lookup_expr | term ) ;
+
+# `lookup <table> <keycol> = <n> mode range give <valcol>` — a RANGE / BRACKET
+# lookup (ADJ-TABLES RS-5c). A `?`-prefixed recall over a `table` read as a step
+# function: it selects the breakpoint row whose key column is the greatest key
+# `<=` the query value, and returns that row's value column WITH the row's
+# citation (below the smallest key it abstains — "below the table's domain").
+# `lookup`/`mode`/`give` are IDENT-matched literals — no new lexer tokens — and
+# `mode <name>` selects the tactic (`range` here; `interpolated` is RS-5d).
+lookup_expr      = "lookup" IDENT IDENT EQUALS signed_number "mode" IDENT "give" IDENT ;
+signed_number    = [ MINUS ] NUMBER ;
 
 # ----------------------------------------------------------------
 # `let <name> = <expr>` — a COMPUTED value (ADJ expansion step 3).

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.13.0] — 2026-07-18 — RS-5c: range / bracket lookup answers (ADJ-TABLES)
+
+### Added
+
+- **`"lookups"` output section** for range/bracket lookups. Each `? lookup <table> <key_col> = <n>
+  mode range give <value_col>` resolves the table (its rows are its facts) by enumerating the
+  relation, selects the breakpoint row whose key is the greatest key `<= n`, and emits
+  `{query, mode, answers:[{bindings, citations}], abstained}` — the value column bound, the
+  **matched breakpoint key** named in the audit, and the selected row's citation carried through
+  (the same `via_facts → provenance` flow as exact recall). A query **below the smallest key**
+  honestly `"abstained": true` — "below the table's domain", never a fabricated classification.
+- The comparison rides the exact `BigRational` order (`ExactRational::as_ratio()` — the identical
+  total order the engine's `CmpOp` exact path uses), so there is **no `f64` hop** in the decision.
+  0 answer-time model calls. The section is omitted entirely when the program declares no
+  `? lookup … mode range …`, so existing output is byte-for-byte unchanged.
+
 ## [0.12.0] — 2026-07-14 — exact-number arc COMPLETE: computed results render every digit (ADJ-EXACT-NUMBERS NX-4)
 
 ### Changed

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -33,12 +33,13 @@ use cli_builder::{load_spec_from_str, Parser};
 use adj_constraint_solver::{
     check, optimize, solve, FeasibilityOutcome, OptimizeOutcome, SolveOutcome,
 };
-use adj_lang::{compile_with_imports, decide, ImportLimits, ImportProvider};
-use logic_core::{atom, LogicVar, Term};
+use adj_lang::{compile_with_imports, decide, ImportLimits, ImportProvider, LoweredRangeLookup};
+use logic_core::{atom, compound, var, LogicVar, Term};
 use logic_engine::govern::Standing;
 use logic_engine::{
-    enumerate_all, enumerate_governing, DerivationOrigin, DifferentialDecision, Fact, GovernStatus,
-    KnowledgeBase, LRAggregateResult, Proof, Provenance, TrustTier,
+    enumerate_all, enumerate_governing, numeric_exact_magnitude, DerivationOrigin,
+    DifferentialDecision, Fact, GovernStatus, KnowledgeBase, LRAggregateResult, Proof, Provenance,
+    TrustTier,
 };
 
 const SPEC: &str = r#"{
@@ -635,6 +636,23 @@ fn main() -> ExitCode {
         format!(",\"governing\":[{}]", governing.join(","))
     };
 
+    // ADJ-TABLES RS-5c: range / bracket lookups over `table`s read as step
+    // functions. Each resolves to its bracketed value + the matched breakpoint
+    // row's citation (or abstains below the table's domain). 0 answer-time model
+    // calls — exact comparison over the CAS-grounded rows. Omitted when the
+    // program declares no `? lookup … mode range …`, so existing output is
+    // byte-for-byte unchanged.
+    let lookups: Vec<String> = lowered
+        .range_lookups
+        .iter()
+        .map(|rl| range_lookup_json(rl, &lowered.kb))
+        .collect();
+    let lookup_section = if lookups.is_empty() {
+        String::new()
+    } else {
+        format!(",\"lookups\":[{}]", lookups.join(","))
+    };
+
     // Render the constraint sections from the outcomes computed above (the
     // solvers are not re-run). Absent a constraint system / `check` / objective,
     // the respective key is omitted entirely.
@@ -662,7 +680,7 @@ fn main() -> ExitCode {
     };
 
     println!(
-        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}{}{}{}}}",
+        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}{}{}{}{}{}{}}}",
         queries.join(","),
         ranked.join(","),
         decision,
@@ -671,6 +689,7 @@ fn main() -> ExitCode {
         optimize_section,
         recall_section,
         governing_section,
+        lookup_section,
         derived_section
     );
     ExitCode::SUCCESS
@@ -745,6 +764,100 @@ fn recall_json(query: &Term, kb: &KnowledgeBase) -> String {
         answers.join(","),
         dag.proofs.is_empty()
     )
+}
+
+/// Resolve a RANGE / BRACKET lookup (ADJ-TABLES RS-5c) against the grounded
+/// table and render it as JSON. The table's rows are its facts, so enumerating
+/// `<table>($c0, …, $cn)` binds every column of every row **and** yields that
+/// row's citing fact (`via_facts`) — the same machinery exact recall uses. Among
+/// the rows whose key column is `<= key_value`, the tactic selects the one with
+/// the greatest key (the breakpoint the query falls in) and returns its value
+/// column WITH that row's citation. The comparison rides the exact `BigRational`
+/// order (`ExactRational::as_ratio()` — the identical total order the engine's
+/// `CmpOp` exact path uses), so there is no `f64` hop in the decision. A query
+/// below the smallest key has no key `<=` it and honestly **abstains** ("below
+/// the table's domain"), never a fabricated classification. 0 answer-time model
+/// calls — pure comparison over the CAS-grounded rows.
+fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
+    // Enumerate every row of the table by unifying an all-fresh-vars goal against
+    // the table relation. `cols[i]` is bound, per proof, to row i's cell in
+    // column i; the proof's `via_facts` is that row's citing fact.
+    let cols: Vec<LogicVar> = (0..rl.arity).map(|i| var(&format!("c{i}"))).collect();
+    let goal = compound(
+        rl.table.clone(),
+        cols.iter().map(|v| Term::Var(v.clone())).collect(),
+    );
+    let dag = enumerate_all(&goal, kb);
+
+    let query_str = format!(
+        "lookup {} {} = {} mode {} give {}",
+        rl.table, rl.key_col, rl.key_value, rl.mode, rl.value_col
+    );
+
+    // The query value, as an exact rational — the right-hand side of every
+    // breakpoint comparison.
+    let q = match numeric_exact_magnitude(&rl.key_value) {
+        Some(x) => x,
+        None => {
+            // The lowerer guarantees a numeric literal, so this is unreachable in
+            // practice; abstain rather than panic if a non-numeric ever arrives.
+            return format!(
+                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true}}",
+                esc(&query_str),
+                esc(&rl.mode)
+            );
+        }
+    };
+
+    // Among all rows, keep those whose key column is `<= q`, then pick the one
+    // with the GREATEST key — the breakpoint the query falls into. Comparison is
+    // exact (`BigRational::cmp`), never `f64`.
+    let mut best: Option<(&Proof, Term, Term, logic_engine::compute::ExactRational)> = None;
+    for proof in &dag.proofs {
+        let key_term = proof.bindings.walk_var(&cols[rl.key_index]);
+        let Some(k) = numeric_exact_magnitude(&key_term) else {
+            continue; // a non-numeric key cell is impossible post-lowering; skip defensively.
+        };
+        if k.as_ratio() > q.as_ratio() {
+            continue; // key is above the query — not a candidate breakpoint.
+        }
+        let value_term = proof.bindings.walk_var(&cols[rl.value_index]);
+        let take = match &best {
+            None => true,
+            Some((_, _, _, best_k)) => k.as_ratio() > best_k.as_ratio(),
+        };
+        if take {
+            best = Some((proof, key_term, value_term, k));
+        }
+    }
+
+    match best {
+        Some((proof, key_term, value_term, _)) => {
+            let cites: Vec<String> = proof
+                .via_facts
+                .iter()
+                .filter_map(|fid| kb.fact(*fid))
+                .map(|f| format!("{{{}}}", prov(&f.provenance)))
+                .collect();
+            // The answer names the value column (the binding) AND the matched
+            // breakpoint key, so the audit shows WHICH bracket the query fell in.
+            format!(
+                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[{{\"bindings\":{{\"{}\":\"{}\",\"{}\":\"{}\"}},\"citations\":[{}]}}],\"abstained\":false}}",
+                esc(&query_str),
+                esc(&rl.mode),
+                esc(&rl.value_col),
+                esc(&format!("{value_term}")),
+                esc(&rl.key_col),
+                esc(&format!("{key_term}")),
+                cites.join(",")
+            )
+        }
+        None => format!(
+            "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true}}",
+            esc(&query_str),
+            esc(&rl.mode)
+        ),
+    }
 }
 
 /// Render the ADJ73 *governance* of a binding query (defeasible precedence): every distinct

--- a/code/packages/rust/adj-lang-cli/tests/rs5c_range_lookup_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5c_range_lookup_e2e.rs
@@ -1,0 +1,161 @@
+//! End-to-end tests for ADJ-TABLES RS-5c — the RANGE / BRACKET lookup tactic —
+//! driven through the built CLI binary. A `table` is read as a step function:
+//! `? lookup <table> <key_col> = <n> mode range give <value_col>` selects the
+//! breakpoint row whose key is the greatest key `<= n` and returns its value
+//! column WITH that row's citation. Four things are proven:
+//!
+//!   (a) BRACKET HIT: a value strictly inside a band binds the band's value AND
+//!       the selected breakpoint row's citation, and the audit names the matched
+//!       key (which bracket it fell in).
+//!   (b) EXACT BOUNDARY: a value equal to a breakpoint selects THAT breakpoint
+//!       (greatest key `<=` value is the value itself) — the exact comparison,
+//!       no `f64` fuzz.
+//!   (c) TOP-OPEN BAND + BELOW-DOMAIN ABSTENTION: a value above the last
+//!       breakpoint falls in the top band; a value below the smallest key has no
+//!       key `<=` it and honestly ABSTAINS ("below the table's domain"), never a
+//!       fabricated classification.
+//!   (d) GUARDS: a `mode interpolated` is rejected (reserved for RS-5d), an
+//!       unknown value column is a clean compile error, and a non-numeric key
+//!       column is rejected (a range key must be a number).
+
+use std::path::Path;
+use std::process::Command;
+
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs5c_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Run the CLI, returning (exit-ok, stdout, stderr) so the error-path tests can
+/// assert on the diagnostic regardless of which stream it lands on.
+fn run_full(program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+fn write(dir: &Path, name: &str, src: &str) {
+    std::fs::write(dir.join(name), src).unwrap();
+}
+
+/// A self-contained BMI-category breakpoint table used across the hit/abstain
+/// cases. Four bands keyed by the band's minimum BMI; the key column is numeric.
+const BMI_TABLE: &str = r#"
+table bmi_categories {
+    columns min_bmi, category
+    row (0, underweight)
+    row (18.5, normal)
+    row (25, overweight)
+    row (30, obese)
+    source "A breakpoint table of BMI weight-status bands keyed by band minimum."
+    locator "https://example.test/bmi-bands"
+    trust consensus
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// (a) Bracket hit — inside a band, carries the selected row's citation + key.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn range_lookup_bracket_hit_binds_band_value_with_citation_and_matched_key() {
+    let dir = scratch("hit");
+    let src = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27.3 mode range give category\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "CLI should succeed; stderr={err}");
+    assert!(out.contains("\"lookups\""), "expected a lookups section: {out}");
+    // 27.3 falls in [25, 30) → overweight, selected breakpoint min_bmi = 25.
+    assert!(out.contains("\"category\":\"overweight\""), "wrong band: {out}");
+    assert!(out.contains("\"min_bmi\":\"25\""), "audit should name the matched breakpoint: {out}");
+    // The selected row's citation travels with the answer.
+    assert!(out.contains("example.test/bmi-bands"), "answer must carry the row citation: {out}");
+    assert!(out.contains("\"trust\":\"consensus\""), "citation must carry the trust tier: {out}");
+    assert!(out.contains("\"abstained\":false"), "a hit is not an abstention: {out}");
+}
+
+// ---------------------------------------------------------------------------
+// (b) Exact boundary — a value equal to a breakpoint selects that breakpoint.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn range_lookup_on_an_exact_breakpoint_selects_that_breakpoint() {
+    let dir = scratch("boundary");
+    let src = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 18.5 mode range give category\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, _err) = run_full(&dir.join("case.adj"));
+    assert!(ok);
+    // greatest key <= 18.5 is 18.5 itself → normal (exact comparison, no f64 fuzz).
+    assert!(out.contains("\"category\":\"normal\""), "exact boundary must land on the breakpoint: {out}");
+    assert!(out.contains("\"min_bmi\":\"18.5\""), "matched key should be the breakpoint itself: {out}");
+}
+
+// ---------------------------------------------------------------------------
+// (c) Top-open band + below-domain abstention.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn range_lookup_top_band_is_open_and_below_domain_abstains() {
+    let dir = scratch("edges");
+    // A value above the last breakpoint falls in the top (open) band.
+    let top = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 42 mode range give category\n");
+    write(&dir, "top.adj", &top);
+    let (ok, out, _e) = run_full(&dir.join("top.adj"));
+    assert!(ok);
+    assert!(out.contains("\"category\":\"obese\""), "top-open band should be selected: {out}");
+
+    // A value below the smallest key has no key <= it → honest abstention.
+    let below = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = -1 mode range give category\n");
+    write(&dir, "below.adj", &below);
+    let (ok2, out2, _e2) = run_full(&dir.join("below.adj"));
+    assert!(ok2);
+    assert!(out2.contains("\"abstained\":true"), "below the domain must abstain, not fabricate: {out2}");
+    assert!(!out2.contains("\"category\":\""), "an abstention has no bound band: {out2}");
+}
+
+// ---------------------------------------------------------------------------
+// (d) Guards — reserved mode, unknown column, non-numeric key.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn range_lookup_reserved_interpolated_mode_is_rejected() {
+    let dir = scratch("mode");
+    let src = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27 mode interpolated give category\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(!ok, "interpolated is RS-5d — must be rejected, not silently run as range");
+    let diag = format!("{out}{err}");
+    assert!(diag.contains("LookupModeUnsupported") || diag.to_lowercase().contains("interpolated"), "diag: {diag}");
+}
+
+#[test]
+fn range_lookup_unknown_value_column_is_a_clean_compile_error() {
+    let dir = scratch("col");
+    let src = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27 mode range give bmi_class\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(!ok, "an unknown value column must be a compile error");
+    let diag = format!("{out}{err}");
+    assert!(diag.contains("LookupUnknownColumn") || diag.contains("bmi_class"), "diag: {diag}");
+}
+
+#[test]
+fn range_lookup_non_numeric_key_column_is_rejected() {
+    let dir = scratch("nonnum");
+    // Here the *category* (an atom column) is (mis)used as the key — a range key
+    // must be numeric, so this is a clean compile error, not a silent skip.
+    let src = format!("{BMI_TABLE}\n? lookup bmi_categories category = 27 mode range give min_bmi\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(!ok, "a non-numeric key column must be rejected");
+    let diag = format!("{out}{err}");
+    assert!(diag.contains("LookupNonNumericKeyColumn") || diag.contains("category"), "diag: {diag}");
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.54.0] — 2026-07-18
+
+### Added — RS-5c: range / bracket lookup over a `table` read as a step function (ADJ-TABLES)
+
+A `table` can now be queried as a **step function**, not only by exact key. The new surface
+`? lookup <table> <key_col> = <n> mode range give <value_col>` selects the breakpoint row whose
+key column is the greatest key `<= n` and returns its value column — the tactic for tax brackets,
+dose bands, and reference-range classification. This is the follow-up to RS-5b's exact lookup;
+range/interpolated were spec'd there and deferred, and this lands the range half.
+
+- **Grammar**: `query_decl` now folds a `lookup_expr` alternative
+  (`QUESTION ( lookup_expr | term )`), so the range form coexists with the exact binding query.
+  `lookup`/`mode`/`give` are IDENT-matched literals — **no new lexer tokens**. Regenerated
+  `_parser_grammar.rs` / `_lexer_grammar.rs`.
+- **AST**: new `Statement::RangeLookup { table, key_col, key_value, mode, value_col }`.
+- **Adapter**: `adapt_lookup` (positional Name-token binding, robust to a column literally named
+  `mode`/`give`) + `adapt_signed_number` (optional leading `MINUS`, folded exactly into the literal).
+- **Lower**: validates against the table registry and resolves the key/value columns to positional
+  indices — new `LookupUnknownTable` / `LookupUnknownColumn` / `LookupNonNumericKeyColumn`
+  (the key column must be numeric) / `LookupModeUnsupported` (`interpolated` is reserved for RS-5d)
+  / `LookupUnknownMode`. Emits the validated `LoweredRangeLookup` (now on `LoweredProgram`).
+- The `table` declaration is **unchanged** — a range table is an ordinary table read differently.
+
 ## [0.53.0] — 2026-07-14
 
 ### Added — NX-2: parse numeric literals to exact values (no silent f64 truncation)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -220,9 +220,35 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"query_decl"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
-                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"lookup_expr"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    ] }) },
             ] },
             line_number: 144,
+        },
+        GrammarRule {
+            name: r#"lookup_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"lookup"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"signed_number"#.to_string() },
+                GrammarElement::Literal { value: r#"mode"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Literal { value: r#"give"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+            ] },
+            line_number: 153,
+        },
+        GrammarRule {
+            name: r#"signed_number"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"MINUS"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+            ] },
+            line_number: 154,
         },
         GrammarRule {
             name: r#"let_decl"#.to_string(),
@@ -232,7 +258,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 158,
+            line_number: 168,
         },
         GrammarRule {
             name: r#"expr"#.to_string(),
@@ -246,7 +272,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 160,
+            line_number: 170,
         },
         GrammarRule {
             name: r#"term_expr"#.to_string(),
@@ -260,7 +286,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 162,
+            line_number: 172,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -279,7 +305,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 164,
+            line_number: 174,
         },
         GrammarRule {
             name: r#"agg"#.to_string(),
@@ -295,7 +321,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 166,
+            line_number: 176,
         },
         GrammarRule {
             name: r#"apply"#.to_string(),
@@ -311,7 +337,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 191,
+            line_number: 201,
         },
         GrammarRule {
             name: r#"latex_expr"#.to_string(),
@@ -319,7 +345,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 198,
+            line_number: 208,
         },
         GrammarRule {
             name: r#"asciimath_expr"#.to_string(),
@@ -327,7 +353,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 209,
+            line_number: 219,
         },
         GrammarRule {
             name: r#"mathml_expr"#.to_string(),
@@ -335,7 +361,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"mathml"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 221,
+            line_number: 231,
         },
         GrammarRule {
             name: r#"unicodemath_expr"#.to_string(),
@@ -343,7 +369,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"unicodemath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 233,
+            line_number: 243,
         },
         GrammarRule {
             name: r#"symbol_decl"#.to_string(),
@@ -353,7 +379,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 243,
+            line_number: 253,
         },
         GrammarRule {
             name: r#"constrain_latex_decl"#.to_string(),
@@ -361,7 +387,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"latex_relation"#.to_string() },
             ] },
-            line_number: 245,
+            line_number: 255,
         },
         GrammarRule {
             name: r#"constrain_asciimath_decl"#.to_string(),
@@ -369,7 +395,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"asciimath_relation"#.to_string() },
             ] },
-            line_number: 255,
+            line_number: 265,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -379,7 +405,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 257,
+            line_number: 267,
         },
         GrammarRule {
             name: r#"latex_relation"#.to_string(),
@@ -387,7 +413,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 259,
+            line_number: 269,
         },
         GrammarRule {
             name: r#"asciimath_relation"#.to_string(),
@@ -395,7 +421,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 261,
+            line_number: 271,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -408,7 +434,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 263,
+            line_number: 273,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -423,12 +449,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 265,
+            line_number: 275,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 267,
+            line_number: 277,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -439,7 +465,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 274,
+            line_number: 284,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -450,7 +476,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 286,
+            line_number: 296,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -461,7 +487,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 288,
+            line_number: 298,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -489,7 +515,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 ] },
             ] },
-            line_number: 290,
+            line_number: 300,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -501,7 +527,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 296,
+            line_number: 306,
         },
         GrammarRule {
             name: r#"rulebook_decl"#.to_string(),
@@ -512,7 +538,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 313,
+            line_number: 323,
         },
         GrammarRule {
             name: r#"use_decl"#.to_string(),
@@ -520,7 +546,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"use"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 315,
+            line_number: 325,
         },
         GrammarRule {
             name: r#"formulabook_decl"#.to_string(),
@@ -531,7 +557,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"formulabook_item"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 346,
+            line_number: 356,
         },
         GrammarRule {
             name: r#"formulabook_item"#.to_string(),
@@ -539,7 +565,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"formula_decl"#.to_string() },
             ] },
-            line_number: 348,
+            line_number: 358,
         },
         GrammarRule {
             name: r#"formula_decl"#.to_string(),
@@ -552,7 +578,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"formula_body"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 350,
+            line_number: 360,
         },
         GrammarRule {
             name: r#"formula_params"#.to_string(),
@@ -563,7 +589,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
             ] },
-            line_number: 352,
+            line_number: 362,
         },
         GrammarRule {
             name: r#"formula_body"#.to_string(),
@@ -579,7 +605,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
                 ] },
             ] },
-            line_number: 365,
+            line_number: 375,
         },
         GrammarRule {
             name: r#"formula_step"#.to_string(),
@@ -589,7 +615,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 367,
+            line_number: 377,
         },
         GrammarRule {
             name: r#"table_decl"#.to_string(),
@@ -603,7 +629,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 401,
+            line_number: 411,
         },
         GrammarRule {
             name: r#"columns_decl"#.to_string(),
@@ -615,7 +641,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
             ] },
-            line_number: 403,
+            line_number: 413,
         },
         GrammarRule {
             name: r#"table_row"#.to_string(),
@@ -629,7 +655,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 405,
+            line_number: 415,
         },
         GrammarRule {
             name: r#"row_item"#.to_string(),
@@ -638,7 +664,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 407,
+            line_number: 417,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -646,7 +672,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 423,
+            line_number: 433,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -656,7 +682,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
             ] },
-            line_number: 435,
+            line_number: 445,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -664,7 +690,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 441,
+            line_number: 451,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -672,7 +698,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 442,
+            line_number: 452,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -680,7 +706,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 443,
+            line_number: 453,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -690,7 +716,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 444,
+            line_number: 454,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -701,7 +727,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 446,
+            line_number: 456,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -725,7 +751,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 468,
+            line_number: 478,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -464,9 +464,88 @@ fn adapt_functional(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
 }
 
 fn adapt_query(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
-    // query_decl = QUESTION term
+    // query_decl = QUESTION ( lookup_expr | term )
+    //
+    // A `lookup_expr` child is the RANGE / BRACKET lookup form (ADJ-TABLES RS-5c);
+    // otherwise the query is the ordinary exact term goal (`? relation(k, $V)`).
+    if let Some(lookup) = first_named_child(node, "lookup_expr") {
+        return adapt_lookup(lookup);
+    }
     let conclusion = expect_term_child(node, "query_decl")?;
     Ok(Statement::Query { conclusion })
+}
+
+fn adapt_lookup(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // lookup_expr   = "lookup" IDENT IDENT EQUALS signed_number "mode" IDENT "give" IDENT
+    // signed_number = [ MINUS ] NUMBER
+    //
+    // The `lookup`/`mode`/`give` literals are IDENT-matched keywords, so they
+    // surface as Name tokens interleaved with the table/column/mode identifiers.
+    // The EQUALS token and the `signed_number` node sit BETWEEN key_col and the
+    // `mode` literal, so the seven direct Name tokens are exactly, in order:
+    //   [ "lookup", <table>, <key_col>, "mode", <mode>, "give", <value_col> ]
+    // We bind by POSITION (not by value) so a column legitimately named "mode" or
+    // "give" is never mistaken for a keyword.
+    let names: Vec<&str> = node
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => Some(t.value.as_str()),
+            _ => None,
+        })
+        .collect();
+    if names.len() != 7 {
+        return Err(AdapterError::MissingChild {
+            rule: "lookup_expr".into(),
+            position: "lookup <table> <key_col> = <n> mode <mode> give <value_col>",
+        });
+    }
+    let table = names[1].to_string();
+    let key_col = names[2].to_string();
+    let mode = names[4].to_string();
+    let value_col = names[6].to_string();
+    let key_value = adapt_signed_number(
+        first_named_child(node, "signed_number").ok_or(AdapterError::MissingChild {
+            rule: "lookup_expr".into(),
+            position: "signed_number (the query value)",
+        })?,
+    )?;
+    Ok(Statement::RangeLookup {
+        table,
+        key_col,
+        key_value,
+        mode,
+        value_col,
+    })
+}
+
+fn adapt_signed_number(node: &GrammarASTNode) -> Result<NumLit, AdapterError> {
+    // signed_number = [ MINUS ] NUMBER — an optional leading MINUS then a NUMBER.
+    // A leading MINUS folds into the parsed literal by prefixing the raw text, so
+    // the exact value is negated with no digit loss (parse handles "-").
+    let mut negative = false;
+    let mut raw: Option<&str> = None;
+    for c in &node.children {
+        if let ASTNodeOrToken::Token(t) = c {
+            match t.type_ {
+                TokenType::Minus => negative = true,
+                TokenType::Number => raw = Some(t.value.as_str()),
+                _ => {}
+            }
+        }
+    }
+    let raw = raw.ok_or(AdapterError::MissingChild {
+        rule: "signed_number".into(),
+        position: "NUMBER",
+    })?;
+    let owned;
+    let text = if negative {
+        owned = format!("-{raw}");
+        owned.as_str()
+    } else {
+        raw
+    };
+    parse_numlit(text, TokenType::Number, "signed_number")
 }
 
 fn adapt_let(node: &GrammarASTNode) -> Result<Statement, AdapterError> {

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -365,6 +365,33 @@ pub enum Statement {
     /// (`? deficient_in(tay_sachs, $E)`) it returns the binding(s) — fact recall
     /// as the single-hop special case of the differential.
     Query { conclusion: Term },
+    /// `? lookup <table> <key_col> = <n> mode <mode> give <value_col>` — a
+    /// RANGE / BRACKET lookup over a [`Statement::Table`] read as a step function
+    /// (ADJ-TABLES RS-5c). Unlike [`Query`] (exact SLD unification on the key), a
+    /// range lookup selects the breakpoint row whose `key_col` is the greatest key
+    /// `<= key_value`, and returns that row's `value_col` **with the row's
+    /// citation** — the tactic for tax brackets, dose bands, and reference-range
+    /// classification. A query below the smallest key abstains ("below the table's
+    /// domain"). `mode` selects the tactic: `range` here; `interpolated` is
+    /// reserved for RS-5d ([`crate::LowerError::LookupModeUnsupported`]).
+    RangeLookup {
+        /// The `table` to read as a step function (must be a declared table:
+        /// [`crate::LowerError::LookupUnknownTable`]).
+        table: String,
+        /// The numeric key column the query value is compared against (must be one
+        /// of the table's columns and hold only numbers:
+        /// [`crate::LowerError::LookupUnknownColumn`] /
+        /// [`crate::LowerError::LookupNonNumericKeyColumn`]).
+        key_col: String,
+        /// The concrete query value to classify. Carried as a [`NumLit`] (sign
+        /// already folded in) so no digit is lost before the exact comparison.
+        key_value: NumLit,
+        /// The lookup tactic named at the call site (`range`; `interpolated` = RS-5d).
+        mode: String,
+        /// The column whose cell is returned for the selected breakpoint row (must
+        /// be one of the table's columns: [`crate::LowerError::LookupUnknownColumn`]).
+        value_col: String,
+    },
     /// `let <name> = <expr>` — bind a **computed** value (ADJ expansion
     /// step 3). The model writes only the formula; the engine evaluates
     /// `expr` on the CPU into a derivation tree and binds it to `name`,

--- a/code/packages/rust/adj-lang/src/lib.rs
+++ b/code/packages/rust/adj-lang/src/lib.rs
@@ -58,7 +58,9 @@ use parser::grammar_parser::{GrammarParseError, GrammarParser};
 
 pub use adapter::{adapt_program, AdapterError};
 pub use ast::{Annotation, Define, DefineKind, OptDir, Program, RelOp, Statement, Term as AstTerm};
-pub use lower::{lower, ConstraintSystem, LowerError, LoweredConstraint, LoweredProgram};
+pub use lower::{
+    lower, ConstraintSystem, LowerError, LoweredConstraint, LoweredProgram, LoweredRangeLookup,
+};
 pub use resolve::{resolve_imports, ImportError, ImportLimits, ImportProvider};
 
 /// Result of compilation. Either the typed program produced by the

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -252,6 +252,43 @@ pub enum LowerError {
     TableNoColumns {
         table: String,
     },
+    /// A `? lookup <table> …` named a table that was never declared (ADJ-TABLES
+    /// RS-5c). A range lookup reads a specific `table` as a step function; an
+    /// unknown name would silently abstain forever, so it is a clean compile
+    /// error. Carries the referenced name.
+    LookupUnknownTable {
+        table: String,
+    },
+    /// A `? lookup <table> <col> …` named a `col` that is not one of the table's
+    /// declared `columns` (ADJ-TABLES RS-5c) — either the key column or the
+    /// `give` value column. Carries the table and the offending column name.
+    LookupUnknownColumn {
+        table: String,
+        column: String,
+    },
+    /// A range lookup's key column holds a non-numeric cell (ADJ-TABLES RS-5c). A
+    /// `range` lookup compares the query value against the key column with the
+    /// exact numeric comparators, so every key cell must be a number; an atom or
+    /// string key is meaningless for a step function. Carries the table, the key
+    /// column, and the offending row index (0-based).
+    LookupNonNumericKeyColumn {
+        table: String,
+        column: String,
+        row: usize,
+    },
+    /// A lookup named `mode <name>` for a mode that is spec'd but not yet built
+    /// (ADJ-TABLES RS-5d) — today only `interpolated`. Rejected explicitly (rather
+    /// than silently treated as `range`) so the reserved surface is honest about
+    /// what the engine can do. Carries the requested mode.
+    LookupModeUnsupported {
+        mode: String,
+    },
+    /// A lookup named a `mode` that is not a recognized tactic at all (ADJ-TABLES
+    /// RS-5c). The valid modes are `range` (built) and `interpolated` (reserved,
+    /// RS-5d). Carries the unrecognized mode.
+    LookupUnknownMode {
+        mode: String,
+    },
     /// An `import "<path>"` survived to lowering (MYCIN-2026 M3). Imports must be
     /// resolved by [`crate::resolve`] *before* `lower` runs — reaching here means
     /// the caller used `compile` directly on a program that still has imports,
@@ -262,12 +299,46 @@ pub enum LowerError {
     },
 }
 
+/// One lowered RANGE / BRACKET lookup (ADJ-TABLES RS-5c) — the validated,
+/// index-resolved form of a `? lookup <table> <key_col> = <n> mode range give
+/// <value_col>` recall. The lowerer has already checked the table and columns
+/// exist and that the key column is numeric, so the runtime tactic (in the CLI)
+/// only has to: read the table's ground facts, convert the key cells and the
+/// query value to exact rationals, select the row whose key is the greatest
+/// `<= key_value`, and return its value cell **with that row's citation** (or
+/// abstain when the query is below the table's domain). Nothing here is `f64`;
+/// the comparison rides the engine's exact `CmpOp`/`BigRational` path.
+#[derive(Debug, Clone)]
+pub struct LoweredRangeLookup {
+    /// The table relation's functor (also the fact functor to scan).
+    pub table: String,
+    /// The relation arity (= the table's column count) — the fact arity to match.
+    pub arity: usize,
+    /// The 0-based position of the key column among the table's columns.
+    pub key_index: usize,
+    /// The 0-based position of the `give` value column among the table's columns.
+    pub value_index: usize,
+    /// The key column's declared name (for the answer's audit trail).
+    pub key_col: String,
+    /// The value column's declared name (the binding name in the answer).
+    pub value_col: String,
+    /// The concrete query value to classify, as a ground `Num` term (exact — no
+    /// digit lost) so the comparison is done on the exact numeric path.
+    pub key_value: CoreTerm,
+    /// The tactic named at the call site — `range` (the only mode this lowers).
+    pub mode: String,
+}
+
 /// The result of lowering — a populated KB, any queries to run, and the
 /// (possibly empty) constraint system the program declared.
 #[derive(Debug)]
 pub struct LoweredProgram {
     pub kb: KnowledgeBase,
     pub queries: Vec<CoreTerm>,
+    /// The RANGE / BRACKET lookups the program declared (ADJ-TABLES RS-5c),
+    /// resolved to relation + column indices + exact query value. Empty for a
+    /// program with no `? lookup … mode range …`. Run by the CLI's range tactic.
+    pub range_lookups: Vec<LoweredRangeLookup>,
     pub constraints: ConstraintSystem,
     /// The controlled vocabulary the program declared (MYCIN-2026): the
     /// `define`d findings + hypotheses, with their surface forms. Empty for a
@@ -316,6 +387,24 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             }
         }
     }
+
+    // ADJ-TABLES RS-5c: register every `table`'s columns + rows into a name→table
+    // map, up front (like the formula map — tables are order-independent, and a
+    // `? lookup` may precede the table it reads, or read an imported one). A range
+    // lookup validates its table/columns against this map and needs the rows to
+    // check the key column is numeric.
+    #[allow(clippy::type_complexity)]
+    let mut tables: HashMap<&str, (&[String], &[crate::ast::TableRow])> = HashMap::new();
+    for stmt in flat.iter().copied() {
+        if let Statement::Table {
+            name, columns, rows, ..
+        } = stmt
+        {
+            tables.insert(name.as_str(), (columns.as_slice(), rows.as_slice()));
+        }
+    }
+    // ADJ-TABLES RS-5c: the validated range/bracket lookups, run by the CLI tactic.
+    let mut range_lookups: Vec<LoweredRangeLookup> = Vec::new();
 
     for stmt in flat.iter().copied() {
         match stmt {
@@ -526,6 +615,67 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                     let mut vars = HashMap::new();
                     queries.push(lower_term_scoped(conclusion, &mut vars));
                 }
+            }
+            Statement::RangeLookup {
+                table,
+                key_col,
+                key_value,
+                mode,
+                value_col,
+            } => {
+                // ADJ-TABLES RS-5c: validate a `? lookup … mode range …` against the
+                // table registry and resolve the key/value columns to positional
+                // indices, so the runtime tactic never has to re-parse column names.
+                let (columns, rows) = tables.get(table.as_str()).ok_or_else(|| {
+                    LowerError::LookupUnknownTable {
+                        table: table.clone(),
+                    }
+                })?;
+                // Mode: `range` is built; `interpolated` is the reserved RS-5d
+                // tactic (rejected honestly, not silently treated as range); any
+                // other word is not a tactic at all.
+                match mode.as_str() {
+                    "range" => {}
+                    "interpolated" => {
+                        return Err(LowerError::LookupModeUnsupported { mode: mode.clone() })
+                    }
+                    _ => return Err(LowerError::LookupUnknownMode { mode: mode.clone() }),
+                }
+                let key_index = columns.iter().position(|c| c == key_col).ok_or_else(|| {
+                    LowerError::LookupUnknownColumn {
+                        table: table.clone(),
+                        column: key_col.clone(),
+                    }
+                })?;
+                let value_index =
+                    columns.iter().position(|c| c == value_col).ok_or_else(|| {
+                        LowerError::LookupUnknownColumn {
+                            table: table.clone(),
+                            column: value_col.clone(),
+                        }
+                    })?;
+                // The key column must be numeric in EVERY row — a `range` lookup
+                // compares the query against it on the exact numeric path, so an
+                // atom/string key cell is a compile error (never a silent skip).
+                for (i, row) in rows.iter().enumerate() {
+                    if !matches!(row.cells.get(key_index), Some(crate::ast::TableCell::Number(_))) {
+                        return Err(LowerError::LookupNonNumericKeyColumn {
+                            table: table.clone(),
+                            column: key_col.clone(),
+                            row: i,
+                        });
+                    }
+                }
+                range_lookups.push(LoweredRangeLookup {
+                    table: table.clone(),
+                    arity: columns.len(),
+                    key_index,
+                    value_index,
+                    key_col: key_col.clone(),
+                    value_col: value_col.clone(),
+                    key_value: lower_numlit(key_value),
+                    mode: mode.clone(),
+                });
             }
             Statement::Let { name, expr } => {
                 // Evaluate the formula against the facts (and any earlier
@@ -756,6 +906,7 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
     Ok(LoweredProgram {
         kb,
         queries,
+        range_lookups,
         constraints,
         dictionary,
     })

--- a/code/specs/ADJ-TABLES.md
+++ b/code/specs/ADJ-TABLES.md
@@ -101,20 +101,30 @@ A binding query over the table relation *is* an exact lookup:
   `formula`** through the existing slot/`Ref` resolution — a table value composes into
   downstream arithmetic with no special case.
 
-### 3.2 Range / bracket lookup (spec'd here, built in a follow-up)
+### 3.2 Range / bracket lookup (RS-5c)
 
 For step functions (tax brackets, dose bands, reference-range classification), rows define
 **breakpoints**: the lookup selects the row whose key is the greatest key `≤` the query
-(or the interval `[key_i, key_{i+1})` the query falls in). This reuses the engine's existing
-exact comparators `CmpOp {Ge,Le,Gt,Lt,Eq}` (both `f64` and exact `BigRational` paths). Call
-site names the mode explicitly, e.g.
+(equivalently, the interval `[key_i, key_{i+1})` the query falls in). This reuses the engine's
+existing exact comparators `CmpOp {Ge,Le,Gt,Lt,Eq}` on the exact `BigRational` path — no new
+number or engine machinery. The final call-site form is a `?`-prefixed recall that names the
+table, the key column bound to a concrete value, the mode, and the value column to return:
 
 ```
-? lookup(tax_brackets, income = 50000, mode range) give marginal_rate
+? lookup bmi_categories min_bmi = 27.3 mode range give category      % overweight
 ```
 
-Final call-site syntax is settled when the tactic is implemented; the table declaration is
-unchanged (a `range` table is an ordinary table read differently).
+- **`lookup`/`mode`/`give`/`range`** are IDENT-matched literals (no new lexer tokens); the form
+  is folded into `query_decl` (`QUESTION ( lookup_expr | term )`) so it coexists with the exact
+  binding query.
+- The table declaration is **unchanged** — a `range` table is an ordinary table read
+  differently. The key column must be numeric (checked at lower time: `LookupNonNumericKeyColumn`);
+  an unknown table or column is `LookupUnknownTable` / `LookupUnknownColumn`; `mode interpolated`
+  is reserved for RS-5d (`LookupModeUnsupported`).
+- A hit returns the value column **with the selected breakpoint row's citation** (the same
+  `via_facts → provenance` flow as exact lookup) and records the matched key in the audit, so the
+  answer names *which* bracket it fell in. A query **below the smallest key** has no key `≤` it
+  and honestly **abstains** — "below the table's domain", not a fabricated classification.
 
 ### 3.3 Interpolated lookup (spec'd here, built in a follow-up)
 
@@ -162,7 +172,7 @@ per conversion, one table cites the NIST page once and every conversion is audit
 |-------|------|--------|
 | RS-5a | this spec | **this PR** |
 | RS-5b | grammar + AST + adapter + lower; rows→relations; **exact lookup** e2e; shipped NIST table | **this PR** |
-| RS-5c | **range/bracket** lookup tactic (reuses `CmpOp`) + e2e (tax brackets) | follow-up |
+| RS-5c | **range/bracket** lookup tactic (reuses the exact `BigRational` order) + e2e (inline BMI bands) | **this PR** |
 | RS-5d | **interpolated** lookup tactic (new, on `BigRational`) + e2e (nomogram) | follow-up |
 
 **Explicitly deferred:** per-row provenance (table-level only for now); multi-key composite


### PR DESCRIPTION
## What

Adds the **range / bracket lookup** tactic to the `table` construct (ADJ-TABLES RS-5c) — the range half of the follow-ups RS-5b spec'd and deferred. A `table` can now be read as a **step function**, not only by exact key:

```
? lookup bmi_categories min_bmi = 27.3 mode range give category      % overweight
```

It selects the breakpoint row whose key column is the greatest key `<=` the query value and returns its value column **with that row's citation** — the tactic for tax brackets, dose bands, and reference-range classification. The `table` declaration is **unchanged**; a range table is an ordinary table read differently.

## How (all layers reuse existing machinery — no new engine/number code)

- **Grammar**: `query_decl = QUESTION ( lookup_expr | term )`. `lookup`/`mode`/`give` are IDENT-matched literals — **no new lexer tokens** (only `_parser_grammar.rs` regenerated, not `_lexer_grammar.rs`).
- **AST**: `Statement::RangeLookup { table, key_col, key_value, mode, value_col }`.
- **Adapter**: `adapt_lookup` (positional Name-token binding, robust to a column literally named `mode`/`give`) + `adapt_signed_number` (optional leading `MINUS` folded exactly into the literal).
- **Lower**: validates against the table registry, resolves key/value columns to positional indices, and adds five clean compile errors — `LookupUnknownTable` / `LookupUnknownColumn` / `LookupNonNumericKeyColumn` (a range key must be numeric) / `LookupModeUnsupported` (`interpolated` reserved for RS-5d) / `LookupUnknownMode`.
- **CLI**: new `"lookups"` output section. Enumerating the table relation binds every column of every row **and** yields that row's citing fact; the tactic picks the greatest key `<=` query and emits `{query, mode, answers:[{bindings, citations}], abstained}`, naming the matched breakpoint in the audit. A query **below the smallest key** → honest `"abstained": true` ("below the table's domain"). The comparison rides the exact `BigRational` order (the same order `CmpOp`'s exact path uses) — **no `f64` hop**, 0 answer-time model calls.

## Grounding-honest scope

This PR ships the **tactic + e2e** (inline BMI bands). Grounded range tables (reference ranges, dose-by-weight, tax brackets) land on the **Facts front** now that the substrate exists — the same discipline the 52-library facts batch used.

## Verification

- `cargo test -p adj-lang -p adj-lang-cli` — green (173 unit + full e2e), nothing regressed from the grammar regen.
- 6 new `rs5c_range_lookup_e2e` tests: bracket hit + citation + matched key, exact boundary, top-open band, below-domain abstention, and reserved-mode / unknown-column / non-numeric-key compile-error guards.
- `/security-review` **PASSED** (no panic paths on crafted input, all JSON interpolation escaped, no index/overflow/DoS surface).

Bumps: adj-lang 0.53.0 → 0.54.0, adj-lang-cli 0.12.0 → 0.13.0. `ADJ-TABLES.md` §3.2 finalized; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)