### PR TITLE
feat(sql): hexadecimal integer literals (0x1F)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.54 — Hexadecimal integer literals
+
+`SELECT 0x1F` now works (was a parse error). SQLite hex integer literals like
+`0x1F` (= 31), `0X10` (= 16), and `0xff` (= 255) are recognised as INTEGERs
+(`typeof(0x1F)` = `'integer'`). They decode as a 64-bit value that wraps, so
+`0x7FFFFFFFFFFFFFFF` is `i64::MAX` and `0xFFFFFFFFFFFFFFFF` is -1, matching
+SQLite. Hex literals compose in arithmetic and predicates like any integer
+(`v + 0x10`, `WHERE v = 0x1F`). More than 16 hex digits overflows 64 bits and is
+rejected, as SQLite does ("hex literal too big"). Implemented by a new `HEX_INT`
+token in `sql-lexer` (matched before `NUMBER` so the whole `0x…` is one token,
+aliased to `NUMBER` so no parser rule changed) plus `0x`-prefix decoding in the
+`sql-planner` number-literal decoder. Verified against the bundled real SQLite in
+the differential oracle.
+
 ## 0.5.53 — GROUP_CONCAT aggregate
 
 `SELECT group_concat(x) FROM t` now works (was "unknown built-in function"). It

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.53"
+version = "0.5.54"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -792,6 +792,33 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id FROM t WHERE v < 2.5e0 OR v = 3e2 ORDER BY id",
     },
+    // Hexadecimal integer literals: `0x1F` (= 31), `0X10` (= 16), `0xff` (= 255).
+    // SQLite reads these as INTEGERs (`typeof(0x1F)` = 'integer'), decoded as a
+    // 64-bit value that wraps, so `0xFFFFFFFFFFFFFFFF` is -1 and
+    // `0x7FFFFFFFFFFFFFFF` is i64::MAX. Previously the lexer had no hex rule, so
+    // `0x1F` tokenised as `0` + `x1F` (a NAME) and failed to parse.
+    Case {
+        id: "hex_integer_literals",
+        setup: &[],
+        query: "SELECT 0x1F AS a, 0X10 AS b, 0xff AS c, 0x0 AS d, typeof(0x1F) AS e, 0xff + 1 AS f",
+    },
+    // 64-bit wrap edge cases: the full 16-digit hex range. `0x7FFF…` is the
+    // largest positive i64; `0xFFFF…FF` wraps to -1; `0x8000…00` is i64::MIN.
+    Case {
+        id: "hex_integer_wrap",
+        setup: &[],
+        query: "SELECT 0x7FFFFFFFFFFFFFFF AS a, 0xFFFFFFFFFFFFFFFF AS b, 0x8000000000000000 AS c",
+    },
+    // Hex literals compose in arithmetic and predicates like any integer. Exercises
+    // a hex literal in a WHERE comparison and in the SELECT list arithmetic.
+    Case {
+        id: "hex_integer_in_query",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, v INTEGER)",
+            "INSERT INTO t VALUES (1, 15), (2, 31), (3, 255)",
+        ],
+        query: "SELECT id, v + 0x10 AS w FROM t WHERE v = 0x1F ORDER BY id",
+    },
     // A doubled single quote (`''`) inside a string literal is SQL's escape for
     // one literal quote — `'it''s'` is the 4-character string `it's`. Exercises
     // string literals in the SELECT list AND in an INSERT'd row value.

--- a/code/packages/rust/sql-lexer/CHANGELOG.md
+++ b/code/packages/rust/sql-lexer/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - Unreleased
+
+### Added
+
+- **Hexadecimal integer-literal token `HEX_INT`.** A new token
+  `HEX_INT = /0[xX][0-9A-Fa-f]+/ -> NUMBER` recognises SQLite hex integers like
+  `0x1F`, `0X10`, and `0xff`. It is placed **before** `NUMBER` so first-match-wins
+  takes the whole `0x…` literal — otherwise `NUMBER` would consume the leading `0`
+  and leave `x1F` to mis-lex as a `NAME` (the previous behaviour, which made
+  `SELECT 0x1F` a parse error). It aliases to `NUMBER`, so it flows through the
+  existing grammar with no new parser rule; the planner's number-literal decoder
+  recognises the `0x` prefix and decodes it as a 64-bit value (see `sql-planner`).
+  A bare `0` (no `x`) still lexes as an ordinary `NUMBER` — the `[xX]` is
+  mandatory. The pattern has no nested quantifier over an overlapping class, so
+  there is no catastrophic-backtracking (ReDoS) risk.
+
 ## [0.1.4] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-lexer/Cargo.toml
+++ b/code/packages/rust/sql-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-lexer"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "SQL lexer — tokenizes SQL source text using the grammar-driven lexer and the sql.tokens grammar file"
 

--- a/code/packages/rust/sql-lexer/src/_grammar.rs
+++ b/code/packages/rust/sql-lexer/src/_grammar.rs
@@ -35,6 +35,24 @@ pub fn token_grammar() -> TokenGrammar {
                 line_number: 17,
                 alias: None,
             },
+            // A hexadecimal integer literal: `0x` / `0X` followed by one or more
+            // hex digits, e.g. `0x1F` (= 31) or `0xff` (= 255). SQLite treats
+            // these as INTEGERs (`typeof(0x1F)` is `'integer'`), decoded as a
+            // 64-bit value that wraps — `0xFFFFFFFFFFFFFFFF` is -1. This MUST come
+            // BEFORE `NUMBER`: the lexer takes the first matching token in order,
+            // and `NUMBER` would otherwise consume just the leading `0`, leaving
+            // `x1F` to tokenise as a separate NAME. Aliased to `NUMBER` so it flows
+            // through the existing grammar with no new parser rule; the planner's
+            // number-literal decoder recognises the `0x` prefix and decodes it as
+            // hex (see `sql-planner`). A bare `0` (no `x`) still falls through to
+            // `NUMBER`, since the `[xX]` here is mandatory.
+            TokenDefinition {
+                name: r#"HEX_INT"#.to_string(),
+                pattern: r#"0[xX][0-9A-Fa-f]+"#.to_string(),
+                is_regex: true,
+                line_number: 18,
+                alias: Some(r#"NUMBER"#.to_string()),
+            },
             TokenDefinition {
                 name: r#"NUMBER"#.to_string(),
                 // A numeric literal: an integer or decimal part, followed by an

--- a/code/packages/rust/sql-lexer/src/lib.rs
+++ b/code/packages/rust/sql-lexer/src/lib.rs
@@ -251,6 +251,39 @@ mod tests {
         assert_eq!(pairs[0].1, "3.14");
     }
 
+    /// Hexadecimal integer literals `0x1F` / `0X10` lex as a single NUMBER token
+    /// carrying the original `0x…` text (the planner decodes the prefix). The
+    /// `HEX_INT` rule is aliased to `NUMBER`, so the emitted `type_` is `Number`.
+    /// Crucially the whole `0x1F` is one token — without the rule (which must sit
+    /// *before* `NUMBER`) the leading `0` alone would match and leave `x1F` as a
+    /// separate NAME.
+    ///
+    /// | Input                | type_  | value                |
+    /// |----------------------|--------|----------------------|
+    /// | "0x1F"               | Number | "0x1F"               |
+    /// | "0X10"               | Number | "0X10"               |
+    /// | "0xff"               | Number | "0xff"               |
+    /// | "0xFFFFFFFFFFFFFFFF" | Number | "0xFFFFFFFFFFFFFFFF" |
+    #[test]
+    fn test_number_hex() {
+        for input in &["0x1F", "0X10", "0xff", "0xFFFFFFFFFFFFFFFF"] {
+            let pairs = lex(input);
+            assert_eq!(pairs.len(), 1, "{input} should be a single token");
+            assert_eq!(pairs[0].0, TokenType::Number, "{input} type");
+            assert_eq!(pairs[0].1, *input, "{input} value preserved verbatim");
+        }
+    }
+
+    /// A bare `0` (no `x`) still lexes as an ordinary NUMBER — the `[xX]` in the
+    /// hex rule is mandatory, so it never swallows a plain zero.
+    #[test]
+    fn test_number_bare_zero_not_hex() {
+        let pairs = lex("0");
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, TokenType::Number);
+        assert_eq!(pairs[0].1, "0");
+    }
+
     // -----------------------------------------------------------------------
     // Test 5: STRING token (single-quoted, quotes stripped)
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.25] - Unreleased
+
+### Added
+
+- **Hexadecimal integer literals (`0x1F`).** The number-literal decoder in
+  `plan_primary_token` now recognises a `0x` / `0X` prefix and decodes the hex
+  digits as a 64-bit value that wraps: `0x1F` → 31, `0x7FFFFFFFFFFFFFFF` →
+  `i64::MAX`, and `0xFFFFFFFFFFFFFFFF` → -1 (parsed as `u64` then bit-cast to
+  `i64`, matching SQLite — an `i64` parse would reject values above `i64::MAX`).
+  These are always INTEGERs (`typeof(0x1F)` = `'integer'`). More than 16 hex
+  digits overflows 64 bits; SQLite rejects that at prepare time ("hex literal too
+  big"), so we return a `PlanError::UnsupportedStatement` rather than silently
+  falling through to a (nonsensical) column reference — a hex token always starts
+  with a digit, so it can never legitimately be a column name. Pairs with the new
+  `HEX_INT` token in `sql-lexer` (aliased to `NUMBER`, so no parser rule changed).
+
 ## [0.2.24] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.24"
+version = "0.2.25"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -3109,6 +3109,26 @@ fn plan_primary_token(tok: &Token) -> Result<SqlExpr, PlanError> {
         return decode_blob_literal(val).map(|bytes| SqlExpr::Literal(SqlValue::Blob(bytes)));
     }
 
+    // Hexadecimal integer literal `0x1F` / `0X1F` (lexed by `HEX_INT`, aliased to
+    // `NUMBER`). SQLite decodes these as 64-bit INTEGERs that wrap: the hex digits
+    // are read as an unsigned 64-bit value and reinterpreted as `i64`, so `0x1F`
+    // is 31, `0x7FFFFFFFFFFFFFFF` is `i64::MAX`, and `0xFFFFFFFFFFFFFFFF` is -1.
+    // Parsing as `u64` (not `i64`) before the `as i64` bit-cast is what admits the
+    // full unsigned range — `i64::from_str_radix` would reject anything above
+    // `i64::MAX`. A hex literal always starts with a digit, so this branch can
+    // never shadow a column reference. More than 16 hex digits overflows 64 bits;
+    // SQLite rejects that at prepare time ("hex literal too big"), so we surface a
+    // plan error rather than silently falling through to a (nonsensical) column
+    // reference — the leading `0x` guarantees this token is a number, not a name.
+    if let Some(hex) = val.strip_prefix("0x").or_else(|| val.strip_prefix("0X")) {
+        return match u64::from_str_radix(hex, 16) {
+            Ok(u) => Ok(SqlExpr::Literal(SqlValue::Int(u as i64))),
+            Err(_) => Err(PlanError::UnsupportedStatement(format!(
+                "hex literal too big: {val}"
+            ))),
+        };
+    }
+
     // NUMBER literal: try integer first, then float.
     if let Ok(i) = val.parse::<i64>() {
         return Ok(SqlExpr::Literal(SqlValue::Int(i)));
@@ -4233,6 +4253,57 @@ mod tests {
         assert_eq!(decode_blob_literal("0a0B").unwrap(), vec![0x0A, 0x0B]);
         // Odd digit count is rejected (matches SQLite's tokenizer error).
         assert!(decode_blob_literal("x'012'").is_err());
+    }
+
+    #[test]
+    fn test_expr_hex_integer_literal() {
+        // `0x1F` → 31; `0X10` → 16 (upper-case prefix). Decoded as INTEGER.
+        for (sql, want) in &[
+            ("SELECT * FROM t WHERE x = 0x1F", 31_i64),
+            ("SELECT * FROM t WHERE x = 0X10", 16),
+            ("SELECT * FROM t WHERE x = 0xff", 255),
+            ("SELECT * FROM t WHERE x = 0x0", 0),
+        ] {
+            let expr = plan_where_expr(sql);
+            if let SqlExpr::BinaryOp { right, .. } = expr {
+                assert_eq!(*right, SqlExpr::Literal(SqlValue::Int(*want)), "{sql}");
+            } else {
+                panic!("Expected EQ comparison for {sql}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_expr_hex_integer_wraps_64bit() {
+        // SQLite reads hex as a 64-bit value that wraps: all-ones is -1, and the
+        // sign bit set is i64::MIN. Parsing as u64 then bit-casting to i64 is what
+        // reproduces this (an i64 parse would reject values above i64::MAX).
+        for (sql, want) in &[
+            ("SELECT * FROM t WHERE x = 0x7FFFFFFFFFFFFFFF", i64::MAX),
+            ("SELECT * FROM t WHERE x = 0xFFFFFFFFFFFFFFFF", -1),
+            ("SELECT * FROM t WHERE x = 0x8000000000000000", i64::MIN),
+        ] {
+            let expr = plan_where_expr(sql);
+            if let SqlExpr::BinaryOp { right, .. } = expr {
+                assert_eq!(*right, SqlExpr::Literal(SqlValue::Int(*want)), "{sql}");
+            } else {
+                panic!("Expected EQ comparison for {sql}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_expr_hex_integer_too_big_errors() {
+        // More than 16 hex digits overflows 64 bits; SQLite rejects it at prepare
+        // time ("hex literal too big"). We surface a plan error rather than
+        // silently treating the token as a column reference.
+        let err = plan_err("SELECT * FROM t WHERE x = 0x1FFFFFFFFFFFFFFFF");
+        match err {
+            PlanError::UnsupportedStatement(msg) => {
+                assert!(msg.contains("hex literal too big"), "got: {msg}");
+            }
+            other => panic!("Expected UnsupportedStatement, got: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds **hexadecimal integer literals** (`0x1F`) to mini-sqlite. `SELECT 0x1F` was previously a parse error; now hex integers work end-to-end and match real SQLite.

- `0x1F` → 31, `0X10` → 16, `0xff` → 255 — all INTEGERs (`typeof(0x1F)` = `'integer'`)
- 64-bit wrap semantics: `0x7FFFFFFFFFFFFFFF` = `i64::MAX`, `0xFFFFFFFFFFFFFFFF` = -1, `0x8000000000000000` = `i64::MIN`
- Compose in arithmetic and predicates like any integer: `v + 0x10`, `WHERE v = 0x1F`
- \>16 hex digits overflow 64 bits → rejected as SQLite does ("hex literal too big"), not silently mis-decoded

## How

- **sql-lexer**: new `HEX_INT` token `0[xX][0-9A-Fa-f]+`, ordered **before** `NUMBER` so first-match-wins takes the whole `0x…` literal (otherwise `NUMBER` grabs the leading `0` and `x1F` mis-lexes as a `NAME`). Aliased to `NUMBER`, so it flows through the existing grammar with **no new parser rule**.
- **sql-planner**: the number-literal decoder in `plan_primary_token` recognises a `0x`/`0X` prefix and decodes the digits as `u64` then bit-casts to `i64` (an `i64` parse would reject values above `i64::MAX`). A hex token always starts with a digit, so this branch can never shadow a column reference.

## Tests

- 3 new **differential-oracle** cases (basic, 64-bit wrap edges, in-query arithmetic/predicate) — verified against the bundled real SQLite.
- Lexer unit tests: hex token (incl. `0X` upper + full 16-digit value), bare-`0`-not-hex.
- Planner unit tests: decode, 64-bit wrap, too-big error path.
- All affected suites green (28→30 lexer, 75→78 planner, oracle + mini-sqlite).

## Security

Inline security review: **clean** — no panicking path (`from_str_radix`→Err on overflow, `as i64` is a bit-cast), no ReDoS (no nested quantifiers), no column-ref shadowing (only `HEX_INT` produces `0x…` values; NAMEs can't start with a digit).

Version bumps: sql-lexer 0.1.4→0.1.5, sql-planner 0.2.24→0.2.25, mini-sqlite 0.5.53→0.5.54 (+ CHANGELOGs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
