### PR TITLE
feat(cobol-iir-compiler): v0.7.0 — alphanumeric item MOVE and comparison

### DIFF
--- a/code/packages/rust/cobol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/cobol-iir-compiler/CHANGELOG.md
@@ -8,6 +8,35 @@ tag.
 
 ## [Unreleased]
 
+### Added — v0.7.0: alphanumeric item MOVE and comparison (PL09 step 4)
+
+The two most commonly-hit character-handling "later rung" errors now lower,
+byte-identical to the oracle. Both reduce to **fixed-length** string ops because
+a character item's stored image is always exactly its declared width and all
+item sizes are known at compile time.
+
+- **Character item-to-item `MOVE`** reshapes the source into the receiver's
+  picture exactly as the oracle's `move_into_char`: keep the leftmost `N`
+  characters when `N ≤ M` (one `str_slice`), else left-justify and space-pad on
+  the right (one `str_concat`). Cross-category (`numeric↔alphanumeric`) moves
+  stay a clean later rung.
+- **Alphanumeric comparison in `IF`** — `emit_condition` now classifies each
+  operand (numeric vs character) and dispatches. A character comparison
+  space-pads both sides to their common (max) length and applies `str_cmp`
+  (byte-lexical, matching the oracle's space-padded `String` compare);
+  `SPACE`/`ZERO` figuratives expand to the other operand's length. `str_cmp`
+  returns an `i64` ordering (−1/0/1), so the relation is applied with `cmp_* … 0`
+  (no `Bool` mismatch). The relation→`cmp_*` mapping is shared with the numeric
+  path via `relation_op`. A numeric operand compared with an alphanumeric one,
+  and two figuratives with no fixed length to borrow, are later rungs.
+- **Tests.** 8 new `jit_e2e.rs` cases (MOVE truncate / space-pad / same-size;
+  equal / not-equal; lexicographic ordering; shorter-literal padding; `SPACES`
+  figurative; move-then-compare round-trip) each byte-identical to the oracle;
+  unit tests for validation and the deferred cross-category move; a
+  `backend_compat` alphanumeric program (wasm/jvm/clr accept the `str_slice` /
+  `str_concat` / `str_cmp` shapes); a `lang_matrix` COBOL row. Full suite **103
+  green** (20 unit + 11 `backend_compat` + 72 `jit_e2e`).
+
 ### Added — v0.6.0: control flow, COMPUTE, ON SIZE ERROR, signed numerics (PL09 step 4)
 
 A consolidated slice completing the COBOL-60 language surface this compiler

--- a/code/packages/rust/cobol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/cobol-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cobol-iir-compiler"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
-description = "COBOL-60 frontend for the LANG VM AOT chain — lowers a parsed COBOL program into interpreter_ir::IIRModule so it runs on every execution backend. v0.6.0: DISPLAY / MOVE / STOP RUN, integer + scaled-decimal (PIC …V…) ADD/SUBTRACT/MULTIPLY/DIVIDE with ROUNDED and ON SIZE ERROR, numeric item-to-item MOVE reshaping, IF/ELSE with relational conditions, GO TO and PERFORM (paragraph / TIMES / UNTIL / VARYING / THRU), COMPUTE with operator precedence, and signed numerics (PIC S9…, trailing overpunch DISPLAY) — over scaled-i64 slots, byte-identical to the cobol-runtime oracle. Group items and alphanumeric comparison remain later rungs. See PL09-codegen.md."
+description = "COBOL-60 frontend for the LANG VM AOT chain — lowers a parsed COBOL program into interpreter_ir::IIRModule so it runs on every execution backend. v0.7.0: DISPLAY / MOVE / STOP RUN, integer + scaled-decimal (PIC …V…) ADD/SUBTRACT/MULTIPLY/DIVIDE with ROUNDED and ON SIZE ERROR, numeric and character item-to-item MOVE reshaping, IF/ELSE with numeric and alphanumeric (space-padded) conditions, GO TO and PERFORM (paragraph / TIMES / UNTIL / VARYING / THRU), COMPUTE with operator precedence, and signed numerics (PIC S9…, trailing overpunch DISPLAY) — over scaled-i64 slots and str slots, byte-identical to the cobol-runtime oracle. Group items and cross-category MOVE remain later rungs. See PL09-codegen.md."
 
 [dependencies]
 coding-adventures-cobol-parser  = { path = "../cobol-parser" }

--- a/code/packages/rust/cobol-iir-compiler/README.md
+++ b/code/packages/rust/cobol-iir-compiler/README.md
@@ -34,10 +34,11 @@ integer `123`); an **alphanumeric** item (`PIC X`/`A`) is a `str`.
 | COBOL | IIR |
 | --- | --- |
 | `VALUE <lit>` / `MOVE <lit> TO item` | the register's `const`/`str_const` — the literal formatted into the item's picture at compile time |
+| `MOVE item TO item` | numeric→numeric rescales the implied point; character→character reshapes to the receiver's size (`str_slice` to truncate, `str_concat` to space-pad) |
 | `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE … [GIVING r] [ROUNDED] [ON SIZE ERROR …]` | `add`/`sub`/`mul`/`div` on the `i64` slots, the result reduced to the receiver's field; a size error runs the handler and leaves the receiver unchanged |
 | `COMPUTE r [ROUNDED] = expr [ON SIZE ERROR …]` | the precedence cascade evaluated bottom-up over scaled `i64`, each step overflow-guarded |
 | `DISPLAY op…` | each operand's image emitted, then `putchar('\n')` — a literal prints its source text, a numeric item via the fixed-width digit helper (signed items via a trailing-overpunch helper), an alphanumeric via `print_str` |
-| `IF cond then… [ELSE else…]` | `cmp_*` on the aligned operands → `jmp_if_false` over the then-branch; `NOT` inverts the relation |
+| `IF cond then… [ELSE else…]` | numeric conditions align operands and `cmp_*`; alphanumeric conditions space-pad both sides and `str_cmp`; `jmp_if_false` over the then-branch; `NOT` inverts the relation |
 | `GO TO para` | `jmp para_<name>` |
 | `PERFORM para [THRU q] [n TIMES \| UNTIL c \| VARYING v FROM a BY b UNTIL c]` | the paragraph range **inlined** at the call site (out-of-line-but-returns semantics), with loop control emitted around it |
 | `STOP RUN` | `ret 0` |
@@ -81,10 +82,17 @@ paragraph range at the call site, which reproduces COBOL's return semantics
 exactly (a `STOP RUN` inside returns, a `GO TO` inside jumps away), bounded by
 depth and instruction-count caps against a recursive `PERFORM`.
 
+Character handling is fixed-length string work: a character item's slot always
+holds exactly its declared width, so an item-to-item `MOVE` and an alphanumeric
+comparison both reduce to a single compile-time-sized `str_slice`/`str_concat`
+(reshape) or a space-pad plus `str_cmp` (compare), with `SPACE`/`ZERO`
+figuratives expanded to the partner operand's length.
+
 ### Deliberately a later rung
 
 Each of these is a clean `CompileError::Unsupported` (never wrong output): group
-items, alphanumeric item `MOVE` and alphanumeric comparison, `COMPUTE` division
+items, cross-category item `MOVE` (`numeric↔alphanumeric`, which needs runtime
+int↔string conversion), a numeric-vs-alphanumeric comparison, `COMPUTE` division
 nested inside a larger expression, and `COMPUTE` exponentiation (`**`).
 
 ## Usage

--- a/code/packages/rust/cobol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/cobol-iir-compiler/src/lib.rs
@@ -436,23 +436,32 @@ impl<'a> Compiler<'a> {
         for dst in dsts {
             match &src {
                 Operandy::Literal(lit) => self.move_literal_into(lit, &dst)?,
-                // Item-to-item MOVE: only numeric→numeric on this rung (the
-                // receiver picture reshapes the source's value). Alphanumerics
-                // (runtime string reshaping) are a later rung.
+                // Item-to-item MOVE reshapes the source into the receiver's
+                // picture: numeric→numeric rescales the implied point; a
+                // character move truncates or space-pads to the receiver's size.
+                // Cross-category (numeric↔alphanumeric) moves are a later rung.
                 Operandy::Name(name) => {
-                    let src_idx = self.numeric_index(name)?;
-                    let (_, src_scale) = self.numeric_dims(src_idx);
-                    let src_reg = self.items[src_idx].reg.clone();
+                    let src_idx = self.item_index(&name)?;
                     let didx = self.item_index(&dst)?;
-                    if !matches!(self.items[didx].kind, ItemKind::Numeric { .. }) {
-                        return Err(CompileError::Unsupported(format!(
-                            "MOVE from {name} into non-numeric {dst} is a later rung"
-                        )));
+                    match (&self.items[src_idx].kind, &self.items[didx].kind) {
+                        (ItemKind::Numeric { .. }, ItemKind::Numeric { .. }) => {
+                            // Re-validate widths and rescale (truncating, never
+                            // rounding) the source into the receiver's decimals.
+                            self.numeric_index(&name)?;
+                            let (src_int, src_scale) = self.numeric_dims(src_idx);
+                            let src_reg = self.items[src_idx].reg.clone();
+                            self.store_scaled(&dst, &src_reg, src_scale, src_int, false)?;
+                        }
+                        (ItemKind::Char { .. }, ItemKind::Char { .. }) => {
+                            self.move_char_item(src_idx, didx);
+                        }
+                        _ => {
+                            return Err(CompileError::Unsupported(format!(
+                                "cross-category MOVE from {name} into {dst} \
+                                 (numeric↔alphanumeric) is a later rung"
+                            )));
+                        }
                     }
-                    // MOVE truncates (never rounds) when the receiver has fewer
-                    // decimals than the source.
-                    let (src_int, _) = self.numeric_dims(src_idx);
-                    self.store_scaled(&dst, &src_reg, src_scale, src_int, false)?;
                 }
             }
         }
@@ -487,6 +496,48 @@ impl<'a> Compiler<'a> {
             }
         }
         Ok(())
+    }
+
+    /// `MOVE src-item TO recv-item` for two **character** items — reshape the
+    /// source's stored image into the receiver's picture, exactly as the oracle's
+    /// `move_into_char` does: the source is always its declared `m` characters, so
+    /// a receiver of `n` characters keeps the leftmost `n` (truncating on the
+    /// right) when `n ≤ m`, or left-justifies and space-pads on the right when
+    /// `n > m`. Both sizes are known at compile time, so the reshape is a single
+    /// fixed `str_slice` or `str_concat`.
+    fn move_char_item(&mut self, src_idx: usize, didx: usize) {
+        let m = self.items[src_idx].width();
+        let n = self.items[didx].width();
+        let src_reg = self.items[src_idx].reg.clone();
+        let recv_reg = self.items[didx].reg.clone();
+        if n <= m {
+            let start = self.fresh("_s0");
+            self.emit("const", Some(&start), vec![Operand::Int(0)], "i64");
+            let end = self.fresh("_sn");
+            self.emit("const", Some(&end), vec![Operand::Int(n as i64)], "i64");
+            self.emit(
+                "str_slice",
+                Some(&recv_reg),
+                vec![Operand::Var(src_reg), Operand::Var(start), Operand::Var(end)],
+                "str",
+            );
+        } else {
+            let pad = self.spaces_const(n - m);
+            self.emit(
+                "str_concat",
+                Some(&recv_reg),
+                vec![Operand::Var(src_reg), Operand::Var(pad)],
+                "str",
+            );
+        }
+    }
+
+    /// A `str` register holding `k` spaces — the right-padding for a character
+    /// reshape or comparison.
+    fn spaces_const(&mut self, k: usize) -> String {
+        let reg = self.fresh("_sp");
+        self.emit("str_const", Some(&reg), vec![Operand::Str(" ".repeat(k))], "str");
+        reg
     }
 
     /// `STOP RUN` → `ret 0`.
@@ -549,20 +600,46 @@ impl<'a> Compiler<'a> {
     }
 
     /// Evaluate a `condition` (`operand relop operand`) to a boolean `i64`
-    /// register (1 = true). Numeric comparison only: operands align to a common
-    /// scale, then `cmp_gt`/`cmp_lt`/`cmp_eq` per the relation; `NOT` inverts.
-    /// Alphanumeric comparison (space-padded strings) is a later rung.
+    /// register (1 = true). A **numeric** comparison aligns the operands to a
+    /// common scale and applies `cmp_gt`/`cmp_lt`/`cmp_eq` (`NOT` inverts the
+    /// relation); an **alphanumeric** comparison space-pads both sides to a common
+    /// length and applies `str_cmp` (COBOL's rule). A numeric operand compared
+    /// with an alphanumeric one is a later rung.
     fn emit_condition(&mut self, cond: &GrammarASTNode) -> Result<String, CompileError> {
         let operands = child_nodes(cond, "operand");
         if operands.len() != 2 {
             return Err(CompileError::Malformed("condition must be operand relop operand".into()));
         }
-        let left = self.read_arith_term(operands[0])?;
-        let right = self.read_arith_term(operands[1])?;
-        let w = self.term_scale(&left).max(self.term_scale(&right));
-        let a = self.emit_term_at_scale(&left, w);
-        let b = self.emit_term_at_scale(&right, w);
+        let op = self.relation_op(cond)?;
 
+        // Classify each operand: `None` = numeric (literal / numeric item / a
+        // numeric figurative), `Some` = a character value.
+        let ls = self.str_operand(operands[0])?;
+        let rs = self.str_operand(operands[1])?;
+        match (ls, rs) {
+            (None, None) => {
+                let left = self.read_arith_term(operands[0])?;
+                let right = self.read_arith_term(operands[1])?;
+                let w = self.term_scale(&left).max(self.term_scale(&right));
+                let a = self.emit_term_at_scale(&left, w);
+                let b = self.emit_term_at_scale(&right, w);
+                let cond_reg = self.fresh("_cond");
+                self.emit(op, Some(&cond_reg), vec![a, b], "i64");
+                Ok(cond_reg)
+            }
+            (Some(a), Some(b)) => self.emit_str_condition(a, b, op),
+            _ => Err(CompileError::Unsupported(
+                "comparing a numeric operand with an alphanumeric one is a later rung".into(),
+            )),
+        }
+    }
+
+    /// Parse a `relop` node to the `cmp_*` op the relation lowers to. `NOT`
+    /// inverts the *relation* directly (`GREATER` → `cmp_le`, …), so the op still
+    /// yields one boolean — the `cmp_*`/`str_cmp`-vs-0 result `jmp_if_false`
+    /// consumes; inverting the boolean itself with `cmp_eq … 0` would be a type
+    /// mismatch (see [`Self::emit_condition`]).
+    fn relation_op(&self, cond: &GrammarASTNode) -> Result<&'static str, CompileError> {
         let relop = child_node(cond, "relop")
             .ok_or_else(|| CompileError::Malformed("condition without a relational operator".into()))?;
         let toks = child_tokens(relop);
@@ -576,22 +653,106 @@ impl<'a> Compiler<'a> {
                 _ => None,
             })
             .ok_or_else(|| CompileError::Malformed("unrecognised relational operator".into()))?;
-
-        // `NOT` inverts the *relation* directly, so the comparison op still yields
-        // a single boolean (the cmp_* ops return `Value::Bool`, which
-        // `jmp_if_false` consumes — inverting the boolean itself with an integer
-        // `cmp_eq … 0` would be a type mismatch).
-        let op = match (base, negated) {
+        Ok(match (base, negated) {
             ("GREATER", false) => "cmp_gt",
             ("GREATER", true) => "cmp_le",
             ("LESS", false) => "cmp_lt",
             ("LESS", true) => "cmp_ge",
             ("EQUAL", false) => "cmp_eq",
             _ => "cmp_ne", // ("EQUAL", true)
+        })
+    }
+
+    /// Read a `condition` operand for an **alphanumeric** comparison. Returns
+    /// `None` for a numeric operand (a numeric literal or numeric item — those
+    /// take the numeric path). A character item or string literal is a
+    /// fixed-length string; `SPACE`/`ZERO` figuratives become fills whose length
+    /// is resolved from the other operand (COBOL's rule).
+    fn str_operand(&mut self, op: &GrammarASTNode) -> Result<Option<StrOperand>, CompileError> {
+        match read_operand(op)? {
+            Operandy::Name(name) => {
+                let idx = self.item_index(&name)?;
+                match &self.items[idx].kind {
+                    ItemKind::Char { .. } => {
+                        let len = self.items[idx].width();
+                        Ok(Some(StrOperand::Fixed { reg: self.items[idx].reg.clone(), len }))
+                    }
+                    ItemKind::Numeric { .. } => Ok(None),
+                }
+            }
+            Operandy::Literal(Src::Str(s)) => {
+                let len = s.len();
+                let reg = self.fresh("_sl");
+                self.emit("str_const", Some(&reg), vec![Operand::Str(s)], "str");
+                Ok(Some(StrOperand::Fixed { reg, len }))
+            }
+            Operandy::Literal(Src::Space) => Ok(Some(StrOperand::Fig(' '))),
+            // `ZERO` is numeric against a numeric operand but the digit `'0'`
+            // against an alphanumeric one; carry it as a figurative and let the
+            // pairing in `emit_condition` decide.
+            Operandy::Literal(Src::Zero) => Ok(Some(StrOperand::Fig('0'))),
+            Operandy::Literal(Src::Num(_)) => Ok(None),
+        }
+    }
+
+    /// Emit an alphanumeric comparison: resolve any figurative to the other
+    /// operand's length, space-pad both sides to their common (max) length, then
+    /// `str_cmp` and apply the relation against zero. `str_cmp` returns an `i64`
+    /// ordering (−1/0/1), so `cmp_* … 0` is an integer comparison (no `Bool`
+    /// mismatch). Two figuratives with no fixed length to borrow is a later rung.
+    fn emit_str_condition(
+        &mut self,
+        a: StrOperand,
+        b: StrOperand,
+        op: &str,
+    ) -> Result<String, CompileError> {
+        let ((a_reg, a_len), (b_reg, b_len)) = match (a, b) {
+            (StrOperand::Fixed { reg: ar, len: al }, StrOperand::Fixed { reg: br, len: bl }) => {
+                ((ar, al), (br, bl))
+            }
+            (StrOperand::Fixed { reg: ar, len: al }, StrOperand::Fig(c)) => {
+                ((ar, al), (self.fig_const(c, al), al))
+            }
+            (StrOperand::Fig(c), StrOperand::Fixed { reg: br, len: bl }) => {
+                ((self.fig_const(c, bl), bl), (br, bl))
+            }
+            (StrOperand::Fig(_), StrOperand::Fig(_)) => {
+                return Err(CompileError::Unsupported(
+                    "comparing two figurative constants is a later rung".into(),
+                ));
+            }
         };
+        let width = a_len.max(b_len);
+        let ap = self.pad_spaces(a_reg, a_len, width);
+        let bp = self.pad_spaces(b_reg, b_len, width);
+        let cmp = self.fresh("_scmp");
+        self.emit("str_cmp", Some(&cmp), vec![Operand::Var(ap), Operand::Var(bp)], "i64");
+        let zero = self.fresh("_z");
+        self.emit("const", Some(&zero), vec![Operand::Int(0)], "i64");
         let cond_reg = self.fresh("_cond");
-        self.emit(op, Some(&cond_reg), vec![a, b], "i64");
+        self.emit(op, Some(&cond_reg), vec![Operand::Var(cmp), Operand::Var(zero)], "i64");
         Ok(cond_reg)
+    }
+
+    /// A `str` register holding character `c` repeated `len` times — a figurative
+    /// constant expanded to the length its comparison partner requires.
+    fn fig_const(&mut self, c: char, len: usize) -> String {
+        let reg = self.fresh("_fig");
+        self.emit("str_const", Some(&reg), vec![Operand::Str(c.to_string().repeat(len))], "str");
+        reg
+    }
+
+    /// Right-pad `reg` (currently `len` characters) with spaces to `width`,
+    /// returning the register to compare. When already at `width`, `reg` is used
+    /// as-is.
+    fn pad_spaces(&mut self, reg: String, len: usize, width: usize) -> String {
+        if len >= width {
+            return reg;
+        }
+        let pad = self.spaces_const(width - len);
+        let out = self.fresh("_pad");
+        self.emit("str_concat", Some(&out), vec![Operand::Var(reg), Operand::Var(pad)], "str");
+        out
     }
 
     // -----------------------------------------------------------------------
@@ -1926,6 +2087,14 @@ enum Term {
     Item(usize),
 }
 
+/// An operand of an **alphanumeric** comparison: either a known-length string
+/// (a character item's slot or a string-literal `str_const`) or a figurative
+/// constant whose length is resolved from the operand it is compared against.
+enum StrOperand {
+    Fixed { reg: String, len: usize },
+    Fig(char),
+}
+
 /// A parsed `COMPUTE` arithmetic expression — the grammar's precedence cascade
 /// (`arith_expr` → `arith_term` → `arith_factor` → `arith_unary` →
 /// `arith_primary`) folded into a tree, mirroring the oracle's `Expr`. Leaves
@@ -2228,11 +2397,33 @@ mod tests {
     }
 
     #[test]
-    fn alphanumeric_comparison_is_deferred() {
-        // Comparing a character field is a later rung (space-padded string compare).
-        let err = compile_source(
-            &wrap(&["01  W  PIC X(4) VALUE \"AB\"."], &["IF W EQUAL \"AB\" DISPLAY \"M\".", "STOP RUN."]),
+    fn alphanumeric_comparison_and_move_now_compile() {
+        // Space-padded character comparison and character item-to-item MOVE both
+        // lower now (str_cmp / str_slice / str_concat), and validate.
+        let m = compile_source(
+            &wrap(
+                &["01  W  PIC X(4) VALUE \"AB\".", "01  V  PIC X(2)."],
+                &["MOVE W TO V.", "IF W EQUAL \"AB\" DISPLAY \"M\".", "STOP RUN."],
+            ),
             "a",
+        )
+        .unwrap();
+        assert!(m.validate().is_empty(), "{:?}", m.validate());
+        let os = ops(&m);
+        assert!(os.contains(&"str_slice".to_string()), "char MOVE truncates via str_slice");
+        assert!(os.contains(&"str_cmp".to_string()), "alphanumeric IF compares via str_cmp");
+    }
+
+    #[test]
+    fn cross_category_move_is_deferred() {
+        // A numeric→alphanumeric (or reverse) item MOVE needs runtime int↔string
+        // conversion — a clean later rung, never wrong output.
+        let err = compile_source(
+            &wrap(
+                &["01  N  PIC 9(3) VALUE 42.", "01  W  PIC X(4)."],
+                &["MOVE N TO W.", "STOP RUN."],
+            ),
+            "x",
         )
         .unwrap_err();
         assert!(matches!(err, CompileError::Unsupported(_)), "got {err:?}");

--- a/code/packages/rust/cobol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/cobol-iir-compiler/src/lib.rs
@@ -441,13 +441,13 @@ impl<'a> Compiler<'a> {
                 // character move truncates or space-pads to the receiver's size.
                 // Cross-category (numeric↔alphanumeric) moves are a later rung.
                 Operandy::Name(name) => {
-                    let src_idx = self.item_index(&name)?;
+                    let src_idx = self.item_index(name)?;
                     let didx = self.item_index(&dst)?;
                     match (&self.items[src_idx].kind, &self.items[didx].kind) {
                         (ItemKind::Numeric { .. }, ItemKind::Numeric { .. }) => {
                             // Re-validate widths and rescale (truncating, never
                             // rounding) the source into the receiver's decimals.
-                            self.numeric_index(&name)?;
+                            self.numeric_index(name)?;
                             let (src_int, src_scale) = self.numeric_dims(src_idx);
                             let src_reg = self.items[src_idx].reg.clone();
                             self.store_scaled(&dst, &src_reg, src_scale, src_int, false)?;

--- a/code/packages/rust/cobol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/cobol-iir-compiler/tests/backend_compat.rs
@@ -258,3 +258,28 @@ fn signed_program_accepted_by_print_backends() {
     let m = compile_source(&src, "signed").unwrap();
     assert_accepted_by_print_backends(&m, "signed overpunch");
 }
+
+#[test]
+fn alphanumeric_move_and_compare_accepted_by_print_backends() {
+    // Character item-to-item MOVE (str_slice / str_concat) and a space-padded
+    // alphanumeric comparison (str_cmp) — the string-op substrate every print
+    // backend must accept (BEAM excluded, as for any printing program).
+    let src = program(&[
+        "IDENTIFICATION DIVISION.",
+        "PROGRAM-ID. P.",
+        "DATA DIVISION.",
+        "WORKING-STORAGE SECTION.",
+        "01  W  PIC X(4) VALUE \"ABCD\".",
+        "01  V  PIC X(2).",
+        "01  U  PIC X(6).",
+        "PROCEDURE DIVISION.",
+        "MAIN.",
+        "    MOVE W TO V.",
+        "    MOVE W TO U.",
+        "    IF W GREATER \"AB\" DISPLAY V U \"|\".",
+        "    IF W EQUAL SPACES DISPLAY \"BLANK\".",
+        "    STOP RUN.",
+    ]);
+    let m = compile_source(&src, "alnum").unwrap();
+    assert_accepted_by_print_backends(&m, "alphanumeric move and compare");
+}

--- a/code/packages/rust/cobol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/cobol-iir-compiler/tests/jit_e2e.rs
@@ -913,3 +913,99 @@ fn signed_scaled_field_overpunches_the_last_fractional_digit() {
     ));
     assert_eq!(out, "1N\n");
 }
+
+// -------------------------------------------------------------------------
+// Alphanumeric item-to-item MOVE + comparison — vs the oracle.
+// -------------------------------------------------------------------------
+
+#[test]
+fn char_item_move_truncates_on_the_right() {
+    // W is "ABCD" (X(4)); moved into V PIC X(2) keeps the leftmost two → "AB".
+    let out = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(4) VALUE \"ABCD\".", "01  V  PIC X(2)."],
+        &["MOVE W TO V.", "DISPLAY V.", "STOP RUN."],
+    ));
+    assert_eq!(out, "AB\n");
+}
+
+#[test]
+fn char_item_move_space_pads_on_the_right() {
+    // W is "AB" (X(2)); moved into V PIC X(5) left-justifies and space-pads → "AB   ".
+    let out = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(2) VALUE \"AB\".", "01  V  PIC X(5)."],
+        &["MOVE W TO V.", "DISPLAY V \"|\".", "STOP RUN."],
+    ));
+    assert_eq!(out, "AB   |\n");
+}
+
+#[test]
+fn char_item_move_same_size_copies() {
+    // Equal sizes: a straight copy of the stored image.
+    let out = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(3) VALUE \"XyZ\".", "01  V  PIC X(3)."],
+        &["MOVE W TO V.", "DISPLAY V.", "STOP RUN."],
+    ));
+    assert_eq!(out, "XyZ\n");
+}
+
+#[test]
+fn alphanumeric_equal_and_not_equal() {
+    // Item vs literal, equal (both "AB  " once padded to width 4 vs "AB" padded).
+    let eq = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(4) VALUE \"AB\"."],
+        &["IF W EQUAL \"AB\" DISPLAY \"YES\" ELSE DISPLAY \"NO\".", "STOP RUN."],
+    ));
+    assert_eq!(eq, "YES\n");
+    // Different content → not equal.
+    let ne = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(4) VALUE \"ABCD\"."],
+        &["IF W NOT EQUAL \"AB\" DISPLAY \"DIFF\".", "STOP RUN."],
+    ));
+    assert_eq!(ne, "DIFF\n");
+}
+
+#[test]
+fn alphanumeric_ordering_is_lexicographic() {
+    // "APPLE" > "APPLY"? No — 'E'(0x45) < 'Y'(0x59), so APPLE < APPLY.
+    let out = assert_matches_oracle(&wrap(
+        &["01  A  PIC X(5) VALUE \"APPLE\".", "01  B  PIC X(5) VALUE \"APPLY\"."],
+        &["IF A LESS B DISPLAY \"A<B\" ELSE DISPLAY \"A>=B\".", "STOP RUN."],
+    ));
+    assert_eq!(out, "A<B\n");
+}
+
+#[test]
+fn alphanumeric_shorter_literal_space_pads_for_compare() {
+    // "AB" (item, X(4) → "AB  ") vs "AB  " literal: padded equal length, equal.
+    // And "AB" item vs "ABX" literal: item pads to "AB " (width 3) < "ABX".
+    let out = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(2) VALUE \"AB\"."],
+        &["IF W LESS \"ABX\" DISPLAY \"LT\".", "STOP RUN."],
+    ));
+    assert_eq!(out, "LT\n");
+}
+
+#[test]
+fn alphanumeric_compare_against_spaces_figurative() {
+    // A blank field equals SPACES; a non-blank one does not.
+    let blank = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(3)."],
+        &["IF W EQUAL SPACES DISPLAY \"BLANK\".", "STOP RUN."],
+    ));
+    assert_eq!(blank, "BLANK\n");
+    let filled = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(3) VALUE \"HI\"."],
+        &["IF W NOT EQUAL SPACES DISPLAY \"FILLED\".", "STOP RUN."],
+    ));
+    assert_eq!(filled, "FILLED\n");
+}
+
+#[test]
+fn char_move_then_compare_round_trips() {
+    // Prove the moved value round-trips through the str slot and compares equal.
+    let out = assert_matches_oracle(&wrap(
+        &["01  W  PIC X(4) VALUE \"WXYZ\".", "01  V  PIC X(4)."],
+        &["MOVE W TO V.", "IF V EQUAL W DISPLAY \"SAME\".", "STOP RUN."],
+    ));
+    assert_eq!(out, "SAME\n");
+}

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -3042,6 +3042,27 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("0K"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // COBOL-60 — character item MOVE + alphanumeric comparison (PL09 step 4).
+    // W = "ABCD" moved into V PIC X(2) truncates to "AB" (str_slice); the
+    // space-padded compare `W GREATER "AB"` is true → prints "AB". Proves the
+    // str_slice / str_cmp substrate lowers on every backend that runs strings.
+    Prog {
+        lang: Language::Cobol60,
+        ext: "cob",
+        src: "000000 IDENTIFICATION DIVISION.\n\
+               000000 PROGRAM-ID. P.\n\
+               000000 DATA DIVISION.\n\
+               000000 WORKING-STORAGE SECTION.\n\
+               000000 01  W  PIC X(4) VALUE \"ABCD\".\n\
+               000000 01  V  PIC X(2).\n\
+               000000 PROCEDURE DIVISION.\n\
+               000000 MAIN.\n\
+               000000     MOVE W TO V.\n\
+               000000     IF W GREATER \"AB\" DISPLAY V.\n\
+               000000     STOP RUN.",
+        expect: Expect::Stdout("AB"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
 ];
 
 /// Is a usable native linker present on this host? On Linux/macOS the AOT path uses


### PR DESCRIPTION
Lowers the two most commonly-hit character-handling "later rung" errors in the COBOL-60 → IIR compiler, each **byte-identical to the `cobol-runtime` oracle** (verified via `jit_e2e.rs`: compile → run on the generic JIT → compare `DISPLAY` bytes). Both reduce to **fixed-length** string ops, because a character item's stored image is always exactly its declared width and all item sizes are known at compile time.

## What's new

- **Character item-to-item `MOVE`** reshapes the source into the receiver's picture exactly as the oracle's `move_into_char`: keep the leftmost `N` characters when `N ≤ M` (one `str_slice`), else left-justify and space-pad on the right (one `str_concat`). Cross-category (`numeric↔alphanumeric`) moves stay a clean `Unsupported` — they'd need runtime int↔string conversion.
- **Alphanumeric comparison in `IF`** — `emit_condition` now classifies each operand (numeric vs character) and dispatches. A character comparison space-pads both sides to their common (max) length and applies `str_cmp` (byte-lexical, matching the oracle's space-padded `String` compare); `SPACE`/`ZERO` figuratives expand to the partner operand's length. `str_cmp` returns an `i64` ordering (−1/0/1), so the relation is applied with `cmp_* … 0` (no `Bool` mismatch — cf. the earlier IF lesson). The relation→`cmp_*` mapping is shared with the numeric path via `relation_op`.

Still deferred (clean errors, never wrong output): group items, cross-category `MOVE`, a numeric-vs-alphanumeric comparison, two-figurative comparison, and the `COMPUTE` corners (nested division, `**`).

## Coverage

- **+8 `jit_e2e`** cases (MOVE truncate / space-pad / same-size; equal / not-equal; lexicographic ordering; shorter-literal padding; `SPACES` figurative; move-then-compare round-trip) — all byte-identical to the oracle.
- **+1 `backend_compat`** (wasm/jvm/clr accept the `str_slice` / `str_concat` / `str_cmp` shapes; BEAM excluded as for every print program).
- **+1 `lang_matrix`** COBOL row (char MOVE truncate + alphanumeric compare → `AB`).
- Cargo → **0.7.0**; CHANGELOG + README updated.

## Testing & safety

Full crate suite **103 green** (20 unit + 11 `backend_compat` + 72 `jit_e2e`). A security review over the whole diff passed: every `usize` subtraction (`n - m`, `width - len`) is guarded by its preceding size comparison, every emitted `str_slice` range stays within the source slot's guaranteed width, and all `str`-repeat allocations are bounded by the picture-size cap (`MAX_PICTURE_SIZE = 65 535`, checked upstream in `cobol-runtime`). No panic, overflow, or unbounded-allocation vector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)