### PR TITLE
feat(semantic-ir-to-javascript): wire SIR22 'APL addendum' codegen — Reduce/Scan/OuterProduct/Shape/Reshape/IndexGenerator/IndexOf/Ravel/Catenate

### DIFF
--- a/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## [0.1.2] - 2026-07-18
+
+### Added
+
+- **`tests/e2e_node.rs`** — this crate's first real end-to-end,
+  `node`-executed test, made possible by `semantic-ir-to-javascript`
+  0.41.0 gaining real codegen for the SIR22 "APL addendum" (`Reduce`/
+  `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+  `Ravel`/`Catenate`) — the nine node kinds essentially every non-trivial
+  APL program uses. Seven tests, each compiling real APL source through
+  `compile_source` → `semantic_ir::validate` → `semantic_ir_to_javascript::
+  compile` → a temp `.js` file → `node`, asserting the printed stdout:
+  `+/1 2 3 4` (reduce-Add) → `10`; `⌈/3 1 4 1 5` (a non-Add reduce, proving
+  the op dispatch isn't hardcoded) → `5`; `-/+\1 2 3` (scan composed with a
+  non-commutative reduce, which only reproduces `¯8` if the three prefix
+  sums were folded in the correct left-to-right order) → `¯8`;
+  `+/,(⍳2)∘.×(⍳3)` (outer product, ravelled and summed) → `18`;
+  `⍴(,2 3)⍴⍳6` (shape of a reshaped matrix) → `2 3`; `⍳5` (index generator)
+  → `1 2 3 4 5`; `,(,2 3)⍴⍳6` (ravel of a reshaped matrix, proving
+  row-major flatten order) → `1 2 3 4 5 6`.
+- Corrected this crate's own stale claim: 0.1.0's changelog entry said "No
+  `tests/e2e_node.rs`: ... a real round-trip through a backend needs
+  `sir-runtime-array`'s SIR22 codegen, which does not exist yet." That
+  premise described the WRONG backend (`sir-runtime-array` is the
+  TypeScript backend's imported npm package, separate, still not shipped)
+  — the actual blocker was `semantic-ir-to-javascript`'s own INLINED
+  runtime lacking codegen for the addendum, now fixed. No further action
+  needed on the 0.1.0 entry itself (changelogs are a historical record,
+  not edited after the fact) beyond this correction here.
+
+### Fixed (test-only, no lowering behavior changed)
+
+- **`tests/test_validator.rs`**: `reduce_and_outer_product_modules_
+  validate_but_compile_still_rejects_them` (asserting `compile()`
+  REJECTED a `Reduce`/`OuterProduct`-using module) renamed
+  `reduce_and_outer_product_modules_now_compile_cleanly` and rewritten to
+  assert `compile()` SUCCEEDS — the old assertion is now false, and
+  leaving it in place would have made this crate's own test suite
+  document a stale, no-longer-true fact about a *different* crate's
+  capabilities.
+
+### Discovered (not fixed here — out of scope, flagged separately)
+
+- **A stranded numeric literal (`1 2 3`) lowers to a single-row
+  `Expr::ArrayLit`, which this backend's (unchanged) base-cut codegen
+  turns into a genuine RANK-2 `[1, n]` "row matrix" at the JS runtime-value
+  level** (`__Sir.Array.fromRows([[1, 2, 3]])`), not a true rank-1 `[n]`
+  vector — contrast `apl-runtime`'s OWN tree-walking evaluator, which
+  builds a true `[n]` via `Array::from_vec` for the identical source (see
+  `apl-runtime/src/eval.rs`). `reduce`/`scan` happen to compute identical
+  numbers either way (their rank-2 branch folds/scans each row
+  independently, and a lone row coincides with a rank-1 fold/scan of the
+  same elements), so `+/`/`+\` on stranded literals are unaffected. `outer`
+  and dyadic `⍴`'s shape ARGUMENT, however, are both scoped to rank <= 1
+  operands ONLY (faithfully mirroring `array_runtime::ops::outer` /
+  `apl_runtime::builtins::reshape`'s own identical restrictions) — so `1
+  2∘.×3 4` and `2 3⍴⍳6` (two bare stranded literals used this way) both
+  throw a clean runtime `Error` today, discovered while writing
+  `tests/e2e_node.rs` above. Worked around in that test file by building
+  the outer-product operands from `⍳` (which constructs a genuine rank-1
+  `[n]` directly, sidestepping `ArrayLit`/`fromRows` entirely) and the
+  reshape shape argument from `,2 3` (ravel of the literal, which — like
+  `⍳` — always constructs a genuine rank-1 result regardless of its
+  input's rank). Root cause is this crate's `ArrayLit` lowering reusing
+  the MATLAB-oriented SIR22 base cut, which has no representation for "a
+  true rank-1 vector distinct from a 1-row matrix" (MATLAB itself has no
+  such distinction — everything is a matrix). A proper fix needs either a
+  new SIR representation for a genuine rank-1 literal, or a
+  targeted `apl-to-semantic-ir`-side workaround routing `OuterProduct`/
+  `Reshape` operands through an implicit ravel; either is a real,
+  separately-scoped follow-up, not a small patch to make inline here.
+
 ## [0.1.1] - 2026-07-16
 
 ### Changed

--- a/code/packages/rust/apl-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/apl-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apl-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "APL CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-4f, the last APL rollout item per HML01."
 
@@ -19,10 +19,13 @@ lexer = { path = "../lexer" }
 # Every lowered module uses at least one SIR22/SIR22-addendum node (there is
 # no purely-scalar-literal escape hatch the way matlab-to-semantic-ir has,
 # since even `3+4` is an `ElementwiseOp` here -- see `src/lower.rs`'s module
-# doc comment, point 1). No backend implements codegen for these nodes yet
-# (`sir-runtime-array`'s SIR22 codegen is separate, not-yet-shipped
-# follow-on work per HML01 §4), so this dev-dependency exists solely to
-# verify the *capability-rejection* path: a real `Module`, checked through
-# the actual `Backend::check_module`, mirroring the same verification
-# pattern `matlab-to-semantic-ir`'s own `tests/test_validator.rs` uses.
+# doc comment, point 1). `semantic-ir-to-javascript` now implements real
+# codegen for the full SIR22 domain (base cut + the "APL addendum" this
+# crate is the first consumer of), so this dev-dependency backs both
+# `tests/test_validator.rs` (capability-acceptance, mirroring
+# `matlab-to-semantic-ir`'s own `tests/test_validator.rs`) and
+# `tests/e2e_node.rs` (real `node`-executed behavioral proof -- the
+# `sir-runtime-array` TypeScript package is SEPARATE, not-yet-shipped
+# follow-on work per HML01 §4; this backend's own INLINED runtime is what
+# these tests exercise).
 semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/apl-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/e2e_node.rs
@@ -1,0 +1,238 @@
+//! End-to-end round-trip: APL → SIR → JavaScript → `node`.
+//!
+//! Mirrors `matlab-to-semantic-ir`'s own `tests/e2e_node.rs` harness exactly:
+//! lower an APL program to SIR with this crate, validate the module, emit
+//! JavaScript with the merged `semantic-ir-to-javascript` backend (a
+//! dev-dependency), write it to a temp file, and **execute it with
+//! `node`**, asserting the printed output.
+//!
+//! Until `semantic-ir-to-javascript` gained real codegen for the SIR22
+//! "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+//! `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`), this file could not exist
+//! at all: every one of this crate's own test programs uses at least one of
+//! these nine nodes (unlike MATLAB, APL has no purely-scalar-literal escape
+//! hatch — see `src/lower.rs`'s module doc comment, point 1 — even `3+4` is
+//! an `ElementwiseOp`), and `compile()` used to reject all of them cleanly
+//! rather than panic. Now that backend implements real codegen for all nine,
+//! this file is the actual, node-executed proof the panic/rejection is gone
+//! — not just that `compile()` returns `Ok`, but that the generated program
+//! computes the RIGHT numbers.
+//!
+//! APL auto-prints a bare (non-assignment) top-level expression (see
+//! `src/lower.rs`'s "Auto-print, not MATLAB-style suppression" section), so
+//! every program below is a single bare expression with no explicit
+//! `disp`-equivalent.
+//!
+//! ## Two representational quirks this file works around
+//!
+//! 1. **No display-formatting story for a printed vector/matrix was ever a
+//!    concern here** — unlike `matlab-to-semantic-ir`'s own `e2e_node.rs`
+//!    (which reads back individual elements via `IndexGet`, since MATLAB's
+//!    `disp` on an un-indexed array had nowhere to route to), this backend's
+//!    `formatSeen` now renders a raw `NDArray` using APL's OWN console
+//!    convention (`ArrayRt.display`, a 1:1 port of `apl_runtime::value::
+//!    display` — high-minus `¯`, space-separated vector, right-aligned
+//!    matrix rows). This was necessary, not optional: APL has NO
+//!    bracket-indexing surface syntax at all in this grammar (confirmed
+//!    against `code/grammars/apl/apl.grammar` and `apl-to-semantic-ir`'s own
+//!    lowering, which never constructs an `Expr::IndexGet`), so
+//!    `matlab-to-semantic-ir`'s "read back one scalar via indexing"
+//!    workaround is simply not expressible in APL source at all — auto-print
+//!    of the whole value is the ONLY way any APL program can ever produce
+//!    output. See `semantic-ir-to-javascript`'s `runtime.rs` `formatSeen`
+//!    for where this is wired in.
+//! 2. **A stranded numeric literal (`1 2 3`) lowers to `Expr::ArrayLit`
+//!    with exactly ONE row** (`src/lower.rs`'s `lower_term`), which this
+//!    backend's (unchanged, out-of-scope-for-this-PR) base-cut codegen
+//!    turns into `__Sir.Array.fromRows([[1, 2, 3]])` — a genuine RANK-2
+//!    `[1, 3]` "row matrix" at the runtime-value level, not a true rank-1
+//!    `[3]` vector (contrast `apl-runtime`'s OWN tree-walking evaluator,
+//!    which builds `Array::from_vec` for the identical source and gets a
+//!    true `[3]`). `reduce`/`scan` happen to compute the identical numbers
+//!    either way (their rank-2 branch folds/scans each row independently,
+//!    and a lone row of length n coincides exactly with a rank-1 fold/scan
+//!    of the same n elements), so `+/`/`+\` on stranded literals below are
+//!    unaffected. `outer`, however, is scoped to rank <= 1 operands ONLY
+//!    (matching `array_runtime::ops::outer`'s own identical restriction) —
+//!    two `[1, n]`-shaped stranded literals both fail that check and throw.
+//!    The outer-product test below therefore builds its operands from `⍳`
+//!    (this crate's own `IndexGenerator`, which constructs a genuine rank-1
+//!    `[n]` by direct `ndarray([n], ...)` construction, sidestepping
+//!    `ArrayLit`/`fromRows` entirely) instead of two bare stranded
+//!    literals. Dyadic `⍴` (reshape)'s shape ARGUMENT hits the identical
+//!    wall — `reshape` rejects a rank > 1 shape argument (mirroring
+//!    `apl_runtime::builtins::reshape`'s own check), and a bare `2 3`
+//!    stranded literal IS rank 2 (`[1, 2]`) at the runtime-value level —
+//!    so the matrix-construction tests below use `,2 3` (ravel of the
+//!    stranded literal, which — like `outer` above — sidesteps the issue
+//!    because `ravel` always constructs a genuine rank-1 result
+//!    regardless of its input's rank) as the shape argument instead of the
+//!    bare literal. This ArrayLit-representation gap is pre-existing
+//!    (shipped in this crate's v0.1.0/v0.1.1, unrelated to and unchanged
+//!    by the codegen work that unblocked this file) and out of scope to
+//!    fix here — flagged separately, not patched around silently.
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use apl_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_via_node(name: &str, src: &str) -> String {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    let artifact =
+        semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("apl_sir_e2e_{name}_{}.js", std::process::id()));
+    // `create_new` fails if the path already exists (including as a
+    // symlink) instead of following it -- unlike `std::fs::write`, which
+    // truncates through a symlink at this predictable, shared-temp-dir
+    // path. Each test uses a unique name+PID, so this should never
+    // legitimately collide; if it does, failing loudly is correct for a
+    // test rather than silently overwriting whatever the path pointed to.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes())
+        .expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn reduce_add_on_a_stranded_vector_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping reduce_add_on_a_stranded_vector_runs_in_node: `node` not available");
+        return;
+    }
+    // `+/1 2 3 4` -- APL reduce with Add, the textbook `+/` example.
+    let out = run_via_node("reduce_add", "+/1 2 3 4\n");
+    assert_eq!(out, "10");
+}
+
+#[test]
+fn reduce_with_a_non_add_op_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping reduce_with_a_non_add_op_runs_in_node: `node` not available");
+        return;
+    }
+    // `⌈/3 1 4 1 5` -- max-reduce, proving the op dispatch inside
+    // `__Sir.Array.reduce` isn't hardcoded to Add (it reuses `applyOp`,
+    // the same dispatch table `elementwise` uses).
+    let out = run_via_node("reduce_max", "⌈/3 1 4 1 5\n");
+    assert_eq!(out, "5");
+}
+
+#[test]
+fn scan_then_reduce_with_a_non_commutative_op_proves_prefix_order_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping scan_then_reduce_with_a_non_commutative_op_proves_prefix_order_in_node: `node` not available"
+        );
+        return;
+    }
+    // `+\1 2 3` (scan) produces the running-total vector [1, 3, 6]. This
+    // backend has no whole-vector print convention exercised here (see
+    // this file's module doc comment) other than APL's own `display`
+    // formatting, which DOES handle a printed vector -- but composing the
+    // scan's result through `-/` (reduce with Sub, non-commutative) gives
+    // a single number that only comes out right if the THREE prefix sums
+    // were computed in the correct left-to-right order: `1 - 3 - 6 = -8`.
+    // A scan that silently reversed order, or that folded from the wrong
+    // seed, would not produce this exact value.
+    let out = run_via_node("scan_then_reduce", "-/+\\1 2 3\n");
+    assert_eq!(out, "¯8");
+}
+
+#[test]
+fn outer_product_of_two_iota_vectors_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping outer_product_of_two_iota_vectors_runs_in_node: `node` not available");
+        return;
+    }
+    // `(⍳2)∘.×(⍳3)` -- outer product between two GENUINE rank-1 vectors
+    // (`⍳n` constructs a true `[n]`-shaped NDArray directly, unlike a bare
+    // stranded literal -- see this file's module doc comment, point 2, for
+    // why two raw stranded literals are not usable as `outer`'s operands
+    // today). `⍳2 = [1, 2]`, `⍳3 = [1, 2, 3]`; ravelling the outer product
+    // and reduce-summing it (`+/,`) gives `(1+2) * (1+2+3) = 3 * 6 = 18` --
+    // every one of the 6 pairwise products counted exactly once, which is
+    // what proves `outer`'s non-square (2x3, not 2x2) case is wired
+    // correctly end to end.
+    let out = run_via_node("outer_product", "+/,(⍳2)∘.×(⍳3)\n");
+    assert_eq!(out, "18");
+}
+
+#[test]
+fn shape_of_a_reshaped_matrix_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping shape_of_a_reshaped_matrix_runs_in_node: `node` not available");
+        return;
+    }
+    // `⍴(,2 3)⍴⍳6` -- dyadic `⍴` (reshape) builds a real 2x3 matrix from
+    // `⍳6 = [1..6]`, then monadic `⍴` (shape) reads its dimensions back as
+    // a vector, printed "2 3". The shape ARGUMENT is `,2 3` (ravel of the
+    // stranded literal), not the bare literal `2 3` -- a raw stranded
+    // literal lowers to a `[1, 2]`-shaped `ArrayLit` (see this file's
+    // module doc comment, point 2), which `reshape` correctly rejects as
+    // rank > 1 (mirroring `apl_runtime::builtins::reshape`'s own identical
+    // "shape argument must be rank <= 1" check); `,2 3` ravels it down to
+    // a genuine rank-1 `[2]` vector first, which reshape then accepts.
+    let out = run_via_node("shape_of_reshape", "⍴(,2 3)⍴⍳6\n");
+    assert_eq!(out, "2 3");
+}
+
+#[test]
+fn index_generator_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping index_generator_runs_in_node: `node` not available");
+        return;
+    }
+    // `⍳5` -- monadic index generator, 1-based per APL's own surface
+    // semantics: `[1, 2, 3, 4, 5]`, printed space-separated.
+    let out = run_via_node("index_generator", "⍳5\n");
+    assert_eq!(out, "1 2 3 4 5");
+}
+
+#[test]
+fn ravel_of_a_reshaped_matrix_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping ravel_of_a_reshaped_matrix_runs_in_node: `node` not available");
+        return;
+    }
+    // `,(,2 3)⍴⍳6` -- monadic ravel flattens the same reshaped 2x3 matrix
+    // (see the previous test for why the shape argument is `,2 3`, not the
+    // bare literal `2 3`) back to a rank-1 vector in ROW-major order:
+    // [1, 2, 3, 4, 5, 6]. Column-major storage means a bug that ravelled
+    // straight from the backing buffer instead of walking row-then-column
+    // would print "1 4 2 5 3 6" instead -- this is exactly the subtlety
+    // `flattenRowMajor`'s own doc comment in `runtime.rs` calls out.
+    let out = run_via_node("ravel_of_reshape", ",(,2 3)⍴⍳6\n");
+    assert_eq!(out, "1 2 3 4 5 6");
+}

--- a/code/packages/rust/apl-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/test_validator.rs
@@ -9,16 +9,18 @@
 //!
 //! `semantic-ir-to-javascript` now implements real codegen for the SIR22
 //! *base cut* (`ElementwiseOp` among them, which is all a simple dyadic
-//! program like `3+4` needs), so those modules are accepted. The SIR22
-//! "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/...) remain
-//! deferred — this crate's own lowering is exactly what motivated adding
-//! `semantic-ir-to-javascript`'s dedicated tree-walk rejection for them
-//! (see that crate's `find_unimplemented_sir22_addendum_node`), since they
-//! share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the now-accepted
-//! base cut and so are NOT caught by the plain `Backend::check_module`
-//! feature check alone — the `reduce_and_outer_product_modules...` test
-//! below calls `compile()`, not `check_module()` directly, for exactly
-//! that reason.
+//! program like `3+4` needs) AND for the SIR22 "APL addendum" (`Reduce`/
+//! `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+//! `Ravel`/`Catenate`) — this crate's own lowering is exactly what
+//! motivated adding that codegen (the addendum nodes share `NDArrays`/
+//! `MatrixOps`/`ArrayColumnMajor` with the base cut, so a plain
+//! feature-flag `Backend::check_module` check alone could never
+//! distinguish "base cut only" from "also uses the addendum" — real
+//! codegen for both closes that gap by making the distinction moot).
+//! `reduce_and_outer_product_modules_now_compile_cleanly` below is the
+//! regression test for the OLD rejection behavior: it now asserts
+//! `compile()` SUCCEEDS. Real, node-executed behavioral proof (not just
+//! "doesn't error") lives in `tests/e2e_node.rs`.
 
 use apl_to_semantic_ir::compile_source;
 use semantic_ir::backend::Backend;
@@ -63,26 +65,27 @@ fn a_pure_scalar_literal_with_no_operator_at_all_still_validates() {
 }
 
 #[test]
-fn reduce_and_outer_product_modules_validate_but_compile_still_rejects_them() {
-    // `Reduce`/`OuterProduct` share `NDArrays`/`MatrixOps`/`ArrayColumnMajor`
-    // with the SIR22 base cut the JS backend now accepts, so
-    // `check_module()` alone (a plain feature-flag check) no longer
-    // catches these -- only the dedicated tree-walk inside `compile()`
-    // does. Confirms both that the module still fails cleanly (not a
-    // panic) AND that the coarse feature check by itself is genuinely
-    // insufficient here (documenting, not just asserting, the gap).
+fn reduce_and_outer_product_modules_now_compile_cleanly() {
+    // Regression test for the gap this crate's own real lowering exposed:
+    // `Reduce`/`OuterProduct` share `NDArrays`/`MatrixOps`/
+    // `ArrayColumnMajor` with the SIR22 base cut, so `check_module()`
+    // alone (a plain feature-flag check) was never able to distinguish
+    // "base cut only" from "also uses the addendum" -- before the JS
+    // backend gained real codegen for these nine nodes, that meant a
+    // dedicated tree-walk had to reject them explicitly inside
+    // `compile()` (a belt-and-suspenders check `check_module()` alone
+    // could not provide). Now that real codegen exists, both
+    // `check_module()` AND `compile()` accept these modules -- the
+    // distinction the old test had to document (coarse feature check vs.
+    // dedicated tree-walk) no longer needs to exist at all.
     let module = assert_valid("+/1 2 3\n");
     let backend = JavaScriptBackend;
     assert!(
         backend.check_module(&module).is_empty(),
-        "check_module alone no longer rejects Reduce -- it shares features with the accepted base cut"
+        "check_module should accept a Reduce-using module"
     );
-    let err = semantic_ir_to_javascript::compile(&module)
-        .expect_err("compile() should still cleanly reject a Reduce-using module");
-    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+    semantic_ir_to_javascript::compile(&module).expect("Reduce-using module now compiles");
 
     let module = assert_valid("1∘.×2\n");
-    let err = semantic_ir_to_javascript::compile(&module)
-        .expect_err("compile() should still cleanly reject an OuterProduct-using module");
-    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+    semantic_ir_to_javascript::compile(&module).expect("OuterProduct-using module now compiles");
 }

--- a/code/packages/rust/j-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/j-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.1.1] - 2026-07-18
+
+### Changed
+
+- **`semantic-ir-to-javascript` now implements real codegen for the SIR22
+  "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+  `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`)** — no code change in this
+  crate; `+/1 2 3` (this crate's own `Expr::Reduce` output, identical to
+  `apl-to-semantic-ir`'s) used to compile down to a clean `compile()`
+  rejection via that backend's now-removed dedicated tree-walk check.
+  Updated `tests/test_validator.rs`'s `reduce_modules_validate_but_
+  compile_still_rejects_them` (renamed `reduce_modules_now_compile_
+  cleanly`) to assert `compile()` now SUCCEEDS instead of asserting the
+  old rejection — mirrors the identical fix in `apl-to-semantic-ir`'s own
+  `tests/test_validator.rs`. No behavioral node-execution test added
+  here; `apl-to-semantic-ir`'s `tests/e2e_node.rs` is the actual
+  node-executed proof for this shared codegen path (both frontends emit
+  the identical `Expr::Reduce`/etc. node shapes).
+
 ## [0.1.0] - 2026-07-17
 
 ### Added

--- a/code/packages/rust/j-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/j-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "j-to-semantic-ir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "J CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-6e."
 
@@ -16,8 +16,10 @@ parser = { path = "../parser" }
 lexer = { path = "../lexer" }
 
 [dev-dependencies]
-# See `apl-to-semantic-ir`'s identical dev-dependency: no backend implements
-# SIR22/SIR22-addendum codegen for the array domain's `Reduce`/`Scan`/etc.
-# yet, so this exists solely to verify the *capability-rejection* path
-# through a real `Backend::check_module`/`compile()` call.
+# See `apl-to-semantic-ir`'s identical dev-dependency. `semantic-ir-to-
+# javascript` now implements real codegen for the SIR22 addendum array
+# domain's `Reduce`/`Scan`/etc. (this crate's `+/` lowers to `Reduce`), so
+# `tests/test_validator.rs`'s `Backend::check_module`/`compile()` calls now
+# exercise real acceptance, not just the capability-rejection path they
+# originally verified.
 semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/j-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/j-to-semantic-ir/tests/test_validator.rs
@@ -41,22 +41,25 @@ fn a_pure_scalar_literal_with_no_operator_at_all_still_validates() {
 }
 
 #[test]
-fn reduce_modules_validate_but_compile_still_rejects_them() {
-    // `Reduce` shares `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the
-    // SIR22 base cut the JS backend now accepts, so `check_module()` alone
-    // (a plain feature-flag check) no longer catches this -- only the
-    // dedicated tree-walk inside `compile()` does. Confirms both that the
-    // module still fails cleanly (not a panic) AND that the coarse feature
-    // check by itself is genuinely insufficient here.
+fn reduce_modules_now_compile_cleanly() {
+    // Regression test for the gap `apl-to-semantic-ir`'s own real lowering
+    // exposed (this crate's `+/` compiles to the identical `Expr::Reduce`
+    // node): `Reduce` shares `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with
+    // the SIR22 base cut, so `check_module()` alone (a plain feature-flag
+    // check) could never distinguish "base cut only" from "also uses the
+    // addendum" -- before `semantic-ir-to-javascript` gained real codegen
+    // for the SIR22 "APL addendum" nodes, a dedicated tree-walk inside
+    // `compile()` rejected them explicitly. Now that real codegen exists,
+    // `compile()` succeeds -- see `semantic-ir-to-javascript`'s own
+    // CHANGELOG and `apl-to-semantic-ir`'s `tests/e2e_node.rs` for the
+    // actual node-executed proof.
     let module = assert_valid("+/1 2 3\n");
     let backend = JavaScriptBackend;
     assert!(
         backend.check_module(&module).is_empty(),
-        "check_module alone no longer rejects Reduce -- it shares features with the accepted base cut"
+        "check_module should accept a Reduce-using module"
     );
-    let err = semantic_ir_to_javascript::compile(&module)
-        .expect_err("compile() should still cleanly reject a Reduce-using module");
-    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+    semantic_ir_to_javascript::compile(&module).expect("Reduce-using module now compiles");
 }
 
 #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,103 @@
 # Changelog
 
+## 0.42.0 — SIR22 "APL addendum" codegen: `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`
+
+Closes the gap the SIR22 spec's own addendum section and this crate's
+`emit.rs`/`lib.rs` doc comments flagged: `apl-to-semantic-ir` (shipped in
+0.1.0/0.1.1) genuinely lowers APL's `/` (reduce), `\` (scan), `∘.` (outer
+product), `⍴` (shape/reshape), `⍳` (index-generator/index-of), and `,`
+(ravel/catenate) to these nine `Expr` variants, but this backend's `emit.rs`
+still `panic!`ed on all nine and `lib.rs` had a dedicated pre-`emit` tree-walk
+(`find_unimplemented_sir22_addendum_node`) to reject them cleanly instead.
+Since APL's whole reason for existing is these nine operators (ordinary
+scalar arithmetic alone isn't really "APL" — see `code/specs/
+MA05-apl-language.md`), essentially no real APL program could compile to JS
+before this release, which blocked ever writing a meaningful end-to-end test
+for that frontend.
+
+### Added
+
+- **`runtime.rs`**: nine new functions in the inlined `__Sir.Array`
+  sub-runtime, ported 1:1 from two Rust references — `array_runtime::
+  ops::{reduce,scan,outer}` (`reduce`/`scan`/`outer`, reusing the existing
+  `applyOp` dispatch table `elementwise` already uses) and `apl_runtime::
+  builtins::{shape,reshape,index_generator,index_of,ravel,catenate}` (the
+  "bespoke, not `BinOp`-shaped" ones). All bounded-allocation checks reuse
+  this file's ONE existing `MAX_ELEMENTS` cap (67,108,864) via
+  `checkedShapeSize` — `apl_runtime::builtins::MAX_ARRAY_LENGTH`'s smaller
+  1,000,000 figure is deliberately NOT reintroduced as a second, competing
+  constant. Two subtleties called out inline where the Rust reference itself
+  flags them as the likely place to introduce a silent wrong-answer bug:
+  `reduce`/`scan`'s rank-2 (matrix) branch folds/scans EACH ROW across
+  columns (column-major indexing, easy to transpose by accident), and
+  `reshape`'s rank-2 target case explicitly transposes a ROW-major cyclic
+  fill back into COLUMN-major storage.
+- **`runtime.rs`'s `formatSeen`** (the shared `print`/`puts`/`format`
+  display path): a new branch renders a raw `NDArray` (`{ shape, data }`)
+  using `ArrayRt.display`, a 1:1 port of `apl_runtime::value::display` —
+  APL's OWN console convention (high-minus `¯` for negatives, no trailing
+  `.0` on whole values, space-separated vector, right-aligned matrix rows).
+  This was necessary, not a side quest: `apl-to-semantic-ir` auto-prints a
+  bare top-level expression through this backend's `print` builtin, and APL
+  has NO bracket-indexing surface syntax at all (confirmed against `code/
+  grammars/apl/apl.grammar`) to read a scalar back with the way
+  `matlab-to-semantic-ir`'s own `e2e_node.rs` does — so without this,
+  literally no APL program's auto-print (not even a single `Reduce` result)
+  could ever render correctly; every array-domain value stays an opaque
+  `{shape,data}` object at the JS level, `[object Object]` without this fix.
+  MATLAB is unaffected (it always reads a computed array back through a
+  scalar `IndexGet`, never a raw print, per `tests/sir22_array.rs`'s own doc
+  comment) — this is purely additive.
+- **`emit.rs`**: nine real-codegen `match` arms replacing the previous
+  combined `panic!` arm, mirroring the existing `ElementwiseOp`/
+  `Transpose`/`MatMul` arms' style — each recurses into its operand(s) and
+  emits a call into the corresponding `__Sir.Array.*` function;
+  `Reduce`/`Scan`/`OuterProduct` reuse `elementwise_op_js_name` for their
+  `op` field exactly like `ElementwiseOp` does.
+- **`lib.rs`**: removed `find_unimplemented_sir22_addendum_node` (the
+  dedicated tree-walk that rejected these nine node kinds before `emit`
+  could panic on them) — no longer needed now that real codegen exists.
+  `compile()`'s step 3b (the call site) is gone too. Doc comments and
+  `ACCEPTED_FEATURES` updated to describe the full SIR22 domain (base cut
+  + addendum) as accepted and implemented, not "base cut done, addendum
+  deferred."
+
+### Changed
+
+- `tests/lib.rs`'s stale `rejects_reduce_node_cleanly_instead_of_panicking_
+  in_emit` regression test is now `compiles_reduce_node_instead_of_
+  rejecting_it`, asserting `compile()` SUCCEEDS with the exact expected
+  `__Sir.Array.reduce("Add", ...)` call shape, plus a new
+  `emits_all_nine_addendum_nodes_as_sir_array_calls` covering the other
+  eight node kinds' call shapes.
+- `runtime.rs`'s test module gained coverage for the nine new functions'
+  presence, the shared bounded-allocation-cap reuse, the empty-vector
+  reduce error, `⍳`'s 1-based indexing, `reshape`'s row-major-to-column-major
+  transpose, and the new APL-style `display` formatting.
+
+### Verified
+
+- `cargo test -p semantic-ir-to-javascript -p apl-to-semantic-ir`: all
+  green (137 unit tests in this crate, plus `sir22_array.rs`/
+  `sir23_symbolic.rs`/`run_with_node.rs`; 40+7+3 tests in
+  `apl-to-semantic-ir`, including a NEW `tests/e2e_node.rs` — this crate's
+  first real `node`-executed proof that APL's `+/`, non-Add reduce, `+\`
+  composed with a non-commutative reduce (proving prefix order), `∘.×`,
+  `⍴`, `⍳`, and `,` all compute the right numbers end to end).
+- Every downstream frontend crate that carries this backend as a
+  dev-dependency re-verified green: `javascript-to-semantic-ir`,
+  `macsyma-to-semantic-ir`, `matlab-to-semantic-ir`, `octave-to-semantic-ir`,
+  `j-to-semantic-ir` (whose own `tests/test_validator.rs` had the identical
+  stale "Reduce rejected" regression test, updated the same way — see that
+  crate's own CHANGELOG), `wolfram-to-semantic-ir`, `sir-conformance`. None
+  needed source changes — only ADDING codegen for previously-panicking node
+  kinds, not changing behavior for anything another frontend already emits.
+- `cargo build --workspace`: no new failures introduced (pre-existing,
+  environment-specific failures unrelated to this change remain: `uefi`'s
+  duplicate `panic_impl` lang item, `paint-vm-direct2d`/`paint-vm-gdi`
+  requiring Windows, `font-parser-python`/`font-parser-ruby` bridge builds —
+  none reference `semantic-ir`/`apl-to-semantic-ir`/`j-to-semantic-ir`).
+
 ## 0.41.0 — `__Sir.matlabTruthy`: a runtime-decided boolean-context coercion for MATLAB/Octave
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -983,40 +983,96 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             emit_index_args(out, indices, indent);
             out.push_str("])");
         }
-        // ── SIR22 addendum: APL primitive operators (still deferred) ──
-        // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
-        // `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` observe the SAME
-        // `NDArrays`/`MatrixOps`/`ArrayColumnMajor` features as the base
-        // cut above (the SIR22 addendum gives them no feature flag of
-        // their own), so accepting those features for the base cut also
-        // lets a module using these nine past the capability check —
-        // unlike every other still-deferred arm in this function, these
-        // nine are NOT purely a "capability check ever drifts" guard.
-        // This is safe today only because no frontend crate emits any of
-        // these nine `Expr` variants yet (`apl-to-semantic-ir` does not
-        // lower APL's reduce/scan/outer-product/shape/reshape/iota/
-        // index-of/ravel/catenate operators to them — see the SIR22 spec's
-        // addendum and `sir-runtime-array`'s own README, which scoped them
-        // out of the runtime package for the identical reason). Wiring
-        // real codegen for these requires porting `array_runtime::ops::
-        // {reduce,scan,outer}` and `apl-runtime::builtins`'s bespoke
-        // shape/reshape/iota/index-of/ravel/catenate logic into this
-        // runtime first — a natural, cleanly-scoped follow-up once a
-        // frontend actually needs them, not part of this PR.
-        Expr::Reduce { span, .. }
-        | Expr::Scan { span, .. }
-        | Expr::OuterProduct { span, .. }
-        | Expr::Shape { span, .. }
-        | Expr::Reshape { span, .. }
-        | Expr::IndexGenerator { span, .. }
-        | Expr::IndexOf { span, .. }
-        | Expr::Ravel { span, .. }
-        | Expr::Catenate { span, .. }
+        // ── SIR22 addendum: APL primitive operators — real codegen ────
+        // Each of the nine maps 1:1 onto a call into the ported
+        // `__Sir.Array.*` sub-runtime (see `runtime.rs`'s "SIR22 addendum"
+        // section) — the same treatment `ElementwiseOp`/`Transpose`/
+        // `MatMul` above already get for the SIR22 base cut.
+        // `Reduce`/`Scan`/`OuterProduct` carry an `ElementwiseOpKind` and
+        // so reuse `elementwise_op_js_name` exactly like `ElementwiseOp`
+        // does; the remaining six have no `op` field at all (they are
+        // "bespoke, not BinOp-shaped" per the SIR22 spec addendum and
+        // `apl-runtime::builtins`'s own doc comment) and just recurse into
+        // their operand(s).
+        Expr::Reduce { op, target, .. } => {
+            let _ = write!(
+                out,
+                "__Sir.Array.reduce({}, ",
+                quote_js_string(elementwise_op_js_name(*op))
+            );
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::Scan { op, target, .. } => {
+            let _ = write!(
+                out,
+                "__Sir.Array.scan({}, ",
+                quote_js_string(elementwise_op_js_name(*op))
+            );
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "__Sir.Array.outer({}, ",
+                quote_js_string(elementwise_op_js_name(*op))
+            );
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::Shape { target, .. } => {
+            out.push_str("__Sir.Array.shape(");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        // Field order here is `shape, target` (per the SIR22 spec: the
+        // shape vector is not interchangeable with the data being
+        // reshaped, so the node spells out the roles instead of reusing
+        // `lhs`/`rhs`) — `__Sir.Array.reshape(shapeArg, target)` takes the
+        // same order, so no argument reordering is needed at this call
+        // site (contrast `Expr::Range`'s `start, step, stop` vs.
+        // `range`'s `start, stop, step` just above, which DOES reorder).
+        Expr::Reshape { shape, target, .. } => {
+            out.push_str("__Sir.Array.reshape(");
+            emit_expr(out, shape, indent);
+            out.push_str(", ");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::IndexGenerator { count, .. } => {
+            out.push_str("__Sir.Array.indexGenerator(");
+            emit_expr(out, count, indent);
+            out.push(')');
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            out.push_str("__Sir.Array.indexOf(");
+            emit_expr(out, haystack, indent);
+            out.push_str(", ");
+            emit_expr(out, needle, indent);
+            out.push(')');
+        }
+        Expr::Ravel { target, .. } => {
+            out.push_str("__Sir.Array.ravel(");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            out.push_str("__Sir.Array.catenate(");
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
         // validated module (capability check rejects it).
-        | Expr::Convert { span, .. } => {
+        Expr::Convert { span, .. } => {
             panic!(
-                "javascript backend reached a deferred SIR22/SIR26 expression ({}) at {span} — not accepted yet",
+                "javascript backend reached a deferred SIR26 expression ({}) at {span} — not accepted yet",
                 e.kind_name()
             );
         }

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -54,16 +54,20 @@
 //! published `sir-runtime-symbolic`/`symbolic-ir`/`cas-pattern-matching`
 //! TypeScript packages, so the artifact stays self-contained.
 //!
-//! It also accepts the SIR22 array/matrix domain's base cut (`NDArrays`,
-//! `MatrixOps`, `ArrayColumnMajor`): an `ArrayLit`/`Range`/`MatMul`/
-//! `ElementwiseOp`/`Transpose`/`IndexGet`/`IndexSet` node lowers to a call
-//! into the inlined `__Sir.Array.*` runtime — a plain-JS port of the
-//! published `sir-runtime-array` TypeScript package, so the artifact stays
-//! self-contained. The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
-//! `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
-//! `Catenate`) remain deferred — no frontend crate emits them yet, and
-//! `sir-runtime-array` itself deliberately does not implement them (see
-//! `emit`'s own doc comment for the resulting capability/emit caveat).
+//! It also accepts the full SIR22 array/matrix domain (`NDArrays`,
+//! `MatrixOps`, `ArrayColumnMajor`): the base cut (`ArrayLit`/`Range`/
+//! `MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/`IndexSet`) AND the
+//! "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+//! `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) both lower to calls into
+//! the inlined `__Sir.Array.*` runtime — a plain-JS port of the published
+//! `sir-runtime-array` TypeScript package for the base cut, and of
+//! `array_runtime::ops::{reduce,scan,outer}` / `apl_runtime::builtins`'s
+//! bespoke shape/reshape/iota/index-of/ravel/catenate logic for the
+//! addendum — so the artifact stays self-contained either way. The
+//! addendum exists specifically because `apl-to-semantic-ir` emits these
+//! nine nodes from real APL source (`+/`, `+\`, `∘.×`, `⍴`, `⍳`, `,`); the
+//! TypeScript sibling package does not implement them yet (separate,
+//! unstarted follow-on work, out of scope for this backend).
 //!
 //! It **rejects** everything else at the capability check — the
 //! remaining SIR18 features (e.g. string interpolation), `TailCalls` (V8
@@ -79,8 +83,7 @@ mod emit;
 mod runtime;
 
 use semantic_ir::{
-    walk_expr_default, Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr,
-    Feature, Module, Span, Visitor,
+    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Feature, Module,
 };
 
 pub use emit::sanitize_ident;
@@ -89,59 +92,6 @@ pub use emit::sanitize_ident;
 /// checks, rejects unsupported features, and lowers to JavaScript.
 pub fn compile(module: &Module) -> Result<Artifact, BackendError> {
     JavaScriptBackend::new().compile(module)
-}
-
-/// Finds the first (if any) SIR22 "APL addendum" node anywhere in a
-/// module — `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
-/// `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`.
-///
-/// These nine variants share `Feature::NDArrays`/`MatrixOps`/
-/// `ArrayColumnMajor` with the SIR22 *base* cut this backend accepts —
-/// the SIR22 addendum spec gives them no feature flag of their own — so
-/// the ordinary `accepts_features()` capability check cannot tell a
-/// module using only the base cut (real codegen, safe) from one that
-/// also uses these nine (still deferred in `emit`, would panic). This
-/// walk is the finer-grained check that closes that gap: found by
-/// auditing `apl-to-semantic-ir`'s downstream tests while wiring this
-/// backend's SIR22 codegen — that crate's *real* lowering logic (not
-/// just a hand-built test fixture) emits `Reduce`/`Scan`/`OuterProduct`
-/// for APL's `+/`/`+\`/`∘.×` operators today, contradicting the SIR22
-/// addendum spec's now-stale "no frontend crate consumes these yet"
-/// claim. Without this check, compiling such a module would sail past
-/// `accepts_features()` (since `NDArrays`/`MatrixOps` are now accepted)
-/// and panic inside `emit` instead of failing cleanly at the capability
-/// boundary — exactly the class of regression the existing `TailCalls`
-/// belt-and-suspenders check in [`JavaScriptBackend::compile`] guards
-/// against for a different feature. See `emit`'s own doc comment on
-/// these nine nodes for why they remain unimplemented.
-fn find_unimplemented_sir22_addendum_node(module: &Module) -> Option<(&'static str, Span)> {
-    struct Finder(Option<(&'static str, Span)>);
-    impl Visitor for Finder {
-        fn visit_expr(&mut self, e: &Expr, depth: usize) {
-            if self.0.is_none() {
-                let hit = match e {
-                    Expr::Reduce { span, .. } => Some(("Reduce", span.clone())),
-                    Expr::Scan { span, .. } => Some(("Scan", span.clone())),
-                    Expr::OuterProduct { span, .. } => Some(("OuterProduct", span.clone())),
-                    Expr::Shape { span, .. } => Some(("Shape", span.clone())),
-                    Expr::Reshape { span, .. } => Some(("Reshape", span.clone())),
-                    Expr::IndexGenerator { span, .. } => Some(("IndexGenerator", span.clone())),
-                    Expr::IndexOf { span, .. } => Some(("IndexOf", span.clone())),
-                    Expr::Ravel { span, .. } => Some(("Ravel", span.clone())),
-                    Expr::Catenate { span, .. } => Some(("Catenate", span.clone())),
-                    _ => None,
-                };
-                if hit.is_some() {
-                    self.0 = hit;
-                    return;
-                }
-            }
-            walk_expr_default(self, e, depth);
-        }
-    }
-    let mut finder = Finder(None);
-    finder.visit_module(module);
-    finder.0
 }
 
 /// The v0 JavaScript backend.
@@ -258,18 +208,14 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // domain below rather than a flag of its own — mirroring the
     // TypeScript backend's identical choice).
     Feature::Rationals,
-    // SIR22: the array/matrix domain's *base cut* — `ArrayLit`, `Range`,
-    // `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`) and
-    // `IndexSet` (a `Stmt`) lower to calls into the inlined
-    // `__Sir.Array.*` runtime (a plain-JS port of the published
-    // `sir-runtime-array` TypeScript package — see `runtime.rs`'s
-    // "array/matrix domain" section and `emit`'s SIR22 arms). The SIR22
-    // "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
-    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) share these
-    // SAME three features (the addendum gives them no flag of their own)
-    // but remain deferred in `emit` — see that module's own doc comment
-    // on why accepting these three features doesn't fully close the
-    // capability/emit gap for those nine specifically.
+    // SIR22: the full array/matrix domain — the base cut (`ArrayLit`,
+    // `Range`, `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an
+    // `Expr`), `IndexSet` (a `Stmt`)) AND the "APL addendum" (`Reduce`/
+    // `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+    // `Ravel`/`Catenate`) share these same three features (the addendum
+    // spec gives them no flag of their own) and both now lower to calls
+    // into the inlined `__Sir.Array.*` runtime — see `runtime.rs`'s
+    // "array/matrix domain" section and `emit`'s SIR22 arms.
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
@@ -317,27 +263,6 @@ impl Backend for JavaScriptBackend {
                 kind: BackendErrorKind::UnsupportedFeature,
                 message: "javascript backend cannot satisfy `tail-calls` feature".into(),
                 span: module.span.clone(),
-            });
-        }
-
-        // 3b. The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
-        //     `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
-        //     `IndexOf`/`Ravel`/`Catenate`) share `NDArrays`/`MatrixOps`/
-        //     `ArrayColumnMajor` with the SIR22 base cut this backend
-        //     accepts (the addendum gives them no flag of their own), so
-        //     step 2's coarse feature check cannot reject a module using
-        //     them — an explicit tree walk is the only way to catch this
-        //     before `emit` panics on one. See
-        //     `find_unimplemented_sir22_addendum_node`'s doc comment for
-        //     why this is a real, not theoretical, gap (`apl-to-semantic-ir`
-        //     emits these from real APL source today).
-        if let Some((kind, span)) = find_unimplemented_sir22_addendum_node(module) {
-            return Err(BackendError {
-                kind: BackendErrorKind::UnsupportedFeature,
-                message: format!(
-                    "javascript backend does not yet implement the SIR22 addendum node `{kind}`"
-                ),
-                span,
             });
         }
 
@@ -501,12 +426,19 @@ mod tests {
 
     // ── SIR22: array/matrix codegen ────────────────────────────────────
     //
-    // The base cut (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
-    // `Transpose`/`IndexGet`/`IndexSet`) is accepted and lowers to calls
-    // into the inlined `__Sir.Array.*` runtime; see `runtime.rs`'s "array/
-    // matrix domain" section and `emit`'s SIR22 arms. Behavioural (actual
-    // `node` execution) coverage lives in `tests/sir22_array.rs`, mirroring
-    // how `tests/sir23_symbolic.rs` complements the shape assertions here.
+    // Both the base cut (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+    // `Transpose`/`IndexGet`/`IndexSet`) and the "APL addendum" (`Reduce`/
+    // `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+    // `Ravel`/`Catenate`) are accepted and lower to calls into the inlined
+    // `__Sir.Array.*` runtime; see `runtime.rs`'s "array/matrix domain"
+    // section and `emit`'s SIR22 arms. Behavioural (actual `node`
+    // execution) coverage for the base cut lives in `tests/sir22_array.rs`
+    // (mirroring how `tests/sir23_symbolic.rs` complements the shape
+    // assertions here); behavioural coverage for the addendum lives in
+    // `apl-to-semantic-ir`'s own `tests/e2e_node.rs` — that crate's real
+    // lowering is what actually exercises these nine nodes from source
+    // text, so that is where a genuine end-to-end proof belongs, rather
+    // than duplicating hand-built-`Expr` node coverage in both crates.
 
     #[test]
     fn accepts_nd_arrays_feature() {
@@ -522,16 +454,18 @@ mod tests {
         compile(&m).expect("matrix-ops accepted");
     }
 
-    /// Regression test for the gap `find_unimplemented_sir22_addendum_node`
-    /// closes: `apl-to-semantic-ir`'s real lowering emits `Expr::Reduce`
-    /// (APL `+/A`) with exactly these three features, and — before this
-    /// check existed — that module would sail past `accepts_features()`
-    /// (since `NDArrays`/`MatrixOps` are now accepted for the SIR22 base
-    /// cut) and panic inside `emit`. Must instead fail cleanly with
-    /// `UnsupportedFeature`, the same error kind every other still-
-    /// deferred node produces, not a panic.
+    /// Regression test for the gap this backend used to reject cleanly
+    /// (`find_unimplemented_sir22_addendum_node`, since removed):
+    /// `apl-to-semantic-ir`'s real lowering emits `Expr::Reduce` (APL
+    /// `+/A`) with exactly these three features. Before this PR, that
+    /// module would sail past `accepts_features()` (since `NDArrays`/
+    /// `MatrixOps` are accepted for the SIR22 base cut) and panic inside
+    /// `emit`, so a dedicated tree-walk rejected it cleanly instead. Now
+    /// that real codegen exists, the module must instead COMPILE — proof
+    /// that the gap is closed by an actual implementation, not merely
+    /// relocated.
     #[test]
-    fn rejects_reduce_node_cleanly_instead_of_panicking_in_emit() {
+    fn compiles_reduce_node_instead_of_rejecting_it() {
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[
             Feature::NDArrays,
@@ -547,8 +481,118 @@ mod tests {
             }),
             span: s(),
         };
-        let err = compile(&m).expect_err("Reduce node rejected cleanly, not a panic");
-        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        let artifact = compile(&m).expect("Reduce node now compiles");
+        assert!(
+            artifact
+                .source
+                .contains("__Sir.Array.reduce(\"Add\", __Sir.Array.fromRows([[1]]))"),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    /// One emitted-call-shape assertion per SIR22-addendum `Expr` variant
+    /// — mirrors `emits_array_lit_and_matmul_as_sir_array_calls`/
+    /// `emits_elementwise_op_with_pascal_case_op_name` below for the base
+    /// cut. Real end-to-end `node` execution (not just shape assertions)
+    /// lives in `apl-to-semantic-ir`'s own `tests/e2e_node.rs`, the actual
+    /// proof this backend's panic is gone for a real frontend's output —
+    /// these are unit-level, this crate's own IR-to-string contract.
+    #[test]
+    fn emits_all_nine_addendum_nodes_as_sir_array_calls() {
+        let features = &[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ];
+        let one = || {
+            Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            })
+        };
+        let two = || {
+            Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 2, span: s() }]],
+                span: s(),
+            })
+        };
+        let cases: Vec<(Expr, &str)> = vec![
+            (
+                Expr::Scan {
+                    op: semantic_ir::ElementwiseOpKind::Add,
+                    target: one(),
+                    span: s(),
+                },
+                "__Sir.Array.scan(\"Add\", __Sir.Array.fromRows([[1]]))",
+            ),
+            (
+                Expr::OuterProduct {
+                    op: semantic_ir::ElementwiseOpKind::Mul,
+                    lhs: one(),
+                    rhs: two(),
+                    span: s(),
+                },
+                "__Sir.Array.outer(\"Mul\", __Sir.Array.fromRows([[1]]), __Sir.Array.fromRows([[2]]))",
+            ),
+            (
+                Expr::Shape {
+                    target: one(),
+                    span: s(),
+                },
+                "__Sir.Array.shape(__Sir.Array.fromRows([[1]]))",
+            ),
+            (
+                Expr::Reshape {
+                    shape: one(),
+                    target: two(),
+                    span: s(),
+                },
+                "__Sir.Array.reshape(__Sir.Array.fromRows([[1]]), __Sir.Array.fromRows([[2]]))",
+            ),
+            (
+                Expr::IndexGenerator {
+                    count: one(),
+                    span: s(),
+                },
+                "__Sir.Array.indexGenerator(__Sir.Array.fromRows([[1]]))",
+            ),
+            (
+                Expr::IndexOf {
+                    haystack: one(),
+                    needle: two(),
+                    span: s(),
+                },
+                "__Sir.Array.indexOf(__Sir.Array.fromRows([[1]]), __Sir.Array.fromRows([[2]]))",
+            ),
+            (
+                Expr::Ravel {
+                    target: one(),
+                    span: s(),
+                },
+                "__Sir.Array.ravel(__Sir.Array.fromRows([[1]]))",
+            ),
+            (
+                Expr::Catenate {
+                    lhs: one(),
+                    rhs: two(),
+                    span: s(),
+                },
+                "__Sir.Array.catenate(__Sir.Array.fromRows([[1]]), __Sir.Array.fromRows([[2]]))",
+            ),
+        ];
+        for (value, expected_call) in cases {
+            let mut m = minimal_module();
+            m.manifest = FeatureManifest::from_features(features);
+            let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+            main.body.value = value;
+            let artifact = compile(&m).expect("addendum node compiles");
+            assert!(
+                artifact.source.contains(expected_call),
+                "expected `{expected_call}` in:\n{}",
+                artifact.source
+            );
+        }
     }
 
     /// End-to-end version: a real module body using `Expr::ArrayLit` and

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -305,6 +305,23 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       const s = Symbolic.toDisplayString(v);
       if (s !== undefined) { return s; }
     }
+    // SIR22/APL: an `NDArray` (the `{ shape, data }` value this file's
+    // "array/matrix domain" section below constructs) has no Ruby/Scheme
+    // display convention of its own. The MATLAB frontend never reaches this
+    // branch -- it always reads a computed array back through a scalar
+    // `IndexGet` instead of printing the whole thing (see
+    // `semantic-ir-to-javascript`'s own `tests/sir22_array.rs` doc
+    // comments) -- but APL auto-prints a bare top-level expression (see
+    // `apl-to-semantic-ir`'s "Auto-print, not MATLAB-style suppression"),
+    // and APL has no bracket-indexing syntax to read a value back with, so
+    // a real APL program's `print` call can only ever be made to work by
+    // rendering the NDArray itself. `ArrayRt.display` (below) is a 1:1 port
+    // of `apl_runtime::value::display` -- APL's OWN console convention
+    // (high-minus `¯` negatives, no name/`ans=` prefix), which is exactly
+    // what an `apl-runtime` session would print for the same value.
+    if (v !== null && typeof v === "object" && Array.isArray(v.shape) && v.data instanceof Float64Array) {
+      return ArrayRt.display(v);
+    }
     return String(v);
   }
 
@@ -2882,17 +2899,24 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // whole scope, like the Rust reference and the TypeScript sibling, is
   // rank ≤ 2.
   //
-  // ## Scope: the SIR22 "APL addendum" is NOT ported here
+  // ## The SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+  // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`)
   //
-  // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
-  // `IndexOf`/`Ravel`/`Catenate` remain deferred in `emit.rs` (still a
-  // `panic!`, unchanged by this port) — no frontend crate emits these
-  // nine `Expr` variants yet (`apl-to-semantic-ir` does not lower APL's
-  // reduce/scan/outer-product operators to them), and the TypeScript
-  // sibling package deliberately scoped them out for the same reason
-  // (see `sir-runtime-array`'s own `src/index.ts` doc comment). Porting
-  // them now would be speculative rather than filling a real gap —
-  // exactly the same reasoning that package's own README states.
+  // These nine were deferred when the base cut above first landed (no
+  // frontend crate emitted them yet) but `apl-to-semantic-ir` now does —
+  // APL's `/` (reduce), `\` (scan), `∘.` (outer product), `⍴`, `⍳`, and `,`
+  // are first-class glyphs, not library calls, so real APL source reaches
+  // every one of these nodes. They are ported here (below, after the base
+  // cut's own helpers) from TWO Rust references, exactly as the SIR22
+  // spec's addendum section describes: `array_runtime::ops::{reduce,scan,
+  // outer}` (the three that take an `ElementwiseOpKind` and so reuse
+  // `applyOp` above, unchanged) and `apl_runtime::builtins::{shape,reshape,
+  // index_generator,index_of,ravel,catenate}` (the "bespoke, not
+  // BinOp-shaped" ones — see that Rust file's own module doc comment for
+  // why). The TypeScript sibling (`sir-runtime-array`) still does not
+  // implement these — that package gaining them is separate, unstarted
+  // follow-on work (SIR22 spec, "Backend impact"), not a precondition for
+  // this inlined port.
   const ArrayRt = (() => {
     // SECURITY: every factory below validates a shape/output size
     // *before* allocating a `Float64Array` from it — a compiled
@@ -3346,9 +3370,481 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       throw new Error(`indexSet: only 1 or 2 index arguments are supported (rank <= 2 scope), got ${indices.length}`);
     }
 
+    // ── SIR22 addendum: APL primitive operators ────────────────────
+    // `Reduce`/`Scan`/`OuterProduct` reuse `applyOp` above (the same
+    // dispatch table `elementwise` uses) — see this section's own module
+    // doc comment for the two Rust references every function below ports
+    // 1:1. `MAX_ELEMENTS` (defined above) is reused as-is for every new
+    // bounded-allocation check here — this file has exactly one array-size
+    // cap, not one per domain, so `⍳`/dyadic `⍴`/`⍳` (index-of)/`,`
+    // (catenate) share it with `matmul`/`range`/`indexGet` rather than
+    // reintroducing `apl_runtime::builtins::MAX_ARRAY_LENGTH`'s smaller
+    // 1,000,000 figure as a second, competing constant.
+
+    /**
+     * `+/A` (APL reduce, dyadic-op monadic-adverb) — fold `target` with
+     * `op` along its one axis. Ported 1:1 from `array_runtime::ops::
+     * reduce`:
+     * - rank 0 (scalar): nothing to fold, returns `target` itself.
+     * - rank 1 (vector `[n]`): left-fold across all `n` elements
+     *   (`op(op(op(v0, v1), v2), …)`); an EMPTY vector is a clean error —
+     *   unlike `sum`/`mean` (which have a built-in identity, 0), `reduce`
+     *   is generic over any `op`, and guessing an identity (is it `0` for
+     *   `Add`, `1` for `Mul`, `-Infinity` for `Max`?) for an arbitrary,
+     *   possibly-future op would be silently wrong for most of them.
+     * - rank 2 (matrix `[r, c]`): folds EACH ROW independently across its
+     *   `c` columns, producing a `[r]` vector (one folded value per row).
+     *   Column-major storage means element `(row, col)` lives at
+     *   `col * r + row` — the row loop reads `d[row]` as the seed (column
+     *   0) then walks `d[col * r + row]` for `col = 1..c`; getting `row`
+     *   and `col` swapped here silently transposes the result instead of
+     *   throwing, so this indexing is the single easiest place to
+     *   introduce a wrong-answer bug when reading this function.
+     */
+    function reduce(op, a) {
+      a = toArrayValue(a);
+      const shape = a.shape;
+      if (shape.length === 0) {
+        return a;
+      }
+      if (shape.length === 1) {
+        const n = shape[0];
+        if (n === 0) {
+          throw new Error("reduce: cannot fold an empty vector (no identity element for an arbitrary op)");
+        }
+        const d = a.data;
+        let acc = d[0];
+        for (let i = 1; i < n; i++) {
+          acc = applyOp(op, acc, d[i]);
+        }
+        return ndarray([], Float64Array.of(acc));
+      }
+      if (shape.length === 2) {
+        const [r, c] = shape;
+        if (c === 0) {
+          throw new Error("reduce: cannot fold an empty row (no identity element for an arbitrary op)");
+        }
+        const d = a.data;
+        const out = new Float64Array(r);
+        for (let row = 0; row < r; row++) {
+          let acc = d[row]; // column-major: (row, 0) lives at plain `row`
+          for (let col = 1; col < c; col++) {
+            acc = applyOp(op, acc, d[col * r + row]);
+          }
+          out[row] = acc;
+        }
+        return ndarray([r], out);
+      }
+      throw new Error(`reduce: rank > 2 not yet supported (shape ${JSON.stringify(shape)})`);
+    }
+
+    /**
+     * `+\A` (APL scan) — the same fold as `reduce`, but keeping EVERY
+     * intermediate result instead of only the last; output has the same
+     * shape as `target`. Ported 1:1 from `array_runtime::ops::scan`. An
+     * empty axis is NOT an error here (unlike `reduce`): there is simply
+     * nothing to scan, and the (empty) output shape already says so.
+     */
+    function scan(op, a) {
+      a = toArrayValue(a);
+      const shape = a.shape;
+      if (shape.length === 0) {
+        return a;
+      }
+      if (shape.length === 1) {
+        const n = shape[0];
+        const d = a.data;
+        const out = new Float64Array(n);
+        let acc;
+        let started = false;
+        for (let i = 0; i < n; i++) {
+          acc = started ? applyOp(op, acc, d[i]) : d[i];
+          started = true;
+          out[i] = acc;
+        }
+        return ndarray([n], out);
+      }
+      if (shape.length === 2) {
+        const [r, c] = shape;
+        const d = a.data;
+        const out = new Float64Array(d.length);
+        for (let row = 0; row < r; row++) {
+          let acc;
+          let started = false;
+          for (let col = 0; col < c; col++) {
+            const x = d[col * r + row]; // column-major
+            acc = started ? applyOp(op, acc, x) : x;
+            started = true;
+            out[col * r + row] = acc;
+          }
+        }
+        return ndarray([r, c], out);
+      }
+      throw new Error(`scan: rank > 2 not yet supported (shape ${JSON.stringify(shape)})`);
+    }
+
+    /**
+     * `A∘.×B` (APL outer product) — apply `op` to every pair `(aᵢ, bⱼ)`,
+     * producing a result of rank `rank(a) + rank(b)`. Ported 1:1 from
+     * `array_runtime::ops::outer`, scoped identically to `rank(a) <= 1`
+     * and `rank(b) <= 1` (the vector⊗vector case below already reaches
+     * this domain's rank-2 ceiling). `checkedShapeSize` validates the
+     * `[m, n]` output shape *before* allocating — `m`/`n` are two
+     * INDEPENDENT operand lengths, each individually under
+     * `MAX_ELEMENTS`, but nothing bounds their product alone (the same
+     * outer-product-shaped allocation `matmul`/`indexGet` above guard).
+     */
+    function outer(op, a, b) {
+      a = toArrayValue(a);
+      b = toArrayValue(b);
+      const as = a.shape;
+      const bs = b.shape;
+      if (as.length === 0 && bs.length === 0) {
+        return ndarray([], Float64Array.of(applyOp(op, a.data[0], b.data[0])));
+      }
+      if (as.length === 0 && bs.length === 1) {
+        const x = a.data[0];
+        return ndarray([bs[0]], Float64Array.from(b.data, (y) => applyOp(op, x, y)));
+      }
+      if (as.length === 1 && bs.length === 0) {
+        const y = b.data[0];
+        return ndarray([as[0]], Float64Array.from(a.data, (x) => applyOp(op, x, y)));
+      }
+      if (as.length === 1 && bs.length === 1) {
+        const m = as[0];
+        const n = bs[0];
+        const outLen = checkedShapeSize([m, n]);
+        const ad = a.data;
+        const bd = b.data;
+        const out = new Float64Array(outLen);
+        for (let j = 0; j < n; j++) {
+          for (let i = 0; i < m; i++) {
+            out[j * m + i] = applyOp(op, ad[i], bd[j]); // column-major
+          }
+        }
+        return ndarray([m, n], out);
+      }
+      throw new Error(`outer: operands of rank > 1 not yet supported (shapes ${JSON.stringify(as)}, ${JSON.stringify(bs)})`);
+    }
+
+    /**
+     * Flatten (rank <= 2, this domain's ceiling) `a` to ROW-major order —
+     * last axis varies fastest. `a` itself stores COLUMN-major (`get`'s
+     * own doc comment), so a matrix must be walked "row, then column" via
+     * `get` to produce true row-major order; returning the raw
+     * column-major buffer would silently ravel in the WRONG order. Always
+     * returns a fresh `Float64Array` (never `a.data` itself, even in the
+     * rank <= 1 no-op case) — mirrors `apl_runtime::builtins::flatten`
+     * returning an owned `Vec`, not a borrow, so the result never
+     * accidentally aliases `a`'s own buffer.
+     */
+    function flattenRowMajor(a) {
+      const shape = a.shape;
+      if (shape.length <= 1) {
+        return Float64Array.from(a.data);
+      }
+      if (shape.length === 2) {
+        const [r, c] = shape;
+        const out = new Float64Array(r * c);
+        let k = 0;
+        for (let row = 0; row < r; row++) {
+          for (let col = 0; col < c; col++) {
+            out[k++] = get(a, row, col);
+          }
+        }
+        return out;
+      }
+      // Unreachable in practice (this domain's rank <= 2 ceiling) -- total
+      // rather than throwing, mirroring the Rust reference's own fallback.
+      return Float64Array.from(a.data);
+    }
+
+    /**
+     * Monadic `⍴` (shape-of) — `target`'s dimensions as a vector. Ported
+     * 1:1 from `apl_runtime::builtins::shape`: a SCALAR has zero
+     * dimensions, so its shape is the EMPTY vector (not a scalar!) — `⍴5`
+     * is `⍳0`-shaped, a length-0 vector, mirroring `shape.length === 0`
+     * exactly. A vector `[n]` has shape `[n]` (one element); a matrix
+     * `[r, c]` has shape `[r, c]` (two elements).
+     */
+    function shape(a) {
+      a = toArrayValue(a);
+      const dims = Float64Array.from(a.shape);
+      return ndarray([dims.length], dims);
+    }
+
+    /**
+     * Dyadic `⍴` (reshape) — reinterpret `target`'s data under the new
+     * dimensions `shapeArg`. Ported 1:1 from `apl_runtime::builtins::
+     * reshape`. `shapeArg` must itself be a scalar or vector (rank <= 1)
+     * of non-negative integers, and is itself capped at rank <= 2 (this
+     * domain's ceiling — a longer target shape is a clean error, not a
+     * silent truncation). `target`'s elements are ravelled
+     * (`flattenRowMajor`) then cyclically repeated or truncated to fill
+     * the target shape's element count.
+     *
+     * CRITICAL: the cyclic fill happens in ROW-major order (APL's reshape
+     * fills the LAST axis fastest, same convention as ravel), but this
+     * domain's storage is COLUMN-major — so for a rank-2 target the
+     * row-major `filled` sequence must be TRANSPOSED into column-major
+     * storage (`data[col * r + row] = filled[row * c + col]`) before
+     * calling `ndarray`. Handing `filled` straight to `ndarray` would
+     * silently reshape column-major instead of APL's row-major
+     * convention — a wrong answer that still LOOKS plausible (right
+     * multiset of values, wrong positions).
+     */
+    function reshape(shapeArg, target) {
+      shapeArg = toArrayValue(shapeArg);
+      target = toArrayValue(target);
+      if (shapeArg.shape.length > 1) {
+        throw new Error(`reshape: shape argument must be a scalar or vector (got rank ${shapeArg.shape.length})`);
+      }
+      const dims = Array.from(shapeArg.data, (x) => {
+        if (!(Number.isInteger(x) && x >= 0)) {
+          throw new Error(`reshape: shape elements must be non-negative integers, got ${x}`);
+        }
+        return x;
+      });
+      if (dims.length > 2) {
+        throw new Error(`reshape: reshape to rank > 2 is not yet supported (target shape ${JSON.stringify(dims)})`);
+      }
+      const total = checkedShapeSize(dims);
+      const source = flattenRowMajor(target);
+      if (total > 0 && source.length === 0) {
+        throw new Error("reshape: cannot reshape an empty source into a non-empty shape");
+      }
+      const filled = new Float64Array(total);
+      for (let k = 0; k < total; k++) {
+        filled[k] = source[k % source.length];
+      }
+      if (dims.length <= 1) {
+        return ndarray(dims, filled);
+      }
+      const [r, c] = dims;
+      const data = new Float64Array(total);
+      for (let row = 0; row < r; row++) {
+        for (let col = 0; col < c; col++) {
+          data[col * r + row] = filled[row * c + col];
+        }
+      }
+      return ndarray(dims, data);
+    }
+
+    /**
+     * Monadic `⍳` (index generator / iota) — `⍳n` is the 1-BASED vector
+     * `[1, 2, …, n]`. Ported 1:1 from `apl_runtime::builtins::
+     * index_generator` — note this is 1-based, unlike every 0-based index
+     * elsewhere in this domain (`indexGet`/`indexSet`), because that is
+     * genuinely what APL's `⍳` means at the SURFACE-SYNTAX level (the
+     * `Expr::IndexGenerator` doc comment in `semantic-ir`'s `nodes.rs`
+     * makes the same point). `checkedShapeSize([n])` both validates `n`
+     * is a non-negative integer AND caps it at `MAX_ELEMENTS` before
+     * allocating — `n` is a runtime value a compiled program computes,
+     * not a fixed constant, so `⍳` of an absurd size must fail cleanly.
+     */
+    function indexGenerator(a) {
+      a = toArrayValue(a);
+      if (!isScalar(a)) {
+        throw new Error("indexGenerator: monadic argument must be a scalar");
+      }
+      const x = a.data[0];
+      if (!(Number.isInteger(x) && x >= 0)) {
+        throw new Error(`indexGenerator: monadic argument must be a non-negative integer, got ${x}`);
+      }
+      const n = checkedShapeSize([x]);
+      const out = new Float64Array(n);
+      for (let i = 0; i < n; i++) {
+        out[i] = i + 1;
+      }
+      return ndarray([n], out);
+    }
+
+    /**
+     * Dyadic `⍳` (index-of / search) — for every element of `needle`, the
+     * 1-based index of its first occurrence in the vector `haystack` (or
+     * `haystack.length + 1` if not found — "not found" is a valid,
+     * always-in-range position, not `-1`/`undefined`). Ported 1:1 from
+     * `apl_runtime::builtins::index_of`: plain EXACT equality (no
+     * floating-point tolerance — `Float64Array.prototype.indexOf` already
+     * uses strict `===`, so `NaN` correctly never matches, same as Rust's
+     * `==`). The work done is O(len(haystack) * len(needle)) (a full
+     * linear scan per needle element) — `checkedShapeSize` is reused here
+     * purely for its "product <= MAX_ELEMENTS" check (both lengths are
+     * already valid non-negative integers, so its dimension-validity half
+     * is a no-op) to cap the PRODUCT before scanning, since each operand
+     * individually staying under `MAX_ELEMENTS` does not bound their
+     * product (up to ~4.5 * 10^15 comparisons otherwise).
+     */
+    function indexOf(a, b) {
+      a = toArrayValue(a);
+      b = toArrayValue(b);
+      if (a.shape.length > 1) {
+        throw new Error(`indexOf: left argument must be a scalar or vector (got rank ${a.shape.length})`);
+      }
+      checkedShapeSize([a.data.length, b.data.length]);
+      const haystack = a.data;
+      const out = Float64Array.from(b.data, (needle) => {
+        const idx = haystack.indexOf(needle);
+        return idx === -1 ? haystack.length + 1 : idx + 1;
+      });
+      return ndarray(b.shape, out);
+    }
+
+    /**
+     * Monadic `,` (ravel) — flatten `target` to a rank-1 vector, in
+     * row-major order (see `flattenRowMajor`'s own doc comment for the
+     * column-major-storage-vs-row-major-order subtlety). Ported 1:1 from
+     * `apl_runtime::builtins::ravel`.
+     */
+    function ravel(a) {
+      a = toArrayValue(a);
+      const flat = flattenRowMajor(a);
+      return ndarray([flat.length], flat);
+    }
+
+    /**
+     * Dyadic `,` (catenate) — supports scalar-scalar, scalar-vector,
+     * vector-scalar, vector-vector (all producing a vector), and
+     * matrix-matrix-with-equal-row-counts (column/last-axis catenate,
+     * producing `[r, ca + cb]`). Any other rank combination is a clean
+     * "not yet supported" error. Ported 1:1 from `apl_runtime::builtins::
+     * catenate`. The combined-length cap check happens ONCE, up front,
+     * regardless of which rank combination follows (mirroring the Rust
+     * reference's own structure) — neither operand alone need be
+     * oversized for the RESULT to be, since a script that repeatedly
+     * catenates a value with itself (`A←A,A`) doubles the size every line
+     * with no other ceiling.
+     */
+    function catenate(a, b) {
+      a = toArrayValue(a);
+      b = toArrayValue(b);
+      checkedShapeSize([a.data.length + b.data.length]);
+      const ra = a.shape.length;
+      const rb = b.shape.length;
+      if (ra === 0 && rb === 0) {
+        return ndarray([2], Float64Array.of(a.data[0], b.data[0]));
+      }
+      if (ra === 0 && rb === 1) {
+        const out = new Float64Array(1 + b.data.length);
+        out[0] = a.data[0];
+        out.set(b.data, 1);
+        return ndarray([out.length], out);
+      }
+      if (ra === 1 && rb === 0) {
+        const out = new Float64Array(a.data.length + 1);
+        out.set(a.data, 0);
+        out[a.data.length] = b.data[0];
+        return ndarray([out.length], out);
+      }
+      if (ra === 1 && rb === 1) {
+        const out = new Float64Array(a.data.length + b.data.length);
+        out.set(a.data, 0);
+        out.set(b.data, a.data.length);
+        return ndarray([out.length], out);
+      }
+      if (ra === 2 && rb === 2) {
+        const r = nrows(a);
+        if (r !== nrows(b)) {
+          throw new Error(`catenate: matrix catenate needs equal row counts (${r} vs ${nrows(b)})`);
+        }
+        const ca = ncols(a);
+        const cb = ncols(b);
+        const outLen = checkedShapeSize([r, ca + cb]);
+        const data = new Float64Array(outLen);
+        for (let row = 0; row < r; row++) {
+          for (let col = 0; col < ca; col++) {
+            data[col * r + row] = get(a, row, col);
+          }
+          for (let col = 0; col < cb; col++) {
+            data[(ca + col) * r + row] = get(b, row, col);
+          }
+        }
+        return ndarray([r, ca + cb], data);
+      }
+      throw new Error(`catenate: catenate of rank ${ra} and rank ${rb} is not yet supported`);
+    }
+
+    /**
+     * Format one number the way `apl_runtime::value::fmt_num` does (ported
+     * 1:1): the high-minus glyph `¯` (never ASCII `-`) prefixes a negative
+     * number; a whole-valued float prints without a trailing `.0`. Unlike
+     * the Rust source, no separate integer-vs-float branch is needed for
+     * the whole-value case — `String(5)` and `String(5.0)` are both `"5"`
+     * in JS, where Rust needs `format!("{}", mag as i64)` specifically to
+     * avoid `5.0`'s `Display` impl printing a trailing `.0`. `x < 0` (a
+     * numeric comparison) already excludes `-0` from the high-minus branch
+     * on its own — `-0 < 0` is `false` in JS — so, unlike Rust's
+     * `is_sign_negative()` (a bit-level check that says `true` for `-0`),
+     * no separate `-0`-is-plain-`0` guard is needed here either.
+     */
+    function fmtNum(x) {
+      if (Number.isNaN(x)) {
+        return "NaN";
+      }
+      if (!Number.isFinite(x)) {
+        return x < 0 ? "¯∞" : "∞";
+      }
+      const body = String(Math.abs(x));
+      return x < 0 ? "¯" + body : body;
+    }
+
+    /**
+     * Render `a` the way an APL session echoes a bare (auto-printed)
+     * result — ported 1:1 from `apl_runtime::value::display`. This is
+     * APL's OWN display convention (high-minus negatives, no name/`ans=`
+     * prefix), distinct from MATLAB's own `Array` `Display` impl (never
+     * reached from this backend — MATLAB always reads a computed array
+     * back through a scalar `IndexGet` instead, see `formatSeen`'s call
+     * site above).
+     *
+     * - rank 0 (scalar): the one number.
+     * - rank 1 (vector): elements, space-separated, on one line (the
+     *   empty vector prints as the empty string — an APL session shows a
+     *   blank line for `⍳0`, `⍴5`, etc.).
+     * - rank 2 (matrix): one row per line, elements space-separated and
+     *   right-aligned to the widest cell's width IN THIS DISPLAY.
+     */
+    function display(a) {
+      const shape = a.shape;
+      if (shape.length === 0) {
+        return fmtNum(a.data[0]);
+      }
+      if (shape.length === 1) {
+        const n = shape[0];
+        if (n === 0) {
+          return "";
+        }
+        return Array.from(a.data, fmtNum).join(" ");
+      }
+      if (shape.length === 2) {
+        const [r, c] = shape;
+        // Formatted once, up front (in the array's own column-major
+        // storage order), so the alignment width is independent of
+        // row/column traversal order -- only the WIDEST cell matters, and
+        // order doesn't affect a max().
+        const width = Array.from(a.data, fmtNum).reduce((w, s) => Math.max(w, s.length), 1);
+        const lines = [];
+        for (let row = 0; row < r; row++) {
+          const rowCells = [];
+          for (let col = 0; col < c; col++) {
+            rowCells.push(fmtNum(get(a, row, col)).padStart(width, " "));
+          }
+          lines.push(rowCells.join(" "));
+        }
+        return lines.join("\n");
+      }
+      // Unreachable in practice (this domain's rank <= 2 ceiling) --
+      // render something total rather than throwing, mirroring the Rust
+      // reference's own `_ => format!("{a}")` fallback.
+      return String(Array.from(a.data));
+    }
+
     return {
       ndarray, fromRows, isScalar, nrows, ncols, get, set,
       elementwise, matmul, transpose, range, indexGet, indexSet,
+      // SIR22 addendum (APL primitives).
+      reduce, scan, outer, shape, reshape, indexGenerator, indexOf, ravel,
+      catenate, display,
     };
   })();
 
@@ -3783,5 +4279,96 @@ mod tests {
         // `assertValidPosition` first), but it is part of this module's
         // exported public surface, so it must stay NaN-safe on its own.
         assert!(RUNTIME.contains("if (!(r >= 0 && c >= 0 && r < nrows(a) && c < ncols(a))) {"));
+    }
+
+    // ── SIR22 addendum: APL primitive operators ────────────────────────
+
+    #[test]
+    fn runtime_defines_array_addendum_functions() {
+        // `apl-to-semantic-ir` emits `Reduce`/`Scan`/`OuterProduct`/`Shape`/
+        // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`; the
+        // emitter's arms for all nine call into these, plus `display` (the
+        // APL auto-print formatter `formatSeen` dispatches to).
+        for needed in [
+            "function reduce(",
+            "function scan(",
+            "function outer(",
+            "function shape(",
+            "function reshape(",
+            "function indexGenerator(",
+            "function indexOf(",
+            "function ravel(",
+            "function catenate(",
+            "function flattenRowMajor(",
+            "function fmtNum(",
+            "function display(",
+        ] {
+            assert!(RUNTIME.contains(needed), "Array runtime missing `{needed}`");
+        }
+        assert!(RUNTIME.contains("reduce, scan, outer, shape, reshape, indexGenerator, indexOf, ravel,"));
+    }
+
+    #[test]
+    fn array_addendum_reuses_the_one_bounded_allocation_cap() {
+        // SECURITY: `⍳`'s length, dyadic `⍴`'s target element count,
+        // `⍳`(index-of)'s O(len*len) product, and `,`(catenate)'s combined
+        // length are all runtime-computed from potentially attacker-
+        // influenced program values -- every one of them must route
+        // through `checkedShapeSize` (this file's ONE existing
+        // `MAX_ELEMENTS`-capped guard), not a freshly-invented cap value
+        // (`apl_runtime::builtins::MAX_ARRAY_LENGTH` is a *different*,
+        // smaller Rust-side constant that this port deliberately does not
+        // reintroduce -- see the addendum's own module doc comment).
+        assert!(RUNTIME.contains("const n = checkedShapeSize([x]);"));
+        assert!(RUNTIME.contains("const total = checkedShapeSize(dims);"));
+        assert!(RUNTIME.contains("checkedShapeSize([a.data.length, b.data.length]);"));
+        assert!(RUNTIME.contains("checkedShapeSize([a.data.length + b.data.length]);"));
+        // (A JS-side doc comment nearby mentions the Rust constant's NAME in
+        // prose, explaining why it is deliberately NOT reintroduced here —
+        // so this asserts there is no `const MAX_ARRAY_LENGTH` DECLARATION,
+        // not that the identifier never appears as text anywhere at all.)
+        assert!(!RUNTIME.contains("const MAX_ARRAY_LENGTH"));
+    }
+
+    #[test]
+    fn reduce_on_an_empty_vector_is_a_clean_error_not_a_guessed_identity() {
+        // `reduce` has no built-in identity for an arbitrary op (unlike
+        // `sum`, which hardcodes 0) -- an empty axis must throw, not
+        // silently return e.g. 0.
+        assert!(RUNTIME.contains(
+            "throw new Error(\"reduce: cannot fold an empty vector (no identity element for an arbitrary op)\");"
+        ));
+    }
+
+    #[test]
+    fn index_generator_is_one_based_unlike_the_rest_of_this_domain() {
+        // `⍳n` is `[1, 2, ..., n]` -- 1-based, unlike `indexGet`/`indexSet`
+        // elsewhere in this same Array namespace, which are 0-based. This
+        // is a real APL-surface-syntax fact (see `semantic-ir`'s
+        // `Expr::IndexGenerator` doc comment), not an inconsistency.
+        assert!(RUNTIME.contains("out[i] = i + 1;"));
+    }
+
+    #[test]
+    fn reshape_transposes_row_major_fill_into_column_major_storage() {
+        // The single easiest place to introduce a silent wrong-answer bug
+        // in this whole port: reshape's cyclic fill is computed in
+        // ROW-major order (APL convention) but must be written back into
+        // COLUMN-major storage (this domain's convention) for a rank-2
+        // target -- `filled[row * c + col]` read, `data[col * r + row]`
+        // written, never the other way around.
+        assert!(RUNTIME.contains("data[col * r + row] = filled[row * c + col];"));
+    }
+
+    #[test]
+    fn array_display_uses_apl_high_minus_and_no_trailing_dot_zero() {
+        // `apl-to-semantic-ir` auto-prints a bare top-level expression
+        // through this backend's shared `print` builtin, and APL has no
+        // bracket-indexing syntax to read a scalar back with (unlike
+        // MATLAB) -- so `formatSeen` must render a raw NDArray using APL's
+        // OWN console convention (high-minus `¯`, matching
+        // `apl_runtime::value::fmt_num` 1:1), not `[object Object]`.
+        assert!(RUNTIME.contains("return x < 0 ? \"¯\" + body : body;"));
+        assert!(RUNTIME.contains("ArrayRt.display(v)"));
     }
 }


### PR DESCRIPTION
## Summary

`apl-to-semantic-ir` (v0.1.0/0.1.1) genuinely lowers APL's `/` (reduce), `\` (scan), `∘.` (outer product), `⍴` (shape/reshape), `⍳` (index-generator/index-of), and `,` (ravel/catenate) to real `semantic_ir::Expr` variants — `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` (the SIR22 spec's "APL addendum"). But `semantic-ir-to-javascript` implemented codegen for none of them: a pre-`emit` tree-walk (`find_unimplemented_sir22_addendum_node`) cleanly rejected any module using one, and `emit.rs`'s own arm just `panic!`ed, with a comment claiming this was "safe only because no frontend crate emits these yet" — a premise `apl-to-semantic-ir` had already broken.

Since APL's entire reason for existing is these nine operators (ordinary scalar arithmetic alone isn't really "APL" — see `code/specs/MA05-apl-language.md`), **essentially no real APL program could compile to JS** before this PR, which also blocked ever writing a meaningful end-to-end test for the APL frontend.

## Changes

- **`semantic-ir-to-javascript/src/runtime.rs`**: 9 new functions in the inlined `__Sir.Array` sub-runtime, ported 1:1 from `array_runtime::ops::{reduce,scan,outer}` and `apl_runtime::builtins::{shape,reshape,index_generator,index_of,ravel,catenate}`. Reuses the existing `applyOp`/`checkedShapeSize`/`MAX_ELEMENTS` conventions throughout — no new, competing bounded-allocation cap introduced. Also adds `ArrayRt.display`, a 1:1 port of `apl_runtime::value::display` (APL's own high-minus `¯` console convention), wired into the shared `print`/`puts`/`format` path — necessary because APL auto-prints a bare top-level expression and has no bracket-indexing syntax to read a value back with instead (confirmed against `code/grammars/apl/apl.grammar`).
- **`semantic-ir-to-javascript/src/emit.rs`**: replaced the combined `panic!` arm with 9 real-codegen arms, mirroring the existing `ElementwiseOp`/`Transpose`/`MatMul` style.
- **`semantic-ir-to-javascript/src/lib.rs`**: removed `find_unimplemented_sir22_addendum_node` and its `compile()` call site — no longer needed now that real codegen exists.
- **`apl-to-semantic-ir/tests/e2e_node.rs`** (new): this crate's first real `node`-executed end-to-end test — 7 tests proving `+/`, a non-`Add` reduce, `+\` composed with a non-commutative reduce (proving prefix order), `∘.×`, `⍴`, `⍳`, and `,` all compute the right numbers through the full APL → SIR → JS → `node` pipeline.
- **`j-to-semantic-ir/tests/test_validator.rs`**: had the identical stale "Reduce rejected" regression test (this crate's `+/` lowers to the same `Expr::Reduce`); updated the same way.
- CHANGELOGs + version bumps for `semantic-ir-to-javascript` (0.41.0 was already claimed by a concurrently-merged PR, so this bumps to 0.42.0), `apl-to-semantic-ir` (0.1.2), `j-to-semantic-ir` (0.1.1).

## Two correctness subtleties called out explicitly (and tested)

- `reduce`/`scan`'s rank-2 branch folds/scans **each row** independently across columns — column-major storage means this is the easiest place to accidentally transpose the result.
- `reshape`'s rank-2 case fills in APL's row-major order but must transpose the result back into this runtime's column-major storage before returning — a bug here would produce a plausible-looking but transposed wrong answer. `ravel_of_a_reshaped_matrix_runs_in_node` in the new e2e test specifically exercises this.

## Known, disclosed, out-of-scope findings

- **`semantic-ir-to-typescript`/`sir-runtime-array` (the npm package)** don't implement these 9 node kinds either. Out of scope here — the TS backend imports a real npm package rather than inlining, so `sir-runtime-array` needs these ported first. Tracked as a separate follow-up.
- **A pre-existing shape bug in `apl-to-semantic-ir`'s own lowering** (not touched by this PR): a stranded literal like `1 2 3` lowers to a `[1,n]`-shaped "row matrix," not a true rank-1 `[n]` vector — this silently breaks `outer`/dyadic `⍴`'s shape argument when fed bare stranded literals directly (both correctly scoped to rank ≤ 1, mirroring their Rust references). The new e2e tests route around it using `⍳`/ravel (which construct genuine rank-1 values). Tracked as a separate follow-up task.

## Test plan

- [x] `cargo test -p semantic-ir-to-javascript -p apl-to-semantic-ir` — all green
- [x] Downstream consumers re-verified: `javascript-to-semantic-ir`, `macsyma-to-semantic-ir`, `matlab-to-semantic-ir`, `octave-to-semantic-ir`, `j-to-semantic-ir`, `wolfram-to-semantic-ir`, `sir-conformance` — all green, no source changes needed (only adding codegen for previously-panicking node kinds)
- [x] `cargo build --workspace` — no new failures
- [x] `cargo clippy --all-targets` on touched crates — clean
- [x] `/security-review` — **PASSED, no vulnerabilities found** (reviewed the bounded-allocation discipline in `indexOf`'s O(n·m) product cap and `catenate`'s repeated-growth cap specifically)
- [x] Rebased onto current `origin/main` tip, resolved a CHANGELOG version-number conflict with a concurrently-merged PR (0.41.0 → 0.42.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)