### PR TITLE
feat(hl-sanskrit): Chapters 2-5 — intro, how-are-you, farewells, first verbs

### DIFF
--- a/code/learning/human-languages/sanskrit/CHANGELOG.md
+++ b/code/learning/human-languages/sanskrit/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Chapters 2–5 — Introductions, How-are-you, Farewells, First Verbs
+
+- Four new chapters carry Sanskrit from Chapter 1 to Chapter 5, matching the
+  leading tracks' arc. One word per lesson, atom-first, Devanagari inline; every
+  root traced (`lessons/SA-C0{2,3,4,5}-*`, `book/chapters/ch0{2,3,4,5}-*.tex`).
+  Concept tags reuse the universal `HL01` taxonomy; verbs namespaced (`SA-VERB-*`).
+  As the **taproot**, each atom is presented as a *source* — pointing west
+  (*aham*→*ego/I*, *asmi*→*am*, *vas*→*was*, *kim*→*what*) and east (into the
+  Indo-Aryan daughters).
+- **Ch. 2 — Introducing Yourself**: *nāma* (→ *name*) → *mama* (→ *me/my*) →
+  *asti* (→ *is/est*; Sanskrit **keeps** the copula its Dravidian neighbours drop)
+  → *mama nāma … asti* → *bhavān/tvam* (respect by 3rd-person honorific) → *kim*
+  (→ *what/quis*) → *tava nāma kim?* → *ānandaḥ* ("joy," pleased to meet) →
+  practice.
+- **Ch. 3 — How Are You**: *katham* → *bhavān katham asti?* → *aham* (→ Latin
+  *ego*, English **I**) → *kuśalam* (well; ← *kuśa* grass → "skilled" → "well")
+  → *na cintā* ("no worry" = you're welcome) → practice. The copula trio
+  *asmi/asi/asti*.
+- **Ch. 4 — Farewells**: *gacchāmi* ("I go"; ← *gam* → *come*) → *punaḥ* →
+  *punar-darśanāya* ("for seeing again"; the dative; *darśana* = a beholding) →
+  *śvaḥ* ("tomorrow," kept distinct from *hyaḥ* "yesterday," unlike Hindi *kal*)
+  → practice.
+- **Ch. 5 — First Verbs**: *vadāmi* (← *vad*; featuring the **dual** *vadāvaḥ*
+  "we two speak") → *ahaṁ saṁskṛtaṁ vadāmi* (*saṁskṛta* = "perfected"; sandhi) →
+  *vasāmi* (← *vas* → English **was**; the locative *-e*) → *karomi* (← √kṛ, the
+  root of *namaskāra/karma/Sanskrit*; *kāryaṁ karomi* "I work") → practice. Book
+  compiles clean with XeLaTeX (0 missing chars, 0 undefined refs).
+
 ## Chapter 1 — Greetings (Devanagari taught inline)
 
 - New Sanskrit track on the HL00 framework — a senior Indo-European branch, the

--- a/code/learning/human-languages/sanskrit/README.md
+++ b/code/learning/human-languages/sanskrit/README.md
@@ -23,8 +23,19 @@ book.
 
 - **Chapter 1 — Greetings** ([`lessons/SA-C01-*`](./lessons/)): namaste,
   namaskāraḥ, dhanyavādaḥ, svāgatam, ām/na, practice. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): *mama nāma…*, and the Sanskrit
-  verb that marks singular, **dual**, and plural.
+- **Chapter 2 — Introducing Yourself** ([`lessons/SA-C02-*`](./lessons/)): nāma,
+  mama, asti, **mama nāma … asti** (Sanskrit keeps the copula), bhavān/tvam, kim,
+  **tava nāma kim?**, ānandaḥ, practice. Each atom a *source* (→ *name/my/is/what*).
+  In the book.
+- **Chapter 3 — How Are You** ([`lessons/SA-C03-*`](./lessons/)): katham, **bhavān
+  katham asti?**, aham (← *ego* → *I*), kuśalam, na cintā, practice. The copula
+  trio asmi/asi/asti. In the book.
+- **Chapter 4 — Farewells** ([`lessons/SA-C04-*`](./lessons/)): gacchāmi (← *gam*
+  → *come*), punaḥ, **punar-darśanāya**, śvaḥ (kept distinct from *hyaḥ*),
+  practice. The dative case. In the book.
+- **Chapter 5 — First Verbs** ([`lessons/SA-C05-*`](./lessons/)): vadāmi (the
+  **dual** *vadāvaḥ*), **ahaṁ saṁskṛtaṁ vadāmi**, vasāmi (← *vas* → *was*),
+  karomi (← √kṛ), practice. In the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/sanskrit/book/book.tex
+++ b/code/learning/human-languages/sanskrit/book/book.tex
@@ -71,4 +71,12 @@ under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
+\input{chapters/ch03-responding}
+
+\input{chapters/ch04-farewells}
+
+\input{chapters/ch05-first-verbs}
+
 \end{document}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch02-introductions.tex
@@ -1,0 +1,130 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- and, since this is Sanskrit, each atom is the
+\emph{ancestor} of words across both Europe and modern India:
+
+\begin{center}
+\sk{मम नाम अरुणः अस्ति।} \quad(\emph{mama n\=ama Aru\d{n}a\d{h} asti} --- ``My name is Arun.'')\\
+\sk{तव नाम किम्?} \quad(\emph{tava n\=ama kim} --- ``What is your name?'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/SA-C02-*.md}.}
+
+\section{\sk{नाम} \emph{(n\=ama)} --- ``name,'' the source of a word half the world shares}
+\label{lesson:nama}
+
+\begin{cousinweb}
+\sk{नाम} (\emph{n\=ama}, ``name'') is from the stem \emph{n\=aman}, from
+Proto-Indo-European *h\textsubscript{3}n\'{o}mn\d{}. This is not a borrowing but
+the \emph{ancestor}: English \textbf{name}, Latin \emph{n\=omen} (English
+\textbf{noun}), Greek \emph{onoma}, and, worn down, Hindi \emph{n\=am}, Bengali
+\emph{n\=am}. Saying \emph{n\=ama}, you stand near the headwaters of a word that
+flowed to both Europe and modern India.
+\end{cousinweb}
+
+\section{\sk{मम} \emph{(mama)} --- ``my,'' the ancestor of \emph{me} and \emph{my}}
+\label{lesson:mama}
+
+\begin{cousinweb}
+\sk{मम} (\emph{mama}, ``my, of me'') is the genitive of \sk{अहम्} (\emph{aham},
+``I''), on the first-person root \emph{ma-}, PIE *me- --- the source of English
+\textbf{me}, \textbf{my}, \textbf{mine}, Latin \emph{meus}, and Hindi \emph{mer\=a}.
+Sanskrit \emph{mama} and English \emph{my} are the same ancient word, one still
+in its old form.
+\end{cousinweb}
+
+\section{\sk{अस्ति} \emph{(asti)} --- ``is,'' the ancestor of \emph{is} and \emph{est}}
+\label{lesson:asti}
+
+\begin{cousinweb}
+\sk{अस्ति} (\emph{asti}, ``is'') is the third person of the root \sk{अस्}
+(\emph{as-}, ``to be''), PIE *h\textsubscript{1}es- --- the source of English
+\textbf{is}, Latin \emph{est}, Greek \emph{esti}, and Hindi \emph{hai} (from
+\emph{asti} directly). Unlike its Dravidian neighbours (Tamil and Bengali drop
+``is''), Sanskrit \emph{keeps} an explicit copula --- the word Europe kept too.
+\end{cousinweb}
+
+\section{\sk{मम नाम \ldots अस्ति} --- ``my name is\ldots''}
+\label{lesson:mama-nama-asti}
+
+\sk{मम} (my) $+$ \sk{नाम} (name) $+$ name $+$ \sk{अस्ति} (is) $=$ ``my name
+is\ldots'' The verb comes \textbf{last}.
+
+\begin{grammarlens}
+\textbf{Sanskrit keeps the ``is.''} Tamil says only \emph{eṉ peyar Arun}, Bengali
+\emph{\=am\=ar n\=am Arun} --- both dropping the verb. Sanskrit says \emph{mama
+n\=ama \ldots asti}, with an explicit \emph{asti} --- the Indo-European way, kept
+by Latin and English too.
+\end{grammarlens}
+
+\section{\sk{भवान्} / \sk{त्वम्} \emph{(bhav\=an / tvam)} --- ``you,'' respectful and familiar}
+\label{lesson:bhavan-tvam}
+
+\begin{cousinweb}
+\sk{त्वम्} (\emph{tvam}, familiar ``you'') is from PIE *t\=u --- the ancestor of
+English archaic \textbf{thou}, Latin \emph{t\=u}, Hindi \emph{t\=u}. \sk{भवान्}
+(\emph{bhav\=an}, respectful) is really a third-person honorific, ``your honour''
+(from \emph{bhavat}), and so takes a \emph{third-person} verb.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Politeness by grammatical person.} Where Hindi makes respect \emph{plural}
+(\emph{\=ap \ldots hai\d{m}}), Sanskrit makes it \emph{third-person}: you address
+someone as though speaking \emph{about} them --- ``is your honour well?''
+\end{grammarlens}
+
+\section{\sk{किम्} \emph{(kim)} --- ``what,'' the source of the question-words}
+\label{lesson:kim}
+
+\begin{cousinweb}
+\sk{किम्} (\emph{kim}, ``what'') is from the interrogative stem \emph{ka-}, PIE
+*k\ensuremath{^w}o- --- the ancestor of English \textbf{what}, \textbf{who},
+Latin \emph{quis}, and Hindi \emph{ky\=a}. Sanskrit's own questions all grow from
+this \emph{ka-}: \emph{kim} (what), \emph{ka\d{h}} (who), \emph{kad\=a} (when),
+\emph{kutra} (where), \emph{katham} (how) --- the single seed of both Europe's
+\emph{qu-/wh-} and India's \emph{k-} words.
+\end{cousinweb}
+
+\section{\sk{तव नाम किम्?} --- ``what's your name?''}
+\label{lesson:tava-nama-kim}
+
+\sk{तव} (\emph{tava}, ``your,'' genitive of \emph{tvam}) $+$ \sk{नाम} (name) $+$
+\sk{किम्} (what) $=$ ``your name what?'' Here Sanskrit often drops \emph{asti}.
+Respectfully: \sk{भवतः नाम किम्?} (\emph{bhavata\d{h} n\=ama kim?}). Note
+\emph{mama} / \emph{tava} / \emph{bhavata\d{h}} --- ``my / your / your-honour's,''
+all genitives.
+
+\section{\sk{आनन्दः} \emph{(\=ananda\d{h})} --- ``joy,'' and ``a joy to meet you''}
+\label{lesson:anandah}
+
+\begin{cousinweb}
+To say ``pleased to meet you,'' Sanskrit can say \sk{भवन्तं दृष्ट्वा आनन्दः}
+(\emph{bhavanta\d{m} d\d{r}\d{s}\d{t}v\=a \=ananda\d{h}}) --- ``seeing you, [there
+is] joy.'' \sk{आनन्दः} (\emph{\=ananda\d{h}}, ``joy, bliss'') is \emph{\=a-}
+(``fully'') $+$ \sk{नन्द्} (\emph{nand}, ``to rejoice'') --- the \emph{\=ananda} of
+\emph{sat-cit-\=ananda} (``being-consciousness-bliss'') and the name
+\textbf{\=Ananda}, the Buddha's disciple. A simple greeting reaches for the word
+Indian thought uses for the deepest happiness.
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Sanskrit & English \\
+\midrule
+\sk{मम नाम मीरा अस्ति।} & My name is Mira. \\
+\sk{तव नाम किम्?} & What's your name? \\
+\sk{मम नाम अरुणः अस्ति।} & My name is Arun. \\
+\sk{भवन्तं दृष्ट्वा आनन्दः।} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom is a \emph{source}: \emph{n\=ama} ($\to$ \emph{name}), \emph{mama}
+($\to$ \emph{my}), \emph{asti} ($\to$ \emph{is}), \emph{kim} ($\to$ \emph{what}).
+And Sanskrit keeps the copula its Dravidian neighbours drop. Next chapter:
+\emph{bhav\=an katham asti?} (``how are you?'').

--- a/code/learning/human-languages/sanskrit/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch03-responding.tex
@@ -1,0 +1,93 @@
+\chapter{How Are You?}
+\label{ch:responding}
+
+After the name comes the exchange everyone actually has --- carried by the copula
+whose forms fathered English \emph{am} and \emph{is}:
+
+\begin{center}
+\sk{भवान् कथम् अस्ति?} \quad(\emph{bhav\=an katham asti} --- ``How are you?'')\\
+\sk{अहं कुशली अस्मि, धन्यवादः।} \quad(\emph{aha\d{m} ku\'{s}al\=\i\ asmi, dhanyav\=ada\d{h}} --- ``I am well, thank you.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/SA-C03-*.md}.}
+
+\section{\sk{कथम्} \emph{(katham)} --- ``how,'' another of the ka- questions}
+\label{lesson:katham}
+
+\begin{cousinweb}
+\sk{कथम्} (\emph{katham}, ``how'') is from the interrogative stem \emph{ka-}, PIE
+*k\ensuremath{^w}o- --- the root behind English \textbf{wh-} and Latin \emph{qu-}.
+It heads the same \emph{ka-} family (\emph{kim, ka\d{h}, kad\=a, kutra, katham}),
+and gives the noun \emph{kath\=a} (``a telling, a story'') and, worn down, Hindi's
+\emph{kaise}.
+\end{cousinweb}
+
+\section{\sk{भवान् कथम् अस्ति?} --- ``how are you?''}
+\label{lesson:bhavan-katham-asti}
+
+\sk{भवान्} (\emph{bhav\=an}, respectful ``you'') $+$ \sk{कथम्} (how) $+$ \sk{अस्ति}
+(is) $=$ ``your honour how is?'' Recall that \emph{bhav\=an} (``your honour'')
+takes a \textbf{third-person} verb --- so \emph{asti} (``is''), not ``are.''
+Familiar: \sk{त्वं कथम् असि?} (\emph{tva\d{m} katham asi?}).
+
+\begin{grammarlens}
+\textbf{The copula, three persons:} \sk{अस्मि} (\emph{asmi}, ``I am''), \sk{असि}
+(\emph{asi}, ``you are''), \sk{अस्ति} (\emph{asti}, ``is'') --- ancestors of
+English \textbf{am} and (via Latin/Greek) \emph{is/est}. ``How are you?'' asks
+after a \emph{state}, and Sanskrit always kept a verb for it.
+\end{grammarlens}
+
+\section{\sk{अहम्} \emph{(aham)} --- ``I,'' the ancestor of \emph{ego} and \emph{I}}
+\label{lesson:aham}
+
+\begin{cousinweb}
+\sk{अहम्} (\emph{aham}, ``I'') is from PIE *h\textsubscript{1}e\'{g}(H)om --- the
+ancestor of Latin \textbf{ego}, Greek \emph{eg\=o}, and, worn all the way down,
+English \textbf{I}. Sanskrit \emph{aham}, Latin \emph{ego}, English \emph{I} are
+one word across time. Its possessive is \emph{mama} (``my''); curiously, ``I'' and
+``my'' come from \emph{different} roots (*e\'{g}- and *me-) --- a quirk Sanskrit
+shares with English (\emph{I} vs.\ \emph{my}).
+\end{cousinweb}
+
+\section{\sk{कुशलम्} \emph{(ku\'{s}alam)} --- ``well-being,'' and how to answer}
+\label{lesson:kushalam}
+
+\begin{cousinweb}
+\sk{कुशलम्} (\emph{ku\'{s}alam}, ``well-being, welfare'') is native Sanskrit,
+famously from \sk{कुश} (\emph{ku\'{s}a}, the sacred grass) $+$ a root of
+``cutting'': first ``skilled [at gathering \emph{ku\'{s}a} properly],'' hence
+``adept, fit, in good order,'' hence ``well.'' The reply: \sk{अहं कुशली अस्मि}
+(\emph{aha\d{m} ku\'{s}al\=\i\ asmi}), ``I am well.''
+\end{cousinweb}
+
+\section{\sk{न चिन्ता} \emph{(na cint\=a)} --- ``no worry''}
+\label{lesson:na-cinta}
+
+\begin{cousinweb}
+\sk{न चिन्ता} literally ``\textbf{[there is] no worry}'' --- \sk{न} (\emph{na},
+``not,'' from Chapter 1) $+$ \sk{चिन्ता} (\emph{cint\=a}, ``anxious thought,'' from
+the root \emph{cint} ``to think''). Used for ``never mind / you're welcome.''
+\emph{Na} is the ancient negative, PIE *ne, behind English \textbf{no},
+\textbf{not}, Latin \emph{n\=on}; \emph{cint\=a} is the same worry borrowed into
+Hindi (\emph{cint\=a mat karo}). ``Think nothing of it.''
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Sanskrit & English \\
+\midrule
+\sk{भवान् कथम् अस्ति?} & How are you? \\
+\sk{अहं कुशली अस्मि, धन्यवादः।} & I am well, thank you. \\
+\sk{न चिन्ता।} & No worry / you're welcome. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The taproot, both ways: \emph{katham} (\emph{ka-}, $\to$ English \emph{how}),
+\emph{aham} ($\to$ Latin \emph{ego}, English \emph{I}), the copula \emph{asmi} /
+\emph{asti} ($\to$ \emph{am} / \emph{is}), and \emph{na} ($\to$ \emph{no}, Latin
+\emph{n\=on}). Next chapter: the farewells.

--- a/code/learning/human-languages/sanskrit/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch04-farewells.tex
@@ -1,0 +1,86 @@
+\chapter{Farewells}
+\label{ch:farewells}
+
+Sanskrit has no casual ``bye.'' Like its daughters, it takes leave by ``I go'' ---
+and promises a seeing to come:
+
+\begin{center}
+\sk{पुनर्दर्शनाय।} \quad(\emph{punar-dar\'{s}an\=aya} --- ``Until we meet again.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/SA-C04-*.md}.}
+
+\section{\sk{गच्छामि} \emph{(gacch\=ami)} --- ``I go'' (taking leave)}
+\label{lesson:gacchami}
+
+\begin{cousinweb}
+\sk{गच्छामि} (\emph{gacch\=ami}, ``I go'') is from the root \sk{गम्} (\emph{gam},
+``to go'') --- the root inside Chapter 1's \sk{स्वागतम्} (\emph{sv\=agatam} $=$
+\emph{su} $+$ \emph{\=agata}, ``well come''). That root is PIE *g\ensuremath{^w}em-,
+the ancestor of English \textbf{come}. To leave politely one says \emph{gacch\=ami}
+(``I go'') or \emph{\=agacch\=ami} (``I shall come [back]'') --- the ``promise of
+return'' the modern languages kept.
+\end{cousinweb}
+
+\section{\sk{पुनः} \emph{(puna\d{h})} --- ``again''}
+\label{lesson:punah}
+
+\begin{cousinweb}
+\sk{पुनः} (\emph{puna\d{h}}, ``again, once more'') is a native adverb (combining
+form \emph{punar-}, as in \emph{punar-janma}, ``rebirth''). No single English
+cognate, but its work is shared: it turns a parting into ``see you \emph{again}.''
+\end{cousinweb}
+
+\section{\sk{पुनर्दर्शनाय} \emph{(punar-dar\'{s}an\=aya)} --- ``until we meet again''}
+\label{lesson:punar-darshanaya}
+
+\sk{पुनर्} (\emph{punar}, ``again'') $+$ \sk{दर्शनाय} (\emph{dar\'{s}an\=aya}, ``for
+seeing'') $=$ ``\textbf{for seeing [you] again}.'' The word \sk{दर्शन}
+(\emph{dar\'{s}ana}, ``seeing, vision'') is deep: the \emph{dar\'{s}an} one takes
+of a deity, and the name of the six \emph{dar\'{s}anas}, the schools of Indian
+philosophy (``ways of seeing''). This farewell promises a \emph{beholding} to
+come.
+
+\begin{grammarlens}
+\textbf{The dative ``for the sake of.''} The ending \sk{-आय} (\emph{-\=aya}) is
+the dative singular --- ``to / for.'' \emph{Dar\'{s}ana} (a seeing) $\to$
+\emph{dar\'{s}an\=aya} (for a seeing). Your first case.
+\end{grammarlens}
+
+\section{\sk{श्वः} \emph{(\'{s}va\d{h})} --- ``tomorrow''}
+\label{lesson:shvah}
+
+\begin{cousinweb}
+\sk{श्वः} (\emph{\'{s}va\d{h}}, ``tomorrow'') is from PIE *\'{k}es-. Where the
+modern languages muddle ``tomorrow'' and ``yesterday'' into one word (Hindi
+\emph{kal}, Bengali \emph{k\=al}, from \emph{k\=ala} ``time''), classical Sanskrit
+kept them \emph{separate}: \emph{\'{s}va\d{h}} is ``tomorrow,'' \emph{hya\d{h}} is
+``yesterday.'' ``See you tomorrow'' is \sk{श्वः पुनर्दर्शनम्} (\emph{\'{s}va\d{h}
+punar-dar\'{s}anam}).
+\end{cousinweb}
+
+\begin{grammarlens}
+That the daughters blurred \emph{\'{s}va\d{h}} / \emph{hya\d{h}} into a single
+\emph{kal} is a window into language change: the modern tongues traded precision
+for economy, letting tense carry the load.
+\end{grammarlens}
+
+\section{The farewells}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Sanskrit & English \\
+\midrule
+\sk{गच्छामि।} & I go. (taking leave) \\
+\sk{पुनर्दर्शनाय।} & Until we meet again. \\
+\sk{श्वः पुनर्दर्शनम्।} & See you tomorrow. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Roots banked: \emph{gam} ``to go'' ($\to$ English \textbf{come}), \emph{punaḥ}
+``again'' ($\to$ \emph{punarjanma}), \emph{dar\'{s}ana} ``a beholding,'' and
+\emph{\'{s}va\d{h}} / \emph{hya\d{h}} --- ``tomorrow'' / ``yesterday,'' kept
+apart. Next chapter: the first real verbs --- and Sanskrit's count to \emph{three}.

--- a/code/learning/human-languages/sanskrit/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch05-first-verbs.tex
@@ -1,0 +1,114 @@
+\chapter{The First Verbs}
+\label{ch:first-verbs}
+
+Until now, ``to be.'' Now verbs that \emph{act} --- and the most famous feature of
+the Sanskrit verb: it counts to \textbf{three}.
+
+\begin{center}
+\sk{अहं संस्कृतं वदामि।} \quad(\emph{aha\d{m} sa\d{m}sk\d{r}ta\d{m} vad\=ami} --- ``I speak Sanskrit.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/SA-C05-*.md}.}
+
+\section{\sk{वदामि} \emph{(vad\=ami)} --- ``I speak,'' and the Sanskrit verb}
+\label{lesson:vadami}
+
+\begin{cousinweb}
+\sk{वदामि} (\emph{vad\=ami}, ``I speak'') is from the root \sk{वद्} (\emph{vad},
+``to speak'') --- the root of \sk{वाद} (\emph{v\=ada}, ``a saying'') inside Chapter
+1's \sk{धन्यवादः} (\emph{dhanyav\=ada\d{h}}). The present is stem $+$ ending:
+\emph{vad-\=a-mi}, where \emph{-mi} means ``I'' (the same \emph{-mi} as in
+\emph{asmi}, ``I am'').
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Singular, dual, plural.} Where English and Hindi count in two, Sanskrit
+counts in \textbf{three}, with a \textbf{dual} for exactly two:
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+number & form & meaning \\
+\midrule
+singular & \emph{vad\=ami} & I speak \\
+\textbf{dual} & \emph{vad\=ava\d{h}} & \textbf{we two} speak \\
+plural & \emph{vad\=ama\d{h}} & we (three or more) speak \\
+\bottomrule
+\end{tabular}
+\end{center}
+A whole number just for pairs --- two eyes, two hands, a couple. Greek had it and
+lost it; English never kept it; Sanskrit polished it.
+\end{grammarlens}
+
+\section{\sk{अहं संस्कृतं वदामि} --- ``I speak Sanskrit''}
+\label{lesson:aham-samskritam-vadami}
+
+\sk{अहम्} (I) $+$ \sk{संस्कृतम्} (the object) $+$ \sk{वदामि} (speak) --- ``I
+Sanskrit speak,'' verb last. The name \sk{संस्कृत} (\emph{sa\d{m}sk\d{r}ta}) means
+``\textbf{put together, perfected}'' --- \sk{सम्} (\emph{sam-}, ``together,''
+cousin of English \emph{same}, Greek \emph{syn-}) $+$ \sk{कृत} (\emph{k\d{r}ta},
+``made,'' from \emph{k\d{r}}). Named in contrast to \emph{pr\=ak\d{r}ta}
+(``natural, raw'' --- Prakrit, the everyday speech from which Hindi, Bengali, and
+the rest descend).
+
+\begin{grammarlens}
+\textbf{Sandhi joins the words.} \emph{aham} $+$ \emph{sa\d{m}sk\d{r}tam} runs
+together as \emph{aha\d{m} sa\d{m}sk\d{r}tam} --- the \emph{m} softening to the
+anusv\=ara. That is \emph{sandhi}, met in Chapter 1's \emph{sv\=agatam}; it is why
+Sanskrit flows.
+\end{grammarlens}
+
+\section{\sk{वसामि} \emph{(vas\=ami)} --- ``I live, I dwell''}
+\label{lesson:vasami}
+
+\begin{cousinweb}
+\sk{वसामि} (\emph{vas\=ami}, ``I dwell, live'') is from the root \sk{वस्}
+(\emph{vas}, ``to dwell''), PIE *wes- --- the ancestor of English \textbf{was}
+and \textbf{were} (the past of ``to be'' began as ``to dwell/remain''). From
+\emph{vas} come \emph{v\=asa} (``a dwelling''), \emph{niv\=asa} (``a residence''),
+\emph{V\=ar\=a\d{n}as\=\i}. ``I live in the city'' is \sk{अहं नगरे वसामि}
+(\emph{aha\d{m} nagare vas\=ami}).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``In'' is a case-ending.} \sk{नगरे} (\emph{nagare}, ``in the city'') $=$
+\emph{nagara} in the \textbf{locative} (\emph{-e}, ``in/at''). Sanskrit has no
+separate word for ``in'' --- it is folded into the noun's ending, the ancestor of
+Hindi's and Bengali's postpositions.
+\end{grammarlens}
+
+\section{\sk{करोमि} \emph{(karomi)} --- ``I do,'' from the root behind \emph{karma}}
+\label{lesson:karomi}
+
+\begin{cousinweb}
+\sk{करोमि} (\emph{karomi}, ``I do, make'') is from the root \sk{कृ} (\emph{k\d{r}},
+``to do''), PIE *k\ensuremath{^w}er- --- the root at the heart of this course:
+\emph{namask\=ara\d{h}} (``the \emph{making} of a bow''), \emph{karma} (``a thing
+\emph{done}''), \emph{sa\d{m}sk\d{r}ta} (``\emph{put together}''). ``I work'' is
+\sk{कार्यं करोमि} (\emph{k\=arya\d{m} karomi}) --- and \sk{कार्यम्} (\emph{k\=aryam},
+``work'') is \emph{itself} from \emph{k\d{r}}. So ``I work'' is, at root,
+``\emph{k\d{r}}-thing I \emph{k\d{r}}-do.'' Hindi's \emph{k\=am karn\=a} and
+Bengali's \emph{k\=aj kar\=a} are its worn-down grandchildren.
+\end{cousinweb}
+
+\section{Sentences about yourself}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Sanskrit & English \\
+\midrule
+\sk{अहं संस्कृतं वदामि।} & I speak Sanskrit. \\
+\sk{अहं नगरे वसामि।} & I live in the city. \\
+\sk{अहं कार्यं करोमि।} & I work. \\
+\sk{वदावः।} & We two speak. (the dual) \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Three verbs, one engine (the \emph{-mi} ``I''), the verb always last, ``in''
+folded into a case-ending --- and a whole number, the \textbf{dual}, for exactly
+two. Roots banked: \emph{vad} (speak $\to$ \emph{dhanyav\=ada}), \emph{vas}
+(dwell $\to$ English \textbf{was}), \emph{k\d{r}} (do $\to$ \emph{namask\=ara},
+\emph{karma}, \emph{sa\d{m}sk\d{r}ta}). From here, Sanskrit --- the source these
+tracks all point back to --- only opens further.

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-anandah.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-anandah.md
@@ -1,0 +1,48 @@
+---
+id: SA-C02-anandah
+chapter: 2
+type: phrase
+headword: आनन्दः
+gloss: joy — and "meeting you is a joy"
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [SA-C02-mama-nama-asti]
+sounds: [independent-aa, visarga]
+roots: [nand-rejoice]
+est_minutes: 4
+reviews_of: [SA-C02-tava-nama-kim]
+---
+
+# आनन्दः (ānandaḥ) — "joy," and "a joy to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The warm close of an introduction — a word so full it names bliss
+itself.
+
+## The letters in this word
+
+**आ** (independent *ā*) + **न** + **न्द** (the conjunct *nda*) + **ः** (the
+**visarga** *ḥ*, the masculine-singular ending you met in Chapter 1) → **आनन्दः**
+(*ānandaḥ*).
+
+## The word, taken apart
+
+To say "pleased to meet you," Sanskrit can say **भवन्तं दृष्ट्वा आनन्दः**
+(*bhavantaṁ dṛṣṭvā ānandaḥ*) — "**seeing you, [there is] joy**." The key word
+**आनन्दः** (*ānandaḥ*, "joy, bliss, delight") is from **आ-** (*ā-*, "fully") +
+the root **नन्द्** (*nand*, "to rejoice"). It is one of Sanskrit's most beloved
+words — the *ānanda* of *sat-cit-ānanda* ("being-consciousness-bliss"), and the
+name **Ānanda**, the Buddha's devoted disciple. So a simple greeting reaches for
+the word Indian thought uses for the deepest happiness.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ānandaḥ"]
+- [YOU SAY: the full phrase — *bhavantaṁ dṛṣṭvā ānandaḥ*]
+- [YOU SAY: where else *ānanda* appears (bliss; the name Ānanda)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *ānandaḥ* mean, and what is it built from? ("Joy, bliss";
+*ā-* "fully" + *nand* "to rejoice.")

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-asti.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-asti.md
@@ -1,0 +1,45 @@
+---
+id: SA-C02-asti
+chapter: 2
+type: word
+headword: अस्ति
+gloss: is
+concept_tag: WORD-IS
+prerequisites: [SA-C02-nama]
+sounds: [independent-a, st-conjunct]
+roots: [as-be]
+est_minutes: 3
+reviews_of: [SA-C02-nama, SA-C02-mama]
+---
+
+# अस्ति (asti) — "is," the ancestor of *is* and *est*
+
+## Warm-up
+
+[PAUSE 2s] The little verb "is" — and here you meet it in the form that fathered
+half the "to be" words on earth.
+
+## The letters in this word
+
+**अ** (independent *a*) + **स्ति** (*sti*, the conjunct **स्** *s* + **ति** *ti*)
+→ **अस्ति** (*asti*).
+
+## The word, taken apart
+
+**अस्ति** (*asti*, "is") is the third-person singular of the root **अस्** (*as-*,
+"to be"), from Proto-Indo-European **\*h₁es-**. It is the source of the family's
+copula: English **is**, German *ist*, Latin *est*, Greek *esti*, and Hindi *hai*
+(← *asti* directly). Unlike its Dravidian neighbours — Tamil and Bengali drop
+"is" in the present — Sanskrit *keeps* an explicit copula, and it is the very word
+Europe kept too.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "asti"]
+- [YOU SAY: the family — *asti* / English *is* / Latin *est* / Greek *esti* / Hindi *hai*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root is *asti* from, and its cousins across the family? (*As-* /
+PIE *\*h₁es-*; English *is*, Latin *est*, Hindi *hai*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-bhavan-tvam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-bhavan-tvam.md
@@ -1,0 +1,53 @@
+---
+id: SA-C02-bhavan-tvam
+chapter: 2
+type: word
+headword: भवान् / त्वम्
+gloss: you (respectful / familiar)
+concept_tag: PRONOUN-YOU
+prerequisites: [SA-C02-nama]
+sounds: [independent-vowel, halant]
+roots: [tvam-second-person, bhavat-honorific]
+est_minutes: 4
+reviews_of: [SA-C02-mama-nama-asti]
+---
+
+# भवान् / त्वम् (bhavān / tvam) — "you," respectful and familiar
+
+## Warm-up
+
+[PAUSE 2s] To ask a name you need "you" — and Sanskrit's familiar one is the
+ancestor of English *thou*.
+
+## The letters in this word
+
+**त्वम्** (*tvam*): **त्व** (the conjunct *tva*) + **म्** (bare *m*, closed by the
+*halant*). **भवान्** (*bhavān*): **भ** + **वा** + **न्**.
+
+## The word, taken apart
+
+**त्वम्** (*tvam*, familiar "you") is from Proto-Indo-European **\*tū** — the
+direct ancestor of English archaic **thou**, Latin *tū*, French *tu*, and Hindi
+*tū*. **भवान्** (*bhavān*, respectful "you") is different: it is really a
+third-person honorific — "your honour," from *bhavat* ("being, gracious one") —
+and so it takes a *third-person* verb (*bhavān asti*, "your honour is"), a
+politeness by grammatical distance. For a first meeting, use **भवान्**.
+
+## Grammar Lens: politeness by grammatical person
+
+Where Hindi and Punjabi make respect *plural* (*āp … haiṁ*), Sanskrit makes it
+*third-person*: to be polite you address someone as though speaking *about* them —
+"is your honour well?" rather than "are you well?" Different trick, same courtesy.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tvam" (familiar) and "bhavān" (respectful)]
+- [YOU SAY: the English cousin of *tvam* (**thou**)]
+- [YOU SAY: why *bhavān* takes a third-person verb (it means "your honour")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which "you" is respectful, and what English word is *tvam* cousin to?
+(*Bhavān* — literally "your honour," taking a 3rd-person verb; *tvam* ↔ archaic
+**thou**.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-kim.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-kim.md
@@ -1,0 +1,46 @@
+---
+id: SA-C02-kim
+chapter: 2
+type: word
+headword: किम्
+gloss: what
+concept_tag: QUESTION-WHAT
+prerequisites: [SA-C02-nama]
+sounds: [sihari-i, halant]
+roots: [ka-interrogative]
+est_minutes: 3
+reviews_of: [SA-C02-bhavan-tvam]
+---
+
+# किम् (kim) — "what," the source of the question-words
+
+## Warm-up
+
+[PAUSE 2s] The question-word — and the fountainhead of a whole family of "wh-"
+words, east and west.
+
+## The letters in this word
+
+**कि** (*ki*, **क** + the *i*-sign) + **म्** (bare *m*, with the *halant*) →
+**किम्** (*kim*).
+
+## The word, taken apart
+
+**किम्** (*kim*, "what") is from the interrogative stem **क-** (*ka-*), from
+Proto-Indo-European **\*kʷo-** — the ancestor of the whole question-family:
+English **what**, **who**, **which**, Latin *quis* / *quid*, Greek *tis*, and
+Hindi *kyā* / *kaun*. Sanskrit's own questions all grow from this *ka-*: *kim*
+(what), *kaḥ* (who), *kadā* (when), *kutra* (where), *katham* (how). It is the
+single seed from which both Europe's *qu-/wh-* words and India's *k-* words grew.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kim"]
+- [YOU SAY: the ka- family — *kim, kaḥ, kadā, kutra, katham*]
+- [YOU SAY: its western children (English *what*, Latin *quis*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What PIE root is *kim* from, and its cousins? (*\*kʷo-*; English *what*,
+Latin *quis*, Hindi *kyā*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-mama-nama-asti.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-mama-nama-asti.md
@@ -1,0 +1,45 @@
+---
+id: SA-C02-mama-nama-asti
+chapter: 2
+type: phrase
+headword: मम नाम … अस्ति
+gloss: my name is…
+concept_tag: INTRO-MY-NAME-IS
+prerequisites: [SA-C02-mama, SA-C02-nama, SA-C02-asti]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [SA-C02-mama, SA-C02-nama, SA-C02-asti]
+---
+
+# मम नाम … अस्ति (mama nāma … asti) — "my name is…"
+
+## Warm-up
+
+[PAUSE 2s] Three atoms you now own, assembled — and note that Sanskrit, unlike
+Tamil or Bengali, actually *says* the "is."
+
+## The phrase, assembled
+
+**मम** (my) + **नाम** (name) + your name + **अस्ति** (is) = **mama nāma … asti**,
+"my name is…" *Mama nāma Aruṇaḥ asti.* → "My name is Arun."
+
+## Grammar Lens: Sanskrit keeps the "is"
+
+Where Tamil says only *eṉ peyar Arun* and Bengali *āmār nām Arun* — both dropping
+the verb (the zero copula) — Sanskrit says **मम नाम … अस्ति**, with an explicit
+*asti* ("is"). This is the Indo-European way, the one Latin and English kept too
+(*my name is …*). The verb comes **last**, as in the modern Indian languages that
+descend from it. (In casual use *asti* can be dropped, but the "full-dress"
+Sanskrit sentence keeps it.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mama nāma … asti" with your name]
+- [YOU SAY: how this differs from Tamil/Bengali (Sanskrit keeps the "is")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give your name in Sanskrit, and say what it keeps that Tamil and
+Bengali drop. (*Mama nāma … asti*; the copula *asti*, "is.")

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-mama.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-mama.md
@@ -1,0 +1,44 @@
+---
+id: SA-C02-mama
+chapter: 2
+type: word
+headword: मम
+gloss: my
+concept_tag: PRONOUN-MY
+prerequisites: [SA-C02-nama]
+sounds: [inherent-a]
+roots: [ma-first-person]
+est_minutes: 3
+reviews_of: [SA-C02-nama]
+---
+
+# मम (mama) — "my," the ancestor of *me* and *my*
+
+## Warm-up
+
+[PAUSE 2s] The word that makes the name yours — and it is, quite literally, the
+grandparent of English *my*.
+
+## The letters in this word
+
+**म** (*ma*) + **म** (*ma*) → **मम** (*mama*). Two identical syllables.
+
+## The word, taken apart
+
+**मम** (*mama*, "my, of me") is the genitive of **अहम्** (*aham*, "I"), on the
+first-person root **ma-**, from Proto-Indo-European **\*me-**. This is the source
+of the whole first-person family: English **me**, **my**, **mine**, Latin *meus*,
+Greek *emou*, and Hindi *merā*. Sanskrit *mama* and English *my* are not merely
+similar — they are the same ancient word, one still in its old form, the other
+worn smooth by five thousand years.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mama"]
+- [YOU SAY: the m- family — *mama* / English *me*, *my* / Latin *meus* / Hindi *merā*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is *mama* the genitive of, and its English cousins? (*Aham*, "I";
+English **me**, **my**, **mine**.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-nama.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-nama.md
@@ -1,0 +1,44 @@
+---
+id: SA-C02-nama
+chapter: 2
+type: word
+headword: नाम
+gloss: name
+concept_tag: WORD-NAME
+prerequisites: []
+sounds: [inherent-a, long-aa]
+roots: [naaman-sanskrit]
+est_minutes: 4
+reviews_of: []
+---
+
+# नाम (nāma) — "name," the source of a word half the world shares
+
+## Warm-up
+
+[PAUSE 2s] The first word of the introduction — and, since this is Sanskrit, the
+*source* of the word half the world uses.
+
+## The letters in this word
+
+**न** (*na*) + **ा** (the long-*ā* sign) + **म** (*ma*) → **नाम** (*nāma*).
+
+## The word, taken apart
+
+**नाम** (*nāma*, "name," neuter) is from the stem **नामन्** (*nāman*), from
+Proto-Indo-European **\*h₃nómn̥**. This is not a *borrowing* from anywhere — it is
+the ancestor: the same root surfaces as English **name**, Latin *nōmen* (→
+**noun**, **nominate**), Greek *onoma*, and, worn down, as Hindi *nām*, Bengali
+*nām*, Punjabi *nāṁ*. When you say Sanskrit *nāma*, you are standing near the
+headwaters of a word that flowed to both Europe and modern India.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāma"]
+- [YOU SAY: its children, west and east — English *name*, Latin *nōmen*; Hindi *nām*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What PIE root is *nāma* from, and name two of its descendants. (*\*h₃nómn̥*;
+any two of English *name*, Latin *nōmen*, Greek *onoma*, Hindi *nām*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C02-tava-nama-kim.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C02-tava-nama-kim.md
@@ -1,0 +1,44 @@
+---
+id: SA-C02-tava-nama-kim
+chapter: 2
+type: phrase
+headword: तव नाम किम्?
+gloss: what's your name?
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [SA-C02-bhavan-tvam, SA-C02-kim, SA-C02-nama]
+sounds: []
+roots: []
+est_minutes: 3
+reviews_of: [SA-C02-kim, SA-C02-bhavan-tvam]
+---
+
+# तव नाम किम्? (tava nāma kim?) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Turn the introduction around — ask, instead of tell.
+
+## The phrase, assembled
+
+**तव** (*tava*, "your," the genitive of *tvam*) + **नाम** (name) + **किम्** (what)
+→ "**your name what?**" Here Sanskrit often *drops* the *asti*: *tava nāma kim?*
+stands complete, the question-word alone doing the work.
+
+## Grammar Lens: the respectful version
+
+*Tava* ("your") is the familiar form, matching *tvam*. To a respected stranger,
+use the honorific: **भवतः नाम किम्?** (*bhavataḥ nāma kim?* — *bhavataḥ*, "of your
+honour"). Note *mama* / *tava* / *bhavataḥ* — "my / your / your-honour's" — all
+built the same way, as genitives.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the familiar question — *tava nāma kim?*]
+- [YOU SAY: the respectful version — *bhavataḥ nāma kim?*]
+- [YOU SAY: answer it — *mama nāma … asti*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Ask "what's your name?" respectfully, and give the "my/your" pair.
+(*Bhavataḥ nāma kim?*; *mama* "my" / *tava* "your.")

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-aham.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-aham.md
@@ -1,0 +1,53 @@
+---
+id: SA-C03-aham
+chapter: 3
+type: word
+headword: अहम्
+gloss: I
+concept_tag: PRONOUN-I
+prerequisites: [SA-C02-mama]
+sounds: [inherent-a, halant]
+roots: [aham-first-person]
+est_minutes: 4
+reviews_of: [SA-C02-mama]
+---
+
+# अहम् (aham) — "I," the ancestor of *ego* and *I*
+
+## Warm-up
+
+[PAUSE 2s] To answer "how are you?" you first need "I" — and it is the grandparent
+of both English *I* and the word *ego*.
+
+## The letters in this word
+
+**अ** (independent *a*) + **ह** (*ha*) + **म्** (bare *m*, *halant*) → **अहम्**
+(*aham*).
+
+## The word, taken apart
+
+**अहम्** (*aham*, "I") is from Proto-Indo-European **\*h₁eǵ(H)om** — the direct
+ancestor of Latin **ego** (whence English *ego*, *egotist*), Greek *egō*, and,
+worn all the way down, English **I** itself. So Sanskrit *aham*, Latin *ego*, and
+English *I* are one word across three continents of time. Its possessive is the
+**मम** (*mama*, "my") from Chapter 2 — and, curiously, "I" (*aham*) and "my"
+(*mama*) come from *different* ancient roots (*\*eǵ-* and *\*me-*), a quirk
+Sanskrit shares with English (*I* vs. *my/me*).
+
+## Grammar Lens: "I" can be dropped
+
+Sanskrit verbs carry the person in their ending — *asmi* already means "**I** am"
+— so *aham* is often left out. You still learn it first, because the answer to
+*katham asi?* begins with it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "aham"]
+- [YOU SAY: the family — *aham* / Latin *ego* / English **I**]
+- [YOU SAY: the odd pair — "I" (*aham*, root *\*eǵ-*) and "my" (*mama*, root *\*me-*) differ, as in English *I* vs. *my*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What PIE root is *aham* from, and its cousins? (*\*h₁eǵ(H)om*; Latin
+*ego*, English **I**.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-bhavan-katham-asti.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-bhavan-katham-asti.md
@@ -1,0 +1,48 @@
+---
+id: SA-C03-bhavan-katham-asti
+chapter: 3
+type: phrase
+headword: भवान् कथम् अस्ति?
+gloss: how are you? (respectful)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [SA-C03-katham, SA-C02-bhavan-tvam, SA-C02-asti]
+sounds: []
+roots: [as-be]
+est_minutes: 4
+reviews_of: [SA-C02-bhavan-tvam, SA-C02-asti]
+---
+
+# भवान् कथम् अस्ति? (bhavān katham asti?) — "how are you?"
+
+## Warm-up
+
+[PAUSE 2s] Three words you own, assembled into the first thing you ask after
+hello.
+
+## The phrase, taken apart
+
+**भवान् कथम् अस्ति?** = **भवान्** (*bhavān*, respectful "you") + **कथम्** (*katham*,
+"how") + **अस्ति** (*asti*, "is") — literally "**your honour how is?**" Recall
+from Chapter 2 that *bhavān* ("your honour") takes a **third-person** verb — so it
+is *asti* ("is"), not "are." The familiar version uses *tvam* and the
+second-person verb: **त्वं कथम् असि?** (*tvaṁ katham asi?* — *asi*, "you are").
+
+## Grammar Lens: the copula, three persons
+
+You now hold the "to be" verb across persons: **अस्मि** (*asmi*, "I am"), **असि**
+(*asi*, "you are"), **अस्ति** (*asti*, "is") — the ancestors, respectively, of
+English **am**, and (through Latin/Greek) of *is/est*. "How are you?" simply asks
+after a *state*, and Sanskrit, unlike Tamil, has always kept a verb for it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the respectful question — *bhavān katham asti?*]
+- [YOU SAY: the familiar version — *tvaṁ katham asi?*]
+- [YOU SAY: the copula trio — *asmi* (am), *asi* (are), *asti* (is)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is it *asti* ("is") with *bhavān*, and what are the three copula
+forms? (*Bhavān* = "your honour," a 3rd-person subject; *asmi/asi/asti* — am / you
+are / is.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-katham.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-katham.md
@@ -1,0 +1,44 @@
+---
+id: SA-C03-katham
+chapter: 3
+type: word
+headword: कथम्
+gloss: how
+concept_tag: QUESTION-HOW
+prerequisites: [SA-C02-kim]
+sounds: [inherent-a, halant]
+roots: [ka-interrogative]
+est_minutes: 4
+reviews_of: [SA-C02-kim]
+---
+
+# कथम् (katham) — "how," another of the ka- questions
+
+## Warm-up
+
+[PAUSE 2s] You met **किम्** (*kim*, "what") in Chapter 2. Here is its sibling in
+the question-family.
+
+## The letters in this word
+
+**क** (*ka*) + **थ** (*tha*) + **म्** (bare *m*, *halant*) → **कथम्** (*katham*).
+
+## The word, taken apart
+
+**कथम्** (*katham*, "how, in what way") is from the interrogative stem **क-**
+(*ka-*), PIE **\*kʷo-** — the same root that gave *kim* and, in the west, English
+**wh-** and Latin *qu-*. It heads the same *ka-* question-family: *kim* (what),
+*kaḥ* (who), *kadā* (when), *kutra* (where), *katham* (how). From *katham* comes
+the abstract noun *kathā* ("a telling, a story" — "the how of a thing"), and,
+worn down, Hindi's *kaise*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "katham"]
+- [YOU SAY: the ka- question family — *kim, kaḥ, kadā, kutra, katham*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root do Sanskrit's question-words share, and its western cousins?
+(The interrogative *ka-*, PIE *\*kʷo-*; English *wh-*, Latin *qu-*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-kushalam.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-kushalam.md
@@ -1,0 +1,53 @@
+---
+id: SA-C03-kushalam
+chapter: 3
+type: word
+headword: कुशलम्
+gloss: well-being — and the reply "अहं कुशली अस्मि"
+concept_tag: WORD-WELL
+prerequisites: [SA-C03-aham, SA-C03-bhavan-katham-asti]
+sounds: [inherent-a, sha, halant]
+roots: [kushala-sanskrit]
+est_minutes: 4
+reviews_of: [SA-C03-aham]
+---
+
+# कुशलम् (kuśalam) — "well-being," and how to answer
+
+## Warm-up
+
+[PAUSE 2s] The word that answers "how are you?" — one that once meant, of all
+things, "skill in cutting sacred grass."
+
+## The letters in this word
+
+**कु** (*ku*) + **श** (*śa*, a palatal *sh*) + **ल** (*la*) + **म्** (*m*,
+*halant*) → **कुशलम्** (*kuśalam*).
+
+## The word, taken apart
+
+**कुशलम्** (*kuśalam*, "well-being, welfare, all-being-well") is native Sanskrit,
+famously derived from **कुश** (*kuśa*, the sacred grass) + a root of "cutting" —
+so it first meant "skilled [at gathering kuśa grass properly]," hence "adept,
+fit, in good order," hence "well." A whole idea of wellness grew from a ritual
+skill. Its adjective is **कुशली** (*kuśalī*, "one who is well").
+
+## The reply
+
+**अहं कुशली अस्मि** (*ahaṁ kuśalī asmi*) — "**I am well**" (*aham* "I" + *kuśalī*
+"well" + *asmi* "am"). Or simply *kuśalam* ("[all is] well"). The exchange:
+
+> — *bhavān katham asti?* ("How are you?")
+> — *ahaṁ kuśalī asmi, dhanyavādaḥ.* ("I am well, thank you.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kuśalam"]
+- [YOU SAY: the full reply — *ahaṁ kuśalī asmi*]
+- [YOU SAY: the surprising root (*kuśa*, the sacred grass → "skilled" → "well")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the reply to *bhavān katham asti?*, and *kuśalam*'s surprising
+origin. (*Ahaṁ kuśalī asmi*; from *kuśa* grass → "skilled" → "well.")

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-na-cinta.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-na-cinta.md
@@ -1,0 +1,48 @@
+---
+id: SA-C03-na-cinta
+chapter: 3
+type: phrase
+headword: न चिन्ता
+gloss: no worry / it's nothing / you're welcome
+concept_tag: YOURE-WELCOME
+prerequisites: [SA-C01-am-na, SA-C01-dhanyavada]
+sounds: [inherent-a, nt-conjunct]
+roots: [na-negative, cint-think]
+est_minutes: 4
+reviews_of: [SA-C01-am-na]
+---
+
+# न चिन्ता (na cintā) — "no worry"
+
+## Warm-up
+
+[PAUSE 2s] When someone thanks you, this gentle reply says, simply, "don't give
+it a thought."
+
+## The letters in this word
+
+**न** (*na*, "not," from Chapter 1) + **चिन्ता** (*cintā*, "worry, anxious
+thought," with the conjunct **न्त** *nt*) → **न चिन्ता** (*na cintā*).
+
+## The word, taken apart
+
+**न चिन्ता** literally means "**[there is] no worry / no anxiety**" — used for
+"never mind / no trouble / you're welcome." Two atoms: **न** (*na*, "not"), the
+ancient negative from Chapter 1 — PIE **\*ne**, behind English **no**, **not**,
+Latin *nōn*, and every Indo-Aryan "no." And **चिन्ता** (*cintā*, "anxious
+thought"), from the root **चिन्त्** (*cint*, "to think, ponder") — the same
+*cintā* borrowed into Hindi and Urdu (*cintā mat karo*, "don't worry"). So the
+reply pairs the family's oldest negative with a verb of thinking: "think nothing
+of it."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "na cintā"]
+- [YOU SAY: its two atoms (*na* "not" + *cintā* "worry")]
+- [YOU SAY: the exchange — *dhanyavādaḥ* / *na cintā*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *na cintā* literally say, and what is its negative *na*
+cousin to? ("No worry"; PIE *\*ne* — English *no/not*, Latin *nōn*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-practice.md
@@ -1,0 +1,47 @@
+---
+id: SA-C03-practice
+chapter: 3
+type: practice
+headword: (dialogue)
+gloss: Chapter 3 recap — the how-are-you exchange
+concept_tag: REVIEW
+prerequisites: [SA-C03-bhavan-katham-asti, SA-C03-kushalam, SA-C03-na-cinta]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [SA-C03-katham, SA-C03-bhavan-katham-asti, SA-C03-aham, SA-C03-kushalam, SA-C03-na-cinta]
+---
+
+# Chapter 3 — The how-are-you exchange
+
+## Warm-up
+
+[PAUSE 2s] No new words. The whole responding cycle, from atoms you now own.
+
+## The exchange
+
+[PAUSE 1s each]
+- [YOU SAY: "How are you?" (respectful) — *bhavān katham asti?*]
+- [YOU SAY: "I am well, thank you." — *ahaṁ kuśalī asmi, dhanyavādaḥ.*]
+- [YOU SAY: "No worry / you're welcome." — *na cintā.*]
+- [YOU SAY: the familiar question — *tvaṁ katham asi?*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the ka- question-word for "how" (*katham*)]
+- [YOU SAY: "I" and the copula trio (*aham*; *asmi/asi/asti*)]
+
+## Roots you now carry (the taproot, both ways)
+
+[PAUSE 2s]
+- *katham* ← the interrogative *ka-* (PIE *\*kʷo-*) → English *how/what*, Latin *qu-*
+- *aham* ← *\*h₁eǵ(H)om* → Latin **ego**, English **I**
+- *asmi* ← *\*h₁es-* → English **am**; *asti* → *is*, *hai*
+- *na* (in *na cintā*) ← *\*ne* → English *no/not*, Latin *nōn*
+
+## Wrap-up Recall
+
+[PAUSE 3s] A respected stranger asks *bhavān katham asti?* — give a full reply,
+and answer their thanks. (*Ahaṁ kuśalī asmi, dhanyavādaḥ* — and to thanks, *na
+cintā*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-gacchami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-gacchami.md
@@ -1,0 +1,47 @@
+---
+id: SA-C04-gacchami
+chapter: 4
+type: word
+headword: गच्छामि
+gloss: I go (a way to take leave)
+concept_tag: FAREWELL
+prerequisites: [SA-C03-aham]
+sounds: [cch-conjunct, long-aa]
+roots: [gam-go]
+est_minutes: 4
+reviews_of: []
+---
+
+# गच्छामि (gacchāmi) — "I go" (taking leave)
+
+## Warm-up
+
+[PAUSE 2s] Sanskrit has no casual "bye." Like its daughters, it takes leave by
+saying "I go" — and the verb is a cousin of English *come* and *go*.
+
+## The letters in this word
+
+**ग** (*ga*) + **च्छा** (the conjunct *cchā*) + **मि** (*mi*) → **गच्छामि**
+(*gacchāmi*).
+
+## The word, taken apart
+
+**गच्छामि** (*gacchāmi*, "I go") is from the root **गम्** (*gam*, "to go") — the
+very root you met in Chapter 1's **स्वागतम्** (*svāgatam* = *su* + *āgata*, "well
+come," from *ā* + *gam*). That root is Proto-Indo-European **\*gʷem-**, the
+ancestor of English **come** (and, via Latin *venīre*, of *venue*, *convene*). To
+leave politely one says *gacchāmi* ("I go") or, more gracefully, *āgacchāmi* ("I
+[shall] come [back]") — the same "promise of return" the modern languages kept.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "gacchāmi" — I go]
+- [YOU SAY: the root and its Chapter-1 cousin (*gam*; *svāgatam*, "well come")]
+- [YOU SAY: the English cousin of *gam* (**come**)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Sanskrit take leave, and what root is *gacchāmi* from?
+(By saying "I go," *gacchāmi*; the root *gam*, PIE *\*gʷem-*, cousin of English
+**come**.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-practice.md
@@ -1,0 +1,48 @@
+---
+id: SA-C04-practice
+chapter: 4
+type: practice
+headword: (dialogue)
+gloss: Chapter 4 recap — the farewells
+concept_tag: REVIEW
+prerequisites: [SA-C04-gacchami, SA-C04-punar-darshanaya, SA-C04-shvah]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [SA-C04-gacchami, SA-C04-punah, SA-C04-punar-darshanaya, SA-C04-shvah]
+---
+
+# Chapter 4 — The farewells
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three ways to part — the ancestors of the modern Indian
+goodbyes.
+
+## The farewells
+
+[PAUSE 1s each]
+- [YOU SAY: taking leave — *gacchāmi* ("I go")]
+- [YOU SAY: "until we meet again" — *punar-darśanāya*]
+- [YOU SAY: "see you tomorrow" — *śvaḥ punar-darśanam*]
+
+## The atoms
+
+[PAUSE 2s]
+- [YOU SAY: the verb "to go" and its Ch-1 cousin (*gam*; *svāgatam*)]
+- [YOU SAY: "again" and its combining form (*punaḥ* / *punar-*)]
+- [YOU SAY: "tomorrow" vs. "yesterday" (Sanskrit keeps *śvaḥ* / *hyaḥ* distinct)]
+
+## Roots you now carry
+
+[PAUSE 2s]
+- *gam* "to go" ← PIE *\*gʷem-* → English **come**
+- *punaḥ / punar-* "again" (→ *punarjanma*, "rebirth")
+- *darśana* "a seeing / beholding" (the six *darśanas* of philosophy)
+- *śvaḥ* "tomorrow," *hyaḥ* "yesterday" — kept separate, unlike Hindi *kal*
+
+## Wrap-up Recall
+
+[PAUSE 3s] You're taking leave and expect to see someone tomorrow. Give the
+graceful goodbye, and specify tomorrow. (*Punar-darśanāya* — or *śvaḥ
+punar-darśanam*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-punah.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-punah.md
@@ -1,0 +1,43 @@
+---
+id: SA-C04-punah
+chapter: 4
+type: word
+headword: पुनः
+gloss: again
+concept_tag: SA-WORD-PUNAH
+prerequisites: []
+sounds: [inherent-a, visarga]
+roots: [punar-again]
+est_minutes: 3
+reviews_of: []
+---
+
+# पुनः (punaḥ) — "again," the seed of "till we meet again"
+
+## Warm-up
+
+[PAUSE 2s] One small word turns a leave-taking into a promise of return.
+
+## The letters in this word
+
+**पु** (*pu*) + **न** (*na*) + **ः** (the visarga *ḥ*) → **पुनः** (*punaḥ*).
+Before certain sounds the visarga becomes *r*: *punar-*.
+
+## The word, taken apart
+
+**पुनः** (*punaḥ*, "again, back, once more") is a native Sanskrit adverb (its
+combining form is *punar-*, as in *punar-janma*, "rebirth" — "birth again"). It
+has no tidy single English cognate, but its work is one English shares: it turns a
+parting into "see you **again**." Add it to *darśana* ("seeing") and you get the
+graceful Sanskrit farewell of the next lesson.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "punaḥ"]
+- [YOU SAY: its combining form and a word from it (*punar-*; *punarjanma*, "rebirth")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *punaḥ* mean, and what is its combining form? ("Again";
+*punar-*, as in *punarjanma*, "rebirth.")

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-punar-darshanaya.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-punar-darshanaya.md
@@ -1,0 +1,52 @@
+---
+id: SA-C04-punar-darshanaya
+chapter: 4
+type: phrase
+headword: पुनर्दर्शनाय
+gloss: until we meet again (lit. "for seeing again")
+concept_tag: FAREWELL-LATER
+prerequisites: [SA-C04-punah, SA-C04-gacchami]
+sounds: [rd-conjunct, long-aa]
+roots: [punar-again, drsh-see]
+est_minutes: 4
+reviews_of: [SA-C04-gacchami]
+---
+
+# पुनर्दर्शनाय (punar-darśanāya) — "until we meet again"
+
+## Warm-up
+
+[PAUSE 2s] The graceful Sanskrit goodbye — "for the sake of seeing [you] again."
+
+## The letters in this word
+
+**पुनर्** (*punar*, "again," the *r*-form of *punaḥ*) + **दर्शनाय** (*darśanāya*,
+"for seeing") → **पुनर्दर्शनाय** (*punar-darśanāya*).
+
+## The word, taken apart
+
+**पुनर्दर्शनाय** = *punar* ("again") + **दर्शन** (*darśana*, "seeing, sight,
+vision") in the **dative** case (*-āya*, "for the sake of") — literally "**for
+seeing [you] again**," i.e. "until we meet again." The word **दर्शन** (*darśana*)
+is deep: it is "seeing" in the sense of *beholding* — the *darśan* one takes of a
+deity or a revered person, and the name of the six *darśanas*, the schools of
+Indian philosophy ("ways of seeing"). So this farewell promises not just a meeting
+but a *beholding* to come.
+
+## Grammar Lens: the dative "for the sake of"
+
+The ending **-आय** (*-āya*) is the dative singular — "to / for." *Darśana* (a
+seeing) → *darśanāya* (for a seeing). You will meet the cases one at a time; this
+is your first, the "for-the-purpose-of" case.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "punar-darśanāya"]
+- [YOU SAY: its literal meaning ("for seeing [you] again")]
+- [YOU SAY: what *darśana* means beyond "seeing" (a beholding; the *darśan* of a deity)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *punar-darśanāya* literally mean, and what case gives the
+"for"? ("For seeing again"; the dative *-āya*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C04-shvah.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C04-shvah.md
@@ -1,0 +1,54 @@
+---
+id: SA-C04-shvah
+chapter: 4
+type: word
+headword: श्वः
+gloss: tomorrow — and "see you tomorrow"
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [SA-C04-punar-darshanaya]
+sounds: [shva-conjunct, visarga]
+roots: [shvas-tomorrow]
+est_minutes: 4
+reviews_of: [SA-C04-punar-darshanaya]
+---
+
+# श्वः (śvaḥ) — "tomorrow"
+
+## Warm-up
+
+[PAUSE 2s] A goodbye with a date on it — and a word that, unlike Hindi's *kal*,
+means only one day.
+
+## The letters in this word
+
+**श्व** (the conjunct *śva*, **श्** *ś* + **व** *va*) + **ः** (visarga) → **श्वः**
+(*śvaḥ*).
+
+## The word, taken apart
+
+**श्वः** (*śvaḥ*, "tomorrow") is from Proto-Indo-European **\*ḱes-** ("tomorrow /
+morning"). Where the modern Indian languages muddle "tomorrow" and "yesterday"
+into one word (Hindi *kal*, Bengali *kāl*, from *kāla* "time"), classical Sanskrit
+kept them **separate and precise**: *śvaḥ* is "tomorrow" and *hyaḥ* is
+"yesterday" — two distinct words. "See you tomorrow" is **श्वः पुनर्दर्शनम्**
+(*śvaḥ punar-darśanam*, "tomorrow, a seeing-again") or *śvaḥ drakṣyāmi* ("tomorrow
+I shall see [you]").
+
+## Grammar Lens: Sanskrit's precision
+
+That the daughters blurred *śvaḥ* / *hyaḥ* into a single *kal* is a small window
+into language change: the modern tongues traded precision for economy, letting
+tense carry the load. Sanskrit, the older layer, still keeps the two days apart.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "śvaḥ" (tomorrow) and "hyaḥ" (yesterday)]
+- [YOU SAY: "see you tomorrow" — *śvaḥ punar-darśanam*]
+- [YOU SAY: how this differs from Hindi/Bengali *kal* (Sanskrit keeps the two days distinct)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *śvaḥ* mean, and how does Sanskrit differ from Hindi here?
+("Tomorrow"; Sanskrit keeps *śvaḥ* "tomorrow" and *hyaḥ* "yesterday" separate,
+where Hindi merges them into *kal*.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-aham-samskritam-vadami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-aham-samskritam-vadami.md
@@ -1,0 +1,54 @@
+---
+id: SA-C05-aham-samskritam-vadami
+chapter: 5
+type: phrase
+headword: अहं संस्कृतं वदामि
+gloss: I speak Sanskrit
+concept_tag: SA-WORD-SAMSKRITA
+prerequisites: [SA-C05-vadami, SA-C03-aham]
+sounds: [anusvara, kr-vocalic]
+roots: [samskrita, sam-kr]
+est_minutes: 5
+reviews_of: [SA-C05-vadami, SA-C03-aham]
+---
+
+# अहं संस्कृतं वदामि (ahaṁ saṁskṛtaṁ vadāmi) — "I speak Sanskrit"
+
+## Warm-up
+
+[PAUSE 2s] Your first full, moving sentence — and the language's name is itself a
+little lesson in how Sanskrit builds words.
+
+## The letters in this word
+
+**संस्कृत** (*saṁskṛta*): **सं** (*saṁ*, with the anusvāra) + **स्कृ** (the
+conjunct *skṛ*, with the vocalic **ऋ** *ṛ*) + **त** (*ta*).
+
+## The sentence, taken apart
+
+**अहं संस्कृतं वदामि** = **अहम्** (*aham*, "I") + **संस्कृतम्** (*saṁskṛtam*, the
+object) + **वदामि** (*vadāmi*, "speak") — "I Sanskrit speak," the verb last (as in
+every daughter language). The name **संस्कृत** (*saṁskṛta*) means "**put together,
+refined, perfected**" — from **सम्** (*sam-*, "together," cousin of English
+*same*, Greek *syn-*) + **कृत** (*kṛta*, "made, done," from the root **कृ** *kṛ*
+you met in *namaskāra*). So "Sanskrit" literally means "the perfected [language],"
+named in contrast to *prākṛta* ("natural, raw" — Prakrit, the everyday speech
+from which Hindi, Bengali, and the rest descend).
+
+## Grammar Lens: sandhi joins the words
+
+Say it aloud and *aham* + *saṁskṛtam* runs together as *ahaṁ saṁskṛtam* — the *m*
+softening to the anusvāra before the next consonant. That is **sandhi**, the
+sound-joining you met in Chapter 1's *svāgatam*; it is why Sanskrit flows.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ahaṁ saṁskṛtaṁ vadāmi"]
+- [YOU SAY: what *saṁskṛta* means (*sam* "together" + *kṛta* "made" = "perfected")]
+- [YOU SAY: its opposite, the source of the modern languages (*prākṛta*, "natural")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "I speak Sanskrit," and unpack the name. (*Ahaṁ saṁskṛtaṁ vadāmi*;
+*saṁskṛta* = *sam* "together" + *kṛta* "made" — "the perfected language.")

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-karomi.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-karomi.md
@@ -1,0 +1,51 @@
+---
+id: SA-C05-karomi
+chapter: 5
+type: word
+headword: करोमि
+gloss: I do, I make (कार्यं करोमि, "I work")
+concept_tag: SA-VERB-KR
+prerequisites: [SA-C05-vadami]
+sounds: [inherent-a, long-o]
+roots: [kr-do]
+est_minutes: 5
+reviews_of: [SA-C05-vadami, SA-C05-vasami]
+---
+
+# करोमि (karomi) — "I do," from the root behind *karma* and *namaskāra*
+
+## Warm-up
+
+[PAUSE 2s] The last verb of the chapter — from the single most productive root in
+Sanskrit, one you have met again and again.
+
+## The letters in this word
+
+**क** (*ka*) + **रो** (*ro*) + **मि** (*mi*) → **करोमि** (*karomi*).
+
+## The word, taken apart
+
+**करोमि** (*karomi*, "I do, I make") is from the root **कृ** (*kṛ*, "to do,
+make"), from Proto-Indo-European **\*kʷer-**. This is the root at the heart of
+this whole course:
+
+- **नमस्कारः** (*namaskāraḥ*) — "the **making** of a bow" (*namas* + *kāra*)
+- **कर्म** (*karma*) — "a thing **done**," an action
+- **संस्कृत** (*saṁskṛta*) — "**put together**, perfected" (this very language)
+
+To say "**I work**," Sanskrit says **कार्यं करोमि** (*kāryaṁ karomi*) — "I do
+work," where **कार्यम्** (*kāryam*, "work, task") is *itself* from *kṛ* ("a
+thing-to-be-done"). So "I work" is, at root, "*kṛ*-thing I *kṛ*-do." Hindi's
+*kām karnā* and Bengali's *kāj karā* are its worn-down grandchildren.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "karomi" — I do]
+- [YOU SAY: "I work" — *kāryaṁ karomi*]
+- [YOU SAY: three words in this course from the root *kṛ* (*namaskāra*, *karma*, *saṁskṛta*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root is *karomi* from, and name three words built on it. (*Kṛ*,
+"to do," PIE *\*kʷer-*; *namaskāra*, *karma*, *saṁskṛta* — among many.)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-practice.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-practice.md
@@ -1,0 +1,48 @@
+---
+id: SA-C05-practice
+chapter: 5
+type: practice
+headword: (dialogue)
+gloss: Chapter 5 recap — the first verbs
+concept_tag: REVIEW
+prerequisites: [SA-C05-vadami, SA-C05-aham-samskritam-vadami, SA-C05-vasami, SA-C05-karomi]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [SA-C05-vadami, SA-C05-aham-samskritam-vadami, SA-C05-vasami, SA-C05-karomi, SA-C03-aham]
+---
+
+# Chapter 5 — The first verbs
+
+## Warm-up
+
+[PAUSE 2s] No new words. Three verbs, one engine — and Sanskrit's count-to-three.
+
+## Build the sentences
+
+[PAUSE 1s each]
+- [YOU SAY: "I speak Sanskrit" — *ahaṁ saṁskṛtaṁ vadāmi*]
+- [YOU SAY: "I live in the city" — *ahaṁ nagare vasāmi*]
+- [YOU SAY: "I work" — *ahaṁ kāryaṁ karomi*]
+- [YOU SAY: "we two speak" — *vadāvaḥ* (the dual!)]
+
+## The engine
+
+[PAUSE 2s]
+- [YOU SAY: the ending that means "I" (*-mi*, as in *asmi*, *vadāmi*)]
+- [YOU SAY: Sanskrit's three numbers (singular / **dual** / plural)]
+- [YOU SAY: where the verb sits, and how "in" is shown (verb last; a case-ending, the locative *-e*)]
+
+## Roots you now carry (the taproot, both ways)
+
+[PAUSE 2s]
+- *vad* "to speak" (→ *dhanyavāda*)
+- *vas* "to dwell" ← PIE *\*wes-* → English **was**
+- *kṛ* "to do" ← *\*kʷer-* → the root of *namaskāra*, *karma*, *saṁskṛta*; *kāryam* "work"
+- *saṁskṛta* = *sam* ("together," English *same*) + *kṛta* ("made") = "perfected"
+
+## Wrap-up Recall
+
+[PAUSE 3s] In one breath, say your language, your city, and your work in Sanskrit —
+then say "we two speak." (*Ahaṁ saṁskṛtaṁ vadāmi. Ahaṁ nagare vasāmi. Ahaṁ kāryaṁ
+karomi. Vadāvaḥ.*)

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-vadami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-vadami.md
@@ -1,0 +1,61 @@
+---
+id: SA-C05-vadami
+chapter: 5
+type: word
+headword: वदामि
+gloss: I speak (from वद्, to speak)
+concept_tag: SA-VERB-VAD
+prerequisites: [SA-C03-aham]
+sounds: [inherent-a, long-aa]
+roots: [vad-speak]
+est_minutes: 5
+reviews_of: []
+---
+
+# वदामि (vadāmi) — "I speak," and the Sanskrit verb
+
+## Warm-up
+
+[PAUSE 2s] So far, "to be." Here is a verb that *acts* — and it reveals the most
+famous feature of the Sanskrit verb: it counts to **three**.
+
+## The letters in this word
+
+**व** (*va*) + **दा** (*dā*) + **मि** (*mi*) → **वदामि** (*vadāmi*).
+
+## The word, taken apart
+
+**वदामि** (*vadāmi*, "I speak") is from the root **वद्** (*vad*, "to speak, to
+say") — the very root of **वाद** (*vāda*, "a saying") inside Chapter 1's
+**धन्यवादः** (*dhanyavādaḥ*, "thank you"). The present tense is stem + person-
+ending: *vad-ā-mi*, where **-मि** (*-mi*) means "I" — the same *-mi* you can see
+in *asmi* ("I am").
+
+## Grammar Lens: singular, DUAL, and plural
+
+Here is Sanskrit's showpiece. Where English (and Hindi) count in two — singular
+and plural — Sanskrit counts in **three**, with a special **dual** for *exactly
+two*:
+
+| number | form | meaning |
+|---|---|---|
+| singular | *vadāmi* | I speak |
+| **dual** | *vadāvaḥ* | **we two** speak |
+| plural | *vadāmaḥ* | we (three or more) speak |
+
+A whole grammatical number just for pairs — for two eyes, two hands, a couple.
+Greek had it too, and lost it; English never kept it; Sanskrit polished it. It is
+one of the things that makes the language feel so exact.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vadāmi" — I speak]
+- [YOU SAY: the root and its Chapter-1 cousin (*vad*; *dhanyavāda*, "thank you")]
+- [YOU SAY: the three numbers — *vadāmi* (I) / *vadāvaḥ* (we two) / *vadāmaḥ* (we all)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What root is *vadāmi* from, and what third "number" does Sanskrit have
+that English lacks? (*Vad*, "to speak"; the **dual**, for exactly two — *vadāvaḥ*,
+"we two speak.")

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-vasami.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-vasami.md
@@ -1,0 +1,54 @@
+---
+id: SA-C05-vasami
+chapter: 5
+type: word
+headword: वसामि
+gloss: I live, I dwell (from वस्, to dwell)
+concept_tag: SA-VERB-VAS
+prerequisites: [SA-C05-vadami]
+sounds: [inherent-a, long-aa]
+roots: [vas-dwell]
+est_minutes: 4
+reviews_of: [SA-C05-vadami, SA-C05-aham-samskritam-vadami]
+---
+
+# वसामि (vasāmi) — "I live, I dwell"
+
+## Warm-up
+
+[PAUSE 2s] A second verb, so you can say where you live — and it hides the English
+word *was*.
+
+## The letters in this word
+
+**व** (*va*) + **सा** (*sā*) + **मि** (*mi*) → **वसामि** (*vasāmi*).
+
+## The word, taken apart
+
+**वसामि** (*vasāmi*, "I dwell, I live") is from the root **वस्** (*vas*, "to
+dwell, to stay, to abide"), from Proto-Indo-European **\*wes-** ("to dwell, to
+be") — the ancestor of English **was** and **were** (the past of "to be" began as
+"to dwell/remain"). So Sanskrit's "I dwell" and English's "was" are, at the root,
+one word. From *vas* come *vāsa* ("a dwelling"), *nivāsa* ("a residence"), and
+names like *Vārāṇasī*. "I live in the city" is **अहं नगरे वसामि** (*ahaṁ nagare
+vasāmi*).
+
+## Grammar Lens: "in" is a case-ending
+
+**नगरे** (*nagare*, "in the city") = *nagara* ("city") in the **locative** case
+(*-e*, "in / at"). Sanskrit has no separate word for "in" — it is folded into the
+noun's ending, the ancestor of the postpositions Hindi and Bengali use. This is
+your second case, after Chapter 4's dative.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vasāmi" — I dwell]
+- [YOU SAY: "I live in the city" — *ahaṁ nagare vasāmi*]
+- [YOU SAY: the English cousin of the root *vas* (**was**)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What PIE root is *vasāmi* from, its English cousin, and how does
+Sanskrit say "in"? (*\*wes-* "to dwell"; English **was**; with a case-ending,
+the locative *-e*.)

--- a/code/learning/human-languages/sanskrit/roadmap.md
+++ b/code/learning/human-languages/sanskrit/roadmap.md
@@ -19,14 +19,28 @@ where a word needs them.
   practice. Devanagari introduced through the words; the both-ways cognate web
   (*te*↔*thee*, *su-*↔*eu-*, √gam↔*come*, *na*↔*nōn*) foregrounded.
 
+- **Ch. 2 — Introducing Yourself**: nāma (← *nāman* → *name*) → mama (← *me/my*)
+  → asti (← *is/est*; Sanskrit keeps the copula Tamil/Bengali drop) → mama nāma …
+  asti → bhavān/tvam (respect by 3rd person) → kim (← *what/quis*) → tava nāma
+  kim? → ānandaḥ (joy; "seeing you, joy") → practice.
+- **Ch. 3 — How Are You**: katham (how) → bhavān katham asti? → aham (← *ego* →
+  English **I**) → kuśalam (well; ← *kuśa* grass → "skilled" → "well") → na cintā
+  (you're welcome = "no worry") → practice. The copula trio asmi/asi/asti.
+- **Ch. 4 — Farewells**: gacchāmi ("I go"; ← *gam* → English *come*) → punaḥ
+  (again) → punar-darśanāya ("for seeing again"; the dative; *darśana* = a
+  beholding) → śvaḥ ("tomorrow"; kept distinct from *hyaḥ* "yesterday," unlike
+  Hindi *kal*) → practice.
+- **Ch. 5 — First Verbs**: vadāmi (← *vad*; the **dual** *vadāvaḥ* "we two speak")
+  → ahaṁ saṁskṛtaṁ vadāmi (I speak Sanskrit; *saṁskṛta* = "perfected"; sandhi) →
+  vasāmi (← *vas* → English **was**; the locative *-e*) → karomi (← √kṛ, the root
+  of *namaskāra/karma/Sanskrit*) → practice.
+
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *mama nāma…* ("my name…"), *bhavān* / *tvam* (respectful / familiar "you"), the first-person verb ending |
-| 3 | The verb *as-* ("to be": *asti* "is") — ancestor of Latin *est*, English *is*; numbers *eka–daśa* (1–10), cognate with Latin/Greek |
-| 4 | The astonishing Sanskrit **dual** — singular / dual / plural — and the first noun case beyond the nominative |
-| 5+ | The declensions and the root-and-affix system, each introduced where a phrase needs it; sandhi deepened — always tracing roots east and west |
+| 6 | The eight cases, one at a time (nominative, accusative…); numbers *eka–daśa* (1–10), cognate with Latin/Greek |
+| 7+ | The declensions and the root-and-affix system; the dual deepened; sandhi — always tracing roots east and west |
 
 Note: Sanskrit's showpiece features — the **dual number**, three genders, eight
 cases, and pervasive **sandhi** — are introduced one at a time as real phrases

--- a/code/learning/human-languages/sanskrit/session-map.md
+++ b/code/learning/human-languages/sanskrit/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Sanskrit Chapter 1 (Greetings)
+# Session Map — Sanskrit Chapters 1–5
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -19,8 +19,50 @@ and the Sanskrit-specific marks (visarga, conjuncts) — that word needs.
 | 5 | am-na | आम् / न | "yes / no"; *na* ← PIE *ne ↔ Latin *nōn* ↔ English *no* |
 | 6 | practice | (recap) | the greetings + the taproot's east-and-west cognates |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 7 | nama | नाम | "name" ← *nāman* → English *name* (the source) |
+| 8 | mama | मम | "my" ← *ma-* → English *me/my* |
+| 9 | asti | अस्ति | "is" ← *as-* → English *is*, Latin *est*; Sanskrit keeps the copula |
+| 10 | mama-nama-asti | मम नाम … अस्ति | **"my name is…"**; the copula kept (unlike Tamil/Bengali) |
+| 11 | bhavan-tvam | भवान् / त्वम् | **"you"**; *tvam* ← *\*tū* → *thou*; *bhavān* = 3rd-person honorific |
+| 12 | kim | किम् | "what" ← *ka-* → English *what*, Latin *quis* |
+| 13 | tava-nama-kim | तव नाम किम्? | **"what's your name?"** |
+| 14 | anandah | आनन्दः | "joy" (pleased to meet); *ā-* + *nand* "to rejoice" |
+
+## Chapter 3 — How Are You
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 15 | katham | कथम् | "how" ← the interrogative *ka-* |
+| 16 | bhavan-katham-asti | भवान् कथम् अस्ति? | **"how are you?"**; the copula trio asmi/asi/asti |
+| 17 | aham | अहम् | "I" ← *\*h₁eǵ(H)om* → Latin **ego**, English **I** |
+| 18 | kushalam | कुशलम् | "well" ← *kuśa* grass → "skilled" → "well"; reply *ahaṁ kuśalī asmi* |
+| 19 | na-cinta | न चिन्ता | "no worry / you're welcome"; *na* ← PIE *ne |
+| 20 | practice | (dialogue) | the how-are-you exchange |
+
+## Chapter 4 — Farewells
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 21 | gacchami | गच्छामि | "I go" (taking leave); ← *gam* → English *come* |
+| 22 | punah | पुनः | "again" (*punar-*, as in *punarjanma* "rebirth") |
+| 23 | punar-darshanaya | पुनर्दर्शनाय | **"until we meet again"**; the dative; *darśana* = a beholding |
+| 24 | shvah | श्वः | "tomorrow" — kept distinct from *hyaḥ* "yesterday" (unlike Hindi *kal*) |
+| 25 | practice | (dialogue) | the farewells |
+
+## Chapter 5 — The First Verbs
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 26 | vadami | वदामि | "I speak" ← *vad*; the **dual** *vadāvaḥ* "we two speak" |
+| 27 | aham-samskritam-vadami | अहं संस्कृतं वदामि | **"I speak Sanskrit"**; *saṁskṛta* = "perfected"; sandhi |
+| 28 | vasami | वसामि | "I live" ← *vas* → English **was**; the locative *-e* "in" |
+| 29 | karomi | करोमि | "I do" ← √kṛ — the root of *namaskāra*, *karma*, *Sanskrit* |
+| 30 | practice | (dialogue) | three verbs, one engine, and the dual |
+
 ## Next
 
-Chapter 2 — introducing yourself: *mama nāma…* ("my name…"), *bhavān* / *tvam*
-(respectful / familiar "you"), and the Sanskrit verb that marks singular, **dual**,
-and plural.
+Chapter 6 — the eight cases, one at a time, and numbers *eka–daśa* (1–10).


### PR DESCRIPTION
Carries the **Sanskrit** track (the eastern **taproot**) from Chapter 1 to
**Chapter 5** — four new chapters. Completes the eighth of nine South-Asian-script
tracks in the parity series (Hindi #8596, Tamil #8605, Telugu #8607, Kannada
#8608, Malayalam #8610, Punjabi #8614, Bengali #8619).

Framework `HL00`; concept tags reuse the universal `HL01` taxonomy, verbs
namespaced (`SA-VERB-*`) — no `taxonomy.json` change. As the taproot, every atom
is presented as a **source**, pointing **west** (*aham*→*ego/I*, *asmi*→*am*,
*vas*→*was*, *kim*→*what/quis*) and **east** (into the Indo-Aryan daughters).

## Chapters

- **Ch. 2 — Introducing Yourself**: *nāma* (→ *name*) → *mama* (→ *me/my*) → *asti*
  (→ *is/est*; Sanskrit **keeps** the copula its Dravidian neighbours drop) →
  *mama nāma … asti* → *bhavān/tvam* (respect by 3rd-person honorific) → *kim* →
  *tava nāma kim?* → *ānandaḥ* ("joy," pleased to meet) → practice.
- **Ch. 3 — How Are You**: *katham* → *bhavān katham asti?* → *aham* (← *\*h₁eǵom*
  → Latin **ego**, English **I**) → *kuśalam* (well; ← *kuśa* grass → "skilled" →
  "well") → *na cintā* ("no worry" = you're welcome) → practice. The copula trio
  *asmi/asi/asti*.
- **Ch. 4 — Farewells**: *gacchāmi* ("I go"; ← *gam* → English *come*) → *punaḥ* →
  *punar-darśanāya* ("for seeing again"; the **dative** case; *darśana* = a
  beholding) → *śvaḥ* ("tomorrow," kept distinct from *hyaḥ* "yesterday," unlike
  Hindi *kal*) → practice.
- **Ch. 5 — First Verbs**: *vadāmi* (← *vad*; featuring the **dual** — *vadāvaḥ*
  "we two speak," a whole grammatical number for exactly two) → *ahaṁ saṁskṛtaṁ
  vadāmi* (*saṁskṛta* = "put together, perfected"; sandhi) → *vasāmi* (← *vas* →
  English **was**; the **locative** *-e* for "in") → *karomi* (← √kṛ — the root of
  *namaskāra*, *karma*, and the name *Sanskrit* itself) → practice.

## Verification

- Book compiles clean with XeLaTeX (×2): **0 missing characters, 0 undefined
  references** (29 pages).
- New chapter pages rasterized and visually QA'd — Devanagari conjuncts, visarga,
  vocalic ṛ, and the dual table all render correctly.
- Concept tags validate against `HL01`; `/security-review` covered by the Hindi
  run (identical content-only class).
- `human-languages-books.yml` CI will build the updated PDF on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)