### PR TITLE
feat(sir-runtime-array): port SIR22 APL-addendum primitives (Reduce/Scan/OuterProduct/Shape/Reshape/IndexGenerator/IndexOf/Ravel/Catenate)

### DIFF
--- a/code/packages/typescript/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-array/CHANGELOG.md
@@ -2,6 +2,123 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-07-19
+
+### Added
+
+The SIR22 spec's "APL addendum" — `Reduce`/`Scan`/`OuterProduct`/`Shape`/
+`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` — deferred since this
+package's 0.1.0 release because no frontend crate emitted these nine `Expr`
+variants yet. That is no longer true: `apl-to-semantic-ir` genuinely lowers
+APL's `/` (reduce), `\` (scan), `∘.` (outer product), `⍴`, `⍳`, and `,`
+glyphs to these nine nodes, and `semantic-ir-to-javascript` (the sibling
+backend, which inlines its own copy of this logic rather than importing this
+package) already shipped real codegen for all nine — see that crate's "SIR22
+APL-addendum codegen" PR (#8595). That already-merged, already-reviewed,
+already-tested port is the primary reference this release mechanically
+ports into real TypeScript source, split across this package's existing
+module-per-concern convention rather than one new giant file. The two Rust
+crates those nine primitives were originally derived from
+(`array_runtime::ops::{reduce,scan,outer}` and `apl_runtime::builtins::
+{shape,reshape,index_generator,index_of,ravel,catenate}`) were read directly
+as well, for the authoritative edge-case semantics the JS port's own
+comments reference.
+
+- **`reduce(op, a)` / `scan(op, a)`** (`src/reduce.ts`) — `+/A`/`+\A`, folding
+  `a` with an arbitrary `ElementwiseOpKind` along its one axis (`reduce`) or
+  keeping every intermediate result (`scan`). Both reuse this package's own
+  `applyOp` (now exported from `elementwise.ts`, not duplicated into a second
+  dispatch switch) for the op application itself. Rank 0 folds to itself;
+  rank 1 is a left fold (`reduce`) or a running fold (`scan`); rank 2 folds
+  **each row** independently across its columns. `reduce` on an empty vector
+  or an empty matrix row is a clean error (no identity element exists for an
+  arbitrary op); `scan` on an empty vector is simply an empty result, not an
+  error. The rank-2 branch's column-major row-fold indexing
+  (`d[col * r + row]`, never `d[row * c + col]`) is the single easiest place
+  to introduce a silent wrong-answer bug in this whole release — a swapped
+  index would produce a plausible-but-transposed result rather than
+  crashing, so it's called out explicitly in both the doc comments and a
+  dedicated regression test.
+- **`outer(op, a, b)`** (`src/outer.ts`) — `A∘.×B`, applying `op` to every
+  pair `(aᵢ, bⱼ)`. Scalar⊗scalar/scalar⊗vector/vector⊗vector, scoped to
+  `rank(a) ≤ 1` and `rank(b) ≤ 1` (the vector⊗vector case already reaches
+  this package's rank-2 ceiling). `m`/`n` are two independent operand
+  lengths; `checkedShapeSize([m, n])` validates the output shape before
+  allocating, since neither length alone bounds their product (an
+  outer-product-shaped call can still request an absurd output even with
+  small individual operands — the same class of gap `matmul`'s own
+  bounded-allocation check closes).
+- **`shape(a)` / `reshape(shapeArg, target)`** (`src/shape.ts`) — monadic and
+  dyadic `⍴`. `shape` returns `a`'s dimensions as a vector (a scalar's shape
+  is the *empty* vector, not a scalar). `reshape` cyclically repeats or
+  truncates `target`'s ravelled elements to fill `shapeArg`'s dimensions.
+  **Correctness trap preserved from the JS port**: the cyclic fill runs in
+  ROW-major order (APL's convention), but this package's storage is
+  COLUMN-major, so a rank-2 target requires transposing the row-major fill
+  into column-major storage (`data[col * r + row] = filled[row * c + col]`)
+  — handing the row-major fill straight to `ndarray` would silently produce
+  the right multiset of values in the wrong positions. A dedicated test
+  constructs exactly this case and confirms the correct (non-transposed)
+  positions.
+- **`indexGenerator(a)` / `indexOf(haystack, needle)`** (`src/iota.ts`) —
+  monadic and dyadic `⍳`. `indexGenerator` produces the **1-based** vector
+  `[1, 2, …, n]` — genuinely 1-based at APL's surface-syntax level, unlike
+  every other index in this package (`indexGet`/`indexSet` are 0-based).
+  `indexOf` returns, for each element of `needle`, its 1-based position in
+  `haystack` (or `haystack.length + 1` if not found). **Security**: `indexOf`
+  does O(len(haystack) × len(needle)) work — a full scan per needle element
+  — so `checkedShapeSize([haystack.data.length, needle.data.length])` caps
+  the *product* before scanning, not each operand's length individually;
+  neither operand alone need be oversized for the work to be.
+- **`ravel(a)` / `catenate(a, b)`** (`src/ravel.ts`) — monadic and dyadic `,`.
+  `ravel` flattens `a` to a rank-1 vector in row-major order via the new
+  `flattenRowMajor` helper (exported from `ravel.ts`, reused by `reshape`).
+  `catenate` supports scalar/vector combinations (producing a vector) and
+  matrix-with-equal-row-counts (column catenate, producing `[r, ca + cb]`).
+  **Security**: the combined-length cap
+  (`checkedShapeSize([a.data.length + b.data.length])`) runs *before* any
+  rank-dispatch, on every call — a script that repeatedly catenates a value
+  with itself doubles the size each time with no other ceiling, so the check
+  must re-run per call rather than being satisfiable once.
+- `applyOp` (in `elementwise.ts`) is now exported, not file-private — the
+  one op-dispatch table `reduce`/`scan`/`outer` import directly instead of
+  reintroducing a second copy of the same switch statement.
+- `index.ts`'s "Deliberately out of scope" doc-comment section is replaced
+  with a "The SIR22 'APL addendum' is now implemented" section, mirroring
+  how `semantic-ir-to-javascript`'s own module doc comment was updated when
+  it made the identical port.
+- 44 new tests (108 total, up from 64), covering every rank case each
+  function documents supporting, the empty-vector/empty-row `reduce` error,
+  the 1-based `indexGenerator`, an adversarial reshape test that would fail
+  with a plausible-but-wrong transposed answer if the row-major/column-major
+  transpose were backwards, and both bounded-allocation checks (`indexOf`'s
+  product cap via two cheap 8,200-element buffers whose product exceeds
+  `MAX_ELEMENTS`; `catenate`'s combined-length cap via two real, if
+  zero-filled and therefore cheap to allocate, ~33.5M-element buffers).
+  100% statement/branch/function/line coverage maintained.
+
+### Not included (deliberate scope decisions, not oversights)
+
+- **No display/auto-print formatting helper.** The JS backend's inlined
+  port needed one (`ArrayRt.display`/`fmtNum`, a 1:1 port of
+  `apl_runtime::value::display`) because APL auto-prints a bare top-level
+  expression and has no bracket-indexing syntax to read a value back with
+  instead — `semantic-ir-to-javascript` had nowhere else to route a
+  computed array's display through. Checked whether
+  `semantic-ir-to-typescript` has the identical problem: it does not — that
+  backend does not yet consume any APL-sourced module at all (wiring codegen
+  for these nine nodes is the separate follow-up below), so there is no real
+  consumer to build a display convention for yet. Adding one now would be
+  exactly the same "speculative, not filling a real gap" mistake this
+  package originally avoided by deferring the nine addendum nodes
+  themselves in 0.1.0.
+- **`semantic-ir-to-typescript` codegen wiring is explicitly out of scope
+  for this release.** That backend's own `find_unimplemented_sir22_addendum_
+  node` tree-walk still rejects a module using any of these nine nodes,
+  unchanged by this package gaining them — this release only makes the
+  primitives available for a future codegen PR to call, mirroring exactly
+  how this package's 0.1.0 base cut preceded its own consumer.
+
 ## [0.2.0] - 2026-07-17
 
 This package went from "built but unconsumed" to actually imported —

--- a/code/packages/typescript/sir-runtime-array/README.md
+++ b/code/packages/typescript/sir-runtime-array/README.md
@@ -28,6 +28,11 @@ on every result.
 | Transpose | `transpose(a, conjugate?)` | `array_runtime::ops::transpose` |
 | Range | `range(start, stop, step?)` | `matlab-runtime`'s `eval_colon` |
 | Indexing | `indexGet`/`indexSet` | (SIR-level only — no Rust runtime equivalent yet) |
+| Reduce / scan | `reduce(op, a)` / `scan(op, a)` | `array_runtime::ops::{reduce,scan}` |
+| Outer product | `outer(op, a, b)` | `array_runtime::ops::outer` |
+| Shape / reshape | `shape(a)` / `reshape(shapeArg, target)` | `apl_runtime::builtins::{shape,reshape}` |
+| Index generator / index-of | `indexGenerator(a)` / `indexOf(haystack, needle)` | `apl_runtime::builtins::{index_generator,index_of}` |
+| Ravel / catenate | `ravel(a)` / `catenate(a, b)` | `apl_runtime::builtins::{ravel,catenate}` |
 
 ## Backend consumers
 
@@ -42,6 +47,19 @@ the wiring. This package landed first (mirroring exactly how
 `sir-runtime-symbolic`, SIR23's runtime, preceded its own Stream-B codegen)
 so those backend PRs only had to wire up calls, not design an array
 representation from scratch.
+
+The SIR22 "APL addendum" (`reduce`/`scan`/`outer`/`shape`/`reshape`/
+`indexGenerator`/`indexOf`/`ravel`/`catenate`, below) followed the same
+pattern one release later: `semantic-ir-to-javascript` shipped real codegen
+for all nine first (its "SIR22 APL-addendum codegen" PR), since
+`apl-to-semantic-ir` genuinely emits these nine nodes for APL's `/`/`\`/
+`∘.`/`⍴`/`⍳`/`,` glyphs. This package now carries the identical port, but
+`semantic-ir-to-typescript` has **not** wired codegen for them yet — that
+backend still rejects a module using any of these nine nodes via its own
+`find_unimplemented_sir22_addendum_node` tree-walk, unchanged by this
+package gaining them. Wiring `__SirArray.reduce(...)`/etc. call sites into
+`semantic-ir-to-typescript`'s `emit.rs` is a separate, not-yet-started
+follow-up.
 
 ## How emitted code uses it
 
@@ -86,24 +104,43 @@ const row0 = __SirArray.indexGet(A, [{ kind: "scalar", value: 0 }, { kind: "whol
   `IndexSet` mutates in place rather than returning a new array, matching
   MATLAB assignment semantics and the spec's own "statement, not
   expression" treatment of it.
+- **`reduce`/`scan`** (`reduce.ts`) and **`outer`** (`outer.ts`) — the SIR22
+  "APL addendum"'s three `ElementwiseOpKind`-parameterized adverbs (`+/A`,
+  `+\A`, `A∘.×B`), mirroring `array_runtime::ops::{reduce,scan,outer}`
+  exactly, including their column-major row/column-fold indexing (getting
+  that indexing backwards silently transposes the result instead of
+  throwing — see `reduce.ts`'s own doc comment).
+- **`shape`/`reshape`** (`shape.ts`), **`indexGenerator`/`indexOf`**
+  (`iota.ts`), and **`ravel`/`catenate`** (`ravel.ts`) — the SIR22
+  addendum's six "bespoke" (non-`BinOp`-shaped) APL primitives (`⍴`, `⍳`,
+  `,`), mirroring `apl_runtime::builtins::{shape,reshape,index_generator,
+  index_of,ravel,catenate}` exactly. `reshape`'s row-major cyclic fill must
+  be transposed into this package's column-major storage for a rank-2
+  target (`shape.ts`'s own doc comment covers this in detail — it is the
+  single easiest place in this whole package to introduce a silent
+  wrong-answer bug); `indexGenerator` is 1-based (`⍳n` is `[1, …, n]`),
+  unlike every other index in this package.
 
 ## Deliberately out of scope
 
-The SIR22 spec's "APL addendum" `Expr` variants (`Reduce`/`Scan`/
-`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
-`Catenate`) are **not** implemented here, even though `array_runtime::ops`
-already has Rust reference implementations for `reduce`/`scan`/`outer` and
-`apl-to-semantic-ir`'s real lowering already emits `Reduce`/`Scan`/
-`OuterProduct` for APL's `+/`/`+\`/`∘.×` operators — porting them is a
-natural, cleanly-scoped follow-up once a JS/TS-backend consumer actually
-needs them, not speculative work. Both backend consumers guard against a
-module using one of these nine slipping past their feature-flag check (the
-addendum shares its three features with the base cut above) via an explicit
-tree walk that fails cleanly instead of reaching an emit-time panic — see
-`find_unimplemented_sir22_addendum_node` in each backend crate.
+`Complex`/`Rational` scalar support (shared `SirType`s with SIR23) is out of
+scope — `transpose`'s `conjugate` flag is accepted for API-shape parity with
+the spec but is a no-op today, matching `array-runtime`'s own real-only
+scope. No operation in this package (including the nine APL-addendum
+functions above) is defined beyond rank ≤ 2, matching every Rust reference's
+own ceiling.
 
-`Complex`/`Rational` scalar support (shared `SirType`s with SIR23) is also
-out of scope for the same reason.
+This package also does **not** include a display/auto-print formatting
+helper (the equivalent of `apl_runtime::value::display`/
+`semantic-ir-to-javascript`'s inlined `ArrayRt.display`). That JS backend
+needed one because APL auto-prints a bare top-level expression and has no
+bracket-indexing syntax to read a value back with instead — there was
+nowhere else to route a computed array's display through.
+`semantic-ir-to-typescript` does not have that problem today because it does
+not yet consume any APL-sourced module at all (see "Backend consumers"
+above) — building a display convention now, with no real consumer, would be
+exactly the same "speculative, not filling a real gap" mistake this package
+avoided by deferring the APL addendum itself for two releases.
 
 ## Security: bounded allocation
 
@@ -120,6 +157,17 @@ late, since the allocation attempt itself can throw an uncaught
 reject anything cleanly. `checkedShapeSize` also rejects negative and
 non-integer dimensions, closing a variant where two negative dimensions
 multiply to a small, cap-passing positive product.
+
+The APL-addendum functions reuse this exact same `MAX_ELEMENTS` cap for two
+allocation-adjacent gaps that are easy to miss because no single operand is
+oversized: `indexOf`'s work is O(len(haystack) × len(needle)) — each length
+can individually sit well under `MAX_ELEMENTS` while their *product* is
+still absurd — and `catenate`'s combined output length is the *sum* of two
+operands that can each individually be valid on their own (a script that
+repeatedly does `A = catenate(A, A)` doubles the size every call with no
+other ceiling). Both check the product/sum *before* any allocation or
+scanning, on every call, exactly like every other bounded-allocation check
+in this package.
 
 ## Where it fits
 

--- a/code/packages/typescript/sir-runtime-array/package-lock.json
+++ b/code/packages/typescript/sir-runtime-array/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-array",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-array",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",

--- a/code/packages/typescript/sir-runtime-array/package.json
+++ b/code/packages/typescript/sir-runtime-array/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-array",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "N-D array/matrix runtime for Semantic-IR-emitted TypeScript/JavaScript (SIR22)",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-array/src/elementwise.ts
+++ b/code/packages/typescript/sir-runtime-array/src/elementwise.ts
@@ -43,7 +43,19 @@ export type ElementwiseOpKind =
   | "Ge"
   | "Gt";
 
-function applyOp(op: ElementwiseOpKind, a: number, b: number): number {
+/**
+ * Apply one `ElementwiseOpKind` to a pair of plain numbers — the single
+ * op-dispatch table this whole package uses. Exported (not file-private)
+ * so `reduce`/`scan`/`outer` (`./reduce.ts`, `./outer.ts` — the SIR22 "APL
+ * addendum", which reuses this exact table per `array_runtime::ops::
+ * {reduce,scan,outer}` and the SIR22 spec's own "`Reduce`/`Scan`/
+ * `OuterProduct` reuse the whole `ElementwiseOpKind` enum" note) can import
+ * it directly instead of duplicating this switch a second time. Mirrors
+ * `semantic-ir-to-javascript`'s inlined port, which reuses its own
+ * (file-scoped, not exported — JS has no module boundary to cross there)
+ * `applyOp` for the identical reason.
+ */
+export function applyOp(op: ElementwiseOpKind, a: number, b: number): number {
   const b2f = (cond: boolean): number => (cond ? 1 : 0);
   switch (op) {
     case "Add":

--- a/code/packages/typescript/sir-runtime-array/src/index.ts
+++ b/code/packages/typescript/sir-runtime-array/src/index.ts
@@ -37,23 +37,56 @@
  * - **`indexGet`/`indexSet`** (`./indexing`) — `A(i)`/`A(i,j)` read and
  *   in-place write, covering the SIR22 spec's `Scalar`/`Whole`/`Range`
  *   `IndexArg` shapes.
+ * - **`reduce`/`scan`** (`./reduce`) and **`outer`** (`./outer`) — the SIR22
+ *   "APL addendum"'s three `ElementwiseOpKind`-parameterized adverbs (`+/A`,
+ *   `+\A`, `A∘.×B`), mirroring `array_runtime::ops::{reduce,scan,outer}`
+ *   exactly, including their column-major row/column-fold indexing.
+ * - **`shape`/`reshape`** (`./shape`), **`indexGenerator`/`indexOf`**
+ *   (`./iota`), and **`ravel`/`catenate`** (`./ravel`) — the SIR22 addendum's
+ *   six "bespoke" (non-`BinOp`-shaped) APL primitives (`⍴`, `⍳`, `,`),
+ *   mirroring `apl_runtime::builtins::{shape,reshape,index_generator,
+ *   index_of,ravel,catenate}` exactly, including `reshape`'s row-major-fill
+ *   transposed into column-major storage and `indexGenerator`'s 1-based
+ *   (not 0-based) result.
+ *
+ * ## The SIR22 "APL addendum" is now implemented
+ *
+ * `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+ * `IndexOf`/`Ravel`/`Catenate` were deferred when this package first shipped
+ * (0.1.0) — no frontend crate emitted these nine `Expr` variants yet at the
+ * time. That is no longer true: `apl-to-semantic-ir` genuinely lowers APL's
+ * `/` (reduce), `\` (scan), `∘.` (outer product), `⍴`, `⍳`, and `,` glyphs
+ * to these nine nodes, and `semantic-ir-to-javascript` (the sibling backend,
+ * which inlines its own copy of this same logic rather than importing this
+ * package) already ported all nine into real codegen — see that crate's
+ * "SIR22 APL-addendum codegen" PR. This package now carries the identical
+ * port, so a future `semantic-ir-to-typescript` codegen PR wiring
+ * `__SirArray.reduce(...)`/`.scan(...)`/`.outer(...)`/`.shape(...)`/
+ * `.reshape(...)`/`.indexGenerator(...)`/`.indexOf(...)`/`.ravel(...)`/
+ * `.catenate(...)` call sites only has to *wire up calls*, exactly the same
+ * "runtime lands before its codegen consumer" pattern this whole package
+ * followed for the base cut. That wiring is a separate, not-yet-started
+ * follow-up — `semantic-ir-to-typescript` itself still rejects a module
+ * using any of these nine nodes via its own
+ * `find_unimplemented_sir22_addendum_node` tree-walk, unchanged by this
+ * package gaining them.
  *
  * ## Deliberately out of scope
  *
- * The SIR22 spec's "APL addendum" `Expr` variants (`Reduce`/`Scan`/
- * `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
- * `Catenate`) are **not** implemented here, even though `array_runtime::ops`
- * already has Rust reference implementations for `reduce`/`scan`/`outer` —
- * no frontend crate emits these nine `Expr` variants yet (per that spec's
- * own "No frontend crate consumes any of these nine variants yet" note), so
- * porting them now would be speculative rather than filling a real gap.
- * They are a natural, cleanly-scoped follow-up once `apl-to-semantic-ir`'s
- * own JS-backend consumption needs them.
- *
- * `Complex`/`Rational` scalar support (shared `SirType`s with SIR23) is also
- * out of scope — `transpose`'s `conjugate` flag is accepted for API-shape
+ * `Complex`/`Rational` scalar support (shared `SirType`s with SIR23) is out
+ * of scope — `transpose`'s `conjugate` flag is accepted for API-shape
  * parity with the spec but is a no-op today, matching `array-runtime`'s own
- * real-only scope.
+ * real-only scope. No operation in this package (including the nine above)
+ * is defined beyond rank ≤ 2, matching every Rust reference's own ceiling.
+ * A display/auto-print formatter (`apl_runtime::value::display`'s
+ * equivalent) is also not included here — unlike `semantic-ir-to-javascript`
+ * (which needs one because APL auto-prints a bare top-level expression and
+ * has no bracket-indexing syntax to read a value back with instead),
+ * `semantic-ir-to-typescript` does not yet consume any APL-sourced module at
+ * all, so there is no real consumer to build a display convention for yet —
+ * adding one now would be exactly the same "speculative, not filling a real
+ * gap" mistake this package originally avoided by deferring the nine
+ * addendum nodes themselves.
  */
 
 export { ndarray, checkedShapeSize, scalar, fromVec, fromRows, zeros, ndims, isScalar, nrows, ncols, get, set, MAX_ELEMENTS, type NDArray } from "./ndarray.js";
@@ -62,3 +95,8 @@ export { matmul } from "./matmul.js";
 export { transpose } from "./transpose.js";
 export { range } from "./range.js";
 export { indexGet, indexSet, type IndexArg } from "./indexing.js";
+export { reduce, scan } from "./reduce.js";
+export { outer } from "./outer.js";
+export { shape, reshape } from "./shape.js";
+export { indexGenerator, indexOf } from "./iota.js";
+export { ravel, catenate } from "./ravel.js";

--- a/code/packages/typescript/sir-runtime-array/src/iota.ts
+++ b/code/packages/typescript/sir-runtime-array/src/iota.ts
@@ -1,0 +1,85 @@
+/**
+ * `IndexGenerator`/`IndexOf` — the SIR22 addendum's monadic and dyadic `⍳`
+ * (APL index generator / index-of). Named `iota.ts`, not `range.ts` (already
+ * taken by this package's MATLAB-style `start:step:stop` materialization),
+ * to avoid colliding with that unrelated concern despite both being
+ * "produce a sequence of numbers" functions.
+ *
+ * Ported 1:1 from `apl_runtime::builtins::{index_generator,index_of}`
+ * (`code/packages/rust/apl-runtime/src/builtins.rs`), previously ported
+ * once already into `semantic-ir-to-javascript`'s inlined runtime (see that
+ * crate's "SIR22 APL-addendum codegen" PR) — this is the same port made a
+ * third time, mechanically, into this package's own module-per-concern
+ * layout.
+ */
+import { ndarray, checkedShapeSize, isScalar, type NDArray } from "./ndarray.js";
+
+/**
+ * Monadic `⍳` (index generator / iota) — `⍳n` is the **1-based** vector
+ * `[1, 2, …, n]`. Ported 1:1 from `apl_runtime::builtins::index_generator`.
+ *
+ * NOTE the 1-basedness: unlike every other index in this package
+ * (`indexGet`/`indexSet` in `./indexing.js` are 0-based, matching this
+ * package's own JS/TS-native convention), `⍳` is genuinely 1-based at the
+ * SURFACE-SYNTAX level in real APL — `⍳5` is `1 2 3 4 5`, never `0 1 2 3 4`
+ * — so this is a real, deliberate inconsistency with the rest of this
+ * package's indexing, not an oversight. (The SIR22 spec's own
+ * `Expr::IndexGenerator` doc-comment prose describes a 0-based
+ * `0, 1, …, N-1` result, but that text predates `apl-runtime`'s actual
+ * implementation and the already-merged `semantic-ir-to-javascript` port
+ * both of which are genuinely 1-based — this function follows those two
+ * real references, not the spec's stale prose.)
+ *
+ * SECURITY: `checkedShapeSize([n])` both validates `n` is a non-negative
+ * integer AND caps it at `MAX_ELEMENTS` before allocating — `n` is a
+ * runtime value a compiled program computes, not a fixed constant, so `⍳`
+ * of an absurd size must fail cleanly.
+ */
+export function indexGenerator(a: NDArray): NDArray {
+  if (!isScalar(a)) {
+    throw new Error("indexGenerator: monadic argument must be a scalar");
+  }
+  const x = a.data[0];
+  if (!(Number.isInteger(x) && x >= 0)) {
+    throw new Error(`indexGenerator: monadic argument must be a non-negative integer, got ${x}`);
+  }
+  const n = checkedShapeSize([x]);
+  const out = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    out[i] = i + 1;
+  }
+  return ndarray([n], out);
+}
+
+/**
+ * Dyadic `⍳` (index-of / search) — for every element of `needle`, the
+ * 1-based index of its first occurrence in the vector `haystack` (or
+ * `haystack.length + 1` if not found — "not found" is a valid, always-in-
+ * range position, not `-1`/`undefined`). Ported 1:1 from
+ * `apl_runtime::builtins::index_of`: plain EXACT equality (no
+ * floating-point tolerance — `Float64Array.prototype.indexOf` already uses
+ * strict `===`, so `NaN` correctly never matches, same as Rust's `==`). The
+ * result has `needle`'s shape.
+ *
+ * SECURITY: the work done is O(len(haystack) × len(needle)) — a full linear
+ * scan of `haystack` per element of `needle` — so each operand
+ * individually staying under `MAX_ELEMENTS` does NOT bound their *product*
+ * (up to ~4.5 × 10¹⁵ comparisons otherwise, a compute-bound DoS even though
+ * no single allocation is oversized). `checkedShapeSize` is reused here
+ * purely for its "product ≤ MAX_ELEMENTS" check (both lengths are already
+ * valid non-negative integers by construction, so its dimension-validity
+ * half is a no-op) — it runs *before* any scanning, not after, exactly like
+ * every other bounded-allocation check in this package.
+ */
+export function indexOf(haystack: NDArray, needle: NDArray): NDArray {
+  if (haystack.shape.length > 1) {
+    throw new Error(`indexOf: left argument must be a scalar or vector (got rank ${haystack.shape.length})`);
+  }
+  checkedShapeSize([haystack.data.length, needle.data.length]);
+  const hay = haystack.data;
+  const out = Float64Array.from(needle.data, (n) => {
+    const idx = hay.indexOf(n);
+    return idx === -1 ? hay.length + 1 : idx + 1;
+  });
+  return ndarray(needle.shape, out);
+}

--- a/code/packages/typescript/sir-runtime-array/src/outer.ts
+++ b/code/packages/typescript/sir-runtime-array/src/outer.ts
@@ -1,0 +1,64 @@
+/**
+ * `OuterProduct` — the SIR22 addendum's `A∘.×B` (APL outer product). Ported
+ * 1:1 from `array_runtime::ops::outer`
+ * (`code/packages/rust/array-runtime/src/ops.rs`), and previously ported
+ * once already into `semantic-ir-to-javascript`'s inlined runtime (see that
+ * crate's "SIR22 APL-addendum codegen" PR) — this is the same port made a
+ * third time, mechanically, into this package's own module-per-concern
+ * layout.
+ */
+import { ndarray, checkedShapeSize, type NDArray } from "./ndarray.js";
+import { applyOp, type ElementwiseOpKind } from "./elementwise.js";
+
+/**
+ * `A∘.×B` — apply `op` to every pair `(aᵢ, bⱼ)`, producing a result of rank
+ * `rank(a) + rank(b)`:
+ *
+ * - scalar ⊗ scalar → scalar (`op(a, b)`).
+ * - scalar ⊗ vector `[n]` (or vector ⊗ scalar) → vector `[n]` (the scalar
+ *   broadcasts, exactly like `elementwise`'s own scalar case).
+ * - vector `[m]` ⊗ vector `[n]` → matrix `[m, n]`, element `(i, j) =
+ *   op(a[i], b[j])`.
+ *
+ * Scoped to `rank(a) ≤ 1` and `rank(b) ≤ 1` — the vector⊗vector case
+ * already reaches this package's rank-2 ceiling, matching
+ * `array_runtime::ops::outer`'s identical scope — a higher-rank operand is a
+ * clean "not yet supported" error rather than silently-wrong output.
+ *
+ * SECURITY: `m`/`n` are two INDEPENDENT operand lengths, each individually
+ * already validated (≤ `MAX_ELEMENTS`, since each came from an existing,
+ * already-constructed `NDArray`), but nothing bounds their *product* on its
+ * own — the exact outer-product-shaped allocation gap `matmul`/`indexGet`
+ * elsewhere in this package guard against. `checkedShapeSize([m, n])`
+ * validates the `[m, n]` output shape *before* allocating `out`, not after.
+ */
+export function outer(op: ElementwiseOpKind, a: NDArray, b: NDArray): NDArray {
+  const as = a.shape;
+  const bs = b.shape;
+  if (as.length === 0 && bs.length === 0) {
+    return ndarray([], Float64Array.of(applyOp(op, a.data[0], b.data[0])));
+  }
+  if (as.length === 0 && bs.length === 1) {
+    const x = a.data[0];
+    return ndarray([bs[0]], Float64Array.from(b.data, (y) => applyOp(op, x, y)));
+  }
+  if (as.length === 1 && bs.length === 0) {
+    const y = b.data[0];
+    return ndarray([as[0]], Float64Array.from(a.data, (x) => applyOp(op, x, y)));
+  }
+  if (as.length === 1 && bs.length === 1) {
+    const m = as[0];
+    const n = bs[0];
+    const outLen = checkedShapeSize([m, n]);
+    const ad = a.data;
+    const bd = b.data;
+    const out = new Float64Array(outLen);
+    for (let j = 0; j < n; j++) {
+      for (let i = 0; i < m; i++) {
+        out[j * m + i] = applyOp(op, ad[i], bd[j]); // column-major
+      }
+    }
+    return ndarray([m, n], out);
+  }
+  throw new Error(`outer: operands of rank > 1 not yet supported (shapes ${JSON.stringify(as)}, ${JSON.stringify(bs)})`);
+}

--- a/code/packages/typescript/sir-runtime-array/src/ravel.ts
+++ b/code/packages/typescript/sir-runtime-array/src/ravel.ts
@@ -1,0 +1,130 @@
+/**
+ * `Ravel`/`Catenate` — the SIR22 addendum's monadic and dyadic `,`
+ * (APL ravel / catenate). Ported 1:1 from `apl_runtime::builtins::
+ * {ravel,catenate}` (`code/packages/rust/apl-runtime/src/builtins.rs`),
+ * previously ported once already into `semantic-ir-to-javascript`'s inlined
+ * runtime (see that crate's "SIR22 APL-addendum codegen" PR) — this is the
+ * same port made a third time, mechanically, into this package's own
+ * module-per-concern layout.
+ */
+import { ndarray, checkedShapeSize, nrows, ncols, type NDArray } from "./ndarray.js";
+
+/**
+ * Flatten (rank ≤ 2, this package's ceiling) `a` to ROW-major order — the
+ * *last* axis varies fastest. `a` itself stores data COLUMN-major
+ * (`ndarray.ts`'s own doc comment: element `(row, col)` lives at flat offset
+ * `col * nrows + row`), so a matrix must be walked "row, then column" to
+ * produce true row-major order — simply returning the raw column-major
+ * buffer (`a.data`) would silently ravel in the WRONG order.
+ *
+ * Reads `a.data` directly with that same column-major formula, rather than
+ * through `get` (whose `number | undefined` return would force an
+ * always-false bounds check on every element here, since `row`/`col` are
+ * derived from `a`'s own shape and so are always in range) — mirrors how
+ * `matmul.ts`/`transpose.ts` already index `.data` directly for the same
+ * reason.
+ *
+ * Always returns a FRESH `Float64Array` (never `a.data` itself, even in the
+ * rank ≤ 1 no-op case) — mirrors `apl_runtime::builtins::flatten` returning
+ * an owned `Vec`, not a borrow, so a caller mutating the ravelled result
+ * never accidentally mutates `a`'s own buffer.
+ *
+ * Exported (not file-private) so `./shape.js`'s `reshape` can reuse this
+ * exact row-major walk rather than duplicating it a second time.
+ */
+export function flattenRowMajor(a: NDArray): Float64Array {
+  const { shape } = a;
+  if (shape.length <= 1) {
+    return Float64Array.from(a.data);
+  }
+  if (shape.length === 2) {
+    const r = nrows(a);
+    const c = ncols(a);
+    const out = new Float64Array(r * c);
+    let k = 0;
+    for (let row = 0; row < r; row++) {
+      for (let col = 0; col < c; col++) {
+        out[k++] = a.data[col * r + row]; // column-major storage, row-major output order
+      }
+    }
+    return out;
+  }
+  // Unreachable in practice (this package's rank ≤ 2 ceiling) — total
+  // rather than throwing, mirroring the Rust reference's own fallback
+  // (`_ => a.data().to_vec()`).
+  return Float64Array.from(a.data);
+}
+
+/**
+ * Monadic `,` (ravel) — flatten `a` to a rank-1 vector, in row-major order
+ * (see `flattenRowMajor`'s own doc comment for the column-major-storage
+ * vs. row-major-order subtlety). Ported 1:1 from
+ * `apl_runtime::builtins::ravel`.
+ */
+export function ravel(a: NDArray): NDArray {
+  const flat = flattenRowMajor(a);
+  return ndarray([flat.length], flat);
+}
+
+/**
+ * Dyadic `,` (catenate) — supports scalar-scalar, scalar-vector,
+ * vector-scalar, vector-vector (all producing a vector), and
+ * matrix-matrix-with-equal-row-counts (column/last-axis catenate, producing
+ * `[r, ca + cb]`). Any other rank combination is a clean "not yet
+ * supported" error. Ported 1:1 from `apl_runtime::builtins::catenate`.
+ *
+ * SECURITY: the combined-length cap check happens ONCE, up front, before
+ * any rank-dispatch below — mirroring the Rust reference's own structure —
+ * because neither operand alone need be oversized for the RESULT to be: a
+ * script that repeatedly catenates a value with itself (`A←A,A`) doubles
+ * the size every call with no other ceiling, and each individual `catenate`
+ * call only ever sees its own two (individually already-valid) operands, so
+ * the check must re-run on *every* call rather than being satisfied once
+ * and cached.
+ */
+export function catenate(a: NDArray, b: NDArray): NDArray {
+  checkedShapeSize([a.data.length + b.data.length]);
+  const ra = a.shape.length;
+  const rb = b.shape.length;
+  if (ra === 0 && rb === 0) {
+    return ndarray([2], Float64Array.of(a.data[0], b.data[0]));
+  }
+  if (ra === 0 && rb === 1) {
+    const out = new Float64Array(1 + b.data.length);
+    out[0] = a.data[0];
+    out.set(b.data, 1);
+    return ndarray([out.length], out);
+  }
+  if (ra === 1 && rb === 0) {
+    const out = new Float64Array(a.data.length + 1);
+    out.set(a.data, 0);
+    out[a.data.length] = b.data[0];
+    return ndarray([out.length], out);
+  }
+  if (ra === 1 && rb === 1) {
+    const out = new Float64Array(a.data.length + b.data.length);
+    out.set(a.data, 0);
+    out.set(b.data, a.data.length);
+    return ndarray([out.length], out);
+  }
+  if (ra === 2 && rb === 2) {
+    const r = nrows(a);
+    if (r !== nrows(b)) {
+      throw new Error(`catenate: matrix catenate needs equal row counts (${r} vs ${nrows(b)})`);
+    }
+    const ca = ncols(a);
+    const cb = ncols(b);
+    const outLen = checkedShapeSize([r, ca + cb]);
+    const data = new Float64Array(outLen);
+    for (let row = 0; row < r; row++) {
+      for (let col = 0; col < ca; col++) {
+        data[col * r + row] = a.data[col * r + row]; // a has the same r rows
+      }
+      for (let col = 0; col < cb; col++) {
+        data[(ca + col) * r + row] = b.data[col * r + row]; // b has the same r rows
+      }
+    }
+    return ndarray([r, ca + cb], data);
+  }
+  throw new Error(`catenate: catenate of rank ${ra} and rank ${rb} is not yet supported`);
+}

--- a/code/packages/typescript/sir-runtime-array/src/reduce.ts
+++ b/code/packages/typescript/sir-runtime-array/src/reduce.ts
@@ -1,0 +1,123 @@
+/**
+ * `Reduce`/`Scan` — the SIR22 "APL addendum"'s two adverbs that fold an
+ * array with an arbitrary `ElementwiseOpKind` along its one axis. Ported
+ * 1:1 from `array_runtime::ops::{reduce,scan}`
+ * (`code/packages/rust/array-runtime/src/ops.rs`), which is itself the
+ * primary reference this file mirrors — that Rust source (and its own test
+ * suite) is the authority for every edge case documented below. This same
+ * port was already made once, into `semantic-ir-to-javascript`'s inlined
+ * `runtime.rs` string (see that crate's "SIR22 APL-addendum codegen" PR),
+ * and is ported again here mechanically, reusing this package's own
+ * `applyOp` (`./elementwise.js`) rather than re-deriving a second op-dispatch
+ * switch.
+ */
+import { ndarray, type NDArray } from "./ndarray.js";
+import { applyOp, type ElementwiseOpKind } from "./elementwise.js";
+
+/**
+ * `+/A` (APL reduce, dyadic-op monadic-adverb) — fold `a` with `op` along
+ * its one axis:
+ *
+ * - rank 0 (scalar): nothing to fold, returns `a` itself.
+ * - rank 1 (vector `[n]`): a left fold across all `n` elements
+ *   (`op(op(op(v0, v1), v2), …)`). An EMPTY vector is a clean error — unlike
+ *   `sum`/`mean` (which have a built-in identity, `0`), `reduce` is generic
+ *   over any `op`, and guessing an identity (is it `0` for `Add`, `1` for
+ *   `Mul`, `-Infinity` for `Max`?) would be silently wrong for most of them.
+ * - rank 2 (matrix `[r, c]`): folds EACH ROW independently across its `c`
+ *   columns, producing a `[r]` vector (one folded value per row). Storage
+ *   here is column-major (`ndarray.ts`'s own doc comment: element
+ *   `(row, col)` lives at flat offset `col * r + row`), so the row loop
+ *   below reads `d[row]` as the seed (column 0, at flat offset `0 * r +
+ *   row === row`) and then walks `d[col * r + row]` for `col = 1..c`.
+ *   **Getting `row` and `col` swapped in that formula silently
+ *   TRANSPOSES the result instead of throwing** — this is the single
+ *   easiest place to introduce a wrong-answer bug when editing this
+ *   function, called out explicitly here (and in the Rust reference's own
+ *   doc comment) for exactly that reason.
+ */
+export function reduce(op: ElementwiseOpKind, a: NDArray): NDArray {
+  const { shape } = a;
+  if (shape.length === 0) {
+    return a;
+  }
+  if (shape.length === 1) {
+    const n = shape[0];
+    if (n === 0) {
+      throw new Error("reduce: cannot fold an empty vector (no identity element for an arbitrary op)");
+    }
+    const d = a.data;
+    let acc = d[0];
+    for (let i = 1; i < n; i++) {
+      acc = applyOp(op, acc, d[i]);
+    }
+    return ndarray([], Float64Array.of(acc));
+  }
+  if (shape.length === 2) {
+    const [r, c] = shape;
+    if (c === 0) {
+      throw new Error("reduce: cannot fold an empty row (no identity element for an arbitrary op)");
+    }
+    const d = a.data;
+    const out = new Float64Array(r);
+    for (let row = 0; row < r; row++) {
+      let acc = d[row]; // column-major: (row, 0) lives at plain `row`
+      for (let col = 1; col < c; col++) {
+        acc = applyOp(op, acc, d[col * r + row]);
+      }
+      out[row] = acc;
+    }
+    return ndarray([r], out);
+  }
+  throw new Error(`reduce: rank > 2 not yet supported (shape ${JSON.stringify(shape)})`);
+}
+
+/**
+ * `+\A` (APL scan) — the same fold as `reduce`, but keeping EVERY
+ * intermediate result instead of only the last; the output has the same
+ * shape as `a`. Ported 1:1 from `array_runtime::ops::scan`. An empty axis is
+ * NOT an error here (unlike `reduce`): there is simply nothing to scan, and
+ * the (empty) output shape already says so — `scan`'s rank-1 branch below
+ * degrades to an empty loop and returns a `[0]`-shaped empty vector rather
+ * than throwing.
+ *
+ * The rank-2 branch has the identical column-major indexing trap `reduce`
+ * documents above: each row is scanned independently across its columns via
+ * `d[col * r + row]`/`out[col * r + row]`, never `d[row * c + col]`.
+ */
+export function scan(op: ElementwiseOpKind, a: NDArray): NDArray {
+  const { shape } = a;
+  if (shape.length === 0) {
+    return a;
+  }
+  if (shape.length === 1) {
+    const n = shape[0];
+    const d = a.data;
+    const out = new Float64Array(n);
+    let acc = 0;
+    let started = false;
+    for (let i = 0; i < n; i++) {
+      acc = started ? applyOp(op, acc, d[i]) : d[i];
+      started = true;
+      out[i] = acc;
+    }
+    return ndarray([n], out);
+  }
+  if (shape.length === 2) {
+    const [r, c] = shape;
+    const d = a.data;
+    const out = new Float64Array(d.length);
+    for (let row = 0; row < r; row++) {
+      let acc = 0;
+      let started = false;
+      for (let col = 0; col < c; col++) {
+        const x = d[col * r + row]; // column-major
+        acc = started ? applyOp(op, acc, x) : x;
+        started = true;
+        out[col * r + row] = acc;
+      }
+    }
+    return ndarray([r, c], out);
+  }
+  throw new Error(`scan: rank > 2 not yet supported (shape ${JSON.stringify(shape)})`);
+}

--- a/code/packages/typescript/sir-runtime-array/src/shape.ts
+++ b/code/packages/typescript/sir-runtime-array/src/shape.ts
@@ -1,0 +1,86 @@
+/**
+ * `Shape`/`Reshape` — the SIR22 addendum's monadic and dyadic `⍴`
+ * (APL shape-of / reshape). Ported 1:1 from `apl_runtime::builtins::
+ * {shape,reshape}` (`code/packages/rust/apl-runtime/src/builtins.rs`),
+ * previously ported once already into `semantic-ir-to-javascript`'s inlined
+ * runtime (see that crate's "SIR22 APL-addendum codegen" PR) — this is the
+ * same port made a third time, mechanically, into this package's own
+ * module-per-concern layout.
+ */
+import { ndarray, checkedShapeSize, type NDArray } from "./ndarray.js";
+import { flattenRowMajor } from "./ravel.js";
+
+/**
+ * Monadic `⍴` (shape-of) — `a`'s dimensions as a vector. Ported 1:1 from
+ * `apl_runtime::builtins::shape`: a SCALAR has zero dimensions, so its shape
+ * is the EMPTY vector (not a scalar!) — `⍴5` is `⍳0`-shaped, a length-0
+ * vector, mirroring `shape.length === 0` exactly. A vector `[n]` has shape
+ * `[n]` (one element); a matrix `[r, c]` has shape `[r, c]` (two elements).
+ */
+export function shape(a: NDArray): NDArray {
+  const dims = Float64Array.from(a.shape);
+  return ndarray([dims.length], dims);
+}
+
+/**
+ * Dyadic `⍴` (reshape) — reinterpret `target`'s data under the new
+ * dimensions `shapeArg`. Ported 1:1 from `apl_runtime::builtins::reshape`.
+ * `shapeArg` must itself be a scalar or vector (rank ≤ 1) of non-negative
+ * integers, and the target shape it describes is itself capped at rank ≤ 2
+ * (this package's ceiling — a longer target shape is a clean error, not a
+ * silent truncation). `target`'s elements are ravelled (`flattenRowMajor`,
+ * `./ravel.js`) then cyclically repeated or truncated to fill the target
+ * shape's element count.
+ *
+ * **CRITICAL correctness trap** (the single easiest place in this whole
+ * addendum to introduce a silent wrong-answer bug): the cyclic fill happens
+ * in ROW-major order (APL's reshape fills the *last* axis fastest, the same
+ * convention `ravel` uses), but this package's storage is COLUMN-major
+ * (`ndarray.ts`'s own doc comment) — so for a rank-2 target, the row-major
+ * `filled` sequence must be TRANSPOSED into column-major storage
+ * (`data[col * r + row] = filled[row * c + col]`) before calling `ndarray`.
+ * Handing `filled` straight to `ndarray` would silently reshape
+ * column-major instead of APL's row-major convention — a wrong answer that
+ * still LOOKS plausible (the right multiset of values, in the wrong
+ * positions), which is exactly why this needs calling out rather than
+ * trusting a future refactor to rediscover it.
+ */
+export function reshape(shapeArg: NDArray, target: NDArray): NDArray {
+  if (shapeArg.shape.length > 1) {
+    throw new Error(`reshape: shape argument must be a scalar or vector (got rank ${shapeArg.shape.length})`);
+  }
+  const dims = Array.from(shapeArg.data, (x) => {
+    if (!(Number.isInteger(x) && x >= 0)) {
+      throw new Error(`reshape: shape elements must be non-negative integers, got ${x}`);
+    }
+    return x;
+  });
+  if (dims.length > 2) {
+    throw new Error(`reshape: reshape to rank > 2 is not yet supported (target shape ${JSON.stringify(dims)})`);
+  }
+  const total = checkedShapeSize(dims);
+  const source = flattenRowMajor(target);
+  if (total > 0 && source.length === 0) {
+    throw new Error("reshape: cannot reshape an empty source into a non-empty shape");
+  }
+  const filled = new Float64Array(total);
+  for (let k = 0; k < total; k++) {
+    filled[k] = source[k % source.length];
+  }
+  // Rank ≤ 1: row-major and column-major coincide, so `filled` is already
+  // in the right order for `ndarray` (which expects column-major data).
+  if (dims.length <= 1) {
+    return ndarray(dims, filled);
+  }
+  // Rank 2: transpose the row-major fill into column-major storage — see
+  // this function's own doc comment above for why this direction, and only
+  // this direction, is correct.
+  const [r, c] = dims;
+  const data = new Float64Array(total);
+  for (let row = 0; row < r; row++) {
+    for (let col = 0; col < c; col++) {
+      data[col * r + row] = filled[row * c + col];
+    }
+  }
+  return ndarray(dims, data);
+}

--- a/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
+++ b/code/packages/typescript/sir-runtime-array/tests/sir-runtime-array.test.ts
@@ -523,3 +523,419 @@ describe("indexGet / indexSet", () => {
     expect(() => arr.set(a, 0, NaN, 9)).toThrow(/out of bounds/);
   });
 });
+
+// ── SIR22 addendum: APL primitive operators ─────────────────────────────
+//
+// `reduce`/`scan`/`outer`/`shape`/`reshape`/`indexGenerator`/`indexOf`/
+// `ravel`/`catenate` — ported from `array_runtime::ops::{reduce,scan,outer}`
+// and `apl_runtime::builtins::{shape,reshape,index_generator,index_of,
+// ravel,catenate}`, by way of `semantic-ir-to-javascript`'s own already-
+// merged, already-reviewed inlined port of the same nine functions (see
+// that crate's "SIR22 APL-addendum codegen" PR). Every rank case each
+// function documents supporting gets its own test, plus the two named
+// correctness traps (column-major reduce/scan row-folding, and reshape's
+// row-major-fill-transposed-into-column-major-storage requirement) and the
+// two bounded-allocation checks (indexOf's O(len*len) product cap,
+// catenate's combined-length cap).
+
+describe("reduce / scan", () => {
+  it("reduce/scan of a scalar is the scalar itself (nothing to fold)", () => {
+    const s = arr.scalar(7);
+    expect(Array.from(arr.reduce("Add", s).data)).toEqual([7]);
+    expect(Array.from(arr.scan("Add", s).data)).toEqual([7]);
+  });
+
+  it("reduce folds a vector left-to-right", () => {
+    const v = arr.fromVec([1, 2, 3, 4]);
+    // +/v = ((1+2)+3)+4 = 10
+    const r = arr.reduce("Add", v);
+    expect(arr.isScalar(r)).toBe(true);
+    expect(Array.from(r.data)).toEqual([10]);
+    // ×/v = ((1×2)×3)×4 = 24
+    expect(Array.from(arr.reduce("Mul", v).data)).toEqual([24]);
+  });
+
+  it("scan keeps every running fold, same shape as the input", () => {
+    const v = arr.fromVec([1, 2, 3, 4]);
+    // +\v = [1, 1+2, 1+2+3, 1+2+3+4] = [1, 3, 6, 10]
+    const s = arr.scan("Add", v);
+    expect(s.shape).toEqual([4]);
+    expect(Array.from(s.data)).toEqual([1, 3, 6, 10]);
+  });
+
+  it("reduce folds each row of a matrix across its columns (the column-major indexing trap)", () => {
+    // [[1,2,3],[4,5,6]] (2x3): row0 -> 1+2+3=6, row1 -> 4+5+6=15. The
+    // backing store is column-major ([1,4,2,5,3,6], per `fromRows`'s own
+    // test above) — a row/col-swapped indexing bug in the fold (reading
+    // `d[row * c + col]` instead of the correct `d[col * r + row]`) would
+    // silently produce [7, 14] instead: a plausible-looking but WRONG
+        // answer, not a crash, which is exactly why this needs its own test
+    // rather than trusting the code reads correctly.
+    const m = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    const r = arr.reduce("Add", m);
+    expect(r.shape).toEqual([2]);
+    expect(Array.from(r.data)).toEqual([6, 15]);
+  });
+
+  it("scan scans each row of a matrix independently across its columns", () => {
+    // [[1,2,3],[4,5,6]]: row0 running sums [1,3,6], row1 [4,9,15].
+    const m = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    const s = arr.scan("Add", m);
+    expect(s.shape).toEqual([2, 3]);
+    expect(arr.get(s, 0, 0)).toBe(1);
+    expect(arr.get(s, 0, 1)).toBe(3);
+    expect(arr.get(s, 0, 2)).toBe(6);
+    expect(arr.get(s, 1, 0)).toBe(4);
+    expect(arr.get(s, 1, 1)).toBe(9);
+    expect(arr.get(s, 1, 2)).toBe(15);
+  });
+
+  it("reduce/scan work with Max, not just Add/Mul (generic over any ElementwiseOpKind)", () => {
+    const v = arr.fromVec([3, 7, 2, 9, 4]);
+    expect(Array.from(arr.reduce("Max", v).data)).toEqual([9]);
+    expect(Array.from(arr.scan("Max", v).data)).toEqual([3, 7, 7, 9, 9]);
+  });
+
+  it("reduce rejects an empty vector or an empty matrix row (no identity element for an arbitrary op)", () => {
+    const emptyVec = arr.fromVec([]);
+    expect(() => arr.reduce("Add", emptyVec)).toThrow(/cannot fold an empty vector/);
+    expect(() => arr.reduce("Mul", emptyVec)).toThrow(/cannot fold an empty vector/);
+
+    const emptyRowMatrix = arr.ndarray([2, 0], new Float64Array(0));
+    expect(() => arr.reduce("Add", emptyRowMatrix)).toThrow(/cannot fold an empty row/);
+  });
+
+  it("scan of an empty vector is an empty vector, not an error", () => {
+    const empty = arr.fromVec([]);
+    const s = arr.scan("Add", empty);
+    expect(s.shape).toEqual([0]);
+    expect(s.data.length).toBe(0);
+  });
+
+  it("reduce/scan reject rank > 2", () => {
+    const cube = arr.ndarray([2, 2, 2], new Float64Array(8));
+    expect(() => arr.reduce("Add", cube)).toThrow(/rank > 2 not yet supported/);
+    expect(() => arr.scan("Add", cube)).toThrow(/rank > 2 not yet supported/);
+  });
+});
+
+describe("outer", () => {
+  it("scalar outer scalar is a scalar", () => {
+    const r = arr.outer("Mul", arr.scalar(6), arr.scalar(7));
+    expect(arr.isScalar(r)).toBe(true);
+    expect(Array.from(r.data)).toEqual([42]);
+  });
+
+  it("scalar outer vector broadcasts, either side", () => {
+    const v = arr.fromVec([1, 2, 3]);
+    const r1 = arr.outer("Mul", arr.scalar(10), v);
+    expect(r1.shape).toEqual([3]);
+    expect(Array.from(r1.data)).toEqual([10, 20, 30]);
+
+    const r2 = arr.outer("Mul", v, arr.scalar(10));
+    expect(Array.from(r2.data)).toEqual([10, 20, 30]);
+  });
+
+  it("vector outer vector is a rank-sum matrix", () => {
+    // [1,2,3] outer-x [10,100] = [[10,100],[20,200],[30,300]] (3x2).
+    const a = arr.fromVec([1, 2, 3]);
+    const b = arr.fromVec([10, 100]);
+    const r = arr.outer("Mul", a, b);
+    expect(r.shape).toEqual([3, 2]);
+    expect(arr.get(r, 0, 0)).toBe(10);
+    expect(arr.get(r, 0, 1)).toBe(100);
+    expect(arr.get(r, 1, 0)).toBe(20);
+    expect(arr.get(r, 1, 1)).toBe(200);
+    expect(arr.get(r, 2, 0)).toBe(30);
+    expect(arr.get(r, 2, 1)).toBe(300);
+  });
+
+  it("outer Add matches manual pairwise sums", () => {
+    const a = arr.fromVec([1, 2]);
+    const b = arr.fromVec([100, 200, 300]);
+    const r = arr.outer("Add", a, b);
+    expect(r.shape).toEqual([2, 3]);
+    for (let i = 0; i < 2; i++) {
+      for (let j = 0; j < 3; j++) {
+        expect(arr.get(r, i, j)).toBe(a.data[i] + b.data[j]);
+      }
+    }
+  });
+
+  it("outer rejects operands of rank > 1", () => {
+    const m = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]);
+    const v = arr.fromVec([1, 2]);
+    expect(() => arr.outer("Add", m, v)).toThrow(/rank > 1 not yet supported/);
+    expect(() => arr.outer("Add", v, m)).toThrow(/rank > 1 not yet supported/);
+  });
+
+  it("outer of an empty vector operand is an empty result, not an error", () => {
+    const empty = arr.fromVec([]);
+    const v = arr.fromVec([1, 2, 3]);
+    const r = arr.outer("Mul", empty, v);
+    expect(r.shape).toEqual([0, 3]);
+    expect(r.data.length).toBe(0);
+  });
+
+  it("an outer-product call whose output would exceed MAX_ELEMENTS is a clean error, not an OOM", () => {
+    // Each operand is individually tiny (its actual `data` is length 1);
+    // only the claimed shape's PRODUCT (m * n) is absurd. Proves the output
+    // shape is validated (`checkedShapeSize`) before `outer` ever allocates
+    // `out`, not after — the same allocate-after-validate ordering
+    // `matmul`'s own equivalent test proves.
+    const a: arr.NDArray = { shape: [100000], data: new Float64Array(1) };
+    const b: arr.NDArray = { shape: [100000], data: new Float64Array(1) };
+    expect(() => arr.outer("Mul", a, b)).toThrow(/exceeds/);
+  });
+});
+
+describe("shape / reshape", () => {
+  it("shape of a scalar is the empty vector, not a scalar", () => {
+    // ⍴5 is ⍳0-shaped: a length-0 vector, not a length-1 one.
+    const s = arr.shape(arr.scalar(7));
+    expect(s.shape).toEqual([0]);
+    expect(s.data.length).toBe(0);
+  });
+
+  it("shape of a vector and a matrix", () => {
+    expect(Array.from(arr.shape(arr.fromVec([1, 2, 3])).data)).toEqual([3]);
+    const m = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    expect(Array.from(arr.shape(m).data)).toEqual([2, 3]);
+  });
+
+  it("reshape cycles a shorter source, filling in ROW-major order (the correctness trap)", () => {
+    // 2 3⍴1 2 -- cycles [1, 2] to fill 6 elements, row-major fill order:
+    // row0 = [1, 2, 1], row1 = [2, 1, 2]. Getting the row-major-fill-
+    // transposed-into-column-major-storage step backwards here would
+    // silently produce row0 = [1, 1, 1], row1 = [2, 2, 2] instead — the
+    // right multiset of values, in the WRONG positions, which is exactly
+    // the plausible-but-wrong failure mode this test exists to catch.
+    const shapeArg = arr.fromVec([2, 3]);
+    const source = arr.fromVec([1, 2]);
+    const r = arr.reshape(shapeArg, source);
+    expect(r.shape).toEqual([2, 3]);
+    expect(arr.get(r, 0, 0)).toBe(1);
+    expect(arr.get(r, 0, 1)).toBe(2);
+    expect(arr.get(r, 0, 2)).toBe(1);
+    expect(arr.get(r, 1, 0)).toBe(2);
+    expect(arr.get(r, 1, 1)).toBe(1);
+    expect(arr.get(r, 1, 2)).toBe(2);
+  });
+
+  it("reshape truncates a longer source", () => {
+    // 2 2⍴1 2 3 4 5 6 -- only the first 4 elements are used.
+    const shapeArg = arr.fromVec([2, 2]);
+    const source = arr.fromVec([1, 2, 3, 4, 5, 6]);
+    const r = arr.reshape(shapeArg, source);
+    expect(r.shape).toEqual([2, 2]);
+    expect(arr.get(r, 0, 0)).toBe(1);
+    expect(arr.get(r, 0, 1)).toBe(2);
+    expect(arr.get(r, 1, 0)).toBe(3);
+    expect(arr.get(r, 1, 1)).toBe(4);
+  });
+
+  it("reshape into a rank <= 1 target needs no row-major/column-major transpose", () => {
+    // Rank <= 1 is the branch where row-major and column-major coincide --
+    // `filled` is handed straight to `ndarray` with no transpose step.
+    const shapeArg = arr.fromVec([4]);
+    const source = arr.fromVec([1, 2]);
+    const r = arr.reshape(shapeArg, source);
+    expect(r.shape).toEqual([4]);
+    expect(Array.from(r.data)).toEqual([1, 2, 1, 2]);
+  });
+
+  it("reshape rejects a rank > 1 shape argument", () => {
+    const shapeArg = arr.fromRows([[2, 2]]);
+    const source = arr.fromVec([1]);
+    expect(() => arr.reshape(shapeArg, source)).toThrow(/must be a scalar or vector/);
+  });
+
+  it("reshape rejects negative or non-integer shape elements", () => {
+    const source = arr.fromVec([1]);
+    expect(() => arr.reshape(arr.fromVec([-1]), source)).toThrow(/non-negative integers/);
+    expect(() => arr.reshape(arr.fromVec([2.5]), source)).toThrow(/non-negative integers/);
+  });
+
+  it("reshape rejects a target shape of rank > 2", () => {
+    const shapeArg = arr.fromVec([2, 2, 2]);
+    const source = arr.fromVec([1]);
+    expect(() => arr.reshape(shapeArg, source)).toThrow(/rank > 2 is not yet supported/);
+  });
+
+  it("reshape of an empty source into a non-empty target is an error", () => {
+    const shapeArg = arr.fromVec([3]);
+    const empty = arr.fromVec([]);
+    expect(() => arr.reshape(shapeArg, empty)).toThrow(/cannot reshape an empty source/);
+  });
+
+  it("reshape caps the target element count before allocating", () => {
+    const shapeArg = arr.fromVec([arr.MAX_ELEMENTS + 1]);
+    const source = arr.fromVec([1]);
+    expect(() => arr.reshape(shapeArg, source)).toThrow(/exceeds/);
+  });
+});
+
+describe("indexGenerator / indexOf", () => {
+  it("indexGenerator produces a 1-based run, unlike this package's 0-based indexGet/indexSet", () => {
+    const r = arr.indexGenerator(arr.scalar(5));
+    expect(Array.from(r.data)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("indexGenerator of zero is empty", () => {
+    const r = arr.indexGenerator(arr.scalar(0));
+    expect(r.data.length).toBe(0);
+  });
+
+  it("indexGenerator rejects negative and non-integer arguments", () => {
+    expect(() => arr.indexGenerator(arr.scalar(-1))).toThrow(/non-negative integer/);
+    expect(() => arr.indexGenerator(arr.scalar(2.5))).toThrow(/non-negative integer/);
+  });
+
+  it("indexGenerator rejects a non-scalar argument", () => {
+    const v = arr.fromVec([1, 2]);
+    expect(() => arr.indexGenerator(v)).toThrow(/must be a scalar/);
+  });
+
+  it("indexGenerator caps n before allocating", () => {
+    const huge = arr.scalar(arr.MAX_ELEMENTS + 1);
+    expect(() => arr.indexGenerator(huge)).toThrow(/exceeds/);
+  });
+
+  it("indexOf finds each needle's 1-based position, or haystack.length + 1 if not found", () => {
+    const haystack = arr.fromVec([10, 20, 30]);
+    const needles = arr.fromVec([20, 99, 10]);
+    const r = arr.indexOf(haystack, needles);
+    // 20 is at 1-based index 2, 99 is not found (len+1 = 4), 10 is at index 1.
+    expect(Array.from(r.data)).toEqual([2, 4, 1]);
+    expect(r.shape).toEqual(needles.shape);
+  });
+
+  it("indexOf rejects a haystack of rank > 1", () => {
+    const m = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]);
+    const needles = arr.fromVec([1]);
+    expect(() => arr.indexOf(m, needles)).toThrow(/must be a scalar or vector/);
+  });
+
+  it("indexOf caps the O(len(haystack) * len(needle)) work product before scanning", () => {
+    // Neither operand alone exceeds MAX_ELEMENTS, but their PRODUCT (the
+    // work this does) does: 8200 * 8200 ≈ 67.24M > MAX_ELEMENTS (2^26 ≈
+    // 67.11M) -- this is the shape a security review flags as unbounded if
+    // the cap were missing, or checked each operand's own length instead of
+    // their product. Both buffers are individually tiny to allocate (8200
+    // zero-filled elements), so this stays fast despite exercising the cap.
+    const n = 8200;
+    const haystack = arr.ndarray([n], new Float64Array(n));
+    const needle = arr.ndarray([n], new Float64Array(n));
+    expect(() => arr.indexOf(haystack, needle)).toThrow(/exceeds/);
+  });
+});
+
+describe("ravel / catenate", () => {
+  it("ravel flattens a matrix in row-major order", () => {
+    // [[1,2,3],[4,5,6]] ravels to [1,2,3,4,5,6] (row-major), even though
+    // the backing store is column-major [1,4,2,5,3,6].
+    const m = arr.fromRows([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    expect(Array.from(arr.ravel(m).data)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("ravel of a scalar and a vector is a no-op reshape", () => {
+    expect(Array.from(arr.ravel(arr.scalar(9)).data)).toEqual([9]);
+    const v = arr.fromVec([1, 2]);
+    expect(Array.from(arr.ravel(v).data)).toEqual([1, 2]);
+  });
+
+  it("ravel is total (not throwing) even on a rank > 2 array, though such input is unreachable via any function in this package", () => {
+    // No function in this package's own public surface *produces* a rank > 2
+    // `NDArray` -- but `ndarray()` itself doesn't reject one either (only
+    // `reduce`/`scan`/`outer` explicitly cap at rank <= 2), so a directly
+    // constructed rank-3 array is a real, if unusual, input `flattenRowMajor`
+    // must stay total over rather than crash on — mirroring the Rust
+    // reference's own `_ => a.data().to_vec()` fallback.
+    const cube = arr.ndarray([2, 2, 2], Float64Array.from([1, 2, 3, 4, 5, 6, 7, 8]));
+    const r = arr.ravel(cube);
+    expect(r.shape).toEqual([8]);
+    expect(Array.from(r.data)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("catenate scalar and scalar", () => {
+    const r = arr.catenate(arr.scalar(1), arr.scalar(2));
+    expect(Array.from(r.data)).toEqual([1, 2]);
+  });
+
+  it("catenate scalar and vector prepends or appends", () => {
+    const v = arr.fromVec([2, 3]);
+    expect(Array.from(arr.catenate(arr.scalar(1), v).data)).toEqual([1, 2, 3]);
+    expect(Array.from(arr.catenate(v, arr.scalar(4)).data)).toEqual([2, 3, 4]);
+  });
+
+  it("catenate vector and vector", () => {
+    const a = arr.fromVec([1, 2]);
+    const b = arr.fromVec([3, 4, 5]);
+    expect(Array.from(arr.catenate(a, b).data)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("catenate matrices with equal row counts concatenates columns", () => {
+    const a = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]); // 2x2
+    const b = arr.fromRows([[5], [6]]); // 2x1
+    const r = arr.catenate(a, b);
+    expect(r.shape).toEqual([2, 3]);
+    expect(arr.get(r, 0, 0)).toBe(1);
+    expect(arr.get(r, 0, 1)).toBe(2);
+    expect(arr.get(r, 0, 2)).toBe(5);
+    expect(arr.get(r, 1, 2)).toBe(6);
+  });
+
+  it("catenate rejects mismatched matrix row counts", () => {
+    const a = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]); // 2x2
+    const b = arr.fromRows([[5, 6]]); // 1x2
+    expect(() => arr.catenate(a, b)).toThrow(/equal row counts/);
+  });
+
+  it("catenate rejects a matrix paired with a vector", () => {
+    const a = arr.fromRows([
+      [1, 2],
+      [3, 4],
+    ]);
+    const v = arr.fromVec([1, 2]);
+    expect(() => arr.catenate(a, v)).toThrow(/not yet supported/);
+    expect(() => arr.catenate(v, a)).toThrow(/not yet supported/);
+  });
+
+  it("catenate caps the combined length before allocating, re-checked on every call", () => {
+    // Neither operand alone exceeds MAX_ELEMENTS, but their sum does -- a
+    // script that repeatedly did `A = catenate(A, A)` would otherwise
+    // double the size every call with no ceiling at all. The check reads
+    // the operands' actual `data.length` (not a claimed shape, unlike the
+    // `outer`/`matmul` tests above), so this needs two real buffers -- cheap
+    // to allocate since a `Float64Array` of a given length is zero-filled
+    // directly, not built up incrementally.
+    const half = Math.floor(arr.MAX_ELEMENTS / 2) + 1;
+    const a = arr.ndarray([half], new Float64Array(half));
+    const b = arr.ndarray([half], new Float64Array(half));
+    expect(() => arr.catenate(a, b)).toThrow(/exceeds/);
+  });
+});


### PR DESCRIPTION
## Summary

`sir-runtime-array`'s own module doc comment flagged the SIR22 "APL addendum" node kinds — `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` — as out of scope, "pending a JS/TS-backend consumer actually needing them." That consumer now exists: `apl-to-semantic-ir` genuinely emits these 9 node kinds, and the sibling `semantic-ir-to-javascript` backend already implements real codegen for all 9 by porting `array_runtime::ops::{reduce,scan,outer}` and `apl_runtime::builtins::{shape,reshape,index_generator,index_of,ravel,catenate}` (Rust) into its own inlined JS runtime.

This PR ports that same, already-merged, already-security-reviewed implementation into `sir-runtime-array` — the real npm package `semantic-ir-to-typescript` imports as a dependency (unlike the JS backend, which inlines its own copy) — following this package's existing module-per-concern file layout instead of one giant new file.

## Changes

- `src/reduce.ts` — `reduce`, `scan` (reuses this package's own `applyOp`, now exported from `elementwise.ts`, rather than duplicating the op-dispatch switch)
- `src/outer.ts` — `outer`
- `src/shape.ts` — `shape`, `reshape`
- `src/iota.ts` — `indexGenerator` (1-based, per real APL `⍳` semantics — the SIR22 spec's own prose describing 0-based results predates the actual `apl-runtime`/JS-backend implementations, both of which are genuinely 1-based; this follows those working references, not the stale spec text), `indexOf`
- `src/ravel.ts` — `ravel`, `catenate`, plus an exported `flattenRowMajor` helper `reshape` also reuses
- `src/index.ts` — new exports + updated "Deliberately out of scope" doc section
- `README.md`/`CHANGELOG.md` — updated coverage table, new 0.3.0 entry
- `package.json` — 0.2.0 → 0.3.0 (backward-compatible feature addition)

Both correctness traps the JS port's own comments call out are preserved verbatim here, each with a dedicated adversarial test:
- **`reduce`/`scan`'s rank-2 branch**: column-major indexing (`d[col * r + row]`, folding/scanning each row across columns) — swapping row/col silently transposes the result instead of throwing.
- **`reshape`'s rank-2 case**: the cyclic fill happens in row-major order but must be transposed into this package's column-major storage before returning — getting this backwards produces a plausible-looking but wrong (transposed) answer.

**Judgment call**: did not add a display/formatting helper (the JS backend's `ArrayRt.display`/`fmtNum` equivalent) — confirmed `semantic-ir-to-typescript` doesn't yet have any codegen wiring that would consume one (that's the next follow-up, tracked separately), so building one now would be speculative.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 108/108 tests passing (up from 64 baseline)
- [x] `npx vitest run --coverage` — 100% statements/branches/functions/lines
- [x] `/security-review` — **PASSED, no vulnerabilities found** (specifically hand-traced: `indexOf`'s O(n·m) product cap runs before scanning, `catenate`'s combined-length cap re-runs on every call rather than being cached, `outer`'s `[m,n]` cap runs before allocation, and `reshape`'s row-major→column-major transpose has no off-by-one or swapped-index bug)
- [x] Rebased onto current `origin/main` tip, no conflicts

Out of scope for this PR (separate, already-tracked follow-ups): wiring `semantic-ir-to-typescript`'s actual codegen to call these new exports, and APL oracle/golden tests exercising them end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)