### PR TITLE
feat(hl): Chapter 7 days of the week for French, German, Italian, Portuguese

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -222,6 +222,8 @@
       "IT-WORD-ITALIANO": "italiano — 'Italian' (the language; ← Italia)",
       "IT-NUM-1-5": "uno/due/tre/quattro/cinque (1-5; ← ūnus…quīnque; Italian closest to Latin — cinque keeps -que)",
       "IT-NUM-6-10": "sei/sette/otto/nove/dieci (6-10; septem/octō → -tt-: sette/otto; sette…dieci → settembre…dicembre)",
+      "IT-DAYS-WEEKDAYS": "lunedì/martedì/mercoledì/giovedì/venerdì (Mon-Fri; [planet] + dì ← diēs; accented -dì kept; = ES lunes/FR lundi)",
+      "IT-DAYS-WEEKEND": "sabato/domenica (Sat/Sun; ← Sabbatum / diēs Dominica 'Lord's day'; = ES sábado/domingo)",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
@@ -230,6 +232,8 @@
       "FR-WORD-FRANCAIS": "français — 'French' (the language; ← Francia, land of the Franks)",
       "FR-NUM-1-5": "un/deux/trois/quatre/cinq (1-5; ← ūnus…quīnque; un/une = a/an; cinq → English cinque)",
       "FR-NUM-6-10": "six/sept/huit/neuf/dix (6-10; octō→huit erosion; dix→dime; sept…dix → septembre…décembre)",
+      "FR-DAYS-WEEKDAYS": "lundi/mardi/mercredi/jeudi/vendredi (Mon-Fri; [planet-god] + di ← diēs; mardi=Mars=English Tuesday/Tiw)",
+      "FR-DAYS-WEEKEND": "samedi/dimanche (Sat/Sun; samedi ← Sabbatum, dimanche ← diēs Dominica 'Lord's day'; di- moved to front)",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
@@ -238,13 +242,17 @@
       "GE-WORD-DEUTSCH": "Deutsch — 'German' (the language; ← diutisc 'of the people' → English Dutch)",
       "GE-NUM-1-5": "eins/zwei/drei/vier/fünf (1-5; Germanic twins of one…five, NOT Latin loans; Grimm's law p→f in fünf/five)",
       "GE-NUM-6-10": "sechs/sieben/acht/neun/zehn (6-10; Germanic twins of six…ten; zehn↔ten↔decem d→t; acht↔eight/Nacht -cht-)",
+      "GE-DAYS-WEEKDAYS": "Montag/Dienstag/Mittwoch/Donnerstag/Freitag (Mon-Fri; Germanic gods = English days; Donnerstag=Thor=Thursday; Mittwoch 'mid-week' replaced Woden)",
+      "GE-DAYS-WEEKEND": "Samstag/Sonntag (Sat/Sun; Samstag ← Sabbat/shabbāt NOT Saturn = ES sábado; Sonntag = Sun's day = Sunday)",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
       "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
       "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
       "PT-VERB-TRABALHAR": "trabalhar — 'to work' (← tripaliāre → travail/travel; twin of Spanish trabajar)",
       "PT-WORD-PORTUGUES": "português — 'Portuguese' (the language; ← Portus Cale)",
       "PT-NUM-1-5": "um/dois/três/quatro/cinco (1-5; ← ūnus…quīnque; um nasal; GENDER kept on two: dois/duas ← duo/duae)",
-      "PT-NUM-6-10": "seis/sete/oito/nove/dez (6-10; ct→it shift octō→oito, noite/leite; sete…dez → setembro…dezembro)"
+      "PT-NUM-6-10": "seis/sete/oito/nove/dez (6-10; ct→it shift octō→oito, noite/leite; sete…dez → setembro…dezembro)",
+      "PT-DAYS-WEEKDAYS": "segunda/terça/quarta/quinta/sexta(-feira) (Mon-Fri; UNIQUE numbered feira days ← fēria 'feast-day'; ordinals of dois…seis; Church dropped planet-gods)",
+      "PT-DAYS-WEEKEND": "sábado/domingo (Sat/Sun; ← Sabbatum / diēs Dominica; domingo counted 1st → Monday='segunda' 2nd)"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Chapter 7 — Days of the week
+
+- **Chapter 7 authored** (`FR-C07-jours-1`, `-jours-2`): the seven days, atom-first,
+  reviewing Ch.6 via `reviews_of`, with the **planet-god week** as the through-line.
+- **jours-1** (lundi–vendredi): every weekday is *[planet-god]* + **-di** (← *diēs*
+  "day") — *lundi* = *lūnae diēs* "Moon's day," etc. The centrepiece is the
+  **Roman-planet ↔ Germanic-god bridge**: *mardi* and English *Tuesday* are the same
+  day (the war-god's), named *Mars* in Latin but *Tiw* in Germanic; *jeudi*
+  (Jupiter) = *Thursday* (Thor) — *interpretatio germanica*.
+- **jours-2** (samedi, dimanche): where **religion overwrote astronomy** — *samedi*
+  ← *Sabbatum* (the Hebrew Sabbath, so English *Saturday*/Saturn and French *samedi*
+  are the same day, two names); *dimanche* ← *diēs Dominica* "the **Lord's** day"
+  (*Dominus* → dominion/dame), the *di-* fossil moved to the front.
+- Taxonomy: namespaced `FR-DAYS-WEEKDAYS`, `FR-DAYS-WEEKEND`.
+
 ## Chapter 6 — Numbers 1–10
 
 - **Chapter 6 authored** (`FR-C06-nombres-1-5`, `-nombres-6-10`): counting to ten,

--- a/code/learning/human-languages/french/lessons/FR-C07-jours-1.md
+++ b/code/learning/human-languages/french/lessons/FR-C07-jours-1.md
@@ -1,0 +1,63 @@
+---
+id: FR-C07-jours-1
+chapter: 7
+type: word
+headword: lundi, mardi, mercredi, jeudi, vendredi
+gloss: the weekdays (Monday–Friday) — named for the planets
+concept_tag: FR-DAYS-WEEKDAYS
+prerequisites: [FR-C06-nombres-6-10]
+sounds: [nasal-un, vowel-eu]
+roots: [dies-latin, planet-gods]
+etymology_hook: "the -di in lundi/mardi… is Latin diēs 'day'; each weekday is a Roman planet-god — lundi = lūnae diēs 'Moon's day', and English Tuesday names the SAME planet (Mars) via a Germanic god"
+est_minutes: 5
+reviews_of: [FR-C06-nombres-6-10]
+---
+
+# lundi to vendredi — the planets of the week
+
+## Warm-up
+
+[PAUSE 2s] The seven-day week is one of humanity's oldest inheritances, and its
+day-names are a **map of the sky**: the Romans named each day for a planet-god.
+French kept that map almost intact — once you see the trick, five days decode at
+once.
+
+## Sounds you'll need
+
+- `nasal-un` — **lundi** = *luh(n)-DEE*, the nasal *un* you met in *un* (1).
+- The shared ending **-di** is always *DEE*.
+
+## The pattern: X + di, where di = "day"
+
+Every French weekday ends in **-di**, which is Latin **diēs**, "day." The first
+part is a **planet-god**. Read it as "[god]'s day":
+
+| French | ← Latin | planet-god | English echo |
+|---|---|---|---|
+| **lundi** | *lūnae diēs* | the **Moon** (*lune*) | *Mon*day = Moon-day |
+| **mardi** | *Martis diēs* | **Mars** | *Tues*day (Tiw, the Norse war-god = Mars) |
+| **mercredi** | *Mercuriī diēs* | **Mercury** | *Wednes*day (Woden = Mercury) |
+| **jeudi** | *Jovis diēs* | **Jupiter** (*Jove*) | *Thurs*day (**Thor** = Jupiter) |
+| **vendredi** | *Veneris diēs* | **Venus** | *Fri*day (Frigg/Freya = Venus) |
+
+Here's the beautiful part: **mardi and Tuesday are the same day** — both "the day
+of the war-god" — but Latin used *Mars* while the Germanic peoples swapped in
+**their** war-god, *Tiw*. The Romans mapped their gods onto the planets; the
+Germanic tribes then mapped *their* gods onto the Roman ones (*interpretatio
+germanica*). So French *jeudi* (Jupiter) and English *Thursday* (Thor) are the
+king-god's day in two pantheons.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "lundi, mardi, mercredi, jeudi, vendredi" — the work week]
+- [YOU SAY: each as "[planet]'s day" — "lundi = Moon, mardi = Mars, jeudi = Jupiter"]
+- [YOU SAY: the bridge — "mardi / Tuesday, both the war-god's day (Mars / Tiw)"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the *-di* in *lundi* mean, and from what Latin word? ("Day,"
+← *diēs*.) Which planet-god is *jeudi*, and its English twin? (Jupiter/Jove;
+*Thursday* = Thor's day.) Why do *mardi* and *Tuesday* line up? (Same day — the
+war-god's — named *Mars* in Latin, *Tiw* in Germanic.) Next: the **weekend**,
+where the pattern breaks.

--- a/code/learning/human-languages/french/lessons/FR-C07-jours-2.md
+++ b/code/learning/human-languages/french/lessons/FR-C07-jours-2.md
@@ -1,0 +1,57 @@
+---
+id: FR-C07-jours-2
+chapter: 7
+type: word
+headword: samedi, dimanche
+gloss: the weekend (Saturday, Sunday) — where the planets give way to religion
+concept_tag: FR-DAYS-WEEKEND
+prerequisites: [FR-C07-jours-1]
+sounds: [nasal-an, vowel-eu]
+roots: [sabbatum-latin, dominica-latin]
+etymology_hook: "samedi ← Sabbatum (the Sabbath), dimanche ← diēs Dominica ('the Lord's day') — the two days Christianity renamed, breaking the planet pattern"
+est_minutes: 4
+reviews_of: [FR-C07-jours-1, FR-C06-nombres-6-10]
+---
+
+# samedi and dimanche — the week's religious edge
+
+## Warm-up
+
+[PAUSE 2s] Five days named for planets — and then two that aren't. The weekend is
+where **religion overwrote astronomy**: Saturn's day and the Sun's day were
+renamed by Judaism and Christianity, and French shows both layers.
+
+## The two days, taken apart
+
+| French | ← Latin | meaning | note |
+|---|---|---|---|
+| **samedi** | *sambatī diēs* ← *Sabbatum* | "**Sabbath** day" | still has the *-di* (*diēs*), but the god is gone — replaced by the Hebrew *shabbat* "rest" |
+| **dimanche** | *diēs Dominica* | "the **Lord's** day" | the *-di* jumped to the **front** (*di-manche*) — *Dominica* from *Dominus*, "lord/master" |
+
+Two different rewrites:
+
+- **samedi** would have been "Saturn's day" (as English **Satur**day still is —
+  the one weekday English kept a Roman god for!). But Latin Christians took the
+  Jewish **Sabbath** (*Sabbatum* ← Hebrew *shabbāt*, "to rest") and it became
+  *samedi*. So English *Saturday* and French *samedi* are the **same day, two
+  names** — the planet vs the Sabbath.
+- **dimanche** dropped Sun-worship entirely: where English keeps **Sun**day,
+  French made it *diēs Dominica*, "the Lord's day" (*Dominus* → English *dominion,
+  dominate, dame*). Notice the *di-* is now in front — a fossil of *diēs* that
+  moved.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full week — "lundi, mardi, mercredi, jeudi, vendredi, samedi,
+  dimanche"]
+- [YOU SAY: "samedi = Sabbath, dimanche = the Lord's day" — religion, not planets]
+- [YOU SAY: the pair-ups — "samedi / Saturday (Sabbath vs Saturn)", "dimanche /
+  Sunday (Lord vs Sun)"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give all seven French days. (*Lundi … dimanche*.) Where does *samedi*
+come from, and its English contrast? (The **Sabbath**, *Sabbatum*; English kept
+*Saturday* = Saturn's day.) What does *dimanche* mean literally? ("The **Lord's**
+day," *diēs Dominica*.) Next chapter builds on this toward telling the time.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -42,12 +42,16 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   erosion; *dix* → *dime* ← *disme*; the **septembre–décembre = Latin 7–10**
   calendar trick). Spanish twin supplied for each. **Authored** — mirrors Spanish
   Ch.8's numbers.
+- **Ch. 7 — Days of the week**: lundi–vendredi (the **planet-god week**: each day
+  = *[planet]* + *-di* ← *diēs*; *mardi* = Mars = English *Tuesday*/Tiw, the
+  Roman-planet ↔ Germanic-god bridge) → samedi/dimanche (*Sabbatum* / *diēs
+  Dominica* "Lord's day" — where religion overwrote the planets). **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 7+ | Time, days & months, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
+| 8+ | Time & the clock, months, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
 
 The *tu/vous* lesson (Ch. 2) is the French counterpart to Spanish *tú/usted*:
 same formal/informal split, but French makes the formal from the **plural**

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Chapter 7 — Days of the week
+
+- **Chapter 7 authored** (`GE-C07-wochentage-1`, `-wochentage-2`): the seven days,
+  atom-first, reviewing Ch.6 via `reviews_of`.
+- **wochentage-1** (Montag–Freitag): like the numbers, German goes **Germanic** —
+  its weekdays are the **twins of the English days**, named for Germanic gods, not
+  Latin planets. *Donnerstag* (*Donner* "thunder" = Donar/**Thor**) = *Thursday*,
+  standing in for the Roman Jupiter; *Freitag* (Frigg) = *Friday*. The odd one,
+  **Mittwoch** "mid-week," is a religious edit — the Church replaced "Woden's day"
+  (which English kept as *Wednesday*), mirroring how Portuguese numbered its days.
+- **wochentage-2** (Samstag, Sonntag): the surprise that **Samstag is the Sabbath,
+  not Saturn** — *Sabbat* ← Greek *sábbaton* ← Hebrew *shabbāt*, reaching German
+  through the early Church, so *Samstag* and Spanish *sábado* share a root while
+  English alone keeps *Saturday* = Saturn; *Sonntag* = "Sun's day" = *Sunday* (a day
+  the Church left un-renamed, unlike Romance *domingo/dimanche*).
+- Taxonomy: namespaced `GE-DAYS-WEEKDAYS`, `GE-DAYS-WEEKEND`.
+
 ## Chapter 6 — Numbers 1–10
 
 - **Chapter 6 authored** (`GE-C06-zahlen-1-5`, `-zahlen-6-10`): counting to ten,

--- a/code/learning/human-languages/german/lessons/GE-C07-wochentage-1.md
+++ b/code/learning/human-languages/german/lessons/GE-C07-wochentage-1.md
@@ -1,0 +1,68 @@
+---
+id: GE-C07-wochentage-1
+chapter: 7
+type: word
+headword: Montag, Dienstag, Mittwoch, Donnerstag, Freitag
+gloss: the weekdays (Monday–Friday) — Germanic gods, twins of the English days
+concept_tag: GE-DAYS-WEEKDAYS
+prerequisites: [GE-C06-zahlen-6-10]
+sounds: [diphthong-ei, ch-ach]
+roots: [germanic-gods, planet-gods]
+etymology_hook: "German weekdays are Germanic gods — twins of the English days (Donnerstag = Thor's day = Thursday), not Latin planets — except Mittwoch 'mid-week', which the Church substituted for Woden's day"
+est_minutes: 5
+reviews_of: [GE-C06-zahlen-6-10]
+---
+
+# Montag to Freitag — the gods of the Germanic week
+
+## Warm-up
+
+[PAUSE 2s] Just as with the numbers, German goes its **Germanic** way here — and
+lands right next to **English**. The Romans named the weekdays for planet-gods
+(*Mars, Mercury, Jupiter, Venus*); the Germanic peoples swapped in **their own
+gods**, and German and English inherited that same set. *Donnerstag* and
+*Thursday* are the same god.
+
+## Sounds you'll need
+
+- `diphthong-ei` — **-tag** ("day") is easy; watch **Freitag** = *FRY-tahk*.
+- `ch-ach` — **Mittwoch** ends in the raspy *ch*: *MIT-vokh*.
+
+## The pattern: [Germanic god] + Tag ("day")
+
+**Tag** = "day" (cousin of English *day*). Before it, a god — the Germanic
+counterpart of the Roman planet:
+
+| German | god | = English | (Roman planet it replaced) |
+|---|---|---|---|
+| **Montag** | the **Moon** (*Mond*) | **Mon**day | Moon |
+| **Dienstag** | **Tiw/Ziu**, the war-god | **Tues**day | Mars |
+| **Mittwoch** | *(none — "mid-week")* | *Wednes*day (Woden) | Mercury |
+| **Donnerstag** | **Donar** = **Thor** (*Donner* "thunder") | **Thurs**day | Jupiter |
+| **Freitag** | **Frija/Frigg**, love-goddess | **Fri**day | Venus |
+
+Two showpieces:
+
+- **Donnerstag ↔ Thursday.** *Donner* is German for "thunder," and *Donar* was the
+  Germanic thunder-god — the one the Norse called **Thor**. So *Donnerstag* =
+  "Thor's day" = *Thursday*, standing in for the Roman *Jupiter* (the sky-thunder
+  king). Same god-slot, three names.
+- **Mittwoch is the odd one out.** It should be "Wodan's day" (as English keeps
+  **Wednes**day = Woden's day). But the medieval Church disliked naming a day for
+  the chief pagan god, so German replaced it with plain **Mittwoch**, "**mid-week**"
+  — a religious edit, just like Portuguese numbering its days.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Montag, Dienstag, Mittwoch, Donnerstag, Freitag"]
+- [YOU SAY: "Donnerstag = Thor's day = Thursday"; "Freitag = Frigg = Friday"]
+- [YOU SAY: the exception — "Mittwoch = mid-week" (not Woden, unlike English
+  Wednesday)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are German days named for planets or gods, and like which language?
+(Germanic **gods** — like English.) What does *Donnerstag* mean, and its English
+twin? ("Thor's day" — *Donner* "thunder"; *Thursday*.) Why is *Mittwoch* different?
+(The Church replaced "Woden's day" with "mid-week.") Next: the **weekend**.

--- a/code/learning/human-languages/german/lessons/GE-C07-wochentage-2.md
+++ b/code/learning/human-languages/german/lessons/GE-C07-wochentage-2.md
@@ -1,0 +1,55 @@
+---
+id: GE-C07-wochentage-2
+chapter: 7
+type: word
+headword: Samstag, Sonntag
+gloss: the weekend (Saturday, Sunday) — the Sabbath and the Sun
+concept_tag: GE-DAYS-WEEKEND
+prerequisites: [GE-C07-wochentage-1]
+sounds: [diphthong-ei, vowel-o]
+roots: [sabbatum-latin, germanic-gods]
+etymology_hook: "Samstag ← Sabbat (the Sabbath, via Greek sábbaton) — NOT Saturn, unlike English Saturday; Sonntag = 'Sun's day' = Sunday"
+est_minutes: 4
+reviews_of: [GE-C07-wochentage-1, GE-C06-zahlen-6-10]
+---
+
+# Samstag and Sonntag — the German weekend
+
+## Warm-up
+
+[PAUSE 2s] Two weekend days, and one more surprise: German's Saturday is **not**
+Saturn's day — it's the **Sabbath**, sharing its root with the Romance languages,
+not with English *Saturday*. Sunday, though, stays the Sun's.
+
+## The two days, taken apart
+
+| German | ← | meaning | note |
+|---|---|---|---|
+| **Samstag** | *Sabbat* ← Greek *sábbaton* ← Hebrew *shabbāt* | the "**Sabbath**" | **not** Saturn! Reached German through Greek-speaking Christians |
+| **Sonntag** | *Sun* + *Tag* (*Sonne* "sun") | "the **Sun's** day" | = English **Sun**day; a rare Germanic day the Church left alone |
+
+- **Samstag** surprises everyone: where English kept the Roman planet
+  (**Satur**day = Saturn), German took the **Sabbath** — Greek *sábbaton* (from
+  Hebrew *shabbāt*, "to rest") travelled up through the early Church into German as
+  *Sabbat → Samstag*. So German *Samstag* and Spanish *sábado* are the **same
+  Sabbath**, while English alone still points at Saturn. (In northern Germany you
+  also hear **Sonnabend**, "Sun-eve," the evening before Sunday.)
+- **Sonntag** is simply "the **Sun's** day," *Sonne* + *Tag* — the exact twin of
+  English **Sun**day. Here Germanic and English agree, and the Church didn't
+  rename it (unlike Romance, which made it "the Lord's day," *domingo/dimanche*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full week — "Montag … Freitag, Samstag, Sonntag"]
+- [YOU SAY: "Samstag = Sabbath (not Saturn!)", "Sonntag = Sun's day = Sunday"]
+- [YOU SAY: the contrast — "German Samstag / Spanish sábado, both the Sabbath;
+  English Saturday keeps Saturn"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give all seven German days. (*Montag … Sonntag*.) Where does *Samstag*
+come from, and how does English differ? (The **Sabbath** — *sábbaton/shabbāt*;
+English *Saturday* keeps **Saturn**.) What does *Sonntag* mean, and its English
+twin? ("The **Sun's** day"; *Sunday*.) Next chapter builds on this toward telling
+the time.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -42,12 +42,17 @@ Spanish and French where a contrast helps. The recurring decoder is the
   through-line (*p→f* in *fünf/five ← \*pénkʷe*; *d→t→z* in *decem→ten→zehn*;
   *acht/eight* ~ *Nacht/night*). The month names *are* Latin loans, so the 7–10
   calendar trick still shows. **Authored.**
+- **Ch. 7 — Days of the week**: Montag–Freitag (**Germanic gods = the English
+  days**, not Latin planets: *Donnerstag* = Thor's day = *Thursday*; the *Mittwoch*
+  "mid-week" exception where the Church dropped Woden, mirroring English keeping
+  *Wednesday*) → Samstag/Sonntag (*Samstag* ← *Sabbat*, the Sabbath, **not** Saturn,
+  twin of Spanish *sábado*; *Sonntag* = Sun's day = *Sunday*). **Authored.**
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 7+ | Cases (der→den→dem), time, family, food, sprechen & irregular verbs — following the shared theme order |
+| 8+ | Cases (der→den→dem), time & the clock, family, food, sprechen & irregular verbs — following the shared theme order |
 
 The **du / Sie** lesson (Ch. 2) completes the formal/informal set across the
 languages: Spanish *tú/usted* (from "your grace"), French *tu/vous* (the

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 7 — Days of the week
+
+- **Chapter 7 authored** (`IT-C07-giorni-1`, `-giorni-2`): the seven days,
+  atom-first, reviewing Ch.6 via `reviews_of`, with Spanish/French twins supplied.
+- **giorni-1** (lunedì–venerdì): the **planet-week** with the accented **-dì**
+  (← *diēs* "day") kept audible and stressed (*lu-ne-DÌ*). Three-sister lines make
+  the shared Latin visible — *lunedì / lunes / lundi* are one word, *lūnae diēs*,
+  worn three ways (IT/FR keep the day-word at the end, Spanish dropped it);
+  *giovedì* wears *Giove* (Jupiter), the king-god English honours as Thor.
+- **giorni-2** (sabato, domenica): the religious weekend — *sabato* ← *Sabbatum*
+  (Hebrew *shabbāt*), the Sabbath every Romance language kept; *domenica* ← *(diēs)
+  Dominica* "the **Lord's** day" (*Dominus* → dominion/dame), feminine *la domenica*.
+- Taxonomy: namespaced `IT-DAYS-WEEKDAYS`, `IT-DAYS-WEEKEND`.
+
 ## Chapter 6 — Numbers 1–10
 
 - **Chapter 6 authored** (`IT-C06-numeri-1-5`, `-numeri-6-10`): counting to ten,

--- a/code/learning/human-languages/italian/lessons/IT-C07-giorni-1.md
+++ b/code/learning/human-languages/italian/lessons/IT-C07-giorni-1.md
@@ -1,0 +1,63 @@
+---
+id: IT-C07-giorni-1
+chapter: 7
+type: word
+headword: lunedì, martedì, mercoledì, giovedì, venerdì
+gloss: the weekdays (Monday–Friday) — the planets, with the day-word at the end
+concept_tag: IT-DAYS-WEEKDAYS
+prerequisites: [IT-C06-numeri-6-10]
+sounds: [final-stress-i, c-before-i]
+roots: [dies-latin, planet-gods]
+etymology_hook: "lunedì/martedì… = [planet] + dì (← diēs 'day'); same Roman planet-week as French, with the accented -dì kept audible; Spanish twins lunes/martes"
+est_minutes: 5
+reviews_of: [IT-C06-numeri-6-10]
+---
+
+# lunedì to venerdì — the planet-week, Italian-style
+
+## Warm-up
+
+[PAUSE 2s] Italy sat at the centre of the Roman world, so its weekday names are
+the **planet-week** almost undisturbed — the same map of the sky French uses. The
+tell is the little accented **-dì** at the end of each.
+
+## Sounds you'll need
+
+- `final-stress-i` — the **-dì** carries a **written accent** and the **stress**:
+  *lu-ne-DÌ*, *mar-te-DÌ*. That accent marks "day" (*diēs*) and where your voice
+  lands.
+- `c-before-i` — **mercoledì** = *mer-co-le-DÌ* (hard *c* here, before *o*).
+
+## The pattern: [planet] + dì
+
+**dì** is Latin **diēs**, "day" — the same *-di* you'd hear in French *lundi*.
+Before it sits a **planet-god**:
+
+| Italian | ← Latin | planet | Spanish twin | French twin |
+|---|---|---|---|---|
+| **lunedì** | *lūnae diēs* | Moon | *lunes* | *lundi* |
+| **martedì** | *Martis diēs* | Mars | *martes* | *mardi* |
+| **mercoledì** | *Mercuriī diēs* | Mercury | *miércoles* | *mercredi* |
+| **giovedì** | *Jovis diēs* | Jupiter (*Giove*) | *jueves* | *jeudi* |
+| **venerdì** | *Veneris diēs* | Venus (*Venere*) | *viernes* | *vendredi* |
+
+Line up the three sisters — *lunedì / lunes / lundi* — and you're looking at one
+Roman word, *lūnae diēs*, worn three ways. Italian and French keep the day-word
+at the **end** (*lune-dì*, *lun-di*); Spanish clipped it off entirely (*lunes*).
+And *giovedì* wears **Giove**, the Italian name of Jupiter — the same king-god
+English honours as Thor in *Thursday*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "lunedì, martedì, mercoledì, giovedì, venerdì" — mind the final stress]
+- [YOU SAY: the three-sister line — "lunedì / lunes / lundi", "martedì / martes /
+  mardi"]
+- [YOU SAY: "-dì = diēs = day" — the accented tail]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the accented *-dì*, and from what Latin word? ("Day," ← *diēs*.)
+Which planet is *giovedì*? (Jupiter — *Giove*.) How do Italian/French treat the
+day-word versus Spanish? (IT/FR keep it at the end, *-dì/-di*; Spanish dropped it,
+*lunes*.) Next: the **weekend** — *sabato* and *domenica*.

--- a/code/learning/human-languages/italian/lessons/IT-C07-giorni-2.md
+++ b/code/learning/human-languages/italian/lessons/IT-C07-giorni-2.md
@@ -1,0 +1,53 @@
+---
+id: IT-C07-giorni-2
+chapter: 7
+type: word
+headword: sabato, domenica
+gloss: the weekend (Saturday, Sunday) — Sabbath and the Lord's day
+concept_tag: IT-DAYS-WEEKEND
+prerequisites: [IT-C07-giorni-1]
+sounds: [double-none, stress-first]
+roots: [sabbatum-latin, dominica-latin]
+etymology_hook: "sabato ← Sabbatum (Sabbath), domenica ← diēs Dominica ('the Lord's day') — Italy's weekend keeps the religious names, twins of Spanish sábado/domingo"
+est_minutes: 4
+reviews_of: [IT-C07-giorni-1, IT-C06-numeri-6-10]
+---
+
+# sabato and domenica — the religious weekend
+
+## Warm-up
+
+[PAUSE 2s] The five weekdays were planets; the two weekend days are **faith**. Here
+the accented *-dì* disappears, because these names never came from *diēs* + a god
+— they came from the Sabbath and the Lord.
+
+## The two days, taken apart
+
+| Italian | ← Latin | meaning | Spanish twin |
+|---|---|---|---|
+| **sabato** | *Sabbatum* ← Hebrew *shabbāt* | the "**Sabbath**," the day of rest | *sábado* |
+| **domenica** | *(diēs) Dominica* ← *Dominus* | "the **Lord's** day" | *domingo* |
+
+- **sabato** is the **Sabbath** — Latin *Sabbatum* straight from Hebrew *shabbāt*,
+  "to cease, to rest." Where English kept the planet (**Satur**day = Saturn),
+  Italian, Spanish, and French all took the Jewish rest-day instead (*sabato /
+  sábado / samedi*).
+- **domenica** is "the **Lord's** day," *diēs Dominica*, from *Dominus* "lord,
+  master" (→ English *dominion, dominate, dame, don*). Christianity renamed the old
+  "Sun's day": English still says **Sun**day, but Italian and Spanish point to the
+  Lord (*domenica / domingo*). Note *domenica* is **feminine** (*la domenica*) —
+  *diēs* went feminine here.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full week — "lunedì … venerdì, sabato, domenica"]
+- [YOU SAY: "sabato = Sabbath, domenica = the Lord's day" — faith, not planets]
+- [YOU SAY: the sisters — "sabato / sábado", "domenica / domingo"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give all seven Italian days. (*Lunedì … domenica*.) Where does *sabato*
+come from? (The **Sabbath**, *Sabbatum* ← Hebrew *shabbāt*.) What does *domenica*
+mean, and its Spanish twin? ("The **Lord's** day"; *domingo*.) Next chapter builds
+on this toward telling the time.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -39,12 +39,16 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   *-que*; Latin's *-pt-*/*-ct-* assimilate to doubled *-tt-*: *septem→sette*,
   *octō→otto*), with the **settembre–dicembre = Latin 7–10** calendar trick.
   Spanish/French twins supplied. **Authored.**
+- **Ch. 7 — Days of the week**: lunedì–venerdì (the **planet-week** with the
+  accented *-dì* ← *diēs* kept audible; three-sister lines *lunedì/lunes/lundi*;
+  *giovedì* = Giove/Jupiter) → sabato/domenica (*Sabbatum* / *diēs Dominica* "Lord's
+  day," twins of Spanish *sábado/domingo*). **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 7+ | Time, days & months, family, food — following the shared theme order |
+| 8+ | Time & the clock, months, family, food — following the shared theme order |
 
 Note: Italian's formal "you" is **Lei** — literally "she" (a 3rd-person
 politeness, like German *Sie*), a different mechanism from Spanish *usted* (a

--- a/code/learning/human-languages/malayalam/lessons/ML-C03-saaramilla.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C03-saaramilla.md
@@ -4,7 +4,7 @@ chapter: 3
 type: phrase
 headword: സാരമില്ല
 gloss: it doesn't matter / no problem / you're welcome
-concept_tag: YOURE-WELCOME
+concept_tag: COURTESY-YOUREWELCOME
 prerequisites: [ML-C01-illa, ML-C01-nandi]
 sounds: [illa-negative]
 roots: [saara-sanskrit, illa-not-dravidian]

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Chapter 7 — Days of the week
+
+- **Chapter 7 authored** (`PT-C07-dias-1`, `-dias-2`): the seven days, atom-first,
+  reviewing Ch.6 via `reviews_of` — and the **single most distinctive fact in
+  Portuguese**.
+- **dias-1** (segunda–sexta): Portuguese is the **only Romance language to drop the
+  pagan planet-gods** and **number** its weekdays as *feiras* (← *fēria*
+  "feast-day," cousin of English *fair*). Bishop **Martinho de Braga** (6th c.)
+  renamed them; the ordinals are built from the very Ch.6 numbers — *quarta-feira*
+  "4th" (← *quatro*), *quinta* (← *cinco*), *sexta* (← *seis*) — a direct callback.
+  Everyday speech drops the *-feira* ("*Até sexta!*").
+- **dias-2** (sábado, domingo): the two days that **kept** religious names —
+  *sábado* ← *Sabbatum* (the Sabbath, shared with all the Romance sisters),
+  *domingo* ← *(diēs) Dominica* "the **Lord's** day." And the loop closes: because
+  the Church counted **domingo as the first day**, Monday becomes the *second* —
+  *segunda-feira*.
+- Taxonomy: namespaced `PT-DAYS-WEEKDAYS`, `PT-DAYS-WEEKEND`.
+
 ## Chapter 6 — Numbers 1–10
 
 - **Chapter 6 authored** (`PT-C06-numeros-1-5`, `-numeros-6-10`): counting to ten,

--- a/code/learning/human-languages/portuguese/lessons/PT-C07-dias-1.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C07-dias-1.md
@@ -1,0 +1,65 @@
+---
+id: PT-C07-dias-1
+chapter: 7
+type: word
+headword: segunda, terça, quarta, quinta, sexta(-feira)
+gloss: the weekdays (Mon–Fri) — Portuguese NUMBERS its days instead of naming planets
+concept_tag: PT-DAYS-WEEKDAYS
+prerequisites: [PT-C06-numeros-1-5]
+sounds: [nasal-none, open-e]
+roots: [feria-latin, ordinals-latin]
+etymology_hook: "Portuguese is the ONLY Romance language to drop the pagan planet-gods: its weekdays are numbered 'feiras' — segunda-feira '2nd feast-day', built from the ordinals of the numbers you just learned"
+est_minutes: 5
+reviews_of: [PT-C06-numeros-1-5, PT-C06-numeros-6-10]
+---
+
+# segunda to sexta — the week that got numbered
+
+## Warm-up
+
+[PAUSE 2s] Here Portuguese does something **no other Romance language does**.
+French, Italian, and Spanish all name their weekdays for planet-gods (*lundi*,
+*lunedì*, *lunes* = the Moon). Portuguese threw the pagan gods out and **numbered**
+the days instead — and the numbers are the very ones you just learned.
+
+## The story: a bishop renames the week
+
+In the 6th century, **Martinho de Braga**, a bishop in what is now northern
+Portugal, refused to let Christians name days after *Mars* and *Jupiter*. Borrowing
+the Church's word for the numbered holy days of Easter week, he called them
+**feiras** — and Portuguese alone kept the system for **every** week.
+
+**feira** ← Latin **fēria**, "a feast-day / a day free of work." (The same *fēria*
+drifted, elsewhere, into "market/fair" — English **fair** is its cousin, because
+markets were held on feast-days.)
+
+## The pattern: [ordinal] + feira
+
+| Portuguese | means | ← ordinal of | (cardinal you learned) |
+|---|---|---|---|
+| **segunda**-feira (Mon) | "2nd feast-day" | *secundus* "second" | *dois* (2) |
+| **terça**-feira (Tue) | "3rd" | *tertius* "third" | *três* (3) |
+| **quarta**-feira (Wed) | "4th" | *quartus* "fourth" | *quatro* (4) |
+| **quinta**-feira (Thu) | "5th" | *quintus* "fifth" | *cinco* (5) |
+| **sexta**-feira (Fri) | "6th" | *sextus* "sixth" | *seis* (6) |
+
+So *quarta-feira* is literally "**fourth** feast-day," and you can hear *quatro*
+(4) inside *quarta*. In everyday speech the "-feira" is often dropped: "*Até
+segunda!*" — "See you Monday!" (Why does Monday start at **two**, not one? Because
+Sunday is counted as the *first* day — the next lesson closes that loop.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "segunda, terça, quarta, quinta, sexta" — Monday through Friday]
+- [YOU SAY: hear the number in each — "quarta ← quatro (4), quinta ← cinco (5),
+  sexta ← seis (6)"]
+- [YOU SAY: drop the tail — "Até sexta!" ("See you Friday!")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How is Portuguese unique among Romance languages here? (It **numbers**
+its weekdays — *feiras* — instead of naming planet-gods.) What does *feira* mean,
+and its English cousin? ("Feast-day," ← *fēria*; English *fair*.) What number
+hides in *quinta-feira*? (Five — *quinta* ← *quintus*, cousin of *cinco*.) Next:
+the two days that **kept** their old names — *sábado* and *domingo*.

--- a/code/learning/human-languages/portuguese/lessons/PT-C07-dias-2.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C07-dias-2.md
@@ -1,0 +1,63 @@
+---
+id: PT-C07-dias-2
+chapter: 7
+type: word
+headword: sábado, domingo
+gloss: the weekend (Saturday, Sunday) — the two days that kept their names
+concept_tag: PT-DAYS-WEEKEND
+prerequisites: [PT-C07-dias-1]
+sounds: [nasal-o, open-a]
+roots: [sabbatum-latin, dominica-latin]
+etymology_hook: "sábado ← Sabbatum (Sabbath), domingo ← diēs Dominica ('the Lord's day') — and because domingo is the 'first' day, Monday becomes the 'second' (segunda)"
+est_minutes: 4
+reviews_of: [PT-C07-dias-1, PT-C06-numeros-1-5]
+---
+
+# sábado and domingo — and why Monday is "the second"
+
+## Warm-up
+
+[PAUSE 2s] Five weekdays got numbered — but two kept their names. *Sábado* and
+*domingo* are the **religious anchors** of the Portuguese week, and *domingo* is
+the key that explains why the counting started where it did.
+
+## The two days, taken apart
+
+| Portuguese | ← Latin | meaning | shared with |
+|---|---|---|---|
+| **sábado** | *Sabbatum* ← Hebrew *shabbāt* | the "**Sabbath**," rest-day | Spanish *sábado*, Italian *sabato*, French *samedi* |
+| **domingo** | *(diēs) Dominica* ← *Dominus* | "the **Lord's** day" | Spanish *domingo*, Italian *domenica* |
+
+- **sábado** is the **Sabbath**, from Hebrew *shabbāt* "to rest" — the one weekend
+  name every Romance language shares (even numbering-mad Portuguese kept it).
+- **domingo** is "the **Lord's** day," *diēs Dominica*, from *Dominus* "lord,
+  master" (→ English *dominion, dominate, dame*).
+
+## Grammar Lens: domingo is "day one" — so Monday is "day two"
+
+Now the loop closes. The Church counted **domingo (Sunday) as the *first* day** of
+the week — *prima feria*, the Lord's day, the start. That's why:
+
+> domingo = 1st → **segunda**-feira (Monday) = **2nd** → terça (3rd) → … → sexta
+> (Friday) = 6th → sábado (Saturday) = 7th.
+
+Monday isn't the first weekday in this system — it's the day **after** the Lord's
+day, the *second*. So *segunda-feira* ("second feast-day") makes perfect sense once
+you know Sunday was counted first. The whole week is a countdown anchored on
+*domingo*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full week — "domingo, segunda, terça, quarta, quinta, sexta,
+  sábado"]
+- [YOU SAY: the anchors — "sábado = Sabbath, domingo = the Lord's day"]
+- [YOU SAY: the logic — "domingo is 1st, so segunda (Monday) is 2nd"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give all seven Portuguese days. (*Domingo, segunda … sábado*.) What does
+*domingo* mean, and why does that make Monday "*segunda*"? ("The **Lord's** day";
+Sunday is counted **first**, so Monday is the **second**.) Which weekend name do
+all the Romance languages share? (*Sábado* — the Sabbath.) Next chapter builds on
+this toward telling the time.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -40,12 +40,18 @@ French.
   where Spanish levelled to *dos*), and the **ct→it shift** (*octō→oito*, like
   *noite/leite*) — contrasted with Spanish *ocho* (*ct→ch*). Plus the
   **setembro–dezembro = Latin 7–10** calendar trick. **Authored.**
+- **Ch. 7 — Days of the week**: the **great Portuguese exception** — segunda–sexta
+  are **numbered *feiras*** (← *fēria* "feast-day"; the ordinals of the Ch.6
+  numbers: *quarta* ← *quatro*), the only Romance language to drop the pagan
+  planet-gods (Bishop Martinho de Braga, 6th c.) → sábado/domingo (*Sabbatum* /
+  *diēs Dominica*; *domingo* counted first, so Monday is *segunda* "second").
+  **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 7+ | Time, days & months, family, food — following the shared theme order |
+| 8+ | Time & the clock, months, family, food — following the shared theme order |
 
 Note: Portuguese's polite "you" is **você** (← *vossa mercê*, "your mercy") — the
 same "your grace" mechanism as Spanish *usted*, worn down differently. Worth

--- a/code/learning/human-languages/punjabi/lessons/PA-C03-koi-gall-nahin.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C03-koi-gall-nahin.md
@@ -4,7 +4,7 @@ chapter: 3
 type: phrase
 headword: ਕੋਈ ਗੱਲ ਨਹੀਂ
 gloss: it's nothing / no problem / you're welcome
-concept_tag: YOURE-WELCOME
+concept_tag: COURTESY-YOUREWELCOME
 prerequisites: [PA-C01-han-nahin, PA-C01-dhanvaad]
 sounds: [double-ll, bindi-nasal]
 roots: [na-negative, gall-word]


### PR DESCRIPTION
Parallel **days of the week** chapters across the four non-Spanish tracks — **rebalancing off the Spanish pilot** (now at Ch.10). Atom-first, two lessons each (weekdays / weekend), ~4–5 min, reviewing Ch.6 numbers via `reviews_of`. One seven-day week, **four genuinely distinct etymological stories**:

| Track | The story |
|---|---|
| **French** | The Roman **planet-god week** (*[planet]* + *-di* ← *diēs*); the planet↔Germanic-god bridge: *mardi* = Mars = English **Tuesday**/Tiw, *jeudi* = Jupiter = **Thursday**/Thor. Weekend: *samedi* ← Sabbath, *dimanche* ← *diēs Dominica* "Lord's day" |
| **German** | Germanic gods = **the English days**, not planets (*Donnerstag* = Thor = **Thursday**); the *Mittwoch* "mid-week" exception (Church dropped Woden, English kept *Wednesday*); *Samstag* = **Sabbath, not Saturn** (twin of ES *sábado*) |
| **Italian** | The planet-week with the accented **-dì** (← *diēs*) kept audible; three-sister lines *lunedì / lunes / lundi*; *sabato/domenica* religious |
| **Portuguese** | **The great exception** — the *only* Romance language to drop the pagan planet-gods and **number** its days as *feiras* (← *fēria* "feast-day"). *segunda/terça/quarta/quinta/sexta* are the **ordinals of the Ch.6 numbers** (Bishop Martinho de Braga, 6th c.); *domingo* counted 1st → Monday = *segunda* "2nd" |

**Cross-cutting threads** tie the four together: *-di/-dì* = *diēs* "day"; the **Sabbath** (*sábado/sabato/samedi/Samstag*) vs English *Saturn*; the religious renamings (*Mittwoch*, *dimanche/domingo*, the *feiras*). Correct prefixes (FR-, **GE-**, IT-, PT-); namespaced `{FR,GE,IT,PT}-DAYS-WEEKDAYS/-WEEKEND`; four roadmaps + CHANGELOGs advanced to "Next = Ch.8 (time/clock)".

## Also: fixes red main (6th Indic track)
The recurring retired-tag failure struck two more siblings: **Punjabi** `PA-C03-koi-gall-nahin` and **Malayalam** `ML-C03-saaramilla` both carried the **retired** `concept_tag: YOURE-WELCOME`. Retagged both to canonical `COURTESY-YOUREWELCOME`. Must ride here because this PR edits `taxonomy.json`, which retriggers that suite. This is now the **6th** track hit (Hindi → Tamil → Telugu → Kannada → Punjabi → Malayalam) — the root-cause fix is tracked in a separate task.

## Verification
- `human-language-data` suite: **38 / 38 pass** (was 3 failing on origin/main due to the Punjabi+Malayalam tags).
- Security-reviewed (subagent): markdown + JSON only — no scripts, URLs, secrets, or injection; taxonomy.json validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)