### PR TITLE
feat(loss-functions): add Haskell port

### DIFF
--- a/code/packages/haskell/loss-functions/BUILD
+++ b/code/packages/haskell/loss-functions/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/loss-functions/BUILD_windows
+++ b/code/packages/haskell/loss-functions/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/loss-functions/CHANGELOG.md
+++ b/code/packages/haskell/loss-functions/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add mean squared, mean absolute, binary cross-entropy, and categorical
+  cross-entropy losses.
+- Add derivatives for every loss and clamp probability inputs away from zero
+  and one.
+- Reject empty and length-mismatched input vectors explicitly.

--- a/code/packages/haskell/loss-functions/README.md
+++ b/code/packages/haskell/loss-functions/README.md
@@ -1,0 +1,25 @@
+# loss-functions
+
+Pure Haskell loss functions and derivatives for small machine-learning
+examples.
+
+## API
+
+- `mse` and `mae` compute mean squared and mean absolute error.
+- `bce` and `cce` compute binary and categorical cross-entropy.
+- `mseDerivative`, `maeDerivative`, `bceDerivative`, and `cceDerivative`
+  compute gradients with respect to the predictions.
+
+Every operation returns `Either String ...` so empty and length-mismatched
+vectors are rejected explicitly. Cross-entropy inputs are clamped to
+`epsilon .. 1 - epsilon` to keep logarithms and gradients finite.
+
+## Dependencies
+
+The library depends only on `base`. Tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/loss-functions/cabal.project
+++ b/code/packages/haskell/loss-functions/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/loss-functions/loss-functions.cabal
+++ b/code/packages/haskell/loss-functions/loss-functions.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          loss-functions
+version:       0.1.0
+synopsis:      Loss functions and derivatives for machine-learning examples
+description:   Pure loss functions and gradients with explicit vector validation.
+category:      Math
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  LossFunctions
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    LossFunctionsSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , loss-functions
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/loss-functions/src/LossFunctions.hs
+++ b/code/packages/haskell/loss-functions/src/LossFunctions.hs
@@ -1,0 +1,95 @@
+-- | Pure loss functions and derivatives for machine-learning examples.
+module LossFunctions
+    ( epsilon
+    , mse
+    , mae
+    , bce
+    , cce
+    , mseDerivative
+    , maeDerivative
+    , bceDerivative
+    , cceDerivative
+    ) where
+
+-- | Smallest probability used by the cross-entropy functions.
+epsilon :: Double
+epsilon = 1e-7
+
+-- | Mean squared error.
+mse :: [Double] -> [Double] -> Either String Double
+mse actual predicted = do
+    count <- validateInputs actual predicted
+    let squaredError truth prediction = (truth - prediction) ^ (2 :: Int)
+    pure $ sum (zipWith squaredError actual predicted) / fromIntegral count
+
+-- | Mean absolute error.
+mae :: [Double] -> [Double] -> Either String Double
+mae actual predicted = do
+    count <- validateInputs actual predicted
+    pure $ sum (zipWith (\truth prediction -> abs (truth - prediction)) actual predicted)
+        / fromIntegral count
+
+-- | Binary cross-entropy, with predictions clamped away from zero and one.
+bce :: [Double] -> [Double] -> Either String Double
+bce actual predicted = do
+    count <- validateInputs actual predicted
+    let term truth prediction =
+            let probability = clampProbability prediction
+            in truth * log probability
+                + (1.0 - truth) * log (1.0 - probability)
+    pure $ negate (sum (zipWith term actual predicted) / fromIntegral count)
+
+-- | Categorical cross-entropy for a one-hot target vector.
+cce :: [Double] -> [Double] -> Either String Double
+cce actual predicted = do
+    count <- validateInputs actual predicted
+    let term truth prediction = truth * log (clampProbability prediction)
+    pure $ negate (sum (zipWith term actual predicted) / fromIntegral count)
+
+-- | Gradient of 'mse' with respect to each prediction.
+mseDerivative :: [Double] -> [Double] -> Either String [Double]
+mseDerivative actual predicted = do
+    count <- validateInputs actual predicted
+    let scale = 2.0 / fromIntegral count
+    pure $ zipWith (\truth prediction -> scale * (prediction - truth)) actual predicted
+
+-- | Gradient of 'mae' with respect to each prediction.
+maeDerivative :: [Double] -> [Double] -> Either String [Double]
+maeDerivative actual predicted = do
+    count <- validateInputs actual predicted
+    let scale = 1.0 / fromIntegral count
+        derivative truth prediction
+            | prediction > truth = scale
+            | prediction < truth = negate scale
+            | otherwise = 0.0
+    pure $ zipWith derivative actual predicted
+
+-- | Gradient of 'bce' with respect to each prediction.
+bceDerivative :: [Double] -> [Double] -> Either String [Double]
+bceDerivative actual predicted = do
+    count <- validateInputs actual predicted
+    let scale = 1.0 / fromIntegral count
+        derivative truth prediction =
+            let probability = clampProbability prediction
+            in scale * ((probability - truth) / (probability * (1.0 - probability)))
+    pure $ zipWith derivative actual predicted
+
+-- | Gradient of 'cce' with respect to each prediction.
+cceDerivative :: [Double] -> [Double] -> Either String [Double]
+cceDerivative actual predicted = do
+    count <- validateInputs actual predicted
+    let scale = negate (1.0 / fromIntegral count)
+        derivative truth prediction = scale * truth / clampProbability prediction
+    pure $ zipWith derivative actual predicted
+
+validateInputs :: [Double] -> [Double] -> Either String Int
+validateInputs actual predicted
+    | null actual = Left "Inputs must have the same non-zero length"
+    | length actual /= length predicted = Left "Inputs must have the same non-zero length"
+    | otherwise = Right (length actual)
+
+clampProbability :: Double -> Double
+clampProbability value
+    | value < epsilon = epsilon
+    | value > 1.0 - epsilon = 1.0 - epsilon
+    | otherwise = value

--- a/code/packages/haskell/loss-functions/test/LossFunctionsSpec.hs
+++ b/code/packages/haskell/loss-functions/test/LossFunctionsSpec.hs
@@ -1,0 +1,99 @@
+module LossFunctionsSpec (spec) where
+
+import Control.Monad (zipWithM_)
+import Data.Either (isLeft)
+import LossFunctions
+import Test.Hspec
+
+tolerance :: Double
+tolerance = 1e-6
+
+shouldBeCloseTo :: Double -> Double -> Expectation
+actual `shouldBeCloseTo` expected =
+    abs (actual - expected) `shouldSatisfy` (<= tolerance)
+
+shouldBeCloseList :: [Double] -> [Double] -> Expectation
+actual `shouldBeCloseList` expected = do
+    length actual `shouldBe` length expected
+    zipWithM_ shouldBeCloseTo actual expected
+
+rightValue :: Show error => Either error value -> IO value
+rightValue result = case result of
+    Left err -> expectationFailure (show err) >> error "unreachable"
+    Right value -> pure value
+
+spec :: Spec
+spec = do
+    describe "mse" $ do
+        it "matches the shared reference vector" $ do
+            result <- rightValue $ mse [1.0, 0.0] [0.9, 0.1]
+            result `shouldBeCloseTo` 0.01
+        it "is zero for identical vectors" $ do
+            result <- rightValue $ mse [1.0, 0.0, 0.5] [1.0, 0.0, 0.5]
+            result `shouldBeCloseTo` 0.0
+
+    describe "mae" $ do
+        it "matches the shared reference vector" $ do
+            result <- rightValue $ mae [1.0, 0.0] [0.9, 0.1]
+            result `shouldBeCloseTo` 0.1
+        it "is zero for identical vectors" $ do
+            result <- rightValue $ mae [1.0, 0.0, 0.5] [1.0, 0.0, 0.5]
+            result `shouldBeCloseTo` 0.0
+
+    describe "bce" $ do
+        it "matches the shared reference vector" $ do
+            result <- rightValue $ bce [1.0, 0.0] [0.9, 0.1]
+            result `shouldBeCloseTo` 0.1053605
+        it "clamps zero and one predictions" $ do
+            result <- rightValue $ bce [1.0, 0.0] [0.0, 1.0]
+            result `shouldBeCloseTo` (negate (log epsilon))
+
+    describe "cce" $ do
+        it "matches the shared reference vector" $ do
+            result <- rightValue $ cce [1.0, 0.0] [0.9, 0.1]
+            result `shouldBeCloseTo` 0.0526802
+        it "clamps a zero prediction" $ do
+            result <- rightValue $ cce [1.0, 0.0] [0.0, 1.0]
+            result `shouldBeCloseTo` (negate (log epsilon) / 2.0)
+
+    describe "derivatives" $ do
+        it "computes the MSE gradient" $ do
+            result <- rightValue $ mseDerivative [1.0, 0.0] [0.8, 0.2]
+            result `shouldBeCloseList` [-0.2, 0.2]
+        it "computes all three MAE gradient branches" $ do
+            result <- rightValue $ maeDerivative [1.0, 0.0, 0.5] [0.8, 0.2, 0.5]
+            result `shouldBeCloseList` [-1.0 / 3.0, 1.0 / 3.0, 0.0]
+        it "computes the BCE gradient" $ do
+            result <- rightValue $ bceDerivative [1.0, 0.0] [0.8, 0.2]
+            result `shouldBeCloseList` [-0.625, 0.625]
+        it "computes the CCE gradient" $ do
+            result <- rightValue $ cceDerivative [1.0, 0.0] [0.8, 0.2]
+            result `shouldBeCloseList` [-0.625, 0.0]
+        it "clamps derivative probabilities" $ do
+            binary <- rightValue $ bceDerivative [1.0, 0.0] [0.0, 1.0]
+            categorical <- rightValue $ cceDerivative [1.0, 0.0] [0.0, 1.0]
+            all (not . isInfinite) binary `shouldBe` True
+            categorical `shouldBeCloseList` [(-0.5) / epsilon, 0.0]
+
+    describe "input validation" $ do
+        it "rejects empty vectors for every loss and derivative" $ do
+            all isLeft [mse [] [], mae [] [], bce [] [], cce [] []] `shouldBe` True
+            all isLeft
+                [ mseDerivative [] []
+                , maeDerivative [] []
+                , bceDerivative [] []
+                , cceDerivative [] []
+                ] `shouldBe` True
+        it "rejects length mismatches for every loss and derivative" $ do
+            all isLeft
+                [ mse [1.0] [0.9, 0.1]
+                , mae [1.0] [0.9, 0.1]
+                , bce [1.0] [0.9, 0.1]
+                , cce [1.0] [0.9, 0.1]
+                ] `shouldBe` True
+            all isLeft
+                [ mseDerivative [1.0] [0.9, 0.1]
+                , maeDerivative [1.0] [0.9, 0.1]
+                , bceDerivative [1.0] [0.9, 0.1]
+                , cceDerivative [1.0] [0.9, 0.1]
+                ] `shouldBe` True

--- a/code/packages/haskell/loss-functions/test/Spec.hs
+++ b/code/packages/haskell/loss-functions/test/Spec.hs
@@ -1,0 +1,5 @@
+import LossFunctionsSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -116,11 +116,11 @@ ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
-`scytale-cipher`, and `feature-normalization` ports:
+`scytale-cipher`, `feature-normalization`, and `loss-functions` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 306 |
+| Present in 10-15 languages | 172 | 305 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 703 | 9,842 |
@@ -166,7 +166,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 306
+The 172 packages present in at least ten implementation languages need 305
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -177,7 +177,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 31 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 30 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -412,6 +412,15 @@ including the shared matrix, population deviation, constant columns, negative
 ranges, new observations, and every validation branch. The package now spans
 14 implementation lanes, reduces the high-consensus backlog to 306 slots, and
 leaves 31 gaps in the Haskell lane.
+
+The fourth Haskell high-consensus slice is complete: `loss-functions` now
+provides dependency-free ML04 mean squared, mean absolute, binary
+cross-entropy, and categorical cross-entropy losses together with their
+prediction gradients, explicit vector validation, and finite probability
+clamping. Its package-native suite exercises 15 examples covering reference
+values, every derivative branch, boundary probabilities, and all validation
+paths. The package now spans 14 implementation lanes, reduces the
+high-consensus backlog to 305 slots, and leaves 30 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add a dependency-free Haskell port of `loss-functions`
- implement MSE, MAE, BCE, and CCE with prediction derivatives and explicit input validation
- clamp cross-entropy probabilities to keep losses and gradients finite
- update the package-parity roadmap from 306 to 305 high-consensus gaps and Haskell from 31 to 30

## Validation
- `stack test --coverage` (GHC 9.4.8): 15 examples, 0 failures, 99% expression coverage, 100% top-level declaration coverage
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py`: 6 passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: 0 collisions; 305 high-consensus gaps; 30 Haskell gaps; 14 loss-functions lanes
- `git diff --cached --check`