### PR TITLE
feat(trig): add Haskell port

### DIFF
--- a/code/packages/haskell/trig/BUILD
+++ b/code/packages/haskell/trig/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/trig/BUILD_windows
+++ b/code/packages/haskell/trig/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/trig/CHANGELOG.md
+++ b/code/packages/haskell/trig/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add first-principles sine and cosine using range-reduced Maclaurin series.
+- Add degree/radian conversion and Newton-method square root.
+- Add tangent with pole guards plus arctangent and four-quadrant arctangent.

--- a/code/packages/haskell/trig/README.md
+++ b/code/packages/haskell/trig/README.md
@@ -1,0 +1,26 @@
+# trig
+
+Trigonometric functions implemented from first principles with basic
+arithmetic.
+
+## API
+
+- `piValue`, `twoPi`, and `halfPi` provide the shared angle constants.
+- `sin` and `cos` use 20-term Maclaurin series after reducing angles to
+  `[-pi, pi]`.
+- `radians` and `degrees` convert angle units.
+- `sqrt` uses Newton's method and rejects negative inputs explicitly.
+- `tan` uses the local sine and cosine implementations and returns a large
+  signed finite value near a pole.
+- `atan` uses complementary and half-angle reduction before its series;
+  `atan2` selects the correct quadrant.
+
+## Dependencies
+
+The library depends only on `base`. Tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/trig/cabal.project
+++ b/code/packages/haskell/trig/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/trig/src/Trig.hs
+++ b/code/packages/haskell/trig/src/Trig.hs
@@ -1,0 +1,125 @@
+-- | Trigonometric functions implemented from first principles.
+module Trig
+    ( piValue
+    , twoPi
+    , halfPi
+    , sin
+    , cos
+    , radians
+    , degrees
+    , sqrt
+    , tan
+    , atan
+    , atan2
+    ) where
+
+import Data.Fixed (mod')
+import Data.List (foldl')
+import Prelude hiding (atan, atan2, cos, sin, sqrt, tan)
+
+-- | Pi to full 'Double' precision.
+piValue :: Double
+piValue = 3.141592653589793
+
+-- | One complete rotation in radians.
+twoPi :: Double
+twoPi = 2.0 * piValue
+
+-- | A quarter rotation in radians.
+halfPi :: Double
+halfPi = piValue / 2.0
+
+-- | Sine via a 20-term Maclaurin series after range reduction.
+sin :: Double -> Double
+sin angle = snd $ foldl' step (reduced, reduced) [1 .. 19]
+  where
+    reduced = rangeReduce angle
+    step (term, total) n =
+        let index = fromIntegral n
+            denominator = (2.0 * index) * (2.0 * index + 1.0)
+            next = term * negate (reduced * reduced) / denominator
+        in (next, total + next)
+
+-- | Cosine via a 20-term Maclaurin series after range reduction.
+cos :: Double -> Double
+cos angle = snd $ foldl' step (1.0, 1.0) [1 .. 19]
+  where
+    reduced = rangeReduce angle
+    step (term, total) n =
+        let index = fromIntegral n
+            denominator = (2.0 * index - 1.0) * (2.0 * index)
+            next = term * negate (reduced * reduced) / denominator
+        in (next, total + next)
+
+-- | Convert degrees to radians.
+radians :: Double -> Double
+radians value = value * piValue / 180.0
+
+-- | Convert radians to degrees.
+degrees :: Double -> Double
+degrees value = value * 180.0 / piValue
+
+-- | Square root via Newton's method.
+sqrt :: Double -> Either String Double
+sqrt value
+    | value < 0.0 = Left "sqrt: input must be non-negative"
+    | otherwise = Right (sqrtNonnegative value)
+
+-- | Tangent as local sine divided by local cosine.
+-- Near a pole, returns a large finite value with the divergence sign.
+tan :: Double -> Double
+tan angle
+    | abs cosine < 1e-15 = if sine > 0.0 then 1e308 else -1e308
+    | otherwise = sine / cosine
+  where
+    sine = sin angle
+    cosine = cos angle
+
+-- | Arctangent in the range @(-pi/2, pi/2)@.
+atan :: Double -> Double
+atan value
+    | value == 0.0 = 0.0
+    | value > 1.0 = halfPi - atanCore (1.0 / value)
+    | value < -1.0 = negate halfPi - atanCore (1.0 / value)
+    | otherwise = atanCore value
+
+-- | Four-quadrant arctangent in the range @(-pi, pi]@.
+atan2 :: Double -> Double -> Double
+atan2 y x
+    | x > 0.0 = atan (y / x)
+    | x < 0.0 && y >= 0.0 = atan (y / x) + piValue
+    | x < 0.0 && y < 0.0 = atan (y / x) - piValue
+    | y > 0.0 = halfPi
+    | y < 0.0 = negate halfPi
+    | otherwise = 0.0
+
+rangeReduce :: Double -> Double
+rangeReduce angle
+    | wrapped > piValue = wrapped - twoPi
+    | otherwise = wrapped
+  where
+    wrapped = angle `mod'` twoPi
+
+sqrtNonnegative :: Double -> Double
+sqrtNonnegative value
+    | value == 0.0 = 0.0
+    | otherwise = iterateNewton 60 initial
+  where
+    initial = if value >= 1.0 then value else 1.0
+    iterateNewton remaining guess
+        | remaining == (0 :: Int) = guess
+        | abs (next - guess) < 1e-15 * guess + 1e-300 = next
+        | otherwise = iterateNewton (remaining - 1) next
+      where
+        next = (guess + value / guess) / 2.0
+
+atanCore :: Double -> Double
+atanCore value = 2.0 * snd (foldl' step (reduced, reduced) [1 .. 30])
+  where
+    reduced = value / (1.0 + sqrtNonnegative (1.0 + value * value))
+    squared = reduced * reduced
+    step (term, total) n =
+        let index = fromIntegral n
+            next = term * negate squared * (2.0 * index - 1.0)
+                / (2.0 * index + 1.0)
+        in (next, total + next)

--- a/code/packages/haskell/trig/test/Spec.hs
+++ b/code/packages/haskell/trig/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec (hspec)
+import TrigSpec (spec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/trig/test/TrigSpec.hs
+++ b/code/packages/haskell/trig/test/TrigSpec.hs
@@ -1,0 +1,138 @@
+module TrigSpec (spec) where
+
+import Data.Either (isLeft)
+import Test.Hspec
+import Trig
+import Prelude hiding (atan, atan2, cos, sin, sqrt, tan)
+
+tolerance :: Double
+tolerance = 1e-10
+
+shouldBeCloseTo :: Double -> Double -> Expectation
+actual `shouldBeCloseTo` expected =
+    abs (actual - expected) `shouldSatisfy` (<= tolerance)
+
+rightValue :: Show error => Either error value -> IO value
+rightValue result = case result of
+    Left err -> expectationFailure (show err) >> error "unreachable"
+    Right value -> pure value
+
+spec :: Spec
+spec = do
+    describe "constants" $
+        it "provides the shared angle values" $ do
+            twoPi `shouldBeCloseTo` (2.0 * piValue)
+            halfPi `shouldBeCloseTo` (piValue / 2.0)
+
+    describe "sin" $ do
+        it "matches special angles" $ do
+            let cases =
+                    [ (0.0, 0.0)
+                    , (piValue / 6.0, 0.5)
+                    , (piValue / 4.0, 0.7071067811865476)
+                    , (piValue / 3.0, 0.8660254037844386)
+                    , (halfPi, 1.0)
+                    , (piValue, 0.0)
+                    , (3.0 * halfPi, -1.0)
+                    , (twoPi, 0.0)
+                    ]
+            mapM_ (\(angle, expected) -> sin angle `shouldBeCloseTo` expected) cases
+        it "is odd" $
+            mapM_ (\angle -> sin (-angle) `shouldBeCloseTo` (negate (sin angle)))
+                [0.5, 1.0, 1.5, 2.0, 2.7]
+
+    describe "cos" $ do
+        it "matches special angles" $ do
+            let cases =
+                    [ (0.0, 1.0)
+                    , (piValue / 6.0, 0.8660254037844386)
+                    , (piValue / 4.0, 0.7071067811865476)
+                    , (piValue / 3.0, 0.5)
+                    , (halfPi, 0.0)
+                    , (piValue, -1.0)
+                    , (3.0 * halfPi, 0.0)
+                    , (twoPi, 1.0)
+                    ]
+            mapM_ (\(angle, expected) -> cos angle `shouldBeCloseTo` expected) cases
+        it "is even" $
+            mapM_ (\angle -> cos (-angle) `shouldBeCloseTo` cos angle)
+                [0.5, 1.0, 1.5, 2.0, 2.7]
+
+    describe "shared identities" $ do
+        it "satisfies the Pythagorean identity" $
+            mapM_ checkIdentity
+                [0.0, piValue / 6.0, piValue / 4.0, halfPi, piValue, -2.5, 5.5]
+        it "range-reduces large positive and negative inputs" $ do
+            sin (1000.0 * piValue) `shouldBeCloseTo` 0.0
+            cos (1000.0 * piValue) `shouldBeCloseTo` 1.0
+            sin (-100.0) `shouldBeCloseTo` (negate (sin 100.0))
+
+    describe "angle conversion" $ do
+        it "converts known values" $ do
+            radians 180.0 `shouldBeCloseTo` piValue
+            radians 90.0 `shouldBeCloseTo` halfPi
+            degrees piValue `shouldBeCloseTo` 180.0
+            degrees halfPi `shouldBeCloseTo` 90.0
+        it "round trips degrees and radians" $ do
+            mapM_ (\value -> degrees (radians value) `shouldBeCloseTo` value)
+                [0.0, 30.0, 45.0, 90.0, 180.0, 360.0]
+            mapM_ (\value -> radians (degrees value) `shouldBeCloseTo` value)
+                [0.0, piValue / 6.0, piValue / 4.0, halfPi, piValue, twoPi]
+
+    describe "sqrt" $ do
+        it "matches exact and irrational reference values" $ do
+            let cases =
+                    [ (0.0, 0.0)
+                    , (1.0, 1.0)
+                    , (4.0, 2.0)
+                    , (9.0, 3.0)
+                    , (2.0, 1.41421356237)
+                    , (0.25, 0.5)
+                    , (1e10, 1e5)
+                    ]
+            mapM_ checkSquareRoot cases
+        it "rejects negative input" $
+            sqrt (-1.0) `shouldSatisfy` isLeft
+
+    describe "tan" $ do
+        it "matches reference values" $ do
+            tan 0.0 `shouldBeCloseTo` 0.0
+            tan (piValue / 4.0) `shouldBeCloseTo` 1.0
+            tan (-piValue / 4.0) `shouldBeCloseTo` (-1.0)
+            rootThree <- rightValue $ sqrt 3.0
+            tan (piValue / 6.0) `shouldBeCloseTo` (1.0 / rootThree)
+        it "returns signed finite sentinels at poles" $ do
+            tan halfPi `shouldBe` 1e308
+            tan (negate halfPi) `shouldBe` (-1e308)
+
+    describe "atan" $ do
+        it "matches reference values and all range branches" $ do
+            rootThree <- rightValue $ sqrt 3.0
+            atan 0.0 `shouldBeCloseTo` 0.0
+            atan 1.0 `shouldBeCloseTo` (piValue / 4.0)
+            atan (-1.0) `shouldBeCloseTo` (-piValue / 4.0)
+            atan rootThree `shouldBeCloseTo` (piValue / 3.0)
+            atan (1.0 / rootThree) `shouldBeCloseTo` (piValue / 6.0)
+            abs (atan 1e10 - halfPi) `shouldSatisfy` (<= 1e-5)
+            abs (atan (-1e10) + halfPi) `shouldSatisfy` (<= 1e-5)
+        it "inverts tangent inside the principal range" $
+            atan (tan (piValue / 4.0)) `shouldBeCloseTo` (piValue / 4.0)
+
+    describe "atan2" $ do
+        it "handles both axes and the origin" $ do
+            atan2 0.0 1.0 `shouldBeCloseTo` 0.0
+            atan2 1.0 0.0 `shouldBeCloseTo` halfPi
+            atan2 0.0 (-1.0) `shouldBeCloseTo` piValue
+            atan2 (-1.0) 0.0 `shouldBeCloseTo` (negate halfPi)
+            atan2 0.0 0.0 `shouldBeCloseTo` 0.0
+        it "selects all four quadrants" $ do
+            atan2 1.0 1.0 `shouldBeCloseTo` (piValue / 4.0)
+            atan2 1.0 (-1.0) `shouldBeCloseTo` (3.0 * piValue / 4.0)
+            atan2 (-1.0) (-1.0) `shouldBeCloseTo` (-3.0 * piValue / 4.0)
+            atan2 (-1.0) 1.0 `shouldBeCloseTo` (-piValue / 4.0)
+  where
+    checkIdentity angle =
+        (sin angle * sin angle + cos angle * cos angle) `shouldBeCloseTo` 1.0
+    checkSquareRoot (value, expected) = do
+        actual <- rightValue $ sqrt value
+        actual `shouldBeCloseTo` expected

--- a/code/packages/haskell/trig/trig.cabal
+++ b/code/packages/haskell/trig/trig.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          trig
+version:       0.1.0
+synopsis:      Trigonometric functions from first principles
+description:   Pure range-reduced trigonometry and Newton-method square root.
+category:      Math
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Trig
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    TrigSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , trig
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -116,11 +116,11 @@ ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
-`scytale-cipher`, `feature-normalization`, and `loss-functions` ports:
+`scytale-cipher`, `feature-normalization`, `loss-functions`, and `trig` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 305 |
+| Present in 10-15 languages | 172 | 304 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 703 | 9,842 |
@@ -166,7 +166,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 305
+The 172 packages present in at least ten implementation languages need 304
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -177,7 +177,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 30 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 29 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -421,6 +421,16 @@ clamping. Its package-native suite exercises 15 examples covering reference
 values, every derivative branch, boundary probabilities, and all validation
 paths. The package now spans 14 implementation lanes, reduces the
 high-consensus backlog to 305 slots, and leaves 30 gaps in the Haskell lane.
+
+The fifth Haskell high-consensus slice is complete: `trig` now provides the
+dependency-free PHY00 angle constants, range-reduced sine and cosine series,
+degree/radian conversions, Newton-method square root, pole-guarded tangent,
+and inverse tangent functions. Its package-native suite exercises 17 examples
+with 99% expression coverage, including reference angles, identities,
+large-input reduction, conversions, domain validation, tangent poles, inverse
+ranges, axes, and all quadrants. The package now spans 14 implementation
+lanes, reduces the high-consensus backlog to 304 slots, leaves 29 gaps in the
+Haskell lane, and unlocks the dependent `wave` port.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add a dependency-free, first-principles Haskell port of `trig`
- implement range-reduced sine/cosine series, angle conversions, Newton square root, tangent, arctangent, and four-quadrant arctangent
- cover numerical identities, large-angle reduction, domains, poles, inverse ranges, axes, and quadrants
- update the package-parity roadmap from 305 to 304 high-consensus gaps and Haskell from 30 to 29, unlocking the dependent `wave` port

## Validation
- `stack test --coverage` (GHC 9.4.8): 17 examples, 0 failures, 99% expression coverage, 100% top-level declaration coverage
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py`: 6 passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: 0 collisions; 304 high-consensus gaps; 29 Haskell gaps; 14 trig lanes
- `git diff --check`