### PR TITLE
fix(semantic-ir-to-javascript): unwrap scalar NDArray in numOf, fixes MATLAB while-loop non-termination

### DIFF
--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -102,6 +102,44 @@
   branch; added a regression test asserting a float-literal program both
   validates and is accepted by the JS backend.
 
+- **Correctness: a `while` loop whose condition variable was also a
+  non-literal arithmetic accumulator ran its body exactly once, not to
+  convergence.** Found and diagnosed by `tests/oracle.rs`'s
+  `known_bug_while_loop_accumulator_terminates_after_one_iteration` (the
+  oracle test added just above, same PR). This was a silent wrong
+  *computation* — no error, no validator issue, no crash — and the most
+  severe finding of that oracle-harness effort. Root cause traced end to
+  end: `expr_is_known_scalar` (this crate's own scalar/array
+  disambiguation heuristic) only treats a *literal*-derived expression as
+  provably scalar, so `n = n + 1` (where `n` is a variable) always lowers
+  to the SIR22 `Expr::ElementwiseOp` path regardless of what `n` actually
+  holds; `semantic-ir-to-javascript`'s `ElementwiseOp` codegen always
+  returns an NDArray-shaped `{ shape, data }` object even for a
+  logically-scalar result; and that backend's shared `numOf` helper (used
+  by every comparison and by `neg`/`minus`/`mod`) only unwrapped a tagged
+  `SirFloat` box, not a scalar (`shape.length === 0`) NDArray — so `n < 10`
+  compiled to `__Sir.lt(n, 10)`, which coerced the wrapped `n` through
+  `ToPrimitive` to `NaN`, and `NaN < 10` is silently `false`. **Fixed in
+  `semantic-ir-to-javascript` (this crate's own `src/` needed no change):
+  `numOf` now also unwraps a scalar NDArray** — see that crate's own
+  0.40.0 CHANGELOG entry for the full write-up, including the
+  `numof_unwraps_scalar_ndarray_for_comparison_and_negation` regression
+  test and confirmation that the same fix also resolves the
+  unary-minus-on-power bug (`-2 ^ 2` giving `NaN`) documented below, for
+  free. `tests/oracle.rs`'s `known_bug_while_loop_accumulator_
+  terminates_after_one_iteration` is renamed to
+  `while_loop_accumulator_converges_correctly` and now asserts the correct
+  converged value (`10`), with its doc comment rewritten to describe the
+  fix instead of the bug; the corresponding bullet in that file's module
+  doc comment is updated to say FIXED.
+
+- **Correctness: unary minus on a power expression gave `NaN`, not the
+  correct value** (`-2 ^ 2` should be `-4`; documented alongside the
+  while-loop bug above, same root cause, same fix — see that entry and
+  `semantic-ir-to-javascript`'s 0.40.0 CHANGELOG entry). Confirmed fixed
+  end to end by re-running `compile_source("disp(-2 ^ 2)\n")` →
+  `semantic_ir_to_javascript::compile` → `node`: prints `-4`.
+
 ## [0.1.0] - 2026-07-11
 
 ### Added

--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -140,6 +140,21 @@
   end to end by re-running `compile_source("disp(-2 ^ 2)\n")` →
   `semantic_ir_to_javascript::compile` → `node`: prints `-4`.
 
+- **`matlab-to-semantic-ir` never declared `Feature::ShortCircuit` for
+  `&&`/`||`/`&`/`|`.** `try_logical` (`src/lower.rs`) built
+  `Expr::LogicalAnd`/`Expr::LogicalOr` nodes without ever calling
+  `self.observed.add(Feature::ShortCircuit)`, so any MATLAB program using
+  those operators failed `semantic_ir::validate()` outright with
+  `"manifest does not declare feature short-circuit but module uses it"`
+  even though the lowering itself was otherwise correct (confirmed via
+  probe, `x > 3 && y > 5`; documented in `tests/oracle.rs`'s module doc,
+  same PR as the bugs above). Fixed with a one-line addition of
+  `self.observed.add(Feature::ShortCircuit)` in `try_logical`, right
+  alongside every sibling frontend's own convention for this feature
+  (e.g. `ruby-to-semantic-ir`'s `lower.rs`). Regression test:
+  `tests/test_validator.rs`'s
+  `a_logical_and_program_validates_and_declares_short_circuit`.
+
 ## [0.1.0] - 2026-07-11
 
 ### Added

--- a/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
@@ -949,6 +949,16 @@ impl Lowerer {
             return Ok(None);
         }
         self.check_chain_length(node)?;
+        // `Expr::LogicalAnd`/`Expr::LogicalOr` (built below) require
+        // `Feature::ShortCircuit` in the manifest -- see
+        // `semantic-ir/src/validator.rs`'s `check_expr`, and every sibling
+        // frontend that emits these nodes (e.g. `ruby-to-semantic-ir`'s
+        // `lower.rs`) declares it right alongside construction. This crate
+        // used to omit it entirely, so any MATLAB program using `&&`/`||`/
+        // `&`/`|` failed `semantic_ir::validate()` outright with "manifest
+        // does not declare feature short-circuit but module uses it" even
+        // though the lowering itself was otherwise correct.
+        self.observed.add(Feature::ShortCircuit);
         let mut acc: Option<Expr> = None;
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {

--- a/code/packages/rust/matlab-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/oracle.rs
@@ -82,48 +82,63 @@
 //!
 //! The corpus below is restricted to programs this frontend/backend pair
 //! can *actually* execute correctly today. Getting there surfaced four
-//! confirmed, previously-unknown bugs/gaps — each is a **discovery of this
-//! oracle harness doing its job**, not a defect in the harness:
+//! confirmed, previously-unknown bugs/gaps — each was a **discovery of
+//! this oracle harness doing its job**, not a defect in the harness. Three
+//! of the four have since been FIXED (a follow-up PR to the one that added
+//! this file); one remains open:
 //!
-//! - **Integer-literal division floors instead of true-dividing.** MATLAB
-//!   has no integer type — every number is a double, so `7 / 2` is always
-//!   `3.5`. But `number_literal_expr` (`src/lower.rs`) lowers a
-//!   decimal-point-free literal to `Expr::IntLit`, and the JS backend's
-//!   shared `divide()` runtime helper (built for *Ruby's* `Integer#/`,
-//!   which really does floor) floors whenever both operands are
-//!   integer-valued — so the compiled path prints `3`. Excluded from
+//! - **Integer-literal division floors instead of true-dividing** (still
+//!   OPEN). MATLAB has no integer type — every number is a double, so
+//!   `7 / 2` is always `3.5`. But `number_literal_expr` (`src/lower.rs`)
+//!   lowers a decimal-point-free literal to `Expr::IntLit`, and the JS
+//!   backend's shared `divide()` runtime helper (built for *Ruby's*
+//!   `Integer#/`, which really does floor) floors whenever both operands
+//!   are integer-valued — so the compiled path prints `3`. Excluded from
 //!   `CORPUS`; not independently re-demonstrated as its own test here
 //!   since it needs no `node` process to see (`grep -n "Math.floor" src/
 //!   runtime.rs` in `semantic-ir-to-javascript` plus this file's own
 //!   probe history is confirmation enough), but recorded in the CHANGELOG.
-//! - **Unary minus on a power expression gives `NaN`, not the correct
-//!   value.** `^`/`.^` *unconditionally* lower to the SIR22
+//!   Left open because a real fix needs a source-language-aware division
+//!   convention (MATLAB has no integer type at all, unlike Ruby, whose
+//!   `Integer#/`-flooring convention `divide()` was actually built for) —
+//!   a bigger design decision than the fixes below, not a one-line change.
+//! - **FIXED: unary minus on a power expression gave `NaN`, not the
+//!   correct value.** `^`/`.^` *unconditionally* lower to the SIR22
 //!   `ElementwiseOp::Pow` node (`try_power`, `src/lower.rs`) — unlike
 //!   `+`/`-`/`*`, there is no literal-only scalar fast path for power at
 //!   all. So even `2 ^ 2` (both literals) evaluates to an NDArray-shaped
-//!   `{shape, data}` object, not a plain JS number. Unary minus's `neg`
-//!   builtin then compiles to a bare native `-(...)` (`emit.rs`), and
-//!   negating that object coerces it to `NaN` via `ToPrimitive`. Real
-//!   MATLAB: `-2 ^ 2 == -4` (unary binds looser than `^`, confirmed by
-//!   `matlab-runtime`'s own `scalar_arithmetic_echoes_ans` test). Excluded
-//!   from `CORPUS` for the same reason as the division bug above.
-//! - **A `while` loop whose condition variable is also a non-literal
-//!   arithmetic accumulator runs its body exactly once, not to
-//!   convergence.** This is the most severe finding — a silent wrong
-//!   *computation*, not just a wrong *display* — and gets its own
-//!   dedicated, always-informative test:
-//!   [`known_bug_while_loop_accumulator_terminates_after_one_iteration`]
-//!   below, with the full root-cause writeup in its doc comment.
-//! - **`matlab-to-semantic-ir` never declares `Feature::ShortCircuit`**
-//!   for `&&`/`||`/`&`/`|` (`try_logical`, `src/lower.rs` has no
-//!   `self.observed.add(Feature::ShortCircuit)` anywhere), so any MATLAB
-//!   program using them fails `semantic_ir::validate()` outright with
-//!   `"manifest does not declare feature short-circuit but module uses
-//!   it"`. Confirmed via probe (`x > 3 && y > 5`); excluded from `CORPUS`.
-//!   This one is squarely inside this crate's own `src/`, unlike the
-//!   others above, but fixing frontend source is out of scope for this PR
-//!   (test infrastructure only) — flagged here and in the CHANGELOG for a
-//!   follow-up.
+//!   `{shape, data}` object, not a plain JS number, and unary minus's
+//!   `neg` builtin (`emit.rs`) calls the runtime's `numOf` to unwrap its
+//!   operand before negating — the exact same `numOf` gap the while-loop
+//!   bug below turned out to hinge on. Fixing `numOf` (see that bug's
+//!   entry) fixed this one too, for free, in the same commit: real MATLAB
+//!   `-2 ^ 2 == -4` (unary binds looser than `^`, confirmed by
+//!   `matlab-runtime`'s own `scalar_arithmetic_echoes_ans` test) now holds
+//!   through the compiled path too.
+//! - **FIXED: a `while` loop whose condition variable is also a
+//!   non-literal arithmetic accumulator ran its body exactly once, not to
+//!   convergence.** This was the most severe finding — a silent wrong
+//!   *computation*, not just a wrong *display* — and still gets its own
+//!   dedicated, always-informative regression test:
+//!   [`while_loop_accumulator_converges_correctly`] below (renamed from
+//!   `known_bug_while_loop_accumulator_terminates_after_one_iteration`),
+//!   with the full root-cause writeup and the fix in its doc comment.
+//!   Root cause, in one sentence: `semantic-ir-to-javascript`'s shared
+//!   `numOf` helper (`runtime.rs`) unwrapped a tagged `SirFloat` box but
+//!   not a rank-0 (scalar) NDArray, so a comparison against an
+//!   NDArray-wrapped accumulator silently evaluated to `NaN < 10 ==
+//!   false`; `numOf` now unwraps both.
+//! - **FIXED: `matlab-to-semantic-ir` never declared `Feature::
+//!   ShortCircuit`** for `&&`/`||`/`&`/`|` (`try_logical`, `src/lower.rs`
+//!   had no `self.observed.add(Feature::ShortCircuit)` anywhere), so any
+//!   MATLAB program using them failed `semantic_ir::validate()` outright
+//!   with `"manifest does not declare feature short-circuit but module
+//!   uses it"`. Confirmed via probe (`x > 3 && y > 5`); a one-line fix
+//!   (`tests/test_validator.rs`'s
+//!   `a_logical_and_program_validates_and_declares_short_circuit` is the
+//!   regression test) — but such programs are still not in `CORPUS`
+//!   below, since none of this crate's `&&`/`||` support has an oracle
+//!   case here yet, just validator coverage.
 //!
 //! Two more constructs turned out to be impossible to oracle-test at all,
 //! not just currently-buggy, because `matlab-runtime` itself cannot run
@@ -193,6 +208,19 @@ const CORPUS: &[Case] = &[
         setup: "x = 3 + 4 * 2 - 5;\n",
         final_expr: "x",
         expected: "6",
+    },
+    // Regression case for the (now-fixed) unary-minus-on-power bug
+    // documented in this file's module doc: `^` always lowers to the
+    // SIR22 `ElementwiseOp::Pow` node, even for two literals, so `2 ^ 2`
+    // evaluated to an NDArray-shaped scalar and `neg` on it used to give
+    // `NaN` instead of `-4` (unary minus binds looser than `^`, so this is
+    // `-(2 ^ 2)`, not `(-2) ^ 2`). Fixed by the same `semantic-ir-to-
+    // javascript` `numOf` change that fixed the while-loop bug below.
+    Case {
+        name: "unary_minus_on_power",
+        setup: "",
+        final_expr: "-2 ^ 2",
+        expected: "-4",
     },
     // A bare comparison. See the module doc's "Normalization" section for
     // why `expected` is written in MATLAB's own 0/1 numeric-logical
@@ -355,18 +383,18 @@ fn oracle_corpus_matches_native_matlab_runtime() {
     }
 }
 
-/// KNOWN BUG, found while building this harness (not fixed here -- test
-/// infrastructure only; see the CHANGELOG this PR adds): a MATLAB `while`
-/// loop whose condition variable is *also* the target of a non-literal
-/// (variable-involving) arithmetic update runs its body exactly **once**
-/// through the compiled JS path, instead of iterating to convergence.
+/// FIXED (previously `known_bug_while_loop_accumulator_terminates_after_
+/// one_iteration`): a MATLAB `while` loop whose condition variable is
+/// *also* the target of a non-literal (variable-involving) arithmetic
+/// update used to run its body exactly **once** through the compiled JS
+/// path, instead of iterating to convergence.
 ///
 /// Root cause, traced via the actual generated JavaScript
 /// (`semantic_ir_to_javascript::compile` on `"n = 0;\nwhile n < 10\n  n =
 /// n + 1;\nend\n"` emits, in `function main()`:
 /// ```js
 /// let n = 0;
-/// while (__Sir.truthy((n < 10))) {
+/// while (__Sir.truthy(__Sir.lt(n, 10))) {
 ///   n = __Sir.Array.elementwise("Add", n, 1);
 /// }
 /// ```
@@ -377,47 +405,62 @@ fn oracle_corpus_matches_native_matlab_runtime() {
 ///    crate's own README) only ever treats a *literal*-derived expression
 ///    as provably scalar. `n + 1`, where `n` is a variable, is therefore
 ///    always lowered as an SIR22 `Expr::ElementwiseOp`, regardless of what
-///    `n` actually holds at runtime.
+///    `n` actually holds at runtime. This part of the diagnosis was
+///    correct and remains true after the fix below -- it is exactly what
+///    still makes this a genuinely useful regression test, not merely a
+///    coincidentally-passing one.
 /// 2. `semantic-ir-to-javascript`'s `ElementwiseOp` codegen always returns
 ///    an NDArray-shaped `{ shape: number[], data: Float64Array }` object
 ///    (`runtime.rs`'s `ArrayRt.elementwise`), even for a logically-scalar
 ///    result. So after one iteration, `n` holds an *object*, not a JS
-///    number.
-/// 3. Comparison builtins compile to bare native infix operators
-///    (`emit.rs`: `"<" => Some("<")`) shared by every language this
-///    backend serves — there is no array-aware comparison helper. `n < 10`
-///    with `n` now an object triggers `ToPrimitive` coercion (no custom
-///    `valueOf`/`Symbol.toPrimitive` on a plain `{shape, data}` object), so
-///    the comparison is unconditionally `false`.
+///    number. Also still true after the fix -- and fine, because...
+/// 3. ...comparison builtins compile to thin runtime helpers that already
+///    existed for a *different* reason (unwrapping a tagged `SirFloat` box
+///    so `7.0 < 8` doesn't hit `NaN` via `ToPrimitive` on the box --
+///    `emit.rs`: `"<" => Some("__Sir.lt")`), which in turn unwrap through
+///    `runtime.rs`'s shared `numOf`. The ORIGINAL diagnosis (recorded in
+///    this crate's CHANGELOG for the PR that found this bug) described
+///    comparisons as bare native infix operators with "no array-aware
+///    comparison helper" -- that was already stale by the time this bug
+///    was investigated for a fix: the helper existed, it just didn't know
+///    about NDArrays yet. `numOf` unwrapped a `SirFloat` box but returned
+///    every other value (including a scalar NDArray) unchanged, so `n <
+///    10` still coerced the NDArray object through `ToPrimitive` to `NaN`,
+///    and `NaN < 10` is silently `false`.
 ///
-/// The loop body therefore runs exactly once and then silently stops --
-/// no error, no validator issue, no crash, and the resulting `n = 1` looks
-/// like a plausible (if wrong) answer in isolation. This is the most
-/// severe finding of this whole exercise: a silent wrong *computation*,
-/// not merely a wrong *display* (contrast the division/power-operator bugs
-/// documented in this file's module doc, which only corrupt what gets
-/// printed). `for`-loop accumulators (see `for_loop_accumulator` in
-/// `CORPUS` above) are not immune to the underlying NDArray-wrapping --
-/// they simply never hit it, because a `for` loop's OWN termination test
-/// is driven by the loop index (always a plain number, incremented via
-/// native `+`, never `ElementwiseOp`), not by the accumulator variable.
-/// Any future construct whose OWN loop/branch condition reads a
-/// variable that has previously been updated via non-literal arithmetic
-/// would hit this same failure mode.
+/// **The fix** (`semantic-ir-to-javascript/src/runtime.rs`): `numOf` now
+/// also unwraps a rank-0 (scalar) NDArray -- `x.shape.length === 0` --
+/// to its sole `data[0]` element, alongside its existing `SirFloat` case.
+/// `numOf` is the identity on anything it doesn't recognise and only
+/// MATLAB/APL-style SIR22 frontends ever construct an NDArray, so this is
+/// a no-op for every other language this backend serves and a real fix
+/// for comparisons, negation, subtraction, and modulo against a
+/// scalar-shaped array result -- see
+/// `semantic-ir-to-javascript/tests/run_with_node.rs`'s
+/// `numof_unwraps_scalar_ndarray_for_comparison_and_negation` for the
+/// runtime-level regression test, which also confirms this incidentally
+/// fixes the unary-minus-on-power bug documented in this file's module
+/// doc (same root cause: `neg` calls `numOf` too).
 ///
-/// This test intentionally asserts **today's (wrong) behavior**, not the
-/// correct one, precisely so that it fails loudly -- as a prompt to
-/// promote it into a real `CORPUS` entry (with `expected: "10"`) -- the
-/// moment someone fixes the underlying gap (either give `ElementwiseOp` a
-/// scalar-returning fast path mirroring the literal one, or make
-/// comparison codegen array-aware).
+/// Previously the loop body ran exactly once and then silently stopped --
+/// no error, no validator issue, no crash, and the resulting `n = 1`
+/// looked like a plausible (if wrong) answer in isolation: a silent wrong
+/// *computation*, not merely a wrong *display* (contrast the
+/// division/power-operator bugs documented in this file's module doc,
+/// which only corrupt what gets printed). `for`-loop accumulators (see
+/// `for_loop_accumulator` in `CORPUS` above) were never affected by the
+/// underlying NDArray-wrapping in the first place -- a `for` loop's OWN
+/// termination test is driven by the loop index (always a plain number,
+/// incremented via native `+`, never `ElementwiseOp`), not by the
+/// accumulator variable -- but any construct whose OWN loop/branch
+/// condition reads a variable previously updated via non-literal
+/// arithmetic would have hit this same failure mode; the fix is general
+/// (in `numOf`, not in the while-loop's own codegen), so all such
+/// constructs are covered, not just this one shape.
 #[test]
-fn known_bug_while_loop_accumulator_terminates_after_one_iteration() {
+fn while_loop_accumulator_converges_correctly() {
     if !node_available() {
-        eprintln!(
-            "skipping known_bug_while_loop_accumulator_terminates_after_one_iteration: \
-             `node` not available"
-        );
+        eprintln!("skipping while_loop_accumulator_converges_correctly: `node` not available");
         return;
     }
     let setup = "n = 0;\nwhile n < 10\n  n = n + 1;\nend\n";
@@ -428,10 +471,11 @@ fn known_bug_while_loop_accumulator_terminates_after_one_iteration() {
         "matlab-runtime ground truth for this loop changed -- update this test's premise"
     );
 
-    let got = compiled("while_loop_accumulator_bug", setup, "n(1)");
+    let got = compiled("while_loop_accumulator_converges", setup, "n(1)");
     assert_eq!(
-        got, "1",
-        "the while-loop/NDArray-accumulator bug documented above appears to be fixed -- \
-         promote this into a real `CORPUS` entry (expected \"10\") instead of leaving it here"
+        got, "10",
+        "the while-loop/NDArray-accumulator bug appears to have regressed -- \
+         see this test's doc comment (and semantic-ir-to-javascript's `numOf`, \
+         `runtime.rs`) for the fix this used to be a `known_bug_*` guard against"
     );
 }

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_validator.rs
@@ -78,6 +78,23 @@ fn a_float_literal_program_validates_and_declares_floats() {
 }
 
 #[test]
+fn a_logical_and_program_validates_and_declares_short_circuit() {
+    // Regression test for a confirmed, previously-shipped bug: `try_logical`
+    // (`src/lower.rs`) built `Expr::LogicalAnd`/`Expr::LogicalOr` nodes for
+    // `&&`/`||`/`&`/`|` without ever calling `self.observed.add(Feature::
+    // ShortCircuit)`, so any MATLAB program using them failed
+    // `semantic_ir::validate()` outright with "manifest does not declare
+    // feature short-circuit but module uses it" -- even though the lowering
+    // itself was otherwise correct. Found while scoping `tests/oracle.rs`'s
+    // corpus (probe: `x > 3 && y > 5`), fixed here alongside it.
+    let module = assert_valid("x = 5;\ny = 10;\nif x > 3 && y > 5\n  disp(1);\nend\n");
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::ShortCircuit));
+}
+
+#[test]
 fn control_flow_with_a_variable_accumulator_validates_but_needs_array_features() {
     let module = assert_valid(
         "total = 0;\nfor i = 1:10\n  if i > 5\n    total = total + i;\n  end\nend\ndisp(total);\n",

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 0.40.0 — `numOf` unwraps a scalar NDArray too (fixes a silent MATLAB `while`-loop non-termination bug)
+
+### Fixed
+
+- **`numOf` (`src/runtime.rs`), the shared helper every comparison
+  (`eq`/`ne`/`lt`/`gt`/`le`/`ge`) and re-tagging arithmetic helper
+  (`neg`/`minus`/`mod`) unwraps its operands through, only ever recognised
+  a tagged `SirFloat` box.** A rank-0 (scalar) SIR22 `NDArray` — `{ shape:
+  [], data: <one element> }`, exactly what `ArrayRt.elementwise` (the
+  `ElementwiseOp` codegen target) returns even when both operands are
+  plain numbers — fell through as an opaque object. A bare `<`/`>`/`-` on
+  that object coerces through `ToPrimitive` to `NaN`, which is silently
+  *wrong* rather than a crash (`NaN < 10` is `false`, not an error).
+  `numOf` now also unwraps a `shape.length === 0` NDArray to its sole
+  `data[0]` element, alongside the existing `SirFloat` case. `numOf` is
+  the identity on any value it doesn't recognise, and only MATLAB/APL/
+  J-style SIR22 frontends ever construct an NDArray in the first place, so
+  this is a no-op for every other language this backend serves (Ruby, JS,
+  Wolfram/Macsyma's symbolic domain, …) and a real, general fix for
+  "compare/negate/subtract-from a value that happens to have taken the
+  array-domain codegen path" — not specific to any one construct's shape.
+  - **Found by**: `matlab-to-semantic-ir`'s oracle test (`tests/
+    oracle.rs`, added in the PR immediately before this one),
+    `known_bug_while_loop_accumulator_terminates_after_one_iteration`: a
+    MATLAB `while` loop whose condition variable is also a non-literal
+    (variable-involving) arithmetic accumulator ran its body exactly
+    **once** instead of converging, because `matlab-to-semantic-ir`'s
+    scalar/array disambiguation heuristic (`expr_is_known_scalar`, see
+    that crate's `src/lower.rs`) only ever treats a *literal*-derived
+    expression as provably scalar — a variable, even one that only ever
+    holds scalars at runtime, always takes the `ElementwiseOp` path, so
+    the accumulator becomes an NDArray-shaped object after its first
+    update, and the loop's own `n < 10` condition (compiled to
+    `__Sir.lt(n, 10)`) silently evaluated to `false` every time from the
+    second iteration on. This is the most severe bug that PR found: a
+    silent wrong *computation*, not merely a wrong *display*.
+  - **Also fixes, for free, in the same commit**: unary minus on a power
+    expression (`-2 ^ 2` gave `NaN` instead of `-4`, also documented in
+    `matlab-to-semantic-ir`'s oracle test module doc) — `^`/`.^`
+    unconditionally lower to `ElementwiseOp::Pow` (no literal-only scalar
+    fast path at all, unlike `+`/`-`/`*`), so even two literal operands
+    produce a scalar NDArray, and `neg`'s codegen calls this same `numOf`.
+    Confirmed by re-running the exact repro through the real pipeline
+    after the fix (`compile_source` → `compile` → `node`): prints `-4`.
+  - Regression test: `tests/run_with_node.rs`'s
+    `numof_unwraps_scalar_ndarray_for_comparison_and_negation`, exercising
+    `numOf`/`lt`/`gt`/`eq`/`ne`/`neg`/`minus` directly against a
+    hand-built scalar `__Sir.Array.ndarray([], Float64Array.of(7))` via a
+    raw-JS runtime snippet (mirrors the existing
+    `tagged_float_helpers_behave` test's own pattern for exercising
+    runtime helpers directly).
+  - Full existing suite (228 tests across `src/` unit tests +
+    `run_with_node.rs` + `sir22_array.rs` + `sir23_symbolic.rs` + doctest)
+    passes unchanged, plus every downstream frontend crate with this
+    backend as a dev-dependency (`apl-to-semantic-ir`,
+    `javascript-to-semantic-ir`, `macsyma-to-semantic-ir`,
+    `j-to-semantic-ir`, `matlab-to-semantic-ir`, `sir-conformance`,
+    `wolfram-to-semantic-ir`) re-verified green — the new branch is only
+    ever reachable by a value an SIR22 array-domain frontend constructed,
+    so it is provably inert for every other consumer.
+
 ## 0.39.0 — tagged-float flip: faithful Ruby `Integer#/` vs `Float#/`, and `7.0` prints `7.0`
 
 Wires the dormant tagged-float substrate (0.38.0) into the emitter and every

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -140,7 +140,37 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // `numOf` unwraps to the raw f64 for arithmetic/comparison; `isNum`
   // recognises "a number" at type gates; `isFloat` recognises "a Ruby
   // Float" (boxed integral OR non-integral native).
-  function numOf(x) { return x instanceof SirFloat ? x.f : x; }
+  //
+  // SECOND unwrap case, added alongside the `SirFloat` one above: a
+  // rank-0 (scalar) SIR22 `NDArray` — `{ shape: [], data: <1 element> }`
+  // (see the "SIR22: array/matrix domain" section far below, `ndarray`/
+  // `toArrayValue`). A scalar-only MATLAB accumulator (`n = n + 1` inside
+  // a `while` loop, where `n` was never provably scalar to the *frontend*
+  // because it is a variable, not a literal — see `matlab-to-semantic-ir`'s
+  // `expr_is_known_scalar`) takes the array-domain `ElementwiseOp` codegen
+  // path even though every value it ever holds is a plain number, so `n`
+  // becomes this NDArray shape after its first update. Every OTHER
+  // consumer of `numOf` (arithmetic re-tagging, comparisons) then sees an
+  // object where it expects a number; a bare JS `<`/`>`/native `-` on that
+  // object coerces through `ToPrimitive` to `NaN`, which is silently
+  // wrong (`NaN < 10` is `false`, not an error) rather than a crash. Since
+  // `numOf` is the identity on any value it doesn't recognise, and only
+  // MATLAB/APL-style SIR22 frontends ever construct an NDArray in the
+  // first place, this second branch is a no-op for every other language
+  // this backend serves (Ruby, JS, …) and a real fix for this one: it
+  // makes "a comparison/negation/subtraction/mod against a 0-D NDArray"
+  // behave exactly like "against the plain number it degenerately holds"
+  // — fixing not just the while-loop non-termination bug this was written
+  // for, but also (for free, same mechanism) unary minus on a scalar power
+  // expression (`-2 ^ 2`, which lowers to `ElementwiseOp::Pow` even for two
+  // literals and previously gave `NaN` via `neg`'s own `numOf` call).
+  function numOf(x) {
+    if (x instanceof SirFloat) { return x.f; }
+    if (x !== null && typeof x === "object" && Array.isArray(x.shape) && x.shape.length === 0) {
+      return x.data[0];
+    }
+    return x;
+  }
   function isNum(x) { return typeof x === "number" || x instanceof SirFloat; }
   function isFloat(x) {
     return x instanceof SirFloat || (typeof x === "number" && !Number.isInteger(x));

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -260,6 +260,43 @@ console.log(o.join("|"));
     }
 }
 
+#[test]
+fn numof_unwraps_scalar_ndarray_for_comparison_and_negation() {
+    // Regression test for the while-loop-accumulator bug found by
+    // `matlab-to-semantic-ir`'s oracle test (`tests/oracle.rs`, previously
+    // `known_bug_while_loop_accumulator_terminates_after_one_iteration`, now
+    // fixed): a rank-0 (scalar) SIR22 `NDArray` -- `{ shape: [], data: [x] }`,
+    // exactly what `__Sir.Array.elementwise` returns even for two plain-number
+    // operands (any variable-involving arithmetic takes this path, since the
+    // frontend's scalar heuristic only recognises *literal* chains as
+    // provably scalar) -- must compare/negate/subtract exactly like the
+    // plain number `x` it degenerately holds. Before this fix, `numOf` only
+    // unwrapped a tagged `SirFloat`; a scalar NDArray fell through as an
+    // opaque object, and a native `<`/`>`/`-` on it coerced through
+    // `ToPrimitive` to `NaN` -- `NaN < 10` is silently `false`, not an error,
+    // which is exactly why a `while n < 10 ... n = n + 1 ... end` loop whose
+    // `n` starts as a literal but is re-assigned via variable-involving
+    // arithmetic used to terminate after its first iteration instead of
+    // converging.
+    let snippet = r#"
+const F = __Sir; const o = [];
+const seven = F.Array.ndarray([], Float64Array.of(7));
+const ten = F.Array.ndarray([], Float64Array.of(10));
+o.push(String(F.numOf(seven)));       // 7  -- unwrapped to a plain number
+o.push(String(F.lt(seven, 10)));      // true  (7 < 10; used to be NaN < 10 = false)
+o.push(String(F.lt(ten, 7)));         // false (10 < 7)
+o.push(String(F.gt(seven, ten)));     // false (7 > 10)
+o.push(String(F.eq(seven, 7)));       // true  (value equality vs. the plain number)
+o.push(String(F.ne(seven, ten)));     // true
+o.push(String(F.neg(seven)));         // -7    (bare native `-` on the old object gave NaN)
+o.push(String(F.minus(ten, seven)));  // 3
+console.log(o.join("|"));
+"#;
+    if let Some(stdout) = run_runtime_snippet(snippet, "ndarray_numof") {
+        assert_eq!(stdout, "7|true|false|false|true|true|-7|3");
+    }
+}
+
 fn puts_(arg: Expr) -> Stmt {
     Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: sp() }
 }


### PR DESCRIPTION
## Summary

Follow-up to [PR #8549](https://github.com/adhithyan15/coding-adventures/pull/8549)'s oracle tests, which found a real silent-wrong-computation bug: a MATLAB `while` loop whose condition variable is also a non-literal arithmetic accumulator (`n = n + 1` inside `while n < 10`) ran its body exactly once instead of converging, with no error at all.

**Root cause** (confirmed directly against the generated JS, not just the prior diagnosis): comparisons already route through a shared `__Sir.lt` helper backed by `numOf` in `semantic-ir-to-javascript`'s runtime prelude — but `numOf` only unwrapped a tagged `SirFloat` box, passing every other value (including a rank-0/scalar `NDArray`-shaped `{shape: [], data: [x]}` object, which `n` becomes after `n + 1` takes the array-domain codegen path) through unchanged. `numOf(NDArray) < 10` → `NaN < 10` → `false`, so the loop's own accumulator update made its *own* condition permanently false after the first iteration.

**Fix**: `numOf` now also unwraps a scalar (rank-0) NDArray to its sole `data[0]` element — the general fix, not a MATLAB-specific one, since it corrects *any* comparison/negation against a value that happened to take the array-domain path. This fixed a second, independently-found bug for free: unary minus on a power expression (`-2 ^ 2`) previously gave `NaN`, now correctly gives `-4` — strong evidence the fix sits at the right layer.

Also fixed: `matlab-to-semantic-ir` never declared `Feature::ShortCircuit` for `&&`/`||`/`&`/`|`, failing `semantic_ir::validate()` for any program using them (one-line fix).

**Left open, deliberately**: integer-literal division floors instead of true-dividing (`7 / 2` → `3`) — needs a source-language-aware division convention (MATLAB has no integer type at all), a real design decision rather than a small fix, tracked separately.

## Downstream consumer verification

`semantic-ir-to-javascript` is a shared runtime crate — per this repo's own convention, verified every downstream consumer, not just the frontend that found the bug: `matlab-to-semantic-ir`, `apl-to-semantic-ir`, `javascript-to-semantic-ir`, `macsyma-to-semantic-ir`, `j-to-semantic-ir`, `wolfram-to-semantic-ir`, and `sir-conformance` (the full cross-backend matrix, real `rustc`/`go run`/`node` toolchain invocations) all pass clean.

## Test plan

- [x] `matlab-to-semantic-ir/tests/oracle.rs`'s `known_bug_while_loop_accumulator_terminates_after_one_iteration` renamed to `while_loop_accumulator_converges_correctly`, now asserts the correct converged value (10)
- [x] New regression test `numof_unwraps_scalar_ndarray_for_comparison_and_negation` in `semantic-ir-to-javascript`
- [x] New oracle corpus case for `unary_minus_on_power`, cross-checked against native `matlab-runtime` (agrees: `-4`)
- [x] New test `a_logical_and_program_validates_and_declares_short_circuit`
- [x] `cargo test -p matlab-to-semantic-ir -p semantic-ir-to-javascript` — all green (rebased onto current main and re-verified)
- [x] `/security-review` — passed, with explicit verification that a single unwrap level is provably sufficient (the only two constructors of scalar-shaped NDArrays always produce a length-1 `Float64Array`, which can never itself need unwrapping) and that neither hunk introduces any generated-code-injection surface (both are static runtime-prelude/feature-flag changes, no string interpolation of source-derived data)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>