### PR TITLE
feat(hl-german): Chapter 5 — the first weak verbs (Ich lerne Deutsch; the pronoun rule, 3 ways)

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -213,6 +213,10 @@
       "FR-WORD-FRANCAIS": "français — 'French' (the language; ← Francia, land of the Franks)",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
+      "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
+      "GE-VERB-MACHEN": "machen — 'to make/do' (← makōn → make); 'Was machst du?'",
+      "GE-VERB-LERNEN": "lernen — 'to learn' (← liznōjan → learn/lore)",
+      "GE-WORD-DEUTSCH": "Deutsch — 'German' (the language; ← diutisc 'of the people' → English Dutch)",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'"
     }
   },

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Chapter 5 — The first verbs (sentences start to move)
+
+- **Chapter 5 authored** (`GE-C05-wohnen`, `-machen`, `-lernen`,
+  `-ich-lerne-deutsch`, `-practice`): German's first **grammar-engine** chapter,
+  parallel to French Ch.5 / Spanish Ch.6. Uses **regular (weak) verbs only** —
+  *sprechen* is irregular and deferred.
+- **The regular weak present tense** — drop *-en*, add *-e/-st/-t/-en/-t/-en*.
+  Taught on **wohnen** and cemented on **machen** and **lernen**. Unlike French,
+  **German endings are audible** (*wohne/wohnst/wohnt* differ).
+- **The pronoun rule completed across three languages**: Spanish **drops** *yo*
+  (the ending says who); French **keeps** *je* (endings silent); German **keeps**
+  *ich* — for yet another reason: its grammar needs an **overt subject**
+  (structure, not sound).
+- **Etymology, English-cousins-you-own**: *wohnen* ← *wonēn* (→ *wont*
+  "accustomed"); *machen* ← *makōn* (= English **make**; the High German *k*→*ch*
+  shift); *lernen* ← *liznōjan* (= **learn**; kin of *lore*); *Deutsch* ←
+  *diutisc* "of the people" (→ English **Dutch**, **Teutonic**). First
+  self-assembled sentence: **Ich lerne Deutsch**.
+- Taxonomy: namespaced `GE-VERB-WOHNEN/MACHEN/LERNEN`, `GE-WORD-DEUTSCH`
+  documented.
+
 ## Writing nuances — the eszett, the umlauts, capital nouns
 
 - **First German `writing`-type lessons** (`GE-W01-eszett`, `GE-W02-umlauts`,

--- a/code/learning/human-languages/german/lessons/GE-C05-ich-lerne-deutsch.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-ich-lerne-deutsch.md
@@ -1,0 +1,72 @@
+---
+id: GE-C05-ich-lerne-deutsch
+chapter: 5
+type: phrase
+headword: Ich lerne Deutsch
+gloss: "I'm learning German" — your first full sentence (Deutsch = German)
+concept_tag: GE-WORD-DEUTSCH
+prerequisites: [GE-C05-lernen]
+sounds: [eu-vowel, tsch-ch]
+roots: [diutisc-ohg]
+etymology_hook: "Deutsch ← Old High German diutisc 'of the people' (← *þeudō 'folk') → English Dutch, Teutonic"
+est_minutes: 4
+reviews_of: [GE-C05-lernen, GE-C02-ich]
+---
+
+# Ich lerne Deutsch — your first real sentence
+
+## Warm-up
+
+[PAUSE 2s] Everything pays off: you take a **verb** you conjugated and a **noun**,
+and build a sentence no one handed you — *Ich lerne Deutsch*, "I'm learning
+German." (There's no separate "am …-ing" in German — *ich lerne* covers both "I
+learn" and "I am learning.")
+
+## The new word: Deutsch
+
+**Deutsch** = "German" (the language) — and note it's **capitalized**, because
+it's a noun here (your *Großschreibung* writing lesson). It comes from Old High
+German **diutisc**, *"of the people, of the folk"* — from **þeudō**, "the people."
+The Germanic tribes simply called their own tongue *"the people's [language]"*, as
+opposed to Latin.
+
+That "folk" root spread far:
+
+- English **Dutch** — the *same* word (it once meant all continental West
+  Germanic; English later narrowed it to the Netherlands).
+- **Teutonic** — via Latin *Teutonicus*, from the same *þeudō*.
+- Italian calls Germany **Tedesco**, French **thiois** (historical) — all echoes
+  of *diutisc*.
+
+Say it *DOYTCH* (`eu-vowel` = *oy*; `tsch-ch` = the *tch* of "match").
+
+## The sentence, and why German keeps *ich*
+
+> **Ich** (I) + **lerne** (learn, from *lernen*) = **Ich lerne Deutsch.**
+
+Now the contrast that completes the verb chapter:
+
+- **German keeps the pronoun** (*ich, du, er…*) — like French, **unlike** Spanish
+  or Italian, which drop it.
+- **But for a different reason.** Spanish drops *yo* because *hablo* already says
+  "I". French keeps *je* because its endings are *silent*. German's endings
+  *aren't* silent (*wohne / wohnst / wohnt* differ) — yet German still needs the
+  pronoun because its **grammar demands an overt subject** (German sentences are
+  built around the verb sitting in second position, with something before it). So:
+  Spanish **drops**, French keeps for **sound**, German keeps for **structure**.
+
+Swap the pieces: **Ich wohne in Berlin.** · **Was machst du?**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Ich lerne Deutsch" — *ikh LER-neh DOYTCH*]
+- [YOU SAY: keep the *ich* — German can't drop it (structure), unlike Spanish]
+- [YOU SAY: "Deutsch" ↔ English "Dutch" — the same *diutisc*, "of the people"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does *Deutsch* come from, and what English word is its twin?
+(*diutisc*, "of the people"; English *Dutch*.) Spanish drops *yo*, French keeps
+*je* for silence — why does German keep *ich*? (Its grammar needs an overt subject
+— structure, not sound.) Next: practice.

--- a/code/learning/human-languages/german/lessons/GE-C05-lernen.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-lernen.md
@@ -1,0 +1,61 @@
+---
+id: GE-C05-lernen
+chapter: 5
+type: word
+headword: lernen
+gloss: to learn (a third weak verb — the pattern is yours)
+concept_tag: GE-VERB-LERNEN
+prerequisites: [GE-C05-wohnen]
+sounds: [r-uvular-german]
+roots: [liznojan-germanic]
+etymology_hook: "lernen ← Germanic liznōjan 'to learn' → English 'learn'; kin of 'lore' (what is learned)"
+est_minutes: 3
+reviews_of: [GE-C05-machen]
+---
+
+# lernen — "to learn," and it *is* English learn
+
+## Warm-up
+
+[PAUSE 2s] A third weak verb to make the pattern automatic — **lernen** ("to
+learn") — and it sets up your first full German sentence. It's a straight cousin
+of English *learn*.
+
+## Sounds you'll need
+
+- `r-uvular-german` — the German **r** is a soft guttural at the back of the
+  throat: **lernen** = *LER-nen*.
+
+## The word, taken apart
+
+**lernen** comes from Germanic **liznōjan**, *"to learn, to get to know"* — the
+**same root as English "learn."** Its close relatives are lovely:
+
+- **lore** — the body of what has been *learned* (folklore, the *lore* of a
+  craft).
+- **last** (a shoemaker's *last*) and Gothic *lais* ("I know") share the deep
+  root — the idea of *following a track* to knowledge.
+
+So *lernen* isn't foreign at all — it's *learn*, and its noun *die Lehre* ("the
+teaching, the lesson") is *lore*.
+
+## Grammar Lens: same weak endings, one last time
+
+| ich lerne · du lernst · er lernt | (-e / -st / -t) |
+| wir lernen · ihr lernt · sie lernen | |
+
+Three verbs — *wohne, mache, lerne* — one pattern. You now conjugate the regular
+German present.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "lernen" — *LER-nen*, guttural *r*]
+- [YOU SAY: "ich lerne, du lernst, er lernt"]
+- [YOU SAY: "lernen" then English "learn, lore" — one Germanic root]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What English verb is *lernen*? (*Learn* — same root.) What English noun
+for "accumulated knowledge" shares it? (*Lore*.) Say "I learn." (*Ich lerne*.)
+Next: build your first German sentence — **Ich lerne Deutsch**.

--- a/code/learning/human-languages/german/lessons/GE-C05-machen.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-machen.md
@@ -1,0 +1,63 @@
+---
+id: GE-C05-machen
+chapter: 5
+type: word
+headword: machen
+gloss: to make / to do (a second weak verb — same endings)
+concept_tag: GE-VERB-MACHEN
+prerequisites: [GE-C05-wohnen]
+sounds: [ch-ach, vowel-a-german]
+roots: [makon-germanic]
+etymology_hook: "machen ← Germanic makōn 'to make, shape' → English 'make'; behind 'Was machst du?'"
+est_minutes: 3
+reviews_of: [GE-C05-wohnen]
+---
+
+# machen — "to make / to do," and it's just English *make*
+
+## Warm-up
+
+[PAUSE 2s] A second weak verb — snap it into the endings you just learned.
+**machen** is one of the most-used verbs in German: "to make" **and** "to do,"
+and it powers the everyday question *Was machst du?* — "What are you doing?"
+
+## Sounds you'll need
+
+- `ch-ach` — the **ch** after *a* is the raspy *ach*-sound (from the throat, like
+  Scottish *loch*): **machen** = *MAKH-en*.
+- `vowel-a-german` — a clean open *ah*.
+
+## The word, taken apart
+
+**machen** descends from Germanic **makōn**, *"to make, to shape, to fit
+together"* — the **same word as English "make."** (The German *k*-sound became
+the *ch* rasp along the way, by the High German consonant shift: *make* → *machen*,
+just as *ik* → *ich*, *book* → *Buch*.) So *machen* is *make*, wearing German
+pronunciation.
+
+German uses it for both "make" and "do":
+
+- **Ich mache einen Kuchen.** — "I'm making a cake."
+- **Was machst du?** — "What are you doing?"
+
+## Grammar Lens: same weak endings
+
+| ich mache · du machst · er macht | (-e / -st / -t) |
+| wir machen · ihr macht · sie machen | |
+
+Identical to *wohnen* — nothing new to learn. That's the payoff of a regular
+pattern.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "machen" — *MAKH-en*, raspy *ch*]
+- [YOU SAY: "ich mache, du machst, er macht"]
+- [YOU SAY: "Was machst du?" — "What are you doing?"; and *machen* = *make*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What English word is *machen*, at the root? (*Make* — same Germanic
+*makōn*.) What consonant shift turned *k* into *ch*? (The High German shift:
+*make → machen*, *ik → ich*.) Ask "what are you doing?" (*Was machst du?*) Next:
+**lernen**, "to learn."

--- a/code/learning/human-languages/german/lessons/GE-C05-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-practice.md
@@ -1,0 +1,69 @@
+---
+id: GE-C05-practice
+chapter: 5
+type: practice-mix
+headword: (practice)
+gloss: making sentences with weak verbs, and why German keeps the pronoun
+concept_tag: CH5-PRACTICE
+prerequisites: [GE-C05-wohnen, GE-C05-machen, GE-C05-lernen, GE-C05-ich-lerne-deutsch]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [GE-C05-wohnen, GE-C05-machen, GE-C05-lernen, GE-C05-ich-lerne-deutsch, GE-C03-practice]
+---
+
+# Practice — making sentences with weak verbs
+
+## Warm-up
+
+[PAUSE 2s] For the first time you're **building** German sentences from a pattern,
+not reciting phrases. Drill the three verbs and the everyday exchange until it's
+automatic.
+
+## Conjugate on command
+
+[PAUSE 1s] Run each through *ich / du / er*:
+
+- **wohnen**: ich wohne · du wohnst · er wohnt
+- **machen**: ich mache · du machst · er macht
+- **lernen**: ich lerne · du lernst · er lernt
+
+Same endings every time (**-e / -st / -t**), and — unlike French — you can
+**hear** them all. But you still keep the pronoun (German needs an overt subject).
+
+## Say something real
+
+> — **Wo wohnst** du? — **Ich wohne** in Berlin. Und du?
+> — Ich wohne in Wien. **Was machst** du?
+> — **Ich lerne** Deutsch! — Sehr gut!
+> — Danke! — Bitte.
+
+## What you've built this chapter
+
+- **the regular (weak) present tense** — drop *-en*, add *-e/-st/-t/-en/-t/-en*;
+  the endings are **audible** (contrast: French's are silent).
+- **wohnen** (← *wonēn* → *wont*), **machen** (← *makōn* → *make*; *Was machst
+  du?*), **lernen** (← *liznōjan* → *learn/lore*).
+- **Ich lerne Deutsch** — first self-assembled sentence (*Deutsch* ← *diutisc*,
+  "of the people" → English *Dutch*).
+- **The pronoun rule, three ways**: Spanish **drops** *yo* (ending says who);
+  French **keeps** *je* (endings silent); German **keeps** *ich* (grammar needs an
+  overt subject).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: conjugate all three verbs, ich/du/er — hear the endings]
+- [YOU SAY: answer about yourself — where you live, what you're doing]
+- [YOU SAY: chain it — "Hallo! Ich lerne Deutsch. Wo wohnst du? … Auf
+  Wiedersehen!"]
+
+[REPEAT x2] "Wo wohnst du? — Ich wohne in Berlin."
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the three singular weak endings, and are they audible?
+(*-e/-st/-t*; yes — unlike French.) Give the "I" forms of the three verbs. (*Ich
+wohne, ich mache, ich lerne*.) Why does German keep *ich* when Spanish drops
+*yo*? (German grammar needs an overt subject.) German now moves in real
+sentences.

--- a/code/learning/human-languages/german/lessons/GE-C05-wohnen.md
+++ b/code/learning/human-languages/german/lessons/GE-C05-wohnen.md
@@ -1,0 +1,73 @@
+---
+id: GE-C05-wohnen
+chapter: 5
+type: word
+headword: wohnen
+gloss: to live / to dwell (your first regular "weak" verb)
+concept_tag: GE-VERB-WOHNEN
+prerequisites: [GE-C02-ich, GE-C02-du-sie]
+sounds: [w-is-v, h-pronounced]
+roots: [wonen-ohg]
+etymology_hook: "wohnen ← Old High German wonēn 'to dwell, be accustomed' → English 'wont' (accustomed), archaic 'won'"
+est_minutes: 5
+reviews_of: [GE-C03-wie-geht-es, GE-C02-practice]
+---
+
+# wohnen — "to live," and the regular German verb
+
+## Warm-up
+
+[PAUSE 2s] Until now you've assembled fixed phrases. **wohnen** ("to live, to
+dwell") is your first real **verb** — and the model for the **regular (weak)**
+German verb, the pattern behind thousands. Learn its endings once.
+
+## Sounds you'll need
+
+- `w-is-v` — German **w** is an English **v**: **wohnen** = *VOH-nen*.
+- `h-pronounced` — here the *h* just **lengthens** the *o* (*woh-* = long *oh*),
+  it isn't breathy.
+
+## The word, taken apart
+
+**wohnen** comes from Old High German **wonēn**, *"to dwell, to be accustomed,
+to be content."* Dwelling and *being used to* a place were the same idea. That
+root survives in English, just barely:
+
+- **wont** — "accustomed" (*as is his wont*), and **won't**'s distant cousin.
+- archaic **won** / **wone** — "to dwell."
+- it's also kin to **win** and **wish** (all from a root about *striving for /
+  being content*).
+
+## Grammar Lens: the regular (weak) present tense
+
+Drop **-en** to get the stem *wohn-*, then add the endings:
+
+| person | ending | *wohnen* → |
+|---|---|---|
+| ich (I) | **-e** | **ich wohne** |
+| du (you) | **-st** | **du wohnst** |
+| er / sie / es | **-t** | **er wohnt** |
+| wir (we) | **-en** | wir wohnen |
+| ihr (you all) | **-t** | ihr wohnt |
+| sie / Sie | **-en** | sie wohnen |
+
+Unlike French (where *-e/-es/-ent* are all silent), **German endings are
+audible**: *wohne / wohnst / wohnt* really sound different. So you *could* almost
+tell who's speaking from the ending alone — but German still **keeps the
+pronoun** (you'll see why in the *Ich lerne Deutsch* lesson). Now you can answer
+a *wo* ("where") question:
+
+> **Ich wohne in Berlin.** — "I live in Berlin."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "wohnen" — *VOH-nen*, *w* = *v*]
+- [YOU SAY: "ich wohne, du wohnst, er wohnt" — hear the endings change]
+- [YOU SAY: "wohnen" then English "wont" (accustomed) — the *wonēn* root]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does German *w* sound like, and what does *wohnen* mean? (*V*; "to
+live/dwell.") The three singular endings? (*-e / -st / -t*.) What English word for
+"accustomed" shares its root? (*Wont*.) Next: **machen**, "to make."

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -31,12 +31,17 @@ Spanish and French where a contrast helps. The recurring decoder is the
   length; a long-s+z ligature); the umlauts ä/ö/ü (a shrunken *e*; the fronting
   that marks plurals — Mann→Männer); Großschreibung (every noun capitalized).
   **Authored.**
+- **Ch. 5 — The first verbs**: wohnen (← *wonēn* → *wont*; the regular WEAK
+  present -e/-st/-t) → machen (← *makōn* = *make*) → lernen (← *liznōjan* =
+  *learn/lore*) → **Ich lerne Deutsch** (first sentence; *Deutsch* ← *diutisc* →
+  *Dutch*) → practice. **Authored** — parallel to French Ch.5, and completes the
+  three-way pronoun rule (ES drops / FR keeps for silence / DE keeps for structure).
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 5+ | Numbers, cases (der→den→dem), family, food — following the shared theme order |
+| 6+ | Numbers, cases (der→den→dem), family, food, sprechen & irregular verbs — following the shared theme order |
 
 The **du / Sie** lesson (Ch. 2) completes the formal/informal set across the
 languages: Spanish *tú/usted* (from "your grace"), French *tu/vous* (the


### PR DESCRIPTION
## German Chapter 5 — the first verbs (sentences start to move)

Loop item 9. German's first **grammar-engine** chapter, parallel to French Ch.5 /
Spanish Ch.6. Uses **regular (weak) verbs only** — *sprechen* is irregular and
deferred. Five atom-first lessons, each reviewing Ch.3–4.

### What's new
- **The regular weak present tense** — drop *-en*, add *-e/-st/-t/-en/-t/-en*.
  Taught on **wohnen**, cemented on **machen** and **lernen**. Unlike French,
  **German endings are audible** (*wohne / wohnst / wohnt* really differ).
- **First self-assembled sentence — *Ich lerne Deutsch***.

### The pronoun rule, now complete across three languages
- **Spanish drops** *yo* — the ending (*-o*) already says who.
- **French keeps** *je* — its endings are silent, so the pronoun must carry the person.
- **German keeps** *ich* — for a *third* reason: its endings *aren't* silent, but
  German grammar needs an **overt subject** (structure, not sound).

### Etymology — English cousins you already own
- **wohnen** ← *wonēn* "to dwell / be accustomed" → English **wont**.
- **machen** ← *makōn* = English **make** (the High German *k*→*ch* shift: *make →
  machen*, *ik → ich*); powers *Was machst du?*
- **lernen** ← *liznōjan* = English **learn**; kin of **lore**.
- **Deutsch** ← *diutisc* "of the people/folk" → English **Dutch**, **Teutonic**.

### Checks
- Namespaced `GE-VERB-WOHNEN/MACHEN/LERNEN`, `GE-WORD-DEUTSCH` documented.
- 38 data-package tests pass; validator clean. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
