### PR TITLE
feat(feature-normalization): add Haskell port

### DIFF
--- a/code/packages/haskell/feature-normalization/BUILD
+++ b/code/packages/haskell/feature-normalization/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/feature-normalization/BUILD_windows
+++ b/code/packages/haskell/feature-normalization/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/feature-normalization/CHANGELOG.md
+++ b/code/packages/haskell/feature-normalization/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add standard and min-max scaler fitting and transformation.
+- Map constant feature columns to zero without dividing by zero.
+- Add explicit validation for empty, zero-width, ragged, and mismatched input.

--- a/code/packages/haskell/feature-normalization/README.md
+++ b/code/packages/haskell/feature-normalization/README.md
@@ -1,0 +1,21 @@
+# feature-normalization
+
+Pure Haskell feature scaling utilities for small machine-learning examples.
+
+## API
+
+- `fitStandardScaler` computes each column's mean and population standard
+  deviation.
+- `transformStandard` centers and scales data with a fitted standard scaler.
+- `fitMinMaxScaler` computes each column's minimum and maximum.
+- `transformMinMax` maps data into the `0.0..1.0` range.
+
+Every operation returns `Either String ...` so empty, zero-width, ragged, and
+scaler-width-mismatched matrices are rejected explicitly. Constant columns map
+to zero. The library depends only on `base`; tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/feature-normalization/cabal.project
+++ b/code/packages/haskell/feature-normalization/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/feature-normalization/feature-normalization.cabal
+++ b/code/packages/haskell/feature-normalization/feature-normalization.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          feature-normalization
+version:       0.1.0
+synopsis:      Feature scaling utilities for machine-learning examples
+description:   Pure standard and min-max feature scaling with explicit matrix validation.
+category:      Math
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  FeatureNormalization
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    FeatureNormalizationSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , feature-normalization
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/feature-normalization/src/FeatureNormalization.hs
+++ b/code/packages/haskell/feature-normalization/src/FeatureNormalization.hs
@@ -1,0 +1,95 @@
+-- | Pure feature scaling for rectangular matrices.
+module FeatureNormalization
+    ( Matrix
+    , StandardScaler (..)
+    , MinMaxScaler (..)
+    , fitStandardScaler
+    , transformStandard
+    , fitMinMaxScaler
+    , transformMinMax
+    ) where
+
+import Data.List (transpose)
+
+-- | Rows of observations containing feature columns.
+type Matrix = [[Double]]
+
+-- | Per-column parameters for standard scaling.
+data StandardScaler = StandardScaler
+    { means :: [Double]
+    , standardDeviations :: [Double]
+    }
+    deriving (Eq, Show)
+
+-- | Per-column parameters for min-max scaling.
+data MinMaxScaler = MinMaxScaler
+    { minimums :: [Double]
+    , maximums :: [Double]
+    }
+    deriving (Eq, Show)
+
+-- | Fit column means and population standard deviations.
+fitStandardScaler :: Matrix -> Either String StandardScaler
+fitStandardScaler rows = do
+    _ <- validateMatrix rows
+    let columns = transpose rows
+        rowCount = fromIntegral (length rows)
+        columnMeans = map ((/ rowCount) . sum) columns
+        deviations =
+            zipWith
+                (\mean column -> sqrt (sum (map (squareDistance mean) column) / rowCount))
+                columnMeans
+                columns
+    Right (StandardScaler columnMeans deviations)
+
+-- | Apply a fitted standard scaler to a matrix.
+transformStandard :: Matrix -> StandardScaler -> Either String Matrix
+transformStandard rows scaler = do
+    width <- validateMatrix rows
+    validateScalerWidth width [length (means scaler), length (standardDeviations scaler)]
+    Right (map transformRow rows)
+  where
+    transformRow row = zipWith3 scale row (means scaler) (standardDeviations scaler)
+    scale value mean deviation
+        | deviation == 0.0 = 0.0
+        | otherwise = (value - mean) / deviation
+
+-- | Fit per-column minima and maxima.
+fitMinMaxScaler :: Matrix -> Either String MinMaxScaler
+fitMinMaxScaler rows = do
+    _ <- validateMatrix rows
+    let columns = transpose rows
+    Right (MinMaxScaler (map minimum columns) (map maximum columns))
+
+-- | Apply a fitted min-max scaler to a matrix.
+transformMinMax :: Matrix -> MinMaxScaler -> Either String Matrix
+transformMinMax rows scaler = do
+    width <- validateMatrix rows
+    validateScalerWidth width [length (minimums scaler), length (maximums scaler)]
+    Right (map transformRow rows)
+  where
+    transformRow row = zipWith3 scale row (minimums scaler) (maximums scaler)
+    scale value minimumValue maximumValue
+        | spanValue == 0.0 = 0.0
+        | otherwise = (value - minimumValue) / spanValue
+      where
+        spanValue = maximumValue - minimumValue
+
+validateMatrix :: Matrix -> Either String Int
+validateMatrix [] = Left "matrix must have at least one row and one column"
+validateMatrix rows@(firstRow : _)
+    | null firstRow = Left "matrix must have at least one row and one column"
+    | any ((/= width) . length) rows = Left "all rows must have the same number of columns"
+    | otherwise = Right width
+  where
+    width = length firstRow
+
+validateScalerWidth :: Int -> [Int] -> Either String ()
+validateScalerWidth width widths
+    | all (== width) widths = Right ()
+    | otherwise = Left "matrix width must match scaler width"
+
+squareDistance :: Double -> Double -> Double
+squareDistance center value = difference * difference
+  where
+    difference = value - center

--- a/code/packages/haskell/feature-normalization/test/FeatureNormalizationSpec.hs
+++ b/code/packages/haskell/feature-normalization/test/FeatureNormalizationSpec.hs
@@ -1,0 +1,102 @@
+module FeatureNormalizationSpec (spec) where
+
+import FeatureNormalization
+import Test.Hspec
+
+tolerance :: Double
+tolerance = 1e-9
+
+rows :: Matrix
+rows =
+    [ [1000.0, 3.0, 1.0]
+    , [1500.0, 4.0, 0.0]
+    , [2000.0, 5.0, 1.0]
+    ]
+
+shouldBeCloseTo :: Double -> Double -> Expectation
+actual `shouldBeCloseTo` expected =
+    abs (actual - expected) `shouldSatisfy` (<= tolerance)
+
+shouldBeMatrixCloseTo :: Matrix -> Matrix -> Expectation
+actual `shouldBeMatrixCloseTo` expected = do
+    length actual `shouldBe` length expected
+    zipWithM_ checkRow actual expected
+  where
+    checkRow actualRow expectedRow = do
+        length actualRow `shouldBe` length expectedRow
+        zipWithM_ shouldBeCloseTo actualRow expectedRow
+
+spec :: Spec
+spec = do
+    describe "fitStandardScaler" $ do
+        it "fits the shared column means" $
+            means <$> fitStandardScaler rows `shouldBe` Right [1500.0, 4.0, 2.0 / 3.0]
+        it "uses population standard deviation" $ do
+            let Right scaler = fitStandardScaler rows
+            standardDeviations scaler !! 0 `shouldBeCloseTo` sqrt (500000.0 / 3.0)
+            standardDeviations scaler !! 1 `shouldBeCloseTo` sqrt (2.0 / 3.0)
+
+    describe "transformStandard" $ do
+        it "centers and scales the shared matrix" $ do
+            let transformed = fitStandardScaler rows >>= transformStandard rows
+            transformed `shouldSatisfy` either (const False) (const True)
+            let Right actual = transformed
+            actual `shouldBeMatrixCloseTo`
+                [ [-1.224744871391589, -1.224744871391589, 0.7071067811865476]
+                , [0.0, 0.0, -1.414213562373095]
+                , [1.224744871391589, 1.224744871391589, 0.7071067811865476]
+                ]
+        it "applies a fitted scaler to new rows" $
+            transformStandard [[2500.0, 6.0, 2.0]]
+                (StandardScaler [1500.0, 4.0, 1.0] [500.0, 1.0, 2.0])
+                `shouldBe` Right [[2.0, 2.0, 0.5]]
+        it "maps constant columns to zero" $ do
+            let constantRows = [[1.0, 7.0], [2.0, 7.0]]
+            (fitStandardScaler constantRows >>= transformStandard constantRows)
+                `shouldBe` Right [[-1.0, 0.0], [1.0, 0.0]]
+
+    describe "fitMinMaxScaler" $
+        it "fits every column's extrema" $
+            fitMinMaxScaler rows
+                `shouldBe` Right (MinMaxScaler [1000.0, 3.0, 0.0] [2000.0, 5.0, 1.0])
+
+    describe "transformMinMax" $ do
+        it "maps the shared matrix to the unit range" $ do
+            let transformed = fitMinMaxScaler rows >>= transformMinMax rows
+            transformed `shouldBe` Right
+                [ [0.0, 0.0, 1.0]
+                , [0.5, 0.5, 0.0]
+                , [1.0, 1.0, 1.0]
+                ]
+        it "supports negative feature ranges" $
+            transformMinMax [[-5.0], [0.0], [5.0]] (MinMaxScaler [-5.0] [5.0])
+                `shouldBe` Right [[0.0], [0.5], [1.0]]
+        it "maps constant columns to zero" $ do
+            let constantRows = [[1.0, 7.0], [2.0, 7.0]]
+            (fitMinMaxScaler constantRows >>= transformMinMax constantRows)
+                `shouldBe` Right [[0.0, 0.0], [1.0, 0.0]]
+
+    describe "matrix validation" $ do
+        it "rejects an empty matrix" $ do
+            fitStandardScaler [] `shouldBe` Left "matrix must have at least one row and one column"
+            fitMinMaxScaler [] `shouldBe` Left "matrix must have at least one row and one column"
+        it "rejects a zero-width matrix" $
+            fitStandardScaler [[]] `shouldBe` Left "matrix must have at least one row and one column"
+        it "rejects ragged matrices" $ do
+            fitStandardScaler [[1.0], [1.0, 2.0]]
+                `shouldBe` Left "all rows must have the same number of columns"
+            transformMinMax [[1.0], [1.0, 2.0]] (MinMaxScaler [0.0] [1.0])
+                `shouldBe` Left "all rows must have the same number of columns"
+        it "rejects standard scaler width mismatches" $ do
+            transformStandard [[1.0, 2.0]] (StandardScaler [0.0] [1.0])
+                `shouldBe` Left "matrix width must match scaler width"
+            transformStandard [[1.0]] (StandardScaler [0.0] [])
+                `shouldBe` Left "matrix width must match scaler width"
+        it "rejects min-max scaler width mismatches" $ do
+            transformMinMax [[1.0, 2.0]] (MinMaxScaler [0.0] [1.0])
+                `shouldBe` Left "matrix width must match scaler width"
+            transformMinMax [[1.0]] (MinMaxScaler [0.0] [])
+                `shouldBe` Left "matrix width must match scaler width"
+
+zipWithM_ :: (a -> b -> Expectation) -> [a] -> [b] -> Expectation
+zipWithM_ action left right = sequence_ (zipWith action left right)

--- a/code/packages/haskell/feature-normalization/test/Spec.hs
+++ b/code/packages/haskell/feature-normalization/test/Spec.hs
@@ -1,0 +1,5 @@
+import FeatureNormalizationSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -115,12 +115,12 @@ and `hash-set` ports, the paired `in-memory-data-store-engine` and
 ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
-`fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`
-and `scytale-cipher` ports:
+`fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
+`scytale-cipher`, and `feature-normalization` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 307 |
+| Present in 10-15 languages | 172 | 306 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 703 | 9,842 |
@@ -166,7 +166,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 309
+The 172 packages present in at least ten implementation languages need 306
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -177,7 +177,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 32 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 31 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -403,6 +403,15 @@ examples with 98% expression coverage, including reference vectors, padded and
 uneven grids, mixed-character round trips, and the complete shared key range.
 The package now spans 14 implementation lanes, reduces the high-consensus
 backlog to 307 slots, and leaves 32 gaps in the Haskell lane.
+
+The third Haskell high-consensus slice is complete: `feature-normalization`
+now provides dependency-free ML05 standard and min-max scaler fitting and
+transformation with explicit rectangular-matrix and scaler-width validation.
+Its package-native suite exercises 14 examples with 99% expression coverage,
+including the shared matrix, population deviation, constant columns, negative
+ranges, new observations, and every validation branch. The package now spans
+14 implementation lanes, reduces the high-consensus backlog to 306 slots, and
+leaves 31 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a dependency-free Haskell port of the ML05 `feature-normalization` contract
- expose standard and min-max scaler fitting and transformation with explicit `Either` validation
- cover empty, zero-width, ragged, scaler-width-mismatched, constant-column, negative-range, and new-observation behavior
- update the parity roadmap from 307 to 306 high-consensus gaps and from 32 to 31 Haskell gaps

## Why this slice

`feature-normalization` was the smallest dependency-safe 13-lane Haskell gap. The similarly small `wave` package depends on `trig`, which is not yet present in the Haskell lane.

## Validation

- Stack / GHC 9.4.8 `test --coverage`: 14 examples, 0 failures, 99% expression coverage
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'`: 6 tests passed
- live parity report: zero collisions, 306 high-consensus gaps, 31 Haskell gaps, and 14 `feature-normalization` implementation lanes
- `bash code/packages/haskell/feature-normalization/BUILD_windows`: intentional Windows CI capability skip
- `git diff --cached --check`
