### PR TITLE
feat(lz78): add Haskell port

### DIFF
--- a/code/packages/haskell/lz78/BUILD
+++ b/code/packages/haskell/lz78/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/lz78/BUILD_windows
+++ b/code/packages/haskell/lz78/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/lz78/CHANGELOG.md
+++ b/code/packages/haskell/lz78/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Add CMP01 LZ78 token encoding and checked decoding.
+- Add an immutable byte-trie cursor for stepwise dictionary construction.
+- Add strict fixed-width wire serialization and one-shot compression helpers.

--- a/code/packages/haskell/lz78/README.md
+++ b/code/packages/haskell/lz78/README.md
@@ -1,0 +1,27 @@
+# lz78
+
+A pure Haskell implementation of the CMP01 LZ78 lossless compression
+algorithm. The encoder builds an explicit dictionary of byte sequences and
+emits `(dictionary index, next byte)` tokens; the decoder reconstructs the same
+dictionary without receiving it on the wire.
+
+## API
+
+- `Token` is the fixed-width LZ78 token model.
+- `emptyCursor`, `stepCursor`, `insertCursor`, and `resetCursor` expose the
+  immutable trie cursor used by the encoder.
+- `encode` and `decode` operate on token streams.
+- `serialiseTokens` and `deserialiseTokens` implement the CMP01 big-endian
+  header and four-byte token records.
+- `compress`, `compressDefault`, and `decompress` provide the one-shot API.
+
+Checked decoding returns `Either Lz78Error ByteString`, rejecting malformed
+headers, truncated or overlong streams, non-zero reserved bytes, invalid
+dictionary references, and decoded-length mismatches. Encoding and
+serialization are deterministic and use only pure data transformations.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/lz78/cabal.project
+++ b/code/packages/haskell/lz78/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/lz78/lz78.cabal
+++ b/code/packages/haskell/lz78/lz78.cabal
@@ -1,0 +1,32 @@
+cabal-version: 3.0
+name:          lz78
+version:       0.1.0
+synopsis:      Pure explicit-dictionary LZ78 compression
+description:   CMP01 token encoding, checked decoding, and fixed-width wire serialization.
+category:      Codec
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Lz78
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , containers >=0.6 && <0.8
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Lz78Spec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , hspec == 2.*
+                    , lz78
+    default-language: Haskell2010

--- a/code/packages/haskell/lz78/src/Lz78.hs
+++ b/code/packages/haskell/lz78/src/Lz78.hs
@@ -1,0 +1,252 @@
+-- | LZ78 explicit-dictionary compression from CMP01.
+--
+-- The encoder and decoder independently build the same dictionary. The wire
+-- representation stores the original length, a token count, and fixed-width
+-- four-byte token records.
+module Lz78
+    ( Token (..)
+    , Lz78Error (..)
+    , TrieCursor
+    , defaultMaxDictionarySize
+    , emptyCursor
+    , stepCursor
+    , insertCursor
+    , resetCursor
+    , cursorDictId
+    , cursorAtRoot
+    , encode
+    , decode
+    , serialiseTokens
+    , deserialiseTokens
+    , compress
+    , compressDefault
+    , decompress
+    ) where
+
+import Data.Bits ((.|.), shiftL, shiftR)
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import qualified Data.IntMap.Strict as IntMap
+import Data.IntMap.Strict (IntMap)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Word (Word16, Word32, Word8)
+
+-- | One LZ78 token. Index zero denotes the empty dictionary prefix.
+data Token = Token
+    { dictIndex :: Word16
+    , nextChar :: Word8
+    }
+    deriving (Eq, Show)
+
+-- | Structural failures detected while reading or decoding a token stream.
+data Lz78Error
+    = HeaderTooShort Int
+    | WireLengthMismatch Int Int
+    | NonZeroReservedByte Int Word8
+    | InvalidDictionaryIndex Word16 Int
+    | InvalidOriginalLength Int
+    | DecodedLengthMismatch Int Int
+    deriving (Eq, Show)
+
+data TrieNode = TrieNode
+    { nodeDictId :: Word16
+    , nodeChildren :: Map Word8 Int
+    }
+    deriving (Eq, Show)
+
+-- | Immutable cursor over an arena-backed byte trie.
+data TrieCursor = TrieCursor
+    { cursorNodes :: IntMap TrieNode
+    , cursorCurrent :: Int
+    , cursorNextNode :: Int
+    }
+    deriving (Eq, Show)
+
+-- | Maximum dictionary size supported by the 16-bit wire index.
+defaultMaxDictionarySize :: Int
+defaultMaxDictionarySize = 65536
+
+-- | An empty trie whose root represents dictionary index zero.
+emptyCursor :: TrieCursor
+emptyCursor =
+    TrieCursor
+        { cursorNodes = IntMap.singleton 0 (TrieNode 0 Map.empty)
+        , cursorCurrent = 0
+        , cursorNextNode = 1
+        }
+
+-- | Follow one byte edge, returning 'Nothing' when the edge is absent.
+stepCursor :: Word8 -> TrieCursor -> Maybe TrieCursor
+stepCursor byte cursor = do
+    node <- IntMap.lookup (cursorCurrent cursor) (cursorNodes cursor)
+    child <- Map.lookup byte (nodeChildren node)
+    pure cursor{cursorCurrent = child}
+
+-- | Add a byte edge at the current node. The cursor does not advance.
+insertCursor :: Word8 -> Word16 -> TrieCursor -> TrieCursor
+insertCursor byte newDictId cursor =
+    cursor
+        { cursorNodes =
+            IntMap.insert newNodeIndex newNode
+                (IntMap.adjust addChild (cursorCurrent cursor) (cursorNodes cursor))
+        , cursorNextNode = newNodeIndex + 1
+        }
+  where
+    newNodeIndex = cursorNextNode cursor
+    newNode = TrieNode newDictId Map.empty
+    addChild node = node{nodeChildren = Map.insert byte newNodeIndex (nodeChildren node)}
+
+-- | Return a cursor to the trie root without changing its dictionary.
+resetCursor :: TrieCursor -> TrieCursor
+resetCursor cursor = cursor{cursorCurrent = 0}
+
+-- | Dictionary ID at the current cursor position.
+cursorDictId :: TrieCursor -> Word16
+cursorDictId cursor = maybe 0 nodeDictId (IntMap.lookup (cursorCurrent cursor) (cursorNodes cursor))
+
+-- | Whether the cursor currently points at the trie root.
+cursorAtRoot :: TrieCursor -> Bool
+cursorAtRoot cursor = cursorCurrent cursor == 0
+
+-- | Encode bytes as LZ78 tokens, capping the dictionary at the requested size.
+encode :: ByteString -> Int -> [Token]
+encode input maxDictionarySize = reverse (finish finalCursor reversedTokens)
+  where
+    cappedSize = max 1 (min defaultMaxDictionarySize maxDictionarySize)
+    (finalCursor, _, reversedTokens) = BS.foldl' encodeByte (emptyCursor, 1, []) input
+
+    encodeByte (cursor, nextId, tokens) byte =
+        case stepCursor byte cursor of
+            Just advanced -> (advanced, nextId, tokens)
+            Nothing ->
+                let token = Token (cursorDictId cursor) byte
+                    canInsert = nextId < cappedSize
+                    inserted =
+                        if canInsert
+                            then insertCursor byte (fromIntegral nextId) cursor
+                            else cursor
+                    followingId = if canInsert then nextId + 1 else nextId
+                 in (resetCursor inserted, followingId, token : tokens)
+
+    finish cursor tokens
+        | cursorAtRoot cursor = tokens
+        | otherwise = Token (cursorDictId cursor) 0 : tokens
+
+-- | Decode tokens, optionally enforcing and trimming to an original length.
+decode :: [Token] -> Maybe Int -> Either Lz78Error ByteString
+decode tokens originalLength = do
+    validateLength originalLength
+    (outputReversed, _, _) <- foldTokens tokens
+    let output = BS.pack (reverse outputReversed)
+        trimmed = maybe output (`BS.take` output) originalLength
+        actualLength = BS.length trimmed
+    case originalLength of
+        Just expected
+            | actualLength /= expected -> Left (DecodedLengthMismatch expected actualLength)
+        _ -> Right trimmed
+  where
+    validateLength (Just value)
+        | value < 0 = Left (InvalidOriginalLength value)
+    validateLength _ = Right ()
+
+    foldTokens = go (IntMap.singleton 0 (0, 0)) 1 [] 0
+
+    go table _ output outputLength [] = Right (output, outputLength, table)
+    go table nextId output outputLength (token : rest) = do
+        prefix <- reconstruct table nextId (dictIndex token)
+        let withPrefix = reverse prefix ++ output
+            prefixLength = outputLength + length prefix
+            includeNext = maybe True (prefixLength <) originalLength
+            withNext = if includeNext then nextChar token : withPrefix else withPrefix
+            nextLength = if includeNext then prefixLength + 1 else prefixLength
+            nextTable = IntMap.insert nextId (dictIndex token, nextChar token) table
+        go nextTable (nextId + 1) withNext nextLength rest
+
+-- | Rebuild one dictionary entry by following its parent chain.
+reconstruct :: IntMap (Word16, Word8) -> Int -> Word16 -> Either Lz78Error [Word8]
+reconstruct table nextId index = walk index []
+  where
+    walk 0 bytes = Right bytes
+    walk current bytes =
+        case IntMap.lookup (fromIntegral current) table of
+            Nothing -> Left (InvalidDictionaryIndex current nextId)
+            Just (parent, byte) -> walk parent (byte : bytes)
+
+-- | Serialize tokens using the CMP01 big-endian fixed-width wire format.
+serialiseTokens :: [Token] -> Int -> ByteString
+serialiseTokens tokens originalLength =
+    BS.pack
+        ( word32Bytes (fromIntegral originalLength)
+            ++ word32Bytes (fromIntegral (length tokens))
+            ++ concatMap tokenBytes tokens
+        )
+  where
+    tokenBytes token = word16Bytes (dictIndex token) ++ [nextChar token, 0]
+
+-- | Parse and validate a complete CMP01 wire stream.
+deserialiseTokens :: ByteString -> Either Lz78Error ([Token], Int)
+deserialiseTokens input
+    | actualLength < 8 = Left (HeaderTooShort actualLength)
+    | actualLength /= expectedLength = Left (WireLengthMismatch expectedLength actualLength)
+    | otherwise = do
+        tokens <- traverse readToken [0 .. tokenCount - 1]
+        Right (tokens, originalLength)
+  where
+    actualLength = BS.length input
+    originalLength = fromIntegral (readWord32 input 0)
+    tokenCount = fromIntegral (readWord32 input 4)
+    expectedLength = 8 + tokenCount * 4
+
+    readToken tokenNumber =
+        let offset = 8 + tokenNumber * 4
+            reserved = BS.index input (offset + 3)
+         in if reserved /= 0
+                then Left (NonZeroReservedByte tokenNumber reserved)
+                else
+                    Right
+                        Token
+                            { dictIndex = readWord16 input offset
+                            , nextChar = BS.index input (offset + 2)
+                            }
+
+-- | Encode and serialize bytes with an explicit dictionary cap.
+compress :: ByteString -> Int -> ByteString
+compress input maxDictionarySize =
+    serialiseTokens (encode input maxDictionarySize) (BS.length input)
+
+-- | Encode and serialize bytes with the 65,536-entry default dictionary.
+compressDefault :: ByteString -> ByteString
+compressDefault input = compress input defaultMaxDictionarySize
+
+-- | Parse and decode a complete CMP01 wire stream.
+decompress :: ByteString -> Either Lz78Error ByteString
+decompress input = do
+    (tokens, originalLength) <- deserialiseTokens input
+    decode tokens (Just originalLength)
+
+word16Bytes :: Word16 -> [Word8]
+word16Bytes value =
+    [ fromIntegral (value `shiftR` 8)
+    , fromIntegral value
+    ]
+
+word32Bytes :: Word32 -> [Word8]
+word32Bytes value =
+    [ fromIntegral (value `shiftR` 24)
+    , fromIntegral (value `shiftR` 16)
+    , fromIntegral (value `shiftR` 8)
+    , fromIntegral value
+    ]
+
+readWord16 :: ByteString -> Int -> Word16
+readWord16 input offset =
+    (fromIntegral (BS.index input offset) `shiftL` 8)
+        .|. fromIntegral (BS.index input (offset + 1))
+
+readWord32 :: ByteString -> Int -> Word32
+readWord32 input offset =
+    (fromIntegral (BS.index input offset) `shiftL` 24)
+        .|. (fromIntegral (BS.index input (offset + 1)) `shiftL` 16)
+        .|. (fromIntegral (BS.index input (offset + 2)) `shiftL` 8)
+        .|. fromIntegral (BS.index input (offset + 3))

--- a/code/packages/haskell/lz78/test/Lz78Spec.hs
+++ b/code/packages/haskell/lz78/test/Lz78Spec.hs
@@ -1,0 +1,105 @@
+module Lz78Spec (spec) where
+
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import Lz78
+import Test.Hspec
+
+bytes :: String -> ByteString
+bytes = BS.pack . map (fromIntegral . fromEnum)
+
+roundTrip :: ByteString -> Either Lz78Error ByteString
+roundTrip = decompress . compressDefault
+
+spec :: Spec
+spec = do
+    describe "TrieCursor" $ do
+        it "starts at the root and reports missing edges" $ do
+            cursorAtRoot emptyCursor `shouldBe` True
+            cursorDictId emptyCursor `shouldBe` 0
+            stepCursor 65 emptyCursor `shouldBe` Nothing
+
+        it "inserts, follows, and resets immutable edges" $ do
+            let inserted = insertCursor 65 7 emptyCursor
+                advanced = stepCursor 65 inserted
+            fmap cursorAtRoot advanced `shouldBe` Just False
+            fmap cursorDictId advanced `shouldBe` Just 7
+            fmap (cursorAtRoot . resetCursor) advanced `shouldBe` Just True
+            cursorAtRoot emptyCursor `shouldBe` True
+
+    describe "encode and decode" $ do
+        it "handles empty and single-byte inputs" $ do
+            encode BS.empty defaultMaxDictionarySize `shouldBe` []
+            encode (bytes "A") defaultMaxDictionarySize `shouldBe` [Token 0 65]
+            decode [] (Just 0) `shouldBe` Right BS.empty
+            decode [Token 0 65] (Just 1) `shouldBe` Right (bytes "A")
+
+        it "matches the CMP01 AABCBBABC vector" $ do
+            encode (bytes "AABCBBABC") defaultMaxDictionarySize
+                `shouldBe` [ Token 0 65
+                           , Token 1 66
+                           , Token 0 67
+                           , Token 0 66
+                           , Token 4 65
+                           , Token 4 67
+                           ]
+
+        it "emits the specified end-of-stream flush token" $ do
+            let tokens = [Token 0 65, Token 0 66, Token 1 66, Token 3 0]
+            encode (bytes "ABABAB") defaultMaxDictionarySize `shouldBe` tokens
+            decode tokens (Just 6) `shouldBe` Right (bytes "ABABAB")
+            decode tokens Nothing `shouldBe` Right (BS.snoc (bytes "ABABAB") 0)
+
+        it "caps dictionary indices at the requested size" $ do
+            let capped = encode (bytes "ABCABCABCABCABC") 3
+                literalsOnly = encode (bytes "AAAA") 1
+                clamped = encode (bytes "AAAA") 0
+            all ((< 3) . dictIndex) capped `shouldBe` True
+            map dictIndex literalsOnly `shouldBe` replicate 4 0
+            clamped `shouldBe` literalsOnly
+
+        it "round-trips text and arbitrary bytes" $ do
+            let cases =
+                    [ BS.empty
+                    , bytes "A"
+                    , bytes "ABCDE"
+                    , bytes "AAAAAAA"
+                    , bytes "ABABABAB"
+                    , bytes "AABCBBABC"
+                    , bytes "hello world"
+                    , BS.pack [0, 0, 0, 255, 255]
+                    , BS.pack [0 .. 255]
+                    ]
+            map roundTrip cases `shouldBe` map Right cases
+
+        it "rejects invalid dictionary references and lengths" $ do
+            decode [Token 2 65] (Just 1) `shouldBe` Left (InvalidDictionaryIndex 2 1)
+            decode [Token 0 65] (Just (-1)) `shouldBe` Left (InvalidOriginalLength (-1))
+            decode [Token 0 65] (Just 2) `shouldBe` Left (DecodedLengthMismatch 2 1)
+
+    describe "wire format" $ do
+        it "serializes fields in big-endian four-byte records" $ do
+            serialiseTokens [Token 0x1234 0xab] 0x01020304
+                `shouldBe` BS.pack [1, 2, 3, 4, 0, 0, 0, 1, 0x12, 0x34, 0xab, 0]
+
+        it "deserializes complete token streams" $ do
+            let tokens = [Token 0 65, Token 1 66]
+                wire = serialiseTokens tokens 3
+            deserialiseTokens wire `shouldBe` Right (tokens, 3)
+
+        it "rejects short, truncated, and overlong streams" $ do
+            deserialiseTokens (BS.pack [0, 1, 2]) `shouldBe` Left (HeaderTooShort 3)
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 0, 0, 1])
+                `shouldBe` Left (WireLengthMismatch 12 8)
+            deserialiseTokens (BS.pack [0, 0, 0, 0, 0, 0, 0, 0, 1])
+                `shouldBe` Left (WireLengthMismatch 8 9)
+
+        it "rejects non-zero reserved token bytes" $ do
+            let malformed = BS.pack [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 65, 9]
+            deserialiseTokens malformed `shouldBe` Left (NonZeroReservedByte 0 9)
+
+        it "composes the one-shot API deterministically" $ do
+            let input = bytes "ABCABCABCABC"
+                compressed = compress input 32
+            compressed `shouldBe` compress input 32
+            decompress compressed `shouldBe` Right input

--- a/code/packages/haskell/lz78/test/Spec.hs
+++ b/code/packages/haskell/lz78/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified Lz78Spec
+import Test.Hspec
+
+main :: IO ()
+main = hspec Lz78Spec.spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -117,11 +117,11 @@ ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
 `scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
-`matrix`, `vigenere-cipher`, `uuid`, and `document-ast` ports:
+`matrix`, `vigenere-cipher`, `uuid`, `document-ast`, and `lz78` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 299 |
+| Present in 10-15 languages | 172 | 298 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 705 | 9,870 |
@@ -167,7 +167,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 299
+The 172 packages present in at least ten implementation languages need 298
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -178,7 +178,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 24 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 23 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -481,6 +481,16 @@ traversal without external dependencies. Its package-native suite exercises
 family, payload accessor, nesting shape, and discriminator. The package now
 spans 14 implementation lanes, reduces the high-consensus backlog to 299 slots,
 and leaves 24 gaps in the Haskell lane.
+
+The eleventh Haskell high-consensus slice is complete: `lz78` now provides the
+CMP01 token model, an immutable byte-trie cursor, dictionary-capped encoding,
+checked decoding, strict big-endian wire serialization, and deterministic
+one-shot compression. Its package-native suite exercises 13 examples with 98%
+expression and 96% alternative coverage, including both canonical token
+vectors, end-of-stream flushing, dictionary caps, text and binary round trips,
+exact wire bytes, and every malformed-input error family. The package now spans
+13 implementation lanes, reduces the high-consensus backlog to 298 slots, and
+leaves 23 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## What changed

- add a pure Haskell CMP01 LZ78 package with immutable token and trie-cursor APIs
- implement dictionary-capped encoding, checked decoding, strict fixed-width wire serialization, and one-shot compression helpers
- add package-native tests for canonical vectors, flush behavior, dictionary limits, text and binary round trips, exact wire bytes, and malformed streams
- refresh the parity roadmap from the live reporter output

## Why this slice is next

The Haskell 13-of-15 queue is complete. Of the remaining 12-of-15 gaps, `lz78` is the smallest dependency-safe pure-language port: its contract is fully specified by CMP01 and requires only byte storage and immutable maps. This moves `lz78` to 13 established implementation lanes without pulling in the larger DEFLATE, Zstandard, or SQL dependency graphs.

## Impact

Haskell now has a deterministic, binary-safe LZ78 implementation that interoperates with the repository's CMP01 four-byte token format. The high-consensus backlog falls from 299 to 298 missing slots, with 23 Haskell gaps remaining and zero canonical identity collisions.

## Validation

- `stack test --coverage --ghc-options '-Wall -Werror'` (13 examples, 0 failures; 98% expressions, 96% alternatives)
- `stack sdist` (including Cabal common-mistake validation)
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'` (6 tests)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- `git diff --check`
