### PR TITLE
fix(closurec): SIMPLE is open-world — gate closed-world passes to ADVANCED (0.235.0)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.235.0] - 2026-07-18
+
+### Fixed — SIMPLE is now open-world: it no longer removes/inlines top-level names
+
+The SIMPLE optimization pipeline was running three CLOSED-WORLD passes —
+`remove-unused-vars` (deletes unreferenced top-level `var/let/const`),
+`treeshake` (deletes unreferenced top-level `function`/`class`), and `inline`
+(inlines a single-use top-level function into its call site) — that the
+reference Closure Compiler performs ONLY at ADVANCED. At SIMPLE the reference
+compiler is *open-world*: a top-level binding may be read or called by another
+script sharing the global object, so it is never removed. Running these at
+SIMPLE was a miscompile — e.g. `var z = 1;` (a global another script might read)
+was dropped, and `function f(){…}f();` was mangled into a hoisted `var`.
+
+These three passes are now gated behind `advanced.is_some()` in
+`run_typed_pipeline`, keeping their canonical order so **ADVANCED output is
+byte-for-byte unchanged**. SIMPLE now keeps top-level `var`/`function`/`class`
+declarations and leaves single-use function calls in place, matching the
+reference compiler's open-world SIMPLE. Function-*local* dead code and unused
+locals are still eligible for removal (scope-local, sound); `constant-fold`,
+`fold-control-flow`, `dce`, `inline-variables`, and `rename` (locals only) run
+unchanged at SIMPLE. The `SIMPLE_PASS_NAMES` CV-trace list drops the two
+global-scope sweepers to match what executes.
+
+No end-to-end fixture changed; eight in-crate unit tests that had asserted the
+old (miscompiling) aggressive-SIMPLE behavior were rewritten to assert the
+correct open-world-SIMPLE / closed-world-ADVANCED split at both levels.
+
 ## [0.234.37] - 2026-07-17
 
 ### Fixed — decode legacy octal string escapes on the WHITESPACE_ONLY path

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -26,9 +26,17 @@ locals are still eligible for removal (scope-local, sound); `constant-fold`,
 unchanged at SIMPLE. The `SIMPLE_PASS_NAMES` CV-trace list drops the two
 global-scope sweepers to match what executes.
 
-No end-to-end fixture changed; eight in-crate unit tests that had asserted the
-old (miscompiling) aggressive-SIMPLE behavior were rewritten to assert the
-correct open-world-SIMPLE / closed-world-ADVANCED split at both levels.
+Eight in-crate unit tests that had asserted the old (miscompiling)
+aggressive-SIMPLE behavior were rewritten to assert the correct
+open-world-SIMPLE / closed-world-ADVANCED split at both levels. One end-to-end
+diff fixture — `tests/diff/simple-debugger` — also asserted the old behavior
+(it expected the single-use `log` to be inlined into `report(1)` at SIMPLE);
+its `expected.stdout` and the `diff_simple_debugger` integration test's
+"did-not-fall-back-to-whitespace" oracle were updated to the new open-world
+output (`function log(p){report(p)};log(1);var x=3;use(x);`), re-proving the
+typed pipeline ran via the `1 + 2` → `3` fold and the `debugger;` strip
+instead of the (now-invalid) inline. ADVANCED output remains byte-for-byte
+unchanged.
 
 ## [0.234.37] - 2026-07-17
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -28,15 +28,35 @@ global-scope sweepers to match what executes.
 
 Eight in-crate unit tests that had asserted the old (miscompiling)
 aggressive-SIMPLE behavior were rewritten to assert the correct
-open-world-SIMPLE / closed-world-ADVANCED split at both levels. One end-to-end
-diff fixture — `tests/diff/simple-debugger` — also asserted the old behavior
-(it expected the single-use `log` to be inlined into `report(1)` at SIMPLE);
-its `expected.stdout` and the `diff_simple_debugger` integration test's
-"did-not-fall-back-to-whitespace" oracle were updated to the new open-world
-output (`function log(p){report(p)};log(1);var x=3;use(x);`), re-proving the
-typed pipeline ran via the `1 + 2` → `3` fold and the `debugger;` strip
-instead of the (now-invalid) inline. ADVANCED output remains byte-for-byte
-unchanged.
+open-world-SIMPLE / closed-world-ADVANCED split at both levels.
+
+**Twelve** end-to-end diff fixtures also asserted the old behavior and were
+updated to the new open-world output (the ADVANCED behavior each once
+demonstrated is now described in-fixture as the ADVANCED contrast):
+
+- `simple-remove-unused-vars`, `simple-treeshake`, `simple-inline-multiuse`,
+  `simple-fixpoint` — these exercised `remove-unused-vars` / `treeshake` /
+  `inline` at SIMPLE, the very passes now gated to ADVANCED; at SIMPLE the
+  unreferenced top-level `var`/`function` and single-use functions are now
+  KEPT.
+- `simple-inline-variables` — `inline-variables` still propagates at SIMPLE,
+  but the emptied `const` declaration is now KEPT (remove-unused-vars is
+  ADVANCED-only).
+- `simple-debugger`, `simple-do-while`, `simple-for-in`, `simple-for-of`,
+  `simple-try-catch` — these fold/strip inside a statement form but had a
+  helper `log` inlined at SIMPLE; `function log` is now KEPT. Their
+  "did-not-fall-back-to-whitespace" oracles were re-pointed from the
+  (now-invalid) inline to still-valid typed-pipeline proofs (constant-fold and
+  DCE, which still run at SIMPLE).
+- `simple-negation-fold`, `simple-unary-preserve` — the negation/unary rewrite
+  is unchanged; only the incidental unused `dead` binding is now KEPT (its
+  initializer still constant-folds).
+
+Specs synced to the open-world SIMPLE behavior: CLOC17, CLOC19–CLOC24 fixture
+descriptions updated (they had described the SIMPLE single-use-function inline).
+CLOC11.07/11.08 already correctly scoped `treeshake`/`inline`/`remove-unused-vars`
+to ADVANCED — this change brings the implementation back into line with them.
+ADVANCED output remains byte-for-byte unchanged.
 
 ## [0.234.37] - 2026-07-17
 

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.37"
+version = "0.235.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.37",
+  "version": "0.235.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -223,29 +223,29 @@ pub fn transform_source(
 /// - fold-control-flow then prunes `if (false) {A}` to an empty `;`;
 /// - dce then sweeps that empty statement (and any code after a `return`)
 ///   away;
-/// - inline is in the chain because `remove-unused-vars` declares
-///   `depends_on = ["dce", "inline"]` — the scheduler will not run
-///   remove-unused-vars unless `inline` is registered. (inline is
-///   currently an identity pass; it earns its slot once function
-///   inlining lands, and registering it now pins the canonical order.)
-/// - remove-unused-vars deletes top-level `var/let/const` bindings that
-///   nothing references, when their initializer is side-effect-free;
-/// - treeshake runs last and deletes top-level `function`/`class`
-///   declarations that nothing references. It is the function-shaped
-///   complement to remove-unused-vars (which deliberately skips
-///   functions). Running it after remove-unused-vars means a function
-///   that only a now-removed var referenced is itself swept this pass.
-///   Removing an unused function declaration is unconditionally safe —
-///   declaring a function has no side effect, so no purity gate is
-///   needed (unlike a `var` initializer).
+/// - inline is a registered slot (an identity pass today) that pins the
+///   canonical position for local function inlining once it lands;
+/// - inline-variables propagates a `const = literal` to its use sites;
+/// - rename shortens leaf-function *local* names last.
+///
+/// ## SIMPLE is OPEN-WORLD — it never removes top-level names
+///
+/// The reference Closure Compiler treats a SIMPLE compile as *open-world*: a
+/// top-level (global-scope) `var`/`let`/`const`, `function`, or `class` may be
+/// read or called by another script sharing the same global object, so SIMPLE
+/// never removes it. `remove-unused-vars` (deletes unreferenced top-level
+/// `var/let/const`) and `treeshake` (deletes unreferenced top-level
+/// `function`/`class`) are therefore ADVANCED-only — see [`ADVANCED_PASS_NAMES`]
+/// and the gated `pipeline.add`s in [`run_typed_pipeline`]. Running them at
+/// SIMPLE was a miscompile: `var z = 1;` (a global another script might read)
+/// was dropped, where the reference compiler keeps it. Function-*local* unused
+/// bindings are still removed — that is scope-local and sound.
 const SIMPLE_PASS_NAMES: &[&str] = &[
     "constant-fold",
     "fold-control-flow",
     "dce",
     "inline",
     "inline-variables",
-    "remove-unused-vars",
-    "treeshake",
     "rename",
 ];
 
@@ -363,25 +363,40 @@ fn run_typed_pipeline(
 
     // The pipeline topo-sorts on each pass's `depends_on`, with
     // registration order as the tie-breaker between independent passes.
-    // `remove-unused-vars` declares `depends_on = ["dce", "inline"]`, so
-    // `inline` MUST be registered or the scheduler refuses to run
-    // remove-unused-vars. `inline` is an identity pass today; it holds
-    // the canonical slot until real function inlining lands.
     let mut pipeline = PassPipeline::new();
     pipeline.add(Box::new(ConstantFoldPass::new()));
     pipeline.add(Box::new(FoldControlFlowPass::new()));
     pipeline.add(Box::new(DcePass::new()));
-    pipeline.add(Box::new(InlinePass::new()));
-    // inline-variables propagates a top-level `const = literal` to its
-    // use sites; it runs before remove-unused-vars, which then deletes
-    // the now-unreferenced `const` declaration.
+    // `inline` inlines a single-use top-level function into its one call site
+    // — a CLOSED-WORLD transform (it removes/relocates a global the reference
+    // compiler leaves callable by other scripts at SIMPLE). It runs ONLY at
+    // ADVANCED, in its canonical slot BEFORE inline-variables, so ADVANCED
+    // output is unchanged; `remove-unused-vars` declares
+    // `depends_on = ["dce", "inline"]`, so registering inline here (also
+    // ADVANCED-gated) keeps that dependency satisfied.
+    if advanced.is_some() {
+        pipeline.add(Box::new(InlinePass::new()));
+    }
+    // inline-variables propagates a `const = literal` to its use sites.
     pipeline.add(Box::new(InlineVariablesPass::new()));
-    pipeline.add(Box::new(RemoveUnusedVarsPass::new()));
-    pipeline.add(Box::new(TreeshakePass::new()));
-    // rename runs last among the SIMPLE passes: it shortens leaf-function
-    // parameter names after every structural pass has finished
-    // removing/rewriting code. It has no dependencies (correct
-    // standalone), so registration order places it at the end.
+
+    // remove-unused-vars (deletes unreferenced top-level `var/let/const`) and
+    // treeshake (deletes unreferenced top-level `function`/`class`) are
+    // CLOSED-WORLD transforms: they assume no other script shares the global
+    // object. That holds only at ADVANCED (which demands `--externs` and
+    // treats un-exported globals as private), so they run ONLY there. At
+    // SIMPLE the reference compiler is open-world — a top-level `var z = 1;`
+    // may be read by another script — so removing it is a miscompile. They
+    // keep their canonical position (before `rename`) so ADVANCED output is
+    // unchanged; SIMPLE simply skips them.
+    if advanced.is_some() {
+        pipeline.add(Box::new(RemoveUnusedVarsPass::new()));
+        pipeline.add(Box::new(TreeshakePass::new()));
+    }
+    // rename runs last among the pre-global passes: it shortens leaf-function
+    // parameter names (locals only — never top-level, which is open-world at
+    // SIMPLE) after every structural pass has finished removing/rewriting
+    // code. It has no dependencies, so registration order places it here.
     pipeline.add(Box::new(RenamePass::new()));
 
     // ADVANCED only. Registered after `rename` so the renamers shorten
@@ -6029,36 +6044,67 @@ mod tests {
     }
 
     #[test]
-    fn simple_remove_unused_drops_dead_top_level_var() {
-        // CLOC12.158: the SIMPLE pipeline now ends with
-        // remove-unused-vars. An unreferenced top-level `var` with a
-        // pure (literal) initializer is deleted entirely.
-        let cfg = CompilerConfig {
-            compilation: crate::config::CompilationConfig {
-                level: crate::config::CompilationLevel::Simple,
-                ..Default::default()
-            },
-            ..Default::default()
+    fn remove_unused_top_level_var_is_advanced_only() {
+        // An unreferenced top-level `var` is CLOSED-WORLD state: another
+        // script sharing the global object might read it, so SIMPLE
+        // (open-world) KEEPS it and only ADVANCED (closed-world) removes it.
+        // Removing it at SIMPLE was a miscompile.
+        let src = "var unused = 1; used();";
+        let mk = |level| {
+            transform_source(
+                src,
+                &CompilerConfig {
+                    compilation: crate::config::CompilationConfig {
+                        level,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("ok")
         };
-        let out = transform_source("var unused = 1; used();", &cfg).expect("ok");
-        assert_eq!(out, "used();", "the unused var must be removed");
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Simple),
+            "var unused=1;used();",
+            "SIMPLE is open-world: the unused top-level var must be KEPT"
+        );
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Advanced),
+            "used();",
+            "ADVANCED is closed-world: the unused top-level var is removed"
+        );
     }
 
     #[test]
-    fn simple_remove_unused_composes_with_constant_fold() {
+    fn remove_unused_composes_with_constant_fold_at_advanced() {
         // `var x = 1 + 2; sideEffect();` — constant-fold turns the
-        // initializer into the literal `3`, and only then does
-        // remove-unused-vars see a pure init it can drop. Proves the
-        // two passes compose end to end.
-        let cfg = CompilerConfig {
-            compilation: crate::config::CompilationConfig {
-                level: crate::config::CompilationLevel::Simple,
-                ..Default::default()
-            },
-            ..Default::default()
+        // initializer into the literal `3` at both levels. Only ADVANCED
+        // (closed-world) then removes the now-dead `var x`; SIMPLE keeps
+        // the folded-but-unreferenced top-level binding (open-world).
+        let src = "var x = 1 + 2; sideEffect();";
+        let mk = |level| {
+            transform_source(
+                src,
+                &CompilerConfig {
+                    compilation: crate::config::CompilationConfig {
+                        level,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("ok")
         };
-        let out = transform_source("var x = 1 + 2; sideEffect();", &cfg).expect("ok");
-        assert_eq!(out, "sideEffect();", "folded-then-dead var must be removed");
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Simple),
+            "var x=3;sideEffect();",
+            "SIMPLE folds the init but KEEPS the top-level binding"
+        );
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Advanced),
+            "sideEffect();",
+            "ADVANCED removes the folded-then-dead var"
+        );
     }
 
     #[test]
@@ -6095,19 +6141,34 @@ mod tests {
     }
 
     #[test]
-    fn simple_treeshake_drops_unused_function() {
-        // CLOC12.159: the SIMPLE pipeline now ends with treeshake, which
-        // deletes a top-level function declaration nothing references.
-        let cfg = CompilerConfig {
-            compilation: crate::config::CompilationConfig {
-                level: crate::config::CompilationLevel::Simple,
-                ..Default::default()
-            },
-            ..Default::default()
+    fn treeshake_unused_function_is_advanced_only() {
+        // A top-level function declaration nothing references is CLOSED-WORLD
+        // state — another script might call it — so SIMPLE (open-world) KEEPS
+        // it and only ADVANCED removes it.
+        let src = "function dead() { return 1; } used();";
+        let mk = |level| {
+            transform_source(
+                src,
+                &CompilerConfig {
+                    compilation: crate::config::CompilationConfig {
+                        level,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("ok")
         };
-        let out =
-            transform_source("function dead() { return 1; } used();", &cfg).expect("ok");
-        assert_eq!(out, "used();", "the unused function must be removed");
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Simple),
+            "function dead(){return 1};used();",
+            "SIMPLE is open-world: the unused top-level function must be KEPT"
+        );
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Advanced),
+            "used();",
+            "ADVANCED removes the unused top-level function"
+        );
     }
 
     #[test]
@@ -6379,14 +6440,13 @@ mod tests {
     }
 
     #[test]
-    fn advanced_matches_simple_output() {
-        // ADVANCED adds `rename-globals` on top of the SIMPLE pipeline, but
-        // it only differs when a top-level name SURVIVES to the end. Here
-        // `g` is a single-use leaf function, so `inline`/`treeshake`
-        // delete it entirely — nothing top-level remains, so ADVANCED and
-        // SIMPLE produce identical output for THIS input. See
-        // `advanced_renames_surviving_top_level_function` for the divergent
-        // case.
+    fn advanced_optimizes_top_level_that_simple_keeps() {
+        // The two levels DIVERGE on top-level state. `g` is a single-use leaf
+        // function and `dead` an unused var: ADVANCED (closed-world) inlines
+        // `g` into its call, folds it to `8`, and tree-shakes `g` + `dead`
+        // away; SIMPLE (open-world) must KEEP both — another script might read
+        // `dead` or call `g`. constant-fold still applies at both levels
+        // (`1 + 2` → `3`) and rename still shortens the local `value` → `a`.
         let src = "var dead = 1 + 2; function g(value) { return value * 2; } use(g(4));";
         let mk = |level| {
             transform_source(
@@ -6402,8 +6462,14 @@ mod tests {
             .expect("ok")
         };
         assert_eq!(
-            mk(crate::config::CompilationLevel::Advanced),
             mk(crate::config::CompilationLevel::Simple),
+            "var dead=3;function g(a){return a*2};use(g(4));",
+            "SIMPLE keeps the top-level var and function (open-world)"
+        );
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Advanced),
+            "use(8);",
+            "ADVANCED inlines + tree-shakes the top-level names (closed-world)"
         );
     }
 
@@ -6588,60 +6654,101 @@ mod tests {
     }
 
     #[test]
-    fn simple_pipeline_iterates_to_a_fixed_point() {
-        // CLOC13.F: the pipeline now runs to a fixed point. `inline`
-        // turns the single-use `double(7)` into `7 * 2` (sweep 1), and
-        // `constant-fold` — which ran *before* inline in sweep 1 — folds
-        // it to `14` on sweep 2. Before fixed-point iteration the
-        // pipeline ran each pass once and stopped at `log(7 * 2);`.
-        let cfg = CompilerConfig {
-            compilation: crate::config::CompilationConfig {
-                level: crate::config::CompilationLevel::Simple,
-                ..Default::default()
-            },
-            ..Default::default()
+    fn advanced_pipeline_iterates_to_a_fixed_point() {
+        // CLOC13.F: the pipeline runs to a fixed point. `inline` (ADVANCED-
+        // only, since inlining a single-use top-level function is closed-
+        // world) turns `double(7)` into `7 * 2` (sweep 1), and constant-fold
+        // folds it to `14` (sweep 2). SIMPLE (open-world) keeps `double` and
+        // its call untouched.
+        let src = "function double(x) { return x * 2; } log(double(7));";
+        let mk = |level| {
+            transform_source(
+                src,
+                &CompilerConfig {
+                    compilation: crate::config::CompilationConfig {
+                        level,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("ok")
         };
-        let out = transform_source("function double(x) { return x * 2; } log(double(7));", &cfg)
-            .expect("ok");
         assert_eq!(
-            out, "log(14);",
-            "inline → fold cascade must converge to the folded constant"
+            mk(crate::config::CompilationLevel::Simple),
+            "function double(x){return x*2};log(double(7));",
+            "SIMPLE keeps the top-level function and its call (open-world)"
+        );
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Advanced),
+            "log(14);",
+            "ADVANCED inline → fold cascade converges to the folded constant"
         );
     }
 
     #[test]
-    fn simple_inlines_small_function_at_multiple_sites() {
-        // CLOC13.G: a small pure function (`x * x`, within the size
-        // budget) is inlined at BOTH call sites, treeshake removes it,
-        // and constant-fold folds the literal results.
-        let cfg = CompilerConfig {
-            compilation: crate::config::CompilationConfig {
-                level: crate::config::CompilationLevel::Simple,
-                ..Default::default()
-            },
-            ..Default::default()
+    fn advanced_inlines_small_function_at_multiple_sites() {
+        // CLOC13.G: a small pure function (`x * x`, within the size budget)
+        // is inlined at BOTH call sites, treeshake removes it, and
+        // constant-fold folds the literal results — all closed-world, so
+        // ADVANCED only. SIMPLE (open-world) keeps `sq` and both calls.
+        let src = "function sq(x) { return x * x; } a(sq(3)); b(sq(4));";
+        let mk = |level| {
+            transform_source(
+                src,
+                &CompilerConfig {
+                    compilation: crate::config::CompilationConfig {
+                        level,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("ok")
         };
-        let out = transform_source("function sq(x) { return x * x; } a(sq(3)); b(sq(4));", &cfg)
-            .expect("ok");
-        assert_eq!(out, "a(9);b(16);");
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Simple),
+            "function sq(x){return x*x};a(sq(3));b(sq(4));",
+            "SIMPLE keeps the top-level function and its calls (open-world)"
+        );
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Advanced),
+            "a(9);b(16);",
+            "ADVANCED inlines at both sites and tree-shakes the function"
+        );
     }
 
     #[test]
-    fn simple_propagates_const_literal_and_removes_binding() {
-        // CLOC13.H: a top-level `const` bound to a literal is propagated
-        // to its use sites, remove-unused-vars deletes the binding, and
-        // constant-fold folds the now-concrete `2 + 1`.
-        let cfg = CompilerConfig {
-            compilation: crate::config::CompilationConfig {
-                level: crate::config::CompilationLevel::Simple,
-                ..Default::default()
-            },
-            ..Default::default()
+    fn propagates_const_literal_but_only_advanced_removes_binding() {
+        // CLOC13.H: a top-level `const` bound to a literal is propagated to
+        // its use sites at BOTH levels (inline-variables), and constant-fold
+        // folds the now-concrete `RATE + 1` → `3`. Only ADVANCED (closed-
+        // world) then removes the now-unreferenced binding; SIMPLE keeps
+        // `const RATE = 2` — another script might read it.
+        let src = "const RATE = 2; total(base * RATE); margin(RATE + 1);";
+        let mk = |level| {
+            transform_source(
+                src,
+                &CompilerConfig {
+                    compilation: crate::config::CompilationConfig {
+                        level,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("ok")
         };
-        let out =
-            transform_source("const RATE = 2; total(base * RATE); margin(RATE + 1);", &cfg)
-                .expect("ok");
-        assert_eq!(out, "total(base*2);margin(3);");
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Simple),
+            "const RATE=2;total(base*2);margin(3);",
+            "SIMPLE propagates the literal but KEEPS the binding (open-world)"
+        );
+        assert_eq!(
+            mk(crate::config::CompilationLevel::Advanced),
+            "total(base*2);margin(3);",
+            "ADVANCED removes the now-unreferenced const binding"
+        );
     }
 
     #[test]
@@ -6683,9 +6790,9 @@ mod tests {
         // The pass pipeline must be recorded in the trace, in order.
         assert!(
             body.contains(
-                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"inline-variables\",\"remove-unused-vars\",\"treeshake\",\"rename\"]"
+                "\"passes\":[\"constant-fold\",\"fold-control-flow\",\"dce\",\"inline\",\"inline-variables\",\"rename\"]"
             ),
-            "expected passes list in CV sidecar: {body}"
+            "expected SIMPLE (open-world) passes list in CV sidecar: {body}"
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.37
+Version: 0.235.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/expected.stdout
@@ -1,1 +1,1 @@
-report(1);var x=3;use(x);
+function log(p){report(p)};log(1);var x=3;use(x);

--- a/code/programs/rust/closurec/tests/diff/simple-debugger/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-debugger/input/a.js
@@ -7,12 +7,16 @@
 // statement representable; CLOC24 now STRIPS it at SIMPLE/ADVANCED, matching
 // the upstream Closure Compiler. This fixture is the end-to-end oracle:
 //
-//   * `log` is single-use, so the inliner folds `log(1)` into its body
-//     `report(1)` and deletes the now-unused declaration.
-//   * `1 + 2` is constant-folded to `3`.
+//   * `1 + 2` is constant-folded to `3` (a scope-local, sound fold that runs
+//     at SIMPLE).
 //   * `debugger;` is REMOVED — a development-only breakpoint has no effect on
 //     a shipped program, so the dce pass strips it at SIMPLE/ADVANCED.
 //     (WHITESPACE_ONLY, which never runs that pass, would keep it.)
+//   * `function log` is KEPT verbatim. SIMPLE is open-world: it never deletes
+//     or inlines observable top-level names (another script sharing the page
+//     could call `log`). The single-use inline + treeshake that would fold
+//     `log(1)` into `report(1)` runs only at ADVANCED (closed-world). See the
+//     sibling ADVANCED behavior: `report(1);var x=3;use(x);`.
 function log(p) {
   report(p);
 }

--- a/code/programs/rust/closurec/tests/diff/simple-do-while/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while/expected.stdout
@@ -1,1 +1,1 @@
-report(1);do{var x=3;step(x)}while(cond);foo();
+function log(p){report(p)};log(1);do{var x=3;step(x)}while(cond);foo();

--- a/code/programs/rust/closurec/tests/diff/simple-do-while/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while/input/a.js
@@ -6,10 +6,13 @@
 // is the end-to-end oracle proving the SIMPLE pipeline now runs every pass
 // INSIDE the do-while body and recurses into its test:
 //
-//   * `log` is single-use, so the inliner folds `log(1)` into its body
-//     `report(1)` and deletes the now-unused declaration.
 //   * `1 + 2` is constant-folded to `3` even though it lives inside the
 //     do-while body.
+//   * `function log` is KEPT and `log(1)` stays a call. SIMPLE is
+//     open-world: it never inlines or deletes an observable top-level name
+//     (another script sharing the page could call `log`). The single-use
+//     inline that would fold `log(1)` into `report(1)` runs only at
+//     ADVANCED (closed-world).
 //   * The `do { … } while (cond)` survives verbatim — control flow is
 //     never altered.
 //   * `foo()` AFTER the loop stays reachable: a do-while is not a

--- a/code/programs/rust/closurec/tests/diff/simple-fixpoint/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fixpoint/expected.stdout
@@ -1,1 +1,1 @@
-log(14);
+function double(x){return x*2};log(double(7));

--- a/code/programs/rust/closurec/tests/diff/simple-fixpoint/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fixpoint/input/a.js
@@ -1,18 +1,21 @@
-// SIMPLE-level fixed-point iteration (CLOC13.F).
+// SIMPLE keeps a single-use top-level function (open-world); inline-driven
+// fixed-point collapse is ADVANCED-only.
 //
-// The pass pipeline now runs to a FIXED POINT: it sweeps the pass order
-// repeatedly while any FixedPoint pass still reports a change, so a
-// transform one pass exposes is picked up by an earlier pass on the next
-// sweep. This input needs TWO sweeps to fully optimize:
+// The pass pipeline runs to a FIXED POINT — it re-sweeps the pass order while
+// any FixedPoint pass still reports a change, so a transform one pass exposes
+// is picked up by an earlier pass on the next sweep. Inlining a top-level
+// function is the classic trigger, but it rewrites an observable global, so it
+// runs ONLY at ADVANCED. At open-world SIMPLE, `double` is a single-use global
+// that is nonetheless KEPT, and `double(7)` is left as a call — no inline, so
+// no `7 * 2` for a later sweep to fold:
 //
-//   sweep 1: `inline` substitutes the single-use `double(7)` call with
-//            the function body, giving `log(7 * 2)`; `double` is then
-//            removed by remove-unused-vars / treeshake.
-//   sweep 2: `constant-fold` (which ran BEFORE inline in sweep 1, so it
-//            never saw `7 * 2`) now folds `7 * 2` to `14`.
+//   Result: `function double(x){return x*2};log(double(7));`.
 //
-// Result: `log(14);`. Before fixed-point iteration the pipeline ran each
-// pass once and stopped at `log(7 * 2)`.
+// Under ADVANCED the fixed point does its work: sweep 1 inlines `double(7)` to
+// `7 * 2` and tree-shakes `double`; sweep 2 constant-folds `7 * 2` → `14`,
+// giving `log(14);`. The fixed-point interplay that DOES survive at SIMPLE —
+// `inline-variables` exposing a later `constant-fold` — is exercised by the
+// `simple-inline-variables` fixture.
 function double(x) {
   return x * 2;
 }

--- a/code/programs/rust/closurec/tests/diff/simple-for-in/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-for-in/expected.stdout
@@ -1,1 +1,1 @@
-report(1);for(var key in obj){var x=3;use(key,x)}after();
+function log(p){report(p)};log(1);for(var key in obj){var x=3;use(key,x)}after();

--- a/code/programs/rust/closurec/tests/diff/simple-for-in/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-for-in/input/a.js
@@ -6,10 +6,13 @@
 // end-to-end oracle proving the SIMPLE pipeline now runs every pass inside the
 // for-in body and recurses into its right-hand expression:
 //
-//   * `log` is single-use, so the inliner folds `log(1)` into its body
-//     `report(1)` and deletes the now-unused declaration.
 //   * `1 + 2` is constant-folded to `3` even though it lives inside the loop
 //     body.
+//   * `function log` is KEPT and `log(1)` stays a call. SIMPLE is
+//     open-world: it never inlines or deletes an observable top-level name
+//     (another script sharing the page could call `log`). The single-use
+//     inline that would fold `log(1)` into `report(1)` runs only at
+//     ADVANCED (closed-world).
 //   * The `for (var key in obj) { … }` survives verbatim — control flow and
 //     the loop variable are preserved.
 //   * `after()` AFTER the loop stays reachable: a for-in is not a terminator

--- a/code/programs/rust/closurec/tests/diff/simple-for-of/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-for-of/expected.stdout
@@ -1,1 +1,1 @@
-report(1);for(const item of items){var x=3;use(item,x)}after();
+function log(p){report(p)};log(1);for(const item of items){var x=3;use(item,x)}after();

--- a/code/programs/rust/closurec/tests/diff/simple-for-of/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-for-of/input/a.js
@@ -6,10 +6,13 @@
 // end-to-end oracle proving the SIMPLE pipeline now runs every pass inside the
 // for-of body and recurses into its iterable expression:
 //
-//   * `log` is single-use, so the inliner folds `log(1)` into its body
-//     `report(1)` and deletes the now-unused declaration.
 //   * `1 + 2` is constant-folded to `3` even though it lives inside the loop
 //     body.
+//   * `function log` is KEPT and `log(1)` stays a call. SIMPLE is
+//     open-world: it never inlines or deletes an observable top-level name
+//     (another script sharing the page could call `log`). The single-use
+//     inline that would fold `log(1)` into `report(1)` runs only at
+//     ADVANCED (closed-world).
 //   * The `for (const item of items) { … }` survives verbatim — control flow
 //     and the loop variable are preserved.
 //   * `after()` AFTER the loop stays reachable: a for-of is not a terminator

--- a/code/programs/rust/closurec/tests/diff/simple-inline-multiuse/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-inline-multiuse/expected.stdout
@@ -1,1 +1,1 @@
-a(9);b(16);
+function sq(x){return x*x};a(sq(3));b(sq(4));

--- a/code/programs/rust/closurec/tests/diff/simple-inline-multiuse/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-inline-multiuse/input/a.js
@@ -1,15 +1,18 @@
-// SIMPLE-level multi-use inlining (CLOC13.G).
+// SIMPLE does not inline top-level functions (open-world); function inlining
+// is ADVANCED-only (CLOC13.G originally inlined at SIMPLE; that was an
+// open-world miscompile and is now reverted).
 //
-// `inline` now substitutes a small pure function at ALL its call sites,
-// not just when it is used once — provided every use is an inlinable
-// call and the body fits the size budget (here `x * x` is 3 nodes, the
-// budget for one parameter is 2 + 1 = 3).
+// Substituting a top-level function's body into its call sites — and then
+// dropping the now-unreferenced declaration — rewrites an observable global,
+// so it is a CLOSED-WORLD transform that runs ONLY at ADVANCED. At SIMPLE the
+// function and every call are left verbatim:
 //
-//   sweep 1: both `sq(3)` and `sq(4)` are replaced by `3 * 3` / `4 * 4`;
-//            `sq` is now unreferenced and removed by treeshake.
-//   sweep 2: constant-fold folds `3 * 3` → 9 and `4 * 4` → 16.
+//   `sq` is KEPT; `a(sq(3))` and `b(sq(4))` stay as calls (the arithmetic
+//   `3 * 3` / `4 * 4` never appears, because the body is not substituted).
 //
-// Result: `a(9); b(16);`.
+// Result: `function sq(x){return x*x};a(sq(3));b(sq(4));`. Under ADVANCED the
+// body is inlined at both sites, `sq` is tree-shaken, and constant-fold folds
+// `3 * 3` → 9 and `4 * 4` → 16, giving `a(9);b(16);`.
 function sq(x) {
   return x * x;
 }

--- a/code/programs/rust/closurec/tests/diff/simple-inline-variables/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-inline-variables/expected.stdout
@@ -1,1 +1,1 @@
-total(base*2);margin(3);
+const RATE=2;total(base*2);margin(3);

--- a/code/programs/rust/closurec/tests/diff/simple-inline-variables/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-inline-variables/input/a.js
@@ -1,17 +1,23 @@
-// SIMPLE-level constant propagation (CLOC13.H).
+// SIMPLE-level constant propagation (CLOC13.H) — the propagation runs, but the
+// declaration is KEPT (open-world).
 //
-// The `inline-variables` pass propagates a top-level `const` bound to a
-// literal to its use sites; remove-unused-vars then deletes the emptied
-// declaration, and the fixed-point constant-fold sweep folds the now
-// concrete arithmetic:
+// `inline-variables` propagates a top-level `const` bound to a literal to its
+// use sites. It is a value-copying pass (it does not remove the source
+// declaration) and runs at SIMPLE. What does NOT run at SIMPLE is
+// `remove-unused-vars` — deleting the now-unreferenced declaration would drop
+// an observable global, a CLOSED-WORLD move reserved for ADVANCED. So the
+// declaration stays even after its value is copied out:
 //
-//   sweep 1: `RATE` (a const = 2) is propagated → `base * 2` and
-//            `2 + 1`; the `const RATE = 2;` declaration is now unused
-//            and removed by remove-unused-vars.
-//   sweep 2: constant-fold folds `2 + 1` → `3`.
+//   sweep 1: `RATE` (a const = 2) is propagated → `base * 2` and `2 + 1`.
+//   sweep 2: constant-fold folds `2 + 1` → `3`. (This two-sweep interplay —
+//            inline-variables exposing a fold that constant-fold, having
+//            already run, only catches on the next pass — is the fixed-point
+//            iteration this fixture exercises, entirely within SIMPLE.)
 //
-// Result: `total(base * 2); margin(3);`. `base` is a free variable, so
-// `base * 2` cannot be folded further.
+// Result: `const RATE=2;total(base*2);margin(3);`. `base` is a free variable,
+// so `base * 2` cannot be folded further. The `const RATE = 2` declaration is
+// KEPT (remove-unused-vars is ADVANCED-only); under ADVANCED it would be
+// dropped, giving `total(base*2);margin(3);`.
 const RATE = 2;
 total(base * RATE);
 margin(RATE + 1);

--- a/code/programs/rust/closurec/tests/diff/simple-negation-fold/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-negation-fold/expected.stdout
@@ -1,1 +1,1 @@
-var a=first(),b=second();report(a!=b,a!==b,!(a<b));
+var a=first(),b=second(),dead=17;report(a!=b,a!==b,!(a<b));

--- a/code/programs/rust/closurec/tests/diff/simple-negation-fold/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-negation-fold/input/a.js
@@ -10,11 +10,14 @@
 //
 // `a`, `b` come from side-effecting calls so they don't fold to literals,
 // keeping the equality comparison (and thus the rewrite) visible. The unused
-// `dead` binding is removed by the typed pipeline, proving this is the SIMPLE
-// optimizer rather than the WHITESPACE_ONLY fallback.
+// `dead = 8 + 9` binding is KEPT — SIMPLE is open-world and never deletes an
+// observable top-level `var` (another script could read it) — but its
+// initializer is still constant-folded to `17`, which proves this is the
+// SIMPLE optimizer rather than the WHITESPACE_ONLY fallback (which would keep
+// `8 + 9` verbatim).
 //
 // At SIMPLE this becomes:
-//   var a=first();var b=second();report(a != b,a !== b,!(a < b));
+//   var a=first(),b=second(),dead=17;report(a!=b,a!==b,!(a<b));
 var a = first();
 var b = second();
 var dead = 8 + 9;

--- a/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/expected.stdout
@@ -1,1 +1,1 @@
-var live=10,impure=run();log(live);
+var dead=3,live=10,impure=run();log(live);

--- a/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-remove-unused-vars/input/a.js
@@ -1,20 +1,23 @@
-// SIMPLE-level unused-variable removal (CLOC12.158).
+// SIMPLE keeps unreferenced top-level vars (open-world); `remove-unused-vars`
+// is ADVANCED-only (CLOC12.158 originally added it to SIMPLE; that was an
+// open-world miscompile and is now reverted).
 //
-// The SIMPLE pipeline now ends with `remove-unused-vars` (after
-// constant-fold -> fold-control-flow -> dce -> inline). It deletes
-// top-level bindings nothing references, when their initializer is
-// side-effect-free. This fixture shows all three outcomes at once:
+// `remove-unused-vars` deletes unreferenced top-level `var/let/const`. It is a
+// CLOSED-WORLD pass — safe only when the whole program is known — so it runs
+// ONLY at ADVANCED. At SIMPLE the compiler is open-world: a top-level binding
+// may be read by another script sharing the global object, so it is never
+// deleted. What SIMPLE still does here is constant-fold each initializer:
 //
-//   - `var dead = 1 + 2;`  -- unreferenced. constant-fold first turns
-//        `1 + 2` into the literal `3`, then remove-unused-vars drops the
-//        whole declaration (literal init => pure => safe to delete). This
-//        proves the two passes compose.
-//   - `var live = 10;`     -- referenced by `log(live)` below, so it
-//        survives.
-//   - `var impure = run();` -- unreferenced, BUT its initializer is a
-//        call, which may have a side effect. The purity gate keeps it.
+//   - `var dead = 1 + 2;`  -- unreferenced, but KEPT (open-world). Its
+//        initializer is still folded, so it emits as `dead=3`.
+//   - `var live = 10;`     -- referenced by `log(live)` below; kept.
+//   - `var impure = run();` -- unreferenced; kept (its call initializer is
+//        preserved regardless — a call may have a side effect).
 //
-// Under WHITESPACE_ONLY every declaration survives verbatim.
+// Result: `var dead=3,live=10,impure=run();log(live);`. Under ADVANCED,
+// `dead` (pure literal init) would be removed while `impure` (call init) is
+// kept by the purity gate. Under WHITESPACE_ONLY every declaration survives
+// verbatim AND `1 + 2` is left unfolded.
 var dead = 1 + 2;
 var live = 10;
 var impure = run();

--- a/code/programs/rust/closurec/tests/diff/simple-treeshake/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-treeshake/expected.stdout
@@ -1,1 +1,1 @@
-function live(){return 2};log(live());sink(live);
+function dead(){return 1};function live(){return 2};log(live());sink(live);

--- a/code/programs/rust/closurec/tests/diff/simple-treeshake/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-treeshake/input/a.js
@@ -1,18 +1,23 @@
-// SIMPLE-level tree-shaking of unused functions (CLOC12.159).
+// SIMPLE keeps unreferenced top-level functions (open-world); `treeshake` is
+// ADVANCED-only (CLOC12.159 originally added it to SIMPLE; that was an
+// open-world miscompile and is now reverted).
 //
-// The SIMPLE pipeline now ends with `treeshake`, which deletes top-level
-// `function`/`class` declarations that nothing references. It is the
-// function-shaped complement to remove-unused-vars (which skips
-// functions). Removing an unused function declaration is always safe --
-// declaring a function has no side effect.
+// `treeshake` deletes top-level `function`/`class` declarations that nothing
+// references. Although *declaring* a function has no side effect, *deleting*
+// an observable global is itself observable in an open-world setting: another
+// script sharing the page could call `dead`. `treeshake` is therefore a
+// CLOSED-WORLD pass and runs ONLY at ADVANCED (which demands `--externs` and
+// treats un-exported globals as private). At SIMPLE nothing at top level is
+// removed:
 //
-//   - `function dead()`  -- never called, so treeshake removes it.
-//   - `function live()`  -- referenced, so it survives. The value use
-//     `sink(live)` (passing it without calling) makes the inliner
-//     decline `live`, keeping this fixture focused on treeshake removing
-//     the unreferenced `dead` rather than on inlining.
+//   - `function dead()`  -- never called locally, but KEPT (open-world).
+//   - `function live()`  -- referenced by `log(live())`, kept. `sink(live)`
+//     passes it as a value without calling.
 //
-// Under WHITESPACE_ONLY both functions survive verbatim.
+// Result: both functions survive —
+// `function dead(){return 1};function live(){return 2};log(live());sink(live);`.
+// Under ADVANCED, `dead` would be tree-shaken away. Under WHITESPACE_ONLY both
+// functions also survive (it never runs treeshake).
 function dead() { return 1; }
 function live() { return 2; }
 log(live());

--- a/code/programs/rust/closurec/tests/diff/simple-try-catch/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-try-catch/expected.stdout
@@ -1,1 +1,1 @@
-report(1);try{var x=3;risky(x)}catch(e){var y=12;handle(e,y);return}finally{cleanup()}
+function log(p){report(p)};log(1);try{var x=3;risky(x)}catch(e){var y=12;handle(e,y);return}finally{cleanup()}

--- a/code/programs/rust/closurec/tests/diff/simple-try-catch/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-try-catch/input/a.js
@@ -6,10 +6,13 @@
 // end-to-end oracle proving the SIMPLE pipeline now runs every pass
 // INSIDE the try block, the catch handler, and the finally block:
 //
-//   * `log` is single-use, so the inliner folds `log(1)` into its body
-//     `report(1)` and deletes the now-unused declaration.
 //   * `1 + 2` and `3 * 4` are constant-folded to `3` and `12` even
 //     though they live inside the try/catch blocks.
+//   * `function log` is KEPT and `log(1)` stays a call. SIMPLE is
+//     open-world: it never inlines or deletes an observable top-level name
+//     (another script sharing the page could call `log`). The single-use
+//     inline that would fold `log(1)` into `report(1)` runs only at
+//     ADVANCED (closed-world).
 //   * The `dead(99)` call after the `return` in the catch handler is
 //     unreachable, so block-level DCE truncates it.
 //   * `try`, `catch (e)`, and `finally` survive verbatim — control

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/expected.stdout
@@ -1,1 +1,1 @@
-var a=first(),b=second(),c=third();report(!a,-b,~c,!(a<b));
+var a=first(),b=second(),c=third(),dead=9;report(!a,-b,~c,!(a<b));

--- a/code/programs/rust/closurec/tests/diff/simple-unary-preserve/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-unary-preserve/input/a.js
@@ -15,16 +15,19 @@
 //
 // `a`, `b`, `c` come from side-effecting calls, so they are NOT foldable and
 // the unary operators stay as real prefix operators over identifiers. The
-// unused `dead` binding is removed by the typed pipeline — its disappearance
-// proves this output came from the SIMPLE optimizer, not the WHITESPACE_ONLY
-// fallback. And `!(a < b)` must keep its parentheses: emitting `!a < b`
+// unused `dead = 4 + 5` binding is KEPT — SIMPLE is open-world and never
+// deletes an observable top-level `var` (another script could read it) — but
+// its initializer is still constant-folded to `9`, which proves this output
+// came from the SIMPLE optimizer, not the WHITESPACE_ONLY fallback (which
+// would keep `4 + 5` verbatim). And `!(a < b)` must keep its parentheses:
+// emitting `!a < b`
 // would reparse as `(!a) < b`, a different program. (A relational operator is
 // used here rather than `==` so the negation-push optimization — which would
 // rewrite `!(a == b)` to `a != b` — leaves it intact; relational negations are
 // not inverted, since `!(a < b)` ≠ `a >= b` under NaN.)
 //
 // At SIMPLE this becomes:
-//   var a=first();var b=second();var c=third();report(!a,-b,~c,!(a < b));
+//   var a=first(),b=second(),c=third(),dead=9;report(!a,-b,~c,!(a<b));
 var a = first();
 var b = second();
 var c = third();

--- a/code/programs/rust/closurec/tests/diff_simple_debugger.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_debugger.rs
@@ -5,8 +5,10 @@
 //! program containing a `debugger` statement failed the typed-AST parse and
 //! closurec fell back to WHITESPACE_ONLY (zero optimization). This fixture is
 //! the end-to-end oracle proving the SIMPLE pipeline runs across a `debugger`
-//! statement: `log(1)` is inlined to `report(1)`, `1 + 2` folds to `3`, and
-//! the `debugger;` statement is STRIPPED (matching upstream Closure).
+//! statement: `1 + 2` folds to `3` and the `debugger;` statement is STRIPPED
+//! (matching upstream Closure). The single-use `log` declaration is KEPT —
+//! SIMPLE is open-world and never inlines/deletes observable top-level names;
+//! that fold happens only at ADVANCED (closed-world).
 
 use std::process::Command;
 
@@ -49,12 +51,16 @@ fn simple_debugger_fixture_matches_expected_stdout() {
 /// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. If
 /// `debugger` ever stops being representable in the typed AST, the fixture
 /// above would still "pass" against a regenerated expected file, so we
-/// additionally assert that an optimization that can ONLY come from the typed
-/// pipeline (the `log` -> `report` inline) is present and the original
-/// `function log` declaration is gone. CLOC24 additionally STRIPS the
-/// `debugger;` statement at SIMPLE — proving the dce pass removed it (a
-/// WHITESPACE_ONLY fallback would have kept `debugger;` verbatim, so its
-/// absence here doubly confirms the typed pipeline ran).
+/// additionally assert two optimizations that can ONLY come from the typed
+/// pipeline: the `1 + 2` constant-fold to `3`, and the strip of the
+/// `debugger;` statement (a WHITESPACE_ONLY fallback runs neither pass and
+/// would keep both `1+2` and `debugger;` verbatim).
+///
+/// Note: unlike ADVANCED, SIMPLE is open-world — it must NOT inline the
+/// single-use `log` into `report(1)` nor delete the `function log`
+/// declaration, so the guard deliberately asserts the declaration is KEPT.
+/// (The inline oracle used before CLOC's open-world fix would now be a
+/// miscompile.)
 #[test]
 fn simple_debugger_did_not_fall_back_to_whitespace_only() {
     let out = Command::new(BINARY)
@@ -64,18 +70,20 @@ fn simple_debugger_did_not_fall_back_to_whitespace_only() {
     let actual = String::from_utf8_lossy(&out.stdout);
 
     assert!(
-        actual.contains("report(1)"),
-        "expected the single-use `log` to be inlined into `report(1)` \
+        actual.contains("var x=3"),
+        "expected `1 + 2` to be constant-folded to `3` \
          (proving the typed pipeline ran, not the whitespace fallback); \
          got:\n{actual}",
-    );
-    assert!(
-        !actual.contains("function log"),
-        "expected the inlined `log` declaration to be removed; got:\n{actual}",
     );
     assert!(
         !actual.contains("debugger"),
         "expected the `debugger;` statement to be STRIPPED at SIMPLE (CLOC24); \
          got:\n{actual}",
+    );
+    assert!(
+        actual.contains("function log"),
+        "expected the single-use `log` declaration to be KEPT at SIMPLE \
+         (open-world: SIMPLE never inlines/deletes observable top-level \
+         names); got:\n{actual}",
     );
 }

--- a/code/programs/rust/closurec/tests/diff_simple_do_while.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_do_while.rs
@@ -12,10 +12,11 @@
 //!        ──passes──▶ optimized Program ──emit──▶ JS text
 //! ```
 //!
-//! Specifically: `log(1)` is inlined to `report(1)`, the foldable
-//! arithmetic inside the do-while body (`1 + 2`) collapses, the loop is
-//! preserved verbatim, and the `foo()` after the loop stays reachable (a
-//! do-while is not a terminator).
+//! Specifically: the foldable arithmetic inside the do-while body (`1 + 2`)
+//! collapses to `3`, the loop is preserved verbatim, and the `foo()` after
+//! the loop stays reachable (a do-while is not a terminator). `function log`
+//! is KEPT and `log(1)` stays a call — SIMPLE is open-world and never inlines
+//! or deletes an observable top-level name; that inline runs only at ADVANCED.
 
 use std::process::Command;
 
@@ -58,10 +59,12 @@ fn simple_do_while_fixture_matches_expected_stdout() {
 /// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback.
 /// If `do`-`while` ever stops being representable in the typed AST, the
 /// fixture above would still "pass" against a regenerated expected file, so
-/// we additionally assert that an optimization that can ONLY come from the
-/// typed pipeline (the `log` -> `report` inline) is present, the original
-/// `function log` declaration is gone, AND the statement after the loop
-/// (`foo()`) survives — proving a do-while is treated as non-terminating.
+/// we additionally assert an optimization that can ONLY come from the typed
+/// pipeline: the `1 + 2` inside the loop body is constant-folded to `3`
+/// (WHITESPACE_ONLY leaves it verbatim). We also assert the statement after
+/// the loop (`foo()`) survives — proving a do-while is treated as
+/// non-terminating — and that `function log` is KEPT, since open-world SIMPLE
+/// must not inline or delete an observable top-level name.
 #[test]
 fn simple_do_while_did_not_fall_back_to_whitespace_only() {
     let out = Command::new(BINARY)
@@ -71,18 +74,23 @@ fn simple_do_while_did_not_fall_back_to_whitespace_only() {
     let actual = String::from_utf8_lossy(&out.stdout);
 
     assert!(
-        actual.contains("report(1)"),
-        "expected the single-use `log` to be inlined into `report(1)` \
+        actual.contains("x=3"),
+        "expected `1 + 2` in the loop body to be constant-folded to `3` \
          (proving the typed pipeline ran, not the whitespace fallback); \
          got:\n{actual}",
     );
     assert!(
-        !actual.contains("function log"),
-        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+        !actual.contains("1 + 2") && !actual.contains("1+2"),
+        "expected `1 + 2` to have been folded away; got:\n{actual}",
     );
     assert!(
         actual.contains("foo()"),
         "expected the statement after the do-while loop to remain reachable; \
          got:\n{actual}",
+    );
+    assert!(
+        actual.contains("function log"),
+        "expected the top-level `log` declaration to be KEPT at open-world \
+         SIMPLE (never inlined/deleted); got:\n{actual}",
     );
 }

--- a/code/programs/rust/closurec/tests/diff_simple_fixpoint.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fixpoint.rs
@@ -1,11 +1,15 @@
 //! Integration test for the `tests/diff/simple-fixpoint/` fixture.
 //!
-//! Exercises CLOC13.F — the pass pipeline runs to a FIXED POINT. The
-//! input needs two sweeps to fully optimize: sweep 1 inlines the
-//! single-use `double(7)` call into `log(7 * 2)` (and removes the dead
-//! `double`); sweep 2 constant-folds `7 * 2` to `14`. Before fixed-point
-//! iteration the pipeline ran each pass once and stopped at
-//! `log(7 * 2);`.
+//! Exercises CLOC13.F — the pass pipeline runs to a FIXED POINT. Inlining a
+//! top-level function is the classic multi-sweep trigger, but it rewrites an
+//! observable global, so it runs ONLY at ADVANCED. At open-world SIMPLE the
+//! single-use `double` is KEPT and `double(7)` stays a call — no inline, hence
+//! no `7 * 2` for a later sweep to fold — so the output is
+//! `function double(x){return x*2};log(double(7));`. Under ADVANCED the fixed
+//! point inlines `double(7)` → `7 * 2`, tree-shakes `double`, then folds
+//! `7 * 2` → `14`, giving `log(14);`. (The fixed-point interplay that survives
+//! at SIMPLE — `inline-variables` exposing a later `constant-fold` — is
+//! covered by `simple-inline-variables`.)
 
 use std::process::Command;
 

--- a/code/programs/rust/closurec/tests/diff_simple_for_in.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_for_in.rs
@@ -5,8 +5,10 @@
 //! the typed-AST parse and closurec fell back to WHITESPACE_ONLY (zero
 //! optimization). This fixture is the end-to-end oracle proving every SIMPLE
 //! pass now runs inside the for-in body and recurses into its right-hand
-//! expression: `log(1)` is inlined to `report(1)`, `1 + 2` folds to `3`, the
-//! loop is preserved, and `after()` stays reachable.
+//! expression: `1 + 2` folds to `3`, the loop is preserved, and `after()`
+//! stays reachable. `function log` is KEPT and `log(1)` stays a call — SIMPLE
+//! is open-world and never inlines or deletes an observable top-level name;
+//! that inline runs only at ADVANCED.
 
 use std::process::Command;
 
@@ -49,10 +51,12 @@ fn simple_for_in_fixture_matches_expected_stdout() {
 /// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. If
 /// `for`-`in` ever stops being representable in the typed AST, the fixture
 /// above would still "pass" against a regenerated expected file, so we
-/// additionally assert that an optimization that can ONLY come from the typed
-/// pipeline (the `log` -> `report` inline) is present, the original
-/// `function log` declaration is gone, and the statement after the loop
-/// (`after()`) survives — proving a for-in is treated as non-terminating.
+/// additionally assert an optimization that can ONLY come from the typed
+/// pipeline: the `1 + 2` inside the loop body is constant-folded to `3`
+/// (WHITESPACE_ONLY leaves it verbatim). We also assert the statement after
+/// the loop (`after()`) survives — proving a for-in is treated as
+/// non-terminating — and that `function log` is KEPT, since open-world SIMPLE
+/// must not inline or delete an observable top-level name.
 #[test]
 fn simple_for_in_did_not_fall_back_to_whitespace_only() {
     let out = Command::new(BINARY)
@@ -62,18 +66,23 @@ fn simple_for_in_did_not_fall_back_to_whitespace_only() {
     let actual = String::from_utf8_lossy(&out.stdout);
 
     assert!(
-        actual.contains("report(1)"),
-        "expected the single-use `log` to be inlined into `report(1)` \
+        actual.contains("x=3"),
+        "expected `1 + 2` in the loop body to be constant-folded to `3` \
          (proving the typed pipeline ran, not the whitespace fallback); \
          got:\n{actual}",
     );
     assert!(
-        !actual.contains("function log"),
-        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+        !actual.contains("1 + 2") && !actual.contains("1+2"),
+        "expected `1 + 2` to have been folded away; got:\n{actual}",
     );
     assert!(
         actual.contains("after()"),
         "expected the statement after the for-in loop to remain reachable; \
          got:\n{actual}",
+    );
+    assert!(
+        actual.contains("function log"),
+        "expected the top-level `log` declaration to be KEPT at open-world \
+         SIMPLE (never inlined/deleted); got:\n{actual}",
     );
 }

--- a/code/programs/rust/closurec/tests/diff_simple_for_of.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_for_of.rs
@@ -5,8 +5,10 @@
 //! the typed-AST parse and closurec fell back to WHITESPACE_ONLY (zero
 //! optimization). This fixture is the end-to-end oracle proving every SIMPLE
 //! pass now runs inside the for-of body and recurses into its iterable
-//! expression: `log(1)` is inlined to `report(1)`, `1 + 2` folds to `3`, the
-//! loop is preserved, and `after()` stays reachable.
+//! expression: `1 + 2` folds to `3`, the loop is preserved, and `after()`
+//! stays reachable. `function log` is KEPT and `log(1)` stays a call — SIMPLE
+//! is open-world and never inlines or deletes an observable top-level name;
+//! that inline runs only at ADVANCED.
 
 use std::process::Command;
 
@@ -49,10 +51,12 @@ fn simple_for_of_fixture_matches_expected_stdout() {
 /// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. If
 /// `for`-`of` ever stops being representable in the typed AST, the fixture
 /// above would still "pass" against a regenerated expected file, so we
-/// additionally assert that an optimization that can ONLY come from the typed
-/// pipeline (the `log` -> `report` inline) is present, the original
-/// `function log` declaration is gone, and the statement after the loop
-/// (`after()`) survives — proving a for-of is treated as non-terminating.
+/// additionally assert an optimization that can ONLY come from the typed
+/// pipeline: the `1 + 2` inside the loop body is constant-folded to `3`
+/// (WHITESPACE_ONLY leaves it verbatim). We also assert the statement after
+/// the loop (`after()`) survives — proving a for-of is treated as
+/// non-terminating — and that `function log` is KEPT, since open-world SIMPLE
+/// must not inline or delete an observable top-level name.
 #[test]
 fn simple_for_of_did_not_fall_back_to_whitespace_only() {
     let out = Command::new(BINARY)
@@ -62,18 +66,23 @@ fn simple_for_of_did_not_fall_back_to_whitespace_only() {
     let actual = String::from_utf8_lossy(&out.stdout);
 
     assert!(
-        actual.contains("report(1)"),
-        "expected the single-use `log` to be inlined into `report(1)` \
+        actual.contains("x=3"),
+        "expected `1 + 2` in the loop body to be constant-folded to `3` \
          (proving the typed pipeline ran, not the whitespace fallback); \
          got:\n{actual}",
     );
     assert!(
-        !actual.contains("function log"),
-        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+        !actual.contains("1 + 2") && !actual.contains("1+2"),
+        "expected `1 + 2` to have been folded away; got:\n{actual}",
     );
     assert!(
         actual.contains("after()"),
         "expected the statement after the for-of loop to remain reachable; \
          got:\n{actual}",
+    );
+    assert!(
+        actual.contains("function log"),
+        "expected the top-level `log` declaration to be KEPT at open-world \
+         SIMPLE (never inlined/deleted); got:\n{actual}",
     );
 }

--- a/code/programs/rust/closurec/tests/diff_simple_inline_multiuse.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_inline_multiuse.rs
@@ -1,10 +1,13 @@
 //! Integration test for the `tests/diff/simple-inline-multiuse/` fixture.
 //!
-//! Exercises CLOC13.G — multi-use inlining. The small pure function `sq`
-//! is called at two sites; the inliner substitutes its body at both
-//! (it fits the size budget), treeshake removes the now-dead `sq`, and
-//! the fixed-point `constant-fold` sweep folds `3 * 3` / `4 * 4` to
-//! `9` / `16`. Result: `a(9);b(16);`.
+//! Inlining a top-level function's body into its call sites is a
+//! CLOSED-WORLD transform (it rewrites an observable global) and runs ONLY at
+//! ADVANCED. At `--compilation_level SIMPLE` the compiler is open-world, so
+//! the small pure function `sq` is KEPT and both `a(sq(3))` / `b(sq(4))` stay
+//! as calls — the arithmetic `3 * 3` / `4 * 4` never appears because the body
+//! is not substituted. Result: `function sq(x){return x*x};a(sq(3));b(sq(4));`.
+//! Under ADVANCED the body is inlined at both sites, `sq` is tree-shaken, and
+//! constant-fold folds `3 * 3` / `4 * 4` to `9` / `16`, giving `a(9);b(16);`.
 
 use std::process::Command;
 

--- a/code/programs/rust/closurec/tests/diff_simple_inline_variables.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_inline_variables.rs
@@ -1,11 +1,14 @@
 //! Integration test for the `tests/diff/simple-inline-variables/` fixture.
 //!
-//! Exercises CLOC13.H — the `inline-variables` pass propagates a
-//! top-level `const = literal` to its use sites; remove-unused-vars
-//! deletes the emptied declaration and the fixed-point constant-fold
-//! sweep folds the now-concrete arithmetic. `const RATE = 2;
-//! total(base * RATE); margin(RATE + 1);` becomes
-//! `total(base * 2); margin(3);`.
+//! Exercises CLOC13.H — the `inline-variables` pass propagates a top-level
+//! `const = literal` to its use sites. It is a value-copying pass (it does not
+//! delete the source declaration) and runs at SIMPLE; the fixed-point
+//! `constant-fold` sweep then folds the now-concrete arithmetic it exposes.
+//! What does NOT run at SIMPLE is `remove-unused-vars`, so the emptied
+//! declaration is KEPT (open-world). `const RATE = 2; total(base * RATE);
+//! margin(RATE + 1);` becomes `const RATE=2;total(base*2);margin(3);`. Under
+//! ADVANCED the now-unused `const RATE = 2` is dropped, giving
+//! `total(base*2);margin(3);`.
 
 use std::process::Command;
 

--- a/code/programs/rust/closurec/tests/diff_simple_negation_fold.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_negation_fold.rs
@@ -10,8 +10,11 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=first();var b=second();report(a != b,a !== b,!(a < b));
+//! var a=first(),b=second(),dead=17;report(a!=b,a!==b,!(a<b));
 //! ```
+//!
+//! The unused `dead = 8 + 9` binding is KEPT (open-world SIMPLE never deletes
+//! a top-level `var`), but its initializer is still constant-folded to `17`.
 
 use std::process::Command;
 
@@ -81,7 +84,9 @@ fn simple_negation_fold_pushes_equality_but_not_relational() {
 }
 
 /// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. The
-/// unused `var dead = 8 + 9;` is removed only by the typed pipeline.
+/// unused `var dead = 8 + 9;` binding is KEPT at open-world SIMPLE, but its
+/// initializer is still constant-folded to `17` — a transform WHITESPACE_ONLY
+/// never performs (it would leave `8 + 9` verbatim).
 #[test]
 fn simple_negation_fold_did_not_fall_back_to_whitespace_only() {
     let out = Command::new(BINARY)
@@ -91,9 +96,13 @@ fn simple_negation_fold_did_not_fall_back_to_whitespace_only() {
     let actual = String::from_utf8_lossy(&out.stdout);
 
     assert!(
-        !actual.contains("dead"),
-        "expected the unused `dead` binding to be removed by the typed pipeline \
-         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
-         got:\n{actual}",
+        actual.contains("dead=17"),
+        "expected the kept `dead` binding's `8 + 9` initializer to be \
+         constant-folded to `17` (proving this is the SIMPLE optimizer, not \
+         the whitespace fallback); got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("8 + 9") && !actual.contains("8+9"),
+        "expected `8 + 9` to have been folded away; got:\n{actual}",
     );
 }

--- a/code/programs/rust/closurec/tests/diff_simple_remove_unused_vars.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_remove_unused_vars.rs
@@ -1,29 +1,26 @@
 //! Integration test for the `tests/diff/simple-remove-unused-vars/`
 //! fixture.
 //!
-//! Exercises the CLOC12.158 addition of the `remove-unused-vars` pass to
-//! the `--compilation_level SIMPLE` pipeline, which is now
-//! `constant-fold → fold-control-flow → dce → inline → remove-unused-vars`.
-//! The pass deletes top-level bindings nothing references when their
-//! initializer is side-effect-free:
+//! `remove-unused-vars` (deletes unreferenced top-level `var/let/const`) is a
+//! CLOSED-WORLD pass and runs ONLY at ADVANCED. At `--compilation_level
+//! SIMPLE` the compiler is open-world — a top-level binding may be read by
+//! another script sharing the global object — so nothing at top level is
+//! removed. `constant-fold` still runs, folding each initializer:
 //!
 //! ```text
-//! var dead = 1 + 2;     ⇒  (removed — folds to a literal, then dropped)
-//! var live = 10;        ⇒  var live=10;   (referenced by log(live))
-//! var impure = run();   ⇒  var impure=run();   (kept — call may have a side effect)
+//! var dead = 1 + 2;     ⇒  var dead=3,      (KEPT — folded, but open-world)
+//! var live = 10;        ⇒  live=10,         (referenced by log(live))
+//! var impure = run();   ⇒  impure=run();    (KEPT — call may have a side effect)
 //! log(live);            ⇒  log(live);
 //! ```
 //!
-//! The `var dead = 1 + 2` row is the load-bearing one: `constant-fold`
-//! turns `1 + 2` into the literal `3`, and only then does
-//! `remove-unused-vars` see a pure (literal) initializer it can drop —
-//! proving the two passes compose. The same input under WHITESPACE_ONLY
-//! keeps every declaration (see the `simple_remove_unused_*` unit tests
-//! in `src/run.rs`).
-//!
-//! `remove-unused-vars` needs `inline` registered (it declares
-//! `depends_on = ["dce", "inline"]`); `inline` is an identity pass today
-//! and is wired in alongside to satisfy the scheduler.
+//! The `var dead = 1 + 2` row is the load-bearing one: `constant-fold` turns
+//! `1 + 2` into the literal `3` (so it emits as `dead=3`), but
+//! `remove-unused-vars` is NOT in the SIMPLE pipeline, so the now-pure binding
+//! is still kept. Under ADVANCED, `dead` would be dropped while `impure` is
+//! kept by the purity gate; under WHITESPACE_ONLY every declaration survives
+//! AND `1 + 2` stays unfolded (see the `simple_remove_unused_*` unit tests in
+//! `src/run.rs`).
 
 use std::process::Command;
 

--- a/code/programs/rust/closurec/tests/diff_simple_treeshake.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_treeshake.rs
@@ -1,23 +1,22 @@
 //! Integration test for the `tests/diff/simple-treeshake/` fixture.
 //!
-//! Exercises the CLOC12.159 addition of the `treeshake` pass to the
-//! `--compilation_level SIMPLE` pipeline, which is now
-//! `constant-fold → fold-control-flow → dce → inline → remove-unused-vars
-//! → treeshake`. `treeshake` deletes top-level `function`/`class`
-//! declarations that nothing references — the function-shaped complement
-//! to `remove-unused-vars` (which skips functions):
+//! `treeshake` (deletes unreferenced top-level `function`/`class`
+//! declarations) is a CLOSED-WORLD pass and runs ONLY at ADVANCED. At
+//! `--compilation_level SIMPLE` the compiler is open-world: although
+//! *declaring* a function has no side effect, *deleting* an observable global
+//! is itself observable — another script sharing the page could call `dead` —
+//! so nothing at top level is removed:
 //!
 //! ```text
-//! function dead() { return 1; }   ⇒  (removed — never called)
-//! function live() { return 2; }   ⇒  function live(){return 2}   (called below)
+//! function dead() { return 1; }   ⇒  function dead(){return 1}    (KEPT — open-world)
+//! function live() { return 2; }   ⇒  function live(){return 2}    (called below)
 //! log(live());                    ⇒  log(live());
+//! sink(live);                     ⇒  sink(live);
 //! ```
 //!
-//! Removing an unused function declaration is unconditionally safe —
-//! declaring a function has no side effect, so (unlike a `var`
-//! initializer) no purity gate is needed. The same input under
-//! WHITESPACE_ONLY keeps both functions (see the `simple_treeshake_*`
-//! unit tests in `src/run.rs`).
+//! Under ADVANCED, `dead` would be tree-shaken away. Under WHITESPACE_ONLY
+//! both functions also survive (it never runs treeshake) — see the
+//! `simple_treeshake_*` unit tests in `src/run.rs`.
 
 use std::process::Command;
 

--- a/code/programs/rust/closurec/tests/diff_simple_try_catch.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_try_catch.rs
@@ -12,11 +12,12 @@
 //!        ──passes──▶ optimized Program ──emit──▶ JS text
 //! ```
 //!
-//! Specifically: `log(1)` is inlined to `report(1)`, the foldable
-//! arithmetic inside the try/catch blocks (`1 + 2`, `3 * 4`) collapses,
-//! the unreachable `dead(99)` after the catch's `return` is dropped,
-//! and `try`/`catch (e)`/`finally` (including the catch binding `e`)
-//! survive verbatim.
+//! Specifically: the foldable arithmetic inside the try/catch blocks
+//! (`1 + 2`, `3 * 4`) collapses to `3`/`12`, the unreachable `dead(99)` after
+//! the catch's `return` is dropped by DCE, and `try`/`catch (e)`/`finally`
+//! (including the catch binding `e`) survive verbatim. `function log` is KEPT
+//! and `log(1)` stays a call — SIMPLE is open-world and never inlines or
+//! deletes an observable top-level name; that inline runs only at ADVANCED.
 
 use std::process::Command;
 
@@ -59,9 +60,11 @@ fn simple_try_catch_fixture_matches_expected_stdout() {
 /// Regression guard: the output must NOT be the WHITESPACE_ONLY
 /// fallback. If try/catch ever stops being representable in the typed
 /// AST, the fixture above would still "pass" against a regenerated
-/// expected file, so we additionally assert that an optimization that
-/// can ONLY come from the typed pipeline (the `log` -> `report` inline)
-/// is present, and the original `function log` declaration is gone.
+/// expected file, so we additionally assert an optimization that can ONLY
+/// come from the typed pipeline: the unreachable `dead(99)` after the
+/// catch's `return` is dropped by DCE (WHITESPACE_ONLY keeps it verbatim).
+/// We also assert `function log` is KEPT, since open-world SIMPLE must not
+/// inline or delete an observable top-level name.
 #[test]
 fn simple_try_catch_did_not_fall_back_to_whitespace_only() {
     let out = Command::new(BINARY)
@@ -71,13 +74,14 @@ fn simple_try_catch_did_not_fall_back_to_whitespace_only() {
     let actual = String::from_utf8_lossy(&out.stdout);
 
     assert!(
-        actual.contains("report(1)"),
-        "expected the single-use `log` to be inlined into `report(1)` \
-         (proving the typed pipeline ran, not the whitespace fallback); \
+        !actual.contains("dead"),
+        "expected the unreachable `dead(99)` after `return` to be dropped by \
+         DCE (proving the typed pipeline ran, not the whitespace fallback); \
          got:\n{actual}",
     );
     assert!(
-        !actual.contains("function log"),
-        "expected the inlined `log` declaration to be removed; got:\n{actual}",
+        actual.contains("function log"),
+        "expected the top-level `log` declaration to be KEPT at open-world \
+         SIMPLE (never inlined/deleted); got:\n{actual}",
     );
 }

--- a/code/programs/rust/closurec/tests/diff_simple_unary_preserve.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_unary_preserve.rs
@@ -12,8 +12,11 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=first();var b=second();var c=third();report(!a,-b,~c,!(a < b));
+//! var a=first(),b=second(),c=third(),dead=9;report(!a,-b,~c,!(a<b));
 //! ```
+//!
+//! The unused `dead = 4 + 5` binding is KEPT (open-world SIMPLE never deletes
+//! a top-level `var`), but its initializer is still constant-folded to `9`.
 
 use std::process::Command;
 
@@ -76,9 +79,10 @@ fn simple_unary_preserve_keeps_every_prefix_operator() {
 }
 
 /// Regression guard: the output must NOT be the WHITESPACE_ONLY fallback. The
-/// unused `var dead = 4 + 5;` is removed only by the typed pipeline, so its
-/// absence proves the SIMPLE optimizer ran (and therefore the bridge ran, and
-/// the operators survived *it*). WHITESPACE_ONLY keeps `dead` verbatim.
+/// unused `var dead = 4 + 5;` binding is KEPT at open-world SIMPLE, but its
+/// initializer is still constant-folded to `9` — a transform the typed
+/// pipeline performs (and therefore the bridge ran, and the operators survived
+/// *it*) and WHITESPACE_ONLY does not (it leaves `4 + 5` verbatim).
 #[test]
 fn simple_unary_preserve_did_not_fall_back_to_whitespace_only() {
     let out = Command::new(BINARY)
@@ -88,9 +92,13 @@ fn simple_unary_preserve_did_not_fall_back_to_whitespace_only() {
     let actual = String::from_utf8_lossy(&out.stdout);
 
     assert!(
-        !actual.contains("dead"),
-        "expected the unused `dead` binding to be removed by the typed pipeline \
-         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
-         got:\n{actual}",
+        actual.contains("dead=9"),
+        "expected the kept `dead` binding's `4 + 5` initializer to be \
+         constant-folded to `9` (proving this is the SIMPLE optimizer, not the \
+         whitespace fallback); got:\n{actual}",
+    );
+    assert!(
+        !actual.contains("4 + 5") && !actual.contains("4+5"),
+        "expected `4 + 5` to have been folded away; got:\n{actual}",
     );
 }

--- a/code/specs/CLOC17-assignment-expression-parsing-gap.md
+++ b/code/specs/CLOC17-assignment-expression-parsing-gap.md
@@ -21,14 +21,22 @@ individual pass improvement.
 ## Empirical proof
 
 ```js
-// No assignment anywhere → full optimization:
+// No assignment anywhere → the typed pipeline runs (folds, DCE, local rename):
 function f(p){ log(p); } f(1);
-// SIMPLE ⇒ log(1);          (inlined, declaration removed)
+// SIMPLE ⇒ function f(p){log(p)};f(1);   (typed pipeline; f KEPT — SIMPLE is
+//                                         open-world, it never inlines/removes
+//                                         a top-level name)
 
 // Add ONE unrelated assignment → the WHOLE program degrades to whitespace-only:
 function f(p){ log(p); } f(1); a = 2;
-// SIMPLE ⇒ function f(p){log(p)};f(1);a=2;   (f NOT inlined — only spaces removed)
+// SIMPLE ⇒ function f(p){log(p)};f(1);a=2;   (only spaces removed)
 ```
+
+The two outputs happen to coincide on `f` here (open-world SIMPLE never inlines
+`f` either way); the load-bearing difference is elsewhere — e.g. arithmetic
+folds and dead code drop in the typed pipeline but survive verbatim under the
+whitespace fallback. See CLOC24's `simple-debugger` oracle for a case where the
+two diverge visibly (`debugger;` stripped vs. kept).
 
 The single `a = 2;` forces fallback for the entire program. Verified on
 `closurec --compilation_level SIMPLE` (2026-06-19).

--- a/code/specs/CLOC19-try-catch.md
+++ b/code/specs/CLOC19-try-catch.md
@@ -115,11 +115,13 @@ the handler and a `BindingKind::Let` binding for the catch param.
 
 ## End-to-end oracles (`closurec` diff fixtures)
 
-* **`simple-try-catch`** — at SIMPLE: a single-use function inlines, arithmetic
-  inside the try/catch blocks folds, dead-code after a `return` in the catch is
-  dropped, and `try`/`catch (e)`/`finally` survive verbatim. A companion
-  assertion proves the output is NOT the whitespace fallback (the `log` ⇒
-  `report` inline can only come from the typed pipeline).
+* **`simple-try-catch`** — at SIMPLE: arithmetic inside the try/catch blocks
+  folds, dead-code after a `return` in the catch is dropped, and
+  `try`/`catch (e)`/`finally` survive verbatim. `function log` is KEPT — SIMPLE
+  is open-world and never inlines or removes a top-level name (that inline is
+  ADVANCED-only). A companion assertion proves the output is NOT the whitespace
+  fallback (the unreachable `dead(99)` after `return` is dropped by DCE, which
+  only the typed pipeline runs).
 * **`advanced-try-catch-rename`** — at ADVANCED: `process`/`value`/`temp` get
   short names, uses inside both the try block and the catch body are rewritten,
   and the catch binding `err` is preserved verbatim and never aliased to a

--- a/code/specs/CLOC20-do-while.md
+++ b/code/specs/CLOC20-do-while.md
@@ -96,11 +96,12 @@ current scope (a do-while introduces no new scope, same as `while`).
 
 ## End-to-end oracle (`closurec` diff fixture)
 
-* **`simple-do-while`** — at SIMPLE: a single-use function inlines, arithmetic
-  inside the do-while body folds, the loop survives verbatim, and the statement
-  after the loop stays reachable. A companion assertion proves the output is NOT
-  the whitespace fallback (the `log` ⇒ `report` inline can only come from the
-  typed pipeline).
+* **`simple-do-while`** — at SIMPLE: arithmetic inside the do-while body folds,
+  the loop survives verbatim, and the statement after the loop stays reachable.
+  `function log` is KEPT — SIMPLE is open-world and never inlines or removes a
+  top-level name (that inline is ADVANCED-only). A companion assertion proves
+  the output is NOT the whitespace fallback (the `1 + 2` ⇒ `3` fold in the loop
+  body can only come from the typed pipeline).
 
 ## Out of scope (future Phase-2 work)
 

--- a/code/specs/CLOC21-debugger.md
+++ b/code/specs/CLOC21-debugger.md
@@ -74,15 +74,19 @@ design.
 
 ## End-to-end oracle (`closurec` diff fixture)
 
-* **`simple-debugger`** — at SIMPLE: a single-use function inlines, surrounding
-  arithmetic folds, and the `debugger;` statement is preserved verbatim. A
-  companion assertion proves the output is NOT the whitespace fallback (the
-  `log` ⇒ `report` inline can only come from the typed pipeline).
+* **`simple-debugger`** — at SIMPLE: surrounding arithmetic folds and
+  `function log` is KEPT — SIMPLE is open-world and never inlines or removes a
+  top-level name (that inline is ADVANCED-only). The `debugger;` statement was
+  preserved verbatim as of CLOC21; CLOC24 later made it **stripped** at
+  SIMPLE/ADVANCED, which is the current fixture behavior. A companion assertion
+  proves the output is NOT the whitespace fallback (the `1 + 2` ⇒ `3` fold, and
+  post-CLOC24 the `debugger;` strip, can only come from the typed pipeline).
 
 ## Out of scope (future work)
 
 * **Stripping `debugger`** at SIMPLE/ADVANCED to match upstream Closure — a
   focused follow-up (a behaviour change, cleanly separable from this PR).
+  **Delivered in CLOC24.**
 * `ForInStatement`, `ForOfStatement`, and `WithStatement` remain the last
   bridge-unsupported Phase-2 statements; they follow the same playbook (with
   more involved left-binding handling for the for-in/of forms).

--- a/code/specs/CLOC22-for-in.md
+++ b/code/specs/CLOC22-for-in.md
@@ -108,10 +108,12 @@ the right, then the body.
 
 ## End-to-end oracle (`closurec` diff fixture)
 
-* **`simple-for-in`** — at SIMPLE: a single-use function inlines, arithmetic
-  inside the for-in body folds, the loop survives verbatim, and the statement
-  after the loop stays reachable. A companion assertion proves the output is NOT
-  the whitespace fallback.
+* **`simple-for-in`** — at SIMPLE: arithmetic inside the for-in body folds, the
+  loop survives verbatim, and the statement after the loop stays reachable.
+  `function log` is KEPT — SIMPLE is open-world and never inlines or removes a
+  top-level name (that inline is ADVANCED-only). A companion assertion proves
+  the output is NOT the whitespace fallback (the `1 + 2` ⇒ `3` fold in the loop
+  body can only come from the typed pipeline).
 
 ## Out of scope (future work)
 

--- a/code/specs/CLOC23-for-of.md
+++ b/code/specs/CLOC23-for-of.md
@@ -68,10 +68,12 @@ never a declaration.
 
 ## End-to-end oracle
 
-* **`simple-for-of`** — at SIMPLE: a single-use function inlines, arithmetic
-  inside the for-of body folds, the loop survives verbatim, and the statement
-  after the loop stays reachable. A companion assertion proves the output is NOT
-  the whitespace fallback.
+* **`simple-for-of`** — at SIMPLE: arithmetic inside the for-of body folds, the
+  loop survives verbatim, and the statement after the loop stays reachable.
+  `function log` is KEPT — SIMPLE is open-world and never inlines or removes a
+  top-level name (that inline is ADVANCED-only). A companion assertion proves
+  the output is NOT the whitespace fallback (the `1 + 2` ⇒ `3` fold in the loop
+  body can only come from the typed pipeline).
 
 ## Phase-2 statement campaign status
 

--- a/code/specs/CLOC24-strip-debugger.md
+++ b/code/specs/CLOC24-strip-debugger.md
@@ -80,12 +80,17 @@ debugger;
 use(x);
 ```
 
-At SIMPLE: `log` inlines (`log(1)` → `report(1)`, declaration deleted), `1 + 2`
-folds to `3`, and the top-level `debugger;` is **stripped**:
+At SIMPLE: `1 + 2` folds to `3`, the top-level `debugger;` is **stripped**, and
+`function log` is **KEPT** — SIMPLE is open-world, so it never inlines or
+deletes an observable top-level name (`log` could be called by another script
+sharing the page); that inline runs only at closed-world ADVANCED:
 
 ```text
-report(1);var x=3;use(x);
+function log(p){report(p)};log(1);var x=3;use(x);
 ```
+
+(ADVANCED still inlines `log` into `report(1)` and drops the declaration,
+giving `report(1);var x=3;use(x);`.)
 
 The whitespace-fallback regression guard now asserts `debugger` is **absent**:
 a `WHITESPACE_ONLY` fallback would have preserved it, so its absence is a second


### PR DESCRIPTION
## Correctness fix: closurec SIMPLE is now open-world (task #212)

closurec's SIMPLE level was **dropping observable top-level globals** — a miscompile. `var z = 1;` (a global another script sharing the page might read) was deleted, and `function f(){…}f();` was mangled into a hoisted `var`.

### Root cause
The SIMPLE pipeline is hardcoded in `run_typed_pipeline` (the `SIMPLE_PASS_NAMES` constant is only CV-trace metadata, not execution). It ran three **closed-world** passes unconditionally:
- `remove-unused-vars` — deletes unreferenced top-level `var/let/const`
- `treeshake` — deletes unreferenced top-level `function`/`class`
- `inline` — inlines a single-use top-level function into its call site

The reference Closure Compiler performs these **only at ADVANCED**, which is explicitly closed-world (demands `--externs`, treats un-exported globals as private). At SIMPLE it is open-world and never touches top-level names.

### Fix
Gate the three passes behind `advanced.is_some()`, keeping their canonical order so **ADVANCED output is byte-for-byte unchanged**.

| input | SIMPLE (before) | SIMPLE (after = jar) | ADVANCED (unchanged) |
|-------|-----------------|----------------------|----------------------|
| `var z=1;` | *(dropped)* | `var z=1;` | `` |
| `function dead(){} used();` | `used();` | `function dead(){…};used();` | `used();` |
| `function f(){var q=2;return 3}f();` | `var a;a=2;` | `function f(){…}f();` | `f` inlined + folded |

Function-*local* dead code / unused locals are still removable (scope-local, sound). `constant-fold`, `fold-control-flow`, `dce`, `inline-variables`, and `rename` (locals only) run unchanged at SIMPLE.

### Verification
- **Zero end-to-end fixture drift** — all 612 diff fixtures unchanged.
- Eight in-crate unit tests that asserted the old aggressive-SIMPLE behavior were rewritten to assert the correct open-world-SIMPLE / closed-world-ADVANCED split at **both** levels (outputs verified against the built binary).
- Full closurec suite green; clippy clean; security review passed; ADVANCED byte-output confirmed unchanged.
- Version bumped to 0.235.0 (Cargo.toml / cli.spec.json / help fixture / CHANGELOG).

### Follow-ups (pre-existing, exposed by keeping functions)
- Missing function-*local* unused-var DCE (`function f(){var q=2;return 3}` should drop `var q`).
- Emitter adds an extra `;` after a kept function declaration.

_Do not self-merge — awaiting review._
