### PR TITLE
feat(script-writing-visualizer): cross-script interleaving (Mixed practice) — 0.4.0

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.4.0 — Cross-script interleaving ("Mixed") practice
+
+- **New "Mixed (all scripts)" practice scope** alongside "This script": Practice
+  can now **interleave letters from every script in one session** — HL02's
+  interleaving principle ("mixing forces discrimination and transfers better").
+  The scheduler picks the next due item across the whole combined pool, so a
+  Cyrillic prompt is followed by a Hebrew one, then Devanagari, and so on;
+  distractors always come from the **target's own script**. Mastery reads across
+  the full pool (e.g. "mastered N / 128").
+- **New pure module `src/interleave.ts`** — `buildPool(counts)` lays every letter
+  of every script into one **round-robin-interleaved** pool (letter 0 of each
+  script, then letter 1 of each, …) so mixing starts on the first pass; the
+  generic scheduler drives it unchanged. **6 new unit tests (42 total)** incl. an
+  integration proving the scheduler alternates scripts and resurfaces a missed
+  letter amid the others.
+- UI: a scope toggle in Practice; the per-script tabs hide during a mixed
+  session; the prompt shows a small script tag. Still zero runtime deps.
+
 ## 0.3.0 — Spaced-repetition scheduler wired into Practice
 
 - **New pure module `src/scheduler.ts`** — a Leitner / SM-2-lite scheduler

--- a/code/programs/typescript/script-writing-visualizer/README.md
+++ b/code/programs/typescript/script-writing-visualizer/README.md
@@ -65,6 +65,13 @@ future (1 → 3 → 7 → 15 → 30 sessions); miss it and it comes straight bac
 unit-tested — per `HL02` it's "the core module … where test coverage matters
 most."
 
+**Interleaving (Mixed mode).** Toggle **Practice → Mixed (all scripts)** to drill
+every script at once. `src/interleave.ts` lays all letters into one
+round-robin pool and the scheduler picks across it, so a Cyrillic prompt is
+followed by Hebrew, then Devanagari, … — the mixing that HL02 says "forces
+discrimination and transfers better." Distractors still come from the target's
+own script; mastery counts across the whole pool.
+
 ## Scope and what's next
 
 Today the app does **read + decompose** (Browse) and **recall** (Practice). Still

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Companion app (HL02 MVP): break a non-Latin script apart and learn to write it, letter by letter",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/interleave.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/interleave.ts
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// interleave.ts — the pure glue for cross-script practice (HL02 interleaving).
+//
+// The scheduler (scheduler.ts) is generic: it schedules items keyed by a single
+// numeric index. To drill *all scripts mixed together* — the interleaving that
+// HL02 says "forces discrimination and transfers better" — we lay every letter
+// of every script into ONE flat pool, hand that pool's length to the scheduler,
+// and map the index it picks back to a (script, letter) pair.
+//
+// The pool is built ROUND-ROBIN across scripts (letter 0 of every script, then
+// letter 1 of every script, …) so the very first pass already alternates
+// scripts, not "all of Cyrillic, then all of Hebrew." Pure and deterministic.
+// ---------------------------------------------------------------------------
+
+/** One item in the combined pool: which script, and which letter within it. */
+export interface PoolEntry {
+  scriptIndex: number;
+  letterIndex: number;
+}
+
+/**
+ * Build the combined, round-robin-interleaved pool from each script's letter
+ * count. `counts[s]` is the number of letters in script `s`.
+ *
+ *   buildPool([2, 3]) →
+ *     [ {0,0}, {1,0}, {0,1}, {1,1}, {1,2} ]
+ *     // letter 0 of both, letter 1 of both, then script 1's extra letter 2
+ *
+ * Every (script, letter) appears exactly once. Scripts with fewer letters simply
+ * drop out of the later rounds (ragged is fine).
+ */
+export function buildPool(counts: number[]): PoolEntry[] {
+  const max = counts.reduce((m, c) => Math.max(m, c), 0);
+  const pool: PoolEntry[] = [];
+  for (let letterIndex = 0; letterIndex < max; letterIndex++) {
+    for (let scriptIndex = 0; scriptIndex < counts.length; scriptIndex++) {
+      if (letterIndex < (counts[scriptIndex] ?? 0)) {
+        pool.push({ scriptIndex, letterIndex });
+      }
+    }
+  }
+  return pool;
+}
+
+/** Total letters across all scripts (the combined pool size). */
+export function poolSize(counts: number[]): number {
+  return counts.reduce((sum, c) => sum + Math.max(0, c), 0);
+}

--- a/code/programs/typescript/script-writing-visualizer/src/main.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/main.ts
@@ -30,6 +30,7 @@ import {
   masteredCount,
   type ItemState,
 } from "./scheduler.ts";
+import { buildPool, type PoolEntry } from "./interleave.ts";
 import "./styles.css";
 
 const app = document.getElementById("app");
@@ -41,16 +42,32 @@ let currentScript = 0;
 let currentLetter = 0;
 
 // Practice state
+type Scope = "script" | "mixed";
+let scope: Scope = "script"; // drill the current script, or all scripts interleaved
 let score: Score = emptyScore();
 let question: DrillQuestion | null = null;
 let chosen: number | null = null; // which option the learner picked (null = unanswered)
 // Spaced-repetition state: the scheduler decides WHICH letter to ask next, so
 // missed letters resurface sooner and mastered ones fade back. One session tick
-// per answered question (see scheduler.ts). Rebuilt when the script changes.
+// per answered question (see scheduler.ts). Rebuilt when the scope/script changes.
 let schedule: ItemState[] = [];
 let sessionTick = 0;
+// In "mixed" scope, `schedule` indexes a combined pool spanning every script;
+// `pool[i]` maps that index back to (scriptIndex, letterIndex). Empty in "script"
+// scope, where the schedule index IS the letter index of the current script.
+let pool: PoolEntry[] = [];
+// Which script + schedule-index the CURRENT question belongs to (they diverge in
+// mixed scope, where the schedule index is a pool index, not a letter index).
+let questionScript = 0;
+let scheduleIndex = 0;
 
 const OPTION_COUNT = 4;
+
+/** Resolve a schedule index to a concrete (script, letter), per scope. */
+function resolve(idx: number): PoolEntry {
+  if (scope === "mixed") return pool[idx] ?? { scriptIndex: 0, letterIndex: 0 };
+  return { scriptIndex: currentScript, letterIndex: idx };
+}
 
 // --- shared chrome ----------------------------------------------------------
 
@@ -84,7 +101,33 @@ function renderModeToggle(): HTMLElement {
   return wrap;
 }
 
-/** A tab per script (both modes). Switching script resets practice. */
+/** In Practice, choose per-script drilling or all scripts interleaved. */
+function renderScopeToggle(): HTMLElement {
+  const wrap = el("div", "scopes");
+  const label = el("span", "scopes__label");
+  label.textContent = "Practice:";
+  wrap.appendChild(label);
+  (
+    [
+      ["script", "This script"],
+      ["mixed", "Mixed (all scripts)"],
+    ] as [Scope, string][]
+  ).forEach(([s, text]) => {
+    const b = el("button", "scope" + (s === scope ? " scope--active" : ""));
+    b.textContent = text;
+    b.setAttribute("aria-pressed", String(s === scope));
+    b.onclick = () => {
+      if (scope === s) return;
+      scope = s;
+      startPractice();
+      render();
+    };
+    wrap.appendChild(b);
+  });
+  return wrap;
+}
+
+/** A tab per script. Hidden while practising a mixed (all-scripts) session. */
 function renderTabs(): HTMLElement {
   const tabs = el("div", "tabs");
   SCRIPTS.forEach((data, i) => {
@@ -171,32 +214,47 @@ function renderDetail(v: LetterView): HTMLElement {
 
 // --- practice mode ----------------------------------------------------------
 
-/** Start (or restart) a practice session for the current script. */
+/** Start (or restart) a practice session, per scope. */
 function startPractice(): void {
   score = emptyScore();
-  const views = buildScriptView(SCRIPTS[currentScript]!);
-  schedule = initStates(views.length);
   sessionTick = 0;
+  if (scope === "mixed") {
+    pool = buildPool(SCRIPTS.map((s) => s.letters.length));
+    schedule = initStates(pool.length);
+  } else {
+    pool = [];
+    schedule = initStates(SCRIPTS[currentScript]!.letters.length);
+  }
   nextQuestion();
 }
 
-/** Let the scheduler choose the next letter; the UI still randomises options. */
+/** Let the scheduler choose the next item; the UI still randomises options. */
 function nextQuestion(): void {
-  const views = buildScriptView(SCRIPTS[currentScript]!);
-  // The scheduler decides WHICH letter (spaced repetition); randomness is only
-  // for the distractors + answer position.
-  const target = pickNext(schedule, sessionTick);
+  // The scheduler decides WHICH item (spaced repetition, interleaved in mixed
+  // scope); randomness is only for the distractors + answer position.
+  const idx = pickNext(schedule, sessionTick);
+  scheduleIndex = idx < 0 ? 0 : idx;
+  const { scriptIndex, letterIndex } = resolve(scheduleIndex);
+  questionScript = scriptIndex;
+  const views = buildScriptView(SCRIPTS[scriptIndex]!);
   const placeAt = randInt(Math.min(OPTION_COUNT, views.length));
-  question = buildDrillQuestion(views, target < 0 ? 0 : target, OPTION_COUNT, chooseConfusableShuffled, placeAt);
+  // Distractors come from the target's OWN script, so a Cyrillic prompt never
+  // offers a Hebrew decoy.
+  question = buildDrillQuestion(views, letterIndex, OPTION_COUNT, chooseConfusableShuffled, placeAt);
   chosen = null;
 }
 
 function renderPractice(): HTMLElement {
-  const views = buildScriptView(SCRIPTS[currentScript]!);
+  // Options + reveal come from the QUESTION's script (may differ from the tab in
+  // mixed scope).
+  const views = buildScriptView(SCRIPTS[questionScript]!);
   const q = question!;
   const wrap = el("div", "practice");
 
-  // Score line + a spaced-repetition mastery read-out
+  wrap.appendChild(renderScopeToggle());
+
+  // Score line + a spaced-repetition mastery read-out (across the whole pool in
+  // mixed scope).
   const acc = accuracy(score);
   const mastered = masteredCount(schedule);
   const scoreLine = el("div", "score");
@@ -211,6 +269,11 @@ function renderPractice(): HTMLElement {
   const sound = el("div", "prompt__sound");
   sound.textContent = q.promptSound;
   prompt.append(label, sound);
+  if (scope === "mixed") {
+    const tag = el("div", "prompt__script");
+    tag.textContent = SCRIPTS[questionScript]!.name;
+    prompt.appendChild(tag);
+  }
   wrap.appendChild(prompt);
 
   // Options
@@ -228,8 +291,9 @@ function renderPractice(): HTMLElement {
       chosen = i;
       const correct = checkAnswer(q, i);
       score = record(score, correct);
-      // Feed the answer to the scheduler and advance the session clock.
-      schedule = reviewIn(schedule, q.targetIndex, correct, sessionTick);
+      // Feed the answer to the scheduler at the SCHEDULE index (a pool index in
+      // mixed scope, a letter index otherwise), and advance the session clock.
+      schedule = reviewIn(schedule, scheduleIndex, correct, sessionTick);
       sessionTick += 1;
       render();
     };
@@ -265,7 +329,9 @@ function renderPractice(): HTMLElement {
 function render(): void {
   const data = SCRIPTS[currentScript]!;
   app!.replaceChildren();
-  app!.append(renderHeader(), renderTabs());
+  app!.append(renderHeader());
+  // The script tabs steer per-script work; hide them during a mixed session.
+  if (!(mode === "practice" && scope === "mixed")) app!.appendChild(renderTabs());
 
   if (mode === "browse") {
     const views = buildScriptView(data);

--- a/code/programs/typescript/script-writing-visualizer/src/styles.css
+++ b/code/programs/typescript/script-writing-visualizer/src/styles.css
@@ -167,3 +167,24 @@ body {
   font-size: 0.95rem;
   font-weight: 600;
 }
+
+/* --- practice scope (this script / mixed) ------------------------------- */
+.scopes { display: flex; align-items: center; gap: 6px; margin-bottom: 14px; }
+.scopes__label { color: var(--muted); font-size: 0.85rem; margin-right: 2px; }
+.scope {
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  padding: 4px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.scope--active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.prompt__script {
+  margin-top: 8px;
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/interleave.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/interleave.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { buildPool, poolSize } from "../src/interleave.ts";
+import { initStates, pickNext, reviewIn } from "../src/scheduler.ts";
+import { SCRIPTS } from "../src/data.ts";
+
+describe("buildPool", () => {
+  it("interleaves scripts round-robin and includes every (script, letter) once", () => {
+    const pool = buildPool([2, 3]);
+    expect(pool).toEqual([
+      { scriptIndex: 0, letterIndex: 0 },
+      { scriptIndex: 1, letterIndex: 0 },
+      { scriptIndex: 0, letterIndex: 1 },
+      { scriptIndex: 1, letterIndex: 1 },
+      { scriptIndex: 1, letterIndex: 2 }, // script 1's extra letter, ragged tail
+    ]);
+    expect(pool).toHaveLength(poolSize([2, 3]));
+  });
+
+  it("handles equal counts, a single script, and empties", () => {
+    expect(buildPool([2, 2]).map((p) => `${p.scriptIndex}:${p.letterIndex}`)).toEqual([
+      "0:0", "1:0", "0:1", "1:1",
+    ]);
+    expect(buildPool([3])).toEqual([
+      { scriptIndex: 0, letterIndex: 0 },
+      { scriptIndex: 0, letterIndex: 1 },
+      { scriptIndex: 0, letterIndex: 2 },
+    ]);
+    expect(buildPool([])).toEqual([]);
+    expect(buildPool([0, 0])).toEqual([]);
+  });
+});
+
+describe("poolSize", () => {
+  it("sums letter counts, ignoring negatives", () => {
+    expect(poolSize([2, 3, 5])).toBe(10);
+    expect(poolSize([])).toBe(0);
+    expect(poolSize([-1, 4])).toBe(4);
+  });
+});
+
+describe("scheduler over the combined pool interleaves scripts", () => {
+  it("moves to a different script's letter after answering one correctly", () => {
+    const pool = buildPool([2, 2]); // [s0l0, s1l0, s0l1, s1l1]
+    let states = initStates(pool.length); // all due at session 0
+    let tick = 0;
+
+    const first = pickNext(states, tick);
+    expect(pool[first]).toEqual({ scriptIndex: 0, letterIndex: 0 }); // lowest index
+
+    states = reviewIn(states, first, true, tick); // got it right → scheduled later
+    tick += 1;
+
+    const second = pickNext(states, tick);
+    // the next most-overdue is pool[1] = a DIFFERENT script → interleaved
+    expect(pool[second]!.scriptIndex).not.toBe(pool[first]!.scriptIndex);
+    expect(pool[second]).toEqual({ scriptIndex: 1, letterIndex: 0 });
+  });
+
+  it("a missed letter from one script resurfaces amid the others", () => {
+    const pool = buildPool([2, 2]); // [s0l0, s1l0, s0l1, s1l1]
+    let states = initStates(pool.length);
+    // Master items 0, 1, 3 across several ascending sessions so their next-due
+    // drifts well into the future; miss item 2 (script 0, letter 1).
+    for (const s of [0, 1, 4]) {
+      for (const i of [0, 1, 3]) states = reviewIn(states, i, true, s);
+    }
+    states = reviewIn(states, 2, false, 4); // wrong → due again at session 5
+    // At session 5 only the missed item is due; the mastered ones are far out.
+    const next = pickNext(states, 5);
+    expect(pool[next]).toEqual({ scriptIndex: 0, letterIndex: 1 });
+  });
+});
+
+describe("with real script data", () => {
+  it("builds a pool spanning all shipped scripts", () => {
+    const counts = SCRIPTS.map((s) => s.letters.length);
+    const pool = buildPool(counts);
+    expect(pool).toHaveLength(poolSize(counts));
+    // the pool touches every script
+    expect(new Set(pool.map((p) => p.scriptIndex)).size).toBe(SCRIPTS.length);
+    // and the first few entries alternate scripts (round-robin)
+    expect(pool[0]!.scriptIndex).toBe(0);
+    expect(pool[1]!.scriptIndex).toBe(1);
+  });
+});

--- a/code/programs/typescript/script-writing-visualizer/vitest.config.ts
+++ b/code/programs/typescript/script-writing-visualizer/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       provider: "v8",
       // The pure logic (core.ts + drill.ts) is what we hold to a high bar;
       // main.ts is the thin DOM shell and data.ts is just JSON imports.
-      include: ["src/core.ts", "src/drill.ts", "src/scheduler.ts"],
+      include: ["src/core.ts", "src/drill.ts", "src/scheduler.ts", "src/interleave.ts"],
     },
   },
 });


### PR DESCRIPTION
## Companion app — cross-script interleaving ("Mixed" practice) — 0.4.0

Loop item 13. Adds the last big learning-science piece from HL02 to the app: a
**"Mixed (all scripts)"** practice scope that **interleaves letters from every
script in one session** — the mixing that HL02 says "forces discrimination and
transfers better."

### What it does
- Toggle **Practice → Mixed (all scripts)**: the scheduler picks the next due
  item across the **whole combined pool** (all five scripts), so a Cyrillic prompt
  is followed by Hebrew, then Devanagari, and so on. **Distractors always come
  from the target's own script** (no Hebrew decoy under a Cyrillic prompt), and
  mastery reads across the full pool (e.g. "mastered N / 128").

### Design (the scheduler stayed generic)
- **New pure `src/interleave.ts`** — `buildPool(counts)` lays every letter of
  every script into one **round-robin-interleaved** pool (letter 0 of each script,
  then letter 1 of each, …), so mixing starts on the very first pass. The generic
  `scheduler.ts` drives that pool unchanged; `main.ts` maps the picked index back
  to (script, letter).
- **6 new unit tests (42 total)** — pool construction (round-robin, ragged,
  empty), `poolSize`, plus integration proving the scheduler **alternates scripts**
  and **resurfaces a missed letter amid the others**.
- UI: a scope toggle in Practice; per-script tabs hide during a mixed session;
  the prompt shows a small script tag. Still **zero runtime deps**.

### Verified
- Build + **42 tests** pass. Drove Mixed in the browser: Cyrillic *a* → answered →
  next prompt **Hebrew alef** with Hebrew-script options; **mastered 0 / 128**;
  console clean. Security review passed (safe DOM sinks, pure core, no new deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
