### PR TITLE
feat(hl-kannada): Chapters 3-5 — how-are-you, farewells, first verbs

### DIFF
--- a/code/learning/human-languages/kannada/CHANGELOG.md
+++ b/code/learning/human-languages/kannada/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Chapters 3–5 — How-are-you, Farewells, First Verbs
+
+- Three new chapters carry Kannada to Chapter 5, matching the leading tracks' arc.
+  One word per lesson, atom-first, Kannada script inline; every root traced
+  (`lessons/KA-C0{3,4,5}-*`, `book/chapters/ch0{3,4,5}-*.tex`). Concept tags reuse
+  the universal `HL01` taxonomy; verbs namespaced (`KA-VERB-*`). The
+  Sanskrit-borrowing-yet-Dravidian-grammar thread runs throughout.
+- **Ch. 3 — How Are You**: *hēge* (how; the native *ē-/yā-* questions) → *nīvu
+  hēgiddīrā?* (the verb *iru* "to be," the same word Tamil uses) → *nānu* (I ←
+  Proto-Dravidian, unrelated to *me*) → *cennāgi* (well ← *cennu* "beautiful";
+  *nānu cennāgiddēne* "I'm well") → *paravāgilla* ("no harm" = you're welcome, on
+  the Dravidian *illa* shared with Tamil/Malayalam — where Telugu uses *lēdu*) →
+  practice.
+- **Ch. 4 — Farewells**: *hōgu*/*bā* → *hōgi baruttēne* ("I'll go and come back,"
+  tabled across the family) → *nāḷe sigōṇa* (see you tomorrow; *nāḷ* "day" shared
+  with Tamil, the "let's ___" *-ōṇa*) → *matte sigōṇa* (we'll meet again; native
+  *sigu*, where Tamil borrowed Sanskrit *sandi*) → practice.
+- **Ch. 5 — First Verbs**: *mātanāḍu* (← *mātu* "word") → *nānu kannaḍa
+  mātanāḍuttēne* (I speak Kannada; no 1st-person gender) → *iru* (to be/stay/live;
+  the postposition *-alli*) → *kelasa māḍu* (to work; noun + *māḍu*, the twin of
+  Hindi's *karnā*) → practice. Book compiles clean with XeLaTeX (0 missing chars,
+  0 undefined refs).
+
 ## Chapter 2 — Introducing Yourself
 
 - New chapter around the introduction dialogue (*nanna hesaru … / nimma hesaru

--- a/code/learning/human-languages/kannada/README.md
+++ b/code/learning/human-languages/kannada/README.md
@@ -35,6 +35,15 @@ book.
   **nimma hesaru ēnu?** ("what's your name?"), santōṣa, practice. Every atom
   traced (*hesaru* ← *\*pesar*, p→h; *santōṣa* Sanskrit vs. Tamil *magiḻcci*).
   In the book.
+- **Chapter 3 — How Are You** ([`lessons/KA-C03-*`](./lessons/)): hēge, **nīvu
+  hēgiddīrā?**, nānu, cennāgi, paravāgilla, practice. The verb *iru* ("to be,"
+  same as Tamil); the Dravidian *illa*. In the book.
+- **Chapter 4 — Farewells** ([`lessons/KA-C04-*`](./lessons/)): hōgu/bā, **hōgi
+  baruttēne** ("I'll go and come back"), nāḷe sigōṇa, matte sigōṇa, practice. The
+  Dravidian promise-of-return goodbye. In the book.
+- **Chapter 5 — First Verbs** ([`lessons/KA-C05-*`](./lessons/)): mātanāḍu, **nānu
+  kannaḍa mātanāḍuttēne**, iru, kelasa māḍu, practice. Stem + tense + person; no
+  1st-person gender. In the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/kannada/book/book.tex
+++ b/code/learning/human-languages/kannada/book/book.tex
@@ -69,4 +69,10 @@ rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/ch02-introductions}
 
+\input{chapters/ch03-responding}
+
+\input{chapters/ch04-farewells}
+
+\input{chapters/ch05-first-verbs}
+
 \end{document}

--- a/code/learning/human-languages/kannada/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch03-responding.tex
@@ -1,0 +1,116 @@
+\chapter{How Are You?}
+\label{ch:responding}
+
+After the name comes the exchange everyone actually has --- carried by the
+Dravidian verb ``to be'':
+
+\begin{center}
+\kn{ನೀವು ಹೇಗಿದ್ದೀರಾ?} \quad(\emph{n\=\i vu h\=egidd\=\i r\=a} --- ``How are you?'')\\
+\kn{ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ, ಧನ್ಯವಾದ.} \quad(\emph{n\=anu cenn\=agidd\=ene, dhanyav\=ada} --- ``I'm well, thank you.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/KA-C03-*.md}.}
+
+\section{\kn{ಹೇಗೆ} \emph{(h\=ege)} --- ``how,'' another of the \=e- questions}
+\label{lesson:hege}
+
+\begin{sounds}
+\kn{ಹೇ} (\emph{h\=e}) $+$ \kn{ಗೆ} (\emph{ge}) $\to$ \kn{ಹೇಗೆ} (\emph{h\=ege}).
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ಹೇಗೆ} (\emph{h\=ege}, ``how'') is native Dravidian, on the interrogative base
+\emph{\=e-/y\=a-} from \emph{\=enu}. Kannada gathers its questions here:
+\emph{\=enu} (what), \emph{h\=ege} (how), \emph{y\=aru} (who), \emph{elli}
+(where), \emph{y\=av\=aga} (when). It is the same Dravidian question-root heading
+Tamil's \emph{eppa\d{t}i} and Telugu's \emph{el\=a} --- a family older than the
+Sanskrit words Kannada otherwise borrows so readily.
+\end{cousinweb}
+
+\section{\kn{ನೀವು ಹೇಗಿದ್ದೀರಾ?} --- ``how are you?''}
+\label{lesson:niivu-hegiddiira}
+
+The new word is \kn{ಹೇಗಿದ್ದೀರಾ} (\emph{h\=egidd\=\i r\=a}): \emph{h\=ege}
+(``how'') fused with the verb \kn{ಇರು} (\emph{iru}, ``to be, exist, stay'') $+$
+the respectful-you ending. So \kn{ನೀವು ಹೇಗಿದ್ದೀರಾ?} is ``you how are?'', the verb
+last, as in every Kannada sentence. The verb \emph{iru} is the very same native
+Dravidian ``to be'' that Tamil uses --- and (Chapter 5) the verb for ``I live.''
+
+\begin{grammarlens}
+\textbf{The verb carries ``you.''} The ending already means ``you (respectful),''
+so \emph{n\=\i vu} can be dropped. To a friend: \kn{ನೀನು ಹೇಗಿದ್ದೀಯಾ?} (\emph{n\=\i
+nu h\=egidd\=\i y\=a?}). Match the ``you'' to the verb-ending.
+\end{grammarlens}
+
+\section{\kn{ನಾನು} \emph{(n\=anu)} --- ``I,'' the Dravidian first person}
+\label{lesson:naanu}
+
+\begin{sounds}
+\kn{ನಾ} (\emph{n\=a}) $+$ \kn{ನು} (\emph{nu}) $\to$ \kn{ನಾನು} (\emph{n\=anu}).
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ನಾನು} (\emph{n\=anu}, ``I'') $\leftarrow$ Proto-Dravidian *y\=a\d{n} / *n\=a\d{n}
+--- native, and (unlike Hindi's \emph{mai\d{m}}, cousin of English \emph{me})
+\textbf{not} related to the European ``I/me'' family. Its possessive is the
+\kn{ನನ್ನ} (\emph{nanna}, ``my'') you met in Chapter 2. Kannada borrows Sanskrit
+freely for higher vocabulary, but its bedrock pronouns stayed Dravidian.
+\end{cousinweb}
+
+\section{\kn{ಚೆನ್ನಾಗಿ} \emph{(cenn\=agi)} --- ``well,'' and how to answer}
+\label{lesson:cennaagi}
+
+\begin{sounds}
+\kn{ಚೆ} (\emph{ce} --- the letter \kn{ಚ} is ``ch as in \emph{cheese}'') $+$
+\kn{ನ್ನಾ} (\emph{nn\=a}) $+$ \kn{ಗಿ} (\emph{gi}) $\to$ \kn{ಚೆನ್ನಾಗಿ}.
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ಚೆನ್ನಾಗಿ} (\emph{cenn\=agi}, ``well, nicely'') is native Dravidian, from
+\kn{ಚೆನ್ನು} (\emph{cennu}, ``good, beautiful'') $+$ the adverb-maker \emph{-\=agi}
+(``in a \ldots\ way'') --- so it means, at heart, ``in a beautiful way.'' The root
+\emph{cennu} is pure Kannada, no Sanskrit or European cousin.
+\end{cousinweb}
+
+Fuse it with \emph{iru}: \kn{ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ} (\emph{n\=anu cenn\=agidd\=ene})
+--- ``I am well.''
+
+\section{\kn{ಪರವಾಗಿಲ್ಲ} \emph{(parav\=agilla)} --- ``no problem''}
+\label{lesson:paravaagilla}
+
+\begin{cousinweb}
+\kn{ಪರವಾಗಿಲ್ಲ} means ``\textbf{it does not matter / there is no harm}'' ---
+\emph{parav\=a} (``harm'') $+$ \kn{ಇಲ್ಲ} (\emph{illa}, ``is-not''), the Chapter-1
+negative. It serves as ``it's okay / no worries / you're welcome.'' The atom
+\kn{ಇಲ್ಲ} (\emph{illa}) is Kannada's ``is-not,'' the mirror of \emph{iru}
+(``is''). It is shared, almost unchanged, across \textbf{Kannada, Tamil, and
+Malayalam} --- a deep Dravidian bond; only Telugu breaks away to \emph{l\=edu} (so
+Telugu's ``no problem'' is \emph{parav\=aledu}, Kannada's \emph{parav\=agilla}).
+\end{cousinweb}
+
+\begin{grammarlens}
+\emph{Illa} negates existence and stands alone as ``no'': \emph{du\d{d}\d{d}u
+illa} (``there's no money''). Hold \emph{iru} / \emph{illa} together --- ``is'' and
+``is-not.''
+\end{grammarlens}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Kannada & English \\
+\midrule
+\kn{ನೀವು ಹೇಗಿದ್ದೀರಾ?} & How are you? \\
+\kn{ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ, ಧನ್ಯವಾದ.} & I'm well, thank you. \\
+\kn{ಪರವಾಗಿಲ್ಲ.} & No problem / you're welcome. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{h\=ege} (the native \=e- questions), \emph{n\=anu}
+(Proto-Dravidian, unrelated to \emph{me}), \emph{cenn\=agi} (``beautifully''), and
+the \emph{iru} / \emph{illa} pair --- ``is'' and ``is-not,'' the \emph{illa} shared
+with Tamil and Malayalam. Next chapter: the farewells --- and Kannada, like all
+its family, never says a plain ``goodbye.''

--- a/code/learning/human-languages/kannada/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch04-farewells.tex
@@ -1,0 +1,102 @@
+\chapter{Farewells}
+\label{ch:farewells}
+
+Kannada, like every Dravidian language, does not say a plain ``goodbye.'' It
+promises to return:
+
+\begin{center}
+\kn{ಹೋಗಿ ಬರುತ್ತೇನೆ.} \quad(\emph{h\=ogi barutt\=ene} --- ``I'll go and come back.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/KA-C04-*.md}.}
+
+\section{\kn{ಹೋಗು} \emph{(h\=ogu)} --- ``go,'' and \kn{ಬಾ} (come)}
+\label{lesson:hoogu}
+
+\begin{sounds}
+\kn{ಹೋ} (\emph{h\=o}) $+$ \kn{ಗು} (\emph{gu}) $\to$ \kn{ಹೋಗು}. Its partner
+\kn{ಬಾ} (\emph{b\=a}, ``come'').
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ಹೋಗು} (\emph{h\=ogu}, ``to go'') and \kn{ಬಾ} (\emph{b\=a}, ``come'') are
+native Dravidian verbs. As commands they are whole words: \emph{h\=ogu!}
+(``go!''), \emph{b\=a!} (``come!''). You need both, because Kannada's goodbye is
+``I go, and I \emph{come back}.''
+\end{cousinweb}
+
+\section{\kn{ಹೋಗಿ ಬರುತ್ತೇನೆ} \emph{(h\=ogi barutt\=ene)} --- ``I'll go and come back''}
+\label{lesson:hoogi-baruttene}
+
+\kn{ಹೋಗಿ} (\emph{h\=ogi}, ``having gone'') $+$ \kn{ಬರುತ್ತೇನೆ} (\emph{barutt\=ene},
+``I come'') --- literally ``\textbf{having gone, I come [back]},'' i.e. ``I'll go
+and come back.'' A Kannada speaker never signs off with a bare ``I'm leaving.''
+The warm reply is \kn{ಹೋಗಿ ಬನ್ನಿ} (\emph{h\=ogi banni}, ``go and come [back]'').
+
+\begin{cognates}
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Language & ``go and come back'' (goodbye) \\
+\midrule
+\textbf{Kannada} & \emph{h\=ogi barutt\=ene} \\
+Tamil & \emph{p\=oy varugi\d{r}\=e\d{n}} \\
+Telugu & \emph{ve\d{l}\d{l}i vast\=anu} \\
+Malayalam & \emph{p\=oyi var\=a\d{m}} \\
+\midrule
+Bengali (Indo-Aryan) & \emph{\=ashi} (``I come'') \\
+\bottomrule
+\end{tabular}
+\end{center}
+The whole south, and beyond, prefers a promise of return to a blunt farewell.
+\end{cognates}
+
+\section{\kn{ನಾಳೆ ಸಿಗೋಣ} \emph{(n\=a\d{l}e sig\=o\d{n}a)} --- ``see you tomorrow''}
+\label{lesson:naale-sigona}
+
+\begin{sounds}
+\kn{ನಾಳೆ} (\emph{n\=a\d{l}e}): \kn{ನಾ} (\emph{n\=a}) $+$ \kn{ಳೆ} (\emph{\d{l}e},
+retroflex \kn{ಳ} \emph{\d{l}}). \kn{ಸಿಗೋಣ} (\emph{sig\=o\d{n}a}) $=$ \emph{sigu}
+(``meet'') $+$ \emph{-\=o\d{n}a} (``let's'').
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ನಾಳೆ} (\emph{n\=a\d{l}e}, ``tomorrow'') is native, from \emph{n\=a\d{l}}
+(``day'') --- the same root as Tamil's \emph{n\=a\d{l}ai}. \kn{ಸಿಗು} (\emph{sigu},
+``to meet, be found'') gives \emph{sig\=o\d{n}a} (``let's meet'') --- ``tomorrow,
+let's meet.'' The \emph{-\=o\d{n}a} ending is Kannada's warm ``let's \ldots'':
+\emph{h\=og\=o\d{n}a} (``let's go'').
+\end{cousinweb}
+
+\section{\kn{ಮತ್ತೆ ಸಿಗೋಣ} \emph{(matte sig\=o\d{n}a)} --- ``we'll meet again''}
+\label{lesson:matte-sigona}
+
+\begin{cousinweb}
+\kn{ಮತ್ತೆ ಸಿಗೋಣ} $=$ \kn{ಮತ್ತೆ} (\emph{matte}, ``again'') $+$ \emph{sig\=o\d{n}a}
+(``let's meet''). Both are native Dravidian: \emph{matte} (``again'') and
+\emph{sigu} (``to meet''). Where Tamil's ``we'll meet again'' reaches for the
+Sanskrit loan \emph{sandi}, Kannada keeps the native \emph{sigu} --- the same
+phrase, from home-grown stock.
+\end{cousinweb}
+
+\section{The farewells}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Kannada & English \\
+\midrule
+\kn{ಹೋಗಿ ಬರುತ್ತೇನೆ.} & I'll go and come back. (goodbye) \\
+\kn{ಹೋಗಿ ಬನ್ನಿ.} & Go and come back. (the reply) \\
+\kn{ನಾಳೆ ಸಿಗೋಣ.} & See you tomorrow. \\
+\kn{ಮತ್ತೆ ಸಿಗೋಣ.} & We'll meet again. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Roots banked: \emph{h\=ogu}/\emph{b\=a} (go/come), \emph{n\=a\d{l}e} (``tomorrow''
+$\leftarrow$ \emph{n\=a\d{l}} ``day,'' shared with Tamil), and \emph{sigu}
+(``meet,'' native --- where Tamil borrowed \emph{sandi}). Next chapter: the first
+real verbs --- \emph{n\=anu kanna\d{d}a m\=atan\=a\d{d}utt\=ene} --- and Kannada's
+sentences begin to move.

--- a/code/learning/human-languages/kannada/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch05-first-verbs.tex
@@ -1,0 +1,115 @@
+\chapter{The First Verbs}
+\label{ch:first-verbs}
+
+Until now, ``to be'' and ``to be-not.'' Now verbs that \emph{act} --- and
+Kannada's sentences begin to move:
+
+\begin{center}
+\kn{ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ.} \quad(\emph{n\=anu kanna\d{d}a m\=atan\=a\d{d}utt\=ene} --- ``I speak Kannada.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/KA-C05-*.md}.}
+
+\section{\kn{ಮಾತನಾಡು} \emph{(m\=atan\=a\d{d}u)} --- ``to speak,'' your first full verb}
+\label{lesson:maatanaadu}
+
+\begin{sounds}
+\kn{ಮಾ} (\emph{m\=a}) $+$ \kn{ತ} (\emph{ta}) $+$ \kn{ನಾ} (\emph{n\=a}) $+$ \kn{ಡು}
+(\emph{\d{d}u}) $\to$ \kn{ಮಾತನಾಡು}.
+\end{sounds}
+
+\begin{cousinweb}
+\kn{ಮಾತನಾಡು} (\emph{m\=atan\=a\d{d}u}, ``to speak'') is native Dravidian, built on
+\kn{ಮಾತು} (\emph{m\=atu}, ``word, speech''). To say ``I speak,'' Kannada stacks
+two endings on the stem --- tense then person:
+\begin{center}
+\emph{m\=atan\=a\d{d}-} $+$ \emph{-utt-} (present) $+$ \emph{-\=ene} (``I'') $\to$
+\kn{ಮಾತನಾಡುತ್ತೇನೆ} (\emph{m\=atan\=a\d{d}utt\=ene}), ``I speak.''
+\end{center}
+The \emph{-\=ene} ending \emph{is} ``I,'' so \emph{n\=anu} is rarely needed:
+\emph{m\=atan\=a\d{d}utt\=ane} (he), \emph{m\=atan\=a\d{d}utt\=a\d{l}e} (she),
+\emph{m\=atan\=a\d{d}utt\=are} (they / you-respectful).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Stem $+$ tense $+$ person.} Every Kannada verb is built this way. And,
+like Tamil and Telugu, Kannada marks \textbf{no gender in the first person}:
+\emph{m\=atan\=a\d{d}utt\=ene} is the same for a man or a woman.
+\end{grammarlens}
+
+\section{\kn{ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ} --- ``I speak Kannada''}
+\label{lesson:naanu-kannada-maatanaaduttene}
+
+\kn{ನಾನು} (I) $+$ \kn{ಕನ್ನಡ} (\emph{kanna\d{d}a}, the object) $+$ \kn{ಮಾತನಾಡುತ್ತೇನೆ}
+(speak) --- ``I Kannada speak,'' verb last. The name \kn{ಕನ್ನಡ} (\emph{kanna\d{d}a})
+is native, often linked to \emph{kar-n\=a\d{d}u} (``the high/black land,'' whence
+\emph{Karnataka}). Kannada has a literature over a thousand years old and a store
+of classical honours --- a classical tongue of some fifty million speakers.
+
+\begin{grammarlens}
+\textbf{No gender on ``I speak.''} \emph{M\=atan\=a\d{d}utt\=ene} is the same
+whether a man or a woman says it --- Kannada, like Tamil and Telugu, marks no
+gender in the first or second person (only the third: \emph{-\=ane} he,
+\emph{-\=a\d{l}e} she).
+\end{grammarlens}
+
+\section{\kn{ಇರು} \emph{(iru)} --- ``to be, to stay, to live''}
+\label{lesson:iru}
+
+\begin{cousinweb}
+\kn{ಇರು} (\emph{iru}, ``to be, exist, stay, live'') is native Dravidian --- the
+very same \emph{iru} Tamil uses, and the verb behind Chapter 3's \emph{h\=egidd\=\i r\=a}
+(``how are you'') and \emph{cenn\=agidd\=ene} (``I'm well''). It also means ``to
+reside'': \kn{ನಾನು ಬೆಂಗಳೂರಿನಲ್ಲಿ ಇದ್ದೇನೆ} (\emph{n\=anu Be\d{n}ga\d{l}\=urinalli
+idd\=ene}, ``I live in Bangalore''). One verb covers ``be,'' ``stay,'' and
+``live.''
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``In'' comes after the noun.} \kn{ಬೆಂಗಳೂರಿನಲ್ಲಿ} (\emph{Be\d{n}ga\d{l}\=urinalli})
+$=$ \emph{Be\d{n}ga\d{l}\=uru} $+$ \emph{-alli} (``in''), glued to the \emph{end}
+of the noun. Kannada uses \textbf{post}positions (case-suffixes): ``Bangalore-in I
+am,'' the verb last.
+\end{grammarlens}
+
+\section{\kn{ಕೆಲಸ ಮಾಡು} \emph{(kelasa m\=a\d{d}u)} --- ``to work''}
+\label{lesson:kelasa-maadu}
+
+\begin{cousinweb}
+\kn{ಮಾಡು} (\emph{m\=a\d{d}u}, ``to do, make'') is a core native verb, and Kannada
+--- like Hindi with \emph{karn\=a}, Tamil with \emph{sey}, and Telugu with
+\emph{c\=eyu} --- builds compounds by putting a noun in front of it: \kn{ಕೆಲಸ ಮಾಡು}
+(\emph{kelasa m\=a\d{d}u}, ``work-do'' $=$ ``to work''), \emph{a\d{d}uge m\=a\d{d}u}
+(``to cook''), \emph{sah\=aya m\=a\d{d}u} (``to help,'' with a \textbf{Sanskrit}
+noun on the \textbf{native} \emph{m\=a\d{d}u}). So ``I work'' is \kn{ನಾನು ಕೆಲಸ
+ಮಾಡುತ್ತೇನೆ} (\emph{n\=anu kelasa m\=a\d{d}utt\=ene}).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Noun $+$ \kn{ಮಾಡು} $=$ a new verb} --- the exact twin of Hindi's ``noun $+$
+\emph{karn\=a},'' Tamil's ``noun $+$ \emph{sey},'' and Telugu's ``noun $+$
+\emph{c\=eyu}.'' Four languages, two from an unrelated family, all landed on the
+same trick.
+\end{grammarlens}
+
+\section{Sentences about yourself}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Kannada & English \\
+\midrule
+\kn{ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ.} & I speak Kannada. \\
+\kn{ನಾನು ಬೆಂಗಳೂರಿನಲ್ಲಿ ಇದ್ದೇನೆ.} & I live in Bangalore. \\
+\kn{ನಾನು ಕೆಲಸ ಮಾಡುತ್ತೇನೆ.} & I work. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Three verbs, one engine: a stem, a tense-marker, a person-ending, the verb always
+last --- and no gender in the first person. Roots banked: \emph{m\=atan\=a\d{d}u}
+(speak $\leftarrow$ \emph{m\=atu} ``word''), \emph{iru} (be/stay/live, with
+\emph{-alli} ``in'' on the noun's end), and \emph{m\=a\d{d}u} (do $\to$ \emph{kelasa
+m\=a\d{d}u} ``to work,'' the twin of Hindi's \emph{karn\=a}). From here, Kannada's
+sentences only grow.

--- a/code/learning/human-languages/kannada/lessons/KA-C03-cennaagi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-cennaagi.md
@@ -1,0 +1,55 @@
+---
+id: KA-C03-cennaagi
+chapter: 3
+type: word
+headword: ಚೆನ್ನಾಗಿ
+gloss: well, nicely — and the reply "ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ"
+concept_tag: WORD-WELL
+prerequisites: [KA-C03-naanu, KA-C03-niivu-hegiddiira]
+sounds: [ca-sound, double-nn]
+roots: [cennu-good-dravidian]
+est_minutes: 4
+reviews_of: [KA-C03-naanu]
+---
+
+# ಚೆನ್ನಾಗಿ (cennāgi) — "well," and how to answer
+
+## Warm-up
+
+[PAUSE 2s] The word that answers "how are you?" — and it means, at heart,
+"beautifully."
+
+## The letters in this word
+
+**ಚೆ** (*ce* — the letter **ಚ** is "ch as in *cheese*," so this sounds like
+"che") + **ನ್ನಾ** (*nnā*, doubled *n* + long *ā*) + **ಗಿ** (*gi*) → **ಚೆನ್ನಾಗಿ**
+(*cennāgi*).
+
+## The word, taken apart
+
+**ಚೆನ್ನಾಗಿ** (*cennāgi*, "well, nicely") is native Dravidian, from **ಚೆನ್ನು**
+(*cennu*, "good, beautiful, fine") + the adverb-maker *-āgi* ("in a … way"). So it
+literally means "in a beautiful way" — Kannada answers "how are you?" by saying,
+in effect, "beautifully." The root *cennu* is pure Kannada, with no Sanskrit or
+European cousin.
+
+## The reply
+
+Fuse it with the *iru* verb: **ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ** (*nānu cennāgiddēne*) — "**I
+am well**" (*cennāgi* + *iddēne*, "I am"). The whole exchange:
+
+> — *nīvu hēgiddīrā?* ("How are you?")
+> — *nānu cennāgiddēne, dhanyavāda.* ("I'm well, thank you.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "cennāgi" (the ಚ = "ch")]
+- [YOU SAY: the full reply — *nānu cennāgiddēne*]
+- [YOU SAY: what *cennu* means at root ("good / beautiful")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the full reply to *nīvu hēgiddīrā?*, and say what *cennāgi*
+literally means. (*Nānu cennāgiddēne*; "in a beautiful way," from *cennu*
+"good/beautiful.")

--- a/code/learning/human-languages/kannada/lessons/KA-C03-hege.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-hege.md
@@ -1,0 +1,44 @@
+---
+id: KA-C03-hege
+chapter: 3
+type: word
+headword: ಹೇಗೆ
+gloss: how
+concept_tag: QUESTION-HOW
+prerequisites: [KA-C02-enu]
+sounds: [long-e]
+roots: [e-interrogative-dravidian]
+est_minutes: 4
+reviews_of: [KA-C02-enu]
+---
+
+# ಹೇಗೆ (hēge) — "how," another of the ē- questions
+
+## Warm-up
+
+[PAUSE 2s] You met **ಏನು** (*ēnu*, "what") in Chapter 2. Here is its sibling in
+Kannada's question family.
+
+## The letters in this word
+
+*(Skim if you read Kannada.)* **ಹೇ** (*hē*, *ha* + the long-*ē* sign) + **ಗೆ**
+(*ge*) → **ಹೇಗೆ** (*hēge*).
+
+## The word, taken apart
+
+**ಹೇಗೆ** (*hēge*, "how") is native Dravidian, on the interrogative base **ē-/yā-**
+you met in *ēnu*. Kannada gathers its questions here: *ēnu* (what), *hēge* (how),
+*yāru* (who), *elli* (where), *yāvāga* (when), *yāke* (why). It is the same
+Dravidian question-root heading Tamil's *eppaḍi* and Telugu's *elā* — a family
+far older than the Sanskrit words Kannada, like its sisters, borrows so readily.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hēge"]
+- [YOU SAY: the question family — *ēnu, hēge, yāru, elli, yāvāga*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What base do Kannada's question-words share, and which cousins head
+their own? (The interrogative *ē-/yā-*; Tamil's *eppaḍi*, Telugu's *elā*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C03-naanu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-naanu.md
@@ -1,0 +1,50 @@
+---
+id: KA-C03-naanu
+chapter: 3
+type: word
+headword: ನಾನು
+gloss: I
+concept_tag: PRONOUN-I
+prerequisites: [KA-C02-nanna]
+sounds: [long-aa]
+roots: [naan-dravidian]
+est_minutes: 3
+reviews_of: [KA-C02-nanna]
+---
+
+# ನಾನು (nānu) — "I," the Dravidian first person
+
+## Warm-up
+
+[PAUSE 2s] To answer "how are you?" you first need "I." In Chapter 2 you learned
+*nanna* ("my"); here is its owner.
+
+## The letters in this word
+
+**ನಾ** (*nā*, *na* + long-*ā* sign) + **ನು** (*nu*) → **ನಾನು** (*nānu*).
+
+## The word, taken apart
+
+**ನಾನು** (*nānu*, "I") ← Proto-Dravidian **\*yāṉ / \*nāṉ** — native, and (unlike
+Hindi's *maiṁ*, cousin of English *me*) **not** related to the European "I/me"
+family. Its possessive is the **ನನ್ನ** (*nanna*, "my") you already met: *nānu*
+"I," *nanna* "my." Kannada borrows Sanskrit words freely for higher vocabulary,
+but its bedrock pronouns stayed Dravidian.
+
+## Grammar Lens: "I" you can drop
+
+Kannada verbs carry the person in their ending — *iddēne* already means "**I** am"
+— so *nānu* is often left out. You still learn it first, because the answer to
+*hēgiddīrā?* begins with it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nānu"]
+- [YOU SAY: the pair — *nānu* (I), *nanna* (my)]
+- [YOU SAY: is it related to English *me*? (No — native Dravidian)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is *nānu*'s possessive, and is Kannada's "I" cousin to English
+*me*? (*Nanna*, "my"; no — it is native Dravidian.)

--- a/code/learning/human-languages/kannada/lessons/KA-C03-niivu-hegiddiira.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-niivu-hegiddiira.md
@@ -1,0 +1,51 @@
+---
+id: KA-C03-niivu-hegiddiira
+chapter: 3
+type: phrase
+headword: ನೀವು ಹೇಗಿದ್ದೀರಾ?
+gloss: how are you? (respectful)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [KA-C03-hege, KA-C02-niinu-niivu]
+sounds: [double-dd, long-ii]
+roots: [iru-be-dravidian]
+est_minutes: 5
+reviews_of: [KA-C02-niinu-niivu, KA-C03-hege]
+---
+
+# ನೀವು ಹೇಗಿದ್ದೀರಾ? (nīvu hēgiddīrā?)
+
+## Warm-up
+
+[PAUSE 2s] The everyday "how are you?" — and the verb "to be" that carries it.
+
+## The letters in this word
+
+The new word is **ಹೇಗಿದ್ದೀರಾ** (*hēgiddīrā*): *hēge* ("how") fused with
+**ಇದ್ದೀರಾ** (*iddīrā*, "are you"), from the verb **ಇರು** (*iru*, "to be, exist,
+stay") + the respectful-you ending. Note the doubled **ದ್ದ** (*dd*).
+
+## The phrase, taken apart
+
+**ನೀವು ಹೇಗಿದ್ದೀರಾ?** = **ನೀವು** (*nīvu*, "you," respectful) + **ಹೇಗಿದ್ದೀರಾ**
+(*hēgiddīrā*, "how are you") — the verb **last**, as always. The verb is **ಇರು**
+(*iru*, "to be / exist / stay") — the same native Dravidian *iru* that Tamil uses
+for "how are you," and (in Chapter 5) the verb for "I live."
+
+## Grammar Lens: the verb carries "you"
+
+The ending already means "you (respectful)," so *nīvu* can be dropped:
+*hēgiddīrā?* alone is a complete "how are you?" To a friend (*nīnu*), it shifts:
+**ನೀನು ಹೇಗಿದ್ದೀಯಾ?** (*nīnu hēgiddīyā?*). Match the "you" to the verb-ending, as
+Kannada always does.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the respectful question — *nīvu hēgiddīrā?*]
+- [YOU SAY: the familiar version — *nīnu hēgiddīyā?*]
+- [YOU SAY: the verb and its meaning (*iru* — "to be / exist / stay")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What verb powers "how are you?", and which Dravidian sister uses the
+same one? (*Iru*, "to be"; Tamil — its *iru* is the same word.)

--- a/code/learning/human-languages/kannada/lessons/KA-C03-paravaagilla.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-paravaagilla.md
@@ -1,0 +1,55 @@
+---
+id: KA-C03-paravaagilla
+chapter: 3
+type: phrase
+headword: ಪರವಾಗಿಲ್ಲ
+gloss: it's okay / no problem / you're welcome
+concept_tag: YOURE-WELCOME
+prerequisites: [KA-C01-illa, KA-C01-dhanyavada]
+sounds: [illa-negative]
+roots: [illa-not-dravidian]
+est_minutes: 4
+reviews_of: [KA-C01-illa]
+---
+
+# ಪರವಾಗಿಲ್ಲ (paravāgilla) — "no problem"
+
+## Warm-up
+
+[PAUSE 2s] When someone thanks you — or apologises — this is the easy, gracious
+reply, built on a word you met in Chapter 1.
+
+## The letters in this word
+
+**ಪರವಾ** (*paravā*, "harm, concern") + **ಗಿಲ್ಲ** (*gilla*, a fused form of *āgi* +
+**ಇಲ್ಲ** *illa*, "is not") → **ಪರವಾಗಿಲ್ಲ** (*paravāgilla*).
+
+## The word, taken apart
+
+**ಪರವಾಗಿಲ್ಲ** means "**it does not matter / there is no harm**" — *paravā*
+("harm, concern") + **ಇಲ್ಲ** (*illa*, "is-not"). It serves as "it's okay / no
+worries / never mind / you're welcome." The key atom, **ಇಲ್ಲ** (*illa*), you met
+in Chapter 1 — Kannada's word for negation and non-existence, the mirror of *iru*
+("to be"). Where *iru* says "it is," *illa* says "it is not." This *illa* is
+shared, almost unchanged, across **Kannada, Tamil, and Malayalam** — one of the
+deep bonds of the Dravidian south. (Telugu alone breaks away, to *lēdu* — so
+Telugu's "no problem" is *paravālēdu*, Kannada's is *paravāgilla*, each on its own
+"not.")
+
+## Grammar Lens: ಇಲ್ಲ, the all-purpose "no"
+
+*Illa* negates existence and equations alike, and stands alone as "no": *duḍḍu
+illa* ("there's no money"), *nānu illa* ("it's not me"). Hold *iru* / *illa*
+together — "is" and "is-not."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "paravāgilla"]
+- [YOU SAY: what it literally means ("it does not matter / no harm")]
+- [YOU SAY: the three Dravidian sisters that share *illa* (Kannada, Tamil, Malayalam)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *paravāgilla* literally say, and which languages share its
+*illa*? ("There is no harm"; Kannada, Tamil, Malayalam — Telugu uses *lēdu*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C03-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-practice.md
@@ -1,0 +1,48 @@
+---
+id: KA-C03-practice
+chapter: 3
+type: practice
+headword: (dialogue)
+gloss: Chapter 3 recap — the how-are-you exchange
+concept_tag: REVIEW
+prerequisites: [KA-C03-niivu-hegiddiira, KA-C03-cennaagi, KA-C03-paravaagilla]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [KA-C03-hege, KA-C03-niivu-hegiddiira, KA-C03-naanu, KA-C03-cennaagi, KA-C03-paravaagilla]
+---
+
+# Chapter 3 — The how-are-you exchange
+
+## Warm-up
+
+[PAUSE 2s] No new words. The whole responding cycle, from atoms you now own.
+
+## The exchange
+
+[PAUSE 1s each]
+- [YOU SAY: "How are you?" (respectful) — *nīvu hēgiddīrā?*]
+- [YOU SAY: "I'm well, thank you." — *nānu cennāgiddēne, dhanyavāda.*]
+- [YOU SAY: "No problem / you're welcome." — *paravāgilla.*]
+- [YOU SAY: the familiar version of the question — *nīnu hēgiddīyā?*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the ē- question-word for "how" (*hēge*)]
+- [YOU SAY: "I" and the verb "to be" (*nānu*, *iru*)]
+- [YOU SAY: the "is / is-not" pair (*iru* / *illa*)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *hēge* ← the interrogative *ē-/yā-* (native Dravidian, like Tamil *eppaḍi*)
+- *nānu* ← Proto-Dravidian (unrelated to English *me*); possessive *nanna*
+- *cennāgi* ← *cennu* "good/beautiful" — "in a beautiful way"
+- *iru* / *illa* — "is" and "is-not"; *illa* shared with Tamil & Malayalam
+
+## Wrap-up Recall
+
+[PAUSE 3s] A stranger asks *nīvu hēgiddīrā?* — give a full, polite reply, and
+answer their thanks. (*Nānu cennāgiddēne, dhanyavāda* — and to thanks,
+*paravāgilla*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C04-hoogi-baruttene.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-hoogi-baruttene.md
@@ -1,0 +1,50 @@
+---
+id: KA-C04-hoogi-baruttene
+chapter: 4
+type: phrase
+headword: ಹೋಗಿ ಬರುತ್ತೇನೆ
+gloss: goodbye (lit. "I'll go and come back")
+concept_tag: FAREWELL
+prerequisites: [KA-C04-hoogu, KA-C03-naanu]
+sounds: [hoogi-participle]
+roots: [hoogu-go-dravidian, baa-come-dravidian]
+est_minutes: 4
+reviews_of: [KA-C04-hoogu]
+---
+
+# ಹೋಗಿ ಬರುತ್ತೇನೆ (hōgi baruttēne) — "I'll go and come back"
+
+## Warm-up
+
+[PAUSE 2s] The everyday Kannada goodbye — a promise, not a parting.
+
+## The letters in this word
+
+**ಹೋಗಿ** (*hōgi*, "having gone") is *hōgu* + the "-i" that means "having …d."
+**ಬರುತ್ತೇನೆ** (*baruttēne*, "I come") is from *baru* ("come") + present + "I."
+
+## The word, taken apart
+
+**ಹೋಗಿ ಬರುತ್ತೇನೆ** = **ಹೋಗಿ** (*hōgi*, "having gone") + **ಬರುತ್ತೇನೆ**
+(*baruttēne*, "I come") — literally "**having gone, I come [back]**," i.e. "I'll
+go and come back." A Kannada speaker never signs off with a bare "I'm leaving" —
+it sounds final. It is the same "go-and-come-back" farewell across the Dravidian
+south (Tamil *pōy varugiṟēṉ*, Telugu *veḷḷi vastānu*, Malayalam *pōyi varāṁ*). The
+warm reply is **ಹೋಗಿ ಬನ್ನಿ** (*hōgi banni*, "go and come [back]").
+
+## Grammar Lens: the "having …d" participle
+
+*Hōgi* chains actions: "having gone, (then) I come." Kannada, like its sisters,
+strings verbs with one in the participle form and the last one fully conjugated.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the goodbye — *hōgi baruttēne*]
+- [YOU SAY: its literal meaning ("having gone, I come" → "I'll come back")]
+- [YOU SAY: the warm reply — *hōgi banni*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the Kannada goodbye literally promise, and how do you answer?
+("I'll go and come back"; reply *hōgi banni*, "go and come back".)

--- a/code/learning/human-languages/kannada/lessons/KA-C04-hoogu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-hoogu.md
@@ -1,0 +1,42 @@
+---
+id: KA-C04-hoogu
+chapter: 4
+type: word
+headword: ಹೋಗು
+gloss: to go (and ಬಾ, come)
+concept_tag: KA-VERB-HOOGU
+prerequisites: [KA-C03-naanu]
+sounds: [long-o]
+roots: [hoogu-go-dravidian, baa-come-dravidian]
+est_minutes: 3
+reviews_of: []
+---
+
+# ಹೋಗು (hōgu) — "go," and ಬಾ (come)
+
+## Warm-up
+
+[PAUSE 2s] Two everyday verbs — and together they make the Kannada goodbye.
+
+## The letters in this word
+
+**ಹೋ** (*hō*, *ha* + long-*ō* sign) + **ಗು** (*gu*) → **ಹೋಗು** (*hōgu*). Its
+partner: **ಬಾ** (*bā*, "come").
+
+## The word, taken apart
+
+**ಹೋಗು** (*hōgu*, "to go") and **ಬಾ** (*bā*, "come") are native Dravidian verbs.
+As commands they are whole words: *hōgu!* ("go!"), *bā!* ("come!"). You need
+both, because Kannada — like every Dravidian language — does not say a plain
+"goodbye." It says "I go, and I **come back**."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hōgu" (go) and "bā" (come)]
+- [YOU SAY: why you need both to say goodbye (Kannada's farewell is "I'll go and come back")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *hōgu* and *bā* mean, and why will you need both to part? ("Go"
+and "come"; the Kannada goodbye is "I'll go and come back.")

--- a/code/learning/human-languages/kannada/lessons/KA-C04-matte-sigona.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-matte-sigona.md
@@ -1,0 +1,43 @@
+---
+id: KA-C04-matte-sigona
+chapter: 4
+type: phrase
+headword: ಮತ್ತೆ ಸಿಗೋಣ
+gloss: we'll meet again
+concept_tag: FAREWELL-LATER
+prerequisites: [KA-C04-naale-sigona]
+sounds: [double-tt]
+roots: [matte-again-dravidian, sigu-meet-dravidian]
+est_minutes: 3
+reviews_of: [KA-C04-naale-sigona]
+---
+
+# ಮತ್ತೆ ಸಿಗೋಣ (matte sigōṇa) — "we'll meet again"
+
+## Warm-up
+
+[PAUSE 2s] The open-ended, warm goodbye — no date, just a promise.
+
+## The letters in this word
+
+**ಮತ್ತೆ** (*matte*): note the doubled **ತ್ತ** (*tt*). **ಸಿಗೋಣ** (*sigōṇa*, "let's
+meet") you just learned.
+
+## The word, taken apart
+
+**ಮತ್ತೆ ಸಿಗೋಣ** = **ಮತ್ತೆ** (*matte*, "again") + **ಸಿಗೋಣ** (*sigōṇa*, "let's
+meet") — "**we'll meet again**." Both words are native Dravidian: *matte*
+("again") and *sigu* ("to meet"). Where Tamil's "we'll meet again" (*mīṇḍum
+sandippōm*) reaches for the Sanskrit loan *sandi* to say "meet," Kannada keeps the
+native *sigu* — the same phrase, from home-grown stock.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "matte sigōṇa"]
+- [YOU SAY: "again" and "let's meet" (*matte*, *sigōṇa*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the phrase mean, and which native verb does Kannada use for
+"meet"? ("We'll meet again"; *sigu* — where Tamil borrowed the Sanskrit *sandi*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C04-naale-sigona.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-naale-sigona.md
@@ -1,0 +1,45 @@
+---
+id: KA-C04-naale-sigona
+chapter: 4
+type: phrase
+headword: ನಾಳೆ ಸಿಗೋಣ
+gloss: see you tomorrow
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [KA-C04-hoogi-baruttene]
+sounds: [long-aa, retroflex-l]
+roots: [naale-tomorrow-dravidian, sigu-meet-dravidian]
+est_minutes: 4
+reviews_of: [KA-C04-hoogi-baruttene]
+---
+
+# ನಾಳೆ ಸಿಗೋಣ (nāḷe sigōṇa) — "see you tomorrow"
+
+## Warm-up
+
+[PAUSE 2s] A goodbye with a date on it.
+
+## The letters in this word
+
+**ನಾಳೆ** (*nāḷe*): **ನಾ** (*nā*) + **ಳೆ** (*ḷe*, with the retroflex **ಳ** *ḷ*).
+**ಸಿಗೋಣ** (*sigōṇa*) = *sigu* ("meet, be found") + *-ōṇa* ("let's").
+
+## The word, taken apart
+
+**ನಾಳೆ** (*nāḷe*, "tomorrow") is native Dravidian, from **ನಾಳ್** (*nāḷ*, "day") —
+the very same *nāḷ* behind Tamil's *nāḷai*. **ಸಿಗೋಣ** (*sigōṇa*, "let's meet") is
+from **ಸಿಗು** (*sigu*, "to meet, to be found") — so the phrase is "**tomorrow,
+let's meet**." The **-ಓಣ** (*-ōṇa*) ending is Kannada's warm "let's ___":
+*hōgōṇa* ("let's go"), *tinnōṇa* ("let's eat").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāḷe sigōṇa"]
+- [YOU SAY: the word for "day" inside "tomorrow" (*nāḷ*, shared with Tamil *nāḷai*)]
+- [YOU SAY: the "let's ___" ending (*-ōṇa*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the two pieces of *nāḷe sigōṇa*, and what Tamil word shares the
+"day" root? (*Nāḷe* "tomorrow" + *sigu* "meet"; Tamil *nāḷai* — both from *nāḷ*
+"day.")

--- a/code/learning/human-languages/kannada/lessons/KA-C04-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C04-practice.md
@@ -1,0 +1,47 @@
+---
+id: KA-C04-practice
+chapter: 4
+type: practice
+headword: (dialogue)
+gloss: Chapter 4 recap — the farewells
+concept_tag: REVIEW
+prerequisites: [KA-C04-hoogi-baruttene, KA-C04-naale-sigona, KA-C04-matte-sigona]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [KA-C04-hoogu, KA-C04-hoogi-baruttene, KA-C04-naale-sigona, KA-C04-matte-sigona]
+---
+
+# Chapter 4 — The farewells
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three ways to part — none of them a blunt "goodbye."
+
+## The farewells
+
+[PAUSE 1s each]
+- [YOU SAY: the everyday goodbye — *hōgi baruttēne* ("I'll go and come back")]
+- [YOU SAY: the warm reply — *hōgi banni* ("go and come back")]
+- [YOU SAY: "see you tomorrow" — *nāḷe sigōṇa*]
+- [YOU SAY: "we'll meet again" — *matte sigōṇa*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the two verbs (*hōgu* go, *bā* come)]
+- [YOU SAY: "day" inside "tomorrow" (*nāḷ*), "again," "let's meet" (*matte*, *sigōṇa*)]
+- [YOU SAY: the "let's ___" ending (*-ōṇa*)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *hōgi baruttēne* — "having gone, I come"; the Dravidian promise-of-return goodbye
+- *nāḷe* ← *nāḷ* "day" (shared with Tamil *nāḷai*); *sigu* "to meet" (native)
+- *matte* "again" — where Tamil borrowed Sanskrit *sandi* for "meet," Kannada kept *sigu*
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does Kannada never say a plain "I'm leaving," and what does its
+everyday goodbye promise instead? (It sounds too final; *hōgi baruttēne* promises
+"I'll go and come back.")

--- a/code/learning/human-languages/kannada/lessons/KA-C05-iru.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-iru.md
@@ -1,0 +1,50 @@
+---
+id: KA-C05-iru
+chapter: 5
+type: word
+headword: ಇರು
+gloss: to be, to stay, to live
+concept_tag: KA-VERB-IRU
+prerequisites: [KA-C05-maatanaadu, KA-C03-niivu-hegiddiira]
+sounds: [independent-i]
+roots: [iru-be-dravidian]
+est_minutes: 4
+reviews_of: [KA-C03-niivu-hegiddiira]
+---
+
+# ಇರು (iru) — "to be, to stay, to live"
+
+## Warm-up
+
+[PAUSE 2s] You have already used this verb — in "how are you." Now meet it in its
+own right, and use it to say where you live.
+
+## The letters in this word
+
+**ಇ** (independent *i*) + **ರು** (*ru*) → **ಇರು** (*iru*).
+
+## The word, taken apart
+
+**ಇರು** (*iru*, "to be, to exist, to stay, to live") is native Dravidian — the
+very same *iru* Tamil uses, and the verb behind Chapter 3's *hēgiddīrā* ("how are
+you") and *cennāgiddēne* ("I'm well"). It also means "to reside": **ನಾನು
+ಬೆಂಗಳೂರಿನಲ್ಲಿ ಇದ್ದೇನೆ** (*nānu Beṅgaḷūrinalli iddēne*, "I live in Bangalore"). One
+verb covers "be," "stay," and "live."
+
+## Grammar Lens: "in" comes after the noun
+
+**ಬೆಂಗಳೂರಿನಲ್ಲಿ** (*Beṅgaḷūrinalli*) = *Bengaḷūru* + **-ಅಲ್ಲಿ** (*-alli*, "in"),
+glued to the **end** of the noun. Kannada uses **post**positions (case-suffixes)
+where English uses prepositions: "Bangalore-in I am," the verb last.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "iru"]
+- [YOU SAY: "I live in Bangalore" — *nānu Beṅgaḷūrinalli iddēne*]
+- [YOU SAY: where "in" (*-alli*) sits — glued to the end of the noun]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name three things the one verb *iru* can mean, and say where "in" goes.
+("To be / to stay / to live"; *-alli* "in" attaches to the **end** of the noun.)

--- a/code/learning/human-languages/kannada/lessons/KA-C05-kelasa-maadu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-kelasa-maadu.md
@@ -1,0 +1,58 @@
+---
+id: KA-C05-kelasa-maadu
+chapter: 5
+type: word
+headword: ಕೆಲಸ ಮಾಡು
+gloss: to work (lit. "work-do")
+concept_tag: KA-VERB-MAADU
+prerequisites: [KA-C05-maatanaadu]
+sounds: [long-aa]
+roots: [maadu-do-dravidian, kelasa-work-dravidian]
+est_minutes: 5
+reviews_of: [KA-C05-maatanaadu, KA-C05-iru]
+---
+
+# ಕೆಲಸ ಮಾಡು (kelasa māḍu) — "to work"
+
+## Warm-up
+
+[PAUSE 2s] The last verb of the chapter — and, like Hindi's *karnā* and Tamil's
+*sey*, it is a "do" verb that builds a hundred others.
+
+## The letters in this word
+
+**ಕೆಲಸ** (*kelasa*, "work"): **ಕೆ** (*ke*) + **ಲ** (*la*) + **ಸ** (*sa*).
+**ಮಾಡು** (*māḍu*, "do"): **ಮಾ** (*mā*) + **ಡು** (*ḍu*).
+
+## The word, taken apart
+
+**ಮಾಡು** (*māḍu*, "to do, to make") is a core native Dravidian verb, and Kannada
+— like Hindi with *karnā*, Tamil with *sey*, and Telugu with *cēyu* — builds
+compound verbs by putting a noun in front of it:
+
+- **ಕೆಲಸ ಮಾಡು** (*kelasa māḍu*) = "work-do" = "**to work**" (*kelasa*, "work")
+- **ಅಡುಗೆ ಮಾಡು** (*aḍuge māḍu*) = "to cook"
+- **ಸಹಾಯ ಮಾಡು** (*sahāya māḍu*) = "to help" (*sahāya* ← Sanskrit)
+
+So "I work" is **ನಾನು ಕೆಲಸ ಮಾಡುತ್ತೇನೆ** (*nānu kelasa māḍuttēne*). Notice *sahāya
+māḍu* ("to help") pairs a **Sanskrit** noun with the **native** *māḍu* — Kannada's
+two vocabularies working together in one verb.
+
+## Grammar Lens: noun + ಮಾಡು = a new verb
+
+This "noun + *māḍu*" pattern is the exact twin of Hindi's "noun + *karnā*,"
+Tamil's "noun + *sey*," and Telugu's "noun + *cēyu*." Four languages — two of
+them from an unrelated family — all landed on the same trick.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kelasa māḍu" (to work)]
+- [YOU SAY: "I work" — *nānu kelasa māḍuttēne*]
+- [YOU SAY: the Hindi, Tamil, and Telugu twins of this trick (*karnā*, *sey*, *cēyu*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Kannada turn "work" into "to work," and what verbs work the
+same way in its neighbours? (*Kelasa* + *māḍu* = "work-do"; Hindi *karnā*, Tamil
+*sey*, Telugu *cēyu*.)

--- a/code/learning/human-languages/kannada/lessons/KA-C05-maatanaadu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-maatanaadu.md
@@ -1,0 +1,56 @@
+---
+id: KA-C05-maatanaadu
+chapter: 5
+type: word
+headword: ಮಾತನಾಡು
+gloss: to speak
+concept_tag: KA-VERB-MATANADU
+prerequisites: [KA-C03-naanu]
+sounds: [long-aa]
+roots: [maatu-word-dravidian]
+est_minutes: 4
+reviews_of: []
+---
+
+# ಮಾತನಾಡು (mātanāḍu) — "to speak," your first full verb
+
+## Warm-up
+
+[PAUSE 2s] So far, "to be." Here is a verb that *does* something — and it shows
+how Kannada builds "I do X."
+
+## The letters in this word
+
+**ಮಾ** (*mā*) + **ತ** (*ta*) + **ನಾ** (*nā*) + **ಡು** (*ḍu*) → **ಮಾತನಾಡು**
+(*mātanāḍu*).
+
+## The word, taken apart
+
+**ಮಾತನಾಡು** (*mātanāḍu*, "to speak, to talk") is native Dravidian, built on
+**ಮಾತು** (*mātu*, "word, speech") + *āḍu* ("to play/do") — "to word-play," i.e.
+to converse. To say "**I speak**," Kannada adds a two-part ending to the stem:
+
+> *mātanāḍ-* + *-utt-* (present) + *-ēne* ("I") → **ಮಾತನಾಡುತ್ತೇನೆ**
+> (*mātanāḍuttēne*), "I speak."
+
+The **-ಏನೆ** (*-ēne*) ending *is* "I," so *nānu* is rarely needed. Change the
+ending, change the person: *mātanāḍuttāne* (he), *mātanāḍuttāḷe* (she),
+*mātanāḍuttāre* (they / you-respectful).
+
+## Grammar Lens: stem + tense + person
+
+Every Kannada verb is built this way — a stem, a tense-marker, a person-ending.
+And, like Tamil and Telugu, Kannada marks **no gender in the first person**:
+*mātanāḍuttēne* is the same for a man or a woman.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mātanāḍu" (speak)]
+- [YOU SAY: "I speak" — *mātanāḍuttēne*]
+- [YOU SAY: the word "speech" inside it (*mātu*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Build "I speak" from *mātanāḍu*, and name the noun it's built on.
+(*Mātanāḍuttēne*; *mātu*, "word / speech.")

--- a/code/learning/human-languages/kannada/lessons/KA-C05-naanu-kannada-maatanaaduttene.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-naanu-kannada-maatanaaduttene.md
@@ -1,0 +1,52 @@
+---
+id: KA-C05-naanu-kannada-maatanaaduttene
+chapter: 5
+type: phrase
+headword: ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ
+gloss: I speak Kannada
+concept_tag: KA-WORD-KANNADA
+prerequisites: [KA-C05-maatanaadu, KA-C03-naanu]
+sounds: [double-nn]
+roots: [kannada]
+est_minutes: 5
+reviews_of: [KA-C05-maatanaadu, KA-C03-naanu]
+---
+
+# ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ (nānu kannaḍa mātanāḍuttēne) — "I speak Kannada"
+
+## Warm-up
+
+[PAUSE 2s] Your first full, moving sentence — and it names one of the classical
+languages of India.
+
+## The letters in this word
+
+**ಕನ್ನಡ** (*kannaḍa*): **ಕ** (*ka*) + **ನ್ನ** (*nna*, doubled) + **ಡ** (*ḍa*).
+
+## The sentence, taken apart
+
+**ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ** = **ನಾನು** (*nānu*, "I") + **ಕನ್ನಡ** (*kannaḍa*, the
+object) + **ಮಾತನಾಡುತ್ತೇನೆ** (*mātanāḍuttēne*, "speak") — "I Kannada speak," the
+verb last as always. The name **ಕನ್ನಡ** (*kannaḍa*) is native (often linked to
+*kar-nāḍu*, "the black/high land," whence *Karnataka*). Kannada has a literature
+over a thousand years old and holds the second-most Jnanpith literary awards of
+any Indian language — a classical tongue, spoken by some fifty million.
+
+## Grammar Lens: no gender on "I speak"
+
+*Mātanāḍuttēne* is the same whether a man or a woman says it — Kannada, like Tamil
+and Telugu, marks **no gender in the first or second person** (only the third:
+*-āne* he, *-āḷe* she). This is unlike Hindi, where even "I speak" changes for the
+speaker's gender (*boltā/boltī*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nānu kannaḍa mātanāḍuttēne"]
+- [YOU SAY: the likely meaning of *kannaḍa* (*kar-nāḍu*, "the high/black land" → *Karnataka*)]
+- [YOU SAY: does "I speak" change for a man vs. a woman? (No — no 1st-person gender)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "I speak Kannada," and give the likely root of the name. (*Nānu
+kannaḍa mātanāḍuttēne*; *kar-nāḍu*, "the high/black land.")

--- a/code/learning/human-languages/kannada/lessons/KA-C05-practice.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C05-practice.md
@@ -1,0 +1,48 @@
+---
+id: KA-C05-practice
+chapter: 5
+type: practice
+headword: (dialogue)
+gloss: Chapter 5 recap — the first verbs
+concept_tag: REVIEW
+prerequisites: [KA-C05-maatanaadu, KA-C05-naanu-kannada-maatanaaduttene, KA-C05-iru, KA-C05-kelasa-maadu]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [KA-C05-maatanaadu, KA-C05-naanu-kannada-maatanaaduttene, KA-C05-iru, KA-C05-kelasa-maadu, KA-C03-naanu]
+---
+
+# Chapter 5 — The first verbs
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three verbs, one engine — build real sentences about
+yourself.
+
+## Build the sentences
+
+[PAUSE 1s each]
+- [YOU SAY: "I speak Kannada" — *nānu kannaḍa mātanāḍuttēne*]
+- [YOU SAY: "I live in Bangalore" — *nānu Beṅgaḷūrinalli iddēne*]
+- [YOU SAY: "I work" — *nānu kelasa māḍuttēne*]
+- [YOU SAY: "he speaks" vs. "she speaks" — *mātanāḍuttāne* / *mātanāḍuttāḷe*]
+
+## The engine
+
+[PAUSE 2s]
+- [YOU SAY: the three stacked pieces of every Kannada verb (stem + tense + person)]
+- [YOU SAY: the ending that means "I" (*-ēne*)]
+- [YOU SAY: where Kannada marks gender — and where it doesn't (3rd person only)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *mātanāḍu* "to speak" ← *mātu* "word"
+- *iru* "to be / stay / live"; *-alli* "in" attaches to the noun's end
+- *māḍu* "to do" → *kelasa māḍu* "to work" (the twin of *karnā* / *sey* / *cēyu*)
+- *kannaḍa* ← *kar-nāḍu*, "the high/black land" (→ *Karnataka*)
+
+## Wrap-up Recall
+
+[PAUSE 3s] In one breath, say your language, your city, and your work in Kannada.
+(*Nānu kannaḍa mātanāḍuttēne. Nānu … alli iddēne. Nānu kelasa māḍuttēne.*)

--- a/code/learning/human-languages/kannada/roadmap.md
+++ b/code/learning/human-languages/kannada/roadmap.md
@@ -24,13 +24,25 @@ needs it.
   *peyar*; *santōṣa* a Sanskrit loan for "pleased" vs. Tamil's native
   *magiḻcci*); the zero copula.
 
+- **Ch. 3 — How Are You**: hēge (how; the native *ē-/yā-* questions) → nīvu
+  hēgiddīrā? (the verb *iru* "to be") → nānu (I ← Proto-Dravidian) → cennāgi
+  (well ← *cennu* "beautiful") → paravāgilla (you're welcome = "no harm," on the
+  Dravidian *illa* shared with Tamil/Malayalam) → practice.
+- **Ch. 4 — Farewells**: hōgu/bā (go/come) → hōgi baruttēne ("I'll go and come
+  back") → nāḷe sigōṇa (see you tomorrow; *nāḷ* "day" shared with Tamil) → matte
+  sigōṇa (we'll meet again; native *sigu*, where Tamil borrowed Sanskrit *sandi*)
+  → practice.
+- **Ch. 5 — First Verbs**: mātanāḍu (to speak ← *mātu* "word") → nānu kannaḍa
+  mātanāḍuttēne (I speak Kannada; no 1st-person gender) → iru (to be/stay/live;
+  postposition *-alli*) → kelasa māḍu (to work; noun + *māḍu*, the twin of
+  Hindi's *karnā*) → practice.
+
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 3 | Responding: *hēgiddīra?* ("how are you"), *chennāgiddēne* ("I'm well"), the verb *iru* ("to be") |
-| 4 | The case-endings (Kannada's agglutinative suffixes), numbers 1–10 |
-| 5+ | Postpositions, tense on the verb, family, food — always with the Dravidian-cognate thread |
+| 6 | Case-endings (Kannada's agglutinative suffixes: *-ge, -alli, -inda*); more verbs |
+| 7+ | Tense, numbers, family, food — always with the Dravidian-cognate thread |
 
 Note: Kannada marks "you" by **register** (*nīnu* familiar / *nīvu* respectful,
 also plural) — like the other tracks, worth teaching beside them.

--- a/code/learning/human-languages/kannada/session-map.md
+++ b/code/learning/human-languages/kannada/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Kannada Chapters 1–2
+# Session Map — Kannada Chapters 1–5
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -34,7 +34,37 @@ independent vowels — all in the service of real greetings.
 | 13 | santosha | ಸಂತೋಷ | "pleased to meet you" — **Sanskrit** (vs. Tamil's native *magiḻcci*) |
 | 14 | practice | (dialogue) | the whole exchange |
 
+## Chapter 3 — How Are You
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 15 | hege | ಹೇಗೆ | "how" ← the native *ē-/yā-* question family |
+| 16 | niivu-hegiddiira | ನೀವು ಹೇಗಿದ್ದೀರಾ? | **"how are you?"**; the verb *iru* "to be" (same as Tamil) |
+| 17 | naanu | ನಾನು | "I" ← Proto-Dravidian; possessive *nanna* |
+| 18 | cennaagi | ಚೆನ್ನಾಗಿ | "well" ← *cennu* "good/beautiful" — "in a beautiful way" |
+| 19 | paravaagilla | ಪರವಾಗಿಲ್ಲ | "no problem / you're welcome" = "no harm"; the Dravidian *illa* |
+| 20 | practice | (dialogue) | the whole how-are-you exchange |
+
+## Chapter 4 — Farewells
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 21 | hoogu | ಹೋಗು / ಬಾ | "go" / "come" |
+| 22 | hoogi-baruttene | ಹೋಗಿ ಬರುತ್ತೇನೆ | **"I'll go and come back"** — the Dravidian promise-of-return goodbye |
+| 23 | naale-sigona | ನಾಳೆ ಸಿಗೋಣ | "see you tomorrow"; *nāḷ* "day" + *sigu* "meet" + the "let's ___" *-ōṇa* |
+| 24 | matte-sigona | ಮತ್ತೆ ಸಿಗೋಣ | "we'll meet again"; native *sigu* (where Tamil borrowed *sandi*) |
+| 25 | practice | (dialogue) | the farewells |
+
+## Chapter 5 — The First Verbs
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 26 | maatanaadu | ಮಾತನಾಡು | "to speak" ← *mātu* "word"; stem + tense + person |
+| 27 | naanu-kannada-maatanaaduttene | ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ | **"I speak Kannada"**; no 1st-person gender |
+| 28 | iru | ಇರು | "to be / stay / live" (same as Tamil); the postposition *-alli* |
+| 29 | kelasa-maadu | ಕೆಲಸ ಮಾಡು | "to work" (noun + *māḍu*) — the twin of Hindi's *karnā* |
+| 30 | practice | (dialogue) | three verbs, one engine |
+
 ## Next
 
-Chapter 3 — *hēgiddīra?* ("how are you?") and answering with *chennāgiddēne* —
-the responding cycle.
+Chapter 6 — the case-endings (Kannada's agglutinative suffixes *-ge, -alli, -inda*).


### PR DESCRIPTION
Carries the **Kannada** track from Chapter 2 to **Chapter 5**, matching the
leading tracks' early-learner arc. Part of the per-track parity series (Hindi
#8596, Tamil #8605, Telugu #8607).

Framework `HL00`; concept tags reuse the universal `HL01` taxonomy, verbs
namespaced (`KA-VERB-*`) — no `taxonomy.json` change. The
Sanskrit-borrowing-yet-Dravidian-grammar thread runs throughout.

## Chapters

- **Ch. 3 — How Are You**: *hēge* (how; the native *ē-/yā-* questions) → *nīvu
  hēgiddīrā?* (the verb *iru* "to be," the same word Tamil uses) → *nānu* (I ←
  Proto-Dravidian, unrelated to English *me*) → *cennāgi* (well ← *cennu*
  "beautiful"; *nānu cennāgiddēne* "I'm well") → *paravāgilla* ("no harm" =
  you're welcome, on the Dravidian *illa* shared with Tamil/Malayalam) → practice.
- **Ch. 4 — Farewells**: *hōgu*/*bā* → *hōgi baruttēne* ("I'll go and come back"
  — the Dravidian promise-of-return goodbye, tabled across the family) → *nāḷe
  sigōṇa* (see you tomorrow) → *matte sigōṇa* (we'll meet again; native *sigu*,
  where Tamil borrowed Sanskrit *sandi*) → practice.
- **Ch. 5 — First Verbs**: *mātanāḍu* (← *mātu* "word") → *nānu kannaḍa
  mātanāḍuttēne* (I speak Kannada; no 1st-person gender) → *iru* (to be/stay/live;
  the postposition *-alli*) → *kelasa māḍu* (to work; noun + *māḍu*, the twin of
  Hindi's *karnā*) → practice.

## Verification

- Book compiles clean with XeLaTeX (×2): **0 missing characters, 0 undefined
  references** (29 pages).
- New chapter pages rasterized and visually QA'd — Kannada script, ottakṣara
  conjuncts, and grammar tables all render correctly.
- Concept tags validate against `HL01`; `/security-review` covered by the Hindi
  run (identical content-only class).
- `human-languages-books.yml` CI will build the updated PDF on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)