### PR TITLE
feat(fpga): add C# and F# ports

### DIFF
--- a/code/packages/csharp/fpga/BUILD
+++ b/code/packages/csharp/fpga/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Fpga.Tests/CodingAdventures.Fpga.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Fpga]*"

--- a/code/packages/csharp/fpga/BUILD_windows
+++ b/code/packages/csharp/fpga/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Fpga.Tests/CodingAdventures.Fpga.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Fpga]*"

--- a/code/packages/csharp/fpga/CHANGELOG.md
+++ b/code/packages/csharp/fpga/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add SRAM-backed LUTs, slices, configurable logic blocks, switch matrices, and I/O blocks.
+- Add immutable bitstream configuration, JSON parsing, and configured FPGA fabric evaluation.

--- a/code/packages/csharp/fpga/CodingAdventures.Fpga.csproj
+++ b/code/packages/csharp/fpga/CodingAdventures.Fpga.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>CodingAdventures.Fpga.CSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure C# configurable FPGA fabric simulator</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+    <ProjectReference Include="../logic-gates/CodingAdventures.LogicGates.csproj" />
+    <ProjectReference Include="../block-ram/CodingAdventures.BlockRam.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/fpga/Fpga.cs
+++ b/code/packages/csharp/fpga/Fpga.cs
@@ -1,0 +1,547 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using CodingAdventures.BlockRam;
+using Gates = CodingAdventures.LogicGates.LogicGates;
+
+namespace CodingAdventures.Fpga;
+
+internal static class Validation
+{
+    internal static void Bit(int value, string name)
+    {
+        if (value is not (0 or 1))
+        {
+            throw new ArgumentOutOfRangeException(name, value, $"{name} must be 0 or 1");
+        }
+    }
+
+    internal static int[] Bits(IReadOnlyList<int> values, int length, string name)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Count != length)
+        {
+            throw new ArgumentException($"{name} length {values.Count} does not match {length}", name);
+        }
+
+        var result = new int[length];
+        for (var index = 0; index < length; index++)
+        {
+            Bit(values[index], $"{name}[{index}]");
+            result[index] = values[index];
+        }
+
+        return result;
+    }
+}
+
+/// <summary>A K-input lookup table backed by SRAM cells.</summary>
+public sealed class LUT
+{
+    private readonly SRAMCell[] _cells;
+
+    public LUT(int k = 4, IReadOnlyList<int>? truthTable = null)
+    {
+        if (k is < 2 or > 6)
+        {
+            throw new ArgumentOutOfRangeException(nameof(k), k, "k must be between 2 and 6");
+        }
+
+        K = k;
+        _cells = Enumerable.Range(0, 1 << k).Select(_ => new SRAMCell()).ToArray();
+        if (truthTable is not null)
+        {
+            Configure(truthTable);
+        }
+    }
+
+    public int K { get; }
+
+    public IReadOnlyList<int> TruthTable => Array.AsReadOnly(_cells.Select(cell => cell.Read(1)!.Value).ToArray());
+
+    public void Configure(IReadOnlyList<int> truthTable)
+    {
+        var bits = Validation.Bits(truthTable, _cells.Length, nameof(truthTable));
+        for (var index = 0; index < bits.Length; index++)
+        {
+            _cells[index].Write(1, bits[index]);
+        }
+    }
+
+    public int Evaluate(IReadOnlyList<int> inputs)
+    {
+        var bits = Validation.Bits(inputs, K, nameof(inputs));
+        var tableIndex = 0;
+        for (var index = 0; index < bits.Length; index++)
+        {
+            tableIndex |= bits[index] << index;
+        }
+
+        return _cells[tableIndex].Read(1)!.Value;
+    }
+}
+
+public readonly record struct SliceOutput(int OutputA, int OutputB, int CarryOut);
+
+internal sealed class FlipFlop
+{
+    private int _master;
+    private int _output;
+
+    internal int Evaluate(int data, int clock)
+    {
+        Validation.Bit(data, nameof(data));
+        Validation.Bit(clock, nameof(clock));
+        if (clock == 1)
+        {
+            _master = data;
+        }
+        else
+        {
+            _output = _master;
+        }
+
+        return _output;
+    }
+}
+
+/// <summary>Two LUTs, optional registers, and a carry chain.</summary>
+public sealed class Slice
+{
+    private FlipFlop _flipFlopA = new();
+    private FlipFlop _flipFlopB = new();
+    private bool _flipFlopAEnabled;
+    private bool _flipFlopBEnabled;
+    private bool _carryEnabled;
+
+    public Slice(int lutInputs = 4)
+    {
+        LutA = new LUT(lutInputs);
+        LutB = new LUT(lutInputs);
+        K = lutInputs;
+    }
+
+    public LUT LutA { get; }
+    public LUT LutB { get; }
+    public int K { get; }
+
+    public void Configure(
+        IReadOnlyList<int> lutATable,
+        IReadOnlyList<int> lutBTable,
+        bool flipFlopAEnabled = false,
+        bool flipFlopBEnabled = false,
+        bool carryEnabled = false)
+    {
+        LutA.Configure(lutATable);
+        LutB.Configure(lutBTable);
+        _flipFlopAEnabled = flipFlopAEnabled;
+        _flipFlopBEnabled = flipFlopBEnabled;
+        _carryEnabled = carryEnabled;
+        _flipFlopA = new FlipFlop();
+        _flipFlopB = new FlipFlop();
+    }
+
+    public SliceOutput Evaluate(
+        IReadOnlyList<int> inputsA,
+        IReadOnlyList<int> inputsB,
+        int clock,
+        int carryIn = 0)
+    {
+        Validation.Bit(clock, nameof(clock));
+        Validation.Bit(carryIn, nameof(carryIn));
+        var lutA = LutA.Evaluate(inputsA);
+        var lutB = LutB.Evaluate(inputsB);
+        var outputA = _flipFlopAEnabled ? _flipFlopA.Evaluate(lutA, clock) : lutA;
+        var outputB = _flipFlopBEnabled ? _flipFlopB.Evaluate(lutB, clock) : lutB;
+        var carry = _carryEnabled
+            ? Gates.Or(Gates.And(lutA, lutB), Gates.And(carryIn, Gates.Xor(lutA, lutB)))
+            : 0;
+        return new SliceOutput(outputA, outputB, carry);
+    }
+}
+
+public readonly record struct CLBOutput(SliceOutput Slice0, SliceOutput Slice1);
+
+/// <summary>A configurable logic block containing two slices.</summary>
+public sealed class CLB
+{
+    public CLB(int lutInputs = 4)
+    {
+        Slice0 = new Slice(lutInputs);
+        Slice1 = new Slice(lutInputs);
+        K = lutInputs;
+    }
+
+    public Slice Slice0 { get; }
+    public Slice Slice1 { get; }
+    public int K { get; }
+
+    public CLBOutput Evaluate(
+        IReadOnlyList<int> slice0InputsA,
+        IReadOnlyList<int> slice0InputsB,
+        IReadOnlyList<int> slice1InputsA,
+        IReadOnlyList<int> slice1InputsB,
+        int clock,
+        int carryIn = 0)
+    {
+        var first = Slice0.Evaluate(slice0InputsA, slice0InputsB, clock, carryIn);
+        var second = Slice1.Evaluate(slice1InputsA, slice1InputsB, clock, first.CarryOut);
+        return new CLBOutput(first, second);
+    }
+}
+
+/// <summary>A programmable crossbar with one driver per destination.</summary>
+public sealed class SwitchMatrix
+{
+    private readonly HashSet<string> _ports;
+    private readonly Dictionary<string, string> _connections = new(StringComparer.Ordinal);
+
+    public SwitchMatrix(IEnumerable<string> ports)
+    {
+        ArgumentNullException.ThrowIfNull(ports);
+        _ports = new HashSet<string>(ports, StringComparer.Ordinal);
+        if (_ports.Count == 0 || _ports.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException("ports must contain non-empty unique names", nameof(ports));
+        }
+    }
+
+    public IReadOnlySet<string> Ports => _ports;
+    public IReadOnlyDictionary<string, string> Connections =>
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(_connections, StringComparer.Ordinal));
+    public int ConnectionCount => _connections.Count;
+
+    public void Connect(string source, string destination)
+    {
+        if (!_ports.Contains(source))
+        {
+            throw new ArgumentException($"unknown source port: {source}", nameof(source));
+        }
+
+        if (!_ports.Contains(destination))
+        {
+            throw new ArgumentException($"unknown destination port: {destination}", nameof(destination));
+        }
+
+        if (source == destination)
+        {
+            throw new ArgumentException("a port cannot connect to itself", nameof(destination));
+        }
+
+        if (!_connections.TryAdd(destination, source))
+        {
+            throw new InvalidOperationException($"destination {destination} is already connected");
+        }
+    }
+
+    public void Disconnect(string destination)
+    {
+        if (!_ports.Contains(destination))
+        {
+            throw new ArgumentException($"unknown port: {destination}", nameof(destination));
+        }
+
+        if (!_connections.Remove(destination))
+        {
+            throw new InvalidOperationException($"port {destination} is not connected");
+        }
+    }
+
+    public void Clear() => _connections.Clear();
+
+    public IReadOnlyDictionary<string, int> Route(IReadOnlyDictionary<string, int> inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        var outputs = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var (destination, source) in _connections)
+        {
+            if (inputs.TryGetValue(source, out var value))
+            {
+                Validation.Bit(value, $"inputs[{source}]");
+                outputs[destination] = value;
+            }
+        }
+
+        return new ReadOnlyDictionary<string, int>(outputs);
+    }
+}
+
+public enum IOMode
+{
+    Input,
+    Output,
+    Tristate,
+}
+
+/// <summary>A configurable external I/O pad.</summary>
+public sealed class IOBlock
+{
+    private int _padValue;
+    private int _internalValue;
+
+    public IOBlock(string name, IOMode mode = IOMode.Input)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("name must be non-empty", nameof(name));
+        }
+
+        Name = name;
+        Mode = mode;
+    }
+
+    public string Name { get; }
+    public IOMode Mode { get; private set; }
+
+    public void Configure(IOMode mode) => Mode = mode;
+
+    public void DrivePad(int value)
+    {
+        Validation.Bit(value, nameof(value));
+        _padValue = value;
+    }
+
+    public void DriveInternal(int value)
+    {
+        Validation.Bit(value, nameof(value));
+        _internalValue = value;
+    }
+
+    public int ReadInternal() => Mode == IOMode.Input ? _padValue : _internalValue;
+
+    public int? ReadPad() => Mode switch
+    {
+        IOMode.Input => _padValue,
+        IOMode.Output => _internalValue,
+        _ => null,
+    };
+}
+
+public sealed class SliceConfig
+{
+    public SliceConfig(
+        IReadOnlyList<int>? lutA = null,
+        IReadOnlyList<int>? lutB = null,
+        bool flipFlopAEnabled = false,
+        bool flipFlopBEnabled = false,
+        bool carryEnabled = false)
+    {
+        LutA = (lutA ?? Array.Empty<int>()).ToArray();
+        LutB = (lutB ?? Array.Empty<int>()).ToArray();
+        FlipFlopAEnabled = flipFlopAEnabled;
+        FlipFlopBEnabled = flipFlopBEnabled;
+        CarryEnabled = carryEnabled;
+    }
+
+    public IReadOnlyList<int> LutA { get; }
+    public IReadOnlyList<int> LutB { get; }
+    public bool FlipFlopAEnabled { get; }
+    public bool FlipFlopBEnabled { get; }
+    public bool CarryEnabled { get; }
+}
+
+public sealed record CLBConfig(SliceConfig Slice0, SliceConfig Slice1);
+public sealed record RouteConfig(string Source, string Destination);
+public sealed record IOConfig(string Mode);
+
+/// <summary>Immutable FPGA configuration data.</summary>
+public sealed class Bitstream
+{
+    public Bitstream(
+        IReadOnlyDictionary<string, CLBConfig>? clbs = null,
+        IReadOnlyDictionary<string, IReadOnlyList<RouteConfig>>? routing = null,
+        IReadOnlyDictionary<string, IOConfig>? io = null,
+        int lutK = 4)
+    {
+        if (lutK is < 2 or > 6)
+        {
+            throw new ArgumentOutOfRangeException(nameof(lutK), lutK, "lutK must be between 2 and 6");
+        }
+
+        LutK = lutK;
+        Clbs = new ReadOnlyDictionary<string, CLBConfig>(
+            (clbs ?? new Dictionary<string, CLBConfig>())
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal));
+        Routing = new ReadOnlyDictionary<string, IReadOnlyList<RouteConfig>>(
+            (routing ?? new Dictionary<string, IReadOnlyList<RouteConfig>>())
+                .ToDictionary(pair => pair.Key, pair => (IReadOnlyList<RouteConfig>)pair.Value.ToArray(), StringComparer.Ordinal));
+        IO = new ReadOnlyDictionary<string, IOConfig>(
+            (io ?? new Dictionary<string, IOConfig>())
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal));
+    }
+
+    public IReadOnlyDictionary<string, CLBConfig> Clbs { get; }
+    public IReadOnlyDictionary<string, IReadOnlyList<RouteConfig>> Routing { get; }
+    public IReadOnlyDictionary<string, IOConfig> IO { get; }
+    public int LutK { get; }
+
+    public static Bitstream Empty(int lutK = 4) => new(lutK: lutK);
+
+    public static Bitstream ParseJson(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new JsonException("bitstream JSON root must be an object");
+        }
+
+        var lutK = root.TryGetProperty("lut_k", out var lutElement) ? lutElement.GetInt32() : 4;
+        if (lutK is < 2 or > 6)
+        {
+            throw new JsonException("lut_k must be between 2 and 6");
+        }
+
+        var tableLength = 1 << lutK;
+        var clbs = new Dictionary<string, CLBConfig>(StringComparer.Ordinal);
+        if (root.TryGetProperty("clbs", out var clbElement))
+        {
+            foreach (var property in clbElement.EnumerateObject())
+            {
+                clbs[property.Name] = new CLBConfig(
+                    ParseSlice(property.Value, "slice0", tableLength),
+                    ParseSlice(property.Value, "slice1", tableLength));
+            }
+        }
+
+        var routing = new Dictionary<string, IReadOnlyList<RouteConfig>>(StringComparer.Ordinal);
+        if (root.TryGetProperty("routing", out var routingElement))
+        {
+            foreach (var property in routingElement.EnumerateObject())
+            {
+                routing[property.Name] = property.Value.EnumerateArray()
+                    .Select(route => new RouteConfig(route.GetProperty("src").GetString()!, route.GetProperty("dst").GetString()!))
+                    .ToArray();
+            }
+        }
+
+        var io = new Dictionary<string, IOConfig>(StringComparer.Ordinal);
+        if (root.TryGetProperty("io", out var ioElement))
+        {
+            foreach (var property in ioElement.EnumerateObject())
+            {
+                var mode = property.Value.TryGetProperty("mode", out var modeElement) ? modeElement.GetString() ?? "input" : "input";
+                io[property.Name] = new IOConfig(mode);
+            }
+        }
+
+        return new Bitstream(clbs, routing, io, lutK);
+    }
+
+    private static SliceConfig ParseSlice(JsonElement clb, string name, int tableLength)
+    {
+        if (!clb.TryGetProperty(name, out var slice))
+        {
+            return new SliceConfig(new int[tableLength], new int[tableLength]);
+        }
+
+        return new SliceConfig(
+            ParseTable(slice, "lut_a", tableLength),
+            ParseTable(slice, "lut_b", tableLength),
+            slice.TryGetProperty("ff_a", out var ffA) && ffA.GetBoolean(),
+            slice.TryGetProperty("ff_b", out var ffB) && ffB.GetBoolean(),
+            slice.TryGetProperty("carry", out var carry) && carry.GetBoolean());
+    }
+
+    private static int[] ParseTable(JsonElement slice, string name, int tableLength) =>
+        slice.TryGetProperty(name, out var table)
+            ? table.EnumerateArray().Select(value => value.GetInt32()).ToArray()
+            : new int[tableLength];
+}
+
+/// <summary>A configured FPGA fabric with CLBs, routing, and I/O blocks.</summary>
+public sealed class FPGA
+{
+    private readonly Dictionary<string, CLB> _clbs = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, SwitchMatrix> _switches = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IOBlock> _ioBlocks = new(StringComparer.Ordinal);
+
+    public FPGA(Bitstream bitstream)
+    {
+        ArgumentNullException.ThrowIfNull(bitstream);
+        Bitstream = bitstream;
+        Configure(bitstream);
+    }
+
+    public Bitstream Bitstream { get; }
+    public IReadOnlyDictionary<string, CLB> Clbs => new ReadOnlyDictionary<string, CLB>(_clbs);
+    public IReadOnlyDictionary<string, SwitchMatrix> Switches => new ReadOnlyDictionary<string, SwitchMatrix>(_switches);
+    public IReadOnlyDictionary<string, IOBlock> IOBlocks => new ReadOnlyDictionary<string, IOBlock>(_ioBlocks);
+
+    public CLBOutput EvaluateCLB(
+        string name,
+        IReadOnlyList<int> slice0InputsA,
+        IReadOnlyList<int> slice0InputsB,
+        IReadOnlyList<int> slice1InputsA,
+        IReadOnlyList<int> slice1InputsB,
+        int clock,
+        int carryIn = 0)
+    {
+        if (!_clbs.TryGetValue(name, out var clb))
+        {
+            throw new KeyNotFoundException($"CLB {name} was not found");
+        }
+
+        return clb.Evaluate(slice0InputsA, slice0InputsB, slice1InputsA, slice1InputsB, clock, carryIn);
+    }
+
+    public IReadOnlyDictionary<string, int> Route(string name, IReadOnlyDictionary<string, int> signals)
+    {
+        if (!_switches.TryGetValue(name, out var matrix))
+        {
+            throw new KeyNotFoundException($"switch matrix {name} was not found");
+        }
+
+        return matrix.Route(signals);
+    }
+
+    public void SetInput(string name, int value) => GetIO(name).DrivePad(value);
+    public void DriveOutput(string name, int value) => GetIO(name).DriveInternal(value);
+    public int? ReadOutput(string name) => GetIO(name).ReadPad();
+
+    private IOBlock GetIO(string name) =>
+        _ioBlocks.TryGetValue(name, out var io) ? io : throw new KeyNotFoundException($"I/O pin {name} was not found");
+
+    private void Configure(Bitstream bitstream)
+    {
+        foreach (var (name, config) in bitstream.Clbs)
+        {
+            var clb = new CLB(bitstream.LutK);
+            ConfigureSlice(clb.Slice0, config.Slice0);
+            ConfigureSlice(clb.Slice1, config.Slice1);
+            _clbs[name] = clb;
+        }
+
+        foreach (var (name, routes) in bitstream.Routing)
+        {
+            var ports = routes.SelectMany(route => new[] { route.Source, route.Destination }).ToHashSet(StringComparer.Ordinal);
+            if (ports.Count == 0)
+            {
+                continue;
+            }
+
+            var matrix = new SwitchMatrix(ports);
+            foreach (var route in routes)
+            {
+                matrix.Connect(route.Source, route.Destination);
+            }
+
+            _switches[name] = matrix;
+        }
+
+        foreach (var (name, config) in bitstream.IO)
+        {
+            _ioBlocks[name] = new IOBlock(name, ParseMode(config.Mode));
+        }
+    }
+
+    private static void ConfigureSlice(Slice slice, SliceConfig config) =>
+        slice.Configure(config.LutA, config.LutB, config.FlipFlopAEnabled, config.FlipFlopBEnabled, config.CarryEnabled);
+
+    private static IOMode ParseMode(string mode) => mode.ToLowerInvariant() switch
+    {
+        "output" => IOMode.Output,
+        "tristate" => IOMode.Tristate,
+        _ => IOMode.Input,
+    };
+}

--- a/code/packages/csharp/fpga/README.md
+++ b/code/packages/csharp/fpga/README.md
@@ -1,0 +1,24 @@
+# FPGA (C#)
+
+Pure C# simulation primitives for a small field-programmable gate array. The
+package composes the existing logic-gates and block-ram packages into SRAM-backed
+lookup tables, slices, configurable logic blocks, routing matrices, and I/O pads.
+
+```csharp
+using CodingAdventures.Fpga;
+
+var table = new[] { 0, 0, 0, 1 };
+var lut = new LUT(2, table);
+var output = lut.Evaluate([1, 1]); // 1
+
+var bitstream = Bitstream.ParseJson("""
+    {"lut_k":2,"io":{"led":{"mode":"output"}}}
+    """);
+var fpga = new FPGA(bitstream);
+fpga.DriveOutput("led", 1);
+```
+
+Inputs are represented as integer bits (`0` or `1`), with the first LUT input
+as the least-significant truth-table index bit. Bitstreams can be constructed in
+code or parsed from caller-provided JSON; the package performs no file or network
+access.

--- a/code/packages/csharp/fpga/required_capabilities.json
+++ b/code/packages/csharp/fpga/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "csharp/fpga",
+  "capabilities": [],
+  "justification": "Pure computation package. Simulates caller-configured FPGA logic and parses caller-provided JSON without external access."
+}

--- a/code/packages/csharp/fpga/tests/CodingAdventures.Fpga.Tests/CodingAdventures.Fpga.Tests.csproj
+++ b/code/packages/csharp/fpga/tests/CodingAdventures.Fpga.Tests/CodingAdventures.Fpga.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../CodingAdventures.Fpga.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/csharp/fpga/tests/CodingAdventures.Fpga.Tests/FpgaTests.cs
+++ b/code/packages/csharp/fpga/tests/CodingAdventures.Fpga.Tests/FpgaTests.cs
@@ -1,0 +1,423 @@
+using System.Text.Json;
+using CodingAdventures.Fpga;
+
+namespace CodingAdventures.Fpga.Tests;
+
+public sealed class FpgaTests
+{
+    private static int[] Zeros(int k = 4) => new int[1 << k];
+
+    private static int[] AndTable(int k = 4)
+    {
+        var table = Zeros(k);
+        for (var index = 0; index < table.Length; index++)
+        {
+            table[index] = (index & 3) == 3 ? 1 : 0;
+        }
+
+        return table;
+    }
+
+    private static int[] XorTable(int k = 4)
+    {
+        var table = Zeros(k);
+        for (var index = 0; index < table.Length; index++)
+        {
+            table[index] = ((index & 1) ^ ((index >> 1) & 1));
+        }
+
+        return table;
+    }
+
+    private static Bitstream MakeBitstream()
+    {
+        var slice0 = new SliceConfig(AndTable(), Zeros());
+        var slice1 = new SliceConfig(Zeros(), Zeros());
+        return new Bitstream(
+            new Dictionary<string, CLBConfig> { ["clb0"] = new(slice0, slice1) },
+            new Dictionary<string, IReadOnlyList<RouteConfig>>
+            {
+                ["switch0"] = [new("clb_out", "east"), new("north", "south")],
+            },
+            new Dictionary<string, IOConfig>
+            {
+                ["in"] = new("input"),
+                ["out"] = new("output"),
+                ["tri"] = new("tristate"),
+            });
+    }
+
+    [Fact]
+    public void LutImplementsAndTruthTable()
+    {
+        var lut = new LUT(4, AndTable());
+        Assert.Equal(0, lut.Evaluate([0, 0, 0, 0]));
+        Assert.Equal(0, lut.Evaluate([1, 0, 0, 0]));
+        Assert.Equal(0, lut.Evaluate([0, 1, 0, 0]));
+        Assert.Equal(1, lut.Evaluate([1, 1, 0, 0]));
+    }
+
+    [Fact]
+    public void LutImplementsXorTruthTable()
+    {
+        var lut = new LUT(4, XorTable());
+        Assert.Equal(1, lut.Evaluate([1, 0, 0, 0]));
+        Assert.Equal(1, lut.Evaluate([0, 1, 0, 0]));
+        Assert.Equal(0, lut.Evaluate([1, 1, 0, 0]));
+    }
+
+    [Fact]
+    public void LutDefaultsToZeros()
+    {
+        var lut = new LUT(2);
+        Assert.Equal(2, lut.K);
+        Assert.All(new[] { new[] { 0, 0 }, [1, 0], [0, 1], [1, 1] }, inputs => Assert.Equal(0, lut.Evaluate(inputs)));
+    }
+
+    [Fact]
+    public void LutCanBeReconfigured()
+    {
+        var lut = new LUT(4, AndTable());
+        lut.Configure(XorTable());
+        Assert.Equal(0, lut.Evaluate([1, 1, 0, 0]));
+        Assert.Equal(1, lut.Evaluate([1, 0, 0, 0]));
+    }
+
+    [Fact]
+    public void LutTruthTableIsDefensivelyCopied()
+    {
+        var source = AndTable();
+        var lut = new LUT(4, source);
+        source[3] = 0;
+        var snapshot = lut.TruthTable.ToArray();
+        snapshot[3] = 0;
+        Assert.Equal(1, lut.Evaluate([1, 1, 0, 0]));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    public void LutRejectsInvalidWidths(int k) => Assert.Throws<ArgumentOutOfRangeException>(() => new LUT(k));
+
+    [Fact]
+    public void LutRejectsWrongTruthTableLength() =>
+        Assert.Throws<ArgumentException>(() => new LUT(4).Configure([0, 1]));
+
+    [Fact]
+    public void LutRejectsNonBitTruthTableValues()
+    {
+        var table = Zeros();
+        table[5] = 2;
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LUT(4, table));
+    }
+
+    [Fact]
+    public void LutRejectsInvalidInputs()
+    {
+        var lut = new LUT(4);
+        Assert.Throws<ArgumentException>(() => lut.Evaluate([0, 1]));
+        Assert.Throws<ArgumentOutOfRangeException>(() => lut.Evaluate([0, 0, -1, 0]));
+        Assert.Throws<ArgumentNullException>(() => lut.Evaluate(null!));
+    }
+
+    [Fact]
+    public void SliceEvaluatesIndependentCombinationalLuts()
+    {
+        var slice = new Slice();
+        slice.Configure(AndTable(), XorTable());
+        var result = slice.Evaluate([1, 1, 0, 0], [1, 0, 0, 0], 0);
+        Assert.Equal(new SliceOutput(1, 1, 0), result);
+    }
+
+    [Fact]
+    public void SliceRegistersOutputsAcrossHighThenLowClock()
+    {
+        var slice = new Slice();
+        slice.Configure(AndTable(), AndTable(), true, true);
+        Assert.Equal(new SliceOutput(0, 0, 0), slice.Evaluate([1, 1, 0, 0], [1, 1, 0, 0], 1));
+        Assert.Equal(new SliceOutput(1, 1, 0), slice.Evaluate([1, 1, 0, 0], [1, 1, 0, 0], 0));
+    }
+
+    [Fact]
+    public void SliceReconfigurationResetsRegisters()
+    {
+        var slice = new Slice();
+        slice.Configure(AndTable(), AndTable(), true, true);
+        slice.Evaluate([1, 1, 0, 0], [1, 1, 0, 0], 1);
+        slice.Evaluate([1, 1, 0, 0], [1, 1, 0, 0], 0);
+        slice.Configure(AndTable(), AndTable(), true, true);
+        Assert.Equal(0, slice.Evaluate([1, 1, 0, 0], [1, 1, 0, 0], 1).OutputA);
+    }
+
+    [Fact]
+    public void SliceCarryChainGeneratesPropagatesAndBlocks()
+    {
+        var slice = new Slice();
+        slice.Configure(AndTable(), AndTable(), carryEnabled: true);
+        Assert.Equal(1, slice.Evaluate([1, 1, 0, 0], [1, 1, 0, 0], 0).CarryOut);
+        Assert.Equal(1, slice.Evaluate([1, 1, 0, 0], [0, 0, 0, 0], 0, 1).CarryOut);
+        Assert.Equal(0, slice.Evaluate([0, 0, 0, 0], [0, 0, 0, 0], 0, 1).CarryOut);
+    }
+
+    [Fact]
+    public void SliceValidatesClockAndCarry()
+    {
+        var slice = new Slice();
+        Assert.Throws<ArgumentOutOfRangeException>(() => slice.Evaluate([0, 0, 0, 0], [0, 0, 0, 0], 2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => slice.Evaluate([0, 0, 0, 0], [0, 0, 0, 0], 0, -1));
+    }
+
+    [Fact]
+    public void ClbEvaluatesSlicesIndependently()
+    {
+        var clb = new CLB();
+        clb.Slice0.Configure(AndTable(), AndTable());
+        clb.Slice1.Configure(AndTable(), AndTable());
+        var result = clb.Evaluate([1, 1, 0, 0], [1, 1, 0, 0], [0, 1, 0, 0], [1, 0, 0, 0], 0);
+        Assert.Equal(1, result.Slice0.OutputA);
+        Assert.Equal(0, result.Slice1.OutputA);
+        Assert.Equal(4, clb.K);
+    }
+
+    [Fact]
+    public void ClbChainsCarryBetweenSlices()
+    {
+        var clb = new CLB();
+        clb.Slice0.Configure(AndTable(), AndTable(), carryEnabled: true);
+        clb.Slice1.Configure(AndTable(), AndTable(), carryEnabled: true);
+        var ones = new[] { 1, 1, 0, 0 };
+        var result = clb.Evaluate(ones, ones, ones, ones, 0);
+        Assert.Equal(1, result.Slice0.CarryOut);
+        Assert.Equal(1, result.Slice1.CarryOut);
+    }
+
+    [Fact]
+    public void SwitchMatrixRoutesConnectedSignals()
+    {
+        var matrix = new SwitchMatrix(["north", "south", "east", "out"]);
+        matrix.Connect("out", "east");
+        matrix.Connect("north", "south");
+        var routed = matrix.Route(new Dictionary<string, int> { ["out"] = 1, ["north"] = 0 });
+        Assert.Equal(1, routed["east"]);
+        Assert.Equal(0, routed["south"]);
+    }
+
+    [Fact]
+    public void SwitchMatrixSupportsFanOut()
+    {
+        var matrix = new SwitchMatrix(["source", "a", "b"]);
+        matrix.Connect("source", "a");
+        matrix.Connect("source", "b");
+        var routed = matrix.Route(new Dictionary<string, int> { ["source"] = 1 });
+        Assert.Equal(1, routed["a"]);
+        Assert.Equal(1, routed["b"]);
+    }
+
+    [Fact]
+    public void SwitchMatrixOmitsDestinationsWithoutSourceValues()
+    {
+        var matrix = new SwitchMatrix(["a", "b"]);
+        matrix.Connect("a", "b");
+        Assert.Empty(matrix.Route(new Dictionary<string, int> { ["b"] = 1 }));
+    }
+
+    [Fact]
+    public void SwitchMatrixDisconnectsAndClears()
+    {
+        var matrix = new SwitchMatrix(["a", "b", "c"]);
+        matrix.Connect("a", "b");
+        matrix.Disconnect("b");
+        Assert.Equal(0, matrix.ConnectionCount);
+        matrix.Connect("a", "b");
+        matrix.Connect("a", "c");
+        matrix.Clear();
+        Assert.Empty(matrix.Connections);
+    }
+
+    [Fact]
+    public void SwitchMatrixExposesPortsAndConnectionSnapshots()
+    {
+        var matrix = new SwitchMatrix(["a", "b"]);
+        matrix.Connect("a", "b");
+        Assert.Equal(2, matrix.Ports.Count);
+        Assert.Equal("a", matrix.Connections["b"]);
+    }
+
+    [Fact]
+    public void SwitchMatrixRejectsInvalidPortSets()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SwitchMatrix(null!));
+        Assert.Throws<ArgumentException>(() => new SwitchMatrix([]));
+        Assert.Throws<ArgumentException>(() => new SwitchMatrix([""]));
+    }
+
+    [Fact]
+    public void SwitchMatrixRejectsInvalidConnections()
+    {
+        var matrix = new SwitchMatrix(["a", "b", "c"]);
+        Assert.Throws<ArgumentException>(() => matrix.Connect("x", "a"));
+        Assert.Throws<ArgumentException>(() => matrix.Connect("a", "x"));
+        Assert.Throws<ArgumentException>(() => matrix.Connect("a", "a"));
+        matrix.Connect("a", "b");
+        Assert.Throws<InvalidOperationException>(() => matrix.Connect("c", "b"));
+    }
+
+    [Fact]
+    public void SwitchMatrixRejectsInvalidDisconnectsAndBits()
+    {
+        var matrix = new SwitchMatrix(["a", "b", "c"]);
+        Assert.Throws<ArgumentException>(() => matrix.Disconnect("x"));
+        Assert.Throws<InvalidOperationException>(() => matrix.Disconnect("c"));
+        matrix.Connect("a", "b");
+        Assert.Throws<ArgumentOutOfRangeException>(() => matrix.Route(new Dictionary<string, int> { ["a"] = 2 }));
+    }
+
+    [Fact]
+    public void IoBlockInputModeReadsPad()
+    {
+        var io = new IOBlock("sensor");
+        io.DrivePad(1);
+        Assert.Equal(1, io.ReadInternal());
+        Assert.Equal(1, io.ReadPad());
+    }
+
+    [Fact]
+    public void IoBlockOutputModeDrivesPad()
+    {
+        var io = new IOBlock("led", IOMode.Output);
+        io.DriveInternal(1);
+        Assert.Equal(1, io.ReadInternal());
+        Assert.Equal(1, io.ReadPad());
+    }
+
+    [Fact]
+    public void IoBlockCanBeReconfiguredToTristate()
+    {
+        var io = new IOBlock("bus", IOMode.Output);
+        io.DriveInternal(1);
+        io.Configure(IOMode.Tristate);
+        Assert.Null(io.ReadPad());
+        Assert.Equal(IOMode.Tristate, io.Mode);
+    }
+
+    [Fact]
+    public void IoBlockValidatesNameAndBits()
+    {
+        Assert.Throws<ArgumentException>(() => new IOBlock(" "));
+        var io = new IOBlock("pin");
+        Assert.Throws<ArgumentOutOfRangeException>(() => io.DrivePad(2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => io.DriveInternal(-1));
+        Assert.Equal("pin", io.Name);
+    }
+
+    [Fact]
+    public void EmptyBitstreamUsesRequestedLutWidth()
+    {
+        var bitstream = Bitstream.Empty(3);
+        Assert.Equal(3, bitstream.LutK);
+        Assert.Empty(bitstream.Clbs);
+        Assert.Empty(bitstream.Routing);
+        Assert.Empty(bitstream.IO);
+    }
+
+    [Fact]
+    public void BitstreamDefensivelyCopiesCollections()
+    {
+        var clbs = new Dictionary<string, CLBConfig>();
+        var bitstream = new Bitstream(clbs: clbs);
+        clbs["later"] = new(new SliceConfig(), new SliceConfig());
+        Assert.Empty(bitstream.Clbs);
+    }
+
+    [Fact]
+    public void BitstreamRejectsInvalidLutWidths() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => Bitstream.Empty(8));
+
+    [Fact]
+    public void JsonBitstreamParsesAllConfigurationSections()
+    {
+        var bitstream = Bitstream.ParseJson("""
+            {"lut_k":2,"clbs":{"c":{"slice0":{"lut_a":[0,0,0,1],"ff_a":true}}},
+             "routing":{"s":[{"src":"a","dst":"b"}]},
+             "io":{"in":{"mode":"input"},"out":{"mode":"output"}}}
+            """);
+        Assert.Equal(2, bitstream.LutK);
+        Assert.True(bitstream.Clbs["c"].Slice0.FlipFlopAEnabled);
+        Assert.Equal(1, bitstream.Clbs["c"].Slice0.LutA[3]);
+        Assert.Equal("b", Assert.Single(bitstream.Routing["s"]).Destination);
+        Assert.Equal("output", bitstream.IO["out"].Mode);
+    }
+
+    [Fact]
+    public void JsonBitstreamSuppliesMissingDefaults()
+    {
+        var bitstream = Bitstream.ParseJson("{\"clbs\":{\"c\":{\"slice0\":{\"ff_b\":true}}}}");
+        Assert.Equal(4, bitstream.LutK);
+        Assert.Equal(16, bitstream.Clbs["c"].Slice0.LutA.Count);
+        Assert.Equal(16, bitstream.Clbs["c"].Slice1.LutB.Count);
+        Assert.True(bitstream.Clbs["c"].Slice0.FlipFlopBEnabled);
+    }
+
+    [Fact]
+    public void JsonBitstreamRejectsMalformedDocuments()
+    {
+        Assert.Throws<ArgumentNullException>(() => Bitstream.ParseJson(null!));
+        Assert.Throws<JsonException>(() => Bitstream.ParseJson("[]"));
+        Assert.Throws<JsonException>(() => Bitstream.ParseJson("{\"lut_k\":9}"));
+        Assert.ThrowsAny<JsonException>(() => Bitstream.ParseJson("{invalid"));
+    }
+
+    [Fact]
+    public void FpgaEvaluatesConfiguredClbs()
+    {
+        var fpga = new FPGA(MakeBitstream());
+        var result = fpga.EvaluateCLB("clb0", [1, 1, 0, 0], Zeros()[..4], Zeros()[..4], Zeros()[..4], 0);
+        Assert.Equal(1, result.Slice0.OutputA);
+        Assert.Single(fpga.Clbs);
+    }
+
+    [Fact]
+    public void FpgaRoutesConfiguredSignals()
+    {
+        var fpga = new FPGA(MakeBitstream());
+        var routed = fpga.Route("switch0", new Dictionary<string, int> { ["clb_out"] = 1, ["north"] = 0 });
+        Assert.Equal(1, routed["east"]);
+        Assert.Equal(0, routed["south"]);
+        Assert.Single(fpga.Switches);
+    }
+
+    [Fact]
+    public void FpgaDrivesInputOutputAndTristatePins()
+    {
+        var fpga = new FPGA(MakeBitstream());
+        fpga.SetInput("in", 1);
+        Assert.Equal(1, fpga.ReadOutput("in"));
+        fpga.DriveOutput("out", 1);
+        Assert.Equal(1, fpga.ReadOutput("out"));
+        Assert.Null(fpga.ReadOutput("tri"));
+        Assert.Equal(3, fpga.IOBlocks.Count);
+    }
+
+    [Fact]
+    public void FpgaRejectsUnknownResources()
+    {
+        var fpga = new FPGA(MakeBitstream());
+        Assert.Throws<KeyNotFoundException>(() => fpga.EvaluateCLB("missing", Zeros()[..4], Zeros()[..4], Zeros()[..4], Zeros()[..4], 0));
+        Assert.Throws<KeyNotFoundException>(() => fpga.Route("missing", new Dictionary<string, int>()));
+        Assert.Throws<KeyNotFoundException>(() => fpga.SetInput("missing", 0));
+        Assert.Throws<KeyNotFoundException>(() => fpga.DriveOutput("missing", 0));
+        Assert.Throws<KeyNotFoundException>(() => fpga.ReadOutput("missing"));
+    }
+
+    [Fact]
+    public void FpgaAcceptsAnEmptyBitstream()
+    {
+        var bitstream = Bitstream.Empty();
+        var fpga = new FPGA(bitstream);
+        Assert.Same(bitstream, fpga.Bitstream);
+        Assert.Empty(fpga.Clbs);
+        Assert.Empty(fpga.Switches);
+        Assert.Empty(fpga.IOBlocks);
+        Assert.Throws<ArgumentNullException>(() => new FPGA(null!));
+    }
+}

--- a/code/packages/fsharp/fpga/BUILD
+++ b/code/packages/fsharp/fpga/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Fpga.Tests/CodingAdventures.Fpga.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Fpga.FSharp]*"

--- a/code/packages/fsharp/fpga/BUILD_windows
+++ b/code/packages/fsharp/fpga/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Fpga.Tests/CodingAdventures.Fpga.Tests.fsproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[CodingAdventures.Fpga.FSharp]*"

--- a/code/packages/fsharp/fpga/CHANGELOG.md
+++ b/code/packages/fsharp/fpga/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add SRAM-backed LUTs, slices, configurable logic blocks, switch matrices, and I/O blocks.
+- Add immutable bitstream configuration, JSON parsing, and configured FPGA fabric evaluation.

--- a/code/packages/fsharp/fpga/CodingAdventures.Fpga.fsproj
+++ b/code/packages/fsharp/fpga/CodingAdventures.Fpga.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>CodingAdventures.Fpga.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.Fpga.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>Pure F# configurable FPGA fabric simulator</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../logic-gates/CodingAdventures.LogicGates.fsproj" />
+    <ProjectReference Include="../block-ram/CodingAdventures.BlockRam.fsproj" />
+    <Compile Include="Fpga.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/fpga/Fpga.fs
+++ b/code/packages/fsharp/fpga/Fpga.fs
@@ -1,0 +1,442 @@
+namespace CodingAdventures.Fpga.FSharp
+
+open System
+open System.Collections.Generic
+open System.Text.Json
+open CodingAdventures.BlockRam.FSharp
+open CodingAdventures.LogicGates
+
+module internal Validation =
+    let bit name value =
+        if value <> 0 && value <> 1 then
+            raise (ArgumentOutOfRangeException(name, value, $"{name} must be 0 or 1"))
+
+    let bits name length (values: int array) =
+        if isNull values then
+            nullArg name
+
+        if values.Length <> length then
+            raise (ArgumentException($"{name} length {values.Length} does not match {length}", name))
+
+        values |> Array.iteri (fun index value -> bit $"{name}[{index}]" value)
+        Array.copy values
+
+/// A K-input lookup table backed by SRAM cells.
+type LUT(k: int, ?truthTable: int array) =
+    do
+        if k < 2 || k > 6 then
+            raise (ArgumentOutOfRangeException("k", k, "k must be between 2 and 6"))
+
+    let cells = Array.init (1 <<< k) (fun _ -> SRAMCell())
+
+    do
+        match truthTable with
+        | Some values ->
+            let validated = Validation.bits "truthTable" cells.Length values
+            Array.iter2 (fun (cell: SRAMCell) value -> cell.Write(1, value)) cells validated
+        | None -> ()
+
+    member _.K = k
+    member _.TruthTable = cells |> Array.map (fun cell -> cell.Read(1) |> Option.get)
+
+    member _.Configure(truthTable: int array) =
+        let values = Validation.bits "truthTable" cells.Length truthTable
+        Array.iter2 (fun (cell: SRAMCell) value -> cell.Write(1, value)) cells values
+
+    member _.Evaluate(inputs: int array) =
+        let values = Validation.bits "inputs" k inputs
+        let tableIndex = values |> Array.mapi (fun index value -> value <<< index) |> Array.sum
+        cells[tableIndex].Read(1) |> Option.get
+
+type SliceOutput =
+    { OutputA: int
+      OutputB: int
+      CarryOut: int }
+
+type private FlipFlop() =
+    let mutable master = 0
+    let mutable output = 0
+
+    member _.Evaluate(data: int, clock: int) =
+        Validation.bit "data" data
+        Validation.bit "clock" clock
+
+        if clock = 1 then
+            master <- data
+        else
+            output <- master
+
+        output
+
+/// Two LUTs, optional registers, and a carry chain.
+type Slice(lutInputs: int) =
+    let lutA = LUT(lutInputs)
+    let lutB = LUT(lutInputs)
+    let mutable flipFlopA = FlipFlop()
+    let mutable flipFlopB = FlipFlop()
+    let mutable flipFlopAEnabled = false
+    let mutable flipFlopBEnabled = false
+    let mutable carryEnabled = false
+
+    new() = Slice(4)
+
+    member _.LutA = lutA
+    member _.LutB = lutB
+    member _.K = lutInputs
+
+    member _.Configure(
+        lutATable: int array,
+        lutBTable: int array,
+        ?enableFlipFlopA: bool,
+        ?enableFlipFlopB: bool,
+        ?enableCarry: bool
+    ) =
+        lutA.Configure lutATable
+        lutB.Configure lutBTable
+        flipFlopAEnabled <- defaultArg enableFlipFlopA false
+        flipFlopBEnabled <- defaultArg enableFlipFlopB false
+        carryEnabled <- defaultArg enableCarry false
+        flipFlopA <- FlipFlop()
+        flipFlopB <- FlipFlop()
+
+    member _.Evaluate(inputsA: int array, inputsB: int array, clock: int, ?carryIn: int) =
+        let carryIn = defaultArg carryIn 0
+        Validation.bit "clock" clock
+        Validation.bit "carryIn" carryIn
+        let valueA = lutA.Evaluate inputsA
+        let valueB = lutB.Evaluate inputsB
+        let outputA = if flipFlopAEnabled then flipFlopA.Evaluate(valueA, clock) else valueA
+        let outputB = if flipFlopBEnabled then flipFlopB.Evaluate(valueB, clock) else valueB
+
+        let carryOut =
+            if carryEnabled then
+                LogicGates.orGate
+                    (LogicGates.andGate valueA valueB)
+                    (LogicGates.andGate carryIn (LogicGates.xorGate valueA valueB))
+            else
+                0
+
+        { OutputA = outputA
+          OutputB = outputB
+          CarryOut = carryOut }
+
+type CLBOutput =
+    { Slice0: SliceOutput
+      Slice1: SliceOutput }
+
+/// A configurable logic block containing two slices.
+type CLB(lutInputs: int) =
+    let slice0 = Slice(lutInputs)
+    let slice1 = Slice(lutInputs)
+
+    new() = CLB(4)
+
+    member _.Slice0 = slice0
+    member _.Slice1 = slice1
+    member _.K = lutInputs
+
+    member _.Evaluate(
+        slice0InputsA: int array,
+        slice0InputsB: int array,
+        slice1InputsA: int array,
+        slice1InputsB: int array,
+        clock: int,
+        ?carryIn: int
+    ) =
+        let first = slice0.Evaluate(slice0InputsA, slice0InputsB, clock, defaultArg carryIn 0)
+        let second = slice1.Evaluate(slice1InputsA, slice1InputsB, clock, first.CarryOut)
+        { Slice0 = first; Slice1 = second }
+
+/// A programmable crossbar with one driver per destination.
+type SwitchMatrix(ports: seq<string>) =
+    do
+        if isNull (box ports) then
+            nullArg "ports"
+
+    let ports = HashSet<string>(ports, StringComparer.Ordinal)
+    let connections = Dictionary<string, string>(StringComparer.Ordinal)
+
+    do
+        if ports.Count = 0 || ports |> Seq.exists String.IsNullOrWhiteSpace then
+            invalidArg "ports" "ports must contain non-empty unique names"
+
+    member _.Ports = ports |> Set.ofSeq
+    member _.Connections = connections |> Seq.map (fun pair -> pair.Key, pair.Value) |> Map.ofSeq
+    member _.ConnectionCount = connections.Count
+
+    member _.Connect(source: string, destination: string) =
+        if not (ports.Contains source) then
+            invalidArg "source" $"unknown source port: {source}"
+
+        if not (ports.Contains destination) then
+            invalidArg "destination" $"unknown destination port: {destination}"
+
+        if source = destination then
+            invalidArg "destination" "a port cannot connect to itself"
+
+        if not (connections.TryAdd(destination, source)) then
+            raise (InvalidOperationException($"destination {destination} is already connected"))
+
+    member _.Disconnect(destination: string) =
+        if not (ports.Contains destination) then
+            invalidArg "destination" $"unknown port: {destination}"
+
+        if not (connections.Remove destination) then
+            raise (InvalidOperationException($"port {destination} is not connected"))
+
+    member _.Clear() = connections.Clear()
+
+    member _.Route(inputs: Map<string, int>) =
+        if isNull (box inputs) then
+            nullArg "inputs"
+
+        connections
+        |> Seq.choose (fun pair ->
+            inputs
+            |> Map.tryFind pair.Value
+            |> Option.map (fun value ->
+                Validation.bit $"inputs[{pair.Value}]" value
+                pair.Key, value))
+        |> Map.ofSeq
+
+type IOMode =
+    | Input
+    | Output
+    | Tristate
+
+/// A configurable external I/O pad.
+type IOBlock(name: string, ?mode: IOMode) =
+    do
+        if String.IsNullOrWhiteSpace name then
+            invalidArg "name" "name must be non-empty"
+
+    let mutable mode = defaultArg mode Input
+    let mutable padValue = 0
+    let mutable internalValue = 0
+
+    member _.Name = name
+    member _.Mode = mode
+    member _.Configure(newMode: IOMode) = mode <- newMode
+
+    member _.DrivePad(value: int) =
+        Validation.bit "value" value
+        padValue <- value
+
+    member _.DriveInternal(value: int) =
+        Validation.bit "value" value
+        internalValue <- value
+
+    member _.ReadInternal() = if mode = Input then padValue else internalValue
+
+    member _.ReadPad() =
+        match mode with
+        | Input -> Some padValue
+        | Output -> Some internalValue
+        | Tristate -> None
+
+type SliceConfig =
+    { LutA: int array
+      LutB: int array
+      FlipFlopAEnabled: bool
+      FlipFlopBEnabled: bool
+      CarryEnabled: bool }
+
+type CLBConfig = { Slice0: SliceConfig; Slice1: SliceConfig }
+type RouteConfig = { Source: string; Destination: string }
+type IOConfig = { Mode: string }
+
+/// Immutable FPGA configuration data.
+type Bitstream(clbs: Map<string, CLBConfig>, routing: Map<string, RouteConfig list>, io: Map<string, IOConfig>, lutK: int) =
+    do
+        if lutK < 2 || lutK > 6 then
+            raise (ArgumentOutOfRangeException("lutK", lutK, "lutK must be between 2 and 6"))
+
+    let copySlice config =
+        { config with
+            LutA = Array.copy config.LutA
+            LutB = Array.copy config.LutB }
+
+    let clbs = clbs |> Map.map (fun _ config -> { Slice0 = copySlice config.Slice0; Slice1 = copySlice config.Slice1 })
+    let routing = routing |> Map.map (fun _ routes -> List.ofSeq routes)
+
+    member _.Clbs = clbs
+    member _.Routing = routing
+    member _.IO = io
+    member _.LutK = lutK
+
+    static member Empty(?lutK: int) = Bitstream(Map.empty, Map.empty, Map.empty, defaultArg lutK 4)
+
+    static member Create(
+        ?clbs: Map<string, CLBConfig>,
+        ?routing: Map<string, RouteConfig list>,
+        ?io: Map<string, IOConfig>,
+        ?lutK: int
+    ) =
+        Bitstream(defaultArg clbs Map.empty, defaultArg routing Map.empty, defaultArg io Map.empty, defaultArg lutK 4)
+
+    static member ParseJson(json: string) =
+        if isNull json then
+            nullArg "json"
+
+        use document = JsonDocument.Parse json
+        let root = document.RootElement
+
+        if root.ValueKind <> JsonValueKind.Object then
+            raise (JsonException("bitstream JSON root must be an object"))
+
+        let tryProperty (name: string) (element: JsonElement) =
+            let mutable value = Unchecked.defaultof<JsonElement>
+            if element.TryGetProperty(name, &value) then Some value else None
+
+        let lutK = tryProperty "lut_k" root |> Option.map _.GetInt32() |> Option.defaultValue 4
+
+        if lutK < 2 || lutK > 6 then
+            raise (JsonException("lut_k must be between 2 and 6"))
+
+        let tableLength = 1 <<< lutK
+
+        let parseTable name (slice: JsonElement) =
+            match tryProperty name slice with
+            | Some table -> table.EnumerateArray() |> Seq.map _.GetInt32() |> Array.ofSeq
+            | None -> Array.zeroCreate tableLength
+
+        let parseSlice name (clb: JsonElement) =
+            match tryProperty name clb with
+            | None ->
+                { LutA = Array.zeroCreate tableLength
+                  LutB = Array.zeroCreate tableLength
+                  FlipFlopAEnabled = false
+                  FlipFlopBEnabled = false
+                  CarryEnabled = false }
+            | Some slice ->
+                let flag property =
+                    tryProperty property slice |> Option.exists _.GetBoolean()
+
+                { LutA = parseTable "lut_a" slice
+                  LutB = parseTable "lut_b" slice
+                  FlipFlopAEnabled = flag "ff_a"
+                  FlipFlopBEnabled = flag "ff_b"
+                  CarryEnabled = flag "carry" }
+
+        let clbs =
+            match tryProperty "clbs" root with
+            | None -> Map.empty
+            | Some values ->
+                values.EnumerateObject()
+                |> Seq.map (fun property ->
+                    property.Name,
+                    { Slice0 = parseSlice "slice0" property.Value
+                      Slice1 = parseSlice "slice1" property.Value })
+                |> Map.ofSeq
+
+        let routing =
+            match tryProperty "routing" root with
+            | None -> Map.empty
+            | Some values ->
+                values.EnumerateObject()
+                |> Seq.map (fun property ->
+                    property.Name,
+                    (property.Value.EnumerateArray()
+                     |> Seq.map (fun route ->
+                         { Source = route.GetProperty("src").GetString()
+                           Destination = route.GetProperty("dst").GetString() })
+                     |> List.ofSeq))
+                |> Map.ofSeq
+
+        let io =
+            match tryProperty "io" root with
+            | None -> Map.empty
+            | Some values ->
+                values.EnumerateObject()
+                |> Seq.map (fun property ->
+                    let mode =
+                        tryProperty "mode" property.Value
+                        |> Option.bind (fun value -> Option.ofObj (value.GetString()))
+                        |> Option.defaultValue "input"
+
+                    property.Name, { Mode = mode })
+                |> Map.ofSeq
+
+        Bitstream(clbs, routing, io, lutK)
+
+/// A configured FPGA fabric with CLBs, routing, and I/O blocks.
+type FPGA(bitstream: Bitstream) =
+    do
+        if isNull (box bitstream) then
+            nullArg "bitstream"
+
+    let clbs = Dictionary<string, CLB>(StringComparer.Ordinal)
+    let switches = Dictionary<string, SwitchMatrix>(StringComparer.Ordinal)
+    let ioBlocks = Dictionary<string, IOBlock>(StringComparer.Ordinal)
+
+    let configureSlice (slice: Slice) config =
+        slice.Configure(
+            config.LutA,
+            config.LutB,
+            config.FlipFlopAEnabled,
+            config.FlipFlopBEnabled,
+            config.CarryEnabled
+        )
+
+    let parseMode (mode: string) =
+        match mode.ToLowerInvariant() with
+        | "output" -> Output
+        | "tristate" -> Tristate
+        | _ -> Input
+
+    do
+        for KeyValue(name, config) in bitstream.Clbs do
+            let clb = CLB(bitstream.LutK)
+            configureSlice clb.Slice0 config.Slice0
+            configureSlice clb.Slice1 config.Slice1
+            clbs[name] <- clb
+
+        for KeyValue(name, routes) in bitstream.Routing do
+            let ports = routes |> Seq.collect (fun route -> [ route.Source; route.Destination ]) |> Set.ofSeq
+            if not ports.IsEmpty then
+                let matrix = SwitchMatrix ports
+                routes |> List.iter (fun route -> matrix.Connect(route.Source, route.Destination))
+                switches[name] <- matrix
+
+        for KeyValue(name, config) in bitstream.IO do
+            ioBlocks[name] <- IOBlock(name, parseMode config.Mode)
+
+    let getIO name =
+        match ioBlocks.TryGetValue name with
+        | true, value -> value
+        | _ -> raise (KeyNotFoundException($"I/O pin {name} was not found"))
+
+    member _.Bitstream = bitstream
+    member _.Clbs = clbs |> Seq.map (fun pair -> pair.Key, pair.Value) |> Map.ofSeq
+    member _.Switches = switches |> Seq.map (fun pair -> pair.Key, pair.Value) |> Map.ofSeq
+    member _.IOBlocks = ioBlocks |> Seq.map (fun pair -> pair.Key, pair.Value) |> Map.ofSeq
+
+    member _.EvaluateCLB(
+        name: string,
+        slice0InputsA: int array,
+        slice0InputsB: int array,
+        slice1InputsA: int array,
+        slice1InputsB: int array,
+        clock: int,
+        ?carryIn: int
+    ) =
+        match clbs.TryGetValue name with
+        | true, clb ->
+            clb.Evaluate(
+                slice0InputsA,
+                slice0InputsB,
+                slice1InputsA,
+                slice1InputsB,
+                clock,
+                defaultArg carryIn 0
+            )
+        | _ -> raise (KeyNotFoundException($"CLB {name} was not found"))
+
+    member _.Route(name: string, signals: Map<string, int>) =
+        match switches.TryGetValue name with
+        | true, matrix -> matrix.Route signals
+        | _ -> raise (KeyNotFoundException($"switch matrix {name} was not found"))
+
+    member _.SetInput(name: string, value: int) = getIO name |> fun io -> io.DrivePad value
+    member _.DriveOutput(name: string, value: int) = getIO name |> fun io -> io.DriveInternal value
+    member _.ReadOutput(name: string) = getIO name |> fun io -> io.ReadPad()

--- a/code/packages/fsharp/fpga/README.md
+++ b/code/packages/fsharp/fpga/README.md
@@ -1,0 +1,24 @@
+# FPGA (F#)
+
+Pure F# simulation primitives for a small field-programmable gate array. The
+package composes the existing logic-gates and block-ram packages into SRAM-backed
+lookup tables, slices, configurable logic blocks, routing matrices, and I/O pads.
+
+```fsharp
+open CodingAdventures.Fpga.FSharp
+
+let table = [| 0; 0; 0; 1 |]
+let lut = LUT(2, table)
+let output = lut.Evaluate [| 1; 1 |] // 1
+
+let bitstream =
+    Bitstream.ParseJson """{"lut_k":2,"io":{"led":{"mode":"output"}}}"""
+
+let fpga = FPGA bitstream
+fpga.DriveOutput("led", 1)
+```
+
+Inputs are represented as integer bits (`0` or `1`), with the first LUT input
+as the least-significant truth-table index bit. Bitstreams can be constructed in
+code or parsed from caller-provided JSON; the package performs no file or network
+access.

--- a/code/packages/fsharp/fpga/required_capabilities.json
+++ b/code/packages/fsharp/fpga/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/fpga",
+  "capabilities": [],
+  "justification": "Pure computation package. Simulates caller-configured FPGA logic and parses caller-provided JSON without external access."
+}

--- a/code/packages/fsharp/fpga/tests/CodingAdventures.Fpga.Tests/CodingAdventures.Fpga.Tests.fsproj
+++ b/code/packages/fsharp/fpga/tests/CodingAdventures.Fpga.Tests/CodingAdventures.Fpga.Tests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.Fpga.fsproj" />
+    <Compile Include="FpgaTests.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/fpga/tests/CodingAdventures.Fpga.Tests/FpgaTests.fs
+++ b/code/packages/fsharp/fpga/tests/CodingAdventures.Fpga.Tests/FpgaTests.fs
@@ -1,0 +1,354 @@
+namespace CodingAdventures.Fpga.FSharp.Tests
+
+open System
+open System.Collections.Generic
+open System.Text.Json
+open Xunit
+open CodingAdventures.Fpga.FSharp
+
+module Helpers =
+    let zeros k = Array.zeroCreate (1 <<< k)
+
+    let andTable k =
+        Array.init (1 <<< k) (fun index -> if index &&& 3 = 3 then 1 else 0)
+
+    let xorTable k =
+        Array.init (1 <<< k) (fun index -> (index &&& 1) ^^^ ((index >>> 1) &&& 1))
+
+    let sliceConfig lutA lutB =
+        { LutA = lutA
+          LutB = lutB
+          FlipFlopAEnabled = false
+          FlipFlopBEnabled = false
+          CarryEnabled = false }
+
+    let bitstream () =
+        let slice0 = sliceConfig (andTable 4) (zeros 4)
+        let slice1 = sliceConfig (zeros 4) (zeros 4)
+
+        Bitstream(
+            Map.ofList [ "clb0", { Slice0 = slice0; Slice1 = slice1 } ],
+            Map.ofList
+                [ "switch0",
+                  [ { Source = "clb_out"; Destination = "east" }
+                    { Source = "north"; Destination = "south" } ] ],
+            Map.ofList
+                [ "in", { Mode = "input" }
+                  "out", { Mode = "output" }
+                  "tri", { Mode = "tristate" } ],
+            4
+        )
+
+type LUTTests() =
+    [<Fact>]
+    member _.``implements AND truth table``() =
+        let lut = LUT(4, Helpers.andTable 4)
+        Assert.Equal(0, lut.Evaluate [| 0; 0; 0; 0 |])
+        Assert.Equal(0, lut.Evaluate [| 1; 0; 0; 0 |])
+        Assert.Equal(0, lut.Evaluate [| 0; 1; 0; 0 |])
+        Assert.Equal(1, lut.Evaluate [| 1; 1; 0; 0 |])
+
+    [<Fact>]
+    member _.``implements XOR truth table``() =
+        let lut = LUT(4, Helpers.xorTable 4)
+        Assert.Equal(1, lut.Evaluate [| 1; 0; 0; 0 |])
+        Assert.Equal(1, lut.Evaluate [| 0; 1; 0; 0 |])
+        Assert.Equal(0, lut.Evaluate [| 1; 1; 0; 0 |])
+
+    [<Fact>]
+    member _.``defaults to zeros``() =
+        let lut = LUT(2)
+        Assert.Equal(2, lut.K)
+
+        [| [| 0; 0 |]; [| 1; 0 |]; [| 0; 1 |]; [| 1; 1 |] |]
+        |> Array.iter (fun inputs -> Assert.Equal(0, lut.Evaluate inputs))
+
+    [<Fact>]
+    member _.``can be reconfigured``() =
+        let lut = LUT(4, Helpers.andTable 4)
+        lut.Configure(Helpers.xorTable 4)
+        Assert.Equal(0, lut.Evaluate [| 1; 1; 0; 0 |])
+        Assert.Equal(1, lut.Evaluate [| 1; 0; 0; 0 |])
+
+    [<Fact>]
+    member _.``truth tables are defensively copied``() =
+        let source = Helpers.andTable 4
+        let lut = LUT(4, source)
+        source[3] <- 0
+        let snapshot = lut.TruthTable
+        snapshot[3] <- 0
+        Assert.Equal(1, lut.Evaluate [| 1; 1; 0; 0 |])
+
+    [<Fact>]
+    member _.``rejects invalid widths``() =
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> LUT(1) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> LUT(7) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``rejects invalid tables``() =
+        Assert.Throws<ArgumentException>(fun () -> LUT(4).Configure [| 0; 1 |]) |> ignore
+        let table = Helpers.zeros 4
+        table[5] <- 2
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> LUT(4, table) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``rejects invalid inputs``() =
+        let lut = LUT(4)
+        Assert.Throws<ArgumentException>(fun () -> lut.Evaluate [| 0; 1 |] |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> lut.Evaluate [| 0; 0; -1; 0 |] |> ignore) |> ignore
+        Assert.Throws<ArgumentNullException>(fun () -> lut.Evaluate null |> ignore) |> ignore
+
+type SliceAndCLBTests() =
+    [<Fact>]
+    member _.``slice evaluates independent combinational LUTs``() =
+        let slice = Slice()
+        slice.Configure(Helpers.andTable 4, Helpers.xorTable 4)
+        let result = slice.Evaluate([| 1; 1; 0; 0 |], [| 1; 0; 0; 0 |], 0)
+        Assert.Equal({ OutputA = 1; OutputB = 1; CarryOut = 0 }, result)
+
+    [<Fact>]
+    member _.``slice registers outputs across high then low clock``() =
+        let slice = Slice()
+        slice.Configure(Helpers.andTable 4, Helpers.andTable 4, enableFlipFlopA = true, enableFlipFlopB = true)
+        let ones = [| 1; 1; 0; 0 |]
+        Assert.Equal({ OutputA = 0; OutputB = 0; CarryOut = 0 }, slice.Evaluate(ones, ones, 1))
+        Assert.Equal({ OutputA = 1; OutputB = 1; CarryOut = 0 }, slice.Evaluate(ones, ones, 0))
+
+    [<Fact>]
+    member _.``slice reconfiguration resets registers``() =
+        let slice = Slice()
+        let ones = [| 1; 1; 0; 0 |]
+        slice.Configure(Helpers.andTable 4, Helpers.andTable 4, enableFlipFlopA = true, enableFlipFlopB = true)
+        slice.Evaluate(ones, ones, 1) |> ignore
+        slice.Evaluate(ones, ones, 0) |> ignore
+        slice.Configure(Helpers.andTable 4, Helpers.andTable 4, enableFlipFlopA = true, enableFlipFlopB = true)
+        Assert.Equal(0, slice.Evaluate(ones, ones, 1).OutputA)
+
+    [<Fact>]
+    member _.``slice carry chain generates propagates and blocks``() =
+        let slice = Slice()
+        slice.Configure(Helpers.andTable 4, Helpers.andTable 4, enableCarry = true)
+        let ones = [| 1; 1; 0; 0 |]
+        let zeros = [| 0; 0; 0; 0 |]
+        Assert.Equal(1, slice.Evaluate(ones, ones, 0).CarryOut)
+        Assert.Equal(1, slice.Evaluate(ones, zeros, 0, carryIn = 1).CarryOut)
+        Assert.Equal(0, slice.Evaluate(zeros, zeros, 0, carryIn = 1).CarryOut)
+
+    [<Fact>]
+    member _.``slice validates clock and carry``() =
+        let slice = Slice()
+        let zeros = [| 0; 0; 0; 0 |]
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> slice.Evaluate(zeros, zeros, 2) |> ignore) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> slice.Evaluate(zeros, zeros, 0, carryIn = -1) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``CLB evaluates slices independently``() =
+        let clb = CLB()
+        clb.Slice0.Configure(Helpers.andTable 4, Helpers.andTable 4)
+        clb.Slice1.Configure(Helpers.andTable 4, Helpers.andTable 4)
+        let result = clb.Evaluate([| 1; 1; 0; 0 |], [| 1; 1; 0; 0 |], [| 0; 1; 0; 0 |], [| 1; 0; 0; 0 |], 0)
+        Assert.Equal(1, result.Slice0.OutputA)
+        Assert.Equal(0, result.Slice1.OutputA)
+        Assert.Equal(4, clb.K)
+
+    [<Fact>]
+    member _.``CLB chains carry between slices``() =
+        let clb = CLB()
+        clb.Slice0.Configure(Helpers.andTable 4, Helpers.andTable 4, enableCarry = true)
+        clb.Slice1.Configure(Helpers.andTable 4, Helpers.andTable 4, enableCarry = true)
+        let ones = [| 1; 1; 0; 0 |]
+        let result = clb.Evaluate(ones, ones, ones, ones, 0)
+        Assert.Equal(1, result.Slice0.CarryOut)
+        Assert.Equal(1, result.Slice1.CarryOut)
+
+type SwitchMatrixTests() =
+    [<Fact>]
+    member _.``routes connected signals``() =
+        let matrix = SwitchMatrix [ "north"; "south"; "east"; "out" ]
+        matrix.Connect("out", "east")
+        matrix.Connect("north", "south")
+        let routed = matrix.Route(Map.ofList [ "out", 1; "north", 0 ])
+        Assert.Equal(1, routed["east"])
+        Assert.Equal(0, routed["south"])
+
+    [<Fact>]
+    member _.``supports fan out``() =
+        let matrix = SwitchMatrix [ "source"; "a"; "b" ]
+        matrix.Connect("source", "a")
+        matrix.Connect("source", "b")
+        let routed = matrix.Route(Map.ofList [ "source", 1 ])
+        Assert.Equal(1, routed["a"])
+        Assert.Equal(1, routed["b"])
+
+    [<Fact>]
+    member _.``omits destinations without source values``() =
+        let matrix = SwitchMatrix [ "a"; "b" ]
+        matrix.Connect("a", "b")
+        Assert.Empty(matrix.Route(Map.ofList [ "b", 1 ]))
+
+    [<Fact>]
+    member _.``disconnects and clears``() =
+        let matrix = SwitchMatrix [ "a"; "b"; "c" ]
+        matrix.Connect("a", "b")
+        matrix.Disconnect("b")
+        Assert.Equal(0, matrix.ConnectionCount)
+        matrix.Connect("a", "b")
+        matrix.Connect("a", "c")
+        matrix.Clear()
+        Assert.Empty(matrix.Connections)
+
+    [<Fact>]
+    member _.``exposes port and connection snapshots``() =
+        let matrix = SwitchMatrix [ "a"; "b" ]
+        matrix.Connect("a", "b")
+        Assert.Equal(2, matrix.Ports.Count)
+        Assert.Equal("a", matrix.Connections["b"])
+
+    [<Fact>]
+    member _.``rejects invalid port sets``() =
+        Assert.Throws<ArgumentNullException>(fun () -> SwitchMatrix null |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> SwitchMatrix [] |> ignore) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> SwitchMatrix [ "" ] |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``rejects invalid connections``() =
+        let matrix = SwitchMatrix [ "a"; "b"; "c" ]
+        Assert.Throws<ArgumentException>(fun () -> matrix.Connect("x", "a")) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> matrix.Connect("a", "x")) |> ignore
+        Assert.Throws<ArgumentException>(fun () -> matrix.Connect("a", "a")) |> ignore
+        matrix.Connect("a", "b")
+        Assert.Throws<InvalidOperationException>(fun () -> matrix.Connect("c", "b")) |> ignore
+
+    [<Fact>]
+    member _.``rejects invalid disconnects and bits``() =
+        let matrix = SwitchMatrix [ "a"; "b"; "c" ]
+        Assert.Throws<ArgumentException>(fun () -> matrix.Disconnect("x")) |> ignore
+        Assert.Throws<InvalidOperationException>(fun () -> matrix.Disconnect("c")) |> ignore
+        matrix.Connect("a", "b")
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> matrix.Route(Map.ofList [ "a", 2 ]) |> ignore) |> ignore
+
+type IOBlockTests() =
+    [<Fact>]
+    member _.``input mode reads pad``() =
+        let io = IOBlock("sensor")
+        io.DrivePad 1
+        Assert.Equal(1, io.ReadInternal())
+        Assert.Equal(Some 1, io.ReadPad())
+
+    [<Fact>]
+    member _.``output mode drives pad``() =
+        let io = IOBlock("led", Output)
+        io.DriveInternal 1
+        Assert.Equal(1, io.ReadInternal())
+        Assert.Equal(Some 1, io.ReadPad())
+
+    [<Fact>]
+    member _.``can be reconfigured to tristate``() =
+        let io = IOBlock("bus", Output)
+        io.DriveInternal 1
+        io.Configure Tristate
+        Assert.Equal(None, io.ReadPad())
+        Assert.Equal(Tristate, io.Mode)
+
+    [<Fact>]
+    member _.``validates name and bits``() =
+        Assert.Throws<ArgumentException>(fun () -> IOBlock(" ") |> ignore) |> ignore
+        let io = IOBlock("pin")
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> io.DrivePad 2) |> ignore
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> io.DriveInternal -1) |> ignore
+        Assert.Equal("pin", io.Name)
+
+type BitstreamAndFabricTests() =
+    [<Fact>]
+    member _.``empty bitstream uses requested LUT width``() =
+        let bitstream = Bitstream.Empty(lutK = 3)
+        Assert.Equal(3, bitstream.LutK)
+        Assert.Empty(bitstream.Clbs)
+        Assert.Empty(bitstream.Routing)
+        Assert.Empty(bitstream.IO)
+
+    [<Fact>]
+    member _.``bitstream defensively copies tables``() =
+        let table = Helpers.andTable 4
+        let slice = Helpers.sliceConfig table (Helpers.zeros 4)
+        let bitstream = Bitstream(Map.ofList [ "c", { Slice0 = slice; Slice1 = slice } ], Map.empty, Map.empty, 4)
+        table[3] <- 0
+        Assert.Equal(1, bitstream.Clbs["c"].Slice0.LutA[3])
+
+    [<Fact>]
+    member _.``bitstream rejects invalid LUT widths``() =
+        Assert.Throws<ArgumentOutOfRangeException>(fun () -> Bitstream.Empty(lutK = 8) |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``JSON parses all configuration sections``() =
+        let bitstream =
+            Bitstream.ParseJson(
+                """{"lut_k":2,"clbs":{"c":{"slice0":{"lut_a":[0,0,0,1],"ff_a":true}}},"routing":{"s":[{"src":"a","dst":"b"}]},"io":{"in":{"mode":"input"},"out":{"mode":"output"}}}"""
+            )
+
+        Assert.Equal(2, bitstream.LutK)
+        Assert.True(bitstream.Clbs["c"].Slice0.FlipFlopAEnabled)
+        Assert.Equal(1, bitstream.Clbs["c"].Slice0.LutA[3])
+        Assert.Equal("b", bitstream.Routing["s"].Head.Destination)
+        Assert.Equal("output", bitstream.IO["out"].Mode)
+
+    [<Fact>]
+    member _.``JSON supplies missing defaults``() =
+        let bitstream = Bitstream.ParseJson("""{"clbs":{"c":{"slice0":{"ff_b":true}}}}""")
+        Assert.Equal(4, bitstream.LutK)
+        Assert.Equal(16, bitstream.Clbs["c"].Slice0.LutA.Length)
+        Assert.Equal(16, bitstream.Clbs["c"].Slice1.LutB.Length)
+        Assert.True(bitstream.Clbs["c"].Slice0.FlipFlopBEnabled)
+
+    [<Fact>]
+    member _.``JSON rejects malformed documents``() =
+        Assert.Throws<ArgumentNullException>(fun () -> Bitstream.ParseJson null |> ignore) |> ignore
+        Assert.Throws<JsonException>(fun () -> Bitstream.ParseJson "[]" |> ignore) |> ignore
+        Assert.Throws<JsonException>(fun () -> Bitstream.ParseJson "{\"lut_k\":9}" |> ignore) |> ignore
+        Assert.ThrowsAny<JsonException>(fun () -> Bitstream.ParseJson "{invalid" |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``fabric evaluates configured CLBs``() =
+        let fpga = FPGA(Helpers.bitstream ())
+        let zeros = [| 0; 0; 0; 0 |]
+        let result = fpga.EvaluateCLB("clb0", [| 1; 1; 0; 0 |], zeros, zeros, zeros, 0)
+        Assert.Equal(1, result.Slice0.OutputA)
+        Assert.Single(fpga.Clbs) |> ignore
+
+    [<Fact>]
+    member _.``fabric routes configured signals``() =
+        let fpga = FPGA(Helpers.bitstream ())
+        let routed = fpga.Route("switch0", Map.ofList [ "clb_out", 1; "north", 0 ])
+        Assert.Equal(1, routed["east"])
+        Assert.Equal(0, routed["south"])
+        Assert.Single(fpga.Switches) |> ignore
+
+    [<Fact>]
+    member _.``fabric drives input output and tristate pins``() =
+        let fpga = FPGA(Helpers.bitstream ())
+        fpga.SetInput("in", 1)
+        Assert.Equal(Some 1, fpga.ReadOutput "in")
+        fpga.DriveOutput("out", 1)
+        Assert.Equal(Some 1, fpga.ReadOutput "out")
+        Assert.Equal(None, fpga.ReadOutput "tri")
+        Assert.Equal(3, fpga.IOBlocks.Count)
+
+    [<Fact>]
+    member _.``fabric rejects unknown resources``() =
+        let fpga = FPGA(Helpers.bitstream ())
+        let zeros = [| 0; 0; 0; 0 |]
+        Assert.Throws<KeyNotFoundException>(fun () -> fpga.EvaluateCLB("missing", zeros, zeros, zeros, zeros, 0) |> ignore) |> ignore
+        Assert.Throws<KeyNotFoundException>(fun () -> fpga.Route("missing", Map.empty) |> ignore) |> ignore
+        Assert.Throws<KeyNotFoundException>(fun () -> fpga.SetInput("missing", 0)) |> ignore
+        Assert.Throws<KeyNotFoundException>(fun () -> fpga.DriveOutput("missing", 0)) |> ignore
+        Assert.Throws<KeyNotFoundException>(fun () -> fpga.ReadOutput "missing" |> ignore) |> ignore
+
+    [<Fact>]
+    member _.``fabric accepts an empty bitstream``() =
+        let bitstream = Bitstream.Empty()
+        let fpga = FPGA(bitstream)
+        Assert.Same(bitstream, fpga.Bitstream)
+        Assert.Empty(fpga.Clbs)
+        Assert.Empty(fpga.Switches)
+        Assert.Empty(fpga.IOBlocks)
+        Assert.Throws<ArgumentNullException>(fun () -> FPGA(null) |> ignore) |> ignore

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -114,12 +114,12 @@ and `hash-set` ports, the paired `in-memory-data-store-engine` and
 `x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
 ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
-ports, followed by the paired `ed25519`, `font-parser`, and
-`asciidoc-parser` ports:
+ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
+`fpga` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 313 |
+| Present in 10-15 languages | 172 | 311 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 703 | 9,842 |
@@ -165,7 +165,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 313
+The 172 packages present in at least ten implementation languages need 311
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -174,8 +174,8 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
 | Lua | 0 | Complete; paired data-structure/storage wave |
 | Perl | 0 | Complete; paired data-structure/storage wave |
-| C# | 2 | Move with F# |
-| F# | 2 | Move with C# |
+| C# | 1 | Move with F# |
+| F# | 1 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
@@ -365,6 +365,15 @@ exercise 33 test cases in each lane, including lenient unterminated blocks and
 malformed inline delimiters, with more than 97% line coverage. The
 package now spans 12 implementation lanes, reduces the high-consensus backlog
 to 313 slots, and leaves 2 paired gaps in each lane.
+
+The sixteenth paired C#/F# slice is complete: `fpga` now provides native
+SRAM-backed lookup tables, dual-LUT slices with optional registers and carry
+chains, configurable logic blocks, programmable switch matrices, I/O pads, and
+immutable JSON bitstream configuration in both lanes. The ports compose the
+existing native `logic-gates` and `block-ram` packages, and their package-local
+suites exercise 40 C# and 38 F# cases with more than 97% line coverage. The
+package now spans 12 implementation lanes, reduces the high-consensus backlog
+to 311 slots, and leaves only `zstd` as a paired gap in C# and F#.
 
 Recommended family order:
 


### PR DESCRIPTION
## What changed

- add native C# and F# `fpga` packages with SRAM-backed LUTs, slices, CLBs, programmable routing, I/O blocks, immutable bitstreams, and JSON configuration
- compose each port from its lane's existing `logic-gates` and `block-ram` packages
- add package-native test suites, build metadata, capability declarations, READMEs, and changelogs
- refresh the package-parity roadmap from the live reporter

## Why

`fpga` was one of the final two high-consensus gaps in both C# and F#. This dependency-safe paired slice brings the package to 12 implementation lanes and leaves only `zstd` missing in those two lanes.

## Validation

- C#: 40 tests pass; 99.13% line coverage
- F#: 38 tests pass; 97.54% line coverage
- `dotnet format --verify-no-changes --no-restore` for the C# library and tests
- package parity report: 311 high-consensus missing slots, zero collisions, only `zstd` missing in C# and F#
- package parity reporter unit tests: 6 pass
- `git diff --check`
