### PR TITLE
feat(matrix): add Haskell port

### DIFF
--- a/code/packages/haskell/matrix/BUILD
+++ b/code/packages/haskell/matrix/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/matrix/BUILD_windows
+++ b/code/packages/haskell/matrix/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/matrix/CHANGELOG.md
+++ b/code/packages/haskell/matrix/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add immutable rectangular matrix construction and inspection.
+- Add arithmetic, matrix multiplication, reductions, and element-wise math.
+- Add immutable indexed updates, reshaping, extraction, and comparison helpers.

--- a/code/packages/haskell/matrix/README.md
+++ b/code/packages/haskell/matrix/README.md
@@ -1,0 +1,27 @@
+# matrix
+
+A pure Haskell rectangular matrix implementation. Matrices are immutable, use
+row-major `Double` storage, and reject ragged input, invalid dimensions, shape
+mismatches, and out-of-bounds access explicitly.
+
+## API
+
+- `fromRows`, `scalar`, `rowVector`, `empty`, `zeros`, `identity`, and
+  `fromDiagonal` construct matrices.
+- `toRows`, `rows`, `cols`, `get`, and `set` inspect or immutably update values.
+- `add`, `subtract`, `addScalar`, `subtractScalar`, `scale`, `transpose`, and
+  `dot` provide arithmetic.
+- `sumElements`, `sumRows`, `sumColumns`, `mean`, `minimumElement`,
+  `maximumElement`, `argmin`, and `argmax` provide reductions.
+- `mapElements`, `squareRoot`, `absolute`, and `power` transform every element.
+- `flatten`, `reshape`, `row`, `column`, and `slice` rearrange or extract data.
+- `exactEquals`, `close`, and `closeWithin` compare matrices.
+
+Operations that can fail return `Either String`; all successful operations
+return new matrices and leave their inputs unchanged.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/matrix/cabal.project
+++ b/code/packages/haskell/matrix/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/matrix/matrix.cabal
+++ b/code/packages/haskell/matrix/matrix.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          matrix
+version:       0.1.0
+synopsis:      Immutable rectangular matrices from first principles
+description:   Pure matrix construction, arithmetic, reductions, element-wise math, and shape operations.
+category:      Math
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Matrix
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    MatrixSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , matrix
+    default-language: Haskell2010

--- a/code/packages/haskell/matrix/src/Matrix.hs
+++ b/code/packages/haskell/matrix/src/Matrix.hs
@@ -1,0 +1,417 @@
+-- | Immutable rectangular matrices from first principles.
+module Matrix
+    ( Matrix
+    , fromRows
+    , scalar
+    , rowVector
+    , empty
+    , toRows
+    , rows
+    , cols
+    , zeros
+    , identity
+    , fromDiagonal
+    , add
+    , addScalar
+    , subtract
+    , subtractScalar
+    , scale
+    , transpose
+    , dot
+    , get
+    , set
+    , sumElements
+    , sumRows
+    , sumColumns
+    , mean
+    , minimumElement
+    , maximumElement
+    , argmin
+    , argmax
+    , mapElements
+    , squareRoot
+    , absolute
+    , power
+    , flatten
+    , reshape
+    , row
+    , column
+    , slice
+    , exactEquals
+    , close
+    , closeWithin
+    ) where
+
+import Prelude hiding (subtract)
+
+-- | A rectangular matrix stored in row-major order.
+data Matrix = Matrix
+    { matrixValues :: [[Double]]
+    , matrixRowCount :: Int
+    , matrixColumnCount :: Int
+    }
+    deriving (Eq, Show)
+
+-- | Construct a matrix from rows, rejecting ragged input.
+fromRows :: [[Double]] -> Either String Matrix
+fromRows [] = Right empty
+fromRows values@(firstRow : remainingRows)
+    | any ((/= width) . length) remainingRows =
+        Left "all rows must have the same number of columns"
+    | otherwise = Right (Matrix values (length values) width)
+  where
+    width = length firstRow
+
+-- | Construct a one-by-one matrix.
+scalar :: Double -> Matrix
+scalar value = Matrix [[value]] 1 1
+
+-- | Construct a one-row matrix.
+rowVector :: [Double] -> Matrix
+rowVector values = Matrix [values] 1 (length values)
+
+-- | The empty zero-by-zero matrix.
+empty :: Matrix
+empty = Matrix [] 0 0
+
+-- | Return the matrix's row-major values.
+toRows :: Matrix -> [[Double]]
+toRows = matrixValues
+
+-- | Number of rows.
+rows :: Matrix -> Int
+rows = matrixRowCount
+
+-- | Number of columns.
+cols :: Matrix -> Int
+cols = matrixColumnCount
+
+-- | Construct a matrix filled with zeros.
+zeros :: Int -> Int -> Either String Matrix
+zeros rowCount columnCount = do
+    validateDimensions rowCount columnCount
+    Right (Matrix (replicate rowCount (replicate columnCount 0.0)) rowCount columnCount)
+
+-- | Construct a square identity matrix.
+identity :: Int -> Either String Matrix
+identity size
+    | size < 0 = Left "matrix dimensions must be non-negative"
+    | otherwise =
+        Right
+            ( Matrix
+                [ [if rowIndex == columnIndex then 1.0 else 0.0 | columnIndex <- indices size]
+                | rowIndex <- indices size
+                ]
+                size
+                size
+            )
+
+-- | Construct a square matrix whose only non-zero values are diagonal.
+fromDiagonal :: [Double] -> Matrix
+fromDiagonal values =
+    Matrix
+        [ [if rowIndex == columnIndex then values !! rowIndex else 0.0 | columnIndex <- indices size]
+        | rowIndex <- indices size
+        ]
+        size
+        size
+  where
+    size = length values
+
+-- | Add matrices element by element.
+add :: Matrix -> Matrix -> Either String Matrix
+add = combine "addition" (+)
+
+-- | Add a scalar to every element.
+addScalar :: Matrix -> Double -> Matrix
+addScalar matrix value = mapElements (+ value) matrix
+
+-- | Subtract matrices element by element.
+subtract :: Matrix -> Matrix -> Either String Matrix
+subtract = combine "subtraction" (-)
+
+-- | Subtract a scalar from every element.
+subtractScalar :: Matrix -> Double -> Matrix
+subtractScalar matrix value = mapElements (\element -> element - value) matrix
+
+-- | Multiply every element by a scalar.
+scale :: Matrix -> Double -> Matrix
+scale matrix value = mapElements (* value) matrix
+
+-- | Swap rows and columns.
+transpose :: Matrix -> Matrix
+transpose (Matrix values rowCount columnCount) =
+    Matrix
+        [ [values !! rowIndex !! columnIndex | rowIndex <- indices rowCount]
+        | columnIndex <- indices columnCount
+        ]
+        columnCount
+        rowCount
+
+-- | Multiply two matrices.
+dot :: Matrix -> Matrix -> Either String Matrix
+dot left right
+    | cols left /= rows right =
+        Left
+            ( "dot product dimension mismatch: "
+                ++ show (cols left)
+                ++ " columns vs "
+                ++ show (rows right)
+                ++ " rows"
+            )
+    | otherwise =
+        Right
+            ( Matrix
+                [ [ cell rowIndex columnIndex
+                  | columnIndex <- indices (cols right)
+                  ]
+                | rowIndex <- indices (rows left)
+                ]
+                (rows left)
+                (cols right)
+            )
+  where
+    cell rowIndex columnIndex =
+        sum
+            [ matrixValues left !! rowIndex !! innerIndex
+                * matrixValues right !! innerIndex !! columnIndex
+            | innerIndex <- indices (cols left)
+            ]
+
+-- | Read an element at a zero-based row and column.
+get :: Int -> Int -> Matrix -> Either String Double
+get rowIndex columnIndex matrix
+    | not (validIndex rowIndex columnIndex matrix) = Left (indexError rowIndex columnIndex matrix)
+    | otherwise = Right (matrixValues matrix !! rowIndex !! columnIndex)
+
+-- | Return a new matrix with one element replaced.
+set :: Int -> Int -> Double -> Matrix -> Either String Matrix
+set rowIndex columnIndex value matrix
+    | not (validIndex rowIndex columnIndex matrix) = Left (indexError rowIndex columnIndex matrix)
+    | otherwise =
+        Right
+            matrix
+                { matrixValues =
+                    replaceAt
+                        rowIndex
+                        (replaceAt columnIndex value (matrixValues matrix !! rowIndex))
+                        (matrixValues matrix)
+                }
+
+-- | Sum every element.
+sumElements :: Matrix -> Double
+sumElements = sum . map sum . matrixValues
+
+-- | Sum each row into a column vector.
+sumRows :: Matrix -> Matrix
+sumRows matrix = Matrix (map (\values -> [sum values]) (matrixValues matrix)) (rows matrix) 1
+
+-- | Sum each column into a row vector.
+sumColumns :: Matrix -> Matrix
+sumColumns matrix =
+    Matrix
+        [ [ sum [matrixValues matrix !! rowIndex !! columnIndex | rowIndex <- indices (rows matrix)]
+          | columnIndex <- indices (cols matrix)
+          ]
+        ]
+        1
+        (cols matrix)
+
+-- | Arithmetic mean of every element.
+mean :: Matrix -> Either String Double
+mean matrix
+    | elementCount == 0 = Left "cannot compute mean of an empty matrix"
+    | otherwise = Right (sumElements matrix / fromIntegral elementCount)
+  where
+    elementCount = rows matrix * cols matrix
+
+-- | Smallest element.
+minimumElement :: Matrix -> Either String Double
+minimumElement matrix = do
+    (_, value) <- extreme (<) "minimum" matrix
+    Right value
+
+-- | Largest element.
+maximumElement :: Matrix -> Either String Double
+maximumElement matrix = do
+    (_, value) <- extreme (>) "maximum" matrix
+    Right value
+
+-- | Position of the first smallest element in row-major order.
+argmin :: Matrix -> Either String (Int, Int)
+argmin matrix = fst <$> extreme (<) "argmin" matrix
+
+-- | Position of the first largest element in row-major order.
+argmax :: Matrix -> Either String (Int, Int)
+argmax matrix = fst <$> extreme (>) "argmax" matrix
+
+-- | Apply a function to every element.
+mapElements :: (Double -> Double) -> Matrix -> Matrix
+mapElements transform matrix = matrix {matrixValues = map (map transform) (matrixValues matrix)}
+
+-- | Take the square root of every element, rejecting negative inputs.
+squareRoot :: Matrix -> Either String Matrix
+squareRoot matrix
+    | any (< 0.0) (concat (matrixValues matrix)) = Left "cannot take square root of a negative matrix element"
+    | otherwise = Right (mapElements sqrt matrix)
+
+-- | Take the absolute value of every element.
+absolute :: Matrix -> Matrix
+absolute = mapElements abs
+
+-- | Raise every element to a power.
+power :: Matrix -> Double -> Matrix
+power matrix exponent = mapElements (** exponent) matrix
+
+-- | Flatten a matrix into one row in row-major order.
+flatten :: Matrix -> Matrix
+flatten matrix = Matrix [concat (matrixValues matrix)] 1 (rows matrix * cols matrix)
+
+-- | Rearrange elements into a new rectangular shape.
+reshape :: Int -> Int -> Matrix -> Either String Matrix
+reshape rowCount columnCount matrix = do
+    validateDimensions rowCount columnCount
+    if rowCount * columnCount /= elementCount
+        then
+            Left
+                ( "cannot reshape "
+                    ++ show (rows matrix)
+                    ++ "x"
+                    ++ show (cols matrix)
+                    ++ " matrix into "
+                    ++ show rowCount
+                    ++ "x"
+                    ++ show columnCount
+                )
+        else Right (Matrix reshaped rowCount columnCount)
+  where
+    elementCount = rows matrix * cols matrix
+    flattened = concat (matrixValues matrix)
+    reshaped
+        | columnCount == 0 = replicate rowCount []
+        | otherwise = chunksOf columnCount flattened
+
+-- | Extract one row as a one-row matrix.
+row :: Int -> Matrix -> Either String Matrix
+row rowIndex matrix
+    | rowIndex < 0 || rowIndex >= rows matrix =
+        Left ("row " ++ show rowIndex ++ " out of bounds for " ++ show (rows matrix) ++ "-row matrix")
+    | otherwise = Right (Matrix [matrixValues matrix !! rowIndex] 1 (cols matrix))
+
+-- | Extract one column as a column vector.
+column :: Int -> Matrix -> Either String Matrix
+column columnIndex matrix
+    | columnIndex < 0 || columnIndex >= cols matrix =
+        Left ("column " ++ show columnIndex ++ " out of bounds for " ++ show (cols matrix) ++ "-column matrix")
+    | otherwise =
+        Right
+            ( Matrix
+                [[values !! columnIndex] | values <- matrixValues matrix]
+                (rows matrix)
+                1
+            )
+
+-- | Extract rows @[r0,r1)@ and columns @[c0,c1)@.
+slice :: Int -> Int -> Int -> Int -> Matrix -> Either String Matrix
+slice r0 r1 c0 c1 matrix
+    | r0 < 0 || r1 > rows matrix || c0 < 0 || c1 > cols matrix =
+        Left "slice bounds are outside the matrix"
+    | r0 >= r1 || c0 >= c1 =
+        Left "slice dimensions must be positive"
+    | otherwise =
+        Right
+            ( Matrix
+                (map (take (c1 - c0) . drop c0) (take (r1 - r0) (drop r0 (matrixValues matrix))))
+                (r1 - r0)
+                (c1 - c0)
+            )
+
+-- | Exact shape and element equality.
+exactEquals :: Matrix -> Matrix -> Bool
+exactEquals = (==)
+
+-- | Element-wise comparison with the default tolerance of @1e-9@.
+close :: Matrix -> Matrix -> Bool
+close = closeWithin 1e-9
+
+-- | Element-wise comparison with an explicit absolute tolerance.
+closeWithin :: Double -> Matrix -> Matrix -> Bool
+closeWithin tolerance left right =
+    rows left == rows right
+        && cols left == cols right
+        && and
+            ( zipWith
+                (\leftRow rightRow -> and (zipWith (\a b -> abs (a - b) <= tolerance) leftRow rightRow))
+                (matrixValues left)
+                (matrixValues right)
+            )
+
+combine :: String -> (Double -> Double -> Double) -> Matrix -> Matrix -> Either String Matrix
+combine operation transform left right
+    | rows left /= rows right || cols left /= cols right =
+        Left
+            ( operation
+                ++ " dimension mismatch: "
+                ++ show (rows left)
+                ++ "x"
+                ++ show (cols left)
+                ++ " vs "
+                ++ show (rows right)
+                ++ "x"
+                ++ show (cols right)
+            )
+    | otherwise =
+        Right
+            left
+                { matrixValues =
+                    zipWith (zipWith transform) (matrixValues left) (matrixValues right)
+                }
+
+extreme :: (Double -> Double -> Bool) -> String -> Matrix -> Either String ((Int, Int), Double)
+extreme better operation matrix =
+    case indexedValues of
+        [] -> Left ("cannot compute " ++ operation ++ " of an empty matrix")
+        first : remaining -> Right (foldl choose first remaining)
+  where
+    indexedValues =
+        [ ((rowIndex, columnIndex), matrixValues matrix !! rowIndex !! columnIndex)
+        | rowIndex <- indices (rows matrix)
+        , columnIndex <- indices (cols matrix)
+        ]
+    choose best@(_, bestValue) candidate@(_, candidateValue)
+        | candidateValue `better` bestValue = candidate
+        | otherwise = best
+
+validateDimensions :: Int -> Int -> Either String ()
+validateDimensions rowCount columnCount
+    | rowCount < 0 || columnCount < 0 = Left "matrix dimensions must be non-negative"
+    | otherwise = Right ()
+
+validIndex :: Int -> Int -> Matrix -> Bool
+validIndex rowIndex columnIndex matrix =
+    rowIndex >= 0
+        && rowIndex < rows matrix
+        && columnIndex >= 0
+        && columnIndex < cols matrix
+
+indexError :: Int -> Int -> Matrix -> String
+indexError rowIndex columnIndex matrix =
+    "index ("
+        ++ show rowIndex
+        ++ ", "
+        ++ show columnIndex
+        ++ ") out of bounds for "
+        ++ show (rows matrix)
+        ++ "x"
+        ++ show (cols matrix)
+        ++ " matrix"
+
+replaceAt :: Int -> value -> [value] -> [value]
+replaceAt index value values = take index values ++ [value] ++ drop (index + 1) values
+
+chunksOf :: Int -> [value] -> [[value]]
+chunksOf _ [] = []
+chunksOf size values = take size values : chunksOf size (drop size values)
+
+indices :: Int -> [Int]
+indices size = [0 .. size - 1]

--- a/code/packages/haskell/matrix/test/MatrixSpec.hs
+++ b/code/packages/haskell/matrix/test/MatrixSpec.hs
@@ -1,0 +1,161 @@
+module MatrixSpec (spec) where
+
+import Matrix
+import Prelude hiding (subtract)
+import Test.Hspec
+
+matrix2x2 :: Matrix
+matrix2x2 = rightMatrix [[1.0, 2.0], [3.0, 4.0]]
+
+other2x2 :: Matrix
+other2x2 = rightMatrix [[5.0, 6.0], [7.0, 8.0]]
+
+rightMatrix :: [[Double]] -> Matrix
+rightMatrix values =
+    case fromRows values of
+        Right matrix -> matrix
+        Left message -> error message
+
+spec :: Spec
+spec = do
+    describe "construction" $ do
+        it "constructs scalars, row vectors, and the empty matrix" $ do
+            toRows (scalar 5.0) `shouldBe` [[5.0]]
+            toRows (rowVector [1.0, 2.0, 3.0]) `shouldBe` [[1.0, 2.0, 3.0]]
+            (rows empty, cols empty, toRows empty) `shouldBe` (0, 0, [])
+        it "constructs rectangular matrices" $ do
+            fromRows [[1.0, 2.0], [3.0, 4.0]] `shouldBe` Right matrix2x2
+            (rows matrix2x2, cols matrix2x2) `shouldBe` (2, 2)
+        it "rejects ragged rows" $
+            fromRows [[1.0], [2.0, 3.0]]
+                `shouldBe` Left "all rows must have the same number of columns"
+        it "constructs zero matrices and rejects negative dimensions" $ do
+            fmap toRows (zeros 2 3) `shouldBe` Right [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+            zeros (-1) 2 `shouldBe` Left "matrix dimensions must be non-negative"
+            zeros 2 (-1) `shouldBe` Left "matrix dimensions must be non-negative"
+        it "constructs identity matrices and rejects negative sizes" $ do
+            fmap toRows (identity 3)
+                `shouldBe` Right [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+            identity (-1) `shouldBe` Left "matrix dimensions must be non-negative"
+        it "constructs diagonal matrices" $ do
+            toRows (fromDiagonal [2.0, 3.0]) `shouldBe` [[2.0, 0.0], [0.0, 3.0]]
+            fromDiagonal [] `shouldBe` empty
+
+    describe "arithmetic" $ do
+        it "adds and subtracts element by element" $ do
+            fmap toRows (add matrix2x2 other2x2) `shouldBe` Right [[6.0, 8.0], [10.0, 12.0]]
+            fmap toRows (subtract other2x2 matrix2x2) `shouldBe` Right [[4.0, 4.0], [4.0, 4.0]]
+        it "rejects mismatched element-wise shapes" $ do
+            let one = scalar 1.0
+            add matrix2x2 one `shouldBe` Left "addition dimension mismatch: 2x2 vs 1x1"
+            subtract matrix2x2 one `shouldBe` Left "subtraction dimension mismatch: 2x2 vs 1x1"
+        it "broadcasts and scales scalars" $ do
+            toRows (addScalar matrix2x2 2.0) `shouldBe` [[3.0, 4.0], [5.0, 6.0]]
+            toRows (subtractScalar matrix2x2 1.0) `shouldBe` [[0.0, 1.0], [2.0, 3.0]]
+            toRows (scale matrix2x2 2.0) `shouldBe` [[2.0, 4.0], [6.0, 8.0]]
+        it "transposes regular and zero-row matrices" $ do
+            toRows (transpose (rightMatrix [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+                `shouldBe` [[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]]
+            fmap (\matrix -> (rows matrix, cols matrix, toRows matrix)) (transpose <$> zeros 0 3)
+                `shouldBe` Right (3, 0, [[], [], []])
+        it "multiplies square matrices" $
+            fmap toRows (dot matrix2x2 other2x2)
+                `shouldBe` Right [[19.0, 22.0], [43.0, 50.0]]
+        it "multiplies vectors and rejects mismatched shapes" $ do
+            let columnVector = rightMatrix [[4.0], [5.0], [6.0]]
+            fmap toRows (dot (rowVector [1.0, 2.0, 3.0]) columnVector) `shouldBe` Right [[32.0]]
+            dot matrix2x2 columnVector
+                `shouldBe` Left "dot product dimension mismatch: 2 columns vs 3 rows"
+        it "leaves a matrix unchanged when multiplied by identity" $ do
+            let tall = rightMatrix [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+            (identity 3 >>= (`dot` tall)) `shouldBe` Right tall
+
+    describe "element access" $ do
+        it "reads each corner" $ do
+            get 0 0 matrix2x2 `shouldBe` Right 1.0
+            get 1 1 matrix2x2 `shouldBe` Right 4.0
+        it "rejects out-of-bounds reads" $ do
+            get (-1) 0 matrix2x2 `shouldBe` Left "index (-1, 0) out of bounds for 2x2 matrix"
+            get 0 2 matrix2x2 `shouldBe` Left "index (0, 2) out of bounds for 2x2 matrix"
+        it "updates immutably" $ do
+            let updated = set 0 0 99.0 matrix2x2
+            get 0 0 matrix2x2 `shouldBe` Right 1.0
+            (updated >>= get 0 0) `shouldBe` Right 99.0
+            fmap toRows updated `shouldBe` Right [[99.0, 2.0], [3.0, 4.0]]
+        it "rejects out-of-bounds updates" $
+            set 2 0 5.0 matrix2x2
+                `shouldBe` Left "index (2, 0) out of bounds for 2x2 matrix"
+
+    describe "reductions" $ do
+        it "sums all elements, rows, and columns" $ do
+            sumElements matrix2x2 `shouldBe` 10.0
+            toRows (sumRows matrix2x2) `shouldBe` [[3.0], [7.0]]
+            toRows (sumColumns matrix2x2) `shouldBe` [[4.0, 6.0]]
+        it "computes a mean and rejects an empty mean" $ do
+            mean matrix2x2 `shouldBe` Right 2.5
+            mean empty `shouldBe` Left "cannot compute mean of an empty matrix"
+        it "finds extrema across negative values" $ do
+            let values = rightMatrix [[-5.0, 3.0], [0.0, -1.0]]
+            minimumElement values `shouldBe` Right (-5.0)
+            maximumElement values `shouldBe` Right 3.0
+        it "finds first extrema positions on ties" $ do
+            argmin (rightMatrix [[3.0, 1.0], [4.0, 2.0]]) `shouldBe` Right (0, 1)
+            argmax (rightMatrix [[4.0, 2.0], [3.0, 4.0]]) `shouldBe` Right (0, 0)
+        it "rejects extrema on an empty matrix" $ do
+            minimumElement empty `shouldBe` Left "cannot compute minimum of an empty matrix"
+            maximumElement empty `shouldBe` Left "cannot compute maximum of an empty matrix"
+            argmin empty `shouldBe` Left "cannot compute argmin of an empty matrix"
+            argmax empty `shouldBe` Left "cannot compute argmax of an empty matrix"
+
+    describe "element-wise math" $ do
+        it "maps functions and square roots" $ do
+            let squares = rightMatrix [[1.0, 4.0], [9.0, 16.0]]
+            toRows (mapElements sqrt squares) `shouldBe` [[1.0, 2.0], [3.0, 4.0]]
+            fmap toRows (squareRoot squares) `shouldBe` Right [[1.0, 2.0], [3.0, 4.0]]
+        it "rejects square roots of negative elements" $
+            squareRoot (rowVector [1.0, -1.0])
+                `shouldBe` Left "cannot take square root of a negative matrix element"
+        it "computes absolute values and powers" $ do
+            toRows (absolute (rightMatrix [[-1.0, 2.0], [-3.0, 4.0]]))
+                `shouldBe` [[1.0, 2.0], [3.0, 4.0]]
+            toRows (power matrix2x2 2.0) `shouldBe` [[1.0, 4.0], [9.0, 16.0]]
+            (squareRoot matrix2x2 >>= Right . (`power` 2.0))
+                `shouldSatisfy` either (const False) (`close` matrix2x2)
+
+    describe "shape operations" $ do
+        it "flattens in row-major order and reshapes round-trip" $ do
+            toRows (flatten matrix2x2) `shouldBe` [[1.0, 2.0, 3.0, 4.0]]
+            reshape 2 2 (flatten matrix2x2) `shouldBe` Right matrix2x2
+        it "reshapes row vectors and zero-width matrices" $ do
+            fmap toRows (reshape 2 3 (rowVector [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+                `shouldBe` Right [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+            fmap (\matrix -> (rows matrix, cols matrix, toRows matrix)) (reshape 2 0 empty)
+                `shouldBe` Right (2, 0, [[], []])
+        it "rejects invalid reshapes" $ do
+            reshape 3 3 matrix2x2
+                `shouldBe` Left "cannot reshape 2x2 matrix into 3x3"
+            reshape (-1) 4 matrix2x2
+                `shouldBe` Left "matrix dimensions must be non-negative"
+        it "extracts rows and columns" $ do
+            fmap toRows (row 1 matrix2x2) `shouldBe` Right [[3.0, 4.0]]
+            fmap toRows (column 0 matrix2x2) `shouldBe` Right [[1.0], [3.0]]
+        it "rejects invalid row and column indices" $ do
+            row 2 matrix2x2 `shouldBe` Left "row 2 out of bounds for 2-row matrix"
+            column (-1) matrix2x2 `shouldBe` Left "column -1 out of bounds for 2-column matrix"
+        it "extracts half-open slices" $
+            fmap toRows (slice 0 2 1 3 (rightMatrix [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]))
+                `shouldBe` Right [[2.0, 3.0], [5.0, 6.0]]
+        it "rejects out-of-bounds and empty slices" $ do
+            slice 0 3 0 1 matrix2x2 `shouldBe` Left "slice bounds are outside the matrix"
+            slice 1 1 0 1 matrix2x2 `shouldBe` Left "slice dimensions must be positive"
+
+    describe "comparison" $ do
+        it "compares exact values and shapes" $ do
+            exactEquals matrix2x2 (rightMatrix [[1.0, 2.0], [3.0, 4.0]]) `shouldBe` True
+            exactEquals matrix2x2 (rightMatrix [[1.0, 2.0], [3.0, 5.0]]) `shouldBe` False
+            exactEquals (rowVector [1.0, 2.0]) (rightMatrix [[1.0], [2.0]]) `shouldBe` False
+        it "compares floating-point values with tolerances" $ do
+            let near = rightMatrix [[1.0 + 1e-10, 2.0 - 1e-10], [3.0, 4.0]]
+            close matrix2x2 near `shouldBe` True
+            closeWithin 1e-12 matrix2x2 near `shouldBe` False
+            close matrix2x2 (scalar 1.0) `shouldBe` False

--- a/code/packages/haskell/matrix/test/Spec.hs
+++ b/code/packages/haskell/matrix/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified MatrixSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec MatrixSpec.spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -167,7 +167,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 303
+The 172 packages present in at least ten implementation languages need 302
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -178,7 +178,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 28 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 27 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -441,6 +441,15 @@ including construction, validation, derived quantities, the full cycle,
 periodicity, phase offsets, and the zero-amplitude case. The package now spans
 14 implementation lanes, reduces the high-consensus backlog to 303 slots, and
 leaves 28 gaps in the Haskell lane.
+
+The seventh Haskell high-consensus slice is complete: `matrix` now provides
+immutable rectangular matrices with factories, arithmetic, multiplication,
+indexed updates, reductions, element-wise math, shape operations, and exact or
+tolerant comparison. Its package-native suite exercises 34 examples with 96%
+expression coverage, including rectangular validation, every operation family,
+empty and zero-width shapes, mismatched dimensions, invalid indices, and
+half-open slices. The package now spans 14 implementation lanes, reduces the
+high-consensus backlog to 302 slots, and leaves 27 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `matrix` package with immutable rectangular storage
- implement factories, arithmetic, matrix multiplication, indexed updates, reductions, element-wise math, shape operations, and exact/tolerant comparisons
- add package-native Hspec coverage and update the package-parity roadmap from 303 to 302 high-consensus gaps

## Why

`matrix` is the smallest dependency-safe leaf in the remaining 13-lane Haskell high-consensus set. Completing it also prepares the Haskell lane for later matrix-shaped ML ports such as gradient descent and perceptron.

## Validation

- `stack test --coverage`: 34 examples, 0 failures
- coverage: 96% expressions, 97% alternatives, 92% top-level declarations
- `python code/scripts/tests/test_package_parity_report.py`: 6 tests passed
- live parity report: 0 canonical collisions, 302 high-consensus gaps, 27 Haskell gaps, `matrix` at 14 implementation lanes
- `git diff --cached --check`
