### PR TITLE
feat(hl-spanish): Chapter 7 — the -er/-ir present tense + first questions (¿Qué comes? ¿Dónde vives?)

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -117,6 +117,7 @@
 
     "QUESTION-WHAT": { "family": "QUESTION", "gloss": "what", "core": true, "retires": ["WHAT"] },
     "QUESTION-HOW": { "family": "QUESTION", "gloss": "how", "core": false, "retires": ["HOW"] },
+    "QUESTION-WHERE": { "family": "QUESTION", "gloss": "where", "core": false, "retires": ["WHERE"] },
 
     "INTRO-MY-NAME-IS": {
       "family": "INTRO",
@@ -200,6 +201,9 @@
       "ES-VERB-TRABAJAR": "trabajar — 'to work' (← tripaliāre 'to torture' → travail/travel)",
       "ES-VERB-ESTUDIAR": "estudiar — 'to study' (← studēre 'to be eager' → student)",
       "ES-WORD-ESPANOL": "español — 'Spanish' (the language; ← Hispania)",
+      "ES-VERB-COMER": "comer — 'to eat' (first -er verb; ← comedere → edible)",
+      "ES-VERB-VIVIR": "vivir — 'to live' (first -ir verb; ← vīvere → vivid/survive)",
+      "ES-VERB-BEBER": "beber — 'to drink' (-er; ← bibere → beverage/imbibe)",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Chapter 7 — The rest of the present tense, and the first questions
+
+- **Chapter 7 authored** (`ES-C07-comer`, `-vivir`, `-beber`, `-que`, `-donde`,
+  `-practice`): completes the **regular present tense** and starts **asking
+  questions** — the learner can now hold a real back-and-forth.
+- **The -er and -ir families**: *comer* (← *comedere* → edible/comestible) teaches
+  the *-o/-es/-e* endings; *vivir* (← *vīvere* → vivid/survive/revive) shows *-ir*
+  is **identical to -er in the singular**; *beber* (← *bibere* → beverage/imbibe)
+  cements it. The three-family table (*hablo/como/vivo*) makes the whole system
+  visible: *-ar* → -o/-as/-a, *-er*/*-ir* → -o/-es/-e.
+- **First question words**: *qué* (← *quid* → quiddity/quid-pro-quo) and *dónde*
+  (← *de unde* "from whence"), both wearing the **accent** (diacrítica) and opening
+  with **¿** — reusing the writing chapter. Real questions land: *¿Qué comes?*,
+  *¿Dónde vives?*, with the first preposition *en* in the answers.
+- **Taxonomy**: canonical `QUESTION-WHERE` (`core:false`) added alongside
+  `QUESTION-WHAT`; namespaced `ES-VERB-COMER/VIVIR/BEBER` documented.
+
 ## Chapter 6 — Please, and the first verbs (sentences start to move)
 
 - **Chapter 6 authored** (`ES-C06-por-favor`, `-hablar`, `-trabajar`,

--- a/code/learning/human-languages/spanish/lessons/ES-C07-beber.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-beber.md
@@ -1,0 +1,63 @@
+---
+id: ES-C07-beber
+chapter: 7
+type: word
+headword: beber
+gloss: to drink (another -er verb — cementing the pattern)
+concept_tag: ES-VERB-BEBER
+prerequisites: [ES-C07-comer]
+sounds: [v-b, r-tap]
+roots: [bibere-latin]
+etymology_hook: "beber ← Latin bibere 'to drink' → English beverage, imbibe, bibulous, bib"
+est_minutes: 3
+reviews_of: [ES-C07-comer, ES-C07-vivir]
+---
+
+# beber — "to drink," and the pattern is yours
+
+## Warm-up
+
+[PAUSE 2s] One more **-er** verb to make the pattern automatic — **beber**, "to
+drink." Pair it with *comer* and you can talk about eating and drinking, the
+heart of any café or restaurant.
+
+## Sounds you'll need
+
+- `v-b` — both *b*'s are the soft Spanish *b*: *be-**BER***.
+
+## The word, taken apart
+
+**beber** comes from Latin **bibere**, *"to drink"* — a thirsty little root that
+soaked into English:
+
+- **beverage** — a drink (via Old French *bevrage*, from *bibere*).
+- **imbibe** — to drink in (*in-* + *bibere*).
+- **bibulous** — fond of drinking; **bib** — the cloth that catches drips; even
+  **beer**'s cousins hover nearby.
+
+## Grammar Lens: no new grammar — that's the point
+
+*beber* is a regular **-er** verb, so it takes the endings you already own:
+
+| yo | **bebo** | I drink |
+| tú | **bebes** | you drink |
+| él/ella/usted | **bebe** | he/she drinks / you (formal) drink |
+
+Nothing new to learn — you're just *reusing the machine*. Now you can say:
+
+> **Como** pan y **bebo** agua. — "I eat bread and drink water."
+
+Two verbs, two nouns, one sentence you built yourself.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "beber" — *be-BER*]
+- [YOU SAY: "bebo, bebes, bebe" — the familiar *-o/-es/-e*]
+- [YOU SAY: "Como y bebo" — "I eat and drink"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *beber* from, and its English cousins? (*bibere* —
+beverage, imbibe.) Did *beber* need any new endings? (No — it's a regular *-er*
+verb.) Say "I drink." (*Bebo*.) Next: start **asking** — *qué*, "what?"

--- a/code/learning/human-languages/spanish/lessons/ES-C07-comer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-comer.md
@@ -1,0 +1,70 @@
+---
+id: ES-C07-comer
+chapter: 7
+type: word
+headword: comer
+gloss: to eat (your first -er verb)
+concept_tag: ES-VERB-COMER
+prerequisites: [ES-C06-hablar]
+sounds: [r-tap, vowel-o]
+roots: [comedere-latin]
+etymology_hook: "comer ← Latin comedere 'to eat up' (com- + edere 'eat') → English edible, comestible"
+est_minutes: 5
+reviews_of: [ES-C06-hablar, ES-C06-practice]
+---
+
+# comer — "to eat," and the second verb family
+
+## Warm-up
+
+[PAUSE 2s] Last chapter you learned the **-ar** verbs. Spanish has two more
+families — **-er** and **-ir** — and here's the good news: they're **almost the
+same**. Meet **comer** ("to eat"), your first **-er** verb.
+
+## Sounds you'll need
+
+- `r-tap` — one soft tap: *ko-**MER***.
+- The *c* before *o* is a hard *k*: *comer* = *ko-MER*.
+
+## The word, taken apart
+
+**comer** comes from Latin **comedere**, *"to eat up"* — **com-** (intensifier,
+"completely") + **edere**, "to eat." That **edere** is the twin of English **eat**
+(both from the same ancient root), and it feeds a small English family:
+
+- **edible** — fit to be eaten.
+- **comestible** — a fancy word for food (straight from *comedere*).
+- English **eat** itself — the Germanic cousin of Latin *edere*.
+
+## Grammar Lens: the -er present tense
+
+The pattern is the **-ar** one with the *a*'s swapped for *e*'s. Drop **-er**, add:
+
+| person | -ar was | **-er** is | *comer* → |
+|---|---|---|---|
+| yo | -o | **-o** | **como** (I eat) |
+| tú | -as | **-es** | **comes** (you eat) |
+| él/ella/usted | -a | **-e** | **come** (he/she eats) |
+| (nosotros) | -amos | -emos | comemos |
+| (ellos/ustedes) | -an | -en | comen |
+
+So the **yo** form is identical (**-o**), and *tú*/*él* just trade *a* for *e*:
+*hablas/habla* → *comes/come*. If you know *-ar*, you already 90% know *-er*.
+
+> ⚠️ Watch the false friend: **como** means "I eat" **and** "like/as" (*como tú*,
+> "like you") **and**, with an accent, **cómo** = "how?". Same four letters,
+> three jobs — the accent and context sort them out.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "comer" — *ko-MER*]
+- [YOU SAY: "como, comes, come" — note the *-o/-es/-e* endings]
+- [YOU SAY: "comer" then English "edible, comestible, eat" — the *edere* family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *comer* from, and its English cousins? (*comedere*
+← *edere* — edible, eat.) What are the three singular *-er* endings? (*-o / -es /
+-e*.) How do they differ from *-ar*? (Only the vowel: *a* → *e*.) Next: your
+first **-ir** verb, *vivir*.

--- a/code/learning/human-languages/spanish/lessons/ES-C07-donde.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-donde.md
@@ -1,0 +1,62 @@
+---
+id: ES-C07-donde
+chapter: 7
+type: word
+headword: dónde
+gloss: where?
+concept_tag: QUESTION-WHERE
+prerequisites: [ES-C07-que, ES-C07-vivir]
+sounds: [d-soft, accent-mark]
+roots: [de-unde-latin]
+etymology_hook: "dónde ← Latin de unde 'from where' (unde 'whence'); the accent marks the question"
+est_minutes: 3
+reviews_of: [ES-C07-que, ES-C07-vivir]
+---
+
+# dónde — "where?"
+
+## Warm-up
+
+[PAUSE 2s] A second question word, and a second real question you can build:
+**dónde**, "where?" Pair it with *vivir* and you can ask the single most common
+getting-to-know-you question: *where do you live?*
+
+## Sounds you'll need
+
+- `d-soft` — the middle *d* is soft, near the *th* of *this*: *DON-deh*.
+- `accent-mark` — like *qué*, the **accent on *ó*** marks the question word
+  (*dónde* = "where?"; *donde* without = "where," a relative — "the place *where*").
+
+## The word, taken apart
+
+**dónde** comes from Latin **de unde**, literally *"from whence."* *unde* meant
+"from where," and Spanish glued *de* onto the front and wore the pair down to
+*dónde*. (English once had the matching set *whence / where / whither* — "from
+where / at where / to where"; Spanish keeps that flavour in *de dónde* "from
+where", *dónde* "where", *adónde* "to where".)
+
+## Grammar Lens: your first getting-to-know-you questions
+
+Two question words + verbs you own = real conversation:
+
+> **¿Dónde vives?** — "Where do you live?" → *Vivo en Madrid.*
+> **¿Dónde trabajas?** — "Where do you work?"
+> **¿Qué estudias?** — "What do you study?"
+
+Notice the little **en** ("in," ← Latin *in*) in the answer — the first
+preposition, slipping in exactly where you need it. You're now trading real
+questions and answers, not fixed phrases.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "dónde" — *DON-deh*, soft *d*]
+- [YOU SAY: "¿Dónde vives?" — "Where do you live?"]
+- [YOU SAY: answer — "Vivo en …" with your city]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin phrase is *dónde* from, and what did it mean? (*De unde* —
+"from whence.") Why the accent? (It marks the *question* word.) Ask "where do you
+live?" and answer it. (*¿Dónde vives? — Vivo en …*) Next: put the questions and
+verbs together in practice.

--- a/code/learning/human-languages/spanish/lessons/ES-C07-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-practice.md
@@ -1,0 +1,67 @@
+---
+id: ES-C07-practice
+chapter: 7
+type: practice-mix
+headword: (practice)
+gloss: asking and answering — the full present tense in real questions
+concept_tag: CH7-PRACTICE
+prerequisites: [ES-C07-comer, ES-C07-vivir, ES-C07-beber, ES-C07-que, ES-C07-donde]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C07-comer, ES-C07-vivir, ES-C07-que, ES-C07-donde, ES-C06-practice]
+---
+
+# Practice — asking real questions
+
+## Warm-up
+
+[PAUSE 2s] You now have all three verb families **and** two question words. This
+is where it becomes a conversation: you can **ask** and **answer**, not just
+recite. Drill until the questions come without thinking.
+
+## The whole present tense, at a glance
+
+[PAUSE 1s] Conjugate *yo → tú → él/ella* — feel how little differs:
+
+- **-ar** *hablar*: hablo · hablas · habla
+- **-er** *comer*: como · comes · come
+- **-ir** *vivir*: vivo · vives · vive
+
+**Endings:** *-ar* → -o/-as/-a; *-er* and *-ir* → **-o/-es/-e** (identical in the
+singular). Master these and you conjugate almost any regular verb.
+
+## Real exchanges
+
+> — ¿**Dónde vives**? — **Vivo** en Sevilla. ¿Y tú?
+> — **Vivo** en México. ¿**Qué estudias**?
+> — **Estudio** español. ¿**Qué comes**?
+> — **Como** una tapa y **bebo** un café. ¿Algo más? — Un agua, **por favor**.
+
+## What you've built this chapter
+
+- **comer / beber** (-er), **vivir** (-ir) — the two remaining verb families;
+  singular endings **-o / -es / -e**.
+- **qué** (← *quid*) and **dónde** (← *de unde*) — your first question words,
+  each wearing the **accent** and opening with **¿**.
+- **Real questions**: *¿Qué comes? ¿Dónde vives? ¿Dónde trabajas?* — and the first
+  preposition, **en** ("in"), in the answers.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: conjugate all three families, yo/tú/él, back to back]
+- [YOU SAY: ask a stranger three things — where they live, what they study, what
+  they're eating — and answer for yourself]
+- [YOU SAY: chain a whole café moment — greet, order "por favor", ask/answer,
+  say "gracias", "adiós"]
+
+[REPEAT x2] "¿Dónde vives? — Vivo en … ¿Y tú?"
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the singular endings for *-er/-ir* verbs? (*-o / -es / -e*.)
+Give the "I" forms of *comer, vivir, beber*. (*Como, vivo, bebo*.) Ask "what do
+you study?" and "where do you live?" (*¿Qué estudias? ¿Dónde vives?*) You can now
+hold a simple back-and-forth — the course is fully in sentence territory. Next:
+**numbers** (uno, dos, tres) and telling someone your age and phone.

--- a/code/learning/human-languages/spanish/lessons/ES-C07-que.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-que.md
@@ -1,0 +1,63 @@
+---
+id: ES-C07-que
+chapter: 7
+type: word
+headword: qué
+gloss: what? (your first question word)
+concept_tag: QUESTION-WHAT
+prerequisites: [ES-C07-comer]
+sounds: [k-hard, accent-mark]
+roots: [quid-latin]
+etymology_hook: "qué ← Latin quid 'what' → English quiddity, quid pro quo; the accent marks the question"
+est_minutes: 3
+reviews_of: [ES-C07-comer, ES-W01-acento]
+---
+
+# qué — "what?", your first question word
+
+## Warm-up
+
+[PAUSE 2s] You can make statements; now start **asking**. The first question word
+is **qué**, "what?" — and it puts to work two things from your writing chapter:
+the **accent** and the **¿ ?**.
+
+## Sounds you'll need
+
+- `k-hard` — **qu** is a plain hard **k** (the *u* is silent): *qué* = *keh*.
+- `accent-mark` — the **accent on *é*** marks this as the *question* word (recall
+  the diacrítica: *qué* = "what?"; *que* = "that"). Question words wear the accent.
+
+## The word, taken apart
+
+**qué** comes from Latin **quid**, *"what"* — the neuter of *quis*, "who." It's a
+small function word with a few learned English descendants:
+
+- **quiddity** — the "what-ness," the essence of a thing.
+- **quid pro quo** — "*what* for *what*," this for that.
+- the *qu-* question family it heads in Spanish: *qué, quién* (who), *cuál*
+  (which) — Latin's *qu-* interrogatives, the same *wh-* instinct as English
+  (Latin *qu-* and English *wh-* are ancient cousins).
+
+## Grammar Lens: asking with a verb you know
+
+Put **qué** in front of a verb, wrap it in **¿ ?**, and you have a real question:
+
+> **¿Qué comes?** — "What are you eating? / What do you eat?"
+> **¿Qué bebes?** — "What are you drinking?"
+
+Remember the opening **¿** (from the writing lesson) warns the reader a question
+is coming; the accent on *qué* marks it as the question word. Answer with the
+verb you already conjugate: *Como pan.* ("I eat bread.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "qué" — *keh*, silent *u*]
+- [YOU SAY: "¿Qué comes?" / "¿Qué bebes?" — ask with verbs you know]
+- [YOU SAY: "qué" vs "que" — the accent marks the *question*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word is *qué* from? (*quid* — quiddity, quid pro quo.) Why
+does *qué* carry an accent? (It's the *question* word; *que* without = "that.")
+Ask "what are you eating?" (*¿Qué comes?*) Next: asking **where** — *dónde*.

--- a/code/learning/human-languages/spanish/lessons/ES-C07-vivir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C07-vivir.md
@@ -1,0 +1,68 @@
+---
+id: ES-C07-vivir
+chapter: 7
+type: word
+headword: vivir
+gloss: to live (your first -ir verb)
+concept_tag: ES-VERB-VIVIR
+prerequisites: [ES-C07-comer]
+sounds: [v-b, r-tap]
+roots: [vivere-latin]
+etymology_hook: "vivir ← Latin vīvere 'to live' → English vivid, survive, revive, vivacious, convivial"
+est_minutes: 4
+reviews_of: [ES-C07-comer]
+---
+
+# vivir — "to live," and the third family (that's barely new)
+
+## Warm-up
+
+[PAUSE 2s] The third and last verb family: **-ir**, and **vivir** ("to live") is
+your first. Here's the punchline — in the present tense, **-ir is almost
+identical to -er**. You've nearly finished learning the whole regular present.
+
+## Sounds you'll need
+
+- `v-b` — Spanish *v* = a soft *b*: *vivir* ≈ *bee-BEER*.
+- `r-tap` — one tap on the final *r*.
+
+## The word, taken apart
+
+**vivir** comes from Latin **vīvere**, *"to live"* — one of the most alive roots
+in English:
+
+- **vivid** — "full of life."
+- **survive** (*super-vīvere*, "to live beyond"), **revive** ("live again").
+- **vivacious**, **convivial** ("living together" — sociable), **viva!**,
+  **vivarium**. (And *vīta*, "life," gives **vital**, **vitamin**.)
+
+## Grammar Lens: the -ir present tense
+
+Compare the three families, singular — this is the whole system:
+
+| person | -ar (*hablar*) | -er (*comer*) | **-ir** (*vivir*) |
+|---|---|---|---|
+| yo | habl**o** | com**o** | **vivo** |
+| tú | habl**as** | com**es** | **vives** |
+| él/ella | habl**a** | com**e** | **vive** |
+
+Look: **-er and -ir are identical in the singular** (*-o / -es / -e*). They only
+part company in the "we/you-all" forms (*comemos/coméis* vs *vivimos/vivís*). So
+learning *-ir* costs you almost nothing.
+
+**Three families, three vowels, one idea.** You can now conjugate the present
+tense of virtually any regular Spanish verb.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vivir" — *bee-BEER*]
+- [YOU SAY: "vivo, vives, vive" — same endings as *como, comes, come*]
+- [YOU SAY: "vivir" then English "vivid, survive, revive" — the *vīvere* family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *vivir* from, and two English cousins? (*vīvere* —
+vivid, survive.) In the singular, how do *-er* and *-ir* endings compare? (They're
+**identical**: *-o / -es / -e*.) Say "I live." (*Vivo*.) Next: the drink verb,
+*beber*.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -44,10 +44,16 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   español** (first self-assembled sentence; pro-drop; *español* ← *Hispania*) →
   practice. **Authored** — the pilot's first grammar-engine chapter.
 
-Next: **Ch. 7** — the **-er/-ir** verbs (comer, vivir) to complete the regular
-present tense, and the first real **questions** (*qué*, *dónde*, *cuándo*). From
-here the course hands over rules, not phrases. Grammar accumulates piece by
-piece. The theme skeleton below plans the wider road ahead.
+- **Ch. 7 — The rest of the present tense + first questions**: comer (← *comedere*
+  → edible; first *-er*) → vivir (← *vīvere* → vivid; first *-ir*, singular =
+  *-er*) → beber (← *bibere* → beverage) → **qué** (← *quid*) → **dónde** (← *de
+  unde*) → practice. **Authored** — the three verb families are complete and the
+  learner asks/answers real questions (*¿Dónde vives?*).
+
+Next: **Ch. 8** — **numbers** (uno–diez, then the *dieciséis* fusion), age and
+"how many" (*cuántos años tienes?*), introducing *tener* and *cuándo/cuánto*. Then
+**ser vs estar** head-on. From here the course hands over rules, not phrases.
+Grammar accumulates piece by piece. The theme skeleton below plans the wider road.
 
 ## Theme Skeleton (planning only)
 


### PR DESCRIPTION
## Spanish Chapter 7 — the rest of the present tense + the first questions

Loop item 6. Completes the **regular present tense** and starts the learner
**asking questions** — the point where it becomes a real back-and-forth, not
recited phrases. Six atom-first lessons, each reviewing Ch.6.

### What's new
- **The -er and -ir verb families** finish the system started in Ch.6:
  - **comer** (← *comedere* → edible/comestible/eat) teaches the *-o/-es/-e* endings.
  - **vivir** (← *vīvere* → vivid/survive/revive/convivial) — *-ir* is **identical
    to -er in the singular**, so it costs almost nothing.
  - **beber** (← *bibere* → beverage/imbibe/bibulous) cements the pattern.
  - The three-family table makes the whole present tense visible at once
    (*hablo / como / vivo*): *-ar* → -o/-as/-a, *-er*/*-ir* → -o/-es/-e.
- **The first question words**: **qué** (← *quid* → quiddity, quid-pro-quo) and
  **dónde** (← *de unde* "from whence"), both wearing the **accent** and opening
  with **¿** — putting the writing chapter to work. Real questions land:
  *¿Qué comes?*, *¿Dónde vives?*, with the first preposition *en* in the answers.

### Checks
- Taxonomy: canonical **`QUESTION-WHERE`** (`core:false`) added beside
  `QUESTION-WHAT`; namespaced `ES-VERB-COMER/VIVIR/BEBER` documented.
- 38 data-package tests pass (the join test keys off `GREETING-HELLO`, so the new
  canonical concept didn't disturb any counts). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
