### PR TITLE
feat(maple-parser): maple.grammar + maple-parser crate (MA09 MP-3)

### DIFF
--- a/code/grammars/maple/maple.grammar
+++ b/code/grammars/maple/maple.grammar
@@ -1,0 +1,435 @@
+# @version 1
+
+# =============================================================================
+# maple.grammar — Parser grammar for Maple (a subset)
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from maple-lexer (MP-2). See
+# code/specs/MA09-maple-language.md §3 for the full surface-grammar table this
+# grammar implements, and §1/§2 for why Maple — despite looking, on the
+# surface, like a close cousin of REDUCE (the same `:=` spelling, the same
+# `and`/`or`/`not` keywords) — genuinely is not "REDUCE again": three
+# aggregate literal types instead of one (this subset covers two, list `[...]`
+# and set `{...}`), and a `f(x) := expr` spelling that means something
+# narrower (a remember-table patch, MA09 §1) than REDUCE's/Derive's own
+# general-definition idiom of the identical shape.
+#
+# Token names (UPPERCASE) come from the Maple lexer
+# (code/grammars/maple/maple.tokens):
+#   NUMBER NAME                  literals and symbols
+#   ASSIGN (:=)                   Maple's one assignment/arrow-definition
+#                                  marker (Programming Guide §5.5)
+#   ARROW (->)                    the functional/arrow operator (Help page
+#                                  `operators/functional`) — this subset's
+#                                  general-purpose function-definition
+#                                  spelling; REDUCE's/Derive's `.grammar`
+#                                  files have no analogous token at all
+#   EQ (=)  NEQ (<>)  LESS (<)  GREATER (>)  LE (<=)  GE (>=)
+#                                  relational (Programming Guide §3.10) — `=`
+#                                  is NEVER assignment, `:=` alone owns that
+#                                  role (same split every sibling CAS-family
+#                                  grammar in this repo already draws)
+#   PLUS MINUS TIMES SLASH CARET  arithmetic (Programming Guide §3.9); `^`
+#                                  ONLY — no `**` synonym exists in real Maple
+#                                  or in maple.tokens (MA09 §3)
+#   LPAREN RPAREN                 grouping AND function-call application AND
+#                                  the arrow-operator's own parenthesised
+#                                  parameter list
+#   LBRACKET RBRACKET             list literal `[a, b, c]` (ordered, MA09 §3)
+#   LBRACE RBRACE                 set literal `{a, b, c}` (unordered, MA09 §3)
+#   COMMA                         argument / list / set element separator
+#   SEMI COLON                    statement terminators — `;` displays the
+#                                  result, `:` suppresses it (Programming
+#                                  Guide §5.3); which one was used is an MP-4
+#                                  concern, invisible to this grammar, exactly
+#                                  as reduce.grammar treats its own SEMI/DOLLAR
+#                                  pair as interchangeable terminators
+#   "and"/"or"/"not"/"if"/"then"/"elif"/"else"/"end"/"fi"/"true"/"false"
+#                                  lowercase KEYWORD tokens (maple.tokens' own
+#                                  `keywords:` block — a shared KEYWORD token
+#                                  TYPE, disambiguated by VALUE, not per-word
+#                                  token types), matched here by literal
+#                                  spelling, the identical convention
+#                                  reduce.grammar already uses for its own
+#                                  `and`/`or`/`not`/`neq`/`if`/`then`/`else`
+#                                  word-operators (`GrammarElement::Literal`
+#                                  matches by the token's `.value`, regardless
+#                                  of its `.type_`, so this works unchanged).
+#
+# Precedence cascade (loosest binds first -> tightest binds last), MA09 §3's
+# own transcription of the real Maple Help page `operators/precedence` table,
+# pruned to the operators this grammar supports (MA09 §3's own note lists
+# every dropped tier in relative order: `assuming`, the general comma
+# sequence operator, `implies`, `xor`, `$` sequence-repetition, `..` range,
+# `mod`, `.`/non-commutative-multiplication and `intersect`/`union`/`minus`,
+# `!` factorial, `++`/`--`, custom `&`-operators, `::` type declaration, `||`
+# concatenation, `:-` module-member selection — none of which this subset's
+# surface uses, so none of them appear anywhere below):
+# ---------------------------------------------------------------
+#   assignment      :=                 (a STATEMENT, not an expression — see
+#                                        "Design decision: statements vs.
+#                                        expressions" below)
+#   arrow           ->                 (used ONLY as a Define right-hand side
+#                                        — see "Design decision: where the
+#                                        arrow binds" below — never a general
+#                                        expression operator)
+#   logical_or      or
+#   logical_and     and
+#   logical_not     not                (prefix)
+#   comparison      = <> < > <= >=     (flat, non-chaining — see "Design
+#                                        decision: the comparison tier" below)
+#   additive        + -
+#   multiplicative  * /                (explicit `*` REQUIRED — MA09 §3/§4;
+#                                        see "Design decision: no
+#                                        juxtaposition" below)
+#   unary           -                  (prefix; no unary `+`, matching MA09
+#                                        §3's own asymmetric listing)
+#   power           ^                  (right-associative; `^` ONLY, no `**`
+#                                        — MA09 §3, matching maple.tokens'
+#                                        own lack of a POW token)
+#   postfix         f(...)             (function/call application — a single
+#                                        call suffix, see "Design decision:
+#                                        one call suffix, not a chain" below)
+#   atom            literals, symbols, true/false, lists `[...]`,
+#                   sets `{...}`, `( ... )`
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Design decision: statements vs. expressions — `if` and `:=` never nest
+# inside an ordinary expression
+# -----------------------------------------------------------------------------
+# reduce.grammar's own `expr = if_expr | group_expr | assignment` puts REDUCE's
+# `if`/`<<...>>` ABOVE assignment specifically because MA08 §3 makes an
+# explicit, citable claim: `if` "returns whichever branch ran" and `<<...>>`
+# "evaluates to its last statement's value" — both are genuinely
+# value-producing REDUCE expressions, so REDUCE's grammar lets them appear
+# anywhere an `expr` is expected (an assignment's right-hand side, a call's
+# argument, nested inside each other).
+#
+# MA09 makes NO equivalent claim for Maple's `if` — and real Maple confirms
+# the opposite: Maple's own idiom for a conditional VALUE is the `piecewise`
+# library function (`piecewise(x>0, x, -x)`), an ORDINARY function call this
+# grammar's `postfix` production already parses for free, needing no
+# dedicated grammar support at all. You cannot write `x := if a then 1 else 2
+# end if` in real Maple the way you can write `x := if a then 1 else -1` in
+# REDUCE. This is corroborated structurally by MA09 §6's own citation list,
+# which places `if`/`:=` in the Programming Guide's Chapter 5 "Maple
+# Statements" (§5.5 "Assignments", §5.6 "Flow Control") — a chapter distinct
+# from Chapter 3 "Maple Expressions" (§3.9/§3.10/§3.11, which this grammar's
+# `expr` chain below implements) — exactly the split this grammar encodes as
+# two separate nonterminals that never call back into each other:
+#
+#   statement = if_expr | assignment          (Chapter 5 — "Maple Statements")
+#   expr      = logical_or -> ... -> atom      (Chapter 3 — "Maple Expressions")
+#
+# Neither `if_expr` nor `assignment` is reachable from anywhere inside `expr`
+# (contrast reduce.grammar, where `expr` — not a narrower `logical_or` — sits
+# at the very top specifically so `if_expr`/`assignment` ARE reachable from
+# every position `expr` appears). Consequences, both deliberate:
+#   - `x := if a then 1 else 2 end if;` is a SYNTAX ERROR here (contrast
+#     REDUCE's `x := if a>0 then 1 else -1;`, which is valid there).
+#   - `a := b := c;` is a SYNTAX ERROR here too (contrast REDUCE's manual
+#     §2.7 "a:=b:=c evaluates as a:=(b:=c)", explicitly cited by MA08 §3 —
+#     MA09 has no equivalent citation for chained Maple assignment, and every
+#     worked example in MA09 §3 is a single, non-chained `x := e`).
+# This is a disclosed, judgment-call divergence from reduce.grammar's
+# identical-looking `assignment` shape, not an oversight — flagged in
+# maple-parser's own CHANGELOG/README for a future maple-runtime (MP-4) to
+# rely on.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Design decision: where the arrow (`->`) binds
+# -----------------------------------------------------------------------------
+# MA09 §3 is explicit that `->` is "used only as a Define right-hand side in
+# this subset" — never a general expression operator. Two designs were
+# considered (see the MP-3 task brief): (a) a dedicated `arrow_def` production
+# tried as `assignment`'s first alternative, or (b) treat ARROW as an ordinary
+# low-precedence expression operator and restrict its placement at the
+# runtime/lowering layer instead.
+#
+# This grammar picks (a). `ARROW` appears in exactly ONE place in this entire
+# file — `arrow_def`'s own production below — which is reachable from exactly
+# one position: `assignment`'s first alternative, tried immediately after
+# `NAME ASSIGN`. No other rule anywhere in this grammar references `ARROW`,
+# so `->` cannot appear as a bare statement, nested inside arithmetic, as a
+# function argument, or anywhere else MA09 §3 doesn't sanction — the GRAMMAR
+# is the enforcement point, not a runtime check, matching this repo's stated
+# preference (this crate's own MP-3 brief: "err toward the grammar being the
+# enforcement point if that's cleanly expressible... the more common
+# convention in this repo's sibling grammars").
+#
+# No lookahead predicate is needed to make this deterministic: `NAME ASSIGN
+# ( arrow_def | expr )` tries `arrow_def` first (ordered choice); if the
+# name-or-parenthesised-name-list isn't followed by an `ARROW`, `arrow_def`'s
+# own `Sequence` fails at that exact point and the packrat engine backtracks
+# cleanly (restoring position) to try the `expr` alternative instead —
+# ordinary PEG ordered-choice, memoized per `(rule, pos)`, no ambiguity and no
+# combinatorial blowup. Concretely: `f := x;` (assigning a variable's value,
+# NOT a definition) tries `arrow_def`, matches the bare-NAME parameter form
+# `x`, then fails to find `ARROW` (sees `;` instead), backtracks, and
+# succeeds via the plain `expr` alternative instead.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Design decision: assignment's left-hand side is a bare NAME, not a general
+# call-shaped expression — deliberately NARROWER than reduce.grammar's own
+# `assignment = logical_or [ ASSIGN expr ]`
+# -----------------------------------------------------------------------------
+# reduce.grammar's `assignment` left-hand side is a full `logical_or` (which
+# bottoms out, through `postfix`, at a call shape `h(l, m)`) BECAUSE REDUCE's
+# `h(l, m) := e` genuinely IS its general procedure-definition idiom (MA08
+# §3, citing the manual's own `h(l,m) := x-2*y` example, "where h is an
+# operator"). Maple's identical-looking `f(x) := e` spelling means something
+# NARROWER and DIFFERENT: a remember-table specific-value patch onto an
+# ALREADY-EXISTING procedure/operator (MA09 §1, the `remember` Help page),
+# and MA09 §4 is explicit that this spelling is "deliberately EXCLUDED (not
+# merely deferred)... precisely because its surface spelling collides with
+# REDUCE's/Derive's own general-definition idiom... so no Maple program in
+# this subset can accidentally mean the narrower remember-table thing."
+#
+# Mirroring reduce.grammar's LHS shape here would let `f(x) := e` parse
+# STRUCTURALLY (as an `assignment` whose LHS happens to be a parsed call) —
+# pushing onto a future maple-runtime (MP-4) an interpretation question MA09
+# §4 already settled at the SPEC level: this spelling should not be
+# expressible at all in this subset. So this grammar's `assignment` left-hand
+# side is a bare `NAME` token, full stop:
+#
+#   assignment = NAME ASSIGN ( arrow_def | expr ) | expr ;
+#
+# `f(x) := e` therefore FAILS TO PARSE: after `NAME "f"`, the next token is
+# `LPAREN`, not `ASSIGN`, so `assignment`'s first alternative fails outright
+# (no backtracking needed — the very next token rules it out); `f(x)` alone
+# then parses fine as a plain `expr`-shaped statement via the second
+# alternative (an ordinary call), but the leftover `:= e` has nowhere left to
+# attach — `statement_line`'s own terminator check (`SEMI | COLON`) sees
+# `ASSIGN` instead and the whole statement fails cleanly. Confirmed by this
+# crate's own `remember_table_spelling_is_rejected` regression test.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Design decision: the comparison tier is flat and non-chaining
+# -----------------------------------------------------------------------------
+# MA09 §3 lists `=`/`<>`/`<`/`>`/`<=`/`>=` as one relative-precedence tier but
+# — like the real Maple Help page `operators/precedence` table it transcribes
+# — does not say whether chained comparisons (`a < b < c`) are themselves
+# meaningful or how each operator nests relative to its neighbours within the
+# tier. reduce.grammar's own `comparison` rule already resolves the identical
+# gap for REDUCE with one flat, non-chaining production (MA08 §3: "a
+# deliberate simplification for a first cut, not a verified claim about real
+# Reduce's exact grammar"); this grammar reuses that exact precedent rather
+# than re-deriving a fresh simplification, since MA09's own comparison row is
+# structurally the same kind of open question REDUCE's manual already left.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Design decision: no juxtaposition production exists anywhere in this file
+# -----------------------------------------------------------------------------
+# MA09 §3/§4 confirms explicit `*` is REQUIRED in real Maple — confirmed
+# genuinely absent, not a scope-narrowing choice here (the `arithop` Help
+# page's own worked examples always show `3*x*y`, never `3xy`, and Maple's
+# own "invalid product or quotient" error exists precisely because `3xy` is a
+# parse error there too). `multiplicative` below has exactly one production,
+# `unary { ( TIMES | SLASH ) unary }`, with no alternative anywhere that
+# admits two atoms placed back-to-back with no operator between them — so
+# `a b` (two bare names with nothing between them) is a syntax error by
+# construction: the first `atom` consumes `a`, then every tier's own
+# continuation (multiplicative's `{ (TIMES|SLASH) ... }`, additive's `{
+# (PLUS|MINUS) ... }`, comparison's `[ (EQ|...) ... ]`, logical_and's `{ "and"
+# ... }`, logical_or's `{ "or" ... }`) fails to match against `b` (a bare
+# NAME, none of those tokens), so parsing of that one statement stops after
+# `a`, leaving `b` unconsumed — which then fails the statement terminator
+# check. Confirmed by this crate's own
+# `bare_juxtaposed_names_with_no_operator_is_rejected` regression test,
+# mirroring reduce.grammar's identically-named, identically-motivated test.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Design decision: one call suffix, not a repeated chain
+# -----------------------------------------------------------------------------
+# reduce.grammar's `postfix = atom { LPAREN [ arglist ] RPAREN } ;` uses
+# REPEATED call suffixes specifically because REDUCE's own `a(5)`/`b(i, q)`
+# array-name-with-subscript reads share the identical call-shaped production
+# (MA08 §3) and REDUCE's manual mentions array names as a building block
+# generally enough that a repeated suffix was the safer, more literal
+# transcription. MA09 §3 documents no analogous array-subscript-read
+# convention for Maple at all — every worked example is a single `f(a, b)`
+# call — so this grammar uses a single OPTIONAL call suffix instead:
+#
+#   postfix = atom [ LPAREN [ arglist ] RPAREN ] ;
+#
+# a deliberately narrower, more spec-literal shape than the sibling's,
+# erring toward not inventing surface Maple never documents "for
+# completeness."
+# -----------------------------------------------------------------------------
+
+# A program is zero or more `;`/`:`-terminated statements, optionally
+# followed by ONE final statement with no terminator at all (so a source file
+# need not end with a trailing `;`/`:`).
+#
+# Why the optional tail sits OUTSIDE the repetition rather than folded into
+# `statement_line` as a third alternative: identical reasoning to
+# reduce.grammar's own `program` comment (which this grammar reuses verbatim
+# rather than re-deriving) — a bare, terminator-less `statement` alternative
+# INSIDE a repeated rule is silently re-triable on every iteration, not just
+# the final one, so `{ statement_line }` would greedily accept `a AND b;` as
+# THREE separate bare-statement iterations (`a`, then `AND`, then `b;`) —
+# `AND` uppercase lexes as an ordinary NAME (maple.tokens' keywords are
+# lowercase-only, MA09 §3), and no juxtaposition production exists anywhere
+# in this file (see "no juxtaposition" above), so three bare names in a row
+# with no operator between them must be a syntax error, not three separate
+# statements that happen to consume all the input. Moving the
+# terminator-less case to a single `[ statement ]` *outside* the repetition
+# means it can only ever match once, and only once `{ statement_line }` has
+# already failed to find a terminator for whatever comes next. Confirmed by
+# this crate's own `bare_juxtaposed_names_with_no_operator_is_rejected`
+# regression test.
+program = { statement_line } [ statement ] ;
+
+# Maple has no significant newline (maple.tokens' own header) — statements
+# end with `;` or `:` (Programming Guide §5.3); a lone terminator with no
+# statement before it is not part of this grammar's `statement_line`,
+# mirroring reduce.grammar's identical note.
+statement_line = statement ( SEMI | COLON ) ;
+
+# Chapter 5 "Maple Statements" — see "statements vs. expressions" above for
+# why this is a nonterminal wholly separate from `expr`.
+statement = if_expr | assignment ;
+
+# if b then s1 elif b2 then s2 else s3 end if | fi (MA09 §3; Programming
+# Guide §5.6 "Flow Control"; the `if` Help page confirms `fi` — "if" reversed
+# — is short for `end if`).
+#
+# maple-lexer emits `end` and `if` as two INDEPENDENT KEYWORD tokens (it does
+# not special-case the two-word sequence into one token — see that crate's
+# own lib.rs doc comment, "`end`/`fi` — two distinct tokens, not one"), so
+# this production is where the `end if` / `fi` composition actually happens:
+# an ordered choice between the two-token sequence `"end" "if"` and the
+# single token `"fi"`. This is fully deterministic with no ambiguity or
+# backtracking risk: `end`, `if`, and `fi` are three distinct KEYWORD VALUES,
+# so at the position where this alternative is tried, at most one of the two
+# choices can possibly match the current token — seeing `"end"` commits to
+# needing `"if"` immediately next (and it genuinely must follow — "end" not
+# followed by "if" is invalid Maple in this subset, since `proc`/`do` closers
+# are out of scope), seeing `"fi"` commits to the other choice, and seeing
+# neither is a syntax error. This mirrors reduce.grammar's own
+# "commit-early-on-leading-keyword" ordered-choice discipline.
+#
+# Genuinely NEW relative to every sibling CAS-family `if` in this repo:
+# because Maple requires an explicit close (`end if` or `fi`) for every
+# `if_expr`, there is NO dangling-else ambiguity here at all — contrast
+# reduce.grammar's `if_expr`, whose own doc comment has to explain how
+# ordinary recursive-descent order-of-attempt resolves `if a then if b then c
+# else d` in favour of attaching `else` to the innermost `if`. Here, a nested
+# `if_expr` inside a `then`/`elif`/`else` branch must run all the way to ITS
+# OWN `end if`/`fi` before the OUTER `if_expr`'s own `elif`/`else`/close is
+# ever reached — there is structurally only one place an outer `else` could
+# possibly attach, by construction, not by a resolution convention.
+#
+# Each `elif` desugars to a nested `If` IR node at MP-4 (a runtime concern,
+# not this grammar's); the flat `{ "elif" ... }` EBNF repetition here
+# preserves the whole elif chain, in order, as sibling children — no
+# information is lost that MP-4 would need to fold it right-to-left.
+#
+# Branches are `statement` (not the narrower `expr`) so an `if` can branch to
+# an assignment or a nested conditional (`if a then x := 1 else x := 2 end
+# if`) — matching MA09 §3's own generic `s1`/`s2`/`s3` labelling (which reads
+# as statement-shaped, not narrowly expression-shaped) — while an `if_expr`
+# itself is still never reachable FROM `expr` (see "statements vs.
+# expressions" above; a branch containing an `if` is still a *statement*
+# nested inside a *statement*, not an expression use).
+if_expr = "if" expr "then" statement
+          { "elif" expr "then" statement }
+          [ "else" statement ]
+          ( "end" "if" | "fi" ) ;
+
+# `x := e` (Programming Guide §5.5); `f := (x, y) -> e` / `f := x -> e` (the
+# arrow/functional operator, Help page `operators/functional`; MA09 §3). See
+# "where the arrow binds" and "assignment's left-hand side" above for why
+# this shape is deliberately narrower than reduce.grammar's own `assignment`.
+assignment = NAME ASSIGN ( arrow_def | expr )
+           | expr ;
+
+arrow_def = arrow_params ARROW expr ;
+
+# `f := (x, y) -> e` / `f := x -> e` — MA09 §3's own two worked spellings:
+# a single bare parameter needs no parentheses, two-or-more do. Zero
+# parameters (`() -> e`, a nullary constant function) falls out of the
+# optional inner list for free — not one of MA09 §3's own worked examples,
+# but not excluded by §4 either, and a natural, low-risk consequence of this
+# exact shape rather than a deliberately added production.
+arrow_params = NAME
+             | LPAREN [ NAME { COMMA NAME } ] RPAREN ;
+
+# The arithmetic/logical/comparison chain — MA09 §3's own precedence table,
+# transcribed one tier per rule below, Chapter 3 "Maple Expressions". Named
+# `expr` (rather than folding this alias directly into `logical_or`) purely
+# for readability and to match reduce.grammar's own top-level name; see
+# "statements vs. expressions" above for why `expr` itself never reaches
+# back to `if_expr` or `assignment`.
+expr = logical_or ;
+
+logical_or  = logical_and { "or" logical_and } ;
+logical_and = logical_not { "and" logical_not } ;
+logical_not = "not" logical_not | comparison ;
+
+# See "Design decision: the comparison tier is flat and non-chaining" above.
+comparison = additive [ ( EQ | NEQ | LESS | GREATER | LE | GE ) additive ] ;
+
+additive       = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+
+# See "Design decision: no juxtaposition production exists anywhere in this
+# file" above.
+multiplicative = unary { ( TIMES | SLASH ) unary } ;
+
+# Prefix minus only — MA09 §3 lists no unary `+`, matching REDUCE's/Derive's
+# identical asymmetry. Binds looser than power, so `-x^2` is `Neg[Pow[x,2]]`,
+# never `Pow[Neg[x],2]`.
+unary = MINUS unary | power ;
+
+# Right-associative: `a^b^c` = `a^(b^c)` (the optional continuation's own
+# right-hand side is `unary`, which falls through to `power` again absent a
+# leading `-`, mirroring reduce.grammar's identical `power`/`unary` mutual
+# reference). `^` ONLY, no `**` synonym — MA09 §3 confirms real Maple
+# documents none (unlike REDUCE's `^`/`**` pair), and maple.tokens has no
+# `POW` token at all, so writing `**` here would reference a token that does
+# not exist in this grammar's own vocabulary.
+power = postfix [ CARET unary ] ;
+
+# See "Design decision: one call suffix, not a repeated chain" above.
+postfix = atom [ LPAREN [ arglist ] RPAREN ] ;
+
+arglist = expr { COMMA expr } ;
+
+atom = NUMBER
+     | NAME
+     | "true"
+     | "false"
+     | list_literal
+     | set_literal
+     | group ;
+
+# `[a, b, c]` — list (ordered, duplicates kept — Programming Guide §4.3;
+# MA09 §3). Reuses the SAME `arglist` production a function call's own
+# argument list uses (mirroring reduce.grammar's identical list-literal
+# reuse), since both are just "comma-separated `expr`s." Empty `[]` falls out
+# of the optional inner `arglist` for free — not one of MA09 §3's worked
+# examples, but not excluded by §4 either.
+list_literal = LBRACKET [ arglist ] RBRACKET ;
+
+# `{a, b, c}` — set (unordered, duplicates removed at MP-4 — same §4.3, and
+# the `set` Help page's own worked example: `{x, y, y}` and `{y, x, y}` both
+# produce `{x, y}`; MA09 §3). This is the SAME bracket REDUCE uses for its
+# OWN list literal — same spelling, different meaning both times, the exact
+# family-resemblance trap MA09 §1 names by title. This grammar only assigns
+# the `LBRACE`/`RBRACE` tokens a STRUCTURE (a `set_literal` node, syntactically
+# distinct from `list_literal` purely by which bracket was used) — the
+# Set-vs-List *semantic* tag is what a future maple-runtime (MP-4) attaches
+# when it lowers this node to a `Set[...]` IRNode head (MA09 §5) rather than
+# `List[...]`; this grammar's job is only to keep the two shapes separate,
+# which it does simply by having two distinct rules. Empty `{}` falls out of
+# the optional inner `arglist` for free, same as the empty-list case above.
+set_literal = LBRACE [ arglist ] RBRACE ;
+
+group = LPAREN expr RPAREN ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -264,6 +264,7 @@ members = [
     "reduce-runtime",
     "reduce-repl",
     "maple-lexer",
+    "maple-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/maple-parser/BUILD
+++ b/code/packages/rust/maple-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maple-parser -- --nocapture

--- a/code/packages/rust/maple-parser/BUILD_windows
+++ b/code/packages/rust/maple-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maple-parser -- --nocapture

--- a/code/packages/rust/maple-parser/CHANGELOG.md
+++ b/code/packages/rust/maple-parser/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Changelog
+
+## [0.1.0] - 2026-07-19
+
+### Added
+
+- Initial grammar-driven Rust Maple parser (MA09 §2, task MP-3).
+- `maple.grammar` (compiled ahead of time into the committed
+  `src/_grammar.rs`), implementing the MP-1-scoped precedence cascade from
+  MA09 §3: a `statement`/`expr` split (`statement = if_expr | assignment`,
+  `expr = logical_or -> ... -> atom`) → assignment (`:=`, left-hand side a
+  bare `NAME`) → the arrow operator (`->`, `Define`-right-hand-side only,
+  via a dedicated `arrow_def` production) → `or` → `and` → `not` →
+  comparison (`=`/`<>`/`<`/`>`/`<=`/`>=`, flat non-chaining) → additive →
+  multiplicative (explicit `*` required, no juxtaposition production exists
+  anywhere in the grammar) → unary minus → power (`^` only, right-assoc,
+  no `**` synonym) → postfix function-call application (single call
+  suffix) → atoms, plus square-bracket list literals and curly-brace set
+  literals (both reusing one shared `arglist` production).
+- Three deliberate, disclosed divergences from `reduce-parser`'s
+  identical-looking shape, each with its own header comment in
+  `maple.grammar` citing MA09's own text:
+  1. **`if` and `:=` are statement-only, never nested inside an `expr`.**
+     MA09 makes no equivalent claim to MA08 §3's explicit "if... returns
+     whichever branch ran" for Maple, and real Maple's own conditional-value
+     idiom is the `piecewise(...)` library call (an ordinary function call
+     this grammar already parses for free), not embedding `if` where a
+     value is expected — corroborated by MA09 §6's own citation split
+     (Chapter 5 "Maple Statements" vs. Chapter 3 "Maple Expressions").
+     Consequence: `x := if a then 1 else 2 end if;` and chained assignment
+     `a := b := c;` are both syntax errors in this subset.
+  2. **`assignment`'s left-hand side is a bare `NAME`, not a general
+     call-shaped expression.** REDUCE's `h(l,m) := e` IS its general
+     definition idiom, so `reduce.grammar`'s LHS is deliberately a full
+     `logical_or` (bottoming out at a call). Maple's identical-looking
+     `f(x) := e` means the narrower, EXCLUDED (MA09 §4) remember-table
+     mechanism instead, so this grammar never lets it parse at all —
+     `f(x) := 1;` fails at the terminator check, not at a later lowering
+     stage.
+  3. **`postfix` allows at most one call suffix**, not `reduce.grammar`'s
+     repeated `{ LPAREN [arglist] RPAREN }` chain — MA09 documents no
+     analogue of REDUCE's `a(5)`/`b(i,q)` array-subscript-read convention
+     that motivated the repeated shape there.
+- The `if`/`elif`/`else`/(`end if`|`fi`) conditional, MA09's one genuinely
+  new grammatical shape relative to every CAS-family sibling in this repo:
+  `if_expr = "if" expr "then" statement { "elif" expr "then" statement }
+  [ "else" statement ] ( "end" "if" | "fi" ) ;`. Deterministic, ambiguity-free
+  ordered choice between the two closing spellings (`end`/`if`/`fi` are
+  three distinct KEYWORD values). Unlike `reduce-parser`'s `if`, there is
+  **no dangling-else ambiguity** here at all, because every `if_expr`
+  requires an explicit close before an enclosing `if`'s own `elif`/`else`
+  can ever be reached.
+- A bespoke `MAX_RULE_DEPTH = 150` recursion-depth cap. Six distinct
+  self-referential productions were measured independently (parenthesised
+  nesting, list-literal nesting, a `not` prefix chain, a unary-minus prefix
+  chain, a power chain, nested `if`/`end if`) — every "flat chain of one
+  operator" production written with EBNF `{ x }` repetition instead was
+  confirmed, by reading `parser::grammar_parser`'s own `Repetition`
+  implementation directly, to cost zero native stack regardless of width
+  (the same engine-level fact `reduce-parser` already established, reused
+  here rather than re-measured by a fresh throwaway probe). Set-literal
+  nesting was proven structurally identical to list-literal nesting by
+  direct inspection of the shared `arglist` production (`list_literal` and
+  `set_literal` both wrap `arglist` identically, differing only in which
+  bracket token is matched), so it was not separately measured — a provable
+  identity, not an assumed shape resemblance.
+- A genuine surprise once each shape's *nesting-count* crash floor was
+  converted into *rule-frame* terms (the units `MAX_RULE_DEPTH` actually
+  bounds): the `not` prefix chain tolerates by far the *most* nesting levels
+  of the six (205 safe / 206 crash, alongside its near-twin the unary-minus
+  chain) but has the *lowest* rule-frame floor (218 safe / 219 crash) —
+  lower than nested-`if`'s 289/290, despite nested-`if` crashing at far
+  fewer levels (137/138), and lower than parenthesised nesting's 298/299,
+  which crashes at the fewest levels of all (23/24). Neither "the shape
+  that tolerates the fewest levels must bind" nor "parenthesised nesting
+  binds, since it does for nearly every sibling `*-parser` crate in this
+  repo" holds here — both would have shipped a cap unsafe specifically for
+  `not`/unary-minus prefix chains. `150` sits about 31.2% below the binding
+  218 floor. Full measurement table and reasoning in `MAX_RULE_DEPTH`'s own
+  doc comment (`src/lib.rs`).
+- 45 tests covering every construct in the MP-1 surface grammar: function
+  calls (including nested and multi-arg), assignment vs. equation (`:=` vs
+  `=`) staying distinct, every comparison operator, the arrow-operator
+  `Define` shape with two parameters, one bare parameter, and zero
+  parameters, a regression test confirming a plain `f := x;` assignment
+  does *not* spuriously produce an `arrow_def` node, regression tests
+  confirming `->` never appears outside an assignment's right-hand side or
+  nested inside arithmetic, a regression test confirming the remember-table
+  spelling `f(x) := e` / `h(l, m) := e` is rejected outright, regression
+  tests confirming `if` is not usable as an assignment's right-hand side and
+  that chained assignment is rejected, list vs. set literal parsing as
+  genuinely distinct productions (including empty `[]`/`{}`), boolean
+  literals and keywords with their lowercase-only case sensitivity, a
+  `bare_juxtaposed_names_with_no_operator_is_rejected` regression test
+  mirroring `reduce-parser`'s own, arithmetic precedence/associativity
+  (including the explicit-`*`-required check that `a ** b` does not parse as
+  a single power expression), grouping, `if`/`elif`/`else` closed both ways
+  (`end if` and bare `fi`, proven structurally equivalent) with elif-chain
+  preservation and assignment-branching, nested `if` resolving with no
+  dangling-else ambiguity, multi-statement programs, syntax-error rejection,
+  and 4 depth-guard tests exercising all six measured shapes at once (deep
+  adversarial input on an enlarged-stack thread returns a clean error for
+  every shape, the cap trips before the native stack would overflow even on
+  a default-stack thread for every shape, reasonable hand-written nesting
+  for every shape stays well under the cap, and an exact boundary test —
+  mirroring `j-parser`'s own per-shape boundary tests — proving the measured
+  real-input headroom for every shape parses cleanly one level below the
+  cap and trips cleanly one level at the cap).
+- `code/grammars/maple/maple.grammar` validated with
+  `grammar-tools validate-grammar` and cross-validated against
+  `code/grammars/maple/maple.tokens` with `grammar-tools validate`.

--- a/code/packages/rust/maple-parser/Cargo.toml
+++ b/code/packages/rust/maple-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-maple-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for Maple (a subset, MP-3)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-maple-lexer = { path = "../maple-lexer" }

--- a/code/packages/rust/maple-parser/README.md
+++ b/code/packages/rust/maple-parser/README.md
@@ -1,0 +1,217 @@
+# coding-adventures-maple-parser
+
+Maple parser backed by `code/grammars/maple/maple.grammar`, compiled to Rust
+and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the MP-1-scoped subset fixed by
+[MA09 §3](../../../specs/MA09-maple-language.md). Maple looks, on the
+surface, like a close cousin of REDUCE (the same `:=` assignment spelling,
+the same `and`/`or`/`not` keywords) but genuinely is not "REDUCE again":
+Maple has three aggregate literal types where REDUCE/Derive each have one
+(this subset covers two, list `[...]` and set `{...}`), and its `f(x) := e`
+spelling means something narrower (a remember-table patch) than REDUCE's own
+general-definition idiom of the identical shape — this parser's grammar is
+the enforcement point for that distinction (see below).
+
+## Statements vs. expressions — the one structural divergence from `reduce-parser`
+
+`reduce-parser`'s own `expr = if_expr | group_expr | assignment` sits `if`/
+`<<...>>` *above* assignment specifically because MA08 §3 makes an explicit
+claim: REDUCE's `if` "returns whichever branch ran" and its group statement
+"evaluates to its last statement's value" — both are genuinely
+value-producing REDUCE expressions.
+
+MA09 makes no equivalent claim for Maple's `if`, and real Maple's own idiom
+for a conditional *value* is the `piecewise(...)` library function — an
+ordinary call this grammar's `postfix` production already parses for free —
+not embedding an `if` where a value is expected. So this grammar splits
+cleanly into two nonterminals that never call back into each other:
+
+```
+statement = if_expr | assignment          (Chapter 5 — "Maple Statements")
+expr      = logical_or -> ... -> atom      (Chapter 3 — "Maple Expressions")
+```
+
+Consequences: `x := if a then 1 else 2 end if;` and chained assignment
+`a := b := c;` are both **syntax errors** in this subset — unlike
+`reduce-parser`'s identical-looking `assignment`, which supports both. See
+`maple.grammar`'s own "Design decision: statements vs. expressions" header
+comment for the full reasoning and citations.
+
+## `f(x) := e` (the remember-table spelling) does not parse at all
+
+`reduce-parser`'s `assignment` left-hand side is a full `logical_or` (which
+bottoms out at a call shape `h(l, m)`) *because* REDUCE's `h(l, m) := e` is
+its general procedure-definition idiom. Maple's identical-looking
+`f(x) := e` means something narrower and different — a remember-table
+specific-value patch onto an *already-existing* procedure (MA09 §1) —
+deliberately **excluded** from this subset (MA09 §4), not merely deferred.
+
+So this grammar's `assignment` left-hand side is a bare `NAME` token, full
+stop:
+
+```
+assignment = NAME ASSIGN ( arrow_def | expr ) | expr ;
+```
+
+`f(x) := 1;` fails to parse entirely: after `NAME "f"`, the next token is
+`LPAREN`, not `ASSIGN`, so `assignment`'s first alternative fails outright;
+`f(x)` alone then parses as an ordinary call-shaped `expr` statement via the
+second alternative, but the leftover `:= 1` has nowhere to attach, so the
+whole statement fails at the terminator check. This is a deliberate,
+grammar-level enforcement of MA09 §4's exclusion — not a runtime concern
+pushed onto a future `maple-runtime`.
+
+## The arrow (`->`) operator: grammar-enforced placement
+
+MA09 §3: `->` is "used only as a `Define` right-hand side in this subset."
+`ARROW` appears in exactly one place in `maple.grammar` — `arrow_def`'s own
+production, tried as `assignment`'s first alternative right after
+`NAME ASSIGN`:
+
+```
+assignment   = NAME ASSIGN ( arrow_def | expr ) | expr ;
+arrow_def    = arrow_params ARROW expr ;
+arrow_params = NAME | LPAREN [ NAME { COMMA NAME } ] RPAREN ;
+```
+
+No other rule references `ARROW`, so `->` cannot appear as a bare statement,
+nested inside arithmetic, or as a function argument — the grammar itself is
+the enforcement point, matching this repo's stated preference for catching
+invalid shapes at parse time. Backtracking (not a lookahead predicate) makes
+this deterministic: `f := x;` tries `arrow_def` first, fails to find `ARROW`
+after the bare name `x`, and cleanly backtracks to the plain `expr`
+alternative — ordinary memoized PEG ordered-choice, no ambiguity.
+
+## `if`/`elif`/`else` closed two ways, with no dangling-else ambiguity
+
+Real Maple closes an `if` with either the two-keyword sequence `end if` or
+the standalone `fi` ("if" reversed). `maple-lexer` emits `end` and `if` as
+two independent `KEYWORD` tokens, so this grammar is where the composition
+actually happens:
+
+```
+if_expr = "if" expr "then" statement
+          { "elif" expr "then" statement }
+          [ "else" statement ]
+          ( "end" "if" | "fi" ) ;
+```
+
+Because every `if_expr` requires an explicit close, there is **no
+dangling-else ambiguity** here at all — unlike `reduce-parser`'s own `if`,
+which has to rely on ordinary recursive-descent order-of-attempt to resolve
+`if a then if b then c else d`. A nested `if` inside a branch must run all
+the way to its own `end if`/`fi` before an outer `if`'s own `elif`/`else`/
+close is ever reached — there is structurally only one place an outer
+`else` can attach.
+
+Branches are `statement` (not the narrower `expr`), so an `if` can branch to
+an assignment or a nested conditional (`if a then x := 1 else x := 2 end
+if`) — matching MA09 §3's own generic `s1`/`s2`/`s3` labelling — while an
+`if_expr` itself is still never reachable *from* `expr`.
+
+## List vs. set literals — two productions, one shared `arglist`
+
+`[a, b, c]` (list, ordered, duplicates kept) and `{a, b, c}` (set,
+unordered, duplicates removed at a future `maple-runtime`) are syntactically
+distinct productions that both reuse the same `arglist = expr { COMMA expr
+}` production a function call's own argument list uses:
+
+```
+list_literal = LBRACKET [ arglist ] RBRACKET ;
+set_literal  = LBRACE [ arglist ] RBRACE ;
+```
+
+Empty `[]`/`{}` fall out of the optional inner `arglist` for free. `{a, b,
+c}` is the *same* bracket REDUCE uses for its own list literal — same
+spelling, different meaning both times, the exact family-resemblance trap
+MA09 §1 names by title; this grammar only assigns the bracket a *structure*
+(which rule matched), the Set-vs-List semantic tag is a future
+`maple-runtime`'s concern when it lowers to `Set[...]` vs `List[...]`.
+
+## Precedence, loosest to tightest
+
+```
+statement = if_expr | assignment            (never reachable from `expr`)
+  assignment (NAME :=, LHS is a bare NAME -- see above)
+    RHS: arrow_def (params -> expr) | expr
+  expr = logical_or
+    → OR
+      → AND
+        → NOT (prefix)
+          → comparison (= <> < > <= >=, flat non-chaining)
+            → additive (+ -)
+              → multiplicative (* /, explicit `*` required)
+                → unary minus (prefix)
+                  → power (^, right-assoc, no `**` synonym)
+                    → postfix application  f(...)  (single call suffix)
+                      → atom  (NUMBER, NAME, true, false,
+                               [list literal], {set literal}, ( ... ))
+```
+
+`=` is Maple's *equation* operator — never assignment; `:=` alone owns that
+role. `<>` is Maple's own not-equal spelling (not REDUCE's word-keyword
+`neq`, not Wolfram's `!=`). `and`/`or`/`not`/`if`/`then`/`elif`/`else`/`end`/
+`fi`/`true`/`false` are lowercase `KEYWORD` tokens, matched by literal
+spelling (the mirror image of `derive-lexer`'s uppercase `AND`/`OR`/`NOT`).
+
+## Usage
+
+```rust
+use coding_adventures_maple_parser::parse_maple;
+
+let ast = parse_maple("f := (x, y) -> x + y;\nf(1, 2);\n");
+assert_eq!(ast.rule_name, "program");
+```
+
+`parse_maple` panics on a malformed source string; use `try_parse_maple` for
+the `Result`-returning form, or `create_maple_parser` directly if you need
+the raw `GrammarParser`.
+
+## Recursion-depth guard: six shapes, and a genuine surprise
+
+`maple.grammar` has six distinct self-referential recursion shapes —
+parenthesised grouping, list-literal nesting (proven structurally identical
+to set-literal nesting by direct inspection of the shared `arglist`
+production, so not separately measured), a `not` prefix chain, a
+unary-minus prefix chain, a power (`^`) chain, and nested `if`/`end if`
+(or `fi`) — each measured independently (binary search, uncapped parser,
+default-stack worker thread, debug build, one fresh subprocess per data
+point), per [MA06](../../../specs/MA06-j-language.md) §6's established
+methodology. Every "flat chain of one operator" production written with
+EBNF `{ x }` repetition instead (`logical_or`, `logical_and`, `additive`,
+`multiplicative`, the `elif` chain, `arglist`) costs *zero* native stack
+regardless of width — confirmed by reading `parser::grammar_parser`'s own
+`Repetition` implementation directly (a plain iterative loop), the same
+engine-level fact `reduce-parser` already established.
+
+The genuine surprise: converting each shape's nesting-count crash floor into
+rule-frame terms (the units `MAX_RULE_DEPTH` actually bounds) shows the
+`not` prefix chain — which tolerates by far the *most* nesting levels of
+the six (205, alongside its near-twin the unary-minus chain) — has the
+*lowest* rule-frame floor (218), lower even than nested-`if` (289), which
+tolerates far fewer levels (137). Assuming either "the shape with the fewest
+tolerated levels must bind" (nested-`if`, wrong here) or "parenthesised
+nesting binds, since it does for nearly every sibling `*-parser` crate in
+this repo" (also wrong — parens has the *highest* rule-frame floor of the
+six) would each have shipped a cap unsafe specifically for prefix chains.
+`MAX_RULE_DEPTH = 150` sits about 31.2% below the binding 218 floor. Full
+measurement table and reasoning in `MAX_RULE_DEPTH`'s own doc comment
+(`src/lib.rs`).
+
+## Where this fits
+
+`maple-parser` is MP-3 of Maple's frontend crates, consuming the token
+stream from `maple-lexer` (MP-2) against
+`code/grammars/maple/maple.grammar` to build the `GrammarASTNode` CST a
+future `maple-runtime` (MP-4, not yet started) will lower into
+`symbolic_ir::IRNode` and evaluate with `symbolic_vm::VM` over the stock
+`SymbolicBackend`. MP-4 will need to know this crate's two disclosed
+divergences from `reduce-parser`'s shape when it lowers: `if`/`:=` are
+statement-only (never nested inside an `expr`), and `f(x) := e` never
+reaches the lowering stage at all, since it never parses.

--- a/code/packages/rust/maple-parser/required_capabilities.json
+++ b/code/packages/rust/maple-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/maple-parser",
+  "capabilities": [],
+  "justification": "Pure computation. The Maple grammar is embedded as generated Rust code; tokenizing and parsing need no filesystem, network, or process access."
+}

--- a/code/packages/rust/maple-parser/src/_grammar.rs
+++ b/code/packages/rust/maple-parser/src/_grammar.rs
@@ -1,0 +1,281 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: maple.grammar
+// Regenerate with: grammar-tools compile-grammar maple.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+            ] },
+            line_number: 288,
+        },
+        GrammarRule {
+            name: r#"statement_line"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"SEMI"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 294,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"if_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+            ] },
+            line_number: 298,
+        },
+        GrammarRule {
+            name: r#"if_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"if"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Literal { value: r#"then"#.to_string() },
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"elif"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                        GrammarElement::Literal { value: r#"then"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"else"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"end"#.to_string() },
+                            GrammarElement::Literal { value: r#"if"#.to_string() },
+                        ] },
+                        GrammarElement::Literal { value: r#"fi"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 342,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"ASSIGN"#.to_string() },
+                    GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::RuleReference { name: r#"arrow_def"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 351,
+        },
+        GrammarRule {
+            name: r#"arrow_def"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"arrow_params"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ARROW"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 354,
+        },
+        GrammarRule {
+            name: r#"arrow_params"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                            GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                    GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                                ] }) },
+                        ] }) },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+            ] },
+            line_number: 362,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+            line_number: 371,
+        },
+        GrammarRule {
+            name: r#"logical_or"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"or"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 373,
+        },
+        GrammarRule {
+            name: r#"logical_and"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"and"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 374,
+        },
+        GrammarRule {
+            name: r#"logical_not"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"not"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
+            ] },
+            line_number: 375,
+        },
+        GrammarRule {
+            name: r#"comparison"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NEQ"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LESS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GREATER"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 378,
+        },
+        GrammarRule {
+            name: r#"additive"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 380,
+        },
+        GrammarRule {
+            name: r#"multiplicative"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"TIMES"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 384,
+        },
+        GrammarRule {
+            name: r#"unary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"power"#.to_string() },
+            ] },
+            line_number: 389,
+        },
+        GrammarRule {
+            name: r#"power"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"postfix"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"CARET"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 398,
+        },
+        GrammarRule {
+            name: r#"postfix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"atom"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arglist"#.to_string() }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 401,
+        },
+        GrammarRule {
+            name: r#"arglist"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 403,
+        },
+        GrammarRule {
+            name: r#"atom"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Literal { value: r#"true"#.to_string() },
+                GrammarElement::Literal { value: r#"false"#.to_string() },
+                GrammarElement::RuleReference { name: r#"list_literal"#.to_string() },
+                GrammarElement::RuleReference { name: r#"set_literal"#.to_string() },
+                GrammarElement::RuleReference { name: r#"group"#.to_string() },
+            ] },
+            line_number: 405,
+        },
+        GrammarRule {
+            name: r#"list_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arglist"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 419,
+        },
+        GrammarRule {
+            name: r#"set_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arglist"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 433,
+        },
+        GrammarRule {
+            name: r#"group"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 435,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/maple-parser/src/lib.rs
+++ b/code/packages/rust/maple-parser/src/lib.rs
@@ -1,0 +1,776 @@
+//! # Maple Parser — building a syntax tree for Maple (a subset).
+//!
+//! Turns the token stream from [`coding_adventures_maple_lexer`] into a parse
+//! tree using the generic
+//! [`GrammarParser`](parser::grammar_parser::GrammarParser), driven by the
+//! embedded `maple.grammar` (`src/_grammar.rs`). It hand-writes no parsing
+//! logic. A sibling of `reduce-parser` / `derive-parser` / `macsyma-parser` /
+//! `wolfram-parser`. See `code/specs/MA09-maple-language.md`.
+//!
+//! ## What the tree captures
+//!
+//! Maple's surface splits into two nonterminals that never call back into
+//! each other — `statement` (assignment, the arrow-operator definition, and
+//! the `if`/`elif`/`else`/`end if`|`fi` conditional — Programming Guide
+//! Chapter 5 "Maple Statements") and `expr` (the ordinary arithmetic/
+//! relational/logical chain — Chapter 3 "Maple Expressions"). See
+//! `maple.grammar`'s own "Design decision: statements vs. expressions"
+//! header comment for why this split exists and what it deliberately
+//! excludes (`if`/`:=` are never usable as a nested expression in this
+//! subset, unlike `reduce-parser`'s identical-looking shape). This parser
+//! produces the surface tree whose rule names (`statement`, `if_expr`,
+//! `assignment`, `arrow_def`, `logical_or`, `comparison`, `additive`,
+//! `multiplicative`, `power`, `postfix`, `atom`, `list_literal`,
+//! `set_literal`, …) a future `maple-runtime` (MP-4) will lower into the
+//! canonical `symbolic-ir` heads (`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`/
+//! `Equal`/`NotEqual`/`Less`/`Greater`/`LessEqual`/`GreaterEqual`/`And`/`Or`/
+//! `Not`/`Assign`/`Define`/`If`/`List`/`Set`/…).
+//!
+//! ```text
+//! Maple source
+//!    |
+//!    v
+//! coding_adventures_maple_lexer::tokenize_maple  ->  Vec<Token>
+//!    |
+//!    v
+//! parser::GrammarParser  (driven by the embedded maple.grammar)
+//!    |
+//!    v
+//! GrammarASTNode  <- the tree MP-4 lowers to symbolic-ir
+//! ```
+
+use coding_adventures_maple_lexer::{tokenize_maple, try_tokenize_maple};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+mod _grammar;
+
+/// Recursion-depth cap for the Maple [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own `Result`-returning entry points ever get a chance to report
+/// anything).
+///
+/// # Six recursion shapes, measured independently, per MA06 §6's established
+/// methodology
+///
+/// `maple.grammar` has no single dominant recursive shape the way a plain
+/// arithmetic-only grammar might — the statement/expression split (see
+/// `maple.grammar`'s own "statements vs. expressions" design-decision
+/// comment) and the two distinct bracket-delimited aggregate literals each
+/// introduce their own self-referential production. Every "flat chain of one
+/// operator" production written with EBNF `{ x }` repetition
+/// (`logical_or`, `logical_and`, `additive`, `multiplicative`, the `elif`
+/// chain in `if_expr`, `arglist`, `arrow_params`' own `{ COMMA NAME }`) costs
+/// *zero* native stack regardless of width — confirmed directly by reading
+/// [`parser::grammar_parser`]'s own `match_element` implementation (not
+/// re-measured by a throwaway probe here, since `reduce-parser`'s own
+/// `MAX_RULE_DEPTH` doc comment already established this as a fact about the
+/// *shared engine* itself, not about any one grammar: the `Repetition` arm is
+/// a plain `loop { ... }` where each iteration's `match_element` call
+/// returns before the next iteration begins, so the *native* call stack
+/// never grows with iteration count, only with the nesting *within* one
+/// iteration's own match — the same reasoning applies unchanged to every
+/// grammar built on this parser, including this one).
+///
+/// What genuinely recurses in `maple.grammar` are its distinct
+/// self-referential (right-recursive, prefix-recursive, or mutually-nested)
+/// productions, each measured independently below with the same methodology
+/// every sibling `*-parser` crate's own `MAX_RULE_DEPTH` doc comment uses:
+/// binary search, an *uncapped* `GrammarParser` (`max_depth = usize::MAX`),
+/// a `std::thread::spawn` worker with the **default ~2 MiB stack** (no
+/// `stack_size` override), one fresh **subprocess per data point** (a real
+/// native-stack overflow calls `process::abort()`, which kills the whole
+/// process, not just the offending thread — an in-process loop cannot
+/// survive past the first crash to report a clean number), in a **debug**
+/// build (`cargo test`'s own default) since debug frames are meaningfully
+/// larger than release frames.
+///
+/// 1. **Parenthesised nesting**, `((((…5…))))` — `group -> expr ->
+///    logical_or -> logical_and -> logical_not -> comparison -> additive ->
+///    multiplicative -> unary -> power -> postfix -> atom -> group -> …` —
+///    cycles through the *entire* expression precedence cascade every
+///    nesting level. Measured: parses safely up to **23 levels**, crashes
+///    the process at **24**.
+/// 2. **List-literal nesting**, `[[[[…5…]]]]` — `list_literal -> arglist ->
+///    expr -> … -> atom -> list_literal -> …` — structurally distinct from
+///    parenthesised nesting (one extra `arglist` rule-frame per level,
+///    confirmed by inspecting `maple.grammar`'s own rule graph, not
+///    assumed): `group` wraps `expr` directly, but `list_literal` wraps
+///    `expr` through `arglist` first. Set-literal nesting (`{{{…}}}`) shares
+///    this *exact* rule-frame shape (`set_literal -> arglist -> expr -> …`
+///    is identical in every respect except which bracket token is matched),
+///    so it was not separately measured — this was confirmed by direct
+///    inspection of the rule graph (both `list_literal` and `set_literal`
+///    reuse the identical `arglist` production), not assumed by shape
+///    resemblance the way MA06 §6 warns against; the two productions are
+///    provably, not just plausibly, identical in recursion cost. Measured:
+///    parses safely up to **21 levels**, crashes at **22**.
+/// 3. **A `not` prefix chain**, `not not not … x` — `logical_not`'s own
+///    `"not" logical_not` self-reference. Measured: parses safely up to
+///    **205 levels**, crashes at **206**.
+/// 4. **A unary-minus prefix chain**, `- - - … x` — `unary`'s own `MINUS
+///    unary` self-reference. Measured: parses safely up to **205 levels**,
+///    crashes at **206**.
+/// 5. **A flat power (`^`) chain**, `1^1^1^ … ^1` — `power`'s own `[ CARET
+///    unary ]` continuation, cycling `power -> unary -> power -> …` per
+///    level (mirroring `reduce-parser`'s identical `power`/`unary` mutual
+///    reference; Maple has no `**` synonym, so only `^` was used). Measured:
+///    parses safely up to **102 levels**, crashes at **103**.
+/// 6. **Nested `if`/`end if`, or `fi`**, `if 1 then if 1 then … 5 … end if
+///    end if` — `if_expr`'s `then`-branch is a `statement`, and `statement`'s
+///    first alternative is `if_expr` again, so nesting `if`s inside their
+///    own `then`-branch cycles `if_expr -> statement -> if_expr -> …`. This
+///    is the one genuinely new shape with no `reduce-parser` analogue at all
+///    (REDUCE's `if`/`else` chain has no closing keyword to nest through;
+///    Maple's does) — measured using the `end if` closing spelling. Measured:
+///    parses safely up to **137 levels**, crashes at **138**. The `fi`
+///    closing spelling was spot-checked at this exact boundary (136 and 137
+///    levels) and confirmed to behave identically (137 safe, 138 crash) —
+///    expected, since the closing spelling is matched entirely within one
+///    `if_expr` invocation on the way *back up* the recursion and does not
+///    itself add or remove any recursive call.
+///
+/// # The binding constraint is a rule-frame floor, not a nesting-count one
+///
+/// Exactly as `reduce-parser`'s own doc comment warns, the *nesting-count*
+/// floors above do not by themselves say which shape binds
+/// `MAX_RULE_DEPTH` — `self.depth` counts *named-rule* invocations, and
+/// different shapes cost a different number of rule-frames per nesting
+/// level. Converting each measured nesting-count floor into rule-frame terms
+/// (binary search over `with_max_depth` against a fixed 5000-level input of
+/// each shape, so the *cap itself* — not the input's own finite length — is
+/// always what triggers first; same default ~2 MiB stack, same debug build):
+///
+/// | Shape | Nesting-count floor | Rule-frame floor |
+/// |---|---|---|
+/// | Parens | 23 safe / 24 crash | 298 safe / 299 crash |
+/// | List-literal (= set-literal) | 21 safe / 22 crash | 289 safe / 290 crash |
+/// | `not` chain | 205 safe / 206 crash | **218 safe / 219 crash** |
+/// | Unary-minus chain | 205 safe / 206 crash | 219 safe / 220 crash |
+/// | Power (`^`) chain | 102 safe / 103 crash | 220 safe / 221 crash |
+/// | Nested `if`/`end if` (= `fi`) | 137 safe / 138 crash | 289 safe / 290 crash |
+///
+/// The genuine surprise, mirroring `reduce-parser`'s own: the `not` prefix
+/// chain — which tolerates by far the *most* nesting levels of the six (205,
+/// alongside its near-twin the unary-minus chain) — has the *lowest*
+/// rule-frame floor (218), lower even than the nested-`if` shape (289),
+/// which tolerates *far fewer* levels (137) before crashing. Each `not`
+/// link's *persistent* per-level cost is exactly one `logical_not`
+/// rule-frame (mirroring the unary-minus chain's identical one-`unary`-frame
+/// cost) — cheaper, in rule-frame-count terms, than parenthesised nesting's
+/// twelve frames per level or nested-`if`'s two (`if_expr` + `statement`) —
+/// yet whatever native-stack *bytes* this specific self-referential call
+/// path (`logical_not` calling `match_element` on a `Sequence` containing a
+/// `Literal` match followed immediately by a recursive `RuleReference` back
+/// into `logical_not`) consumes per crossing evidently costs more than the
+/// other five shapes' own per-frame byte cost, so it reaches the native
+/// ceiling at a *lower total rule-frame count* despite needing *far more*
+/// levels to get there. Naively assuming either "the shape that tolerates
+/// fewest nesting levels must bind" (nested-`if`, wrong) or "parenthesised
+/// nesting binds, since it does for nearly every sibling `*-parser` crate in
+/// this repo" (also wrong — parens has the *highest* rule-frame floor of the
+/// six here) would each have shipped a cap unsafe specifically for `not`/
+/// unary-minus prefix chains. This confirms, rather than merely restates,
+/// MA06 §6's warning that shape analogies — nesting-count rankings *and*
+/// which shape historically binds in a sibling grammar — do not transfer
+/// across grammars with a different rule-recursion shape.
+///
+/// `MAX_RULE_DEPTH` is set to **150** — about 31.2% below the binding
+/// `not`-chain rule-frame floor of 218 (a comparable margin to
+/// `reduce-parser`'s own ~28.5%, `apl-parser`'s ~26.5%, `j-parser`'s ~30%,
+/// `derive-parser`'s ~33%), and therefore safely below all five other
+/// rule-frame floors (219, 220, 289, 289, 298) as well.
+///
+/// Measured real-input headroom at `150` (using the CAPPED parser, i.e.
+/// `create_maple_parser`/`try_parse_maple`, so no crash risk at all):
+/// parenthesised nesting parses cleanly up to 11 levels (12 trips the cap);
+/// list-literal (and, by the proven-identical shape above, set-literal)
+/// nesting parses cleanly up to 10 levels (11 trips); a `not` chain and a
+/// unary-minus chain each parse cleanly up to 135 levels (136 trips); a
+/// power chain parses cleanly up to 67 levels (68 trips); nested `if`s parse
+/// cleanly up to 67 levels (68 trips) — all comfortably beyond anything a
+/// hand-written Maple program needs, and all six independently confirmed not
+/// to crash a default-stack thread even thousands of levels past the cap
+/// (see this crate's tests).
+const MAX_RULE_DEPTH: usize = 150;
+
+/// Create a [`GrammarParser`] wired to the Maple grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+pub fn create_maple_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_maple(source);
+    GrammarParser::new(tokens, _grammar::parser_grammar()).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Parse Maple source text into a [`GrammarASTNode`] rooted at `program`.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_maple`] to handle
+/// errors.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_maple_parser::parse_maple;
+/// let ast = parse_maple("x := 5;\n");
+/// assert_eq!(ast.rule_name, "program");
+/// ```
+pub fn parse_maple(source: &str) -> GrammarASTNode {
+    create_maple_parser(source)
+        .parse()
+        .unwrap_or_else(|e| panic!("Maple parse failed: {e}"))
+}
+
+/// Parse Maple source text, returning a `Result` instead of panicking.
+pub fn try_parse_maple(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_maple(source)?;
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+        .with_max_depth(MAX_RULE_DEPTH)
+        .parse()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        node.rule_name == name
+            || node.children.iter().any(|c| match c {
+                ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                ASTNodeOrToken::Token(_) => false,
+            })
+    }
+
+    fn parses(src: &str) -> bool {
+        try_parse_maple(src).is_ok()
+    }
+
+    #[test]
+    fn program_is_the_root() {
+        assert_eq!(parse_maple("1;\n").rule_name, "program");
+    }
+
+    #[test]
+    fn bare_trailing_statement_with_no_terminator_parses() {
+        assert!(parses("1"));
+    }
+
+    #[test]
+    fn semi_and_colon_are_interchangeable_terminators() {
+        assert!(parses("x := 1; y := 2:"));
+    }
+
+    // --- Function application uses ordinary parens -------------------------
+
+    #[test]
+    fn function_call_uses_ordinary_parens() {
+        let ast = parse_maple("sin(x);\n");
+        assert!(contains_rule(&ast, "postfix"));
+        assert!(contains_rule(&ast, "arglist"));
+    }
+
+    #[test]
+    fn multi_arg_calls_parse() {
+        assert!(parses("f(x, y, z);\n"));
+    }
+
+    #[test]
+    fn nested_function_calls_parse() {
+        assert!(parses("f(g(x));\n"));
+    }
+
+    // --- `:=` is assignment, `=` is equation, never confused ---------------
+
+    #[test]
+    fn assignment_parses() {
+        let ast = parse_maple("x := 5;\n");
+        assert!(contains_rule(&ast, "assignment"));
+    }
+
+    #[test]
+    fn eq_is_equation_distinct_from_assign() {
+        assert!(parses("x = 4;\n"));
+        assert!(contains_rule(&parse_maple("x = 4;\n"), "comparison"));
+    }
+
+    #[test]
+    fn every_comparison_operator_parses() {
+        for op in ["=", "<>", "<", ">", "<=", ">="] {
+            let src = format!("a {op} b;\n");
+            assert!(parses(&src), "`{src}` should parse");
+        }
+    }
+
+    // --- The arrow-operator / Define shape ----------------------------------
+
+    #[test]
+    fn arrow_definition_with_two_parameters_parses() {
+        let ast = parse_maple("f := (x, y) -> x + y;\n");
+        assert!(contains_rule(&ast, "arrow_def"));
+        assert!(contains_rule(&ast, "arrow_params"));
+    }
+
+    #[test]
+    fn arrow_definition_with_one_bare_parameter_parses() {
+        let ast = parse_maple("f := x -> x;\n");
+        assert!(contains_rule(&ast, "arrow_def"));
+    }
+
+    #[test]
+    fn arrow_definition_with_zero_parameters_parses() {
+        // `() -> 5` -- a nullary constant function. Not one of MA09 §3's own
+        // worked examples, but a natural, undeliberate fallout of
+        // `arrow_params`' own optional inner list -- see maple.grammar's
+        // "arrow_params" comment.
+        assert!(parses("f := () -> 5;\n"));
+    }
+
+    #[test]
+    fn plain_assignment_does_not_produce_an_arrow_def_node() {
+        // `f := x;` (assigning a variable's VALUE) must backtrack cleanly
+        // out of `arrow_def` (which requires an ARROW after the bare name)
+        // and fall through to the plain `expr` alternative instead.
+        let ast = parse_maple("f := x;\n");
+        assert!(contains_rule(&ast, "assignment"));
+        assert!(!contains_rule(&ast, "arrow_def"));
+    }
+
+    #[test]
+    fn arrow_never_appears_outside_an_assignment_rhs() {
+        // MA09 §3: `->` is used ONLY as a Define right-hand side. A bare
+        // arrow expression with no `NAME :=` prefix must be a syntax error
+        // -- there is nowhere else in this grammar `ARROW` is referenced.
+        assert!(try_parse_maple("(x) -> x;\n").is_err());
+        assert!(try_parse_maple("x -> x;\n").is_err());
+    }
+
+    #[test]
+    fn arrow_cannot_nest_inside_arithmetic() {
+        assert!(try_parse_maple("y := 1 + (x -> x);\n").is_err());
+    }
+
+    // --- `f(x) := e` (the remember-table spelling) is rejected --------------
+
+    #[test]
+    fn remember_table_spelling_is_rejected() {
+        // MA09 §1/§4: `f(x) := expr` is real Maple's narrower remember-table
+        // mechanism, deliberately EXCLUDED from this subset -- this
+        // grammar's `assignment` left-hand side is a bare NAME, so this
+        // spelling must fail to parse entirely, not merely lower
+        // differently at a later stage. See maple.grammar's own "assignment
+        // left-hand side" design-decision comment.
+        assert!(try_parse_maple("f(x) := 1;\n").is_err());
+        assert!(try_parse_maple("h(l, m) := l + m;\n").is_err());
+    }
+
+    // --- `if` and `:=` are statements, never nested expressions -------------
+
+    #[test]
+    fn if_is_not_usable_as_an_assignment_rhs() {
+        // Unlike reduce-parser's `if_is_usable_as_an_expression` test --
+        // MA09 makes no equivalent claim for Maple, and real Maple's own
+        // conditional-VALUE idiom is the `piecewise` library call, not a
+        // bare `if`. See maple.grammar's "statements vs. expressions" design
+        // decision.
+        assert!(try_parse_maple("x := if a then 1 else 2 end if;\n").is_err());
+    }
+
+    #[test]
+    fn chained_assignment_is_rejected() {
+        // Unlike reduce-parser's `assignment_right_associates` test -- MA09
+        // cites no equivalent to REDUCE manual §2.7's "a:=b:=c evaluates as
+        // a:=(b:=c)" for Maple, and every MA09 §3 worked example is a
+        // single, non-chained assignment.
+        assert!(try_parse_maple("a := b := 5;\n").is_err());
+    }
+
+    // --- List vs. set literals are genuinely distinct productions ----------
+
+    #[test]
+    fn list_literal_uses_square_brackets() {
+        let ast = parse_maple("[a, b, c];\n");
+        assert!(contains_rule(&ast, "list_literal"));
+        assert!(!contains_rule(&ast, "set_literal"));
+    }
+
+    #[test]
+    fn set_literal_uses_curly_braces() {
+        let ast = parse_maple("{a, b, c};\n");
+        assert!(contains_rule(&ast, "set_literal"));
+        assert!(!contains_rule(&ast, "list_literal"));
+    }
+
+    #[test]
+    fn empty_list_literal_parses() {
+        let ast = parse_maple("[];\n");
+        assert!(contains_rule(&ast, "list_literal"));
+    }
+
+    #[test]
+    fn empty_set_literal_parses() {
+        let ast = parse_maple("{};\n");
+        assert!(contains_rule(&ast, "set_literal"));
+    }
+
+    #[test]
+    fn list_and_set_literal_in_a_call_snippet() {
+        assert!(parses("g([1, 2, 3], {1, 2, 2});\n"));
+    }
+
+    // --- Boolean literals and logical operators -----------------------------
+
+    #[test]
+    fn boolean_literals_parse() {
+        assert!(parses("true;\n"));
+        assert!(parses("false;\n"));
+    }
+
+    #[test]
+    fn boolean_keywords_parse() {
+        assert!(parses("a and b or not c;\n"));
+        assert!(contains_rule(&parse_maple("a and b;\n"), "logical_and"));
+        assert!(contains_rule(&parse_maple("a or b;\n"), "logical_or"));
+        assert!(contains_rule(&parse_maple("not a;\n"), "logical_not"));
+    }
+
+    #[test]
+    fn uppercase_keyword_spellings_lex_as_plain_names_not_keywords() {
+        // maple.tokens' keywords are lowercase-only (mirroring
+        // reduce.tokens, the opposite of derive.tokens' uppercase
+        // AND/OR/NOT) -- `AND` here is just a NAME, so this is a bare `a
+        // AND b` juxtaposition with no operator between two names, which is
+        // not valid syntax in this subset (no juxtaposition production
+        // exists anywhere in this grammar, MA09 §4).
+        assert!(try_parse_maple("a AND b;\n").is_err());
+    }
+
+    #[test]
+    fn bare_juxtaposed_names_with_no_operator_is_rejected() {
+        // Mirrors reduce-parser's identically-named, identically-motivated
+        // regression test: this is a regression test for exactly the bug
+        // `program`'s own grammar comment documents -- an earlier draft
+        // could fold "no terminator" into `statement_line` itself (tried
+        // per repetition iteration, not just once at the very end), which
+        // would let `a`, `AND`, and `b;` each parse as their own bare
+        // statement and silently consume the entire input as three separate
+        // program items.
+        assert!(try_parse_maple("a AND b;\n").is_err());
+        assert!(try_parse_maple("a b\n").is_err());
+    }
+
+    // --- Arithmetic precedence and associativity ----------------------------
+
+    #[test]
+    fn arithmetic_precedence_nests_correctly() {
+        // `1 + 2 * 3` must parse as `1 + (2*3)`, not `(1+2)*3` -- the tree
+        // must contain both `additive` and `multiplicative`, with
+        // `multiplicative` nested inside the `additive` continuation.
+        let ast = parse_maple("1 + 2 * 3;\n");
+        assert!(contains_rule(&ast, "additive"));
+        assert!(contains_rule(&ast, "multiplicative"));
+    }
+
+    #[test]
+    fn explicit_star_is_required_no_pow_synonym_double_star() {
+        // MA09 §3: `^` ONLY, no `**` synonym. `a ** b` must NOT parse as a
+        // single power expression -- `**` lexes as two TIMES tokens
+        // (confirmed by maple-lexer's own `double_star_is_not_a_single_pow_token`
+        // test), so `a ** b` is `a` followed by a bare `*` with nothing
+        // between the two stars, i.e. `a * (* b)` -- a syntax error, since
+        // `multiplicative`'s right operand must be a `unary`, and a bare
+        // `*` is not a valid start of one.
+        assert!(try_parse_maple("a ** b;\n").is_err());
+    }
+
+    #[test]
+    fn power_is_right_associative_by_shape() {
+        assert!(parses("4^3^2;\n"));
+        let ast = parse_maple("4^3^2;\n");
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn unary_minus_binds_looser_than_power() {
+        let ast = parse_maple("-x^2;\n");
+        assert!(contains_rule(&ast, "unary"));
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn grouping_parens_parse() {
+        assert!(parses("(1 + 2) * 3;\n"));
+        assert!(contains_rule(&parse_maple("(1 + 2) * 3;\n"), "group"));
+    }
+
+    // --- `if`/`elif`/`else` closed both ways --------------------------------
+
+    #[test]
+    fn if_then_end_if_parses() {
+        let ast = parse_maple("if x > 0 then 1 end if;\n");
+        assert!(contains_rule(&ast, "if_expr"));
+    }
+
+    #[test]
+    fn if_then_else_end_if_parses() {
+        let ast = parse_maple("if x > 0 then 1 else -1 end if;\n");
+        assert!(contains_rule(&ast, "if_expr"));
+    }
+
+    #[test]
+    fn if_then_fi_parses() {
+        // The `fi` closing spelling -- "if" reversed.
+        let ast = parse_maple("if x > 0 then 1 else -1 fi;\n");
+        assert!(contains_rule(&ast, "if_expr"));
+    }
+
+    #[test]
+    fn if_elif_else_end_if_and_fi_produce_equivalent_shapes() {
+        // Both closing spellings must parse to a structurally equivalent
+        // if_expr shape (same number of elif arms, same else presence) --
+        // matching MA09 §3's own two-worked-spelling example.
+        let end_if = parse_maple(
+            "if x > 0 then 1 elif x < 0 then -1 else 0 end if;\n",
+        );
+        let fi = parse_maple("if x > 0 then 1 elif x < 0 then -1 else 0 fi;\n");
+        assert!(contains_rule(&end_if, "if_expr"));
+        assert!(contains_rule(&fi, "if_expr"));
+
+        fn count_nodes(node: &GrammarASTNode, name: &str) -> usize {
+            let mut n = if node.rule_name == name { 1 } else { 0 };
+            for c in &node.children {
+                if let ASTNodeOrToken::Node(child) = c {
+                    n += count_nodes(child, name);
+                }
+            }
+            n
+        }
+        // Both must contain exactly one `if_expr` and the elif condition
+        // must have been parsed (an `expr`/`comparison` for `x < 0`).
+        assert_eq!(count_nodes(&end_if, "if_expr"), 1);
+        assert_eq!(count_nodes(&fi, "if_expr"), 1);
+    }
+
+    #[test]
+    fn elif_chain_preserves_every_arm() {
+        let ast = parse_maple(
+            "if a then 1 elif b then 2 elif c then 3 else 4 end if;\n",
+        );
+        // Every `elif` condition ("b" and "c") and its body ("2" and "3")
+        // must appear somewhere in the tree, in order -- the flat `{ "elif"
+        // ... }` repetition preserves the whole chain as sibling children.
+        fn all_names(node: &GrammarASTNode, out: &mut Vec<String>) {
+            for c in &node.children {
+                match c {
+                    ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                        out.push(t.value.clone())
+                    }
+                    ASTNodeOrToken::Node(n) => all_names(n, out),
+                    _ => {}
+                }
+            }
+        }
+        let mut names = Vec::new();
+        all_names(&ast, &mut names);
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn if_can_branch_to_an_assignment() {
+        // MA09 §3's own s1/s2/s3 labelling reads as statement-shaped, not
+        // narrowly expression-shaped -- an `if` branching to an assignment
+        // must be supported even though `if` is never itself usable as a
+        // nested expression (see maple.grammar's "statements vs.
+        // expressions" design decision).
+        let ast = parse_maple("if a then x := 1 else x := 2 end if;\n");
+        assert!(contains_rule(&ast, "if_expr"));
+        assert!(contains_rule(&ast, "assignment"));
+    }
+
+    #[test]
+    fn nested_if_resolves_unambiguously_with_no_dangling_else() {
+        // Unlike reduce-parser's dangling-else test -- Maple's explicit
+        // closing keywords mean there is only one place an outer `else`
+        // could possibly attach, by construction.
+        assert!(parses("if a then if b then c end if else d end if;\n"));
+        let ast = parse_maple("if a then if b then c end if else d end if;\n");
+        fn count_if_exprs(node: &GrammarASTNode) -> usize {
+            let mut n = if node.rule_name == "if_expr" { 1 } else { 0 };
+            for c in &node.children {
+                if let ASTNodeOrToken::Node(child) = c {
+                    n += count_if_exprs(child);
+                }
+            }
+            n
+        }
+        assert_eq!(count_if_exprs(&ast), 2);
+    }
+
+    // --- Multi-statement programs --------------------------------------------
+
+    #[test]
+    fn a_multi_statement_program_parses() {
+        let ast = parse_maple("x := 1; y := 2; x + y;\n");
+        let stmt_lines: usize = ast
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement_line"))
+            .count();
+        assert_eq!(stmt_lines, 3);
+    }
+
+    #[test]
+    fn syntax_error_is_reported() {
+        assert!(try_parse_maple("1 +\n").is_err());
+        assert!(try_parse_maple("(1 + 2\n").is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- exercises all six
+    // independently-measured shapes documented on `MAX_RULE_DEPTH`.
+    // -------------------------------------------------------------------
+
+    fn nested_paren_source(n: usize) -> String {
+        format!("{}5{};\n", "(".repeat(n), ")".repeat(n))
+    }
+
+    fn nested_list_source(n: usize) -> String {
+        format!("{}5{};\n", "[".repeat(n), "]".repeat(n))
+    }
+
+    fn not_chain_source(n: usize) -> String {
+        format!("{}a;\n", "not ".repeat(n))
+    }
+
+    fn unary_minus_chain_source(n: usize) -> String {
+        format!("{}a;\n", "-".repeat(n))
+    }
+
+    fn power_chain_source(n: usize) -> String {
+        let mut s = String::from("1");
+        for _ in 0..n {
+            s.push_str("^1");
+        }
+        s.push_str(";\n");
+        s
+    }
+
+    fn nested_if_source(n: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str("if 1 then ");
+        }
+        s.push('5');
+        for _ in 0..n {
+            s.push_str(" end if");
+        }
+        s.push_str(";\n");
+        s
+    }
+
+    /// Deeply-nested input, for every measured shape, must produce a
+    /// recoverable error, not overflow the native stack. Parses 5000
+    /// levels -- far past `MAX_RULE_DEPTH` -- on a worker thread with a
+    /// generous 32 MiB stack, so the *guard* is what stops the recursion,
+    /// not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow_for_every_shape() {
+        let sources = vec![
+            nested_paren_source(5000),
+            nested_list_source(5000),
+            not_chain_source(5000),
+            unary_minus_chain_source(5000),
+            power_chain_source(5000),
+            nested_if_source(2000),
+        ];
+        let handle = std::thread::Builder::new()
+            .name("maple-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                for src in sources {
+                    let result = try_parse_maple(&src);
+                    assert!(
+                        result.is_err(),
+                        "deeply-nested input must fail with an error, not parse or crash"
+                    );
+                }
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. Parses far-too-deep input, for every
+    /// shape, on a worker thread with **no** `stack_size` override (the
+    /// same ~2 MiB a default thread gets).
+    #[test]
+    fn test_cap_trips_before_overflow_on_default_stack_for_every_shape() {
+        let sources = vec![
+            nested_paren_source(5000),
+            nested_list_source(5000),
+            not_chain_source(5000),
+            unary_minus_chain_source(5000),
+            power_chain_source(5000),
+            nested_if_source(2000),
+        ];
+        let handle = std::thread::spawn(move || {
+            for src in sources {
+                let result = try_parse_maple(&src);
+                assert!(result.is_err(), "deeply-nested input must error, not crash");
+            }
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// Reasonable, hand-writable nesting for every shape stays well under
+    /// the cap.
+    #[test]
+    fn test_reasonable_nesting_stays_under_the_cap_for_every_shape() {
+        assert!(try_parse_maple(&nested_paren_source(3)).is_ok());
+        assert!(try_parse_maple(&nested_list_source(3)).is_ok());
+        assert!(try_parse_maple(&not_chain_source(5)).is_ok());
+        assert!(try_parse_maple(&unary_minus_chain_source(5)).is_ok());
+        assert!(try_parse_maple(&power_chain_source(5)).is_ok());
+        assert!(try_parse_maple(&nested_if_source(3)).is_ok());
+    }
+
+    /// Input that nests *exactly up to* `MAX_RULE_DEPTH`'s measured
+    /// real-input headroom for every shape still parses cleanly, and one
+    /// level deeper cleanly trips the cap. These exact boundary counts were
+    /// found empirically by binary-searching `try_parse_maple` (the CAPPED
+    /// public API, `MAX_RULE_DEPTH = 150`) against increasing nesting counts
+    /// for each shape -- see `MAX_RULE_DEPTH`'s own doc comment ("Measured
+    /// real-input headroom at `150`"). Without this test, a future change to
+    /// the constant could silently move these boundaries without anyone
+    /// noticing, mirroring `j-parser`'s own per-shape boundary tests.
+    #[test]
+    fn test_headroom_boundary_for_every_shape() {
+        assert!(try_parse_maple(&nested_paren_source(11)).is_ok());
+        assert!(try_parse_maple(&nested_paren_source(12)).is_err());
+
+        assert!(try_parse_maple(&nested_list_source(10)).is_ok());
+        assert!(try_parse_maple(&nested_list_source(11)).is_err());
+
+        assert!(try_parse_maple(&not_chain_source(135)).is_ok());
+        assert!(try_parse_maple(&not_chain_source(136)).is_err());
+
+        assert!(try_parse_maple(&unary_minus_chain_source(135)).is_ok());
+        assert!(try_parse_maple(&unary_minus_chain_source(136)).is_err());
+
+        assert!(try_parse_maple(&power_chain_source(67)).is_ok());
+        assert!(try_parse_maple(&power_chain_source(68)).is_err());
+
+        assert!(try_parse_maple(&nested_if_source(67)).is_ok());
+        assert!(try_parse_maple(&nested_if_source(68)).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Implements **MP-3** from `code/specs/MA09-maple-language.md` — the second implementation item for Maple, following the merged MP-2 (`maple-lexer`, #8600). Adds `code/grammars/maple/maple.grammar` (EBNF-like grammar) and a new `maple-parser` crate, over the generic `parser::GrammarParser` engine, mirroring `reduce-parser`'s structure (MA09 §2 explicitly mirrors MA08's 4-part split).

## Design decisions (each documented at length in the grammar file itself)

- **Statements vs. expressions are two separate nonterminals that never call back into each other.** Unlike `reduce.grammar` (where `if`/`<<...>>` sit *above* assignment because REDUCE's manual explicitly says both are value-producing), MA09 makes no equivalent claim for Maple's `if` — real Maple's conditional-*value* idiom is the `piecewise(...)` function call, which the ordinary `postfix` production already handles for free. So `x := if a then 1 else 2 end if;` and `a := b := c;` are both syntax errors here — a disclosed, deliberate divergence from `reduce-parser`'s identical-looking shape.
- **The arrow operator (`->`) is confined to exactly one production** (`assignment`'s first alternative, tried via ordered-choice before falling through to a plain expression) — it cannot appear as a bare statement, inside arithmetic, or as a function argument. The grammar is the enforcement point, not a runtime check.
- **Assignment's LHS is a bare `NAME`**, deliberately narrower than `reduce-parser`'s call-shaped LHS — MA09 §4 explicitly excludes the `f(x) := e` remember-table spelling (which collides with REDUCE's/Derive's own general-definition idiom of the identical shape) from this subset entirely, so it's made unparseable at the grammar level rather than deferred to the runtime.
- **`if`/`elif`/`else`/(`end if`|`fi`)** — Maple's two ways to close a conditional, composed via ordered choice at the one point they can appear, since `maple-lexer` emits `end`/`if`/`fi` as independent keyword tokens. No dangling-else ambiguity exists here at all (unlike every sibling CAS `if`), since Maple requires an explicit close for every conditional.
- **Two distinct bracket-delimited literals** — list `[...]` (ordered) and set `{...}` (unordered) — both reuse the same `arglist` production, syntactically distinguished only by which bracket was used; the Set-vs-List semantic tag is MP-4's (a future runtime) job.

## `MAX_RULE_DEPTH` — measured, not assumed (MA06 §6 methodology)

150, derived by independently measuring 6 distinct self-referential grammar shapes (parenthesized nesting, list/set-literal nesting, `not`-prefix chains, unary-minus chains, `^`-chains, nested `if`) via binary search against an uncapped parser on a real default-stack thread, one fresh subprocess per data point. The binding constraint is the `not`-chain's rule-frame floor (218) — counterintuitively the *lowest* floor despite tolerating the *most* nesting levels of any shape, confirming MA06 §6's warning that nesting-count rankings don't predict which shape actually binds. 150 sits ~31% below that floor and comfortably below all six.

## Test plan

- [x] `cargo test -p coding-adventures-maple-parser` — 45 tests + 1 doctest, all passing (including 4 dedicated depth-cap regression tests proving deeply-nested input returns a clean error, not a crash, on a real default-stack thread)
- [x] `cargo clippy -p coding-adventures-maple-parser --all-targets` — clean
- [x] `grammar-tools validate-grammar` / cross-validation against `maple.tokens` — clean (22 rules, 24 tokens)
- [x] `cargo build --workspace` — no new failures (pre-existing environment-specific `uefi` failure unrelated)
- [x] `/security-review` — **PASSED, no vulnerabilities found** (specifically verified: the depth guard is wired into every public entry point with no bypass path, the cap-derivation reasoning matches the real grammar's actual recursive shapes, no unbounded allocation/recursion outside the counted rule-dispatch mechanism, no unsafe/unwrap on untrusted input)
- [x] Rebased onto current `origin/main` tip (includes the just-merged APL stranded-literal fix, #8606), no conflicts

MP-4 (`maple-runtime` + `maple-repl`) is a separate, unstarted follow-up, exactly like `reduce-runtime`/`reduce-repl` followed `reduce-parser` in their own standalone PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)