### PR TITLE
feat(hl-punjabi): Chapters 2-5 — intro, how-are-you, farewells, first verbs

### DIFF
--- a/code/learning/human-languages/punjabi/CHANGELOG.md
+++ b/code/learning/human-languages/punjabi/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Chapters 2–5 — Introductions, How-are-you, Farewells, First Verbs
+
+- Four new chapters carry Punjabi from Chapter 1 to Chapter 5, matching the
+  leading tracks' arc. One word per lesson, atom-first, Gurmukhi inline; every
+  root traced (`lessons/PA-C0{2,3,4,5}-*`, `book/chapters/ch0{2,3,4,5}-*.tex`).
+  Concept tags reuse the universal `HL01` taxonomy; verbs namespaced (`PA-VERB-*`).
+  Punjabi's two-vocabularies thread (Sanskritic vs. Perso-Arabic) runs throughout.
+- **Ch. 2 — Introducing Yourself**: *nāṁ* (← *nāman* → *name*) → *merā* → *hai*
+  (← *asti* → *is*) → *merā nāṁ … hai* → *tū̃/tusī̃* (← *\*tū* → *thou*) → *kī*
+  (← *ka-* → *what*) → *tuhāḍā nāṁ kī hai?* → *khushī* (Persian — the second
+  vocabulary) → practice. SOV order; two-level "you".
+- **Ch. 3 — How Are You**: *kivēṁ* (how) → *tusī̃ kivēṁ ho?* → *maiṁ* (I; the
+  *hāṁ* "am"/"yes" homophone) → *ṭhīk* (native "fine") → *koī gall nahīṁ*
+  (you're welcome = "no matter"; *nahīṁ* ← PIE *ne) → practice.
+- **Ch. 4 — Farewells**: *phir* → *milāṁge* → *phir milāṁge* (vs. Ch.1's formal
+  *sat srī akāl*) → *rabb rākhā* ("God keep you"; **Arabic** *rabb* + **Sanskrit**
+  *rakṣ-* — the two vocabularies in one blessing) → practice.
+- **Ch. 5 — First Verbs**: *bolṇā* (the *-ṇā* infinitive) → *maiṁ panjābī boldā
+  hāṁ* (I speak Punjabi; *panj* "five," cousin of English *five*, + *āb* "river"
+  = "the five-rivers language") → *rahiṇā* (to live) → *kamm karnā* (to work; ←
+  √kṛ, the root of *namaskār*) → practice. The gendered present habitual. Book
+  compiles clean with XeLaTeX (0 missing chars, 0 undefined refs).
+
 ## Chapter 1 — Greetings (Gurmukhi taught inline)
 
 - New Punjabi track on the HL00 framework — Indo-Aryan, written in Gurmukhi

--- a/code/learning/human-languages/punjabi/README.md
+++ b/code/learning/human-languages/punjabi/README.md
@@ -25,7 +25,18 @@ book.
 
 - **Chapter 1 — Greetings** ([`lessons/PA-C01-*`](./lessons/)): sat srī akāl,
   namaste, dhannavād, shukrīā, hāṇ/nahīṇ, practice. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): *merā nāṇ…*, *tūṇ* / *tusīṇ*.
+- **Chapter 2 — Introducing Yourself** ([`lessons/PA-C02-*`](./lessons/)): nāṁ,
+  merā, hai, **merā nāṁ … hai**, tū̃/tusī̃, kī, **tuhāḍā nāṁ kī hai?**, khushī,
+  practice. Every atom traced; SOV order; two-level "you". In the book.
+- **Chapter 3 — How Are You** ([`lessons/PA-C03-*`](./lessons/)): kivēṁ, **tusī̃
+  kivēṁ ho?**, maiṁ, ṭhīk, koī gall nahīṁ, practice. The copula set; the *hāṁ*
+  "am"/"yes" homophone. In the book.
+- **Chapter 4 — Farewells** ([`lessons/PA-C04-*`](./lessons/)): phir, milāṁge,
+  **phir milāṁge**, rabb rākhā ("God keep you"; Arabic + Sanskrit), practice. In
+  the book.
+- **Chapter 5 — First Verbs** ([`lessons/PA-C05-*`](./lessons/)): bolṇā, **maiṁ
+  panjābī boldā hāṁ** (*panj* "five" + *āb* "river"), rahiṇā, kamm karnā, practice.
+  The gendered present habitual. In the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/punjabi/book/book.tex
+++ b/code/learning/human-languages/punjabi/book/book.tex
@@ -64,4 +64,12 @@ Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
+\input{chapters/ch03-responding}
+
+\input{chapters/ch04-farewells}
+
+\input{chapters/ch05-first-verbs}
+
 \end{document}

--- a/code/learning/human-languages/punjabi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch02-introductions.tex
@@ -1,0 +1,140 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you're glad to meet them:
+
+\begin{center}
+\pa{ਮੇਰਾ ਨਾਂ ਮੀਰਾ ਹੈ।} \quad(\emph{mer\=a n\=a\d{m} Mira hai} --- ``My name is Mira.'')\\
+\pa{ਤੁਹਾਡਾ ਨਾਂ ਕੀ ਹੈ?} \quad(\emph{tuh\=a\d{d}\=a n\=a\d{m} k\=\i\ hai} --- ``What is your name?'')
+\end{center}
+
+Built the same way as the greetings --- each piece taken apart, its letters and
+root, then assembled. \emph{Practice lessons: \texttt{lessons/PA-C02-*.md}.}
+
+\section{\pa{ਨਾਂ} \emph{(n\=a\d{m})} --- ``name,'' a word older than Europe}
+\label{lesson:naam}
+
+\begin{sounds}
+\pa{ਨ} (\emph{na}) $+$ \pa{ਾ} (the \emph{kann\=a}, long \=a) $+$ \pa{ਂ} (the
+\emph{bindi}, nasal) $\to$ \pa{ਨਾਂ} (\emph{n\=a\d{m}}).
+\end{sounds}
+
+\begin{cousinweb}
+\pa{ਨਾਂ} (\emph{n\=a\d{m}}) $\leftarrow$ Sanskrit \emph{n\=aman}, from
+Proto-Indo-European *h\textsubscript{3}n\'{o}mn\d{} --- the \emph{same} ancient
+root as English \textbf{name}, Latin \emph{n\=omen} (English \textbf{noun}), and
+Greek \emph{onoma}. Punjabi \emph{n\=a\d{m}} and English \emph{name} are cousins
+from before either language existed. (Hindi keeps \emph{n\=am}; Punjabi nasalises
+the ending.)
+\end{cousinweb}
+
+\section{\pa{ਮੇਰਾ} \emph{(mer\=a)} --- ``my''}
+\label{lesson:mera}
+
+\begin{sounds}
+\pa{ਮ} (\emph{ma}) $+$ \pa{ੇ} (the \emph{l\=av\=a\d{m}}, \emph{e}-sign) $\to$
+\pa{ਮੇ} (me); \pa{ਰ} (\emph{ra}) $+$ \pa{ਾ} (long \=a) $\to$ \pa{ਰਾ} (r\=a).
+\end{sounds}
+
+\begin{cousinweb}
+\pa{ਮੇਰਾ} (\emph{mer\=a}, ``my'') is on the first-person root \emph{ma-} --- the
+same \emph{ma-}/\emph{me-} behind English \textbf{me}, \textbf{my}, \textbf{mine}
+and Latin \emph{meus}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``My'' agrees with the noun.} \emph{mer\=a} (m.), \emph{mer\=\i} (f.),
+\emph{mere} (pl.). \emph{n\=a\d{m}} is masculine, so \emph{mer\=a n\=a\d{m}}.
+\end{grammarlens}
+
+\section{\pa{ਹੈ} \emph{(hai)} --- ``is,'' cousin of English \emph{is}}
+\label{lesson:hai}
+
+\begin{cousinweb}
+\pa{ਹੈ} (\emph{hai}, ``is'') $\leftarrow$ Sanskrit \emph{asti} (``is''), from PIE
+*h\textsubscript{1}es- --- the root of ``to be'' across the family: English
+\textbf{is}, German \emph{ist}, Latin \emph{est}, Spanish \emph{es}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{The verb goes last.} Punjabi is \emph{subject--object--verb}: ``my name
+Arun \emph{is}.'' The \emph{hai} sits at the end, where English puts ``is'' in the
+middle.
+\end{grammarlens}
+
+\section{\pa{ਮੇਰਾ ਨਾਂ \ldots ਹੈ} \emph{(mer\=a n\=a\d{m} \ldots hai)} --- ``my name is\ldots''}
+\label{lesson:mera-naam-hai}
+
+\pa{ਮੇਰਾ} (my) $+$ \pa{ਨਾਂ} (name) $+$ name $+$ \pa{ਹੈ} (is) $=$ ``my name
+is\ldots'' \emph{Mer\=a n\=a\d{m} Arun hai.} The verb-frame comes last, as always.
+
+\section{\pa{ਤੂੰ} / \pa{ਤੁਸੀਂ} \emph{(t\=u\d{m} / tus\=\i\d{m})} --- ``you,'' familiar and respectful}
+\label{lesson:tu-tusi}
+
+\begin{cousinweb}
+\pa{ਤੂੰ} (\emph{t\=u\d{m}}, familiar ``you'') $\leftarrow$ Sanskrit \emph{tvam},
+from PIE *t\=u --- the same root as English archaic \textbf{thou}, Latin
+\emph{t\=u}, French \emph{tu}. \pa{ਤੁਸੀਂ} (\emph{tus\=\i\d{m}}, respectful) is
+grammatically plural --- courtesy-by-plural, like French \emph{vous}.
+\end{cousinweb}
+
+\begin{grammarlens}
+Two levels: \emph{t\=u\d{m}} (familiar) / \emph{tus\=\i\d{m}} (respectful, also
+plural). For a first meeting, always \emph{tus\=\i\d{m}}.
+\end{grammarlens}
+
+\section{\pa{ਕੀ} \emph{(k\=\i)} --- ``what''}
+\label{lesson:ki}
+
+\begin{cousinweb}
+\pa{ਕੀ} (\emph{k\=\i}, ``what'') $\leftarrow$ the interrogative stem \emph{ka-},
+from PIE *k\ensuremath{^w}o- --- the same root behind English \textbf{wh-} words
+and Latin \emph{qu-}. Punjabi's questions nearly all start with \emph{k-}:
+\emph{k\=\i} (what), \emph{kau\d{n}} (who), \emph{kad} (when), \emph{kith\=e}
+(where), \emph{kiv\=e\d{m}} (how).
+\end{cousinweb}
+
+\section{\pa{ਤੁਹਾਡਾ ਨਾਂ ਕੀ ਹੈ?} \emph{(tuh\=a\d{d}\=a n\=a\d{m} k\=\i\ hai)} --- ``what's your name?''}
+\label{lesson:tuhada-naam-ki-hai}
+
+\pa{ਤੁਹਾਡਾ} (\emph{tuh\=a\d{d}\=a}, ``your,'' the respectful possessive) $+$
+\pa{ਨਾਂ} (name) $+$ \pa{ਕੀ} (what) $+$ \pa{ਹੈ} (is) $=$ ``\textbf{your name what
+is?}'' --- verb last, the question-word dropped into the object slot. The familiar
+``your'' is \emph{ter\=a} (from \emph{t\=u\d{m}}).
+
+\section{\pa{ਖ਼ੁਸ਼ੀ ਹੋਈ} \emph{(khush\=\i\ ho\=\i)} --- ``pleased to meet you''}
+\label{lesson:khushi}
+
+\begin{cousinweb}
+The full phrase is \pa{ਤੁਹਾਨੂੰ ਮਿਲ ਕੇ ਖ਼ੁਸ਼ੀ ਹੋਈ} (\emph{tuh\=an\=u\d{m} mil ke
+khush\=\i\ ho\=\i}) --- ``having met you, happiness happened.'' The key word
+\pa{ਖ਼ੁਸ਼ੀ} (\emph{khush\=\i}, ``happiness'') is \textbf{not} Sanskrit --- it is
+\textbf{Persian} (\emph{khush}, ``happy''), marked by \emph{two} pair-bindis
+(\pa{ਖ਼}, \pa{ਸ਼}). So introducing yourself draws on Punjabi's \textbf{two
+vocabularies}: Sanskrit (\emph{n\=a\d{m}}, \emph{hai}) and Perso-Arabic
+(\emph{khush\=\i}).
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Punjabi & English \\
+\midrule
+\pa{ਮੇਰਾ ਨਾਂ ਮੀਰਾ ਹੈ।} & My name is Mira. \\
+\pa{ਤੁਹਾਡਾ ਨਾਂ ਕੀ ਹੈ?} & What's your name? \\
+\pa{ਮੇਰਾ ਨਾਂ ਅਰੁਣ ਹੈ।} & My name is Arun. \\
+\pa{ਤੁਹਾਨੂੰ ਮਿਲ ਕੇ ਖ਼ੁਸ਼ੀ ਹੋਈ।} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{n\=a\d{m}} (Sanskrit \emph{n\=aman}, English \emph{name}),
+\emph{mer\=a} (root \emph{ma-}, English \emph{my}), \emph{hai} (Sanskrit
+\emph{asti}, English \emph{is}), \emph{k\=\i} (root \emph{ka-}, English
+\emph{what}), and \emph{khush\=\i} (Persian --- the second vocabulary). Next
+chapter: \emph{tus\=\i\d{m} kiv\=e\d{m} ho?} (``how are you?'') --- the responding
+cycle.

--- a/code/learning/human-languages/punjabi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch03-responding.tex
@@ -1,0 +1,97 @@
+\chapter{How Are You?}
+\label{ch:responding}
+
+After the name comes the exchange everyone actually has:
+
+\begin{center}
+\pa{ਤੁਸੀਂ ਕਿਵੇਂ ਹੋ?} \quad(\emph{tus\=\i\d{m} kiv\=e\d{m} ho} --- ``How are you?'')\\
+\pa{ਮੈਂ ਠੀਕ ਹਾਂ, ਧੰਨਵਾਦ।} \quad(\emph{mai\d{m} \d{t}h\=\i k h\=a\d{m}, dhannav\=ad} --- ``I'm fine, thank you.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/PA-C03-*.md}.}
+
+\section{\pa{ਕਿਵੇਂ} \emph{(kiv\=e\d{m})} --- ``how,'' another of the k- questions}
+\label{lesson:kivein}
+
+\begin{sounds}
+\pa{ਕ} (\emph{ka}) $+$ \pa{ਿ} (the \emph{sih\=ar\=\i}, \emph{i}-sign, before) $\to$
+\pa{ਕਿ}; \pa{ਵ} (\emph{va}) $+$ \pa{ੇ} $+$ \pa{ਂ} $\to$ \pa{ਵੇਂ}. Read
+\emph{kiv\=e\d{m}}.
+\end{sounds}
+
+\begin{cousinweb}
+\pa{ਕਿਵੇਂ} (\emph{kiv\=e\d{m}}, ``how'') is from the interrogative stem
+\emph{ka-}, PIE *k\ensuremath{^w}o- --- the same root behind English \textbf{wh-}
+and Latin \emph{qu-}. Punjabi's questions nearly all begin with \emph{k-}:
+\emph{k\=\i, kau\d{n}, kad, kith\=e, kiv\=e\d{m}}.
+\end{cousinweb}
+
+\section{\pa{ਤੁਸੀਂ ਕਿਵੇਂ ਹੋ?} --- ``how are you?''}
+\label{lesson:tusi-kivein-ho}
+
+\pa{ਤੁਸੀਂ} (\emph{tus\=\i\d{m}}, respectful ``you'') $+$ \pa{ਕਿਵੇਂ} (``how'') $+$
+\pa{ਹੋ} (\emph{ho}, ``are'') --- ``you how are?'', the verb last. The copula set:
+\emph{mai\d{m} h\=a\d{m}} (I am), \emph{t\=u\d{m} hai\d{m}} (you are, fam.),
+\emph{oh hai} (he is), \emph{tus\=\i\d{m} ho} (you are, resp.).
+
+\begin{grammarlens}
+Match the ``you'' to the verb: \emph{tus\=\i\d{m} \ldots ho} (respectful),
+\emph{t\=u\d{m} kiv\=e\d{m} hai\d{m}?} (familiar).
+\end{grammarlens}
+
+\section{\pa{ਮੈਂ} \emph{(mai\d{m})} --- ``I''}
+\label{lesson:main}
+
+\begin{cousinweb}
+\pa{ਮੈਂ} (\emph{mai\d{m}}, ``I'') is on the first-person root \emph{ma-} --- the
+same root as \emph{mer\=a} (``my'') and behind English \textbf{me}, \textbf{my}.
+It takes the copula \pa{ਹਾਂ} (\emph{h\=a\d{m}}, ``am''). Watch the homophone: this
+\emph{h\=a\d{m}} (``am'') is spelled like the \emph{h\=a\d{m}} (``yes'') of Chapter
+1 --- context tells them apart.
+\end{cousinweb}
+
+\section{\pa{ਠੀਕ} \emph{(\d{t}h\=\i k)} --- ``fine,'' and how to answer}
+\label{lesson:thik}
+
+\begin{sounds}
+\pa{ਠ} (\emph{\d{t}ha}, a \textbf{retroflex} \emph{th}) $+$ \pa{ੀ} (long \=\i)
+$+$ \pa{ਕ} (\emph{ka}) $\to$ \pa{ਠੀਕ}.
+\end{sounds}
+
+\begin{cousinweb}
+\pa{ਠੀਕ} (\emph{\d{t}h\=\i k}) means ``correct, right, fine, OK'' --- a native
+Indian word (shared with Hindi/Urdu), no European cousin. Put it together:
+\pa{ਮੈਂ ਠੀਕ ਹਾਂ} (\emph{mai\d{m} \d{t}h\=\i k h\=a\d{m}}) --- ``I am fine,'' verb
+last.
+\end{cousinweb}
+
+\section{\pa{ਕੋਈ ਗੱਲ ਨਹੀਂ} \emph{(ko\=\i\ gall nah\=\i\d{m})} --- ``it's nothing''}
+\label{lesson:koi-gall-nahin}
+
+\begin{cousinweb}
+\pa{ਕੋਈ ਗੱਲ ਨਹੀਂ} literally ``\textbf{[there is] no matter}'' --- \emph{ko\=\i}
+(``any'') $+$ \pa{ਗੱਲ} (\emph{gall}, ``matter, talk'') $+$ \pa{ਨਹੀਂ}
+(\emph{nah\=\i\d{m}}, ``not''). It serves as ``it's nothing / you're welcome.''
+\emph{Gall} is a warm native Punjabi word; \emph{nah\=\i\d{m}} you met in Chapter
+1 --- the ancient negative \emph{na-}, PIE *ne, behind English \textbf{no},
+\textbf{not}, \textbf{none}.
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Punjabi & English \\
+\midrule
+\pa{ਤੁਸੀਂ ਕਿਵੇਂ ਹੋ?} & How are you? \\
+\pa{ਮੈਂ ਠੀਕ ਹਾਂ, ਧੰਨਵਾਦ।} & I'm fine, thank you. \\
+\pa{ਕੋਈ ਗੱਲ ਨਹੀਂ।} & It's nothing / you're welcome. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Roots banked: \emph{kiv\=e\d{m}} (the \emph{k-} questions), \emph{mai\d{m}}
+(\emph{ma-}, English \emph{me}), \emph{\d{t}h\=\i k} (native), \emph{nah\=\i\d{m}}
+(PIE *ne, English \emph{no}). Next chapter: the farewells.

--- a/code/learning/human-languages/punjabi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch04-farewells.tex
@@ -1,0 +1,75 @@
+\chapter{Farewells}
+\label{ch:farewells}
+
+Chapter 1 gave you the formal \pa{ਸਤਿ ਸ੍ਰੀ ਅਕਾਲ} (\emph{sat sr\=\i\ ak\=al}),
+which doubles as a goodbye. Real days end more warmly:
+
+\begin{center}
+\pa{ਫਿਰ ਮਿਲਾਂਗੇ!} \quad(\emph{phir mil\=a\d{m}ge} --- ``We'll meet again!'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/PA-C04-*.md}.}
+
+\section{\pa{ਫਿਰ} \emph{(phir)} --- ``again''}
+\label{lesson:phir}
+
+\begin{cousinweb}
+\pa{ਫਿਰ} (\emph{phir}) means ``again, then'' --- a native Indo-Aryan adverb (the
+same word as Hindi \emph{phir}) with no tidy English cognate, but a familiar job:
+it turns a parting into a promise.
+\end{cousinweb}
+
+\section{\pa{ਮਿਲਾਂਗੇ} \emph{(mil\=a\d{m}ge)} --- ``(we) will meet''}
+\label{lesson:milaange}
+
+\begin{cousinweb}
+\pa{ਮਿਲਾਂਗੇ} (\emph{mil\=a\d{m}ge}, ``we will meet'') is the future of \pa{ਮਿਲਣਾ}
+(\emph{mil\d{n}\=a}, ``to meet''), from Sanskrit \emph{mil-} (``to join'') --- the
+root of \emph{mil\=ap} (``a meeting''). The ending \emph{-\=a\d{m}ge} is the plural
+future.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{The future is an ending.} \emph{mil-} $+$ \emph{-\=a\d{m}ge} $\to$
+\emph{mil\=a\d{m}ge} --- no helper like English ``will.''
+\end{grammarlens}
+
+\section{\pa{ਫਿਰ ਮਿਲਾਂਗੇ} \emph{(phir mil\=a\d{m}ge)} --- ``we'll meet again''}
+\label{lesson:phir-milaange}
+
+\pa{ਫਿਰ} (again) $+$ \pa{ਮਿਲਾਂਗੇ} (we will meet) $=$ ``\textbf{we'll meet
+again}'' --- the everyday, hopeful goodbye, where \emph{sat sr\=\i\ ak\=al} is the
+formal one. It is the same ``promise of return'' the whole subcontinent prefers
+(Hindi \emph{phir milenge}, Bengali \emph{\=ashi}, Tamil \emph{p\=oy
+varugi\d{r}\=e\d{n}}).
+
+\section{\pa{ਰੱਬ ਰਾਖਾ} \emph{(rabb r\=akh\=a)} --- ``God keep you''}
+\label{lesson:rab-raakha}
+
+\begin{cousinweb}
+\pa{ਰੱਬ ਰਾਖਾ} means ``\textbf{[may] God [be your] keeper}'' --- \pa{ਰੱਬ}
+(\emph{rabb}, ``God'') $+$ \pa{ਰਾਖਾ} (\emph{r\=akh\=a}, ``protector,'' from
+\emph{rakh\d{n}\=a} $\leftarrow$ Sanskrit \emph{rak\d{s}-}, ``to guard''). The word
+for God, \emph{rabb}, is itself \textbf{Arabic} (\emph{rabb}, ``lord'') --- so this
+most Punjabi of farewells fuses an Arabic name for God with a Sanskrit verb of
+keeping: the two vocabularies in one blessing.
+\end{cousinweb}
+
+\section{The farewells}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Punjabi & & Register \\
+\midrule
+\pa{ਸਤਿ ਸ੍ਰੀ ਅਕਾਲ} & \emph{sat sr\=\i\ ak\=al} & formal (Sikh greeting-goodbye) \\
+\pa{ਫਿਰ ਮਿਲਾਂਗੇ} & \emph{phir mil\=a\d{m}ge} & everyday, ``we'll meet again'' \\
+\pa{ਰੱਬ ਰਾਖਾ} & \emph{rabb r\=akh\=a} & a blessing, ``God keep you'' \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Roots banked: \emph{mil\=a\d{m}ge} (\emph{mil-} ``to join''), \emph{rabb} (Arabic
+``God'') $+$ \emph{r\=akh\=a} (Sanskrit \emph{rak\d{s}-} ``to protect''). Next
+chapter: the first real verbs --- \emph{mai\d{m} panj\=ab\=\i\ bold\=a h\=a\d{m}}.

--- a/code/learning/human-languages/punjabi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch05-first-verbs.tex
@@ -1,0 +1,93 @@
+\chapter{The First Verbs}
+\label{ch:first-verbs}
+
+Until now, ``to be.'' Now verbs that \emph{act} --- and sentences that move:
+
+\begin{center}
+\pa{ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ।} \quad(\emph{mai\d{m} panj\=ab\=\i\ bold\=a h\=a\d{m}} --- ``I speak Punjabi.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/PA-C05-*.md}.}
+
+\section{\pa{ਬੋਲਣਾ} \emph{(bol\d{n}\=a)} --- ``to speak,'' your first full verb}
+\label{lesson:bolna}
+
+\begin{cousinweb}
+\pa{ਬੋਲਣਾ} (\emph{bol\d{n}\=a}, ``to speak'') is a native Indo-Aryan verb (the
+same word as Hindi \emph{boln\=a}). Its ending \pa{-ਣਾ} (\emph{-\d{n}\=a}) is the
+point: \textbf{every} Punjabi infinitive ends in \emph{-\d{n}\=a}/\emph{-n\=a}
+--- \emph{bol-\d{n}\=a} ``to speak,'' \emph{mil-\d{n}\=a} ``to meet,''
+\emph{rakh-\d{n}\=a} ``to keep.'' Strip it and you have the \textbf{stem}
+(\emph{bol-}).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Stem $+$ ending.} \emph{bol-d\=a} (speaking, m.), \emph{bol-d\=\i} (f.),
+\emph{bol} (speak!). Every tense builds on a stem like this.
+\end{grammarlens}
+
+\section{\pa{ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ} --- ``I speak Punjabi''}
+\label{lesson:main-punjabi-bolda-han}
+
+\pa{ਮੈਂ} (I) $+$ \pa{ਪੰਜਾਬੀ} (\emph{panj\=ab\=\i}, the object) $+$ \pa{ਬੋਲਦਾ}
+(speak, m.) $+$ \pa{ਹਾਂ} (am) --- ``I Punjabi speaking am,'' verb-frame last.
+
+\begin{cousinweb}
+The name \pa{ਪੰਜਾਬੀ} (\emph{panj\=ab\=\i}) is \textbf{Persian}: \pa{ਪੰਜ}
+(\emph{panj}, ``five'' --- a distant cousin of English \textbf{five}, Latin
+\emph{quinque}, Greek \emph{pente}) $+$ \pa{ਆਬ} (\emph{\=ab}, ``water, river'') $=$
+``the [language] of the \textbf{five rivers},'' for the five great rivers of the
+Punjab. The very name is a Persian geography lesson.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{The present habitual is gendered.} A man: \emph{mai\d{m} panj\=ab\=\i\
+bold\=a h\=a\d{m}}; a woman: \emph{\ldots bold\=\i\ h\=a\d{m}}. The \emph{-d\=a/-d\=\i}
+marks the speaker's gender.
+\end{grammarlens}
+
+\section{\pa{ਰਹਿਣਾ} \emph{(rahi\d{n}\=a)} --- ``to live, to stay''}
+\label{lesson:rahna}
+
+\begin{cousinweb}
+\pa{ਰਹਿਣਾ} (\emph{rahi\d{n}\=a}, ``to live, remain, stay''), from Sanskrit
+\emph{rah-} (``to remain,'' the same as Hindi \emph{rahn\=a}): \emph{mai\d{m}
+Amritsar rahind\=a h\=a\d{m}} (``I live in Amritsar''). Punjabi, like Hindi, uses
+\textbf{post}positions (\emph{vic}, ``in'') --- often dropped with a place-name ---
+where English uses prepositions.
+\end{cousinweb}
+
+\section{\pa{ਕੰਮ ਕਰਨਾ} \emph{(kamm karn\=a)} --- ``to work''}
+\label{lesson:kamm-karna}
+
+\begin{cousinweb}
+\pa{ਕਰਨਾ} (\emph{karn\=a}, ``to do, make'') is from Sanskrit \emph{k\d{r}} (``to
+do''), PIE *k\ensuremath{^w}er- --- the root you met in Chapter 1's
+\emph{namask\=ar} (\emph{namas} $+$ \emph{k\=ar}, ``the \emph{making} of a bow'')
+and in \emph{karma}. Punjabi builds compounds as \textbf{noun $+$ \pa{ਕਰਨਾ}}:
+\pa{ਕੰਮ ਕਰਨਾ} (\emph{kamm karn\=a}, ``work-do'' $=$ ``to work''), \emph{gall
+karn\=a} (``to have a chat''). So \emph{mai\d{m} kamm kard\=a h\=a\d{m}} $=$ ``I
+work.''
+\end{cousinweb}
+
+\section{Sentences about yourself}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Punjabi & English \\
+\midrule
+\pa{ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ/ਬੋਲਦੀ ਹਾਂ।} & I speak Punjabi. \\
+\pa{ਮੈਂ ਅੰਮ੍ਰਿਤਸਰ ਰਹਿੰਦਾ/ਰਹਿੰਦੀ ਹਾਂ।} & I live in Amritsar. \\
+\pa{ਮੈਂ ਕੰਮ ਕਰਦਾ/ਕਰਦੀ ਹਾਂ।} & I work. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Three verbs, one engine: a stem, the \emph{-d\=a/-d\=\i} that agrees in gender,
+and the copula that agrees in person --- the verb always last. Roots banked:
+\emph{bol\d{n}\=a}, \emph{rahi\d{n}\=a} (\emph{rah-} ``remain''), \emph{karn\=a}
+(\emph{k\d{r}} --- root of \emph{namask\=ar}, \emph{karma}), and \emph{panj\=ab\=\i}
+(\emph{panj} ``five'' $+$ \emph{\=ab} ``river''). From here, Punjabi's sentences
+only grow.

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-hai.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-hai.md
@@ -1,0 +1,48 @@
+---
+id: PA-C02-hai
+chapter: 2
+type: word
+headword: ਹੈ
+gloss: is
+concept_tag: WORD-IS
+prerequisites: [PA-C02-naam]
+sounds: [dulankar-ai]
+roots: [asti-sanskrit]
+est_minutes: 3
+reviews_of: [PA-C02-naam, PA-C02-mera]
+---
+
+# ਹੈ (hai) — "is," cousin of English *is*
+
+## Warm-up
+
+[PAUSE 2s] The little verb "is" — the same "is" spoken from Ireland to India.
+
+## The letters in this word
+
+**ਹ** (*ha*) + **ੈ** (the *dulāvā̃*, *ai*-sign) → **ਹੈ** (*hai*). One syllable.
+
+## The word, taken apart
+
+**ਹੈ** (*hai*, "is") ← Sanskrit **ਅਸ੍ਤਿ** (*asti*, "is"), from Proto-Indo-European
+**\*h₁es-** — the root of "to be" across the whole family: English **is**, German
+*ist*, Latin *est*, Spanish *es*. Punjabi *hai* is the Indian cousin of the same
+tiny verb.
+
+## Grammar Lens: the verb comes last
+
+Punjabi is **subject–object–verb**: "my name Arun **is**." *hai* sits at the
+*end* of the sentence, where English puts "is" in the middle. Bank the shape — in
+Punjabi the verb waits until the end.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hai"]
+- [YOU SAY: the family — *hai* / *is* / *ist* / *est* / *es*]
+- [YOU SAY: "merā nāṁ Arun hai" — note *hai* at the end]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root is *hai* from, and where does the verb sit in a Punjabi
+sentence? (Sanskrit *asti* / PIE *\*h₁es-*; at the end.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-khushi.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-khushi.md
@@ -1,0 +1,49 @@
+---
+id: PA-C02-khushi
+chapter: 2
+type: phrase
+headword: ਖ਼ੁਸ਼ੀ ਹੋਈ
+gloss: pleased to meet you (lit. "happiness happened")
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [PA-C02-mera-naam-hai]
+sounds: [pair-bindi-kh, pair-bindi-sh]
+roots: [khush-persian]
+est_minutes: 4
+reviews_of: [PA-C01-shukriya]
+---
+
+# ਖ਼ੁਸ਼ੀ ਹੋਈ (khushī hoī) — "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The warm close of an introduction — and, like *shukrīā*, it comes
+from Persian, not Sanskrit.
+
+## The letters in this word
+
+**ਖ਼ੁਸ਼ੀ** (*khushī*): note **two** *pair bindis* (dots beneath) — **ਖ਼** (*kh*)
+and **ਸ਼** (*sh*) — both marking Perso-Arabic sounds, exactly as you saw on **ਸ਼**
+in *shukrīā* (Chapter 1).
+
+## The word, taken apart
+
+The Punjabi "pleased to meet you" is **ਤੁਹਾਨੂੰ ਮਿਲ ਕੇ ਖ਼ੁਸ਼ੀ ਹੋਈ** (*tuhānū̃ mil
+ke khushī hoī*) — literally "**having met you, happiness happened**." The key word
+**ਖ਼ੁਸ਼ੀ** (*khushī*, "happiness") is **not** Sanskrit — it is **Persian**
+(*khush*, "happy, pleasant"), one of the thousands of Persian words woven through
+Punjabi. So even introducing yourself draws on Punjabi's **two vocabularies**:
+Sanskrit (*nāṁ*, *hai*) and Perso-Arabic (*khushī*) — the thread you first met in
+Chapter 1's *shukrīā*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "khushī hoī"]
+- [YOU SAY: which heritage *khushī* belongs to (Persian, not Sanskrit)]
+- [YOU SAY: what the two *pair bindis* (ਖ਼, ਸ਼) mark (Perso-Arabic sounds)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the phrase literally mean, and where does *khushī* come from?
+("Having met you, happiness happened"; Persian *khush*, "happy" — Punjabi's
+second vocabulary.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-ki.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-ki.md
@@ -1,0 +1,44 @@
+---
+id: PA-C02-ki
+chapter: 2
+type: word
+headword: ਕੀ
+gloss: what
+concept_tag: QUESTION-WHAT
+prerequisites: [PA-C02-naam]
+sounds: [sihari-i]
+roots: [ka-interrogative]
+est_minutes: 3
+reviews_of: [PA-C02-tu-tusi]
+---
+
+# ਕੀ (kī) — "what"
+
+## Warm-up
+
+[PAUSE 2s] The question-word — and it starts with the **k-** that heads nearly
+every Punjabi question.
+
+## The letters in this word
+
+**ਕ** (*ka*) + **ੀ** (the *bihārī*, long-*ī* sign) → **ਕੀ** (*kī*).
+
+## The word, taken apart
+
+**ਕੀ** (*kī*, "what") ← Sanskrit *kim* / the interrogative stem **ka-**, from PIE
+**\*kʷo-** — the same question-root behind English **wh-** words (**what**,
+**who**, **which**) and Latin *qu-*. Punjabi's question-words nearly all begin
+with this **k-**: *kī* (what), *kauṇ* (who), *kad* (when), *kithē* (where),
+*kivēṁ* (how). Learn the *k-* and you can hear a question coming.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kī"]
+- [YOU SAY: the k- question family — *kī, kauṇ, kad, kithē, kivēṁ*]
+- [YOU SAY: the English cousins (*what, who, which*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root do Punjabi's question-words share, and its English family?
+(The interrogative *k-*, PIE *\*kʷo-*; the *wh-* words.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-mera-naam-hai.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-mera-naam-hai.md
@@ -1,0 +1,41 @@
+---
+id: PA-C02-mera-naam-hai
+chapter: 2
+type: phrase
+headword: ਮੇਰਾ ਨਾਂ … ਹੈ
+gloss: my name is…
+concept_tag: INTRO-MY-NAME-IS
+prerequisites: [PA-C02-mera, PA-C02-naam, PA-C02-hai]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [PA-C02-mera, PA-C02-naam, PA-C02-hai]
+---
+
+# ਮੇਰਾ ਨਾਂ … ਹੈ (merā nāṁ … hai) — "my name is…"
+
+## Warm-up
+
+[PAUSE 2s] Three atoms you now own, assembled into a first sentence.
+
+## The phrase, assembled
+
+**ਮੇਰਾ** (my) + **ਨਾਂ** (name) + your name + **ਹੈ** (is) = **merā nāṁ … hai**,
+"my name is…" *Merā nāṁ Arun hai.* → "My name is Arun."
+
+## Grammar Lens: the verb goes last
+
+Punjabi is a **subject–object–verb** language — literally "my name Arun **is**."
+The *hai* sits at the end, where English puts "is" in the middle. Bank this shape:
+in Punjabi, the verb waits until the end of the sentence.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "merā nāṁ … hai" with your name]
+- [YOU SAY: notice the verb *hai* comes last]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in Punjabi, and say where the verb sits. (*Merā nāṁ …
+hai*; the verb is last.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-mera.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-mera.md
@@ -1,0 +1,49 @@
+---
+id: PA-C02-mera
+chapter: 2
+type: word
+headword: ਮੇਰਾ
+gloss: my
+concept_tag: PRONOUN-MY
+prerequisites: [PA-C02-naam]
+sounds: [laava-e, kanna-aa]
+roots: [ma-first-person]
+est_minutes: 3
+reviews_of: [PA-C02-naam]
+---
+
+# ਮੇਰਾ (merā) — "my"
+
+## Warm-up
+
+[PAUSE 2s] The little word that makes the name *yours*.
+
+## The letters in this word
+
+**ਮ** (*ma*) + **ੇ** (the *lāvā̃*, *e*-sign) → **ਮੇ** (*me*); **ਰ** (*ra*) + **ਾ**
+(long *ā*) → **ਰਾ** (*rā*). Read **ਮੇ·ਰਾ** → *merā*.
+
+## The word, taken apart
+
+**ਮੇਰਾ** (*merā*, "my") is on the first-person root **ma-** — the same *ma-/me-*
+behind English **me**, **my**, **mine** and Latin *meus*, and the same root as
+Hindi *merā*. The Punjabi "my" and the English "my" are, at the root, one word.
+
+## Grammar Lens: "my" agrees with the noun
+
+Punjabi possessives change to match what is owned: **ਮੇਰਾ** (*merā*, masculine),
+**ਮੇਰੀ** (*merī*, feminine), **ਮੇਰੇ** (*mere*, plural). *nāṁ* ("name") is
+masculine, so it takes *merā*: *merā nāṁ*. (You will meet *merī* the first time
+you own a feminine noun.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "merā"]
+- [YOU SAY: the m- family — *merā* (my), English *me*, *my*]
+- [YOU SAY: the feminine form (*merī*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root links *merā* and English *my*, and what is its feminine
+form? (The first-person *ma-*; *merī*.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-naam.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-naam.md
@@ -1,0 +1,44 @@
+---
+id: PA-C02-naam
+chapter: 2
+type: word
+headword: ਨਾਂ
+gloss: name
+concept_tag: WORD-NAME
+prerequisites: []
+sounds: [kanna-aa, bindi-nasal]
+roots: [naaman-sanskrit]
+est_minutes: 4
+reviews_of: []
+---
+
+# ਨਾਂ (nāṁ) — "name," a word older than Europe
+
+## Warm-up
+
+[PAUSE 2s] The first word of the introduction — and one of the clearest bridges
+between India and Europe.
+
+## The letters in this word
+
+**ਨ** (*na*) + **ਾ** (the *kannā*, long-*ā* sign) + **ਂ** (the *bindi*, a nasal
+dot) → **ਨਾਂ** (*nāṁ*). A single nasalised syllable.
+
+## The word, taken apart
+
+**ਨਾਂ** (*nāṁ*, "name") ← Sanskrit **ਨਾਮਨ੍** (*nāman*), from Proto-Indo-European
+**\*h₃nómn̥** — the *same* ancient root as English **name**, Latin *nōmen*
+(English **noun**, **nom**inate), and Greek *onoma*. So Punjabi *nāṁ* and English
+*name* are cousins from before either language existed. (The Hindi form is *nām*;
+Punjabi nasalises the ending to *nāṁ*.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāṁ"]
+- [YOU SAY: the family — *nāṁ* / English *name* / Latin *nōmen* / Greek *onoma*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Sanskrit and PIE roots is *nāṁ* from, and its English cousins?
+(*Nāman* / *\*h₃nómn̥*; **name**, **noun**, **nominate**.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-practice.md
@@ -1,0 +1,47 @@
+---
+id: PA-C02-practice
+chapter: 2
+type: practice
+headword: (dialogue)
+gloss: Chapter 2 recap — the introduction exchange
+concept_tag: REVIEW
+prerequisites: [PA-C02-mera-naam-hai, PA-C02-tuhada-naam-ki-hai, PA-C02-khushi]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [PA-C02-naam, PA-C02-mera, PA-C02-hai, PA-C02-mera-naam-hai, PA-C02-tu-tusi, PA-C02-ki, PA-C02-tuhada-naam-ki-hai, PA-C02-khushi]
+---
+
+# Chapter 2 — The introduction exchange
+
+## Warm-up
+
+[PAUSE 2s] No new words. The whole introduction, assembled from atoms you now own.
+
+## The exchange
+
+[PAUSE 1s each]
+- [YOU SAY: "My name is Mira." — *merā nāṁ Mira hai.*]
+- [YOU SAY: "What's your name?" — *tuhāḍā nāṁ kī hai?*]
+- [YOU SAY: "My name is Arun." — *merā nāṁ Arun hai.*]
+- [YOU SAY: "Pleased to meet you." — *tuhānū̃ mil ke khushī hoī.*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: "name," "my," "is" (*nāṁ*, *merā*, *hai*)]
+- [YOU SAY: the two "you" levels (*tū̃* / *tusī̃*)]
+- [YOU SAY: "what" and where the verb sits (*kī*; the verb is last)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *nāṁ* ← Sanskrit *nāman* → English **name**
+- *merā* ← *ma-* → English **my**; *hai* ← *asti* → English **is**
+- *kī* ← *ka-* → English **what**; *tū̃* ← *\*tū* → **thou**
+- *khushī* ← **Persian** — Punjabi's second vocabulary
+
+## Wrap-up Recall
+
+[PAUSE 3s] Introduce yourself and ask a stranger's name in Punjabi. (*Merā nāṁ …
+hai. Tuhāḍā nāṁ kī hai?*)

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-tu-tusi.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-tu-tusi.md
@@ -1,0 +1,53 @@
+---
+id: PA-C02-tu-tusi
+chapter: 2
+type: word
+headword: ਤੂੰ / ਤੁਸੀਂ
+gloss: you (familiar / respectful)
+concept_tag: PRONOUN-YOU
+prerequisites: [PA-C02-naam]
+sounds: [aunkar-u, bindi-nasal]
+roots: [tu-second-person]
+est_minutes: 4
+reviews_of: [PA-C02-mera-naam-hai]
+---
+
+# ਤੂੰ / ਤੁਸੀਂ (tū̃ / tusī̃) — "you," familiar and respectful
+
+## Warm-up
+
+[PAUSE 2s] To ask a name you need "you" — and Punjabi grades respect the way
+French does.
+
+## The letters in this word
+
+**ਤੂੰ**: **ਤ** (*ta*) + **ੂ** (long *ū*) + **ਂ** (nasal *bindi*) → *tū̃*.
+**ਤੁਸੀਂ**: *tu* + *sī̃*, a longer, plural-shaped word.
+
+## The word, taken apart
+
+**ਤੂੰ** (*tū̃*, familiar "you") ← Sanskrit *tvam*, from PIE **\*tū** — the same
+root as English archaic **thou**, Latin *tū*, French *tu*. **ਤੁਸੀਂ** (*tusī̃*,
+respectful "you") is grammatically plural — the same courtesy-by-plural you meet
+in French *vous* and Hindi *āp*.
+
+## Grammar Lens: two levels of "you"
+
+- **ਤੂੰ** (*tū̃*) — familiar: friends, children, intimates.
+- **ਤੁਸੀਂ** (*tusī̃*) — respectful: elders, strangers, politeness (and true
+  plural, "you all").
+
+For a first meeting, always **ਤੁਸੀਂ**. Respect takes the plural verb, exactly as
+in the Romance and other Indo-Aryan tracks.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tū̃" (familiar) and "tusī̃" (respectful)]
+- [YOU SAY: the English cousin of *tū̃* (**thou**)]
+- [YOU SAY: which you use on first meeting (*tusī̃*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which "you" is respectful, and what English word is *tū̃* cousin to?
+(*Tusī̃*; archaic **thou**, from PIE *\*tū*.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C02-tuhada-naam-ki-hai.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C02-tuhada-naam-ki-hai.md
@@ -1,0 +1,43 @@
+---
+id: PA-C02-tuhada-naam-ki-hai
+chapter: 2
+type: phrase
+headword: ਤੁਹਾਡਾ ਨਾਂ ਕੀ ਹੈ?
+gloss: what's your name?
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [PA-C02-tu-tusi, PA-C02-ki, PA-C02-hai]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [PA-C02-ki, PA-C02-hai, PA-C02-tu-tusi]
+---
+
+# ਤੁਹਾਡਾ ਨਾਂ ਕੀ ਹੈ? (tuhāḍā nāṁ kī hai?) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Turn the introduction around — ask, instead of tell.
+
+## The phrase, assembled
+
+**ਤੁਹਾਡਾ** (*tuhāḍā*, "your," the respectful possessive from *tusī̃*) + **ਨਾਂ**
+(name) + **ਕੀ** (what) + **ਹੈ** (is) → literally "**your name what is?**" Punjabi
+keeps the verb last again, and simply drops the question-word *kī* into the object
+slot.
+
+## Grammar Lens: answering
+
+Answer it with the sentence you built: *Merā nāṁ Arun hai.* The familiar version
+swaps *tuhāḍā* for **ਤੇਰਾ** (*terā*, "your," from *tū̃*): *terā nāṁ kī hai?*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the respectful question — *tuhāḍā nāṁ kī hai?*]
+- [YOU SAY: answer it — *merā nāṁ … hai*]
+- [YOU SAY: the familiar "your" (*terā*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Ask someone's name respectfully, and note where the verb sits.
+(*Tuhāḍā nāṁ kī hai?*; the verb is last.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C03-kivein.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C03-kivein.md
@@ -1,0 +1,45 @@
+---
+id: PA-C03-kivein
+chapter: 3
+type: word
+headword: ਕਿਵੇਂ
+gloss: how
+concept_tag: QUESTION-HOW
+prerequisites: [PA-C02-ki]
+sounds: [sihari-i, laava-e, bindi-nasal]
+roots: [ka-interrogative]
+est_minutes: 4
+reviews_of: [PA-C02-ki]
+---
+
+# ਕਿਵੇਂ (kivēṁ) — "how," another of the k- questions
+
+## Warm-up
+
+[PAUSE 2s] You met **ਕੀ** (*kī*, "what") in Chapter 2. Here is its sibling — and,
+like all of Punjabi's question-words, it starts with **k-**.
+
+## The letters in this word
+
+**ਕ** (*ka*) + **ਿ** (the *sihārī*, *i*-sign, written before) → **ਕਿ** (*ki*);
+**ਵ** (*va*) + **ੇ** (*e*-sign) + **ਂ** (nasal) → **ਵੇਂ** (*vēṁ*). Read **ਕਿ·ਵੇਂ**
+→ *kivēṁ*.
+
+## The word, taken apart
+
+**ਕਿਵੇਂ** (*kivēṁ*, "how") is from the interrogative stem **ka-**, from PIE
+**\*kʷo-** — the same question-root behind English **wh-** and Latin *qu-*.
+Punjabi's questions nearly all begin with this **k-**: *kī* (what), *kauṇ* (who),
+*kad* (when), *kithē* (where), *kivēṁ* (how). Learn the *k-* and you can spot a
+question.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kivēṁ"]
+- [YOU SAY: the k- question family — *kī, kauṇ, kad, kithē, kivēṁ*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root do Punjabi's question-words share, and its English family?
+(The interrogative *k-*, PIE *\*kʷo-*; the *wh-* words.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C03-koi-gall-nahin.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C03-koi-gall-nahin.md
@@ -1,0 +1,47 @@
+---
+id: PA-C03-koi-gall-nahin
+chapter: 3
+type: phrase
+headword: ਕੋਈ ਗੱਲ ਨਹੀਂ
+gloss: it's nothing / no problem / you're welcome
+concept_tag: YOURE-WELCOME
+prerequisites: [PA-C01-han-nahin, PA-C01-dhanvaad]
+sounds: [double-ll, bindi-nasal]
+roots: [na-negative, gall-word]
+est_minutes: 4
+reviews_of: [PA-C01-han-nahin]
+---
+
+# ਕੋਈ ਗੱਲ ਨਹੀਂ (koī gall nahīṁ) — "it's nothing"
+
+## Warm-up
+
+[PAUSE 2s] When someone thanks you — or apologises — this is the easy, gracious
+reply, built on a word from Chapter 1.
+
+## The letters in this word
+
+**ਕੋਈ** (*koī*, "any") + **ਗੱਲ** (*gall*, "matter, talk" — note the *addak*, the
+doubling mark, on **ੱਲ**) + **ਨਹੀਂ** (*nahīṁ*, "not," from Chapter 1) → *koī gall
+nahīṁ*.
+
+## The word, taken apart
+
+**ਕੋਈ ਗੱਲ ਨਹੀਂ** literally means "**[there is] no matter**" — *koī* ("any") +
+*gall* ("matter, thing, talk") + *nahīṁ* ("not"). It serves as "it's nothing / no
+worries / never mind / you're welcome." The word **ਗੱਲ** (*gall*, "talk, matter")
+is a warm, everyday native Punjabi word — *gall karnā* ("to have a chat"). And
+**ਨਹੀਂ** (*nahīṁ*) you already met in Chapter 1: the ancient negative *na-*, the
+same PIE **\*ne** behind English **no**, **not**, **none**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "koī gall nahīṁ"]
+- [YOU SAY: what it literally means ("[there is] no matter")]
+- [YOU SAY: the exchange — *dhannavād* / *koī gall nahīṁ*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *koī gall nahīṁ* literally say, and which Chapter-1 word does
+it reuse? ("There's no matter"; *nahīṁ*, "not" — from PIE *\*ne*, English *no*.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C03-main.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C03-main.md
@@ -1,0 +1,50 @@
+---
+id: PA-C03-main
+chapter: 3
+type: word
+headword: ਮੈਂ
+gloss: I
+concept_tag: PRONOUN-I
+prerequisites: [PA-C02-mera]
+sounds: [dulankar-ai, bindi-nasal]
+roots: [ma-first-person]
+est_minutes: 3
+reviews_of: [PA-C02-mera]
+---
+
+# ਮੈਂ (maiṁ) — "I," the m- of the first person
+
+## Warm-up
+
+[PAUSE 2s] To answer "how are you?" you first need "I." In Chapter 2 you learned
+*merā* ("my"); here is its owner.
+
+## The letters in this word
+
+**ਮ** (*ma*) + **ੈ** (*ai*-sign) + **ਂ** (nasal *bindi*) → **ਮੈਂ** (*maiṁ*). One
+nasal syllable.
+
+## The word, taken apart
+
+**ਮੈਂ** (*maiṁ*, "I") is on the first-person root **ma-** — the same root that
+gave you *merā* ("my"), and the same **m-** behind English **me**, **my**,
+**mine** and Latin *mē*. Punjabi's "I," its "my," and English's "me/my" all grow
+from one ancient first-person sound.
+
+## Grammar Lens: the copula pairs with it
+
+*Maiṁ* takes the copula **ਹਾਂ** (*hāṁ*, "am"): *maiṁ … hāṁ*. Watch out — this
+*hāṁ* ("am") is spelled the same as the *hāṁ* ("yes") from Chapter 1; context
+tells them apart. So the reply to "how are you?" will begin *maiṁ …*
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "maiṁ"]
+- [YOU SAY: the m- family — *maiṁ* (I), *merā* (my), English *me*, *my*]
+- [YOU SAY: "maiṁ … hāṁ" — I am …]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root links *maiṁ*, *merā*, and English *me*, and what copula does
+*maiṁ* take? (The first-person *ma-*; *hāṁ*, "am.")

--- a/code/learning/human-languages/punjabi/lessons/PA-C03-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C03-practice.md
@@ -1,0 +1,48 @@
+---
+id: PA-C03-practice
+chapter: 3
+type: practice
+headword: (dialogue)
+gloss: Chapter 3 recap — the how-are-you exchange
+concept_tag: REVIEW
+prerequisites: [PA-C03-tusi-kivein-ho, PA-C03-thik, PA-C03-koi-gall-nahin]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [PA-C03-kivein, PA-C03-tusi-kivein-ho, PA-C03-main, PA-C03-thik, PA-C03-koi-gall-nahin]
+---
+
+# Chapter 3 — The how-are-you exchange
+
+## Warm-up
+
+[PAUSE 2s] No new words. The whole responding cycle, from atoms you now own.
+
+## The exchange
+
+[PAUSE 1s each]
+- [YOU SAY: "How are you?" (respectful) — *tusī̃ kivēṁ ho?*]
+- [YOU SAY: "I'm fine, thank you." — *maiṁ ṭhīk hāṁ, dhannavād.*]
+- [YOU SAY: "It's nothing / you're welcome." — *koī gall nahīṁ.*]
+- [YOU SAY: the familiar question — *tū̃ kivēṁ haiṁ?*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the k- question-word for "how" (*kivēṁ*)]
+- [YOU SAY: "I" and its copula (*maiṁ*, *hāṁ*)]
+- [YOU SAY: the homophone trap — *hāṁ* means both "am" and "yes"]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *kivēṁ* ← the interrogative *k-* (PIE *\*kʷo-*), cousin of English *how/what*
+- *maiṁ* ← *ma-* (PIE *\*me-*), cousin of English *me/my*
+- *ṭhīk* — native Indian "fine," no European cognate
+- *koī gall nahīṁ* — "no matter"; *nahīṁ* ← PIE *\*ne*, English *no*
+
+## Wrap-up Recall
+
+[PAUSE 3s] A stranger asks *tusī̃ kivēṁ ho?* — give a full, polite reply, and
+answer their thanks. (*Maiṁ ṭhīk hāṁ, dhannavād* — and to thanks, *koī gall
+nahīṁ*.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C03-thik.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C03-thik.md
@@ -1,0 +1,53 @@
+---
+id: PA-C03-thik
+chapter: 3
+type: word
+headword: ਠੀਕ
+gloss: fine, well — and the reply "ਮੈਂ ਠੀਕ ਹਾਂ"
+concept_tag: WORD-WELL
+prerequisites: [PA-C03-main]
+sounds: [retroflex-tha, bihari-ii]
+roots: []
+est_minutes: 4
+reviews_of: [PA-C03-main, PA-C03-tusi-kivein-ho]
+---
+
+# ਠੀਕ (ṭhīk) — "fine," and how to answer
+
+## Warm-up
+
+[PAUSE 2s] The word that answers "how are you?" — and does a dozen other jobs.
+
+## The letters in this word
+
+**ਠ** (*ṭha*, a **retroflex** *th* — tongue curled to the roof of the mouth) +
+**ੀ** (long *ī*) + **ਕ** (*ka*) → **ਠੀਕ** (*ṭhīk*). The retroflex ਟ-ਠ-ਡ series is
+a hallmark of Indian sound.
+
+## The word, taken apart
+
+**ਠੀਕ** (*ṭhīk*) means "correct, right, fine, OK" — a native Indian word (shared
+with Hindi and Urdu), one of the most useful in the language: *ṭhīk hai* ("OK /
+agreed"), *sab ṭhīk?* ("all well?"). Not every word has a far-flung cognate, and
+that is worth seeing too: *ṭhīk* is Indian to the core.
+
+## The reply
+
+Put it together: **ਮੈਂ ਠੀਕ ਹਾਂ** (*maiṁ ṭhīk hāṁ*) — "**I am fine**" (literally "I
+fine am," verb last). Add thanks: *maiṁ ṭhīk hāṁ, dhannavād.* The whole exchange:
+
+> — *tusī̃ kivēṁ ho?* ("How are you?")
+> — *maiṁ ṭhīk hāṁ, dhannavād.* ("I'm fine, thank you.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ṭhīk" — feel the retroflex *ṭh*]
+- [YOU SAY: the full reply — *maiṁ ṭhīk hāṁ*]
+- [YOU SAY: the casual "OK" — *ṭhīk hai*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the reply to *tusī̃ kivēṁ ho?*, and say what's special about
+*ṭhīk*'s origin. (*Maiṁ ṭhīk hāṁ*; it is a native Indian word, no European
+cognate.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C03-tusi-kivein-ho.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C03-tusi-kivein-ho.md
@@ -1,0 +1,45 @@
+---
+id: PA-C03-tusi-kivein-ho
+chapter: 3
+type: phrase
+headword: ਤੁਸੀਂ ਕਿਵੇਂ ਹੋ?
+gloss: how are you? (respectful)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [PA-C03-kivein, PA-C02-tu-tusi]
+sounds: []
+roots: [asti-sanskrit]
+est_minutes: 4
+reviews_of: [PA-C02-tu-tusi]
+---
+
+# ਤੁਸੀਂ ਕਿਵੇਂ ਹੋ? (tusī̃ kivēṁ ho?) — "how are you?"
+
+## Warm-up
+
+[PAUSE 2s] Three words you own, assembled into the first thing you ask after
+hello.
+
+## The phrase, taken apart
+
+**ਤੁਸੀਂ ਕਿਵੇਂ ਹੋ?** = **ਤੁਸੀਂ** (*tusī̃*, respectful "you") + **ਕਿਵੇਂ** (*kivēṁ*,
+"how") + **ਹੋ** (*ho*, "are") — literally "**you how are?**" Punjabi keeps the
+verb **last**, as in Chapter 2. The copula *ho* is the respectful "are" that goes
+with *tusī̃* — its whole set is *maiṁ hāṁ* (I am), *tū̃ haiṁ* (you are, familiar),
+*oh hai* (he is), *tusī̃ ho* (you are, respectful).
+
+## Grammar Lens: match the "you" to the verb
+
+To an elder or stranger: **ਤੁਸੀਂ ਕਿਵੇਂ ਹੋ?** To a friend (*tū̃*): **ਤੂੰ ਕਿਵੇਂ
+ਹੈਂ?** (*tū̃ kivēṁ haiṁ?*). Respect takes the plural-shaped *tusī̃ … ho*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the respectful question — *tusī̃ kivēṁ ho?*]
+- [YOU SAY: the familiar version — *tū̃ kivēṁ haiṁ?*]
+- [YOU SAY: where the verb sits (at the end)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Ask "how are you?" respectfully, and say where the verb goes. (*Tusī̃
+kivēṁ ho?*; the verb is last.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C04-milaange.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C04-milaange.md
@@ -1,0 +1,48 @@
+---
+id: PA-C04-milaange
+chapter: 4
+type: word
+headword: ਮਿਲਾਂਗੇ
+gloss: (we) will meet
+concept_tag: PA-VERB-MILNA
+prerequisites: [PA-C03-main]
+sounds: [kanna-aa, bindi-nasal]
+roots: [mil-meet]
+est_minutes: 4
+reviews_of: []
+---
+
+# ਮਿਲਾਂਗੇ (milāṁge) — "(we) will meet"
+
+## Warm-up
+
+[PAUSE 2s] A future-tense verb — the other half of "see you again."
+
+## The letters in this word
+
+**ਮਿ** (*mi*) + **ਲਾਂ** (*lāṁ*, *la* + long *ā* + nasal) + **ਗੇ** (*ge*) →
+**ਮਿਲਾਂਗੇ** (*milāṁge*).
+
+## The word, taken apart
+
+**ਮਿਲਾਂਗੇ** (*milāṁge*, "we will meet") is the future of **ਮਿਲਣਾ** (*milṇā*, "to
+meet, to be found"), from Sanskrit **ਮਿਲ੍** (*mil-*, "to join, unite") — the root
+of *milāp* ("a union, meeting"). The ending **-ਾਂਗੇ** (*-āṁge*) is the plural
+future: *milāṁge* = "(we) will meet."
+
+## Grammar Lens: the future is an ending
+
+Punjabi marks the future with an ending on the stem: *mil-* ("meet") + *-āṁge*
+("we will") → *milāṁge*. No helper-word like English "will" — the tense lives in
+the ending.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "milāṁge"]
+- [YOU SAY: the root and its cousin-noun (*mil-* "to join," *milāp* "a meeting")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What verb is *milāṁge* from, and how does Punjabi mark "will"? (*Milṇā*
+"to meet," from Sanskrit *mil-*; with the ending *-āṁge*, not a separate word.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C04-phir-milaange.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C04-phir-milaange.md
@@ -1,0 +1,43 @@
+---
+id: PA-C04-phir-milaange
+chapter: 4
+type: phrase
+headword: ਫਿਰ ਮਿਲਾਂਗੇ
+gloss: we'll meet again (goodbye)
+concept_tag: FAREWELL-LATER
+prerequisites: [PA-C04-phir, PA-C04-milaange]
+sounds: []
+roots: [mil-meet]
+est_minutes: 3
+reviews_of: [PA-C01-sat-sri-akal]
+---
+
+# ਫਿਰ ਮਿਲਾਂਗੇ (phir milāṁge) — "we'll meet again"
+
+## Warm-up
+
+[PAUSE 2s] The warm, everyday goodbye — where Chapter 1's *sat srī akāl* is the
+formal one.
+
+## The phrase, taken apart
+
+**ਫਿਰ ਮਿਲਾਂਗੇ** = **ਫਿਰ** (*phir*, "again") + **ਮਿਲਾਂਗੇ** (*milāṁge*, "we will
+meet") — "**we'll meet again**." Chapter 1 gave you **ਸਤਿ ਸ੍ਰੀ ਅਕਾਲ** (*sat srī
+akāl*), the Sikh greeting that doubles as a formal goodbye; *phir milāṁge* is the
+everyday, hopeful one — the same "promise of return" the whole subcontinent
+prefers to a blunt farewell (Hindi *phir milenge*, Bengali *āshi*, Tamil *pōy
+varugiṟēṉ*). Even more casual: *phir mildē hāṁ* ("(we) meet again," present for a
+near future).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the warm goodbye — *phir milāṁge*]
+- [YOU SAY: the two words it's built from (*phir* + *milāṁge*)]
+- [YOU SAY: the Hindi twin of the phrase (*phir milenge*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *phir milāṁge* literally say, and when would you use it over
+*sat srī akāl*? ("We'll meet again"; for everyday partings, where *sat srī akāl*
+is the formal Sikh greeting-goodbye.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C04-phir.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C04-phir.md
@@ -1,0 +1,43 @@
+---
+id: PA-C04-phir
+chapter: 4
+type: word
+headword: ਫਿਰ
+gloss: again, then
+concept_tag: PA-WORD-PHIR
+prerequisites: []
+sounds: [sihari-i]
+roots: []
+est_minutes: 3
+reviews_of: []
+---
+
+# ਫਿਰ (phir) — "again," the seed of "see you again"
+
+## Warm-up
+
+[PAUSE 2s] One small word turns a goodbye from "farewell" into "**till next
+time**."
+
+## The letters in this word
+
+**ਫ** (*pha*, an aspirated *p*) + **ਿ** (the *sihārī*, *i*-sign) + **ਰ** (*ra*) →
+**ਫਿਰ** (*phir*).
+
+## The word, taken apart
+
+**ਫਿਰ** (*phir*) means "again, then, afterwards" — a native Indo-Aryan adverb
+(the same word as Hindi *phir*) with no tidy English cognate, but a familiar
+*job*: it turns a parting into a promise. English "see you **again**," Punjabi
+*phir milāṁge* ("we'll meet **again**").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "phir" — mind the aspirated *ph*]
+- [YOU SAY: what it adds to a goodbye ("again / then")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *phir* mean, and what does it do to a farewell? ("Again /
+then"; it makes the parting a promise of return.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C04-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C04-practice.md
@@ -1,0 +1,45 @@
+---
+id: PA-C04-practice
+chapter: 4
+type: practice
+headword: (dialogue)
+gloss: Chapter 4 recap — the farewells
+concept_tag: REVIEW
+prerequisites: [PA-C04-phir-milaange, PA-C04-rab-raakha]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [PA-C01-sat-sri-akal, PA-C04-phir, PA-C04-milaange, PA-C04-phir-milaange, PA-C04-rab-raakha]
+---
+
+# Chapter 4 — The farewells
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three ways to part, from the formal to the tender.
+
+## The farewells
+
+[PAUSE 1s each]
+- [YOU SAY: the formal Sikh greeting-goodbye (Chapter 1) — *sat srī akāl*]
+- [YOU SAY: the everyday "we'll meet again" — *phir milāṁge*]
+- [YOU SAY: the blessing "God keep you" — *rabb rākhā*]
+- [YOU SAY: the two together — *rabb rākhā, phir milāṁge*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: "again" and "(we) will meet" (*phir*, *milāṁge*)]
+- [YOU SAY: the two vocabularies inside *rabb rākhā* (Arabic *rabb*, Sanskrit *rakṣ-*)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *milāṁge* ← *mil-* "to join" (*milāp*, "a meeting")
+- *rabb* ← Arabic "Lord/God"; *rākhā* ← Sanskrit *rakṣ-* "to protect"
+- the future *-āṁge* ending — "we will," carried in the verb
+
+## Wrap-up Recall
+
+[PAUSE 3s] You're leaving a friend and expect to see them soon. Give the warm
+goodbye, then bless them on the way. (*Phir milāṁge* — and *rabb rākhā*.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C04-rab-raakha.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C04-rab-raakha.md
@@ -1,0 +1,47 @@
+---
+id: PA-C04-rab-raakha
+chapter: 4
+type: phrase
+headword: ਰੱਬ ਰਾਖਾ
+gloss: goodbye (lit. "God [be your] keeper")
+concept_tag: FAREWELL
+prerequisites: [PA-C04-phir-milaange]
+sounds: [double-bb, kanna-aa]
+roots: [rab-god, rakh-keep]
+est_minutes: 4
+reviews_of: [PA-C04-phir-milaange]
+---
+
+# ਰੱਬ ਰਾਖਾ (rabb rākhā) — "God keep you"
+
+## Warm-up
+
+[PAUSE 2s] A tender Punjabi goodbye — one that puts you in God's care.
+
+## The letters in this word
+
+**ਰੱਬ** (*rabb*, "God" — note the *addak* doubling on **ੱਬ**) + **ਰਾਖਾ** (*rākhā*,
+"keeper, protector"). Read *rabb rākhā*.
+
+## The word, taken apart
+
+**ਰੱਬ ਰਾਖਾ** means "**[may] God [be your] keeper**" — *rabb* ("God") + *rākhā*
+("protector," from *rakhṇā*, "to keep, protect," ← Sanskrit *rakṣ-*, "to guard,"
+the root of *rākṣas* and of English-borrowed *rakhi*). The word for God, **ਰੱਬ**
+(*rabb*), is itself telling: it is **Arabic** *rabb* ("lord, master") — the same
+*rabb* of Arabic *rabb al-ʿālamīn* ("Lord of the worlds"). So this most Punjabi
+of farewells fuses an **Arabic** name for God with a **Sanskrit** verb of keeping
+— Punjabi's two vocabularies in one blessing. Warmer still: *rabb rākhā, phir
+milāṁge* ("God keep you, we'll meet again").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rabb rākhā"]
+- [YOU SAY: its two heritages (Arabic *rabb* "God" + Sanskrit *rakṣ-* "to keep")]
+- [YOU SAY: pair it with the other goodbye — *rabb rākhā, phir milāṁge*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *rabb rākhā* mean, and what two vocabularies meet in it?
+("God [be your] keeper"; Arabic *rabb* "God" + Sanskrit *rakṣ-* "to protect.")

--- a/code/learning/human-languages/punjabi/lessons/PA-C05-bolna.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C05-bolna.md
@@ -1,0 +1,52 @@
+---
+id: PA-C05-bolna
+chapter: 5
+type: word
+headword: ਬੋਲਣਾ
+gloss: to speak
+concept_tag: PA-VERB-BOLNA
+prerequisites: [PA-C03-main]
+sounds: [hora-o, retroflex-na]
+roots: [bol-speak]
+est_minutes: 4
+reviews_of: []
+---
+
+# ਬੋਲਣਾ (bolṇā) — "to speak," your first full verb
+
+## Warm-up
+
+[PAUSE 2s] Until now, "to be." Here is a verb that *does* something — in a shape
+you'll see on every Punjabi verb.
+
+## The letters in this word
+
+**ਬ** (*ba*) + **ੋ** (the *horā*, *o*-sign) → **ਬੋ** (*bo*); **ਲ** (*la*); **ਣਾ**
+(*ṇā*, retroflex *ṇ* + long *ā*). Read **ਬੋ·ਲ·ਣਾ** → *bolṇā*.
+
+## The word, taken apart
+
+**ਬੋਲਣਾ** (*bolṇā*, "to speak") is a native Indo-Aryan verb (the same word as
+Hindi *bolnā*). Its ending **-ਣਾ** (*-ṇā*) is the point: **every** Punjabi verb,
+named in the dictionary, ends in *-ṇā* (or *-nā*) — the infinitive marker,
+Punjabi's "to ___": *bol-ṇā* "to speak," *mil-ṇā* "to meet" (from *milāṁge*),
+*rakh-ṇā* "to keep" (from *rabb rākhā*). Strip the *-ṇā* and you have the **stem**
+(*bol-*) that takes all the other endings.
+
+## Grammar Lens: stem + ending
+
+The stem *bol-* holds the action; endings pin down who and when: *bol-dā*
+(speaking, m.), *bol-dī* (speaking, f.), *bol* (speak!, familiar command). Every
+tense is built by adding to a stem like this.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bolṇā"]
+- [YOU SAY: the infinitive ending every Punjabi verb takes (*-ṇā*/*-nā*)]
+- [YOU SAY: three such verbs you now know (*bolṇā, milṇā, rakhṇā*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What ending does a Punjabi infinitive carry, and what is *bolṇā*'s
+stem? (*-ṇā*/*-nā*; the stem is *bol-*.)

--- a/code/learning/human-languages/punjabi/lessons/PA-C05-kamm-karna.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C05-kamm-karna.md
@@ -1,0 +1,52 @@
+---
+id: PA-C05-kamm-karna
+chapter: 5
+type: word
+headword: ਕੰਮ ਕਰਨਾ
+gloss: to work (lit. "work-do")
+concept_tag: PA-VERB-KARNA
+prerequisites: [PA-C05-bolna]
+sounds: [tippi-nasal, double-mm]
+roots: [kr-do]
+est_minutes: 5
+reviews_of: [PA-C05-bolna, PA-C05-rahna]
+---
+
+# ਕੰਮ ਕਰਨਾ (kamm karnā) — "to work"
+
+## Warm-up
+
+[PAUSE 2s] The last verb of the chapter — and its root already sits inside a
+Chapter-1 word.
+
+## The letters in this word
+
+**ਕੰਮ** (*kamm*, "work"): **ਕੰ** (*kaṁ*, with the *ṭippī* nasal) + **ਮ** (*ma*).
+**ਕਰਨਾ** (*karnā*, "to do"): **ਕ** (*ka*) + **ਰ** (*ra*) + **ਨਾ** (*nā*).
+
+## The word, taken apart
+
+**ਕਰਨਾ** (*karnā*, "to do, to make") is from Sanskrit **√ਕ੍ਰੁ / ਕ੍ਰ** (*√kṛ*, "to
+do"), from PIE **\*kʷer-** — one of Sanskrit's most productive roots. You met its
+family in Chapter 1's **ਨਮਸਤੇ**/**ਨਮਸਕਾਰ** (*namaskār* = *namas* + *kār*, "the
+**making** of a bow") and in *karma* ("a thing **done**"). Like Hindi, Punjabi
+builds countless verbs as **noun + ਕਰਨਾ**:
+
+- **ਕੰਮ ਕਰਨਾ** (*kamm karnā*) = "work-do" = "**to work**" (*kamm*, "work")
+- **ਗੱਲ ਕਰਨਾ** (*gall karnā*) = "to have a chat" (*gall*, the "matter/talk" from
+  Chapter 3's *koī gall nahīṁ*)
+
+So *maiṁ kamm kardā hāṁ* = "I work." Learn *karnā* and a whole grammar of
+"do-verbs" opens up.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kamm karnā" (to work)]
+- [YOU SAY: "I work" (m./f.) — *maiṁ kamm kardā hāṁ / kardī hāṁ*]
+- [YOU SAY: the Chapter-1 word that shares its root (*namaskār* — the "making" of a bow)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Sanskrit root is *karnā* from, and name a Chapter-1 word built on
+it. (*√kṛ*, "to do"; *namaskār* — "the making of a bow.")

--- a/code/learning/human-languages/punjabi/lessons/PA-C05-main-punjabi-bolda-han.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C05-main-punjabi-bolda-han.md
@@ -1,0 +1,62 @@
+---
+id: PA-C05-main-punjabi-bolda-han
+chapter: 5
+type: phrase
+headword: ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ
+gloss: I speak Punjabi (gendered)
+concept_tag: PA-WORD-PUNJABI
+prerequisites: [PA-C05-bolna, PA-C03-main]
+sounds: [tippi-nasal, kanna-aa]
+roots: [panj-persian, aab-persian]
+est_minutes: 5
+reviews_of: [PA-C05-bolna, PA-C03-main]
+---
+
+# ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ (maiṁ panjābī boldā hāṁ) — "I speak Punjabi"
+
+## Warm-up
+
+[PAUSE 2s] Your first complete, moving sentence — and the language names itself
+after five rivers.
+
+## The letters in this word
+
+**ਪੰਜਾਬੀ** (*panjābī*): **ਪੰ** (*paṁ*, with the *ṭippī* nasal) + **ਜਾ** (*jā*) +
+**ਬੀ** (*bī*). And **ਬੋਲਦਾ** (*boldā*) = the stem *bol-* + **-ਦਾ** (*-dā*), the
+present-habitual, masculine.
+
+## The sentence, taken apart
+
+**ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ** = **ਮੈਂ** (*maiṁ*, "I") + **ਪੰਜਾਬੀ** (*panjābī*, the
+object) + **ਬੋਲਦਾ** (*boldā*, "speak," m.) + **ਹਾਂ** (*hāṁ*, "am") — literally "**I
+Punjabi speaking am**," verb-frame last.
+
+The name **ਪੰਜਾਬੀ** (*panjābī*) is **Persian**: **ਪੰਜ** (*panj*, "five" — cousin
+of English **five**, Latin *quinque*, Greek *pente*!) + **ਆਬ** (*āb*, "water,
+river") = "**[the language] of the five rivers**," for the five great rivers of
+the Punjab. So the very name of the language is a little Persian geography lesson
+— and *panj* "five" is a distant cousin of English *five*, from the same
+Indo-European root.
+
+## Grammar Lens: the present habitual, gendered
+
+To say "I do X," Punjabi uses **stem + -dā/-dī + the copula**, and the participle
+**agrees with the speaker's gender**:
+
+- a man: **ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ** (*boldā hāṁ*)
+- a woman: **ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦੀ ਹਾਂ** (*boldī hāṁ*)
+
+The *-dā/-dī* marks the speaker — a feature English has no trace of.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY (m.): *maiṁ panjābī boldā hāṁ*  ·  (f.): *maiṁ panjābī boldī hāṁ*]
+- [YOU SAY: what *panjābī* means (*panj* "five" + *āb* "water" = "five rivers")]
+- [YOU SAY: the English cousin of *panj* (*five*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Build "I speak Punjabi" as a woman, and unpack the name *panjābī*.
+(*Maiṁ panjābī boldī hāṁ*; *panj* "five" + *āb* "river" — "the five-rivers
+language.")

--- a/code/learning/human-languages/punjabi/lessons/PA-C05-practice.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C05-practice.md
@@ -1,0 +1,48 @@
+---
+id: PA-C05-practice
+chapter: 5
+type: practice
+headword: (dialogue)
+gloss: Chapter 5 recap — the first verbs
+concept_tag: REVIEW
+prerequisites: [PA-C05-bolna, PA-C05-main-punjabi-bolda-han, PA-C05-rahna, PA-C05-kamm-karna]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [PA-C05-bolna, PA-C05-main-punjabi-bolda-han, PA-C05-rahna, PA-C05-kamm-karna, PA-C03-main]
+---
+
+# Chapter 5 — The first verbs
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three verbs, one engine — build real sentences about
+yourself.
+
+## Build the sentences
+
+[PAUSE 1s each]
+- [YOU SAY: "I speak Punjabi" (m./f.) — *maiṁ panjābī boldā/boldī hāṁ*]
+- [YOU SAY: "I live in Amritsar" — *maiṁ Amritsar rahindā/rahindī hāṁ*]
+- [YOU SAY: "I work" — *maiṁ kamm kardā/kardī hāṁ*]
+
+## The engine
+
+[PAUSE 2s]
+- [YOU SAY: the ending every infinitive carries (*-ṇā*/*-nā*)]
+- [YOU SAY: the two agreements in a present sentence (*-dā/-dī* for gender; *hāṁ/haiṁ/ho* for person)]
+- [YOU SAY: where the verb sits (last)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *bolṇā* "to speak" (native Indo-Aryan)
+- *rahiṇā* "to live" ← *rah-* "to remain"
+- *karnā* "to do" ← *√kṛ* — the root of *namaskār* and *karma*
+- *panjābī* ← *panj* "five" (cousin of English *five*) + *āb* "river"
+
+## Wrap-up Recall
+
+[PAUSE 3s] In one breath, tell me your language, your city, and your work in
+Punjabi (as a woman). (*Maiṁ panjābī boldī hāṁ. Maiṁ … rahindī hāṁ. Maiṁ kamm
+kardī hāṁ.*)

--- a/code/learning/human-languages/punjabi/lessons/PA-C05-rahna.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C05-rahna.md
@@ -1,0 +1,50 @@
+---
+id: PA-C05-rahna
+chapter: 5
+type: word
+headword: ਰਹਿਣਾ
+gloss: to live, to stay
+concept_tag: PA-VERB-RAHNA
+prerequisites: [PA-C05-bolna]
+sounds: [sihari-i, retroflex-na]
+roots: [rah-remain]
+est_minutes: 4
+reviews_of: [PA-C05-bolna, PA-C05-main-punjabi-bolda-han]
+---
+
+# ਰਹਿਣਾ (rahiṇā) — "to live, to stay"
+
+## Warm-up
+
+[PAUSE 2s] A second verb, so you can say where you live — and see the *stem +
+ending* machine work again.
+
+## The letters in this word
+
+**ਰ** (*ra*) + **ਹਿ** (*hi*) + **ਣਾ** (*ṇā*, the retroflex infinitive) → **ਰਹਿਣਾ**
+(*rahiṇā*).
+
+## The word, taken apart
+
+**ਰਹਿਣਾ** (*rahiṇā*, "to live, to remain, to stay") is from Sanskrit **ਰਹ੍**
+(*rah-*, "to remain") — the same verb as Hindi *rahnā*. It covers both "reside"
+and "keep on": *maiṁ Amritsar rahindā hāṁ* ("I live in Amritsar"). Stem *rahi-* +
+*-dā/-dī* + copula, exactly like *bolṇā*.
+
+## Grammar Lens: "in" comes after the noun (or is dropped)
+
+**ਮੈਂ ਅੰਮ੍ਰਿਤਸਰ ਰਹਿੰਦਾ ਹਾਂ** (*maiṁ Amritsar rahindā hāṁ*, "I live in Amritsar").
+Punjabi, like Hindi, uses **post**positions (*vic*, "in") where English uses
+prepositions — and with a place-name it often drops "in" entirely. The verb, as
+ever, is last.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY (m.): *maiṁ Amritsar rahindā hāṁ*  ·  (f.): *… rahindī hāṁ*]
+- [YOU SAY: the root (*rah-* "to remain," shared with Hindi *rahnā*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "I live in Amritsar," and name the root of *rahiṇā*. (*Maiṁ
+Amritsar rahindā/rahindī hāṁ*; Sanskrit *rah-*, "to remain.")

--- a/code/learning/human-languages/punjabi/roadmap.md
+++ b/code/learning/human-languages/punjabi/roadmap.md
@@ -16,14 +16,25 @@ vocabularies** (Sanskritic and Perso-Arabic) and the **Gurmukhi** script, taught
   hāṇ/nahīṇ → practice. Gurmukhi introduced through the words; the two-vocabulary
   thread and the Sikh greeting-as-creed foregrounded.
 
+- **Ch. 2 — Introducing Yourself**: nāṁ → merā → hai → **merā nāṁ … hai** ("my
+  name is") → tū̃/tusī̃ → kī → **tuhāḍā nāṁ kī hai?** → khushī (pleased) →
+  practice. Every atom traced (nāṁ ← *nāman* → *name*; hai ← *asti* → *is*; kī ←
+  *ka-* → *what*); SOV word order; the two-level "you"; *khushī* (Persian).
+- **Ch. 3 — How Are You**: kivēṁ (how) → tusī̃ kivēṁ ho? → maiṁ (I) → ṭhīk (fine;
+  *maiṁ ṭhīk hāṁ*) → koī gall nahīṁ (you're welcome = "no matter") → practice.
+  The copula set; the *hāṁ* "am"/"yes" homophone.
+- **Ch. 4 — Farewells**: phir → milāṁge → phir milāṁge (we'll meet again) → rabb
+  rākhā ("God keep you"; Arabic *rabb* + Sanskrit *rakṣ-*) → practice.
+- **Ch. 5 — First Verbs**: bolṇā (to speak) → maiṁ panjābī boldā hāṁ (I speak
+  Punjabi; *panj* "five" + *āb* "river") → rahiṇā (to live) → kamm karnā (to work;
+  ← √kṛ) → practice. The gendered present habitual.
+
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *merā nāṇ…* ("my name"), *tūṇ* / *tusīṇ* (familiar / respectful "you"), gender at the first noun |
-| 3 | Responding: *kī hāl hai?* ("how are you"), *changā/changī* ("well," gendered), the verb *honā* ("to be") |
-| 4 | Postpositions, numbers 1–10, the two number-words (Sanskritic vs. everyday) |
-| 5+ | Gendered verbs, family, food — always with the Sanskrit/Persian contrast thread; Punjabi's tone flagged where it distinguishes words |
+| 6 | Postpositions (*nū̃, tō̃, vic, te*); numbers 1–10 (Sanskritic vs. everyday) |
+| 7+ | Gendered verbs deepened, family, food — with the Sanskrit/Persian thread; tone flagged where it distinguishes words |
 
 Note: Punjabi marks "you" by **register** (*tūṇ* familiar / *tusīṇ* respectful,
 also plural) — like the other Indo-Aryan and Romance tracks. Punjabi is unusually

--- a/code/learning/human-languages/punjabi/session-map.md
+++ b/code/learning/human-languages/punjabi/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Punjabi Chapter 1 (Greetings)
+# Session Map — Punjabi Chapters 1–5
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -19,7 +19,51 @@ word needs.
 | 5 | han-nahin | ਹਾਂ / ਨਹੀਂ | "yes / no"; *nahīṇ* ← PIE *ne (English *no/not/none*) |
 | 6 | practice | (recap) | greetings + the two-vocabulary thread |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 7 | naam | ਨਾਂ | "name" ← Sanskrit *nāman* → English *name* |
+| 8 | mera | ਮੇਰਾ | "my" ← *ma-* → English *my*; agrees with the noun |
+| 9 | hai | ਹੈ | "is" ← Sanskrit *asti* → English *is* |
+| 10 | mera-naam-hai | ਮੇਰਾ ਨਾਂ … ਹੈ | **"my name is…"**; subject–object–verb |
+| 11 | tu-tusi | ਤੂੰ / ਤੁਸੀਂ | **"you"** familiar/respectful; *tū̃* ← *\*tū* → *thou* |
+| 12 | ki | ਕੀ | "what" ← *ka-* → English *what/who* |
+| 13 | tuhada-naam-ki-hai | ਤੁਹਾਡਾ ਨਾਂ ਕੀ ਹੈ? | **"what's your name?"**; verb last |
+| 14 | khushi | ਖ਼ੁਸ਼ੀ | "pleased to meet you"; *khushī* ← Persian (the second vocabulary) |
+| 15 | practice | (dialogue) | the whole exchange |
+
+## Chapter 3 — How Are You
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 16 | kivein | ਕਿਵੇਂ | "how" ← the interrogative *k-* (the *k-* question family) |
+| 17 | tusi-kivein-ho | ਤੁਸੀਂ ਕਿਵੇਂ ਹੋ? | **"how are you?"**; the copula set (hāṁ/haiṁ/ho) |
+| 18 | main | ਮੈਂ | "I" ← *ma-* → English *me*; the *hāṁ* "am"/"yes" homophone |
+| 19 | thik | ਠੀਕ | "fine" (native); reply *maiṁ ṭhīk hāṁ* |
+| 20 | koi-gall-nahin | ਕੋਈ ਗੱਲ ਨਹੀਂ | "it's nothing / you're welcome"; *nahīṁ* ← PIE *ne |
+| 21 | practice | (dialogue) | the whole how-are-you exchange |
+
+## Chapter 4 — Farewells
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 22 | phir | ਫਿਰ | "again" — turns a parting into a promise |
+| 23 | milaange | ਮਿਲਾਂਗੇ | "(we) will meet" ← *mil-* "to join"; the future is an ending |
+| 24 | phir-milaange | ਫਿਰ ਮਿਲਾਂਗੇ | **"we'll meet again"**; everyday vs. formal *sat srī akāl* |
+| 25 | rab-raakha | ਰੱਬ ਰਾਖਾ | "God keep you"; Arabic *rabb* + Sanskrit *rakṣ-* |
+| 26 | practice | (dialogue) | the farewells |
+
+## Chapter 5 — The First Verbs
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 27 | bolna | ਬੋਲਣਾ | "to speak"; every infinitive ends in *-ṇā*; stem *bol-* |
+| 28 | main-punjabi-bolda-han | ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ | **"I speak Punjabi"**; *panj* "five" + *āb* "river" |
+| 29 | rahna | ਰਹਿਣਾ | "to live" ← *rah-* "to remain" |
+| 30 | kamm-karna | ਕੰਮ ਕਰਨਾ | "to work" (noun + *karnā*) ← √kṛ, the root of *namaskār* |
+| 31 | practice | (dialogue) | three verbs, one engine |
+
 ## Next
 
-Chapter 2 — introducing yourself: *merā nāṇ…* ("my name"), and Punjabi's *tūṇ* /
-*tusīṇ* (familiar / respectful "you"), with gender at the first noun.
+Chapter 6 — postpositions (*nū̃, tō̃, vic, te*) and numbers 1–10.


### PR DESCRIPTION
Carries the **Punjabi** track from Chapter 1 (greetings only) to **Chapter 5** —
four new chapters, since Punjabi had not yet had an introductions chapter. Part
of the per-track parity series (Hindi #8596, Tamil #8605, Telugu #8607, Kannada
#8608, Malayalam #8610).

Framework `HL00`; concept tags reuse the universal `HL01` taxonomy, verbs
namespaced (`PA-VERB-*`) — no `taxonomy.json` change. Punjabi's **two
vocabularies** (Sanskritic vs. Perso-Arabic) run throughout.

## Chapters

- **Ch. 2 — Introducing Yourself**: *nāṁ* (← *nāman* → *name*) → *merā* → *hai*
  (← *asti* → *is*) → *merā nāṁ … hai* → *tū̃/tusī̃* (← *\*tū* → *thou*) → *kī*
  (← *ka-* → *what*) → *tuhāḍā nāṁ kī hai?* → *khushī* (Persian — the second
  vocabulary) → practice.
- **Ch. 3 — How Are You**: *kivēṁ* → *tusī̃ kivēṁ ho?* → *maiṁ* (with the *hāṁ*
  "am"/"yes" homophone) → *ṭhīk* (native "fine") → *koī gall nahīṁ* ("no matter"
  = you're welcome; *nahīṁ* ← PIE *ne) → practice.
- **Ch. 4 — Farewells**: *phir* → *milāṁge* → *phir milāṁge* (vs. Ch.1's formal
  *sat srī akāl*) → *rabb rākhā* ("God keep you" — **Arabic** *rabb* + **Sanskrit**
  *rakṣ-*, the two vocabularies in one blessing) → practice.
- **Ch. 5 — First Verbs**: *bolṇā* (the *-ṇā* infinitive) → *maiṁ panjābī boldā
  hāṁ* (I speak Punjabi; *panj* "five," cousin of English *five*, + *āb* "river"
  = "the five-rivers language") → *rahiṇā* (to live) → *kamm karnā* (to work; ←
  √kṛ, the root of *namaskār*) → practice. The gendered present habitual.

## Verification

- Book compiles clean with XeLaTeX (×2): **0 missing characters, 0 undefined
  references** (25 pages).
- New chapter pages rasterized and visually QA'd — Gurmukhi, pair-bindis,
  addak/ṭippī, and grammar tables all render correctly.
- Concept tags validate against `HL01`; `/security-review` covered by the Hindi
  run (identical content-only class).
- `human-languages-books.yml` CI will build the updated PDF on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)