### PR TITLE
feat(maple-lexer): maple.tokens + maple-lexer crate (MA09 MP-2)

### DIFF
--- a/code/grammars/maple/maple.tokens
+++ b/code/grammars/maple/maple.tokens
@@ -1,0 +1,222 @@
+# Maple Token Grammar
+# ============================================================================
+#
+# Tokenizes the MP-1-scoped subset of Maple (Keith Geddes & Gaston Gonnet,
+# University of Waterloo, 1980-82; still actively developed and sold by
+# Maplesoft) — see code/specs/MA09-maple-language.md §1/§3 for the full
+# surface-grammar derivation. On the surface Maple reads like a close
+# cousin of REDUCE (the same `:=` assignment spelling, the same
+# `and`/`or`/`not` keywords) but it is genuinely NOT "REDUCE again": Maple
+# has THREE aggregate literal types where REDUCE/Derive each have one, and
+# its own `f(x) := expr` spelling means something narrower (a remember-table
+# patch onto an existing procedure, MA09 §1) than REDUCE's/Derive's own
+# general-definition idiom of the same shape — real Maple's general
+# function definition is the arrow/functional operator, `f := (x, y) -> e`
+# (Help page `operators/functional`), which is why this grammar has an
+# ARROW token REDUCE's/Derive's own `.tokens` files do not.
+#
+# Maple is CASE-SENSITIVE, and — like REDUCE, unlike Derive's uppercase
+# `AND`/`OR`/`NOT` — its word operators and statement keywords are spelled
+# in LOWERCASE (`and`, `or`, `not`, `if`, `then`, `elif`, `else`, `end`,
+# `fi`, `true`, `false` — MA09 §3, citing the Maple Programming Guide
+# §3.10/§5.6 and the `if`/`type/truefalseFAIL` Help pages), so the
+# `keywords:` block below lists the lowercase spellings, mirroring
+# reduce.tokens's own case rule exactly (the mirror image of
+# derive.tokens's uppercase convention).
+#
+# Statement separation is `;` or `:` (MA09 §3, citing Programming Guide
+# §5.3 "Statement Separators" — `;` displays the result, `:` suppresses
+# it), never a significant newline: Maple's own interactive session has no
+# `#n:`/`In[n]:=` numbered-worksheet-prompt convention either (MA09 §5), so
+# (unlike derive.tokens/wolfram.tokens) this file has no NEWLINE token and
+# needs no bracket-interior-newline post-tokenize hook — every newline is
+# ordinary whitespace, exactly mirroring reduce.tokens's/macsyma.tokens's
+# identical `;`/`$`(or `:`)-terminated statement model. `;` and `:` are
+# kept as two DISTINCT token types (SEMI/COLON) even though a later parser
+# may treat both as statement terminators — the same discipline
+# reduce.tokens documents for its own SEMI/DOLLAR split ("the parser, not
+# this lexer, is where the two spellings collapse onto one production").
+#
+# @version 1
+
+# Strings and comments are out of this subset's scope entirely (no STRING
+# token, no comment skip pattern) — MA09 §4 explicitly excludes both:
+# "`#` line comments, `(* ... *)` nestable block comments ... are not part
+# of this grammar" and "this subset's programs are a flat sequence of
+# `;`/`:`-terminated expression statements, assignments, arrow-operator
+# definitions, and `if` statements."
+escapes: none
+
+# ============================================================================
+# SECTION 1: Multi-character operators
+#
+# Longest-match-first: every multi-character operator is listed before any
+# shorter operator it begins with, so `:=` wins over bare `:` (COLON,
+# SECTION 2 — unlike reduce.tokens, this subset genuinely needs a bare `:`
+# token, since Maple's `:` is the result-suppressing statement separator,
+# MA09 §3), `->` wins over bare `-` (MINUS), `<>` wins over bare `<`
+# (LESS), and `<=`/`>=` win over bare `<`/`>` (LESS/GREATER) — the same
+# defensive convention reduce.tokens/derive.tokens use for their own
+# `:=`/`<=`/`>=` pairs.
+# ============================================================================
+
+# Maple's one assignment operator (Programming Guide §5.5 "Assignments") —
+# identical spelling to REDUCE's/Derive's own, per MA09 §1, though (per
+# MA09 §3/§4) `f(x) := expr` in real Maple is the narrower remember-table
+# mechanism, not general definition; that distinction is a parser/runtime
+# concern (MP-3/MP-4), invisible to this lexer, which just emits ASSIGN for
+# every `:=` regardless of what precedes it.
+ASSIGN      = ":="
+
+# The arrow/functional operator (Help page `operators/functional`, "A
+# functional operator... written using arrow notation") — Maple's real
+# general-purpose function-definition spelling, `f := (x, y) -> e` / `f :=
+# x -> e` (MA09 §3). REDUCE's and Derive's `.tokens` files have no ARROW
+# token at all, because neither language uses this construct; Maple
+# genuinely does, which is why this token is new to this repo's CAS-family
+# lexers.
+ARROW       = "->"
+
+# Maple's own not-equal spelling (`equation` Help page; MA09 §3) — NOT
+# REDUCE's word-spelled `neq` keyword, and NOT Wolfram's `!=`. A symbolic
+# two-character operator, grouped here with the other relational operators
+# rather than in the `keywords:` section (SECTION 5) since it is spelled
+# with punctuation, not a word.
+NEQ         = "<>"
+
+LE          = "<="
+GE          = ">="
+
+# ============================================================================
+# SECTION 2: Single-character operators and delimiters
+# ============================================================================
+
+PLUS        = "+"
+MINUS       = "-"
+TIMES       = "*"
+SLASH       = "/"
+
+# Power (Programming Guide §3.9 "Arithmetic Expressions"; MA09 §3) — `^`
+# ONLY. Real Maple documents no `**` synonym the way REDUCE's manual lists
+# `^`/`**` as one tier, so (deliberately, per MA09 §3's own note) there is
+# no POW token here mirroring reduce.tokens's `CARET`/`POW` pair — adding
+# one "for completeness" would invent a Maple operator that does not exist.
+CARET       = "^"
+
+# `=` is Maple's equation/relational operator (Programming Guide §3.10
+# "Boolean and Relational Expressions") — NEVER assignment; the same
+# `=`-is-equation / `:=`-is-assignment split every sibling CAS-family
+# grammar in this repo already draws (REDUCE, Derive, Macsyma, Wolfram).
+EQ          = "="
+LESS        = "<"
+GREATER     = ">"
+
+LPAREN      = "("
+RPAREN      = ")"
+
+# List literals use SQUARE brackets (`[a, b, c]`, ordered, duplicates
+# preserved — Programming Guide §4.3 "Immutable Data Structures"; MA09 §3).
+# This is the OPPOSITE bracket choice from Derive's `[a,b,c]` *vector*
+# literal (same brackets, different meaning, MA09 §1) and from REDUCE's
+# curly-brace *list* literal — Maple is the first language in this repo
+# that needs both a list bracket and a set bracket (SECTION below), since
+# it has three aggregate types where every prior CAS sibling here has one
+# (MA09 §1/§2).
+LBRACKET    = "["
+RBRACKET    = "]"
+
+# Set literals use CURLY braces (`{a, b, c}`, unordered, duplicates
+# silently removed — same §4.3, and the `set` Help page's own worked
+# example: `{x, y, y}` and `{y, x, y}` both produce `{x, y}`; MA09 §3).
+# This is the same bracket REDUCE uses for its *list* literal — same
+# spelling, different meaning (MA09 §1) — which is exactly the
+# family-resemblance trap MA09 §1 calls out by name; this lexer only
+# assigns the token a name (LBRACE/RBRACE), the Set-vs-List *meaning* is
+# carried entirely by which bracket (square vs. curly) was used, resolved
+# by the parser/runtime (MP-3/MP-4).
+LBRACE      = "{"
+RBRACE      = "}"
+
+# The comma separator plays its usual dual role — list/set element
+# separator (`[a, b, c]`, `{a, b, c}`) and function-call argument
+# separator (`f(a, b)`) — exactly the same overload every sibling
+# CAS-family grammar's comma already has (MA09 §3).
+COMMA       = ","
+
+# Statement separators (Programming Guide §5.3 "Statement Separators";
+# MA09 §3): `;` displays the result of the statement, `:` suppresses it.
+# The same *shape* as Macsyma's/REDUCE's own `;`/`$` pair — a
+# display-vs-suppress distinction the parser (MP-3), not this lexer,
+# unifies into one statement-terminator production — just spelled `;`/`:`
+# here instead of `;`/`$`. Kept as two distinct token types (SEMI/COLON),
+# mirroring reduce.tokens's SEMI/DOLLAR split and macsyma.tokens's
+# identical SEMI/DOLLAR split.
+SEMI        = ";"
+COLON       = ":"
+
+# ============================================================================
+# SECTION 3: Literal value tokens
+#
+# NUMBER requires a leading digit, so a bare `.5` is not a number (matches
+# every sibling symbolic-family lexer's convention — reduce.tokens,
+# derive.tokens, macsyma.tokens, wolfram.tokens). NAME is a case-sensitive
+# identifier; built-in names conventionally spelled lowercase (`sin`,
+# `diff`, `int` — MA09 §3, "unlike Derive's uppercase convention") are
+# ordinary NAMEs resolved later by the runtime (MP-4), exactly like
+# REDUCE's `df`/`log`/`first` — so, aside from the `keywords:` block below,
+# there is no reserved-word list here.
+# ============================================================================
+
+NUMBER = /[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?/
+NAME   = /[a-zA-Z][a-zA-Z0-9]*/
+
+# ============================================================================
+# SECTION 4: Skip patterns
+#
+# Maple newlines are NOT significant — statements end with `;` or `:`
+# (Programming Guide §5.3), exactly mirroring reduce.tokens's/
+# macsyma.tokens's identical rationale — so newlines are just whitespace
+# here, and (unlike derive.tokens/wolfram.tokens) this file declares no
+# NEWLINE token and needs no bracket-interior-newline post-tokenize hook in
+# maple-lexer.
+# ============================================================================
+
+skip:
+  WHITESPACE = /[ \t\r\n]+/
+
+# ============================================================================
+# SECTION 5: Keywords
+#
+# These words are NAMEs at the lexer level but are reclassified to their
+# own KEYWORD token by the grammar-driven lexer, matched by EXACT
+# lowercase spelling (MA09 §3) — uppercase spellings (`AND`, `IF`, ...) lex
+# as ordinary NAMEs here, mirroring reduce.tokens's identical case rule
+# (the mirror image of derive.tokens's uppercase keywords).
+#
+# `and`/`or`/`not` — logical operators (Programming Guide §3.10).
+# `if`/`then`/`elif`/`else`/`end` — conditional-statement keywords
+# (Programming Guide §5.6 "Flow Control"). Real Maple closes an `if` with
+# either `end if` (two words — `end` here, and `if` itself already exists
+# as a keyword above, so the parser (MP-3) recognizes the two-keyword
+# sequence `end if`; this lexer just emits them as two ordinary KEYWORD
+# tokens in a row, exactly as it would any other keyword pair) or the
+# standalone `fi` keyword ("if" reversed — the `if` Help page confirms
+# `fi` is short for `end if`; MA09 §3).
+# `fi` — short form of `end if` (`if` Help page).
+# `true`/`false` — boolean literals (`type/truefalseFAIL` Help page; MA09
+# §3 — Maple's boolean logic is really three-valued with `FAIL`, but `FAIL`
+# is out of scope, MA09 §4).
+# ============================================================================
+
+keywords:
+  and
+  or
+  not
+  if
+  then
+  elif
+  else
+  end
+  fi
+  true
+  false

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -263,6 +263,7 @@ members = [
     "reduce-parser",
     "reduce-runtime",
     "reduce-repl",
+    "maple-lexer",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/maple-lexer/BUILD
+++ b/code/packages/rust/maple-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maple-lexer -- --nocapture

--- a/code/packages/rust/maple-lexer/BUILD_windows
+++ b/code/packages/rust/maple-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maple-lexer -- --nocapture

--- a/code/packages/rust/maple-lexer/CHANGELOG.md
+++ b/code/packages/rust/maple-lexer/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+## [0.1.0] - 2026-07-18
+
+### Added
+
+- Initial grammar-driven Rust Maple tokenizer (MA09 §2, task MP-2).
+- Statically linked compiled token grammar
+  (`code/grammars/maple/maple.tokens`), covering the MP-1-scoped surface
+  (MA09 §3): ordinary-parenthesis function/procedure application
+  (`f(x, y)`), the single `:=` assignment operator, the arrow/functional
+  operator `->` (Maple's real general-purpose function-definition
+  spelling, `f := (x, y) -> e` — a token neither `reduce-lexer` nor
+  `derive-lexer` needs), `=` as the *equation* operator (never assignment
+  — shared with REDUCE/Derive/Macsyma's convention), comparison
+  (`< > <= >= <>` — `<>` is Maple's own not-equal spelling, not REDUCE's
+  word-spelled `neq` and not Wolfram's `!=`), the word-spelled logical
+  keywords `and`/`or`/`not` (lowercase reserved words, like REDUCE's —
+  the mirror image of `derive-lexer`'s uppercase `AND`/`OR`/`NOT`), the
+  `if`/`then`/`elif`/`else`/`end`/`fi` conditional keywords (`end`/`fi`
+  are two distinct ways real Maple closes an `if` — `end if` or bare
+  `fi` — both lexed as ordinary `KEYWORD` tokens, with `end`+`if`
+  composition left to the parser), the `true`/`false` boolean literals,
+  `[a, b, c]` square-bracket **list** literals (ordered, duplicates kept
+  — the *opposite* bracket choice from Derive's `[a,b,c]` vector literal)
+  and `{a, b, c}` curly-brace **set** literals (unordered, duplicates
+  removed — the same bracket REDUCE uses for its own *list* literal,
+  different meaning) as four distinct token types (`LBRACKET`/`RBRACKET`,
+  `LBRACE`/`RBRACE`) — the first CAS-family lexer in this repo to need
+  two aggregate-literal brackets instead of one (MA09 §1), both statement
+  terminators `;` and `:` (kept as distinct `SEMI`/`COLON` tokens,
+  mirroring `reduce-lexer`'s `SEMI`/`DOLLAR` split), and arithmetic
+  `+ - * / ^` (`^` only — deliberately no `POW`/`**` token, since real
+  Maple documents no `**` synonym, unlike REDUCE's `^`/`**` pair).
+- No `NEWLINE` token and no post-tokenize hook: Maple's `;`/`:`-
+  terminated statement model (Programming Guide §5.3) has no significant
+  newlines, mirroring `reduce-lexer`/`macsyma-lexer` exactly rather than
+  `derive-lexer`/`wolfram-lexer`'s worksheet-style significant-newline
+  model.
+- 28 tests covering function application, `:=` vs `=` vs bare `:`
+  disambiguation, the `->` arrow operator winning over a split `-`/`>`,
+  `<>`/`<=`/`>=` winning over their shorter prefixes, square-bracket list
+  vs. curly-brace set literals lexing as distinct token types, `^`-only
+  arithmetic (`**` is NOT a power operator — it lexes as two `TIMES`
+  tokens), `;`/`:` terminator distinctness, `NUMBER`/`NAME` literals
+  (including the no-leading-dot rule), every keyword (`and`/`or`/`not`/
+  `if`/`then`/`elif`/`else`/`end`/`fi`/`true`/`false`) promoting to
+  `KEYWORD` case-sensitively (and that uppercase spellings are NOT
+  promoted), `end`+`if` lexing as two separate keyword tokens rather than
+  one, newlines being plain whitespace, case-sensitive names, and two
+  realistic end-to-end snippets from MA09 §3 (`f := (x, y) -> x + y;` and
+  `if x > 0 then 1 elif x < 0 then -1 else 0 end if;`).

--- a/code/packages/rust/maple-lexer/Cargo.toml
+++ b/code/packages/rust/maple-lexer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-maple-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "Tokenizer for the Maple symbolic-CAS frontend (MP-2)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/maple-lexer/README.md
+++ b/code/packages/rust/maple-lexer/README.md
@@ -1,0 +1,125 @@
+# coding-adventures-maple-lexer
+
+Maple tokenizer backed by `code/grammars/maple/maple.tokens`, compiled to
+Rust and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the MP-1-scoped subset fixed by
+[MA09 §3](../../../specs/MA09-maple-language.md): ordinary-parenthesis
+function/procedure application (`f(x, y)`), the single `:=` assignment
+operator, the arrow/functional operator `->` (Maple's real general-purpose
+function-definition spelling, `f := (x, y) -> e`), `=` as the *equation*
+operator (never assignment), comparison (`< > <= >= <>`), the word-spelled
+logical keywords `and`/`or`/`not`, the `if`/`then`/`elif`/`else`/`end`/`fi`
+conditional keywords, the `true`/`false` boolean literals, `[a, b, c]`
+square-bracket **list** literals and `{a, b, c}` curly-brace **set**
+literals (two distinct aggregate types — see below), both statement
+terminators `;` and `:`, and arithmetic `+ - * / ^` (`^` only — no `**`
+synonym).
+
+## Why Maple needs a lexer of its own, not "REDUCE again"
+
+[MA09 §1](../../../specs/MA09-maple-language.md) confirms Maple is not a
+close-enough cousin of REDUCE to reuse `reduce-lexer`'s grammar wholesale,
+despite sharing `:=` assignment and `and`/`or`/`not` keywords:
+
+- **Two distinct bracket-delimited aggregate types, not REDUCE's/Derive's
+  one.** `[a, b, c]` is Maple's ordered, duplicates-preserved **list**
+  (Programming Guide §4.3) — the *opposite* bracket choice from Derive's
+  `[a,b,c]` *vector* literal (same spelling, different meaning). `{a, b,
+  c}` is Maple's unordered, duplicates-removed **set** — the same bracket
+  REDUCE uses for its own *list* literal (same spelling, different
+  meaning again). This lexer keeps `LBRACKET`/`RBRACKET` and
+  `LBRACE`/`RBRACE` as four distinct token types; which aggregate a
+  bracket pair denotes is carried entirely by which bracket was used, not
+  by any lexer-level disambiguation.
+- **A real `ARROW` (`->`) token neither REDUCE's nor Derive's `.tokens`
+  file needs.** Real Maple's general-purpose function definition is the
+  arrow/functional operator, `f := (x, y) -> e` (Help page
+  `operators/functional`) — `f(x) := expr` in real Maple is instead a
+  narrower **remember-table** patch onto an *already-existing* procedure
+  (the `remember` Help page), not a general definition. This lexer does
+  not (and cannot, at the lexing stage) tell those two `:=` uses apart —
+  it emits the same `ASSIGN` token either way; the arrow-operator-vs-
+  remember-table distinction is invisible until MP-3/MP-4 see the whole
+  statement shape.
+
+## Maple's keywords are lowercase — like REDUCE, unlike Derive
+
+Like [`reduce-lexer`](../reduce-lexer) (whose logical/statement keywords
+are lowercase `and`/`or`/`not`/`if`/`then`/`else`), and unlike
+[`derive-lexer`](../derive-lexer) (whose boolean-algebra keywords
+`AND`/`OR`/`NOT` are UPPERCASE, matching Derive's own conventionally
+uppercase built-in names), Maple's real surface spells its word operators
+and statement keywords in lowercase: `and`, `or`, `not`, `if`, `then`,
+`elif`, `else`, `end`, `fi`, `true`, `false` (MA09 §3, citing Programming
+Guide §3.10/§5.6 and the `if`/`type/truefalseFAIL` Help pages).
+`maple.tokens`'s `keywords:` block lists the lowercase spellings and
+matches case-sensitively, so `AND`/`IF`/etc. in uppercase lex as ordinary
+`NAME`s here.
+
+## `^` only — no `**` synonym
+
+Unlike REDUCE's manual (which states `^` and `**` are literally the same
+power operator, one precedence tier, kept as REDUCE's own distinct
+`CARET`/`POW` tokens), real Maple documents no `**` synonym for `^`
+(MA09 §3's own note on the `arithop`/precedence pages). This grammar has
+no `POW` token at all — `a ** b` lexes as two separate `TIMES` tokens
+(`a`, `*`, `*`, `b`), never a single power operator, since inventing one
+"for completeness" would add a Maple operator that does not exist.
+
+## No significant newlines — the same statement model as REDUCE/Macsyma
+
+Unlike `derive-lexer`/`wolfram-lexer` (whose worksheet-style grammars have
+a significant top-level `NEWLINE`, needing a bracket-interior newline-
+dropping post-tokenize hook), Maple statements are separated by `;` or `:`
+(Programming Guide §5.3 "Statement Separators" — `;` displays the result,
+`:` suppresses it) — a newline is never significant, and real Maple's own
+interactive session has no `#n:`/`In[n]:=` numbered-worksheet-prompt
+convention either (MA09 §5). This mirrors `reduce-lexer`'s/
+`macsyma-lexer`'s identical `;`/`$`(or `:`)-terminated statement model
+exactly: `maple.tokens` emits no `NEWLINE` token at all (every newline is
+ordinary skipped whitespace), so this crate needs nothing beyond a bare
+`GrammarLexer::new` — no post-tokenize hook, unlike `derive-lexer`.
+
+`;` and `:` are kept as two distinct token types (`SEMI`/`COLON`) even
+though a later parser may treat both as statement terminators — the same
+discipline `reduce-lexer` documents for its own `SEMI`/`DOLLAR` split:
+"the parser, not this lexer, is where the two spellings collapse onto one
+production."
+
+## `end`/`fi` — two ways to close an `if`, one token shape each
+
+Real Maple closes an `if` statement with either `end if` (two keywords in
+a row — `end`, then the already-existing `if` keyword) or the standalone
+`fi` keyword ("if" reversed — the `if` Help page confirms `fi` is short
+for `end if`; MA09 §3). This lexer emits `end` and `if` as two independent
+`KEYWORD` tokens; it does not special-case the `end if` sequence into one
+token. Composing `end` + `if` into one production (vs. accepting bare
+`fi` as the alternative) is left entirely to the parser (MP-3).
+
+## Usage
+
+```rust
+use coding_adventures_maple_lexer::tokenize_maple;
+
+let tokens = tokenize_maple("f := (x, y) -> x + y;\nf(1, 2);");
+```
+
+`tokenize_maple` panics on a malformed source string; use
+`create_maple_lexer` directly if you need the `Result`-returning
+`GrammarLexer::tokenize` instead, or the crate-level `try_tokenize_maple`
+convenience wrapper.
+
+## Where this fits
+
+`maple-lexer` is the first of Maple's frontend crates (MP-2); the sibling
+`maple-parser` crate (MP-3) will consume this crate's token stream against
+`code/grammars/maple/maple.grammar` to build the `GrammarASTNode` CST a
+future `maple-runtime` (MP-4) will lower into `symbolic_ir::IRNode` and
+evaluate with `symbolic_vm::VM`'s shared `SymbolicBackend`, reused
+unchanged.

--- a/code/packages/rust/maple-lexer/required_capabilities.json
+++ b/code/packages/rust/maple-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/maple-lexer",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/maple-lexer/src/_grammar.rs
+++ b/code/packages/rust/maple-lexer/src/_grammar.rs
@@ -1,0 +1,209 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: maple.tokens
+// Regenerate with: grammar-tools compile-tokens maple.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"ASSIGN"#.to_string(),
+                pattern: r#":="#.to_string(),
+                is_regex: false,
+                line_number: 69,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"ARROW"#.to_string(),
+                pattern: r#"->"#.to_string(),
+                is_regex: false,
+                line_number: 78,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NEQ"#.to_string(),
+                pattern: r#"<>"#.to_string(),
+                is_regex: false,
+                line_number: 85,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LE"#.to_string(),
+                pattern: r#"<="#.to_string(),
+                is_regex: false,
+                line_number: 87,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GE"#.to_string(),
+                pattern: r#">="#.to_string(),
+                is_regex: false,
+                line_number: 88,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PLUS"#.to_string(),
+                pattern: r#"+"#.to_string(),
+                is_regex: false,
+                line_number: 94,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"MINUS"#.to_string(),
+                pattern: r#"-"#.to_string(),
+                is_regex: false,
+                line_number: 95,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"TIMES"#.to_string(),
+                pattern: r#"*"#.to_string(),
+                is_regex: false,
+                line_number: 96,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SLASH"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 97,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"CARET"#.to_string(),
+                pattern: r#"^"#.to_string(),
+                is_regex: false,
+                line_number: 104,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQ"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 110,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LESS"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 111,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GREATER"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 112,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 114,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 115,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACKET"#.to_string(),
+                pattern: r#"["#.to_string(),
+                is_regex: false,
+                line_number: 125,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACKET"#.to_string(),
+                pattern: r#"]"#.to_string(),
+                is_regex: false,
+                line_number: 126,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACE"#.to_string(),
+                pattern: r#"{"#.to_string(),
+                is_regex: false,
+                line_number: 137,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACE"#.to_string(),
+                pattern: r#"}"#.to_string(),
+                is_regex: false,
+                line_number: 138,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMA"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 144,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SEMI"#.to_string(),
+                pattern: r#";"#.to_string(),
+                is_regex: false,
+                line_number: 154,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COLON"#.to_string(),
+                pattern: r#":"#.to_string(),
+                is_regex: false,
+                line_number: 155,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 170,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[a-zA-Z][a-zA-Z0-9]*"#.to_string(),
+                is_regex: true,
+                line_number: 171,
+                alias: None,
+            },
+        ],
+        keywords: vec![r#"and"#.to_string(), r#"or"#.to_string(), r#"not"#.to_string(), r#"if"#.to_string(), r#"then"#.to_string(), r#"elif"#.to_string(), r#"else"#.to_string(), r#"end"#.to_string(), r#"fi"#.to_string(), r#"true"#.to_string(), r#"false"#.to_string()],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t\r\n]+"#.to_string(),
+                is_regex: true,
+                line_number: 185,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: Some(r#"none"#.to_string()),
+        error_definitions: vec![],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
+    }
+}

--- a/code/packages/rust/maple-lexer/src/lib.rs
+++ b/code/packages/rust/maple-lexer/src/lib.rs
@@ -1,0 +1,448 @@
+//! # Maple Lexer — tokenizing the Maple symbolic-CAS subset (MP-2).
+//!
+//! Maple (Keith Geddes & Gaston Gonnet, University of Waterloo, 1980-82;
+//! still actively developed and sold by Maplesoft) looks, on the surface,
+//! like a close cousin of REDUCE — the same `:=` assignment spelling, the
+//! same `and`/`or`/`not` keywords — but MA09 §1 confirms it genuinely is
+//! not: Maple has THREE aggregate literal types (an expression sequence,
+//! a list `[a, b, c]`, and a set `{a, b, c}` — this subset covers the
+//! latter two, MA09 §2/§3) where REDUCE/Derive each have one, and its own
+//! `f(x) := expr` spelling means something narrower (a remember-table
+//! patch onto an *existing* procedure, MA09 §1) than REDUCE's/Derive's own
+//! general-definition idiom of the same shape. Real Maple's general
+//! function definition is the arrow/functional operator — `f := (x, y)
+//! -> e` (Help page `operators/functional`) — which is why this crate's
+//! grammar has an `ARROW` token neither `reduce-lexer` nor `derive-lexer`
+//! needs. This crate is a thin wrapper over the generic [`GrammarLexer`]
+//! (a sibling of `reduce-lexer`/`derive-lexer`/`wolfram-lexer`/
+//! `macsyma-lexer`). See `code/specs/MA09-maple-language.md`.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! maple.tokens         (grammar file — declares every token pattern)
+//!     |  (compiled ahead of time into src/_grammar.rs)
+//!     v
+//! lexer::GrammarLexer  (tokenizes source using the embedded TokenGrammar)
+//!     |
+//!     v
+//! maple-lexer          (this crate)
+//! ```
+//!
+//! ## No post-tokenize hook needed
+//!
+//! Unlike `derive-lexer`/`wolfram-lexer` (whose worksheet-style grammars
+//! have a significant top-level `NEWLINE` and so need a bracket-interior
+//! newline-dropping hook), Maple statements are separated by `;` or `:`
+//! (Programming Guide §5.3 "Statement Separators" — `;` displays the
+//! result, `:` suppresses it) — a newline is never significant, and real
+//! Maple's own interactive session has no `#n:`/`In[n]:=` numbered-
+//! worksheet-prompt convention either (MA09 §5). This exactly mirrors
+//! `reduce-lexer`'s/`macsyma-lexer`'s identical `;`/`$`(or `:`)-terminated
+//! statement model, so `maple.tokens` emits no `NEWLINE` token at all
+//! (every newline is ordinary skipped whitespace), and this crate needs
+//! nothing beyond a bare [`GrammarLexer::new`] — the same shape as
+//! `reduce-lexer`/`macsyma-lexer`/`j-lexer`.
+//!
+//! ## `end`/`fi` — two distinct tokens, not one
+//!
+//! Real Maple closes an `if` statement with either `end if` (two
+//! keywords in a row) or the standalone `fi` keyword ("if" reversed — the
+//! `if` Help page confirms `fi` is short for `end if`; MA09 §3). This
+//! lexer treats `end` and `if` as two independent `KEYWORD` tokens (`if`
+//! is already a keyword from the conditional's own opening); it does not
+//! special-case the `end if` sequence into one token. Composing `end` +
+//! `if` into one production (vs. accepting bare `fi`) is a parser
+//! concern — MP-3, not this lexer.
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+/// Create a [`GrammarLexer`] configured for Maple source text.
+pub fn create_maple_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    GrammarLexer::new(source, &grammar)
+}
+
+/// Tokenize Maple source text into a vector of tokens (ending in an `EOF`).
+///
+/// # Panics
+///
+/// Panics on an unrecognized character. Use [`try_tokenize_maple`] for a
+/// `Result`.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_maple_lexer::tokenize_maple;
+/// let tokens = tokenize_maple("f(x, y)");
+/// assert_eq!(tokens[0].value, "f");
+/// assert_eq!(tokens[1].effective_type_name(), "LPAREN");
+/// ```
+pub fn tokenize_maple(source: &str) -> Vec<Token> {
+    create_maple_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Maple tokenization failed: {e}"))
+}
+
+/// Tokenize Maple source text, returning a `Result` instead of panicking.
+pub fn try_tokenize_maple(source: &str) -> Result<Vec<Token>, String> {
+    create_maple_lexer(source)
+        .tokenize()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lexer::token::TokenType;
+
+    /// Lex, dropping the trailing EOF, into `(effective_type_name, value)` pairs.
+    fn lex(source: &str) -> Vec<(String, String)> {
+        tokenize_maple(source)
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| (t.effective_type_name().to_string(), t.value.clone()))
+            .collect()
+    }
+
+    fn pair(p: &[(String, String)], i: usize, ty: &str, val: &str) {
+        assert_eq!(
+            (p[i].0.as_str(), p[i].1.as_str()),
+            (ty, val),
+            "tok {i} in {p:?}"
+        );
+    }
+
+    fn types(p: &[(String, String)]) -> Vec<&str> {
+        p.iter().map(|t| t.0.as_str()).collect()
+    }
+
+    // --- Function application uses ordinary parens -------------------------
+
+    #[test]
+    fn function_application_uses_ordinary_parens() {
+        let p = lex("f(x, y);");
+        pair(&p, 0, "NAME", "f");
+        pair(&p, 1, "LPAREN", "(");
+        pair(&p, 2, "NAME", "x");
+        pair(&p, 3, "COMMA", ",");
+        pair(&p, 4, "NAME", "y");
+        pair(&p, 5, "RPAREN", ")");
+        pair(&p, 6, "SEMI", ";");
+    }
+
+    // --- `:=` is assignment, `=` is equation, never confused ---------------
+
+    #[test]
+    fn assign_and_eq_are_distinct_tokens() {
+        pair(&lex("x := 5;"), 1, "ASSIGN", ":=");
+        let p = lex("x = 4;");
+        pair(&p, 1, "EQ", "=");
+        assert!(!types(&p).contains(&"ASSIGN"));
+    }
+
+    #[test]
+    fn assign_wins_over_bare_colon_then_eq() {
+        let p = lex("x:=5;");
+        assert!(types(&p).contains(&"ASSIGN"));
+        assert!(!types(&p).contains(&"COLON"));
+        assert!(!types(&p).contains(&"EQ"));
+    }
+
+    // --- `->` is the arrow/functional operator, never split as `-` `>` -----
+
+    #[test]
+    fn arrow_wins_over_minus_then_greater() {
+        let p = lex("f := (x, y) -> x + y;");
+        assert!(types(&p).contains(&"ARROW"));
+        assert!(!types(&p).contains(&"GREATER"));
+    }
+
+    #[test]
+    fn arrow_operator_definition_snippet_lexes_end_to_end() {
+        // MA09 §3's own worked example of the general-purpose
+        // function-definition idiom.
+        let p = lex("f := (x, y) -> x + y;");
+        assert_eq!(
+            types(&p),
+            vec![
+                "NAME", "ASSIGN", "LPAREN", "NAME", "COMMA", "NAME", "RPAREN", "ARROW", "NAME",
+                "PLUS", "NAME", "SEMI",
+            ]
+        );
+    }
+
+    // --- `<>` is not-equal, distinct from a split `<` `>` -------------------
+
+    #[test]
+    fn not_equal_wins_over_less_then_greater() {
+        let p = lex("a <> b;");
+        assert!(types(&p).contains(&"NEQ"));
+        assert!(!types(&p).contains(&"LESS"));
+        assert!(!types(&p).contains(&"GREATER"));
+    }
+
+    // --- `<=`/`>=` win over bare `<`/`>` -------------------------------------
+
+    #[test]
+    fn le_and_ge_win_over_bare_less_and_greater() {
+        let p1 = lex("a <= b;");
+        assert!(types(&p1).contains(&"LE"));
+        assert!(!types(&p1).contains(&"LESS"));
+
+        let p2 = lex("a >= b;");
+        assert!(types(&p2).contains(&"GE"));
+        assert!(!types(&p2).contains(&"GREATER"));
+    }
+
+    #[test]
+    fn bare_less_and_greater_still_lex_alone() {
+        let p1 = lex("a < b;");
+        assert!(types(&p1).contains(&"LESS"));
+        let p2 = lex("a > b;");
+        assert!(types(&p2).contains(&"GREATER"));
+    }
+
+    // --- List literals use SQUARE brackets, set literals use CURLY braces --
+
+    #[test]
+    fn list_literal_lexes_with_square_brackets_and_commas() {
+        let p = lex("[a, b, c];");
+        assert_eq!(
+            types(&p),
+            vec![
+                "LBRACKET", "NAME", "COMMA", "NAME", "COMMA", "NAME", "RBRACKET", "SEMI",
+            ]
+        );
+    }
+
+    #[test]
+    fn set_literal_lexes_with_curly_braces_and_commas() {
+        let p = lex("{a, b, c};");
+        assert_eq!(
+            types(&p),
+            vec![
+                "LBRACE", "NAME", "COMMA", "NAME", "COMMA", "NAME", "RBRACE", "SEMI",
+            ]
+        );
+    }
+
+    #[test]
+    fn list_and_set_brackets_are_distinct_token_types() {
+        // Same element content, different bracket -- must not collapse to
+        // the same token type (MA09 §1's own "two brackets, two meanings"
+        // point).
+        let list_lexed = lex("[x];");
+        let set_lexed = lex("{x};");
+        let list_types = types(&list_lexed);
+        let set_types = types(&set_lexed);
+        assert_eq!(list_types[0], "LBRACKET");
+        assert_eq!(set_types[0], "LBRACE");
+        assert_ne!(list_types[0], set_types[0]);
+    }
+
+    // --- Single-char arithmetic operators, `^` only (no `**` synonym) ------
+
+    #[test]
+    fn arithmetic_and_power_operators() {
+        for (src, ty) in [
+            ("a + b;", "PLUS"),
+            ("a - b;", "MINUS"),
+            ("a * b;", "TIMES"),
+            ("a / b;", "SLASH"),
+            ("a ^ b;", "CARET"),
+        ] {
+            assert!(
+                types(&lex(src)).contains(&ty),
+                "expected {ty} in {src:?}: {:?}",
+                types(&lex(src))
+            );
+        }
+    }
+
+    #[test]
+    fn double_star_is_not_a_single_pow_token() {
+        // Real Maple documents no `**` synonym for `^` (MA09 §3) -- `**`
+        // must lex as two separate TIMES tokens, never a POW token (there
+        // is no POW token in this grammar at all).
+        let p = lex("a ** b;");
+        assert_eq!(
+            types(&p).iter().filter(|t| **t == "TIMES").count(),
+            2,
+            "{:?}",
+            types(&p)
+        );
+        assert!(!types(&p).contains(&"POW"));
+        assert!(!types(&p).contains(&"CARET"));
+    }
+
+    // --- Statement separators `;`/`:` are distinct terminator tokens -------
+
+    #[test]
+    fn semi_and_colon_are_distinct_terminator_tokens() {
+        assert_eq!(lex("a := 1;").last().unwrap().0, "SEMI");
+        assert_eq!(lex("a := 1:").last().unwrap().0, "COLON");
+    }
+
+    #[test]
+    fn colon_never_collides_with_assign() {
+        // A bare `:` (not immediately followed by `=`) must lex as COLON,
+        // never accidentally consumed as half of an ASSIGN.
+        let p = lex("a := 1: b := 2;");
+        assert_eq!(
+            types(&p),
+            vec![
+                "NAME", "ASSIGN", "NUMBER", "COLON", "NAME", "ASSIGN", "NUMBER", "SEMI",
+            ]
+        );
+    }
+
+    // --- NUMBER / NAME literals, no-leading-dot convention ------------------
+
+    #[test]
+    fn numbers_and_names() {
+        pair(&lex("42;"), 0, "NUMBER", "42");
+        pair(&lex("1.5;"), 0, "NUMBER", "1.5");
+        pair(&lex("x;"), 0, "NAME", "x");
+    }
+
+    #[test]
+    fn leading_dot_is_not_a_number() {
+        // `.5` is not a valid Maple NUMBER in this grammar -- there is no
+        // DOT token here at all (unlike reduce.tokens's cons operator), so
+        // a bare `.` is simply an unrecognized character.
+        assert!(try_tokenize_maple(".5;").is_err());
+    }
+
+    // --- Keywords lex as KEYWORD, case-sensitively (lowercase only) --------
+
+    #[test]
+    fn logical_keywords_promote_to_keyword_token_type() {
+        let p = lex("a and b or not c;");
+        assert_eq!(
+            p,
+            vec![
+                ("NAME".to_string(), "a".to_string()),
+                ("KEYWORD".to_string(), "and".to_string()),
+                ("NAME".to_string(), "b".to_string()),
+                ("KEYWORD".to_string(), "or".to_string()),
+                ("KEYWORD".to_string(), "not".to_string()),
+                ("NAME".to_string(), "c".to_string()),
+                ("SEMI".to_string(), ";".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn conditional_keywords_promote_to_keyword_token_type() {
+        // Positions: if(0) a(1) then(2) b(3) elif(4) c(5) then(6) d(7)
+        // else(8) e(9) end(10) ;(11) -- `if`/`then`/`elif`/`then`/`else`/
+        // `end` are all KEYWORD, `a`/`b`/`c`/`d`/`e` remain ordinary NAMEs.
+        let p = lex("if a then b elif c then d else e end;");
+        assert_eq!(
+            types(&p),
+            vec![
+                "KEYWORD", "NAME", "KEYWORD", "NAME", "KEYWORD", "NAME", "KEYWORD", "NAME",
+                "KEYWORD", "NAME", "KEYWORD", "SEMI",
+            ]
+        );
+    }
+
+    #[test]
+    fn fi_keyword_promotes_to_keyword_token_type() {
+        let p = lex("if x > 0 then 1 else -1 fi");
+        assert!(types(&p).contains(&"KEYWORD"));
+        assert_eq!(p.last().unwrap(), &("KEYWORD".to_string(), "fi".to_string()));
+    }
+
+    #[test]
+    fn end_and_if_are_two_separate_keyword_tokens_not_one() {
+        let p = lex("if true then 1 else 0 end if");
+        assert_eq!(
+            (
+                p[p.len() - 2].0.as_str(),
+                p[p.len() - 2].1.as_str(),
+                p[p.len() - 1].0.as_str(),
+                p[p.len() - 1].1.as_str(),
+            ),
+            ("KEYWORD", "end", "KEYWORD", "if")
+        );
+    }
+
+    #[test]
+    fn boolean_literals_promote_to_keyword_token_type() {
+        let p = lex("true; false;");
+        pair(&p, 0, "KEYWORD", "true");
+        pair(&p, 2, "KEYWORD", "false");
+    }
+
+    #[test]
+    fn uppercase_keyword_spellings_are_ordinary_names_not_keywords() {
+        // Maple's keywords are lowercase, like REDUCE's -- the mirror
+        // image of Derive's uppercase AND/OR/NOT. Uppercase spellings of
+        // the same words are NOT the reserved words here; only the exact
+        // lowercase spelling is.
+        let p = lex("AND OR NOT IF THEN ELIF ELSE END FI TRUE FALSE;");
+        assert_eq!(
+            types(&p),
+            vec![
+                "NAME", "NAME", "NAME", "NAME", "NAME", "NAME", "NAME", "NAME", "NAME", "NAME",
+                "NAME", "SEMI",
+            ]
+        );
+    }
+
+    // --- Case sensitivity of ordinary symbols --------------------------------
+
+    #[test]
+    fn names_are_case_sensitive() {
+        pair(&lex("Sin;"), 0, "NAME", "Sin");
+        pair(&lex("sin;"), 0, "NAME", "sin");
+    }
+
+    // --- Newlines are ordinary whitespace, never a distinct token ----------
+
+    #[test]
+    fn newlines_are_plain_whitespace_not_a_token() {
+        let p = lex("a := 1;\nb := 2:\n");
+        assert!(!types(&p).contains(&"NEWLINE"));
+    }
+
+    // --- End-to-end realistic snippets from MA09 §3 -------------------------
+
+    #[test]
+    fn if_elif_else_end_if_snippet_lexes_end_to_end() {
+        let p = lex("if x > 0 then 1 elif x < 0 then -1 else 0 end if;");
+        assert_eq!(
+            types(&p),
+            vec![
+                "KEYWORD", "NAME", "GREATER", "NUMBER", "KEYWORD", "NUMBER", "KEYWORD", "NAME",
+                "LESS", "NUMBER", "KEYWORD", "MINUS", "NUMBER", "KEYWORD", "NUMBER", "KEYWORD",
+                "KEYWORD", "SEMI",
+            ]
+        );
+    }
+
+    #[test]
+    fn list_and_set_literal_in_a_call_snippet() {
+        let p = lex("g([1, 2, 3], {1, 2, 2});");
+        assert_eq!(
+            types(&p),
+            vec![
+                "NAME", "LPAREN", "LBRACKET", "NUMBER", "COMMA", "NUMBER", "COMMA", "NUMBER",
+                "RBRACKET", "COMMA", "LBRACE", "NUMBER", "COMMA", "NUMBER", "COMMA", "NUMBER",
+                "RBRACE", "RPAREN", "SEMI",
+            ]
+        );
+    }
+
+    // --- Errors ---------------------------------------------------------------
+
+    #[test]
+    fn unknown_char_is_an_error() {
+        assert!(try_tokenize_maple("x ~ y;").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Implements **MP-2** from `code/specs/MA09-maple-language.md` — the first real implementation item for Maple, following the MA09 kickoff spec (#8531). Adds `code/grammars/maple/maple.tokens` (a new declarative token grammar) and a new `maple-lexer` crate wrapping it, mirroring `reduce-lexer`'s exact structure (MA09 §2 explicitly mirrors MA08's 4-part split: spec / tokens+lexer / grammar+parser / runtime+repl).

## Why Maple needs its own lexer, not "REDUCE again"

Maple looks like a close cousin of REDUCE on the surface (same `:=` assignment, same `and`/`or`/`not` keywords), but genuinely isn't:

- **Two distinct bracket-delimited aggregate types**, where every prior CAS sibling here has one: `[a, b, c]` is Maple's ordered, duplicates-preserved **list** (the *opposite* bracket choice from Derive's `[a,b,c]` vector literal); `{a, b, c}` is Maple's unordered, duplicates-removed **set** (the same bracket REDUCE uses for its own *list* literal — same spelling, different meaning). `LBRACKET`/`RBRACKET` and `LBRACE`/`RBRACE` are kept as four distinct token types.
- **A new `ARROW` (`->`) token** neither REDUCE's nor Derive's lexer needs — Maple's real general-purpose function definition is `f := (x, y) -> e` (the `operators/functional` Help page), distinct from `f(x) := expr`, which in real Maple is a narrower remember-table patch onto an *already-existing* procedure, not a general definition (invisible at the lexing stage — both spellings emit the same `ASSIGN` token; the distinction is MP-3/MP-4's job).
- **`^` only, no `**` synonym** — real Maple documents no `**` alias for `^`, unlike REDUCE's `^`/`**` pair.
- **`;`/`:` statement separators** (display vs. suppress), kept as distinct `SEMI`/`COLON` tokens, mirroring `reduce-lexer`'s `SEMI`/`DOLLAR` split.
- **`end`/`fi`** — Maple closes an `if` with either `end if` (two keywords) or bare `fi`; this lexer emits `end` and `if` as two independent `KEYWORD` tokens, leaving the two-keyword composition to MP-3.

No significant `NEWLINE` token (statements are `;`/`:`-terminated, mirroring `reduce-lexer`/`macsyma-lexer`, not `derive-lexer`/`wolfram-lexer`'s worksheet model).

## Test plan

- [x] `cargo test -p coding-adventures-maple-lexer` — 28 tests + 1 doctest, all passing
- [x] `cargo clippy -p coding-adventures-maple-lexer --all-targets` — clean
- [x] `grammar-tools validate-tokens maple.tokens` — `OK (24 tokens)`
- [x] `_grammar.rs` genuinely generated via `grammar-tools compile-tokens`, not hand-authored
- [x] `cargo build --workspace` — no new failures (pre-existing `uefi` duplicate-`panic_impl` failure is environment-specific and unrelated)
- [x] `/security-review` — **PASSED, no vulnerabilities found**
- [x] Rebased onto current `origin/main` tip, no conflicts

MP-3 (parser) and MP-4 (runtime/repl) are separate, unstarted follow-ups, exactly like `reduce-parser`/`reduce-runtime` followed `reduce-lexer` in their own standalone PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)