### PR TITLE
feat(script-writing-visualizer): Practice mode — recall drill (sound → pick the glyph)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.2.0 — Practice mode (recall drill)
+
+- **New "Practice" mode** alongside "Browse": a recall drill that shows a
+  letter's **sound** and asks the learner to pick the matching **glyph** from
+  four options, then reveals right/wrong, shows the answer's decomposition, and
+  tracks a running **score** (correct / total / %). Recognition builds reading;
+  recall (sound → glyph) is the harder second half.
+- **Confusable distractors**: wrong answers are drawn from the same script and
+  ranked by confusability (same role / same false-friend status rank higher), so
+  the choices are meaningfully hard rather than random noise.
+- **New pure module `src/drill.ts`** — `buildDrillQuestion`, `confusabilityOrder`,
+  `checkAnswer`, and immutable scoring (`record`/`accuracy`). All randomness is
+  **injected by the UI** (target, distractor pick, answer position), so the core
+  stays deterministic; **10 new unit tests** (22 total) incl. edge cases
+  (small inventories, sloppy choosers, clamping) and a real-data check.
+- UI toggle wired in `main.ts` with vanilla DOM (still **zero runtime deps**);
+  `main.ts` holds the only `Math.random`.
+
 ## 0.1.0 — HL02 MVP: break a script apart and write it
 
 - **New app** (`script-writing-visualizer`): the companion "how to write it"

--- a/code/programs/typescript/script-writing-visualizer/README.md
+++ b/code/programs/typescript/script-writing-visualizer/README.md
@@ -47,10 +47,19 @@ npm run build      # production build to dist/
 npm run preview    # serve the production build
 ```
 
-## Scope (MVP) and what's next
+## Practice mode (recall drill)
 
-v1 is **read + decompose** only — recognition and hand-writing practice, no
-in-app handwriting capture and no scheduler. The next steps toward the full
-`HL02` spec are the **interleaving scheduler** (spaced, cross-language review)
-and **recall drills** (prompt → pick the glyph). See
+Toggle **Practice** to drill *recall*: the app shows a **sound** and you pick the
+matching **glyph** from four options. Wrong answers are the **confusable** ones
+(same role / same false-friend status), reveal shows the answer's decomposition,
+and a running **score** tracks correct / total / %. The drill logic lives in the
+pure, unit-tested `src/drill.ts` (`buildDrillQuestion`, `confusabilityOrder`,
+`checkAnswer`, scoring); all randomness is injected by the UI so the core stays
+deterministic.
+
+## Scope and what's next
+
+Today the app does **read + decompose** (Browse) and **recall** (Practice). Still
+to come toward the full `HL02` spec: the **interleaving scheduler** (spaced,
+cross-language review, measured in sessions) and a **write/produce** mode. See
 `code/specs/HL02-companion-practice-app.md`.

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Companion app (HL02 MVP): break a non-Latin script apart and learn to write it, letter by letter",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/drill.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/drill.ts
@@ -1,0 +1,143 @@
+// ---------------------------------------------------------------------------
+// drill.ts — the pure logic of the "recall" practice mode.
+//
+// Recognition is the first half of reading a script; recall is the second:
+// given a *sound*, can you produce the *glyph*? This module builds a
+// multiple-choice recall question and scores answers. Like core.ts it is
+// deterministic and DOM-free — all randomness is INJECTED by the caller (the UI
+// passes a seeded picker / position), so every function here is unit-testable
+// without a browser and without flaky Math.random.
+// ---------------------------------------------------------------------------
+
+import type { LetterView } from "./core.ts";
+
+/** One selectable answer: a glyph, tagged with the letter it came from. */
+export interface DrillOption {
+  glyph: string;
+  /** Index into the original letters array (lets the UI show its decomposition). */
+  letterIndex: number;
+}
+
+/** A single recall question: "which glyph makes this sound?" */
+export interface DrillQuestion {
+  /** The prompt shown to the learner — the target letter's sound. */
+  promptSound: string;
+  /** The correct glyph (also findable at options[answerIndex]). */
+  targetGlyph: string;
+  targetIndex: number;
+  /** The shuffled choices. */
+  options: DrillOption[];
+  /** Which option is correct. */
+  answerIndex: number;
+}
+
+/**
+ * Rank the *other* letters by how confusable they are with the target, so a
+ * question's wrong answers are meaningfully hard (not random noise). The score
+ * favours letters that share the target's role (consonant/vowel) and its
+ * false-friend status; ties keep inventory order (stable). Pure and
+ * deterministic — no randomness.
+ *
+ * Returns candidate indices, most-confusable first, excluding the target.
+ */
+export function confusabilityOrder(letters: LetterView[], targetIndex: number): number[] {
+  const target = letters[targetIndex];
+  if (!target) return [];
+  const candidates = letters
+    .map((_, i) => i)
+    .filter((i) => i !== targetIndex);
+  const score = (i: number): number => {
+    const c = letters[i]!;
+    return (c.role === target.role ? 2 : 0) + (c.falseFriend === target.falseFriend ? 1 : 0);
+  };
+  // Stable sort by score descending (Array.sort is stable in modern JS, but we
+  // tie-break on original index explicitly to be certain across engines).
+  return candidates.sort((a, b) => score(b) - score(a) || a - b);
+}
+
+/** Default distractor chooser: the top-N most-confusable, deterministically. */
+export function topDistractors(ranked: number[], count: number): number[] {
+  return ranked.slice(0, Math.max(0, count));
+}
+
+/**
+ * Build a recall question for `targetIndex`.
+ *
+ * @param optionCount  total choices to show (clamped to what's available).
+ * @param choose       picks the distractor indices from the confusability-ranked
+ *                     candidates. Defaults to the top-N; the UI can pass a
+ *                     seeded picker for variety. MUST return distinct indices,
+ *                     none equal to targetIndex.
+ * @param placeAt      where the correct answer sits among the options (injected
+ *                     so tests are deterministic and the answer isn't always
+ *                     first). Clamped into range.
+ */
+export function buildDrillQuestion(
+  letters: LetterView[],
+  targetIndex: number,
+  optionCount = 4,
+  choose: (ranked: number[], count: number) => number[] = topDistractors,
+  placeAt = 0,
+): DrillQuestion {
+  const target = letters[targetIndex];
+  if (!target) throw new RangeError(`targetIndex ${targetIndex} out of range`);
+
+  const ranked = confusabilityOrder(letters, targetIndex);
+  const wantDistractors = Math.max(0, Math.min(optionCount, letters.length) - 1);
+
+  // Take the chooser's picks, but defensively drop the target and duplicates and
+  // anything out of range, then top up from the ranked list if the chooser
+  // returned too few. This keeps the function total even for a sloppy chooser.
+  const seen = new Set<number>();
+  const distractors: number[] = [];
+  const consider = (i: number) => {
+    if (i === targetIndex || seen.has(i) || i < 0 || i >= letters.length) return;
+    seen.add(i);
+    distractors.push(i);
+  };
+  choose(ranked, wantDistractors).forEach(consider);
+  for (const i of ranked) {
+    if (distractors.length >= wantDistractors) break;
+    consider(i);
+  }
+
+  const options: DrillOption[] = distractors.map((i) => ({ glyph: letters[i]!.glyph, letterIndex: i }));
+  const at = clamp(placeAt, 0, options.length);
+  options.splice(at, 0, { glyph: target.glyph, letterIndex: targetIndex });
+
+  return {
+    promptSound: target.sound,
+    targetGlyph: target.glyph,
+    targetIndex,
+    options,
+    answerIndex: at,
+  };
+}
+
+/** True when the chosen option is the correct one. */
+export function checkAnswer(q: DrillQuestion, chosenIndex: number): boolean {
+  return chosenIndex === q.answerIndex;
+}
+
+// --- scoring ----------------------------------------------------------------
+
+export interface Score {
+  correct: number;
+  total: number;
+}
+
+export const emptyScore = (): Score => ({ correct: 0, total: 0 });
+
+/** Fold one answer into the running score (immutably). */
+export function record(score: Score, wasCorrect: boolean): Score {
+  return { correct: score.correct + (wasCorrect ? 1 : 0), total: score.total + 1 };
+}
+
+/** Percentage 0–100, or null before any answer (avoids 0/0). */
+export function accuracy(score: Score): number | null {
+  return score.total === 0 ? null : Math.round((score.correct / score.total) * 100);
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}

--- a/code/programs/typescript/script-writing-visualizer/src/main.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/main.ts
@@ -1,9 +1,11 @@
-// main.ts — the thin DOM shell. It wires the pure view-models from core.ts to
-// the page: a row of script tabs, a grid of letter tiles, and a detail panel
-// that "breaks apart" the selected letter into its pieces and stroke order.
+// main.ts — the thin DOM shell. It wires the pure view-models from core.ts and
+// drill.ts to the page. Two modes:
+//   • Browse   — a grid of letters + a "break it apart / write it" detail panel.
+//   • Practice — a recall drill: see a sound, pick the glyph, get scored.
 //
-// Deliberately framework-free vanilla DOM: an MVP a beginner can read top to
-// bottom. All the interesting logic lives in core.ts (and is unit-tested there).
+// Deliberately framework-free vanilla DOM. All the interesting logic lives in
+// core.ts / drill.ts (and is unit-tested there); the ONLY randomness lives here,
+// in the UI, so the pure modules stay deterministic and testable.
 
 import { SCRIPTS } from "./data.ts";
 import {
@@ -12,15 +14,65 @@ import {
   type LetterView,
   type ScriptSummary,
 } from "./core.ts";
+import {
+  buildDrillQuestion,
+  checkAnswer,
+  record,
+  accuracy,
+  emptyScore,
+  type DrillQuestion,
+  type Score,
+} from "./drill.ts";
 import "./styles.css";
 
 const app = document.getElementById("app");
 if (!app) throw new Error("missing #app root");
 
+type Mode = "browse" | "practice";
+let mode: Mode = "browse";
 let currentScript = 0;
 let currentLetter = 0;
 
-/** Build a tab button per script. */
+// Practice state
+let score: Score = emptyScore();
+let question: DrillQuestion | null = null;
+let chosen: number | null = null; // which option the learner picked (null = unanswered)
+
+const OPTION_COUNT = 4;
+
+// --- shared chrome ----------------------------------------------------------
+
+function renderHeader(): HTMLElement {
+  const header = el("header", "header");
+  const h1 = el("h1", "");
+  h1.textContent = "Script writing — learn it, then write it";
+  const sub = el("p", "sub");
+  sub.textContent =
+    mode === "browse"
+      ? "Pick a script and a letter to see its pieces and stroke order — for pen-and-paper practice."
+      : "Recall drill: read the sound, pick the matching letter. Wrong answers are the confusable ones.";
+  header.append(h1, sub, renderModeToggle());
+  return header;
+}
+
+function renderModeToggle(): HTMLElement {
+  const wrap = el("div", "modes");
+  (["browse", "practice"] as Mode[]).forEach((m) => {
+    const b = el("button", "mode" + (m === mode ? " mode--active" : ""));
+    b.textContent = m === "browse" ? "Browse" : "Practice";
+    b.setAttribute("aria-pressed", String(m === mode));
+    b.onclick = () => {
+      if (mode === m) return;
+      mode = m;
+      if (mode === "practice") startPractice();
+      render();
+    };
+    wrap.appendChild(b);
+  });
+  return wrap;
+}
+
+/** A tab per script (both modes). Switching script resets practice. */
 function renderTabs(): HTMLElement {
   const tabs = el("div", "tabs");
   SCRIPTS.forEach((data, i) => {
@@ -31,6 +83,7 @@ function renderTabs(): HTMLElement {
     b.onclick = () => {
       currentScript = i;
       currentLetter = 0;
+      if (mode === "practice") startPractice();
       render();
     };
     tabs.appendChild(b);
@@ -38,7 +91,8 @@ function renderTabs(): HTMLElement {
   return tabs;
 }
 
-/** The header line: what this script is, and how many letters / false friends. */
+// --- browse mode ------------------------------------------------------------
+
 function renderSummary(s: ScriptSummary): HTMLElement {
   const box = el("div", "summary");
   box.appendChild(kv("System", s.system));
@@ -53,7 +107,6 @@ function renderSummary(s: ScriptSummary): HTMLElement {
   return box;
 }
 
-/** The clickable grid of letters. */
 function renderGrid(views: LetterView[], dir: "ltr" | "rtl"): HTMLElement {
   const grid = el("div", "grid");
   grid.dir = dir;
@@ -62,7 +115,7 @@ function renderGrid(views: LetterView[], dir: "ltr" | "rtl"): HTMLElement {
     const glyph = el("span", "tile__glyph");
     glyph.textContent = v.glyph;
     const sound = el("span", "tile__sound");
-    sound.textContent = v.sound.split(/[ (]/)[0]; // the bare romanization
+    sound.textContent = bareSound(v.sound);
     tile.append(glyph, sound);
     tile.title = v.sound;
     tile.onclick = () => {
@@ -74,10 +127,8 @@ function renderGrid(views: LetterView[], dir: "ltr" | "rtl"): HTMLElement {
   return grid;
 }
 
-/** The "break it apart and write it" detail for one letter. */
 function renderDetail(v: LetterView): HTMLElement {
   const d = el("div", "detail");
-
   const head = el("div", "detail__head");
   const big = el("div", "detail__glyph");
   big.textContent = v.glyph;
@@ -96,10 +147,8 @@ function renderDetail(v: LetterView): HTMLElement {
   }
   head.append(big, meta);
   d.appendChild(head);
-
   d.appendChild(section("Break it apart — the pieces", listOf(v.components, "pieces")));
   d.appendChild(section(`Write it — stroke order (${v.strokeOrderNote})`, orderedListOf(v.strokeOrder)));
-
   if (v.notes) {
     const note = el("p", "detail__notes");
     note.textContent = v.notes;
@@ -108,28 +157,135 @@ function renderDetail(v: LetterView): HTMLElement {
   return d;
 }
 
-/** Full re-render (small enough that a rebuild-on-every-click is fine). */
-function render(): void {
-  const data = SCRIPTS[currentScript]!;
-  const views = buildScriptView(data);
-  const active = views[currentLetter] ?? views[0]!;
+// --- practice mode ----------------------------------------------------------
 
-  app!.replaceChildren();
-  const header = el("header", "header");
-  const h1 = el("h1", "");
-  h1.textContent = "Script writing — break it apart, then write it";
-  const sub = el("p", "sub");
-  sub.textContent = "Pick a script, pick a letter, and see its pieces and stroke order — for pen-and-paper practice.";
-  header.append(h1, sub);
-
-  app!.append(header, renderTabs(), renderSummary(scriptSummary(data)));
-
-  const body = el("div", "body");
-  body.append(renderGrid(views, data.direction), renderDetail(active));
-  app!.appendChild(body);
+/** Start (or restart) a practice session for the current script. */
+function startPractice(): void {
+  score = emptyScore();
+  nextQuestion();
 }
 
-// --- tiny DOM helpers (kept trivial and dependency-free) --------------------
+/** Pick a fresh random target + options for the current script. */
+function nextQuestion(): void {
+  const views = buildScriptView(SCRIPTS[currentScript]!);
+  const target = randInt(views.length);
+  const placeAt = randInt(Math.min(OPTION_COUNT, views.length));
+  // Draw distractors from the most-confusable pool, shuffled for variety.
+  question = buildDrillQuestion(views, target, OPTION_COUNT, chooseConfusableShuffled, placeAt);
+  chosen = null;
+}
+
+function renderPractice(): HTMLElement {
+  const views = buildScriptView(SCRIPTS[currentScript]!);
+  const q = question!;
+  const wrap = el("div", "practice");
+
+  // Score line
+  const acc = accuracy(score);
+  const scoreLine = el("div", "score");
+  scoreLine.textContent =
+    acc === null ? "Score: 0 / 0" : `Score: ${score.correct} / ${score.total}  ·  ${acc}%`;
+  wrap.appendChild(scoreLine);
+
+  // Prompt
+  const prompt = el("div", "prompt");
+  const label = el("div", "prompt__label");
+  label.textContent = "Which letter makes this sound?";
+  const sound = el("div", "prompt__sound");
+  sound.textContent = q.promptSound;
+  prompt.append(label, sound);
+  wrap.appendChild(prompt);
+
+  // Options
+  const opts = el("div", "options");
+  q.options.forEach((opt, i) => {
+    const b = el("button", "option");
+    b.textContent = opt.glyph;
+    if (chosen !== null) {
+      b.disabled = true;
+      if (i === q.answerIndex) b.classList.add("option--correct");
+      else if (i === chosen) b.classList.add("option--wrong");
+    }
+    b.onclick = () => {
+      if (chosen !== null) return; // already answered
+      chosen = i;
+      score = record(score, checkAnswer(q, i));
+      render();
+    };
+    opts.appendChild(b);
+  });
+  wrap.appendChild(opts);
+
+  // Reveal + next
+  if (chosen !== null) {
+    const correct = checkAnswer(q, chosen);
+    const reveal = el("div", "reveal");
+    const verdict = el("div", "reveal__verdict " + (correct ? "ok" : "no"));
+    verdict.textContent = correct
+      ? "✓ Correct"
+      : `✗ Not quite — that sound is ${q.targetGlyph}`;
+    reveal.appendChild(verdict);
+    // show the answer's decomposition, reusing the browse detail
+    reveal.appendChild(renderDetail(views[q.targetIndex]!));
+    const next = el("button", "next");
+    next.textContent = "Next →";
+    next.onclick = () => {
+      nextQuestion();
+      render();
+    };
+    reveal.appendChild(next);
+    wrap.appendChild(reveal);
+  }
+  return wrap;
+}
+
+// --- top-level render -------------------------------------------------------
+
+function render(): void {
+  const data = SCRIPTS[currentScript]!;
+  app!.replaceChildren();
+  app!.append(renderHeader(), renderTabs());
+
+  if (mode === "browse") {
+    const views = buildScriptView(data);
+    const active = views[currentLetter] ?? views[0]!;
+    app!.appendChild(renderSummary(scriptSummary(data)));
+    const body = el("div", "body");
+    body.append(renderGrid(views, data.direction), renderDetail(active));
+    app!.appendChild(body);
+  } else {
+    if (!question) startPractice();
+    app!.appendChild(renderPractice());
+  }
+}
+
+// --- helpers ----------------------------------------------------------------
+
+/** The bare romanization (drop any "(as in …)" gloss). */
+function bareSound(sound: string): string {
+  return sound.split(/[ (]/)[0] ?? sound;
+}
+
+/** UI-only randomness: an int in [0, n). Never used inside the pure modules. */
+function randInt(n: number): number {
+  return Math.floor(Math.random() * Math.max(1, n));
+}
+
+/**
+ * Distractor chooser for the UI: draw from the top of the confusability ranking
+ * (roughly twice the needed count) and shuffle, so wrong answers stay hard but
+ * vary between questions. Deterministic core stays untouched — this is the
+ * seeded/random layer.
+ */
+function chooseConfusableShuffled(ranked: number[], count: number): number[] {
+  const poolSize = Math.min(ranked.length, Math.max(count, count * 2));
+  const pool = ranked.slice(0, poolSize);
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j]!, pool[i]!];
+  }
+  return pool.slice(0, count);
+}
 
 function el(tag: string, className: string): HTMLElement {
   const node = document.createElement(tag);

--- a/code/programs/typescript/script-writing-visualizer/src/styles.css
+++ b/code/programs/typescript/script-writing-visualizer/src/styles.css
@@ -104,3 +104,66 @@ body {
 .strokes li { margin: 3px 0; }
 .detail__notes { margin: 0; }
 .muted { color: var(--muted); font-style: italic; }
+
+/* --- mode toggle + practice mode ---------------------------------------- */
+.modes { display: flex; gap: 6px; margin-top: 10px; }
+.mode {
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  padding: 5px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+.mode--active { background: var(--ink); color: #fff; border-color: var(--ink); }
+
+.practice { max-width: 560px; }
+.score { color: var(--muted); font-size: 0.9rem; margin-bottom: 14px; }
+
+.prompt {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 22px;
+  text-align: center;
+  margin-bottom: 16px;
+}
+.prompt__label { color: var(--muted); font-size: 0.85rem; margin-bottom: 8px; }
+.prompt__sound { font-size: 1.8rem; font-weight: 700; }
+
+.options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 10px;
+}
+.option {
+  font-size: 2.4rem;
+  line-height: 1;
+  padding: 18px 8px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  cursor: pointer;
+}
+.option:hover:not(:disabled) { border-color: var(--accent); }
+.option:disabled { cursor: default; }
+.option--correct { background: #e6f6ec; border-color: #38a169; }
+.option--wrong { background: #fdecea; border-color: #e05353; }
+
+.reveal { margin-top: 18px; }
+.reveal__verdict { font-weight: 700; margin-bottom: 10px; }
+.reveal__verdict.ok { color: #2f855a; }
+.reveal__verdict.no { color: #c53030; }
+.next {
+  margin-top: 12px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  padding: 8px 18px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/drill.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/drill.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  confusabilityOrder,
+  topDistractors,
+  buildDrillQuestion,
+  checkAnswer,
+  emptyScore,
+  record,
+  accuracy,
+} from "../src/drill.ts";
+import type { LetterView } from "../src/core.ts";
+import { buildScriptView } from "../src/core.ts";
+import { SCRIPTS } from "../src/data.ts";
+
+function lv(glyph: string, over: Partial<LetterView> = {}): LetterView {
+  return {
+    glyph,
+    sound: glyph,
+    role: "consonant",
+    components: [],
+    strokeOrder: [],
+    strokeOrderNote: "",
+    notes: "",
+    falseFriend: false,
+    strokeCount: 0,
+    ...over,
+  };
+}
+
+// a=target(consonant, ff), b=consonant ff, c=consonant, d=vowel, e=vowel ff
+const LETTERS: LetterView[] = [
+  lv("a", { sound: "ah", role: "consonant", falseFriend: true }),
+  lv("b", { role: "consonant", falseFriend: true }),
+  lv("c", { role: "consonant", falseFriend: false }),
+  lv("d", { role: "vowel", falseFriend: false }),
+  lv("e", { role: "vowel", falseFriend: true }),
+];
+
+describe("confusabilityOrder", () => {
+  it("ranks same-role + same-false-friend highest, excludes the target, stable on ties", () => {
+    const order = confusabilityOrder(LETTERS, 0); // target 'a': consonant + ff
+    expect(order).not.toContain(0); // target excluded
+    // b (consonant+ff) is the best match → first
+    expect(order[0]).toBe(1);
+    // c (consonant, not-ff) beats the vowels
+    expect(order[1]).toBe(2);
+    // e (vowel but shares false-friend=true) outranks d (vowel, not-ff)
+    expect(order).toEqual([1, 2, 4, 3]); // full deterministic order
+  });
+
+  it("returns empty for an out-of-range target", () => {
+    expect(confusabilityOrder(LETTERS, 99)).toEqual([]);
+  });
+});
+
+describe("buildDrillQuestion", () => {
+  it("prompts with the sound and places the answer at placeAt", () => {
+    const q = buildDrillQuestion(LETTERS, 0, 4, topDistractors, 2);
+    expect(q.promptSound).toBe("ah");
+    expect(q.targetGlyph).toBe("a");
+    expect(q.options).toHaveLength(4);
+    expect(q.answerIndex).toBe(2);
+    expect(q.options[q.answerIndex]!.glyph).toBe("a");
+    expect(checkAnswer(q, 2)).toBe(true);
+    expect(checkAnswer(q, 0)).toBe(false);
+  });
+
+  it("fills distractors from the most-confusable first", () => {
+    const q = buildDrillQuestion(LETTERS, 0, 4, topDistractors, 0);
+    const distractorGlyphs = q.options.filter((_, i) => i !== q.answerIndex).map((o) => o.glyph);
+    expect(distractorGlyphs).toEqual(["b", "c", "e"]); // top-3 confusable (b,c,e — e shares ff)
+    expect(distractorGlyphs).not.toContain("a"); // never the target
+  });
+
+  it("never includes the target among distractors and never duplicates", () => {
+    // a sloppy chooser that returns the target + a duplicate + out-of-range
+    const q = buildDrillQuestion(LETTERS, 0, 4, () => [0, 1, 1, 99], 0);
+    const glyphs = q.options.map((o) => o.glyph);
+    expect(new Set(glyphs).size).toBe(glyphs.length); // no dupes
+    const nonAnswer = q.options.filter((_, i) => i !== q.answerIndex);
+    expect(nonAnswer.every((o) => o.letterIndex !== 0)).toBe(true); // no target
+    expect(q.options).toHaveLength(4); // topped up to the requested count
+  });
+
+  it("clamps optionCount to the available letters (small inventory)", () => {
+    const two = LETTERS.slice(0, 2);
+    const q = buildDrillQuestion(two, 0, 4, topDistractors, 0);
+    expect(q.options).toHaveLength(2); // only 2 letters exist
+    expect(q.options.map((o) => o.glyph).sort()).toEqual(["a", "b"]);
+  });
+
+  it("clamps placeAt into range", () => {
+    const q = buildDrillQuestion(LETTERS, 0, 3, topDistractors, 99);
+    expect(q.answerIndex).toBe(q.options.length - 1);
+    expect(q.options[q.answerIndex]!.glyph).toBe("a");
+  });
+
+  it("throws on an out-of-range target", () => {
+    expect(() => buildDrillQuestion(LETTERS, 99)).toThrow(RangeError);
+  });
+});
+
+describe("scoring", () => {
+  it("accumulates correct/total immutably and computes accuracy", () => {
+    let s = emptyScore();
+    expect(accuracy(s)).toBeNull(); // no answers yet → not 0/0
+    s = record(s, true);
+    s = record(s, false);
+    s = record(s, true);
+    expect(s).toEqual({ correct: 2, total: 3 });
+    expect(accuracy(s)).toBe(67);
+  });
+});
+
+describe("with real script data", () => {
+  it("builds a valid Cyrillic question with 4 distinct options containing the answer", () => {
+    const cyr = buildScriptView(SCRIPTS.find((s) => s.script === "cyrillic")!);
+    const q = buildDrillQuestion(cyr, 2, 4, topDistractors, 1); // в
+    expect(q.options).toHaveLength(4);
+    expect(new Set(q.options.map((o) => o.glyph)).size).toBe(4);
+    expect(q.options[q.answerIndex]!.glyph).toBe(q.targetGlyph);
+    expect(checkAnswer(q, q.answerIndex)).toBe(true);
+  });
+});

--- a/code/programs/typescript/script-writing-visualizer/vitest.config.ts
+++ b/code/programs/typescript/script-writing-visualizer/vitest.config.ts
@@ -6,9 +6,9 @@ export default defineConfig({
     globals: true,
     coverage: {
       provider: "v8",
-      // The pure logic in core.ts is what we hold to a high bar; main.ts is the
-      // thin DOM shell and data.ts is just JSON imports.
-      include: ["src/core.ts"],
+      // The pure logic (core.ts + drill.ts) is what we hold to a high bar;
+      // main.ts is the thin DOM shell and data.ts is just JSON imports.
+      include: ["src/core.ts", "src/drill.ts"],
     },
   },
 });


### PR DESCRIPTION
## Companion app — Practice (recall drill) mode

Loop item 5. Adds a second mode to `script-writing-visualizer` (bumped to 0.2.0),
the first *practice* slice of HL02. Browse teaches recognition; **Practice drills
recall** — the harder half of reading a script.

### What it does
- Toggle **Practice**: the app shows a letter's **sound** and you pick the matching
  **glyph** from four options → reveal marks right/wrong, shows the answer's
  decomposition (reusing the Browse detail), and a running **score** tracks
  correct / total / %.
- **Confusable distractors**: wrong answers come from the same script, ranked by
  confusability (same role / same false-friend status rank higher), so the choices
  are meaningfully hard — not random noise. (For Cyrillic, the false-friend traps
  в/р/с/н naturally show up as each other's distractors.)

### Design (matches the app's existing split)
- **New pure module `src/drill.ts`** — `buildDrillQuestion`, `confusabilityOrder`,
  `checkAnswer`, immutable scoring (`record`/`accuracy`). **All randomness is
  injected by the UI** (target, distractor pick, answer position), so the core is
  deterministic and fully testable.
- **10 new unit tests (22 total)** — edge cases (small inventories, a deliberately
  sloppy chooser returning the target/dupes/out-of-range, placeAt clamping) plus a
  real-Cyrillic-data check.
- UI toggle in `main.ts` (vanilla DOM, **still zero runtime deps**; `main.ts` holds
  the only `Math.random`).

### Verified
- `npm run build` + **22 tests** pass. Drove Practice in the browser: prompt "b" →
  options к д з б → picked б → **✓ Correct, score 1/1 · 100%**, decomposition
  revealed; **console clean**. Security review passed (safe DOM sinks only, no eval/
  innerHTML, no new deps).

### Next (HL02)
The interleaving scheduler (spaced, cross-language, session-based) and a
write/produce mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
