### PR TITLE
fix(sql-vm): integer arithmetic overflow promotes to REAL

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.52 — integer arithmetic overflow promotes to REAL
+
+`SELECT 9223372036854775807 + 1` now returns `9.2233720369e18` (real) instead of
+erroring. When the exact `i64` result of `+`/`-`/`*` or unary `-` overflows,
+SQLite redoes the operation in floating point and yields a REAL — never an error
+or a wrap. `min_i64 - 1`, `max_i64 * 2`, and `-(min_i64)` all promote likewise;
+`typeof` of an overflowed result is `'real'`. Non-overflowing arithmetic still
+returns INTEGER. Fixed in sql-vm 0.4.29 (`checked_int_binop` + unary `Neg`). One
+new differential-oracle case. (The `i64::MIN / -1` division/modulo edge, which is
+entangled with SQLite's integer-coercing `%` operator, is a separate follow-up.)
+
 ## 0.5.51 — scientific-notation numeric literals
 
 `SELECT 1e3` now parses (→ `1000.0`), along with `2.5e2`, `1.5e-3`, `10e+2`, and

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.51"
+version = "0.5.52"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1561,6 +1561,19 @@ const CASES: &[Case] = &[
         setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
         query: "SELECT (7 / 2) AS a, (-7 / 2) AS b, (7 % 3) AS c, (7.0 / 2) AS d FROM t",
     },
+    // Integer arithmetic OVERFLOW promotes to REAL, matching SQLite: when the
+    // exact i64 result of `+`/`-`/`*` (or unary `-`) does not fit, SQLite redoes
+    // the operation in floating point and returns a REAL rather than erroring or
+    // wrapping. `max_i64 + 1` = 9.2233720369e18 (real), `min_i64 - 1` likewise,
+    // `max_i64 * 2` = 1.8446744074e19, and `-(min_i64)` = 9.2233720369e18.
+    // Previously mini errored ("integer overflow in addition"). Non-overflowing
+    // arithmetic still returns INTEGER (the last two columns guard against
+    // over-promoting the common case).
+    Case {
+        id: "int_overflow_promotes_to_real",
+        setup: &[],
+        query: "SELECT 9223372036854775807 + 1 AS a, typeof(9223372036854775807 + 1) AS at, -9223372036854775807 - 2 AS b, 9223372036854775807 * 2 AS c, -(-9223372036854775808) AS d, 100 + 200 AS e, typeof(100 + 200) AS et",
+    },
     // Binary arithmetic applies NUMERIC affinity to text/blob operands, matching
     // SQLite: `'5'+0` = 5 (integer), `'5.5'+0` = 5.5 (real), `'abc'+1` = 1 (no
     // numeric prefix → 0), `'12abc'+0` = 12, and `'10'-'3'` = 7 (both coerced).

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.29] - Unreleased
+
+### Fixed
+
+- **Integer arithmetic overflow now promotes to REAL instead of erroring.** When
+  the exact `i64` result of `+`, `-`, `*`, or unary `-` does not fit, SQLite
+  redoes the operation in floating point and yields a REAL — it never errors or
+  wraps. `9223372036854775807 + 1` = `9.2233720369e18` (real), `min_i64 - 1` and
+  `max_i64 * 2` likewise, and `-(-9223372036854775808)` = `9.2233720369e18`.
+  `checked_int_binop`'s int/int arm now falls back to `float_op` on the widened
+  `f64` operands (the same float path the mixed-operand arms use), and the unary
+  `Neg` arm falls back to `-(n as f64)` for `i64::MIN`; the `op_name` parameter,
+  which existed only for the removed overflow-error message, was dropped.
+  Non-overflowing arithmetic still returns INTEGER. (Division/modulo of
+  `i64::MIN / -1` — where the operands are true integers rather than
+  overflow-to-REAL literals — is a distinct edge left for a follow-up, tangled
+  with SQLite's integer-coercing `%` semantics.)
+
 ## [0.4.28] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.28"
+version = "0.4.29"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1987,12 +1987,15 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
     match op {
         // ── Arithmetic ────────────────────────────────────────────────────────
         //
-        // Integer arithmetic uses checked variants so that overflow produces a
-        // VmError rather than panicking in debug builds or silently wrapping in
-        // release builds.  Float arithmetic wraps naturally (IEEE 754 semantics).
-        BinaryOp::Add => checked_int_binop(l, r, i64::checked_add, |a, b| a + b, "addition"),
-        BinaryOp::Sub => checked_int_binop(l, r, i64::checked_sub, |a, b| a - b, "subtraction"),
-        BinaryOp::Mul => checked_int_binop(l, r, i64::checked_mul, |a, b| a * b, "multiplication"),
+        // Integer arithmetic uses checked variants so overflow is detected rather
+        // than panicking (debug) or silently wrapping (release). For `+`/`-`/`*`
+        // an overflow PROMOTES the operation to REAL (see `checked_int_binop`),
+        // matching SQLite; only `/` and `%` still surface the rare `i64::MIN`
+        // overflow as a VmError (a follow-up). Float arithmetic wraps naturally
+        // (IEEE 754 semantics).
+        BinaryOp::Add => checked_int_binop(l, r, i64::checked_add, |a, b| a + b),
+        BinaryOp::Sub => checked_int_binop(l, r, i64::checked_sub, |a, b| a - b),
+        BinaryOp::Mul => checked_int_binop(l, r, i64::checked_mul, |a, b| a * b),
         BinaryOp::Div => {
             // SQLite returns NULL for division by zero (integer OR float) — e.g.
             // `SELECT 5/0`, `5.0/0`, and `0/0` all yield NULL, never an error.
@@ -2154,16 +2157,20 @@ fn checked_int_binop(
     r: SqlValue,
     int_op: impl Fn(i64, i64) -> Option<i64>,
     float_op: impl Fn(f64, f64) -> f64,
-    op_name: &'static str,
 ) -> Result<SqlValue, VmError> {
     // SQLite applies numeric affinity to arithmetic operands: `'5' + 0` = 5.
     let (l, r) = (coerce_arith(l), coerce_arith(r));
     match (l, r) {
-        (SqlValue::Int(a), SqlValue::Int(b)) => {
-            int_op(a, b).map(SqlValue::Int).ok_or_else(|| {
-                VmError::TypeMismatch(format!("integer overflow in {op_name}"))
-            })
-        }
+        // Two integers: return the exact i64 result when it fits. On overflow
+        // SQLite does NOT error or wrap — it PROMOTES the operation to floating
+        // point and yields a REAL. `9223372036854775807 + 1` = 9.2233720369e18
+        // (real), `min_i64 - 1` and `max_i64 * 2` likewise. We recompute with
+        // `float_op` on the f64-widened operands (the same float path the
+        // mixed-operand arms use), so the result carries REAL affinity.
+        (SqlValue::Int(a), SqlValue::Int(b)) => Ok(match int_op(a, b) {
+            Some(v) => SqlValue::Int(v),
+            None => SqlValue::Float(float_op(a as f64, b as f64)),
+        }),
         (SqlValue::Float(a), SqlValue::Float(b)) => Ok(SqlValue::Float(float_op(a, b))),
         (SqlValue::Int(a), SqlValue::Float(b)) => Ok(SqlValue::Float(float_op(a as f64, b))),
         (SqlValue::Float(a), SqlValue::Int(b)) => Ok(SqlValue::Float(float_op(a, b as f64))),
@@ -2234,14 +2241,16 @@ fn eval_unary(op: &UnaryOp, v: SqlValue) -> Result<SqlValue, VmError> {
                     SqlValue::Null => unreachable!("NULL handled by the outer match"),
                 };
                 match num {
-                    // -i64::MIN overflows; use checked_neg to return an error
-                    // instead of panicking (debug) or wrapping (release).
-                    SqlValue::Int(n) => n
-                        .checked_neg()
-                        .map(SqlValue::Int)
-                        .ok_or_else(|| VmError::TypeMismatch(
-                            "integer overflow in unary negation (value is i64::MIN)".to_string(),
-                        )),
+                    // `-n` fits in i64 for every value except i64::MIN, whose
+                    // negation overflows. SQLite PROMOTES that one case to REAL
+                    // (`-(-9223372036854775808)` = 9.2233720369e18) rather than
+                    // erroring/wrapping — mirroring the binary-overflow promotion
+                    // in `checked_int_binop`. `checked_neg` isolates the overflow
+                    // without ever panicking (debug) or wrapping (release).
+                    SqlValue::Int(n) => Ok(match n.checked_neg() {
+                        Some(v) => SqlValue::Int(v),
+                        None => SqlValue::Float(-(n as f64)),
+                    }),
                     SqlValue::Float(f) => Ok(SqlValue::Float(-f)),
                     _ => unreachable!("text_to_numeric returns Int or Float"),
                 }


### PR DESCRIPTION
## fix(sql-vm): integer arithmetic overflow promotes to REAL

`SELECT 9223372036854775807 + 1` **errored** in mini-sqlite ("integer overflow in addition") where SQLite **promotes to REAL**. When the exact `i64` result of `+`/`-`/`*` or unary `-` doesn't fit, SQLite redoes the operation in floating point and yields a REAL — never an error or a wrap.

### Change (sql-vm 0.4.29)
- `checked_int_binop`'s int/int arm falls back to `float_op` on the f64-widened operands when `int_op` returns `None` (the same float path the mixed Int/Float arms already use).
- The unary `Neg` arm falls back to `-(n as f64)` for the sole overflowing value `i64::MIN`.
- The `op_name` param (only used for the removed overflow-error message) was dropped.
- **Non-overflowing arithmetic still returns INTEGER.**

Matches SQLite: `max_i64 + 1` = `9.2233720369e18` (real), `min_i64 - 1` / `max_i64 * 2` likewise, `-(min_i64)` = `9.2233720369e18`. The promotion is **bit-identical** to SQLite's own overflow path (both round `i64`→`f64` nearest-ties-even then apply the IEEE op), so the imprecision at ~1e19 magnitudes is faithful.

### Verification
- Probed vs real `sqlite3` 3.51.0.
- New oracle case `int_overflow_promotes_to_real`: `+`/`-`/`*`/unary-neg overflow + `typeof` + a non-overflow INTEGER guard (`100+200`→Int).
- Green: sql-vm 45, mini-sqlite lib (108) + differential-oracle.
- **Security review (inline, adversarial):** clean. No panic/wrap (f64 ops on finite operands never panic; NULL is short-circuited before this fn; the non-numeric catch-all is unreachable dead-defensive code), and bit-exact SQLite parity.

### Deliberately out of scope (follow-up)
`i64::MIN / -1` division and `i64::MIN % -1` modulo of *genuine-integer* operands. These are entangled with SQLite's integer-coercing `%` operator and can't be cleanly oracle-tested via SQL literals (the token `9223372036854775808` is itself a REAL literal, since it overflows `i64`). mini-sqlite 0.5.52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
