### PR TITLE
feat(hl): French & German writing nuances — accents/cédille/tréma + eszett/umlauts/capital nouns

### DIFF
--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Writing nuances — the accents, the cédille, the tréma
+
+- **First French `writing`-type lessons** (`FR-W01-accents`, `FR-W02-cedille`,
+  `FR-W03-trema`): orthography taught etymology-first, the same way as the
+  Spanish writing lessons, once enough accented words have accumulated.
+- **The three accents on *e*** (`é è ê`): *é* aigu = "ay", *è* grave = open "eh"
+  (and the grave that only separates look-alikes, *a/à*, *ou/où*), and the star —
+  the **circonflexe ê as a tombstone for a lost *s***, with the English cousin
+  usually keeping it (*forêt*→forest, *hôpital*→hospital, *île*→isle,
+  *bête*→beast, *être*→*stāre*). The single most useful French reading trick.
+- **The cédille ç**: keeps *c* soft (*s*) before *a/o/u* (*français*, *garçon*),
+  and the hook's origin as a shrunken subscript *z* (Spanish *zedilla*, "little z").
+- **The tréma ï/ë**: "pronounce these vowels **separately**" (*naïve*, *Noël*,
+  *maïs* vs *mais*) — explicitly contrasted with the German umlaut (which *changes*
+  a vowel rather than *splitting* two).
+- Uses the `writing` lesson type (no `concept_tag`) — no taxonomy change.
+
 ## Chapter 4 — Farewells (parallel of Spanish Ch. 5)
 
 - **Chapter 4 authored** (`FR-C04-au-revoir`, `-a-plus-tard`, `-a-bientot`,

--- a/code/learning/human-languages/french/lessons/FR-W01-accents.md
+++ b/code/learning/human-languages/french/lessons/FR-W01-accents.md
@@ -1,0 +1,72 @@
+---
+id: FR-W01-accents
+chapter: 4
+type: writing
+headword: "é è ê"
+gloss: the three accents on e (aigu, grave, circonflexe) — and the circumflex's hidden s
+prerequisites: [FR-C01-bien, FR-C03-comment-ca-va]
+sounds: [vowel-e-acute, vowel-e-grave]
+roots: []
+est_minutes: 5
+reviews_of: [FR-C02-enchante, FR-C03-comme-ci-comme-ca]
+---
+
+# é è ê — the three hats on *e*, and the one that hides an *s*
+
+## Warm-up
+
+[PAUSE 2s] French sprinkles little marks over its vowels, and they are **not**
+decoration — each does a specific job. You've read them since *enchanté* and
+*très*. Three of them ride on *e*, and one of the three hides a word you already
+know in English.
+
+## The three accents, and what they do
+
+- **é** — *accent aigu* (rising stroke, like Spanish's). It fixes the sound:
+  **é = a crisp "ay"** (no glide). *café*, *enchanté*, *été* ("summer").
+- **è** — *accent grave* (falling stroke). **è = an open "eh"** as in *bed*.
+  *très* ("very"), *mère* ("mother"), *père*. The grave also just **separates
+  look-alikes**: *a* ("has") vs **à** ("to"); *ou* ("or") vs **où** ("where") —
+  same job as Spanish *tu/tú*.
+- **ê** — *accent circonflexe* (a little hat). This one is a **fossil**.
+
+## The circumflex is a tombstone for a lost *s*
+
+Centuries ago French dropped an *s* before certain consonants, and left a **hat**
+where it used to stand. English, having borrowed the older form, usually **still
+has that s** — so the circumflex is a decoder ring between the two languages:
+
+| French (hat) | the lost *s* | English kept it |
+|---|---|---|
+| **forêt** | forest | **forest** |
+| **hôpital** | hospital | **hospital** |
+| **île** | isle | **isle / island** |
+| **bête** | beste | **beast** |
+| **fête** | feste | **feast** |
+| **pâte** | paste | **paste / pasta** |
+| **goût** | gust | (Latin *gustus*, cf. *gusto*) |
+| **être** | estre | (Latin *stāre*, cf. *stare/estar*) |
+
+So when you meet a circumflex, **mentally slot an *s* back in** and an English
+cousin often appears. *Hôpital → hospital.* It's the single most useful reading
+trick in French spelling.
+
+## How to write them
+
+All three are small strokes **above** the vowel: **é** leans right (up-stroke),
+**è** leans left (down-stroke), **ê** is a little peak (^). Get the *lean*
+right — *é* and *è* are different sounds, so the direction matters.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "é" = *ay* (*café*), "è" = *eh* (*très*) — hear the two sounds]
+- [YOU SAY: forêt → forest, hôpital → hospital, île → isle — put the *s* back]
+- [YOU SAY: "à" vs "a", "où" vs "ou" — the grave that only separates]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which accent makes *e* say "ay," and which "eh"? (*é* aigu = ay; *è*
+grave = eh.) What does the circumflex **ê** usually mark, and how do you use it?
+(A lost *s* — slot it back to find the English cousin: *forêt* → forest.) Next
+writing lesson: the little hook under *c* — the **cédille**.

--- a/code/learning/human-languages/french/lessons/FR-W02-cedille.md
+++ b/code/learning/human-languages/french/lessons/FR-W02-cedille.md
@@ -1,0 +1,65 @@
+---
+id: FR-W02-cedille
+chapter: 4
+type: writing
+headword: "ç"
+gloss: the cédille — the little hook that keeps c soft before a, o, u
+prerequisites: [FR-W01-accents]
+sounds: [soft-c-s]
+roots: [zeda-spanish]
+est_minutes: 3
+reviews_of: [FR-W01-accents]
+---
+
+# ç — the little tail that softens *c*
+
+## Warm-up
+
+[PAUSE 2s] You've seen it in **français** and **garçon**. The **cédille** is the
+tiny hook under a *c* — **ç** — and it exists to solve one specific spelling
+problem.
+
+## The problem it solves
+
+In French (as in Latin, Italian, Spanish), **c is soft (an *s* sound) before *e*
+and *i***, but **hard (a *k*) before *a*, *o*, *u***:
+
+- *ce*, *ci* → soft: *ceci* = *suh-SEE*.
+- *ca*, *co*, *cu* → hard: *car*, *comme*, *cure* = *k*.
+
+So "franc-ais" would read *frank-ay* — wrong. To force the **soft** *s* before
+*a/o/u*, French adds the hook: **ç**.
+
+- **français** = *frahn-**SEH*** (not "frank-").
+- **garçon** = *gar-**SOHN*** ("boy").
+- **ça** = *sa* ("that" — the *ça* of *ça va?*).
+- **reçu** = *ruh-SÜ* ("received").
+
+The rule is tidy: **ç only ever appears before a, o, u** — never before *e/i*,
+where *c* is already soft and the hook would be pointless.
+
+## Where the hook came from
+
+The *cédille* is literally **"a little *z*."** Its name is Spanish **zedilla**
+("little zeta") — medieval scribes wrote a small subscript **z** under the *c* to
+say "pronounce this like *z/s*, not *k*." Over time the little *z* shrank into the
+hook you write today. So **ç = c + a ghost z.** (Spanish later dropped it; French
+and Portuguese kept it — *ç* is alive in *português* itself.)
+
+## How to write it
+
+Write a normal **c**, then add a small **hook curling left off the bottom**, like
+a tiny *5*'s tail. Only ever under *c*, only before *a/o/u*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "français", "garçon", "ça" — the ç forcing a soft *s*]
+- [YOU SAY: imagine no cédille — "franc-ais" as *frank-ay* — that's what it prevents]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the cédille do, and before which letters does it appear?
+(Keeps *c* soft (*s*) — only before *a, o, u*.) What is the hook, historically?
+(A shrunken subscript *z* — Spanish *zedilla*, "little z".) Next writing lesson:
+the two dots — the **tréma**.

--- a/code/learning/human-languages/french/lessons/FR-W03-trema.md
+++ b/code/learning/human-languages/french/lessons/FR-W03-trema.md
@@ -1,0 +1,57 @@
+---
+id: FR-W03-trema
+chapter: 4
+type: writing
+headword: "ï ë ü"
+gloss: the tréma (two dots) — "pronounce this vowel separately"
+prerequisites: [FR-W01-accents]
+sounds: [vowel-split]
+roots: []
+est_minutes: 3
+reviews_of: [FR-W01-accents, FR-W02-cedille]
+---
+
+# ï ë ü — the two dots that say "say me on my own"
+
+## Warm-up
+
+[PAUSE 2s] The last French mark: two little dots over a vowel — the **tréma**
+(English calls it a *diaeresis*). It answers one question the reader would
+otherwise get wrong: **do these two vowels blend, or not?**
+
+## The problem it solves
+
+French loves to fuse vowel pairs into one sound: *ai* = *eh*, *au* = *oh*, *ou* =
+*oo*, *oi* = *wa*. Usually that's what you want. But sometimes two vowels really
+should be sounded **separately** — and the tréma is how the spelling says so:
+**"break these apart; pronounce the marked vowel on its own."**
+
+- **naïve** = *na-**EEV*** (na-i, two syllables) — not "nave." (English kept the
+  dots: *naïve*.)
+- **Noël** = *no-**EL*** ("Christmas") — *o* and *e* separately, not "nurl."
+- **maïs** = *ma-**EES*** ("corn") — vs **mais** (*meh*, "but"). The two dots are
+  the *only* difference, and they flip the meaning.
+- **Citroën**, **Israël**, **égoïste** — same rule: split the vowels.
+
+So the tréma is the **opposite** of a blend instruction: where *ai* says "merge,"
+*aï* says "don't."
+
+## How to write it
+
+Two dots, side by side, **above** the vowel that starts its **own** sound — the
+*second* vowel of the pair (na-**ï**-ve). (It looks like a German umlaut, but the
+job is different: German ä/ö/ü *change* the vowel; the French tréma *separates*
+it. Same two dots, opposite purpose — that's the next lesson.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "naïve" = na-EEV, "Noël" = no-EL — two syllables each]
+- [YOU SAY: "maïs" (ma-EES, corn) vs "mais" (meh, but) — the dots flip it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the tréma tell you to do? (Pronounce the two vowels
+**separately**, not blended.) How is it different from a German umlaut? (Tréma
+*separates* vowels; umlaut *changes* a vowel's sound.) That's the French writing
+kit: **é è ê**, **ç**, and **ï ë**.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -27,6 +27,10 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   "see-again" goodbye, twin of German *auf Wiedersehen*) → à plus tard (*tard* ←
   *tarde*, = Spanish *tarde*) → à bientôt (*bien* + *tôt*) → à demain (*dē māne*,
   shares *māne* with *mañana*) → practice. **Authored** — mirror of Spanish Ch. 5.
+- **Writing nuances** (`FR-W01`–`W03`, type: writing): the three accents on *e*
+  (é aigu / è grave / **ê circonflexe = a lost *s***: forêt→forest); the cédille
+  ç (soft *c* before a/o/u; ← "little z"); the tréma ï/ë (split the vowels).
+  **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Writing nuances — the eszett, the umlauts, capital nouns
+
+- **First German `writing`-type lessons** (`GE-W01-eszett`, `GE-W02-umlauts`,
+  `GE-W03-capitalization`): orthography taught etymology-first, once enough
+  special-character words have accumulated (*heißen*, *weiß*, *Straße*).
+- **ß (eszett)**: a long-*s* + *s/z* ligature (hence "es-zett"), always a sharp
+  *s*; the rule **ß after long vowels, ss after short** (*Straße* vs *Fluss*) —
+  which doubles as a vowel-length cue; no word-initial/lowercase-only quirks
+  (ALL-CAPS → SS; Switzerland drops it).
+- **Umlauts ä/ö/ü**: the two dots as a **shrunken migrated *e*** (ASCII fallback
+  *ae/oe/ue*: *Müller = Mueller*); "um-laut" = around-sound (vowel fronting); and
+  the grammar it marks — plural/comparative/diminutive fronting (*Mann→Männer*,
+  *groß→größer*, *Hund→Hündchen*). Contrasted with the French tréma.
+- **Großschreibung**: German capitalizes **every noun**, mid-sentence and all —
+  a part-of-speech signal that disambiguates (*essen* "to eat" vs *das Essen*
+  "the food"), a living fossil of older European printing (English dropped it
+  ~1700s).
+- Uses the `writing` lesson type (no `concept_tag`) — no taxonomy change.
+
 ## Chapter 4 — Farewells (completes the ES/FR/DE farewell trilogy)
 
 - **Chapter 4 authored** (`GE-C04-auf-wiedersehen`, `-tschuss`, `-bis-bald`,

--- a/code/learning/human-languages/german/lessons/GE-W01-eszett.md
+++ b/code/learning/human-languages/german/lessons/GE-W01-eszett.md
@@ -1,0 +1,73 @@
+---
+id: GE-W01-eszett
+chapter: 4
+type: writing
+headword: "ß"
+gloss: the eszett (scharfes S) — a doubled-s ligature, used after long vowels
+prerequisites: [GE-C02-heissen]
+sounds: [eszett]
+roots: []
+est_minutes: 4
+reviews_of: [GE-C02-ich-heisse]
+---
+
+# ß — the letter that is two *s*'s in a coat
+
+## Warm-up
+
+[PAUSE 2s] German has one letter the other Latin alphabets don't: **ß**, the
+*eszett* or *scharfes S* ("sharp S"). You've already met it — *heißen* ("to be
+called"), *weiß* ("white"), *Straße* ("street"). It's not a *B*, and it's not
+exotic: it's just **"ss"** wearing a single character.
+
+## What it is
+
+**ß** is a **ligature** — two letters fused into one shape. Its very name says
+which two: **es-zett** = **"s-z."** In the old German (Fraktur/Sütterlin) hand,
+a "long s" (**ſ**, the tall *s* that looks like an *f*) was joined to a following
+*z* or *s* → **ſs** → **ß**. So *ß* literally *is* a written-together double s,
+and it always **sounds like a plain sharp *s*** (never *z*, never *b*).
+
+## The rule: ß after long, ss after short
+
+Modern spelling (since the 1996 reform) uses a clean rule — and it doubles as a
+**vowel-length cue**, which is genuinely useful:
+
+- **ß** follows a **long** vowel or a diphthong.
+- **ss** follows a **short** vowel.
+
+| ß (long vowel) | ss (short vowel) |
+|---|---|
+| **Straße** (*SHTRAH-se*, long a) | **Fluss** (*flooss*, short u) |
+| **Fuß** (foot, long u) | **muss** (must, short u) |
+| **weiß** (white, diphthong *ei*) | **Kuss** (kiss, short u) |
+| **groß** (big, long o) | **Schloss** (castle, short o) |
+
+So seeing *ß* tells you *"the vowel before me is long"* — *Straße* stretches its
+*a*; *Fluss* clips its *u*. One letter, two pieces of information.
+
+## How to write it — and its quirks
+
+Draw it like a tall **ß** (a long-s curve joined to an s/z tail). Two things to
+know:
+
+- **It has no everyday capital.** *ß* starts no word (German nouns start with a
+  capital, but no word *starts* with *ß*). In ALL-CAPS you traditionally write
+  **SS** (STRASSE). (A capital **ẞ** was finally made official in 2017, but SS is
+  still standard.)
+- **Switzerland dropped it entirely** — Swiss German always writes **ss**
+  (*Strasse*). So *ß* is a Germany/Austria marker.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Straße" (long a) vs "Fluss" (short u) — hear the vowel length the
+  ß/ss is telling you]
+- [YOU SAY: "heißen", "weiß", "groß" — all a sharp *s*, all long vowels]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two letters is *ß* a ligature of, and what does it sound like?
+(*s* + *z* — a sharp *s*.) What does *ß* tell you about the vowel before it? (It's
+**long**; *ss* means short.) How do you write it in all-caps? (*SS*.) Next: the
+two dots — the **umlaut**.

--- a/code/learning/human-languages/german/lessons/GE-W02-umlauts.md
+++ b/code/learning/human-languages/german/lessons/GE-W02-umlauts.md
@@ -1,0 +1,79 @@
+---
+id: GE-W02-umlauts
+chapter: 4
+type: writing
+headword: "ä ö ü"
+gloss: the umlauts — two dots that are a shrunken "e", fronting the vowel
+prerequisites: [GE-W01-eszett]
+sounds: [u-umlaut]
+roots: []
+est_minutes: 4
+reviews_of: [GE-W01-eszett]
+---
+
+# ä ö ü — the two dots that used to be an *e*
+
+## Warm-up
+
+[PAUSE 2s] German's other famous marks: the two dots over **ä ö ü**, the
+*Umlaut*. They look like the French tréma but do the **opposite** job — and their
+dots hide a tiny letter.
+
+## What "umlaut" means, and what the dots do
+
+**Um-laut** = **"around-sound"** (*um* "around" + *Laut* "sound"): the vowel's
+sound shifts **forward** in the mouth. Say the plain vowel, then brighten it
+toward *ee*:
+
+- **a → ä**: *ah* → *eh* (like *bed*). *Mann → Männer*.
+- **o → ö**: *oh* → the vowel of English *her* (rounded *eh*). *schon → schön*.
+- **u → ü**: *oo* → say *ee* with tightly **rounded lips** (the French *u*).
+  *Mutter → Mütter*.
+
+## The dots are a migrated *e*
+
+Here's the hidden history: the fronting was originally caused by an *e* in the
+next syllable, and scribes marked it by writing a small **e above the vowel**. In
+the old German hand that *e* was two little vertical strokes (**ⁿ**) — which,
+shrunk and simplified, became **two dots**. So an umlaut is a **fossilized *e*
+sitting on top of the vowel.**
+
+That's why the **ASCII fallback for ä ö ü is ae oe ue** — you're just putting the
+ghost *e* back down on the line:
+
+- **Müller = Mueller**, **schön = schoen**, **Bär = Baer** (the surname).
+
+## Grammar Lens: the umlaut *does* work
+
+Umlauts aren't random — fronting a vowel is how German marks whole grammatical
+changes. Learn to *expect* it:
+
+| base | umlauted | change |
+|---|---|---|
+| **Mann** (man) | **Männer** | plural |
+| **Buch** (book) | **Bücher** | plural |
+| **Vater** (father) | **Väter** | plural |
+| **groß** (big) | **größer** | comparative ("bigger") |
+| **Hund** (dog) | **Hündchen** | diminutive ("little dog") |
+
+So when a word "brightens" its vowel, something grammatical happened to it —
+usually *more than one*, *smaller*, or *more*.
+
+## How to write it
+
+Two dots, side by side, **above** the vowel — same as the French tréma to the
+eye, but remember: **umlaut = change the sound; tréma = split two vowels.**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Mann → Männer", "Buch → Bücher" — hear the vowel brighten for plural]
+- [YOU SAY: "ü" = *ee* with rounded lips (*Mütter*) — the French *u* sound]
+- [YOU SAY: "schön = schoen", "Müller = Mueller" — put the ghost *e* back]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *Umlaut* literally mean, and what are the dots, historically?
+("Around-sound"; a shrunken *e* that migrated on top.) What's the ASCII fallback
+for *ü*? (*ue*.) Name one grammar job the umlaut does. (Plural: *Mann → Männer*;
+or comparative/diminutive.) Next: why German capitalizes **every noun**.

--- a/code/learning/human-languages/german/lessons/GE-W03-capitalization.md
+++ b/code/learning/human-languages/german/lessons/GE-W03-capitalization.md
@@ -1,0 +1,79 @@
+---
+id: GE-W03-capitalization
+chapter: 4
+type: writing
+headword: "das Haus, die Freiheit"
+gloss: Großschreibung — German capitalizes every noun, and why that helps
+prerequisites: [GE-C01-der-die-das]
+sounds: []
+roots: []
+est_minutes: 4
+reviews_of: [GE-W02-umlauts]
+---
+
+# Großschreibung — why German shouts every noun
+
+## Warm-up
+
+[PAUSE 2s] Open any German text and something jumps out: **Nouns Start With
+Capitals. All Of Them.** *der **H**und*, *das **H**aus*, *die **F**reiheit*. This
+isn't fussiness — it's a real rule (**Großschreibung**, "capital-writing"), and
+it's genuinely useful once you see what it does.
+
+## The rule
+
+**Every noun is capitalized, everywhere in the sentence** — not just names, not
+just sentence starts, but *every* noun:
+
+> **Der Hund** frisst **das Essen** in **der Küche**.
+> ("The dog eats the food in the kitchen.")
+
+Three nouns, three capitals, mid-sentence. Also capitalized: the polite "you"
+**Sie**, and any word *used as* a noun (*das Gute*, "the good").
+
+## Why it actually helps
+
+Capitalization here carries **meaning** — it disambiguates words that are spelled
+alike but do different jobs:
+
+| lower-case | capital (noun) |
+|---|---|
+| **essen** = "to eat" (verb) | **das Essen** = "the food / the meal" |
+| **jung** = "young" (adj.) | **der Junge** = "the boy" |
+| **laut** = "loud" (adj.) | **der Laut** = "the sound" |
+
+So the capital letter is a **part-of-speech signal**: it tells you *"this is a
+thing, not an action or a quality."* Combined with the article (*der/die/das*,
+your Chapter 1 lesson), German flags its nouns twice — you can pick out the
+skeleton of a sentence at a glance. Long German sentences are easier to parse
+*because* of it.
+
+## A little history
+
+English used to do this too — read a page of 1700s English (or the U.S.
+Constitution: "We the People… establish Justice, insure domestic Tranquility")
+and the **Nouns** are Capitalized. English dropped the habit in the 18th century;
+German kept and codified it. So German capitalization is a **living fossil of
+older European printing.**
+
+## How to apply it
+
+When you write a German noun, **capitalize its first letter — always**, wherever
+it sits. If you're unsure whether a word is a noun, check for a *der/die/das* (or
+*ein/eine*) in front, or an *-ung/-heit/-keit/-schaft* ending — those are noun
+factories (*Freiheit*, *Zeitung*, *Freundschaft*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Der Hund frisst das Essen" — every noun capitalized]
+- [YOU SAY: "essen" (eat) vs "das Essen" (the food) — the capital flips it]
+- [YOU SAY: spot the nouns by their capitals in a German sentence]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which words does German capitalize? (**Every noun**, anywhere in the
+sentence — plus *Sie*.) What does the capital tell you? (That the word is a
+*noun*, not a verb/adjective — *essen* vs *das Essen*.) Which language used to do
+this and stopped? (English, in the 1700s.) That completes the German writing kit:
+**ß**, **ä ö ü**, and **capital nouns**.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -27,6 +27,10 @@ Spanish and French where a contrast helps. The recurring decoder is the
   *adiós*) → bis bald (*bald* = English *bold*) → bis morgen (*Morgen* =
   *morning/morrow*) → practice. **Authored** — completes the ES/FR/DE farewell
   trilogy; the "bis …" family mirrors Spanish *hasta* / French *à*.
+- **Writing nuances** (`GE-W01`–`W03`, type: writing): the eszett ß (ss↔ß vowel
+  length; a long-s+z ligature); the umlauts ä/ö/ü (a shrunken *e*; the fronting
+  that marks plurals — Mann→Männer); Großschreibung (every noun capitalized).
+  **Authored.**
 
 ## Planned
 


### PR DESCRIPTION
## French + German writing nuances — accents, cédille, tréma; eszett, umlauts, capital nouns

Loop item 3. Extends the writing-lesson thread (Spanish already has acute-accent /
ñ / ¿¡) to French and German, using the `writing` lesson type already on main
(no `concept_tag`, so **no taxonomy change**). Six lessons, etymology-first, each
saying *why* the mark exists and *how to write it*.

### French (`FR-W01`–`W03`)
- **The three accents on *e***: *é* aigu ("ay"), *è* grave (open "eh", also the
  disambiguator *a/à*, *ou/où*), and the star — the **circonflexe *ê* as a
  tombstone for a lost *s***. Slot the *s* back and the English cousin appears:
  *forêt*→forest, *hôpital*→hospital, *île*→isle, *bête*→beast, *être*↔*stāre*.
- **The cédille ç** — keeps *c* soft before a/o/u (*français*, *garçon*); the hook
  is a shrunken subscript *z* (Spanish *zedilla*, "little z").
- **The tréma ï/ë** — "pronounce the vowels **separately**" (*naïve*, *maïs* vs
  *mais*); explicitly contrasted with the German umlaut.

### German (`GE-W01`–`W03`)
- **ß (eszett)** — a long-*s* + *s/z* ligature (hence "es-zett"); **ß after long
  vowels, ss after short** (*Straße* vs *Fluss*), so it doubles as a vowel-length
  cue; ALL-CAPS → SS; Switzerland drops it.
- **Umlauts ä/ö/ü** — the two dots are a **shrunken migrated *e*** (ASCII *ae/oe/ue*:
  *Müller = Mueller*); the fronting marks grammar — *Mann→Männer*, *groß→größer*,
  *Hund→Hündchen*.
- **Großschreibung** — German capitalizes **every noun**, a part-of-speech signal
  that disambiguates (*essen* "to eat" vs *das Essen* "the food"); a living fossil
  of 18th-c. printing English dropped.

### Checks
- All `writing` type — **no taxonomy change**. 38 data-package tests pass;
  validator clean. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
