### PR TITLE
feat(hl-french): Chapter 5 — the first -er verbs (Je parle français; the pro-drop contrast)

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -207,6 +207,10 @@
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
+      "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
+      "FR-VERB-HABITER": "habiter — 'to live/dwell' (← habitāre → habitat/inhabit)",
+      "FR-VERB-TRAVAILLER": "travailler — 'to work' (← tripaliāre → travail/travel; twin of ES trabajar)",
+      "FR-WORD-FRANCAIS": "français — 'French' (the language; ← Francia, land of the Franks)",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'"

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 5 — The first verbs (sentences start to move)
+
+- **Chapter 5 authored** (`FR-C05-parler`, `-habiter`, `-travailler`,
+  `-je-parle-francais`, `-practice`): French's first **grammar-engine** chapter,
+  mirroring the Spanish Ch.6 verbs chapter. The learner stops reciting phrases and
+  starts **building sentences from a pattern**.
+- **The regular -er present tense** — the biggest French verb family: drop *-er*,
+  add *-e/-es/-e/-ons/-ez/-ent*. Taught on **parler** and cemented on **habiter**
+  and **travailler**.
+- **The silent-ending insight + the pro-drop contrast**: *-e/-es/-ent* are all
+  **silent**, so *je parle / tu parles / ils parlent* sound identical (*parl*) —
+  which is exactly **why French keeps its subject pronouns** where Spanish/Italian
+  drop them (the ear can't hear the person, so the pronoun must). Stated as the
+  single biggest structural difference from the Iberian cousins.
+- **Etymology**: *parler* ← *parabolāre* "tell parables" (→ parable/parole/
+  palaver/parley); *habiter* ← *habitāre* "keep having a place" (→ habitat/
+  inhabit); *travailler* ← *tripalium* "torture" (→ **travail/travel**; twin of
+  Spanish *trabajar*); *français* ← *Francia* (the Franks, whose name meant
+  "free" → English *frank*). First self-assembled sentence: **Je parle français**.
+- Taxonomy: namespaced `FR-VERB-PARLER/HABITER/TRAVAILLER`, `FR-WORD-FRANCAIS`
+  documented.
+
 ## Writing nuances — the accents, the cédille, the tréma
 
 - **First French `writing`-type lessons** (`FR-W01-accents`, `FR-W02-cedille`,

--- a/code/learning/human-languages/french/lessons/FR-C05-habiter.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-habiter.md
@@ -1,0 +1,64 @@
+---
+id: FR-C05-habiter
+chapter: 5
+type: word
+headword: habiter
+gloss: to live / to dwell (a second -er verb — same pattern)
+concept_tag: FR-VERB-HABITER
+prerequisites: [FR-C05-parler]
+sounds: [silent-final, r-uvular]
+roots: [habitare-latin]
+etymology_hook: "habiter ← Latin habitāre 'to dwell' (frequentative of habēre 'to have') → English habitat, inhabit"
+est_minutes: 3
+reviews_of: [FR-C05-parler]
+---
+
+# habiter — "to live," and it's about *having a place*
+
+## Warm-up
+
+[PAUSE 2s] A second **-er** verb — snap it into the exact template you just
+learned. **habiter** ("to live, to dwell") lets you say *where* you live, the
+answer to a *où* ("where") question.
+
+## Sounds you'll need
+
+- `silent-final` — the **h is silent** (French *h* never sounds): **habiter** =
+  *a-bee-TAY*. Same *-er* = *ay* ending as *parler*.
+
+## The word, taken apart
+
+**habiter** comes from Latin **habitāre**, *"to dwell, to keep on having [a
+place]"* — the **frequentative** of **habēre**, "to have." To *dwell* somewhere
+is to *keep having* it as your place. That root is thoroughly English:
+
+- **habitat** — the place a creature dwells.
+- **inhabit**, **inhabitant**, **habitation** — to dwell in / one who dwells.
+- and (via *habēre*, "have") **habit** — what you "keep having," and **able**,
+  **ability** (what you "have" it in you to do).
+
+## Grammar Lens: same -er template
+
+Drop **-er**, add the endings — identical to *parler*, silent trap and all:
+
+| j'habite · tu habites · il habite | (all *a-BEET*) |
+| nous habitons · vous habitez | (a-bee-TON · a-bee-TAY) |
+
+Note **j'habite** — *je* elides to **j'** before the vowel of *habite* (the *h*
+is silent, so it counts as a vowel). Now you can answer *où* questions:
+
+> **J'habite à Paris.** — "I live in Paris."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "habiter" — *a-bee-TAY*, silent *h*]
+- [YOU SAY: "j'habite, tu habites, il habite" — all *a-BEET*]
+- [YOU SAY: "habiter" then English "habitat, inhabit" — the *habitāre* root]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *habiter* from, and what does it literally involve?
+(*habitāre*, "keep having a place" — from *habēre*, "to have.") English cousins?
+(Habitat, inhabit, habitation.) Say "I live in Paris." (*J'habite à Paris.*)
+Next: **travailler**, "to work."

--- a/code/learning/human-languages/french/lessons/FR-C05-je-parle-francais.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-je-parle-francais.md
@@ -1,0 +1,66 @@
+---
+id: FR-C05-je-parle-francais
+chapter: 5
+type: phrase
+headword: Je parle français
+gloss: "I speak French" — your first full sentence (français = French)
+concept_tag: FR-WORD-FRANCAIS
+prerequisites: [FR-C05-parler]
+sounds: [nasal-an, soft-c-s]
+roots: [francia-latin]
+etymology_hook: "français ← Francia, 'land of the Franks'; the Franks' name meant 'free' → English frank"
+est_minutes: 4
+reviews_of: [FR-C05-parler, FR-C02-je]
+---
+
+# Je parle français — your first real sentence
+
+## Warm-up
+
+[PAUSE 2s] The moment it all pays off: you take a **verb** you conjugated and a
+**noun**, and build a sentence **no one handed you pre-made** — *Je parle
+français*, "I speak French."
+
+## The new word: français
+
+**français** = "French" (the language, and a French person), from **Francia**,
+"land of the **Franks**" — the Germanic people who settled Roman Gaul and gave
+France its name. And here's the twist: the Franks' own name meant **"free"** —
+which is why English **frank** / **frankly** means open and unguarded, and why
+the coin was a *franc*. Say it *frahn-SEH* (`soft-c-s`: the *ç*-less *c* before
+nothing here is soft *s*; the *ai* is a nasal-ish *eh*).
+
+## The sentence, assembled
+
+Snap together two things you own:
+
+> **Je** (I, ← *ego*) + **parle** (speak, from *parler*) = **Je parle français.**
+
+A complete, grammatical French sentence. Now note the contrast that defines
+French:
+
+- **You keep the *je*.** Spanish drops it (*hablo español*), because the Spanish
+  ending *-o* says "I". But French *parle / parles / parlent* all sound the same
+  (*parl*) — the ear can't tell who — so **the pronoun must stay** to carry the
+  person. **This is the single biggest structural difference** between French and
+  its Iberian cousins.
+- **No article on the language**: *je parle français*, not "*le* français" (here).
+
+Swap the pieces and it generates:
+
+- **J'habite à Paris.** — "I live in Paris."
+- **Tu parles français ?** — "Do you speak French?" (just raise the tone).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Je parle français" — *zhuh parl frahn-SEH*]
+- [YOU SAY: keep the *je* — French can't drop it (unlike Spanish *hablo*)]
+- [YOU SAY: swap — "Tu parles français ?", "J'habite à Paris"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does *français* come from, and what did the Franks' name mean?
+(*Francia*, "land of the Franks"; the name meant "free" — English *frank*.) Why
+must French keep *je* where Spanish drops *yo*? (French endings are silent, so
+the pronoun carries the person.) Next: practice.

--- a/code/learning/human-languages/french/lessons/FR-C05-parler.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-parler.md
@@ -1,0 +1,77 @@
+---
+id: FR-C05-parler
+chapter: 5
+type: word
+headword: parler
+gloss: to speak / to talk (your first regular -er verb)
+concept_tag: FR-VERB-PARLER
+prerequisites: [FR-C02-je, FR-C02-tu-vous]
+sounds: [er-ending, r-uvular]
+roots: [parabolare-latin]
+etymology_hook: "parler ← Late Latin parabolāre 'to tell parables, to talk' (← parabola) → English parable, parole, palaver"
+est_minutes: 5
+reviews_of: [FR-C03-comment-ca-va, FR-C02-practice]
+---
+
+# parler — "to speak," and the great regular French verb
+
+## Warm-up
+
+[PAUSE 2s] Until now you've assembled fixed phrases. **parler** ("to speak") is
+your first real **verb** — and it's the model for the **biggest** French verb
+family by far: the **-er** verbs. Learn this one pattern and you can drive
+thousands.
+
+## Sounds you'll need
+
+- `er-ending` — the infinitive **-er** is a clean *ay*: **parler** = *par-LAY*
+  (the *r* is silent in the ending). The stem is *parl-*.
+
+## The word, taken apart
+
+**parler** comes from Late Latin **parabolāre**, *"to tell parables, to
+discourse"* — from **parabola**, "a comparison, a speech" (itself from Greek
+*parabolē*, "a throwing-beside"). So to *speak*, in French, is at root to *tell
+parables*. That root fans into English:
+
+- **parable** — the story-comparison itself.
+- **parole** — a spoken word of honour (a prisoner's *parole*).
+- **palaver** — a long talk; **parley** — to talk terms; even **parliament** —
+  a *talking*-place.
+
+## Grammar Lens: the -er present tense (and its silent trap)
+
+Drop **-er**, add the ending for the person:
+
+| person | ending | *parler* → | sounds like |
+|---|---|---|---|
+| je | **-e** | **je parle** | *parl* |
+| tu | **-es** | **tu parles** | *parl* |
+| il / elle | **-e** | **il parle** | *parl* |
+| nous | -ons | **nous parlons** | par-LON |
+| vous | -ez | **vous parlez** | par-LAY |
+| ils / elles | **-ent** | **ils parlent** | *parl* |
+
+Here is the great French surprise: **-e, -es, and -ent are all SILENT** — *je
+parle*, *tu parles*, *ils parlent* **all sound identical**, just *parl*. Only
+*nous* (*-ons*) and *vous* (*-ez*) are audible.
+
+**This is exactly why French keeps its subject pronouns** (*je, tu, il…*) where
+Spanish and Italian *drop* them: in Spanish the ending tells you who (*hablo* vs
+*hablas*), but in French your ear can't hear the difference — so the **pronoun**
+has to carry the person. A key contrast to hold onto.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "parler" — *par-LAY*]
+- [YOU SAY: "je parle, tu parles, il parle" — all *parl*, identical]
+- [YOU SAY: "parler" then English "parable, parole, palaver" — the *parabola* root]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word is *parler* from, and its English cousins?
+(*parabolāre* ← *parabola* — parable, parole.) Which three present-tense endings
+are silent? (*-e, -es, -ent* — je/tu/ils all sound *parl*.) Why does French keep
+*je/tu* when Spanish drops *yo/tú*? (The endings are silent, so the pronoun
+carries the person.) Next: **habiter**, "to live."

--- a/code/learning/human-languages/french/lessons/FR-C05-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-practice.md
@@ -1,0 +1,68 @@
+---
+id: FR-C05-practice
+chapter: 5
+type: practice-mix
+headword: (practice)
+gloss: making sentences with -er verbs, and the silent-ending trap
+concept_tag: CH5-PRACTICE
+prerequisites: [FR-C05-parler, FR-C05-habiter, FR-C05-travailler, FR-C05-je-parle-francais]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [FR-C05-parler, FR-C05-habiter, FR-C05-travailler, FR-C05-je-parle-francais, FR-C03-practice]
+---
+
+# Practice — making sentences with -er verbs
+
+## Warm-up
+
+[PAUSE 2s] For the first time you're not reciting phrases — you're **building**
+sentences from a pattern. Drill the three verbs, and burn in the French rule the
+whole language turns on: **keep the pronoun** (the endings are silent).
+
+## Conjugate on command
+
+[PAUSE 1s] Run each through *je / tu / il*:
+
+- **parler**: je parle · tu parles · il parle — all **parl**
+- **habiter**: j'habite · tu habites · il habite — all **a-beet**
+- **travailler**: je travaille · tu travailles · il travaille — all **tra-vye**
+
+Every singular form (and the *ils* form) **sounds the same** — the *-e/-es/-ent*
+are silent. That's why *je, tu, il* stay put: they carry the person your ear
+can't hear.
+
+## Say something real
+
+> — **Tu parles** français ? — Oui, je **parle** un peu. (Do you speak French? —
+> Yes, I speak a little.)
+> — **Où** habites-tu ? — **J'habite** à Lyon. Et je **travaille** à Paris.
+> — Merci ! — De rien.
+
+## What you've built this chapter
+
+- **the regular -er present tense** — drop *-er*, add *-e/-es/-e/-ons/-ez/-ent*;
+  the singular + *ils* endings are **silent**, so the pronoun is mandatory (the
+  big contrast with Spanish/Italian pro-drop).
+- **parler** (← *parabolāre* → parable/parole), **habiter** (← *habitāre* →
+  habitat/inhabit), **travailler** (← *tripalium* → travail/travel; twin of
+  Spanish *trabajar*).
+- **Je parle français** — your first self-assembled sentence (*français* ←
+  *Francia*, the Franks = "free").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: conjugate all three verbs, je/tu/il — hear that they don't change]
+- [YOU SAY: answer about yourself — where you live, where you work, what you speak]
+- [YOU SAY: chain it — "Bonjour ! Je parle français. Tu parles français ? …
+  Au revoir !"]
+
+[REPEAT x2] "Tu parles français ? — Oui, je parle un peu."
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which -er endings are silent, and what follows from that? (*-e, -es,
+-ent* — so French keeps its subject pronouns.) Give "I" forms of the three verbs.
+(*Je parle, j'habite, je travaille*.) Say "I live in Paris and I work in Lyon."
+(*J'habite à Paris et je travaille à Lyon.*) French now moves in real sentences.

--- a/code/learning/human-languages/french/lessons/FR-C05-travailler.md
+++ b/code/learning/human-languages/french/lessons/FR-C05-travailler.md
@@ -1,0 +1,69 @@
+---
+id: FR-C05-travailler
+chapter: 5
+type: word
+headword: travailler
+gloss: to work (a third -er verb — and the origin of "travel")
+concept_tag: FR-VERB-TRAVAILLER
+prerequisites: [FR-C05-parler]
+sounds: [ai-y, r-uvular]
+roots: [tripalium-latin]
+etymology_hook: "travailler ← Vulgar Latin tripaliāre 'to torture' (← tripalium) → English travail, travel"
+est_minutes: 4
+reviews_of: [FR-C05-habiter]
+---
+
+# travailler — "to work," and the torture behind "travel"
+
+## Warm-up
+
+[PAUSE 2s] A third **-er** verb, and it shares its dark, delightful origin with a
+Spanish word you may already know: **travailler** ("to work") began as a word for
+**torture**, and it's the secret ancestor of English **travel**.
+
+## Sounds you'll need
+
+- `ai-y` — the **-ill-** is a *y* glide: **travailler** = *tra-va-YAY*. Same
+  *-er* = *ay* ending.
+
+## The word, taken apart
+
+**travailler** comes from Vulgar Latin **tripaliāre**, *"to torture"* — from
+**tripalium**, a Roman instrument of torture made of **three stakes** (*tri-*
+"three" + *pālus* "stake" → English *pale*, *impale*).
+
+The slide of meaning is grim and logical: *torture* → *painful toil* → **work**.
+And two English words came down the same road:
+
+- **travail** — painful, laborious effort.
+- **travel** — journeying was once such an **ordeal** that *travail* (toil)
+  became *travel* (to make a journey). You are, etymologically, *tortured* every
+  time you travel.
+
+This is the exact same word as **Spanish *trabajar*** (from the same
+*tripaliāre*) — the *-al-* stayed in French (*travail*) and softened to *-aj-* in
+Spanish (*trabajo*). A perfect cross-language twin, torture and all.
+
+## Grammar Lens: same -er template
+
+| je travaille · tu travailles · il travaille | (all *tra-VYE*) |
+| nous travaillons · vous travaillez | |
+
+> **Je travaille à Paris.** — "I work in Paris."
+
+Nothing new to learn — that's the point. **One template, every -er verb.**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "travailler" — *tra-va-YAY*]
+- [YOU SAY: "je travaille" — *je tra-VYE*, "I work"]
+- [YOU SAY: travailler → travail → travel — torture became a journey; twin of
+  Spanish *trabajar*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did *travailler* originally mean, and from what device? ("To
+torture," ← *tripalium*, three stakes.) What two English words share the root?
+(*Travail* and *travel*.) Its Spanish twin? (*Trabajar* — same *tripaliāre*.)
+Next: build your first full sentence — **Je parle français**.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -31,12 +31,18 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   (é aigu / è grave / **ê circonflexe = a lost *s***: forêt→forest); the cédille
   ç (soft *c* before a/o/u; ← "little z"); the tréma ï/ë (split the vowels).
   **Authored.**
+- **Ch. 5 — The first verbs**: parler (← *parabolāre* → parable/parole; the big
+  regular *-er* verb + present tense) → habiter (← *habitāre* → habitat) →
+  travailler (← *tripalium* → travail/travel; twin of Spanish *trabajar*) → **Je
+  parle français** (first sentence; *français* ← *Francia*) → practice.
+  **Authored** — mirrors Spanish Ch.6, and teaches the **pro-drop contrast**
+  (French keeps *je* because its *-er* endings are silent).
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 5+ | Numbers, time, days & months, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
+| 6+ | Numbers, time, days & months, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
 
 The *tu/vous* lesson (Ch. 2) is the French counterpart to Spanish *tú/usted*:
 same formal/informal split, but French makes the formal from the **plural**


### PR DESCRIPTION
## French Chapter 5 — the first verbs (sentences start to move)

Loop item 8. French's first **grammar-engine** chapter, the deliberate mirror of
the merged Spanish Ch.6 — the learner stops reciting phrases and starts **building
sentences from a pattern**. Five atom-first lessons, each reviewing Ch.3–4.

### What's new
- **The regular -er present tense** — the biggest French verb family: drop *-er*,
  add *-e/-es/-e/-ons/-ez/-ent*. Taught on **parler**, cemented on **habiter** and
  **travailler**.
- **First self-assembled sentence — *Je parle français***.

### The insight this chapter turns on
French **-e/-es/-ent are silent**, so *je parle / tu parles / ils parlent* all
sound identical (*parl*). That's exactly **why French keeps its subject pronouns**
where Spanish and Italian *drop* them — the ear can't hear the person, so the
pronoun must carry it. Framed as the single biggest structural difference from the
Iberian cousins (and a callback to the *io/eu/yo*-dropping lessons).

### Etymology (the method)
- **parler** ← *parabolāre* "tell parables" → parable / parole / palaver / parley.
- **habiter** ← *habitāre* "keep having a place" → habitat / inhabit.
- **travailler** ← *tripalium* (a three-stake torture device) → **travail / travel**
  — the exact twin of Spanish *trabajar*.
- **français** ← *Francia*, "land of the Franks" — whose name meant **"free"**
  (→ English *frank*).

### Checks
- Namespaced `FR-VERB-PARLER/HABITER/TRAVAILLER`, `FR-WORD-FRANCAIS` documented.
- 38 data-package tests pass; validator clean. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
