### PR TITLE
feat(scytale-cipher): add Haskell port

### DIFF
--- a/code/packages/haskell/scytale-cipher/BUILD
+++ b/code/packages/haskell/scytale-cipher/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/scytale-cipher/BUILD_windows
+++ b/code/packages/haskell/scytale-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/scytale-cipher/CHANGELOG.md
+++ b/code/packages/haskell/scytale-cipher/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add padded Scytale encryption and decryption with explicit key validation.
+- Add brute-force candidate generation across the shared CR02 key range.
+- Add tests for reference vectors, uneven candidates, round trips, character
+  preservation, validation, and brute force.

--- a/code/packages/haskell/scytale-cipher/README.md
+++ b/code/packages/haskell/scytale-cipher/README.md
@@ -1,0 +1,22 @@
+# scytale-cipher
+
+Pure Haskell implementation of the ancient Spartan Scytale transposition
+cipher and its small-key-space brute-force attack.
+
+## API
+
+- `encrypt` writes text row-by-row into a keyed grid, pads the final row with
+  spaces, and reads the result column-by-column.
+- `decrypt` reverses the transposition and removes trailing padding spaces.
+- `bruteForce` returns `BruteForceResult` candidates for keys from two through
+  half the ciphertext length.
+
+`encrypt` and `decrypt` return `Either String String` so invalid keys are
+explicit. Empty text returns `Right ""` for every key, matching the shared
+CR02 contract. The library depends only on `base`; tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/scytale-cipher/cabal.project
+++ b/code/packages/haskell/scytale-cipher/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/scytale-cipher/scytale-cipher.cabal
+++ b/code/packages/haskell/scytale-cipher/scytale-cipher.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          scytale-cipher
+version:       0.1.0
+synopsis:      Ancient Spartan transposition cipher
+description:   A pure Haskell implementation of the classical Scytale cipher and brute-force attack.
+category:      Cryptography
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  ScytaleCipher
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    ScytaleCipherSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , scytale-cipher
+    default-language: Haskell2010

--- a/code/packages/haskell/scytale-cipher/src/ScytaleCipher.hs
+++ b/code/packages/haskell/scytale-cipher/src/ScytaleCipher.hs
@@ -1,0 +1,73 @@
+module ScytaleCipher
+    ( BruteForceResult (..)
+    , encrypt
+    , decrypt
+    , bruteForce
+    ) where
+
+import Data.List (dropWhileEnd)
+
+-- | One candidate plaintext from a brute-force Scytale attack.
+data BruteForceResult = BruteForceResult
+    { bruteForceKey :: Int
+    , bruteForceText :: String
+    }
+    deriving (Eq, Show)
+
+-- | Encrypt text by writing it row-by-row into a grid with @key@ columns,
+-- padding the final row with spaces, and reading the grid column-by-column.
+encrypt :: String -> Int -> Either String String
+encrypt "" _ = Right ""
+encrypt text key = do
+    validateKey (length text) key
+    let rowCount = ceilingDiv (length text) key
+        paddedLength = rowCount * key
+        padded = text ++ replicate (paddedLength - length text) ' '
+    Right
+        [ padded !! (row * key + column)
+        | column <- [0 .. key - 1]
+        , row <- [0 .. rowCount - 1]
+        ]
+
+-- | Decrypt Scytale text with @key@ columns and remove trailing space padding.
+-- Uneven ciphertext lengths are supported so brute-force candidates remain
+-- well-defined for every key in the search range.
+decrypt :: String -> Int -> Either String String
+decrypt "" _ = Right ""
+decrypt text key = do
+    validateKey textLength key
+    let rowCount = ceilingDiv textLength key
+        remainder = textLength `mod` key
+        columnLengths =
+            [ if remainder == 0 || column < remainder
+                then rowCount
+                else rowCount - 1
+            | column <- [0 .. key - 1]
+            ]
+        columnStarts = scanl (+) 0 columnLengths
+        plaintext =
+            [ text !! (columnStarts !! column + row)
+            | row <- [0 .. rowCount - 1]
+            , column <- [0 .. key - 1]
+            , row < columnLengths !! column
+            ]
+    Right (dropWhileEnd (== ' ') plaintext)
+  where
+    textLength = length text
+
+-- | Try every key from 2 through half the ciphertext length.
+bruteForce :: String -> [BruteForceResult]
+bruteForce text =
+    [ BruteForceResult key plaintext
+    | key <- [2 .. length text `div` 2]
+    , Right plaintext <- [decrypt text key]
+    ]
+
+validateKey :: Int -> Int -> Either String ()
+validateKey textLength key
+    | key < 2 = Left "Key must be >= 2."
+    | key > textLength = Left "Key must be <= text length."
+    | otherwise = Right ()
+
+ceilingDiv :: Int -> Int -> Int
+ceilingDiv dividend divisor = (dividend + divisor - 1) `div` divisor

--- a/code/packages/haskell/scytale-cipher/test/ScytaleCipherSpec.hs
+++ b/code/packages/haskell/scytale-cipher/test/ScytaleCipherSpec.hs
@@ -1,0 +1,64 @@
+module ScytaleCipherSpec (spec) where
+
+import ScytaleCipher
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "encrypt" $ do
+        it "matches the HELLO WORLD reference vector" $
+            encrypt "HELLO WORLD" 3 `shouldBe` Right "HLWLEOODL R "
+        it "matches evenly divided reference vectors" $ do
+            encrypt "ABCDEF" 2 `shouldBe` Right "ACEBDF"
+            encrypt "ABCDEF" 3 `shouldBe` Right "ADBECF"
+            encrypt "ABCDEFGH" 4 `shouldBe` Right "AEBFCGDH"
+        it "pads incomplete rows with spaces" $
+            encrypt "HELLO" 3 `shouldBe` Right "HLEOL "
+        it "preserves every character through transposition" $
+            encrypt "AB,CD!" 2 `shouldBe` Right "A,DBC!"
+        it "returns empty text before validating a key" $
+            encrypt "" 1 `shouldBe` Right ""
+
+    describe "decrypt" $ do
+        it "recovers the HELLO WORLD reference vector" $
+            decrypt "HLWLEOODL R " 3 `shouldBe` Right "HELLO WORLD"
+        it "recovers evenly divided reference vectors" $ do
+            decrypt "ACEBDF" 2 `shouldBe` Right "ABCDEF"
+            decrypt "ADBECF" 3 `shouldBe` Right "ABCDEF"
+        it "supports uneven ciphertext lengths" $
+            decrypt "ABCDEFGHIJ" 4 `shouldBe` Right "ADGIBEHJCF"
+        it "strips only trailing padding spaces" $
+            decrypt "HLEOL " 3 `shouldBe` Right "HELLO"
+        it "returns empty text before validating a key" $
+            decrypt "" 1 `shouldBe` Right ""
+
+    describe "round trips" $ do
+        it "round-trips all valid keys for mixed text" $ do
+            let original = "The quick brown fox jumps over 13 lazy dogs!"
+            mapM_ (checkRoundTrip original) [2 .. length original]
+        it "round-trips punctuation, newlines, and Unicode" $ do
+            let original = "Hello,\nWorld! caf\x00e9 \x2764"
+            (encrypt original 5 >>= (`decrypt` 5)) `shouldBe` Right original
+
+    describe "key validation" $ do
+        it "rejects keys below two" $ do
+            encrypt "HELLO" 1 `shouldBe` Left "Key must be >= 2."
+            decrypt "HELLO" 0 `shouldBe` Left "Key must be >= 2."
+        it "rejects keys longer than non-empty text" $ do
+            encrypt "HI" 3 `shouldBe` Left "Key must be <= text length."
+            decrypt "HI" 3 `shouldBe` Left "Key must be <= text length."
+
+    describe "bruteForce" $ do
+        it "finds the original plaintext" $ do
+            let Right ciphertext = encrypt "HELLO WORLD" 3
+            bruteForce ciphertext `shouldContain`
+                [BruteForceResult 3 "HELLO WORLD"]
+        it "tries every key from two through half the length" $
+            map bruteForceKey (bruteForce "ABCDEFGHIJ") `shouldBe` [2, 3, 4, 5]
+        it "returns no candidates for short text" $ do
+            bruteForce "AB" `shouldBe` []
+            bruteForce "ABC" `shouldBe` []
+  where
+    checkRoundTrip original key = do
+        let encrypted = encrypt original key
+        (encrypted >>= (`decrypt` key)) `shouldBe` Right original

--- a/code/packages/haskell/scytale-cipher/test/Spec.hs
+++ b/code/packages/haskell/scytale-cipher/test/Spec.hs
@@ -1,0 +1,5 @@
+import ScytaleCipherSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -116,11 +116,11 @@ ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`
-port:
+and `scytale-cipher` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 308 |
+| Present in 10-15 languages | 172 | 307 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 703 | 9,842 |
@@ -177,7 +177,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 33 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 32 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -395,6 +395,14 @@ including complete alphabets, non-ASCII pass-through, and the cipher's
 self-inverse property. The package now spans 13 implementation lanes, reduces
 the high-consensus backlog to 308 slots, and leaves 33 gaps in the Haskell
 lane.
+
+The second Haskell high-consensus slice is complete: `scytale-cipher` now
+provides dependency-free CR02 encryption, decryption, explicit key validation,
+and brute-force candidate generation. Its package-native suite exercises 17
+examples with 98% expression coverage, including reference vectors, padded and
+uneven grids, mixed-character round trips, and the complete shared key range.
+The package now spans 14 implementation lanes, reduces the high-consensus
+backlog to 307 slots, and leaves 32 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a dependency-free Haskell port of CR02 `scytale-cipher`
- expose encryption, decryption, explicit key validation, and brute-force candidates through an `Either`-based API
- add package metadata, documentation, build scripts, and package-native tests
- update the parity roadmap from 308 to 307 high-consensus gaps and from 33 to 32 Haskell gaps

## Validation

- `stack test --coverage`: 17 examples, 0 failures, 98% expression coverage
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'`: 6 tests passed
- live parity report: zero collisions, 307 high-consensus gaps, 32 Haskell gaps, and 14 `scytale-cipher` implementation lanes
- `bash code/packages/haskell/scytale-cipher/BUILD_windows`: intentional Windows CI capability skip
- `git diff --cached --check`
