### PR TITLE
feat(vigenere-cipher): add Haskell port

### DIFF
--- a/code/packages/haskell/vigenere-cipher/BUILD
+++ b/code/packages/haskell/vigenere-cipher/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/vigenere-cipher/BUILD_windows
+++ b/code/packages/haskell/vigenere-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/vigenere-cipher/CHANGELOG.md
+++ b/code/packages/haskell/vigenere-cipher/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add case-preserving Vigenere encryption and decryption.
+- Add index-of-coincidence key-length estimation.
+- Add chi-squared key recovery and automatic cipher breaking.

--- a/code/packages/haskell/vigenere-cipher/README.md
+++ b/code/packages/haskell/vigenere-cipher/README.md
@@ -1,0 +1,25 @@
+# vigenere-cipher
+
+A pure Haskell implementation of the Vigenere polyalphabetic substitution
+cipher and its classic statistical attack.
+
+## API
+
+- `encrypt` and `decrypt` preserve ASCII letter case, pass every other
+  character through unchanged, and advance the key only for ASCII letters.
+- `findKeyLength` estimates a key length up to 20 with the index of
+  coincidence.
+- `findKeyLengthWithLimit` applies the same analysis with an explicit limit.
+- `findKey` recovers key letters with chi-squared English-frequency scoring.
+- `breakCipher` combines length estimation, key recovery, and decryption.
+- `englishFrequencies` exposes the A-through-Z reference distribution.
+
+Keys are case-insensitive but must be non-empty and contain only ASCII
+letters. Statistical recovery needs a sufficiently long sample of ordinary
+English prose.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/vigenere-cipher/cabal.project
+++ b/code/packages/haskell/vigenere-cipher/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/vigenere-cipher/src/VigenereCipher.hs
+++ b/code/packages/haskell/vigenere-cipher/src/VigenereCipher.hs
@@ -1,0 +1,181 @@
+-- | The Vigenere cipher and classical statistical cryptanalysis.
+module VigenereCipher
+    ( BreakResult (..)
+    , encrypt
+    , decrypt
+    , englishFrequencies
+    , findKeyLength
+    , findKeyLengthWithLimit
+    , findKey
+    , breakCipher
+    ) where
+
+import Data.Char (chr, isAsciiLower, isAsciiUpper, ord, toUpper)
+import Data.List (foldl')
+
+-- | Result of automatic Vigenere cryptanalysis.
+data BreakResult = BreakResult
+    { recoveredKey :: String
+    , recoveredPlaintext :: String
+    }
+    deriving (Eq, Show)
+
+-- | Expected English letter frequencies from A through Z.
+englishFrequencies :: [Double]
+englishFrequencies =
+    [ 0.08167, 0.01492, 0.02782, 0.04253, 0.12702, 0.02228
+    , 0.02015, 0.06094, 0.06966, 0.00153, 0.00772, 0.04025
+    , 0.02406, 0.06749, 0.07507, 0.01929, 0.00095, 0.05987
+    , 0.06327, 0.09056, 0.02758, 0.00978, 0.02360, 0.00150
+    , 0.01974, 0.00074
+    ]
+
+-- | Encrypt ASCII letters with a repeating alphabetic key.
+encrypt :: String -> String -> Either String String
+encrypt plaintext key = do
+    shifts <- keyShifts key
+    Right (applyCipher 1 shifts plaintext)
+
+-- | Decrypt text encrypted with the given Vigenere key.
+decrypt :: String -> String -> Either String String
+decrypt ciphertext key = do
+    shifts <- keyShifts key
+    Right (applyCipher (-1) shifts ciphertext)
+
+-- | Estimate the key length, considering candidates up to 20 letters.
+findKeyLength :: String -> Int
+findKeyLength ciphertext = findKeyLengthWithLimit ciphertext 20
+
+-- | Estimate the key length using average index of coincidence.
+findKeyLengthWithLimit :: String -> Int -> Int
+findKeyLengthWithLimit ciphertext maximumLength
+    | letterCount < 2 || limit < 2 = 1
+    | bestIc <= 0.0 = 1
+    | otherwise = fst (head candidates)
+  where
+    letters = extractAlphaUpper ciphertext
+    letterCount = length letters
+    limit = min maximumLength (letterCount `div` 2)
+    scores = [(keyLength, averageIc letters keyLength) | keyLength <- [2 .. limit]]
+    bestIc = maximum (map snd scores)
+    threshold = bestIc * 0.9
+    candidates = filter ((>= threshold) . snd) scores
+
+-- | Recover an uppercase key of the requested length with chi-squared scoring.
+findKey :: String -> Int -> String
+findKey ciphertext keyLength
+    | keyLength <= 0 = ""
+    | otherwise = map recoverPosition [0 .. keyLength - 1]
+  where
+    letters = extractAlphaUpper ciphertext
+    recoverPosition position =
+        case positionGroup letters keyLength position of
+            [] -> 'A'
+            group -> chr (ord 'A' + bestShift group)
+
+-- | Estimate the key, decrypt the ciphertext, and return both results.
+breakCipher :: String -> BreakResult
+breakCipher ciphertext =
+    BreakResult key (applyCipher (-1) shifts ciphertext)
+  where
+    key = findKey ciphertext (findKeyLength ciphertext)
+    shifts = map ((subtractCode 'A') . toUpper) key
+
+keyShifts :: String -> Either String [Int]
+keyShifts "" = Left "key must not be empty"
+keyShifts key
+    | all isAsciiLetter key = Right (map ((subtractCode 'A') . toUpper) key)
+    | otherwise = Left "key must contain only ASCII letters"
+
+applyCipher :: Int -> [Int] -> String -> String
+applyCipher direction shifts = go 0
+  where
+    keyLength = length shifts
+    go _ [] = []
+    go keyIndex (char : remaining)
+        | isAsciiUpper char || isAsciiLower char =
+            shiftAscii direction (shifts !! (keyIndex `mod` keyLength)) char
+                : go (keyIndex + 1) remaining
+        | otherwise = char : go keyIndex remaining
+
+shiftAscii :: Int -> Int -> Char -> Char
+shiftAscii direction amount char
+    | isAsciiUpper char = shiftFrom 'A'
+    | otherwise = shiftFrom 'a'
+  where
+    shiftFrom base =
+        chr
+            ( ord base
+                + (subtractCode base char + direction * amount) `mod` 26
+            )
+
+extractAlphaUpper :: String -> String
+extractAlphaUpper = map toUpper . filter isAsciiLetter
+
+isAsciiLetter :: Char -> Bool
+isAsciiLetter char = isAsciiUpper char || isAsciiLower char
+
+averageIc :: String -> Int -> Double
+averageIc letters keyLength
+    | null usableGroups = 0.0
+    | otherwise = sum (map indexOfCoincidence usableGroups) / fromIntegral (length usableGroups)
+  where
+    usableGroups = filter ((> 1) . length) groups
+    groups = [positionGroup letters keyLength position | position <- [0 .. keyLength - 1]]
+
+positionGroup :: String -> Int -> Int -> String
+positionGroup letters keyLength position =
+    [ letter
+    | (index, letter) <- zip [0 ..] letters
+    , index `mod` keyLength == position
+    ]
+
+indexOfCoincidence :: String -> Double
+indexOfCoincidence letters
+    | letterCount < 2 = 0.0
+    | otherwise = fromIntegral numerator / fromIntegral denominator
+  where
+    letterCount = length letters
+    counts = letterCounts letters
+    numerator = sum [count * (count - 1) | count <- counts]
+    denominator = letterCount * (letterCount - 1)
+
+bestShift :: String -> Int
+bestShift group = fst (foldl' choose firstCandidate remainingCandidates)
+  where
+    candidates = [(shift, shiftScore group shift) | shift <- [0 .. 25]]
+    firstCandidate = head candidates
+    remainingCandidates = tail candidates
+    choose best@(_, bestScore) candidate@(_, candidateScore)
+        | candidateScore < bestScore = candidate
+        | otherwise = best
+
+shiftScore :: String -> Int -> Double
+shiftScore group shift = chiSquared counts
+  where
+    decrypted =
+        [ chr (ord 'A' + (subtractCode 'A' letter - shift) `mod` 26)
+        | letter <- group
+        ]
+    counts = letterCounts decrypted
+
+letterCounts :: String -> [Int]
+letterCounts letters =
+    [ length [() | letter <- letters, subtractCode 'A' letter == index]
+    | index <- [0 .. 25]
+    ]
+
+chiSquared :: [Int] -> Double
+chiSquared counts
+    | total == 0 = 1 / 0
+    | otherwise = sum (zipWith contribution counts englishFrequencies)
+  where
+    total = sum counts
+    totalDouble = fromIntegral total
+    contribution observed frequency = difference * difference / expected
+      where
+        expected = totalDouble * frequency
+        difference = fromIntegral observed - expected
+
+subtractCode :: Char -> Char -> Int
+subtractCode base char = ord char - ord base

--- a/code/packages/haskell/vigenere-cipher/test/Spec.hs
+++ b/code/packages/haskell/vigenere-cipher/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified VigenereCipherSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec VigenereCipherSpec.spec

--- a/code/packages/haskell/vigenere-cipher/test/VigenereCipherSpec.hs
+++ b/code/packages/haskell/vigenere-cipher/test/VigenereCipherSpec.hs
@@ -1,0 +1,126 @@
+module VigenereCipherSpec (spec) where
+
+import VigenereCipher
+import Test.Hspec
+
+longEnglishText :: String
+longEnglishText =
+    concat
+        [ "The quick brown fox jumps over the lazy dog and then runs around the "
+        , "entire neighborhood looking for more adventures to embark upon while "
+        , "the sun slowly sets behind the distant mountains casting long shadows "
+        , "across the valley below where the river winds its way through ancient "
+        , "forests filled with towering oak trees and singing birds that herald "
+        , "the coming of spring with their melodious songs echoing through the "
+        , "canopy above where squirrels chase each other from branch to branch "
+        , "gathering acorns and other nuts for the long winter months ahead when "
+        , "the ground will be covered in a thick blanket of pristine white snow "
+        , "and the children will build snowmen and throw snowballs at each other "
+        , "laughing and playing until their parents call them inside for dinner "
+        , "where warm soup and fresh bread await them on the old wooden table"
+        ]
+
+encryptedWith :: String -> String
+encryptedWith key =
+    case encrypt longEnglishText key of
+        Right ciphertext -> ciphertext
+        Left message -> error message
+
+spec :: Spec
+spec = do
+    describe "encrypt" $ do
+        it "matches the ATTACKATDAWN parity vector" $
+            encrypt "ATTACKATDAWN" "LEMON" `shouldBe` Right "LXFOPVEFRNHR"
+        it "preserves mixed case and punctuation" $
+            encrypt "Hello, World!" "key" `shouldBe` Right "Rijvs, Uyvjn!"
+        it "handles lowercase text and mixed-case keys" $ do
+            encrypt "attackatdawn" "lemon" `shouldBe` Right "lxfopvefrnhr"
+            encrypt "ATTACKATDAWN" "LeMoN" `shouldBe` Right "LXFOPVEFRNHR"
+        it "cycles single-character keys and wraps the alphabet" $ do
+            encrypt "ABC" "B" `shouldBe` Right "BCD"
+            encrypt "AB" "Z" `shouldBe` Right "ZA"
+        it "allows a key longer than the alphabetic content" $
+            encrypt "AB" "LONGERKEY" `shouldBe` Right "LP"
+        it "does not advance the key on non-letters" $
+            encrypt "A T" "LE" `shouldBe` Right "L X"
+        it "passes digits, punctuation, and Unicode through unchanged" $
+            encrypt "Hello 123! caf\x00e9 \x2764" "key"
+                `shouldBe` Right "Rijvs 123! akj\x00e9 \x2764"
+        it "encrypts empty text with a valid key" $
+            encrypt "" "KEY" `shouldBe` Right ""
+        it "rejects empty and non-ASCII keys before processing text" $ do
+            encrypt "hello" "" `shouldBe` Left "key must not be empty"
+            encrypt "hello" "key1" `shouldBe` Left "key must contain only ASCII letters"
+            encrypt "" "caf\x00e9" `shouldBe` Left "key must contain only ASCII letters"
+
+    describe "decrypt" $ do
+        it "matches the ATTACKATDAWN parity vector" $
+            decrypt "LXFOPVEFRNHR" "LEMON" `shouldBe` Right "ATTACKATDAWN"
+        it "restores mixed case and punctuation" $
+            decrypt "Rijvs, Uyvjn!" "key" `shouldBe` Right "Hello, World!"
+        it "handles lowercase and empty ciphertext" $ do
+            decrypt "lxfopvefrnhr" "lemon" `shouldBe` Right "attackatdawn"
+            decrypt "" "KEY" `shouldBe` Right ""
+        it "rejects invalid keys" $ do
+            decrypt "hello" "" `shouldBe` Left "key must not be empty"
+            decrypt "hello" "ke y" `shouldBe` Left "key must contain only ASCII letters"
+
+    describe "round trips" $ do
+        it "round-trips representative text and keys" $
+            mapM_
+                checkRoundTrip
+                [ ("ATTACKATDAWN", "LEMON")
+                , ("Hello, World!", "key")
+                , ("The quick brown fox!", "SECRET")
+                , ("abc def ghi", "xyz")
+                , ("MiXeD CaSe 123", "AbCdE")
+                , ("a", "z")
+                , ("ZZZZZZ", "A")
+                ]
+        it "round-trips punctuation, newlines, and Unicode" $
+            checkRoundTrip ("Hello,\nWorld! caf\x00e9 \x2764", "Mixed")
+
+    describe "findKeyLength" $ do
+        it "returns one for insufficient alphabetic signal" $ do
+            findKeyLength "" `shouldBe` 1
+            findKeyLength "A" `shouldBe` 1
+            findKeyLength "A!B" `shouldBe` 1
+        it "returns one when every candidate has zero coincidence" $
+            findKeyLengthWithLimit "ABCD" 20 `shouldBe` 1
+        it "recovers three-, five-, and six-letter key lengths" $ do
+            findKeyLength (encryptedWith "KEY") `shouldBe` 3
+            findKeyLength (encryptedWith "LEMON") `shouldBe` 5
+            findKeyLength (encryptedWith "SECRET") `shouldBe` 6
+        it "respects an explicit maximum length" $ do
+            let result = findKeyLengthWithLimit (encryptedWith "LEMON") 3
+            result `shouldSatisfy` (\value -> value >= 1 && value <= 3)
+            findKeyLengthWithLimit (encryptedWith "LEMON") 1 `shouldBe` 1
+
+    describe "findKey" $ do
+        it "recovers known keys with chi-squared analysis" $ do
+            findKey (encryptedWith "KEY") 3 `shouldBe` "KEY"
+            findKey (encryptedWith "LEMON") 5 `shouldBe` "LEMON"
+            findKey (encryptedWith "SECRET") 6 `shouldBe` "SECRET"
+        it "returns an empty key for non-positive lengths" $ do
+            findKey "ABC" 0 `shouldBe` ""
+            findKey "ABC" (-1) `shouldBe` ""
+        it "uses A for positions with no ciphertext group" $
+            findKey "E" 3 `shouldBe` "AAA"
+
+    describe "breakCipher" $ do
+        it "recovers LEMON and the original plaintext" $
+            breakCipher (encryptedWith "LEMON")
+                `shouldBe` BreakResult "LEMON" longEnglishText
+        it "recovers SECRET and the original plaintext" $
+            breakCipher (encryptedWith "SECRET")
+                `shouldBe` BreakResult "SECRET" longEnglishText
+        it "returns a stable short-text result" $
+            breakCipher "" `shouldBe` BreakResult "A" ""
+
+    describe "englishFrequencies" $
+        it "contains one positive value per ASCII letter" $ do
+            length englishFrequencies `shouldBe` 26
+            englishFrequencies `shouldSatisfy` all (> 0.0)
+  where
+    checkRoundTrip (text, key) =
+        (encrypt text key >>= (`decrypt` key)) `shouldBe` Right text

--- a/code/packages/haskell/vigenere-cipher/vigenere-cipher.cabal
+++ b/code/packages/haskell/vigenere-cipher/vigenere-cipher.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          vigenere-cipher
+version:       0.1.0
+synopsis:      Vigenere cipher and statistical cryptanalysis
+description:   Pure case-preserving Vigenere encryption, decryption, and key recovery.
+category:      Cryptography
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  VigenereCipher
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    VigenereCipherSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , vigenere-cipher
+    default-language: Haskell2010

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -167,7 +167,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 302
+The 172 packages present in at least ten implementation languages need 301
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -178,7 +178,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 27 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 26 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -450,6 +450,16 @@ expression coverage, including rectangular validation, every operation family,
 empty and zero-width shapes, mismatched dimensions, invalid indices, and
 half-open slices. The package now spans 14 implementation lanes, reduces the
 high-consensus backlog to 302 slots, and leaves 27 gaps in the Haskell lane.
+
+The eighth Haskell high-consensus slice is complete: `vigenere-cipher` now
+provides case-preserving encryption and decryption, strict ASCII-key
+validation, index-of-coincidence key-length estimation, chi-squared key
+recovery, and automatic cipher breaking. Its package-native suite exercises 26
+examples with 97% expression coverage, including parity vectors, punctuation,
+Unicode pass-through, invalid keys, round trips, three recovery key lengths,
+and short-input behavior. The package now spans 14 implementation lanes,
+reduces the high-consensus backlog to 301 slots, and leaves 26 gaps in the
+Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `vigenere-cipher` package with case-preserving encryption and decryption
- add index-of-coincidence key-length estimation, chi-squared key recovery, and automatic cipher breaking
- cover parity vectors, invalid keys, Unicode pass-through, round trips, and recovery behavior
- update the package-parity roadmap from 302 to 301 high-consensus gaps and from 27 to 26 Haskell gaps

## Validation

- `stack --color never --stack-yaml %TEMP%\\vigenere-parity-stack.yaml test --coverage` (26 examples, 0 failures; 97% expressions, 86% alternatives)
- `python code/scripts/tests/test_package_parity_report.py` (6 tests passed)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions; backlog 301; Haskell gaps 26; package lanes 14)
- `git diff --check`
