### PR TITLE
feat(font-parser): add C# and F# ports

### DIFF
--- a/code/packages/csharp/font-parser/BUILD
+++ b/code/packages/csharp/font-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.FontParser]*"

--- a/code/packages/csharp/font-parser/BUILD_windows
+++ b/code/packages/csharp/font-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.FontParser]*"

--- a/code/packages/csharp/font-parser/CHANGELOG.md
+++ b/code/packages/csharp/font-parser/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add a dependency-free metrics-only OpenType and TrueType parser.
+- Support global metrics, BMP glyph lookup, horizontal metrics, names, and legacy kerning pairs.

--- a/code/packages/csharp/font-parser/CodingAdventures.FontParser.csproj
+++ b/code/packages/csharp/font-parser/CodingAdventures.FontParser.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.FontParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# metrics-only OpenType and TrueType font parser</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/font-parser/FontParser.cs
+++ b/code/packages/csharp/font-parser/FontParser.cs
@@ -1,0 +1,419 @@
+using System.Text;
+
+namespace CodingAdventures.FontParser;
+
+/// <summary>Identifies why a font could not be parsed.</summary>
+public enum FontErrorKind
+{
+    /// <summary>A read would extend past the supplied bytes.</summary>
+    BufferTooShort,
+    /// <summary>The sfnt version is neither TrueType nor OpenType.</summary>
+    InvalidMagic,
+    /// <summary>The required head table sentinel is invalid.</summary>
+    InvalidHeadMagic,
+    /// <summary>A required metrics table is missing.</summary>
+    TableNotFound,
+}
+
+/// <summary>Raised when an OpenType or TrueType binary is malformed.</summary>
+public sealed class FontParseException(FontErrorKind kind, string message) : Exception(message)
+{
+    /// <summary>The stable category for this parse failure.</summary>
+    public FontErrorKind Kind { get; } = kind;
+}
+
+/// <summary>Global typographic metrics in font design units.</summary>
+public sealed record FontMetrics(
+    ushort UnitsPerEm,
+    short Ascender,
+    short Descender,
+    short LineGap,
+    short? XHeight,
+    short? CapHeight,
+    ushort NumGlyphs,
+    string FamilyName,
+    string SubfamilyName);
+
+/// <summary>Horizontal metrics for a single glyph.</summary>
+public sealed record GlyphMetrics(ushort AdvanceWidth, short LeftSideBearing);
+
+internal readonly record struct TableRecord(int Offset, int Length);
+
+/// <summary>An immutable handle to a parsed font binary.</summary>
+public sealed class FontFile
+{
+    internal FontFile(byte[] data, IReadOnlyDictionary<string, TableRecord> tables)
+    {
+        Data = data;
+        Tables = tables;
+    }
+
+    internal byte[] Data { get; }
+    internal IReadOnlyDictionary<string, TableRecord> Tables { get; }
+}
+
+/// <summary>Metrics-only OpenType and TrueType font parser.</summary>
+public static class FontParser
+{
+    private const uint TrueTypeMagic = 0x0001_0000;
+    private const uint OpenTypeMagic = 0x4F54_544F;
+    private const uint HeadMagic = 0x5F0F_3CF5;
+
+    /// <summary>Parse a complete font binary and retain an immutable copy.</summary>
+    public static FontFile Load(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        if (bytes.Length < 12)
+        {
+            Throw(FontErrorKind.BufferTooShort, "font buffer is too small to contain an sfnt header");
+        }
+
+        var data = (byte[])bytes.Clone();
+        var magic = ReadU32(data, 0);
+        if (magic is not TrueTypeMagic and not OpenTypeMagic)
+        {
+            Throw(FontErrorKind.InvalidMagic, $"invalid sfnt version 0x{magic:X8}");
+        }
+
+        var numTables = ReadU16(data, 4);
+        var tables = new Dictionary<string, TableRecord>(StringComparer.Ordinal);
+        for (var i = 0; i < numTables; i++)
+        {
+            var recordOffset = checked(12 + (i * 16));
+            EnsureRange(data, recordOffset, 16);
+            var tag = Encoding.ASCII.GetString(data, recordOffset, 4);
+            var offset = CheckedInt(ReadU32(data, recordOffset + 8), "table offset");
+            var length = CheckedInt(ReadU32(data, recordOffset + 12), "table length");
+            EnsureRange(data, offset, length);
+            tables[tag] = new TableRecord(offset, length);
+        }
+
+        foreach (var tag in new[] { "head", "hhea", "maxp", "cmap", "hmtx" })
+        {
+            RequireTable(tables, tag);
+        }
+
+        var head = RequireTable(tables, "head");
+        if (ReadU32(data, head.Offset + 12) != HeadMagic)
+        {
+            Throw(FontErrorKind.InvalidHeadMagic, "invalid head.magicNumber");
+        }
+
+        return new FontFile(data, tables);
+    }
+
+    /// <summary>Return global font metrics, preferring OS/2 typographic values.</summary>
+    public static FontMetrics GetFontMetrics(FontFile font)
+    {
+        ArgumentNullException.ThrowIfNull(font);
+        var data = font.Data;
+        var head = RequireTable(font.Tables, "head");
+        var hhea = RequireTable(font.Tables, "hhea");
+        var maxp = RequireTable(font.Tables, "maxp");
+
+        var ascender = ReadI16(data, hhea.Offset + 4);
+        var descender = ReadI16(data, hhea.Offset + 6);
+        var lineGap = ReadI16(data, hhea.Offset + 8);
+        short? xHeight = null;
+        short? capHeight = null;
+
+        if (font.Tables.TryGetValue("OS/2", out var os2))
+        {
+            var version = ReadU16(data, os2.Offset);
+            if (os2.Length >= 74)
+            {
+                ascender = ReadI16(data, os2.Offset + 68);
+                descender = ReadI16(data, os2.Offset + 70);
+                lineGap = ReadI16(data, os2.Offset + 72);
+            }
+
+            if (version >= 2 && os2.Length >= 90)
+            {
+                xHeight = ReadI16(data, os2.Offset + 86);
+                capHeight = ReadI16(data, os2.Offset + 88);
+            }
+        }
+
+        return new FontMetrics(
+            ReadU16(data, head.Offset + 18),
+            ascender,
+            descender,
+            lineGap,
+            xHeight,
+            capHeight,
+            ReadU16(data, maxp.Offset + 4),
+            ReadName(font, 1) ?? "(unknown)",
+            ReadName(font, 2) ?? "(unknown)");
+    }
+
+    /// <summary>Map a BMP Unicode codepoint to a glyph identifier.</summary>
+    public static ushort? GetGlyphId(FontFile font, int codepoint)
+    {
+        ArgumentNullException.ThrowIfNull(font);
+        if (codepoint is < 0 or > 0xFFFF)
+        {
+            return null;
+        }
+
+        var data = font.Data;
+        var cmap = RequireTable(font.Tables, "cmap");
+        var numSubtables = ReadU16(data, cmap.Offset + 2);
+        int? selected = null;
+
+        for (var i = 0; i < numSubtables; i++)
+        {
+            var record = cmap.Offset + 4 + (i * 8);
+            var platform = ReadU16(data, record);
+            var encoding = ReadU16(data, record + 2);
+            var relative = CheckedInt(ReadU32(data, record + 4), "cmap subtable offset");
+            var absolute = checked(cmap.Offset + relative);
+            if (platform == 3 && encoding == 1)
+            {
+                selected = absolute;
+                break;
+            }
+
+            if (platform == 0 && selected is null)
+            {
+                selected = absolute;
+            }
+        }
+
+        if (selected is null || ReadU16(data, selected.Value) != 4)
+        {
+            return null;
+        }
+
+        var subtable = selected.Value;
+        var segmentCount = ReadU16(data, subtable + 6) / 2;
+        var endCodes = subtable + 14;
+        var startCodes = subtable + 16 + (segmentCount * 2);
+        var deltas = subtable + 16 + (segmentCount * 4);
+        var rangeOffsets = subtable + 16 + (segmentCount * 6);
+
+        var lo = 0;
+        var hi = segmentCount;
+        while (lo < hi)
+        {
+            var mid = lo + ((hi - lo) / 2);
+            if (ReadU16(data, endCodes + (mid * 2)) < codepoint)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid;
+            }
+        }
+
+        if (lo >= segmentCount)
+        {
+            return null;
+        }
+
+        var start = ReadU16(data, startCodes + (lo * 2));
+        var end = ReadU16(data, endCodes + (lo * 2));
+        if (codepoint < start || codepoint > end)
+        {
+            return null;
+        }
+
+        var delta = ReadI16(data, deltas + (lo * 2));
+        var rangeOffsetAddress = rangeOffsets + (lo * 2);
+        var rangeOffset = ReadU16(data, rangeOffsetAddress);
+        ushort glyph;
+        if (rangeOffset == 0)
+        {
+            glyph = unchecked((ushort)(codepoint + delta));
+        }
+        else
+        {
+            var glyphAddress = checked(rangeOffsetAddress + rangeOffset + ((codepoint - start) * 2));
+            glyph = ReadU16(data, glyphAddress);
+            if (glyph != 0)
+            {
+                glyph = unchecked((ushort)(glyph + delta));
+            }
+        }
+
+        return glyph == 0 ? null : glyph;
+    }
+
+    /// <summary>Return horizontal metrics for a glyph, or null when out of range.</summary>
+    public static GlyphMetrics? GetGlyphMetrics(FontFile font, int glyphId)
+    {
+        ArgumentNullException.ThrowIfNull(font);
+        var data = font.Data;
+        var maxp = RequireTable(font.Tables, "maxp");
+        var hhea = RequireTable(font.Tables, "hhea");
+        var hmtx = RequireTable(font.Tables, "hmtx");
+        var numGlyphs = ReadU16(data, maxp.Offset + 4);
+        var numHorizontalMetrics = ReadU16(data, hhea.Offset + 34);
+
+        if (glyphId < 0 || glyphId >= numGlyphs || numHorizontalMetrics == 0)
+        {
+            return null;
+        }
+
+        if (glyphId < numHorizontalMetrics)
+        {
+            var offset = hmtx.Offset + (glyphId * 4);
+            return new GlyphMetrics(ReadU16(data, offset), ReadI16(data, offset + 2));
+        }
+
+        var lastMetric = hmtx.Offset + ((numHorizontalMetrics - 1) * 4);
+        var bearing = hmtx.Offset + (numHorizontalMetrics * 4) + ((glyphId - numHorizontalMetrics) * 2);
+        return new GlyphMetrics(ReadU16(data, lastMetric), ReadI16(data, bearing));
+    }
+
+    /// <summary>Return a legacy kern format 0 adjustment, or zero when absent.</summary>
+    public static short GetKerning(FontFile font, int leftGlyphId, int rightGlyphId)
+    {
+        ArgumentNullException.ThrowIfNull(font);
+        if (leftGlyphId is < 0 or > 0xFFFF || rightGlyphId is < 0 or > 0xFFFF ||
+            !font.Tables.TryGetValue("kern", out var kern))
+        {
+            return 0;
+        }
+
+        var data = font.Data;
+        var tableEnd = checked(kern.Offset + kern.Length);
+        var subtableCount = ReadU16(data, kern.Offset + 2);
+        var position = kern.Offset + 4;
+        var target = ((uint)leftGlyphId << 16) | (uint)rightGlyphId;
+
+        for (var table = 0; table < subtableCount && position + 6 <= tableEnd; table++)
+        {
+            var length = ReadU16(data, position + 2);
+            if (length < 6 || position + length > tableEnd)
+            {
+                break;
+            }
+
+            var format = ReadU16(data, position + 4) >> 8;
+            if (format == 0 && length >= 14)
+            {
+                var pairCount = ReadU16(data, position + 6);
+                var pairs = position + 14;
+                var lo = 0;
+                var hi = (int)pairCount;
+                while (lo < hi)
+                {
+                    var mid = lo + ((hi - lo) / 2);
+                    var pair = pairs + (mid * 6);
+                    if (pair + 6 > position + length)
+                    {
+                        break;
+                    }
+
+                    var key = ((uint)ReadU16(data, pair) << 16) | ReadU16(data, pair + 2);
+                    if (key == target)
+                    {
+                        return ReadI16(data, pair + 4);
+                    }
+
+                    if (key < target)
+                    {
+                        lo = mid + 1;
+                    }
+                    else
+                    {
+                        hi = mid;
+                    }
+                }
+            }
+
+            position += length;
+        }
+
+        return 0;
+    }
+
+    private static string? ReadName(FontFile font, ushort nameId)
+    {
+        if (!font.Tables.TryGetValue("name", out var name))
+        {
+            return null;
+        }
+
+        var data = font.Data;
+        var count = ReadU16(data, name.Offset + 2);
+        var stringBase = name.Offset + ReadU16(data, name.Offset + 4);
+        (int Start, int Length)? fallback = null;
+
+        for (var i = 0; i < count; i++)
+        {
+            var record = name.Offset + 6 + (i * 12);
+            var platform = ReadU16(data, record);
+            var encoding = ReadU16(data, record + 2);
+            if (ReadU16(data, record + 6) != nameId)
+            {
+                continue;
+            }
+
+            var length = ReadU16(data, record + 8);
+            var start = stringBase + ReadU16(data, record + 10);
+            EnsureRange(data, start, length);
+            if (platform == 3 && encoding is 1 or 10)
+            {
+                return Encoding.BigEndianUnicode.GetString(data, start, length);
+            }
+
+            if (platform == 0 && fallback is null)
+            {
+                fallback = (start, length);
+            }
+        }
+
+        return fallback is { } value
+            ? Encoding.BigEndianUnicode.GetString(data, value.Start, value.Length)
+            : null;
+    }
+
+    private static TableRecord RequireTable(IReadOnlyDictionary<string, TableRecord> tables, string tag)
+    {
+        if (!tables.TryGetValue(tag, out var table))
+        {
+            Throw(FontErrorKind.TableNotFound, $"required table '{tag}' was not found");
+        }
+
+        return table;
+    }
+
+    private static ushort ReadU16(byte[] data, int offset)
+    {
+        EnsureRange(data, offset, 2);
+        return (ushort)((data[offset] << 8) | data[offset + 1]);
+    }
+
+    private static short ReadI16(byte[] data, int offset) => unchecked((short)ReadU16(data, offset));
+
+    private static uint ReadU32(byte[] data, int offset)
+    {
+        EnsureRange(data, offset, 4);
+        return ((uint)data[offset] << 24) |
+               ((uint)data[offset + 1] << 16) |
+               ((uint)data[offset + 2] << 8) |
+               data[offset + 3];
+    }
+
+    private static int CheckedInt(uint value, string label)
+    {
+        if (value > int.MaxValue)
+        {
+            Throw(FontErrorKind.BufferTooShort, $"{label} exceeds the supported buffer size");
+        }
+
+        return (int)value;
+    }
+
+    private static void EnsureRange(byte[] data, int offset, int length)
+    {
+        if (offset < 0 || length < 0 || offset > data.Length - length)
+        {
+            Throw(FontErrorKind.BufferTooShort, $"read at offset {offset} with length {length} exceeds the font buffer");
+        }
+    }
+
+    private static void Throw(FontErrorKind kind, string message) => throw new FontParseException(kind, message);
+}

--- a/code/packages/csharp/font-parser/README.md
+++ b/code/packages/csharp/font-parser/README.md
@@ -1,0 +1,19 @@
+# Font Parser (C#)
+
+Pure C# metrics-only OpenType and TrueType parser with no runtime dependencies.
+
+```csharp
+using CodingAdventures.FontParser;
+
+var font = FontParser.Load(File.ReadAllBytes("Inter-Regular.ttf"));
+var metrics = FontParser.GetFontMetrics(font);
+var glyph = FontParser.GetGlyphId(font, 'A');
+var horizontal = FontParser.GetGlyphMetrics(font, glyph!.Value);
+```
+
+The parser reads `head`, `hhea`, `maxp`, `cmap` format 4, `hmtx`, optional
+`name` and `OS/2`, and legacy `kern` format 0 tables. It deliberately does not
+perform glyph outline rasterization.
+
+Run `./BUILD` (or the command in `BUILD_windows`) to execute tests with the
+repository's 80% line-coverage gate.

--- a/code/packages/csharp/font-parser/required_capabilities.json
+++ b/code/packages/csharp/font-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/font-parser",
+  "capabilities": [],
+  "justification": "Pure computation package. Parses caller-provided font bytes without filesystem, network, process, or environment access."
+}

--- a/code/packages/csharp/font-parser/tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.csproj
+++ b/code/packages/csharp/font-parser/tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.FontParser.csproj" />
+    <None Include="../../../../../fixtures/fonts/Inter-Regular.ttf" Link="Fixtures/Inter-Regular.ttf" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/font-parser/tests/CodingAdventures.FontParser.Tests/FontParserTests.cs
+++ b/code/packages/csharp/font-parser/tests/CodingAdventures.FontParser.Tests/FontParserTests.cs
@@ -1,0 +1,275 @@
+using Parser = CodingAdventures.FontParser.FontParser;
+
+namespace CodingAdventures.FontParser.Tests;
+
+public sealed class FontParserTests
+{
+    private static byte[] InterBytes() =>
+        File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "Fixtures", "Inter-Regular.ttf"));
+
+    [Fact]
+    public void LoadRejectsNullAndShortBuffers()
+    {
+        Assert.Throws<ArgumentNullException>(() => Parser.Load(null!));
+        var error = Assert.Throws<FontParseException>(() => Parser.Load([]));
+        Assert.Equal(FontErrorKind.BufferTooShort, error.Kind);
+    }
+
+    [Fact]
+    public void LoadRejectsInvalidMagicAndMissingTables()
+    {
+        var invalid = new byte[12];
+        invalid[0] = 0xDE;
+        var magicError = Assert.Throws<FontParseException>(() => Parser.Load(invalid));
+        Assert.Equal(FontErrorKind.InvalidMagic, magicError.Kind);
+
+        var emptyDirectory = new byte[12];
+        WriteU32(emptyDirectory, 0, 0x00010000);
+        var tableError = Assert.Throws<FontParseException>(() => Parser.Load(emptyDirectory));
+        Assert.Equal(FontErrorKind.TableNotFound, tableError.Kind);
+    }
+
+    [Fact]
+    public void LoadRejectsTruncatedDirectoriesAndBadHeadMagic()
+    {
+        var truncated = new byte[12];
+        WriteU32(truncated, 0, 0x00010000);
+        WriteU16(truncated, 4, 1);
+        Assert.Equal(
+            FontErrorKind.BufferTooShort,
+            Assert.Throws<FontParseException>(() => Parser.Load(truncated)).Kind);
+
+        var badHead = BuildSyntheticFont();
+        var head = FindTable(badHead, "head");
+        WriteU32(badHead, head + 12, 0);
+        Assert.Equal(
+            FontErrorKind.InvalidHeadMagic,
+            Assert.Throws<FontParseException>(() => Parser.Load(badHead)).Kind);
+    }
+
+    [Fact]
+    public void LoadOwnsAnImmutableCopy()
+    {
+        var bytes = BuildSyntheticFont();
+        var font = Parser.Load(bytes);
+        bytes[0] = 0xFF;
+        Assert.Equal((ushort)1000, Parser.GetFontMetrics(font).UnitsPerEm);
+    }
+
+    [Fact]
+    public void InterExposesGlobalMetricsAndNames()
+    {
+        var metrics = Parser.GetFontMetrics(Parser.Load(InterBytes()));
+        Assert.Equal((ushort)2048, metrics.UnitsPerEm);
+        Assert.Equal("Inter", metrics.FamilyName);
+        Assert.Equal("Regular", metrics.SubfamilyName);
+        Assert.True(metrics.Ascender > 0);
+        Assert.True(metrics.Descender <= 0);
+        Assert.True(metrics.NumGlyphs > 100);
+        Assert.True(metrics.XHeight > 0);
+        Assert.True(metrics.CapHeight > 0);
+    }
+
+    [Fact]
+    public void SyntheticFontUsesHheaFallbackAndUnknownNames()
+    {
+        var metrics = Parser.GetFontMetrics(Parser.Load(BuildSyntheticFont()));
+        Assert.Equal((ushort)1000, metrics.UnitsPerEm);
+        Assert.Equal((short)800, metrics.Ascender);
+        Assert.Equal((short)-200, metrics.Descender);
+        Assert.Equal((short)10, metrics.LineGap);
+        Assert.Null(metrics.XHeight);
+        Assert.Null(metrics.CapHeight);
+        Assert.Equal("(unknown)", metrics.FamilyName);
+        Assert.Equal("(unknown)", metrics.SubfamilyName);
+    }
+
+    [Fact]
+    public void GlyphLookupHandlesMappedUnmappedAndOutOfBmpValues()
+    {
+        var font = Parser.Load(InterBytes());
+        var a = Parser.GetGlyphId(font, 'A');
+        var v = Parser.GetGlyphId(font, 'V');
+        Assert.NotNull(a);
+        Assert.NotNull(v);
+        Assert.NotEqual(a, v);
+        Assert.NotNull(Parser.GetGlyphId(font, ' '));
+        Assert.Null(Parser.GetGlyphId(font, -1));
+        Assert.Null(Parser.GetGlyphId(font, 0x10000));
+        Assert.Null(Parser.GetGlyphId(Parser.Load(BuildSyntheticFont()), 0xFFFF));
+    }
+
+    [Fact]
+    public void GlyphLookupIgnoresUnsupportedCmapFormats()
+    {
+        var bytes = BuildSyntheticFont();
+        var cmap = FindTable(bytes, "cmap");
+        WriteU16(bytes, cmap + 12, 12);
+        Assert.Null(Parser.GetGlyphId(Parser.Load(bytes), 'A'));
+    }
+
+    [Fact]
+    public void GlyphMetricsSupportFullAndSharedAdvanceRecords()
+    {
+        var font = Parser.Load(BuildSyntheticFont());
+        Assert.Equal(new GlyphMetrics(600, 10), Parser.GetGlyphMetrics(font, 0));
+        Assert.Equal(new GlyphMetrics(700, 20), Parser.GetGlyphMetrics(font, 1));
+        Assert.Equal(new GlyphMetrics(700, 40), Parser.GetGlyphMetrics(font, 3));
+        Assert.Null(Parser.GetGlyphMetrics(font, -1));
+        Assert.Null(Parser.GetGlyphMetrics(font, 5));
+
+        var inter = Parser.Load(InterBytes());
+        var glyph = Parser.GetGlyphId(inter, 'A');
+        Assert.True(Parser.GetGlyphMetrics(inter, glyph!.Value)!.AdvanceWidth > 0);
+    }
+
+    [Fact]
+    public void KerningReadsSortedFormatZeroPairs()
+    {
+        var font = Parser.Load(BuildSyntheticFont([(1, 2, -140), (3, 4, 80)]));
+        Assert.Equal((short)-140, Parser.GetKerning(font, 1, 2));
+        Assert.Equal((short)80, Parser.GetKerning(font, 3, 4));
+        Assert.Equal((short)0, Parser.GetKerning(font, 1, 4));
+        Assert.Equal((short)0, Parser.GetKerning(font, 2, 1));
+        Assert.Equal((short)0, Parser.GetKerning(font, -1, 2));
+    }
+
+    [Fact]
+    public void KerningDefaultsToZeroWhenTableIsAbsent()
+    {
+        var font = Parser.Load(InterBytes());
+        var a = Parser.GetGlyphId(font, 'A')!.Value;
+        var v = Parser.GetGlyphId(font, 'V')!.Value;
+        Assert.Equal((short)0, Parser.GetKerning(font, a, v));
+    }
+
+    private static byte[] BuildSyntheticFont((ushort Left, ushort Right, short Value)[]? pairs = null)
+    {
+        pairs ??= [];
+        pairs = pairs.OrderBy(pair => ((uint)pair.Left << 16) | pair.Right).ToArray();
+        const int tableCount = 6;
+        const int headLength = 54;
+        const int hheaLength = 36;
+        const int maxpLength = 6;
+        const int cmapLength = 36;
+        const int hmtxLength = 14;
+        var kernLength = 18 + pairs.Length * 6;
+        var directoryLength = 12 + tableCount * 16;
+        var head = directoryLength;
+        var hhea = head + headLength;
+        var maxp = hhea + hheaLength;
+        var cmap = maxp + maxpLength;
+        var hmtx = cmap + cmapLength;
+        var kern = hmtx + hmtxLength;
+        var bytes = new byte[kern + kernLength];
+
+        WriteU32(bytes, 0, 0x00010000);
+        WriteU16(bytes, 4, tableCount);
+        WriteTable(bytes, 0, "cmap", cmap, cmapLength);
+        WriteTable(bytes, 1, "head", head, headLength);
+        WriteTable(bytes, 2, "hhea", hhea, hheaLength);
+        WriteTable(bytes, 3, "hmtx", hmtx, hmtxLength);
+        WriteTable(bytes, 4, "kern", kern, kernLength);
+        WriteTable(bytes, 5, "maxp", maxp, maxpLength);
+
+        WriteU32(bytes, head, 0x00010000);
+        WriteU32(bytes, head + 12, 0x5F0F3CF5);
+        WriteU16(bytes, head + 18, 1000);
+
+        WriteU32(bytes, hhea, 0x00010000);
+        WriteI16(bytes, hhea + 4, 800);
+        WriteI16(bytes, hhea + 6, -200);
+        WriteI16(bytes, hhea + 8, 10);
+        WriteU16(bytes, hhea + 34, 2);
+
+        WriteU32(bytes, maxp, 0x00005000);
+        WriteU16(bytes, maxp + 4, 5);
+
+        WriteU16(bytes, cmap + 2, 1);
+        WriteU16(bytes, cmap + 4, 3);
+        WriteU16(bytes, cmap + 6, 1);
+        WriteU32(bytes, cmap + 8, 12);
+        WriteU16(bytes, cmap + 12, 4);
+        WriteU16(bytes, cmap + 14, 24);
+        WriteU16(bytes, cmap + 18, 2);
+        WriteU16(bytes, cmap + 20, 2);
+        WriteU16(bytes, cmap + 26, 0xFFFF);
+        WriteU16(bytes, cmap + 28, 0);
+        WriteU16(bytes, cmap + 30, 0xFFFF);
+        WriteI16(bytes, cmap + 32, 1);
+        WriteU16(bytes, cmap + 34, 0);
+
+        WriteU16(bytes, hmtx, 600);
+        WriteI16(bytes, hmtx + 2, 10);
+        WriteU16(bytes, hmtx + 4, 700);
+        WriteI16(bytes, hmtx + 6, 20);
+        WriteI16(bytes, hmtx + 8, 30);
+        WriteI16(bytes, hmtx + 10, 40);
+        WriteI16(bytes, hmtx + 12, 50);
+
+        WriteU16(bytes, kern, 0);
+        WriteU16(bytes, kern + 2, 1);
+        WriteU16(bytes, kern + 4, 0);
+        WriteU16(bytes, kern + 6, kernLength - 4);
+        WriteU16(bytes, kern + 8, 1);
+        WriteU16(bytes, kern + 10, pairs.Length);
+        for (var index = 0; index < pairs.Length; index++)
+        {
+            var offset = kern + 18 + index * 6;
+            WriteU16(bytes, offset, pairs[index].Left);
+            WriteU16(bytes, offset + 2, pairs[index].Right);
+            WriteI16(bytes, offset + 4, pairs[index].Value);
+        }
+
+        return bytes;
+    }
+
+    private static int FindTable(byte[] bytes, string tag)
+    {
+        var count = ReadU16(bytes, 4);
+        for (var index = 0; index < count; index++)
+        {
+            var record = 12 + index * 16;
+            if (System.Text.Encoding.ASCII.GetString(bytes, record, 4) == tag)
+            {
+                return (int)ReadU32(bytes, record + 8);
+            }
+        }
+
+        throw new InvalidOperationException($"Missing table {tag}");
+    }
+
+    private static void WriteTable(byte[] bytes, int index, string tag, int offset, int length)
+    {
+        var record = 12 + index * 16;
+        System.Text.Encoding.ASCII.GetBytes(tag).CopyTo(bytes, record);
+        WriteU32(bytes, record + 8, (uint)offset);
+        WriteU32(bytes, record + 12, (uint)length);
+    }
+
+    private static ushort ReadU16(byte[] bytes, int offset) =>
+        (ushort)((bytes[offset] << 8) | bytes[offset + 1]);
+
+    private static uint ReadU32(byte[] bytes, int offset) =>
+        ((uint)bytes[offset] << 24) |
+        ((uint)bytes[offset + 1] << 16) |
+        ((uint)bytes[offset + 2] << 8) |
+        bytes[offset + 3];
+
+    private static void WriteU16(byte[] bytes, int offset, int value)
+    {
+        bytes[offset] = (byte)(value >> 8);
+        bytes[offset + 1] = (byte)value;
+    }
+
+    private static void WriteI16(byte[] bytes, int offset, short value) =>
+        WriteU16(bytes, offset, unchecked((ushort)value));
+
+    private static void WriteU32(byte[] bytes, int offset, uint value)
+    {
+        bytes[offset] = (byte)(value >> 24);
+        bytes[offset + 1] = (byte)(value >> 16);
+        bytes[offset + 2] = (byte)(value >> 8);
+        bytes[offset + 3] = (byte)value;
+    }
+}

--- a/code/packages/fsharp/font-parser/BUILD
+++ b/code/packages/fsharp/font-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.FontParser.FSharp]*"

--- a/code/packages/fsharp/font-parser/BUILD_windows
+++ b/code/packages/fsharp/font-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.FontParser.FSharp]*"

--- a/code/packages/fsharp/font-parser/CHANGELOG.md
+++ b/code/packages/fsharp/font-parser/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add a dependency-free metrics-only OpenType and TrueType parser.
+- Support global metrics, BMP glyph lookup, horizontal metrics, names, and legacy kerning pairs.

--- a/code/packages/fsharp/font-parser/CodingAdventures.FontParser.fsproj
+++ b/code/packages/fsharp/font-parser/CodingAdventures.FontParser.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.FontParser.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.FontParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# metrics-only OpenType and TrueType font parser</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="FontParser.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/font-parser/FontParser.fs
+++ b/code/packages/fsharp/font-parser/FontParser.fs
@@ -1,0 +1,320 @@
+namespace CodingAdventures.FontParser
+
+open System
+open System.Collections.Generic
+open System.Text
+
+/// Identifies why a font could not be parsed.
+type FontErrorKind =
+    | BufferTooShort
+    | InvalidMagic
+    | InvalidHeadMagic
+    | TableNotFound
+
+/// Raised when an OpenType or TrueType binary is malformed.
+type FontParseException(kind: FontErrorKind, message: string) =
+    inherit Exception(message)
+    member _.Kind = kind
+
+/// Global typographic metrics in font design units.
+type FontMetrics =
+    { UnitsPerEm: uint16
+      Ascender: int16
+      Descender: int16
+      LineGap: int16
+      XHeight: int16 option
+      CapHeight: int16 option
+      NumGlyphs: uint16
+      FamilyName: string
+      SubfamilyName: string }
+
+/// Horizontal metrics for a single glyph.
+type GlyphMetrics =
+    { AdvanceWidth: uint16
+      LeftSideBearing: int16 }
+
+type internal TableRecord =
+    { Offset: int
+      Length: int }
+
+/// An immutable handle to a parsed font binary.
+type FontFile internal (data: byte array, tables: IReadOnlyDictionary<string, TableRecord>) =
+    member internal _.Data = data
+    member internal _.Tables = tables
+
+/// Metrics-only OpenType and TrueType font parser.
+[<RequireQualifiedAccess>]
+module FontParser =
+    let private trueTypeMagic = 0x00010000u
+    let private openTypeMagic = 0x4F54544Fu
+    let private headMagic = 0x5F0F3CF5u
+
+    let private fail kind message = raise (FontParseException(kind, message))
+
+    let private ensureRange (data: byte array) offset length =
+        if offset < 0 || length < 0 || offset > data.Length - length then
+            fail BufferTooShort $"read at offset {offset} with length {length} exceeds the font buffer"
+
+    let private readU16 (data: byte array) offset =
+        ensureRange data offset 2
+        (uint16 data.[offset] <<< 8) ||| uint16 data.[offset + 1]
+
+    let private readI16 data offset =
+        let value = readU16 data offset |> int
+        if value <= 32767 then int16 value else int16 (value - 65536)
+
+    let private readU32 (data: byte array) offset =
+        ensureRange data offset 4
+        (uint32 data.[offset] <<< 24)
+        ||| (uint32 data.[offset + 1] <<< 16)
+        ||| (uint32 data.[offset + 2] <<< 8)
+        ||| uint32 data.[offset + 3]
+
+    let private checkedInt label (value: uint32) =
+        if value > uint32 Int32.MaxValue then
+            fail BufferTooShort $"{label} exceeds the supported buffer size"
+        int value
+
+    let private requireTable (tables: IReadOnlyDictionary<string, TableRecord>) tag =
+        match tables.TryGetValue(tag) with
+        | true, table -> table
+        | false, _ -> fail TableNotFound $"required table '{tag}' was not found"
+
+    /// Parse a complete font binary and retain an immutable copy.
+    let load (bytes: byte array) =
+        nullArgCheck "bytes" bytes |> ignore
+        if bytes.Length < 12 then
+            fail BufferTooShort "font buffer is too small to contain an sfnt header"
+
+        let data = Array.copy bytes
+        let magic = readU32 data 0
+        if magic <> trueTypeMagic && magic <> openTypeMagic then
+            fail InvalidMagic $"invalid sfnt version 0x{magic:X8}"
+
+        let numTables = readU16 data 4 |> int
+        let tables = Dictionary<string, TableRecord>(StringComparer.Ordinal)
+
+        for index in 0 .. numTables - 1 do
+            let recordOffset = 12 + index * 16
+            ensureRange data recordOffset 16
+            let tag = Encoding.ASCII.GetString(data, recordOffset, 4)
+            let offset = readU32 data (recordOffset + 8) |> checkedInt "table offset"
+            let length = readU32 data (recordOffset + 12) |> checkedInt "table length"
+            ensureRange data offset length
+            tables.[tag] <- { Offset = offset; Length = length }
+
+        let readOnlyTables = tables :> IReadOnlyDictionary<string, TableRecord>
+        for tag in [ "head"; "hhea"; "maxp"; "cmap"; "hmtx" ] do
+            requireTable readOnlyTables tag |> ignore
+
+        let head = requireTable readOnlyTables "head"
+        if readU32 data (head.Offset + 12) <> headMagic then
+            fail InvalidHeadMagic "invalid head.magicNumber"
+
+        FontFile(data, readOnlyTables)
+
+    let private readName (font: FontFile) nameId =
+        match font.Tables.TryGetValue("name") with
+        | false, _ -> None
+        | true, name ->
+            let data = font.Data
+            let count = readU16 data (name.Offset + 2) |> int
+            let stringBase = name.Offset + (readU16 data (name.Offset + 4) |> int)
+            let mutable fallback: (int * int) option = None
+            let mutable result: string option = None
+            let mutable index = 0
+
+            while index < count && result.IsNone do
+                let record = name.Offset + 6 + index * 12
+                let platform = readU16 data record
+                let encoding = readU16 data (record + 2)
+                let recordNameId = readU16 data (record + 6)
+
+                if recordNameId = nameId then
+                    let length = readU16 data (record + 8) |> int
+                    let start = stringBase + (readU16 data (record + 10) |> int)
+                    ensureRange data start length
+
+                    if platform = 3us && (encoding = 1us || encoding = 10us) then
+                        result <- Some(Encoding.BigEndianUnicode.GetString(data, start, length))
+                    elif platform = 0us && fallback.IsNone then
+                        fallback <- Some(start, length)
+
+                index <- index + 1
+
+            match result, fallback with
+            | Some value, _ -> Some value
+            | None, Some(start, length) -> Some(Encoding.BigEndianUnicode.GetString(data, start, length))
+            | None, None -> None
+
+    /// Return global font metrics, preferring OS/2 typographic values.
+    let fontMetrics (font: FontFile) =
+        nullArgCheck "font" font |> ignore
+        let data = font.Data
+        let head = requireTable font.Tables "head"
+        let hhea = requireTable font.Tables "hhea"
+        let maxp = requireTable font.Tables "maxp"
+        let mutable ascender = readI16 data (hhea.Offset + 4)
+        let mutable descender = readI16 data (hhea.Offset + 6)
+        let mutable lineGap = readI16 data (hhea.Offset + 8)
+        let mutable xHeight = None
+        let mutable capHeight = None
+
+        match font.Tables.TryGetValue("OS/2") with
+        | true, os2 ->
+            let version = readU16 data os2.Offset
+            if os2.Length >= 74 then
+                ascender <- readI16 data (os2.Offset + 68)
+                descender <- readI16 data (os2.Offset + 70)
+                lineGap <- readI16 data (os2.Offset + 72)
+            if version >= 2us && os2.Length >= 90 then
+                xHeight <- Some(readI16 data (os2.Offset + 86))
+                capHeight <- Some(readI16 data (os2.Offset + 88))
+        | false, _ -> ()
+
+        { UnitsPerEm = readU16 data (head.Offset + 18)
+          Ascender = ascender
+          Descender = descender
+          LineGap = lineGap
+          XHeight = xHeight
+          CapHeight = capHeight
+          NumGlyphs = readU16 data (maxp.Offset + 4)
+          FamilyName = readName font 1us |> Option.defaultValue "(unknown)"
+          SubfamilyName = readName font 2us |> Option.defaultValue "(unknown)" }
+
+    /// Map a BMP Unicode codepoint to a glyph identifier.
+    let glyphId (font: FontFile) codepoint =
+        nullArgCheck "font" font |> ignore
+        if codepoint < 0 || codepoint > 0xFFFF then
+            None
+        else
+            let data = font.Data
+            let cmap = requireTable font.Tables "cmap"
+            let numSubtables = readU16 data (cmap.Offset + 2) |> int
+            let mutable selected: int option = None
+            let mutable index = 0
+            let mutable foundBest = false
+
+            while index < numSubtables && not foundBest do
+                let record = cmap.Offset + 4 + index * 8
+                let platform = readU16 data record
+                let encoding = readU16 data (record + 2)
+                let relative = readU32 data (record + 4) |> checkedInt "cmap subtable offset"
+                let absolute = cmap.Offset + relative
+
+                if platform = 3us && encoding = 1us then
+                    selected <- Some absolute
+                    foundBest <- true
+                elif platform = 0us && selected.IsNone then
+                    selected <- Some absolute
+
+                index <- index + 1
+
+            match selected with
+            | None -> None
+            | Some subtable when readU16 data subtable <> 4us -> None
+            | Some subtable ->
+                let segmentCount = readU16 data (subtable + 6) |> int |> fun value -> value / 2
+                let endCodes = subtable + 14
+                let startCodes = subtable + 16 + segmentCount * 2
+                let deltas = subtable + 16 + segmentCount * 4
+                let rangeOffsets = subtable + 16 + segmentCount * 6
+                let mutable lo = 0
+                let mutable hi = segmentCount
+
+                while lo < hi do
+                    let mid = lo + (hi - lo) / 2
+                    if int (readU16 data (endCodes + mid * 2)) < codepoint then
+                        lo <- mid + 1
+                    else
+                        hi <- mid
+
+                if lo >= segmentCount then
+                    None
+                else
+                    let startCode = readU16 data (startCodes + lo * 2) |> int
+                    let endCode = readU16 data (endCodes + lo * 2) |> int
+                    if codepoint < startCode || codepoint > endCode then
+                        None
+                    else
+                        let delta = readI16 data (deltas + lo * 2) |> int
+                        let rangeAddress = rangeOffsets + lo * 2
+                        let rangeOffset = readU16 data rangeAddress |> int
+                        let glyph =
+                            if rangeOffset = 0 then
+                                (codepoint + delta) &&& 0xFFFF
+                            else
+                                let address = rangeAddress + rangeOffset + (codepoint - startCode) * 2
+                                let raw = readU16 data address |> int
+                                if raw = 0 then 0 else (raw + delta) &&& 0xFFFF
+                        if glyph = 0 then None else Some(uint16 glyph)
+
+    /// Return horizontal metrics for a glyph, or None when out of range.
+    let glyphMetrics (font: FontFile) glyphIdentifier =
+        nullArgCheck "font" font |> ignore
+        let data = font.Data
+        let maxp = requireTable font.Tables "maxp"
+        let hhea = requireTable font.Tables "hhea"
+        let hmtx = requireTable font.Tables "hmtx"
+        let numGlyphs = readU16 data (maxp.Offset + 4) |> int
+        let numHorizontalMetrics = readU16 data (hhea.Offset + 34) |> int
+
+        if glyphIdentifier < 0 || glyphIdentifier >= numGlyphs || numHorizontalMetrics = 0 then
+            None
+        elif glyphIdentifier < numHorizontalMetrics then
+            let offset = hmtx.Offset + glyphIdentifier * 4
+            Some
+                { AdvanceWidth = readU16 data offset
+                  LeftSideBearing = readI16 data (offset + 2) }
+        else
+            let lastMetric = hmtx.Offset + (numHorizontalMetrics - 1) * 4
+            let bearing = hmtx.Offset + numHorizontalMetrics * 4 + (glyphIdentifier - numHorizontalMetrics) * 2
+            Some
+                { AdvanceWidth = readU16 data lastMetric
+                  LeftSideBearing = readI16 data bearing }
+
+    /// Return a legacy kern format 0 adjustment, or zero when absent.
+    let kerning (font: FontFile) leftGlyphId rightGlyphId =
+        nullArgCheck "font" font |> ignore
+        if leftGlyphId < 0 || leftGlyphId > 0xFFFF || rightGlyphId < 0 || rightGlyphId > 0xFFFF then
+            0s
+        else
+            match font.Tables.TryGetValue("kern") with
+            | false, _ -> 0s
+            | true, kern ->
+                let data = font.Data
+                let tableEnd = kern.Offset + kern.Length
+                let subtableCount = readU16 data (kern.Offset + 2) |> int
+                let target = (uint32 leftGlyphId <<< 16) ||| uint32 rightGlyphId
+                let mutable position = kern.Offset + 4
+                let mutable table = 0
+                let mutable result: int16 option = None
+
+                while table < subtableCount && position + 6 <= tableEnd && result.IsNone do
+                    let length = readU16 data (position + 2) |> int
+                    if length < 6 || position + length > tableEnd then
+                        table <- subtableCount
+                    else
+                        let format = readU16 data (position + 4) >>> 8
+                        if format = 0us && length >= 14 then
+                            let pairCount = readU16 data (position + 6) |> int
+                            let pairs = position + 14
+                            let rec search lo hi =
+                                if lo >= hi then
+                                    None
+                                else
+                                    let mid = lo + (hi - lo) / 2
+                                    let pair = pairs + mid * 6
+                                    if pair + 6 > position + length then
+                                        None
+                                    else
+                                        let key = (uint32 (readU16 data pair) <<< 16) ||| uint32 (readU16 data (pair + 2))
+                                        if key = target then Some(readI16 data (pair + 4))
+                                        elif key < target then search (mid + 1) hi
+                                        else search lo mid
+                            result <- search 0 pairCount
+
+                        position <- position + length
+                        table <- table + 1
+
+                result |> Option.defaultValue 0s

--- a/code/packages/fsharp/font-parser/README.md
+++ b/code/packages/fsharp/font-parser/README.md
@@ -1,0 +1,19 @@
+# Font Parser (F#)
+
+Pure F# metrics-only OpenType and TrueType parser with no runtime dependencies.
+
+```fsharp
+open CodingAdventures.FontParser
+
+let font = FontParser.load (System.IO.File.ReadAllBytes "Inter-Regular.ttf")
+let metrics = FontParser.fontMetrics font
+let glyph = FontParser.glyphId font (int 'A')
+let horizontal = glyph |> Option.bind (int >> FontParser.glyphMetrics font)
+```
+
+The parser reads `head`, `hhea`, `maxp`, `cmap` format 4, `hmtx`, optional
+`name` and `OS/2`, and legacy `kern` format 0 tables. It deliberately does not
+perform glyph outline rasterization.
+
+Run `./BUILD` (or the command in `BUILD_windows`) to execute tests with the
+repository's 80% line-coverage gate.

--- a/code/packages/fsharp/font-parser/required_capabilities.json
+++ b/code/packages/fsharp/font-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/font-parser",
+  "capabilities": [],
+  "justification": "Pure computation package. Parses caller-provided font bytes without filesystem, network, process, or environment access."
+}

--- a/code/packages/fsharp/font-parser/tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.fsproj
+++ b/code/packages/fsharp/font-parser/tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.FontParser.fsproj" />
+    <None Include="../../../../../fixtures/fonts/Inter-Regular.ttf" Link="Fixtures/Inter-Regular.ttf" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="FontParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/font-parser/tests/CodingAdventures.FontParser.Tests/FontParserTests.fs
+++ b/code/packages/fsharp/font-parser/tests/CodingAdventures.FontParser.Tests/FontParserTests.fs
@@ -1,0 +1,240 @@
+namespace CodingAdventures.FontParser.Tests
+
+open System
+open System.IO
+open System.Text
+open CodingAdventures.FontParser
+open Xunit
+
+module private Fixture =
+    let writeU16 (bytes: byte array) offset (value: int) =
+        bytes.[offset] <- byte (value >>> 8)
+        bytes.[offset + 1] <- byte value
+
+    let writeI16 bytes offset (value: int16) =
+        writeU16 bytes offset (int value &&& 0xFFFF)
+
+    let writeU32 (bytes: byte array) offset (value: uint32) =
+        bytes.[offset] <- byte (value >>> 24)
+        bytes.[offset + 1] <- byte (value >>> 16)
+        bytes.[offset + 2] <- byte (value >>> 8)
+        bytes.[offset + 3] <- byte value
+
+    let readU16 (bytes: byte array) offset =
+        (int bytes.[offset] <<< 8) ||| int bytes.[offset + 1]
+
+    let readU32 (bytes: byte array) offset =
+        (uint32 bytes.[offset] <<< 24)
+        ||| (uint32 bytes.[offset + 1] <<< 16)
+        ||| (uint32 bytes.[offset + 2] <<< 8)
+        ||| uint32 bytes.[offset + 3]
+
+    let writeTable bytes index (tag: string) offset length =
+        let record = 12 + index * 16
+        Encoding.ASCII.GetBytes(tag).CopyTo(bytes, record)
+        writeU32 bytes (record + 8) (uint32 offset)
+        writeU32 bytes (record + 12) (uint32 length)
+
+    let findTable bytes (tag: string) =
+        seq { 0 .. readU16 bytes 4 - 1 }
+        |> Seq.tryPick (fun index ->
+            let record = 12 + index * 16
+            if Encoding.ASCII.GetString(bytes, record, 4) = tag then
+                Some(int (readU32 bytes (record + 8)))
+            else
+                None)
+        |> Option.defaultWith (fun () -> invalidOp $"Missing table {tag}")
+
+    let buildSyntheticFont (inputPairs: (uint16 * uint16 * int16) list) =
+        let pairs = inputPairs |> List.sortBy (fun (left, right, _) -> (uint32 left <<< 16) ||| uint32 right)
+        let tableCount = 6
+        let headLength = 54
+        let hheaLength = 36
+        let maxpLength = 6
+        let cmapLength = 36
+        let hmtxLength = 14
+        let kernLength = 18 + pairs.Length * 6
+        let directoryLength = 12 + tableCount * 16
+        let head = directoryLength
+        let hhea = head + headLength
+        let maxp = hhea + hheaLength
+        let cmap = maxp + maxpLength
+        let hmtx = cmap + cmapLength
+        let kern = hmtx + hmtxLength
+        let bytes = Array.zeroCreate<byte> (kern + kernLength)
+
+        writeU32 bytes 0 0x00010000u
+        writeU16 bytes 4 tableCount
+        writeTable bytes 0 "cmap" cmap cmapLength
+        writeTable bytes 1 "head" head headLength
+        writeTable bytes 2 "hhea" hhea hheaLength
+        writeTable bytes 3 "hmtx" hmtx hmtxLength
+        writeTable bytes 4 "kern" kern kernLength
+        writeTable bytes 5 "maxp" maxp maxpLength
+
+        writeU32 bytes head 0x00010000u
+        writeU32 bytes (head + 12) 0x5F0F3CF5u
+        writeU16 bytes (head + 18) 1000
+
+        writeU32 bytes hhea 0x00010000u
+        writeI16 bytes (hhea + 4) 800s
+        writeI16 bytes (hhea + 6) -200s
+        writeI16 bytes (hhea + 8) 10s
+        writeU16 bytes (hhea + 34) 2
+
+        writeU32 bytes maxp 0x00005000u
+        writeU16 bytes (maxp + 4) 5
+
+        writeU16 bytes (cmap + 2) 1
+        writeU16 bytes (cmap + 4) 3
+        writeU16 bytes (cmap + 6) 1
+        writeU32 bytes (cmap + 8) 12u
+        writeU16 bytes (cmap + 12) 4
+        writeU16 bytes (cmap + 14) 24
+        writeU16 bytes (cmap + 18) 2
+        writeU16 bytes (cmap + 20) 2
+        writeU16 bytes (cmap + 26) 0xFFFF
+        writeU16 bytes (cmap + 28) 0
+        writeU16 bytes (cmap + 30) 0xFFFF
+        writeI16 bytes (cmap + 32) 1s
+        writeU16 bytes (cmap + 34) 0
+
+        writeU16 bytes hmtx 600
+        writeI16 bytes (hmtx + 2) 10s
+        writeU16 bytes (hmtx + 4) 700
+        writeI16 bytes (hmtx + 6) 20s
+        writeI16 bytes (hmtx + 8) 30s
+        writeI16 bytes (hmtx + 10) 40s
+        writeI16 bytes (hmtx + 12) 50s
+
+        writeU16 bytes kern 0
+        writeU16 bytes (kern + 2) 1
+        writeU16 bytes (kern + 4) 0
+        writeU16 bytes (kern + 6) (kernLength - 4)
+        writeU16 bytes (kern + 8) 1
+        writeU16 bytes (kern + 10) pairs.Length
+
+        pairs
+        |> List.iteri (fun index (left, right, value) ->
+            let offset = kern + 18 + index * 6
+            writeU16 bytes offset (int left)
+            writeU16 bytes (offset + 2) (int right)
+            writeI16 bytes (offset + 4) value)
+
+        bytes
+
+    let interBytes () =
+        File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "Fixtures", "Inter-Regular.ttf"))
+
+module FontParserTests =
+    [<Fact>]
+    let ``load rejects null and short buffers`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> FontParser.load null |> ignore) |> ignore
+        let error = Assert.Throws<FontParseException>(fun () -> FontParser.load [||] |> ignore)
+        Assert.Equal(FontErrorKind.BufferTooShort, error.Kind)
+
+    [<Fact>]
+    let ``load rejects invalid magic and missing tables`` () =
+        let invalid = Array.zeroCreate<byte> 12
+        invalid.[0] <- 0xDEuy
+        let magicError = Assert.Throws<FontParseException>(fun () -> FontParser.load invalid |> ignore)
+        Assert.Equal(FontErrorKind.InvalidMagic, magicError.Kind)
+
+        let emptyDirectory = Array.zeroCreate<byte> 12
+        Fixture.writeU32 emptyDirectory 0 0x00010000u
+        let tableError = Assert.Throws<FontParseException>(fun () -> FontParser.load emptyDirectory |> ignore)
+        Assert.Equal(FontErrorKind.TableNotFound, tableError.Kind)
+
+    [<Fact>]
+    let ``load rejects truncated directories and bad head magic`` () =
+        let truncated = Array.zeroCreate<byte> 12
+        Fixture.writeU32 truncated 0 0x00010000u
+        Fixture.writeU16 truncated 4 1
+        let shortError = Assert.Throws<FontParseException>(fun () -> FontParser.load truncated |> ignore)
+        Assert.Equal(FontErrorKind.BufferTooShort, shortError.Kind)
+
+        let badHead = Fixture.buildSyntheticFont []
+        let head = Fixture.findTable badHead "head"
+        Fixture.writeU32 badHead (head + 12) 0u
+        let headError = Assert.Throws<FontParseException>(fun () -> FontParser.load badHead |> ignore)
+        Assert.Equal(FontErrorKind.InvalidHeadMagic, headError.Kind)
+
+    [<Fact>]
+    let ``load owns an immutable copy`` () =
+        let bytes = Fixture.buildSyntheticFont []
+        let font = FontParser.load bytes
+        bytes.[0] <- 0xFFuy
+        Assert.Equal(1000us, (FontParser.fontMetrics font).UnitsPerEm)
+
+    [<Fact>]
+    let ``Inter exposes global metrics and names`` () =
+        let metrics = Fixture.interBytes () |> FontParser.load |> FontParser.fontMetrics
+        Assert.Equal(2048us, metrics.UnitsPerEm)
+        Assert.Equal("Inter", metrics.FamilyName)
+        Assert.Equal("Regular", metrics.SubfamilyName)
+        Assert.True(metrics.Ascender > 0s)
+        Assert.True(metrics.Descender <= 0s)
+        Assert.True(metrics.NumGlyphs > 100us)
+        Assert.True(metrics.XHeight |> Option.exists (fun value -> value > 0s))
+        Assert.True(metrics.CapHeight |> Option.exists (fun value -> value > 0s))
+
+    [<Fact>]
+    let ``synthetic font uses hhea fallback and unknown names`` () =
+        let metrics = Fixture.buildSyntheticFont [] |> FontParser.load |> FontParser.fontMetrics
+        Assert.Equal(1000us, metrics.UnitsPerEm)
+        Assert.Equal(800s, metrics.Ascender)
+        Assert.Equal(-200s, metrics.Descender)
+        Assert.Equal(10s, metrics.LineGap)
+        Assert.Equal(None, metrics.XHeight)
+        Assert.Equal(None, metrics.CapHeight)
+        Assert.Equal("(unknown)", metrics.FamilyName)
+        Assert.Equal("(unknown)", metrics.SubfamilyName)
+
+    [<Fact>]
+    let ``glyph lookup handles mapped unmapped and out of BMP values`` () =
+        let font = Fixture.interBytes () |> FontParser.load
+        let a = FontParser.glyphId font (int 'A')
+        let v = FontParser.glyphId font (int 'V')
+        Assert.True(a.IsSome)
+        Assert.True(v.IsSome)
+        Assert.NotEqual(a, v)
+        Assert.True((FontParser.glyphId font (int ' ')).IsSome)
+        Assert.Equal(None, FontParser.glyphId font -1)
+        Assert.Equal(None, FontParser.glyphId font 0x10000)
+        Assert.Equal(None, Fixture.buildSyntheticFont [] |> FontParser.load |> fun value -> FontParser.glyphId value 0xFFFF)
+
+    [<Fact>]
+    let ``glyph lookup ignores unsupported cmap formats`` () =
+        let bytes = Fixture.buildSyntheticFont []
+        let cmap = Fixture.findTable bytes "cmap"
+        Fixture.writeU16 bytes (cmap + 12) 12
+        Assert.Equal(None, bytes |> FontParser.load |> fun font -> FontParser.glyphId font (int 'A'))
+
+    [<Fact>]
+    let ``glyph metrics support full and shared advance records`` () =
+        let font = Fixture.buildSyntheticFont [] |> FontParser.load
+        Assert.Equal(Some { AdvanceWidth = 600us; LeftSideBearing = 10s }, FontParser.glyphMetrics font 0)
+        Assert.Equal(Some { AdvanceWidth = 700us; LeftSideBearing = 20s }, FontParser.glyphMetrics font 1)
+        Assert.Equal(Some { AdvanceWidth = 700us; LeftSideBearing = 40s }, FontParser.glyphMetrics font 3)
+        Assert.Equal(None, FontParser.glyphMetrics font -1)
+        Assert.Equal(None, FontParser.glyphMetrics font 5)
+
+        let inter = Fixture.interBytes () |> FontParser.load
+        let glyph = FontParser.glyphId inter (int 'A') |> Option.get |> int
+        Assert.True((FontParser.glyphMetrics inter glyph |> Option.get).AdvanceWidth > 0us)
+
+    [<Fact>]
+    let ``kerning reads sorted format zero pairs`` () =
+        let font = Fixture.buildSyntheticFont [ 1us, 2us, -140s; 3us, 4us, 80s ] |> FontParser.load
+        Assert.Equal(-140s, FontParser.kerning font 1 2)
+        Assert.Equal(80s, FontParser.kerning font 3 4)
+        Assert.Equal(0s, FontParser.kerning font 1 4)
+        Assert.Equal(0s, FontParser.kerning font 2 1)
+        Assert.Equal(0s, FontParser.kerning font -1 2)
+
+    [<Fact>]
+    let ``kerning defaults to zero when table is absent`` () =
+        let font = Fixture.interBytes () |> FontParser.load
+        let a = FontParser.glyphId font (int 'A') |> Option.get |> int
+        let v = FontParser.glyphId font (int 'V') |> Option.get |> int
+        Assert.Equal(0s, FontParser.kerning font a v)

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -164,7 +164,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 317
+The 172 packages present in at least ten implementation languages need 315
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -173,8 +173,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 4 | Move with F# |
-| F# | 4 | Move with C# |
+| C# | 3 | Move with F# |
+| F# | 3 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -342,6 +342,17 @@ tampered signature halves, non-canonical scalars, malformed point encodings,
 and strict seed and secret-key formats. The package now spans 12 implementation
 lanes, reduces the high-consensus backlog to 317 slots, and leaves 4 paired
 gaps in each lane.
+
+The fourteenth paired C#/F# slice is complete: `font-parser` now provides
+dependency-free metrics-only OpenType and TrueType readers in both lanes.
+Native big-endian table parsing covers global metrics and names, BMP `cmap`
+format 4 glyph lookup, complete and shared `hmtx` records, optional `OS/2`
+heights, and legacy `kern` format 0 pairs. Package-native tests exercise the
+shared Inter fixture, in-memory synthetic fonts, malformed directories and
+sentinels, immutable input ownership, unsupported mappings, shared advances,
+and sorted kerning lookup. The package now spans 12 implementation lanes,
+reduces the high-consensus backlog to 315 slots, and leaves 3 paired gaps in
+each lane.
 
 Recommended family order:
 


### PR DESCRIPTION
﻿## Summary

- add dependency-free C# and F# `font-parser` packages for metrics-only OpenType and TrueType parsing
- support `head`, `hhea`, `maxp`, BMP `cmap` format 4, `hmtx`, optional `name` and `OS/2`, and legacy `kern` format 0 tables
- add 11 package-native tests per lane using the shared Inter fixture and synthetic malformed/kerning/metrics fonts
- update the parity roadmap from 317 to 315 high-consensus missing slots, leaving three paired C#/F# gaps

## Validation

- `dotnet test code/packages/csharp/font-parser/tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.FontParser]*"` (11 passed, 91.89% line coverage)
- `dotnet test code/packages/fsharp/font-parser/tests/CodingAdventures.FontParser.Tests/CodingAdventures.FontParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.FontParser.FSharp]*"` (11 passed, 93.77% line coverage)
- `dotnet format` verification for the C# library and test projects
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'` (6 passed)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (315 high-consensus missing slots, 0 collisions)
- `git diff --cached --check`
