### PR TITLE
feat(asciidoc-parser): add C# and F# ports

### DIFF
--- a/code/packages/csharp/asciidoc-parser/AsciidocParser.cs
+++ b/code/packages/csharp/asciidoc-parser/AsciidocParser.cs
@@ -1,0 +1,514 @@
+using System.Text;
+using CodingAdventures.DocumentAst;
+
+namespace CodingAdventures.AsciidocParser;
+
+/// <summary>Parses a portable AsciiDoc subset into the shared document AST.</summary>
+public static class AsciidocParser
+{
+    private enum BlockState
+    {
+        Normal,
+        Paragraph,
+        Code,
+        Literal,
+        Passthrough,
+        Quote,
+        UnorderedList,
+        OrderedList,
+    }
+
+    private readonly record struct ListEntry(int Level, string Text);
+
+    /// <summary>Parse a complete AsciiDoc source string.</summary>
+    public static DocumentNode Parse(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var normalized = source.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var lines = normalized.Split('\n').ToList();
+        if (normalized.EndsWith('\n'))
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        var blocks = new List<IBlockNode>();
+        var paragraphLines = new List<string>();
+        var delimitedLines = new List<string>();
+        var listEntries = new List<ListEntry>();
+        var state = BlockState.Normal;
+        string? pendingLanguage = null;
+        var listOrdered = false;
+
+        void FlushParagraph()
+        {
+            if (paragraphLines.Count == 0)
+            {
+                return;
+            }
+
+            blocks.Add(new ParagraphNode(ParseInline(string.Join('\n', paragraphLines))));
+            paragraphLines.Clear();
+        }
+
+        void FlushList()
+        {
+            if (listEntries.Count == 0)
+            {
+                return;
+            }
+
+            blocks.Add(BuildList(listEntries, listOrdered));
+            listEntries.Clear();
+        }
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+
+            if (state is BlockState.Code or BlockState.Literal or BlockState.Passthrough or BlockState.Quote)
+            {
+                var delimiter = state switch
+                {
+                    BlockState.Code => '-',
+                    BlockState.Literal => '.',
+                    BlockState.Passthrough => '+',
+                    _ => '_',
+                };
+
+                if (IsDelimiter(line, delimiter, 4))
+                {
+                    EmitDelimited(blocks, state, delimitedLines, pendingLanguage);
+                    if (state == BlockState.Code)
+                    {
+                        pendingLanguage = null;
+                    }
+
+                    delimitedLines.Clear();
+                    state = BlockState.Normal;
+                }
+                else
+                {
+                    delimitedLines.Add(rawLine);
+                }
+
+                continue;
+            }
+
+            if (state == BlockState.Paragraph)
+            {
+                if (line.Length == 0)
+                {
+                    FlushParagraph();
+                    state = BlockState.Normal;
+                    continue;
+                }
+
+                if (StartsNewBlock(line))
+                {
+                    FlushParagraph();
+                    state = BlockState.Normal;
+                }
+                else
+                {
+                    paragraphLines.Add(line);
+                    continue;
+                }
+            }
+
+            if (state is BlockState.UnorderedList or BlockState.OrderedList)
+            {
+                if (line.Length == 0)
+                {
+                    FlushList();
+                    state = BlockState.Normal;
+                    continue;
+                }
+
+                var marker = state == BlockState.OrderedList ? '.' : '*';
+                if (TryListItem(line, marker, out var entry))
+                {
+                    listEntries.Add(entry);
+                    continue;
+                }
+
+                FlushList();
+                state = BlockState.Normal;
+            }
+
+            if (line.Length == 0 || line.StartsWith("//", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (TrySourceAttribute(line, out var language))
+            {
+                pendingLanguage = language;
+                continue;
+            }
+
+            if (TryHeading(line, out var level, out var headingText))
+            {
+                blocks.Add(new HeadingNode(level, ParseInline(headingText)));
+                continue;
+            }
+
+            if (IsDelimiter(line, '\'', 3))
+            {
+                blocks.Add(new ThematicBreakNode());
+                continue;
+            }
+
+            if (IsDelimiter(line, '-', 4))
+            {
+                state = BlockState.Code;
+                continue;
+            }
+
+            if (IsDelimiter(line, '.', 4))
+            {
+                state = BlockState.Literal;
+                continue;
+            }
+
+            if (IsDelimiter(line, '+', 4))
+            {
+                state = BlockState.Passthrough;
+                continue;
+            }
+
+            if (IsDelimiter(line, '_', 4))
+            {
+                state = BlockState.Quote;
+                continue;
+            }
+
+            if (TryListItem(line, '*', out var unordered))
+            {
+                listOrdered = false;
+                listEntries.Add(unordered);
+                state = BlockState.UnorderedList;
+                continue;
+            }
+
+            if (TryListItem(line, '.', out var ordered))
+            {
+                listOrdered = true;
+                listEntries.Add(ordered);
+                state = BlockState.OrderedList;
+                continue;
+            }
+
+            paragraphLines.Add(line);
+            state = BlockState.Paragraph;
+        }
+
+        FlushParagraph();
+        FlushList();
+        if (delimitedLines.Count > 0 && state is BlockState.Code or BlockState.Literal or BlockState.Passthrough or BlockState.Quote)
+        {
+            EmitDelimited(blocks, state, delimitedLines, pendingLanguage);
+        }
+
+        return new DocumentNode(blocks);
+    }
+
+    /// <summary>Parse inline AsciiDoc markup into shared inline AST nodes.</summary>
+    public static IReadOnlyList<IInlineNode> ParseInline(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        var output = new List<IInlineNode>();
+        var plain = new StringBuilder();
+        var index = 0;
+
+        void FlushText()
+        {
+            if (plain.Length == 0)
+            {
+                return;
+            }
+
+            output.Add(new TextNode(plain.ToString()));
+            plain.Clear();
+        }
+
+        while (index < text.Length)
+        {
+            if (StartsWith(text, index, "  \n"))
+            {
+                FlushText();
+                output.Add(new HardBreakNode());
+                index += 3;
+                continue;
+            }
+
+            if (StartsWith(text, index, "\\\n"))
+            {
+                FlushText();
+                output.Add(new HardBreakNode());
+                index += 2;
+                continue;
+            }
+
+            if (text[index] == '\n')
+            {
+                FlushText();
+                output.Add(new SoftBreakNode());
+                index++;
+                continue;
+            }
+
+            if (TryDelimitedInline(text, ref index, "`", value => new CodeSpanNode(value), output, FlushText) ||
+                TryDelimitedInline(text, ref index, "**", value => new StrongNode(ParseInline(value)), output, FlushText) ||
+                TryDelimitedInline(text, ref index, "__", value => new EmphasisNode(ParseInline(value)), output, FlushText) ||
+                TryDelimitedInline(text, ref index, "*", value => new StrongNode(ParseInline(value)), output, FlushText) ||
+                TryDelimitedInline(text, ref index, "_", value => new EmphasisNode(ParseInline(value)), output, FlushText))
+            {
+                continue;
+            }
+
+            if (TryMacro(text, ref index, "link:", false, output, FlushText) ||
+                TryMacro(text, ref index, "image:", true, output, FlushText) ||
+                TryCrossReference(text, ref index, output, FlushText) ||
+                TryUrl(text, ref index, output, FlushText))
+            {
+                continue;
+            }
+
+            plain.Append(text[index]);
+            index++;
+        }
+
+        FlushText();
+        return output;
+    }
+
+    private static bool TryDelimitedInline(
+        string text,
+        ref int index,
+        string delimiter,
+        Func<string, IInlineNode> create,
+        List<IInlineNode> output,
+        Action flush)
+    {
+        if (!StartsWith(text, index, delimiter))
+        {
+            return false;
+        }
+
+        var closing = text.IndexOf(delimiter, index + delimiter.Length, StringComparison.Ordinal);
+        if (closing < 0)
+        {
+            return false;
+        }
+
+        flush();
+        output.Add(create(text[(index + delimiter.Length)..closing]));
+        index = closing + delimiter.Length;
+        return true;
+    }
+
+    private static bool TryMacro(string text, ref int index, string prefix, bool image, List<IInlineNode> output, Action flush)
+    {
+        if (!StartsWith(text, index, prefix))
+        {
+            return false;
+        }
+
+        var open = text.IndexOf('[', index + prefix.Length);
+        if (open < 0)
+        {
+            return false;
+        }
+
+        var close = text.IndexOf(']', open + 1);
+        if (close < 0)
+        {
+            return false;
+        }
+
+        var destination = text[(index + prefix.Length)..open];
+        var label = text[(open + 1)..close];
+        flush();
+        output.Add(image
+            ? new ImageNode(destination, null, label)
+            : new LinkNode(destination, null, [new TextNode(label.Length == 0 ? destination : label)]));
+        index = close + 1;
+        return true;
+    }
+
+    private static bool TryCrossReference(string text, ref int index, List<IInlineNode> output, Action flush)
+    {
+        if (!StartsWith(text, index, "<<"))
+        {
+            return false;
+        }
+
+        var close = text.IndexOf(">>", index + 2, StringComparison.Ordinal);
+        if (close < 0)
+        {
+            return false;
+        }
+
+        var parts = text[(index + 2)..close].Split(',', 2);
+        var anchor = parts[0].Trim();
+        var label = parts.Length == 2 ? parts[1].Trim() : anchor;
+        flush();
+        output.Add(new LinkNode($"#{anchor}", null, [new TextNode(label)]));
+        index = close + 2;
+        return true;
+    }
+
+    private static bool TryUrl(string text, ref int index, List<IInlineNode> output, Action flush)
+    {
+        var schemeLength = StartsWith(text, index, "https://") ? 8 : StartsWith(text, index, "http://") ? 7 : 0;
+        if (schemeLength == 0)
+        {
+            return false;
+        }
+
+        var end = index + schemeLength;
+        while (end < text.Length && !char.IsWhiteSpace(text[end]) && text[end] is not '[' and not ']')
+        {
+            end++;
+        }
+
+        var url = text[index..end];
+        flush();
+        if (end < text.Length && text[end] == '[')
+        {
+            var close = text.IndexOf(']', end + 1);
+            if (close >= 0)
+            {
+                var label = text[(end + 1)..close];
+                output.Add(new LinkNode(url, null, [new TextNode(label.Length == 0 ? url : label)]));
+                index = close + 1;
+                return true;
+            }
+        }
+
+        output.Add(new AutolinkNode(url, false));
+        index = end;
+        return true;
+    }
+
+    private static ListNode BuildList(IReadOnlyList<ListEntry> entries, bool ordered)
+    {
+        var index = 0;
+        return BuildListLevel(entries[0].Level, entries, ordered, ref index);
+    }
+
+    private static ListNode BuildListLevel(int level, IReadOnlyList<ListEntry> entries, bool ordered, ref int index)
+    {
+        var children = new List<IListChildNode>();
+        while (index < entries.Count && entries[index].Level >= level)
+        {
+            if (entries[index].Level > level)
+            {
+                break;
+            }
+
+            var entry = entries[index++];
+            var itemBlocks = new List<IBlockNode> { new ParagraphNode(ParseInline(entry.Text)) };
+            while (index < entries.Count && entries[index].Level > level)
+            {
+                itemBlocks.Add(BuildListLevel(entries[index].Level, entries, ordered, ref index));
+            }
+
+            children.Add(new ListItemNode(itemBlocks));
+        }
+
+        return new ListNode(ordered, ordered ? 1 : null, true, children);
+    }
+
+    private static void EmitDelimited(List<IBlockNode> blocks, BlockState state, List<string> lines, string? language)
+    {
+        var value = lines.Count == 0 ? string.Empty : string.Join('\n', lines) + "\n";
+        switch (state)
+        {
+            case BlockState.Code:
+                blocks.Add(new CodeBlockNode(language, value));
+                break;
+            case BlockState.Literal:
+                blocks.Add(new CodeBlockNode(null, value));
+                break;
+            case BlockState.Passthrough:
+                blocks.Add(new RawBlockNode("html", string.Join('\n', lines)));
+                break;
+            case BlockState.Quote:
+                blocks.Add(new BlockquoteNode(Parse(string.Join('\n', lines)).Children));
+                break;
+        }
+    }
+
+    private static bool StartsNewBlock(string line) =>
+        TryHeading(line, out _, out _) ||
+        TrySourceAttribute(line, out _) ||
+        TryListItem(line, '*', out _) ||
+        TryListItem(line, '.', out _) ||
+        line.StartsWith("//", StringComparison.Ordinal) ||
+        IsDelimiter(line, '\'', 3) ||
+        IsDelimiter(line, '-', 4) ||
+        IsDelimiter(line, '.', 4) ||
+        IsDelimiter(line, '+', 4) ||
+        IsDelimiter(line, '_', 4);
+
+    private static bool TryHeading(string line, out int level, out string text)
+    {
+        var count = 0;
+        while (count < line.Length && line[count] == '=')
+        {
+            count++;
+        }
+
+        if (count > 0 && count < line.Length && char.IsWhiteSpace(line[count]))
+        {
+            level = Math.Min(count, 6);
+            text = line[count..].TrimStart();
+            return true;
+        }
+
+        level = 0;
+        text = string.Empty;
+        return false;
+    }
+
+    private static bool TrySourceAttribute(string line, out string language)
+    {
+        if (line.StartsWith("[source", StringComparison.OrdinalIgnoreCase) && line.EndsWith(']'))
+        {
+            var comma = line.IndexOf(',');
+            if (comma >= 0)
+            {
+                language = line[(comma + 1)..^1].Trim();
+                return language.Length > 0;
+            }
+        }
+
+        language = string.Empty;
+        return false;
+    }
+
+    private static bool TryListItem(string line, char marker, out ListEntry entry)
+    {
+        var count = 0;
+        while (count < line.Length && line[count] == marker)
+        {
+            count++;
+        }
+
+        if (count > 0 && count < line.Length && line[count] == ' ')
+        {
+            entry = new ListEntry(count, line[(count + 1)..].Trim());
+            return true;
+        }
+
+        entry = default;
+        return false;
+    }
+
+    private static bool IsDelimiter(string line, char value, int minimum) =>
+        line.Length >= minimum && line.All(character => character == value);
+
+    private static bool StartsWith(string text, int index, string value) =>
+        index + value.Length <= text.Length && text.AsSpan(index, value.Length).SequenceEqual(value);
+}

--- a/code/packages/csharp/asciidoc-parser/BUILD
+++ b/code/packages/csharp/asciidoc-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AsciidocParser.Tests/CodingAdventures.AsciidocParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.AsciidocParser]*"

--- a/code/packages/csharp/asciidoc-parser/BUILD_windows
+++ b/code/packages/csharp/asciidoc-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AsciidocParser.Tests/CodingAdventures.AsciidocParser.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.AsciidocParser]*"

--- a/code/packages/csharp/asciidoc-parser/CHANGELOG.md
+++ b/code/packages/csharp/asciidoc-parser/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add block and inline AsciiDoc parsing into the shared document AST.
+- Support headings, paragraphs, delimited blocks, nested lists, links, images, cross-references, emphasis, strong text, code spans, and line breaks.

--- a/code/packages/csharp/asciidoc-parser/CodingAdventures.AsciidocParser.csproj
+++ b/code/packages/csharp/asciidoc-parser/CodingAdventures.AsciidocParser.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.AsciidocParser.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# AsciiDoc parser producing the shared document AST</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+    <ProjectReference Include="../document-ast/CodingAdventures.DocumentAst.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/asciidoc-parser/README.md
+++ b/code/packages/csharp/asciidoc-parser/README.md
@@ -1,0 +1,17 @@
+# AsciiDoc Parser (C#)
+
+Pure C# parser for a portable AsciiDoc subset, producing the shared
+`CodingAdventures.DocumentAst` representation.
+
+```csharp
+using CodingAdventures.AsciidocParser;
+
+var document = AsciidocParser.Parse("= Title\n\nHello *world*.");
+var inline = AsciidocParser.ParseInline("link:https://example.com[Example]");
+```
+
+The block parser supports headings, paragraphs, thematic breaks, source and
+literal blocks, passthrough HTML, recursive quote blocks, comments, and nested
+ordered or unordered lists. The inline parser supports strong and emphasized
+text, code spans, links, images, cross-references, URLs, and hard or soft line
+breaks.

--- a/code/packages/csharp/asciidoc-parser/required_capabilities.json
+++ b/code/packages/csharp/asciidoc-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/asciidoc-parser",
+  "capabilities": [],
+  "justification": "Pure computation package. Parses caller-provided strings into document AST values without external access."
+}

--- a/code/packages/csharp/asciidoc-parser/tests/CodingAdventures.AsciidocParser.Tests/AsciidocParserTests.cs
+++ b/code/packages/csharp/asciidoc-parser/tests/CodingAdventures.AsciidocParser.Tests/AsciidocParserTests.cs
@@ -1,0 +1,287 @@
+using CodingAdventures.DocumentAst;
+using Parser = CodingAdventures.AsciidocParser.AsciidocParser;
+
+namespace CodingAdventures.AsciidocParser.Tests;
+
+public sealed class AsciidocParserTests
+{
+    [Fact]
+    public void ParseRejectsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => Parser.Parse(null!));
+        Assert.Throws<ArgumentNullException>(() => Parser.ParseInline(null!));
+    }
+
+    [Fact]
+    public void EmptyBlankAndCommentOnlySourcesProduceEmptyDocuments()
+    {
+        Assert.Empty(Parser.Parse(string.Empty).Children);
+        Assert.Empty(Parser.Parse("  \n\t\n").Children);
+        Assert.Empty(Parser.Parse("// hidden\n// also hidden").Children);
+    }
+
+    [Fact]
+    public void HeadingsClampLevelsAndParseInlineMarkup()
+    {
+        var document = Parser.Parse("= One\n== Two\n======= *Deep*");
+        var first = Assert.IsType<HeadingNode>(document.Children[0]);
+        var second = Assert.IsType<HeadingNode>(document.Children[1]);
+        var deep = Assert.IsType<HeadingNode>(document.Children[2]);
+        Assert.Equal(1, first.Level);
+        Assert.Equal(2, second.Level);
+        Assert.Equal(6, deep.Level);
+        Assert.IsType<StrongNode>(Assert.Single(deep.Children));
+    }
+
+    [Fact]
+    public void ParagraphsPreserveSoftBreaksAndBlankLineBoundaries()
+    {
+        var document = Parser.Parse("first line\nsecond line\n\nnext");
+        Assert.Equal(2, document.Children.Count);
+        var first = Assert.IsType<ParagraphNode>(document.Children[0]);
+        Assert.Collection(
+            first.Children,
+            node => Assert.Equal("first line", Assert.IsType<TextNode>(node).Value),
+            node => Assert.IsType<SoftBreakNode>(node),
+            node => Assert.Equal("second line", Assert.IsType<TextNode>(node).Value));
+        Assert.Equal("next", Assert.IsType<TextNode>(Assert.Single(Assert.IsType<ParagraphNode>(document.Children[1]).Children)).Value);
+    }
+
+    [Fact]
+    public void ThematicBreakAndFollowingHeadingInterruptParagraphs()
+    {
+        var document = Parser.Parse("paragraph\n'''\n== Heading");
+        Assert.IsType<ParagraphNode>(document.Children[0]);
+        Assert.IsType<ThematicBreakNode>(document.Children[1]);
+        Assert.IsType<HeadingNode>(document.Children[2]);
+    }
+
+    [Fact]
+    public void SourceAndLiteralBlocksPreserveContent()
+    {
+        var document = Parser.Parse("[source, csharp]\n----\nvar x = 1;\n----\n....\nliteral\n....");
+        var source = Assert.IsType<CodeBlockNode>(document.Children[0]);
+        var literal = Assert.IsType<CodeBlockNode>(document.Children[1]);
+        Assert.Equal("csharp", source.Language);
+        Assert.Equal("var x = 1;\n", source.Value);
+        Assert.Null(literal.Language);
+        Assert.Equal("literal\n", literal.Value);
+    }
+
+    [Fact]
+    public void UnterminatedCodeBlockIsEmittedLeniently()
+    {
+        var block = Assert.IsType<CodeBlockNode>(Assert.Single(Parser.Parse("----\nopen").Children));
+        Assert.Equal("open\n", block.Value);
+    }
+
+    [Fact]
+    public void PassthroughAndQuoteBlocksProduceRawAndRecursiveNodes()
+    {
+        var document = Parser.Parse("++++\n<b>raw</b>\n++++\n____\n= Nested\n\ntext\n____");
+        var raw = Assert.IsType<RawBlockNode>(document.Children[0]);
+        Assert.Equal("html", raw.Format);
+        Assert.Equal("<b>raw</b>", raw.Value);
+        var quote = Assert.IsType<BlockquoteNode>(document.Children[1]);
+        Assert.IsType<HeadingNode>(quote.Children[0]);
+        Assert.IsType<ParagraphNode>(quote.Children[1]);
+    }
+
+    [Fact]
+    public void OrderedUnorderedAndNestedListsAreBuilt()
+    {
+        var document = Parser.Parse("* one\n** nested\n* two\n\n. first\n. second");
+        var unordered = Assert.IsType<ListNode>(document.Children[0]);
+        Assert.False(unordered.Ordered);
+        Assert.Null(unordered.Start);
+        Assert.Equal(2, unordered.Children.Count);
+        var firstItem = Assert.IsType<ListItemNode>(unordered.Children[0]);
+        Assert.IsType<ListNode>(firstItem.Children[1]);
+
+        var ordered = Assert.IsType<ListNode>(document.Children[1]);
+        Assert.True(ordered.Ordered);
+        Assert.Equal(1, ordered.Start);
+        Assert.Equal(2, ordered.Children.Count);
+    }
+
+    [Fact]
+    public void ListsTerminateWhenAnotherBlockStarts()
+    {
+        var document = Parser.Parse("* item\nparagraph\n\n. ordered\n== Heading");
+        Assert.IsType<ListNode>(document.Children[0]);
+        Assert.IsType<ParagraphNode>(document.Children[1]);
+        Assert.IsType<ListNode>(document.Children[2]);
+        Assert.IsType<HeadingNode>(document.Children[3]);
+    }
+
+    [Fact]
+    public void InlineParserHandlesStrongEmphasisCodeAndLiteralDelimiters()
+    {
+        var nodes = Parser.ParseInline("a *bold* **wide** _ital_ __free__ `*code*` and *open");
+        Assert.Contains(nodes, node => node is StrongNode);
+        Assert.Equal(2, nodes.Count(node => node is StrongNode));
+        Assert.Equal(2, nodes.Count(node => node is EmphasisNode));
+        Assert.Equal("*code*", Assert.IsType<CodeSpanNode>(nodes.Single(node => node is CodeSpanNode)).Value);
+        Assert.EndsWith("*open", Assert.IsType<TextNode>(nodes[^1]).Value);
+    }
+
+    [Fact]
+    public void InlineParserHandlesLinksImagesCrossReferencesAndUrls()
+    {
+        var nodes = Parser.ParseInline(
+            "link:https://a.test[A] image:cat.png[Cat] <<intro,Intro>> <<plain>> https://b.test[B] http://c.test");
+        var links = nodes.OfType<LinkNode>().ToArray();
+        Assert.Equal(4, links.Length);
+        Assert.Equal("https://a.test", links[0].Destination);
+        Assert.Equal("#intro", links[1].Destination);
+        Assert.Equal("#plain", links[2].Destination);
+        Assert.Equal("https://b.test", links[3].Destination);
+        Assert.Equal("Cat", Assert.Single(nodes.OfType<ImageNode>()).Alt);
+        Assert.Equal("http://c.test", Assert.Single(nodes.OfType<AutolinkNode>()).Destination);
+    }
+
+    [Fact]
+    public void EmptyLinkLabelsUseTheirDestination()
+    {
+        var macro = Assert.IsType<LinkNode>(Assert.Single(Parser.ParseInline("link:https://a.test[]")));
+        var url = Assert.IsType<LinkNode>(Assert.Single(Parser.ParseInline("https://b.test[]")));
+        Assert.Equal("https://a.test", Assert.IsType<TextNode>(Assert.Single(macro.Children)).Value);
+        Assert.Equal("https://b.test", Assert.IsType<TextNode>(Assert.Single(url.Children)).Value);
+    }
+
+    [Fact]
+    public void InlineParserClassifiesHardAndSoftBreaks()
+    {
+        var nodes = Parser.ParseInline("a  \nb\\\nc\nd");
+        Assert.Equal(2, nodes.Count(node => node is HardBreakNode));
+        Assert.Single(nodes.OfType<SoftBreakNode>());
+    }
+
+    [Fact]
+    public void InlineMarkupCanNestRecursively()
+    {
+        var strong = Assert.IsType<StrongNode>(Assert.Single(Parser.ParseInline("*bold _and italic_*")));
+        Assert.IsType<EmphasisNode>(strong.Children[1]);
+    }
+
+    [Fact]
+    public void CrLfAndBareCarriageReturnsAreNormalized()
+    {
+        var document = Parser.Parse("first\r\nsecond\r\rthird");
+        Assert.Equal(2, document.Children.Count);
+        Assert.Equal(3, Assert.IsType<ParagraphNode>(document.Children[0]).Children.Count);
+    }
+
+    [Fact]
+    public void EmptyDelimitedBlocksProduceEmptyValues()
+    {
+        var document = Parser.Parse("----\n----\n....\n....\n++++\n++++");
+        Assert.Equal(string.Empty, Assert.IsType<CodeBlockNode>(document.Children[0]).Value);
+        Assert.Equal(string.Empty, Assert.IsType<CodeBlockNode>(document.Children[1]).Value);
+        Assert.Equal(string.Empty, Assert.IsType<RawBlockNode>(document.Children[2]).Value);
+    }
+
+    [Fact]
+    public void PassthroughBlocksDoNotAddTrailingNewlines()
+    {
+        var raw = Assert.IsType<RawBlockNode>(Assert.Single(Parser.Parse("++++\nline one\nline two\n++++").Children));
+        Assert.Equal("line one\nline two", raw.Value);
+    }
+
+    [Fact]
+    public void UnterminatedPassthroughBlocksAreEmittedLeniently()
+    {
+        var raw = Assert.IsType<RawBlockNode>(Assert.Single(Parser.Parse("++++\nraw").Children));
+        Assert.Equal("raw", raw.Value);
+    }
+
+    [Fact]
+    public void UnterminatedQuoteBlocksAreParsedRecursively()
+    {
+        var quote = Assert.IsType<BlockquoteNode>(Assert.Single(Parser.Parse("____\n== Inner").Children));
+        Assert.IsType<HeadingNode>(Assert.Single(quote.Children));
+    }
+
+    [Fact]
+    public void ListsInterruptParagraphsWithoutBlankLines()
+    {
+        var document = Parser.Parse("paragraph\n* item\n. ordered");
+        Assert.IsType<ParagraphNode>(document.Children[0]);
+        Assert.IsType<ListNode>(document.Children[1]);
+        Assert.IsType<ListNode>(document.Children[2]);
+    }
+
+    [Fact]
+    public void CommentsAndSourceAttributesInterruptParagraphs()
+    {
+        var document = Parser.Parse("paragraph\n// hidden\n[source, go]\n----\ncode\n----");
+        Assert.Equal(2, document.Children.Count);
+        Assert.IsType<ParagraphNode>(document.Children[0]);
+        Assert.Equal("go", Assert.IsType<CodeBlockNode>(document.Children[1]).Language);
+    }
+
+    [Fact]
+    public void SwitchingListKindsCreatesSeparateLists()
+    {
+        var document = Parser.Parse("* unordered\n. ordered\n* unordered again");
+        Assert.Equal(3, document.Children.Count);
+        Assert.False(Assert.IsType<ListNode>(document.Children[0]).Ordered);
+        Assert.True(Assert.IsType<ListNode>(document.Children[1]).Ordered);
+        Assert.False(Assert.IsType<ListNode>(document.Children[2]).Ordered);
+    }
+
+    [Fact]
+    public void ListsSupportMultipleNestedLevels()
+    {
+        var root = Assert.IsType<ListNode>(Assert.Single(Parser.Parse("* one\n** two\n*** three").Children));
+        var levelTwo = Assert.IsType<ListNode>(Assert.IsType<ListItemNode>(Assert.Single(root.Children)).Children[1]);
+        Assert.IsType<ListNode>(Assert.IsType<ListItemNode>(Assert.Single(levelTwo.Children)).Children[1]);
+    }
+
+    [Fact]
+    public void SourceAttributesAreCaseInsensitiveAndTrimLanguages()
+    {
+        var block = Assert.IsType<CodeBlockNode>(Assert.Single(Parser.Parse("[SOURCE,  rust ]\n----\nx\n----").Children));
+        Assert.Equal("rust", block.Language);
+    }
+
+    [Fact]
+    public void HeadingAndListContentTrimMarkerWhitespace()
+    {
+        var document = Parser.Parse("==   Heading\n\n*   item  ");
+        Assert.Equal("Heading", Assert.IsType<TextNode>(Assert.Single(Assert.IsType<HeadingNode>(document.Children[0]).Children)).Value);
+        var item = Assert.IsType<ListItemNode>(Assert.Single(Assert.IsType<ListNode>(document.Children[1]).Children));
+        Assert.Equal("item", Assert.IsType<TextNode>(Assert.Single(Assert.IsType<ParagraphNode>(item.Children[0]).Children)).Value);
+    }
+
+    [Fact]
+    public void LongDelimitersAreAccepted()
+    {
+        var document = Parser.Parse("'''''\n-----\nx\n-----");
+        Assert.IsType<ThematicBreakNode>(document.Children[0]);
+        Assert.IsType<CodeBlockNode>(document.Children[1]);
+    }
+
+    [Fact]
+    public void PlainInlineInputCoalescesIntoOneTextNode()
+    {
+        Assert.Equal("just plain text", Assert.IsType<TextNode>(Assert.Single(Parser.ParseInline("just plain text"))).Value);
+    }
+
+    [Theory]
+    [InlineData("*open")]
+    [InlineData("_open")]
+    [InlineData("`open")]
+    [InlineData("<<open")]
+    public void UnterminatedInlineConstructsRemainLiteral(string input)
+    {
+        Assert.Equal(input, Assert.IsType<TextNode>(Assert.Single(Parser.ParseInline(input))).Value);
+    }
+
+    [Fact]
+    public void MalformedMacrosRemainLiteralText()
+    {
+        Assert.Equal("link:target[open", Assert.IsType<TextNode>(Assert.Single(Parser.ParseInline("link:target[open"))).Value);
+        Assert.Equal("image:cat.png", Assert.IsType<TextNode>(Assert.Single(Parser.ParseInline("image:cat.png"))).Value);
+    }
+}

--- a/code/packages/csharp/asciidoc-parser/tests/CodingAdventures.AsciidocParser.Tests/CodingAdventures.AsciidocParser.Tests.csproj
+++ b/code/packages/csharp/asciidoc-parser/tests/CodingAdventures.AsciidocParser.Tests/CodingAdventures.AsciidocParser.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.AsciidocParser.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/asciidoc-parser/AsciidocParser.fs
+++ b/code/packages/fsharp/asciidoc-parser/AsciidocParser.fs
@@ -1,0 +1,343 @@
+namespace CodingAdventures.AsciidocParser
+
+open System
+open System.Collections.Generic
+open System.Text
+open CodingAdventures.DocumentAst.FSharp
+
+type private BlockState =
+    | Normal
+    | Paragraph
+    | Code
+    | Literal
+    | Passthrough
+    | Quote
+    | UnorderedList
+    | OrderedList
+
+type private ListEntry = { Level: int; Text: string }
+
+/// Parses a portable AsciiDoc subset into the shared document AST.
+[<RequireQualifiedAccess>]
+module AsciidocParser =
+    let private startsAt (text: string) index (value: string) =
+        index >= 0
+        && index + value.Length <= text.Length
+        && String.CompareOrdinal(text, index, value, 0, value.Length) = 0
+
+    /// Parse inline AsciiDoc markup into shared inline AST nodes.
+    let rec parseInline (text: string) =
+        nullArgCheck "text" text |> ignore
+        let output = ResizeArray<InlineNode>()
+        let plain = StringBuilder()
+        let mutable index = 0
+
+        let flush () =
+            if plain.Length > 0 then
+                output.Add(TextNode(plain.ToString()))
+                plain.Clear() |> ignore
+
+        let tryDelimited delimiter create =
+            if not (startsAt text index delimiter) then
+                false
+            else
+                let closing = text.IndexOf(delimiter, index + delimiter.Length, StringComparison.Ordinal)
+                if closing < 0 then
+                    false
+                else
+                    flush ()
+                    output.Add(create text[(index + delimiter.Length) .. closing - 1])
+                    index <- closing + delimiter.Length
+                    true
+
+        let tryMacro prefix image =
+            if not (startsAt text index prefix) then
+                false
+            else
+                let openBracket = text.IndexOf('[', index + prefix.Length)
+                let closeBracket = if openBracket < 0 then -1 else text.IndexOf(']', openBracket + 1)
+                if openBracket < 0 || closeBracket < 0 then
+                    false
+                else
+                    let destination = text[(index + prefix.Length) .. openBracket - 1]
+                    let label = text[(openBracket + 1) .. closeBracket - 1]
+                    flush ()
+                    if image then
+                        output.Add(ImageNode(destination, None, label))
+                    else
+                        let display = if label.Length = 0 then destination else label
+                        output.Add(LinkNode(destination, None, [ TextNode display ]))
+                    index <- closeBracket + 1
+                    true
+
+        let tryCrossReference () =
+            if not (startsAt text index "<<") then
+                false
+            else
+                let closing = text.IndexOf(">>", index + 2, StringComparison.Ordinal)
+                if closing < 0 then
+                    false
+                else
+                    let content = text[(index + 2) .. closing - 1]
+                    let parts = content.Split(',', 2)
+                    let anchor = parts.[0].Trim()
+                    let label = if parts.Length = 2 then parts.[1].Trim() else anchor
+                    flush ()
+                    output.Add(LinkNode("#" + anchor, None, [ TextNode label ]))
+                    index <- closing + 2
+                    true
+
+        let tryUrl () =
+            let schemeLength =
+                if startsAt text index "https://" then 8
+                elif startsAt text index "http://" then 7
+                else 0
+
+            if schemeLength = 0 then
+                false
+            else
+                let mutable ending = index + schemeLength
+                while ending < text.Length
+                      && not (Char.IsWhiteSpace text.[ending])
+                      && text.[ending] <> '['
+                      && text.[ending] <> ']' do
+                    ending <- ending + 1
+
+                let url = text[index .. ending - 1]
+                flush ()
+                if ending < text.Length && text.[ending] = '[' then
+                    let closeBracket = text.IndexOf(']', ending + 1)
+                    if closeBracket >= 0 then
+                        let label = text[(ending + 1) .. closeBracket - 1]
+                        let display = if label.Length = 0 then url else label
+                        output.Add(LinkNode(url, None, [ TextNode display ]))
+                        index <- closeBracket + 1
+                    else
+                        output.Add(AutolinkNode(url, false))
+                        index <- ending
+                else
+                    output.Add(AutolinkNode(url, false))
+                    index <- ending
+                true
+
+        while index < text.Length do
+            if startsAt text index "  \n" then
+                flush ()
+                output.Add(HardBreakNode)
+                index <- index + 3
+            elif startsAt text index "\\\n" then
+                flush ()
+                output.Add(HardBreakNode)
+                index <- index + 2
+            elif text.[index] = '\n' then
+                flush ()
+                output.Add(SoftBreakNode)
+                index <- index + 1
+            elif tryDelimited "`" CodeSpanNode then ()
+            elif tryDelimited "**" (parseInline >> StrongNode) then ()
+            elif tryDelimited "__" (parseInline >> EmphasisNode) then ()
+            elif tryDelimited "*" (parseInline >> StrongNode) then ()
+            elif tryDelimited "_" (parseInline >> EmphasisNode) then ()
+            elif tryMacro "link:" false then ()
+            elif tryMacro "image:" true then ()
+            elif tryCrossReference () then ()
+            elif tryUrl () then ()
+            else
+                plain.Append(text.[index]) |> ignore
+                index <- index + 1
+
+        flush ()
+        List.ofSeq output
+
+    let private isDelimiter (line: string) value minimum =
+        line.Length >= minimum && line |> Seq.forall ((=) value)
+
+    let private tryHeading (line: string) =
+        let mutable count = 0
+        while count < line.Length && line.[count] = '=' do
+            count <- count + 1
+        if count > 0 && count < line.Length && Char.IsWhiteSpace line.[count] then
+            Some(min count 6, line[count ..].TrimStart())
+        else
+            None
+
+    let private trySourceAttribute (line: string) =
+        if line.StartsWith("[source", StringComparison.OrdinalIgnoreCase) && line.EndsWith(']') then
+            let comma = line.IndexOf(',')
+            if comma >= 0 then
+                let language = line[(comma + 1) .. line.Length - 2].Trim()
+                if language.Length > 0 then Some language else None
+            else
+                None
+        else
+            None
+
+    let private tryListItem (line: string) marker =
+        let mutable count = 0
+        while count < line.Length && line.[count] = marker do
+            count <- count + 1
+        if count > 0 && count < line.Length && line.[count] = ' ' then
+            Some { Level = count; Text = line[(count + 1) ..].Trim() }
+        else
+            None
+
+    let private startsNewBlock line =
+        tryHeading line |> Option.isSome
+        || trySourceAttribute line |> Option.isSome
+        || tryListItem line '*' |> Option.isSome
+        || tryListItem line '.' |> Option.isSome
+        || line.StartsWith("//", StringComparison.Ordinal)
+        || isDelimiter line '\'' 3
+        || isDelimiter line '-' 4
+        || isDelimiter line '.' 4
+        || isDelimiter line '+' 4
+        || isDelimiter line '_' 4
+
+    let private buildList (entries: IReadOnlyList<ListEntry>) ordered =
+        let rec buildLevel level startIndex =
+            let children = ResizeArray<ListChildNode>()
+            let mutable index = startIndex
+            let mutable keepGoing = true
+
+            while index < entries.Count && entries.[index].Level >= level && keepGoing do
+                if entries.[index].Level > level then
+                    keepGoing <- false
+                else
+                    let entry = entries.[index]
+                    index <- index + 1
+                    let blocks = ResizeArray<BlockNode>()
+                    blocks.Add(ParagraphNode(parseInline entry.Text))
+
+                    while index < entries.Count && entries.[index].Level > level do
+                        let sublist, nextIndex = buildLevel entries.[index].Level index
+                        blocks.Add(sublist)
+                        index <- nextIndex
+
+                    children.Add(ListItemNode(List.ofSeq blocks))
+
+            ListNode(ordered, (if ordered then Some 1 else None), true, List.ofSeq children), index
+
+        buildLevel entries.[0].Level 0 |> fst
+
+    /// Parse a complete AsciiDoc source string.
+    let rec parse (source: string) : DocumentNode =
+        nullArgCheck "source" source |> ignore
+        let normalized = source.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n')
+        let lines = ResizeArray<string>(normalized.Split('\n'))
+        if normalized.EndsWith('\n') then
+            lines.RemoveAt(lines.Count - 1)
+
+        let blocks = ResizeArray<BlockNode>()
+        let paragraphLines = ResizeArray<string>()
+        let delimitedLines = ResizeArray<string>()
+        let listEntries = ResizeArray<ListEntry>()
+        let mutable state = Normal
+        let mutable pendingLanguage: string option = None
+        let mutable listOrdered = false
+
+        let flushParagraph () =
+            if paragraphLines.Count > 0 then
+                blocks.Add(ParagraphNode(parseInline (String.Join('\n', paragraphLines))))
+                paragraphLines.Clear()
+
+        let flushList () =
+            if listEntries.Count > 0 then
+                blocks.Add(buildList listEntries listOrdered)
+                listEntries.Clear()
+
+        let emitDelimited activeState =
+            let value = if delimitedLines.Count = 0 then String.Empty else String.Join('\n', delimitedLines) + "\n"
+            match activeState with
+            | Code -> blocks.Add(CodeBlockNode(pendingLanguage, value))
+            | Literal -> blocks.Add(CodeBlockNode(None, value))
+            | Passthrough -> blocks.Add(RawBlockNode("html", String.Join('\n', delimitedLines)))
+            | Quote -> blocks.Add(BlockquoteNode((parse (String.Join('\n', delimitedLines))).Children))
+            | _ -> ()
+
+        for rawLine in lines do
+            let line = rawLine.TrimEnd()
+            let mutable handled = false
+
+            match state with
+            | Code
+            | Literal
+            | Passthrough
+            | Quote ->
+                let delimiter =
+                    match state with
+                    | Code -> '-'
+                    | Literal -> '.'
+                    | Passthrough -> '+'
+                    | _ -> '_'
+
+                if isDelimiter line delimiter 4 then
+                    let completedState = state
+                    emitDelimited completedState
+                    if completedState = Code then pendingLanguage <- None
+                    delimitedLines.Clear()
+                    state <- Normal
+                else
+                    delimitedLines.Add(rawLine)
+                handled <- true
+            | Paragraph ->
+                if line.Length = 0 then
+                    flushParagraph ()
+                    state <- Normal
+                    handled <- true
+                elif startsNewBlock line then
+                    flushParagraph ()
+                    state <- Normal
+                else
+                    paragraphLines.Add(line)
+                    handled <- true
+            | UnorderedList
+            | OrderedList ->
+                if line.Length = 0 then
+                    flushList ()
+                    state <- Normal
+                    handled <- true
+                else
+                    let marker = if state = OrderedList then '.' else '*'
+                    match tryListItem line marker with
+                    | Some entry ->
+                        listEntries.Add(entry)
+                        handled <- true
+                    | None ->
+                        flushList ()
+                        state <- Normal
+            | Normal -> ()
+
+            if not handled then
+                if line.Length = 0 || line.StartsWith("//", StringComparison.Ordinal) then
+                    ()
+                else
+                    match trySourceAttribute line with
+                    | Some language -> pendingLanguage <- Some language
+                    | None ->
+                        match tryHeading line with
+                        | Some(level, headingText) -> blocks.Add(HeadingNode(level, parseInline headingText))
+                        | None when isDelimiter line '\'' 3 -> blocks.Add(ThematicBreakNode)
+                        | None when isDelimiter line '-' 4 -> state <- Code
+                        | None when isDelimiter line '.' 4 -> state <- Literal
+                        | None when isDelimiter line '+' 4 -> state <- Passthrough
+                        | None when isDelimiter line '_' 4 -> state <- Quote
+                        | None ->
+                            match tryListItem line '*' with
+                            | Some entry ->
+                                listOrdered <- false
+                                listEntries.Add(entry)
+                                state <- UnorderedList
+                            | None ->
+                                match tryListItem line '.' with
+                                | Some entry ->
+                                    listOrdered <- true
+                                    listEntries.Add(entry)
+                                    state <- OrderedList
+                                | None ->
+                                    paragraphLines.Add(line)
+                                    state <- Paragraph
+
+        flushParagraph ()
+        flushList ()
+        if delimitedLines.Count > 0 then emitDelimited state
+        { Children = List.ofSeq blocks }

--- a/code/packages/fsharp/asciidoc-parser/BUILD
+++ b/code/packages/fsharp/asciidoc-parser/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AsciidocParser.Tests/CodingAdventures.AsciidocParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.AsciidocParser.FSharp]*"

--- a/code/packages/fsharp/asciidoc-parser/BUILD_windows
+++ b/code/packages/fsharp/asciidoc-parser/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.AsciidocParser.Tests/CodingAdventures.AsciidocParser.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.AsciidocParser.FSharp]*"

--- a/code/packages/fsharp/asciidoc-parser/CHANGELOG.md
+++ b/code/packages/fsharp/asciidoc-parser/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add block and inline AsciiDoc parsing into the shared document AST.
+- Support headings, paragraphs, delimited blocks, nested lists, links, images, cross-references, emphasis, strong text, code spans, and line breaks.

--- a/code/packages/fsharp/asciidoc-parser/CodingAdventures.AsciidocParser.fsproj
+++ b/code/packages/fsharp/asciidoc-parser/CodingAdventures.AsciidocParser.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.AsciidocParser.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.AsciidocParser.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# AsciiDoc parser producing the shared document AST</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../document-ast/CodingAdventures.DocumentAst.fsproj" />
+    <Compile Include="AsciidocParser.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/asciidoc-parser/README.md
+++ b/code/packages/fsharp/asciidoc-parser/README.md
@@ -1,0 +1,17 @@
+# AsciiDoc Parser (F#)
+
+Pure F# parser for a portable AsciiDoc subset, producing the shared
+`CodingAdventures.DocumentAst.FSharp` representation.
+
+```fsharp
+open CodingAdventures.AsciidocParser
+
+let document = AsciidocParser.parse "= Title\n\nHello *world*."
+let inlineNodes = AsciidocParser.parseInline "link:https://example.com[Example]"
+```
+
+The block parser supports headings, paragraphs, thematic breaks, source and
+literal blocks, passthrough HTML, recursive quote blocks, comments, and nested
+ordered or unordered lists. The inline parser supports strong and emphasized
+text, code spans, links, images, cross-references, URLs, and hard or soft line
+breaks.

--- a/code/packages/fsharp/asciidoc-parser/required_capabilities.json
+++ b/code/packages/fsharp/asciidoc-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/asciidoc-parser",
+  "capabilities": [],
+  "justification": "Pure computation package. Parses caller-provided strings into document AST values without external access."
+}

--- a/code/packages/fsharp/asciidoc-parser/tests/CodingAdventures.AsciidocParser.Tests/AsciidocParserTests.fs
+++ b/code/packages/fsharp/asciidoc-parser/tests/CodingAdventures.AsciidocParser.Tests/AsciidocParserTests.fs
@@ -1,0 +1,204 @@
+namespace CodingAdventures.AsciidocParser.FSharp.Tests
+
+open System
+open Xunit
+open CodingAdventures.AsciidocParser
+open CodingAdventures.DocumentAst.FSharp
+
+module AsciidocParserTests =
+    let private unexpected value = failwithf "unexpected AST node: %A" value
+
+    [<Fact>]
+    let ``parse rejects null`` () =
+        Assert.Throws<ArgumentNullException>(fun () -> AsciidocParser.parse Unchecked.defaultof<string> |> ignore)
+        |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> AsciidocParser.parseInline Unchecked.defaultof<string> |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``empty blank and comment-only sources produce empty documents`` () =
+        Assert.Empty((AsciidocParser.parse String.Empty).Children)
+        Assert.Empty((AsciidocParser.parse "  \n\t\n").Children)
+        Assert.Empty((AsciidocParser.parse "// hidden\n// also hidden").Children)
+
+    [<Fact>]
+    let ``headings clamp levels and parse inline markup`` () =
+        match (AsciidocParser.parse "= One\n== Two\n======= *Deep*").Children with
+        | [ HeadingNode(1, _); HeadingNode(2, _); HeadingNode(6, [ StrongNode _ ]) ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``paragraphs preserve soft breaks and blank-line boundaries`` () =
+        match (AsciidocParser.parse "first line\nsecond line\n\nnext").Children with
+        | [ ParagraphNode [ TextNode "first line"; SoftBreakNode; TextNode "second line" ]
+            ParagraphNode [ TextNode "next" ] ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``thematic breaks and headings interrupt paragraphs`` () =
+        match (AsciidocParser.parse "paragraph\n'''\n== Heading").Children with
+        | [ ParagraphNode _; ThematicBreakNode; HeadingNode _ ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``source and literal blocks preserve content`` () =
+        match (AsciidocParser.parse "[source, fsharp]\n----\nlet x = 1\n----\n....\nliteral\n....").Children with
+        | [ CodeBlockNode(Some "fsharp", "let x = 1\n"); CodeBlockNode(None, "literal\n") ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``unterminated code blocks are emitted leniently`` () =
+        match (AsciidocParser.parse "----\nopen\n").Children with
+        | [ CodeBlockNode(None, "open\n") ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``passthrough and quote blocks produce raw and recursive nodes`` () =
+        match (AsciidocParser.parse "++++\n<b>raw</b>\n++++\n____\n= Nested\n\ntext\n____").Children with
+        | [ RawBlockNode("html", "<b>raw</b>"); BlockquoteNode [ HeadingNode _; ParagraphNode _ ] ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``ordered unordered and nested lists are built`` () =
+        match (AsciidocParser.parse "* one\n** nested\n* two\n\n. first\n. second").Children with
+        | [ ListNode(false, None, true, [ ListItemNode [ ParagraphNode _; ListNode _ ]; ListItemNode _ ])
+            ListNode(true, Some 1, true, [ ListItemNode _; ListItemNode _ ]) ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``lists terminate when another block starts`` () =
+        match (AsciidocParser.parse "* item\nparagraph\n\n. ordered\n== Heading").Children with
+        | [ ListNode _; ParagraphNode _; ListNode _; HeadingNode _ ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``inline parser handles strong emphasis code and literal delimiters`` () =
+        let nodes = AsciidocParser.parseInline "a *bold* **wide** _ital_ __free__ `*code*` and *open"
+        let strongCount = nodes |> List.filter (function StrongNode _ -> true | _ -> false) |> List.length
+        let emphasisCount = nodes |> List.filter (function EmphasisNode _ -> true | _ -> false) |> List.length
+        Assert.Equal(2, strongCount)
+        Assert.Equal(2, emphasisCount)
+        Assert.Contains(CodeSpanNode "*code*", nodes)
+        match List.last nodes with
+        | TextNode value -> Assert.EndsWith("*open", value)
+        | node -> unexpected node
+
+    [<Fact>]
+    let ``inline parser handles links images cross-references and URLs`` () =
+        let nodes =
+            AsciidocParser.parseInline
+                "link:https://a.test[A] image:cat.png[Cat] <<intro,Intro>> <<plain>> https://b.test[B] http://c.test"
+        let links = nodes |> List.choose (function LinkNode(destination, _, _) -> Some destination | _ -> None)
+        Assert.Equal<string list>([ "https://a.test"; "#intro"; "#plain"; "https://b.test" ], links)
+        Assert.Contains(ImageNode("cat.png", None, "Cat"), nodes)
+        Assert.Contains(AutolinkNode("http://c.test", false), nodes)
+
+    [<Fact>]
+    let ``empty link labels use their destinations`` () =
+        match AsciidocParser.parseInline "link:https://a.test[]", AsciidocParser.parseInline "https://b.test[]" with
+        | [ LinkNode("https://a.test", None, [ TextNode "https://a.test" ]) ],
+          [ LinkNode("https://b.test", None, [ TextNode "https://b.test" ]) ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``inline parser classifies hard and soft breaks`` () =
+        let nodes = AsciidocParser.parseInline "a  \nb\\\nc\nd"
+        let hardCount = nodes |> List.filter ((=) HardBreakNode) |> List.length
+        let softCount = nodes |> List.filter ((=) SoftBreakNode) |> List.length
+        Assert.Equal(2, hardCount)
+        Assert.Equal(1, softCount)
+
+    [<Fact>]
+    let ``inline markup can nest recursively`` () =
+        match AsciidocParser.parseInline "*bold _and italic_*" with
+        | [ StrongNode [ TextNode "bold "; EmphasisNode [ TextNode "and italic" ] ] ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``CRLF and bare carriage returns are normalized`` () =
+        match (AsciidocParser.parse "first\r\nsecond\r\rthird").Children with
+        | [ ParagraphNode [ TextNode "first"; SoftBreakNode; TextNode "second" ]; ParagraphNode [ TextNode "third" ] ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``empty delimited blocks produce empty values`` () =
+        match (AsciidocParser.parse "----\n----\n....\n....\n++++\n++++").Children with
+        | [ CodeBlockNode(None, ""); CodeBlockNode(None, ""); RawBlockNode("html", "") ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``passthrough blocks do not add trailing newlines`` () =
+        match (AsciidocParser.parse "++++\nline one\nline two\n++++").Children with
+        | [ RawBlockNode("html", "line one\nline two") ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``unterminated passthrough blocks are emitted leniently`` () =
+        match (AsciidocParser.parse "++++\nraw").Children with
+        | [ RawBlockNode("html", "raw") ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``unterminated quote blocks are parsed recursively`` () =
+        match (AsciidocParser.parse "____\n== Inner").Children with
+        | [ BlockquoteNode [ HeadingNode _ ] ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``lists interrupt paragraphs without blank lines`` () =
+        match (AsciidocParser.parse "paragraph\n* item\n. ordered").Children with
+        | [ ParagraphNode _; ListNode(false, _, _, _); ListNode(true, _, _, _) ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``comments and source attributes interrupt paragraphs`` () =
+        match (AsciidocParser.parse "paragraph\n// hidden\n[source, go]\n----\ncode\n----").Children with
+        | [ ParagraphNode _; CodeBlockNode(Some "go", "code\n") ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``switching list kinds creates separate lists`` () =
+        match (AsciidocParser.parse "* unordered\n. ordered\n* unordered again").Children with
+        | [ ListNode(false, _, _, _); ListNode(true, _, _, _); ListNode(false, _, _, _) ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``lists support multiple nested levels`` () =
+        match (AsciidocParser.parse "* one\n** two\n*** three").Children with
+        | [ ListNode(false, _, _, [ ListItemNode [ ParagraphNode _; ListNode(false, _, _, [ ListItemNode [ ParagraphNode _; ListNode _ ] ]) ] ]) ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``source attributes are case-insensitive and trim languages`` () =
+        match (AsciidocParser.parse "[SOURCE,  rust ]\n----\nx\n----").Children with
+        | [ CodeBlockNode(Some "rust", "x\n") ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``heading and list content trim marker whitespace`` () =
+        match (AsciidocParser.parse "==   Heading\n\n*   item  ").Children with
+        | [ HeadingNode(2, [ TextNode "Heading" ]); ListNode(false, _, _, [ ListItemNode [ ParagraphNode [ TextNode "item" ] ] ]) ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``long delimiters are accepted`` () =
+        match (AsciidocParser.parse "'''''\n-----\nx\n-----").Children with
+        | [ ThematicBreakNode; CodeBlockNode(None, "x\n") ] -> ()
+        | nodes -> unexpected nodes
+
+    [<Fact>]
+    let ``plain inline input coalesces into one text node`` () =
+        Assert.Equal<InlineNode list>([ TextNode "just plain text" ], AsciidocParser.parseInline "just plain text")
+
+    [<Theory>]
+    [<InlineData("*open")>]
+    [<InlineData("_open")>]
+    [<InlineData("`open")>]
+    [<InlineData("<<open")>]
+    let ``unterminated inline constructs remain literal`` input =
+        Assert.Equal<InlineNode list>([ TextNode input ], AsciidocParser.parseInline input)
+
+    [<Fact>]
+    let ``malformed macros remain literal text`` () =
+        Assert.Equal<InlineNode list>([ TextNode "link:target[open" ], AsciidocParser.parseInline "link:target[open")
+        Assert.Equal<InlineNode list>([ TextNode "image:cat.png" ], AsciidocParser.parseInline "image:cat.png")

--- a/code/packages/fsharp/asciidoc-parser/tests/CodingAdventures.AsciidocParser.Tests/CodingAdventures.AsciidocParser.Tests.fsproj
+++ b/code/packages/fsharp/asciidoc-parser/tests/CodingAdventures.AsciidocParser.Tests/CodingAdventures.AsciidocParser.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.AsciidocParser.fsproj" />
+    <Compile Include="AsciidocParserTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -114,16 +114,17 @@ and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
 ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
-ports:
+ports, followed by the paired `ed25519`, `font-parser`, and
+`asciidoc-parser` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 317 |
+| Present in 10-15 languages | 172 | 313 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 701 | 9,814 |
+| Present in one language | 703 | 9,842 |
 
-The loop must not start by attempting 9,814 singleton ports. It should finish
+The loop must not start by attempting 9,842 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -164,7 +165,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 315
+The 172 packages present in at least ten implementation languages need 313
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -173,8 +174,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 3 | Move with F# |
-| F# | 3 | Move with C# |
+| C# | 2 | Move with F# |
+| F# | 2 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -353,6 +354,17 @@ sentinels, immutable input ownership, unsupported mappings, shared advances,
 and sorted kerning lookup. The package now spans 12 implementation lanes,
 reduces the high-consensus backlog to 315 slots, and leaves 3 paired gaps in
 each lane.
+
+The fifteenth paired C#/F# slice is complete: `asciidoc-parser` now provides
+native block and inline parsers over each lane's shared `document-ast` model.
+Both implementations cover headings, paragraphs and breaks, source, literal,
+passthrough, and recursive quote blocks, ordered and unordered nested lists,
+comments, thematic breaks, emphasis, strong text, code spans, link and image
+macros, cross-references, and HTTP autolinks. Mirrored package-native suites
+exercise 33 test cases in each lane, including lenient unterminated blocks and
+malformed inline delimiters, with more than 97% line coverage. The
+package now spans 12 implementation lanes, reduces the high-consensus backlog
+to 313 slots, and leaves 2 paired gaps in each lane.
 
 Recommended family order:
 


### PR DESCRIPTION
﻿## Summary
- add native C# and F# `asciidoc-parser` ports over each lane's shared `document-ast`
- cover TE03 block parsing, nested lists and quotes, inline markup, links, images, cross-references, and hard/soft breaks
- refresh the parity roadmap to 313 high-consensus slots with only `fpga` and `zstd` left in each paired lane

## Validation
- C#: 33/33 tests; 98.86% line coverage, 97.01% branch coverage
- F#: 33/33 tests; 97.85% line coverage, 81.67% branch coverage
- `dotnet format --verify-no-changes` for C# library and tests
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py`
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (313 high-consensus gaps, zero collisions)
- `git diff --check`
