### PR TITLE
feat(hl-spanish): Chapter 10 — the near future (ir a) and possessives

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -212,6 +212,9 @@
       "ES-SER-VS-ESTAR": "ser vs estar — the two 'to be' verbs (essence vs state); minimal pairs flip meaning (es/está aburrido, rico, verde, listo)",
       "ES-ORIGIN-SER": "soy de… — origin/profession/nationality take ser (essence); de ← Latin dē; ¿De dónde eres?",
       "ES-LOCATION-ESTAR": "está en… — physical location always takes estar (← stāre 'to stand'); en ← Latin in; ¿Dónde estás?",
+      "ES-VERB-IR": "ir — 'to go' (most suppletive: infinitive ← īre, present voy/vas/va/vamos/van ← vādere → invade/evade; go/went trick)",
+      "ES-NEAR-FUTURE": "ir a + infinitive — the 'going-to' future (voy a hablar = I'm going to speak); a ← ad; mirrors English/French",
+      "ES-POSSESSIVE": "mi/tu/su (+ mis/tus/sus) — possessives ← meus/tuus/suus → my/thy; agree in NUMBER not gender; tu 'your' vs tú 'you'",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -245,6 +248,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/kannada/lessons/KA-C03-paravaagilla.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C03-paravaagilla.md
@@ -4,7 +4,7 @@ chapter: 3
 type: phrase
 headword: ಪರವಾಗಿಲ್ಲ
 gloss: it's okay / no problem / you're welcome
-concept_tag: YOURE-WELCOME
+concept_tag: COURTESY-YOUREWELCOME
 prerequisites: [KA-C01-illa, KA-C01-dhanyavada]
 sounds: [illa-negative]
 roots: [illa-not-dravidian]

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 10 — The near future and possessives
+
+- **Chapter 10 authored** (`ES-C10-ir`, `-ir-a-futuro`, `-mi-tu-su`, `-practice`):
+  the pilot starts running on **rules, not phrases** — reviewing Ch.6–9 via
+  `reviews_of`.
+- **ir** — "to go," the **most suppletive** verb in Spanish: its infinitive is
+  from *īre* (→ exit/transit), but its whole present (*voy/vas/va/vamos/van*) comes
+  from a **different** Latin verb, *vādere* "to advance" (→ invade/evade/wade), and
+  its past from a **third** (*esse/fuī*). Framed as the exact *go/went* suppletion
+  English uses; *voy* wears the *-oy* of *soy/estoy/doy*. Includes *voy a* + place
+  (destination; *a* ← *ad*, *a+el→al*).
+- **The near future** — *ir a* + infinitive (*voy a hablar* = "I'm going to
+  speak"): Spanish builds tomorrow out of the verb "to go," the same metaphor as
+  English *going to* and French *je vais parler* — a whole tense almost for free,
+  the second verb staying a bare infinitive.
+- **mi/tu/su** (← *meus/tuus/suus* → my/thy, and the *-ty* family) — possessives
+  that agree in **number** (*mis/tus/sus*), **not gender**; *su* covers his/her/its/
+  your-formal/their; and *tu* "your" vs *tú* "you" reactivates the *tilde
+  diacrítica* from the writing chapter.
+- Taxonomy: namespaced `ES-VERB-IR`, `ES-NEAR-FUTURE`, `ES-POSSESSIVE`; practice
+  label `CH10-PRACTICE`.
+
 ## Chapter 9 — ser vs estar, head-on
 
 - **Chapter 9 authored** (`ES-C09-ser`, `-ser-vs-estar`, `-soy-de`, `-esta-en`,

--- a/code/learning/human-languages/spanish/lessons/ES-C10-ir-a-futuro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-ir-a-futuro.md
@@ -1,0 +1,64 @@
+---
+id: ES-C10-ir-a-futuro
+chapter: 10
+type: phrase
+headword: voy a + infinitive
+gloss: the near future — "I'm going to…"
+concept_tag: ES-NEAR-FUTURE
+prerequisites: [ES-C10-ir, ES-C06-hablar]
+sounds: [diphthong-oy]
+roots: [ire-vadere-latin, ad-latin]
+etymology_hook: "ir a + infinitive = 'going to' — Spanish builds the future exactly as English does, out of the verb 'to go' (voy a hablar = I'm going to speak)"
+est_minutes: 4
+reviews_of: [ES-C10-ir, ES-C06-hablar, ES-C07-comer]
+---
+
+# voy a + infinitive — the "going-to" future
+
+## Warm-up
+
+[PAUSE 2s] Here's a gift: Spanish builds its everyday future **exactly like
+English**. English says "I'm **going to** speak"; Spanish says "**voy a** hablar."
+Same metaphor — the verb *to go*, aimed at what's coming — so you already know how
+to think it. You get a whole tense for almost free.
+
+## The pattern
+
+Take the present of *ir*, add **a**, add any **infinitive** (the dictionary form
+of a verb — *hablar*, *comer*, *vivir*, all of which you own):
+
+> **voy a** + infinitive → **voy a hablar** = "I'm going to speak."
+
+| yo | **voy a** hablar | "I'm going to speak" |
+| tú | **vas a** comer | "you're going to eat" |
+| él/ella/usted | **va a** estudiar | "she's going to study" |
+| nosotros | **vamos a** vivir | "we're going to live" |
+| ellos/ustedes | **van a** trabajar | "they're going to work" |
+
+Only *ir* changes; the second verb stays a bare **infinitive**, never conjugated —
+just as English keeps "to speak" unchanged after "going to."
+
+## Grammar Lens: why "go" becomes "future" (in both languages)
+
+It's one of the most natural metaphors in human language: *movement toward*
+something becomes *time approaching* it. If you're **going to** a place, you
+haven't arrived — it's ahead of you; so "going to (do)" comes to mean "about to,
+soon." French does it too (*je vais parler*), and English, and Spanish — three
+languages, the same picture. Spanish even keeps the little **a** ("to," ← *ad*)
+that English drops in speech ("gonna").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "voy a hablar, vas a comer, va a estudiar" — *ir* + a + infinitive]
+- [YOU SAY: build three about your day — "Voy a trabajar," "Voy a comer," "Vamos a
+  casa"]
+- [YOU SAY: English "I'm going to…" then Spanish "voy a…" — feel the identical
+  metaphor]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Spanish form the near future? (*ir* in the present + **a** +
+an **infinitive**: *voy a hablar*.) Does the second verb change? (No — it stays an
+infinitive.) What English construction is it a mirror of? ("Going to" + verb.)
+Next: whose things are they — the **possessives** *mi/tu/su*.

--- a/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
@@ -1,0 +1,76 @@
+---
+id: ES-C10-ir
+chapter: 10
+type: word
+headword: ir
+gloss: to go (the most irregular Spanish verb — three Latin verbs in one)
+concept_tag: ES-VERB-IR
+prerequisites: [ES-C09-ser, ES-C04-estar]
+sounds: [vowel-i, diphthong-oy]
+roots: [ire-vadere-latin]
+etymology_hook: "ir ← Latin īre 'to go', but its present (voy/vas/va/vamos/van) comes from a DIFFERENT verb, vādere — suppletion, exactly like English go/went"
+est_minutes: 5
+reviews_of: [ES-C09-ser, ES-C09-practice]
+---
+
+# ir — "to go," stitched from three verbs
+
+## Warm-up
+
+[PAUSE 2s] You've met two suppletive verbs now — *ser* (soy/eres/es…) and, in a
+way, *estar*. **ir**, "to go," is the extreme case: its forms come from **three
+different Latin verbs** fused into one. English does the very same thing with *go*
+/ *went*, so the idea is already familiar.
+
+## Sounds you'll need
+
+- `vowel-i` — the infinitive **ir** is just *eer*, two letters, one of the
+  shortest verbs in Spanish.
+- `diphthong-oy` — **voy** = *boy* (a *b/v* sound + "oy"), sharing the *-oy* tail
+  of *soy, estoy, doy*.
+
+## The word, taken apart — suppletion, in the extreme
+
+Three Latin verbs meaning "go" collapsed into Spanish *ir*:
+
+| where it shows up | ← Latin | note |
+|---|---|---|
+| the infinitive **ir** | *īre* "to go" | gives English *exit* (*ex-īre* "go out"), *transit*, *ambition* |
+| the present **voy, vas, va, vamos, van** | *vādere* "to advance, rush" | gives English **invade, evade, wade** |
+| the past *fui* (later) | *esse/fuī* "to be" | the same *fu-* as *ser*'s past |
+
+So the present tense doesn't come from *ir* at all — it comes from *vādere*:
+
+| yo | **voy** | (the *-oy*, like *soy/estoy/doy*) |
+| tú | **vas** | |
+| él/ella/usted | **va** | |
+| nosotros | **vamos** | (this is also "let's go!") |
+| ellos/ustedes | **van** | |
+
+This is **suppletion** — the exact phenomenon behind English *go* (present) vs
+*went* (past, borrowed from an old verb *wend*). Spanish just does it inside a
+single tense.
+
+## Grammar Lens: voy a + place (going somewhere)
+
+Point *ir* at a destination with **a** ("to," ← Latin *ad*):
+
+> **Voy a** Madrid. — "I'm going to Madrid."
+> **Vamos a** casa. — "We're going home / Let's go home."
+
+*a* + *el* contracts to **al**: *voy al café* ("to the café"). Next lesson, this
+same *voy a…* becomes a way to talk about the **future**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ir" then the present set — "voy, vas, va, vamos, van"]
+- [YOU SAY: "voy" / English "invade", "evade" — the *vādere* family]
+- [YOU SAY: "Voy a Madrid," "Vamos a casa" — *ir a* + a place]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What three Latin verbs feed Spanish *ir*? (*īre* — infinitive; *vādere*
+— the present *voy/vas…*; *esse/fuī* — the past.) What English pair shows the same
+suppletion? (*go / went*.) Give the present of *ir*. (*Voy, vas, va, vamos, van*.)
+Next: turn *voy a…* into **the future**.

--- a/code/learning/human-languages/spanish/lessons/ES-C10-mi-tu-su.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-mi-tu-su.md
@@ -1,0 +1,69 @@
+---
+id: ES-C10-mi-tu-su
+chapter: 10
+type: word
+headword: mi, tu, su
+gloss: my, your, his/her/your-formal (the possessives)
+concept_tag: ES-POSSESSIVE
+prerequisites: [ES-C03-tu-usted, ES-C01-dia]
+sounds: [vowel-i, vowel-u]
+roots: [meus-tuus-suus-latin]
+etymology_hook: "mi/tu/su ← Latin meus/tuus/suus → English my/thy (and the -ty of majesty); agree in NUMBER (mis/tus/sus) not gender"
+est_minutes: 4
+reviews_of: [ES-C10-ir, ES-C03-tu-usted]
+---
+
+# mi, tu, su — my, your, his/her
+
+## Warm-up
+
+[PAUSE 2s] To say **whose** something is, Spanish puts a small word before the
+noun: *mi casa* "my house," *tu café* "your coffee." These come straight from
+Latin and line up neatly with the pronouns you already know.
+
+## The words, taken apart
+
+| Spanish | ← Latin | means | English cousin |
+|---|---|---|---|
+| **mi** | *meus* | my | **my, mine** (and *me*) |
+| **tu** | *tuus* | your (informal, *tú*'s) | **thy, thine** (old "your") |
+| **su** | *suus* | his / her / its / your-*formal* / their | the *-sy* of *sui generis* |
+
+Two things to notice:
+
+- **tu vs tú.** The possessive **tu** ("your") has **no accent**; the pronoun
+  **tú** ("you") does. Same split you met in the writing chapter (*el/él*,
+  *si/sí*) — the accent (*tilde diacrítica*) separates two look-alike words.
+- **su does a lot of work.** Because it covers *his, her, its, your-formal,* and
+  *their* all at once, context tells you which. *Su casa* = "his/her/your/their
+  house";
+  if it's genuinely unclear, Spanish adds *de él, de ella…* ("of him, of her").
+
+## Grammar Lens: they agree in NUMBER, not gender
+
+Unlike most Spanish modifiers, *mi/tu/su* **don't** change for masculine/feminine
+— *mi casa* (fem.) and *mi café* (masc.) both use *mi*. They only change for
+**number**: add **-s** for a plural noun.
+
+| singular | plural |
+|---|---|
+| **mi** libro → **mis** libros | "my book → my books" |
+| **tu** casa → **tus** casas | "your house → your houses" |
+| **su** amigo → **sus** amigos | "his friend → his friends" |
+
+(*nuestro/nuestra* "our," ← *noster*, is the one that *does* flex for gender —
+you'll meet it fully later.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mi, tu, su" — my / your / his-her]
+- [YOU SAY: "mi casa, tu café, su amigo" — before a noun, no gender change]
+- [YOU SAY: pluralize — "mis libros, tus casas, sus amigos" — the *-s* for number]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "my / your / his," and one Latin source. (*Mi/tu/su*, ← *meus/
+tuus/suus*.) What's the difference between *tu* and *tú*? (No accent = "your";
+accent = "you.") Do possessives agree in gender or number? (Number only — add
+*-s*: *mis/tus/sus*.) Next: **practice** the whole chapter.

--- a/code/learning/human-languages/spanish/lessons/ES-C10-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-practice.md
@@ -1,0 +1,67 @@
+---
+id: ES-C10-practice
+chapter: 10
+type: practice-mix
+headword: (practice)
+gloss: going places, the near future, and whose things
+concept_tag: CH10-PRACTICE
+prerequisites: [ES-C10-ir, ES-C10-ir-a-futuro, ES-C10-mi-tu-su]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C10-ir, ES-C10-ir-a-futuro, ES-C10-mi-tu-su, ES-C09-practice]
+---
+
+# Practice — ir, the near future, and possessives
+
+## Warm-up
+
+[PAUSE 2s] Three new powers this chapter: you can **go** places, talk about the
+**future**, and say **whose** things are whose. Drill the irregular *ir* until
+*voy/vas/va/vamos/van* is automatic, because the whole future rides on it.
+
+## Conjugate and build
+
+[PAUSE 1s]
+- **ir**, present: **voy · vas · va · vamos · van** (from *vādere* — the *-oy* of
+  *voy*, like *soy/estoy/doy*).
+- **the near future**: *ir* + **a** + infinitive — **voy a hablar, vas a comer, va
+  a estudiar** ("I'm/you're/she's going to…").
+- **possessives**: **mi · tu · su** (+ plural **mis · tus · sus**) — agree in
+  **number**, not gender.
+
+## Say something real
+
+> — ¿Qué **vas a** hacer hoy? — **Voy a** estudiar en **mi** casa, y luego **voy
+> a** trabajar. ¿Y tú? — **Voy a** comer con **mis** amigos. **Vamos a** un café.
+
+Two chapters working together: *voy a estudiar / voy a comer* (near future →
+**ir**), *mi casa / mis amigos* (**possessives**), *vamos a un café* (**ir a** +
+place).
+
+## What you've built this chapter
+
+- **ir** — "to go," the **most suppletive** Spanish verb (infinitive ← *īre*;
+  present *voy/vas/va/vamos/van* ← *vādere* → invade/evade), the same *go/went*
+  trick English plays.
+- **the near future** — *ir a* + infinitive (*voy a hablar* = "I'm going to
+  speak"), Spanish building tomorrow out of the verb "to go," exactly as English
+  and French do.
+- **mi/tu/su** (← *meus/tuus/suus* → my/thy) — possessives that agree in **number**
+  (*mis/tus/sus*), not gender; and *tu* "your" vs *tú* "you" (the accent again).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: conjugate *ir* fully — "voy, vas, va, vamos, van"]
+- [YOU SAY: three near-future plans — "Voy a … " with hablar / comer / trabajar]
+- [YOU SAY: "mi casa, mis amigos, tu café, su libro" — possessives + number]
+
+[REPEAT x2] "¿Qué vas a hacer? — Voy a … con mis amigos."
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the present of *ir*. (*Voy, vas, va, vamos, van*.) Build "we're
+going to eat." (*Vamos a comer*.) How do *mi/tu/su* change for a plural noun, and
+do they change for gender? (Add *-s* → *mis/tus/sus*; **no** gender change.) Next
+chapter takes these rules further — the course now runs on grammar, not phrases.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -64,9 +64,18 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   (location → estar; *en* ← *in*) → practice. **Authored** — the pilot's payoff
   chapter; the two "to be" verbs sorted for good.
 
-Next: **Ch. 10** — the **near future** (*ir a* + infinitive, "going to…") and
-**possessives** (*mi/tu/su*). From here the course hands over rules, not phrases.
-Grammar accumulates piece by piece. The theme skeleton below plans the wider road.
+- **Ch. 10 — The near future and possessives**: **ir** ("to go," the most
+  suppletive verb — infinitive ← *īre*, present *voy/vas/va/vamos/van* ← *vādere* →
+  invade/evade; the *go/went* trick) → the **near future** *ir a* + infinitive
+  (*voy a hablar* "I'm going to speak," Spanish building tomorrow from "to go," like
+  English/French) → possessives **mi/tu/su** (← *meus/tuus/suus* → my/thy; agree in
+  **number** not gender; *tu* vs *tú*) → practice. **Authored** — the course now
+  runs on rules, not phrases.
+
+Next: **Ch. 11** — *querer/poder* (stem-changing verbs; wants & ability) and more
+possessives (*nuestro*), building toward everyday description. From here the course
+hands over rules, not phrases. Grammar accumulates piece by piece. The theme
+skeleton below plans the wider road.
 
 ## Theme Skeleton (planning only)
 

--- a/code/learning/human-languages/telugu/lessons/TE-C03-paravaaledu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C03-paravaaledu.md
@@ -4,7 +4,7 @@ chapter: 3
 type: phrase
 headword: పరవాలేదు
 gloss: it's okay / no problem / you're welcome
-concept_tag: YOURE-WELCOME
+concept_tag: COURTESY-YOUREWELCOME
 prerequisites: [TE-C01-ledu, TE-C01-dhanyavadamulu]
 sounds: [ledu-negative]
 roots: [ledu-not-dravidian]


### PR DESCRIPTION
Spanish **Chapter 10** — the pilot starts running on **rules, not phrases**. Atom-first, each 3–5 min, reviewing Ch.6–9 via `reviews_of`, deep etymology throughout.

## Lessons (`ES-C10-*`)
- **ir** — "to go," the **most suppletive** verb in Spanish: its infinitive is from *īre* (→ exit/transit), but its entire present *voy/vas/va/vamos/van* comes from a **different** Latin verb *vādere* "to advance" (→ **invade/evade/wade**), and its past from a **third** (*esse/fuī*). Framed as the exact *go/went* suppletion English uses; *voy* wears the *-oy* of *soy/estoy/doy*. Includes *voy a* + place (*a* ← *ad*, *a+el→al*).
- **ir-a-futuro** — the **near future** *ir a* + infinitive (*voy a hablar* = "I'm going to speak"): Spanish builds tomorrow out of the verb "to go," the same metaphor as English *going-to* and French *je vais parler* — a whole tense almost for free, the second verb staying a bare infinitive.
- **mi-tu-su** — possessives ← *meus/tuus/suus* (→ **my/thy**); agree in **number** (*mis/tus/sus*), **not gender**; *su* covers his/her/its/your-formal/their; *tu* "your" vs *tú* "you" reactivates the *tilde diacrítica*.
- **practice** — drills *ir*, the near future, and possessives in one exchange.

## Data / taxonomy
- Namespaced concepts documented: `ES-VERB-IR`, `ES-NEAR-FUTURE`, `ES-POSSESSIVE`; `CH10-PRACTICE` added to the practice-tag note.
- Roadmap advanced (Ch.10 authored; **Next = Ch.11** *querer/poder* + *nuestro*); Spanish CHANGELOG updated.

## Also: fixes red main (again)
Same recurring class as #8603 (Hindi) and #8612 (Tamil), now with two new siblings: **Telugu** `TE-C03-paravaaledu` and **Kannada** `KA-C03-paravaagilla` both carried the **retired** `concept_tag: YOURE-WELCOME` (retired by `COURTESY-YOUREWELCOME`), failing the `human-language-data` validator. Retagged both to canonical (no duplicate realization in either track). Must ride here because **this PR edits `taxonomy.json`, which retriggers that suite**.

Because this is the *fourth* recurrence across Indic tracks, I've flagged a **root-cause task** to fix the shared scaffold these lessons copy from and to improve the validator's error message (name the canonical replacement for a retired tag) — so it stops recurring.

## Verification
- `human-language-data` suite: **38 / 38 pass** (was 3 failing on origin/main due to the Telugu+Kannada tags).
- Security-reviewed (subagent): markdown + JSON only — no scripts, URLs, secrets, or injection; taxonomy.json validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)