### PR TITLE
feat(hl-portuguese): Chapter 5 — the first -ar verbs (Falo português; completes the 5-language verb set)

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -221,7 +221,11 @@
       "GE-VERB-MACHEN": "machen — 'to make/do' (← makōn → make); 'Was machst du?'",
       "GE-VERB-LERNEN": "lernen — 'to learn' (← liznōjan → learn/lore)",
       "GE-WORD-DEUTSCH": "Deutsch — 'German' (the language; ← diutisc 'of the people' → English Dutch)",
-      "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'"
+      "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
+      "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
+      "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
+      "PT-VERB-TRABALHAR": "trabalhar — 'to work' (← tripaliāre → travail/travel; twin of Spanish trabajar)",
+      "PT-WORD-PORTUGUES": "português — 'Portuguese' (the language; ← Portus Cale)"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Chapter 5 — The first verbs (completes the 5-language verb set)
+
+- **Chapter 5 authored** (`PT-C05-falar`, `-morar`, `-trabalhar`,
+  `-falo-portugues`, `-practice`): Portuguese's first **grammar-engine** chapter —
+  and the **fifth and final** track to cross from fixed phrases into
+  **self-assembled sentences**. Parallel to Spanish Ch.6 / French Ch.5 / German
+  Ch.5 / Italian Ch.5.
+- **The regular -ar present tense** — drop *-ar*, add *-o/-as/-a/-amos/-am*.
+  Taught on **falar**, cemented on **morar** and **trabalhar**. Portuguese is
+  **pro-drop** (drops *eu*, like Spanish and Italian).
+- **Etymology, with the sharpest Iberian contrasts**:
+  - *falar* ← *fabulārī* — the **same root as Spanish *hablar***, but **Portuguese
+    kept the Latin *f-*** where Spanish shifted *f→h* (*falar/hablar*,
+    *filho/hijo*, *fazer/hacer*) — the mirror of the Spanish Ch.6 f→h lesson.
+  - *morar* ← *morārī* "to linger/tarry" (→ moratorium, demur) — a root **no
+    sibling uses** for "dwell."
+  - *trabalhar* ← *tripaliāre* "torture" — twin of Spanish *trabajar* (Latin *-li-*
+    → PT *-lh-* / ES *-j-*); Portuguese rejoins the "torture" camp (ES/FR/PT) vs
+    Italian's "labour" (*lavorare*).
+  - First sentence: **Falo português** (*português* ← *Portus Cale*, a harbour town).
+- Taxonomy: namespaced `PT-VERB-FALAR/MORAR/TRABALHAR`, `PT-WORD-PORTUGUES`.
+- **Milestone**: all five tracks (ES/PT/IT/FR/DE) now build real sentences.
+
 ## Chapter 3 — Introducing Yourself
 
 - **Chapter 3 authored** (`PT-C03-eu`, `-me-chamo`, `-como-se-chama`, `-prazer`,

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-falar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-falar.md
@@ -1,0 +1,79 @@
+---
+id: PT-C05-falar
+chapter: 5
+type: word
+headword: falar
+gloss: to speak / to talk (your first regular -ar verb)
+concept_tag: PT-VERB-FALAR
+prerequisites: [PT-C03-eu, PT-C02-como]
+sounds: [final-r, final-a-reduces]
+roots: [fabulari-latin]
+etymology_hook: "falar ← Latin fabulārī 'to chat' (← fābula 'story' → fable); Portuguese KEPT the f- where Spanish shifted f→h"
+est_minutes: 5
+reviews_of: [PT-C03-practice, PT-C04-practice]
+---
+
+# falar — "to speak," and the *f* that Spanish lost
+
+## Warm-up
+
+[PAUSE 2s] Until now you've assembled fixed phrases. **falar** ("to speak") is
+your first real **verb** — the model for the big **-ar** family — and it hides a
+beautiful contrast with Spanish, right at its first letter.
+
+## Sounds you'll need
+
+- `final-r` — **falar** = *fah-LAR*, tapped final *r*. The stem is *fal-*.
+
+## The word, taken apart
+
+**falar** comes from Latin **fabulārī**, *"to chat, to tell tales"* — from
+**fābula**, "a story" (→ English **fable**, **fabulous**, **confabulate**). The
+**same Latin verb as Spanish *hablar*** — but here's the twist:
+
+**Portuguese kept the Latin *f-*; Spanish turned *f-* into *h-*.** So the two
+"speak" verbs diverge at letter one, and the pattern runs through the whole
+vocabulary:
+
+| Latin (f-) | Portuguese (f-) | Spanish (h-, silent) |
+|---|---|---|
+| *fabulārī* | **falar** | hablar |
+| *farīna* | **farinha** (flour) | harina |
+| *fīlius* | **filho** (son) | hijo |
+| *facere* | **fazer** (to do) | hacer |
+| *ferrum* | **ferro** (iron) | hierro |
+
+So when a Spanish word starts with a silent *h*, its Portuguese twin usually
+still has the honest Latin *f* — *hijo/filho*, *hacer/fazer*. Portuguese is the
+more conservative sister here.
+
+## Grammar Lens: the -ar present tense (pro-drop)
+
+Drop **-ar** to get *fal-*, then add the endings:
+
+| person | ending | *falar* → |
+|---|---|---|
+| (eu) | **-o** | **falo** (I speak) |
+| (tu) | **-as** | **falas** (you speak) |
+| (você/ele/ela) | **-a** | **fala** |
+| (nós) | -amos | falamos |
+| (vocês/eles) | -am | falam |
+
+Like Spanish and Italian, **Portuguese drops the subject pronoun** — *falo* already
+says "I," so no *eu* needed. (Portuguese joins the *drop* camp: ES, PT, IT drop;
+FR, DE keep.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "falar" — *fah-LAR*]
+- [YOU SAY: "falo, falas, fala" — no *eu* needed]
+- [YOU SAY: falar ↔ hablar, filho ↔ hijo — Portuguese keeps the *f*, Spanish
+  drops it to silent *h*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *falar* from, and which Spanish verb is its twin?
+(*fabulārī* — Spanish *hablar*.) What sound-law separates them? (Portuguese kept
+*f-*; Spanish shifted *f- → h-*: *filho/hijo*.) Does Portuguese keep or drop the
+pronoun? (Drops it.) Next: **morar**, "to live."

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-falo-portugues.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-falo-portugues.md
@@ -1,0 +1,70 @@
+---
+id: PT-C05-falo-portugues
+chapter: 5
+type: phrase
+headword: Falo português
+gloss: "I speak Portuguese" — your first full sentence (português = Portuguese)
+concept_tag: PT-WORD-PORTUGUES
+prerequisites: [PT-C05-falar]
+sounds: [final-s-sh, nasal-em]
+roots: [portus-cale-latin]
+etymology_hook: "português ← Portus Cale, a port at the Douro's mouth ('warm/fair port') → Portugal, Oporto"
+est_minutes: 4
+reviews_of: [PT-C05-falar, PT-C03-eu]
+---
+
+# Falo português — your first real sentence
+
+## Warm-up
+
+[PAUSE 2s] The payoff: you take a **verb** you conjugated and a **noun**, and
+build a sentence no one handed you — *Falo português*, "I speak Portuguese."
+(*Falo* covers both "I speak" and "I'm speaking.")
+
+## The new word: português
+
+**português** = "Portuguese," from **Portus Cale** — a Roman-era port at the mouth
+of the **Douro** river (today's **Porto** / **Oporto**). *Portus* is Latin "port,
+harbour" (→ English **port**, **portal**, **import**); **Cale** is older and
+debated — perhaps Celtic for "harbour/shelter," or Latin *cālidus* "warm." So
+*Portugal* began as a single **harbour town**, whose name spread to the whole
+country and its language. Say it *por-too-**GESH*** (final *-s* = *sh* in
+Portugal).
+
+## The sentence, assembled
+
+> **Falo** (I speak, from *falar*) + **português** = **Falo português.**
+
+A complete, grammatical Portuguese sentence. As before:
+
+- **No *eu*.** The *-o* of *falo* says "I" — Portuguese drops the pronoun (like
+  Spanish and Italian).
+- **No article** on the language: *falo português*.
+
+With this, **all five languages** you've been building now cross the same line —
+from reciting phrases to **making sentences**:
+
+| | "I speak/learn [language]" |
+|---|---|
+| Spanish | **Hablo** español |
+| Portuguese | **Falo** português |
+| Italian | **Parlo** italiano |
+| French | **Je parle** français |
+| German | **Ich lerne** Deutsch |
+
+Swap the pieces: **Moro em Lisboa.** · **Trabalho no Porto.** · **Você fala
+português?**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Falo português" — *FAH-loo por-too-GESH*]
+- [YOU SAY: drop the *eu* — Portuguese doesn't need it]
+- [YOU SAY: "português" ← *Portus Cale*, a single harbour town that named a nation]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does *português* come from? (*Portus Cale*, a port at the Douro's
+mouth → Porto.) In *Falo português*, why no *eu* and no article? (The *-o* is "I";
+languages take no article.) Which three of the five languages drop the pronoun?
+(Spanish, Portuguese, Italian.) Next: practice.

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-morar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-morar.md
@@ -1,0 +1,60 @@
+---
+id: PT-C05-morar
+chapter: 5
+type: word
+headword: morar
+gloss: to live / to dwell (a second -ar verb — from "to linger")
+concept_tag: PT-VERB-MORAR
+prerequisites: [PT-C05-falar]
+sounds: [final-r, final-a-reduces]
+roots: [morari-latin]
+etymology_hook: "morar ← Latin morārī 'to delay, to linger, to tarry' → English moratorium, demur"
+est_minutes: 3
+reviews_of: [PT-C05-falar]
+---
+
+# morar — "to live," i.e. to *linger* somewhere
+
+## Warm-up
+
+[PAUSE 2s] A second **-ar** verb — and a distinctive Portuguese choice. Where its
+sisters say "live" with *habitāre* ("keep having a place"), everyday Portuguese
+uses **morar** — from a verb that means to **linger**.
+
+## Sounds you'll need
+
+- **morar** = *moh-RAR*, tapped final *r*, clean vowels.
+
+## The word, taken apart
+
+**morar** comes from Latin **morārī**, *"to delay, to linger, to tarry, to stay
+a while."* To *dwell* somewhere is, in Portuguese, to *linger* there — a softer,
+more temporary image than "keeping" a place. That *morārī* root survives in
+English in a couple of unexpected words:
+
+- **moratorium** — an official *delay* (a pause on payments or actions).
+- **demur** — to *linger / hesitate*, to raise an objection (*without demur*).
+
+(Portuguese does also have *habitar* — the *habitāre* verb its sisters use — but
+it's formal; **morar** is what you actually say: *Onde você mora?*, "Where do you
+live?")
+
+## Grammar Lens: same -ar template
+
+| (eu) moro · (tu) moras · (você) mora | (-o / -as / -a) |
+| moramos · moram | |
+
+> **Moro em Lisboa.** — "I live in Lisbon."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "morar" — *moh-RAR*]
+- [YOU SAY: "moro, moras, mora"]
+- [YOU SAY: "Onde você mora?" — "Where do you live?"; "morar" ↔ *moratorium*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *morar* from, and what did it mean? (*morārī* — "to
+delay / linger.") English cousins? (*Moratorium*, *demur*.) Say "I live in
+Lisbon." (*Moro em Lisboa.*) Next: **trabalhar**, "to work."

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-practice.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-practice.md
@@ -1,0 +1,64 @@
+---
+id: PT-C05-practice
+chapter: 5
+type: practice-mix
+headword: (practice)
+gloss: making sentences with -ar verbs — and the whole 5-language verb set
+concept_tag: CH5-PRACTICE
+prerequisites: [PT-C05-falar, PT-C05-morar, PT-C05-trabalhar, PT-C05-falo-portugues]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [PT-C05-falar, PT-C05-morar, PT-C05-trabalhar, PT-C05-falo-portugues, PT-C03-practice]
+---
+
+# Practice — making sentences with -ar verbs
+
+## Warm-up
+
+[PAUSE 2s] For the first time you're **building** Portuguese sentences from a
+pattern. Drill the three verbs until the endings are automatic — and remember,
+Portuguese drops the *eu*.
+
+## Conjugate on command
+
+[PAUSE 1s] Run each through *eu / tu / você* (pronoun dropped in speech):
+
+- **falar**: falo · falas · fala
+- **morar**: moro · moras · mora
+- **trabalhar**: trabalho · trabalhas · trabalha
+
+Same endings every time (**-o / -as / -a**), no pronoun needed.
+
+## Say something real
+
+> — **Você fala** português? — **Falo** um pouco. E você?
+> — Também. **Onde** você **mora**? — **Moro** em Lisboa, e **trabalho** no Porto.
+> — Obrigado! — De nada.
+
+## What you've built this chapter
+
+- **the regular -ar present tense** — drop *-ar*, add *-o/-as/-a/-amos/-am*;
+  pronoun **dropped** (like Spanish, Italian).
+- **falar** (← *fabulārī* → fable; twin of Spanish *hablar* but with the *f* kept),
+  **morar** (← *morārī* "to linger" → moratorium — a root no sibling uses),
+  **trabalhar** (← *tripalium* "torture"; twin of *trabajar*).
+- **Falo português** (← *Portus Cale*, a harbour town) — first self-assembled
+  sentence, and the **fifth language** to cross from phrases into sentences.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: conjugate all three verbs, eu/tu/você — no pronoun spoken]
+- [YOU SAY: answer about yourself — what you speak, where you live, where you work]
+- [YOU SAY: chain it — "Olá! Falo português. Você fala português? … Até logo!"]
+
+[REPEAT x2] "Você fala português? — Falo um pouco."
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the three singular *-ar* endings? (*-o / -as / -a*.) Give the
+"I" forms of the three verbs. (*Falo, moro, trabalho*.) *falar* vs Spanish
+*hablar* — what's the sound-law difference? (Portuguese kept *f-*; Spanish shifted
+*f→h*.) All five of your languages now move in real sentences — the course has
+handed over rules, not phrases.

--- a/code/learning/human-languages/portuguese/lessons/PT-C05-trabalhar.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C05-trabalhar.md
@@ -1,0 +1,66 @@
+---
+id: PT-C05-trabalhar
+chapter: 5
+type: word
+headword: trabalhar
+gloss: to work (a third -ar verb — back on the "torture" road)
+concept_tag: PT-VERB-TRABALHAR
+prerequisites: [PT-C05-falar]
+sounds: [nasal-anha, final-r]
+roots: [tripalium-latin]
+etymology_hook: "trabalhar ← Vulgar Latin tripaliāre 'to torture' (← tripalium) → English travail, travel; twin of Spanish trabajar"
+est_minutes: 3
+reviews_of: [PT-C05-morar]
+---
+
+# trabalhar — "to work," and the torture returns
+
+## Warm-up
+
+[PAUSE 2s] A third **-ar** verb — and Portuguese rejoins its Iberian sister on the
+darkest etymology in the curriculum. **trabalhar** ("to work"), like Spanish
+*trabajar*, began as a word for **torture**.
+
+## Sounds you'll need
+
+- `nasal-anha` — the **-lh-** is a *ly* glide (as in Spanish *ll*): **trabalhar**
+  = *tra-ba-**LYAR***.
+
+## The word, taken apart
+
+**trabalhar** comes from Vulgar Latin **tripaliāre**, *"to torture"* — from
+**tripalium**, a Roman instrument of torture made of **three stakes** (*tri-*
+"three" + *pālus* "stake" → English *pale*, *impale*). *Torture → toil → work*, and
+English took the same road: **travail** (painful effort) → **travel** (a journey
+was an ordeal).
+
+So Portuguese and Spanish are **twins** here — *trabalhar* and *trabajar*, both
+from *tripaliāre*. Only the middle consonant differs: Latin *-li-* became
+Portuguese **-lh-** (*trabalhar*) and Spanish **-j-** (*trabajar*). And this puts
+the "work" verbs of the five languages into two neat camps:
+
+- **Torture** (*tripalium*): Portuguese *trabalhar*, Spanish *trabajar*, French
+  *travailler*.
+- **Labour** (*labor*): Italian *lavorare*.
+
+Three languages remember work as *torture*; only Italy remembers it as *labour*.
+
+## Grammar Lens: same -ar template
+
+| (eu) trabalho · (tu) trabalhas · (você) trabalha | (-o / -as / -a) |
+
+> **Trabalho no Porto.** — "I work in Porto."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "trabalhar" — *tra-ba-LYAR*]
+- [YOU SAY: "trabalho, trabalhas, trabalha"]
+- [YOU SAY: trabalhar ↔ trabajar (twins) → travail → travel — torture to journey]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did *trabalhar* originally mean, and from what device? ("To
+torture," ← *tripalium*, three stakes.) Its Spanish twin, and the one difference?
+(*trabajar*; Latin *-li-* → PT *-lh-* / ES *-j-*.) Which language uses "labour"
+instead? (Italian, *lavorare*.) Next: your first sentence — **Falo português**.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -30,12 +30,17 @@ French.
   (*chamar-se* ← *clāmāre*; *ch* = *sh*; alt. *o meu nome é* ← *nōmen*) → como se
   chama → prazer (← *placēre*; twin of *piacere*) → practice. **Authored** —
   Portuguese now runs greet → introduce → how-are-you → goodbye end to end.
+- **Ch. 5 — The first verbs**: falar (← *fabulārī* = Spanish *hablar*, but PT kept
+  the *f-*; the regular *-ar* present, pro-drop) → morar (← *morārī* "to linger" →
+  moratorium) → trabalhar (← *tripalium* → travail/travel; twin of *trabajar*) →
+  **Falo português** (first sentence; *português* ← *Portus Cale*) → practice.
+  **Authored** — the **fifth and final** track to reach real sentences.
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 5+ | Numbers, time, days & months, family, food — following the shared theme order |
+| 6+ | Numbers, time, days & months, family, food — following the shared theme order |
 
 Note: Portuguese's polite "you" is **você** (← *vossa mercê*, "your mercy") — the
 same "your grace" mechanism as Spanish *usted*, worn down differently. Worth


### PR DESCRIPTION
## Portuguese Chapter 5 — the first verbs (Falo português; the 5-language verb set completes)

Loop item 11. Portuguese's first **grammar-engine** chapter — and the **fifth and
final** track to cross from fixed phrases into **self-assembled sentences**. Five
atom-first lessons, each reviewing Ch.2–4.

### What's new
- **The regular -ar present tense** — drop *-ar*, add *-o/-as/-a/-amos/-am*.
  Taught on **falar**, cemented on **morar** and **trabalhar**. Portuguese is
  **pro-drop** (drops *eu*, like Spanish and Italian).
- **First self-assembled sentence — *Falo português***.

### Etymology — the sharpest Iberian contrasts yet
- **falar** ← *fabulārī* — the **same root as Spanish *hablar***, but **Portuguese
  kept the Latin *f-*** where Spanish shifted *f→h*: *falar/hablar*, *filho/hijo*,
  *fazer/hacer*, *ferro/hierro*. (The mirror image of the Spanish Ch.6 f→h lesson.)
- **morar** ← *morārī* "to linger / tarry" → **moratorium**, **demur** — a root
  **no sibling uses** for "to dwell."
- **trabalhar** ← *tripalium* "torture" — twin of Spanish *trabajar* (Latin *-li-*
  → PT *-lh-* / ES *-j-*). Portuguese rejoins the "torture" camp (ES/FR/PT); only
  Italian's *lavorare* takes the "labour" road.
- **português** ← *Portus Cale*, a Roman harbour town at the Douro's mouth (→ Porto).

### The milestone
All five tracks now build real sentences:
**Hablo** español · **Falo** português · **Parlo** italiano · **Je parle** français
· **Ich lerne** Deutsch — three drop the pronoun (ES/PT/IT), two keep it (FR/DE).

### Checks
- Namespaced `PT-VERB-FALAR/MORAR/TRABALHAR`, `PT-WORD-PORTUGUES` documented.
- 38 data-package tests pass; validator clean. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
