### PR TITLE
feat(script-writing-visualizer): spaced-repetition scheduler wired into Practice (0.3.0)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.3.0 — Spaced-repetition scheduler wired into Practice
+
+- **New pure module `src/scheduler.ts`** — a Leitner / SM-2-lite scheduler
+  measured in **sessions** (no wall-clock, no `Date`), the "core module" of HL02.
+  Each item tracks a Leitner box, `dueAtSession`, lapses, and reps; a correct
+  answer promotes the box and expands the interval (1 → 3 → 7 → 15 → 30 sessions),
+  a wrong answer drops it to box 0 (due again immediately). `pickNext` returns the
+  most-overdue item deterministically (ties → fewest reps → lowest index), falling
+  back to the soonest-due so practice never stalls.
+- **Practice mode now uses it**: instead of a random letter each question, the
+  **scheduler chooses** which letter to ask, so missed letters resurface soon and
+  mastered ones fade back — real spaced repetition. Each answer advances the
+  session clock and feeds `review`. A **"mastered N / total"** read-out joins the
+  score line. (Randomness stays only in distractor choice + answer position.)
+- **14 new unit tests (36 total)** covering promotion/expansion, lapse-reset,
+  `pickNext` ordering + tie-breaks + the never-stall fallback, immutability, and
+  an integration check (a correct streak masters an item; a miss resurfaces).
+
 ## 0.2.0 — Practice mode (recall drill)
 
 - **New "Practice" mode** alongside "Browse": a recall drill that shows a

--- a/code/programs/typescript/script-writing-visualizer/README.md
+++ b/code/programs/typescript/script-writing-visualizer/README.md
@@ -57,6 +57,14 @@ pure, unit-tested `src/drill.ts` (`buildDrillQuestion`, `confusabilityOrder`,
 `checkAnswer`, scoring); all randomness is injected by the UI so the core stays
 deterministic.
 
+**Spaced repetition.** Which letter you're asked isn't random — a Leitner /
+SM-2-lite scheduler (`src/scheduler.ts`, measured in *sessions*, no `Date`)
+picks the most-overdue letter each question. Get it right and it drifts into the
+future (1 → 3 → 7 → 15 → 30 sessions); miss it and it comes straight back. A
+**"mastered N / total"** read-out shows progress. The scheduler is pure and
+unit-tested — per `HL02` it's "the core module … where test coverage matters
+most."
+
 ## Scope and what's next
 
 Today the app does **read + decompose** (Browse) and **recall** (Practice). Still

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Companion app (HL02 MVP): break a non-Latin script apart and learn to write it, letter by letter",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/main.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/main.ts
@@ -23,6 +23,13 @@ import {
   type DrillQuestion,
   type Score,
 } from "./drill.ts";
+import {
+  initStates,
+  pickNext,
+  reviewIn,
+  masteredCount,
+  type ItemState,
+} from "./scheduler.ts";
 import "./styles.css";
 
 const app = document.getElementById("app");
@@ -37,6 +44,11 @@ let currentLetter = 0;
 let score: Score = emptyScore();
 let question: DrillQuestion | null = null;
 let chosen: number | null = null; // which option the learner picked (null = unanswered)
+// Spaced-repetition state: the scheduler decides WHICH letter to ask next, so
+// missed letters resurface sooner and mastered ones fade back. One session tick
+// per answered question (see scheduler.ts). Rebuilt when the script changes.
+let schedule: ItemState[] = [];
+let sessionTick = 0;
 
 const OPTION_COUNT = 4;
 
@@ -162,16 +174,20 @@ function renderDetail(v: LetterView): HTMLElement {
 /** Start (or restart) a practice session for the current script. */
 function startPractice(): void {
   score = emptyScore();
+  const views = buildScriptView(SCRIPTS[currentScript]!);
+  schedule = initStates(views.length);
+  sessionTick = 0;
   nextQuestion();
 }
 
-/** Pick a fresh random target + options for the current script. */
+/** Let the scheduler choose the next letter; the UI still randomises options. */
 function nextQuestion(): void {
   const views = buildScriptView(SCRIPTS[currentScript]!);
-  const target = randInt(views.length);
+  // The scheduler decides WHICH letter (spaced repetition); randomness is only
+  // for the distractors + answer position.
+  const target = pickNext(schedule, sessionTick);
   const placeAt = randInt(Math.min(OPTION_COUNT, views.length));
-  // Draw distractors from the most-confusable pool, shuffled for variety.
-  question = buildDrillQuestion(views, target, OPTION_COUNT, chooseConfusableShuffled, placeAt);
+  question = buildDrillQuestion(views, target < 0 ? 0 : target, OPTION_COUNT, chooseConfusableShuffled, placeAt);
   chosen = null;
 }
 
@@ -180,11 +196,12 @@ function renderPractice(): HTMLElement {
   const q = question!;
   const wrap = el("div", "practice");
 
-  // Score line
+  // Score line + a spaced-repetition mastery read-out
   const acc = accuracy(score);
+  const mastered = masteredCount(schedule);
   const scoreLine = el("div", "score");
-  scoreLine.textContent =
-    acc === null ? "Score: 0 / 0" : `Score: ${score.correct} / ${score.total}  ·  ${acc}%`;
+  const scoreText = acc === null ? "Score: 0 / 0" : `Score: ${score.correct} / ${score.total}  ·  ${acc}%`;
+  scoreLine.textContent = `${scoreText}   ·   mastered ${mastered} / ${schedule.length}`;
   wrap.appendChild(scoreLine);
 
   // Prompt
@@ -209,7 +226,11 @@ function renderPractice(): HTMLElement {
     b.onclick = () => {
       if (chosen !== null) return; // already answered
       chosen = i;
-      score = record(score, checkAnswer(q, i));
+      const correct = checkAnswer(q, i);
+      score = record(score, correct);
+      // Feed the answer to the scheduler and advance the session clock.
+      schedule = reviewIn(schedule, q.targetIndex, correct, sessionTick);
+      sessionTick += 1;
       render();
     };
     opts.appendChild(b);

--- a/code/programs/typescript/script-writing-visualizer/src/scheduler.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/scheduler.ts
@@ -1,0 +1,132 @@
+// ---------------------------------------------------------------------------
+// scheduler.ts — the spaced-repetition heart of Practice mode (HL02).
+//
+// Recognition and recall build memory; *spacing* makes it last. This is a
+// Leitner / SM-2-lite scheduler measured in SESSIONS (not wall-clock, so there
+// is no Date dependency and everything is reproducible). Each answered question
+// advances the session clock by one; a letter you get right drifts further into
+// the future on an expanding schedule (1 → 3 → 7 → 15 → 30 sessions), while a
+// letter you miss drops back to "due now" and resurfaces quickly.
+//
+// Pure and deterministic — no Date, no Math.random. The UI owns the session
+// counter and the per-script state; this module only computes the next state
+// and which item is most due. That is exactly what makes it unit-testable, and
+// per HL02 it is "the core module … where test coverage matters most."
+// ---------------------------------------------------------------------------
+
+/** Scheduling state for one practice item (here, one letter of a script). */
+export interface ItemState {
+  /** The item id — an index into the script's letters. */
+  letterIndex: number;
+  /** Leitner box 0..MAX_BOX; higher = longer interval. */
+  box: number;
+  /** Session index at which this item next becomes due. */
+  dueAtSession: number;
+  /** Session index when it first appeared. */
+  introducedAt: number;
+  /** Times failed. */
+  lapses: number;
+  /** Total reviews (used for tie-breaking and a mastery read-out). */
+  reps: number;
+}
+
+/**
+ * Box → interval in sessions until next due. Matches HL00's open-loop
+ * N+1/N+3/N+7/N+15 baseline, now closed-loop. Box 0 (new or just-lapsed) comes
+ * back next session; each promotion roughly triples the gap.
+ */
+export const INTERVALS = [1, 1, 3, 7, 15, 30];
+export const MAX_BOX = INTERVALS.length - 1;
+
+/** Interval for a given box, clamped into range. */
+export function intervalFor(box: number): number {
+  const b = Math.max(0, Math.min(MAX_BOX, box));
+  return INTERVALS[b]!;
+}
+
+/** Fresh state for `count` items, all due at `session` (default 0). */
+export function initStates(count: number, session = 0): ItemState[] {
+  return Array.from({ length: Math.max(0, count) }, (_, i) => ({
+    letterIndex: i,
+    box: 0,
+    dueAtSession: session,
+    introducedAt: session,
+    lapses: 0,
+    reps: 0,
+  }));
+}
+
+/** Is this item due at (or before) the given session? */
+export function isDue(item: ItemState, session: number): boolean {
+  return item.dueAtSession <= session;
+}
+
+/** How many items are due at `session`. */
+export function dueCount(items: ItemState[], session: number): number {
+  return items.filter((it) => isDue(it, session)).length;
+}
+
+/** How many items have reached a "learned" box (default: box >= 3). */
+export function masteredCount(items: ItemState[], minBox = 3): number {
+  return items.filter((it) => it.box >= minBox).length;
+}
+
+/**
+ * Choose the next item to practise, deterministically.
+ *
+ * Prefer items that are **due** (dueAtSession <= session); among those, the most
+ * overdue (smallest dueAtSession) wins, tie-broken by fewest reps then lowest
+ * letterIndex. If nothing is due yet, fall back to the soonest-due item so
+ * practice never stalls. Returns the item's letterIndex, or -1 if empty.
+ */
+export function pickNext(items: ItemState[], session: number): number {
+  if (items.length === 0) return -1;
+  const due = items.filter((it) => isDue(it, session));
+  const pool = due.length > 0 ? due : items;
+  let best = pool[0]!;
+  for (const it of pool) {
+    if (
+      it.dueAtSession < best.dueAtSession ||
+      (it.dueAtSession === best.dueAtSession && it.reps < best.reps) ||
+      (it.dueAtSession === best.dueAtSession && it.reps === best.reps && it.letterIndex < best.letterIndex)
+    ) {
+      best = it;
+    }
+  }
+  return best.letterIndex;
+}
+
+/**
+ * Fold one answer into an item's state (immutably), at the given session.
+ *
+ * Correct → promote a box (capped) and schedule by the *new* box's interval, so
+ * the gap expands. Wrong → drop to box 0 (due again very soon) and count a lapse.
+ */
+export function review(item: ItemState, wasCorrect: boolean, session: number): ItemState {
+  if (wasCorrect) {
+    const box = Math.min(item.box + 1, MAX_BOX);
+    return {
+      ...item,
+      box,
+      dueAtSession: session + intervalFor(box),
+      reps: item.reps + 1,
+    };
+  }
+  return {
+    ...item,
+    box: 0,
+    dueAtSession: session + intervalFor(0),
+    lapses: item.lapses + 1,
+    reps: item.reps + 1,
+  };
+}
+
+/** Apply `review` to whichever item matches `letterIndex`, leaving others as-is. */
+export function reviewIn(
+  items: ItemState[],
+  letterIndex: number,
+  wasCorrect: boolean,
+  session: number,
+): ItemState[] {
+  return items.map((it) => (it.letterIndex === letterIndex ? review(it, wasCorrect, session) : it));
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/scheduler.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/scheduler.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  INTERVALS,
+  MAX_BOX,
+  intervalFor,
+  initStates,
+  isDue,
+  dueCount,
+  masteredCount,
+  pickNext,
+  review,
+  reviewIn,
+  type ItemState,
+} from "../src/scheduler.ts";
+
+function item(over: Partial<ItemState> = {}): ItemState {
+  return { letterIndex: 0, box: 0, dueAtSession: 0, introducedAt: 0, lapses: 0, reps: 0, ...over };
+}
+
+describe("initStates", () => {
+  it("makes every item due immediately in box 0", () => {
+    const s = initStates(3);
+    expect(s).toHaveLength(3);
+    expect(s.map((x) => x.letterIndex)).toEqual([0, 1, 2]);
+    expect(s.every((x) => x.box === 0 && x.dueAtSession === 0 && x.reps === 0)).toBe(true);
+    expect(dueCount(s, 0)).toBe(3);
+  });
+  it("honours a starting session and clamps negatives", () => {
+    expect(initStates(2, 5).every((x) => x.dueAtSession === 5 && x.introducedAt === 5)).toBe(true);
+    expect(initStates(-4)).toEqual([]);
+  });
+});
+
+describe("intervalFor", () => {
+  it("maps boxes to intervals and clamps out-of-range", () => {
+    expect(intervalFor(0)).toBe(INTERVALS[0]);
+    expect(intervalFor(MAX_BOX)).toBe(INTERVALS[MAX_BOX]);
+    expect(intervalFor(999)).toBe(INTERVALS[MAX_BOX]);
+    expect(intervalFor(-3)).toBe(INTERVALS[0]);
+  });
+});
+
+describe("review", () => {
+  it("promotes a box and expands the interval on correct", () => {
+    const a = review(item({ box: 0, reps: 0 }), true, 10);
+    expect(a.box).toBe(1);
+    expect(a.dueAtSession).toBe(10 + intervalFor(1));
+    expect(a.reps).toBe(1);
+    expect(a.lapses).toBe(0);
+    // chained promotions keep expanding
+    const b = review(a, true, a.dueAtSession);
+    expect(b.box).toBe(2);
+    expect(b.dueAtSession).toBe(a.dueAtSession + intervalFor(2));
+  });
+
+  it("caps the box at MAX_BOX", () => {
+    let s = item({ box: MAX_BOX });
+    s = review(s, true, 0);
+    expect(s.box).toBe(MAX_BOX);
+    expect(s.dueAtSession).toBe(0 + INTERVALS[MAX_BOX]!);
+  });
+
+  it("resets to box 0 and counts a lapse on wrong", () => {
+    const s = review(item({ box: 4, reps: 9, lapses: 1 }), false, 20);
+    expect(s.box).toBe(0);
+    expect(s.dueAtSession).toBe(20 + intervalFor(0)); // due again very soon
+    expect(s.lapses).toBe(2);
+    expect(s.reps).toBe(10);
+  });
+
+  it("does not mutate the input", () => {
+    const original = item({ box: 2 });
+    const snapshot = { ...original };
+    review(original, true, 3);
+    expect(original).toEqual(snapshot);
+  });
+});
+
+describe("pickNext", () => {
+  it("returns -1 for an empty set", () => {
+    expect(pickNext([], 0)).toBe(-1);
+  });
+
+  it("prefers the most-overdue due item", () => {
+    const items = [
+      item({ letterIndex: 0, dueAtSession: 5 }),
+      item({ letterIndex: 1, dueAtSession: 2 }), // most overdue at session 10
+      item({ letterIndex: 2, dueAtSession: 8 }),
+    ];
+    expect(pickNext(items, 10)).toBe(1);
+  });
+
+  it("breaks ties by fewest reps, then lowest index", () => {
+    const items = [
+      item({ letterIndex: 2, dueAtSession: 0, reps: 1 }),
+      item({ letterIndex: 0, dueAtSession: 0, reps: 3 }),
+      item({ letterIndex: 1, dueAtSession: 0, reps: 1 }),
+    ];
+    // reps: idx2=1, idx1=1 tie → lowest index → 1
+    expect(pickNext(items, 0)).toBe(1);
+  });
+
+  it("falls back to the soonest-due item when nothing is due (never stalls)", () => {
+    const items = [
+      item({ letterIndex: 0, dueAtSession: 30 }),
+      item({ letterIndex: 1, dueAtSession: 12 }),
+      item({ letterIndex: 2, dueAtSession: 20 }),
+    ];
+    expect(pickNext(items, 5)).toBe(1); // none due; earliest future
+  });
+});
+
+describe("reviewIn + integration", () => {
+  it("updates only the answered item", () => {
+    const items = initStates(3);
+    const after = reviewIn(items, 1, true, 0);
+    expect(after[0]).toEqual(items[0]); // untouched
+    expect(after[2]).toEqual(items[2]); // untouched
+    expect(after[1]!.box).toBe(1);
+    expect(after[1]!.reps).toBe(1);
+  });
+
+  it("a correct streak masters an item and it stops being picked while easier ones remain", () => {
+    let items = initStates(2);
+    let session = 0;
+    // Drill letter 0 correct several times; letter 1 never touched.
+    for (let k = 0; k < 4; k++) {
+      items = reviewIn(items, 0, true, session);
+      session += 1;
+    }
+    expect(masteredCount(items)).toBeGreaterThanOrEqual(1);
+    // letter 1 is still box 0, due since session 0 → far more overdue → picked
+    expect(pickNext(items, session)).toBe(1);
+  });
+
+  it("a missed item comes back soon (box 0, due next session)", () => {
+    let items = initStates(3);
+    // master 1 and 2 out to the future, miss 0
+    items = reviewIn(items, 1, true, 0);
+    items = reviewIn(items, 2, true, 0);
+    items = reviewIn(items, 0, false, 0); // wrong → due at session 0+interval(0)
+    const dueSoon = items.find((x) => x.letterIndex === 0)!;
+    expect(dueSoon.box).toBe(0);
+    expect(dueSoon.dueAtSession).toBe(intervalFor(0));
+    expect(pickNext(items, intervalFor(0))).toBe(0); // it's the one that resurfaces
+  });
+});

--- a/code/programs/typescript/script-writing-visualizer/vitest.config.ts
+++ b/code/programs/typescript/script-writing-visualizer/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       provider: "v8",
       // The pure logic (core.ts + drill.ts) is what we hold to a high bar;
       // main.ts is the thin DOM shell and data.ts is just JSON imports.
-      include: ["src/core.ts", "src/drill.ts"],
+      include: ["src/core.ts", "src/drill.ts", "src/scheduler.ts"],
     },
   },
 });


### PR DESCRIPTION
## Companion app — spaced-repetition scheduler wired into Practice (0.3.0)

Loop item 7. The Practice mode used to pick a **random** letter each question;
now a **Leitner / SM-2-lite scheduler** chooses, so missed letters resurface soon
and mastered ones fade back — the learning-science heart of HL02.

### What's new
- **`src/scheduler.ts`** — pure, deterministic, measured in **sessions** (no
  `Date`). Per-item `{box, dueAtSession, lapses, reps}`; a **correct** answer
  promotes the Leitner box and expands the interval (**1 → 3 → 7 → 15 → 30**
  sessions), a **wrong** answer drops it to box 0 (due again immediately).
  `pickNext` returns the most-overdue item deterministically (ties → fewest reps
  → lowest index), falling back to the soonest-due so **practice never stalls**.
- **Practice wired to it**: the scheduler picks the letter; each answer advances
  the session clock and feeds `review`. A **"mastered N / total"** read-out joins
  the score line. Randomness stays only in distractor choice + answer position.

### Design & tests
- Matches the `HL02` spec's `ItemState` and its call for "a pure, deterministic,
  unit-tested module … where test coverage matters most."
- **14 new unit tests (36 total)**: box promotion/expansion, lapse-reset,
  `pickNext` ordering + tie-breaks + never-stall fallback, immutability, and an
  integration check (a correct streak masters an item; a miss resurfaces).

### Verified
- Build + 36 tests pass. Drove Practice in the browser: answered *а* correctly →
  the scheduler advanced to **б** (the most-overdue letter); the "mastered 0/33"
  read-out shows; **console clean**. Security review passed (pure integer logic,
  safe DOM sinks, no new deps).

### Next (HL02)
Progressive cross-language interleaving (introduce one (concept, language) at a
time, then fold into cumulative mixed review) and a write/produce mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
