### PR TITLE
feat(gc-core-capi): __gc_collect_precise — argument-less precise-root collect (0.11.0)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this crate are documented here.
 
+## [0.11.0] — 2026-07-18
+
+### Added
+
+- **`__gc_collect_precise()` — the argument-less precise-root collect entry** (the
+  `asm!` half that gives the precise machinery a real machine stack to walk). It is
+  to `collect_mixed` what `__gc_collect` is to `collect_region`:
+  - Spills callee-saved registers (via the same `spill_and_sp` as `__gc_collect`),
+    captures the current **frame pointer** (`x29` / `rbp`, via a new
+    `#[inline(always)]` `current_fp`) and the stack base, then hands `fp`/`sp`/`base`
+    to `precise_walk::build_precise_roots`. The resulting precise **slots**
+    (stack-mapped frames) and conservative **regions** (unmapped frames) go to
+    `gc_core::FlatHeap::collect_mixed` in one cycle. The spilled registers are also
+    handed over as an explicit conservative region — a reference live only in a
+    callee-saved register is named by no stack map yet (that needs a
+    `callee_saved_mask`, a later rung), so it must be scanned, exactly as
+    `__gc_collect` scans it.
+  - **Opportunistic + safe:** with no stack maps registered, every frame resolves
+    conservatively and the regions tile all of `[sp, base)`, so it degrades to
+    exactly `__gc_collect` — safe even if the captured frame pointer is garbage. As
+    backends register maps, matching frames shed floating garbage; at that point a
+    *valid* frame pointer becomes load-bearing (a garbage anchor whose `[fp+8]`
+    aliased a stale return address into a mapped function could exclude a live span),
+    so the map-emitting rung must build this crate with frame pointers (guaranteed by
+    ABI on the aarch64 primary target; tracked as a prerequisite of that rung). If
+    the stack base can't be established it collects **nothing** this cycle
+    (bias-to-leak, matching `__gc_collect`).
+  - Smoke-tested end-to-end (`precise_collect_keeps_live_local_frees_dead`): a live
+    stack local survives, a dead object is reclaimed, and the asm-capture →
+    frame-walk → `collect_mixed` path runs without crashing. (The precise reclaim of
+    a named slot vs. an unnamed neighbour is proven by `precise_walk`'s
+    synthetic-stack tests from 0.10.0.)
+
 ## [0.10.0] — 2026-07-18
 
 ### Added

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/README.md
+++ b/code/packages/rust/gc-core-capi/README.md
@@ -49,6 +49,7 @@ The interpreters use `gc-core`'s managed-object collector; native output uses
 | `int64_t __gc_register_stackmap(func_start, func_len, num_records, pc_offsets, frame_sizes, callee_masks, slot_counts, slots_flat)` | register a function's stack maps (code range + per-safepoint live-ref records) for precise-root resolution; returns records stored, `0` if rejected |
 | `int64_t __gc_stackmap_count(void)` | number of functions registered |
 | `void __gc_stackmap_reset(void)` | drop all registered stack maps (tests / teardown) |
+| `int64_t __gc_collect_precise(void)` | full collect rooted precisely at this thread's stack — walks the frame-pointer chain (stack-mapped frames precise, rest conservative); returns objects freed |
 
 `__gc_alloc` returns a **real, 16-byte-aligned pointer** to memory the caller reads
 and writes directly. Tracing is conservative (raw + tag-stripped candidate words);
@@ -108,21 +109,23 @@ map any unwound return address to the `StackMapRecord` live there in `O(log n)`.
 That is the code-address analogue of `__gc_register_kind` (object-layout map) —
 together, the two maps a precise collector needs.
 
-The **precise stack walk logic** now lands too: `precise_walk::build_precise_roots`
-unwinds the frame-pointer chain, `resolve`s each return address, and builds the two
-inputs to `gc-core`'s `collect_mixed` — precise slots (`frame_root_slots`) for
-mapped frames, conservative `[fp, caller_fp)` regions for unmapped ones — so a real
-stack (which always mixes stack-mapped and un-migrated frames) collects
-precisely-where-it-can and conservatively-everywhere-else in one cycle. It is pure
-walk logic (no `asm!`), exhaustively tested against synthetic stacks.
+The precise stack walk is now wired end-to-end: `precise_walk::build_precise_roots`
+unwinds the frame-pointer chain into precise slots (`frame_root_slots`) for mapped
+frames and conservative `[fp, caller_fp)` regions for unmapped ones, and the
+argument-less **`__gc_collect_precise`** captures the running thread's frame pointer
+/ stack pointer / base (mirroring `__gc_collect`'s register spill), walks, and
+collects both in one `collect_mixed` cycle. With no stack maps registered it degrades
+to exactly `__gc_collect`; as frames are mapped they shed floating garbage. Safe by
+construction — an omitted frame pointer or unwalkable stack degrades to a
+conservative scan, never a missed root.
 
 Still to come (own PRs):
 
-- **The `asm!` entry** — an argument-less `__gc_collect_precise` that captures the
-  running thread's frame pointer / stack pointer / base (mirroring `__gc_collect`'s
-  register spill) and calls `build_precise_roots` + `collect_mixed`. Then the
-  backends (aarch64 / x86_64 / LLVM) emit the stack-map records at safepoints and
-  call sites.
+- **Backend record emission** — the code generators (aarch64 / x86_64 / LLVM) emit
+  `StackMapRecord`s at safepoints and call sites and register them via
+  `__gc_register_stackmap`, so `__gc_collect_precise` actually resolves real frames
+  in production (until then every frame is unmapped → conservative). Precision also
+  needs the image built with frame pointers (`-Cforce-frame-pointers`).
 - **Moving / compacting**, then **incremental** — the rest of the ladder, all as
   `gc-core` algorithms.
 

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -131,6 +131,16 @@ int64_t __gc_register_stackmap(uint64_t func_start, uint64_t func_len,
                                const int32_t *slot_counts,
                                const int32_t *slots_flat);
 
+/* Full collection rooted PRECISELY at this thread's stack. Captures the current
+ * frame pointer and unwinds the frame-pointer chain: frames with a registered stack
+ * map (see __gc_register_stackmap) contribute exact reference slots, the rest are
+ * scanned conservatively — all collected in one cycle. Callee-saved registers are
+ * spilled and scanned conservatively too. With no maps registered it degrades to
+ * exactly __gc_collect; an unwalkable stack likewise degrades to a conservative
+ * scan, never a missed root. Returns objects freed. Same threading contract as
+ * __gc_collect. (For precision the image must be built with frame pointers.) */
+int64_t __gc_collect_precise(void);
+
 /* Number of functions currently registered via __gc_register_stackmap. */
 int64_t __gc_stackmap_count(void);
 

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -29,6 +29,7 @@
 //! | `__gc_live_bytes()` | live payload bytes |
 //! | `__gc_collection_count()` | collections run so far |
 //! | `__gc_reset()` | drop the whole heap (frees everything); mainly for tests / process teardown |
+//! | `__gc_collect_precise()` | full collect rooted precisely at this thread's stack — frame-pointer walk (stack-mapped frames precise, rest conservative) |
 //! | `__gc_register_stackmap(...)` | register a function's stack maps (code range + per-safepoint records) for precise-root resolution |
 //! | `__gc_stackmap_count()` | number of functions registered |
 //! | `__gc_stackmap_reset()` | drop all registered stack maps (tests / teardown) |

--- a/code/packages/rust/gc-core-capi/src/precise_walk.rs
+++ b/code/packages/rust/gc-core-capi/src/precise_walk.rs
@@ -106,11 +106,10 @@ const MAX_FRAMES: usize = 1 << 20;
 /// place. The emitted slot addresses and regions are only *recorded* here, not
 /// dereferenced — `collect_mixed` reads them later under its own contract.
 ///
-/// `#[allow(dead_code)]` until the `asm!` entry point (`__gc_collect_precise`, a
-/// follow-up PR) captures the running thread's `fp`/`sp`/`base` and calls this; it
-/// is exhaustively exercised by this module's synthetic-stack unit tests today,
-/// exactly as `gc-core` shipped `collect_mixed` ahead of its consumer.
-#[allow(dead_code)]
+/// Consumed by the `asm!` entry point [`__gc_collect`](crate::stack_scan)'s sibling
+/// `__gc_collect_precise` (in [`crate::stack_scan`]), which captures the running
+/// thread's `fp`/`sp`/`base` and hands them here; also exhaustively exercised by this
+/// module's synthetic-stack unit tests.
 pub(crate) unsafe fn build_precise_roots(
     start_fp: usize,
     sp: usize,

--- a/code/packages/rust/gc-core-capi/src/stack_scan.rs
+++ b/code/packages/rust/gc-core-capi/src/stack_scan.rs
@@ -193,6 +193,43 @@ unsafe fn spill_and_sp(buf: *mut usize) -> usize {
     sp
 }
 
+// ── 2b. Current frame pointer (for the precise walk) ────────────────────────
+//
+// `current_fp()` returns this frame's **frame pointer** (`x29` on AArch64, `rbp`
+// on x86-64) — the anchor the precise stack walk unwinds from. It MUST be
+// `#[inline(always)]`: inlined into the `#[inline(never)]` collect entry, it reads
+// that entry's own frame pointer; as a separate call it would read its *own* frame
+// and mislead the walk.
+//
+// **Frame-pointer dependency.** This reads whatever the register holds; it is a
+// valid chain anchor only if the compiler maintains a frame pointer for the collect
+// entry. That is guaranteed on `aarch64-apple-darwin` (the Apple ABI mandates the
+// `x29` chain) and holds under Rust's current x86-64-host defaults, but is *not*
+// enforced by this crate's build. While **no stack maps are registered** a bogus
+// anchor is still safe: `build_precise_roots` then classifies every frame
+// conservatively and its regions tile all of `[sp, base)`, so precise collection
+// degrades to exactly `__gc_collect`. Once maps ARE registered, a valid frame
+// pointer becomes load-bearing for safety (a garbage anchor whose `[fp+8]` aliased a
+// stale return address into a mapped function could exclude a live span) — so the
+// backend-record-emission rung must build this crate with `-Cforce-frame-pointers`
+// (or rely on the aarch64 ABI guarantee). Tracked as a prerequisite of that rung.
+
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+unsafe fn current_fp() -> usize {
+    let fp: usize;
+    core::arch::asm!("mov {}, x29", out(reg) fp, options(nomem, nostack, preserves_flags));
+    fp
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+unsafe fn current_fp() -> usize {
+    let fp: usize;
+    core::arch::asm!("mov {}, rbp", out(reg) fp, options(nomem, nostack, preserves_flags));
+    fp
+}
+
 // ── 3. Thread stack base (the high end of the down-growing stack) ───────────
 
 /// macOS: `pthread_get_stackaddr_np` returns the base (highest address) directly.
@@ -360,6 +397,76 @@ pub unsafe extern "C" fn __gc_safepoint() -> i64 {
     }
 }
 
+/// A full collection rooted **precisely** at this thread's stack: the argument-less
+/// entry that gives the precise-root machinery a real machine stack to walk.
+///
+/// Where [`__gc_collect`] scans the whole `[sp, base)` span *conservatively*, this
+/// captures the current frame pointer and hands it, plus `sp`/`base`, to
+/// [`crate::precise_walk::build_precise_roots`], which unwinds the frame-pointer
+/// chain into **precise slots** for stack-mapped frames (registered via
+/// [`__gc_register_stackmap`](crate::__gc_register_stackmap)) and **conservative
+/// regions** for the rest, then collects both in one [`gc_core::FlatHeap::collect_mixed`]
+/// cycle. It is to `collect_mixed` what `__gc_collect` is to `collect_region`.
+///
+/// Callee-saved registers are spilled and handed to the collector as an explicit
+/// conservative region: a reference live *only* in a callee-saved register is named
+/// by no stack map yet (that needs a per-safepoint `callee_saved_mask`, a later
+/// rung), so it must be scanned, exactly as `__gc_collect` scans the spill. The
+/// buffer also lives in this frame — inside the walk's `[sp, fp)` collector region —
+/// so the explicit region is belt-and-suspenders against an absent/garbage frame
+/// pointer.
+///
+/// **Precision is opportunistic and safe:** with no stack maps registered, every
+/// frame resolves to a conservative region whose spans tile all of `[sp, base)`, so
+/// this degrades exactly to `__gc_collect` — safe even if the captured frame pointer
+/// is garbage. As backends register maps, matching frames shed their floating
+/// garbage; at that point a *valid* frame pointer becomes load-bearing for safety
+/// (see [`current_fp`]), so the map-emitting rung must build this crate with frame
+/// pointers (guaranteed by ABI on the aarch64 primary target). An unwalkable stack
+/// still degrades to a conservative scan; if the stack base cannot be established,
+/// it collects **nothing** this cycle rather than risk freeing a live object — the
+/// same bias-to-leak as `__gc_collect`.
+///
+/// # Safety
+///
+/// Same contract as [`__gc_collect`]: sound to call from any thread that owns its
+/// stack (the single-threaded native runtime always does); it must not run while
+/// another thread mutates the same heap.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __gc_collect_precise() -> i64 {
+    // Spill callee-saved registers into a stack buffer (in this frame), then SP.
+    let mut regs = [0usize; SPILL_SLOTS];
+    let sp = spill_and_sp(regs.as_mut_ptr());
+    // Capture this frame's frame pointer — the walk's unwind anchor. `current_fp`
+    // is `#[inline(always)]`, so this reads *this* frame's fp, not a callee's.
+    let fp = current_fp();
+    let base = stack_base();
+
+    // Only collect when the stack range is trustworthy. As in `__gc_collect`, a
+    // failed base detection (base == 0) or an absurd span means we cannot enumerate
+    // all roots — collecting then could free a live object, so we leak this cycle.
+    let freed = if base != 0 && sp < base && base - sp <= MAX_STACK_SCAN {
+        let mut slots: Vec<usize> = Vec::new();
+        let mut regions: Vec<(*const u8, usize)> = Vec::new();
+        // Walk the frame-pointer chain into precise slots + conservative regions.
+        crate::precise_walk::build_precise_roots(fp, sp, base, &mut slots, &mut regions);
+        // Always scan the spilled callee-saved registers, independent of the walk.
+        regions.push((
+            regs.as_ptr() as *const u8,
+            SPILL_SLOTS * core::mem::size_of::<usize>(),
+        ));
+        with_heap(|h| h.collect_mixed(&slots, &regions).freed as i64)
+    } else {
+        0
+    };
+
+    // Keep `regs` materialised across the collect: its address is what makes the
+    // spilled registers part of the scanned roots.
+    core::hint::black_box(&regs);
+    freed
+}
+
 /// Upper bound on how many bytes of stack a single conservative scan will walk
 /// (256 MiB). A corrupt or absurd `base` (far above `sp`) would otherwise make
 /// `collect_region` read hundreds of GB and appear to hang — an
@@ -457,6 +564,42 @@ mod tests {
         );
         assert_eq!(__gc_collection_count(), 1);
 
+        core::hint::black_box(kept);
+    }
+
+    /// End-to-end smoke test for the argument-less `__gc_collect_precise`: an object
+    /// held in a live stack local survives, a dead one is reclaimed, and the whole
+    /// asm-capture → frame-pointer-walk → `collect_mixed` path runs without crashing.
+    ///
+    /// With no stack maps registered, every frame resolves conservatively, so this
+    /// exercises the same safety guarantee as `__gc_collect` (the live local, sitting
+    /// in a walked/tiled frame, is never dropped) while driving the precise plumbing.
+    #[test]
+    fn precise_collect_keeps_live_local_frees_dead() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+        run_precise_collect_case();
+        __gc_reset();
+    }
+
+    #[inline(never)]
+    fn run_precise_collect_case() {
+        let kept = __gc_alloc(16);
+        assert!(kept != 0);
+        let _ = __gc_alloc(16); // dead: no stack slot retains it
+        assert_eq!(__gc_live_bytes(), 32);
+        unsafe { *(kept as *mut i64) = 0x9a11 };
+
+        let freed = unsafe { __gc_collect_precise() };
+
+        assert!(freed >= 1, "the unreferenced object must be reclaimed");
+        assert_eq!(
+            unsafe { *(kept as *const i64) },
+            0x9a11,
+            "the stack-rooted object must survive the precise collect"
+        );
+        assert!(__gc_live_bytes() >= 16);
+        assert_eq!(__gc_collection_count(), 1);
         core::hint::black_box(kept);
     }
 


### PR DESCRIPTION
## What

The **`asm!` half** that gives the precise-root machinery a real machine stack to walk — completing the precise-roots path end-to-end. `__gc_collect_precise` is to `collect_mixed` what `__gc_collect` is to `collect_region`.

```
__gc_collect_precise()
```
- spills callee-saved registers (same `spill_and_sp` as `__gc_collect`), captures the current **frame pointer** (`x29`/`rbp` via a new `#[inline(always)] current_fp`) and stack base;
- gates on a trustworthy `[sp, base)` (`base != 0`, `sp < base`, span ≤ `MAX_STACK_SCAN`) — else collects **nothing** this cycle (bias-to-leak, matching `__gc_collect`);
- hands `fp`/`sp`/`base` to `precise_walk::build_precise_roots` → precise slots (mapped frames) + conservative regions (unmapped), plus the spilled registers as an explicit conservative region, then one `collect_mixed` cycle.

## Opportunistic + safe

With **no** stack maps registered, every frame classifies conservatively and the regions tile all of `[sp, base)`, so it degrades to **exactly `__gc_collect`** — safe even if the captured frame pointer is garbage. As backends register maps, matching frames shed floating garbage.

## Safety review

Adversarial review **PASSED** (traced every path against the conservative `__gc_collect` sibling): spill buffer double-covered with correct length, the gate is a safe bias-to-leak, `sp` non-stale, no Vec/heap-lock re-entrancy, `asm!` options correct. Its one **latent, forward-looking** finding: once maps *are* registered, a **valid frame pointer becomes load-bearing** (a garbage anchor whose `[fp+8]` aliased a stale mapped-function return address could exclude a live span → UAF). Not active today (no maps registered → conservative tiling) and guaranteed by ABI on the aarch64 primary target. The docs/CHANGELOG are corrected to state the guarantee precisely, and **forcing frame pointers on this crate is flagged as a prerequisite of the backend-emission rung** (background task created).

## Tests

Smoke-tested end-to-end (`precise_collect_keeps_live_local_frees_dead`): a live stack local survives, a dead object is reclaimed, and the asm-capture → frame-walk → `collect_mixed` path runs without crashing. `__gc_collect_precise` exports in `libgc_core_capi.a`. (Precise reclaim of a named slot vs. an unnamed neighbour is proven by `precise_walk`'s synthetic-stack tests from 0.10.0.)

gc-core-capi ONLY (7 files). Purely additive.

## Precision ladder

conservative → interior-precise (#8512) → generational (#8526) → precise-roots core (#8539) → registry (#8548) → mixed-collect (#8557) → walk logic (#8566) → **precise collect entry** (this PR).

**Remaining:** backend `StackMapRecord` emission at safepoints / call sites (makes `resolve()` hit in production; needs frame pointers forced), then moving/compacting + incremental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)