### PR TITLE
fix(apl-to-semantic-ir): stranded literals now lower to a genuine rank-1 vector

### DIFF
--- a/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## [0.1.3] - 2026-07-18
+
+### Fixed
+
+- **Stranded literals (`1 2 3`) now lower to a genuine rank-1 vector,
+  closing the gap 0.1.2's changelog flagged and explicitly left as an
+  out-of-scope follow-up** ("Discovered (not fixed here...)" below).
+  Root cause was a doc-comment/implementation mismatch, not a design gap:
+  `lower_term`'s multi-number ("stranding") branch built a bare
+  `Expr::ArrayLit { rows: vec![row], .. }` directly, justified by a comment
+  claiming "`rows.len() == 1` is precisely how a row/rank-1 vector is
+  represented." That claim contradicted `semantic-ir`'s own `ArrayLit` doc
+  comment (`nodes.rs`), which is explicit that a 1-row literal is a *row
+  vector* — under this IR's MATLAB-derived column-major storage convention
+  (`Feature::ArrayColumnMajor`), that means a genuinely rank-2 `[1, n]`
+  value, not rank-1 `[n]`. This crate's own module doc comment always
+  stated the correct INTENT ("`1 2 3` → one rank-1 `Expr::ArrayLit`"); the
+  implementation simply picked the wrong IR node to realize it. The
+  consequence: any SIR22-addendum operation correctly scoped to rank <= 1
+  operands only — `outer` (`A∘.×B`) and dyadic `⍴`'s shape argument — threw
+  a clean runtime `Error` in the generated JS (`outer: operands of rank > 1
+  not yet supported`; `reshape: shape argument must be a scalar or vector`)
+  whenever given a bare stranded literal, even though real APL accepts one
+  there without hesitation.
+- **The fix**: `lower_term`'s stranding branch now builds the same
+  single-row `Expr::ArrayLit` as before, then wraps it in `Expr::Ravel`
+  (SIR22 addendum "monadic `,A`", which already existed and already
+  flattens any input rank down to a genuine rank-1 result — this crate's
+  own monadic `,A` lowering already builds the identical node for the
+  exact same reason). This is invisible to APL source: nothing about the
+  surface syntax changes, only which IR node shape represents a stranded
+  literal. No new `Feature` was needed: `Ravel` observes `MatrixOps` +
+  `ArrayColumnMajor` (on top of the `NDArrays` + `ArrayColumnMajor` the
+  inner `ArrayLit` already added), the same three features every other
+  SIR22-addendum node in this file already observes — `lower_term` now
+  adds `Feature::MatrixOps` alongside the two it already added, matching
+  what `semantic-ir`'s validator independently derives when it walks the
+  emitted `Expr::Ravel` node (omitting it would have made every stranded
+  literal fail validation with "manifest does not declare feature
+  `MatrixOps` but module uses it").
+- **`tests/test_lower.rs`**: three existing tests that asserted a stranded
+  literal's lowered shape directly against a bare `Expr::ArrayLit` now
+  match `Expr::Ravel { target, .. }` first and drill into `**target` for
+  the `ArrayLit` (or just the variant, where the row contents weren't the
+  point) — `stranded_literal_is_a_single_row_array_lit` (renamed
+  `stranded_literal_is_a_ravelled_single_row_array_lit_rank_1_vector` to
+  reflect the new shape), `reduce_over_stranded_vector`, and
+  `dyadic_rho_is_reshape_with_a_as_shape_and_b_as_target` (the `2 3` shape
+  argument). Two new regression tests added:
+  `outer_product_accepts_two_bare_stranded_literals_as_genuine_rank_1_operands`
+  (`1 2∘.×3 4`) and
+  `reshape_accepts_bare_stranded_literal_shape_and_target_as_genuine_rank_1_operands`
+  (`2 3⍴1 2 3 4 5 6`), both asserting the IR shape (`Ravel`-wrapped
+  operands) and clean `semantic_ir::validate`.
+- **`tests/e2e_node.rs`**: two new `node`-executed tests proving the bug is
+  actually fixed end to end, not just at the IR-shape level —
+  `outer_product_of_two_bare_stranded_literals_runs_in_node` (`+/,1
+  2∘.×3 4` → `21`) and
+  `reshape_with_bare_stranded_literal_shape_and_target_runs_in_node`
+  (`⍴2 3⍴1 2 3 4 5 6` → `"2 3"`), neither needing the `⍳`/`,` workaround
+  the file's existing tests use. Confirmed these would have failed before
+  the fix by reverting just the `lower.rs` change locally and re-running
+  them: `node` threw exactly the two errors described above (`outer:
+  operands of rank > 1 not yet supported (shapes [1,2], [1,2])` and
+  `reshape: shape argument must be a scalar or vector (got rank 2)`). The
+  file's module doc comment's "Two representational quirks" section, point
+  2, is updated to record that this gap is now closed — the existing
+  `⍳`/`,`-based tests are left untouched (they remain valid; they exercise
+  prefix order and ravel's row-major-vs-column-major correctness, not this
+  gap) since the workaround they use is harmless, just no longer
+  necessary.
+
 ## [0.1.2] - 2026-07-18
 
 ### Added

--- a/code/packages/rust/apl-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/apl-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apl-to-semantic-ir"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "APL CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-4f, the last APL rollout item per HML01."
 

--- a/code/packages/rust/apl-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/apl-to-semantic-ir/src/lower.rs
@@ -25,8 +25,10 @@
 //!
 //! **Supported** (every construct `apl-parser`'s grammar can produce):
 //! - Number literals (`NUMBER`, high-minus `¯` negative sign), stranded
-//!   literals (`1 2 3` → one rank-1 [`Expr::ArrayLit`]), variables (`NAME`),
-//!   parenthesised grouping.
+//!   literals (`1 2 3` → one genuine rank-1 vector, represented as
+//!   [`Expr::Ravel`] wrapping a single-row [`Expr::ArrayLit`] — see
+//!   `lower_term`'s doc comment for why the bare `ArrayLit` alone is not
+//!   enough), variables (`NAME`), parenthesised grouping.
 //! - Assignment (`←`), including right-associative chained assignment
 //!   (`A←B←3`) — see "Chained assignment" below.
 //! - All 12 scalar dyadic atoms (`+ - × ÷ ⌈ ⌊ = ≠ < ≤ ≥ >`), unconditionally
@@ -505,17 +507,52 @@ impl Lowerer {
                 if numbers.len() == 1 {
                     self.number_literal(numbers[0])
                 } else {
-                    // Per the SIR22 spec's own doc comment on `ArrayLit`,
-                    // `rows.len() == 1` is precisely how a row/rank-1 vector
-                    // is represented -- exactly APL's stranded-literal shape.
+                    // `semantic-ir`'s own `ArrayLit` doc comment (`nodes.rs`)
+                    // is explicit that a 1-row literal (`rows.len() == 1`) is
+                    // a *row vector* -- under this IR's MATLAB-derived
+                    // column-major storage convention (`Feature::
+                    // ArrayColumnMajor`), that means a genuinely rank-2
+                    // `[1, n]` value, NOT a rank-1 `[n]` vector. A bare
+                    // `ArrayLit { rows: vec![row], .. }` is therefore the
+                    // WRONG shape for APL's stranded literal, which genuinely
+                    // is rank 1 -- using it directly here used to silently
+                    // fail any op correctly scoped to rank <= 1 operands only
+                    // (`outer`/`A∘.×B`, and dyadic `⍴`'s shape argument),
+                    // even though real APL accepts a stranded literal there.
+                    //
+                    // Fix: build the row-vector `ArrayLit` as before, then
+                    // wrap it in `Expr::Ravel` (SIR22 addendum "monadic
+                    // `,A`" -- see its doc comment in `nodes.rs`), which
+                    // flattens ANY input rank down to a genuine rank-1
+                    // result. This is invisible to APL source -- nothing
+                    // about the surface syntax changes, only which IR node
+                    // shape represents it, matching this file's module doc
+                    // comment's stated intent ("`1 2 3` -> one rank-1
+                    // `Expr::ArrayLit`", i.e. a rank-1 *value*, not literally
+                    // a bare `ArrayLit` node).
+                    //
+                    // `Ravel` needs no additional `Feature` beyond what
+                    // every other SIR22-addendum node already observes in
+                    // this file (see e.g. the `Expr::Ravel` arm in
+                    // `apply_monadic`, for monadic `,A`): `MatrixOps` +
+                    // `ArrayColumnMajor`, on top of the `NDArrays` +
+                    // `ArrayColumnMajor` the inner `ArrayLit` construction
+                    // already added below. Omitting `MatrixOps` here would
+                    // make the validator reject the module with "manifest
+                    // does not declare feature `MatrixOps` but module uses
+                    // it", since the validator independently observes
+                    // `MatrixOps` when it walks the emitted `Expr::Ravel`
+                    // node (see `semantic-ir`'s `validator.rs`).
                     self.observed.add(Feature::NDArrays);
                     self.observed.add(Feature::ArrayColumnMajor);
+                    self.observed.add(Feature::MatrixOps);
                     let span = self.span_of(node);
                     let row: Vec<Expr> = numbers
                         .iter()
                         .map(|tok| self.number_literal(tok))
                         .collect::<Result<Vec<_>, _>>()?;
-                    Ok(Expr::ArrayLit { rows: vec![row], span })
+                    let array_lit = Expr::ArrayLit { rows: vec![row], span: span.clone() };
+                    Ok(Expr::Ravel { target: Box::new(array_lit), span })
                 }
             }
             Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => {

--- a/code/packages/rust/apl-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/e2e_node.rs
@@ -67,10 +67,22 @@
 //!    stranded literal, which — like `outer` above — sidesteps the issue
 //!    because `ravel` always constructs a genuine rank-1 result
 //!    regardless of its input's rank) as the shape argument instead of the
-//!    bare literal. This ArrayLit-representation gap is pre-existing
+//!    bare literal. This ArrayLit-representation gap was pre-existing
 //!    (shipped in this crate's v0.1.0/v0.1.1, unrelated to and unchanged
-//!    by the codegen work that unblocked this file) and out of scope to
-//!    fix here — flagged separately, not patched around silently.
+//!    by the codegen work that unblocked this file) and left out of scope
+//!    to fix at the time — flagged separately, not patched around
+//!    silently. **It has since been fixed** in `src/lower.rs`'s
+//!    `lower_term`: a stranded literal now lowers to `Expr::Ravel` wrapping
+//!    the single-row `Expr::ArrayLit`, so it is a genuine rank-1 vector at
+//!    the IR level, exactly like `⍳n`. The tests below that route around
+//!    the old gap via `⍳`/`,` are left exactly as they were — they remain
+//!    valid (they exercise prefix order and ravel's row-major-vs-column-
+//!    major correctness, not this gap) and the workaround is harmless now
+//!    that it is no longer necessary. `outer_product_of_two_bare_stranded_
+//!    literals_runs_in_node` and `reshape_with_bare_stranded_literal_
+//!    shape_and_target_runs_in_node` below are the new, added coverage
+//!    proving the fix: the same two operations, but with bare stranded
+//!    literals as operands and NO `⍳`/`,` workaround at all.
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
@@ -190,6 +202,29 @@ fn outer_product_of_two_iota_vectors_runs_in_node() {
 }
 
 #[test]
+fn outer_product_of_two_bare_stranded_literals_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping outer_product_of_two_bare_stranded_literals_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    // `1 2∘.×3 4` -- the fix this file's module doc comment describes:
+    // outer product between two BARE stranded literals, no `⍳` workaround
+    // needed. Before the fix, both `1 2` and `3 4` lowered to a bare,
+    // genuinely rank-2 `[1, n]` `ArrayLit`, and `outer` is scoped to rank
+    // <= 1 operands only -- so this exact program used to throw
+    // `outer: operands of rank > 1 not yet supported` at `node` runtime
+    // (confirmed by reverting just the `lower.rs` change locally: the
+    // error fires with shapes `[1,2]`/`[1,2]`). Now both operands lower to
+    // `Expr::Ravel`-wrapped `ArrayLit`s, genuinely rank-1, so `outer`
+    // accepts them: `1 2 outer* 3 4 = [[3,4],[6,8]]`, ravelled and
+    // reduce-summed (`+/,`) gives `3+4+6+8 = 21`.
+    let out = run_via_node("outer_product_bare", "+/,1 2∘.×3 4\n");
+    assert_eq!(out, "21");
+}
+
+#[test]
 fn shape_of_a_reshaped_matrix_runs_in_node() {
     if !node_available() {
         eprintln!("skipping shape_of_a_reshaped_matrix_runs_in_node: `node` not available");
@@ -205,6 +240,31 @@ fn shape_of_a_reshaped_matrix_runs_in_node() {
     // "shape argument must be rank <= 1" check); `,2 3` ravels it down to
     // a genuine rank-1 `[2]` vector first, which reshape then accepts.
     let out = run_via_node("shape_of_reshape", "⍴(,2 3)⍴⍳6\n");
+    assert_eq!(out, "2 3");
+}
+
+#[test]
+fn reshape_with_bare_stranded_literal_shape_and_target_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping reshape_with_bare_stranded_literal_shape_and_target_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    // `⍴2 3⍴1 2 3 4 5 6` -- the fix this file's module doc comment
+    // describes: dyadic `⍴`'s shape argument is the BARE stranded literal
+    // `2 3`, no `,` (ravel) prefix needed, unlike the previous test's `(,2
+    // 3)`. Before the fix, a bare `2 3` lowered to a genuinely rank-2
+    // `[1, 2]` `ArrayLit`, and `reshape` requires its shape argument to be
+    // rank <= 1 -- so this exact program used to throw `reshape: shape
+    // argument must be a scalar or vector (got rank 2)` at `node` runtime
+    // (confirmed by reverting just the `lower.rs` change locally). Now `2
+    // 3` lowers to an `Expr::Ravel`-wrapped `ArrayLit`, genuinely rank-1,
+    // so `reshape` accepts it: builds a real 2x3 matrix from `1 2 3 4 5
+    // 6`, and monadic `⍴` reads its dimensions back, printed "2 3" --
+    // identical result to the previous test, but with neither operand
+    // needing any workaround.
+    let out = run_via_node("reshape_bare", "⍴2 3⍴1 2 3 4 5 6\n");
     assert_eq!(out, "2 3");
 }
 

--- a/code/packages/rust/apl-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/test_lower.rs
@@ -70,21 +70,32 @@ fn high_minus_negative_float_literal() {
 }
 
 #[test]
-fn stranded_literal_is_a_single_row_array_lit() {
+fn stranded_literal_is_a_ravelled_single_row_array_lit_rank_1_vector() {
+    // A stranded literal must lower to a genuine rank-1 vector, not the
+    // genuinely rank-2 `[1, n]` "row vector" a bare single-row `ArrayLit`
+    // represents on its own (see `semantic-ir`'s own `ArrayLit` doc comment
+    // in `nodes.rs`). The frontend achieves this by wrapping the single-row
+    // `ArrayLit` in `Expr::Ravel`, which flattens it down to a true rank-1
+    // result -- see `lower_term`'s doc comment in `lower.rs` for the full
+    // explanation of why the bare `ArrayLit` alone was the wrong shape.
     let m = compile_ok("1 2 3\n");
     let main = main_fn(&m);
     match printed_value(&main.body.stmts[0]) {
-        Expr::ArrayLit { rows, .. } => {
-            assert_eq!(rows.len(), 1, "stranded literal must be a single row (rank-1 vector)");
-            assert_eq!(rows[0].len(), 3);
-            assert!(matches!(rows[0][0], Expr::IntLit { value: 1, .. }));
-            assert!(matches!(rows[0][1], Expr::IntLit { value: 2, .. }));
-            assert!(matches!(rows[0][2], Expr::IntLit { value: 3, .. }));
-        }
-        other => panic!("expected ArrayLit, got {other:?}"),
+        Expr::Ravel { target, .. } => match &**target {
+            Expr::ArrayLit { rows, .. } => {
+                assert_eq!(rows.len(), 1, "stranded literal's inner ArrayLit must be a single row");
+                assert_eq!(rows[0].len(), 3);
+                assert!(matches!(rows[0][0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(rows[0][1], Expr::IntLit { value: 2, .. }));
+                assert!(matches!(rows[0][2], Expr::IntLit { value: 3, .. }));
+            }
+            other => panic!("expected Ravel's target to be ArrayLit, got {other:?}"),
+        },
+        other => panic!("expected Ravel wrapping ArrayLit, got {other:?}"),
     }
     assert!(m.manifest.iter().any(|f| f == Feature::NDArrays));
     assert!(m.manifest.iter().any(|f| f == Feature::ArrayColumnMajor));
+    assert!(m.manifest.iter().any(|f| f == Feature::MatrixOps));
 }
 
 #[test]
@@ -245,7 +256,9 @@ fn reduce_over_stranded_vector() {
     match printed_value(&main.body.stmts[0]) {
         Expr::Reduce { op, target, .. } => {
             assert_eq!(*op, ElementwiseOpKind::Add);
-            assert!(matches!(**target, Expr::ArrayLit { .. }));
+            // The stranded literal `1 2 3` now lowers to a `Ravel`-wrapped
+            // `ArrayLit` (a genuine rank-1 vector), not a bare `ArrayLit`.
+            assert!(matches!(**target, Expr::Ravel { .. }));
         }
         other => panic!("expected Reduce, got {other:?}"),
     }
@@ -306,6 +319,32 @@ fn outer_product_used_monadically_is_rejected() {
     );
 }
 
+#[test]
+fn outer_product_accepts_two_bare_stranded_literals_as_genuine_rank_1_operands() {
+    // Regression test for the stranded-literal-rank bug: before the fix, a
+    // bare stranded literal lowered to a bare (genuinely rank-2, `[1, n]`)
+    // `ArrayLit`, and `outer` is scoped to rank <= 1 operands only -- so
+    // `1 2∘.×3 4` would compile and validate fine here (this crate's Rust
+    // side never rank-checks; only `semantic-ir-to-javascript`'s runtime
+    // does), but throw at `node` runtime. See `tests/e2e_node.rs`'s
+    // `outer_product_of_two_bare_stranded_literals_runs_in_node` for the
+    // actual node-executed proof; this test only checks the IR shape: both
+    // operands must be `Expr::Ravel` (not a bare `Expr::ArrayLit`), which is
+    // what makes them genuinely rank-1 by construction.
+    let m = compile_ok("1 2∘.×3 4\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            assert_eq!(*op, ElementwiseOpKind::Mul);
+            assert!(matches!(**lhs, Expr::Ravel { .. }), "lhs must be Ravel-wrapped, not bare ArrayLit");
+            assert!(matches!(**rhs, Expr::Ravel { .. }), "rhs must be Ravel-wrapped, not bare ArrayLit");
+        }
+        other => panic!("expected OuterProduct, got {other:?}"),
+    }
+    let report = semantic_ir::validate(&m);
+    assert!(report.is_ok(), "expected clean validation, got: {:?}", report.errors().collect::<Vec<_>>());
+}
+
 // ── ⍴ (shape / reshape) ───────────────────────────────────────────────────
 
 #[test]
@@ -322,11 +361,40 @@ fn dyadic_rho_is_reshape_with_a_as_shape_and_b_as_target() {
     let main = main_fn(&m);
     match printed_value(&main.body.stmts[0]) {
         Expr::Reshape { shape, target, .. } => {
-            assert!(matches!(**shape, Expr::ArrayLit { .. }));
+            // The stranded literal `2 3` now lowers to a `Ravel`-wrapped
+            // `ArrayLit` (a genuine rank-1 vector), not a bare `ArrayLit`.
+            assert!(matches!(**shape, Expr::Ravel { .. }));
             assert!(matches!(**target, Expr::IntLit { value: 1, .. }));
         }
         other => panic!("expected Reshape, got {other:?}"),
     }
+}
+
+#[test]
+fn reshape_accepts_bare_stranded_literal_shape_and_target_as_genuine_rank_1_operands() {
+    // Regression test for the stranded-literal-rank bug: before the fix, a
+    // bare stranded literal used as dyadic `⍴`'s shape ARGUMENT (here, `2
+    // 3`) lowered to a bare (genuinely rank-2, `[1, n]`) `ArrayLit`, and
+    // `reshape` requires its shape argument to be rank <= 1 -- so this
+    // would compile and validate fine here (rank-checking is a
+    // `semantic-ir-to-javascript` runtime concern, not this crate's), but
+    // throw at `node` runtime. See `tests/e2e_node.rs`'s
+    // `reshape_with_bare_stranded_literal_shape_and_target_runs_in_node`
+    // for the actual node-executed proof; this test only checks the IR
+    // shape: the shape argument must be `Expr::Ravel` (not a bare
+    // `Expr::ArrayLit`), which is what makes it genuinely rank-1 by
+    // construction.
+    let m = compile_ok("2 3⍴1 2 3 4 5 6\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::Reshape { shape, target, .. } => {
+            assert!(matches!(**shape, Expr::Ravel { .. }), "shape must be Ravel-wrapped, not bare ArrayLit");
+            assert!(matches!(**target, Expr::Ravel { .. }), "target must be Ravel-wrapped, not bare ArrayLit");
+        }
+        other => panic!("expected Reshape, got {other:?}"),
+    }
+    let report = semantic_ir::validate(&m);
+    assert!(report.is_ok(), "expected clean validation, got: {:?}", report.errors().collect::<Vec<_>>());
 }
 
 // ── ⍳ (index generator / index-of) ───────────────────────────────────────


### PR DESCRIPTION
## Summary

A regression discovered while building the SIR22-addendum end-to-end tests: APL "stranded literals" like `1 2 3` were lowering to a bare `Expr::ArrayLit { rows: vec![row], .. }`, justified by a comment claiming "`rows.len() == 1` is precisely how a row/rank-1 vector is represented." That claim was wrong — `semantic-ir`'s own `ArrayLit` doc comment is explicit that a 1-row literal is a **row vector**: under this IR's MATLAB-derived column-major convention, that's a genuinely **rank-2** `[1, n]` value, not rank-1 `[n]`.

The consequence: any SIR22-addendum operation correctly scoped to rank ≤ 1 operands — `outer` (`A∘.×B`) and dyadic `⍴`'s shape argument — threw a clean runtime error (`operands of rank > 1 not yet supported` / `shape argument must be a scalar or vector`) whenever given a bare stranded literal, even though real APL accepts one there without hesitation. `apl-to-semantic-ir`'s own module doc comment always stated the correct *intent* ("`1 2 3` → one rank-1 `Expr::ArrayLit`") — the implementation just picked the wrong IR node to realize it.

## Fix

`lower_term`'s stranding branch now wraps the same single-row `ArrayLit` in `Expr::Ravel` (the SIR22 addendum's "monadic `,A`" node, which already exists and already flattens any input rank down to a genuine rank-1 result — this crate's own `,` ravel lowering already builds the identical node). Invisible to APL source; only the IR shape changes. Requires adding `Feature::MatrixOps` alongside the two features already observed there, matching what the shared validator independently derives when it walks the emitted `Ravel` node.

## Changes

- `apl-to-semantic-ir/src/lower.rs`: the fix (one production-code change) + corrected doc comments (the old ones that misstated the IR contract).
- `apl-to-semantic-ir/tests/test_lower.rs`: updated 3 existing tests that asserted the old bare-`ArrayLit` shape directly; added 2 new regression tests (`1 2∘.×3 4` outer product, `2 3⍴1 2 3 4 5 6` reshape) checking IR shape + clean validation.
- `apl-to-semantic-ir/tests/e2e_node.rs`: added 2 new `node`-executed tests proving the fix end-to-end with **no** `⍳`/`,` workaround needed — confirmed these fail with exactly the predicted errors when the `lower.rs` fix is reverted. The file's existing `⍳`/`,`-workaround tests are left untouched (they remain valid — they test prefix order and ravel's row-major-vs-column-major correctness, a different concern).
- CHANGELOG + version bump (0.1.2 → 0.1.3).

## Test plan

- [x] `cargo test -p apl-to-semantic-ir` — 55/55 passing
- [x] `cargo clippy -p apl-to-semantic-ir --all-targets` — clean
- [x] `cargo build --workspace` — no new failures (pre-existing environment-specific `uefi` failure unrelated, confirmed via `git stash` reproduces identically without this diff)
- [x] `/security-review` — **PASSED, no vulnerabilities found**
- [x] Confirmed the new e2e tests actually fail with the predicted error messages when the `lower.rs` fix is reverted (real regression coverage, not just IR-shape assertions)
- [x] No shared-crate changes (pure `apl-to-semantic-ir`-side fix), so no downstream-consumer re-verification needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)