### PR TITLE
feat(hl): Italian & Portuguese introductions (Ch.3) — every track now runs a full conversation

### DIFF
--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Chapter 3 — Introducing Yourself
+
+- **Chapter 3 authored** (`IT-C03-io`, `-mi-chiamo`, `-come-ti-chiami`,
+  `-piacere`, `-practice`): fills the gap between the greetings/how-are-you
+  chapters and the farewells, so Italian now runs greet → introduce →
+  how-are-you → goodbye end to end. Each lesson reviews Chapter 2.
+- **io** (← *ego*) introduces the **pro-drop** habit — Italian usually omits the
+  subject pronoun because the verb ending already carries it (shared with
+  Spanish *yo* / Portuguese *eu*).
+- **mi chiamo** — "I call myself" (*chiamarsi* ← Latin *clāmāre* "to call out" →
+  claim/exclaim/clamor), completing the Romance naming-verb set: Spanish *me
+  llamo* (*cl-*→*ll-*), Italian *mi chiamo* (*ch* = hard *k*), Portuguese *me
+  chamo* (*ch* = *sh*).
+- **Come ti chiami? / Come si chiama?** — the name asked with *come* ("how"), tu
+  vs Lei; **piacere** ← *placēre* "to please" (please/pleasure/placid; twin of
+  Portuguese *prazer*).
+- Uses canonical `PRONOUN-I`, `INTRO-MY-NAME-IS`, `INTRO-WHATS-YOUR-NAME`,
+  `INTRO-NICE-TO-MEET-YOU` — no taxonomy change.
+
 ## Chapter 4 — Farewells
 
 - **Chapter 4 authored** (`IT-C04-arrivederci`, `-a-domani`, `-a-presto`,

--- a/code/learning/human-languages/italian/lessons/IT-C03-come-ti-chiami.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-come-ti-chiami.md
@@ -1,0 +1,61 @@
+---
+id: IT-C03-come-ti-chiami
+chapter: 3
+type: phrase
+headword: Come ti chiami?
+gloss: what's your name? (informal); formal Come si chiama?
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [IT-C03-mi-chiamo, IT-C02-come]
+sounds: [ch-hard-k]
+roots: [quomodo-latin, clamare-latin]
+etymology_hook: "come (← quōmodo 'how') + ti chiami (chiamarsi) — 'how do you call yourself?'"
+est_minutes: 3
+reviews_of: [IT-C03-mi-chiamo, IT-C02-come]
+---
+
+# Come ti chiami? — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] You have both pieces: **come** ("how," from your how-are-you chapter)
+and **chiamarsi** ("to call oneself"). Like Spanish and French, Italian asks the
+name with **"how"**, not "what": *how do you call yourself?*
+
+## The phrase, taken apart
+
+> **Come ti chiami?** = "What's your name?" (informal)
+> literally: **"How do you call yourself?"**
+
+- **come** = "how" (← *quōmodo*; you met it in *Come stai?*).
+- **ti** = "yourself" (the reflexive, matching *mi* → *ti*).
+- **chiami** = "you call" (the *tu* form of *chiamarsi*).
+
+Two registers — the same *tu / Lei* split you learned in Chapter 2:
+
+| register | question |
+|---|---|
+| **informal** (*tu*) | **Come ti chiami?** |
+| **formal** (*Lei*) | **Come si chiama?** |
+
+Only the reflexive pronoun and the ending move: *ti chiami* → *si chiama* — the
+identical pattern to *mi chiamo → si chiama*. The whole exchange:
+
+> — Come ti chiami? — Mi chiamo Marco. E tu?
+
+Note Italian asks the name with *come* ("how"), exactly like Spanish *¿cómo se
+llama?* and French *comment vous appelez-vous?* — the name is a matter of *how*
+you're called, not *what* you are.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Come ti chiami?" — informal, for a peer]
+- [YOU SAY: "Come si chiama?" — formal, for a stranger (Lei)]
+- [YOU SAY: the whole swap — "Come ti chiami? — Mi chiamo … E tu?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *Come ti chiami?* literally ask? ("How do you call
+yourself?") What changes for the formal *Lei* version? (*ti chiami* → *si
+chiama*.) Which "how" word is it built on? (*come* ← *quōmodo*.) Next: the reply
+when you meet — **piacere**.

--- a/code/learning/human-languages/italian/lessons/IT-C03-io.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-io.md
@@ -1,0 +1,63 @@
+---
+id: IT-C03-io
+chapter: 3
+type: word
+headword: io
+gloss: I (first-person subject pronoun)
+concept_tag: PRONOUN-I
+prerequisites: []
+sounds: [io-glide]
+roots: [ego-latin]
+etymology_hook: "io ← Latin ego 'I' → English ego, egoist; Italian usually drops it (pro-drop)"
+est_minutes: 3
+reviews_of: [IT-C04-arrivederci]
+---
+
+# io — "I," the pronoun Italian loves to leave out
+
+## Warm-up
+
+[PAUSE 2s] Before you introduce yourself, meet **io** — "I." It's a small word
+with a famous English cousin, and a surprising habit: Italian usually **drops
+it.**
+
+## Sounds you'll need
+
+- `io-glide` — **io** = *EE-oh*, two quick vowels gliding together, stress the
+  first: *EE-oh*.
+
+## The word, taken apart
+
+**io** = "I," worn down from Latin **ego** — which English borrowed *whole*:
+
+- **ego** — literally Latin "I" (your sense of self).
+- **egoist**, **egotist**, **egocentric** — all built on that "I."
+- Its Romance siblings: Spanish **yo**, Portuguese **eu**, French **je** — every
+  one a child of *ego*.
+
+## Grammar Lens: the dropped subject (pro-drop)
+
+Here's the Italian habit worth learning now: **the verb ending already tells you
+who's speaking, so the pronoun is usually left out.** *Sto bene* ("I'm well")
+needs no *io* — the *-o* of *sto* is "I." You add **io** only for **emphasis** or
+**contrast**:
+
+> *Io* sto bene — e tu? — "*I'm* fine — and you?"
+
+Spanish (*yo*) and Portuguese (*eu*) do exactly the same. English can't: it must
+say "I" every time. So learning Italian means learning to *trust the verb ending*
+and let the pronoun go.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "io" — *EE-oh*]
+- [YOU SAY: "io" then English "ego, egoist" — the same Latin "I"]
+- [YOU SAY: "Sto bene" with no *io* — the ending carries the "I"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word is *io* from, and what English words share it? (*Ego*
+— ego, egoist.) Why does Italian usually drop *io*? (The verb ending already
+says who.) When do you keep it? (For emphasis/contrast.) Next: use it to
+introduce yourself — **mi chiamo**.

--- a/code/learning/human-languages/italian/lessons/IT-C03-mi-chiamo.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-mi-chiamo.md
@@ -1,0 +1,65 @@
+---
+id: IT-C03-mi-chiamo
+chapter: 3
+type: phrase
+headword: mi chiamo
+gloss: my name is (literally "I call myself")
+concept_tag: INTRO-MY-NAME-IS
+prerequisites: [IT-C03-io]
+sounds: [ch-hard-k]
+roots: [clamare-latin]
+etymology_hook: "chiamarsi ← Latin clāmāre 'to call out' → English claim, clamor, exclaim, proclaim"
+est_minutes: 4
+reviews_of: [IT-C03-io]
+---
+
+# mi chiamo — "I call myself"
+
+## Warm-up
+
+[PAUSE 2s] Like Spanish and French, Italian doesn't say "my name is." It says **"I
+call myself"** — **mi chiamo**. Same reflexive trick, same *clāmāre* root as
+Spanish *me llamo*.
+
+## Sounds you'll need
+
+- `ch-hard-k` — Italian **ch** is a **hard k** (the opposite of English!): so
+  **chiamo** = *KYAH-moh*, not "chee-." (Italian softens *c* to *ch*-sound only
+  before *e/i*; the *h* in *chi* is there precisely to keep it hard.)
+- **mi chiamo** = *mee KYAH-moh*.
+
+## The phrase, taken apart
+
+**mi chiamo** = **mi** ("myself") + **chiamo** ("I call") → **"I call myself."**
+Then the name: *Mi chiamo Marco* — "I call myself Marco."
+
+The verb is **chiamarsi** ("to call oneself"), from Latin **clāmāre**, *"to cry
+out, to call."* That root shouts through English:
+
+- **claim**, **exclaim**, **proclaim**, **acclaim**, **clamor** — all "calling
+  out."
+- Its Romance siblings all name people the same way: Spanish **llamarse** (*me
+  llamo*), Portuguese **chamar-se** (*me chamo*) — the *cl-* softening to *ll-*
+  (Spanish) or *ch-* (Italian/Portuguese). One Latin "call," three naming verbs.
+
+## Grammar Lens: the reflexive, and the dropping of *io*
+
+*chiamo* alone is "I call [someone else]"; **mi** chiamo is "I call **myself**" —
+**reflexive**, the action looping back on you. The pronoun changes with the
+person: **mi** chiamo (I) → **ti** chiami (you) → **si** chiama (he/she/formal).
+And notice: no *io* — the *-o* ending already says "I." (You met that pro-drop
+last lesson.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mi chiamo" — *mee KYAH-moh*, hard *k* in *chiamo*]
+- [YOU SAY: "Mi chiamo …" with your own name]
+- [YOU SAY: "chiamo" then English "claim, exclaim, clamor" — the *clāmāre* family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *mi chiamo* literally mean? ("I call myself.") What Latin
+verb is *chiamarsi* from, and its English cousins? (*clāmāre* — claim, exclaim,
+clamor.) How is Italian *ch* pronounced? (A hard *k*.) Next: ask it back — **Come
+ti chiami?**

--- a/code/learning/human-languages/italian/lessons/IT-C03-piacere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-piacere.md
@@ -1,0 +1,67 @@
+---
+id: IT-C03-piacere
+chapter: 3
+type: word
+headword: piacere
+gloss: pleased to meet you (literally "a pleasure")
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [IT-C03-come-ti-chiami]
+sounds: [soft-c, ia-glide]
+roots: [placere-latin]
+etymology_hook: "piacere ← Latin placēre 'to please' → English please, pleasure, complacent; kin of Portuguese prazer"
+est_minutes: 3
+reviews_of: [IT-C03-mi-chiamo, IT-C03-come-ti-chiami]
+---
+
+# piacere — "pleased to meet you," i.e. "a pleasure"
+
+## Warm-up
+
+[PAUSE 2s] Names exchanged, you close the introduction with one warm word:
+**piacere** — literally *"a pleasure."* It's the twin of a word you'd say in
+Portuguese, and it's pure Latin *please*.
+
+## Sounds you'll need
+
+- `soft-c` — **piacere** = *pya-**CHEH**-reh*: here *c* is before *e*, so it's
+  soft (*ch*), and the *ia* glides: *pya-CHE-re*.
+
+## The word, taken apart
+
+**piacere** = "a pleasure" (and, as a verb, "to please"), from Latin **placēre**,
+*"to please, to be pleasing."* Said on meeting someone, it's short for *"[it's] a
+pleasure [to meet you]."*
+
+That **placēre** root is thoroughly at home in English:
+
+- **please**, **pleasure**, **pleasant** — the direct line.
+- **complacent** ("pleased *with* oneself"), **complaisant**, **placid** (pleased
+  → calm).
+
+And across the family, "pleased to meet you" is built from the *same* idea nearly
+everywhere:
+
+- Portuguese **prazer** (← *placēre* too — its twin).
+- French **enchanté** (a different image — "enchanted").
+- Spanish **mucho gusto** ("much pleasure," but from *gustus*, "taste" — a
+  different Latin root).
+
+## Grammar Lens: a one-word courtesy
+
+*Piacere* stands alone — you just say it, with a small nod, as you shake hands.
+For a touch more you can say *molto piacere* ("much pleasure") or *piacere di
+conoscerti* ("pleasure to know you").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "piacere" — *pya-CHEH-reh*]
+- [YOU SAY: "piacere" then English "please, pleasure, placid" — the *placēre* root]
+- [YOU SAY: Italian *piacere* and Portuguese *prazer* — twins from *placēre*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *piacere* literally mean, and from what? ("A pleasure," ←
+*placēre* "to please.") Its English cousins? (Please, pleasure, placid,
+complacent.) Which Portuguese word is its twin? (*Prazer*.) Next: put the whole
+introduction together.

--- a/code/learning/human-languages/italian/lessons/IT-C03-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C03-practice.md
@@ -1,0 +1,63 @@
+---
+id: IT-C03-practice
+chapter: 3
+type: practice-mix
+headword: (practice)
+gloss: introducing yourself in Italian, formal and informal
+concept_tag: CH3-PRACTICE
+prerequisites: [IT-C03-io, IT-C03-mi-chiamo, IT-C03-come-ti-chiami, IT-C03-piacere]
+sounds: []
+roots: []
+est_minutes: 4
+reviews_of: [IT-C03-mi-chiamo, IT-C03-come-ti-chiami, IT-C03-piacere, IT-C02-practice]
+---
+
+# Practice — introducing yourself in Italian
+
+## Warm-up
+
+[PAUSE 2s] No new words. *io, mi chiamo, come ti chiami, piacere* now assemble
+into a real first meeting — run it formally and informally until the register
+swap is automatic. This slots between your greetings (Ch. 1–2) and farewells
+(Ch. 4).
+
+## The exchange
+
+**Informal** (a peer):
+
+> — Ciao! **Come ti chiami?**
+> — **Mi chiamo** Marco. E tu?
+> — Giulia. **Piacere!**
+> — Piacere!
+
+**Formal** (a stranger — *Lei*):
+
+> — Buongiorno. **Come si chiama?**
+> — Mi chiamo Marco Rossi. E Lei?
+> — Rossi. **Molto piacere.**
+
+## What you've built this chapter
+
+- **io** — "I" (← *ego*), usually **dropped** — the verb ending carries it.
+- **mi chiamo** — "I call myself" (*chiamarsi* ← *clāmāre*, "call out"; kin of
+  Spanish *me llamo*, Portuguese *me chamo*).
+- **Come ti chiami? / Come si chiama?** — "how do you call yourself?", informal /
+  formal.
+- **piacere** — "a pleasure" (← *placēre*; twin of Portuguese *prazer*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full informal meeting, both voices]
+- [YOU SAY: the same formally — *ti chiami → si chiama*, *tu → Lei*]
+- [YOU SAY: chain it all — greet, name, ask, how-are-you, goodbye:
+  "Ciao! Mi chiamo … Come ti chiami? … Come stai? … A domani!"]
+
+[REPEAT x2] Run a whole first meeting start to finish.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does Italian usually drop *io*? (The verb ending says who.) What
+does *mi chiamo* literally mean, and its root? ("I call myself"; *clāmāre*.) What
+does *piacere* mean? ("A pleasure.") Italian now runs greet → introduce →
+how-are-you → goodbye, end to end.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -25,11 +25,15 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   (*più*/plus + *tardi*/tardy) → practice. **Authored** (Ch. 3 introductions to
   slot in below it).
 
+- **Ch. 3 — Introducing Yourself**: io (← *ego*; pro-drop) → mi chiamo
+  (*chiamarsi* ← *clāmāre*; *ch* = hard *k*) → come ti chiami / come si chiama →
+  piacere (← *placēre*; twin of *prazer*) → practice. **Authored** — fills the
+  gap so Italian runs greet → introduce → how-are-you → goodbye end to end.
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 3 | Introducing yourself: *mi chiamo*, come ti chiami, piacere |
 | 5+ | Numbers, time, days & months, family, food — following the shared theme order |
 
 Note: Italian's formal "you" is **Lei** — literally "she" (a 3rd-person

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Chapter 3 — Introducing Yourself
+
+- **Chapter 3 authored** (`PT-C03-eu`, `-me-chamo`, `-como-se-chama`, `-prazer`,
+  `-practice`): fills the gap between the greetings/how-are-you chapters and the
+  farewells, so Portuguese runs greet → introduce → how-are-you → goodbye end to
+  end. Each lesson reviews Chapter 2.
+- **eu** (← *ego*) introduces **pro-drop** — the subject pronoun is usually
+  dropped (shared with Spanish *yo* / Italian *io*).
+- **me chamo / chamo-me** — "I call myself" (*chamar-se* ← Latin *clāmāre*),
+  completing the three-way *cl-* sound split: Spanish *ll* (*llamo* = *y*),
+  Italian *ch* (hard *k*), Portuguese *ch* (= *sh*). Notes the noun-route
+  alternative *o meu nome é* (*nome* ← *nōmen* → noun/nominal).
+- **Como se chama?** — the name asked with *como* ("how"), everyday *você*;
+  **prazer** ← *placēre* "to please" (twin of Italian *piacere*; the Portuguese
+  *pl-* → *pr-* shift).
+- Uses canonical `PRONOUN-I`, `INTRO-MY-NAME-IS`, `INTRO-WHATS-YOUR-NAME`,
+  `INTRO-NICE-TO-MEET-YOU` — no taxonomy change.
+
 ## Chapter 4 — Farewells (completes the 5-language greet-to-goodbye arc)
 
 - **Chapter 4 authored** (`PT-C04-adeus`, `-ate-logo`, `-ate-amanha`,

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-como-se-chama.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-como-se-chama.md
@@ -1,0 +1,57 @@
+---
+id: PT-C03-como-se-chama
+chapter: 3
+type: phrase
+headword: Como se chama?
+gloss: what's your name? (literally "how do you call yourself?")
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [PT-C03-me-chamo, PT-C02-como]
+sounds: [ch-is-sh]
+roots: [quomodo-latin, clamare-latin]
+etymology_hook: "como (← quōmodo 'how') + se chama (chamar-se) — 'how do you call yourself?'"
+est_minutes: 3
+reviews_of: [PT-C03-me-chamo, PT-C02-como]
+---
+
+# Como se chama? — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Both pieces are yours: **como** ("how," from your *Tudo bem?* chapter)
+and **chamar-se** ("to call oneself"). Portuguese, like all its sisters, asks the
+name with **"how"**: *how do you call yourself?*
+
+## The phrase, taken apart
+
+> **Como se chama?** = "What's your name?"
+> literally: **"How do you call yourself?"**
+
+- **como** = "how" (← *quōmodo*).
+- **se** = "yourself" (the reflexive; *me* → *se*).
+- **chama** = "calls" (*você*/he-she form of *chamar-se*).
+
+Portuguese register is friendly here — the everyday polite form uses **você**:
+
+| form | question |
+|---|---|
+| polite / neutral (*você*) | **Como (você) se chama?** |
+| very formal | **Como se chama o senhor / a senhora?** |
+| familiar (*tu*, more in Portugal) | **Como te chamas?** |
+
+The reply loops right back: *Me chamo Ana. E você?* And just like Spanish *¿cómo
+se llama?* and Italian *come ti chiami?*, the name is a matter of **how** you're
+called — never *what*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Como se chama?" — *KOH-moo suh SHAH-mah*]
+- [YOU SAY: the whole loop — "Como se chama? — Me chamo … E você?"]
+- [YOU SAY: como se chama / cómo se llama / come ti chiami — the same question,
+  three sisters]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *Como se chama?* literally ask? ("How do you call
+yourself?") Which everyday pronoun does the polite form use? (*Você*.) What "how"
+word is it built on? (*Como* ← *quōmodo*.) Next: the warm reply — **prazer**.

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-eu.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-eu.md
@@ -1,0 +1,57 @@
+---
+id: PT-C03-eu
+chapter: 3
+type: word
+headword: eu
+gloss: I (first-person subject pronoun)
+concept_tag: PRONOUN-I
+prerequisites: []
+sounds: [nasal-eu]
+roots: [ego-latin]
+etymology_hook: "eu ← Latin ego 'I' → English ego; Portuguese usually drops it (pro-drop)"
+est_minutes: 3
+reviews_of: [PT-C04-adeus]
+---
+
+# eu — "I," the pronoun Portuguese usually drops
+
+## Warm-up
+
+[PAUSE 2s] Before introducing yourself, meet **eu** — "I." Famous English cousin,
+and the same habit as its Romance sisters: Portuguese usually **leaves it out.**
+
+## Sounds you'll need
+
+- `nasal-eu` — **eu** = *EH-oo*, a gliding vowel with a light nasal colour, one
+  syllable.
+
+## The word, taken apart
+
+**eu** = "I," from Latin **ego** — the same *ego* English borrowed outright:
+
+- **ego**, **egoist**, **egocentric** — all Latin "I."
+- Romance siblings, all from *ego*: Spanish **yo**, Italian **io**, French **je**.
+
+## Grammar Lens: the dropped subject (pro-drop)
+
+The verb ending already names the speaker, so Portuguese usually **omits** the
+pronoun: *chamo-me* ("I call myself") needs no *eu* — the *-o* of *chamo* is "I."
+You add **eu** for **emphasis** or **contrast**:
+
+> *Eu* estou bem, e você? — "*I'm* fine, and you?"
+
+Spanish (*yo*) and Italian (*io*) do the same. It's one of the first real habits
+of a Romance language: trust the verb ending, drop the pronoun.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "eu" — *EH-oo*]
+- [YOU SAY: "eu" then English "ego, egoist" — the same Latin "I"]
+- [YOU SAY: eu / yo / io / je — four children of *ego*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word is *eu* from? (*Ego* — ego, egoist.) Why does
+Portuguese usually drop it? (The verb ending already says "I.") When do you keep
+it? (Emphasis / contrast.) Next: introduce yourself — **me chamo**.

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-me-chamo.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-me-chamo.md
@@ -1,0 +1,71 @@
+---
+id: PT-C03-me-chamo
+chapter: 3
+type: phrase
+headword: me chamo / chamo-me
+gloss: my name is (literally "I call myself")
+concept_tag: INTRO-MY-NAME-IS
+prerequisites: [PT-C03-eu]
+sounds: [ch-is-sh, final-o-is-u]
+roots: [clamare-latin, nomen-latin]
+etymology_hook: "chamar-se ← Latin clāmāre 'to call out' (claim/clamor); alt. 'meu nome é' ← nōmen (name/noun)"
+est_minutes: 4
+reviews_of: [PT-C03-eu]
+---
+
+# me chamo — "I call myself"
+
+## Warm-up
+
+[PAUSE 2s] Like its Iberian and Italian sisters, Portuguese introduces you as
+what you **call yourself** — **me chamo** — from the very same Latin *clāmāre*
+that gave Spanish *me llamo* and Italian *mi chiamo*.
+
+## Sounds you'll need
+
+- `ch-is-sh` — Portuguese **ch** = **"sh"**: **chamo** = *SHAH-moo*. (A neat
+  three-way split from one Latin *cl-*: Spanish *ll* = *y* (*llamo*), Italian
+  *ch* = hard *k* (*chiamo*), Portuguese *ch* = *sh* (*chamo*).)
+- `final-o-is-u` — final *-o* → *u*: *SHAH-moo*.
+
+## The phrase, taken apart
+
+**me chamo** = **me** ("myself") + **chamo** ("I call") → **"I call myself."**
+Brazilians often say **eu me chamo**; European Portuguese prefers **chamo-me**
+(same words, pronoun clipped to the back) — both fine. Then the name: *Me chamo
+Ana* — "I call myself Ana."
+
+The verb **chamar-se** ("to call oneself") is from Latin **clāmāre**, *"to cry
+out, to call"* — shouting through English as **claim**, **exclaim**,
+**proclaim**, **clamor**. Three Romance naming verbs, one Latin call:
+
+| language | "I call myself" | *cl-* became |
+|---|---|---|
+| **Portuguese** | *me chamo* | *ch* (= *sh*) |
+| **Spanish** | *me llamo* | *ll* (= *y*) |
+| **Italian** | *mi chiamo* | *ch* (= hard *k*) |
+
+**Another way to say it:** *o meu nome é …* ("my name is …"), where **nome** ←
+Latin **nōmen**, "name" — the root of English **noun**, **nominal**,
+**nomenclature**, **nominate**. Two routes to the same introduction: the *verb*
+(call myself) or the *noun* (my name is).
+
+## Grammar Lens: the reflexive
+
+*chamo* alone = "I call [someone]"; **me** chamo = "I call **myself**" —
+reflexive. The pronoun shifts with the person: **me** chamo (I) → **se** chama
+(he/she/você). And *eu* is dropped — the *-o* ending already says "I."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "me chamo" — *muh SHAH-moo*, *ch* = *sh*]
+- [YOU SAY: "Me chamo …" with your own name]
+- [YOU SAY: me chamo / me llamo / mi chiamo — one *clāmāre*, three sounds]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *me chamo* literally mean, and its Latin root? ("I call
+myself"; *clāmāre* — claim/clamor.) How is Portuguese *ch* pronounced, vs Italian
+*ch*? (Portuguese *sh*; Italian hard *k*.) What's the noun-route alternative?
+(*O meu nome é …*, *nome* ← *nōmen*.) Next: ask it back — **Como se chama?**

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-practice.md
@@ -1,0 +1,62 @@
+---
+id: PT-C03-practice
+chapter: 3
+type: practice-mix
+headword: (practice)
+gloss: introducing yourself in Portuguese, casual and formal
+concept_tag: CH3-PRACTICE
+prerequisites: [PT-C03-eu, PT-C03-me-chamo, PT-C03-como-se-chama, PT-C03-prazer]
+sounds: []
+roots: []
+est_minutes: 4
+reviews_of: [PT-C03-me-chamo, PT-C03-como-se-chama, PT-C03-prazer, PT-C02-practice]
+---
+
+# Practice — introducing yourself in Portuguese
+
+## Warm-up
+
+[PAUSE 2s] No new words. *eu, me chamo, como se chama, prazer* assemble into a
+real first meeting. This slots between your greetings (Ch. 1–2) and farewells
+(Ch. 4), so Portuguese now runs a whole conversation.
+
+## The exchange
+
+**Casual** (*você*):
+
+> — Olá! **Como você se chama?**
+> — **Me chamo** Ana. E você?
+> — João. **Prazer!**
+> — Prazer!
+
+**More formal** (o senhor / a senhora):
+
+> — Bom dia. **Como se chama a senhora?**
+> — Chamo-me Ana Costa. E o senhor?
+> — Costa. **Muito prazer.**
+
+## What you've built this chapter
+
+- **eu** — "I" (← *ego*), usually **dropped** — the verb ending carries it.
+- **me chamo / chamo-me** — "I call myself" (*chamar-se* ← *clāmāre*; *ch* = *sh*;
+  kin of *me llamo*, *mi chiamo*). Alt: *o meu nome é* (*nome* ← *nōmen*).
+- **Como se chama?** — "how do you call yourself?" (polite *você*).
+- **prazer** — "a pleasure" (← *placēre*; twin of Italian *piacere*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full casual meeting, both voices]
+- [YOU SAY: the same formally — with *o senhor / a senhora*]
+- [YOU SAY: chain it all — greet, name, ask, how-are-you, goodbye:
+  "Olá! Me chamo … Como se chama? … Tudo bem? … Até logo!"]
+
+[REPEAT x2] Run a whole first meeting start to finish.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does Portuguese usually drop *eu*? (The verb ending says who.)
+What does *me chamo* literally mean, and its root? ("I call myself"; *clāmāre*.)
+What does *prazer* mean, and its Italian twin? ("A pleasure"; *piacere*.)
+Portuguese now runs greet → introduce → how-are-you → goodbye, end to end — the
+fifth language to close the loop.

--- a/code/learning/human-languages/portuguese/lessons/PT-C03-prazer.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C03-prazer.md
@@ -1,0 +1,63 @@
+---
+id: PT-C03-prazer
+chapter: 3
+type: word
+headword: prazer
+gloss: pleased to meet you (literally "a pleasure")
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [PT-C03-como-se-chama]
+sounds: [pr-cluster, final-r]
+roots: [placere-latin]
+etymology_hook: "prazer ← Latin placēre 'to please' → English please, pleasure; twin of Italian piacere"
+est_minutes: 3
+reviews_of: [PT-C03-me-chamo, PT-C03-como-se-chama]
+---
+
+# prazer — "pleased to meet you," i.e. "a pleasure"
+
+## Warm-up
+
+[PAUSE 2s] Names traded, you close with **prazer** — "a pleasure." It's the twin
+of Italian *piacere*, and, like it, straight from Latin *please*.
+
+## Sounds you'll need
+
+- `pr-cluster` — **prazer** = *prah-**ZEHR***: the *z* is a true *z*; stress the
+  end. (The *pr-* shows a Portuguese sound-law: Latin *pl-* often became *pr-* —
+  *placēre* → *prazer*, *plūs* → …)
+
+## The word, taken apart
+
+**prazer** = "pleasure" (and, as a verb, "to please"), from Latin **placēre**,
+*"to please."* On meeting someone it's short for *"[it's] a pleasure."*
+
+That *placēre* root is deep in English — **please**, **pleasure**, **pleasant**,
+**complacent**, **placid** — and it names this courtesy across the family:
+
+- Italian **piacere** — its exact twin (same *placēre*).
+- Spanish **mucho gusto** — "much pleasure," but from *gustus* ("taste"), a
+  different root.
+- French **enchanté** — a different picture again ("enchanted").
+
+Portuguese took *placēre*'s *pl-* to *pr-* (a regular shift — compare *branco*
+"white" ← Germanic *blank*, *praia* "beach" ← *plagia*), so *piacere* and
+*prazer* look a little different but are the very same word.
+
+## Grammar Lens: a one-word courtesy
+
+*Prazer* stands alone, with a nod or handshake. Fuller forms: **muito prazer**
+("much pleasure"), or **prazer em conhecê-lo/-la** ("a pleasure to know you").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "prazer" — *prah-ZEHR*]
+- [YOU SAY: "prazer" then English "please, pleasure, placid" — the *placēre* root]
+- [YOU SAY: Portuguese *prazer* and Italian *piacere* — twins from *placēre*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *prazer* mean, and from what Latin verb? ("A pleasure," ←
+*placēre*.) Its Italian twin? (*Piacere*.) What sound-shift turned *pl-* into
+*pr-*? (The Portuguese *placēre* → *prazer* change.) Next: put the whole
+introduction together.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -26,11 +26,15 @@ French.
   (*breve* ← *brevis*) → practice. **Authored** — fifth track to complete the
   greet-to-goodbye arc (Ch. 3 introductions to slot in below it).
 
+- **Ch. 3 — Introducing Yourself**: eu (← *ego*; pro-drop) → me chamo / chamo-me
+  (*chamar-se* ← *clāmāre*; *ch* = *sh*; alt. *o meu nome é* ← *nōmen*) → como se
+  chama → prazer (← *placēre*; twin of *piacere*) → practice. **Authored** —
+  Portuguese now runs greet → introduce → how-are-you → goodbye end to end.
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 3 | Introducing yourself: *chamo-me / o meu nome é*, como se chama, prazer |
 | 5+ | Numbers, time, days & months, family, food — following the shared theme order |
 
 Note: Portuguese's polite "you" is **você** (← *vossa mercê*, "your mercy") — the


### PR DESCRIPTION
## Italian + Portuguese introductions (Ch.3) — every track now runs a full conversation

Loop item 2. Both tracks had greetings (Ch.1) and how-are-you (Ch.2) but skipped
introductions; this fills that gap (numbered **Ch.3**, slotting between how-are-you
and the Ch.4 farewells). With it, **all five languages** run the complete arc:
**greet → introduce → how are you → goodbye**.

10 lessons, atom-first, each reviewing the track's Chapter 2.

### The cross-language payoffs
- **The Romance naming verb, three ways from one Latin *clāmāre* ("call out")**:
  Spanish *me llamo* (*cl-* → *ll* = *y*), Italian *mi chiamo* (*ch* = **hard k**),
  Portuguese *me chamo* (*ch* = **sh**) — same verb, three sound-laws, plus the
  claim/clamor/exclaim English cousins. (Portuguese also gets the noun route: *o
  meu nome é*, *nome* ← *nōmen* → noun/nominal.)
- **"Pleased to meet you" = "a pleasure"**: Italian **piacere** and Portuguese
  **prazer** are twins from Latin *placēre* (please/pleasure/placid) — with the
  Portuguese *pl-* → *pr-* shift shown.
- **Pro-drop introduced**: *io* / *eu* (← *ego*) teach that Romance languages
  usually drop the subject pronoun because the verb ending already carries it.
- The name is asked with **"how"** (*come / como* ← *quōmodo*) in every sister,
  never "what" — reusing the how-word from the how-are-you chapters.

### Checks
- Uses existing `PRONOUN-I` + `INTRO-MY-NAME-IS/WHATS-YOUR-NAME/NICE-TO-MEET-YOU`
  concepts — **no taxonomy change** (no conflict surface).
- 38 data-package tests pass; validator clean. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
