### PR TITLE
feat(atbash-cipher): add Haskell port

### DIFF
--- a/code/packages/haskell/atbash-cipher/BUILD
+++ b/code/packages/haskell/atbash-cipher/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/atbash-cipher/BUILD_windows
+++ b/code/packages/haskell/atbash-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/atbash-cipher/CHANGELOG.md
+++ b/code/packages/haskell/atbash-cipher/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add case-preserving Atbash encryption and decryption for ASCII letters.
+- Preserve punctuation, digits, whitespace, and non-ASCII characters.
+- Add tests for reference examples, complete alphabets, and involution.

--- a/code/packages/haskell/atbash-cipher/README.md
+++ b/code/packages/haskell/atbash-cipher/README.md
@@ -1,0 +1,17 @@
+# atbash-cipher
+
+Pure Haskell implementation of the classical Atbash substitution cipher.
+
+## API
+
+- `encrypt` mirrors ASCII letters across their alphabet (`A` to `Z`, `B` to
+  `Y`, and so on), preserving case and passing every other character through.
+- `decrypt` performs the same transformation because Atbash is its own inverse.
+
+The library depends only on `base`. Tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/atbash-cipher/atbash-cipher.cabal
+++ b/code/packages/haskell/atbash-cipher/atbash-cipher.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          atbash-cipher
+version:       0.1.0
+synopsis:      Case-preserving ASCII Atbash cipher
+description:   A pure Haskell implementation of the classical Atbash substitution cipher.
+category:      Cryptography
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  AtbashCipher
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    AtbashCipherSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , atbash-cipher
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/atbash-cipher/cabal.project
+++ b/code/packages/haskell/atbash-cipher/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/atbash-cipher/src/AtbashCipher.hs
+++ b/code/packages/haskell/atbash-cipher/src/AtbashCipher.hs
@@ -1,0 +1,24 @@
+module AtbashCipher
+    ( encrypt
+    , decrypt
+    ) where
+
+import Data.Char (chr, isAsciiLower, isAsciiUpper, ord)
+
+-- | Encrypt text with the Atbash substitution. ASCII letters are mirrored
+-- within their alphabet while case and all non-letter characters are kept.
+encrypt :: String -> String
+encrypt = map transform
+
+-- | Decrypt Atbash text. Atbash is an involution, so decryption is encryption.
+decrypt :: String -> String
+decrypt = encrypt
+
+transform :: Char -> Char
+transform character
+    | isAsciiUpper character = mirrorFrom 'A'
+    | isAsciiLower character = mirrorFrom 'a'
+    | otherwise = character
+  where
+    mirrorFrom alphabetStart =
+        chr (ord alphabetStart + 25 - (ord character - ord alphabetStart))

--- a/code/packages/haskell/atbash-cipher/test/AtbashCipherSpec.hs
+++ b/code/packages/haskell/atbash-cipher/test/AtbashCipherSpec.hs
@@ -1,0 +1,39 @@
+module AtbashCipherSpec (spec) where
+
+import AtbashCipher
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "encrypt" $ do
+        it "matches the classic HELLO example" $
+            encrypt "HELLO" `shouldBe` "SVOOL"
+        it "preserves letter case" $
+            encrypt "Hello World" `shouldBe` "Svool Dliow"
+        it "preserves punctuation, whitespace, and digits" $
+            encrypt "Hello, World! 123" `shouldBe` "Svool, Dliow! 123"
+        it "maps the complete alphabets in reverse order" $ do
+            encrypt "ABCDEFGHIJKLMNOPQRSTUVWXYZ" `shouldBe`
+                "ZYXWVUTSRQPONMLKJIHGFEDCBA"
+            encrypt "abcdefghijklmnopqrstuvwxyz" `shouldBe`
+                "zyxwvutsrqponmlkjihgfedcba"
+        it "handles empty input" $
+            encrypt "" `shouldBe` ""
+        it "passes non-ASCII characters through" $
+            encrypt "caf\x00e9 \x2764" `shouldBe` "xzu\x00e9 \x2764"
+
+    describe "decrypt" $ do
+        it "recovers the classic example" $
+            decrypt "SVOOL" `shouldBe` "HELLO"
+        it "has the same substitution as encrypt" $
+            decrypt "Svool, Dliow!" `shouldBe` "Hello, World!"
+
+    describe "Atbash invariants" $ do
+        it "is its own inverse" $ do
+            let original = "The Quick Brown Fox jumps over 13 lazy dogs."
+            decrypt (encrypt original) `shouldBe` original
+        it "maps the middle letters across the alphabet boundary" $ do
+            encrypt "MNmn" `shouldBe` "NMnm"
+        it "has no fixed point among ASCII letters" $ do
+            let letters = ['A' .. 'Z'] ++ ['a' .. 'z']
+            zipWith (/=) letters (encrypt letters) `shouldSatisfy` and

--- a/code/packages/haskell/atbash-cipher/test/Spec.hs
+++ b/code/packages/haskell/atbash-cipher/test/Spec.hs
@@ -1,0 +1,5 @@
+import AtbashCipherSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -115,11 +115,12 @@ and `hash-set` ports, the paired `in-memory-data-store-engine` and
 ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
-`fpga` ports, and the paired C#/F# `zstd` ports:
+`fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`
+port:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 309 |
+| Present in 10-15 languages | 172 | 308 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 703 | 9,842 |
@@ -176,7 +177,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 33 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -385,6 +386,15 @@ multi-block frames, malformed input, compression ratios, and cross-language
 compatibility with the established Ruby implementation. The package now spans
 12 implementation lanes, reduces the high-consensus backlog to 309 slots, and
 closes the remaining high-consensus gaps in both C# and F#.
+
+The first Haskell high-consensus slice is complete: `atbash-cipher` now
+provides a dependency-free CR01 implementation that mirrors ASCII letters
+while preserving case and passing all other characters through unchanged.
+Its package-native suite exercises 11 examples with 100% expression coverage,
+including complete alphabets, non-ASCII pass-through, and the cipher's
+self-inverse property. The package now spans 13 implementation lanes, reduces
+the high-consensus backlog to 308 slots, and leaves 33 gaps in the Haskell
+lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a dependency-free Haskell port of the CR01 Atbash cipher
- preserve ASCII letter case while passing punctuation, digits, whitespace, and non-ASCII characters through unchanged
- add package metadata, documentation, BUILD entry points, and an 11-example Hspec suite
- refresh the parity roadmap from 309 to 308 high-consensus gaps and from 34 to 33 Haskell gaps

## Validation

- `stack test --coverage` (11 examples, 0 failures; 100% expression coverage)
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'` (6 tests passed)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions; 308 high-consensus gaps; 33 Haskell gaps)
- `bash code/packages/haskell/atbash-cipher/BUILD_windows`
- `git diff --check`
