### PR TITLE
feat(wave): add Haskell port

### DIFF
--- a/code/packages/haskell/wave/BUILD
+++ b/code/packages/haskell/wave/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/wave/BUILD_windows
+++ b/code/packages/haskell/wave/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/wave/CHANGELOG.md
+++ b/code/packages/haskell/wave/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-07-18
+
+- Add validated sinusoidal waves with amplitude, frequency, and phase.
+- Add period, angular-frequency, and time-evaluation operations.
+- Build on the local first-principles `trig` package.

--- a/code/packages/haskell/wave/README.md
+++ b/code/packages/haskell/wave/README.md
@@ -1,0 +1,24 @@
+# wave
+
+A pure Haskell simple-harmonic wave model:
+
+```text
+y(t) = amplitude * sin(2 * pi * frequency * t + phase)
+```
+
+## API
+
+- `newWave` constructs a zero-phase wave.
+- `newWaveWithPhase` constructs a wave with an explicit phase.
+- `amplitude`, `frequency`, and `phase` inspect the validated parameters.
+- `period`, `angularFrequency`, and `evaluate` derive wave quantities.
+
+Construction rejects negative amplitude and non-positive frequency. A zero
+amplitude is valid and produces a flat wave. Evaluation uses the repository's
+first-principles Haskell `trig` package rather than Prelude trigonometry.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/wave/cabal.project
+++ b/code/packages/haskell/wave/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../trig

--- a/code/packages/haskell/wave/src/Wave.hs
+++ b/code/packages/haskell/wave/src/Wave.hs
@@ -1,0 +1,51 @@
+-- | A validated simple-harmonic wave model.
+module Wave
+    ( Wave
+    , newWave
+    , newWaveWithPhase
+    , amplitude
+    , frequency
+    , phase
+    , period
+    , angularFrequency
+    , evaluate
+    ) where
+
+import qualified Trig
+
+-- | A sinusoidal wave whose amplitude and frequency have been validated.
+data Wave = Wave
+    { amplitude :: Double
+    , frequency :: Double
+    , phase :: Double
+    } deriving (Eq, Show)
+
+-- | Construct a wave with zero phase.
+newWave :: Double -> Double -> Either String Wave
+newWave waveAmplitude waveFrequency =
+    newWaveWithPhase waveAmplitude waveFrequency 0.0
+
+-- | Construct a wave with an explicit phase in radians.
+newWaveWithPhase :: Double -> Double -> Double -> Either String Wave
+newWaveWithPhase waveAmplitude waveFrequency wavePhase
+    | waveAmplitude < 0.0 = Left "amplitude must be non-negative"
+    | waveFrequency <= 0.0 = Left "frequency must be positive"
+    | otherwise = Right Wave
+        { amplitude = waveAmplitude
+        , frequency = waveFrequency
+        , phase = wavePhase
+        }
+
+-- | Duration of one complete cycle in seconds.
+period :: Wave -> Double
+period wave = 1.0 / frequency wave
+
+-- | Angular frequency in radians per second.
+angularFrequency :: Wave -> Double
+angularFrequency wave = 2.0 * Trig.piValue * frequency wave
+
+-- | Evaluate the wave at time @t@ in seconds.
+evaluate :: Wave -> Double -> Double
+evaluate wave time = amplitude wave * Trig.sin angle
+  where
+    angle = angularFrequency wave * time + phase wave

--- a/code/packages/haskell/wave/test/Spec.hs
+++ b/code/packages/haskell/wave/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec (hspec)
+import WaveSpec (spec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/wave/test/WaveSpec.hs
+++ b/code/packages/haskell/wave/test/WaveSpec.hs
@@ -1,0 +1,89 @@
+module WaveSpec (spec) where
+
+import Data.Either (isLeft)
+import Test.Hspec
+import qualified Trig
+import Wave
+
+tolerance :: Double
+tolerance = 1e-10
+
+shouldBeCloseTo :: Double -> Double -> Expectation
+actual `shouldBeCloseTo` expected =
+    abs (actual - expected) `shouldSatisfy` (<= tolerance)
+
+rightValue :: Show error => Either error value -> IO value
+rightValue result = case result of
+    Left err -> expectationFailure (show err) >> error "unreachable"
+    Right value -> pure value
+
+spec :: Spec
+spec = do
+    describe "construction" $ do
+        it "defaults phase to zero" $ do
+            wave <- rightValue $ newWave 1.0 1.0
+            phase wave `shouldBeCloseTo` 0.0
+        it "stores explicit parameters" $ do
+            wave <- rightValue $ newWaveWithPhase 3.5 2.0 1.25
+            amplitude wave `shouldBeCloseTo` 3.5
+            frequency wave `shouldBeCloseTo` 2.0
+            phase wave `shouldBeCloseTo` 1.25
+        it "allows zero amplitude" $ do
+            wave <- rightValue $ newWave 0.0 1.0
+            amplitude wave `shouldBeCloseTo` 0.0
+        it "has an inspectable representation" $ do
+            wave <- rightValue $ newWaveWithPhase 2.0 3.0 0.5
+            same <- rightValue $ newWaveWithPhase 2.0 3.0 0.5
+            different <- rightValue $ newWaveWithPhase 2.0 3.0 0.25
+            wave `shouldBe` same
+            wave `shouldNotBe` different
+            show wave `shouldBe`
+                "Wave {amplitude = 2.0, frequency = 3.0, phase = 0.5}"
+
+    describe "validation" $ do
+        it "rejects negative amplitude" $
+            newWave (-1.0) 1.0 `shouldSatisfy` isLeft
+        it "rejects zero frequency" $
+            newWave 1.0 0.0 `shouldSatisfy` isLeft
+        it "rejects negative frequency" $
+            newWave 1.0 (-5.0) `shouldSatisfy` isLeft
+
+    describe "derived quantities" $ do
+        it "computes period" $ do
+            wave <- rightValue $ newWave 1.0 4.0
+            period wave `shouldBeCloseTo` 0.25
+        it "computes angular frequency" $ do
+            wave <- rightValue $ newWave 1.0 10.0
+            angularFrequency wave `shouldBeCloseTo` (2.0 * Trig.piValue * 10.0)
+
+    describe "evaluate" $ do
+        it "starts at zero without a phase offset" $ do
+            wave <- rightValue $ newWave 5.0 100.0
+            evaluate wave 0.0 `shouldBeCloseTo` 0.0
+        it "reaches the peak at a quarter period" $ do
+            wave <- rightValue $ newWave 1.0 1.0
+            evaluate wave 0.25 `shouldBeCloseTo` 1.0
+        it "returns to zero at half a period" $ do
+            wave <- rightValue $ newWave 1.0 1.0
+            evaluate wave 0.5 `shouldBeCloseTo` 0.0
+        it "reaches the trough at three quarters of a period" $ do
+            wave <- rightValue $ newWave 1.0 1.0
+            evaluate wave 0.75 `shouldBeCloseTo` (-1.0)
+        it "is periodic" $ do
+            wave <- rightValue $ newWaveWithPhase 2.5 3.0 0.7
+            let time = 0.137
+            evaluate wave time `shouldBeCloseTo` evaluate wave (time + period wave)
+
+    describe "phase offsets" $ do
+        it "starts at the peak with phase pi over two" $ do
+            wave <- rightValue $ newWaveWithPhase 1.0 1.0 Trig.halfPi
+            evaluate wave 0.0 `shouldBeCloseTo` 1.0
+        it "starts at the trough with phase three pi over two" $ do
+            wave <- rightValue $ newWaveWithPhase 1.0 1.0 (3.0 * Trig.halfPi)
+            evaluate wave 0.0 `shouldBeCloseTo` (-1.0)
+
+    describe "zero amplitude" $
+        it "is always zero" $ do
+            wave <- rightValue $ newWaveWithPhase 0.0 1.0 Trig.halfPi
+            mapM_ (\time -> evaluate wave time `shouldBeCloseTo` 0.0)
+                [0.0, 0.25, 0.5, 0.75, 1.0]

--- a/code/packages/haskell/wave/wave.cabal
+++ b/code/packages/haskell/wave/wave.cabal
@@ -1,0 +1,31 @@
+cabal-version: 3.0
+name:          wave
+version:       0.1.0
+synopsis:      Simple harmonic waves from first principles
+description:   Validated sinusoidal waves built on the local trig package.
+category:      Physics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Wave
+    build-depends:    base >=4.14 && <5
+                    , trig >=0.1 && <0.2
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    WaveSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , trig >=0.1 && <0.2
+                    , wave
+    default-language: Haskell2010

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -116,11 +116,12 @@ ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
-`scytale-cipher`, `feature-normalization`, `loss-functions`, and `trig` ports:
+`scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, and `wave`
+ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 304 |
+| Present in 10-15 languages | 172 | 303 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 703 | 9,842 |
@@ -166,7 +167,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 304
+The 172 packages present in at least ten implementation languages need 303
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -177,7 +178,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 29 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 28 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -431,6 +432,15 @@ large-input reduction, conversions, domain validation, tangent poles, inverse
 ranges, axes, and all quadrants. The package now spans 14 implementation
 lanes, reduces the high-consensus backlog to 304 slots, leaves 29 gaps in the
 Haskell lane, and unlocks the dependent `wave` port.
+
+The sixth Haskell high-consensus slice is complete: `wave` now builds on the
+local `trig` layer to provide validated PHY01 sinusoidal waves, periods,
+angular frequencies, phase offsets, and time-domain evaluation. Its
+package-native suite exercises 17 examples with 95% expression coverage,
+including construction, validation, derived quantities, the full cycle,
+periodicity, phase offsets, and the zero-amplitude case. The package now spans
+14 implementation lanes, reduces the high-consensus backlog to 303 slots, and
+leaves 28 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary
- add a Haskell port of `wave` on top of the local first-principles `trig` package
- provide validated zero-phase and explicit-phase constructors plus period, angular frequency, and time-domain evaluation
- cover construction, invalid parameters, value semantics, full-cycle behavior, periodicity, phase offsets, and zero amplitude
- update the package-parity roadmap from 304 to 303 high-consensus gaps and Haskell from 29 to 28

## Validation
- `stack test wave --coverage` (GHC 9.4.8): 17 examples, 0 failures, 95% package expression coverage, 92% package top-level declaration coverage
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py`: 6 passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: 0 collisions; 303 high-consensus gaps; 28 Haskell gaps; 14 wave lanes
- `git diff --check`