### PR TITLE
feat(sql): GROUP_CONCAT aggregate

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.53 — GROUP_CONCAT aggregate
+
+`SELECT group_concat(x) FROM t` now works (was "unknown built-in function"). It
+concatenates the non-NULL values of `x` in row order, joined by a separator that
+defaults to `,` and can be overridden by a literal 2nd argument (e.g.
+`group_concat(x, '|')`, or `''` for no separator). NULLs are skipped, an empty or
+all-NULL group is NULL (not an empty string), and `group_concat(DISTINCT x)`
+deduplicates values before joining — all matching SQLite. Spans sql-planner
+0.2.24 (aggregate recognition + separator capture), sql-codegen 0.6.7
+(`AggFn::GroupConcat`), and sql-vm 0.4.30 (accumulation + dedup + DoS caps).
+Three new differential-oracle cases. Known follow-ups (documented, not yet
+matched): `DISTINCT` compares by storage class so `1` and `1.0` dedup separately
+where SQLite collapses them numerically (shared with `COUNT(DISTINCT)`); a
+non-string-literal separator falls back to `,`; and `group_concat(DISTINCT x,
+sep)` is accepted where SQLite rejects it.
+
 ## 0.5.52 — integer arithmetic overflow promotes to REAL
 
 `SELECT 9223372036854775807 + 1` now returns `9.2233720369e18` (real) instead of

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.52"
+version = "0.5.53"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -292,6 +292,46 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT dept, SUM(amt) FROM sales GROUP BY dept ORDER BY dept",
     },
+    // GROUP_CONCAT: concatenate non-NULL values in row order, joined by the
+    // separator (default ","; a literal 2nd arg overrides it, including empty).
+    // NULLs are skipped, an empty/all-NULL group is NULL, and DISTINCT dedups.
+    // Was "unknown built-in function" before this aggregate existed.
+    Case {
+        id: "group_concat_basic",
+        setup: &[
+            "CREATE TABLE t (x)",
+            "INSERT INTO t VALUES ('a'),('a'),('b'),(NULL)",
+        ],
+        query: "SELECT group_concat(x) AS a, group_concat(DISTINCT x) AS b, group_concat(x,'') AS c FROM t",
+    },
+    // GROUP_CONCAT per group, with a custom separator and a NULL skipped inside a
+    // group. Integers render to their text form.
+    Case {
+        id: "group_concat_grouped",
+        setup: &[
+            "CREATE TABLE t (g TEXT, x)",
+            "INSERT INTO t VALUES ('a','p'),('a','q'),('b','r'),('b',NULL)",
+        ],
+        query: "SELECT g, group_concat(x) AS c, group_concat(x,'/') AS c2 FROM t GROUP BY g ORDER BY g",
+    },
+    // Numbers stringify to their decimal form.
+    Case {
+        id: "group_concat_numeric",
+        setup: &[
+            "CREATE TABLE t (x INTEGER)",
+            "INSERT INTO t VALUES (1),(2),(10)",
+        ],
+        query: "SELECT group_concat(x,'+') AS a FROM t",
+    },
+    // An aggregate over zero rows is NULL, not an empty string.
+    Case {
+        id: "group_concat_empty",
+        setup: &[
+            "CREATE TABLE t (x INTEGER)",
+            "INSERT INTO t VALUES (1),(2),(10)",
+        ],
+        query: "SELECT group_concat(x) AS a FROM t WHERE x > 99",
+    },
     Case {
         id: "having",
         setup: &[

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.7] - Unreleased
+
+### Added
+
+- **`AggFn::GroupConcat { sep, distinct }`** for the `GROUP_CONCAT` aggregate. The
+  separator (a plan-time constant) and the `DISTINCT` flag ride on the tag, so the
+  accumulator's value stream stays single-column. `plan_agg_to_agg_fn` /
+  `plan_agg_to_agg_fn_with_distinct` map `AggFunc::GroupConcat`, and the
+  un-aliased column label renders as `GROUP_CONCAT(x)`.
+
 ## [0.6.6] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -192,6 +192,11 @@ pub enum AggFn {
     Min,
     /// `MAX(col)` — maximum value
     Max,
+    /// `GROUP_CONCAT([DISTINCT] col [, sep])` — concatenate non-NULL values in
+    /// row order, joined by `sep` (the constant separator captured at plan time;
+    /// the value stream is just `col`). `distinct` deduplicates values before
+    /// joining, matching `GROUP_CONCAT(DISTINCT col)`.
+    GroupConcat { sep: String, distinct: bool },
 }
 
 /// A sort key emitted by the code generator, used in `SortResult`.
@@ -2318,6 +2323,7 @@ fn aggregate_column_name(item: &AggregateItem) -> String {
         AggFunc::Avg => "AVG",
         AggFunc::Min => "MIN",
         AggFunc::Max => "MAX",
+        AggFunc::GroupConcat { .. } => "GROUP_CONCAT",
     };
     let inner = match &item.arg {
         None => "*".to_string(),
@@ -2443,6 +2449,7 @@ fn plan_agg_to_agg_fn(func: &AggFunc, is_star: bool) -> AggFn {
         AggFunc::Avg => AggFn::Avg,
         AggFunc::Min => AggFn::Min,
         AggFunc::Max => AggFn::Max,
+        AggFunc::GroupConcat { sep } => AggFn::GroupConcat { sep: sep.clone(), distinct: false },
     }
 }
 
@@ -2452,6 +2459,10 @@ fn plan_agg_to_agg_fn(func: &AggFunc, is_star: bool) -> AggFn {
 fn plan_agg_to_agg_fn_with_distinct(func: &AggFunc, is_star: bool, distinct: bool) -> AggFn {
     if distinct && matches!(func, AggFunc::Count) && !is_star {
         AggFn::CountDistinct
+    } else if let AggFunc::GroupConcat { sep } = func {
+        // GROUP_CONCAT carries its own `distinct` (dedup before joining), rather
+        // than mapping to a separate DISTINCT opcode like COUNT does.
+        AggFn::GroupConcat { sep: sep.clone(), distinct }
     } else {
         plan_agg_to_agg_fn(func, is_star)
     }

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.24] - Unreleased
+
+### Added
+
+- **`GROUP_CONCAT` recognised as an aggregate.** `try_plan_as_aggregate` now maps
+  `GROUP_CONCAT` to `AggFunc::GroupConcat { sep }`, capturing the separator from
+  an optional literal second argument (default `","`) via `group_concat_separator`
+  / `collect_call_arg_exprs`; the value stream stays single-column (`x`). Pairs
+  with sql-codegen 0.6.7 / sql-vm 0.4.30.
+
 ## [0.2.23] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -257,6 +257,11 @@ pub enum AggFunc {
     Avg,
     Min,
     Max,
+    /// `GROUP_CONCAT(x [, sep])` — concatenate the non-NULL values of `x` in row
+    /// order, joined by `sep` (which defaults to a comma). The separator is a
+    /// constant captured at plan time and carried on the aggregate, so the value
+    /// stream fed to the accumulator stays single-column (just `x`).
+    GroupConcat { sep: String },
 }
 
 // ===========================================================================
@@ -1711,6 +1716,10 @@ fn try_plan_as_aggregate(func_call: &GrammarASTNode) -> Option<AggregateItem> {
         "AVG" => AggFunc::Avg,
         "MIN" => AggFunc::Min,
         "MAX" => AggFunc::Max,
+        // `GROUP_CONCAT(x [, sep])` — the optional 2nd argument is the separator
+        // (default ","), captured now as a constant so the value stream stays
+        // single-column. `arg` below still resolves to the first argument (`x`).
+        "GROUP_CONCAT" => AggFunc::GroupConcat { sep: group_concat_separator(func_call) },
         _ => return None,
     };
 
@@ -1757,6 +1766,40 @@ fn try_plan_as_aggregate(func_call: &GrammarASTNode) -> Option<AggregateItem> {
         distinct,
         alias: None,
     })
+}
+
+/// Collect the planned argument expressions of a `function_call` node, in order.
+/// Handles both the `value_list` wrapper (multi-arg calls) and a single direct
+/// argument node.
+fn collect_call_arg_exprs(func_call: &GrammarASTNode) -> Vec<SqlExpr> {
+    let mut out = Vec::new();
+    for child in &func_call.children {
+        if let ASTNodeOrToken::Node(n) = child {
+            if n.rule_name == "value_list" {
+                for c2 in &n.children {
+                    if let ASTNodeOrToken::Node(n2) = c2 {
+                        if let Ok(e) = plan_expression(n2) {
+                            out.push(e);
+                        }
+                    }
+                }
+            } else if let Ok(e) = plan_expression(n) {
+                out.push(e);
+            }
+        }
+    }
+    out
+}
+
+/// The separator constant of a `GROUP_CONCAT(x [, sep])` call. SQLite joins with
+/// a comma when no separator is given; a string-literal second argument overrides
+/// it. Anything else (absent, or a non-constant second argument) falls back to
+/// ",".
+fn group_concat_separator(func_call: &GrammarASTNode) -> String {
+    match collect_call_arg_exprs(func_call).get(1) {
+        Some(SqlExpr::Literal(SqlValue::Text(s))) => s.clone(),
+        _ => ",".to_string(),
+    }
 }
 
 // ===========================================================================

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.30] - Unreleased
+
+### Added
+
+- **`GROUP_CONCAT` aggregate execution.** `update_accumulator`/
+  `finalize_accumulator` handle `AggFn::GroupConcat { sep, distinct }`: non-NULL
+  values are rendered with `sql_to_str` and appended, joined by `sep`; an empty or
+  all-NULL group finalises to NULL. `DISTINCT` deduplicates using the same
+  type-tagged key as `COUNT(DISTINCT)`, now factored into a shared `distinct_key`
+  helper. Values are appended IN PLACE (`push_str`, amortised O(total length))
+  rather than rebuilt with `format!` each row (which would be O(n²) and double
+  peak memory). Two DoS guards: the result string is capped at SQLite's default
+  `SQLITE_MAX_LENGTH` (1e9, checked on the first value too) and the distinct set
+  at 1M entries, each returning a `ResourceLimit` error rather than growing
+  unbounded.
+
 ## [0.4.29] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.29"
+version = "0.4.30"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -3039,13 +3039,33 @@ fn parse_real_prefix(s: &str) -> f64 {
 // Helper: aggregate accumulator update / finalize
 // ===========================================================================
 
+/// A canonical, type-tagged string key for a value, used to deduplicate in
+/// `COUNT(DISTINCT …)` and `GROUP_CONCAT(DISTINCT …)`. The leading tag keeps
+/// values of different storage classes distinct (`1` the integer vs `'1'` the
+/// text), matching how SQLite treats them as separate distinct values. NULL is
+/// filtered by callers before this is reached; it maps to a stable key anyway so
+/// this helper never panics.
+fn distinct_key(v: &SqlValue) -> String {
+    match v {
+        SqlValue::Int(n) => format!("i:{}", n),
+        SqlValue::Float(f) => format!("f:{}", f),
+        SqlValue::Text(s) => format!("t:{}", s),
+        SqlValue::Bool(b) => format!("b:{}", b),
+        SqlValue::Blob(bytes) => {
+            let hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
+            format!("x:{}", hex)
+        }
+        SqlValue::Null => "n:".to_string(),
+    }
+}
+
 /// Feed one value into an accumulator.
 ///
 /// - CountStar is handled in the main loop (no stack pop, not called here).
 /// - All other functions skip NULLs.
 ///
 /// Returns `Err(VmError::ResourceLimit)` if a hard per-accumulator memory cap
-/// is reached (currently only for `CountDistinct`).
+/// is reached (`CountDistinct` and `GROUP_CONCAT`).
 fn update_accumulator(acc: &mut AggAccumulator, fn_tag: &AggFn, v: SqlValue) -> Result<(), VmError> {
     match fn_tag {
         AggFn::CountStar => {
@@ -3102,6 +3122,65 @@ fn update_accumulator(acc: &mut AggAccumulator, fn_tag: &AggFn, v: SqlValue) -> 
                 });
             }
         }
+        AggFn::GroupConcat { sep, distinct } => {
+            // Skip NULLs; render each non-NULL value to text and append it,
+            // joined by the constant separator. The running string lives in
+            // `acc.acc` as Text. `sql_to_str` gives each value SQLite's text form
+            // (numbers → their decimal string, text unchanged).
+            //
+            // `DISTINCT` deduplicates values before joining: we track a canonical
+            // key per already-emitted value in `acc.distinct_vals` (the same set
+            // COUNT(DISTINCT) uses) and skip a value whose key was already seen.
+            //
+            // DoS guard: an unbounded concat over a huge table could exhaust
+            // memory. Cap the accumulated length at SQLite's default
+            // SQLITE_MAX_LENGTH (1e9); beyond that SQLite itself raises "string
+            // or blob too big", which we mirror as a ResourceLimit error. The
+            // distinct set is separately capped at 1M entries.
+            const MAX_GROUP_CONCAT_LEN: usize = 1_000_000_000;
+            const MAX_DISTINCT_VALS: usize = 1_000_000;
+            if !matches!(v, SqlValue::Null) {
+                if *distinct {
+                    let key = distinct_key(&v);
+                    let set = acc.distinct_vals.get_or_insert_with(std::collections::HashSet::new);
+                    if set.contains(&key) {
+                        return Ok(()); // already concatenated this value
+                    }
+                    if set.len() >= MAX_DISTINCT_VALS {
+                        return Err(VmError::ResourceLimit(format!(
+                            "GROUP_CONCAT(DISTINCT) exceeded maximum distinct values ({})",
+                            MAX_DISTINCT_VALS
+                        )));
+                    }
+                    set.insert(key);
+                }
+                let piece = sql_to_str(&v);
+                match &mut acc.acc {
+                    // Append IN PLACE (amortised O(total length), not the
+                    // O(n²) that rebuilding the whole string with `format!`
+                    // every row would cost) and without a second full copy.
+                    Some(SqlValue::Text(existing)) => {
+                        if existing.len() + sep.len() + piece.len() > MAX_GROUP_CONCAT_LEN {
+                            return Err(VmError::ResourceLimit(
+                                "GROUP_CONCAT result exceeded maximum length (1e9)".to_string(),
+                            ));
+                        }
+                        existing.push_str(sep);
+                        existing.push_str(&piece);
+                    }
+                    // First non-NULL value (or a slot never populated as Text).
+                    // Cap it too so a single oversized value can't skip the guard.
+                    _ => {
+                        if piece.len() > MAX_GROUP_CONCAT_LEN {
+                            return Err(VmError::ResourceLimit(
+                                "GROUP_CONCAT result exceeded maximum length (1e9)".to_string(),
+                            ));
+                        }
+                        acc.acc = Some(SqlValue::Text(piece));
+                    }
+                }
+            }
+        }
         AggFn::CountDistinct => {
             // Skip NULLs; insert a canonical string representation of non-NULL
             // values into the distinct set.  The set is lazily initialised here
@@ -3112,17 +3191,7 @@ fn update_accumulator(acc: &mut AggAccumulator, fn_tag: &AggFn, v: SqlValue) -> 
             // of hex strings per entry; cap at 1 000 000 distinct values.
             const MAX_DISTINCT_VALS: usize = 1_000_000;
             if !matches!(v, SqlValue::Null) {
-                let key = match &v {
-                    SqlValue::Int(n)   => format!("i:{}", n),
-                    SqlValue::Float(f) => format!("f:{}", f),
-                    SqlValue::Text(s)  => format!("t:{}", s),
-                    SqlValue::Bool(b)  => format!("b:{}", b),
-                    SqlValue::Blob(bytes) => {
-                        let hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
-                        format!("x:{}", hex)
-                    }
-                    SqlValue::Null => unreachable!(),
-                };
+                let key = distinct_key(&v);
                 let set = acc.distinct_vals.get_or_insert_with(std::collections::HashSet::new);
                 if set.len() >= MAX_DISTINCT_VALS && !set.contains(&key) {
                     return Err(VmError::ResourceLimit(format!(
@@ -3148,6 +3217,9 @@ fn finalize_accumulator(acc: &AggAccumulator, fn_tag: &AggFn) -> SqlValue {
         AggFn::Sum => acc.acc.clone().unwrap_or(SqlValue::Null),
         AggFn::Min => acc.acc.clone().unwrap_or(SqlValue::Null),
         AggFn::Max => acc.acc.clone().unwrap_or(SqlValue::Null),
+        // The accumulated Text, or NULL when no non-NULL value was seen (an
+        // empty group or an all-NULL column) — matching SQLite.
+        AggFn::GroupConcat { .. } => acc.acc.clone().unwrap_or(SqlValue::Null),
         AggFn::Avg => match &acc.acc {
             None => SqlValue::Null,
             Some(sum) => {


### PR DESCRIPTION
## feat(sql): GROUP_CONCAT aggregate

`SELECT group_concat(x) FROM t` failed with "unknown built-in function". This adds the `GROUP_CONCAT` aggregate across the pipeline.

### Change
- **sql-planner 0.2.24** — `AggFunc::GroupConcat { sep }`; the aggregate detector recognises `GROUP_CONCAT` and captures the separator from an optional **literal** 2nd argument (default `","`). Value stream stays single-column.
- **sql-codegen 0.6.7** — `AggFn::GroupConcat { sep, distinct }` (both ride on the instruction tag), mapping + column label.
- **sql-vm 0.4.30** — accumulate non-NULL values (rendered via `sql_to_str`), joined by the separator; empty/all-NULL group → `NULL`; `DISTINCT` dedups via a `distinct_key` helper factored out of `COUNT(DISTINCT)`.

Matches SQLite: `group_concat(x)`=`a,b,c`, `group_concat(x,'|')`=`a|b|c`, NULLs skipped, `group_concat(DISTINCT x)` dedups, numbers stringify.

### Robustness (from the inline security review)
Values are appended **in place** (`push_str`, amortised O(total length)) rather than an O(n²) per-row `format!` rebuild — the reviewer flagged the naive rebuild as a CPU/2×-memory DoS on untrusted SQL over a large table. Two caps mirror SQLite: result length ≤ `1e9` (checked on the first value too) and the distinct set ≤ 1M entries, each a `ResourceLimit` error. No panic path (NULL filtered before the accumulator; `distinct_key`'s former `unreachable!` removed).

### Verification
- Probed vs real `sqlite3` 3.51.0; 3 new oracle cases (basic + DISTINCT + empty separator; per-group custom sep + in-group NULL; numeric + zero-row NULL).
- Green: sql-planner 75, sql-codegen 108, sql-vm 45, mini-sqlite lib + differential-oracle.
- Security review: no memory-safety bug, no panic; the one must-fix (O(n²) concat) is fixed above.

### Documented follow-ups (SQLite-parity nuances; not wrong-result on the tested surface)
- `DISTINCT` compares by storage class, so `1` and `1.0` dedup separately where SQLite collapses them numerically (shared with `COUNT(DISTINCT)` — a good joint follow-up).
- A non-string-literal separator falls back to `,`; `group_concat(DISTINCT x, sep)` is accepted where SQLite rejects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
