### PR TITLE
feat(hl-tamil): Chapters 3-5 — how-are-you, farewells, first verbs

### DIFF
--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Chapters 3–5 — How-are-you, Farewells, First Verbs
+
+- Three new chapters carry Tamil to Chapter 5, matching the leading tracks'
+  greet→introduce→how-are-you→farewell→verbs arc. One word per lesson, atom-first,
+  Tamil script inline; every root traced (`lessons/TA-C0{3,4,5}-*`,
+  `book/chapters/ch0{3,4,5}-*.tex`). Concept tags reuse the universal `HL01`
+  taxonomy; verbs namespaced (`TA-VERB-*`). The native-Dravidian-vs-Sanskrit
+  thread runs throughout.
+- **Ch. 3 — How Are You**: *eppaḍi* (how; the native *e-* question family) →
+  *nīṅgaḷ eppaḍi irukkiṟīrgaḷ?* (the verb *iru* "to be" — the copula returns for
+  states, where Ch.2's zero-copula couldn't reach) → *nāṉ* (I ← Proto-Dravidian,
+  unrelated to *me*) → *nalam* (well ← *nal-* "good," the root of *naṉṟi*) →
+  *paravāyillai* ("no harm" = you're welcome; the *iru*/*illai* pair) → practice.
+- **Ch. 4 — Farewells**: *pō*/*vā* → *pōy varugiṟēṉ* ("I'll go and come back" —
+  the Dravidian promise-of-return goodbye, tabled across Kannada/Telugu/Malayalam
+  and the Indo-Aryan tracks) → *nāḷai pārkkalām* (see you tomorrow) → *mīṇḍum
+  sandippōm* (we'll meet again; native *mīṇḍum* + Sanskrit *sandi* ← *sandhi*) →
+  practice.
+- **Ch. 5 — First Verbs**: *pēsu* (stem + tense + person) → *nāṉ tamiḻ pēsugiṟēṉ*
+  (I speak Tamil; the signature retroflex *ḻ*; no gender in the 1st person,
+  unlike Hindi) → *vāḻ* (to live/flourish) → *vēlai sey* (to work; noun + *sey*,
+  the twin of Hindi's *karnā*) → practice. Book compiles clean with XeLaTeX
+  (0 missing chars, 0 undefined refs).
+
 ## Chapter 2 — Introducing Yourself
 
 - New chapter around the introduction dialogue (*eṉ peyar … / uṅgaḷ peyar

--- a/code/learning/human-languages/tamil/README.md
+++ b/code/learning/human-languages/tamil/README.md
@@ -35,6 +35,15 @@ shown, LaTeX book.
   **uṅgaḷ peyar eṉṉa?** ("what's your name?"), magiḻcci, practice. Every atom
   native Dravidian and traced (*peyar* ≠ Indo-European *name*); the **zero
   copula** (no word for "is"). In the book.
+- **Chapter 3 — How Are You** ([`lessons/TA-C03-*`](./lessons/)): eppaḍi, **nīṅgaḷ
+  eppaḍi irukkiṟīrgaḷ?**, nāṉ, nalam, paravāyillai, practice. The verb *iru*
+  ("to be") — the copula returns for states; the *iru*/*illai* pair. In the book.
+- **Chapter 4 — Farewells** ([`lessons/TA-C04-*`](./lessons/)): pō/vā, **pōy
+  varugiṟēṉ** ("I'll go and come back"), nāḷai pārkkalām, mīṇḍum sandippōm,
+  practice. The Dravidian promise-of-return goodbye. In the book.
+- **Chapter 5 — First Verbs** ([`lessons/TA-C05-*`](./lessons/)): pēsu, **nāṉ
+  tamiḻ pēsugiṟēṉ**, vāḻ, vēlai sey, practice. Stem + tense + person; no gender
+  in the 1st person. In the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/tamil/book/book.tex
+++ b/code/learning/human-languages/tamil/book/book.tex
@@ -68,4 +68,10 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch02-introductions}
 
+\input{chapters/ch03-responding}
+
+\input{chapters/ch04-farewells}
+
+\input{chapters/ch05-first-verbs}
+
 \end{document}

--- a/code/learning/human-languages/tamil/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch03-responding.tex
@@ -1,0 +1,121 @@
+\chapter{How Are You?}
+\label{ch:responding}
+
+After the name comes the exchange everyone actually has --- and, for the first
+time, Tamil reaches for a verb ``to be'':
+
+\begin{center}
+\ta{நீங்கள் எப்படி இருக்கிறீர்கள்?} \quad(\emph{n\=\i\d{n}ga\d{l} eppa\d{t}i irukki\d{r}\=\i rga\d{l}} --- ``How are you?'')\\
+\ta{நான் நலமாக இருக்கிறேன்.} \quad(\emph{n\=a\d{n} nalam\=aga irukki\d{r}\=e\d{n}} --- ``I'm well.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/TA-C03-*.md}.}
+
+\section{\ta{எப்படி} \emph{(eppa\d{t}i)} --- ``how,'' another of the e- questions}
+\label{lesson:eppadi}
+
+\begin{sounds}
+\ta{எ} (\emph{e}) $+$ \ta{ப்ப} (\emph{ppa}) $+$ \ta{டி} (\emph{\d{t}i}) $\to$
+\ta{எப்படி} (\emph{eppa\d{t}i}).
+\end{sounds}
+
+\begin{cousinweb}
+\ta{எப்படி} (\emph{eppa\d{t}i}, ``how'') is native Dravidian --- the interrogative
+base \ta{எ} (\emph{e-}) $+$ \emph{pa\d{t}i} (``manner''), ``in what manner.''
+Tamil's questions nearly all begin with this \textbf{e-}: \emph{e\d{n}\d{n}a}
+(what), \emph{eppa\d{t}i} (how), \emph{epp\=odu} (when), \emph{e\d{n}g\=e}
+(where), \emph{\=e\d{n}} (why). Where Hindi gathers questions under \emph{k-} and
+English under \emph{wh-}, Tamil gathers its own under \textbf{e-} --- a separate,
+older family.
+\end{cousinweb}
+
+\section{\ta{நீங்கள் எப்படி இருக்கிறீர்கள்?} --- ``how are you?''}
+\label{lesson:eppadi-irukkirirgal}
+
+The new word is \ta{இருக்கிறீர்கள்} (\emph{irukki\d{r}\=\i rga\d{l}}): the verb
+stem \ta{இரு} (\emph{iru}, ``to be, exist, stay'') $+$ present $+$ \ta{ீர்கள்}
+(\emph{-\=\i rga\d{l}}, ``you,'' respectful). The verb comes last, as always.
+
+\begin{grammarlens}
+\textbf{Now the copula returns.} Chapter 2 showed Tamil drops ``is'' for
+\emph{equations} (\emph{e\d{n} peyar Arun}, ``my name Arun''). But ``how are
+you?'' is about a \emph{state} --- how you \emph{exist} --- and for that Tamil
+does use a verb, \ta{இரு} (\emph{iru}). So: no verb for ``my name is Arun,'' a
+real verb for ``how are you.'' The ending \emph{-\=\i rga\d{l}} already means
+``you (respectful),'' so \emph{n\=\i\d{n}ga\d{l}} can be dropped.
+\end{grammarlens}
+
+\section{\ta{நான்} \emph{(n\=a\d{n})} --- ``I,'' the Dravidian first person}
+\label{lesson:naan}
+
+\begin{sounds}
+\ta{ந} (dental \emph{na}) $+$ \ta{ா} (long \=a) $+$ \ta{ன்} (\emph{\d{n}}) $\to$
+\ta{நான்} (\emph{n\=a\d{n}}).
+\end{sounds}
+
+\begin{cousinweb}
+\ta{நான்} (\emph{n\=a\d{n}}, ``I'') $\leftarrow$ Proto-Dravidian *y\=a\d{n} /
+*n\=a\d{n} --- native, and (unlike Hindi's \emph{mai\d{m}}, cousin of English
+\emph{me}) \textbf{not} related to the European ``I/me'' family. Its possessive is
+the \ta{என்} (\emph{e\d{n}}, ``my'') you already met: \emph{n\=a\d{n}} ``I,''
+\emph{e\d{n}} ``my.'' Tamil's ``I'' is a clear marker that Dravidian grew up apart
+from the Indo-European world around it.
+\end{cousinweb}
+
+\section{\ta{நலம்} \emph{(nalam)} --- ``well,'' and how to answer}
+\label{lesson:nalam}
+
+\begin{sounds}
+\ta{ந} (\emph{na}) $+$ \ta{ல} (\emph{la}) $+$ \ta{ம்} (\emph{m}) $\to$ \ta{நலம்}.
+\end{sounds}
+
+\begin{cousinweb}
+\ta{நலம்} (\emph{nalam}, ``wellness, welfare'') is native Dravidian, from
+\ta{நல்} (\emph{nal-}, ``good'') --- the root behind \ta{நல்ல} (\emph{nalla},
+``good'') and \ta{நன்றி} (\emph{na\d{n}\d{r}i}, ``thanks,'' literally
+``goodness,'' from Chapter 1). So ``thank you'' and ``I'm well'' share a root:
+both are \emph{nal-}, ``good.''
+\end{cousinweb}
+
+Assemble: \ta{நான் நலமாக இருக்கிறேன்} (\emph{n\=a\d{n} nalam\=aga
+irukki\d{r}\=e\d{n}}) --- ``I am well'' (\emph{nalam} $+$ \emph{-\=aga} ``in a
+\ldots\ way'' $+$ \emph{iru} + ``I''). Casually: \emph{nall\=a irukk\=e\d{n}}.
+
+\section{\ta{பரவாயில்லை} \emph{(parav\=ayillai)} --- ``no problem''}
+\label{lesson:paravayillai}
+
+\begin{cousinweb}
+\ta{பரவாயில்லை} literally ``\textbf{there is no harm}'' --- \emph{parav\=ay}
+(``harm'') $+$ \ta{இல்லை} (\emph{illai}, ``is-not''). It serves as ``it's okay /
+no worries / you're welcome.'' The atom \ta{இல்லை} (\emph{illai}), from Chapter
+1, is the Tamil ``is-not,'' the mirror of \emph{iru} (``is''). It is shared,
+almost unchanged, across Tamil, Kannada, and Malayalam (\emph{illa}) --- a deep
+Dravidian bond; only Telugu breaks away to \emph{l\=edu}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\emph{Illai} negates existence and equations alike: \emph{n\=a\d{n} illai}
+(``it's not me''), \emph{pa\d{n}am illai} (``there's no money''), and, alone,
+plain ``no.'' Hold \emph{iru} / \emph{illai} together --- ``is'' and ``is-not.''
+\end{grammarlens}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Tamil & English \\
+\midrule
+\ta{நீங்கள் எப்படி இருக்கிறீர்கள்?} & How are you? \\
+\ta{நான் நலமாக இருக்கிறேன், நன்றி.} & I'm well, thank you. \\
+\ta{பரவாயில்லை.} & No problem / you're welcome. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{eppa\d{t}i} (the native \emph{e-} questions), \emph{n\=a\d{n}}
+(Proto-Dravidian, unrelated to \emph{me}), \emph{nalam} (\emph{nal-} ``good,'' the
+root of \emph{na\d{n}\d{r}i}), and the \emph{iru} / \emph{illai} pair --- ``is''
+and ``is-not.'' Next chapter: the farewells --- and Tamil never says a plain
+``goodbye.''

--- a/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
@@ -1,0 +1,111 @@
+\chapter{Farewells}
+\label{ch:farewells}
+
+Tamil does not say a plain ``goodbye.'' It says something warmer, and stranger to
+English ears --- ``I'll go and \emph{come back}'':
+
+\begin{center}
+\ta{போய் வருகிறேன்.} \quad(\emph{p\=oy varugi\d{r}\=e\d{n}} --- ``I'll go and come back.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/TA-C04-*.md}.}
+
+\section{\ta{போ} \emph{(p\=o)} --- ``go,'' and \ta{வா} (come)}
+\label{lesson:po}
+
+\begin{sounds}
+\ta{ப} (\emph{pa}) $+$ \ta{ோ} (long \=o) $\to$ \ta{போ} (\emph{p\=o}). Its partner
+\ta{வா} (\emph{v\=a}, ``come'').
+\end{sounds}
+
+\begin{cousinweb}
+\ta{போ} (\emph{p\=o}, ``go'') and \ta{வா} (\emph{v\=a}, ``come'') are native
+Dravidian verbs of the deepest layer --- single syllables, whole words on their
+own: \emph{p\=o!} (``go!''), \emph{v\=a!} (``come!''). You need both, because
+Tamil's goodbye is ``I go, and I \emph{come back}.''
+\end{cousinweb}
+
+\section{\ta{போய் வருகிறேன்} \emph{(p\=oy varugi\d{r}\=e\d{n})} --- ``I'll go and come back''}
+\label{lesson:poy-varugiren}
+
+\ta{போய்} (\emph{p\=oy}, ``having gone'') $+$ \ta{வருகிறேன்} (\emph{varugi\d{r}\=e\d{n}},
+``I come'') --- literally ``\textbf{having gone, I come},'' i.e. ``I'll go and
+come back.'' A Tamil speaker never signs off with a bare ``I'm leaving'' --- it
+sounds final, ill-omened. The reply is warm: \ta{போய் வா} (\emph{p\=oy v\=a}, ``go
+and come [back]'').
+
+\begin{cognates}
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Language & ``go and come back'' (goodbye) \\
+\midrule
+\textbf{Tamil} & \emph{p\=oy varugi\d{r}\=e\d{n}} \\
+Kannada & \emph{h\=ogi barutt\=ene} \\
+Telugu & \emph{ve\d{l}\d{l}i vast\=anu} \\
+Malayalam & \emph{p\=oyi var\=a\d{m}} \\
+\midrule
+Bengali (Indo-Aryan) & \emph{\=ashi} (``I come'') \\
+Hindi (Indo-Aryan) & \emph{phir milenge} (``we'll meet again'') \\
+\bottomrule
+\end{tabular}
+\end{center}
+The whole subcontinent, Dravidian and Indo-Aryan alike, prefers a promise of
+return to a blunt farewell.
+\end{cognates}
+
+\begin{grammarlens}
+\textbf{The ``having \ldots d'' participle.} \emph{P\=oy} chains actions:
+``having gone, (then) I come.'' Tamil strings verbs like beads --- all but the
+last in a participle form, the last fully conjugated.
+\end{grammarlens}
+
+\section{\ta{நாளை பார்க்கலாம்} \emph{(n\=a\d{l}ai p\=arkkal\=am)} --- ``see you tomorrow''}
+\label{lesson:naalai}
+
+\begin{sounds}
+\ta{நாளை} (\emph{n\=a\d{l}ai}): \ta{நா} (\emph{n\=a}) $+$ \ta{ளை} (\emph{\d{l}ai},
+retroflex \ta{ள} \emph{\d{l}}). \ta{பார்க்கலாம்} (\emph{p\=arkkal\=am}) $=$
+\emph{p\=ar} (``see'') $+$ \emph{-kkal\=am} (``let's / we may'').
+\end{sounds}
+
+\begin{cousinweb}
+\ta{நாளை} (\emph{n\=a\d{l}ai}, ``tomorrow'') is native, from \ta{நாள்} (\emph{n\=a\d{l}},
+``day''). \ta{பார்} (\emph{p\=ar}, ``to see''); so the phrase is ``tomorrow,
+let's see [each other].'' Note the retroflex \ta{ள்} (\emph{\d{l}}), tongue-tip
+curled up and back --- a sound English lacks.
+\end{cousinweb}
+
+\section{\ta{மீண்டும் சந்திப்போம்} \emph{(m\=\i\d{n}\d{t}um sandipp\=om)} --- ``we'll meet again''}
+\label{lesson:mindum-sandippom}
+
+\begin{cousinweb}
+\ta{மீண்டும் சந்திப்போம்} $=$ \ta{மீண்டும்} (\emph{m\=\i\d{n}\d{t}um}, ``again'')
+$+$ \ta{சந்திப்போம்} (\emph{sandipp\=om}, ``we will meet''). Two vocabularies in
+two words: \emph{m\=\i\d{n}\d{t}um} is \textbf{native Dravidian} (from
+\emph{m\=\i\d{l}}, ``to return''); \ta{சந்தி} (\emph{sandi}, ``to meet'') is a
+\textbf{Sanskrit} loan --- from \emph{sandhi} (``a joining''), the very term
+Sanskrit grammar uses for how sounds join at a boundary. A Dravidian core beside
+a Sanskrit borrowing --- the recurring thread of this track.
+\end{cousinweb}
+
+\section{The farewells}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Tamil & English \\
+\midrule
+\ta{போய் வருகிறேன்.} & I'll go and come back. (goodbye) \\
+\ta{போய் வா.} & Go and come back. (the reply) \\
+\ta{நாளை பார்க்கலாம்.} & See you tomorrow. \\
+\ta{மீண்டும் சந்திப்போம்.} & We'll meet again. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Roots banked: \emph{p\=o}/\emph{v\=a} (the oldest verbs), \emph{n\=a\d{l}} (``day''
+inside ``tomorrow''), and \emph{m\=\i\d{n}\d{t}um} (native) beside \emph{sandi}
+(Sanskrit). Next chapter: the first real verbs --- \emph{n\=a\d{n} tami\d{l}
+p\=esugi\d{r}\=e\d{n}} --- and Tamil's sentences begin to move.

--- a/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
@@ -1,0 +1,114 @@
+\chapter{The First Verbs}
+\label{ch:first-verbs}
+
+Until now, ``to be'' and ``to be-not.'' Now verbs that \emph{act} --- and Tamil's
+sentences begin to move:
+
+\begin{center}
+\ta{நான் தமிழ் பேசுகிறேன்.} \quad(\emph{n\=a\d{n} tami\d{l} p\=esugi\d{r}\=e\d{n}} --- ``I speak Tamil.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/TA-C05-*.md}.}
+
+\section{\ta{பேசு} \emph{(p\=esu)} --- ``to speak,'' your first full verb}
+\label{lesson:pesu}
+
+\begin{sounds}
+\ta{ப} (\emph{pa}) $+$ \ta{ே} (long \=e) $+$ \ta{சு} (\emph{su}) $\to$ \ta{பேசு}
+(\emph{p\=esu}).
+\end{sounds}
+
+\begin{cousinweb}
+\ta{பேசு} (\emph{p\=esu}, ``to speak'') is native Dravidian; the bare stem is also
+the command ``speak!'' To say ``I speak,'' Tamil stacks two endings on the stem
+--- \textbf{tense} then \textbf{person}:
+\begin{center}
+\emph{p\=esu-} (speak) $+$ \emph{-gi\d{r}-} (present) $+$ \emph{-\=e\d{n}} (``I'')
+$\to$ \ta{பேசுகிறேன்} (\emph{p\=esugi\d{r}\=e\d{n}}), ``I speak.''
+\end{center}
+The \emph{-\=e\d{n}} ending \emph{is} ``I,'' so the word \emph{n\=a\d{n}} is
+rarely needed. Change the ending, change the person: \emph{p\=esugi\d{r}\=a\d{n}}
+(he), \emph{p\=esugi\d{r}\=a\d{l}} (she), \emph{p\=esugi\d{r}\=arga\d{l}}
+(they / you-respectful).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Stem $+$ tense $+$ person.} Every Tamil verb is built this way --- a
+stem, a tense-marker, a person-ending, glued in that order. Learn the pattern
+once and every verb follows it.
+\end{grammarlens}
+
+\section{\ta{நான் தமிழ் பேசுகிறேன்} --- ``I speak Tamil''}
+\label{lesson:naan-tamizh-pesugiren}
+
+\ta{நான்} (I) $+$ \ta{தமிழ்} (\emph{tami\d{l}}, ``Tamil,'' the object) $+$
+\ta{பேசுகிறேன்} (speak) --- ``I Tamil speak,'' verb last. The name \ta{தமிழ்}
+(\emph{tami\d{l}}) ends in the famous \ta{ழ} (\emph{\d{l}}), a curled retroflex
+between ``r,'' ``l,'' and ``zh'' found in almost no other language --- Tamil is
+sometimes called ``the \emph{\d{l}} language.'' It names one of the oldest living
+literary tongues on earth, its poetry two thousand years old and still read.
+
+\begin{grammarlens}
+\textbf{No gender on ``I speak.''} \emph{P\=esugi\d{r}\=e\d{n}} is the same whether
+a man or a woman says it --- Tamil marks \textbf{no gender in the first or second
+person} (only the third: \emph{-\=a\d{n}} he / \emph{-\=a\d{l}} she). This is
+unlike Hindi, where even ``I speak'' changes for the speaker's gender
+(\emph{bolt\=a}/\emph{bolt\=\i}). Tamil saves gender for ``he/she/it.''
+\end{grammarlens}
+
+\section{\ta{வாழ்} \emph{(v\=a\d{l})} --- ``to live, to flourish''}
+\label{lesson:vaazh}
+
+\begin{sounds}
+\ta{வா} (\emph{v\=a}) $+$ \ta{ழ்} (\emph{\d{l}}, the retroflex from \emph{tami\d{l}})
+$\to$ \ta{வாழ்} (\emph{v\=a\d{l}}).
+\end{sounds}
+
+\begin{cousinweb}
+\ta{வாழ்} (\emph{v\=a\d{l}}, ``to live, flourish, thrive'') is native, warmer than
+a plain ``reside.'' From it: \ta{வாழ்க்கை} (\emph{v\=a\d{l}kkai}, ``life'') and
+the blessing \ta{வாழ்க} (\emph{v\=a\d{l}ga}, ``may you live / long live''), as in
+\emph{v\=a\d{l}ga tami\d{l}}. ``I live'' $=$ \ta{நான் வாழ்கிறேன்} (\emph{n\=a\d{n}
+v\=a\d{l}gi\d{r}\=e\d{n}}) --- the same stem $+$ present $+$ ``I'' as
+\emph{p\=esugi\d{r}\=e\d{n}}.
+\end{cousinweb}
+
+\section{\ta{வேலை செய்} \emph{(v\=elai sey)} --- ``to work''}
+\label{lesson:velai-sey}
+
+\begin{cousinweb}
+\ta{செய்} (\emph{sey}, ``to do, make'') is a core native verb, and Tamil --- like
+Hindi with \emph{karn\=a} --- builds compounds by putting a noun in front of it:
+\ta{வேலை செய்} (\emph{v\=elai sey}, ``work-do'' $=$ ``to work''),
+\emph{samaiyal sey} (``to cook''), \emph{udavi sey} (``to help''). So ``I work''
+is \ta{நான் வேலை செய்கிறேன்} (\emph{n\=a\d{n} v\=elai seygi\d{r}\=e\d{n}}).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Noun $+$ \ta{செய்} $=$ a new verb} --- the exact twin of Hindi's ``noun
+$+$ \emph{karn\=a}'' (\emph{k\=am karn\=a}). Two unrelated families, Dravidian and
+Indo-Aryan, hit on the same trick: an all-purpose ``do'' verb with nouns bolted
+on. Millennia side by side, Tamil and Hindi quietly traded habits like this.
+\end{grammarlens}
+
+\section{Sentences about yourself}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Tamil & English \\
+\midrule
+\ta{நான் தமிழ் பேசுகிறேன்.} & I speak Tamil. \\
+\ta{நான் சென்னையில் வாழ்கிறேன்.} & I live in Chennai. \\
+\ta{நான் வேலை செய்கிறேன்.} & I work. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Three verbs, one engine: a stem, a tense-marker, a person-ending, the verb always
+last --- and no gender in the first person. Roots banked: \emph{p\=esu} (speak),
+\emph{v\=a\d{l}} (live $\to$ \emph{v\=a\d{l}kkai} ``life,'' \emph{v\=a\d{l}ga}
+``long live''), \emph{sey} (do $\to$ \emph{v\=elai sey} ``to work,'' the twin of
+Hindi's \emph{karn\=a}), and \emph{tami\d{l}} itself, with its signature
+retroflex \emph{\d{l}}. From here, Tamil's sentences only grow.

--- a/code/learning/human-languages/tamil/lessons/TA-C03-eppadi-irukkirirgal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-eppadi-irukkirirgal.md
@@ -1,0 +1,56 @@
+---
+id: TA-C03-eppadi-irukkirirgal
+chapter: 3
+type: phrase
+headword: நீங்கள் எப்படி இருக்கிறீர்கள்?
+gloss: how are you? (respectful)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [TA-C03-eppadi, TA-C02-nii-niingal]
+sounds: [retroflex-kk, iir-gal]
+roots: [iru-be]
+est_minutes: 5
+reviews_of: [TA-C02-nii-niingal, TA-C03-eppadi]
+---
+
+# நீங்கள் எப்படி இருக்கிறீர்கள்? (nīṅgaḷ eppaḍi irukkiṟīrgaḷ?)
+
+## Warm-up
+
+[PAUSE 2s] The everyday "how are you?" — and the first time Tamil actually *needs*
+a verb "to be."
+
+## The letters in this word
+
+The new word is **இருக்கிறீர்கள்** (*irukkiṟīrgaḷ*): the verb stem **இரு** (*iru*)
++ **க்கிற** (present) + **ீர்கள்** (*-īrgaḷ*, "you," respectful/plural). A long
+verb, but built of clean pieces.
+
+## The phrase, taken apart
+
+**நீங்கள் எப்படி இருக்கிறீர்கள்?** = **நீங்கள்** (*nīṅgaḷ*, "you," respectful) +
+**எப்படி** (*eppaḍi*, "how") + **இருக்கிறீர்கள்** (*irukkiṟīrgaḷ*, "are/exist") —
+"you how are?" The verb comes **last**, as in every Tamil sentence.
+
+The verb is **இரு** (*iru*), "to be, to exist, to stay" — native Dravidian.
+
+## Grammar Lens: now the copula returns
+
+In Chapter 2 you learned Tamil drops "is" entirely: *eṉ peyar Arun* ("my name
+Arun"). That **zero copula** works for *equations* (X is Y). But "how are you?" is
+about a **state** — how you *exist* right now — and for that Tamil does use a
+verb: **இரு** (*iru*). So: no verb for "my name is Arun," but a real verb for
+"how are you." The verb ending **-ீர்கள்** (*-īrgaḷ*) already means "you
+(respectful)," so *nīṅgaḷ* can even be dropped.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the respectful question — *nīṅgaḷ eppaḍi irukkiṟīrgaḷ?*]
+- [YOU SAY: the verb and its meaning (*iru* — "to be / exist / stay")]
+- [YOU SAY: why here Tamil needs a verb but "my name is Arun" doesn't (state vs. equation)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What verb does "how are you?" use, and why does this sentence need one
+when "my name is Arun" didn't? (*Iru*, "to be/exist"; because it describes a state,
+not an equation — the zero copula only covers X is Y.)

--- a/code/learning/human-languages/tamil/lessons/TA-C03-eppadi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-eppadi.md
@@ -1,0 +1,47 @@
+---
+id: TA-C03-eppadi
+chapter: 3
+type: word
+headword: எப்படி
+gloss: how
+concept_tag: QUESTION-HOW
+prerequisites: [TA-C02-enna]
+sounds: [e-interrogative]
+roots: [e-interrogative-dravidian]
+est_minutes: 4
+reviews_of: [TA-C02-enna]
+---
+
+# எப்படி (eppaḍi) — "how," another of the e- questions
+
+## Warm-up
+
+[PAUSE 2s] You met **என்ன** (*eṉṉa*, "what") in Chapter 2. Here is its sibling —
+and, like all of Tamil's question-words, it begins with **e-**.
+
+## The letters in this word
+
+*(Skim if you read Tamil.)* **எ** (*e*) + **ப்ப** (*ppa*, a doubled *p*) + **டி**
+(*ḍi*) → **எப்படி** (*eppaḍi*).
+
+## The word, taken apart
+
+**எப்படி** (*eppaḍi*, "how") is native Dravidian, built on the interrogative base
+**எ-** (*e-*) + *paḍi* ("manner, way") — literally "in what manner." Notice the
+pattern: Tamil's questions nearly all start with this **e-** —
+*eṉṉa* (what), *eppaḍi* (how), *eppōdu* (when), *eṅgē* (where), *ēṉ* (why),
+and *yār* (who). Where Hindi and English gather their questions under *k-* / *wh-*,
+Tamil gathers its own under **e-** — a separate, older family, evolved on its own.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "eppaḍi"]
+- [YOU SAY: the e- question family — *eṉṉa, eppaḍi, eppōdu, eṅgē, ēṉ*]
+- [YOU SAY: what it's built from (*e-* "what" + *paḍi* "manner")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What base do Tamil's question-words share, and how is it different from
+Hindi's? (The interrogative *e-*; it is native Dravidian, unrelated to Hindi's
+*k-* / English's *wh-*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C03-naan.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-naan.md
@@ -1,0 +1,52 @@
+---
+id: TA-C03-naan
+chapter: 3
+type: word
+headword: நான்
+gloss: I
+concept_tag: PRONOUN-I
+prerequisites: [TA-C02-en]
+sounds: [long-aa, final-n]
+roots: [yaan-dravidian]
+est_minutes: 3
+reviews_of: [TA-C02-en]
+---
+
+# நான் (nāṉ) — "I," the Dravidian first person
+
+## Warm-up
+
+[PAUSE 2s] To answer "how are you?" you first need "I." In Chapter 2 you learned
+*eṉ* ("my"); here is its owner.
+
+## The letters in this word
+
+**ந** (dental *na*) + **ா** (the long-*ā* sign) + **ன்** (the *ṉ*, a special Tamil
+*n*) → **நான்** (*nāṉ*).
+
+## The word, taken apart
+
+**நான்** (*nāṉ*, "I") ← Proto-Dravidian **\*yāṉ / \*nāṉ** — a native first-person
+word, and (unlike Hindi's *maiṁ*, cousin of English *me*) **not** related to the
+European "I/me" family at all. Its possessive is the **என்** (*eṉ*, "my") you
+already met: *nāṉ* "I," *eṉ* "my" — the same root, one standing, one leaning on a
+noun. Tamil's "I" is one of the clearest markers that Dravidian grew up entirely
+apart from the Indo-European world around it.
+
+## Grammar Lens: "I" you can drop
+
+Tamil verbs carry the person in their ending — *irukk-iṟēṉ* already means "**I**
+am" — so *nāṉ* is often left out once it's clear. You will still learn it first,
+because the answer to *eppaḍi irukkiṟīrgaḷ?* begins with it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāṉ"]
+- [YOU SAY: the pair — *nāṉ* (I), *eṉ* (my)]
+- [YOU SAY: is it related to English *me*? (No — Dravidian, a separate family)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is *nāṉ*'s possessive, and is it cousin to English *me*? (*Eṉ*,
+"my"; no — it is native Dravidian, unrelated to the Indo-European pronouns.)

--- a/code/learning/human-languages/tamil/lessons/TA-C03-nalam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-nalam.md
@@ -1,0 +1,58 @@
+---
+id: TA-C03-nalam
+chapter: 3
+type: word
+headword: நலம்
+gloss: well, wellness, good — and the reply "நான் நலமாக இருக்கிறேன்"
+concept_tag: WORD-WELL
+prerequisites: [TA-C03-naan, TA-C03-eppadi-irukkirirgal]
+sounds: [final-m]
+roots: [nal-good-dravidian]
+est_minutes: 4
+reviews_of: [TA-C03-naan]
+---
+
+# நலம் (nalam) — "well," and how to answer
+
+## Warm-up
+
+[PAUSE 2s] The word that answers "how are you?" — and a whole family of Tamil
+"good" grows from it.
+
+## The letters in this word
+
+**ந** (*na*) + **ல** (*la*) + **ம்** (*m*) → **நலம்** (*nalam*).
+
+## The word, taken apart
+
+**நலம்** (*nalam*, "wellness, good, welfare") is native Dravidian, from the root
+**நல்** (*nal-*, "good") — the same root behind **நல்ல** (*nalla*, "good," an
+everyday adjective) and **நன்றி** (*naṉṟi*, "thanks" — literally "goodness,"
+which you met in Chapter 1). So "thank you" and "I'm well" in Tamil share a root:
+both are *nal-*, "good." A purely Dravidian word, with no Sanskrit or European
+cousin — Tamil answering in its own voice.
+
+## The reply
+
+Assemble it: **நான் நலமாக இருக்கிறேன்** (*nāṉ nalamāga irukkiṟēṉ*) — "**I am
+well**." The piece *nalam* + *-āga* ("in a … way") makes the adverb *nalamāga*
+("well-ly"); *irukkiṟēṉ* is "I am/exist" (the *iru* verb, first person). The whole
+exchange:
+
+> — *nīṅgaḷ eppaḍi irukkiṟīrgaḷ?* ("How are you?")
+> — *nāṉ nalamāga irukkiṟēṉ, naṉṟi.* ("I'm well, thank you.")
+
+Casually, Tamils shorten it to *nallā irukkēṉ* ("I'm good").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nalam"]
+- [YOU SAY: the full reply — *nāṉ nalamāga irukkiṟēṉ*]
+- [YOU SAY: the root it shares with "thanks" (*nal-* "good," as in *naṉṟi*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the full reply to "how are you?", and name the Chapter-1 word that
+shares *nalam*'s root. (*Nāṉ nalamāga irukkiṟēṉ*; *naṉṟi*, "thanks" — both from
+*nal-*, "good.")

--- a/code/learning/human-languages/tamil/lessons/TA-C03-paravayillai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-paravayillai.md
@@ -1,0 +1,56 @@
+---
+id: TA-C03-paravayillai
+chapter: 3
+type: phrase
+headword: பரவாயில்லை
+gloss: it's okay / no problem / you're welcome
+concept_tag: YOURE-WELCOME
+prerequisites: [TA-C01-illai, TA-C01-nandri]
+sounds: [illai-negative]
+roots: [illai-not-dravidian]
+est_minutes: 4
+reviews_of: [TA-C01-illai, TA-C01-nandri]
+---
+
+# பரவாயில்லை (paravāyillai) — "no problem"
+
+## Warm-up
+
+[PAUSE 2s] When someone thanks you — or apologises — this is the easy, gracious
+reply, and it hides one of the most Tamil words there is.
+
+## The letters in this word
+
+Two joined words: **பரவாய்** (*paravāy*, "harm, worry") + **இல்லை** (*illai*,
+"is not") → **பரவாயில்லை** (*paravāyillai*).
+
+## The word, taken apart
+
+**பரவாயில்லை** literally means "**there is no harm**" — *paravāy* ("harm, trouble")
++ **இல்லை** (*illai*, "is-not, there-is-not"). It serves as "it's okay / no worries
+/ never mind / you're welcome." The key atom, **இல்லை** (*illai*), you already
+met in Chapter 1 — the Tamil word for negation and non-existence, the mirror of
+*iru* ("to be"). Where *iru* says "it is," *illai* says "it is not." This one word
+is shared, in almost the same shape, across Tamil, Kannada, and Malayalam
+(*illa*) — one of the deep bonds of the Dravidian south. (Telugu alone breaks
+away, using *lēdu*.)
+
+## Grammar Lens: இல்லை, the all-purpose "no"
+
+*Illai* negates existence and equations alike: *nāṉ illai* ("it's not me"),
+*paṇam illai* ("there's no money"). It is also, on its own, one way to say plain
+"no." Learn *iru* / *illai* together — "is" and "is-not" — and you can already
+affirm or deny almost anything.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "paravāyillai"]
+- [YOU SAY: what it literally means ("there is no harm")]
+- [YOU SAY: the *iru* / *illai* pair — "is" and "is-not"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *paravāyillai* literally say, and which Dravidian languages
+share its *illai*? ("There is no harm"; Tamil, Kannada, Malayalam — Telugu uses
+*lēdu* instead.)

--- a/code/learning/human-languages/tamil/lessons/TA-C03-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-practice.md
@@ -1,0 +1,53 @@
+---
+id: TA-C03-practice
+chapter: 3
+type: practice
+headword: (dialogue)
+gloss: Chapter 3 recap — the how-are-you exchange
+concept_tag: REVIEW
+prerequisites: [TA-C03-eppadi-irukkirirgal, TA-C03-nalam, TA-C03-paravayillai]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [TA-C03-eppadi, TA-C03-eppadi-irukkirirgal, TA-C03-naan, TA-C03-nalam, TA-C03-paravayillai]
+---
+
+# Chapter 3 — The how-are-you exchange
+
+## Warm-up
+
+[PAUSE 2s] No new words. The whole responding cycle, from atoms you now own.
+
+## The exchange
+
+[PAUSE 1s each]
+- [YOU SAY: "How are you?" (respectful) — *nīṅgaḷ eppaḍi irukkiṟīrgaḷ?*]
+- [YOU SAY: "I'm well, thank you." — *nāṉ nalamāga irukkiṟēṉ, naṉṟi.*]
+- [YOU SAY: "No problem / you're welcome." — *paravāyillai.*]
+- [YOU SAY: the casual version — *nallā irukkēṉ.*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the e- question-word for "how" (*eppaḍi*)]
+- [YOU SAY: "I" and the verb "to be" (*nāṉ*, *iru*)]
+- [YOU SAY: the "is / is-not" pair (*iru* / *illai*)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *eppaḍi* ← the interrogative *e-* (native Dravidian, not Hindi's *k-*)
+- *nāṉ* ← Proto-Dravidian *\*nāṉ* (unrelated to English *me*); possessive *eṉ*
+- *nalam* ← *nal-* "good" — the same root as *naṉṟi* ("thanks")
+- *iru* / *illai* — "to be" and "to be-not"; *illai* shared with Kannada & Malayalam
+
+## Grammar you now hold
+
+[PAUSE 2s]
+- [YOU SAY: when Tamil needs the verb *iru* and when it drops the copula (state vs. equation)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] A stranger asks *nīṅgaḷ eppaḍi irukkiṟīrgaḷ?* — give a full, polite
+reply, and answer their thanks. (*Nāṉ nalamāga irukkiṟēṉ, naṉṟi* — and to thanks,
+*paravāyillai*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C04-mindum-sandippom.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-mindum-sandippom.md
@@ -1,0 +1,52 @@
+---
+id: TA-C04-mindum-sandippom
+chapter: 4
+type: phrase
+headword: மீண்டும் சந்திப்போம்
+gloss: we'll meet again
+concept_tag: FAREWELL-LATER
+prerequisites: [TA-C04-poy-varugiren]
+sounds: [retroflex-nd]
+roots: [mindum-again-dravidian, sandhi-sanskrit]
+est_minutes: 4
+reviews_of: [TA-C04-naalai]
+---
+
+# மீண்டும் சந்திப்போம் (mīṇḍum sandippōm) — "we'll meet again"
+
+## Warm-up
+
+[PAUSE 2s] A warmer, open-ended goodbye — and a chance to see Tamil's two
+vocabularies side by side.
+
+## The letters in this word
+
+**மீண்டும்** (*mīṇḍum*): note the retroflex cluster **ண்ட** (*ṇḍ*). **சந்திப்போம்**
+(*sandippōm*): **சந்தி** (*sandi*) + **-ப்போம்** (*-ppōm*, "we will").
+
+## The word, taken apart
+
+**மீண்டும் சந்திப்போம்** = **மீண்டும்** (*mīṇḍum*, "again") + **சந்திப்போம்**
+(*sandippōm*, "we will meet") — "**we'll meet again**." Two vocabularies meet in
+these two words:
+
+- **மீண்டும்** (*mīṇḍum*, "again") is **native Dravidian**, from *mīḷ* ("to
+  return").
+- **சந்தி** (*sandi*, "to meet, a junction") is a **Sanskrit** loan — from
+  *sandhi* ("a joining, union"), the very word Sanskrit grammar uses for how
+  sounds join at a word-boundary.
+
+So even a goodbye shows Tamil's balance: an ancient Dravidian core (*mīṇḍum*)
+beside a Sanskrit borrowing (*sandi*) — the recurring thread of this whole track.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mīṇḍum sandippōm"]
+- [YOU SAY: which word is native Dravidian and which is Sanskrit (*mīṇḍum* / *sandi*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the phrase mean, and which of its two words is the Sanskrit
+loan? ("We'll meet again"; *sandi* "to meet" ← Sanskrit *sandhi* — while *mīṇḍum*
+"again" is native Dravidian.)

--- a/code/learning/human-languages/tamil/lessons/TA-C04-naalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-naalai.md
@@ -1,0 +1,47 @@
+---
+id: TA-C04-naalai
+chapter: 4
+type: phrase
+headword: நாளை பார்க்கலாம்
+gloss: see you tomorrow
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [TA-C04-poy-varugiren]
+sounds: [long-aa, retroflex-l]
+roots: [naal-day-dravidian]
+est_minutes: 4
+reviews_of: [TA-C04-poy-varugiren]
+---
+
+# நாளை பார்க்கலாம் (nāḷai pārkkalām) — "see you tomorrow"
+
+## Warm-up
+
+[PAUSE 2s] A goodbye with a date on it — built on the Tamil word for "day."
+
+## The letters in this word
+
+**நாளை** (*nāḷai*): **நா** (*nā*) + **ளை** (*ḷai*, with the retroflex **ள** *ḷ*,
+tongue curled back). **பார்க்கலாம்** (*pārkkalām*) = *pār* ("see") + *-kkalām*
+("let's / we may").
+
+## The word, taken apart
+
+**நாளை** (*nāḷai*, "tomorrow") is native Dravidian, from **நாள்** (*nāḷ*, "day")
+— the same *nāḷ* in *iṉṟu* / *nāḷ* counting and in *nal-vāḻttukkaḷ* ("good
+[day]-wishes"). **பார்க்கலாம்** (*pārkkalām*) is "let's see / we may see," from
+**பார்** (*pār*, "to see, to look") — so the whole phrase is "**tomorrow, let's
+see [each other]**," the Tamil "see you tomorrow." Note the retroflex **ள்**
+(*ḷ*) — a sound English lacks entirely, made with the tongue-tip curled up and
+back.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāḷai pārkkalām"]
+- [YOU SAY: the word for "day" inside "tomorrow" (*nāḷ*)]
+- [YOU SAY: the verb "to see" (*pār*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *nāḷai* come from, and what does *pārkkalām* add? (*Nāḷ*,
+"day"; "let's see" — from *pār*, "to see" — so "tomorrow, let's see each other.")

--- a/code/learning/human-languages/tamil/lessons/TA-C04-po.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-po.md
@@ -1,0 +1,45 @@
+---
+id: TA-C04-po
+chapter: 4
+type: word
+headword: போ
+gloss: to go (and வா, to come)
+concept_tag: TA-VERB-PO
+prerequisites: [TA-C03-naan]
+sounds: [long-o]
+roots: [po-go-dravidian, vaa-come-dravidian]
+est_minutes: 3
+reviews_of: []
+---
+
+# போ (pō) — "go," and வா (come)
+
+## Warm-up
+
+[PAUSE 2s] Two of the shortest, oldest verbs in Tamil — and together they make
+the Tamil goodbye.
+
+## The letters in this word
+
+**ப** (*pa*) + **ோ** (the long-*ō* sign) → **போ** (*pō*). Its partner: **வா**
+(*vā*, "come") — **வ** (*va*) + long *ā*.
+
+## The word, taken apart
+
+**போ** (*pō*, "to go") and **வா** (*vā*, "to come") are native Dravidian verbs of
+the deepest layer — single syllables, unchanged for millennia. As bare commands
+they are already whole words: *pō!* ("go!"), *vā!* ("come!"). You need both for
+the next lesson, because Tamil does not say a plain "goodbye" — it says "I go, and
+I **come back**."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pō" (go) and "vā" (come)]
+- [YOU SAY: the commands — *pō!* / *vā!*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *pō* and *vā* mean, and why will you need them both to say
+goodbye? ("Go" and "come"; the Tamil farewell is "I go and come back," not "I
+leave.")

--- a/code/learning/human-languages/tamil/lessons/TA-C04-poy-varugiren.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-poy-varugiren.md
@@ -1,0 +1,55 @@
+---
+id: TA-C04-poy-varugiren
+chapter: 4
+type: phrase
+headword: போய் வருகிறேன்
+gloss: goodbye (lit. "I'll go and come back")
+concept_tag: FAREWELL
+prerequisites: [TA-C04-po, TA-C03-naan]
+sounds: [poy-participle]
+roots: [po-go-dravidian, vaa-come-dravidian]
+est_minutes: 4
+reviews_of: [TA-C04-po]
+---
+
+# போய் வருகிறேன் (pōy varugiṟēṉ) — "I'll go and come back"
+
+## Warm-up
+
+[PAUSE 2s] The everyday Tamil goodbye — and it is, quite literally, a promise to
+return.
+
+## The letters in this word
+
+**போய்** (*pōy*, "having gone") is *pō* + the ending **-ய்** that means "having
+…d." **வருகிறேன்** (*varugiṟēṉ*, "I come") is *varu* (come) + present + **-ஏன்**
+("I").
+
+## The phrase, taken apart
+
+**போய் வருகிறேன்** = **போய்** (*pōy*, "having gone") + **வருகிறேன்** (*varugiṟēṉ*,
+"I come") — literally "**having gone, I come**," i.e. "**I'll go and come
+back**." A Tamil speaker never signs off with a bare "I'm leaving" — that sounds
+final, even ill-omened. Instead they promise return. It is the exact "promise of
+return" farewell you meet, in its own words, across the Dravidian south (Kannada
+*hōgi baruttēne*, Telugu *veḷḷi vastānu*, Malayalam *pōyi varāṁ*) — and it echoes
+the Indo-Aryan tracks too (Bengali *āshi*, Marathi *yeto*, Hindi *phir milenge*).
+The reply is warm: **போய் வா** (*pōy vā*, "go and come [back]").
+
+## Grammar Lens: the "having …d" participle
+
+*Pōy* is Tamil's way of chaining actions: "having gone, (then) I come." Tamil
+strings verbs like beads — one in the participle "-y" form, the last one fully
+conjugated. You will see this chaining everywhere.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the goodbye — *pōy varugiṟēṉ*]
+- [YOU SAY: its literal meaning ("having gone, I come" → "I'll come back")]
+- [YOU SAY: the warm reply — *pōy vā*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the Tamil goodbye literally promise, and how do you answer
+it? ("I'll go and come back"; reply *pōy vā*, "go and come [back]".)

--- a/code/learning/human-languages/tamil/lessons/TA-C04-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-practice.md
@@ -1,0 +1,47 @@
+---
+id: TA-C04-practice
+chapter: 4
+type: practice
+headword: (dialogue)
+gloss: Chapter 4 recap — the farewells
+concept_tag: REVIEW
+prerequisites: [TA-C04-poy-varugiren, TA-C04-naalai, TA-C04-mindum-sandippom]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [TA-C04-po, TA-C04-poy-varugiren, TA-C04-naalai, TA-C04-mindum-sandippom]
+---
+
+# Chapter 4 — The farewells
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three ways to part — none of them a blunt "goodbye."
+
+## The farewells
+
+[PAUSE 1s each]
+- [YOU SAY: the everyday goodbye — *pōy varugiṟēṉ* ("I'll go and come back")]
+- [YOU SAY: the warm reply — *pōy vā* ("go and come back")]
+- [YOU SAY: "see you tomorrow" — *nāḷai pārkkalām*]
+- [YOU SAY: "we'll meet again" — *mīṇḍum sandippōm*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the two oldest verbs (*pō* go, *vā* come)]
+- [YOU SAY: "day" hidden in "tomorrow" (*nāḷ*)]
+- [YOU SAY: which farewell-word is a Sanskrit loan (*sandi* ← *sandhi*)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *pōy varugiṟēṉ* — "having gone, I come"; the Dravidian promise-of-return goodbye
+- *nāḷai* ← *nāḷ* "day"; *pār* "to see"
+- *mīṇḍum* (native "again") + *sandi* (Sanskrit "to meet") — the two vocabularies
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does Tamil never say a plain "I'm leaving," and what does its
+everyday goodbye promise instead? (It sounds final/ill-omened; *pōy varugiṟēṉ*
+promises "I'll go and come back.")

--- a/code/learning/human-languages/tamil/lessons/TA-C05-naan-tamizh-pesugiren.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-naan-tamizh-pesugiren.md
@@ -1,0 +1,55 @@
+---
+id: TA-C05-naan-tamizh-pesugiren
+chapter: 5
+type: phrase
+headword: நான் தமிழ் பேசுகிறேன்
+gloss: I speak Tamil
+concept_tag: TA-WORD-TAMIZH
+prerequisites: [TA-C05-pesu, TA-C03-naan]
+sounds: [zh-retroflex]
+roots: [tamizh]
+est_minutes: 5
+reviews_of: [TA-C05-pesu, TA-C03-naan]
+---
+
+# நான் தமிழ் பேசுகிறேன் (nāṉ tamiḻ pēsugiṟēṉ) — "I speak Tamil"
+
+## Warm-up
+
+[PAUSE 2s] Your first full, moving sentence — and it names the language itself,
+with a sound almost no other language has.
+
+## The letters in this word
+
+**தமிழ்** (*tamiḻ*): **த** (*ta*) + **மி** (*mi*) + **ழ்** (*ḻ*) — that last
+letter, **ழ**, is the famous Tamil **ḻ**, a curled retroflex sound between "r,"
+"l," and "zh," found in almost no other language on earth. It is so identified
+with the language that Tamil is sometimes called "the *ḻ* language."
+
+## The sentence, taken apart
+
+**நான் தமிழ் பேசுகிறேன்** = **நான்** (*nāṉ*, "I") + **தமிழ்** (*tamiḻ*, "Tamil,"
+the object) + **பேசுகிறேன்** (*pēsugiṟēṉ*, "speak") — "**I Tamil speak**," the
+verb last as always. The name **தமிழ்** (*tamiḻ*) is native, of debated but
+clearly Dravidian origin (often linked to a sense of "sweetness / one's own
+speech"); it names one of the oldest living literary languages in the world, with
+poetry two thousand years old still read today.
+
+## Grammar Lens: no gender on "I speak"
+
+Notice *pēsugiṟēṉ* is the same whether a man or a woman says it — Tamil marks
+**no gender in the first or second person** (only the third: *pēsugiṟāṉ* he /
+*pēsugiṟāḷ* she). This is unlike Hindi, where even "I speak" changes for a male
+or female speaker (*boltā/boltī*). Tamil saves gender for "he/she/it."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāṉ tamiḻ pēsugiṟēṉ"]
+- [YOU SAY: the special Tamil sound in *tamiḻ* (the retroflex *ḻ*)]
+- [YOU SAY: does "I speak" change for a man vs. a woman? (No — Tamil marks no gender in the 1st person)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "I speak Tamil," and name the rare sound in the word *tamiḻ*.
+(*Nāṉ tamiḻ pēsugiṟēṉ*; the retroflex *ḻ* — ழ.)

--- a/code/learning/human-languages/tamil/lessons/TA-C05-pesu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-pesu.md
@@ -1,0 +1,54 @@
+---
+id: TA-C05-pesu
+chapter: 5
+type: word
+headword: பேசு
+gloss: to speak
+concept_tag: TA-VERB-PESU
+prerequisites: [TA-C03-naan]
+sounds: [long-e]
+roots: [pesu-speak-dravidian]
+est_minutes: 4
+reviews_of: []
+---
+
+# பேசு (pēsu) — "to speak," your first full verb
+
+## Warm-up
+
+[PAUSE 2s] So far, "to be." Here is a verb that *does* something — and it shows
+how Tamil builds "I do X."
+
+## The letters in this word
+
+**ப** (*pa*) + **ே** (the long-*ē* sign) + **சு** (*su*) → **பேசு** (*pēsu*).
+
+## The word, taken apart
+
+**பேசு** (*pēsu*, "to speak") is native Dravidian. The bare stem *pēsu* is also
+the command "speak!" To say "**I speak**," Tamil adds a two-part ending to the
+stem: **tense** + **person**:
+
+> *pēsu-* (speak) + *-giṟ-* (present) + *-ēṉ* ("I") → **பேசுகிறேன்** (*pēsugiṟēṉ*), "I speak."
+
+The **-ஏன்** (*-ēṉ*) ending *is* "I" — so, as with *irukkiṟēṉ*, you rarely need
+the word *nāṉ*. Change the ending, change the person: *pēsugiṟāṉ* ("he speaks"),
+*pēsugiṟāḷ* ("she speaks"), *pēsugiṟārgaḷ* ("they/you-respectful speak").
+
+## Grammar Lens: stem + tense + person
+
+Every Tamil verb is built this way — a stem, a tense-marker, a person-ending,
+stacked in that order and glued together. Learn the pattern once and every verb
+follows it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pēsu" (speak!)]
+- [YOU SAY: "I speak" — *pēsugiṟēṉ*]
+- [YOU SAY: the three stacked pieces (stem *pēsu* + present *-giṟ-* + "I" *-ēṉ*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Build "I speak" from *pēsu*, and name the three pieces of a Tamil verb.
+(*Pēsugiṟēṉ*; stem + tense + person.)

--- a/code/learning/human-languages/tamil/lessons/TA-C05-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-practice.md
@@ -1,0 +1,48 @@
+---
+id: TA-C05-practice
+chapter: 5
+type: practice
+headword: (dialogue)
+gloss: Chapter 5 recap — the first verbs
+concept_tag: REVIEW
+prerequisites: [TA-C05-pesu, TA-C05-naan-tamizh-pesugiren, TA-C05-vaazh, TA-C05-velai-sey]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [TA-C05-pesu, TA-C05-naan-tamizh-pesugiren, TA-C05-vaazh, TA-C05-velai-sey, TA-C03-naan]
+---
+
+# Chapter 5 — The first verbs
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three verbs, one engine — build real sentences about
+yourself.
+
+## Build the sentences
+
+[PAUSE 1s each]
+- [YOU SAY: "I speak Tamil" — *nāṉ tamiḻ pēsugiṟēṉ*]
+- [YOU SAY: "I live in Chennai" — *nāṉ Cheṉṉaiyil vāḻgiṟēṉ*]
+- [YOU SAY: "I work" — *nāṉ vēlai seygiṟēṉ*]
+- [YOU SAY: "he speaks" vs. "she speaks" — *pēsugiṟāṉ* / *pēsugiṟāḷ*]
+
+## The engine
+
+[PAUSE 2s]
+- [YOU SAY: the three stacked pieces of every Tamil verb (stem + tense + person)]
+- [YOU SAY: the ending that means "I" (*-ēṉ*)]
+- [YOU SAY: where Tamil marks gender — and where it doesn't (3rd person only)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *pēsu* "to speak" (native Dravidian)
+- *vāḻ* "to live/flourish" → *vāḻkkai* "life," *vāḻga* "long live"
+- *sey* "to do" → *vēlai sey* "to work" (the twin of Hindi's *karnā*)
+- *tamiḻ* — the language, and its signature retroflex *ḻ*
+
+## Wrap-up Recall
+
+[PAUSE 3s] In one breath, say your language and your work in Tamil, then bless
+someone with the *vāḻ* verb. (*Nāṉ tamiḻ pēsugiṟēṉ. Nāṉ vēlai seygiṟēṉ. Vāḻga!*)

--- a/code/learning/human-languages/tamil/lessons/TA-C05-vaazh.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-vaazh.md
@@ -1,0 +1,52 @@
+---
+id: TA-C05-vaazh
+chapter: 5
+type: word
+headword: வாழ்
+gloss: to live, to flourish
+concept_tag: TA-VERB-VAZH
+prerequisites: [TA-C05-pesu]
+sounds: [zh-retroflex, long-aa]
+roots: [vaazh-live-dravidian]
+est_minutes: 4
+reviews_of: [TA-C05-pesu, TA-C05-naan-tamizh-pesugiren]
+---
+
+# வாழ் (vāḻ) — "to live, to flourish"
+
+## Warm-up
+
+[PAUSE 2s] A second verb — and one of the most beloved words in the language, the
+one Tamils use to bless.
+
+## The letters in this word
+
+**வா** (*vā*) + **ழ்** (*ḻ*, the retroflex you just met in *tamiḻ*) → **வாழ்**
+(*vāḻ*).
+
+## The word, taken apart
+
+**வாழ்** (*vāḻ*, "to live, to flourish, to thrive") is native Dravidian, and
+carries more warmth than a plain "to reside." From it grow **வாழ்க்கை**
+(*vāḻkkai*, "life") and the blessing **வாழ்க** (*vāḻga*, "may you live / long
+live"), heard in *vāḻga tamiḻ* ("long live Tamil"). To say "I live," add the
+familiar ending: **நான் … வாழ்கிறேன்** (*nāṉ … vāḻgiṟēṉ*), stem + present *-giṟ-*
++ "I" *-ēṉ*, exactly like *pēsugiṟēṉ*.
+
+## Grammar Lens: same engine, new verb
+
+You already know the machine: *vāḻ-* (stem) + *-giṟ-* (present) + *-ēṉ* ("I") →
+*vāḻgiṟēṉ* ("I live"). Every verb you learn slots into the same three-part frame
+— that is the reward for learning *pēsu* carefully.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vāḻ" — feel the retroflex *ḻ*]
+- [YOU SAY: "I live" — *nāṉ vāḻgiṟēṉ*]
+- [YOU SAY: the blessing — *vāḻga!* ("long live / may you flourish")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Build "I live" from *vāḻ*, and give the blessing made from it.
+(*Vāḻgiṟēṉ*; *vāḻga!*, "may you live / long live.")

--- a/code/learning/human-languages/tamil/lessons/TA-C05-velai-sey.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-velai-sey.md
@@ -1,0 +1,57 @@
+---
+id: TA-C05-velai-sey
+chapter: 5
+type: word
+headword: வேலை செய்
+gloss: to work (lit. "work-do")
+concept_tag: TA-VERB-SEY
+prerequisites: [TA-C05-pesu]
+sounds: [long-e, ai-sign]
+roots: [sey-do-dravidian, velai-work-dravidian]
+est_minutes: 5
+reviews_of: [TA-C05-pesu, TA-C05-vaazh]
+---
+
+# வேலை செய் (vēlai sey) — "to work"
+
+## Warm-up
+
+[PAUSE 2s] The last verb of the chapter — and, like Hindi's *karnā*, it is a
+"do" verb that builds a hundred others.
+
+## The letters in this word
+
+**வேலை** (*vēlai*, "work"): **வே** (*vē*) + **லை** (*lai*). **செய்** (*sey*,
+"do"): **செ** (*se*) + **ய்** (*y*).
+
+## The word, taken apart
+
+**செய்** (*sey*, "to do, to make") is a core native Dravidian verb, and Tamil —
+like Hindi with *karnā* — builds compound verbs by putting a noun in front of it:
+
+- **வேலை செய்** (*vēlai sey*) = "work-do" = "**to work**" (*vēlai*, "work")
+- **சமையல் செய்** (*samaiyal sey*) = "to cook"
+- **உதவி செய்** (*udavi sey*) = "to help"
+
+So "I work" is **நான் வேலை செய்கிறேன்** (*nāṉ vēlai seygiṟēṉ*) — *sey-* + *-giṟ-*
++ *-ēṉ*, "I do work." Master *sey* and a whole grammar of "do-verbs" opens up.
+
+## Grammar Lens: noun + செய் = a new verb
+
+This "noun + *sey*" pattern is the exact twin of Hindi's "noun + *karnā*" (*kām
+karnā*, "to work"). Two unrelated language families — Dravidian and Indo-Aryan —
+landed on the same clever trick: make an all-purpose "do" verb, then bolt nouns
+onto it. Living side by side for millennia, Tamil and Hindi have quietly traded
+habits like this.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vēlai sey" (to work)]
+- [YOU SAY: "I work" — *nāṉ vēlai seygiṟēṉ*]
+- [YOU SAY: the Hindi twin of this trick (noun + *karnā*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Tamil turn "work" into "to work," and what Hindi verb works
+the same way? (*Vēlai* + *sey* = "work-do"; Hindi's *karnā*, as in *kām karnā*.)

--- a/code/learning/human-languages/tamil/roadmap.md
+++ b/code/learning/human-languages/tamil/roadmap.md
@@ -22,13 +22,26 @@ that needs it.
   Every atom native Dravidian and traced (*peyar* ≠ *name*); the **zero copula**
   (no word for "is"); respect-by-plural like French *vous*.
 
+- **Ch. 3 — How Are You**: eppaḍi (how; the native *e-* questions) → nīṅgaḷ
+  eppaḍi irukkiṟīrgaḷ? (the verb *iru* "to be" — the copula returns for states) →
+  nāṉ (I ← Proto-Dravidian, unrelated to *me*) → nalam (well ← *nal-* "good," the
+  root of *naṉṟi*) → paravāyillai (you're welcome; the *iru*/*illai* pair) →
+  practice.
+- **Ch. 4 — Farewells**: pō/vā (go/come) → pōy varugiṟēṉ ("I'll go and come
+  back" — the Dravidian promise-of-return goodbye) → nāḷai pārkkalām (see you
+  tomorrow) → mīṇḍum sandippōm (we'll meet again; native *mīṇḍum* + Sanskrit
+  *sandi*) → practice.
+- **Ch. 5 — First Verbs**: pēsu (to speak; stem + tense + person) → nāṉ tamiḻ
+  pēsugiṟēṉ (I speak Tamil; the retroflex *ḻ*; no gender in the 1st person) →
+  vāḻ (to live/flourish) → vēlai sey (to work; noun + *sey*, the twin of Hindi's
+  *karnā*) → practice.
+
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 3 | Responding: *eppaḍi irukkīṅgaḷ?* ("how are you"), *nallā irukkēṉ* ("I'm well"), the verb *iru* ("to be") |
-| 4 | The case-endings (Tamil's agglutinative suffixes), numbers 1–10 |
-| 5+ | Postpositions, tense on the verb, family, food — always with the Dravidian-cognate thread |
+| 6 | Case-endings (Tamil's agglutinative suffixes: *-ai, -il, -ukku*); more verbs |
+| 7+ | Tense (past/future), numbers, family, food — always with the Dravidian-cognate thread |
 
 Note: Tamil marks "you" by **register** (*nī* familiar / *nīṅgaḷ* respectful,
 also plural) — like the Romance/Germanic tracks, and worth teaching beside

--- a/code/learning/human-languages/tamil/session-map.md
+++ b/code/learning/human-languages/tamil/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Tamil Chapters 1–2
+# Session Map — Tamil Chapters 1–5
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -34,7 +34,37 @@ puḷḷi, the common vowel signs, the independent vowels, and the three-way
 | 13 | magizhcci | மகிழ்ச்சி | "pleased to meet you" ("joy"); the rare ழ (*ḻ*) |
 | 14 | practice | (dialogue) | the whole exchange |
 
+## Chapter 3 — How Are You
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 15 | eppadi | எப்படி | "how" ← the native *e-* question family (not Hindi's *k-*) |
+| 16 | eppadi-irukkirirgal | நீங்கள் எப்படி இருக்கிறீர்கள்? | **"how are you?"**; the verb *iru* — copula returns for states |
+| 17 | naan | நான் | "I" ← Proto-Dravidian (unrelated to English *me*); possessive *eṉ* |
+| 18 | nalam | நலம் | "well" ← *nal-* "good" — the root of *naṉṟi* ("thanks") |
+| 19 | paravayillai | பரவாயில்லை | "no problem / you're welcome" = "there is no harm"; the *iru*/*illai* pair |
+| 20 | practice | (dialogue) | the whole how-are-you exchange |
+
+## Chapter 4 — Farewells
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 21 | po | போ / வா | "go" / "come" — the two oldest verbs |
+| 22 | poy-varugiren | போய் வருகிறேன் | **"I'll go and come back"** — the Dravidian promise-of-return goodbye |
+| 23 | naalai | நாளை பார்க்கலாம் | "see you tomorrow"; *nāḷ* "day" + *pār* "to see" |
+| 24 | mindum-sandippom | மீண்டும் சந்திப்போம் | "we'll meet again"; native *mīṇḍum* + Sanskrit *sandi* |
+| 25 | practice | (dialogue) | the farewells |
+
+## Chapter 5 — The First Verbs
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 26 | pesu | பேசு | "to speak"; stem + tense + person (*pēsu-giṟ-ēṉ*) |
+| 27 | naan-tamizh-pesugiren | நான் தமிழ் பேசுகிறேன் | **"I speak Tamil"**; the retroflex *ḻ*; no gender in the 1st person |
+| 28 | vaazh | வாழ் | "to live/flourish" → *vāḻkkai* "life," *vāḻga* "long live" |
+| 29 | velai-sey | வேலை செய் | "to work" (noun + *sey*) — the twin of Hindi's *karnā* |
+| 30 | practice | (dialogue) | three verbs, one engine |
+
 ## Next
 
-Chapter 3 — *eppaḍi irukkīṅgaḷ?* ("how are you?") and answering with *nallā* —
-the responding cycle.
+Chapter 6 — the case-endings (Tamil's agglutinative suffixes *-ai, -il, -ukku*).


### PR DESCRIPTION
Carries the **Tamil** track from Chapter 2 to **Chapter 5**, matching the leading
tracks' early-learner arc (greet → introduce → how-are-you → farewell → first
verbs). Part of the per-track series bringing the South-Asian-script tracks to
parity (Hindi #8596 is the first).

Framework `HL00`; concept tags reuse the universal `HL01` taxonomy
(`QUESTION-HOW`, `STATE-HOW-ARE-YOU`, `PRONOUN-I`, `WORD-WELL`, `YOURE-WELCOME`,
`FAREWELL-*`), verbs namespaced (`TA-VERB-*`) — no `taxonomy.json` change. The
**native-Dravidian-vs-Sanskrit** thread runs throughout.

## Chapters

- **Ch. 3 — How Are You**: *eppaḍi* (how; Tamil's native *e-* question family) →
  *nīṅgaḷ eppaḍi irukkiṟīrgaḷ?* (the verb *iru* "to be" — the copula returns for
  *states*, where Ch.2's zero-copula couldn't reach) → *nāṉ* (I ←
  Proto-Dravidian, unrelated to English *me*) → *nalam* (well ← *nal-* "good," the
  root of Ch.1's *naṉṟi*) → *paravāyillai* ("there is no harm" = you're welcome;
  the *iru*/*illai* pair) → practice.
- **Ch. 4 — Farewells**: *pō*/*vā* (go/come) → *pōy varugiṟēṉ* ("I'll go and come
  back" — the Dravidian promise-of-return goodbye, tabled across
  Kannada/Telugu/Malayalam and the Indo-Aryan tracks) → *nāḷai pārkkalām* (see you
  tomorrow) → *mīṇḍum sandippōm* (we'll meet again; native *mīṇḍum* + Sanskrit
  *sandi* ← *sandhi*) → practice.
- **Ch. 5 — First Verbs**: *pēsu* (stem + tense + person) → *nāṉ tamiḻ pēsugiṟēṉ*
  (I speak Tamil; the signature retroflex *ḻ*; **no gender in the 1st person**,
  unlike Hindi) → *vāḻ* (to live/flourish → *vāḻga* "long live") → *vēlai sey*
  (to work; noun + *sey*, the exact twin of Hindi's *karnā*) → practice.

## Verification

- Book compiles clean with XeLaTeX (×2): **0 missing characters, 0 undefined
  references** (29 pages).
- New chapter pages rasterized and visually QA'd — Tamil script, retroflex
  diacritics, and the "go and come back" cognate table all render correctly.
- Concept tags validate against the `HL01` rules; `/security-review` covered by
  the Hindi run (identical content-only class — Markdown + LaTeX).
- `human-languages-books.yml` CI will build the updated PDF on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)