### PR TITLE
fix(matlab): correct MATLAB/Octave logical-negation-of-zero via a runtime truthy intrinsic

### DIFF
--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -123,31 +123,52 @@
     addressed here.) `apl-to-semantic-ir`/`j-to-semantic-ir` are NOT
     affected: v0.1.0 of both has no `if`/`while`/`&&`/`||`/`~` lowering at
     all yet (no boolean-context construct exists to have the bug).
-  - **Fix:** a new `to_matlab_condition` helper (`src/lower.rs`) coerces
-    an already-lowered expression to MATLAB truthiness at the point it
-    reaches a boolean context — wrapping anything that is not already a
-    genuine SIR boolean (per the new `expr_is_known_bool` predicate: a
-    comparison, a `not` call, or `LogicalAnd`/`LogicalOr`) in an explicit
-    `!= 0` comparison. Applied at all four call sites: `lower_if`'s and
-    `lower_while`'s condition, `lower_unary`'s `~` operand, and each
-    operand `try_logical` folds into `LogicalAnd`/`LogicalOr` (so the
-    "deciding operand" a short-circuit returns is always already boolean,
-    by construction, all the way down through nesting). An already-boolean
-    operand (`~(x > 3)`, `if x > 0`) is left untouched — wrapping it again
-    would be wrong, not just redundant (`false != 0` is `true`).
-  - **Regression tests:** 8 new structural tests in `tests/test_lower.rs`
-    (bare-variable negation wraps in `!= 0`; a comparison operand is NOT
-    double-wrapped, for both `~` and `if`; `if`/`while` on a bare variable
-    wrap in `!= 0`; `&&`/`||` wrap each bare operand independently while
-    leaving an already-boolean operand alone) plus 6 new end-to-end
-    `tests/oracle.rs` corpus cases cross-checked against real
-    `matlab-runtime` through an actual `node` process: `~0` is `1`, `~5` is
-    `0`, `if 0`/`if 5` take the correct branch, and `0 && 1` / `0 || 5`
-    resolve correctly through an `if` (observing the branch taken rather
-    than `disp`ing the raw short-circuit value directly, which would hit
-    an unrelated, already-documented representational difference between
-    this frontend's Ruby-style "return the deciding operand" `&&`/`||` and
-    `matlab-runtime`'s coerced-0.0/1.0-double convention).
+  - **First fix attempt had a HIGH-severity regression, caught by
+    `/security-review` before push and corrected in this same PR.** The
+    initial approach wrapped an operand in an explicit `!= 0` comparison
+    only when a new `expr_is_known_bool` predicate could NOT statically
+    prove the operand was already a genuine SIR boolean (matching only
+    `BoolLit`, `LogicalAnd`/`LogicalOr`, or a comparison/`not`
+    `BuiltinCall` by shape). That predicate cannot see through a `VarRef`:
+    a variable that *holds* a stored comparison result (`tf = (5 < 3); if
+    tf`) is indistinguishable, by static shape alone, from a variable
+    holding a bare number — so it fell into the "wrap in `!= 0`" branch
+    too. The shared JS runtime's `ne(a, b)` is `numOf(a) !== numOf(b)`
+    (strict), so `false != 0` evaluates to `true` unconditionally,
+    regardless of whether `tf` was really `true` or `false` — silently
+    inverting (or always-taking) the `if` branch for exactly this pattern.
+  - **Corrected fix:** the boolean-vs-number decision moved from
+    lowering-time static shape analysis to a RUNTIME intrinsic.
+    `to_matlab_condition` (`src/lower.rs`) now UNCONDITIONALLY wraps every
+    operand reaching a boolean context in a new `matlab_truthy`
+    `BuiltinCall`, which `semantic-ir-to-javascript` emits as
+    `__Sir.matlabTruthy(x)` — a runtime helper (`typeof x === "boolean" ?
+    x : numOf(x) !== 0`) that decides "already a genuine boolean, pass
+    through" vs. "a bare number, apply `!= 0`" using the ACTUAL value at
+    runtime, not a static guess. `expr_is_known_bool` is deleted entirely;
+    there is no shape check left to be wrong. Applied at all four call
+    sites unconditionally: `lower_if`'s and `lower_while`'s condition,
+    `lower_unary`'s `~` operand, and each operand `try_logical` folds into
+    `LogicalAnd`/`LogicalOr`.
+  - **Regression tests:** `tests/test_lower.rs` rewrote the structural
+    tests to assert the unconditional `matlab_truthy` wrap (bare-variable
+    and already-a-comparison operands both wrap, for `~`/`if`/`while`/
+    `&&`/`||`), and added the exact regression case that broke the first
+    attempt: `if_condition_on_a_variable_holding_a_stored_comparison_
+    still_wraps_in_matlab_truthy` (a `VarRef` holding a stored comparison
+    result). `tests/oracle.rs` adds two end-to-end cases cross-checked
+    against real `matlab-runtime` through `node`:
+    `if_condition_on_a_variable_holding_a_stored_false_comparison` and
+    `..._true_comparison` — a variable holding `(5 < 3)`/`(5 > 3)` takes
+    the correct `if`/`else` branch, which is the case the first fix
+    attempt got backwards. Plus the original 6 end-to-end oracle cases:
+    `~0` is `1`, `~5` is `0`, `if 0`/`if 5` take the correct branch, and
+    `0 && 1` / `0 || 5` resolve correctly through an `if` (observing the
+    branch taken rather than `disp`ing the raw short-circuit value
+    directly, which would hit an unrelated, already-documented
+    representational difference between this frontend's Ruby-style
+    "return the deciding operand" `&&`/`||` and `matlab-runtime`'s
+    coerced-0.0/1.0-double convention).
   - `octave-to-semantic-ir/tests/oracle.rs`'s `bang_negation_on_comparison`
     doc comment is updated to drop the "confirmed, excluded gap" framing,
     and two new corpus cases (`bang_negation_on_bare_zero_is_true`,

--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -88,6 +88,73 @@
 
 ### Fixed
 
+- **Correctness: bare-numeric truthiness disagreed with MATLAB/Octave's
+  "logicals are doubles" convention.** Real MATLAB/Octave has no separate
+  boolean type — truthiness is "nonzero is true, zero is false" for ANY
+  number (`~0` is `1`, `~5` is `0`), not just the result of a comparison.
+  But `lower_unary` (`~`), `lower_if`, `lower_while`, and `try_logical`
+  (`&&`/`||`) all passed an already-lowered operand straight through to
+  `Expr::If`/`Stmt::While`/`Expr::LogicalAnd`/`Expr::LogicalOr`/
+  `BuiltinCall("not", ..)` unchanged, so a **bare numeric variable or
+  literal** reaching one of these boolean contexts fell through to the
+  shared JS/Python backends' `truthy()` runtime helper, which implements
+  SIR's OWN canonical truthiness instead (only `false`/`nil` are falsy —
+  the Ruby/Lisp convention `ruby-to-semantic-ir` genuinely depends on, per
+  the `sir-runtime` spec's own verification rule that Ruby `0 && x` must
+  yield `x`). So `n = 0; ~n` compiled to `false` — backwards; MATLAB's
+  `~0` is `1`. This was deliberately diagnosed-but-NOT-fixed by PR #8534/
+  #8535 (`octave-to-semantic-ir/tests/oracle.rs`'s `bang_negation_on_
+  comparison` case only ever negated a *comparison result*, which already
+  produces a genuine boolean regardless of convention, sidestepping the
+  bug rather than exercising it).
+  - **Root-cause investigation confirmed the fix belongs in THIS
+    frontend's lowering, not the shared runtime.** `sir-conformance`
+    proves real Ruby source's `&&`/`||`/`~`-equivalent semantics agree
+    across every backend end-to-end (`corpus_agrees_across_all_backends`,
+    still passing, unmodified) — Ruby's own frontend deliberately does NOT
+    wrap a bare numeric operand, because Ruby treats `0` as truthy too, so
+    changing the shared `truthy()` convention globally would silently
+    break every Ruby-sourced program. (Separately confirmed:
+    `python-to-semantic-ir` and `javascript-to-semantic-ir` do not wrap a
+    bare native-falsy operand — `0`/`""`/`[]`/`{}` — either, and appear to
+    share this exact class of latent bug for their own languages' native
+    truthiness; no existing test in either crate exercises it, so it is
+    flagged as a separate, unfixed, out-of-scope finding rather than
+    addressed here.) `apl-to-semantic-ir`/`j-to-semantic-ir` are NOT
+    affected: v0.1.0 of both has no `if`/`while`/`&&`/`||`/`~` lowering at
+    all yet (no boolean-context construct exists to have the bug).
+  - **Fix:** a new `to_matlab_condition` helper (`src/lower.rs`) coerces
+    an already-lowered expression to MATLAB truthiness at the point it
+    reaches a boolean context — wrapping anything that is not already a
+    genuine SIR boolean (per the new `expr_is_known_bool` predicate: a
+    comparison, a `not` call, or `LogicalAnd`/`LogicalOr`) in an explicit
+    `!= 0` comparison. Applied at all four call sites: `lower_if`'s and
+    `lower_while`'s condition, `lower_unary`'s `~` operand, and each
+    operand `try_logical` folds into `LogicalAnd`/`LogicalOr` (so the
+    "deciding operand" a short-circuit returns is always already boolean,
+    by construction, all the way down through nesting). An already-boolean
+    operand (`~(x > 3)`, `if x > 0`) is left untouched — wrapping it again
+    would be wrong, not just redundant (`false != 0` is `true`).
+  - **Regression tests:** 8 new structural tests in `tests/test_lower.rs`
+    (bare-variable negation wraps in `!= 0`; a comparison operand is NOT
+    double-wrapped, for both `~` and `if`; `if`/`while` on a bare variable
+    wrap in `!= 0`; `&&`/`||` wrap each bare operand independently while
+    leaving an already-boolean operand alone) plus 6 new end-to-end
+    `tests/oracle.rs` corpus cases cross-checked against real
+    `matlab-runtime` through an actual `node` process: `~0` is `1`, `~5` is
+    `0`, `if 0`/`if 5` take the correct branch, and `0 && 1` / `0 || 5`
+    resolve correctly through an `if` (observing the branch taken rather
+    than `disp`ing the raw short-circuit value directly, which would hit
+    an unrelated, already-documented representational difference between
+    this frontend's Ruby-style "return the deciding operand" `&&`/`||` and
+    `matlab-runtime`'s coerced-0.0/1.0-double convention).
+  - `octave-to-semantic-ir/tests/oracle.rs`'s `bang_negation_on_comparison`
+    doc comment is updated to drop the "confirmed, excluded gap" framing,
+    and two new corpus cases (`bang_negation_on_bare_zero_is_true`,
+    `bang_negation_on_bare_nonzero_is_false`) exercise the fix through
+    Octave's own `!` spelling — this crate needed no change of its own
+    since it shares 100% of its lowering.
+
 - **Correctness: `Feature::Floats` was never observed for a `FloatLit`.**
   `number_literal_expr` was a free function with no access to the
   lowerer's feature-tracking state, so a module containing a float

--- a/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
@@ -969,9 +969,7 @@ impl Lowerer {
                 // Each operand is forced to MATLAB truthiness ("nonzero is
                 // true") BEFORE it can become the "deciding operand" a
                 // short-circuit returns — see `to_matlab_condition`'s doc
-                // comment. This is what lets `expr_is_known_bool` treat a
-                // `LogicalAnd`/`LogicalOr` node as already-boolean: by
-                // construction, every operand reaching one already is.
+                // comment.
                 let operand = to_matlab_condition(self.lower_expr_d(n, ctx, depth + 1)?);
                 acc = Some(match acc.take() {
                     None => operand,
@@ -1476,10 +1474,7 @@ impl Lowerer {
                 name: "not".to_string(),
                 // `~5` must be `0` and `~0` must be `1` — MATLAB truthiness
                 // ("nonzero is true"), not the shared backend's own — see
-                // `to_matlab_condition`'s doc comment. `to_matlab_condition`
-                // leaves an already-boolean operand (e.g. `~(x > 3)`)
-                // unchanged, so this is a no-op for the case the frontend
-                // already handled correctly.
+                // `to_matlab_condition`'s doc comment.
                 args: vec![to_matlab_condition(operand)],
                 effects: EffectSet::PURE,
                 span,
@@ -2088,30 +2083,6 @@ fn expr_is_known_scalar_d(e: &Expr, depth: usize) -> bool {
     }
 }
 
-/// Is `e` already a genuine SIR boolean — i.e. it produces `true`/`false`
-/// regardless of which convention a backend's truthy-check uses?
-///
-/// A comparison (`= != < > <= >=`, this frontend's `BuiltinCall` spelling
-/// per [`Lowerer::try_comparison`]), a `~`-negation (`BuiltinCall("not",
-/// ..)` per [`Lowerer::lower_unary`]), and `&&`/`||` ([`Expr::LogicalAnd`]/
-/// [`Expr::LogicalOr`]) all qualify. `LogicalAnd`/`LogicalOr` qualify
-/// unconditionally rather than recursively, because [`to_matlab_condition`]
-/// is *always* applied to each of their own operands at the point they are
-/// built (see [`Lowerer::try_logical`]) — so by construction their
-/// "deciding operand" (Ruby-style short-circuit: the node returns whichever
-/// operand decided the result, not a separately-computed bool) is already
-/// one of these same already-boolean shapes, all the way down.
-fn expr_is_known_bool(e: &Expr) -> bool {
-    match e {
-        Expr::BoolLit { .. } => true,
-        Expr::LogicalAnd { .. } | Expr::LogicalOr { .. } => true,
-        Expr::BuiltinCall { name, .. } => {
-            matches!(name.as_str(), "=" | "!=" | "<" | ">" | "<=" | ">=" | "not")
-        }
-        _ => false,
-    }
-}
-
 /// Coerce an already-lowered MATLAB/Octave expression to genuine MATLAB
 /// truthiness at the point it reaches a **boolean context**: an `if`/
 /// `while` condition, the operand of unary `~`, or an operand of `&&`/`||`.
@@ -2129,35 +2100,38 @@ fn expr_is_known_bool(e: &Expr) -> bool {
 /// would silently get Ruby's truthiness instead of MATLAB's: canonical SIR
 /// `truthy(0)` is `true`, backwards from MATLAB's `~0 == 1`.
 ///
-/// The fix belongs HERE, at MATLAB/Octave lowering time, rather than in
-/// the shared runtime — this frontend already knows its own language's
-/// truthiness rule, so it makes the fact `x != 0` an explicit SIR
-/// comparison *before* the value ever reaches a backend's truthy check.
-/// After that, a real SIR boolean means the same thing to every backend
-/// and every source language, canonical-SIR-truthy or not.
+/// The fix belongs HERE, at MATLAB/Octave lowering time (this frontend
+/// already knows its own language's truthiness rule), but it does **not**
+/// try to decide, via static shape analysis of the operand, whether the
+/// value is "already a genuine boolean" (a comparison/`~`/`&&`/`||` result)
+/// versus "a bare number" — an earlier version of this function did
+/// exactly that (an `expr_is_known_bool` shape check gating whether to
+/// wrap in an explicit `!= 0` comparison) and got it wrong for the most
+/// ordinary case there is: a **variable holding a stored comparison
+/// result** (`tf = (5 < 3); if tf ... end`). A bare `VarRef` is never
+/// "known bool" by shape alone, so the old code wrapped it in `tf != 0`
+/// regardless of what `tf` actually held — and the runtime's `!=`
+/// (`numOf(a) !== numOf(b)`) compares a genuine JS `boolean` against the
+/// number `0` by strict identity, which is unconditionally `true` for
+/// EITHER `true` or `false` (`false !== 0` is `true` — different types are
+/// never `===`). So `if tf` silently took its `if` branch regardless of
+/// `tf`'s value, a shape-analysis blind spot no amount of pattern-matching
+/// on the immediate node can close (the same problem recurs for a
+/// function-call result, an array-element read, …).
 ///
-/// A value that [`expr_is_known_bool`] already recognises as one is
-/// returned UNCHANGED — wrapping it again would be both redundant and
-/// actively wrong: the runtime's `!=` unwraps a tagged float via `numOf`
-/// but otherwise compares by strict identity, so `false != 0` is `true`
-/// (a JS `boolean` and `number` are never `===`), which would invert an
-/// already-correct boolean. Everything else — a bare variable, a numeric
-/// literal, an arithmetic result, a function call, an index read, … —
-/// is wrapped in an explicit `!= 0`.
+/// Instead, every operand reaching a boolean context is wrapped,
+/// unconditionally, in the dedicated runtime intrinsic
+/// [`__Sir.matlabTruthy`](../../semantic-ir-to-javascript/src/runtime.rs)
+/// (`BuiltinCall("matlab_truthy", [expr])`), which decides at **runtime**
+/// instead of at compile time: `typeof x === "boolean" ? x : (numOf(x) !==
+/// 0)`. This is correct for every shape uniformly — a genuine boolean
+/// passes through unchanged, a bare number gets MATLAB's `!= 0` rule —
+/// without this frontend ever needing to prove which case it's looking at.
 fn to_matlab_condition(expr: Expr) -> Expr {
-    if expr_is_known_bool(&expr) {
-        return expr;
-    }
     let span = expr.span().clone();
     Expr::BuiltinCall {
-        name: "!=".to_string(),
-        args: vec![
-            expr,
-            Expr::IntLit {
-                value: 0,
-                span: span.clone(),
-            },
-        ],
+        name: "matlab_truthy".to_string(),
+        args: vec![expr],
         effects: EffectSet::PURE,
         span,
     }

--- a/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
@@ -588,7 +588,9 @@ impl Lowerer {
             None => empty_block(if_span.clone()),
         };
         for clause in clauses.into_iter().rev() {
-            let cond = self.lower_expr(clause.cond, ctx)?;
+            // MATLAB truthiness ("nonzero is true"), not the shared
+            // backend's own — see `to_matlab_condition`'s doc comment.
+            let cond = to_matlab_condition(self.lower_expr(clause.cond, ctx)?);
             let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
             let span = cond.span().clone();
             let folded = Expr::If {
@@ -620,7 +622,9 @@ impl Lowerer {
                 ))
             }
         };
-        let cond = self.lower_expr(cond_node, ctx)?;
+        // MATLAB truthiness ("nonzero is true"), not the shared backend's
+        // own — see `to_matlab_condition`'s doc comment.
+        let cond = to_matlab_condition(self.lower_expr(cond_node, ctx)?);
         let body = self.lower_block_body(body_node, ctx, depth + 1)?;
         self.observed.add(Feature::Loops);
         Ok(Stmt::While {
@@ -962,7 +966,13 @@ impl Lowerer {
         let mut acc: Option<Expr> = None;
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
-                let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                // Each operand is forced to MATLAB truthiness ("nonzero is
+                // true") BEFORE it can become the "deciding operand" a
+                // short-circuit returns — see `to_matlab_condition`'s doc
+                // comment. This is what lets `expr_is_known_bool` treat a
+                // `LogicalAnd`/`LogicalOr` node as already-boolean: by
+                // construction, every operand reaching one already is.
+                let operand = to_matlab_condition(self.lower_expr_d(n, ctx, depth + 1)?);
                 acc = Some(match acc.take() {
                     None => operand,
                     Some(lhs) => {
@@ -1464,7 +1474,13 @@ impl Lowerer {
             },
             "~" => Expr::BuiltinCall {
                 name: "not".to_string(),
-                args: vec![operand],
+                // `~5` must be `0` and `~0` must be `1` — MATLAB truthiness
+                // ("nonzero is true"), not the shared backend's own — see
+                // `to_matlab_condition`'s doc comment. `to_matlab_condition`
+                // leaves an already-boolean operand (e.g. `~(x > 3)`)
+                // unchanged, so this is a no-op for the case the frontend
+                // already handled correctly.
+                args: vec![to_matlab_condition(operand)],
                 effects: EffectSet::PURE,
                 span,
             },
@@ -2069,6 +2085,81 @@ fn expr_is_known_scalar_d(e: &Expr, depth: usize) -> bool {
             args.iter().all(|a| expr_is_known_scalar_d(a, depth + 1))
         }
         _ => false,
+    }
+}
+
+/// Is `e` already a genuine SIR boolean — i.e. it produces `true`/`false`
+/// regardless of which convention a backend's truthy-check uses?
+///
+/// A comparison (`= != < > <= >=`, this frontend's `BuiltinCall` spelling
+/// per [`Lowerer::try_comparison`]), a `~`-negation (`BuiltinCall("not",
+/// ..)` per [`Lowerer::lower_unary`]), and `&&`/`||` ([`Expr::LogicalAnd`]/
+/// [`Expr::LogicalOr`]) all qualify. `LogicalAnd`/`LogicalOr` qualify
+/// unconditionally rather than recursively, because [`to_matlab_condition`]
+/// is *always* applied to each of their own operands at the point they are
+/// built (see [`Lowerer::try_logical`]) — so by construction their
+/// "deciding operand" (Ruby-style short-circuit: the node returns whichever
+/// operand decided the result, not a separately-computed bool) is already
+/// one of these same already-boolean shapes, all the way down.
+fn expr_is_known_bool(e: &Expr) -> bool {
+    match e {
+        Expr::BoolLit { .. } => true,
+        Expr::LogicalAnd { .. } | Expr::LogicalOr { .. } => true,
+        Expr::BuiltinCall { name, .. } => {
+            matches!(name.as_str(), "=" | "!=" | "<" | ">" | "<=" | ">=" | "not")
+        }
+        _ => false,
+    }
+}
+
+/// Coerce an already-lowered MATLAB/Octave expression to genuine MATLAB
+/// truthiness at the point it reaches a **boolean context**: an `if`/
+/// `while` condition, the operand of unary `~`, or an operand of `&&`/`||`.
+///
+/// Real MATLAB/Octave has no separate boolean type — logicals are doubles,
+/// and truthiness is simply "nonzero is true, zero is false" (`~0` is `1`,
+/// `~5` is `0`), for ANY numeric value, not just the result of a
+/// comparison. But this backend's shared runtime truthy-check (see
+/// `semantic-ir-to-javascript`'s `truthy()`, also reused as
+/// `semantic-ir-to-python`'s `_sir_truthy`) implements SIR's OWN canonical
+/// truthiness instead — only `false`/`nil` are falsy, the Ruby/Lisp
+/// convention `ruby-to-semantic-ir` depends on (per the `sir-runtime`
+/// spec's own verification rule: a Ruby `0 && x` must yield `x`, i.e. `0`
+/// is truthy there). Passed straight through, a bare MATLAB numeric value
+/// would silently get Ruby's truthiness instead of MATLAB's: canonical SIR
+/// `truthy(0)` is `true`, backwards from MATLAB's `~0 == 1`.
+///
+/// The fix belongs HERE, at MATLAB/Octave lowering time, rather than in
+/// the shared runtime — this frontend already knows its own language's
+/// truthiness rule, so it makes the fact `x != 0` an explicit SIR
+/// comparison *before* the value ever reaches a backend's truthy check.
+/// After that, a real SIR boolean means the same thing to every backend
+/// and every source language, canonical-SIR-truthy or not.
+///
+/// A value that [`expr_is_known_bool`] already recognises as one is
+/// returned UNCHANGED — wrapping it again would be both redundant and
+/// actively wrong: the runtime's `!=` unwraps a tagged float via `numOf`
+/// but otherwise compares by strict identity, so `false != 0` is `true`
+/// (a JS `boolean` and `number` are never `===`), which would invert an
+/// already-correct boolean. Everything else — a bare variable, a numeric
+/// literal, an arithmetic result, a function call, an index read, … —
+/// is wrapped in an explicit `!= 0`.
+fn to_matlab_condition(expr: Expr) -> Expr {
+    if expr_is_known_bool(&expr) {
+        return expr;
+    }
+    let span = expr.span().clone();
+    Expr::BuiltinCall {
+        name: "!=".to_string(),
+        args: vec![
+            expr,
+            Expr::IntLit {
+                value: 0,
+                span: span.clone(),
+            },
+        ],
+        effects: EffectSet::PURE,
+        span,
     }
 }
 

--- a/code/packages/rust/matlab-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/oracle.rs
@@ -359,6 +359,32 @@ const CORPUS: &[Case] = &[
         final_expr: "y",
         expected: "1",
     },
+    // Regression case for a second bug the first fix attempt introduced
+    // (`/security-review` caught it before push): a bare `VarRef` holding a
+    // STORED comparison result is never recognisably boolean by static
+    // shape analysis alone, so a lowering-time-only fix that decides
+    // "already boolean, skip the wrap" vs. "bare number, wrap in `!= 0`" by
+    // inspecting the operand's immediate shape gets this case wrong --
+    // `tf` gets wrapped in `tf != 0` regardless of its actual value, and
+    // the JS runtime's strict-identity `!=` (`numOf(a) !== numOf(b)`) makes
+    // `false != 0` unconditionally `true` (a `boolean` and a `number` are
+    // never `===`), silently taking the `if` branch no matter what `tf`
+    // holds. The fix (`to_matlab_condition` wrapping every operand in the
+    // `matlab_truthy` runtime intrinsic, unconditionally, deciding
+    // boolean-vs-number AT RUNTIME instead) makes this correct regardless
+    // of the operand's static shape. `y` must become `2` (`tf` is `false`).
+    Case {
+        name: "if_condition_on_a_variable_holding_a_stored_false_comparison",
+        setup: "y = 0;\ntf = (5 < 3);\nif tf\n  y = 1;\nelse\n  y = 2;\nend\n",
+        final_expr: "y",
+        expected: "2",
+    },
+    Case {
+        name: "if_condition_on_a_variable_holding_a_stored_true_comparison",
+        setup: "y = 0;\ntf = (5 > 3);\nif tf\n  y = 1;\nelse\n  y = 2;\nend\n",
+        final_expr: "y",
+        expected: "1",
+    },
     // `&&`/`||` given a BARE-ZERO operand, observed through an `if` branch
     // decision rather than a `disp`ed raw value -- `disp`ing a `LogicalAnd`/
     // `LogicalOr` result directly is deliberately NOT done anywhere in this

--- a/code/packages/rust/matlab-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/oracle.rs
@@ -167,6 +167,28 @@
 //! genuine array/matrix (SIR22) cases already proven executable by
 //! `e2e_node.rs` (matrix multiplication, elementwise scalar broadcast),
 //! now cross-checked against `matlab-runtime` for the first time.
+//!
+//! - **FIXED: bare-numeric-value truthiness disagreed with MATLAB's
+//!   "logicals are doubles" convention.** MATLAB/Octave truthiness is
+//!   "nonzero is true, zero is false" for ANY number, not just a comparison
+//!   result — `~0` must be `1`, `~5` must be `0`. This frontend's
+//!   `lower_unary` (`~`), `lower_if`, `lower_while`, and `try_logical`
+//!   (`&&`/`||`) used to pass a bare numeric operand straight through to
+//!   the shared JS backend's `truthy()` runtime helper, which implements
+//!   SIR's OWN canonical truthiness instead (only `false`/`nil` are falsy —
+//!   the Ruby/Lisp convention `ruby-to-semantic-ir` genuinely depends on).
+//!   So `~0` compiled to `false` — backwards. `to_matlab_condition`
+//!   (`src/lower.rs`) now wraps a bare-numeric boolean-context operand in
+//!   an explicit `!= 0` SIR comparison at lowering time, leaving an
+//!   already-boolean operand (a comparison, `~`, or `&&`/`||` result)
+//!   unchanged. See `negation_of_bare_zero_is_true`,
+//!   `negation_of_bare_nonzero_is_false`, `if_bare_zero_condition_is_false`,
+//!   `if_bare_nonzero_condition_is_true`,
+//!   `logical_and_short_circuits_false_on_bare_zero_operand`, and
+//!   `logical_or_true_via_bare_nonzero_second_operand` below. (This gap was
+//!   first documented — deliberately sidestepped, not fixed — by
+//!   `octave-to-semantic-ir/tests/oracle.rs`'s `bang_negation_on_comparison`
+//!   case; see that file's updated doc comment.)
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
@@ -287,6 +309,79 @@ const CORPUS: &[Case] = &[
         setup: "A = [1 2; 3 4];\nB = A .* 2;\n",
         final_expr: "B(2, 2)",
         expected: "8",
+    },
+    // Regression corpus for the (now-fixed) bare-numeric-truthiness bug:
+    // MATLAB has no separate boolean type -- "logicals are doubles", and
+    // truthiness is simply "nonzero is true, zero is false" for ANY number,
+    // not just a comparison result. `~0`/`~5` here negate a BARE numeric
+    // literal directly (no comparison in sight), unlike the `comparison`
+    // case above which negates a comparison RESULT (already a genuine JS
+    // boolean either way a truthy-check reads it). Before the fix, this
+    // frontend's `lower_unary`/`lower_if`/`lower_while`/`try_logical` passed
+    // a bare numeric operand straight through to `BuiltinCall("not", ..)` /
+    // `Expr::If` / `Stmt::While` / `Expr::LogicalAnd`/`LogicalOr` with no
+    // MATLAB-truthiness recoding; the shared JS backend's `truthy()` then
+    // read it under SIR's OWN canonical convention (only `false`/`nil` are
+    // falsy -- see `semantic-ir-to-javascript/src/runtime.rs`), so `~0`
+    // compiled to `false` (wrong; MATLAB's `~0` is `1`) while `matlab-
+    // runtime`'s own ground-truth interpreter (`src/eval.rs`: `Some("~") =>
+    // unary_map(&v, |x| if x == 0.0 { 1.0 } else { 0.0 })`) already got it
+    // right. The fix lives in THIS frontend's lowering
+    // (`to_matlab_condition`, `src/lower.rs`), not the shared runtime: a
+    // bare-numeric operand reaching a boolean context is now wrapped in an
+    // explicit `!= 0` SIR comparison at lowering time, so by the time any
+    // backend's truthy-check sees it, it already IS a genuine boolean --
+    // correct under either convention.
+    Case {
+        name: "negation_of_bare_zero_is_true",
+        setup: "",
+        final_expr: "~0",
+        expected: "1",
+    },
+    Case {
+        name: "negation_of_bare_nonzero_is_false",
+        setup: "",
+        final_expr: "~5",
+        expected: "0",
+    },
+    // `if` on a BARE numeric condition (no comparison at all). Same
+    // pre-declaration workaround as `if_else` above. Zero must NOT enter
+    // the `if` branch; any nonzero number must.
+    Case {
+        name: "if_bare_zero_condition_is_false",
+        setup: "y = 0;\nif 0\n  y = 1;\nelse\n  y = 2;\nend\n",
+        final_expr: "y",
+        expected: "2",
+    },
+    Case {
+        name: "if_bare_nonzero_condition_is_true",
+        setup: "y = 0;\nif 5\n  y = 1;\nelse\n  y = 2;\nend\n",
+        final_expr: "y",
+        expected: "1",
+    },
+    // `&&`/`||` given a BARE-ZERO operand, observed through an `if` branch
+    // decision rather than a `disp`ed raw value -- `disp`ing a `LogicalAnd`/
+    // `LogicalOr` result directly is deliberately NOT done anywhere in this
+    // corpus (see the module doc's corpus-scope note): this frontend's
+    // short-circuit nodes return the Ruby-style "deciding operand" verbatim
+    // (`emit.rs`), while `matlab-runtime` returns a coerced 0.0/1.0 double
+    // (`eval.rs`'s `"&" | "&&"` arm) -- a representational difference
+    // unrelated to this bug, already excluded from the corpus. Routing
+    // through `if` sidesteps that mismatch entirely: only the BRANCH TAKEN
+    // is observed, which is representation-independent. `0 && 1` must be
+    // false (zero operand short-circuits); `0 || 5` must be true (the
+    // nonzero second operand decides).
+    Case {
+        name: "logical_and_short_circuits_false_on_bare_zero_operand",
+        setup: "y = 0;\nif 0 && 1\n  y = 1;\nelse\n  y = 2;\nend\n",
+        final_expr: "y",
+        expected: "2",
+    },
+    Case {
+        name: "logical_or_true_via_bare_nonzero_second_operand",
+        setup: "y = 0;\nif 0 || 5\n  y = 1;\nelse\n  y = 2;\nend\n",
+        final_expr: "y",
+        expected: "1",
     },
 ];
 

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
@@ -274,6 +274,168 @@ fn logical_not_lowers_to_a_not_builtin_call() {
     }
 }
 
+// ── MATLAB truthiness: bare-numeric boolean-context coercion ────────────
+//
+// MATLAB/Octave has no separate boolean type ("logicals are doubles"):
+// truthiness is "nonzero is true, zero is false" for ANY number, not just a
+// comparison result. The shared JS/Python backends' `truthy()` runtime
+// instead implements SIR's OWN canonical truthiness (only `false`/`nil` are
+// falsy — the Ruby/Lisp convention `ruby-to-semantic-ir` depends on), so a
+// bare numeric operand reaching `~`/`if`/`while`/`&&`/`||` must be coerced
+// to an explicit `!= 0` SIR comparison AT LOWERING TIME (`to_matlab_condition`,
+// `src/lower.rs`) — before it ever reaches a backend's truthy check.
+// `tests/oracle.rs` proves this end-to-end against real `matlab-runtime`/
+// `node`; these are the fast, structural (no `node` needed) SIR-shape
+// counterparts.
+
+#[test]
+fn logical_not_on_a_bare_variable_wraps_the_operand_in_a_not_equal_zero_comparison() {
+    let m = compile_ok("x = 0;\ny = ~x;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::BuiltinCall { name, args, .. } if name == "not" => {
+                assert_eq!(args.len(), 1);
+                match &args[0] {
+                    Expr::BuiltinCall { name, args, .. } if name == "!=" => {
+                        assert!(matches!(args[0], Expr::VarRef { .. }));
+                        assert!(matches!(args[1], Expr::IntLit { value: 0, .. }));
+                    }
+                    other => panic!(
+                        "expected the `not` operand to be a `!= 0` comparison, got {other:?}"
+                    ),
+                }
+            }
+            other => panic!("expected a `not` BuiltinCall, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn logical_not_on_a_comparison_result_is_not_double_wrapped() {
+    // `~(x > 3)` -- the operand is ALREADY a genuine boolean (a comparison),
+    // so `to_matlab_condition` must leave it exactly as `try_comparison`
+    // built it, not wrap it again in a redundant (and, for a real boolean,
+    // actively wrong) `!= 0`.
+    let m = compile_ok("x = 5;\ny = ~(x > 3);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::BuiltinCall { name, args, .. } if name == "not" => {
+                assert_eq!(args.len(), 1);
+                assert!(
+                    matches!(&args[0], Expr::BuiltinCall { name, .. } if name == ">"),
+                    "expected the `not` operand to stay the bare `>` comparison, got {:?}",
+                    args[0]
+                );
+            }
+            other => panic!("expected a `not` BuiltinCall, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn if_condition_on_a_bare_variable_wraps_in_a_not_equal_zero_comparison() {
+    let m = compile_ok("x = 0;\nif x\n  y = 1;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::ExprStmt {
+            expr: Expr::If { cond, .. },
+            ..
+        } => match cond.as_ref() {
+            Expr::BuiltinCall { name, args, .. } if name == "!=" => {
+                assert!(matches!(args[0], Expr::VarRef { .. }));
+                assert!(matches!(args[1], Expr::IntLit { value: 0, .. }));
+            }
+            other => panic!("expected the `if` condition to be a `!= 0` comparison, got {other:?}"),
+        },
+        other => panic!("expected ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
+fn if_condition_already_a_comparison_is_not_double_wrapped() {
+    let m = compile_ok("x = 5;\nif x > 3\n  y = 1;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::ExprStmt {
+            expr: Expr::If { cond, .. },
+            ..
+        } => {
+            assert!(
+                matches!(cond.as_ref(), Expr::BuiltinCall { name, .. } if name == ">"),
+                "expected the `if` condition to stay the bare `>` comparison, got {cond:?}"
+            );
+        }
+        other => panic!("expected ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
+fn while_condition_on_a_bare_variable_wraps_in_a_not_equal_zero_comparison() {
+    let m = compile_ok("x = 5;\nwhile x\n  x = x - 1;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::While { cond, .. } => match cond {
+            Expr::BuiltinCall { name, args, .. } if name == "!=" => {
+                assert!(matches!(args[0], Expr::VarRef { .. }));
+                assert!(matches!(args[1], Expr::IntLit { value: 0, .. }));
+            }
+            other => {
+                panic!("expected the `while` condition to be a `!= 0` comparison, got {other:?}")
+            }
+        },
+        other => panic!("expected Stmt::While, got {other:?}"),
+    }
+}
+
+#[test]
+fn logical_and_wraps_each_bare_operand_in_a_not_equal_zero_comparison() {
+    let m = compile_ok("x = 1;\ny = 0;\nz = x && y;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[2] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::LogicalAnd { lhs, rhs, .. } => {
+                for operand in [lhs.as_ref(), rhs.as_ref()] {
+                    match operand {
+                        Expr::BuiltinCall { name, args, .. } if name == "!=" => {
+                            assert!(matches!(args[0], Expr::VarRef { .. }));
+                            assert!(matches!(args[1], Expr::IntLit { value: 0, .. }));
+                        }
+                        other => panic!("expected a `!= 0` comparison operand, got {other:?}"),
+                    }
+                }
+            }
+            other => panic!("expected Expr::LogicalAnd, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn logical_or_operand_already_a_comparison_is_not_double_wrapped() {
+    let m = compile_ok("x = 1;\ny = 2;\nz = (x > 3) || y;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[2] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::LogicalOr { lhs, rhs, .. } => {
+                assert!(
+                    matches!(lhs.as_ref(), Expr::BuiltinCall { name, .. } if name == ">"),
+                    "expected lhs to stay the bare `>` comparison, got {lhs:?}"
+                );
+                assert!(
+                    matches!(rhs.as_ref(), Expr::BuiltinCall { name, .. } if name == "!="),
+                    "expected rhs (a bare variable) to be wrapped in `!= 0`, got {rhs:?}"
+                );
+            }
+            other => panic!("expected Expr::LogicalOr, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
 // ── ranges, transpose, matrices ─────────────────────────────────────────
 
 #[test]

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
@@ -274,37 +274,53 @@ fn logical_not_lowers_to_a_not_builtin_call() {
     }
 }
 
-// ── MATLAB truthiness: bare-numeric boolean-context coercion ────────────
+// ── MATLAB truthiness: boolean-context coercion via `matlab_truthy` ─────
 //
 // MATLAB/Octave has no separate boolean type ("logicals are doubles"):
 // truthiness is "nonzero is true, zero is false" for ANY number, not just a
-// comparison result. The shared JS/Python backends' `truthy()` runtime
-// instead implements SIR's OWN canonical truthiness (only `false`/`nil` are
-// falsy — the Ruby/Lisp convention `ruby-to-semantic-ir` depends on), so a
-// bare numeric operand reaching `~`/`if`/`while`/`&&`/`||` must be coerced
-// to an explicit `!= 0` SIR comparison AT LOWERING TIME (`to_matlab_condition`,
-// `src/lower.rs`) — before it ever reaches a backend's truthy check.
-// `tests/oracle.rs` proves this end-to-end against real `matlab-runtime`/
-// `node`; these are the fast, structural (no `node` needed) SIR-shape
-// counterparts.
+// comparison result. The shared JS backend's `truthy()` runtime instead
+// implements SIR's OWN canonical truthiness (only `false`/`nil` are falsy —
+// the Ruby/Lisp convention `ruby-to-semantic-ir` depends on), so every
+// operand reaching a boolean context (`~`/`if`/`while`/`&&`/`||`) is wrapped,
+// UNCONDITIONALLY, in the `matlab_truthy` builtin (`to_matlab_condition`,
+// `src/lower.rs`) — a runtime intrinsic (`semantic-ir-to-javascript`'s
+// `__Sir.matlabTruthy`) that decides "already a genuine boolean, pass
+// through" vs. "a bare number, apply `!= 0`" at RUNTIME, not by static shape
+// analysis at lowering time.
+//
+// An earlier version of this fix instead tried to decide statically,
+// wrapping in an explicit `!= 0` SIR comparison only when the operand's
+// immediate shape wasn't already recognisably boolean — and got it wrong
+// for the most ordinary case there is: a bare `VarRef` holding a STORED
+// comparison result (`tf = (5 < 3); if tf ... end`) is never recognisably
+// boolean by shape alone, so it got wrapped in `tf != 0` regardless of
+// `tf`'s actual value, and the runtime's strict-identity `!=` made that
+// unconditionally `true` for either `true` or `false` — silently always
+// taking the `if` branch. `always_wraps_a_stored_comparison_variable...`
+// below is the regression test for exactly that case; `tests/oracle.rs`
+// proves the fix end-to-end against real `matlab-runtime`/`node`; these are
+// the fast, structural (no `node` needed) SIR-shape counterparts.
+
+fn assert_matlab_truthy_wraps(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::BuiltinCall { name, args, .. } if name == "matlab_truthy" => {
+            assert_eq!(args.len(), 1);
+            &args[0]
+        }
+        other => panic!("expected a `matlab_truthy` BuiltinCall wrapping the operand, got {other:?}"),
+    }
+}
 
 #[test]
-fn logical_not_on_a_bare_variable_wraps_the_operand_in_a_not_equal_zero_comparison() {
+fn logical_not_on_a_bare_variable_wraps_the_operand_in_matlab_truthy() {
     let m = compile_ok("x = 0;\ny = ~x;\n");
     let main = main_fn(&m);
     match &main.body.stmts[1] {
         Stmt::LetStarBinding { value, .. } => match value {
             Expr::BuiltinCall { name, args, .. } if name == "not" => {
                 assert_eq!(args.len(), 1);
-                match &args[0] {
-                    Expr::BuiltinCall { name, args, .. } if name == "!=" => {
-                        assert!(matches!(args[0], Expr::VarRef { .. }));
-                        assert!(matches!(args[1], Expr::IntLit { value: 0, .. }));
-                    }
-                    other => panic!(
-                        "expected the `not` operand to be a `!= 0` comparison, got {other:?}"
-                    ),
-                }
+                let inner = assert_matlab_truthy_wraps(&args[0]);
+                assert!(matches!(inner, Expr::VarRef { .. }));
             }
             other => panic!("expected a `not` BuiltinCall, got {other:?}"),
         },
@@ -313,21 +329,23 @@ fn logical_not_on_a_bare_variable_wraps_the_operand_in_a_not_equal_zero_comparis
 }
 
 #[test]
-fn logical_not_on_a_comparison_result_is_not_double_wrapped() {
-    // `~(x > 3)` -- the operand is ALREADY a genuine boolean (a comparison),
-    // so `to_matlab_condition` must leave it exactly as `try_comparison`
-    // built it, not wrap it again in a redundant (and, for a real boolean,
-    // actively wrong) `!= 0`.
+fn logical_not_on_a_comparison_result_still_wraps_in_matlab_truthy() {
+    // `~(x > 3)` -- the operand is already a genuine boolean at runtime, but
+    // `to_matlab_condition` no longer tries to prove that statically: it
+    // always wraps in `matlab_truthy`, which passes an already-boolean value
+    // through unchanged AT RUNTIME. Wrapping unconditionally, rather than
+    // skipping based on a (possibly wrong) static shape check, is the whole
+    // point of the fix -- see the module doc comment above.
     let m = compile_ok("x = 5;\ny = ~(x > 3);\n");
     let main = main_fn(&m);
     match &main.body.stmts[1] {
         Stmt::LetStarBinding { value, .. } => match value {
             Expr::BuiltinCall { name, args, .. } if name == "not" => {
                 assert_eq!(args.len(), 1);
+                let inner = assert_matlab_truthy_wraps(&args[0]);
                 assert!(
-                    matches!(&args[0], Expr::BuiltinCall { name, .. } if name == ">"),
-                    "expected the `not` operand to stay the bare `>` comparison, got {:?}",
-                    args[0]
+                    matches!(inner, Expr::BuiltinCall { name, .. } if name == ">"),
+                    "expected the wrapped operand to be the bare `>` comparison, got {inner:?}"
                 );
             }
             other => panic!("expected a `not` BuiltinCall, got {other:?}"),
@@ -337,26 +355,23 @@ fn logical_not_on_a_comparison_result_is_not_double_wrapped() {
 }
 
 #[test]
-fn if_condition_on_a_bare_variable_wraps_in_a_not_equal_zero_comparison() {
+fn if_condition_on_a_bare_variable_wraps_in_matlab_truthy() {
     let m = compile_ok("x = 0;\nif x\n  y = 1;\nend\n");
     let main = main_fn(&m);
     match &main.body.stmts[1] {
         Stmt::ExprStmt {
             expr: Expr::If { cond, .. },
             ..
-        } => match cond.as_ref() {
-            Expr::BuiltinCall { name, args, .. } if name == "!=" => {
-                assert!(matches!(args[0], Expr::VarRef { .. }));
-                assert!(matches!(args[1], Expr::IntLit { value: 0, .. }));
-            }
-            other => panic!("expected the `if` condition to be a `!= 0` comparison, got {other:?}"),
-        },
+        } => {
+            let inner = assert_matlab_truthy_wraps(cond);
+            assert!(matches!(inner, Expr::VarRef { .. }));
+        }
         other => panic!("expected ExprStmt(If), got {other:?}"),
     }
 }
 
 #[test]
-fn if_condition_already_a_comparison_is_not_double_wrapped() {
+fn if_condition_already_a_comparison_still_wraps_in_matlab_truthy() {
     let m = compile_ok("x = 5;\nif x > 3\n  y = 1;\nend\n");
     let main = main_fn(&m);
     match &main.body.stmts[1] {
@@ -364,9 +379,10 @@ fn if_condition_already_a_comparison_is_not_double_wrapped() {
             expr: Expr::If { cond, .. },
             ..
         } => {
+            let inner = assert_matlab_truthy_wraps(cond);
             assert!(
-                matches!(cond.as_ref(), Expr::BuiltinCall { name, .. } if name == ">"),
-                "expected the `if` condition to stay the bare `>` comparison, got {cond:?}"
+                matches!(inner, Expr::BuiltinCall { name, .. } if name == ">"),
+                "expected the wrapped condition to be the bare `>` comparison, got {inner:?}"
             );
         }
         other => panic!("expected ExprStmt(If), got {other:?}"),
@@ -374,38 +390,56 @@ fn if_condition_already_a_comparison_is_not_double_wrapped() {
 }
 
 #[test]
-fn while_condition_on_a_bare_variable_wraps_in_a_not_equal_zero_comparison() {
+fn while_condition_on_a_bare_variable_wraps_in_matlab_truthy() {
     let m = compile_ok("x = 5;\nwhile x\n  x = x - 1;\nend\n");
     let main = main_fn(&m);
     match &main.body.stmts[1] {
-        Stmt::While { cond, .. } => match cond {
-            Expr::BuiltinCall { name, args, .. } if name == "!=" => {
-                assert!(matches!(args[0], Expr::VarRef { .. }));
-                assert!(matches!(args[1], Expr::IntLit { value: 0, .. }));
-            }
-            other => {
-                panic!("expected the `while` condition to be a `!= 0` comparison, got {other:?}")
-            }
-        },
+        Stmt::While { cond, .. } => {
+            let inner = assert_matlab_truthy_wraps(cond);
+            assert!(matches!(inner, Expr::VarRef { .. }));
+        }
         other => panic!("expected Stmt::While, got {other:?}"),
     }
 }
 
 #[test]
-fn logical_and_wraps_each_bare_operand_in_a_not_equal_zero_comparison() {
+fn if_condition_on_a_variable_holding_a_stored_comparison_still_wraps_in_matlab_truthy() {
+    // The exact regression this fix closes: `tf` is a `VarRef`, never
+    // recognisably boolean by static shape alone, even though it holds a
+    // stored comparison result at runtime. `matlab_truthy` (not a static
+    // "is this shape already boolean?" check) is what makes this correct
+    // regardless -- see the module doc comment above. `tests/oracle.rs`
+    // asserts the actual (correct) end-to-end runtime VALUE for this case.
+    let m = compile_ok("x = 5;\ntf = (x > 3);\nif tf\n  y = 1;\nelse\n  y = 2;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[2] {
+        Stmt::ExprStmt {
+            expr: Expr::If { cond, .. },
+            ..
+        } => {
+            let inner = assert_matlab_truthy_wraps(cond);
+            assert!(
+                matches!(inner, Expr::VarRef { .. }),
+                "expected the wrapped condition to be the bare `tf` variable, got {inner:?}"
+            );
+        }
+        other => panic!("expected ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
+fn logical_and_wraps_each_bare_operand_in_matlab_truthy() {
     let m = compile_ok("x = 1;\ny = 0;\nz = x && y;\n");
     let main = main_fn(&m);
     match &main.body.stmts[2] {
         Stmt::LetStarBinding { value, .. } => match value {
             Expr::LogicalAnd { lhs, rhs, .. } => {
                 for operand in [lhs.as_ref(), rhs.as_ref()] {
-                    match operand {
-                        Expr::BuiltinCall { name, args, .. } if name == "!=" => {
-                            assert!(matches!(args[0], Expr::VarRef { .. }));
-                            assert!(matches!(args[1], Expr::IntLit { value: 0, .. }));
-                        }
-                        other => panic!("expected a `!= 0` comparison operand, got {other:?}"),
-                    }
+                    let inner = assert_matlab_truthy_wraps(operand);
+                    assert!(
+                        matches!(inner, Expr::VarRef { .. }),
+                        "expected the wrapped operand to be a bare variable, got {inner:?}"
+                    );
                 }
             }
             other => panic!("expected Expr::LogicalAnd, got {other:?}"),
@@ -415,19 +449,26 @@ fn logical_and_wraps_each_bare_operand_in_a_not_equal_zero_comparison() {
 }
 
 #[test]
-fn logical_or_operand_already_a_comparison_is_not_double_wrapped() {
+fn logical_or_operand_already_a_comparison_still_wraps_in_matlab_truthy() {
+    // `(x > 3) || y` -- the lhs is already a genuine boolean at runtime, but
+    // (as with `~`/`if`/`while` above) `to_matlab_condition` wraps it in
+    // `matlab_truthy` anyway rather than trying to prove it's already boolean
+    // by static shape. `matlabTruthy` passes an already-boolean value through
+    // unchanged at runtime, so this stays correct either way.
     let m = compile_ok("x = 1;\ny = 2;\nz = (x > 3) || y;\n");
     let main = main_fn(&m);
     match &main.body.stmts[2] {
         Stmt::LetStarBinding { value, .. } => match value {
             Expr::LogicalOr { lhs, rhs, .. } => {
+                let lhs_inner = assert_matlab_truthy_wraps(lhs.as_ref());
                 assert!(
-                    matches!(lhs.as_ref(), Expr::BuiltinCall { name, .. } if name == ">"),
-                    "expected lhs to stay the bare `>` comparison, got {lhs:?}"
+                    matches!(lhs_inner, Expr::BuiltinCall { name, .. } if name == ">"),
+                    "expected the wrapped lhs to be the bare `>` comparison, got {lhs_inner:?}"
                 );
+                let rhs_inner = assert_matlab_truthy_wraps(rhs.as_ref());
                 assert!(
-                    matches!(rhs.as_ref(), Expr::BuiltinCall { name, .. } if name == "!="),
-                    "expected rhs (a bare variable) to be wrapped in `!= 0`, got {rhs:?}"
+                    matches!(rhs_inner, Expr::VarRef { .. }),
+                    "expected the wrapped rhs to be a bare variable, got {rhs_inner:?}"
                 );
             }
             other => panic!("expected Expr::LogicalOr, got {other:?}"),

--- a/code/packages/rust/octave-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/octave-to-semantic-ir/CHANGELOG.md
@@ -22,9 +22,10 @@ All notable changes to this project will be documented in this file.
   - `hash_comment_literal_arithmetic` — a `#` comment (MATLAB uses `%`).
   - `bang_equals_not_equal_comparison` — `!=` (MATLAB uses `~=`).
   - `bang_negation_on_comparison` — `!` (MATLAB uses `~`), applied to a
-    parenthesized comparison rather than a bare numeric variable — see the
-    test's own doc comment for a confirmed, deliberately-excluded gap this
-    sidesteps (below).
+    parenthesized comparison. At the time this test was added, negating a
+    *bare numeric variable* directly was a confirmed, deliberately-excluded
+    gap this case sidestepped — since fixed; see the "Fixed" section
+    below.
   - `if_else_endif` — Octave's `endif` block terminator.
   - `for_loop_accumulator_endfor` — Octave's `endfor` block terminator.
   - `while_loop_accumulator_endwhile` — Octave's `endwhile` block
@@ -36,23 +37,27 @@ All notable changes to this project will be documented in this file.
   - All 6 cases pass against `octave-runtime`'s ground truth; no new bug in
     the `octavify` shim itself was found.
 
+### Fixed
+
+- **FIXED (was: "Found", below): negating a bare numeric variable through
+  `!`/`~` disagreed with Octave semantics for zero.** `~x`/`!x` with
+  `x = 0` used to compile to `false` instead of Octave's real `1` (true).
+  Fixed entirely in `matlab-to-semantic-ir` (this crate has no `src/
+  lower.rs` of its own, so the fix — a new `to_matlab_condition` lowering
+  helper applied at `~`, `if`, `while`, and `&&`/`||` — applies here
+  unchanged); see that crate's own `CHANGELOG.md` entry for the full
+  root-cause writeup, including confirmation that Ruby/Python/JS's own
+  truthiness reliance is unaffected. Two new corpus cases exercise the fix
+  through Octave's own `!` spelling specifically (proving the `octavify`
+  `!` → `~` rewrite composes correctly with the fix, not just the `~`
+  spelling MATLAB's own oracle file already covers):
+  `bang_negation_on_bare_zero_is_true` (`!0` → `1`) and
+  `bang_negation_on_bare_nonzero_is_false` (`!5` → `0`).
+  `bang_negation_on_comparison`'s doc comment is trimmed to drop the
+  "confirmed, excluded gap" framing it no longer needs.
+
 ### Found (confirmed, not fixed here — test infrastructure only)
 
-- **Negating a bare numeric variable through `!`/`~` disagrees with Octave
-  semantics for zero.** SIR's shared `truthy()` runtime helper
-  (`semantic-ir-to-javascript/src/runtime.rs`) treats only `false`/`nil` as
-  falsy (a Ruby/Lisp convention); MATLAB/Octave's "logicals are doubles"
-  convention treats numeric `0` as false. So `~x`/`!x` with `x = 0` compiles
-  to `not(0)` → `!__Sir.truthy(0)` → `!true` → `false`, while real
-  Octave/MATLAB gives `1` (true). This is a genuine, confirmed
-  frontend/backend semantic gap inherited unchanged from
-  `matlab-to-semantic-ir` (which has no MATLAB-logicals-aware truthiness
-  recoding) — not something this test-only PR touches. `CORPUS`'s
-  `bang_negation_on_comparison` case sidesteps it by negating a
-  parenthesized *comparison* instead (comparisons already compile to native
-  JS booleans via `__Sir.lt`/`__Sir.gt`/etc., which `truthy()` handles
-  correctly), so the corpus stays green without papering over the gap —
-  flagged here for a follow-up.
 - Confirmed, by inheritance from `matlab-to-semantic-ir` (unchanged, since
   this crate shares 100% of its lowering/codegen): the integer-literal-
   division-floors bug and the missing `Feature::ShortCircuit` declaration

--- a/code/packages/rust/octave-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/octave-to-semantic-ir/tests/oracle.rs
@@ -41,7 +41,7 @@
 //! |----------------------------------------|-------------------------|--------------|
 //! | `# comment`                             | `% comment`             | `hash_comment_literal_arithmetic` |
 //! | `!=`                                    | `~=`                    | `bang_equals_not_equal_comparison` |
-//! | `!` (logical not)                       | `~`                     | `bang_negation_on_comparison` |
+//! | `!` (logical not)                       | `~`                     | `bang_negation_on_comparison`, `bang_negation_on_bare_zero_is_true`, `bang_negation_on_bare_nonzero_is_false` |
 //! | `endif`                                 | `end`                   | `if_else_endif` |
 //! | `endfor`                                | `end`                   | `for_loop_accumulator_endfor` |
 //! | `endwhile`                              | `end`                   | `while_loop_accumulator_endwhile` |
@@ -147,28 +147,46 @@ const CORPUS: &[Case] = &[
         expected: "1",
     },
     // Octave-only `!` (logical not; MATLAB uses `~`), applied to a
-    // PARENTHESIZED COMPARISON rather than a bare numeric variable. This
-    // choice is deliberate, not incidental: SIR's shared `truthy()` runtime
-    // helper (`semantic-ir-to-javascript/src/runtime.rs`) treats only
-    // `false`/`nil` as falsy -- a Ruby/Lisp convention, unlike MATLAB's
-    // "any nonzero number is true, 0 is false" logicals-are-doubles
-    // convention. `~(x > 3)` negates a genuine native-JS boolean (comparison
-    // builtins compile to `__Sir.lt`/`__Sir.gt`/etc., which return real
-    // `true`/`false`, not a MATLAB-style 0.0/1.0 double) -- so `not`'s
-    // `!__Sir.truthy(...)` (`emit.rs`) agrees with MATLAB/Octave semantics
-    // here. Negating a bare numeric variable directly (e.g. `!x` with
-    // `x = 0`) would NOT agree -- `truthy(0)` is `true` under SIR's
-    // convention, so `not(0)` would wrongly give `false` where Octave gives
-    // `1` (true) -- a real, confirmed frontend/backend semantic gap (this
-    // crate inherits it from `matlab-to-semantic-ir`, which has no
-    // MATLAB-logicals-aware truthiness recoding, the same class of gap as
-    // the `comparison` case's `#t`/`#f`-vs-`1`/`0` spelling difference in
-    // the MATLAB oracle file, except this one is NOT just a spelling
-    // difference -- it is excluded from `CORPUS` for exactly that reason.
+    // PARENTHESIZED COMPARISON. `~(x > 3)` negates a genuine native-JS
+    // boolean (comparison builtins compile to `__Sir.lt`/`__Sir.gt`/etc.,
+    // which return real `true`/`false`) -- so `not`'s `!__Sir.truthy(...)`
+    // (`emit.rs`) agrees with MATLAB/Octave semantics here regardless of
+    // the bare-numeric-truthiness gap documented below.
     Case {
         name: "bang_negation_on_comparison",
         setup: "x = 5;\n",
         final_expr: "!(x > 3)",
+        expected: "0",
+    },
+    // FIXED (was: excluded from `CORPUS` as a confirmed, open gap). Octave
+    // `!` applied to a BARE numeric literal -- no comparison in sight --
+    // exercising `octavify`'s `!` -> `~` rewrite together with the negation
+    // fix. MATLAB/Octave has no separate boolean type: "logicals are
+    // doubles", and truthiness is "nonzero is true, zero is false" for ANY
+    // number. This frontend's `lower_unary` (inherited unchanged from
+    // `matlab-to-semantic-ir`, since this crate has no `src/lower.rs` of
+    // its own) used to pass a bare numeric `~`/`!` operand straight through
+    // to the shared JS backend's `truthy()` runtime helper, which
+    // implements SIR's OWN canonical truthiness instead (only `false`/`nil`
+    // are falsy -- the Ruby/Lisp convention `ruby-to-semantic-ir` genuinely
+    // depends on, NOT just a spelling difference the way the `comparison`
+    // case's `#t`/`#f`-vs-`1`/`0` difference in the MATLAB oracle file is).
+    // So `!0` used to compile to `false` -- backwards; Octave's own `!0` is
+    // `1` (true). `matlab-to-semantic-ir`'s `to_matlab_condition`
+    // (`src/lower.rs`) now wraps a bare-numeric boolean-context operand in
+    // an explicit `!= 0` SIR comparison at lowering time, so this crate
+    // gets the fix for free (100% shared lowering) -- see the MATLAB oracle
+    // file's own module doc for the full root-cause writeup.
+    Case {
+        name: "bang_negation_on_bare_zero_is_true",
+        setup: "",
+        final_expr: "!0",
+        expected: "1",
+    },
+    Case {
+        name: "bang_negation_on_bare_nonzero_is_false",
+        setup: "",
+        final_expr: "!5",
         expected: "0",
     },
     // if/else terminated by Octave's `endif` instead of bare `end`. Same

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## 0.41.0 — `__Sir.matlabTruthy`: a runtime-decided boolean-context coercion for MATLAB/Octave
+
+### Added
+
+- **`matlabTruthy(x)` (`src/runtime.rs`)**: `typeof x === "boolean" ? x :
+  numOf(x) !== 0`. A new runtime intrinsic, exported on the `__Sir`
+  namespace object alongside `truthy`, and emitted by `emit_builtin_call`
+  (`src/emit.rs`) for a new one-argument `"matlab_truthy"` SIR builtin
+  (`__Sir.matlabTruthy(x)`).
+  - **Why this exists**: `matlab-to-semantic-ir`'s `~`/`if`/`while`/`&&`/
+    `||` lowering needs to coerce an operand to MATLAB's "logicals are
+    doubles" truthiness (any nonzero number is true, only `0` is false —
+    the OPPOSITE of this backend's own canonical `truthy()`, which treats
+    `0` as truthy per the Ruby/Lisp convention `ruby-to-semantic-ir`
+    depends on). The first attempt at this (in `matlab-to-semantic-ir`,
+    same PR) tried to decide statically at lowering time whether an
+    operand was "already a genuine boolean" (skip wrapping) or "a bare
+    number" (wrap in `!= 0`), using a shape check on the *unevaluated*
+    expression tree. `/security-review` caught a HIGH-severity regression
+    in that approach: a bare `VarRef` holding a *stored* comparison result
+    (`tf = (5 < 3); if tf`) is indistinguishable, by shape alone, from a
+    `VarRef` holding a bare number — so it always got wrapped in `!= 0`,
+    and this backend's own `ne(a, b)` (`numOf(a) !== numOf(b)`, strict)
+    makes `false != 0` unconditionally `true` — silently inverting the
+    `if` regardless of what `tf` actually held.
+  - **The fix**: push the decision to runtime, where the actual value
+    (not its static shape) is known. `matlabTruthy` is applied
+    UNCONDITIONALLY to every operand reaching a MATLAB boolean context —
+    no shape analysis needed, no way for it to be wrong, since it branches
+    on `typeof x` at the moment the value actually exists.
+  - **Regression test**: `tests/run_with_node.rs`'s new
+    `matlab_truthy_passes_through_a_genuine_boolean_and_coerces_a_bare_number`
+    exercises `__Sir.matlabTruthy` directly against both a real JS
+    `true`/`false` and a bare `0`/`5`, via a raw-JS runtime snippet
+    (mirrors `tagged_float_helpers_behave`'s existing pattern). End-to-end
+    coverage of the actual regression case (a variable holding a stored
+    comparison, taking the correct `if`/`else` branch) lives in
+    `matlab-to-semantic-ir/tests/oracle.rs` — see that crate's own
+    CHANGELOG entry for the full write-up.
+  - **Known pre-existing gap, NOT introduced or worsened by this
+    change**: `semantic-ir-to-typescript`'s `emit_builtin_call` only
+    explicitly dispatches a handful of builtins (`+ - * / = < >` among
+    them); anything else, including `!=`/`<=`/`>=` and now
+    `matlab_truthy`, falls through to `__Sir.callBuiltin(name, args)` — a
+    runtime dispatch table in the vendored
+    `code/packages/typescript/sir-runtime-core/src/runtime.ts` whose
+    `builtins` table does not register `!=`/`<=`/`>=` either. Any frontend
+    emitting those comparisons and targeting TypeScript already throws
+    `SIR builtin "..." is not implemented in sir-runtime-core's dispatch
+    table` at runtime — confirmed pre-existing (this PR does not touch
+    `semantic-ir-to-typescript` or `sir-runtime-core`) and flagged as a
+    separate, unfixed, out-of-scope follow-up.
+
 ## 0.40.0 — `numOf` unwraps a scalar NDArray too (fixes a silent MATLAB `while`-loop non-termination bug)
 
 ### Fixed

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -1552,6 +1552,20 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
                 out.push_str("))");
                 return;
             }
+            // MATLAB/Octave-family truthiness ("nonzero is true") for a
+            // boolean-context operand that may be a genuine JS boolean
+            // (an already-lowered comparison/`~`/`&&`/`||`) or a bare
+            // number — `matlabTruthy` handles both correctly, unlike the
+            // canonical `truthy()` above, which implements the unrelated
+            // Ruby/Lisp convention (`0` is truthy there). See
+            // `matlab-to-semantic-ir::lower::to_matlab_condition`, the
+            // sole emitter of this builtin.
+            "matlab_truthy" => {
+                out.push_str("__Sir.matlabTruthy(");
+                emit_expr(out, &args[0], indent);
+                out.push(')');
+                return;
+            }
             "neg" => {
                 // Unary minus re-tags: `-(7.0)` is the boxed Float `-7.0`,
                 // which native `-` on a `SirFloat` object cannot produce.

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -224,6 +224,26 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return v !== false && v !== null && v !== undefined;
   }
 
+  // Real MATLAB/Octave has no separate boolean type: logicals are doubles,
+  // and truthiness is "nonzero is true, zero is false" — the OPPOSITE
+  // convention from `truthy()` above (canonical SIR truthy(0) is `true`;
+  // MATLAB's `~0` is `1`, i.e. `0` is falsy there). A MATLAB/Octave-sourced
+  // value reaching a boolean context can be EITHER a genuine JS boolean
+  // (the output of a comparison/`~`/`&&`/`||`, which this backend already
+  // renders as native `true`/`false`) OR a bare number (a variable, a
+  // function-call result, an array-element read, …) that has never passed
+  // through a comparison at all — `matlabTruthy` handles both correctly in
+  // one place, so the frontend never has to prove, via static shape
+  // analysis alone, which case it's looking at (an earlier version of this
+  // fix tried exactly that — a lowering-time-only `!= 0` wrap gated on
+  // recognising "already boolean" shapes — and got it wrong for the most
+  // ordinary case, a variable holding a stored comparison result, silently
+  // inverting `false`; see `matlab-to-semantic-ir::lower::to_matlab_condition`
+  // for the corrected, always-wrap-through-here approach).
+  function matlabTruthy(x) {
+    return typeof x === "boolean" ? x : (numOf(x) !== 0);
+  }
+
   // ── display / formatting ───────────────────────────────────────
   // `format` renders any SIR value to the string `print` writes.
   // Strings render WITHOUT surrounding quotes (so `print` of a string
@@ -3334,7 +3354,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
 
   return {
     Sym, Pair, Closure,
-    intern, applyClosure, truthy, format, print, puts,
+    intern, applyClosure, truthy, matlabTruthy, format, print, puts,
     plus, times, divide,
     // Tagged floats (Ruby Integer vs Float). Exported so the emitter can
     // mint a boxed float at a `FloatLit` and route `-`/`%`/`neg` through

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -297,6 +297,31 @@ console.log(o.join("|"));
     }
 }
 
+#[test]
+fn matlab_truthy_passes_through_a_genuine_boolean_and_coerces_a_bare_number() {
+    // `matlab-to-semantic-ir` wraps every operand reaching a boolean
+    // context (`~`/`if`/`while`/`&&`/`||`) in `matlab_truthy`, UNCONDITIONALLY
+    // -- no static "is this already boolean?" shape check, because the first
+    // attempt at that check (caught by /security-review before push) could
+    // not see through a `VarRef` holding a *stored* comparison result, and
+    // silently mis-wrapped it in a `!= 0` comparison instead. `matlabTruthy`
+    // makes the boolean-vs-number call at RUNTIME instead, where the actual
+    // value (not its static shape) is known: pass a genuine JS boolean
+    // through unchanged, otherwise apply MATLAB's "nonzero is true" rule.
+    let snippet = r#"
+const F = __Sir; const o = [];
+o.push(String(F.matlabTruthy(true)));   // true  (genuine boolean passes through)
+o.push(String(F.matlabTruthy(false)));  // false (genuine boolean passes through)
+o.push(String(F.matlabTruthy(0)));      // false (bare zero: falsy)
+o.push(String(F.matlabTruthy(5)));      // true  (bare nonzero: truthy)
+o.push(String(F.matlabTruthy(-3)));     // true  (bare negative nonzero: truthy)
+console.log(o.join("|"));
+"#;
+    if let Some(stdout) = run_runtime_snippet(snippet, "matlab_truthy") {
+        assert_eq!(stdout, "true|false|false|true|true");
+    }
+}
+
 fn puts_(arg: Expr) -> Stmt {
     Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: sp() }
 }


### PR DESCRIPTION
## Summary

MATLAB/Octave has no separate boolean type ("logicals are doubles"): truthiness is "nonzero is true, zero is false" for **any** number, not just a comparison result (`~0` is `1`, `~5` is `0`). This frontend's `lower_unary` (`~`), `lower_if`, `lower_while`, and `try_logical` (`&&`/`||`) all passed an already-lowered operand straight through unchanged, so a bare numeric operand fell through to the shared JS backend's `truthy()` runtime helper — which implements SIR's own canonical truthiness instead (only `false`/`nil` are falsy, the Ruby/Lisp convention `ruby-to-semantic-ir` genuinely depends on). So `n = 0; ~n` compiled to `false`, backwards from MATLAB's `~0 == 1`.

## Two rounds of security review, one real regression caught

**Round 1** (initial approach, same PR): decided statically at lowering time whether an operand was "already a genuine SIR boolean" via a shape-matching predicate (`expr_is_known_bool`: matches `BoolLit`/`LogicalAnd`/`LogicalOr`/a comparison or `not` `BuiltinCall`), wrapping in an explicit `!= 0` comparison only when that predicate said no.

`/security-review` caught a **HIGH-severity regression**: a bare `VarRef` holding a *stored* comparison result (`tf = (5 < 3); if tf`) is indistinguishable, by static shape alone, from a `VarRef` holding a bare number — so it always fell into the "wrap in `!= 0`" branch. The shared runtime's `ne(a, b)` is `numOf(a) !== numOf(b)` (strict), so `false != 0` evaluates to `true` unconditionally regardless of whether `tf` was really `true` or `false` — silently inverting (or always-taking) the `if` branch for this pattern.

**Corrected fix** (this PR, round 2 of review passed clean): push the boolean-vs-number decision to **runtime**, where the actual value (not its static shape) is known. `to_matlab_condition` (`matlab-to-semantic-ir/src/lower.rs`) now unconditionally wraps every operand reaching a boolean context in a new `matlab_truthy` SIR builtin, which `semantic-ir-to-javascript` emits as `__Sir.matlabTruthy(x)`:

```js
function matlabTruthy(x) {
  return typeof x === "boolean" ? x : (numOf(x) !== 0);
}
```

`expr_is_known_bool` is deleted entirely — there's no shape check left to be wrong.

## Changes

- `matlab-to-semantic-ir/src/lower.rs`: `to_matlab_condition` unconditionally wraps operands at all 4 call sites (`lower_if`, `lower_while`, `try_logical`, `lower_unary`'s `~`).
- `semantic-ir-to-javascript`: new `matlabTruthy` runtime intrinsic (`src/runtime.rs`) + `"matlab_truthy"` emit dispatch arm (`src/emit.rs`). Bumped to 0.41.0.
- `matlab-to-semantic-ir/tests/test_lower.rs`: rewrote the truthiness structural tests to assert the unconditional wrap, including the exact regression case (`if_condition_on_a_variable_holding_a_stored_comparison_still_wraps_in_matlab_truthy`).
- `matlab-to-semantic-ir/tests/oracle.rs`: 2 new end-to-end cases cross-checked against real `matlab-runtime` through `node` — a variable holding a stored `false`/`true` comparison takes the correct `if`/`else` branch (the exact case round 1 got backwards).
- `octave-to-semantic-ir/tests/oracle.rs` + `CHANGELOG.md`: updated doc comments (shares 100% of the lowering, no code change needed), 2 new corpus cases via Octave's `!` spelling.
- `semantic-ir-to-javascript/tests/run_with_node.rs`: direct runtime test for `matlabTruthy`.

## Known, disclosed, out-of-scope gap

`semantic-ir-to-typescript`'s `emit_builtin_call` and the vendored `sir-runtime-core`'s `callBuiltin` dispatch table don't register `!=`/`<=`/`>=` (or now `matlab_truthy`) — any frontend emitting those already throws at runtime when targeting TypeScript. Confirmed **pre-existing** (this PR touches neither crate) and **not worsened** by this change. Flagged as a separate follow-up, not fixed here.

## Test plan

- [x] `cargo test -p matlab-to-semantic-ir -p semantic-ir-to-javascript -p octave-to-semantic-ir` — all green (65/84/10 passing respectively across suites)
- [x] Downstream consumers of `semantic-ir-to-javascript` re-verified: `apl-to-semantic-ir`, `javascript-to-semantic-ir`, `wolfram-to-semantic-ir`, `j-to-semantic-ir`, `macsyma-to-semantic-ir`, `sir-conformance` — all green
- [x] `/security-review`: round 1 found a HIGH regression (fixed in this same PR); round 2 (final diff) — **PASSED, no vulnerabilities found**
- [x] Rebased onto current `origin/main` tip, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)