### PR TITLE
feat(hl): farewells — Spanish Ch.5, French Ch.4, German Ch.4 (+ first Arabic-loanword deep dive)

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -66,6 +66,12 @@
       "core": false,
       "notes": "hasta pronto / à bientôt / bis bald / a presto / até breve."
     },
+    "FAREWELL-CASUAL": {
+      "family": "GREETING",
+      "gloss": "a casual / colloquial 'bye'",
+      "core": false,
+      "notes": "The informal parting distinct from the neutral FAREWELL: German tschüss, French salut/tchao, Italian ciao, Portuguese tchau."
+    },
 
     "COURTESY-THANKS": {
       "family": "COURTESY",

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -46,7 +46,25 @@
       "gloss": "goodbye / parting word",
       "core": true,
       "retires": ["GREETING-GOODBYE"],
-      "notes": "Unifies the parting word across tracks (valē, āshi, alvidā, येतो/येते)."
+      "notes": "Unifies the parting word across tracks (valē, āshi, alvidā, येतो/येते). The plain goodbye (adiós, au revoir, auf Wiedersehen); the time-specific 'see you …' partings are FAREWELL-LATER/TOMORROW/SOON."
+    },
+    "FAREWELL-LATER": {
+      "family": "GREETING",
+      "gloss": "see you later (a soon-ish parting)",
+      "core": false,
+      "notes": "hasta luego / à bientôt / bis später / a più tardi / até logo. Distinct from the plain FAREWELL."
+    },
+    "FAREWELL-TOMORROW": {
+      "family": "GREETING",
+      "gloss": "see you tomorrow",
+      "core": false,
+      "notes": "hasta mañana / à demain / bis morgen / a domani / até amanhã."
+    },
+    "FAREWELL-SOON": {
+      "family": "GREETING",
+      "gloss": "see you soon",
+      "core": false,
+      "notes": "hasta pronto / à bientôt / bis bald / a presto / até breve."
     },
 
     "COURTESY-THANKS": {
@@ -170,6 +188,7 @@
       "ES-VERB-LLAMAR": "llamar — 'to call' (the Spanish naming verb)",
       "ES-SE-LLAMA": "se llama — 'he/she calls himself' (3rd-person of llamar)",
       "ES-WORD-MUCHO": "mucho — 'much / a lot'",
+      "ES-WORD-HASTA": "hasta — 'until / up to' (← Arabic ḥattā; a rare borrowed function word)",
       "ES-VERB-ESTAR": "estar — 'to be' (temporary state / location; ← Latin stare 'to stand')",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Chapter 4 — Farewells (parallel of Spanish Ch. 5)
+
+- **Chapter 4 authored** (`FR-C04-au-revoir`, `-a-plus-tard`, `-a-bientot`,
+  `-a-demain`, `-practice`): closing a conversation, atom-first, reviewing
+  Chapter 3. Reuses the canonical `FAREWELL` + `FAREWELL-LATER/TOMORROW/SOON`
+  concepts introduced with Spanish Ch. 5, mapping each French goodbye to its
+  Spanish twin.
+- **The "see you again" metaphor**: *au revoir* = "until the re-seeing" (*voir* ←
+  *vidēre* → vision/video/revise) — explicitly paired with German *auf
+  Wiedersehen* ("on the seeing-again"), against Spanish *adiós* ("to God").
+- **Cross-language root callbacks**: *à plus tard* — *tard* ← Latin *tarde*, the
+  same word as Spanish *tarde*; *à demain* — *demain* ← *dē māne* "from the
+  morning", sharing *māne* with Spanish *mañana* (and English *matinée*).
+- **A writing-nuance aside**: the circumflex on *bientôt* (← *tost*) as the ghost
+  of a dropped *s* (*hôtel* ← *hostel*), tying back to the accent-mark thread.
+- All soft goodbyes are **à** + a time, mirroring Spanish's **hasta**.
+
 ## Chapter 3 — "Comment ça va ?" (the parallel of Spanish Ch. 4)
 
 - **Chapter 3 authored** (`FR-C03-merci`, `-de-rien`, `-aller`,

--- a/code/learning/human-languages/french/lessons/FR-C04-a-bientot.md
+++ b/code/learning/human-languages/french/lessons/FR-C04-a-bientot.md
@@ -1,0 +1,64 @@
+---
+id: FR-C04-a-bientot
+chapter: 4
+type: phrase
+headword: à bientôt
+gloss: see you soon (literally "to well-soon")
+concept_tag: FAREWELL-SOON
+prerequisites: [FR-C04-a-plus-tard]
+sounds: [nasal-in, vowel-o, silent-final]
+roots: [bene-latin, tost-latin]
+etymology_hook: "à bientôt = à + bientôt ('soon' = bien 'well' + tôt 'early'); bien ← bene"
+est_minutes: 3
+reviews_of: [FR-C04-a-plus-tard, FR-C01-bien]
+---
+
+# à bientôt — "see you soon"
+
+## Warm-up
+
+[PAUSE 2s] For when you'll genuinely meet again shortly: **à bientôt**, "see you
+soon" — the French twin of Spanish *hasta pronto*. It hides a word you already
+know from Chapter 1: **bien**.
+
+## Sounds you'll need
+
+- `nasal-in` — **bien** = *byɛ̃*, nasal (your Chapter 1 sound).
+- **bientôt** = *byɛ̃-TOH*; the circumflex on *ô* just marks a long *o*, and the
+  final *t* is silent. Whole phrase: *ah byɛ̃-TOH*.
+
+## The phrase, taken apart
+
+> **à bientôt** = "to soon" → "see you soon."
+
+- **à** = "to" (the farewell preposition again).
+- **bientôt** = "soon," and it's a compound you can pull apart:
+  - **bien** = "well" (Chapter 1 — from Latin *bene*, the *bene* of *benefit*).
+  - **tôt** = "early / soon."
+  - Together, *bien + tôt* = "**well-soon**" → *quite soon*. (French loves gluing
+    *bien* onto words for emphasis — *bientôt* "soon", *bienvenue* "welcome" =
+    "well-come".)
+
+The circumflex **ô** is itself a little history lesson: a circumflex usually marks
+an **s that dropped out** (*hôtel* was *hostel*, *forêt* was *forest*). *tôt*
+came from an older *tost* — so the hat on *ô* is the ghost of a lost *s*.
+
+## Grammar Lens: bien, the intensifier
+
+You met *bien* as "well" (an answer to *ça va?*). Here it's doing a second job:
+**gluing onto another word to strengthen it** — *bien + tôt* = "soon indeed."
+Same word, new trick.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "à bientôt" — *ah byɛ̃-TOH*]
+- [YOU SAY: pull it apart — "bien" (well) + "tôt" (early) = bientôt (soon)]
+- [YOU SAY: "à bientôt" = Spanish "hasta pronto" — see you soon]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two words hide inside *bientôt*? (*bien* "well" + *tôt* "early" →
+soon.) What does the circumflex on *ô* usually mark? (A dropped *s* — *tost* →
+*tôt*.) What's the Spanish equivalent of *à bientôt*? (*hasta pronto*.) Next:
+**à demain**.

--- a/code/learning/human-languages/french/lessons/FR-C04-a-demain.md
+++ b/code/learning/human-languages/french/lessons/FR-C04-a-demain.md
@@ -1,0 +1,70 @@
+---
+id: FR-C04-a-demain
+chapter: 4
+type: phrase
+headword: à demain
+gloss: see you tomorrow (literally "to tomorrow")
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [FR-C04-a-bientot]
+sounds: [nasal-in, silent-final]
+roots: [de-mane-latin]
+etymology_hook: "demain ← Latin de mane 'from the morning'; mane 'morning' is the same root as Spanish mañana"
+est_minutes: 3
+reviews_of: [FR-C04-a-bientot, FR-C04-au-revoir]
+---
+
+# à demain — "see you tomorrow"
+
+## Warm-up
+
+[PAUSE 2s] Parting for the day: **à demain**, "until tomorrow" — the twin of
+Spanish *hasta mañana*. And *demain* shares a hidden root with *mañana* that's
+worth seeing.
+
+## Sounds you'll need
+
+- `nasal-in` — **demain** = *duh-Mɛ̃*: the *-ain* is a nasal (like *pain*, *main*);
+  the final consonant is silent. *ah duh-Mɛ̃*.
+
+## The phrase, taken apart
+
+> **à demain** = "to tomorrow" → "see you tomorrow."
+
+- **à** = "to" (the farewell preposition, one last time).
+- **demain** = "tomorrow," from Latin **dē māne**, "**from the morning**":
+  - **dē** = "from" · **māne** = "in the morning."
+  - The next "morning" is *tomorrow* → *de mane* fused into **demain**.
+
+**The hidden twin.** Spanish *mañana* ("tomorrow / morning") comes from Latin
+*(hōra) maneana* — built on the **same** *māne*, "morning." So French **demain**
+and Spanish **mañana** are cousins through Latin *māne*: both turn "morning" into
+"tomorrow," just assembled differently (French *from-morning*, Spanish
+*morning-ish hour*). English keeps *māne* too, in the poetic **matins** (morning
+prayers) and **matinée** (a *morning*/daytime show).
+
+## Grammar Lens: the "à …" farewells, complete
+
+Your French soft-goodbye set, mapped to Spanish:
+
+| French | Spanish | when |
+|---|---|---|
+| **à plus tard** / à plus | hasta luego | later (default) |
+| **à bientôt** | hasta pronto | soon |
+| **à demain** | hasta mañana | tomorrow |
+
+…and **au revoir** for the plain goodbye.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "à demain" — *ah duh-Mɛ̃*]
+- [YOU SAY: "demain" ← *de mane* "from morning"; Spanish "mañana" ← *maneana* —
+  same *māne*]
+- [YOU SAY: the three "à …" goodbyes — à plus tard / à bientôt / à demain]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *demain* literally come from? (*dē māne* — "from the
+morning.") What Spanish word shares that *māne* root? (*mañana*.) Which French
+goodbye for parting until tomorrow? (*à demain*.) Next: put the farewells
+together.

--- a/code/learning/human-languages/french/lessons/FR-C04-a-plus-tard.md
+++ b/code/learning/human-languages/french/lessons/FR-C04-a-plus-tard.md
@@ -1,0 +1,68 @@
+---
+id: FR-C04-a-plus-tard
+chapter: 4
+type: phrase
+headword: à plus tard
+gloss: see you later (literally "to more late")
+concept_tag: FAREWELL-LATER
+prerequisites: [FR-C04-au-revoir]
+sounds: [silent-final, liaison]
+roots: [plus-latin, tarde-latin]
+etymology_hook: "à plus tard = 'to more late'; tard ← Latin tarde 'late' — the same word as Spanish tarde"
+est_minutes: 3
+reviews_of: [FR-C04-au-revoir]
+---
+
+# à plus tard — the casual "see you later"
+
+## Warm-up
+
+[PAUSE 2s] The everyday, friendly "see you later" is **à plus tard** — and among
+friends it shrinks to just **à plus** (*ah PLUSS*, and here you *do* sound the
+final *s*). It's the French twin of Spanish *hasta luego*.
+
+## Sounds you'll need
+
+- `silent-final` — in the full phrase, *plus* is *ploo* (silent *s*): *ah ploo
+  TAR*. But in the clipped **à plus**, the *s* is pronounced: *ah PLUSS*.
+- **tard** = *tar* (silent *d*).
+
+## The phrase, taken apart
+
+> **à plus tard** = literally "to more late" → "see you later."
+
+- **à** = "to / at" (Latin *ad*) — French's all-purpose farewell preposition,
+  the way Spanish leans on *hasta*: *à* + a time = a soft goodbye.
+- **plus** = "more," from Latin **plūs** — the *plus* you already write in
+  English (and the *plu*- of *plural*, *surplus*).
+- **tard** = "late," from Latin **tarde**, "slowly, late." And that is **exactly**
+  the Spanish word **tarde** ("afternoon / late") you met in Chapter 2 — French
+  kept it meaning *late*, Spanish grew it into *afternoon*. Same Latin *tarde*.
+  English keeps it in **tardy** and **retard** ("hold back, make late").
+
+So *à plus tard* is "until more-late" — see you at some later point.
+
+## Grammar Lens: the "à …" farewells
+
+French's soft goodbyes are all **à** + a time word — mirror this against Spanish
+*hasta*:
+
+| French | Spanish | "until / to …" |
+|---|---|---|
+| **à plus tard** / à plus | hasta luego | later |
+| **à bientôt** | hasta pronto | soon |
+| **à demain** | hasta mañana | tomorrow |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "à plus tard" (*ah ploo TAR*), then clipped "à plus" (*ah PLUSS*)]
+- [YOU SAY: "tard" then Spanish "tarde" — the same Latin *tarde*, "late"]
+- [YOU SAY: English "tardy, retard" — held back, late]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *à plus tard* literally mean? ("To more late.") What Spanish
+word is *tard* identical to at the root, and what does each mean now? (*tarde* —
+French "late", Spanish "afternoon".) What preposition carries French's soft
+goodbyes, like Spanish *hasta*? (*à*.) Next: **à bientôt**.

--- a/code/learning/human-languages/french/lessons/FR-C04-au-revoir.md
+++ b/code/learning/human-languages/french/lessons/FR-C04-au-revoir.md
@@ -1,0 +1,63 @@
+---
+id: FR-C04-au-revoir
+chapter: 4
+type: word
+headword: au revoir
+gloss: goodbye (literally "until the seeing-again")
+concept_tag: FAREWELL
+prerequisites: []
+sounds: [r-uvular, vowel-oi, liaison]
+roots: [videre-latin]
+etymology_hook: "au revoir = 'à le revoir' — 'until the re-seeing' (voir ← vidēre 'to see' → vision, video)"
+est_minutes: 3
+reviews_of: [FR-C03-practice]
+---
+
+# au revoir — "goodbye," i.e. "until we see each other again"
+
+## Warm-up
+
+[PAUSE 2s] You can open a French conversation; now close it. The standard
+goodbye is **au revoir** — and where Spanish *adiós* commends you *to God*,
+French makes a promise to **see you again**.
+
+## Sounds you'll need
+
+- `r-uvular` — two guttural French *r*'s: *oh ruh-VWAHR*.
+- `vowel-oi` — **-voir** = *vwahr* (the *oi* = *wa*, as in *soir* from Chapter 1).
+
+## The word, taken apart
+
+**au revoir** is **au** + **revoir** = "at the **re-seeing**":
+
+- **au** = "at/to the" (a fusion of *à* + *le*).
+- **revoir** = "to see again" = **re-** ("again") + **voir** ("to see").
+
+So *au revoir* literally means **"until the seeing-again"** — a small promise
+that this isn't the end. It's built on **voir**, from Latin **vidēre**, "to see"
+— one of the richest roots in English:
+
+- **vis**ion, **vis**ible, **vis**it, **vis**a, **view**, **video** ("I see").
+- **re-vise** ("look again"), **e-vid**ent ("seen out"), **pro-vide**,
+  **super-vise**, **sur-vey**.
+
+### A goodbye that *sees* — French and German agree
+
+Here's a satisfying cross-language pair: **German says the exact same thing.**
+*Auf Wiedersehen* = *auf* ("on") + *wieder* ("again") + *sehen* ("to see") = "on
+the seeing-again." French and German, side by side, both promise a **re-seeing**;
+Spanish *adiós* instead commends you *to God*. Same moment, two different pictures.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "au revoir" — *oh ruh-VWAHR*]
+- [YOU SAY: "au revoir" then English "vision, revise, video" — the *vidēre* family]
+- [YOU SAY: French *au revoir* and German *auf Wiedersehen* — both "see you again"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *au revoir* literally mean? ("Until the seeing-again.") What
+Latin verb is *voir* from, and two English cousins? (*vidēre* — vision, video,
+revise.) Which other language builds its goodbye the same "see again" way?
+(German *auf Wiedersehen*.) Next: **à plus tard**.

--- a/code/learning/human-languages/french/lessons/FR-C04-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C04-practice.md
@@ -1,0 +1,64 @@
+---
+id: FR-C04-practice
+chapter: 4
+type: practice-mix
+headword: (practice)
+gloss: closing a conversation — the French farewells
+concept_tag: CH4-PRACTICE
+prerequisites: [FR-C04-au-revoir, FR-C04-a-plus-tard, FR-C04-a-bientot, FR-C04-a-demain]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [FR-C04-au-revoir, FR-C04-a-plus-tard, FR-C04-a-bientot, FR-C04-a-demain, FR-C03-practice]
+---
+
+# Practice — saying goodbye in French
+
+## Warm-up
+
+[PAUSE 2s] No new words. The farewells — *au revoir* and the three *à …*
+goodbyes — now close a real conversation and fold back into everything since
+*salut*.
+
+## Choosing the right goodbye
+
+| you're… | say |
+|---|---|
+| parting plainly / politely | **Au revoir.** |
+| expecting to meet again shortly | **À bientôt.** |
+| casual "see you" | **À plus (tard).** |
+| leaving for the day | **À demain.** |
+
+## The whole exchange, start to finish
+
+Everything from the French Chapters 1–4:
+
+> — Salut ! Je m'appelle Chloé. Comment tu t'appelles ?
+> — Je m'appelle Marc. Enchanté.
+> — Ça va ?
+> — Ça va bien, merci, et toi ?
+> — Très bien. Bon… **à demain**, Marc.
+> — **À demain**, Chloé. **Au revoir !**
+
+## What you've built this chapter
+
+- **au revoir** — the plain goodbye ("until the seeing-again"; the *voir* /
+  *vidēre* family; twin of German *auf Wiedersehen*).
+- **à plus tard / à bientôt / à demain** — later / soon / tomorrow, all **à** +
+  a time, mirroring Spanish's **hasta**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full conversation, both voices — *salut* to *au revoir*]
+- [YOU SAY: pick the goodbye — a friend you'll see tomorrow? (à demain); a polite
+  plain goodbye? (au revoir)]
+
+[REPEAT x2] Run the exchange, greeting to goodbye, without stopping.
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *au revoir* literally promise? (A *re-seeing* — "until we
+see again.") Which preposition carries French's soft goodbyes? (*à* — like
+Spanish *hasta*.) You can now hold a whole short French exchange, hello to
+goodbye. Next chapter: numbers, or everyday courtesies (*s'il vous plaît*).

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -23,12 +23,15 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   state-verb — vs Spanish *estar* "to stand") → comment ça va / allez-vous /
   vas-tu → comme ci, comme ça → practice. **Authored** — the deliberate mirror of
   Spanish Ch. 4.
+- **Ch. 4 — Farewells**: au revoir (← "à le revoir", *voir* ← *vidēre*; the
+  "see-again" goodbye, twin of German *auf Wiedersehen*) → à plus tard (*tard* ←
+  *tarde*, = Spanish *tarde*) → à bientôt (*bien* + *tôt*) → à demain (*dē māne*,
+  shares *māne* with *mañana*) → practice. **Authored** — mirror of Spanish Ch. 5.
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 4 | Farewells: au revoir, à bientôt, à demain |
 | 5+ | Numbers, time, days & months, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
 
 The *tu/vous* lesson (Ch. 2) is the French counterpart to Spanish *tú/usted*:

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Chapter 4 — Farewells (completes the ES/FR/DE farewell trilogy)
+
+- **Chapter 4 authored** (`GE-C04-auf-wiedersehen`, `-tschuss`, `-bis-bald`,
+  `-bis-morgen`, `-practice`): closing a conversation, atom-first, reviewing
+  Chapter 3. Reuses the shared `FAREWELL` / `FAREWELL-SOON` / `FAREWELL-TOMORROW`
+  concepts and adds `FAREWELL-CASUAL`.
+- **auf Wiedersehen** = "on the seeing-again" (*sehen* = English *see*) — the
+  exact twin of French *au revoir*, both against Spanish *adiós* "to God".
+- **tschüss**, the best etymology in the chapter: *tschüss* ← Low German
+  *atschüs* ← Walloon *adjûs* ← French *adieu* — so the breeziest German bye is
+  secretly **"to God"**, a far-travelled cousin of *adiós* and *adieu*.
+- **The "bis …" family** mirrors Spanish *hasta* / French *à*: *bis bald* (soon —
+  *bald* ← Old High German "bold/quick", = English *bold*), *bis später* (later),
+  *bis morgen* (tomorrow — *Morgen* = English *morning/morrow*, the same
+  morning→tomorrow move as *mañana* / *demain*).
+- Taxonomy: `FAREWELL-CASUAL` added (canonical, `core:false`).
+
 ## Chapter 3 — "Wie geht's?" (completes the how-are-you trilogy)
 
 - **Chapter 3 authored** (`GE-C03-danke`, `-bitte`, `-gehen`, `-wie-geht-es`,

--- a/code/learning/human-languages/german/lessons/GE-C04-auf-wiedersehen.md
+++ b/code/learning/human-languages/german/lessons/GE-C04-auf-wiedersehen.md
@@ -1,0 +1,64 @@
+---
+id: GE-C04-auf-wiedersehen
+chapter: 4
+type: word
+headword: auf Wiedersehen
+gloss: goodbye (formal — literally "on the seeing-again")
+concept_tag: FAREWELL
+prerequisites: []
+sounds: [w-is-v, ie-long-ee, h-pronounced]
+roots: [wieder-german, sehen-german]
+etymology_hook: "auf Wiedersehen = auf + wieder ('again') + sehen ('to see') — 'on the seeing-again'; sehen = English see"
+est_minutes: 3
+reviews_of: [GE-C03-practice]
+---
+
+# auf Wiedersehen — "goodbye," i.e. "till we see again"
+
+## Warm-up
+
+[PAUSE 2s] You can open a German conversation; now close it. The formal goodbye
+is **auf Wiedersehen** — and it's the exact twin of French *au revoir*: both mean
+"**until we see each other again**."
+
+## Sounds you'll need
+
+- `w-is-v` — **Wiedersehen**: German *w* says *v*. *owf VEE-der-zay-en*.
+- `ie-long-ee` — *ie* = a long *ee* (*Wieder* = *VEE-der*).
+- Nouns are capitalized in German, so *Wiedersehen* takes a capital W.
+
+## The word, taken apart
+
+**auf Wiedersehen** breaks cleanly into three familiar pieces:
+
+- **auf** = "on / upon" (cognate of English *up / of*).
+- **wieder** = "again" (cognate of English *withering*? no — of the *with-* in
+  *withdraw*; think "back").
+- **sehen** = "to see" — a **straight cognate of English *see*** (both from
+  Germanic *sehwan*).
+
+So *auf Wiedersehen* = **"on the seeing-again"** → "until we see each other
+again." Put it beside the other two tracks and the picture is lovely:
+
+| language | goodbye | metaphor |
+|---|---|---|
+| **German** | *auf Wiedersehen* | "till we **see** again" |
+| **French** | *au revoir* | "till the **re-seeing**" |
+| **Spanish** | *adiós* | "to **God**" |
+
+German and French shake hands on a **re-seeing**; Spanish commends you to God.
+(*Wiedersehen* even works as a noun — *ein Wiedersehen* is "a reunion.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "auf Wiedersehen" — *owf VEE-der-zay-en*]
+- [YOU SAY: pull it apart — auf (on) + wieder (again) + sehen (see)]
+- [YOU SAY: German *sehen* = English *see*; *auf Wiedersehen* = French *au revoir*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *auf Wiedersehen* literally mean? ("On the seeing-again.")
+What English word is *sehen*? (*See*.) Which language's goodbye matches its
+metaphor exactly? (French *au revoir*.) Next: the casual bye, **tschüss** — with
+a secret past.

--- a/code/learning/human-languages/german/lessons/GE-C04-bis-bald.md
+++ b/code/learning/human-languages/german/lessons/GE-C04-bis-bald.md
@@ -1,0 +1,64 @@
+---
+id: GE-C04-bis-bald
+chapter: 4
+type: phrase
+headword: bis bald
+gloss: see you soon (literally "until soon")
+concept_tag: FAREWELL-SOON
+prerequisites: [GE-C04-tschuss]
+sounds: [i-short, d-t-final]
+roots: [bis-german, bald-german]
+etymology_hook: "bis ('until') + bald ('soon'); bald ← Old High German bald 'bold, quick' → English bold"
+est_minutes: 3
+reviews_of: [GE-C04-tschuss, GE-C04-auf-wiedersehen]
+---
+
+# bis bald — "see you soon"
+
+## Warm-up
+
+[PAUSE 2s] German's soft goodbyes all start with **bis**, "until" — the German
+version of Spanish *hasta* / French *à*. First up: **bis bald**, "until soon" —
+the twin of *hasta pronto* / *à bientôt*.
+
+## Sounds you'll need
+
+- **bis** = *biss* (short *i*). **bald** = *balt* (final *d* hardens to *t* —
+  German always devoices a final *d*). Whole phrase: *biss BALT*.
+
+## The phrase, taken apart
+
+> **bis bald** = "until soon" → "see you soon."
+
+- **bis** = "until, up to" — German's farewell preposition. Just as Spanish builds
+  *hasta luego / mañana* and French builds *à bientôt / demain*, German builds
+  **bis** + a time word.
+- **bald** = "soon." It comes from Old High German **bald**, which meant
+  "**bold, quick, brave**" — and that is the **same word as English *bold*!**
+  The sense drifted: what's done *boldly* is done *quickly* → *soon*. So German
+  "soon" and English "bold" are one word; the German kept the speed, English kept
+  the courage.
+
+## Grammar Lens: the "bis …" family
+
+| German | "until…" | Spanish / French twin |
+|---|---|---|
+| **bis bald** | soon | hasta pronto / à bientôt |
+| **bis später** | later | hasta luego / à plus tard |
+| **bis morgen** | tomorrow | hasta mañana / à demain |
+
+(*bis später* — "until later" — uses *später*, "later," the comparative of *spät*
+"late." You'll meet *bis morgen* next.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bis bald" — *biss BALT*]
+- [YOU SAY: "bald" (soon) ↔ English "bold" — one word, split senses]
+- [YOU SAY: "bis bald" = "hasta pronto" = "à bientôt" — three "see you soon"s]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *bis* mean, and which Spanish/French words does it match?
+("Until"; *hasta* / *à*.) What surprising English word is *bald* ("soon")? (*Bold*
+— speed vs courage.) Next: **bis morgen**.

--- a/code/learning/human-languages/german/lessons/GE-C04-bis-morgen.md
+++ b/code/learning/human-languages/german/lessons/GE-C04-bis-morgen.md
@@ -1,0 +1,69 @@
+---
+id: GE-C04-bis-morgen
+chapter: 4
+type: phrase
+headword: bis morgen
+gloss: see you tomorrow (literally "until tomorrow")
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [GE-C04-bis-bald, GE-C01-morgen]
+sounds: [r-uvular-german]
+roots: [morgen-german]
+etymology_hook: "bis + Morgen ('morning'/'tomorrow') — the same 'morning → tomorrow' move as Spanish mañana, French demain"
+est_minutes: 3
+reviews_of: [GE-C04-bis-bald, GE-C01-morgen]
+---
+
+# bis morgen — "see you tomorrow" (and Morgen comes back)
+
+## Warm-up
+
+[PAUSE 2s] Parting for the day: **bis morgen**, "until tomorrow." It brings back
+**Morgen** — the "morning" from your very first chapter (*Guten Morgen!*) — now
+doing a second job.
+
+## Sounds you'll need
+
+- `r-uvular-german` — the guttural German *r*: **morgen** = *MOR-gen*. Whole
+  phrase: *biss MOR-gen*.
+
+## The phrase, taken apart
+
+> **bis morgen** = "until tomorrow" → "see you tomorrow."
+
+- **bis** = "until" (last lesson).
+- **morgen** = "tomorrow" — **and** "morning," exactly the double meaning you saw
+  in Spanish *mañana* and French *demain*. German just uses **Morgen** for both:
+  - *Guten Morgen!* = "Good **morning**!" (Chapter 1)
+  - *bis morgen* = "until **tomorrow**."
+  - (When it means "morning," it's a capital-M noun, *der Morgen*; as "tomorrow,"
+    lowercase *morgen*.)
+
+**The English cousin.** German *Morgen* is a straight relative of English
+**morning** and the old word **morrow** — "see you on the **morrow**" is
+*bis morgen*, almost word for word. And "to**morrow**" is literally "to (the)
+morrow."
+
+So all three tracks make "tomorrow" out of "morning": German **Morgen**, Spanish
+**mañana** (← *māne*), French **demain** (← *dē māne*). Same idea, three routes.
+
+## Grammar Lens: the "bis …" farewells, complete
+
+You now have German's full soft-goodbye set — **bis bald** (soon), **bis später**
+(later), **bis morgen** (tomorrow) — plus **auf Wiedersehen** (formal) and
+**tschüss** (casual).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bis morgen" — *biss MOR-gen*]
+- [YOU SAY: "Guten Morgen" (good morning) vs "bis morgen" (until tomorrow) — same
+  word, two jobs]
+- [YOU SAY: Morgen ↔ English "morning / morrow"; the tomorrow trio — Morgen /
+  mañana / demain]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two meanings does *Morgen* carry? (Morning; tomorrow.) What
+English words is it cousin to? (*Morning*, *morrow* — "to-morrow".) All three
+tracks build "tomorrow" from what? ("Morning.") Next: put the German farewells
+together.

--- a/code/learning/human-languages/german/lessons/GE-C04-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C04-practice.md
@@ -1,0 +1,71 @@
+---
+id: GE-C04-practice
+chapter: 4
+type: practice-mix
+headword: (practice)
+gloss: closing a conversation — the German farewells
+concept_tag: CH4-PRACTICE
+prerequisites: [GE-C04-auf-wiedersehen, GE-C04-tschuss, GE-C04-bis-bald, GE-C04-bis-morgen]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [GE-C04-auf-wiedersehen, GE-C04-tschuss, GE-C04-bis-bald, GE-C04-bis-morgen, GE-C03-practice]
+---
+
+# Practice — saying goodbye in German
+
+## Warm-up
+
+[PAUSE 2s] No new words. The farewells — *auf Wiedersehen*, *tschüss*, and the
+*bis …* goodbyes — now close a real conversation and fold back into everything
+since *hallo*.
+
+## Choosing the right goodbye
+
+| you're… | say |
+|---|---|
+| formal / to a stranger | **Auf Wiedersehen.** |
+| casual / to a friend | **Tschüss.** |
+| meeting again soon | **Bis bald.** |
+| leaving for the day | **Bis morgen.** |
+
+## The whole exchange, start to finish
+
+Everything from the German Chapters 1–4:
+
+> — Hallo! Ich heiße Anna. Wie heißen Sie?
+> — Ich heiße Peter. Freut mich.
+> — Wie geht es Ihnen?
+> — Danke, gut. Und Ihnen?
+> — Sehr gut. Also… **bis morgen**, Peter.
+> — **Bis morgen**, Anna. **Auf Wiedersehen!**
+
+(Between friends: *Tschüss, bis morgen!*)
+
+## What you've built this chapter
+
+- **auf Wiedersehen** — the formal goodbye ("on the seeing-again"; *sehen* =
+  *see*; twin of French *au revoir*).
+- **tschüss** — casual bye (secretly *adieu* → "to God", cousin of *adiós*).
+- **bis bald / später / morgen** — soon / later / tomorrow, all **bis** + a time,
+  mirroring Spanish *hasta* and French *à*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full formal conversation, both voices — *hallo* to *auf
+  Wiedersehen*]
+- [YOU SAY: the casual sign-off — "Tschüss, bis morgen!"]
+- [YOU SAY: pick the goodbye — a stranger? (auf Wiedersehen); a friend you'll see
+  tomorrow? (tschüss / bis morgen)]
+
+[REPEAT x2] Run the exchange, greeting to goodbye, without stopping.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which German goodbye promises a "re-seeing," and which language
+matches it? (*Auf Wiedersehen*; French *au revoir*.) What does the casual
+*tschüss* secretly mean? ("To God" — from *adieu*.) Which preposition carries the
+"bis …" goodbyes, like Spanish *hasta*? (*bis*.) You can now hold a whole German
+exchange, hello to goodbye. Next chapter: numbers, or everyday courtesies (*bitte
+/ danke* deepened).

--- a/code/learning/human-languages/german/lessons/GE-C04-tschuss.md
+++ b/code/learning/human-languages/german/lessons/GE-C04-tschuss.md
@@ -1,0 +1,68 @@
+---
+id: GE-C04-tschuss
+chapter: 4
+type: word
+headword: tschüss
+gloss: bye (casual)
+concept_tag: FAREWELL-CASUAL
+prerequisites: [GE-C04-auf-wiedersehen]
+sounds: [tsch-ch, u-umlaut]
+roots: [adieu-french]
+etymology_hook: "tschüss ← Low German atschüs ← Walloon adjûs ← French adieu — so tschüss is secretly 'to God', a cousin of adiós!"
+est_minutes: 3
+reviews_of: [GE-C04-auf-wiedersehen]
+---
+
+# tschüss — the casual "bye" that used to say "to God"
+
+## Warm-up
+
+[PAUSE 2s] Between friends, Germans rarely say the full *auf Wiedersehen* — they
+say **tschüss**, a breezy "bye." And it hides one of the best secrets in this
+whole chapter: **tschüss is, distantly, the same word as Spanish *adiós*.**
+
+## Sounds you'll need
+
+- `tsch-ch` — **tschüss** starts with the *ch* of English "**ch**urch": *chüss*.
+- `u-umlaut` — **ü** is the front-rounded vowel (say *ee* with rounded lips);
+  *tschüss* ≈ *chuess*. Short and clipped.
+
+## The word, taken apart — a great migration
+
+*tschüss* looks purely German, but trace it back and it leaves the country:
+
+**French *adieu*** ("to God") → borrowed into **Walloon** (a language of southern
+Belgium) as **adjûs** → carried north into **Low German** dialects as **atschüs /
+atschüss** → clipped to modern **tschüss**.
+
+So the chain is **adieu → adjûs → atschüss → tschüss** — and since *adieu* is
+"**à Dieu**," *"to God,"* the casual German *tschüss* is a far-travelled cousin of:
+
+- French **adieu** — "to God,"
+- Spanish **adiós** — "to God,"
+
+…all three the same little blessing, *"to God,"* just worn down more and more.
+The friendliest, most throwaway German goodbye is secretly the most solemn one.
+(You'll also hear **tschau** — that one is Italian **ciao** borrowed straight.)
+
+## Grammar Lens: register
+
+- **tschüss** — friends, family, peers, casual shops. Never in a formal meeting.
+- **auf Wiedersehen** — strangers, elders, officials, the phone.
+
+Same split you've drilled all along (*du* vs *Sie*): pick the parting to match
+the relationship.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tschüss" — *chüss*, short and light]
+- [YOU SAY: the migration — adieu → adjûs → tschüss ("to God" all along)]
+- [YOU SAY: tschüss (casual) vs auf Wiedersehen (formal) — friend vs stranger]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What language did *tschüss* ultimately come from, and what did it
+originally mean? (French *adieu* — "to God".) What two other goodbyes are its
+cousins? (*adiós*, *adieu*.) When do you use *tschüss* vs *auf Wiedersehen*?
+(Casual vs formal.) Next: **bis bald**.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -22,12 +22,16 @@ Spanish and French where a contrast helps. The recurring decoder is the
   *go*; the state-verb, w/ a first taste of the **dative** *mir/dir*) → wie geht
   es dir/Ihnen → es geht (so-so) → practice. **Authored** — completes the
   Spanish/French/German how-are-you trilogy.
+- **Ch. 4 — Farewells**: auf Wiedersehen ("on the seeing-again", *sehen* = *see*;
+  twin of *au revoir*) → tschüss (← *adieu* → secretly "to God", cousin of
+  *adiós*) → bis bald (*bald* = English *bold*) → bis morgen (*Morgen* =
+  *morning/morrow*) → practice. **Authored** — completes the ES/FR/DE farewell
+  trilogy; the "bis …" family mirrors Spanish *hasta* / French *à*.
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 4 | Farewells: tschüss, auf Wiedersehen, bis morgen |
 | 5+ | Numbers, cases (der→den→dem), family, food — following the shared theme order |
 
 The **du / Sie** lesson (Ch. 2) completes the formal/informal set across the

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter 5 — Farewells (and the first Arabic-loanword deep dive)
+
+- **Chapter 5 authored** (`ES-C05-adios`, `-hasta`, `-hasta-luego`,
+  `-hasta-manana`, `-hasta-pronto`, `-practice`): closing a conversation, each
+  lesson 3–5 min and reviewing Chapter 4. The learner can now open *and* close a
+  Spanish conversation end to end.
+- **The first Arabic-loanword deep dive**, via **hasta** ← Arabic *ḥattā*: 800
+  years of al-Andalus, ~4000 Spanish words from Arabic, and the striking fact
+  that *hasta* is a borrowed **function word** (a preposition — languages almost
+  never borrow those), with the *al-* noun family (*almohada, azúcar, álgebra*)
+  as the visible tip.
+- **Etymology throughout**: *adiós* ← *a Dios* "to God" (twin of *goodbye* ←
+  "God be with ye"; the adiós/adieu/addio/adeus set); *luego* ← *loco* "place" →
+  "then" (local/locus); *mañana* ← *maneana* "early hour" (morning *and*
+  tomorrow) — which **reactivates the ñ writing lesson** (the tilde as a frozen
+  *nn*); *pronto* ← *promptus* → English *prompt*.
+- **Taxonomy**: canonical `FAREWELL-LATER`, `FAREWELL-TOMORROW`, `FAREWELL-SOON`
+  (`core:false`) join the existing `FAREWELL`; namespaced `ES-WORD-HASTA`
+  documented.
+
 ## Writing nuances — the accent, the ñ, the inverted marks
 
 - **First `writing`-type lessons** (`ES-W01-acento`, `ES-W02-enye`,

--- a/code/learning/human-languages/spanish/lessons/ES-C05-adios.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-adios.md
@@ -1,0 +1,69 @@
+---
+id: ES-C05-adios
+chapter: 5
+type: word
+headword: adiós
+gloss: goodbye
+concept_tag: FAREWELL
+prerequisites: []
+sounds: [vowel-a, diphthong-io, s-final]
+roots: [a-dios-latin]
+etymology_hook: "adiós ← 'a Dios' — '(I commend you) to God'; twin of French adieu, and of English goodbye ← 'God be with ye'"
+est_minutes: 3
+reviews_of: [ES-C04-practice]
+---
+
+# adiós — "goodbye," or "to God"
+
+## Warm-up
+
+[PAUSE 2s] You can greet, introduce yourself, and ask how someone is. Time to
+leave gracefully. The final, plainest parting is **adiós** — and, like the
+English *goodbye*, it's a tiny prayer worn smooth.
+
+## Sounds you'll need
+
+- `diphthong-io` — the *-iós* is one glide, *ee-OHS*: *ah-DYOHS*, stress on the
+  end (that's what the accent on *ó* marks — remember the acute-accent lesson).
+
+## The word, taken apart
+
+**adiós** is **a + Dios** — "**to God**." It's the front half of an old blessing,
+*a Dios te encomiendo*, "I commend you **to God**" — said to someone setting off,
+when a journey was dangerous and you left them in God's keeping.
+
+Every Romance sister kept the same farewell-prayer:
+
+| language | goodbye | literally |
+|---|---|---|
+| **Spanish** | *adiós* | "to God" |
+| French | *adieu* | "to God" (*à Dieu*) |
+| Italian | *addio* | "to God" |
+| Portuguese | *adeus* | "to God" |
+
+And English is doing the **exact same thing** without telling you: **goodbye** is
+a crushed-down *"God be with ye."* So *adiós* and *goodbye* are, at heart, the
+same sentence — a blessing for the road.
+
+- **Dios** ("God") ← Latin **Deus** — the *Deus* of English *deity*, *divine*,
+  *adieu*, and (via Greek *Zeus*, same root) the whole sky-god family.
+
+## Grammar Lens: adiós is a *final* goodbye
+
+*adiós* leans toward a **longer** parting — you won't see them soon, or it's the
+end of the day. For "see you later / tomorrow," Spanish reaches for **hasta …**,
+which the rest of this chapter is about — and *hasta* has a surprising origin.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "adiós" — *ah-DYOHS*, stress the end]
+- [YOU SAY: adiós / adieu / addio / adeus — four "to God" farewells]
+- [YOU SAY: English "goodbye" = "God be with ye" — the same prayer]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two words hide inside *adiós*? (*a* + *Dios* — "to God.") What
+English goodbye is built the same way? (*Goodbye* ← "God be with ye.") Is *adiós*
+for a quick "see you soon"? (No — it's the longer/final parting; *hasta …* comes
+next.) Next: **hasta**, and a word Spain borrowed from Arabic.

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
@@ -1,0 +1,66 @@
+---
+id: ES-C05-hasta-luego
+chapter: 5
+type: phrase
+headword: hasta luego
+gloss: see you later (literally "until later")
+concept_tag: FAREWELL-LATER
+prerequisites: [ES-C05-hasta]
+sounds: [diphthong-ue, g-soft-gw]
+roots: [hatta-arabic, loco-latin]
+etymology_hook: "hasta (Arabic) + luego (← Latin loco 'at the place' → then/soon) — 'until soon'"
+est_minutes: 3
+reviews_of: [ES-C05-hasta, ES-C05-adios]
+---
+
+# hasta luego — the everyday "see you later"
+
+## Warm-up
+
+[PAUSE 2s] This is the goodbye you'll actually use most — friendly, casual,
+open-ended. **hasta luego**: "until later." You already own **hasta** ("until");
+today you add **luego** ("later"), and it has a very Latin backstory.
+
+## Sounds you'll need
+
+- `diphthong-ue` — **luego** = *LWEH-goh*: the *ue* is a *w*-glide, *lweh-*.
+- The whole phrase: *AHS-tah LWEH-goh*.
+
+## The phrase, taken apart
+
+> **hasta luego** = "until later" → "see you later."
+
+- **hasta** = "until" (last lesson — Arabic *ḥattā*).
+- **luego** = "later / then / soon," from Latin **loco**, "at the place / at that
+  point." The idea slid from *place* → *point in time* → "then, next, soon." So
+  its cousins in English are all about **place**: **local**, **locus**,
+  **loc**ation, **loc**ate, **al-loc-ate**. Spanish moved *loco* from *where* to
+  *when*.
+
+A nice contrast: **hasta luego** fuses an **Arabic** word and a **Latin** word in
+three syllables — the two great layers of Spanish, shaking hands as you leave.
+
+## Grammar Lens: the "hasta …" family
+
+*hasta* + a time word is Spanish's whole toolkit of soft goodbyes. You'll build
+the other two this chapter:
+
+| phrase | "until …" | when |
+|---|---|---|
+| **hasta luego** | later | the default "see you" |
+| **hasta mañana** | tomorrow | leaving for the day |
+| **hasta pronto** | soon | you expect to meet again shortly |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hasta luego" — *AHS-tah LWEH-goh*]
+- [YOU SAY: "luego" then English "local, location" — the *loco* "place" family]
+- [YOU SAY: "¡Adiós! … no — ¡hasta luego!" — feel the difference: final vs. soon]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *hasta luego* literally mean? ("Until later.") What did
+*luego*'s Latin root *loco* first mean, and what English words keep it? (Place —
+*local, location, locus*.) Which two language layers meet in *hasta luego*?
+(Arabic *hasta* + Latin *luego*.) Next: **hasta mañana**.

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-manana.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-manana.md
@@ -1,0 +1,65 @@
+---
+id: ES-C05-hasta-manana
+chapter: 5
+type: phrase
+headword: hasta mañana
+gloss: see you tomorrow (literally "until tomorrow")
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [ES-C05-hasta-luego, ES-W02-enye]
+sounds: [enye-ny, vowel-a]
+roots: [hatta-arabic, maneana-latin]
+etymology_hook: "mañana ← Latin (hora) maneana 'early hour' → morning → tomorrow; carries the ñ from the ñ-lesson"
+est_minutes: 3
+reviews_of: [ES-C05-hasta-luego, ES-W02-enye]
+---
+
+# hasta mañana — "see you tomorrow" (and the ñ returns)
+
+## Warm-up
+
+[PAUSE 2s] Leaving for the day? **hasta mañana** — "until tomorrow." It brings
+back a letter you studied in the writing lessons: the **ñ**. Here it is, living
+in a word you'll say every evening.
+
+## Sounds you'll need
+
+- `enye-ny` — **mañana** = *mah-NYAH-nah*: the **ñ** is the squished *ny* of
+  "canyon" (your ñ writing lesson — the tilde is a tiny second *n*, remember).
+  Three soft *ah*'s: *ma-**ÑA**-na*.
+
+## The phrase, taken apart
+
+> **hasta mañana** = "until tomorrow" → "see you tomorrow."
+
+- **hasta** = "until" (Arabic *ḥattā*).
+- **mañana** = "tomorrow" — **and** "morning." One word for both, from Latin
+  **(hōra) maneana**, "the **early** hour" (from *māne*, "in the morning"). The
+  logic: the next "early hour" you'll see is *tomorrow morning* → *mañana* came to
+  mean both **morning** and **tomorrow**.
+  - *por la mañana* = "in the morning."
+  - *hasta mañana* = "until tomorrow."
+
+**The ñ, in the wild.** Recall the writing lesson: *ñ* is a frozen *nn* — a
+scribe's shorthand for a doubled *n*. *mañana* comes from Latin *maneana*, whose
+*n*+*ea* palatalized (softened) into that single *ñ* sound. So the tilde is a
+little historical fossil sitting in the middle of "tomorrow."
+
+## Grammar Lens: same word, two meanings — context decides
+
+*mañana* means "morning" **or** "tomorrow"; the sentence tells you which. Paired
+with *hasta*, it's always **tomorrow**: *hasta mañana*, "until tomorrow."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mañana" — *mah-NYAH-nah*, squished *ñ*]
+- [YOU SAY: "hasta mañana" — until tomorrow]
+- [YOU SAY: "por la mañana" (in the morning) vs "hasta mañana" (until tomorrow) —
+  same word, context decides]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two meanings does *mañana* carry? (Morning; tomorrow.) With
+*hasta*, which one? (Tomorrow.) What sound is the *ñ*, and what is its tilde,
+historically? (The *ny* of "canyon"; a frozen doubled-*n*.) Next: **hasta
+pronto**.

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-pronto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-pronto.md
@@ -1,0 +1,66 @@
+---
+id: ES-C05-hasta-pronto
+chapter: 5
+type: phrase
+headword: hasta pronto
+gloss: see you soon (literally "until soon")
+concept_tag: FAREWELL-SOON
+prerequisites: [ES-C05-hasta-luego]
+sounds: [vowel-o, pr-cluster]
+roots: [hatta-arabic, promptus-latin]
+etymology_hook: "pronto ← Latin promptus 'brought forth, ready' → English prompt; 'until soon'"
+est_minutes: 3
+reviews_of: [ES-C05-hasta-luego, ES-C05-hasta-manana]
+---
+
+# hasta pronto — "see you soon"
+
+## Warm-up
+
+[PAUSE 2s] The last of the "hasta …" trio: **hasta pronto**, "until soon" — for
+when you genuinely expect to meet again shortly. One new word, **pronto**, and
+it's hiding in plain sight in English.
+
+## Sounds you'll need
+
+- **hasta pronto** = *AHS-tah PRON-toh* — a clean *pr*, a pure *o*.
+
+## The phrase, taken apart
+
+> **hasta pronto** = "until soon" → "see you soon."
+
+- **hasta** = "until" (Arabic *ḥattā*).
+- **pronto** = "soon / quickly / ready," from Latin **promptus**, "brought forth,
+  ready at hand" (from *prōmere*, "to bring out"). Something *prompt* is brought
+  out **without delay** — so *pronto* slid to "soon."
+
+You already know its English twin: **prompt** (on time; to bring out a response),
+plus **prompt**er, **prompt**ly, and the computer **prompt** (the cursor "ready"
+for input). Italian borrowed *pronto* too — it's what Italians say when they pick
+up the phone (*"Pronto!"* = "Ready!").
+
+## Grammar Lens: the "hasta …" trio, complete
+
+You now have Spanish's three soft goodbyes, sharpest to vaguest in time:
+
+| phrase | until… | nuance |
+|---|---|---|
+| **hasta pronto** | soon | you'll meet again shortly |
+| **hasta luego** | later | the neutral default "see you" |
+| **hasta mañana** | tomorrow | you're parting for the day |
+
+…and **adiós** for the long or final goodbye.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hasta pronto" — *AHS-tah PRON-toh*]
+- [YOU SAY: "pronto" then English "prompt, promptly" — one family]
+- [YOU SAY: the trio — hasta pronto / hasta luego / hasta mañana]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *hasta pronto* mean, and *pronto*'s English twin? ("Until
+soon"; *prompt*.) What Latin word is it from, and its literal sense? (*promptus*,
+"brought forth / ready.") Order the three *hasta* goodbyes by time. (pronto →
+luego → mañana.) Next: put the whole farewell set together.

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
@@ -1,0 +1,75 @@
+---
+id: ES-C05-hasta
+chapter: 5
+type: word
+headword: hasta
+gloss: until / up to
+concept_tag: ES-WORD-HASTA
+prerequisites: [ES-C05-adios]
+sounds: [silent-h, vowel-a]
+roots: [hatta-arabic]
+etymology_hook: "hasta ← Arabic ḥattā حتى 'until' — a rare Arabic FUNCTION word in Spanish (most loans are nouns)"
+est_minutes: 4
+reviews_of: [ES-C05-adios]
+---
+
+# hasta — "until," and Spain's Arabic centuries
+
+## Warm-up
+
+[PAUSE 2s] Spanish says "see you later" as **hasta luego** — literally "**until**
+later." So the key word is **hasta**, "until." And *hasta* carries the single
+most important fact about Spanish's history: **for nearly 800 years, much of
+Spain spoke Arabic.**
+
+## Sounds you'll need
+
+- `silent-h` — Spanish **h is always silent**: **hasta** = *AHS-tah* (no breath
+  on the *h* at all). Stress the front.
+
+## The word, taken apart
+
+**hasta** comes from Arabic **ḥattā** (حَتَّى), "until, up to." From **711 CE**,
+Muslim armies ruled much of the Iberian Peninsula — *al-Andalus* — and Arabic was
+the language of government, science, and poetry there for **centuries**, until
+1492. Spanish absorbed roughly **four thousand** Arabic words in that time — more
+of its vocabulary than from any source except Latin itself.
+
+Most of those loans are **nouns**, and you can spot a huge number by the frozen
+Arabic article **al-** ("the") fused onto the front:
+
+- **almohada** (pillow), **alcázar** (fortress), **alcalde** (mayor), **alfombra**
+  (rug), **aduana** (customs), **álgebra**, **alcohol**.
+- **azúcar** (sugar), **aceite** (oil), **naranja** (orange), **ojalá** ("would
+  that…", literally *wa-šā' allāh*, "God willing").
+
+But **hasta** is special and rare: it is a **function word** — a preposition, part
+of the grammatical skeleton. Languages borrow nouns easily and grammar words
+almost never — so an Arabic *preposition* surviving in everyday Spanish shows how
+deep, how *intimate*, those centuries of contact were. (Its Latin rival *ad*
+"to"/*usque* "up to" simply lost.) You say a piece of al-Andalus every time you
+say goodbye.
+
+## Grammar Lens: hasta = "until," a pointer at a limit
+
+*hasta* marks the **end point** of something — in space or time:
+
+- **hasta aquí** — "up to here."
+- **hasta las tres** — "until three o'clock."
+- **hasta luego / mañana / pronto** — "until later / tomorrow / soon" → the
+  farewells that fill the rest of this chapter.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hasta" — *AHS-tah*, silent h]
+- [YOU SAY: "hasta las tres" — "until three"]
+- [YOU SAY: "hasta" then Arabic *ḥattā* — the same word, 1,300 years apart]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What language is *hasta* from, and what does it mean? (Arabic *ḥattā*
+— "until.") Why is it remarkable that Spanish borrowed it? (It's a *function
+word* / preposition — languages almost never borrow those; it shows how deep the
+Arabic centuries went.) How do you spot many Arabic nouns in Spanish? (The frozen
+*al-* article: *almohada, azúcar, álgebra*.) Next: **hasta luego**.

--- a/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
@@ -1,0 +1,66 @@
+---
+id: ES-C05-practice
+chapter: 5
+type: practice-mix
+headword: (practice)
+gloss: closing a conversation — the full set of farewells
+concept_tag: CH5-PRACTICE
+prerequisites: [ES-C05-adios, ES-C05-hasta, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C05-adios, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto, ES-C04-practice]
+---
+
+# Practice — saying goodbye
+
+## Warm-up
+
+[PAUSE 2s] No new words. This chapter's farewells — *adiós* and the three *hasta
+…* goodbyes — now close a real conversation, and fold back into the whole arc
+you've built since *hola*.
+
+## Choosing the right goodbye
+
+The choice is about **when you'll meet again**:
+
+| you're… | say |
+|---|---|
+| parting for good / a long time | **Adiós.** |
+| expecting to meet again shortly | **Hasta pronto.** |
+| just "see you" (neutral default) | **Hasta luego.** |
+| leaving for the day | **Hasta mañana.** |
+
+## The whole exchange, start to finish
+
+Everything from Chapters 1–5, in one conversation:
+
+> — ¡Hola! Buenos días. Me llamo Ana. ¿Cómo se llama usted?
+> — Me llamo Luis. Mucho gusto.
+> — ¿Cómo está usted?
+> — Bien, gracias. ¿Y usted?
+> — Muy bien. Bueno… **hasta mañana**, Luis.
+> — **Hasta mañana**, Ana. **¡Adiós!**
+
+## What you've built this chapter
+
+- **adiós** — the plain/final goodbye ("to God"; twin of *goodbye*).
+- **hasta** — "until," Spain's everyday Arabic word (← *ḥattā*).
+- **hasta luego / mañana / pronto** — see you later / tomorrow / soon, each an
+  Arabic + Latin handshake.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full conversation above, both voices — greeting to goodbye]
+- [YOU SAY: pick the goodbye — for a friend you'll see tomorrow? (hasta mañana);
+  for someone moving away? (adiós)]
+
+[REPEAT x2] Run the whole exchange, *hola* to *adiós*, without stopping.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which goodbye for someone you won't see for a long time? (*Adiós*.)
+Which everyday word for "until" did Spanish take from Arabic? (*hasta*.) You can
+now open *and* close a conversation in Spanish. Next chapter: **por favor** and
+**gracias**' partner courtesies, then into everyday verbs.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -31,11 +31,17 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   (← *nāta*, "born thing" → "nothing") → **estar** (the *temporary* to-be, ←
   *stāre* "to stand"; vs *ser*) → ¿cómo está usted? / ¿cómo estás? (assembled;
   formal vs informal) → regular / más o menos ("so-so") → practice. **Authored.**
+- **Ch. 5 — Farewells**: adiós (← *a Dios* "to God"; twin of *goodbye*) →
+  **hasta** (← Arabic *ḥattā* — the **first Arabic-loanword deep dive**: 800
+  years of al-Andalus, ~4000 loans, and *hasta* as a rare borrowed *function*
+  word) → hasta luego (*luego* ← *loco* "place" → then) → hasta mañana (*mañana*
+  ← *maneana*; the **ñ** returns) → hasta pronto (*pronto* ← *promptus* →
+  *prompt*) → practice. **Authored.**
 
-Next: **Ch. 5** — **farewells** (hasta luego / hasta mañana / hasta pronto,
-adiós — and *hasta* ← Arabic *ḥattā*, the first of the Arabic-loanword deep
-dives). Sentences grow as grammar accumulates piece by piece. The theme skeleton
-below plans the wider road ahead.
+Next: **Ch. 6** — the courtesy pair **por favor** / **de nada** completed, then
+into **everyday verbs** (the present tense of *-ar* verbs: *hablar, trabajar*),
+where sentences start to move. Grammar accumulates piece by piece. The theme
+skeleton below plans the wider road ahead.
 
 ## Theme Skeleton (planning only)
 


### PR DESCRIPTION
## Farewells — Spanish, French & German (closing a conversation)

The parting bookend to the greetings/how-are-you work already on `main`. The
learner can now **open and close** a conversation in all three languages. Built
as a cross-language set (like the earlier how-are-you trilogy), introducing three
shared canonical concepts — `FAREWELL-LATER / -TOMORROW / -SOON` (+ `FAREWELL-CASUAL`)
— that Spanish introduces and French/German immediately reuse.

### The metaphor map — how each language says "goodbye"

| | plain goodbye | its picture |
|---|---|---|
| **Spanish** | *adiós* | "to **God**" (← *a Dios*; twin of *goodbye* ← "God be with ye") |
| **French** | *au revoir* | "till the **re-seeing**" (*voir* ← *vidēre*) |
| **German** | *auf Wiedersehen* | "on the **seeing-again**" (*sehen* = English *see*) |

French and German both promise a *re-seeing*; Spanish commends you *to God*. And
the soft "see you …" goodbyes all hang off one preposition — Spanish **hasta**,
French **à**, German **bis** — + a time word.

### Highlights per commit
1. **`dbbfe68` Spanish Ch. 5** — the **first Arabic-loanword deep dive**: *hasta*
   ← Arabic *ḥattā*, a borrowed *function word* (rare!), with the al-Andalus story
   and the *al-* noun family. Plus *luego* ← *loco*, *mañana* ← *maneana* (which
   reactivates the ñ writing lesson), *pronto* ← *promptus* → *prompt*.
2. **`0c6c5fb` French Ch. 4** — *au revoir* (see-again, twin of *auf Wiedersehen*);
   *à demain* ← *dē māne* (shares *māne* with *mañana*); *tard* = Spanish *tarde*;
   a writing-nuance aside on the circumflex (*bientôt* ← *tost*, the ghost of a lost *s*).
3. **`bf7ad55` German Ch. 4** — the gem: **tschüss** ← *adieu* (adjûs → atschüss),
   so the breeziest German bye is secretly **"to God,"** a cousin of *adiós*.
   Plus *bald* = English *bold*, *Morgen* = *morning/morrow*.

### Checks
- 38 data-package tests pass on every commit; validator clean.
- Security review: **passed** on both batches (ES; FR+DE), no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
