### PR TITLE
feat(sir-js): tagged-float substrate (dormant) — Ruby Integer vs Float groundwork

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.38.0 — tagged-float substrate (dormant): Ruby `Integer` vs `Float`
+
+Groundwork for faithful `Float` semantics on the JS backend. JavaScript has one
+number type (`f64`), so Ruby `Integer` `7` and `Float` `7.0` are the same value
+— which is why `7.0 / 2` still floors to `3` (should be `3.5`) and `puts 7.0`
+prints `7`. The Rust/Go/C backends carry a tagged `Int`/`Float` runtime value;
+this release adds the JS analogue, **dormant** (nothing emits it yet — no
+behavior change; the atomic flip that wires it lands next).
+
+Added to the runtime (all exported on `__Sir`):
+- `SirFloat` — a frozen box wrapping an integral float value.
+- `mkFloat(v)` — the SOLE float factory. Non-integral floats stay native
+  `number` (already distinguishable); integral floats box, **interned** so
+  equal values share one identity (a boxed `7.0` dedups in `Map`/`Set` by
+  Ruby `eql?`, while Integer `7` stays a distinct key). The intern cache is
+  hard-capped (`FLOAT_INTERN_CAP = 4096`) — past the cap `mkFloat` returns
+  fresh un-interned boxes, so memory is bounded (no unbounded-growth DoS).
+- `numOf` (unwrap to raw f64), `isNum`, `isFloat`, `neg`/`minus`/`mod`
+  (re-tagging arithmetic), and `floatToRubyString` (restores the trailing
+  `.0`, incl. `-0.0` and exponent form `1e21` → `1.0e+21`, matching Rust/Go).
+
+Also: `valEq` gains a numeric arm so Ruby `==` is by value across the
+Integer/Float split (`[7.0].include?(7)` is `true`) while hash keys keep
+`eql?` identity semantics.
+
+Invariant established: Ruby Integer ⟺ integral native `number`; Ruby Float ⟺
+non-integral native `number` OR an interned `SirFloat` holding an integral
+value. Non-integral floats stay native, so the entire existing corpus is
+byte-unchanged. Guarded by a dormant-helper node exec-proof
+(`tests/run_with_node.rs::tagged_float_helpers_behave`) and runtime export
+assertions.
+
+
 ## 0.37.0 — Ruby `Integer#/` floors toward −∞ (SIR21 §E3)
 
 The runtime `divide` returned a bare `a / b` — JavaScript float division — so

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -98,10 +98,86 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return c.fn(...args);
   }
 
+  // ── tagged floats (Ruby Integer vs Float) ──────────────────────
+  //
+  // JavaScript has ONE number type (`f64`), so Ruby's `Integer` `7` and
+  // `Float` `7.0` are the same JS value — and Ruby distinguishes them
+  // everywhere: `7 / 2 == 3` (Integer#/ floors) but `7.0 / 2 == 3.5`
+  // (Float#/ true-divides); `puts 7.0` prints `7.0`, not `7`.  The
+  // Rust/Go/C backends carry a tagged `Int`/`Float` runtime value; we do
+  // the same, but only where JS can't already tell the two apart.
+  //
+  //   INVARIANT.  A Ruby Integer is an INTEGRAL native `number`.  A Ruby
+  //   Float is EITHER a non-integral native `number` (`3.5` — already
+  //   distinguishable, so left native) OR a `SirFloat` box wrapping an
+  //   integral value (`7.0` — otherwise indistinguishable from `7`).
+  //
+  // Only integral-valued floats are boxed, so the whole non-integral
+  // corpus stays native and untouched.  `mkFloat` is the SOLE factory;
+  // everything numeric unwraps through `numOf` and re-tags through
+  // `mkFloat`, so the box never escapes to native arithmetic by accident.
+  class SirFloat {
+    constructor(f) { this.f = f; Object.freeze(this); }
+  }
+  // Interning gives equal integral floats a single identity, so a boxed
+  // `7.0` used as a `Map` key or `Set` member (`tally`, `group_by`,
+  // `uniq`, a Hash literal) dedups by identity exactly like Ruby's `eql?`
+  // — while native Integer `7` stays a DISTINCT key (`7.eql?(7.0)` is
+  // false).  The cache is hard-capped: past the cap `mkFloat` returns
+  // fresh un-interned boxes, so memory is bounded (no unbounded-growth
+  // DoS) at the cost of losing dedup for programs with more than
+  // `FLOAT_INTERN_CAP` distinct integral-float keys — bounded and rare.
+  const FLOAT_INTERN_CAP = 4096;
+  const floatIntern = new Map();
+  function mkFloat(v) {
+    if (!Number.isInteger(v)) { return v; } // non-integral float: stays native
+    const hit = floatIntern.get(v);
+    if (hit !== undefined) { return hit; }
+    const box = new SirFloat(v);
+    if (floatIntern.size < FLOAT_INTERN_CAP) { floatIntern.set(v, box); }
+    return box;
+  }
+  // `numOf` unwraps to the raw f64 for arithmetic/comparison; `isNum`
+  // recognises "a number" at type gates; `isFloat` recognises "a Ruby
+  // Float" (boxed integral OR non-integral native).
+  function numOf(x) { return x instanceof SirFloat ? x.f : x; }
+  function isNum(x) { return typeof x === "number" || x instanceof SirFloat; }
+  function isFloat(x) {
+    return x instanceof SirFloat || (typeof x === "number" && !Number.isInteger(x));
+  }
+  // Arithmetic re-tags: the result is a Float iff an operand is a Float
+  // (or the op forces float, e.g. Float#/).  `mkFloat` then leaves a
+  // non-integral result native and boxes an integral one (`3.5 + 3.5`
+  // → boxed `7.0`; `7.0 - 0.5` → native `6.5`).
+  function neg(x) { return isFloat(x) ? mkFloat(-numOf(x)) : -numOf(x); }
+  function minus(a, b) {
+    const r = numOf(a) - numOf(b);
+    return (isFloat(a) || isFloat(b)) ? mkFloat(r) : r;
+  }
+  function mod(a, b) {
+    const r = numOf(a) % numOf(b);
+    return (isFloat(a) || isFloat(b)) ? mkFloat(r) : r;
+  }
+  // Render a boxed float the way Ruby's `to_s` does.  A box only ever
+  // holds a FINITE INTEGRAL value (non-finite/non-integral never box), so
+  // the job is to restore the trailing `.0` that `String(7)` drops:
+  //   7.0        → "7.0"          (append ".0")
+  //   -0.0       → "-0.0"         (String(-0) loses the sign — special-case)
+  //   1e21       → "1.0e+21"      (insert ".0" BEFORE the exponent)
+  // matching the Rust/Go backends ("shortest decimal, `.0` when integral").
+  function floatToRubyString(f) {
+    if (Object.is(f, -0)) { return "-0.0"; }
+    const s = f.toString();
+    const e = s.search(/[eE]/);
+    if (e >= 0) { return s.slice(0, e) + ".0" + s.slice(e); }
+    return s + ".0";
+  }
+
   // ── truthiness ─────────────────────────────────────────────────
   // SIR truthiness, NOT JavaScript's: only `false` and `nil` (null)
   // are falsy.  `0`, `""`, and `NaN` are all truthy — matching Lisp /
-  // Ruby semantics rather than JS's surprising coercions.
+  // Ruby semantics rather than JS's surprising coercions.  A `SirFloat`
+  // box is an object, so it is truthy — matching Ruby (all numbers are).
   function truthy(v) {
     return v !== false && v !== null && v !== undefined;
   }
@@ -1355,6 +1431,13 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // the display path (`formatSeen`) carries for the same cyclic values.
   function valEq(a, b, seen) {
     if (a === b) { return true; }
+    // Ruby `==` on numbers is by VALUE across Integer/Float: `7.0 == 7` is
+    // true, so `[7.0].include?(7)`. Compare unwrapped payloads (a boxed
+    // `7.0` and native `7` are `===`-distinct objects/values but `==`
+    // equal). NaN stays `== NaN` false, matching Ruby. Hash keys use `eql?`
+    // (identity here), NOT this, so Integer `7` and Float `7.0` remain
+    // distinct KEYS while being `==` equal — exactly Ruby's split.
+    if (isNum(a) && isNum(b)) { return numOf(a) === numOf(b); }
     if (a instanceof Sym && b instanceof Sym) { return a.name === b.name; }
     if (Array.isArray(a) && Array.isArray(b)) {
       if (a.length !== b.length) { return false; }
@@ -3171,6 +3254,10 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     Sym, Pair, Closure,
     intern, applyClosure, truthy, format, print, puts,
     plus, times, divide,
+    // Tagged floats (Ruby Integer vs Float). Exported so the emitter can
+    // mint a boxed float at a `FloatLit` and route `-`/`%`/`neg` through
+    // the re-tagging helpers. `mkFloat` is the sole factory.
+    SirFloat, mkFloat, numOf, isNum, isFloat, neg, minus, mod, floatToRubyString,
     builtins, builtinClosure, callBuiltin, callMethod,
     SirError, raiseError, rescueMatches, registerAncestry,
     // OOP (O3): instantiation, method definition + dispatch, super,
@@ -3249,6 +3336,14 @@ mod tests {
             "includeModule",
             "extendModule",
             "callClassMethod",
+            // Tagged floats (Ruby Integer vs Float): the boxed-float
+            // factory + tag helpers the emitter mints/routes through.
+            "class SirFloat",
+            "mkFloat",
+            "numOf",
+            "isNum",
+            "isFloat",
+            "floatToRubyString",
         ] {
             assert!(RUNTIME.contains(needed), "runtime missing `{needed}`");
         }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -200,6 +200,66 @@ fn floats_arithmetic_promotion_prints_3_5() {
     }
 }
 
+/// Run a raw-JS `snippet` against the embedded `__Sir` runtime.  A compiled
+/// module ends with the top-level `const __Sir = (…)();` followed by
+/// `main();`, so appending JS after it can call the runtime helpers directly
+/// — the way to exercise runtime-level behaviour (here: the dormant
+/// tagged-float helpers) without a program that reaches them yet.  Returns
+/// `None` when Node is unavailable.
+fn run_runtime_snippet(snippet: &str, tag: &str) -> Option<String> {
+    let module = module_with_main(vec![], Expr::NilLit { span: sp() }, &[]);
+    let artifact = compile(&module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping runtime snippet `{tag}`");
+        return None;
+    }
+    let program = format!("{}\n{}\n", artifact.source, snippet);
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_rt_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &program).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstderr: {}\nprogram:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        program,
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    Some(stdout.trim_end_matches(['\n', '\r']).to_string())
+}
+
+#[test]
+fn tagged_float_helpers_behave() {
+    // Exercises the dormant tagged-float substrate directly (nothing emits
+    // boxed floats yet).  Confirms the invariant before the atomic flip:
+    //   - `floatToRubyString` restores the trailing `.0` (incl. `-0.0` and
+    //     exponent form), matching Ruby / the Rust/Go backends;
+    //   - only INTEGRAL floats box (`mkFloat(3.5) === 3.5` stays native);
+    //   - equal integral floats INTERN to one identity (Map/Set dedup);
+    //   - `isFloat`/`isNum`/`numOf` classify and unwrap correctly.
+    let snippet = r#"
+const F = __Sir; const o = [];
+o.push(F.floatToRubyString(7));                 // 7.0
+o.push(F.floatToRubyString(-0));                // -0.0
+o.push(F.floatToRubyString(1e21));              // 1.0e+21
+o.push(String(F.isFloat(F.mkFloat(7))));        // true  (boxed integral float)
+o.push(String(F.isFloat(3.5)));                 // true  (non-integral native float)
+o.push(String(F.isFloat(7)));                   // false (integer)
+o.push(String(F.mkFloat(3.5) === 3.5));         // true  (non-integral stays native)
+o.push(String(F.mkFloat(7) === F.mkFloat(7)));  // true  (interned singleton)
+o.push(String(F.numOf(F.mkFloat(7))));          // 7
+o.push(String(F.isNum(F.mkFloat(7))));          // true
+console.log(o.join("|"));
+"#;
+    if let Some(stdout) = run_runtime_snippet(snippet, "tagfloat") {
+        assert_eq!(
+            stdout,
+            "7.0|-0.0|1.0e+21|true|true|false|true|true|7|true",
+        );
+    }
+}
+
 #[test]
 fn short_circuit_does_not_evaluate_rhs() {
     // (false && <print "boom">) must NOT print "boom"; the whole


### PR DESCRIPTION
## What

First of two PRs making the JavaScript backend faithfully distinguish Ruby `Integer` from `Float`. This one adds the **tagged-float substrate, dormant** — the runtime helpers exist and are exported, but nothing emits them yet, so **there is no behavior change** (all 225 JS-backend tests pass unchanged). The atomic flip that wires it lands in the follow-up PR.

## Why

JavaScript has one number type (`f64`), so Ruby `Integer` `7` and `Float` `7.0` are the same JS value. Consequences the JS backend can't currently get right:
- `7.0 / 2` floors to `3` (should be `3.5`) — the runtime falls back to `Number.isInteger` to pick floor-vs-true-divide, mis-classifying integral floats.
- `puts 7.0` prints `7`; `7.0.to_i`, `float?`, etc. can't be faithful.

The Rust/Go/C backends get this right via a tagged `Int`/`Float` runtime value. This adds the JS analogue. (No type-flow reaches the JS emitter — confirmed `Expr` has no type slot — so the distinction must be runtime-dynamic, born at `FloatLit` emission.)

## Design — "box only integral floats"

**Invariant:** Ruby `Integer` ⟺ an integral native `number`; Ruby `Float` ⟺ a non-integral native `number` (`3.5`, already distinguishable → left native) **OR** an interned `SirFloat` box holding an integral value (`7.0`). Non-integral floats stay native, so the entire existing corpus is byte-unchanged — minimal regression surface.

Added to the runtime (all exported on `__Sir`):
- **`SirFloat`** — a frozen box wrapping an integral float.
- **`mkFloat(v)`** — the sole factory. Integral floats box and are **interned** so equal values share one identity: a boxed `7.0` dedups in `Map`/`Set` by Ruby `eql?`, while Integer `7` stays a *distinct* key (`7.eql?(7.0)` is false). The intern cache is **hard-capped (4096)** — past the cap `mkFloat` returns fresh un-interned boxes, so memory is bounded (no unbounded-growth DoS).
- **`numOf`** (unwrap to raw f64), **`isNum`**, **`isFloat`**, **`neg`/`minus`/`mod`** (re-tagging arithmetic), **`floatToRubyString`** (restores the trailing `.0`, incl. `-0.0` and exponent form `1e21` → `1.0e+21`, matching Rust/Go).
- **`valEq`** gains a numeric arm so Ruby `==` is by value across the Integer/Float split (`[7.0].include?(7)` is `true`) while hash keys keep `eql?` identity.

## Verification

- New dormant-helper node exec-proof (`tests/run_with_node.rs::tagged_float_helpers_behave`) — confirms interning, `-0.0`/`1e21` display, and int-vs-float classification directly against the runtime.
- Runtime export assertions extended for the new helpers.
- Full `semantic-ir-to-javascript` suite (225 tests) passes unchanged — proving zero behavior change.
- Security-reviewed clean (bounded interning, no injection, dormant helpers unreachable from emitted code).

## Version
`semantic-ir-to-javascript` 0.37.0 → **0.38.0**

## Follow-up (next PR)
The atomic flip: `FloatLit` → `mkFloat`, and wire every consumer (display, `divide`, arithmetic re-boxing, operator routing, `numericMethod`, the `typeof === "number"` sweep) + conformance float-division cases and display exec-proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)