### PR TITLE
feat(semantic-ir-to-typescript): wire SIR22 'APL addendum' codegen — Reduce/Scan/OuterProduct/Shape/Reshape/IndexGenerator/IndexOf/Ravel/Catenate

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## 0.11.0 — SIR22 "APL addendum" codegen: `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`
+
+Closes the gap 0.10.0's own CHANGELOG entry (below) flagged as a "scope
+boundary, not silently swept away": `apl-to-semantic-ir` genuinely lowers
+APL's `/` (reduce), `\` (scan), `∘.` (outer product), `⍴` (shape/reshape),
+`⍳` (index-generator/index-of), and `,` (ravel/catenate) to these nine
+`Expr` variants, but this backend's `emit.rs` still `panic!`ed on all nine
+and `lib.rs` had a dedicated pre-`emit` tree-walk
+(`find_unimplemented_sir22_addendum_node`) to reject them cleanly instead.
+The blocker that kept this deferred at 0.10.0 — `sir-runtime-array` itself
+not implementing these nine — is now gone: that package's own SIR22-
+addendum port (mirroring the identical primitives `semantic-ir-to-javascript`
+already inlined) shipped ahead of this release, so this PR is purely
+*wiring up calls* into functions that already exist, exactly the
+"runtime lands before its codegen consumer" pattern the base cut (0.9.0/
+0.10.0) followed too.
+
+Unlike the JavaScript backend's identical fix, this crate imports the
+published npm package rather than inlining a copy of its logic — so there
+is no `runtime.rs` port to write here at all, only call-site wiring in
+`emit.rs` and capability-gate removal in `lib.rs`.
+
+### Added
+
+- **`emit.rs`**: nine real-codegen `match` arms replacing the previous
+  combined `panic!` arm, mirroring the existing `ArrayLit`/`Range`/`MatMul`/
+  `ElementwiseOp`/`Transpose`/`IndexGet` arms' style exactly — each recurses
+  into its operand(s) and emits a call into the corresponding
+  `__SirArray.*` function; `Reduce`/`Scan`/`OuterProduct` reuse
+  `elementwise_op_ts_name` for their `op` field exactly like `ElementwiseOp`
+  does. `Reshape`'s field order was checked directly against
+  `sir-runtime-array`'s `reshape(shapeArg, target)` (`shape.ts`) rather than
+  assumed: `semantic_ir::Expr::Reshape`'s own field order is `shape,
+  target`, which already matches — unlike `Expr::Range`'s `start, step,
+  stop` vs. `range`'s `start, stop, step` (which DOES reorder, see the
+  0.10.0 entry above), no argument reordering was needed at this call site.
+- **`lib.rs`**: removed `find_unimplemented_sir22_addendum_node` (the
+  dedicated tree-walk that rejected these nine node kinds before `emit`
+  could panic on them) and its `compile()` step-3b call site — no longer
+  needed now that real codegen exists. Doc comments and
+  `ACCEPTED_FEATURES` updated to describe the full SIR22 domain (base cut
+  + addendum) as accepted and implemented, not "base cut done, addendum
+  deferred."
+
+### Changed
+
+- The stale `rejects_reduce_node_cleanly_instead_of_panicking_in_emit`
+  regression test is now `compiles_reduce_node_instead_of_rejecting_it`,
+  asserting `compile()` SUCCEEDS with the exact expected
+  `__SirArray.reduce("Add", ...)` call shape, plus a new
+  `emits_all_nine_addendum_nodes_as_sir_array_calls` covering the other
+  seven node kinds' call shapes (`Reshape` gets its own dedicated
+  `emits_reshape_with_shape_before_target_argument_order`, using two
+  DISTINCT operands so a real argument-swap bug would fail the assertion
+  rather than pass by coincidence). These follow this crate's own
+  established structural-test convention for the SIR22 base cut — a
+  hand-crafted `Module` compiled and asserted against the emitted source
+  STRING — not a new real-node-execution harness: TypeScript source
+  carries type annotations `node` cannot run directly, and this crate's
+  existing `tests/run_with_node.rs` already covers that gap for other
+  constructs via a hand-rolled stripping-plus-inline-stub shim, which
+  would need `sir-runtime-array`'s full logic hand-ported into it (or a
+  real `tsc`/`ts-node` dependency) to cover these nine new calls too —
+  out of scope for this PR, same as it was out of scope for the base cut.
+
+### Verified
+
+- `cargo test -p semantic-ir-to-typescript`: 143 tests green (118 in
+  `src/lib.rs` + `src/emit.rs`/`src/runtime.rs` unit tests, 6 in
+  `tests/polymorphic_operators.rs`, 19 in `tests/run_with_node.rs`).
+- `cargo clippy -p semantic-ir-to-typescript --all-targets`: clean.
+- Every downstream frontend crate that carries this backend as a
+  dev-dependency re-verified green: `apl-to-semantic-ir`,
+  `javascript-to-semantic-ir`, `macsyma-to-semantic-ir`,
+  `matlab-to-semantic-ir`, `octave-to-semantic-ir`, `j-to-semantic-ir`,
+  `wolfram-to-semantic-ir`, `sir-conformance`. None needed source
+  changes — this PR only ADDS codegen for previously-panicking/rejected
+  node kinds, it does not change behavior for any node kind another
+  frontend already emits.
+- `cargo build --workspace`: no new failures introduced (the one
+  pre-existing, environment-specific failure — `uefi`'s duplicate
+  `panic_impl` lang item — is unrelated to this change and was present
+  before it).
+
 ## 0.10.0 — SIR22 array/matrix codegen (HML01 Stream A, item 7 TS half)
 
 Real codegen for the SIR22 array/matrix domain's *base cut* — `ArrayLit`,

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/README.md
+++ b/code/packages/rust/semantic-ir-to-typescript/README.md
@@ -75,18 +75,16 @@ The TypeScript backend accepts these SIR features:
   (`__SirSym.rational(numer, denom)`); no other construct in this backend
   triggers it yet.
 - `NDArrays` / `MatrixOps` / `ArrayColumnMajor` (SIR22) — a compiled
-  MATLAB/Octave program's array/matrix nodes (`ArrayLit`/`Range`/`MatMul`/
-  `ElementwiseOp`/`Transpose`/`IndexGet`/`IndexSet`) construct/consume a
-  real `NDArray` value at runtime via the imported
+  MATLAB/Octave/APL program's array/matrix nodes — the base cut
+  (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/
+  `IndexSet`) AND the "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/
+  `Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) — both
+  construct/consume a real `NDArray` value at runtime via the imported
   `@coding-adventures/sir-runtime-array` package, bound as `__SirArray`
   (gated by any of the three features, so a purely-symbolic or purely-OOP
   module never gains the dependency). `A * A` (matrix product) emits
-  `__SirArray.matmul(A, A)`. The SIR22 "APL addendum" nodes (`Reduce`/
-  `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
-  `Ravel`/`Catenate`) share these same three features but remain deferred —
-  a dedicated tree walk (`find_unimplemented_sir22_addendum_node`) rejects
-  a module using one of them cleanly rather than reaching an emit-time
-  panic.
+  `__SirArray.matmul(A, A)`; APL's `+/A` (reduce) emits
+  `__SirArray.reduce("Add", A)`.
 
 It **rejects**:
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -1710,38 +1710,103 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             emit_index_args(out, indices, indent);
             out.push_str("])");
         }
-        // ── SIR22 addendum: APL primitive operators (still deferred) ──
-        // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
-        // `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` observe the SAME
-        // `NDArrays`/`MatrixOps`/`ArrayColumnMajor` features as the base
-        // cut above (the SIR22 addendum spec gives them no feature flag of
-        // their own) — `sir-runtime-array` itself never implemented them
-        // (no frontend needed them when that package shipped), so
-        // real codegen for these nine requires porting
-        // `array_runtime::ops::{reduce,scan,outer}` +
-        // `apl-runtime::builtins`'s bespoke shape/reshape/iota/index-of/
-        // ravel/catenate logic into that package first — a natural,
-        // cleanly-scoped follow-up, not part of this PR. See `lib.rs`'s
-        // `find_unimplemented_sir22_addendum_node` for why accepting
-        // `NDArrays`/`MatrixOps`/`ArrayColumnMajor` for the base cut above
-        // does not, by itself, silently let one of these nine slip past
-        // the capability check and reach this panic.
-        Expr::Reduce { .. }
-        | Expr::Scan { .. }
-        | Expr::OuterProduct { .. }
-        | Expr::Shape { .. }
-        | Expr::Reshape { .. }
-        | Expr::IndexGenerator { .. }
-        | Expr::IndexOf { .. }
-        | Expr::Ravel { .. }
-        | Expr::Catenate { .. }
+        // ── SIR22 addendum: APL primitive operators — real codegen ────
+        // Each of the nine maps 1:1 onto a call into the published
+        // `@coding-adventures/sir-runtime-array` package's own SIR22-
+        // addendum port (see that package's `reduce.ts`/`outer.ts`/
+        // `shape.ts`/`iota.ts`/`ravel.ts`) — the SAME `__SirArray` import
+        // the base cut above already gates in via `uses_array`, so no new
+        // import-gating logic is needed here. `Reduce`/`Scan`/
+        // `OuterProduct` carry an `ElementwiseOpKind` and so reuse
+        // `elementwise_op_ts_name` exactly like `ElementwiseOp` above does;
+        // the remaining six have no `op` field at all (they are "bespoke,
+        // not BinOp-shaped" per the SIR22 spec addendum and
+        // `apl_runtime::builtins`'s own doc comment) and just recurse into
+        // their operand(s).
+        Expr::Reduce { op, target, .. } => {
+            let _ = write!(
+                out,
+                "__SirArray.reduce({}, ",
+                quote_ts_string(elementwise_op_ts_name(*op))
+            );
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::Scan { op, target, .. } => {
+            let _ = write!(
+                out,
+                "__SirArray.scan({}, ",
+                quote_ts_string(elementwise_op_ts_name(*op))
+            );
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "__SirArray.outer({}, ",
+                quote_ts_string(elementwise_op_ts_name(*op))
+            );
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::Shape { target, .. } => {
+            out.push_str("__SirArray.shape(");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        // Field order here is `shape, target` (per the SIR22 spec: the
+        // shape vector is not interchangeable with the data being
+        // reshaped, so the node spells out the roles instead of reusing
+        // `lhs`/`rhs` — see `semantic_ir::Expr::Reshape`'s own doc comment
+        // in `nodes.rs`) — `sir-runtime-array`'s `reshape(shapeArg, target)`
+        // (`shape.ts`) takes that SAME order, so no argument reordering is
+        // needed at this call site (contrast `Expr::Range`'s `start, step,
+        // stop` vs. `range`'s `start, stop, step` just above, which DOES
+        // reorder — checked both directly rather than assumed, since this
+        // crate's own base-cut `Range` arm already proves field order can
+        // legitimately differ between a SIR node and its runtime callee).
+        Expr::Reshape { shape, target, .. } => {
+            out.push_str("__SirArray.reshape(");
+            emit_expr(out, shape, indent);
+            out.push_str(", ");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::IndexGenerator { count, .. } => {
+            out.push_str("__SirArray.indexGenerator(");
+            emit_expr(out, count, indent);
+            out.push(')');
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            out.push_str("__SirArray.indexOf(");
+            emit_expr(out, haystack, indent);
+            out.push_str(", ");
+            emit_expr(out, needle, indent);
+            out.push(')');
+        }
+        Expr::Ravel { target, .. } => {
+            out.push_str("__SirArray.ravel(");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            out.push_str("__SirArray.catenate(");
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
         // validated module.
-        | Expr::Convert { .. } => {
+        Expr::Convert { span, .. } => {
             panic!(
-                "typescript backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
-                e.kind_name(),
-                e.span()
+                "typescript backend reached a deferred SIR26 expression ({}) at {span} — not accepted yet",
+                e.kind_name()
             );
         }
         // SIR23 symbolic-expression/pattern nodes — construct/consume a

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -40,8 +40,7 @@ mod emit;
 mod runtime;
 
 use semantic_ir::{
-    walk_expr_default, Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr,
-    Feature, Module, Span, Visitor,
+    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Feature, Module,
 };
 
 pub use emit::sanitize_ident;
@@ -50,57 +49,6 @@ pub use emit::sanitize_ident;
 /// capability checks, and lowers to TypeScript source.
 pub fn compile(module: &Module) -> Result<Artifact, BackendError> {
     TypeScriptBackend::new().compile(module)
-}
-
-/// Finds the first (if any) SIR22 "APL addendum" node anywhere in a module —
-/// `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
-/// `IndexOf`/`Ravel`/`Catenate`.
-///
-/// These nine variants share `Feature::NDArrays`/`MatrixOps`/
-/// `ArrayColumnMajor` with the SIR22 *base* cut this backend accepts — the
-/// SIR22 addendum spec gives them no feature flag of their own — so the
-/// ordinary `accepts_features()` capability check cannot tell a module using
-/// only the base cut (real codegen, safe) from one that also uses these nine
-/// (still deferred in `emit`, would panic). This walk is the finer-grained
-/// check that closes that gap, mirroring the identical guard
-/// `semantic-ir-to-javascript` added for its own SIR22 codegen (found there
-/// by auditing `apl-to-semantic-ir`'s downstream tests: that crate's *real*
-/// lowering logic, not just a hand-built test fixture, emits `Reduce`/
-/// `Scan`/`OuterProduct` for APL's `+/`/`+\`/`∘.×` operators today,
-/// contradicting the SIR22 addendum spec's "no frontend crate consumes these
-/// yet" claim). Without this check, compiling such a module would sail past
-/// `accepts_features()` and panic inside `emit` instead of failing cleanly
-/// at the capability boundary — exactly the class of regression the
-/// existing `TailCalls` belt-and-suspenders check in
-/// [`TypeScriptBackend::compile`] guards against for a different feature.
-fn find_unimplemented_sir22_addendum_node(module: &Module) -> Option<(&'static str, Span)> {
-    struct Finder(Option<(&'static str, Span)>);
-    impl Visitor for Finder {
-        fn visit_expr(&mut self, e: &Expr, depth: usize) {
-            if self.0.is_none() {
-                let hit = match e {
-                    Expr::Reduce { span, .. } => Some(("Reduce", span.clone())),
-                    Expr::Scan { span, .. } => Some(("Scan", span.clone())),
-                    Expr::OuterProduct { span, .. } => Some(("OuterProduct", span.clone())),
-                    Expr::Shape { span, .. } => Some(("Shape", span.clone())),
-                    Expr::Reshape { span, .. } => Some(("Reshape", span.clone())),
-                    Expr::IndexGenerator { span, .. } => Some(("IndexGenerator", span.clone())),
-                    Expr::IndexOf { span, .. } => Some(("IndexOf", span.clone())),
-                    Expr::Ravel { span, .. } => Some(("Ravel", span.clone())),
-                    Expr::Catenate { span, .. } => Some(("Catenate", span.clone())),
-                    _ => None,
-                };
-                if hit.is_some() {
-                    self.0 = hit;
-                    return;
-                }
-            }
-            walk_expr_default(self, e, depth);
-        }
-    }
-    let mut finder = Finder(None);
-    finder.visit_module(module);
-    finder.0
 }
 
 /// The v0 TypeScript backend.
@@ -188,19 +136,15 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // construct in this backend triggers it yet, so accepting it is scoped
     // exactly to `SymRational`.
     Feature::Rationals,
-    // SIR22: the array/matrix domain's *base cut* — `ArrayLit`, `Range`,
-    // `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`) and
-    // `IndexSet` (a `Stmt`) lower to calls into the imported
-    // `@coding-adventures/sir-runtime-array` package (`__SirArray`), gated
-    // by `uses_array` — see `emit`'s SIR22 arms and
+    // SIR22: the full array/matrix domain — the base cut (`ArrayLit`,
+    // `Range`, `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an
+    // `Expr`), `IndexSet` (a `Stmt`)) AND the "APL addendum" (`Reduce`/
+    // `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+    // `Ravel`/`Catenate`) share these same three features (the addendum
+    // spec gives them no flag of their own) and both now lower to calls
+    // into the imported `@coding-adventures/sir-runtime-array` package
+    // (`__SirArray`), gated by `uses_array` — see `emit`'s SIR22 arms and
     // `code/specs/SIR22-array-matrix-semantic-ir.md` §"Backend impact".
-    // The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/
-    // `Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) share
-    // these SAME three features (the addendum gives them no flag of their
-    // own) but remain deferred in `emit` — see
-    // `find_unimplemented_sir22_addendum_node`'s doc comment for why
-    // accepting these three features doesn't fully close the
-    // capability/emit gap for those nine specifically.
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
@@ -246,27 +190,6 @@ impl Backend for TypeScriptBackend {
                 kind: BackendErrorKind::UnsupportedFeature,
                 message: "typescript backend cannot satisfy `tail_calls` feature".into(),
                 span: module.span.clone(),
-            });
-        }
-
-        // 3b. The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
-        //     `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
-        //     `Ravel`/`Catenate`) share `NDArrays`/`MatrixOps`/
-        //     `ArrayColumnMajor` with the SIR22 base cut this backend
-        //     accepts (the addendum gives them no flag of their own), so
-        //     step 2's coarse feature check cannot reject a module using
-        //     them — an explicit tree walk is the only way to catch this
-        //     before `emit` panics on one. See
-        //     `find_unimplemented_sir22_addendum_node`'s doc comment for
-        //     why this is a real, not theoretical, gap (`apl-to-semantic-ir`
-        //     emits these from real APL source today).
-        if let Some((kind, span)) = find_unimplemented_sir22_addendum_node(module) {
-            return Err(BackendError {
-                kind: BackendErrorKind::UnsupportedFeature,
-                message: format!(
-                    "typescript backend does not yet implement the SIR22 addendum node `{kind}`"
-                ),
-                span,
             });
         }
 
@@ -1912,10 +1835,22 @@ mod tests {
 
     // ── SIR22: array/matrix codegen (HML01 Stream A, item 7 TS half) ───
     //
-    // The base cut (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
-    // `IndexGet`/`IndexSet`) is accepted and lowers to calls into the
-    // imported `@coding-adventures/sir-runtime-array` runtime; see
-    // `runtime.rs`'s `RUNTIME_ARRAY` and `emit`'s SIR22 arms.
+    // Both the base cut (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+    // `Transpose`/`IndexGet`/`IndexSet`) and the "APL addendum" (`Reduce`/
+    // `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+    // `Ravel`/`Catenate`) are accepted and lower to calls into the imported
+    // `@coding-adventures/sir-runtime-array` package; see `runtime.rs`'s
+    // `RUNTIME_ARRAY` and `emit`'s SIR22 arms. These are structural (IR-to-
+    // string) tests only — this crate's OWN established convention for the
+    // base cut, unchanged for the addendum: `tests/run_with_node.rs` proves
+    // *other* emitted constructs actually run via a hand-rolled type-
+    // annotation-stripping + inline-stub-runtime shim (real `.ts` cannot run
+    // directly under plain `node`), but there is no array-specific e2e test
+    // at all for either the base cut or this addendum — building a real
+    // node-execution proof for `__SirArray` would need either a genuine
+    // `tsc`/`ts-node` toolchain dependency or hand-porting all of
+    // `sir-runtime-array`'s logic into that inline stub, and neither has
+    // been done (deliberately out of scope here, mirroring the base cut).
 
     #[test]
     fn accepts_nd_arrays_feature() {
@@ -1961,16 +1896,18 @@ mod tests {
         );
     }
 
-    /// Regression test for the gap `find_unimplemented_sir22_addendum_node`
-    /// closes: `apl-to-semantic-ir`'s real lowering emits `Expr::Reduce`
-    /// (APL `+/A`) with exactly these three features, and — before this
-    /// check existed — that module would sail past `accepts_features()`
-    /// (since `NDArrays`/`MatrixOps` are now accepted for the SIR22 base
-    /// cut) and panic inside `emit`. Must instead fail cleanly with
-    /// `UnsupportedFeature`, the same error kind every other still-deferred
-    /// node produces, not a panic.
+    /// Regression test for the gap this backend used to reject cleanly
+    /// (`find_unimplemented_sir22_addendum_node`, since removed):
+    /// `apl-to-semantic-ir`'s real lowering emits `Expr::Reduce` (APL
+    /// `+/A`) with exactly these three features. Before real codegen
+    /// existed, that module would sail past `accepts_features()` (since
+    /// `NDArrays`/`MatrixOps` are accepted for the SIR22 base cut) and
+    /// panic inside `emit`, so a dedicated tree-walk rejected it cleanly
+    /// instead. Now that real codegen exists, the module must instead
+    /// COMPILE — proof the gap is closed by an actual implementation, not
+    /// merely relocated.
     #[test]
-    fn rejects_reduce_node_cleanly_instead_of_panicking_in_emit() {
+    fn compiles_reduce_node_instead_of_rejecting_it() {
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[
             Feature::NDArrays,
@@ -1986,8 +1923,148 @@ mod tests {
             }),
             span: s(),
         };
-        let err = compile(&m).expect_err("Reduce node rejected cleanly, not a panic");
-        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        let artifact = compile(&m).expect("Reduce node now compiles");
+        assert!(
+            artifact
+                .source
+                .contains("__SirArray.reduce(\"Add\", __SirArray.fromRows([[1]]))"),
+            "got:\n{}",
+            artifact.source
+        );
+    }
+
+    /// One emitted-call-shape assertion per SIR22-addendum `Expr` variant
+    /// (mirrors `emits_array_lit_and_matmul_as_sir_array_calls`/
+    /// `emits_elementwise_op_with_pascal_case_op_name` above for the base
+    /// cut). `Reshape` gets its own dedicated test just below, proving
+    /// argument ORDER, not merely that the call shape is present.
+    #[test]
+    fn emits_all_nine_addendum_nodes_as_sir_array_calls() {
+        let features = &[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ];
+        let one = || {
+            Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            })
+        };
+        let two = || {
+            Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 2, span: s() }]],
+                span: s(),
+            })
+        };
+        let cases: Vec<(Expr, &str)> = vec![
+            (
+                Expr::Scan {
+                    op: semantic_ir::ElementwiseOpKind::Add,
+                    target: one(),
+                    span: s(),
+                },
+                "__SirArray.scan(\"Add\", __SirArray.fromRows([[1]]))",
+            ),
+            (
+                Expr::OuterProduct {
+                    op: semantic_ir::ElementwiseOpKind::Mul,
+                    lhs: one(),
+                    rhs: two(),
+                    span: s(),
+                },
+                "__SirArray.outer(\"Mul\", __SirArray.fromRows([[1]]), __SirArray.fromRows([[2]]))",
+            ),
+            (
+                Expr::Shape {
+                    target: one(),
+                    span: s(),
+                },
+                "__SirArray.shape(__SirArray.fromRows([[1]]))",
+            ),
+            (
+                Expr::IndexGenerator {
+                    count: one(),
+                    span: s(),
+                },
+                "__SirArray.indexGenerator(__SirArray.fromRows([[1]]))",
+            ),
+            (
+                Expr::IndexOf {
+                    haystack: one(),
+                    needle: two(),
+                    span: s(),
+                },
+                "__SirArray.indexOf(__SirArray.fromRows([[1]]), __SirArray.fromRows([[2]]))",
+            ),
+            (
+                Expr::Ravel {
+                    target: one(),
+                    span: s(),
+                },
+                "__SirArray.ravel(__SirArray.fromRows([[1]]))",
+            ),
+            (
+                Expr::Catenate {
+                    lhs: one(),
+                    rhs: two(),
+                    span: s(),
+                },
+                "__SirArray.catenate(__SirArray.fromRows([[1]]), __SirArray.fromRows([[2]]))",
+            ),
+        ];
+        for (value, expected_call) in cases {
+            let mut m = minimal_module();
+            m.manifest = FeatureManifest::from_features(features);
+            let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+            main.body.value = value;
+            let artifact = compile(&m).expect("addendum node compiles");
+            assert!(
+                artifact.source.contains(expected_call),
+                "expected `{expected_call}` in:\n{}",
+                artifact.source
+            );
+        }
+    }
+
+    /// Dedicated field-order test for `Reshape`: `semantic_ir::Expr::Reshape`'s
+    /// own field order is `shape, target` (checked directly in `nodes.rs`,
+    /// not assumed), and `sir-runtime-array`'s `reshape(shapeArg, target)`
+    /// (`shape.ts`) takes that SAME order — so, unlike `Expr::Range`'s
+    /// `start, step, stop` vs. `range`'s `start, stop, step` (which DOES
+    /// reorder at the call site, see `emits_range_with_stop_before_step_
+    /// argument_order` below), no reordering happens here. This test uses
+    /// two DISTINCT operands (`[[1]]` for `shape`, `[[2]]` for `target`) so
+    /// a real argument-order bug — accidentally swapping them — would fail
+    /// this assertion rather than passing by coincidence.
+    #[test]
+    fn emits_reshape_with_shape_before_target_argument_order() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::Reshape {
+            shape: Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 1, span: s() }]],
+                span: s(),
+            }),
+            target: Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit { value: 2, span: s() }]],
+                span: s(),
+            }),
+            span: s(),
+        };
+        let artifact = compile(&m).expect("reshape body compiles");
+        assert!(
+            artifact.source.contains(
+                "__SirArray.reshape(__SirArray.fromRows([[1]]), __SirArray.fromRows([[2]]))"
+            ),
+            "expected shape (`[[1]]`) before target (`[[2]]`); got:\n{}",
+            artifact.source
+        );
     }
 
     /// End-to-end version: a real module body using `Expr::ArrayLit` and


### PR DESCRIPTION
## Summary

Mirrors the already-merged `semantic-ir-to-javascript` PR that did the same thing for its own runtime: `apl-to-semantic-ir` genuinely lowers APL's `/` (reduce), `\` (scan), `∘.` (outer product), `⍴` (shape/reshape), `⍳` (index-generator/index-of), and `,` (ravel/catenate) to 9 real `semantic_ir::Expr` variants — the SIR22 spec's "APL addendum." This backend previously had the identical gap the JS backend had: a pre-`emit` tree-walk (`find_unimplemented_sir22_addendum_node`) cleanly rejected any module using one of these 9 kinds, and `emit.rs`'s own arm just `panic!`ed, since the imported `@coding-adventures/sir-runtime-array` package didn't implement them yet — that gap is now closed by the just-merged `sir-runtime-array` PR, which added `reduce`/`scan`/`outer`/`shape`/`reshape`/`indexGenerator`/`indexOf`/`ravel`/`catenate` to that package.

## Changes

- **`src/emit.rs`**: replaced the combined `panic!` arm with 9 real-codegen arms, each emitting a call into `__SirArray.*` (the already-imported npm package this backend uses for the SIR22 base cut too), reusing `elementwise_op_ts_name` for the three that carry an `ElementwiseOpKind`.
- **`src/lib.rs`**: removed `find_unimplemented_sir22_addendum_node` and its `compile()` call site — no longer needed now that real codegen exists. Updated `ACCEPTED_FEATURES`'s doc comment and other module-level doc comments describing the addendum as "still deferred."
- **`README.md`**: same "deferred" → "implemented" correction.
- Tests: mirror this crate's existing SIR22 base-cut convention — structural (hand-built `Module` → `compile()` → assert the emitted TypeScript string contains the expected `__SirArray.<fn>(...)` call), not a new e2e/node-execution harness (this crate has no array-specific e2e test at all, even for the base cut — building one would require either a real `tsc`/`ts-node` toolchain dependency or hand-porting all of `sir-runtime-array`'s logic into an inline stub, out of scope here). One dedicated test proves `Reshape`'s `(shape, target)` argument order isn't swapped in the emitted call.

**`Reshape` field order**: verified directly against both `semantic_ir::Expr::Reshape`'s own field order (`shape, target`) and `sir-runtime-array`'s `reshape(shapeArg, target)` parameter order — they match, so no reordering was needed at this call site (unlike `Expr::Range`, whose fields genuinely do need reordering against `range()`'s own parameter order at this crate's existing base-cut call site — checked both directly rather than assumed).

## Test plan

- [x] `cargo test -p semantic-ir-to-typescript` — 143 tests passing (118 unit + 6 `polymorphic_operators.rs` + 19 `run_with_node.rs`)
- [x] `cargo clippy -p semantic-ir-to-typescript --all-targets` — clean
- [x] Downstream consumers re-verified: `apl-to-semantic-ir`, `javascript-to-semantic-ir`, `macsyma-to-semantic-ir`, `matlab-to-semantic-ir`, `octave-to-semantic-ir`, `j-to-semantic-ir`, `wolfram-to-semantic-ir`, `sir-conformance` — all green, no source changes needed (only adding codegen for previously-panicking node kinds)
- [x] `cargo build --workspace` — no new failures (pre-existing environment-specific `uefi` failure unrelated)
- [x] `/security-review` — **PASSED, no vulnerabilities found** (specifically verified: no interpolation of attacker-controlled text into emitted TypeScript, the enum-to-string + string-quoting helpers reused by the new arms are unchanged and already-reviewed, `compile()`'s upstream validation/capability/tail-calls guards remain intact)
- [x] Rebased onto current `origin/main` tip, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)