### PR TITLE
feat(hl-telugu): Chapters 3-5 — how-are-you, farewells, first verbs

### DIFF
--- a/code/learning/human-languages/telugu/CHANGELOG.md
+++ b/code/learning/human-languages/telugu/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapters 3–5 — How-are-you, Farewells, First Verbs
+
+- Three new chapters carry Telugu to Chapter 5, matching the leading tracks' arc.
+  One word per lesson, atom-first, Telugu script inline; every root traced
+  (`lessons/TE-C0{3,4,5}-*`, `book/chapters/ch0{3,4,5}-*.tex`). Concept tags reuse
+  the universal `HL01` taxonomy; verbs namespaced (`TE-VERB-*`). Telugu's
+  heavy-Sanskrit-borrowing-yet-Dravidian-grammar character runs throughout.
+- **Ch. 3 — How Are You**: *elā* (how; the native *e-* questions) → *mīru elā
+  unnāru?* (the verb *uṇḍu* "to be") → *nēnu* (I ← Proto-Dravidian, unrelated to
+  *me*) → *bāgā* (well; *nēnu bāgunnānu* "I'm well") → *paravālēdu* ("no harm" =
+  you're welcome, built on Telugu's own *lēdu* — where Tamil/Kannada/Malayalam
+  use *illa*) → practice.
+- **Ch. 4 — Farewells**: *veḷḷu*/*vaccu* → *veḷḷi vastānu* ("I'll go and come
+  back," tabled across the Dravidian family) → *rēpu kaluddām* (see you tomorrow;
+  the "let's ___" *-ddām*) → *maḷḷī kaluddām* (we'll meet again; native *kalu*,
+  where Tamil borrowed Sanskrit *sandi*) → practice.
+- **Ch. 5 — First Verbs**: *māṭlāḍu* (← *māṭa* "word"; stem + tense + person) →
+  *nēnu telugu māṭlāḍatānu* (I speak Telugu — "the Italian of the East"; no
+  1st-person gender) → *uṇḍu* (to be/stay/live; the postposition *-lō*) → *pani
+  cēyu* (to work; noun + *cēyu*, the twin of Hindi's *karnā*) → practice. Book
+  compiles clean with XeLaTeX (0 missing chars, 0 undefined refs).
+
 ## Chapter 2 — Introducing Yourself
 
 - New chapter around the introduction dialogue (*nā pēru … / mī pēru ēmiṭi?*),

--- a/code/learning/human-languages/telugu/README.md
+++ b/code/learning/human-languages/telugu/README.md
@@ -36,6 +36,15 @@ book.
   **mī pēru ēmiṭi?** ("what's your name?"), santōṣam, practice. Every atom
   traced (*pēru* ← *\*pēr*, twin of Tamil *peyar*; *santōṣam* Sanskrit). In the
   book.
+- **Chapter 3 — How Are You** ([`lessons/TE-C03-*`](./lessons/)): elā, **mīru elā
+  unnāru?**, nēnu, bāgā, paravālēdu, practice. The verb *uṇḍu* ("to be"); Telugu's
+  own *lēdu* where its sisters use *illa*. In the book.
+- **Chapter 4 — Farewells** ([`lessons/TE-C04-*`](./lessons/)): veḷḷu/vaccu,
+  **veḷḷi vastānu** ("I'll go and come back"), rēpu kaluddām, maḷḷī kaluddām,
+  practice. The Dravidian promise-of-return goodbye. In the book.
+- **Chapter 5 — First Verbs** ([`lessons/TE-C05-*`](./lessons/)): māṭlāḍu, **nēnu
+  telugu māṭlāḍatānu**, uṇḍu, pani cēyu, practice. Stem + tense + person; no
+  1st-person gender. In the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/telugu/book/book.tex
+++ b/code/learning/human-languages/telugu/book/book.tex
@@ -70,4 +70,10 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch02-introductions}
 
+\input{chapters/ch03-responding}
+
+\input{chapters/ch04-farewells}
+
+\input{chapters/ch05-first-verbs}
+
 \end{document}

--- a/code/learning/human-languages/telugu/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch03-responding.tex
@@ -1,0 +1,117 @@
+\chapter{How Are You?}
+\label{ch:responding}
+
+After the name comes the exchange everyone actually has --- and, for the first
+time, a Telugu verb ``to be'':
+
+\begin{center}
+\te{మీరు ఎలా ఉన్నారు?} \quad(\emph{m\=\i ru el\=a unn\=aru} --- ``How are you?'')\\
+\te{నేను బాగున్నాను, ధన్యవాదములు.} \quad(\emph{n\=enu b\=agunn\=anu, dhanyav\=adamulu} --- ``I'm well, thank you.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/TE-C03-*.md}.}
+
+\section{\te{ఎలా} \emph{(el\=a)} --- ``how,'' another of the e- questions}
+\label{lesson:elaa}
+
+\begin{sounds}
+\te{ఎ} (independent short \emph{e}) $+$ \te{లా} (\emph{l\=a}) $\to$ \te{ఎలా}
+(\emph{el\=a}).
+\end{sounds}
+
+\begin{cousinweb}
+\te{ఎలా} (\emph{el\=a}, ``how'') is native Dravidian, on the interrogative base
+\te{ఎ-} (\emph{e-}) from \emph{\=emi\d{t}i}. Telugu gathers nearly all its
+questions under this \textbf{e-}: \emph{\=emi\d{t}i} (what), \emph{el\=a} (how),
+\emph{evaru} (who), \emph{ekka\d{d}a} (where), \emph{eppu\d{d}u} (when). It is the
+same Dravidian question-root heading Tamil's \emph{eppa\d{t}i} and Kannada's
+\emph{\=enu} --- a family older than the Sanskrit words Telugu otherwise borrows
+so freely.
+\end{cousinweb}
+
+\section{\te{మీరు ఎలా ఉన్నారు?} --- ``how are you?''}
+\label{lesson:miiru-elaa-unnaaru}
+
+The new word is \te{ఉన్నారు} (\emph{unn\=aru}, ``you are''): from the verb
+\te{ఉండు} (\emph{u\d{n}\d{d}u}, ``to be, exist, stay'') $+$ the respectful-you
+ending \emph{-\=aru}. So \te{మీరు ఎలా ఉన్నారు?} is ``you how are?'', the verb
+last, as in every Telugu sentence.
+
+\begin{grammarlens}
+\textbf{The verb carries ``you.''} The ending \emph{-\=aru} already means ``you
+(respectful),'' so \emph{m\=\i ru} can be dropped: \emph{el\=a unn\=aru?} is a
+whole ``how are you?'' To a friend: \te{నువ్వు ఎలా ఉన్నావు?} (\emph{nuvvu el\=a
+unn\=avu?} --- \emph{-\=avu} for the familiar ``you''). Match the ``you'' to the
+verb-ending.
+\end{grammarlens}
+
+\section{\te{నేను} \emph{(n\=enu)} --- ``I,'' the Dravidian first person}
+\label{lesson:nenu}
+
+\begin{sounds}
+\te{నే} (\emph{n\=e}) $+$ \te{ను} (\emph{nu}) $\to$ \te{నేను} (\emph{n\=enu}).
+\end{sounds}
+
+\begin{cousinweb}
+\te{నేను} (\emph{n\=enu}, ``I'') $\leftarrow$ Proto-Dravidian *y\=a\d{n} / *n\=en
+--- native, and (unlike Hindi's \emph{mai\d{m}}, cousin of English \emph{me})
+\textbf{not} related to the European ``I/me'' family. Its possessive is the
+\te{నా} (\emph{n\=a}, ``my'') you met in Chapter 2. For all the Sanskrit Telugu
+borrows elsewhere, its basic pronouns stayed Dravidian to the core.
+\end{cousinweb}
+
+\section{\te{బాగా} \emph{(b\=ag\=a)} --- ``well,'' and how to answer}
+\label{lesson:baagaa}
+
+\begin{sounds}
+\te{బా} (\emph{b\=a}) $+$ \te{గా} (\emph{g\=a}) $\to$ \te{బాగా} (\emph{b\=ag\=a}).
+\end{sounds}
+
+\begin{cousinweb}
+\te{బాగా} (\emph{b\=ag\=a}, ``well, nicely, very''), from \te{బాగు} (\emph{b\=agu},
+``goodness''), is the everyday ``well/good/very.'' To answer ``how are you,'' fuse
+it with the \emph{u\d{n}\d{d}u} verb: \te{నేను బాగున్నాను} (\emph{n\=enu
+b\=agunn\=anu}, ``I am well'' --- \emph{b\=ag\=a} $+$ \emph{unn\=anu} run
+together).
+\end{cousinweb}
+
+\section{\te{పరవాలేదు} \emph{(paraval\=edu)} --- ``no problem''}
+\label{lesson:paravaaledu}
+
+\begin{cousinweb}
+\te{పరవాలేదు} literally ``\textbf{there is no harm}'' --- \emph{parav\=a}
+(``harm'') $+$ \te{లేదు} (\emph{l\=edu}, ``is-not''), the Chapter-1 negative. It
+serves as ``it's okay / no worries / you're welcome.'' The atom \te{లేదు}
+(\emph{l\=edu}) is where Telugu goes its own way: Tamil, Kannada, and Malayalam
+all say \emph{illa(i)} for ``is-not,'' but \textbf{Telugu alone} uses
+\emph{l\=edu} --- so Tamil's ``no problem'' is \emph{parav\=ayillai}, Telugu's is
+\emph{paraval\=edu}, the same idea on each language's own ``not.''
+\end{cousinweb}
+
+\begin{grammarlens}
+\te{లేదు} (\emph{l\=edu}) negates existence: \emph{\d{d}abbu l\=edu} (``there's no
+money''). It is the negative twin of \te{ఉంది} (\emph{undi}, ``there is'') and of
+the \emph{u\d{n}\d{d}u} verb behind ``how are you.'' Hold \emph{undi} / \emph{l\=edu}
+together --- ``there is'' and ``there is not.''
+\end{grammarlens}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Telugu & English \\
+\midrule
+\te{మీరు ఎలా ఉన్నారు?} & How are you? \\
+\te{నేను బాగున్నాను, ధన్యవాదములు.} & I'm well, thank you. \\
+\te{పరవాలేదు.} & No problem / you're welcome. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{el\=a} (the native \emph{e-} questions), \emph{n\=enu}
+(Proto-Dravidian, unrelated to \emph{me}), \emph{b\=ag\=a} (``well''), and the
+\emph{undi} / \emph{l\=edu} pair --- ``there is'' and ``there is not,'' Telugu's
+own ``not'' where its sisters use \emph{illa}. Next chapter: the farewells --- and
+Telugu, like all its family, never says a plain ``goodbye.''

--- a/code/learning/human-languages/telugu/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch04-farewells.tex
@@ -1,0 +1,102 @@
+\chapter{Farewells}
+\label{ch:farewells}
+
+Telugu, like every Dravidian language, does not say a plain ``goodbye.'' It
+promises to return:
+
+\begin{center}
+\te{వెళ్ళి వస్తాను.} \quad(\emph{ve\d{l}\d{l}i vast\=anu} --- ``I'll go and come back.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/TE-C04-*.md}.}
+
+\section{\te{వెళ్ళు} \emph{(ve\d{l}\d{l}u)} --- ``go,'' and \te{వచ్చు} (come)}
+\label{lesson:vellu}
+
+\begin{sounds}
+\te{వె} (\emph{ve}) $+$ \te{ళ్ళు} (\emph{\d{l}\d{l}u}, doubled retroflex \te{ళ}
+\emph{\d{l}}) $\to$ \te{వెళ్ళు}. Its partner \te{వచ్చు} (\emph{vaccu}, ``come'').
+\end{sounds}
+
+\begin{cousinweb}
+\te{వెళ్ళు} (\emph{ve\d{l}\d{l}u}, ``to go'') and \te{వచ్చు} (\emph{vaccu}, ``to
+come'') are native Dravidian verbs. As commands they are whole words:
+\emph{ve\d{l}\d{l}u!} (``go!''), \emph{r\=a!} (``come!''). You need both, because
+Telugu's goodbye is ``I go, and I \emph{come back}.''
+\end{cousinweb}
+
+\section{\te{వెళ్ళి వస్తాను} \emph{(ve\d{l}\d{l}i vast\=anu)} --- ``I'll go and come back''}
+\label{lesson:velli-vastaanu}
+
+\te{వెళ్ళి} (\emph{ve\d{l}\d{l}i}, ``having gone'') $+$ \te{వస్తాను}
+(\emph{vast\=anu}, ``I come'') --- literally ``\textbf{having gone, I come
+[back]},'' i.e. ``I'll go and come back.'' A Telugu speaker never signs off with a
+bare ``I'm leaving.'' The warm reply is \te{వెళ్ళి రండి} (\emph{ve\d{l}\d{l}i
+ra\d{n}\d{d}i}, ``go and come [back]'').
+
+\begin{cognates}
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Language & ``go and come back'' (goodbye) \\
+\midrule
+\textbf{Telugu} & \emph{ve\d{l}\d{l}i vast\=anu} \\
+Tamil & \emph{p\=oy varugi\d{r}\=e\d{n}} \\
+Kannada & \emph{h\=ogi barutt\=ene} \\
+Malayalam & \emph{p\=oyi var\=a\d{m}} \\
+\midrule
+Bengali (Indo-Aryan) & \emph{\=ashi} (``I come'') \\
+\bottomrule
+\end{tabular}
+\end{center}
+The whole south, and beyond, prefers a promise of return to a blunt farewell.
+\end{cognates}
+
+\section{\te{రేపు కలుద్దాం} \emph{(r\=epu kalud\d{d}\=am)} --- ``see you tomorrow''}
+\label{lesson:reepu-kaluddaam}
+
+\begin{sounds}
+\te{రే} (\emph{r\=e}) $+$ \te{పు} (\emph{pu}) $\to$ \te{రేపు}. \te{కలుద్దాం}
+(\emph{kalud\d{d}\=am}) $=$ \emph{kalu} (``meet'') $+$ \emph{-d\d{d}\=am}
+(``let's'').
+\end{sounds}
+
+\begin{cousinweb}
+\te{రేపు} (\emph{r\=epu}, ``tomorrow'') is native; \te{కలు} (\emph{kalu}, ``to
+meet, join'') gives \emph{kalud\d{d}\=am} (``let's meet'') --- ``tomorrow, let's
+meet.'' The \te{-దాం} (\emph{-d\d{d}\=am}) ending is Telugu's ``let's \ldots'':
+\emph{ve\d{l}\d{l}d\d{d}\=am} (``let's go''), \emph{tind\=am} (``let's eat'').
+\end{cousinweb}
+
+\section{\te{మళ్ళీ కలుద్దాం} \emph{(ma\d{l}\d{l}\=\i\ kalud\d{d}\=am)} --- ``we'll meet again''}
+\label{lesson:malli-kaluddaam}
+
+\begin{cousinweb}
+\te{మళ్ళీ కలుద్దాం} $=$ \te{మళ్ళీ} (\emph{ma\d{l}\d{l}\=\i}, ``again'') $+$
+\emph{kalud\d{d}\=am} (``let's meet''). Both are native Dravidian: \emph{ma\d{l}\d{l}\=\i}
+(from \emph{maral}, ``to return'') and \emph{kalu} (``meet''). Where Tamil's
+``we'll meet again'' reaches for the Sanskrit loan \emph{sandi} to say ``meet,''
+Telugu keeps the native \emph{kalu} --- the same phrase, from different stock.
+\end{cousinweb}
+
+\section{The farewells}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Telugu & English \\
+\midrule
+\te{వెళ్ళి వస్తాను.} & I'll go and come back. (goodbye) \\
+\te{వెళ్ళి రండి.} & Go and come back. (the reply) \\
+\te{రేపు కలుద్దాం.} & See you tomorrow. \\
+\te{మళ్ళీ కలుద్దాం.} & We'll meet again. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Roots banked: \emph{ve\d{l}\d{l}u}/\emph{vaccu} (go/come), \emph{r\=epu}
+(``tomorrow''), \emph{kalu} (``meet,'' native --- where Tamil borrowed
+\emph{sandi}), and \emph{ma\d{l}\d{l}\=\i} (``again''). Next chapter: the first
+real verbs --- \emph{n\=enu telugu m\=a\d{t}l\=a\d{d}at\=anu} --- and Telugu's
+sentences begin to move.

--- a/code/learning/human-languages/telugu/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch05-first-verbs.tex
@@ -1,0 +1,114 @@
+\chapter{The First Verbs}
+\label{ch:first-verbs}
+
+Until now, ``to be'' and ``to be-not.'' Now verbs that \emph{act} --- and Telugu's
+sentences begin to move:
+
+\begin{center}
+\te{నేను తెలుగు మాట్లాడతాను.} \quad(\emph{n\=enu telugu m\=a\d{t}l\=a\d{d}at\=anu} --- ``I speak Telugu.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/TE-C05-*.md}.}
+
+\section{\te{మాట్లాడు} \emph{(m\=a\d{t}l\=a\d{d}u)} --- ``to speak,'' your first full verb}
+\label{lesson:maatlaadu}
+
+\begin{sounds}
+\te{మా} (\emph{m\=a}) $+$ \te{ట్లా} (\emph{\d{t}l\=a}) $+$ \te{డు} (\emph{\d{d}u})
+$\to$ \te{మాట్లాడు}.
+\end{sounds}
+
+\begin{cousinweb}
+\te{మాట్లాడు} (\emph{m\=a\d{t}l\=a\d{d}u}, ``to speak'') is native Dravidian,
+built on \te{మాట} (\emph{m\=a\d{t}a}, ``word, speech''). To say ``I speak,''
+Telugu stacks two endings on the stem --- tense then person:
+\begin{center}
+\emph{m\=a\d{t}l\=a\d{d}-} $+$ \emph{-t-} (present) $+$ \emph{-\=anu} (``I'') $\to$
+\te{మాట్లాడతాను} (\emph{m\=a\d{t}l\=a\d{d}at\=anu}), ``I speak.''
+\end{center}
+The \emph{-\=anu} ending \emph{is} ``I,'' so \emph{n\=enu} is rarely needed:
+\emph{m\=a\d{t}l\=a\d{d}t\=a\d{d}u} (he), \emph{m\=a\d{t}l\=a\d{d}tundi}
+(she/it), \emph{m\=a\d{t}l\=a\d{d}t\=aru} (they / you-respectful).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Stem $+$ tense $+$ person.} Every Telugu verb is built this way. And, like
+Tamil, Telugu marks \textbf{no gender in the first person}:
+\emph{m\=a\d{t}l\=a\d{d}at\=anu} is the same for a man or a woman --- unlike Hindi's
+\emph{bolt\=a}/\emph{bolt\=\i}.
+\end{grammarlens}
+
+\section{\te{నేను తెలుగు మాట్లాడతాను} --- ``I speak Telugu''}
+\label{lesson:nenu-telugu-maatlaadataanu}
+
+\te{నేను} (I) $+$ \te{తెలుగు} (\emph{telugu}, the object) $+$ \te{మాట్లాడతాను}
+(speak) --- ``I Telugu speak,'' verb last. The name \te{తెలుగు} (\emph{telugu})
+is native, of debated origin; its vowel-rich sound and habit of ending most words
+in a vowel earned it the old nickname ``\textbf{the Italian of the East}.'' It is
+the tongue of the \emph{K\=avya} poets and of some eighty million speakers today.
+
+\begin{grammarlens}
+\textbf{No gender on ``I speak.''} \emph{M\=a\d{t}l\=a\d{d}at\=anu} is the same
+whether a man or a woman says it --- Telugu, like Tamil, marks no gender in the
+first or second person (only the third: \emph{-\=a\d{d}u} he, \emph{-undi}
+she/it).
+\end{grammarlens}
+
+\section{\te{ఉండు} \emph{(u\d{n}\d{d}u)} --- ``to be, to stay, to live''}
+\label{lesson:undu}
+
+\begin{cousinweb}
+\te{ఉండు} (\emph{u\d{n}\d{d}u}, ``to be, exist, stay, live'') is native Dravidian
+and does enormous work: it is the verb behind Chapter 3's \emph{unn\=aru} (``you
+are'') and \emph{b\=agunn\=anu} (``I'm well''), and it also means ``to reside'':
+\te{నేను హైదరాబాద్‌లో ఉంటాను} (\emph{n\=enu Hyder\=ab\=adl\=o u\d{n}\d{t}\=anu},
+``I live in Hyderabad''). One verb covers ``be,'' ``stay,'' and ``live.''
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``In'' comes after the noun.} \te{హైదరాబాద్‌లో} (\emph{Hyder\=ab\=adl\=o})
+$=$ \emph{Hyderabad} $+$ \te{-లో} (\emph{-l\=o}, ``in''), glued to the \emph{end}
+of the noun. Telugu uses \textbf{post}positions (case-suffixes) where English uses
+prepositions: ``Hyderabad-in I stay,'' the verb last.
+\end{grammarlens}
+
+\section{\te{పని చేయు} \emph{(pani c\=eyu)} --- ``to work''}
+\label{lesson:pani-ceyu}
+
+\begin{cousinweb}
+\te{చేయు} (\emph{c\=eyu}, ``to do, make'') is a core native verb, and Telugu ---
+like Hindi with \emph{karn\=a} and Tamil with \emph{sey} --- builds compounds by
+putting a noun in front of it: \te{పని చేయు} (\emph{pani c\=eyu}, ``work-do'' $=$
+``to work''), \emph{va\d{n}\d{t}a c\=eyu} (``to cook''), \emph{sah\=aya\d{m}
+c\=eyu} (``to help,'' with a \textbf{Sanskrit} noun on the \textbf{native}
+\emph{c\=eyu} --- the two vocabularies in one verb). So ``I work'' is \te{నేను పని
+చేస్తాను} (\emph{n\=enu pani c\=est\=anu}).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Noun $+$ \te{చేయు} $=$ a new verb} --- the exact twin of Hindi's ``noun
+$+$ \emph{karn\=a}'' and Tamil's ``noun $+$ \emph{sey}.'' Three languages, two of
+them from unrelated families, all landed on the same trick.
+\end{grammarlens}
+
+\section{Sentences about yourself}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Telugu & English \\
+\midrule
+\te{నేను తెలుగు మాట్లాడతాను.} & I speak Telugu. \\
+\te{నేను హైదరాబాద్‌లో ఉంటాను.} & I live in Hyderabad. \\
+\te{నేను పని చేస్తాను.} & I work. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Three verbs, one engine: a stem, a tense-marker, a person-ending, the verb always
+last --- and no gender in the first person. Roots banked: \emph{m\=a\d{t}l\=a\d{d}u}
+(speak $\leftarrow$ \emph{m\=a\d{t}a} ``word''), \emph{u\d{n}\d{d}u} (be/stay/live,
+with \emph{-l\=o} ``in'' on the noun's end), and \emph{c\=eyu} (do $\to$ \emph{pani
+c\=eyu} ``to work,'' the twin of Hindi's \emph{karn\=a}). From here, Telugu's
+sentences only grow.

--- a/code/learning/human-languages/telugu/lessons/TE-C03-baagaa.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-baagaa.md
@@ -1,0 +1,52 @@
+---
+id: TE-C03-baagaa
+chapter: 3
+type: word
+headword: బాగా
+gloss: well, fine — and the reply "నేను బాగున్నాను"
+concept_tag: WORD-WELL
+prerequisites: [TE-C03-nenu, TE-C03-miiru-elaa-unnaaru]
+sounds: [long-aa]
+roots: [baaga-good]
+est_minutes: 4
+reviews_of: [TE-C03-nenu]
+---
+
+# బాగా (bāgā) — "well," and how to answer
+
+## Warm-up
+
+[PAUSE 2s] The word that answers "how are you?" — and one Telugu says all the
+time.
+
+## The letters in this word
+
+**బా** (*bā*, *ba* + long *ā*) + **గా** (*gā*, *ga* + long *ā*) → **బాగా**
+(*bāgā*).
+
+## The word, taken apart
+
+**బాగా** (*bāgā*, "well, nicely, very") comes from **బాగు** (*bāgu*, "goodness,
+well-being"). It is the everyday "well/good/very much": *bāgā undi* ("it's good"),
+*bāgā ceppāru* ("well said"). To answer "how are you," fuse it with the *uṇḍu*
+verb:
+
+> **నేను బాగున్నాను** (*nēnu bāgunnānu*) — "**I am well**" (*bāgā* + *unnānu*, "I
+> am," run together).
+
+The whole exchange:
+
+> — *mīru elā unnāru?* ("How are you?")
+> — *nēnu bāgunnānu, dhanyavādamulu.* ("I'm well, thank you.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bāgā"]
+- [YOU SAY: the full reply — *nēnu bāgunnānu*]
+- [YOU SAY: add thanks (from Chapter 1) — *dhanyavādamulu*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the full reply to *mīru elā unnāru?*. (*Nēnu bāgunnānu* — *bāgā*
+"well" fused with *unnānu* "I am.")

--- a/code/learning/human-languages/telugu/lessons/TE-C03-elaa.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-elaa.md
@@ -1,0 +1,45 @@
+---
+id: TE-C03-elaa
+chapter: 3
+type: word
+headword: ఎలా
+gloss: how
+concept_tag: QUESTION-HOW
+prerequisites: [TE-C02-emiti]
+sounds: [independent-e, long-aa]
+roots: [e-interrogative-dravidian]
+est_minutes: 4
+reviews_of: [TE-C02-emiti]
+---
+
+# ఎలా (elā) — "how," another of the e- questions
+
+## Warm-up
+
+[PAUSE 2s] You met **ఏమిటి** (*ēmiṭi*, "what") in Chapter 2. Here is its sibling —
+and, like all of Telugu's question-words, it begins with **e-**.
+
+## The letters in this word
+
+*(Skim if you read Telugu.)* **ఎ** (independent short *e*) + **లా** (*lā*, *la* +
+the long-*ā* sign) → **ఎలా** (*elā*).
+
+## The word, taken apart
+
+**ఎలా** (*elā*, "how") is native Dravidian, on the interrogative base **ఎ-**
+(*e-*) you already met in *ēmiṭi*. Telugu gathers nearly all its questions under
+this **e-**: *ēmiṭi* (what), *elā* (how), *evaru* (who), *ekkaḍa* (where),
+*eppuḍu* (when), *enduku* (why). It is the same Dravidian question-root that heads
+Tamil's *eppaḍi* and Kannada's *ēnu* — a family older than the Sanskrit words that
+Telugu otherwise borrows so freely.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "elā"]
+- [YOU SAY: the e- question family — *ēmiṭi, elā, evaru, ekkaḍa, eppuḍu*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What base do Telugu's question-words share, and which cousins head
+their own? (The interrogative *e-*; Tamil's *eppaḍi*, Kannada's *ēnu*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C03-miiru-elaa-unnaaru.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-miiru-elaa-unnaaru.md
@@ -1,0 +1,52 @@
+---
+id: TE-C03-miiru-elaa-unnaaru
+chapter: 3
+type: phrase
+headword: మీరు ఎలా ఉన్నారు?
+gloss: how are you? (respectful)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [TE-C03-elaa, TE-C02-nuvvu-miiru]
+sounds: [double-nn, retroflex]
+roots: [undu-be-dravidian]
+est_minutes: 5
+reviews_of: [TE-C02-nuvvu-miiru, TE-C03-elaa]
+---
+
+# మీరు ఎలా ఉన్నారు? (mīru elā unnāru?)
+
+## Warm-up
+
+[PAUSE 2s] The everyday "how are you?" — and the verb "to be" that carries it.
+
+## The letters in this word
+
+The new word is **ఉన్నారు** (*unnāru*, "you are/exist"): from the verb **ఉండు**
+(*uṇḍu*, "to be, to exist, to stay") + the respectful-you ending **-ారు**
+(*-āru*). Note the doubled **న్న** (*nn*).
+
+## The phrase, taken apart
+
+**మీరు ఎలా ఉన్నారు?** = **మీరు** (*mīru*, "you," respectful) + **ఎలా** (*elā*,
+"how") + **ఉన్నారు** (*unnāru*, "are") — "you how are?", the verb **last**, as in
+every Telugu sentence. The verb is **ఉండు** (*uṇḍu*), "to be / to exist / to
+stay" — native Dravidian, and the workhorse behind "how are you," "I'm well," and
+(you'll see in Chapter 5) "I live."
+
+## Grammar Lens: the verb carries "you"
+
+The ending **-ారు** (*-āru*) already means "you (respectful)," so *mīru* can be
+dropped: *elā unnāru?* is a complete "how are you?" To a friend (*nuvvu*), the
+ending changes: **నువ్వు ఎలా ఉన్నావు?** (*nuvvu elā unnāvu?* — *-āvu* for the
+familiar "you"). Match the "you" to the verb-ending, as Telugu always does.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the respectful question — *mīru elā unnāru?*]
+- [YOU SAY: the familiar version — *nuvvu elā unnāvu?*]
+- [YOU SAY: the verb and its meaning (*uṇḍu* — "to be / exist / stay")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What verb powers "how are you?", and how does the ending change for a
+friend? (*Uṇḍu*, "to be"; *-āru* → *-āvu* for the familiar *nuvvu*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C03-nenu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-nenu.md
@@ -1,0 +1,52 @@
+---
+id: TE-C03-nenu
+chapter: 3
+type: word
+headword: నేను
+gloss: I
+concept_tag: PRONOUN-I
+prerequisites: [TE-C02-naa]
+sounds: [long-e, double-nn]
+roots: [nen-dravidian]
+est_minutes: 3
+reviews_of: [TE-C02-naa]
+---
+
+# నేను (nēnu) — "I," the Dravidian first person
+
+## Warm-up
+
+[PAUSE 2s] To answer "how are you?" you first need "I." In Chapter 2 you learned
+*nā* ("my"); here is its owner.
+
+## The letters in this word
+
+**నే** (*nē*, *na* + long-*ē* sign) + **ను** (*nu*) → **నేను** (*nēnu*).
+
+## The word, taken apart
+
+**నేను** (*nēnu*, "I") ← Proto-Dravidian **\*yāṉ / \*nēn** — native, and (unlike
+Hindi's *maiṁ*, cousin of English *me*) **not** related to the European "I/me"
+family. Its possessive is the **నా** (*nā*, "my") you already met: *nēnu* "I,"
+*nā* "my." For all that Telugu borrows Sanskrit vocabulary elsewhere, its most
+basic pronouns stayed Dravidian to the core — the grammar's foundations never
+changed hands.
+
+## Grammar Lens: "I" you can drop
+
+Telugu verbs carry the person in their ending — *unnānu* already means "**I** am"
+— so *nēnu* is often left out. You still learn it first, because the answer to
+*elā unnāru?* begins with it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nēnu"]
+- [YOU SAY: the pair — *nēnu* (I), *nā* (my)]
+- [YOU SAY: is it related to English *me*? (No — native Dravidian)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is *nēnu*'s possessive, and is Telugu's "I" cousin to English
+*me*? (*Nā*, "my"; no — it is native Dravidian, unlike the borrowed Sanskrit
+nouns around it.)

--- a/code/learning/human-languages/telugu/lessons/TE-C03-paravaaledu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-paravaaledu.md
@@ -1,0 +1,56 @@
+---
+id: TE-C03-paravaaledu
+chapter: 3
+type: phrase
+headword: పరవాలేదు
+gloss: it's okay / no problem / you're welcome
+concept_tag: YOURE-WELCOME
+prerequisites: [TE-C01-ledu, TE-C01-dhanyavadamulu]
+sounds: [ledu-negative]
+roots: [ledu-not-dravidian]
+est_minutes: 4
+reviews_of: [TE-C01-ledu]
+---
+
+# పరవాలేదు (paravālēdu) — "no problem"
+
+## Warm-up
+
+[PAUSE 2s] When someone thanks you — or apologises — this is the easy, gracious
+reply, and it is built on a word you met in Chapter 1.
+
+## The letters in this word
+
+Two joined words: **పరవా** (*paravā*, "harm, concern") + **లేదు** (*lēdu*, "there
+is not") → **పరవాలేదు** (*paravālēdu*).
+
+## The word, taken apart
+
+**పరవాలేదు** literally means "**there is no harm**" — *paravā* ("harm, concern") +
+**లేదు** (*lēdu*, "is-not / there-is-not"), the Chapter-1 negative. It serves as
+"it's okay / no worries / never mind / you're welcome." The key atom, **లేదు**
+(*lēdu*), is where Telugu goes its own way: Tamil, Kannada, and Malayalam all say
+*illa(i)* for "is-not," but **Telugu alone** uses **లేదు** (*lēdu*) — so Tamil's
+"no problem" is *paravāyillai*, and Telugu's is *paravālēdu*, the same idea built
+on each language's own "not." One phrase shows both the Dravidian bond and the
+one place Telugu breaks from its sisters.
+
+## Grammar Lens: లేదు, Telugu's "is-not"
+
+*Lēdu* negates existence: *ḍabbu lēdu* ("there's no money"), *ēmī lēdu* ("it's
+nothing"). It is the negative twin of **ఉంది** (*undi*, "there is") and of the
+*uṇḍu* verb behind "how are you." Learn *undi* / *lēdu* together — "there is" and
+"there is not."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "paravālēdu"]
+- [YOU SAY: what it literally means ("there is no harm")]
+- [YOU SAY: the Telugu "is-not" that sets it apart from Tamil (*lēdu*, vs. Tamil *illai*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *paravālēdu* literally say, and how does its "not" differ
+from Tamil's? ("There is no harm"; Telugu uses *lēdu* where Tamil/Kannada/Malayalam
+use *illa(i)*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C03-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-practice.md
@@ -1,0 +1,48 @@
+---
+id: TE-C03-practice
+chapter: 3
+type: practice
+headword: (dialogue)
+gloss: Chapter 3 recap — the how-are-you exchange
+concept_tag: REVIEW
+prerequisites: [TE-C03-miiru-elaa-unnaaru, TE-C03-baagaa, TE-C03-paravaaledu]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [TE-C03-elaa, TE-C03-miiru-elaa-unnaaru, TE-C03-nenu, TE-C03-baagaa, TE-C03-paravaaledu]
+---
+
+# Chapter 3 — The how-are-you exchange
+
+## Warm-up
+
+[PAUSE 2s] No new words. The whole responding cycle, from atoms you now own.
+
+## The exchange
+
+[PAUSE 1s each]
+- [YOU SAY: "How are you?" (respectful) — *mīru elā unnāru?*]
+- [YOU SAY: "I'm well, thank you." — *nēnu bāgunnānu, dhanyavādamulu.*]
+- [YOU SAY: "No problem / you're welcome." — *paravālēdu.*]
+- [YOU SAY: the familiar version of the question — *nuvvu elā unnāvu?*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the e- question-word for "how" (*elā*)]
+- [YOU SAY: "I" and the verb "to be" (*nēnu*, *uṇḍu*)]
+- [YOU SAY: the "there is / there is not" pair (*undi* / *lēdu*)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *elā* ← the interrogative *e-* (native Dravidian, like Tamil *eppaḍi*)
+- *nēnu* ← Proto-Dravidian (unrelated to English *me*); possessive *nā*
+- *bāgā* ← *bāgu* "goodness"; *nēnu bāgunnānu* "I'm well"
+- *lēdu* — Telugu's "is-not," where its sisters use *illa(i)*
+
+## Wrap-up Recall
+
+[PAUSE 3s] A stranger asks *mīru elā unnāru?* — give a full, polite reply, and
+answer their thanks. (*Nēnu bāgunnānu, dhanyavādamulu* — and to thanks,
+*paravālēdu*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C04-malli-kaluddaam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-malli-kaluddaam.md
@@ -1,0 +1,45 @@
+---
+id: TE-C04-malli-kaluddaam
+chapter: 4
+type: phrase
+headword: మళ్ళీ కలుద్దాం
+gloss: we'll meet again
+concept_tag: FAREWELL-LATER
+prerequisites: [TE-C04-reepu-kaluddaam]
+sounds: [retroflex-ll]
+roots: [malli-again-dravidian, kalu-meet-dravidian]
+est_minutes: 3
+reviews_of: [TE-C04-reepu-kaluddaam]
+---
+
+# మళ్ళీ కలుద్దాం (maḷḷī kaluddām) — "we'll meet again"
+
+## Warm-up
+
+[PAUSE 2s] The open-ended, warm goodbye — no date, just a promise.
+
+## The letters in this word
+
+**మళ్ళీ** (*maḷḷī*): note the doubled retroflex **ళ్ళ** (*ḷḷ*), the same sound as
+in *veḷḷu*. **కలుద్దాం** (*kaluddām*, "let's meet") you just learned.
+
+## The word, taken apart
+
+**మళ్ళీ కలుద్దాం** = **మళ్ళీ** (*maḷḷī*, "again") + **కలుద్దాం** (*kaluddām*, "let's
+meet") — "**we'll meet again**." Both words are native Dravidian: *maḷḷī*
+("again," from *maral*, "to return") and *kalu* ("to meet"). Where Tamil's "we'll
+meet again" (*mīṇḍum sandippōm*) reaches for the Sanskrit loan *sandi* to say
+"meet," Telugu keeps the native *kalu* — a small reminder that these sisters make
+the same phrase from different stock.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "maḷḷī kaluddām"]
+- [YOU SAY: "again" and "let's meet" (*maḷḷī*, *kaluddām*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the phrase mean, and which Dravidian verb does Telugu use for
+"meet" here? ("We'll meet again"; the native *kalu* — where Tamil used the
+Sanskrit loan *sandi*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C04-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-practice.md
@@ -1,0 +1,47 @@
+---
+id: TE-C04-practice
+chapter: 4
+type: practice
+headword: (dialogue)
+gloss: Chapter 4 recap — the farewells
+concept_tag: REVIEW
+prerequisites: [TE-C04-velli-vastaanu, TE-C04-reepu-kaluddaam, TE-C04-malli-kaluddaam]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [TE-C04-vellu, TE-C04-velli-vastaanu, TE-C04-reepu-kaluddaam, TE-C04-malli-kaluddaam]
+---
+
+# Chapter 4 — The farewells
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three ways to part — none of them a blunt "goodbye."
+
+## The farewells
+
+[PAUSE 1s each]
+- [YOU SAY: the everyday goodbye — *veḷḷi vastānu* ("I'll go and come back")]
+- [YOU SAY: the warm reply — *veḷḷi raṇḍi* ("go and come back")]
+- [YOU SAY: "see you tomorrow" — *rēpu kaluddām*]
+- [YOU SAY: "we'll meet again" — *maḷḷī kaluddām*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the two verbs (*veḷḷu* go, *vaccu* come)]
+- [YOU SAY: "tomorrow," "again," "let's meet" (*rēpu*, *maḷḷī*, *kaluddām*)]
+- [YOU SAY: the "let's ___" ending (*-ddām*)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *veḷḷi vastānu* — "having gone, I come"; the Dravidian promise-of-return goodbye
+- *rēpu* "tomorrow" + *kalu* "meet" (native, where Tamil borrowed *sandi*)
+- *maḷḷī* ← *maral* "to return"
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does Telugu never say a plain "I'm leaving," and what does its
+everyday goodbye promise instead? (It sounds too final; *veḷḷi vastānu* promises
+"I'll go and come back.")

--- a/code/learning/human-languages/telugu/lessons/TE-C04-reepu-kaluddaam.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-reepu-kaluddaam.md
@@ -1,0 +1,44 @@
+---
+id: TE-C04-reepu-kaluddaam
+chapter: 4
+type: phrase
+headword: రేపు కలుద్దాం
+gloss: see you tomorrow
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [TE-C04-velli-vastaanu]
+sounds: [long-e]
+roots: [reepu-tomorrow-dravidian, kalu-meet-dravidian]
+est_minutes: 4
+reviews_of: [TE-C04-velli-vastaanu]
+---
+
+# రేపు కలుద్దాం (rēpu kaluddām) — "see you tomorrow"
+
+## Warm-up
+
+[PAUSE 2s] A goodbye with a date on it.
+
+## The letters in this word
+
+**రే** (*rē*) + **పు** (*pu*) → **రేపు** (*rēpu*). **కలుద్దాం** (*kaluddām*) =
+*kalu* ("meet") + *-ddām* ("let's").
+
+## The word, taken apart
+
+**రేపు** (*rēpu*, "tomorrow") is native Dravidian. **కలుద్దాం** (*kaluddām*, "let's
+meet") is from **కలు** (*kalu*, "to meet, to join") — so the phrase is "**tomorrow,
+let's meet**," the Telugu "see you tomorrow." The **-దాం** (*-ddām*) ending is
+Telugu's "let's ___" — a first-person-plural invitation: *veḷḷddām* ("let's go"),
+*tindām* ("let's eat").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rēpu kaluddām"]
+- [YOU SAY: "tomorrow" and "to meet" (*rēpu*, *kalu*)]
+- [YOU SAY: the "let's ___" ending (*-ddām*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the two pieces of *rēpu kaluddām*, and what does *-ddām* mean?
+(*Rēpu* "tomorrow" + *kalu* "meet"; *-ddām* = "let's ___.")

--- a/code/learning/human-languages/telugu/lessons/TE-C04-velli-vastaanu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-velli-vastaanu.md
@@ -1,0 +1,52 @@
+---
+id: TE-C04-velli-vastaanu
+chapter: 4
+type: phrase
+headword: వెళ్ళి వస్తాను
+gloss: goodbye (lit. "I'll go and come back")
+concept_tag: FAREWELL
+prerequisites: [TE-C04-vellu, TE-C03-nenu]
+sounds: [velli-participle]
+roots: [vellu-go-dravidian, vaccu-come-dravidian]
+est_minutes: 4
+reviews_of: [TE-C04-vellu]
+---
+
+# వెళ్ళి వస్తాను (veḷḷi vastānu) — "I'll go and come back"
+
+## Warm-up
+
+[PAUSE 2s] The everyday Telugu goodbye — a promise, not a parting.
+
+## The letters in this word
+
+**వెళ్ళి** (*veḷḷi*, "having gone") is *veḷḷu* + the "-i" that means "having
+…d." **వస్తాను** (*vastānu*, "I come/will come") is from *vaccu* ("come") + "I."
+
+## The word, taken apart
+
+**వెళ్ళి వస్తాను** = **వెళ్ళి** (*veḷḷi*, "having gone") + **వస్తాను** (*vastānu*,
+"I come") — literally "**having gone, I come [back]**," i.e. "I'll go and come
+back." A Telugu speaker never signs off with a bare "I'm leaving" — that sounds
+final. Instead they promise return. It is the same "go-and-come-back" farewell you
+meet across the Dravidian south (Tamil *pōy varugiṟēṉ*, Kannada *hōgi baruttēne*,
+Malayalam *pōyi varāṁ*) and echoing into the Indo-Aryan tracks (Bengali *āshi*).
+The warm reply is **వెళ్ళి రండి** (*veḷḷi raṇḍi*, "go and come [back]").
+
+## Grammar Lens: the "having …d" participle
+
+*Veḷḷi* is Telugu's way of chaining actions: "having gone, (then) I come." Like
+its sisters, Telugu strings verbs with one in the participle form and the last
+one fully conjugated.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the goodbye — *veḷḷi vastānu*]
+- [YOU SAY: its literal meaning ("having gone, I come" → "I'll come back")]
+- [YOU SAY: the warm reply — *veḷḷi raṇḍi*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the Telugu goodbye literally promise, and how do you answer?
+("I'll go and come back"; reply *veḷḷi raṇḍi*, "go and come back".)

--- a/code/learning/human-languages/telugu/lessons/TE-C04-vellu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C04-vellu.md
@@ -1,0 +1,43 @@
+---
+id: TE-C04-vellu
+chapter: 4
+type: word
+headword: వెళ్ళు
+gloss: to go (and వచ్చు, to come)
+concept_tag: TE-VERB-VELLU
+prerequisites: [TE-C03-nenu]
+sounds: [retroflex-ll, cc]
+roots: [vellu-go-dravidian, vaccu-come-dravidian]
+est_minutes: 3
+reviews_of: []
+---
+
+# వెళ్ళు (veḷḷu) — "go," and వచ్చు (come)
+
+## Warm-up
+
+[PAUSE 2s] Two everyday verbs — and together they make the Telugu goodbye.
+
+## The letters in this word
+
+**వె** (*ve*) + **ళ్ళు** (*ḷḷu*, a doubled retroflex **ళ** *ḷ*) → **వెళ్ళు**
+(*veḷḷu*). Its partner: **వచ్చు** (*vaccu*, "come") with the doubled **చ్చ**
+(*cc*).
+
+## The word, taken apart
+
+**వెళ్ళు** (*veḷḷu*, "to go") and **వచ్చు** (*vaccu*, "to come") are native
+Dravidian verbs. As commands they are whole words: *veḷḷu!* ("go!"), *rā!*
+("come!"). You need both, because Telugu — like every Dravidian language — does
+not say a plain "goodbye." It says "I go, and I **come back**."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "veḷḷu" (go) and "vaccu" (come)]
+- [YOU SAY: why you need both to say goodbye (Telugu's farewell is "I'll go and come back")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *veḷḷu* and *vaccu* mean, and why will you need them both to
+part? ("Go" and "come"; the Telugu goodbye is "I'll go and come back.")

--- a/code/learning/human-languages/telugu/lessons/TE-C05-maatlaadu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-maatlaadu.md
@@ -1,0 +1,56 @@
+---
+id: TE-C05-maatlaadu
+chapter: 5
+type: word
+headword: మాట్లాడు
+gloss: to speak
+concept_tag: TE-VERB-MATLADU
+prerequisites: [TE-C03-nenu]
+sounds: [retroflex-tl, long-aa]
+roots: [maata-word-dravidian]
+est_minutes: 4
+reviews_of: []
+---
+
+# మాట్లాడు (māṭlāḍu) — "to speak," your first full verb
+
+## Warm-up
+
+[PAUSE 2s] So far, "to be." Here is a verb that *does* something — and it shows
+how Telugu builds "I do X."
+
+## The letters in this word
+
+**మా** (*mā*) + **ట్లా** (*ṭlā*) + **డు** (*ḍu*) → **మాట్లాడు** (*māṭlāḍu*).
+
+## The word, taken apart
+
+**మాట్లాడు** (*māṭlāḍu*, "to speak, to talk") is native Dravidian, built on
+**మాట** (*māṭa*, "word, speech"). To say "**I speak**," Telugu adds a two-part
+ending to the stem — tense + person:
+
+> *māṭlāḍ-* (speak) + *-t-* (present/future) + *-ānu* ("I") → **మాట్లాడతాను**
+> (*māṭlāḍatānu*), "I speak / I will speak."
+
+The **-ాను** (*-ānu*) ending *is* "I," so *nēnu* is rarely needed. Change the
+ending, change the person: *māṭlāḍtāḍu* (he), *māṭlāḍtundi* (she/it),
+*māṭlāḍtāru* (they / you-respectful).
+
+## Grammar Lens: stem + tense + person
+
+Every Telugu verb is built this way — a stem, a tense-marker, a person-ending,
+stacked and glued. Learn the pattern once and every verb follows it. (Telugu, like
+Tamil, marks no gender in the first person: *māṭlāḍatānu* is the same for a man or
+a woman.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "māṭlāḍu" (speak)]
+- [YOU SAY: "I speak" — *māṭlāḍatānu*]
+- [YOU SAY: the word "speech" inside it (*māṭa*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Build "I speak" from *māṭlāḍu*, and name the noun it's built on.
+(*Māṭlāḍatānu*; *māṭa*, "word / speech.")

--- a/code/learning/human-languages/telugu/lessons/TE-C05-nenu-telugu-maatlaadataanu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-nenu-telugu-maatlaadataanu.md
@@ -1,0 +1,53 @@
+---
+id: TE-C05-nenu-telugu-maatlaadataanu
+chapter: 5
+type: phrase
+headword: నేను తెలుగు మాట్లాడతాను
+gloss: I speak Telugu
+concept_tag: TE-WORD-TELUGU
+prerequisites: [TE-C05-maatlaadu, TE-C03-nenu]
+sounds: [long-u]
+roots: [telugu]
+est_minutes: 5
+reviews_of: [TE-C05-maatlaadu, TE-C03-nenu]
+---
+
+# నేను తెలుగు మాట్లాడతాను (nēnu telugu māṭlāḍatānu) — "I speak Telugu"
+
+## Warm-up
+
+[PAUSE 2s] Your first full, moving sentence — and it names one of India's most
+musical languages.
+
+## The letters in this word
+
+**తెలుగు** (*telugu*): **తె** (*te*) + **లు** (*lu*) + **గు** (*gu*).
+
+## The sentence, taken apart
+
+**నేను తెలుగు మాట్లాడతాను** = **నేను** (*nēnu*, "I") + **తెలుగు** (*telugu*,
+"Telugu," the object) + **మాట్లాడతాను** (*māṭlāḍatānu*, "speak") — "**I Telugu
+speak**," the verb last as always. The name **తెలుగు** (*telugu*) is native, of
+debated origin (often linked to *tenugu*, and to the land *Trilinga*); its
+vowel-rich sound and habit of ending most words in a vowel earned it the old
+nickname "the Italian of the East." It is the language of the *Kāvya* poets and,
+today, of some eighty million speakers.
+
+## Grammar Lens: no gender on "I speak"
+
+*Māṭlāḍatānu* is the same whether a man or a woman says it — Telugu, like Tamil,
+marks **no gender in the first or second person** (only the third: *-āḍu* he,
+*-undi* she/it). This is unlike Hindi, where even "I speak" changes for the
+speaker's gender (*boltā/boltī*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nēnu telugu māṭlāḍatānu"]
+- [YOU SAY: the old nickname for Telugu and why ("the Italian of the East" — vowel-rich, most words end in a vowel)]
+- [YOU SAY: does "I speak" change for a man vs. a woman? (No — no 1st-person gender)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "I speak Telugu," and give Telugu's old nickname. (*Nēnu telugu
+māṭlāḍatānu*; "the Italian of the East.")

--- a/code/learning/human-languages/telugu/lessons/TE-C05-pani-ceyu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-pani-ceyu.md
@@ -1,0 +1,59 @@
+---
+id: TE-C05-pani-ceyu
+chapter: 5
+type: word
+headword: పని చేయు
+gloss: to work (lit. "work-do")
+concept_tag: TE-VERB-CEYU
+prerequisites: [TE-C05-maatlaadu]
+sounds: [long-e]
+roots: [ceyu-do-dravidian, pani-work-dravidian]
+est_minutes: 5
+reviews_of: [TE-C05-maatlaadu, TE-C05-undu]
+---
+
+# పని చేయు (pani cēyu) — "to work"
+
+## Warm-up
+
+[PAUSE 2s] The last verb of the chapter — and, like Hindi's *karnā* and Tamil's
+*sey*, it is a "do" verb that builds a hundred others.
+
+## The letters in this word
+
+**పని** (*pani*, "work"): **ప** (*pa*) + **ని** (*ni*). **చేయు** (*cēyu*, "do"):
+**చే** (*cē*) + **యు** (*yu*).
+
+## The word, taken apart
+
+**చేయు** (*cēyu*, "to do, to make") is a core native Dravidian verb, and Telugu
+— like Hindi with *karnā* and Tamil with *sey* — builds compound verbs by putting
+a noun in front of it:
+
+- **పని చేయు** (*pani cēyu*) = "work-do" = "**to work**" (*pani*, "work")
+- **వంట చేయు** (*vaṇṭa cēyu*) = "to cook"
+- **సహాయం చేయు** (*sahāyaṁ cēyu*) = "to help" (*sahāyaṁ* ← Sanskrit)
+
+So "I work" is **నేను పని చేస్తాను** (*nēnu pani cēstānu*) — *cēy-* + tense +
+"I." Master *cēyu* and a whole grammar of "do-verbs" opens up — and notice
+*sahāyaṁ cēyu* ("to help") pairs a **Sanskrit** noun with the **native** *cēyu*:
+Telugu's two vocabularies working together in a single verb.
+
+## Grammar Lens: noun + చేయు = a new verb
+
+This "noun + *cēyu*" pattern is the exact twin of Hindi's "noun + *karnā*" and
+Tamil's "noun + *sey*." Three languages — two of them from unrelated families —
+all hit on the same trick: an all-purpose "do" verb with nouns bolted on.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "pani cēyu" (to work)]
+- [YOU SAY: "I work" — *nēnu pani cēstānu*]
+- [YOU SAY: the Hindi and Tamil twins of this trick (*karnā*, *sey*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Telugu turn "work" into "to work," and what verbs work the
+same way in Hindi and Tamil? (*Pani* + *cēyu* = "work-do"; Hindi *karnā*, Tamil
+*sey*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C05-practice.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-practice.md
@@ -1,0 +1,48 @@
+---
+id: TE-C05-practice
+chapter: 5
+type: practice
+headword: (dialogue)
+gloss: Chapter 5 recap — the first verbs
+concept_tag: REVIEW
+prerequisites: [TE-C05-maatlaadu, TE-C05-nenu-telugu-maatlaadataanu, TE-C05-undu, TE-C05-pani-ceyu]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [TE-C05-maatlaadu, TE-C05-nenu-telugu-maatlaadataanu, TE-C05-undu, TE-C05-pani-ceyu, TE-C03-nenu]
+---
+
+# Chapter 5 — The first verbs
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three verbs, one engine — build real sentences about
+yourself.
+
+## Build the sentences
+
+[PAUSE 1s each]
+- [YOU SAY: "I speak Telugu" — *nēnu telugu māṭlāḍatānu*]
+- [YOU SAY: "I live in Hyderabad" — *nēnu Hyderābādlō uṇṭānu*]
+- [YOU SAY: "I work" — *nēnu pani cēstānu*]
+- [YOU SAY: "he speaks" vs. "she speaks" — *māṭlāḍtāḍu* / *māṭlāḍtundi*]
+
+## The engine
+
+[PAUSE 2s]
+- [YOU SAY: the three stacked pieces of every Telugu verb (stem + tense + person)]
+- [YOU SAY: the ending that means "I" (*-ānu*)]
+- [YOU SAY: where Telugu marks gender — and where it doesn't (3rd person only)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *māṭlāḍu* "to speak" ← *māṭa* "word"
+- *uṇḍu* "to be / stay / live"; *-lō* "in" attaches to the noun's end
+- *cēyu* "to do" → *pani cēyu* "to work" (the twin of Hindi's *karnā*, Tamil's *sey*)
+- *telugu* — "the Italian of the East," vowel-rich
+
+## Wrap-up Recall
+
+[PAUSE 3s] In one breath, say your language, your city, and your work in Telugu.
+(*Nēnu telugu māṭlāḍatānu. Nēnu … lō uṇṭānu. Nēnu pani cēstānu.*)

--- a/code/learning/human-languages/telugu/lessons/TE-C05-undu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C05-undu.md
@@ -1,0 +1,53 @@
+---
+id: TE-C05-undu
+chapter: 5
+type: word
+headword: ఉండు
+gloss: to be, to stay, to live
+concept_tag: TE-VERB-UNDU
+prerequisites: [TE-C05-maatlaadu, TE-C03-miiru-elaa-unnaaru]
+sounds: [retroflex-nd]
+roots: [undu-be-dravidian]
+est_minutes: 4
+reviews_of: [TE-C03-miiru-elaa-unnaaru]
+---
+
+# ఉండు (uṇḍu) — "to be, to stay, to live"
+
+## Warm-up
+
+[PAUSE 2s] You have already used this verb — in "how are you." Now meet it in its
+own right, and use it to say where you live.
+
+## The letters in this word
+
+**ఉ** (independent *u*) + **ండు** (*ṇḍu*, with the retroflex cluster **ండ**) →
+**ఉండు** (*uṇḍu*).
+
+## The word, taken apart
+
+**ఉండు** (*uṇḍu*, "to be, to exist, to stay, to live") is native Dravidian and
+does an enormous amount of work. It is the verb behind Chapter 3's *unnāru*
+("you are") and *bāgunnānu* ("I'm well") — and it also means "to reside": **నేను
+హైదరాబాద్‌లో ఉంటాను** (*nēnu Hyderābādlō uṇṭānu*, "I live in Hyderabad"). One
+verb covers "be," "stay," and "live."
+
+## Grammar Lens: "in" comes after the noun
+
+**హైదరాబాద్‌లో** (*Hyderābādlō*) = *Hyderabad* + **-లో** (*-lō*, "in"). The little
+word for "in" is glued to the **end** of the noun — Telugu uses **post**positions
+(really, case-suffixes) where English uses prepositions. "Hyderabad-in I stay,"
+the verb last.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "uṇḍu"]
+- [YOU SAY: "I live in Hyderabad" — *nēnu Hyderābādlō uṇṭānu*]
+- [YOU SAY: where "in" (*-lō*) sits — glued to the end of the noun]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name three things the one verb *uṇḍu* can mean, and say where "in"
+goes. ("To be / to stay / to live"; *-lō* "in" attaches to the **end** of the
+noun.)

--- a/code/learning/human-languages/telugu/roadmap.md
+++ b/code/learning/human-languages/telugu/roadmap.md
@@ -22,13 +22,24 @@ piece by piece, on the first word that needs it.
   Every atom traced (*pēru* ← *\*pēr*, twin of Tamil *peyar*; *santōṣam* a
   Sanskrit loan for "pleased"); the zero copula; respect-by-plural.
 
+- **Ch. 3 — How Are You**: elā (how; the native *e-* questions) → mīru elā
+  unnāru? (the verb *uṇḍu* "to be") → nēnu (I ← Proto-Dravidian) → bāgā (well) →
+  paravālēdu (you're welcome = "no harm," on Telugu's own *lēdu* — where its
+  sisters use *illa*) → practice.
+- **Ch. 4 — Farewells**: veḷḷu/vaccu (go/come) → veḷḷi vastānu ("I'll go and come
+  back") → rēpu kaluddām (see you tomorrow) → maḷḷī kaluddām (we'll meet again;
+  native *kalu*, where Tamil borrowed Sanskrit *sandi*) → practice.
+- **Ch. 5 — First Verbs**: māṭlāḍu (to speak ← *māṭa* "word") → nēnu telugu
+  māṭlāḍatānu (I speak Telugu; "the Italian of the East"; no 1st-person gender)
+  → uṇḍu (to be/stay/live; postposition *-lō*) → pani cēyu (to work; noun +
+  *cēyu*, the twin of Hindi's *karnā*) → practice.
+
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 3 | Responding: *elā unnāru?* ("how are you"), *bāgunnānu* ("I'm well"), the verb *uṇḍu* ("to be") |
-| 4 | The case-endings (Telugu's agglutinative suffixes), numbers 1–10 |
-| 5+ | Postpositions, tense on the verb, family, food — always with the Dravidian-cognate thread |
+| 6 | Case-endings (Telugu's agglutinative suffixes: *-ki, -lō, -tō*); more verbs |
+| 7+ | Tense, numbers, family, food — always with the Dravidian-cognate thread |
 
 Note: Telugu marks "you" by **register** (*nuvvu* familiar / *mīru* respectful,
 also plural) — like the other tracks, worth teaching beside them.

--- a/code/learning/human-languages/telugu/session-map.md
+++ b/code/learning/human-languages/telugu/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Telugu Chapters 1–2
+# Session Map — Telugu Chapters 1–5
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -34,6 +34,37 @@ the independent vowels — all in the service of real greetings.
 | 13 | santosham | సంతోషం | "pleased to meet you" — **Sanskrit** (vs. Tamil's native *magiḻcci*) |
 | 14 | practice | (dialogue) | the whole exchange |
 
+## Chapter 3 — How Are You
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 15 | elaa | ఎలా | "how" ← the native *e-* question family |
+| 16 | miiru-elaa-unnaaru | మీరు ఎలా ఉన్నారు? | **"how are you?"**; the verb *uṇḍu* "to be" |
+| 17 | nenu | నేను | "I" ← Proto-Dravidian (unrelated to *me*); possessive *nā* |
+| 18 | baagaa | బాగా | "well" ← *bāgu* "goodness"; *nēnu bāgunnānu* "I'm well" |
+| 19 | paravaaledu | పరవాలేదు | "no problem / you're welcome" = "no harm"; Telugu's *lēdu* vs. sisters' *illa* |
+| 20 | practice | (dialogue) | the whole how-are-you exchange |
+
+## Chapter 4 — Farewells
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 21 | vellu | వెళ్ళు / వచ్చు | "go" / "come" |
+| 22 | velli-vastaanu | వెళ్ళి వస్తాను | **"I'll go and come back"** — the Dravidian promise-of-return goodbye |
+| 23 | reepu-kaluddaam | రేపు కలుద్దాం | "see you tomorrow"; *rēpu* + *kalu* + the "let's ___" *-ddām* |
+| 24 | malli-kaluddaam | మళ్ళీ కలుద్దాం | "we'll meet again"; native *kalu* (where Tamil borrowed *sandi*) |
+| 25 | practice | (dialogue) | the farewells |
+
+## Chapter 5 — The First Verbs
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 26 | maatlaadu | మాట్లాడు | "to speak" ← *māṭa* "word"; stem + tense + person |
+| 27 | nenu-telugu-maatlaadataanu | నేను తెలుగు మాట్లాడతాను | **"I speak Telugu"**; "the Italian of the East"; no 1st-person gender |
+| 28 | undu | ఉండు | "to be / stay / live"; the postposition *-lō* ("in") |
+| 29 | pani-ceyu | పని చేయు | "to work" (noun + *cēyu*) — the twin of Hindi's *karnā* |
+| 30 | practice | (dialogue) | three verbs, one engine |
+
 ## Next
 
-Chapter 3 — *elā unnāru?* ("how are you?") — the responding cycle.
+Chapter 6 — the case-endings (Telugu's agglutinative suffixes *-ki, -lō, -tō*).


### PR DESCRIPTION
Carries the **Telugu** track from Chapter 2 to **Chapter 5**, matching the
leading tracks' early-learner arc. Part of the per-track parity series (Hindi
#8596, Tamil #8605).

Framework `HL00`; concept tags reuse the universal `HL01` taxonomy, verbs
namespaced (`TE-VERB-*`) — no `taxonomy.json` change. Telugu's signature —
**heavy Sanskrit borrowing but Dravidian grammar**, and its lone divergence
*lēdu* (vs. its sisters' *illa*) — runs throughout.

## Chapters

- **Ch. 3 — How Are You**: *elā* (how; Telugu's native *e-* questions) → *mīru
  elā unnāru?* (the verb *uṇḍu* "to be") → *nēnu* (I ← Proto-Dravidian, unrelated
  to English *me*) → *bāgā* (well; *nēnu bāgunnānu* "I'm well") → *paravālēdu*
  ("there is no harm" = you're welcome, built on Telugu's own *lēdu*) → practice.
- **Ch. 4 — Farewells**: *veḷḷu*/*vaccu* → *veḷḷi vastānu* ("I'll go and come
  back" — the Dravidian promise-of-return goodbye, tabled across the family) →
  *rēpu kaluddām* (see you tomorrow) → *maḷḷī kaluddām* (we'll meet again; native
  *kalu*, where Tamil borrowed Sanskrit *sandi*) → practice.
- **Ch. 5 — First Verbs**: *māṭlāḍu* (← *māṭa* "word") → *nēnu telugu māṭlāḍatānu*
  (I speak Telugu — "the Italian of the East"; no 1st-person gender) → *uṇḍu*
  (to be/stay/live; the postposition *-lō*) → *pani cēyu* (to work; noun +
  *cēyu*, the twin of Hindi's *karnā*) → practice.

## Verification

- Book compiles clean with XeLaTeX (×2): **0 missing characters, 0 undefined
  references** (29 pages).
- New chapter pages rasterized and visually QA'd — Telugu script, conjuncts, the
  ZWNJ in *Hyderābādlō*, and grammar tables all render correctly.
- Concept tags validate against `HL01`; `/security-review` covered by the Hindi
  run (identical content-only class).
- `human-languages-books.yml` CI will build the updated PDF on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)