### PR TITLE
feat(document-ast): add Haskell port

### DIFF
--- a/code/packages/haskell/document-ast/BUILD
+++ b/code/packages/haskell/document-ast/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/document-ast/BUILD_windows
+++ b/code/packages/haskell/document-ast/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/document-ast/CHANGELOG.md
+++ b/code/packages/haskell/document-ast/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add immutable TE00 block and inline node types.
+- Add GFM task-list, strikethrough, and table node types.
+- Add exhaustive algebraic unions and stable discriminator helpers.

--- a/code/packages/haskell/document-ast/README.md
+++ b/code/packages/haskell/document-ast/README.md
@@ -1,0 +1,31 @@
+# document-ast
+
+A pure Haskell implementation of the format-agnostic Document AST defined by
+TE00. Front-end parsers produce this immutable intermediate representation and
+back-end renderers consume it, so document formats can interoperate through one
+stable typed tree.
+
+## API
+
+- Concrete immutable records model documents, headings, paragraphs, code
+  blocks, blockquotes, lists, list items, task items, raw blocks, and tables.
+- Concrete immutable records model text, emphasis, strong text,
+  strikethrough, code spans, resolved links, images, autolinks, raw inline
+  content, and hard and soft breaks.
+- `BlockNode`, `ListChildNode`, `InlineNode`, and `Node` are exhaustive
+  algebraic unions for type-safe traversal.
+- `TableAlignment` preserves left, right, center, and absent alignment hints.
+- `blockNodeTypeName`, `listChildNodeTypeName`, `tableRowNodeTypeName`,
+  `tableCellNodeTypeName`, `inlineNodeTypeName`, and `nodeTypeName` expose the
+  stable cross-language discriminator strings.
+
+The data model performs no parsing or rendering and has no dependencies beyond
+`base`. Producers are responsible for TE00 invariants such as heading levels
+1 through 6, resolved links, non-nested documents, and trailing newlines in
+code blocks.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/document-ast/cabal.project
+++ b/code/packages/haskell/document-ast/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/document-ast/document-ast.cabal
+++ b/code/packages/haskell/document-ast/document-ast.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          document-ast
+version:       0.1.0
+synopsis:      Format-agnostic intermediate representation for documents
+description:   Immutable typed block and inline nodes shared by document parsers and renderers.
+category:      Data
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  DocumentAst
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    DocumentAstSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , document-ast
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/document-ast/src/DocumentAst.hs
+++ b/code/packages/haskell/document-ast/src/DocumentAst.hs
@@ -1,0 +1,295 @@
+-- | A format-agnostic intermediate representation for structured documents.
+--
+-- Front-end parsers produce these immutable values and back-end renderers
+-- consume them. The types implement TE00 Document AST together with the
+-- shared GFM task-list, strikethrough, and table extensions.
+module DocumentAst
+    ( TableAlignment (..)
+    , DocumentNode (..)
+    , HeadingNode (..)
+    , ParagraphNode (..)
+    , CodeBlockNode (..)
+    , BlockquoteNode (..)
+    , ListNode (..)
+    , ListItemNode (..)
+    , TaskItemNode (..)
+    , ThematicBreakNode (..)
+    , RawBlockNode (..)
+    , TableNode (..)
+    , TableRowNode (..)
+    , TableCellNode (..)
+    , TextNode (..)
+    , EmphasisNode (..)
+    , StrongNode (..)
+    , StrikethroughNode (..)
+    , CodeSpanNode (..)
+    , LinkNode (..)
+    , ImageNode (..)
+    , AutolinkNode (..)
+    , RawInlineNode (..)
+    , HardBreakNode (..)
+    , SoftBreakNode (..)
+    , ListChildNode (..)
+    , BlockNode (..)
+    , InlineNode (..)
+    , Node (..)
+    , blockNodeTypeName
+    , listChildNodeTypeName
+    , tableRowNodeTypeName
+    , tableCellNodeTypeName
+    , inlineNodeTypeName
+    , nodeTypeName
+    ) where
+
+-- | Column alignment hint for a table. 'Nothing' represents no hint.
+data TableAlignment
+    = AlignLeft
+    | AlignRight
+    | AlignCenter
+    deriving (Eq, Show)
+
+-- | Root of a document. A well-formed tree does not nest it below another node.
+newtype DocumentNode = DocumentNode
+    { documentChildren :: [BlockNode]
+    }
+    deriving (Eq, Show)
+
+-- | Section heading. Front-ends clamp 'headingLevel' to the range 1 through 6.
+data HeadingNode = HeadingNode
+    { headingLevel :: Int
+    , headingChildren :: [InlineNode]
+    }
+    deriving (Eq, Show)
+
+-- | Block of prose containing inline content.
+newtype ParagraphNode = ParagraphNode
+    { paragraphChildren :: [InlineNode]
+    }
+    deriving (Eq, Show)
+
+-- | Literal code or preformatted text, with an optional language hint.
+data CodeBlockNode = CodeBlockNode
+    { codeBlockLanguage :: Maybe String
+    , codeBlockValue :: String
+    }
+    deriving (Eq, Show)
+
+-- | Quoted block content.
+newtype BlockquoteNode = BlockquoteNode
+    { blockquoteChildren :: [BlockNode]
+    }
+    deriving (Eq, Show)
+
+-- | Ordered or unordered list with its source tightness preserved.
+data ListNode = ListNode
+    { listOrdered :: Bool
+    , listStart :: Maybe Int
+    , listTight :: Bool
+    , listChildren :: [ListChildNode]
+    }
+    deriving (Eq, Show)
+
+-- | Ordinary list item containing block content.
+newtype ListItemNode = ListItemNode
+    { listItemChildren :: [BlockNode]
+    }
+    deriving (Eq, Show)
+
+-- | GFM task-list item containing block content.
+data TaskItemNode = TaskItemNode
+    { taskItemChecked :: Bool
+    , taskItemChildren :: [BlockNode]
+    }
+    deriving (Eq, Show)
+
+-- | Visual separator between sections.
+data ThematicBreakNode = ThematicBreakNode
+    deriving (Eq, Show)
+
+-- | Verbatim block content for one target format.
+data RawBlockNode = RawBlockNode
+    { rawBlockFormat :: String
+    , rawBlockValue :: String
+    }
+    deriving (Eq, Show)
+
+-- | GFM table with one alignment entry per column.
+data TableNode = TableNode
+    { tableAlignments :: [Maybe TableAlignment]
+    , tableRows :: [TableRowNode]
+    }
+    deriving (Eq, Show)
+
+-- | One header or body row in a table.
+data TableRowNode = TableRowNode
+    { tableRowIsHeader :: Bool
+    , tableRowChildren :: [TableCellNode]
+    }
+    deriving (Eq, Show)
+
+-- | One table cell containing inline content.
+newtype TableCellNode = TableCellNode
+    { tableCellChildren :: [InlineNode]
+    }
+    deriving (Eq, Show)
+
+-- | Plain decoded Unicode text.
+newtype TextNode = TextNode
+    { textValue :: String
+    }
+    deriving (Eq, Show)
+
+-- | Stressed emphasis.
+newtype EmphasisNode = EmphasisNode
+    { emphasisChildren :: [InlineNode]
+    }
+    deriving (Eq, Show)
+
+-- | Strong importance.
+newtype StrongNode = StrongNode
+    { strongChildren :: [InlineNode]
+    }
+    deriving (Eq, Show)
+
+-- | GFM deleted or struck-through text.
+newtype StrikethroughNode = StrikethroughNode
+    { strikethroughChildren :: [InlineNode]
+    }
+    deriving (Eq, Show)
+
+-- | Raw inline code.
+newtype CodeSpanNode = CodeSpanNode
+    { codeSpanValue :: String
+    }
+    deriving (Eq, Show)
+
+-- | Hyperlink with a resolved destination and optional title.
+data LinkNode = LinkNode
+    { linkDestination :: String
+    , linkTitle :: Maybe String
+    , linkChildren :: [InlineNode]
+    }
+    deriving (Eq, Show)
+
+-- | Embedded image with plain-text alternative content.
+data ImageNode = ImageNode
+    { imageDestination :: String
+    , imageTitle :: Maybe String
+    , imageAlt :: String
+    }
+    deriving (Eq, Show)
+
+-- | Direct URL or email link.
+data AutolinkNode = AutolinkNode
+    { autolinkDestination :: String
+    , autolinkIsEmail :: Bool
+    }
+    deriving (Eq, Show)
+
+-- | Verbatim inline content for one target format.
+data RawInlineNode = RawInlineNode
+    { rawInlineFormat :: String
+    , rawInlineValue :: String
+    }
+    deriving (Eq, Show)
+
+-- | Forced line break.
+data HardBreakNode = HardBreakNode
+    deriving (Eq, Show)
+
+-- | Source-preserving soft line break.
+data SoftBreakNode = SoftBreakNode
+    deriving (Eq, Show)
+
+-- | The only node shapes permitted directly inside a list.
+data ListChildNode
+    = ListItem ListItemNode
+    | TaskItem TaskItemNode
+    deriving (Eq, Show)
+
+-- | Structural document nodes. Document, list-item, and table component
+-- variants are included to support exhaustive generic traversal.
+data BlockNode
+    = BlockDocument DocumentNode
+    | BlockHeading HeadingNode
+    | BlockParagraph ParagraphNode
+    | BlockCodeBlock CodeBlockNode
+    | BlockBlockquote BlockquoteNode
+    | BlockList ListNode
+    | BlockListItem ListItemNode
+    | BlockTaskItem TaskItemNode
+    | BlockThematicBreak ThematicBreakNode
+    | BlockRawBlock RawBlockNode
+    | BlockTable TableNode
+    | BlockTableRow TableRowNode
+    | BlockTableCell TableCellNode
+    deriving (Eq, Show)
+
+-- | Inline document nodes.
+data InlineNode
+    = InlineText TextNode
+    | InlineEmphasis EmphasisNode
+    | InlineStrong StrongNode
+    | InlineStrikethrough StrikethroughNode
+    | InlineCodeSpan CodeSpanNode
+    | InlineLink LinkNode
+    | InlineImage ImageNode
+    | InlineAutolink AutolinkNode
+    | InlineRawInline RawInlineNode
+    | InlineHardBreak HardBreakNode
+    | InlineSoftBreak SoftBreakNode
+    deriving (Eq, Show)
+
+-- | Union of block and inline nodes for generic traversal.
+data Node
+    = NodeBlock BlockNode
+    | NodeInline InlineNode
+    deriving (Eq, Show)
+
+-- | Stable discriminator used by serializers and renderers.
+blockNodeTypeName :: BlockNode -> String
+blockNodeTypeName (BlockDocument _) = "document"
+blockNodeTypeName (BlockHeading _) = "heading"
+blockNodeTypeName (BlockParagraph _) = "paragraph"
+blockNodeTypeName (BlockCodeBlock _) = "code_block"
+blockNodeTypeName (BlockBlockquote _) = "blockquote"
+blockNodeTypeName (BlockList _) = "list"
+blockNodeTypeName (BlockListItem _) = "list_item"
+blockNodeTypeName (BlockTaskItem _) = "task_item"
+blockNodeTypeName (BlockThematicBreak _) = "thematic_break"
+blockNodeTypeName (BlockRawBlock _) = "raw_block"
+blockNodeTypeName (BlockTable _) = "table"
+blockNodeTypeName (BlockTableRow _) = "table_row"
+blockNodeTypeName (BlockTableCell _) = "table_cell"
+
+-- | Stable discriminator for direct list children.
+listChildNodeTypeName :: ListChildNode -> String
+listChildNodeTypeName (ListItem _) = "list_item"
+listChildNodeTypeName (TaskItem _) = "task_item"
+
+-- | Stable discriminator for table rows.
+tableRowNodeTypeName :: TableRowNode -> String
+tableRowNodeTypeName _ = "table_row"
+
+-- | Stable discriminator for table cells.
+tableCellNodeTypeName :: TableCellNode -> String
+tableCellNodeTypeName _ = "table_cell"
+
+-- | Stable discriminator used by serializers and renderers.
+inlineNodeTypeName :: InlineNode -> String
+inlineNodeTypeName (InlineText _) = "text"
+inlineNodeTypeName (InlineEmphasis _) = "emphasis"
+inlineNodeTypeName (InlineStrong _) = "strong"
+inlineNodeTypeName (InlineStrikethrough _) = "strikethrough"
+inlineNodeTypeName (InlineCodeSpan _) = "code_span"
+inlineNodeTypeName (InlineLink _) = "link"
+inlineNodeTypeName (InlineImage _) = "image"
+inlineNodeTypeName (InlineAutolink _) = "autolink"
+inlineNodeTypeName (InlineRawInline _) = "raw_inline"
+inlineNodeTypeName (InlineHardBreak _) = "hard_break"
+inlineNodeTypeName (InlineSoftBreak _) = "soft_break"
+
+-- | Stable discriminator for either union branch.
+nodeTypeName :: Node -> String
+nodeTypeName (NodeBlock node) = blockNodeTypeName node
+nodeTypeName (NodeInline node) = inlineNodeTypeName node

--- a/code/packages/haskell/document-ast/test/DocumentAstSpec.hs
+++ b/code/packages/haskell/document-ast/test/DocumentAstSpec.hs
@@ -1,0 +1,170 @@
+module DocumentAstSpec (spec) where
+
+import DocumentAst
+import Test.Hspec
+
+text :: String -> InlineNode
+text = InlineText . TextNode
+
+paragraph :: String -> BlockNode
+paragraph = BlockParagraph . ParagraphNode . pure . text
+
+spec :: Spec
+spec = do
+    describe "document structure" $ do
+        it "builds an immutable nested document" $ do
+            let document =
+                    DocumentNode
+                        [ BlockHeading (HeadingNode 1 [text "Title"])
+                        , paragraph "Hello"
+                        , BlockBlockquote (BlockquoteNode [paragraph "Quoted"])
+                        ]
+            length (documentChildren document) `shouldBe` 3
+            blockNodeTypeName (documentChildren document !! 0) `shouldBe` "heading"
+            blockNodeTypeName (documentChildren document !! 2) `shouldBe` "blockquote"
+
+        it "exposes every stable block discriminator" $ do
+            let row = TableRowNode True []
+                cell = TableCellNode []
+                nodes =
+                    [ BlockDocument (DocumentNode [])
+                    , BlockHeading (HeadingNode 2 [])
+                    , BlockParagraph (ParagraphNode [])
+                    , BlockCodeBlock (CodeBlockNode Nothing "code\n")
+                    , BlockBlockquote (BlockquoteNode [])
+                    , BlockList (ListNode False Nothing True [])
+                    , BlockListItem (ListItemNode [])
+                    , BlockTaskItem (TaskItemNode True [])
+                    , BlockThematicBreak ThematicBreakNode
+                    , BlockRawBlock (RawBlockNode "html" "<hr>\n")
+                    , BlockTable (TableNode [] [])
+                    , BlockTableRow row
+                    , BlockTableCell cell
+                    ]
+            map blockNodeTypeName nodes
+                `shouldBe` [ "document"
+                           , "heading"
+                           , "paragraph"
+                           , "code_block"
+                           , "blockquote"
+                           , "list"
+                           , "list_item"
+                           , "task_item"
+                           , "thematic_break"
+                           , "raw_block"
+                           , "table"
+                           , "table_row"
+                           , "table_cell"
+                           ]
+
+        it "exposes concrete block payloads without mutation" $ do
+            let heading = HeadingNode 6 [text "Deep"]
+                para = ParagraphNode [text "Body"]
+                quote = BlockquoteNode [BlockParagraph para]
+                item = ListItemNode [BlockParagraph para]
+                task = TaskItemNode False [BlockParagraph para]
+            (headingLevel heading, headingChildren heading) `shouldBe` (6, [text "Deep"])
+            paragraphChildren para `shouldBe` [text "Body"]
+            blockquoteChildren quote `shouldBe` [BlockParagraph para]
+            listItemChildren item `shouldBe` [BlockParagraph para]
+            (taskItemChecked task, taskItemChildren task)
+                `shouldBe` (False, [BlockParagraph para])
+
+    describe "lists and tables" $ do
+        it "preserves ordered-list metadata and task state" $ do
+            let regular = ListItem (ListItemNode [paragraph "alpha"])
+                task = TaskItem (TaskItemNode True [paragraph "beta"])
+                node = ListNode True (Just 3) False [regular, task]
+            (listOrdered node, listStart node, listTight node) `shouldBe` (True, Just 3, False)
+            map listChildNodeTypeName (listChildren node) `shouldBe` ["list_item", "task_item"]
+            taskItemChecked (TaskItemNode True []) `shouldBe` True
+
+        it "preserves optional GFM table alignment and cell content" $ do
+            let cell = TableCellNode [InlineStrong (StrongNode [text "Name"])]
+                header = TableRowNode True [cell]
+                table = TableNode [Just AlignLeft, Nothing, Just AlignRight, Just AlignCenter] [header]
+            tableAlignments table `shouldBe` [Just AlignLeft, Nothing, Just AlignRight, Just AlignCenter]
+            tableRowIsHeader (head (tableRows table)) `shouldBe` True
+            tableRowChildren header `shouldBe` [cell]
+            tableCellChildren cell `shouldBe` [InlineStrong (StrongNode [text "Name"])]
+            tableRowNodeTypeName header `shouldBe` "table_row"
+            tableCellNodeTypeName cell `shouldBe` "table_cell"
+
+    describe "inline content" $ do
+        it "exposes every stable inline discriminator" $ do
+            let nodes =
+                    [ text "text"
+                    , InlineEmphasis (EmphasisNode [])
+                    , InlineStrong (StrongNode [])
+                    , InlineStrikethrough (StrikethroughNode [])
+                    , InlineCodeSpan (CodeSpanNode "code")
+                    , InlineLink (LinkNode "/" Nothing [])
+                    , InlineImage (ImageNode "cat.png" Nothing "cat")
+                    , InlineAutolink (AutolinkNode "user@example.com" True)
+                    , InlineRawInline (RawInlineNode "html" "<em>x</em>")
+                    , InlineHardBreak HardBreakNode
+                    , InlineSoftBreak SoftBreakNode
+                    ]
+            map inlineNodeTypeName nodes
+                `shouldBe` [ "text"
+                           , "emphasis"
+                           , "strong"
+                           , "strikethrough"
+                           , "code_span"
+                           , "link"
+                           , "image"
+                           , "autolink"
+                           , "raw_inline"
+                           , "hard_break"
+                           , "soft_break"
+                           ]
+
+        it "retains resolved link, image, and autolink data" $ do
+            let link = LinkNode "https://example.com" (Just "Example") [text "click"]
+                image = ImageNode "cat.png" Nothing "a cat"
+                email = AutolinkNode "user@example.com" True
+            (linkDestination link, linkTitle link, linkChildren link)
+                `shouldBe` ("https://example.com", Just "Example", [text "click"])
+            (imageDestination image, imageTitle image, imageAlt image)
+                `shouldBe` ("cat.png", Nothing, "a cat")
+            (autolinkDestination email, autolinkIsEmail email)
+                `shouldBe` ("user@example.com", True)
+
+        it "exposes text and formatting children" $ do
+            let plain = TextNode "value"
+                emphasis = EmphasisNode [InlineText plain]
+                strong = StrongNode [InlineEmphasis emphasis]
+                strike = StrikethroughNode [InlineStrong strong]
+            textValue plain `shouldBe` "value"
+            emphasisChildren emphasis `shouldBe` [InlineText plain]
+            strongChildren strong `shouldBe` [InlineEmphasis emphasis]
+            strikethroughChildren strike `shouldBe` [InlineStrong strong]
+
+        it "retains raw and code payloads without interpretation" $ do
+            let codeBlock = CodeBlockNode (Just "haskell") "main = pure ()\n"
+                rawBlock = RawBlockNode "latex" "\\textbf{x}\n"
+                rawInline = RawInlineNode "html" "<em>x</em>"
+            (codeBlockLanguage codeBlock, codeBlockValue codeBlock)
+                `shouldBe` (Just "haskell", "main = pure ()\n")
+            (rawBlockFormat rawBlock, rawBlockValue rawBlock)
+                `shouldBe` ("latex", "\\textbf{x}\n")
+            (rawInlineFormat rawInline, rawInlineValue rawInline)
+                `shouldBe` ("html", "<em>x</em>")
+            codeSpanValue (CodeSpanNode "&amp;") `shouldBe` "&amp;"
+
+    describe "generic traversal" $ do
+        it "dispatches both Node union branches" $ do
+            nodeTypeName (NodeBlock (paragraph "block")) `shouldBe` "paragraph"
+            nodeTypeName (NodeInline (text "inline")) `shouldBe` "text"
+
+        it "supports structural equality for recursively nested values" $ do
+            let value =
+                    BlockList
+                        ( ListNode
+                            False
+                            Nothing
+                            True
+                            [ListItem (ListItemNode [paragraph "item"])]
+                        )
+            value `shouldBe` value
+            show value `shouldContain` "ListNode"

--- a/code/packages/haskell/document-ast/test/Spec.hs
+++ b/code/packages/haskell/document-ast/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified DocumentAstSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec DocumentAstSpec.spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,7 +105,7 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 18, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
+on July 19, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
 `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
 the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
@@ -116,17 +116,17 @@ ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 `nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
-`scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, and `wave`
-ports:
+`scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
+`matrix`, `vigenere-cipher`, `uuid`, and `document-ast` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 303 |
+| Present in 10-15 languages | 172 | 299 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 703 | 9,842 |
+| Present in one language | 705 | 9,870 |
 
-The loop must not start by attempting 9,842 singleton ports. It should finish
+The loop must not start by attempting 9,870 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -167,7 +167,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 300
+The 172 packages present in at least ten implementation languages need 299
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -178,7 +178,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 25 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 24 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -471,6 +471,16 @@ and byte round trips, all variants, RFC name-based vectors, Unicode names,
 random uniqueness, multicast nodes, and v7 timestamps. The package now spans
 14 implementation lanes, reduces the high-consensus backlog to 300 slots, and
 leaves 25 gaps in the Haskell lane.
+
+The tenth Haskell high-consensus slice is complete: `document-ast` now provides
+immutable algebraic data types for the TE00 block and inline model together
+with the shared GFM task-list, strikethrough, and table extensions. Exhaustive
+unions and stable discriminator helpers support typed parser and renderer
+traversal without external dependencies. Its package-native suite exercises
+11 examples with 100% expression and alternative coverage across every node
+family, payload accessor, nesting shape, and discriminator. The package now
+spans 14 implementation lanes, reduces the high-consensus backlog to 299 slots,
+and leaves 24 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a dependency-free Haskell `document-ast` package implementing the TE00 block and inline model
- include the shared GFM task-list, strikethrough, and table extensions with exhaustive algebraic unions and stable discriminator helpers
- refresh the parity roadmap to 299 high-consensus missing slots and 24 remaining Haskell gaps

## Validation

- Stack tests with `-Wall -Werror`: 11 examples, 0 failures
- HPC: 100% expressions and 100% alternatives for the package and unified report
- `stack sdist`: package archive built and Cabal common-mistake check passed
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'`: 6 tests passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: zero collisions, `document-ast` in 14 lanes, 299 high-consensus gaps
- `git diff --check`
