### PR TITLE
feat(uuid): add Haskell port

### DIFF
--- a/code/packages/haskell/uuid/BUILD
+++ b/code/packages/haskell/uuid/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/uuid/BUILD_windows
+++ b/code/packages/haskell/uuid/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/uuid/CHANGELOG.md
+++ b/code/packages/haskell/uuid/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add UUID parsing, validation, formatting, and comparison.
+- Add v1, v3, v4, v5, and v7 generation.
+- Add standard namespaces and nil/max constants.

--- a/code/packages/haskell/uuid/README.md
+++ b/code/packages/haskell/uuid/README.md
@@ -1,0 +1,23 @@
+# uuid
+
+A native Haskell implementation of UUID generation and parsing from first
+principles, covering RFC 4122 and RFC 9562.
+
+## API
+
+- `uuidFromBytes`, `uuidBytes`, `uuidFromInteger`, and `uuidToInteger` convert
+  the 128-bit value without changing its network byte order.
+- `parse`, `render`, and `isValid` handle canonical, compact, braced, and URN
+  text forms.
+- `uuidVersion`, `uuidVariant`, `isNil`, and `isMax` expose UUID metadata.
+- `v1`, `v4`, and `v7` generate time/random UUIDs in `IO`.
+- `v3` and `v5` generate deterministic name-based UUIDs with the repository's
+  local MD5 and SHA-1 packages.
+- `namespaceDNS`, `namespaceURL`, `namespaceOID`, `namespaceX500`, `nilUUID`,
+  and `maxUUID` provide the standard constants.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/uuid/cabal.project
+++ b/code/packages/haskell/uuid/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../md5 ../sha1

--- a/code/packages/haskell/uuid/src/UUID.hs
+++ b/code/packages/haskell/uuid/src/UUID.hs
@@ -1,0 +1,278 @@
+-- | UUID generation and parsing according to RFC 4122 and RFC 9562.
+module UUID
+    ( UUID
+    , UUIDError (..)
+    , uuidFromBytes
+    , uuidBytes
+    , uuidFromInteger
+    , uuidToInteger
+    , parse
+    , render
+    , isValid
+    , uuidVersion
+    , uuidVariant
+    , isNil
+    , isMax
+    , namespaceDNS
+    , namespaceURL
+    , namespaceOID
+    , namespaceX500
+    , nilUUID
+    , maxUUID
+    , v1
+    , v3
+    , v4
+    , v5
+    , v7
+    ) where
+
+import Data.Bits ((.&.), (.|.), shiftL, shiftR)
+import Data.Char (isHexDigit, isSpace, ord, toLower)
+import Data.List (foldl')
+import Data.Word (Word8, Word16, Word64)
+import qualified Md5
+import Numeric (readHex, showHex)
+import qualified Sha1
+import System.Random (randomIO)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+
+-- | A validated 128-bit UUID in network byte order.
+newtype UUID = UUID [Word8]
+    deriving (Eq, Ord)
+
+-- | Error returned for malformed byte, integer, or text input.
+newtype UUIDError = UUIDError {errorMessage :: String}
+    deriving (Eq, Show)
+
+instance Show UUID where
+    show uuid = "UUID(\"" ++ render uuid ++ "\")"
+
+-- | Construct a UUID from exactly sixteen bytes.
+uuidFromBytes :: [Word8] -> Either UUIDError UUID
+uuidFromBytes bytes
+    | length bytes == 16 = Right (UUID bytes)
+    | otherwise = Left (UUIDError ("UUID bytes must be exactly 16, got " ++ show (length bytes)))
+
+-- | Return the UUID's sixteen bytes in network byte order.
+uuidBytes :: UUID -> [Word8]
+uuidBytes (UUID bytes) = bytes
+
+-- | Construct a UUID from an unsigned 128-bit integer.
+uuidFromInteger :: Integer -> Either UUIDError UUID
+uuidFromInteger value
+    | value < 0 || value >= 2 ^ (128 :: Int) = Left (UUIDError "UUID integer must be in the range 0 through 2^128 - 1")
+    | otherwise = Right (UUID [fromIntegral (value `shiftR` shift) | shift <- [120, 112 .. 0]])
+
+-- | Convert a UUID to its unsigned 128-bit integer representation.
+uuidToInteger :: UUID -> Integer
+uuidToInteger = foldl' (\value byte -> value `shiftL` 8 + fromIntegral byte) 0 . uuidBytes
+
+-- | Parse canonical, compact, braced, or URN UUID text.
+parse :: String -> Either UUIDError UUID
+parse input = do
+    body <- unwrap (trim input)
+    digits <- groupedHex body
+    bytes <- traverse parsePair (pairs digits)
+    uuidFromBytes bytes
+  where
+    invalid = Left (UUIDError ("Invalid UUID string: '" ++ input ++ "'"))
+
+    unwrap value =
+        let withoutUrn =
+                if map toLower (take 9 value) == "urn:uuid:"
+                    then drop 9 value
+                    else value
+         in case withoutUrn of
+                ('{' : rest)
+                    | not (null rest) && last rest == '}' -> Right (init rest)
+                    | otherwise -> invalid
+                _
+                    | '}' `elem` withoutUrn || '{' `elem` withoutUrn -> invalid
+                    | otherwise -> Right withoutUrn
+
+    groupedHex value =
+        case consumeGroups [8, 4, 4, 4, 12] value of
+            Just digits
+                | length digits == 32 && all isHexDigit digits -> Right digits
+            _ -> invalid
+
+    parsePair pair =
+        case readHex pair of
+            [(value, "")] -> Right (fromIntegral (value :: Int))
+            _ -> invalid
+
+-- | Render lowercase canonical 8-4-4-4-12 UUID text.
+render :: UUID -> String
+render uuid = joinGroups [8, 4, 4, 4, 12] hex
+  where
+    hex = concatMap byteHex (uuidBytes uuid)
+
+-- | Return whether text parses as a UUID.
+isValid :: String -> Bool
+isValid value =
+    case parse value of
+        Right _ -> True
+        Left _ -> False
+
+-- | Read the four-bit version field.
+uuidVersion :: UUID -> Int
+uuidVersion uuid = fromIntegral ((uuidBytes uuid !! 6 `shiftR` 4) .&. 0x0f)
+
+-- | Classify the UUID variant field.
+uuidVariant :: UUID -> String
+uuidVariant uuid
+    | byte .&. 0x80 == 0 = "ncs"
+    | byte .&. 0xc0 == 0x80 = "rfc4122"
+    | byte .&. 0xe0 == 0xc0 = "microsoft"
+    | otherwise = "reserved"
+  where
+    byte = uuidBytes uuid !! 8
+
+-- | Return whether all UUID bits are zero.
+isNil :: UUID -> Bool
+isNil = all (== 0) . uuidBytes
+
+-- | Return whether all UUID bits are one.
+isMax :: UUID -> Bool
+isMax = all (== 0xff) . uuidBytes
+
+namespaceDNS, namespaceURL, namespaceOID, namespaceX500, nilUUID, maxUUID :: UUID
+namespaceDNS = literal "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+namespaceURL = literal "6ba7b811-9dad-11d1-80b4-00c04fd430c8"
+namespaceOID = literal "6ba7b812-9dad-11d1-80b4-00c04fd430c8"
+namespaceX500 = literal "6ba7b814-9dad-11d1-80b4-00c04fd430c8"
+nilUUID = UUID (replicate 16 0)
+maxUUID = UUID (replicate 16 0xff)
+
+-- | Generate an RFC 4122 version 1 UUID.
+v1 :: IO UUID
+v1 = do
+    now <- getPOSIXTime
+    clockSequence <- ((.&. 0x3fff) <$> (randomIO :: IO Word16))
+    node <- randomBytes 6
+    let timestamp = fromIntegral (floor (now * 10000000) :: Integer) + gregorianOffset
+        timeLow = timestamp .&. 0xffffffff
+        timeMid = (timestamp `shiftR` 32) .&. 0xffff
+        timeHigh = (timestamp `shiftR` 48) .&. 0x0fff
+        nodeWithMulticast = ((head node .|. 0x01) : tail node)
+        bytes =
+            wordBytes 4 timeLow
+                ++ wordBytes 2 timeMid
+                ++ wordBytes 2 (timeHigh .|. 0x1000)
+                ++ [ 0x80 .|. fromIntegral (clockSequence `shiftR` 8)
+                   , fromIntegral clockSequence
+                   ]
+                ++ nodeWithMulticast
+    pure (UUID bytes)
+
+-- | Generate an RFC 4122 version 3 (MD5 name-based) UUID.
+v3 :: UUID -> String -> UUID
+v3 namespace name = UUID (setVersionVariant 3 (Md5.sumMd5 input))
+  where
+    input = uuidBytes namespace ++ utf8Bytes name
+
+-- | Generate an RFC 4122 version 4 random UUID.
+v4 :: IO UUID
+v4 = UUID . setVersionVariant 4 <$> randomBytes 16
+
+-- | Generate an RFC 4122 version 5 (SHA-1 name-based) UUID.
+v5 :: UUID -> String -> UUID
+v5 namespace name = UUID (setVersionVariant 5 (take 16 (Sha1.sha1 input)))
+  where
+    input = uuidBytes namespace ++ utf8Bytes name
+
+-- | Generate an RFC 9562 version 7 Unix-millisecond UUID.
+v7 :: IO UUID
+v7 = do
+    now <- getPOSIXTime
+    random <- randomBytes 10
+    let timestamp = fromIntegral (floor (now * 1000) :: Integer) :: Word64
+        bytes =
+            wordBytes 6 timestamp
+                ++ [0x70 .|. (random !! 0 .&. 0x0f), random !! 1]
+                ++ [0x80 .|. (random !! 2 .&. 0x3f)]
+                ++ drop 3 random
+    pure (UUID bytes)
+
+gregorianOffset :: Word64
+gregorianOffset = 122192928000000000
+
+setVersionVariant :: Word8 -> [Word8] -> [Word8]
+setVersionVariant version bytes =
+    take 6 bytes
+        ++ [bytes !! 6 .&. 0x0f .|. (version `shiftL` 4)]
+        ++ [bytes !! 7]
+        ++ [bytes !! 8 .&. 0x3f .|. 0x80]
+        ++ drop 9 bytes
+
+randomBytes :: Int -> IO [Word8]
+randomBytes count = sequence (replicate count randomIO)
+
+wordBytes :: Int -> Word64 -> [Word8]
+wordBytes count value =
+    [fromIntegral (value `shiftR` shift) | shift <- [8 * (count - 1), 8 * (count - 2) .. 0]]
+
+utf8Bytes :: String -> [Word8]
+utf8Bytes = concatMap encode
+  where
+    encode char
+        | code <= 0x7f = [fromIntegral code]
+        | code <= 0x7ff =
+            [ fromIntegral (0xc0 .|. code `shiftR` 6)
+            , fromIntegral (0x80 .|. code .&. 0x3f)
+            ]
+        | code <= 0xffff =
+            [ fromIntegral (0xe0 .|. code `shiftR` 12)
+            , fromIntegral (0x80 .|. code `shiftR` 6 .&. 0x3f)
+            , fromIntegral (0x80 .|. code .&. 0x3f)
+            ]
+        | otherwise =
+            [ fromIntegral (0xf0 .|. code `shiftR` 18)
+            , fromIntegral (0x80 .|. code `shiftR` 12 .&. 0x3f)
+            , fromIntegral (0x80 .|. code `shiftR` 6 .&. 0x3f)
+            , fromIntegral (0x80 .|. code .&. 0x3f)
+            ]
+      where
+        code = ord char
+
+consumeGroups :: [Int] -> String -> Maybe String
+consumeGroups [] "" = Just ""
+consumeGroups [] _ = Nothing
+consumeGroups [size] value
+    | length value == size = Just value
+    | otherwise = Nothing
+consumeGroups (size : remainingSizes) value = do
+    let (group, rest) = splitAt size value
+    if length group /= size
+        then Nothing
+        else do
+            suffix <- consumeGroups remainingSizes (dropOptionalHyphen rest)
+            Just (group ++ suffix)
+
+dropOptionalHyphen :: String -> String
+dropOptionalHyphen ('-' : rest) = rest
+dropOptionalHyphen value = value
+
+pairs :: [a] -> [[a]]
+pairs [] = []
+pairs (first : second : rest) = [first, second] : pairs rest
+pairs _ = []
+
+trim :: String -> String
+trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+
+byteHex :: Word8 -> String
+byteHex byte =
+    let value = showHex byte ""
+     in if length value == 1 then '0' : value else value
+
+joinGroups :: [Int] -> String -> String
+joinGroups [] _ = ""
+joinGroups [size] value = take size value
+joinGroups (size : rest) value = take size value ++ "-" ++ joinGroups rest (drop size value)
+
+literal :: String -> UUID
+literal value =
+    case parse value of
+        Right uuid -> uuid
+        Left err -> error (errorMessage err)

--- a/code/packages/haskell/uuid/test/Spec.hs
+++ b/code/packages/haskell/uuid/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified UUIDSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec UUIDSpec.spec

--- a/code/packages/haskell/uuid/test/UUIDSpec.hs
+++ b/code/packages/haskell/uuid/test/UUIDSpec.hs
@@ -1,0 +1,140 @@
+module UUIDSpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Data.Bits ((.&.), shiftL)
+import Data.Either (isLeft)
+import Data.List (nub)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Word (Word8)
+import Test.Hspec
+import UUID
+
+sample :: UUID
+sample = expectRight (parse "550e8400-e29b-41d4-a716-446655440000")
+
+spec :: Spec
+spec = do
+    describe "construction and conversion" $ do
+        it "accepts exactly sixteen bytes" $ do
+            uuidBytes (expectRight (uuidFromBytes [0 .. 15])) `shouldBe` [0 .. 15]
+            uuidFromBytes (replicate 15 0) `shouldSatisfy` isLeft
+            uuidFromBytes (replicate 17 0) `shouldSatisfy` isLeft
+        it "round-trips unsigned 128-bit integers" $ do
+            uuidToInteger (expectRight (uuidFromInteger 0)) `shouldBe` 0
+            uuidToInteger (expectRight (uuidFromInteger (2 ^ (128 :: Int) - 1)))
+                `shouldBe` 2 ^ (128 :: Int) - 1
+            uuidToInteger (expectRight (uuidFromInteger 0x550e8400e29b41d4a716446655440000))
+                `shouldBe` 0x550e8400e29b41d4a716446655440000
+        it "rejects integers outside the unsigned 128-bit range" $ do
+            uuidFromInteger (-1) `shouldSatisfy` isLeft
+            uuidFromInteger (2 ^ (128 :: Int)) `shouldSatisfy` isLeft
+
+    describe "parsing and rendering" $ do
+        it "renders lowercase canonical text" $ do
+            render sample `shouldBe` "550e8400-e29b-41d4-a716-446655440000"
+            show sample `shouldContain` render sample
+        it "accepts uppercase, compact, braced, URN, whitespace, and mixed separators" $
+            mapM_
+                (\value -> parse value `shouldBe` Right sample)
+                [ "550E8400-E29B-41D4-A716-446655440000"
+                , "550e8400e29b41d4a716446655440000"
+                , "{550e8400-e29b-41d4-a716-446655440000}"
+                , "URN:UUID:550e8400-e29b-41d4-a716-446655440000"
+                , "  550e8400-e29b-41d4-a716-446655440000  "
+                , "550e8400-e29b41d4-a716446655440000"
+                ]
+        it "rejects malformed input" $
+            mapM_
+                (\value -> parse value `shouldSatisfy` isLeft)
+                [ ""
+                , "not-a-uuid"
+                , "550e8400-e29b-41d4-a716"
+                , "550e8400-e29b-41d4-a716-4466554400001234"
+                , "550e8400-e29b-41d4-a716-44665544gggg"
+                , "{550e8400-e29b-41d4-a716-446655440000"
+                , "550e8400-e29b-41d4-a716-446655440000}"
+                ]
+        it "validates without throwing" $ do
+            isValid (render sample) `shouldBe` True
+            isValid "not-a-uuid" `shouldBe` False
+
+    describe "metadata and constants" $ do
+        it "reads versions and all variants" $ do
+            uuidVersion sample `shouldBe` 4
+            uuidVariant sample `shouldBe` "rfc4122"
+            variantOf 0x00 `shouldBe` "ncs"
+            variantOf 0x80 `shouldBe` "rfc4122"
+            variantOf 0xc0 `shouldBe` "microsoft"
+            variantOf 0xe0 `shouldBe` "reserved"
+        it "provides ordered nil and max UUIDs" $ do
+            isNil nilUUID `shouldBe` True
+            isMax nilUUID `shouldBe` False
+            isMax maxUUID `shouldBe` True
+            isNil maxUUID `shouldBe` False
+            nilUUID `shouldSatisfy` (< maxUUID)
+        it "provides the four RFC namespaces" $ do
+            render namespaceDNS `shouldBe` "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+            render namespaceURL `shouldBe` "6ba7b811-9dad-11d1-80b4-00c04fd430c8"
+            render namespaceOID `shouldBe` "6ba7b812-9dad-11d1-80b4-00c04fd430c8"
+            render namespaceX500 `shouldBe` "6ba7b814-9dad-11d1-80b4-00c04fd430c8"
+            map uuidVersion [namespaceDNS, namespaceURL, namespaceOID, namespaceX500]
+                `shouldBe` replicate 4 1
+
+    describe "name-based UUIDs" $ do
+        it "matches the v3 DNS python.org RFC vector" $ do
+            render (v3 namespaceDNS "python.org") `shouldBe` "6fa459ea-ee8a-3ca4-894e-db77e160355e"
+            uuidVersion (v3 namespaceDNS "python.org") `shouldBe` 3
+            uuidVariant (v3 namespaceDNS "python.org") `shouldBe` "rfc4122"
+        it "matches v5 DNS and URL vectors" $ do
+            render (v5 namespaceDNS "python.org") `shouldBe` "886313e1-3b8a-5372-9b90-0c9aee199e5d"
+            render (v5 namespaceURL "http://www.python.org/") `shouldBe` "c2a8cbf8-d0f1-5ef4-9740-c3faec8ab1a0"
+        it "is deterministic and incorporates names and namespaces" $ do
+            v5 namespaceDNS "example.com" `shouldBe` v5 namespaceDNS "example.com"
+            v5 namespaceDNS "example.com" `shouldNotBe` v5 namespaceDNS "example.org"
+            v5 namespaceDNS "example.com" `shouldNotBe` v5 namespaceURL "example.com"
+            v3 namespaceDNS "python.org" `shouldNotBe` v5 namespaceDNS "python.org"
+        it "encodes empty and Unicode names as UTF-8" $ do
+            uuidVersion (v5 namespaceDNS "") `shouldBe` 5
+            render (v5 namespaceURL "https://\x4f8b\x3048.jp/")
+                `shouldBe` "eccf5197-3987-5080-845b-82d9b4c8af77"
+            uuidVariant (v5 namespaceURL "https://\x4f8b\x3048.jp/") `shouldBe` "rfc4122"
+
+    describe "random and time UUIDs" $ do
+        it "generates unique RFC v4 UUIDs" $ do
+            values <- sequence (replicate 100 v4)
+            map uuidVersion values `shouldSatisfy` all (== 4)
+            map uuidVariant values `shouldSatisfy` all (== "rfc4122")
+            length (nub values) `shouldBe` 100
+            map (length . uuidBytes) values `shouldSatisfy` all (== 16)
+        it "generates unique RFC v1 UUIDs with multicast nodes" $ do
+            values <- sequence (replicate 20 v1)
+            map uuidVersion values `shouldSatisfy` all (== 1)
+            map uuidVariant values `shouldSatisfy` all (== "rfc4122")
+            length (nub values) `shouldBe` 20
+            map ((.&. 0x01) . (!! 10) . uuidBytes) values `shouldSatisfy` all (== 1)
+        it "generates unique time-bearing RFC v7 UUIDs" $ do
+            first <- v7
+            before <- currentUnixMilliseconds
+            threadDelay 3000
+            second <- v7
+            after <- currentUnixMilliseconds
+            values <- sequence (replicate 50 v7)
+            uuidVersion first `shouldBe` 7
+            uuidVariant first `shouldBe` "rfc4122"
+            uuidTimestamp first `shouldSatisfy` (<= uuidTimestamp second)
+            uuidTimestamp second `shouldSatisfy` (\value -> value >= before && value <= after + 1)
+            length (nub values) `shouldBe` 50
+  where
+    variantOf byte = uuidVariant (expectRight (uuidFromBytes (replicate 8 0 ++ [byte] ++ replicate 7 0)))
+
+expectRight :: Either UUIDError UUID -> UUID
+expectRight result =
+    case result of
+        Right value -> value
+        Left err -> error (errorMessage err)
+
+uuidTimestamp :: UUID -> Integer
+uuidTimestamp = foldl (\value byte -> value `shiftL` 8 + fromIntegral byte) 0 . take 6 . uuidBytes
+
+currentUnixMilliseconds :: IO Integer
+currentUnixMilliseconds = floor . (* 1000) <$> getPOSIXTime

--- a/code/packages/haskell/uuid/uuid.cabal
+++ b/code/packages/haskell/uuid/uuid.cabal
@@ -1,0 +1,34 @@
+cabal-version: 3.0
+name:          uuid
+version:       0.1.0
+synopsis:      UUID generation and parsing from first principles
+description:   RFC 4122 and RFC 9562 UUID v1, v3, v4, v5, and v7 support.
+category:      Data
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  UUID
+    build-depends:    base >=4.14 && <5
+                    , md5 >=0.1 && <0.2
+                    , random >=1.2 && <1.3
+                    , sha1 >=0.1 && <0.2
+                    , time >=1.9 && <1.13
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    UUIDSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , time >=1.9 && <1.13
+                    , uuid
+    default-language: Haskell2010

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -167,7 +167,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 301
+The 172 packages present in at least ten implementation languages need 300
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -178,7 +178,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 26 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 25 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -460,6 +460,17 @@ Unicode pass-through, invalid keys, round trips, three recovery key lengths,
 and short-input behavior. The package now spans 14 implementation lanes,
 reduces the high-consensus backlog to 301 slots, and leaves 26 gaps in the
 Haskell lane.
+
+The ninth Haskell high-consensus slice is complete: `uuid` now provides strict
+128-bit construction, parsing and rendering, standard namespaces, metadata,
+and native v1, v3, v4, v5, and v7 generation. It builds name-based UUIDs on the
+existing Haskell MD5 and SHA-1 ports and uses native time and randomness for
+the generated versions. Its package-native suite exercises 17 examples with
+87% expression coverage, including accepted and rejected text forms, integer
+and byte round trips, all variants, RFC name-based vectors, Unicode names,
+random uniqueness, multicast nodes, and v7 timestamps. The package now spans
+14 implementation lanes, reduces the high-consensus backlog to 300 slots, and
+leaves 25 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a native Haskell `uuid` package with strict byte, integer, and text conversion
- implement RFC v1, v3, v4, v5, and v7 UUID generation using local MD5/SHA-1 dependencies
- cover namespaces, variants, accepted and rejected forms, RFC vectors, Unicode, uniqueness, node bits, and timestamps
- update the parity roadmap from 301 to 300 high-consensus gaps and from 26 to 25 Haskell gaps

## Validation

- `stack --color never --stack-yaml %TEMP%\\uuid-parity-stack.yaml test uuid:spec --coverage` (17 examples, 0 failures; 87% package expressions, 81% alternatives)
- `python code/scripts/tests/test_package_parity_report.py` (6 tests passed)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions; backlog 300; Haskell gaps 25; UUID lanes 14)
- `git diff --check`
