### PR TITLE
feat(hl-spanish): Chapter 9 — ser vs estar, head-on

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -208,6 +208,10 @@
       "ES-VERB-COMER": "comer — 'to eat' (first -er verb; ← comedere → edible)",
       "ES-VERB-VIVIR": "vivir — 'to live' (first -ir verb; ← vīvere → vivid/survive)",
       "ES-VERB-BEBER": "beber — 'to drink' (-er; ← bibere → beverage/imbibe)",
+      "ES-VERB-SER": "ser — 'to be' (identity/essence; ← esse (+ sedēre); suppletive soy/eres/es/somos/son, cousins of English is/am/are)",
+      "ES-SER-VS-ESTAR": "ser vs estar — the two 'to be' verbs (essence vs state); minimal pairs flip meaning (es/está aburrido, rico, verde, listo)",
+      "ES-ORIGIN-SER": "soy de… — origin/profession/nationality take ser (essence); de ← Latin dē; ¿De dónde eres?",
+      "ES-LOCATION-ESTAR": "está en… — physical location always takes estar (← stāre 'to stand'); en ← Latin in; ¿Dónde estás?",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -233,6 +237,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/hindi/CHANGELOG.md
+++ b/code/learning/human-languages/hindi/CHANGELOG.md
@@ -7,7 +7,7 @@
   Devanagari inline; every root traced (`lessons/HI-C0{3,4,5}-*`,
   `book/chapters/ch0{3,4,5}-*.tex`). Concept tags reuse the universal `HL01`
   taxonomy (`QUESTION-HOW`, `STATE-HOW-ARE-YOU`, `PRONOUN-I`, `WORD-WELL`,
-  `YOURE-WELCOME`, `FAREWELL-*`); verbs are namespaced (`HI-VERB-*`).
+  `COURTESY-YOUREWELCOME`, `FAREWELL-*`); verbs are namespaced (`HI-VERB-*`).
 - **Ch. 3 — How Are You**: *kaise* (how; the *k-* question family) → *āp kaise
   haiṁ?* (respect-as-plural) → *maiṁ* (I ← *ma-*) → *hūṁ* (am ← Sanskrit *asmi* →
   English **am**; the copula trio hūṁ/hai/haiṁ) → *ṭhīk* (fine — native, no

--- a/code/learning/human-languages/hindi/lessons/HI-C03-aapka-swagat-hai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C03-aapka-swagat-hai.md
@@ -4,7 +4,7 @@ chapter: 3
 type: phrase
 headword: आपका स्वागत है
 gloss: you're welcome (also "welcome!")
-concept_tag: YOURE-WELCOME
+concept_tag: COURTESY-YOUREWELCOME
 prerequisites: [HI-C02-hai, HI-C01-dhanyavad]
 sounds: [sva-conjunct, matra-a]
 roots: [su-good, gam-come]

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Chapter 9 — ser vs estar, head-on
+
+- **Chapter 9 authored** (`ES-C09-ser`, `-ser-vs-estar`, `-soy-de`, `-esta-en`,
+  `-practice`): the pilot's **payoff chapter** — the two "to be" verbs sorted for
+  good, reviewing *estar* (Ch.4) and *tener* (Ch.8).
+- **ser** — the learner's second irregular and the **most irregular verb in
+  Spanish**: **suppletive** *soy · eres · es · somos · son*, traced to their
+  separate Latin sources (*sum, eris, est, sumus, sunt*) and shown as **cousins of
+  English *is / am / are*** (PIE *\*h₁es-*); root *esse* → essence/essential/
+  present/absent. Completes the pair opened by *estar* (← *stāre*) in Ch.4.
+- **The ser/estar split, derived from the roots**: *essence* (ser) vs
+  *estado/standing* (estar) — the mnemonic *ser = essence, estar = estado*. Proven
+  with **minimal pairs that flip meaning**: *es aburrido* "is boring" vs *está
+  aburrido* "is bored"; *es listo* "clever" vs *está listo* "ready"; *es rico*
+  "rich" vs *está rico* "tastes delicious"; *es verde* "green" vs *está verde*
+  "unripe."
+- **soy de…** (origin, profession, nationality → **ser**, because they define you;
+  *de* ← *dē* → English *de-*/depart/deduct; article-dropping *soy profesor*) and
+  **está en…** (physical location → **estar**, always; *en* ← *in* = English *in*),
+  contrasted through the twin questions *¿De dónde eres?* (ser) vs *¿Dónde estás?*
+  (estar) — same *dónde*, meaning-locked verbs.
+- Taxonomy: namespaced `ES-VERB-SER`, `ES-SER-VS-ESTAR`, `ES-ORIGIN-SER`,
+  `ES-LOCATION-ESTAR`; practice label `CH9-PRACTICE`.
+
 ## Chapter 8 — Numbers, having, and age
 
 - **Chapter 8 authored** (`ES-C08-numeros-1-5`, `-numeros-6-10`, `-tener`,

--- a/code/learning/human-languages/spanish/lessons/ES-C09-esta-en.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-esta-en.md
@@ -1,0 +1,74 @@
+---
+id: ES-C09-esta-en
+chapter: 9
+type: phrase
+headword: está en…
+gloss: "is in/at…" — location always takes estar
+concept_tag: ES-LOCATION-ESTAR
+prerequisites: [ES-C04-estar, ES-C09-ser-vs-estar]
+sounds: [st-no-e, vowel-e]
+roots: [stare-latin, in-latin]
+etymology_hook: "está en… — location is where a thing STANDS, so it takes estar; en ← Latin in 'in, on' → English in"
+est_minutes: 4
+reviews_of: [ES-C04-estar, ES-C09-ser-vs-estar, ES-C07-donde]
+---
+
+# está en… — saying where something is
+
+## Warm-up
+
+[PAUSE 2s] The mirror image of the last lesson. Origin was *ser* (essence). But
+**location** — where a thing physically **stands** right now — is the home turf of
+**estar** (← *stāre*, "to stand"). The root tells you: to be *located* is to
+*stand* somewhere.
+
+## The little word: en
+
+**en** = "in / on / at," from Latin **in** — and it *is* English **in**, barely
+changed in two thousand years. (Latin *in* → Spanish *en*, English *in*; the same
+word runs through *interior*, *include*, *invade* — "in-" everywhere.) One word,
+three English prepositions: *en casa* = "**at** home," *en la mesa* = "**on** the
+table," *en Madrid* = "**in** Madrid."
+
+## The pattern: estar + en + place
+
+Location is always **estar** — never *ser*, no exceptions for physical place:
+
+> **Estoy en** casa. — "I'm at home."
+> **Estás en** Madrid. — "You're in Madrid."
+> **Está en** la mesa. — "It's on the table."
+
+And to ask it, pair *dónde* with **estar**:
+
+> **¿Dónde estás?** — "Where are you?" (*dónde* from Ch.7, now with *estás*)
+> — **Estoy en casa.** — "I'm at home."
+
+## Grammar Lens: the clean contrast
+
+Put the two questions side by side and the whole chapter snaps into focus:
+
+| question | verb | why |
+|---|---|---|
+| **¿De dónde eres?** — "Where are you *from*?" | **ser** (*eres*) | origin = essence |
+| **¿Dónde estás?** — "Where are you *at*?" | **estar** (*estás*) | location = state |
+
+Same word *dónde*, two different be-verbs — and each is locked in by meaning.
+*From* where → what you **are** (ser). *At* where → where you **stand** (estar).
+Even a permanent-seeming place stays *estar*: **Madrid está en España** — cities
+don't move, but *being located* is still *estar*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Estoy en casa" — *es-TOY en KA-sa*]
+- [YOU SAY: ask and answer location — "¿Dónde estás? — Estoy en Madrid."]
+- [YOU SAY: the pair back-to-back — "¿De dónde eres?" (ser) then "¿Dónde estás?"
+  (estar), and feel the split]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which be-verb for physical location, and its Latin root's picture?
+(*estar* — *stāre*, "to stand": where a thing *stands*.) What does *en* mean, and
+its English twin? ("in/on/at"; English *in*.) Contrast *¿De dónde eres?* with
+*¿Dónde estás?* (origin/ser vs location/estar.) Next: **practice** — drill the
+whole split.

--- a/code/learning/human-languages/spanish/lessons/ES-C09-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-practice.md
@@ -1,0 +1,84 @@
+---
+id: ES-C09-practice
+chapter: 9
+type: practice-mix
+headword: (practice)
+gloss: drilling the ser / estar split
+concept_tag: CH9-PRACTICE
+prerequisites: [ES-C09-ser, ES-C09-ser-vs-estar, ES-C09-soy-de, ES-C09-esta-en]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C09-ser-vs-estar, ES-C09-soy-de, ES-C09-esta-en, ES-C04-estar, ES-C08-practice]
+---
+
+# Practice — ser or estar?
+
+## Warm-up
+
+[PAUSE 2s] The whole chapter comes down to one reflex: **essence → ser, state →
+estar.** Drill it until you don't have to think. Say each form aloud, and for
+every sentence, name *why* the verb is the one it is.
+
+## Conjugate both, out loud
+
+[PAUSE 1s]
+- **ser** (essence): **soy · eres · es · somos · son** (suppletive — *sum, eris,
+  est, sumus, sunt*).
+- **estar** (state): **estoy · estás · está · estamos · están** (the *-oy* tail,
+  same as *soy/voy/doy*).
+
+## Sort them — say "ser" or "estar," then the reason
+
+[PAUSE 1s]
+- "I'm a doctor." → **ser** (*soy médico* — identity)
+- "I'm tired." → **estar** (*estoy cansado* — passing state)
+- "She's from Peru." → **ser** (*es de Perú* — origin)
+- "The keys are on the table." → **estar** (*están en la mesa* — location)
+- "We're students." → **ser** (*somos estudiantes* — identity)
+- "You're at home." → **estar** (*estás en casa* — location)
+
+## The minimal pairs — meaning flips with the verb
+
+[PAUSE 1s]
+- **es aburrido** ("is boring") vs **está aburrido** ("is bored")
+- **es listo** ("is clever") vs **está listo** ("is ready")
+- **es rico** ("is rich") vs **está rico** ("tastes delicious")
+- **es verde** ("is green") vs **está verde** ("is unripe")
+
+## Say something real
+
+> — Hola. ¿**De dónde eres**? — **Soy de** México. ¿Y tú?
+> — **Soy de** España. **Soy** profesor. ¿**Dónde estás** ahora?
+> — **Estoy en** casa. **Estoy** un poco cansado, pero bien.
+
+Two verbs, one conversation: *soy de / soy profesor* (essence → **ser**), *estoy
+en casa / estoy cansado* (state → **estar**).
+
+## What you've built this chapter
+
+- **ser** — the *essence* to-be (← *esse* → essence/present; suppletive **soy ·
+  eres · es · somos · son**, cousins of English *is/am/are*), completing the pair
+  begun with *estar* back in Ch.4.
+- **the ser/estar split**, from the roots: *essence* (ser) vs *estado/standing*
+  (estar) — with **minimal pairs** that flip meaning (*es/está aburrido*, *rico*,
+  *verde*, *listo*).
+- **soy de…** (origin → **ser**; *de* ← *dē*) and **está en…** (location →
+  **estar**; *en* ← *in*), plus the twin questions *¿De dónde eres?* vs *¿Dónde
+  estás?*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: conjugate *ser* and *estar* fully, back to back]
+- [YOU SAY: the four minimal pairs, glossing each meaning]
+- [YOU SAY: run the dialogue — introduce where you're from and where you are now]
+
+[REPEAT x2] "¿De dónde eres? — Soy de … . ¿Dónde estás? — Estoy en … ."
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name the rule in three words. (*Essence → ser; state → estar*.) Give the
+five forms of *ser*. (*Soy, eres, es, somos, son*.) What flips between *es rico*
+and *está rico*? ("is rich" → "tastes delicious.") Next chapter: the **near
+future** — *ir a* + infinitive, "going to…" — and possessives.

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser-vs-estar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser-vs-estar.md
@@ -1,0 +1,75 @@
+---
+id: ES-C09-ser-vs-estar
+chapter: 9
+type: phrase
+headword: ser vs estar
+gloss: the two "to be" verbs, contrasted — essence vs state
+concept_tag: ES-SER-VS-ESTAR
+prerequisites: [ES-C09-ser, ES-C04-estar]
+sounds: [r-tap, st-no-e]
+roots: [esse-latin, stare-latin]
+etymology_hook: "the split is baked into the roots: ser ← esse (essence, what a thing IS) vs estar ← stāre (to stand, how it stands right now)"
+est_minutes: 5
+reviews_of: [ES-C09-ser, ES-C04-estar, ES-C04-como-esta]
+---
+
+# ser vs estar — essence vs state
+
+## Warm-up
+
+[PAUSE 2s] This is the lesson every Spanish learner waits for and dreads. Two
+verbs, one English word ("to be"). But the choice isn't arbitrary — it's written
+into the **etymology** you already learned. Get the roots, and the rule follows.
+
+## The rule, from the roots
+
+You met both verbs by their Latin sources. That's the whole key:
+
+| verb | root | picture | used for |
+|---|---|---|---|
+| **ser** | *esse* → **essence** | what a thing **is** | identity, origin, profession, nationality, what something is *made of*, the time |
+| **estar** | *stāre* → **to stand / state** | how a thing **stands** *right now* | mood, condition, location, the temporary |
+
+The mnemonic writes itself: **ser = essence, estar = estado** (Spanish for
+"state," the very word *estar* built). Permanent, defining truth → *ser*.
+Passing state or where-you-are → *estar*.
+
+- **Soy alto.** — "I am tall." (a defining trait → *ser*)
+- **Estoy cansado.** — "I am tired." (a passing state → *estar*)
+- **Es médico.** — "She is a doctor." (identity → *ser*)
+- **Está en casa.** — "She is at home." (location → *estar*, **always**)
+
+## Grammar Lens: minimal pairs that FLIP the meaning
+
+Here's the proof that the split is *real*, not decoration. Swap *ser* for *estar*
+on the **same adjective** and the meaning changes — because *essence* and *state*
+are genuinely different claims:
+
+| with **ser** (essence) | with **estar** (state) |
+|---|---|
+| **es aburrido** — "he *is* boring" (his nature) | **está aburrido** — "he *is* bored" (right now) |
+| **es listo** — "she *is* clever" (a trait) | **está lista** — "she *is* ready" (this moment) |
+| **es rico** — "he *is* rich" (wealth) | **está rico** — "it *tastes* delicious" (this dish, now) |
+| **es verde** — "it *is* green" (its colour) | **está verde** — "it's *unripe*" (its current state) |
+
+Same adjective, two verbs, two worlds. A boring person *is* (ser) boring; a bored
+person merely *stands* (estar) bored today. This is why Spanish keeps two verbs
+English merged into one — it can say things English needs extra words for.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the mnemonic — "ser = essence, estar = estado (state)"]
+- [YOU SAY: each minimal pair aloud — "es aburrido / está aburrido," and gloss
+  each: "is boring / is bored"]
+- [YOU SAY: sort five quick ones — tall (ser), tired (estar), a doctor (ser), at
+  home (estar), from Spain (ser)]
+
+[REPEAT x2] "ser = who/what it IS; estar = how/where it IS right now."
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which verb for a permanent trait, which for a passing state? (*ser* /
+*estar*.) What does *está aburrido* mean vs *es aburrido*? ("is bored" vs "is
+boring.") Give the *estar* reading of *está rico*. ("it tastes delicious.") Next:
+the two workhorses of the split — **soy de…** (origin) and **está en…** (location).

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
@@ -1,0 +1,75 @@
+---
+id: ES-C09-ser
+chapter: 9
+type: word
+headword: ser
+gloss: to be (identity — permanent, essential)
+concept_tag: ES-VERB-SER
+prerequisites: [ES-C04-estar, ES-C08-tener]
+sounds: [vowel-e, r-tap]
+roots: [esse-latin, sedere-latin]
+etymology_hook: "ser ← Latin esse 'to be' (+ sedēre 'to sit'); its forms are suppletive — soy/es/son are cousins of English am/is/are"
+est_minutes: 5
+reviews_of: [ES-C04-estar, ES-C08-tener]
+---
+
+# ser — "to be," the *essential* kind
+
+## Warm-up
+
+[PAUSE 2s] Back in Chapter 4 you met **estar** — the *temporary* to-be (← *stāre*,
+"to stand"): how you *are right now*, and *where*. It always came with a promise:
+Spanish has **two** be-verbs, and here's the other. **ser** is the *permanent*
+one — what a thing essentially **is**. It's also your second irregular verb, and
+its irregularity is spectacular.
+
+## Sounds you'll need
+
+- `r-tap` — *ser* ends in one soft tap of the tongue: *SER*.
+- No propping *e* here (unlike *es-tar*): *ser* already starts with its own vowel.
+
+## The word, taken apart
+
+**ser** comes from Latin **esse**, *"to be"* — the plainest, oldest verb there is.
+(Vulgar Latin actually rebuilt the infinitive as *\*essere*, and even folded in a
+second verb, **sedēre** "to sit," which is why a few forms look like they wandered
+in from elsewhere.) That root **es-** reaches deep into English:
+
+- **essence**, **essential**, **entity**, **is**, **am**, **are** — all the way
+  down, this is the PIE root ***h₁es-*** "to be." When you say *es*, you are
+  saying a cousin of English **is**.
+- with prefixes: **present** (*prae-esse*, "to be before/at hand"), **absent**
+  (*ab-esse*, "to be away"), **interest** (*inter-esse*, "to be between").
+
+So *ser* isn't just a word to memorize — it's the same ancient "be" that English
+carries in *is / am / are*.
+
+## Grammar Lens: the most irregular verb in Spanish
+
+*ser* is **suppletive** — its forms come from *different* Latin words fused into
+one verb, so you can't derive them from the infinitive. You simply learn them:
+
+| person | form | Latin source |
+|---|---|---|
+| yo | **soy** | ← *sum* ("I am"); the *-y* is the same odd tail as in *estoy/voy/doy* |
+| tú | **eres** | ← *eris* ("you will be" — a future form drafted into the present!) |
+| él/ella/usted | **es** | ← *est* — literally **cognate with English *is*** |
+| nosotros | **somos** | ← *sumus* |
+| ellos/ustedes | **son** | ← *sunt* — **cognate with English are-in-plural** |
+
+Say them as a set: **soy · eres · es · somos · son.** Notice how *es* and *son*
+sit right next to English *is* and (Latin) *sunt* — you already half-knew this verb.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ser" — *SER*, one tap]
+- [YOU SAY: "soy, eres, es, somos, son" — the whole suppletive set, twice]
+- [YOU SAY: "es" then English "is"; "son" then Latin "sunt" — hear the family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *ser* from, and one English cousin? (*esse* — essence
+/ essential / present.) Why can't you predict its forms? (It's **suppletive** —
+built from *sum, eris, est, sumus, sunt*.) Give all five present forms. (*Soy,
+eres, es, somos, son*.) Next: the big one — **when to use *ser* and when *estar*.**

--- a/code/learning/human-languages/spanish/lessons/ES-C09-soy-de.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-soy-de.md
@@ -1,0 +1,69 @@
+---
+id: ES-C09-soy-de
+chapter: 9
+type: phrase
+headword: soy de…
+gloss: "I'm from…" — origin and identity take ser
+concept_tag: ES-ORIGIN-SER
+prerequisites: [ES-C09-ser, ES-C06-espanol]
+sounds: [vowel-e, r-tap]
+roots: [esse-latin, de-latin]
+etymology_hook: "soy de… — origin is an essence, so it takes ser; de ← Latin dē 'from, of' → English de- (deduct, depart)"
+est_minutes: 4
+reviews_of: [ES-C09-ser, ES-C06-espanol]
+---
+
+# soy de… — saying where you're from
+
+## Warm-up
+
+[PAUSE 2s] You have *ser*. Now aim it. **Where you're from** and **what you do**
+are treated as *essence* in Spanish — they define you — so both take **ser**, not
+*estar*. This is where the split starts paying rent.
+
+## The little word: de
+
+**de** = "from / of," straight from Latin **dē** ("down from, about"). It's one of
+the most common words in Spanish, and its English children are everywhere as the
+prefix **de-**: **de**duct, **de**part, **de**scend, **de**scribe — all carry the
+"from / down-from" of *dē*.
+
+## The pattern: soy de + place
+
+Origin is a permanent fact about you, so it's **ser + de**:
+
+> **Soy de** México. — "I'm from Mexico."
+> **Eres de** España. — "You're from Spain."
+> **Es de** Colombia. — "She's from Colombia."
+
+And to ask it, Spanish fronts the *de*:
+
+> **¿De dónde eres?** — literally "From where are-you?" (*dónde*, "where," you met
+> in Ch.7; here it rides with *de* to mean *from where*.)
+
+Note it is **eres**, not *estás* — even though *dónde* usually pairs with *estar*
+for location. Origin isn't *where you are standing*; it's *what you are*. Essence
+→ *ser*.
+
+## Same verb, your identity: profession and nationality
+
+Because these define you, they're **ser** too — and they take **no article**:
+
+> **Soy profesor.** — "I'm a teacher." (no *un* — Spanish drops it with bare
+> professions)
+> **Soy español.** — "I'm Spanish." (there's *español* again, from Ch.6, ← *Hispania*)
+> **Somos estudiantes.** — "We're students."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Soy de…" + your city — *soy deh …*]
+- [YOU SAY: ask and answer — "¿De dónde eres? — Soy de México."]
+- [YOU SAY: identity with ser — "Soy profesor," "Soy español" (no *un*/*una*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which be-verb for where you're *from*, and why? (*ser* — origin is an
+essence, not a location you stand in.) What does *de* mean, and one English cousin?
+("from/of"; *depart*/*deduct*.) How do you ask "where are you from"? (*¿De dónde
+eres?*) Next: the other workhorse — **está en…**, location, which is pure *estar*.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -56,9 +56,16 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   **¿cuántos años tienes?** (age is *had*, not *been*; *años* ← *annus*, the ñ) →
   practice. **Authored.**
 
-Next: **Ch. 9** — **ser vs estar** head-on: the two "to be" verbs sorted for good
-(permanent identity vs temporary state/location), then possessives and the near
-future (*ir a* + infinitive). From here the course hands over rules, not phrases.
+- **Ch. 9 — ser vs estar, head-on**: **ser** (← *esse* → essence; the suppletive
+  *soy/eres/es/somos/son*, cousins of English *is/am/are*) → the **contrast**
+  *ser vs estar* — essence vs state, with **minimal pairs** that flip meaning
+  (*es/está aburrido* "boring"/"bored"; *es/está rico* "rich"/"delicious"; *listo*,
+  *verde*) → **soy de…** (origin/profession → ser; *de* ← *dē*) → **está en…**
+  (location → estar; *en* ← *in*) → practice. **Authored** — the pilot's payoff
+  chapter; the two "to be" verbs sorted for good.
+
+Next: **Ch. 10** — the **near future** (*ir a* + infinitive, "going to…") and
+**possessives** (*mi/tu/su*). From here the course hands over rules, not phrases.
 Grammar accumulates piece by piece. The theme skeleton below plans the wider road.
 
 ## Theme Skeleton (planning only)


### PR DESCRIPTION
Spanish **Chapter 9** — the pilot's payoff chapter: the two "to be" verbs sorted for good. Built atom-first (each lesson 3–5 min), reviewing *estar* (Ch.4) and *tener* (Ch.8) via `reviews_of`, with deep etymology throughout.

## Lessons (`ES-C09-*`)
- **ser** — the learner's second irregular and the **most irregular verb in Spanish**: suppletive *soy · eres · es · somos · son*, traced to their separate Latin sources (*sum, eris, est, sumus, sunt*) and shown as **cousins of English *is / am / are*** (PIE *h₁es-*); root *esse* → essence / present / absent.
- **ser-vs-estar** — the split **derived from the roots** (*essence* vs *estado/standing*), proven with **minimal pairs that flip meaning**: *es/está aburrido* (boring/bored), *listo* (clever/ready), *rico* (rich/delicious), *verde* (green/unripe).
- **soy de…** — origin, profession, nationality take **ser** (they define you); *de* ← *dē*; *¿De dónde eres?*
- **está en…** — physical location always takes **estar** (← *stāre* "to stand"); *en* ← *in*; *¿Dónde estás?* — contrasted head-on against *¿De dónde eres?*
- **practice** — drills the whole split (conjugate both, sort by essence/state, the minimal pairs, a real dialogue).

## Data / taxonomy
- Namespaced concepts documented: `ES-VERB-SER`, `ES-SER-VS-ESTAR`, `ES-ORIGIN-SER`, `ES-LOCATION-ESTAR`; `CH9-PRACTICE` added to the practice-tag note.
- Roadmap advanced (Ch.9 authored; **Next = Ch.10** near-future *ir a* + infinitive & possessives); Spanish CHANGELOG updated.

## Also: fixes a pre-existing red main
Sibling PR #8596 (Hindi Ch.3-5) landed `HI-C03-aapka-swagat-hai` carrying the **retired** `concept_tag: YOURE-WELCOME` (retired by `COURTESY-YOUREWELCOME` during the HL01 normalization), which fails the `human-language-data` validator ("neither canonical nor namespaced") — main is currently red on this suite. Retagged to the canonical `COURTESY-YOUREWELCOME` (no duplicate realization in Hindi) and corrected the stale reference in the Hindi CHANGELOG. This fix must ride here because **this PR edits `taxonomy.json`, which retriggers that same test suite**, so the PR could not be green without it.

## Verification
- `human-language-data` suite: **38 / 38 pass** (was 3 failing on origin/main due to the Hindi tag).
- Security-reviewed (subagent): markdown content + JSON data only — no scripts, URLs, secrets, or injection vectors; taxonomy.json validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)