### PR TITLE
feat(hl): Italian & Portuguese farewells (Ch.4) — completes the 5-language greet-to-goodbye arc

### DIFF
--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Chapter 4 — Farewells
+
+- **Chapter 4 authored** (`IT-C04-arrivederci`, `-a-domani`, `-a-presto`,
+  `-a-piu-tardi`, `-practice`): closing a conversation, reviewing Chapter 2. The
+  learner can now run an Italian exchange end to end. Numbered Ch. 4 so the
+  introductions chapter can slot in at Ch. 3.
+- **The "until re-seeing" family**: *arrivederci* = *a + ri(re-) + vedere 'see'
+  + ci 'us'* → "to our seeing-again" — shown beside French *au revoir* and German
+  *auf Wiedersehen*, all the same gesture. The heavier *addio* (*a Dio*, "to
+  God") is flagged as the twin of Spanish *adiós*.
+- **"See you when" set**, each an atom traced: *a domani* (*domani* ← *dē māne*
+  "from the morning", kin of Spanish *mañana*); *a presto* (*presto* ← *praestō*
+  "at hand" → the English music/magic word); *a più tardi* (*più* ~ *plūs*/plus,
+  *tardi* ~ *tardus*/tardy).
+- Uses the canonical `FAREWELL`, `FAREWELL-TOMORROW`, `FAREWELL-SOON`,
+  `FAREWELL-LATER` concepts (shared with the Spanish/French/German farewells) —
+  no taxonomy change.
+
 ## Chapter 2 — "Come stai?" (the how-are-you chapter)
 
 - **Chapter 2 authored** (`IT-C02-prego`, `-come`, `-stare`, `-come-stai`,

--- a/code/learning/human-languages/italian/lessons/IT-C04-a-domani.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-a-domani.md
@@ -1,0 +1,52 @@
+---
+id: IT-C04-a-domani
+chapter: 4
+type: phrase
+headword: a domani
+gloss: see you tomorrow (literally "to tomorrow")
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [IT-C04-arrivederci]
+sounds: [vowel-a-open]
+roots: [de-mane-latin]
+etymology_hook: "domani ← Latin de mane 'from the morning' — same mane 'morning' as Spanish mañana"
+est_minutes: 3
+reviews_of: [IT-C04-arrivederci]
+---
+
+# a domani — "see you tomorrow"
+
+## Warm-up
+
+[PAUSE 2s] The "until re-seeing" pattern gives you a whole family of goodbyes:
+just name **when**. First: **a domani**, "to tomorrow."
+
+## Sounds you'll need
+
+- **a domani** = *ah doh-**MAH**-nee*: clean open vowels, stress the *-ma-*.
+
+## The phrase, taken apart
+
+- **a** = "to / until" (the same *a* from *arrivederci*).
+- **domani** = "tomorrow," from Latin **dē māne**, *"from the morning."*
+
+That word **māne** ("morning") is quietly shared across the Romance family, and
+you may have already met its Spanish child:
+
+- Italian **domani** ("tomorrow") ← *dē māne*.
+- Spanish **mañana** ← *(hōra) māneāna* — which means **both** "morning" *and*
+  "tomorrow," because tomorrow *is* "the coming morning."
+
+So *a domani* literally says **"until the morning [to come]."** You part by
+pointing at daybreak.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "a domani" — *ah doh-MAH-nee*]
+- [YOU SAY: Italian *domani* and Spanish *mañana* — both from *māne*, "morning"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *domani* come from, and what does it literally mean? (*Dē
+māne* — "from the morning.") Which Spanish word shares that *māne* root? (*Mañana*
+— morning *and* tomorrow.) Next: "see you soon" — **a presto**.

--- a/code/learning/human-languages/italian/lessons/IT-C04-a-piu-tardi.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-a-piu-tardi.md
@@ -1,0 +1,52 @@
+---
+id: IT-C04-a-piu-tardi
+chapter: 4
+type: phrase
+headword: a più tardi
+gloss: see you later (literally "to more late")
+concept_tag: FAREWELL-LATER
+prerequisites: [IT-C04-arrivederci]
+sounds: [piu-glide, r-tap]
+roots: [plus-latin, tardus-latin]
+etymology_hook: "più ← Latin plūs 'more'; tardi ← tardus 'slow, late' → English tardy, retard"
+est_minutes: 3
+reviews_of: [IT-C04-a-presto]
+---
+
+# a più tardi — "see you later"
+
+## Warm-up
+
+[PAUSE 2s] The last "when" in the set: **a più tardi**, "to later" — literally
+"to *more late*." Two small words, both alive in English.
+
+## Sounds you'll need
+
+- `piu-glide` — **più** = *pyoo*, one gliding syllable (the accent marks the
+  stress).
+- **a più tardi** = *ah pyoo **TAR**-dee*, tapped *r*.
+
+## The phrase, taken apart
+
+- **a** = "to / until."
+- **più** = "more," from Latin **plūs** — the very word English took for
+  **plus**, and the root of **plural**, **surplus**.
+- **tardi** = "late," from Latin **tardus**, *"slow, late"* → English **tardy**,
+  **re-tard** ("to slow down"), **tardy** slip.
+
+Together, *più tardi* = **"more late"** = "later." So *a più tardi* is "until
+[it's] more-late" — see you later on. (Italian builds "later" as *more late*,
+just as English does with the comparative *-er*.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "a più tardi" — *ah pyoo TAR-dee*]
+- [YOU SAY: "più" ~ English *plus*; "tardi" ~ English *tardy* — both borrowed]
+- [YOU SAY: the four goodbyes — arrivederci / a domani / a presto / a più tardi]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *più* and *tardi* mean, and their English cousins? (*Più* =
+"more" ~ plus; *tardi* = "late" ~ tardy.) So *a più tardi* literally says?
+("To more-late" → see you later.) Next: put the farewells together.

--- a/code/learning/human-languages/italian/lessons/IT-C04-a-presto.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-a-presto.md
@@ -1,0 +1,53 @@
+---
+id: IT-C04-a-presto
+chapter: 4
+type: phrase
+headword: a presto
+gloss: see you soon (literally "to soon")
+concept_tag: FAREWELL-SOON
+prerequisites: [IT-C04-arrivederci]
+sounds: [s-clean]
+roots: [praesto-latin]
+etymology_hook: "presto ← Latin praestō 'at hand, ready' → English presto (music: fast)"
+est_minutes: 3
+reviews_of: [IT-C04-a-domani]
+---
+
+# a presto — "see you soon"
+
+## Warm-up
+
+[PAUSE 2s] Same frame, new "when": **a presto**, "to soon." And *presto* is a
+word English already borrowed whole — from stage magic and music.
+
+## Sounds you'll need
+
+- **a presto** = *ah **PREH**-stoh*: clean *st*, crisp open *e*.
+
+## The phrase, taken apart
+
+- **a** = "to / until."
+- **presto** = "soon, quickly," from Latin **praestō**, *"at hand, ready,
+  present"* (*prae-* "before" + *stō/stāre* "stand" — literally "standing
+  before you," ready to hand).
+
+English took **presto** straight from Italian:
+
+- in **music**, *presto* means "fast."
+- in stage magic, *"presto!"* means "quick — and there it is!"
+- it shares that *stō* ("stand") root with *stare* from your how-are-you chapter,
+  and with English **station**, **stable**, **status**.
+
+So *a presto* is **"until [it is] soon / at hand"** — see you before long.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "a presto" — *ah PREH-stoh*]
+- [YOU SAY: "presto" as music ("fast") and magic ("presto!") — same word]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *presto* mean, and where has English borrowed it? ("Soon /
+quickly" — in music and magic.) What "stand" root does it share with *stare*?
+(Latin *stō/stāre*.) Next: "see you later" — **a più tardi**.

--- a/code/learning/human-languages/italian/lessons/IT-C04-arrivederci.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-arrivederci.md
@@ -1,0 +1,70 @@
+---
+id: IT-C04-arrivederci
+chapter: 4
+type: word
+headword: arrivederci
+gloss: goodbye (literally "until we see each other again")
+concept_tag: FAREWELL
+prerequisites: []
+sounds: [r-tap, soft-c]
+roots: [re-videre-latin]
+etymology_hook: "arrivederci = a + ri(re-) + vedere 'see' + ci 'us' — 'to our seeing-again', twin of au revoir / auf Wiedersehen"
+est_minutes: 4
+reviews_of: [IT-C02-practice]
+---
+
+# arrivederci — "goodbye," i.e. "until we meet again"
+
+## Warm-up
+
+[PAUSE 2s] You can open a conversation in Italian and ask how someone is. Now,
+close it. The standard goodbye is **arrivederci** — and, like its French and
+German cousins, it doesn't say "goodbye" at all. It says **"until we see each
+other again."**
+
+## Sounds you'll need
+
+- **arrivederci** = *ar-ree-veh-**DER**-chee*: a tapped double *r*, and the final
+  *-ci* is soft (*chee*, Italian *c* before *i*). Stress the *-der-*.
+
+## The word, taken apart
+
+Break it into four pieces you can almost read straight off:
+
+- **a** = "to / until" (Latin *ad*).
+- **ri-** = "again" (Latin *re-* — as in English *re*-do, *re*-view).
+- **vedere** = "to see" (Latin *vidēre* → English **video**, **vision**,
+  **evident**, **provide**).
+- **-ci** = "us / each other."
+
+Glued: *a-(ri)-vedere-ci* → **"to our seeing-one-another-again."** You don't say
+farewell; you promise the next meeting.
+
+### The whole family says the same thing
+
+This "until re-seeing" idea is shared right across the languages you're learning
+— a lovely thing to notice:
+
+| language | goodbye | literally |
+|---|---|---|
+| **Italian** | *arrivederci* | "to our re-seeing" |
+| **French** | *au revoir* | "to the re-seeing" (*re* + *voir*, see) |
+| **German** | *auf Wiedersehen* | "on again-seeing" (*wieder* + *sehen*) |
+
+Three languages, one gesture: part by pointing at the reunion, not the parting.
+(Italian keeps a heavier, final "to God" goodbye too — **addio**, *a Dio* — the
+exact twin of Spanish *adiós*; but for everyday partings it's *arrivederci*.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "arrivederci" — *ar-ree-veh-DER-chee*]
+- [YOU SAY: arrivederci / au revoir / auf Wiedersehen — all "until we see again"]
+- [YOU SAY: "vedere" then English "video, vision" — the *see* root]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *arrivederci* literally promise? ("Until we see each other
+again.") What French and German goodbyes share that exact idea? (*au revoir*,
+*auf Wiedersehen*.) Which heavier Italian goodbye means "to God," like Spanish
+*adiós*? (*addio*.) Next: "see you tomorrow" — **a domani**.

--- a/code/learning/human-languages/italian/lessons/IT-C04-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C04-practice.md
@@ -1,0 +1,65 @@
+---
+id: IT-C04-practice
+chapter: 4
+type: practice-mix
+headword: (practice)
+gloss: closing a conversation — the full set of Italian goodbyes
+concept_tag: CH4-PRACTICE
+prerequisites: [IT-C04-arrivederci, IT-C04-a-domani, IT-C04-a-presto, IT-C04-a-piu-tardi]
+sounds: []
+roots: []
+est_minutes: 4
+reviews_of: [IT-C04-arrivederci, IT-C04-a-domani, IT-C04-a-presto, IT-C04-a-piu-tardi, IT-C02-practice]
+---
+
+# Practice — saying goodbye in Italian
+
+## Warm-up
+
+[PAUSE 2s] No new words. You can now open a conversation, ask how someone is, and
+**close** it. Run the goodbyes until the right one comes automatically.
+
+## The closings
+
+**Neutral / polite** (anyone):
+
+> — È stato un piacere. **Arrivederci!**
+> — **Arrivederci!**
+
+**With a "when"** — pick the promise that fits:
+
+> — **A domani!** (see you tomorrow)
+> — **A presto!** (see you soon)
+> — **A più tardi!** (see you later — same day)
+
+**Casual** (a friend): the *ciao* you learned in Chapter 1 doubles as "bye" —
+
+> — **Ciao, a presto!**
+
+## What you've built this chapter
+
+- **arrivederci** — goodbye ("until we re-see each other"; the *au revoir* /
+  *auf Wiedersehen* family). Heavier, final variant: **addio** ("to God," twin
+  of *adiós*).
+- **a domani** — see you tomorrow (*domani* ← *dē māne*, "morning"; kin of Spanish
+  *mañana*).
+- **a presto** — see you soon (*presto* ← *praestō*, "at hand" — the English
+  music/magic word).
+- **a più tardi** — see you later (*più* ~ plus, *tardi* ~ tardy).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: greet, ask, and close — "Ciao! Come stai? … A domani!"]
+- [YOU SAY: choose the right goodbye — leaving till tomorrow / in an hour / for
+  good]
+- [YOU SAY: arrivederci / au revoir / auf Wiedersehen — the "re-seeing" trio]
+
+[REPEAT x2] Open and close a whole tiny exchange without stopping.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which goodbye means "until we see each other again"? (*Arrivederci*.)
+Which says "to the morning"? (*A domani*.) Which Italian goodbye matches Spanish
+*adiós* — "to God"? (*Addio*.) You can now run an Italian conversation start to
+finish.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -19,13 +19,17 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   sta / **va** (also *andare* "to go") → così così → practice. **Authored.**
   *(Reordered ahead of introductions to widen the cross-language how-are-you set;
   register tu/Lei introduced inline.)*
+- **Ch. 4 — Farewells**: arrivederci (← *a + rivedere + ci*, "to our re-seeing";
+  the *au revoir* / *auf Wiedersehen* family; final variant *addio* = *adiós*) →
+  a domani (*domani* ← *dē māne*) → a presto (*presto* ← *praestō*) → a più tardi
+  (*più*/plus + *tardi*/tardy) → practice. **Authored** (Ch. 3 introductions to
+  slot in below it).
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
 | 3 | Introducing yourself: *mi chiamo*, come ti chiami, piacere |
-| 4 | Farewells: arrivederci, a presto, a domani |
 | 5+ | Numbers, time, days & months, family, food — following the shared theme order |
 
 Note: Italian's formal "you" is **Lei** — literally "she" (a 3rd-person

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Chapter 4 — Farewells (completes the 5-language greet-to-goodbye arc)
+
+- **Chapter 4 authored** (`PT-C04-adeus`, `-ate-logo`, `-ate-amanha`,
+  `-ate-breve`, `-practice`): closing a conversation, reviewing Chapter 2.
+  Portuguese becomes the **fifth** track to reach the full greet → how-are-you →
+  goodbye arc. Numbered Ch. 4 so introductions can slot in at Ch. 3.
+- **adeus** ← *a Deus* "to God" — the exact twin of Spanish *adiós*, French
+  *adieu*, Italian *addio*, and English *goodbye* ("God be with ye").
+- **Reinforces the Arabic-loanword deep dive**: *até* ("until") ← **Arabic
+  *ḥattā*** — the *same* borrowed function word as Spanish *hasta*, so *até logo*
+  is the word-for-word twin of *hasta luego* (*logo* ← *locō*, kin of *luego*).
+- **Cross-links**: *até amanhã* (*amanhã* ← *ad māneāna*, kin of *mañana*; the
+  Portuguese **nh** = Spanish **ñ**); *até breve* (*breve* ← *brevis* "short" →
+  brief/brevity/abbreviate).
+- Uses the canonical `FAREWELL`, `FAREWELL-LATER`, `FAREWELL-TOMORROW`,
+  `FAREWELL-SOON` concepts — no taxonomy change.
+
 ## Chapter 2 — "Tudo bem?" (the how-are-you chapter)
 
 - **Chapter 2 authored** (`PT-C02-de-nada`, `-como`, `-tudo`, `-tudo-bem`,

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-adeus.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-adeus.md
@@ -1,0 +1,62 @@
+---
+id: PT-C04-adeus
+chapter: 4
+type: word
+headword: adeus
+gloss: goodbye (literally "to God")
+concept_tag: FAREWELL
+prerequisites: []
+sounds: [nasal-eu, final-s-sh]
+roots: [ad-deum-latin]
+etymology_hook: "adeus ← a Deus 'to God' — the exact twin of Spanish adiós, French adieu, Italian addio"
+est_minutes: 3
+reviews_of: [PT-C02-practice]
+---
+
+# adeus — "goodbye," i.e. "to God"
+
+## Warm-up
+
+[PAUSE 2s] You can greet, ask *tudo bem?*, and reply. Now close the conversation.
+The Portuguese goodbye is **adeus** — and it's a tiny prayer: **"to God."**
+
+## Sounds you'll need
+
+- `nasal-eu` — **adeus** ≈ *ah-**DEH**-oosh*: the *eu* is a gliding vowel; final
+  *-s* is a soft *sh* in Portugal (*-s* → *ss* in Brazil). Stress the *-deus*.
+
+## The word, taken apart
+
+**adeus** = **a** ("to") + **Deus** ("God"), from Latin **ad Deum**, *"to
+God."* It's the fossil of a blessing — *"[I commend you] to God"* — said at
+parting, exactly like the English **goodbye**, which is a worn-down *"God be
+with ye."*
+
+This is one of the most beautiful family resemblances in the whole curriculum —
+five languages, one farewell prayer:
+
+| language | goodbye | = |
+|---|---|---|
+| **Portuguese** | *adeus* | a + Deus |
+| **Spanish** | *adiós* | a + Dios |
+| **French** | *adieu* | à + Dieu |
+| **Italian** | *addio* | a + Dio |
+| **English** | *goodbye* | "God be with ye" |
+
+The *Deus* here is the same one in English **deity**, **divine**, **adieu**, and
+Spanish *Dios*. When you say *adeus*, you're handing someone to God for
+safekeeping until next time.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "adeus" — *ah-DEH-oosh*]
+- [YOU SAY: adeus / adiós / adieu / addio — one "to God" across four languages]
+- [YOU SAY: even English "goodbye" = "God be with ye"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *adeus* literally mean, and from what? ("To God," ← *ad
+Deum*.) Name two sister-language goodbyes with the same "to God" origin.
+(*adiós*, *adieu*, *addio*.) What English goodbye hides "God be with ye"?
+(*Goodbye*.) Next: the softer "see you" goodbyes — starting with **até logo**.

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-ate-amanha.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-ate-amanha.md
@@ -1,0 +1,57 @@
+---
+id: PT-C04-ate-amanha
+chapter: 4
+type: phrase
+headword: até amanhã
+gloss: see you tomorrow (literally "until tomorrow")
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [PT-C04-ate-logo]
+sounds: [nasal-anha, final-o-is-u]
+roots: [hatta-arabic, ad-maneana-latin]
+etymology_hook: "amanhã ← Latin ad māneāna 'to the morning' — kin of Spanish mañana; note the nasal -ã"
+est_minutes: 3
+reviews_of: [PT-C04-ate-logo]
+---
+
+# até amanhã — "see you tomorrow"
+
+## Warm-up
+
+[PAUSE 2s] Same frame — *até* + a "when." **Até amanhã**, "until tomorrow." And
+*amanhã* is the Portuguese cousin of a Spanish word you already know, wearing a
+heavy nasal ending.
+
+## Sounds you'll need
+
+- `nasal-anha` — **amanhã** = *ah-mah-**NYÃ***: the **nh** is the *ny* of
+  "canyon" (Portuguese spells the *ñ* sound as *nh*), and the final **-ã** is a
+  strong **nasal** *a* — air through the nose, no hard consonant. Stress the end.
+
+## The phrase, taken apart
+
+- **até** = "until" (← Arabic *ḥattā*, from the last lesson).
+- **amanhã** = "tomorrow," from Latin **ad māneāna**, *"to the morning [hour]."*
+
+That **māne** ("morning") root is shared right across Romance — you've now met
+three of its children:
+
+- Portuguese **amanhã** ("tomorrow") ← *ad māneāna*.
+- Spanish **mañana** — morning *and* tomorrow (the *ñ* spelled with the tilde).
+- Italian **domani** ("tomorrow") ← *dē māne*.
+
+Same idea everywhere: tomorrow is **"the morning to come."** Portuguese writes
+the *ny* sound as **nh** (*amanhã*), where Spanish uses **ñ** (*mañana*) — two
+spellings, one sound, both from that doubled-*n*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "até amanhã" — *ah-TEH ah-mah-NYÃ*, nasal ending]
+- [YOU SAY: amanhã / mañana / domani — three children of *māne*, "morning"]
+- [YOU SAY: Portuguese *nh* = Spanish *ñ* = the *ny* sound]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *amanhã* come from, and literally mean? (*Ad māneāna* — "to
+the morning.") How does Portuguese spell the *ny* sound that Spanish writes as
+*ñ*? (As *nh*.) Next: "see you soon" — **até breve**.

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-ate-breve.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-ate-breve.md
@@ -1,0 +1,54 @@
+---
+id: PT-C04-ate-breve
+chapter: 4
+type: phrase
+headword: até breve
+gloss: see you soon (literally "until [a] short [while]")
+concept_tag: FAREWELL-SOON
+prerequisites: [PT-C04-ate-logo]
+sounds: [nasal-em, final-e-reduces]
+roots: [hatta-arabic, brevis-latin]
+etymology_hook: "breve ← Latin brevis 'short' → English brief, brevity, abbreviate"
+est_minutes: 3
+reviews_of: [PT-C04-ate-amanha]
+---
+
+# até breve — "see you soon"
+
+## Warm-up
+
+[PAUSE 2s] The last of the *até* goodbyes: **até breve**, "until soon" — literally
+"until [a] *short* [while]." *Breve* is a word English wears in several coats.
+
+## Sounds you'll need
+
+- **até breve** = *ah-TEH **BREH**-vee*: open *e* in *breve*, final *-e* softens
+  toward *ee*.
+
+## The phrase, taken apart
+
+- **até** = "until" (← Arabic *ḥattā*).
+- **breve** = "short, brief," from Latin **brevis**, *"short."*
+
+You already own *brevis* in English, several times over:
+
+- **brief** — short (a *brief* meeting; a legal *brief*).
+- **brevity** — shortness ("brevity is the soul of wit").
+- **abbreviate**, **abridge** — to make short.
+- even the musical **breve** and the little **breve** mark ˘ over a short vowel.
+
+So *até breve* is **"until [a] short [while]"** — see you before long. It's a
+touch warmer and less fixed than *até logo*; both mean "see you soon."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "até breve" — *ah-TEH BREH-vee*]
+- [YOU SAY: "breve" then English "brief, brevity, abbreviate" — one root]
+- [YOU SAY: the three *até* goodbyes — até logo / até amanhã / até breve]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *breve* mean, and its English cousins? ("Short" — brief,
+brevity, abbreviate.) So *até breve* literally says? ("Until a short while" →
+see you soon.) Next: put the Portuguese goodbyes together.

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-ate-logo.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-ate-logo.md
@@ -1,0 +1,58 @@
+---
+id: PT-C04-ate-logo
+chapter: 4
+type: phrase
+headword: até logo
+gloss: see you later (literally "until soon/then")
+concept_tag: FAREWELL-LATER
+prerequisites: [PT-C04-adeus]
+sounds: [final-o-is-u]
+roots: [hatta-arabic, loco-latin]
+etymology_hook: "até ← Arabic ḥattā (the SAME Arabic loan as Spanish hasta); logo ← Latin locō 'in place' → 'soon'"
+est_minutes: 4
+reviews_of: [PT-C04-adeus]
+---
+
+# até logo — "see you later," and a word straight from Arabic
+
+## Warm-up
+
+[PAUSE 2s] The everyday Portuguese goodbye isn't *adeus* (that's a bit final) —
+it's **até logo**, "until soon." And its first word carries the same surprise
+Spanish's *hasta* does: it came from **Arabic**.
+
+## Sounds you'll need
+
+- **até** = *ah-**TEH***, stress the end (the accent on *é*).
+- `final-o-is-u` — **logo** = *LOH-goo*, final *-o* → *u*.
+
+## The word, taken apart
+
+- **até** = "until, up to." Like Spanish **hasta**, it comes from **Arabic
+  *ḥattā* (حتى)**, "until" — carried into Iberian speech across the **800 years
+  of al-Andalus**. Both Iberian languages borrowed the *same* Arabic word for
+  this everyday preposition. That's remarkable: languages freely borrow *nouns*
+  (Portuguese has thousands from Arabic — *almofada*, *açúcar*, *azeite*), but a
+  **function word** like "until" almost never crosses. *até* and *hasta* are twin
+  survivors of that deep Arabic layer under Iberian Romance.
+- **logo** = "soon, right away, then," from Latin **locō**, *"in [that] place"* →
+  "on the spot" → "soon." (Spanish did the identical thing: **luego** ← *locō*,
+  and *hasta luego* is the word-for-word twin of *até logo*.)
+
+So **até logo** = "**until soon**" — the exact mirror of Spanish **hasta luego**,
+Arabic preposition and all.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "até logo" — *ah-TEH LOH-goo*]
+- [YOU SAY: Portuguese *até* and Spanish *hasta* — both from Arabic *ḥattā*]
+- [YOU SAY: *até logo* = *hasta luego*, twin for twin]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does *até* come from, and which Spanish word is its twin?
+(Arabic *ḥattā* — Spanish *hasta*.) Why is borrowing it surprising? (It's a
+*function word*; languages rarely borrow those.) What does *logo* share with
+Spanish *luego*? (Both ← Latin *locō*, "in place" → "soon".) Next: **até
+amanhã**.

--- a/code/learning/human-languages/portuguese/lessons/PT-C04-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C04-practice.md
@@ -1,0 +1,64 @@
+---
+id: PT-C04-practice
+chapter: 4
+type: practice-mix
+headword: (practice)
+gloss: closing a conversation — the full set of Portuguese goodbyes
+concept_tag: CH4-PRACTICE
+prerequisites: [PT-C04-adeus, PT-C04-ate-logo, PT-C04-ate-amanha, PT-C04-ate-breve]
+sounds: []
+roots: []
+est_minutes: 4
+reviews_of: [PT-C04-adeus, PT-C04-ate-logo, PT-C04-ate-amanha, PT-C04-ate-breve, PT-C02-practice]
+---
+
+# Practice — saying goodbye in Portuguese
+
+## Warm-up
+
+[PAUSE 2s] No new words. You can now greet, ask *tudo bem?*, and **close** the
+conversation. Run the goodbyes until the right one is automatic.
+
+## The closings
+
+**Final / formal** — the "to God" goodbye:
+
+> — Foi um prazer. **Adeus!**
+
+**Everyday "see you"** — pick the *até* that fits:
+
+> — **Até logo!** (see you later / soon)
+> — **Até amanhã!** (see you tomorrow)
+> — **Até breve!** (see you soon)
+
+**Casual chain** — greet and part:
+
+> — Olá! Tudo bem? … **Até logo!**
+> — **Até!** (Brazilians often clip it to just *"até!"*)
+
+## What you've built this chapter
+
+- **adeus** — goodbye ("to God"; the *adiós / adieu / addio* family, and English
+  *goodbye* = "God be with ye").
+- **até logo** — see you later (*até* ← **Arabic *ḥattā***, twin of Spanish
+  *hasta*; *logo* ← *locō*, kin of *luego*). *Até logo* = *hasta luego*.
+- **até amanhã** — see you tomorrow (*amanhã* ← *ad māneāna*, kin of *mañana*; the
+  *nh* = Spanish *ñ*).
+- **até breve** — see you soon (*breve* ← *brevis*, "short" — brief/brevity).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: greet, ask, and close — "Olá! Tudo bem? … Até amanhã!"]
+- [YOU SAY: choose the right goodbye — leaving for good / till tomorrow / soon]
+- [YOU SAY: *até logo* and Spanish *hasta luego* — twins, Arabic *até/hasta* and
+  all]
+
+[REPEAT x2] Open and close a whole tiny exchange without stopping.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which Portuguese goodbye means "to God"? (*Adeus*.) Which word inside
+the *até* goodbyes came from Arabic, and what's its Spanish twin? (*Até* ← *ḥattā*
+— Spanish *hasta*.) You can now run a Portuguese conversation start to finish —
+that's the fifth language to reach the full greet-to-goodbye arc.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -20,13 +20,17 @@ French.
   stand) → mais ou menos → practice. **Authored** — the verb-free *Tudo bem?* is
   the distinctive Portuguese move; reordered ahead of introductions, register
   você/o senhor inline.
+- **Ch. 4 — Farewells**: adeus (← *a Deus* "to God"; twin of *adiós/adieu/addio*)
+  → até logo (*até* ← **Arabic *ḥattā***, twin of Spanish *hasta*; *logo* ← *locō*
+  = *luego*) → até amanhã (*amanhã* ← *ad māneāna*; *nh* = *ñ*) → até breve
+  (*breve* ← *brevis*) → practice. **Authored** — fifth track to complete the
+  greet-to-goodbye arc (Ch. 3 introductions to slot in below it).
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
 | 3 | Introducing yourself: *chamo-me / o meu nome é*, como se chama, prazer |
-| 4 | Farewells: adeus, até logo, até amanhã |
 | 5+ | Numbers, time, days & months, family, food — following the shared theme order |
 
 Note: Portuguese's polite "you" is **você** (← *vossa mercê*, "your mercy") — the


### PR DESCRIPTION
## Italian + Portuguese farewells (Ch.4) — completes the 5-language greet-to-goodbye arc

Follow-on to the merged #8545 (which added the `FAREWELL-*` concepts). With this,
**all five languages** — Spanish, French, German, Italian, Portuguese — can run a
conversation end to end: greet → introduce → *how are you?* → **goodbye**.

10 lessons, atom-first, each reviewing the track's Chapter 2. Numbered **Ch.4** so
the introductions chapter can slot in at Ch.3 (that's the next queue item), keeping
book order greet → introduce → how-are-you → farewell.

### The cross-language payoffs
- **"To God" goodbyes**: Portuguese **adeus** ← *a Deus* — the exact twin of Spanish
  *adiós*, French *adieu*, Italian *addio*, and English *goodbye* ("God be with ye").
- **"Until re-seeing"**: Italian **arrivederci** = *a + ri- + vedere 'see' + ci 'us'*
  — shown beside French *au revoir* and German *auf Wiedersehen*, the same gesture.
- **The Arabic loan returns**: Portuguese **até** ← Arabic *ḥattā* — the *same*
  borrowed function word as Spanish *hasta*, so **até logo = hasta luego**, twin for
  twin (both *logo*/*luego* ← Latin *locō*). Reinforces the Spanish Ch.5 deep dive.
- **One "morning" root**: *a domani* / *até amanhã* / *mañana* all ← Latin *māne*
  ("tomorrow = the morning to come"); Portuguese spells the *ñ* sound as **nh**.
- Smaller cousins traced: *presto* ← *praestō* (the music/magic word), *tardi* ~
  tardy, *breve* ← *brevis* (brief/brevity).

### Checks
- Reuses the existing `FAREWELL` / `FAREWELL-LATER/TOMORROW/SOON` concepts — **no
  taxonomy change** (so no conflict surface there).
- 38 data-package tests pass; validator clean. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
