### PR TITLE
feat(hl): Chapter 8 time & the clock for French, German, Italian, Portuguese

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -224,6 +224,8 @@
       "IT-NUM-6-10": "sei/sette/otto/nove/dieci (6-10; septem/octō → -tt-: sette/otto; sette…dieci → settembre…dicembre)",
       "IT-DAYS-WEEKDAYS": "lunedì/martedì/mercoledì/giovedì/venerdì (Mon-Fri; [planet] + dì ← diēs; accented -dì kept; = ES lunes/FR lundi)",
       "IT-DAYS-WEEKEND": "sabato/domenica (Sat/Sun; ← Sabbatum / diēs Dominica 'Lord's day'; = ES sábado/domingo)",
+      "IT-TIME-HOUR": "ora (hour ← hōra ← Greek hṓrā; time via feminine article: è l'una / sono le due)",
+      "IT-TIME-NOON-MIDNIGHT": "mezzogiorno/mezzanotte (noon/midnight; mezzo/mezza ← medius + giorno/notte)",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
@@ -234,6 +236,8 @@
       "FR-NUM-6-10": "six/sept/huit/neuf/dix (6-10; octō→huit erosion; dix→dime; sept…dix → septembre…décembre)",
       "FR-DAYS-WEEKDAYS": "lundi/mardi/mercredi/jeudi/vendredi (Mon-Fri; [planet-god] + di ← diēs; mardi=Mars=English Tuesday/Tiw)",
       "FR-DAYS-WEEKEND": "samedi/dimanche (Sat/Sun; samedi ← Sabbatum, dimanche ← diēs Dominica 'Lord's day'; di- moved to front)",
+      "FR-TIME-HOUR": "heure (hour ← hōra ← Greek hṓrā; silent h + liaison; il est deux heures)",
+      "FR-TIME-NOON-MIDNIGHT": "midi/minuit (noon/midnight ← medius diēs / media nox; mi- 'middle' + di/nuit)",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
@@ -244,6 +248,8 @@
       "GE-NUM-6-10": "sechs/sieben/acht/neun/zehn (6-10; Germanic twins of six…ten; zehn↔ten↔decem d→t; acht↔eight/Nacht -cht-)",
       "GE-DAYS-WEEKDAYS": "Montag/Dienstag/Mittwoch/Donnerstag/Freitag (Mon-Fri; Germanic gods = English days; Donnerstag=Thor=Thursday; Mittwoch 'mid-week' replaced Woden)",
       "GE-DAYS-WEEKEND": "Samstag/Sonntag (Sat/Sun; Samstag ← Sabbat/shabbāt NOT Saturn = ES sábado; Sonntag = Sun's day = Sunday)",
+      "GE-TIME-HOUR": "Uhr (clock/o'clock ← Latin hōra — a LATIN LOAN, unlike native numbers/day-gods; es ist zwei Uhr)",
+      "GE-TIME-NOON-MIDNIGHT": "Mittag/Mitternacht (noon/midnight; NATIVE compounds Mitte+Tag / Mitte+Nacht, vs Latin-loaned Uhr)",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
       "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
       "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
@@ -252,7 +258,9 @@
       "PT-NUM-1-5": "um/dois/três/quatro/cinco (1-5; ← ūnus…quīnque; um nasal; GENDER kept on two: dois/duas ← duo/duae)",
       "PT-NUM-6-10": "seis/sete/oito/nove/dez (6-10; ct→it shift octō→oito, noite/leite; sete…dez → setembro…dezembro)",
       "PT-DAYS-WEEKDAYS": "segunda/terça/quarta/quinta/sexta(-feira) (Mon-Fri; UNIQUE numbered feira days ← fēria 'feast-day'; ordinals of dois…seis; Church dropped planet-gods)",
-      "PT-DAYS-WEEKEND": "sábado/domingo (Sat/Sun; ← Sabbatum / diēs Dominica; domingo counted 1st → Monday='segunda' 2nd)"
+      "PT-DAYS-WEEKEND": "sábado/domingo (Sat/Sun; ← Sabbatum / diēs Dominica; domingo counted 1st → Monday='segunda' 2nd)",
+      "PT-TIME-HOUR": "hora (hour ← hōra ← Greek hṓrā; horas explicit: é uma hora / são duas horas)",
+      "PT-TIME-NOON-MIDNIGHT": "meio-dia/meia-noite (noon/midnight; meio/meia ← medius; noite ← noctem shows ct→it like oito)"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 8 — Time & the clock
+
+- **Chapter 8 authored** (`FR-C08-heure`, `-midi-minuit`): telling the time,
+  atom-first, reviewing Ch.6–7 via `reviews_of`.
+- **heure** ← Latin *hōra* ← Greek *hṓrā* ("a time of day," the *Horae* being the
+  season-goddesses) → English *hour*, the same word spelt apart (both keep the
+  silent Latin *h-*). Telling time: *il est une heure / deux heures* ("it is two
+  hours"), with the liaison *deu-z-eur*.
+- **midi / minuit** ← *medius diēs* "mid-day" / *media nox* "mid-night" — the two
+  unnumbered hours, each *mi-* ("middle," ← *medius*) + *-di* (*diēs*, the day of
+  *lundi*) / *-nuit* (*noctem*, cousin of English *night*). Aside: English *noon*
+  is Latin *nōna hōra* "ninth hour," drifted from mid-afternoon to midday.
+- Taxonomy: namespaced `FR-TIME-HOUR`, `FR-TIME-NOON-MIDNIGHT`.
+
 ## Chapter 7 — Days of the week
 
 - **Chapter 7 authored** (`FR-C07-jours-1`, `-jours-2`): the seven days, atom-first,

--- a/code/learning/human-languages/french/lessons/FR-C08-heure.md
+++ b/code/learning/human-languages/french/lessons/FR-C08-heure.md
@@ -1,0 +1,66 @@
+---
+id: FR-C08-heure
+chapter: 8
+type: word
+headword: heure
+gloss: hour / o'clock — telling the time
+concept_tag: FR-TIME-HOUR
+prerequisites: [FR-C06-nombres-1-5]
+sounds: [silent-h, liaison-z]
+roots: [hora-latin, hora-greek]
+etymology_hook: "heure ← Latin hōra ← Greek hṓrā 'season, time of day' → English hour; 'il est deux heures' = 'it is two hours'"
+est_minutes: 5
+reviews_of: [FR-C06-nombres-1-5, FR-C07-jours-2]
+---
+
+# heure — the hour, and telling the time
+
+## Warm-up
+
+[PAUSE 2s] With your numbers in hand, you can tell the time. The key word is
+**heure**, "hour" — and it's the same word as English *hour*, both worn down from
+Latin **hōra**, which the Romans borrowed from **Greek** *hṓrā*, "a season, a
+time of day."
+
+## Sounds you'll need
+
+- `silent-h` — the **h** of *heure* is silent (as in English *hour*): say *eur*.
+- `liaison-z` — because it starts with a vowel-sound, the number links onto it:
+  **deux heures** = *deu-**z**-eur*, **trois heures** = *troi-**z**-eur*.
+
+## The word, taken apart
+
+**heure** ← Latin **hōra** ← Greek **hṓrā**. The Greek word meant "a period, a
+season, the right time" (the goddesses of the seasons were the *Horae*); Latin
+narrowed it to "hour," and French wore *hōra* down to *heure*. English took the
+same Latin *hōra* and made *hour* — so *heure* and *hour* are the same word, spelt
+apart. (The silent *h* in both is a fossil of the Latin spelling.)
+
+## Grammar Lens: "il est … heure(s)"
+
+To tell the clock time, French says **il est** ("it is") + the number + **heure(s)**:
+
+> **Il est une heure.** — "It is one o'clock." (*une* heure — singular)
+> **Il est deux heures.** — "It is two o'clock." (*deux* heure**s** — plural)
+> **Il est dix heures.** — "It is ten o'clock."
+
+Literally "it is two **hours**" — French counts the hours, where English says
+"o'clock" (itself a worn-down "of the clock"). Add **et quart** ("and a quarter"),
+**et demie** ("and a half"), **moins le quart** ("quarter to") later; the core is
+*il est … heures*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "heure" — *eur*, silent h]
+- [YOU SAY: "il est une heure, il est deux heures, il est trois heures" — hear the
+  liaison *z*]
+- [YOU SAY: "heure / hour" — the same Latin *hōra*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin (and Greek) word is *heure* from, and its English twin?
+(*hōra* ← Greek *hṓrā*; English *hour*.) How does French say "it is three o'clock"?
+(*Il est trois heures* — "it is three hours.") Why does *deux heures* sound like
+*deu-z-eur*? (Liaison — the *x*/*s* links onto the vowel of *heure*.) Next: **midi**
+and **minuit** — noon and midnight.

--- a/code/learning/human-languages/french/lessons/FR-C08-midi-minuit.md
+++ b/code/learning/human-languages/french/lessons/FR-C08-midi-minuit.md
@@ -1,0 +1,59 @@
+---
+id: FR-C08-midi-minuit
+chapter: 8
+type: word
+headword: midi, minuit
+gloss: noon and midnight — the "mid-day" and "mid-night" hours
+concept_tag: FR-TIME-NOON-MIDNIGHT
+prerequisites: [FR-C08-heure]
+sounds: [nasal-in, silent-h]
+roots: [medius-dies-latin, media-nox-latin]
+etymology_hook: "midi ← medius diēs 'mid-day', minuit ← media nox 'mid-night' — the two hours named not by number but by the middle of day and night"
+est_minutes: 4
+reviews_of: [FR-C08-heure, FR-C07-jours-2]
+---
+
+# midi and minuit — noon and midnight
+
+## Warm-up
+
+[PAUSE 2s] Two hours don't get a number — they get a name. **midi** (noon) and
+**minuit** (midnight) are the pivots of the day, and both are literally "the
+**middle**" of the day and the night.
+
+## The two words, taken apart
+
+| French | ← Latin | literally |
+|---|---|---|
+| **midi** | *medius diēs* | "the **mid**-**day**" (*medius* "middle" + *diēs* "day") |
+| **minuit** | *media nox* | "the **mid**-**night**" (*media* "middle" + *nox/noct-* "night") |
+
+- **midi** = *medius diēs*, "mid-day." You can still see both halves: **mi-** is
+  "middle" (from *medius*, cousin of English *medium, mid, middle*), and **-di** is
+  the *diēs* "day" you met in *lundi/mardi*. So *midi* is "the day's middle."
+- **minuit** = *media nox*, "mid-night." Here **mi-** is again "middle," and
+  **-nuit** is *nox/noctem*, "night" (cousin of English *night*, and the *noct-* of
+  *nocturnal*). So *minuit* is "the night's middle" — exactly like English
+  **mid-night**.
+
+To use them, drop the *heures* — they *are* the hour:
+
+> **Il est midi.** — "It is noon." **Il est minuit.** — "It is midnight."
+
+(Fun aside: English **noon** comes from Latin *nōna hōra*, "the **ninth** hour" —
+once mid-afternoon, it drifted earlier to midday. French kept the tidier "mid-day.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "midi" (noon), "minuit" (midnight)]
+- [YOU SAY: break them — "midi = mi (middle) + di (day)", "minuit = mi + nuit
+  (night)"]
+- [YOU SAY: "Il est midi. Il est minuit." — no *heures* needed]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *midi* and *minuit* literally mean, and from what Latin? ("Mid-day"
+← *medius diēs*; "mid-night" ← *media nox*.) What are the two halves of *minuit*?
+(*mi* "middle" + *nuit* "night" ← *noctem*.) How do you say "it is noon"? (*Il est
+midi*.) Next chapter builds on this toward months and family.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -46,12 +46,15 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   = *[planet]* + *-di* ← *diēs*; *mardi* = Mars = English *Tuesday*/Tiw, the
   Roman-planet ↔ Germanic-god bridge) → samedi/dimanche (*Sabbatum* / *diēs
   Dominica* "Lord's day" — where religion overwrote the planets). **Authored.**
+- **Ch. 8 — Time & the clock**: heure (← *hōra* ← Greek *hṓrā* → *hour*; *il est
+  deux heures*, silent-h liaison) → midi/minuit (noon/midnight ← *medius diēs* /
+  *media nox* — "mid-day"/"mid-night"). **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 8+ | Time & the clock, months, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
+| 9+ | Months & seasons, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
 
 The *tu/vous* lesson (Ch. 2) is the French counterpart to Spanish *tú/usted*:
 same formal/informal split, but French makes the formal from the **plural**

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Chapter 8 — Time & the clock
+
+- **Chapter 8 authored** (`GE-C08-uhr`, `-mittag-mitternacht`): telling the time,
+  atom-first, reviewing Ch.6–7 via `reviews_of`.
+- **Uhr** — the **standout Latin loanword**: German's numbers are native (*eins,
+  zwei*) and its weekdays are Germanic gods (*Donnerstag*), but its *clock*-word
+  came from Latin **hōra** (the same *hōra* behind French *heure*, Italian *ora*,
+  English *hour*). Three layers of the day, three origins — native numbers,
+  Germanic day-gods, Latin clock. (Native *Stunde* = an hour's span; *Uhr* =
+  o'clock, no plural: *es ist zwei Uhr*.)
+- **Mittag / Mitternacht** — noon/midnight swing back to **native** compounds:
+  *Mitte* ("middle") + *Tag* ("day") / *Nacht* ("night," the *Nacht/night* twin
+  from the numbers). Same meaning as French *midi/minuit* (*medius diēs*), but
+  built from German's own words rather than borrowed.
+- Taxonomy: namespaced `GE-TIME-HOUR`, `GE-TIME-NOON-MIDNIGHT`.
+
 ## Chapter 7 — Days of the week
 
 - **Chapter 7 authored** (`GE-C07-wochentage-1`, `-wochentage-2`): the seven days,

--- a/code/learning/human-languages/german/lessons/GE-C08-mittag-mitternacht.md
+++ b/code/learning/human-languages/german/lessons/GE-C08-mittag-mitternacht.md
@@ -1,0 +1,63 @@
+---
+id: GE-C08-mittag-mitternacht
+chapter: 8
+type: word
+headword: Mittag, Mitternacht
+gloss: noon and midnight — native "mid-day" and "mid-night"
+concept_tag: GE-TIME-NOON-MIDNIGHT
+prerequisites: [GE-C08-uhr]
+sounds: [ch-ach, vowel-a]
+roots: [germanic-compounds]
+etymology_hook: "Mittag = Mitte + Tag ('mid-day'), Mitternacht = Mitte + Nacht ('mid-night') — native Germanic compounds, unlike the Latin-loaned Uhr"
+est_minutes: 4
+reviews_of: [GE-C08-uhr, GE-C07-wochentage-2]
+---
+
+# Mittag and Mitternacht — the native middle of day and night
+
+## Warm-up
+
+[PAUSE 2s] The clock-word *Uhr* was Latin. But noon and midnight swing back to
+**native German**: *Mittag* and *Mitternacht* are plain Germanic compounds — "the
+day's middle" and "the night's middle" — built from words you can already almost
+read.
+
+## The two words, taken apart
+
+Both start with **Mitte**, "middle" (cousin of English *mid, middle*, and of Latin
+*medius*):
+
+| German | = | literally |
+|---|---|---|
+| **Mittag** | *Mitte* + *Tag* | "**mid**-**day**" (noon) |
+| **Mitternacht** | *Mitter* (Mitte) + *Nacht* | "**mid**-**night**" (midnight) |
+
+- **Mittag** = "mid-day." *Tag* ("day") you met in *Montag, Dienstag*; put "middle"
+  in front and you get noon. Its meaning matches French *midi* (*medius diēs*)
+  exactly — same idea, but German built it from its **own** words instead of
+  borrowing the Latin one.
+- **Mitternacht** = "mid-night." *Nacht* ("night") is the twin of English *night*
+  (remember *acht/eight*, *Nacht/night* — the *-cht/-ght* pair). So *Mitternacht*
+  and English *mid-night* are the same compound in two Germanic tongues.
+
+To tell the time with them:
+
+> **Es ist Mittag.** — "It is noon." **Es ist Mitternacht.** — "It is midnight."
+
+So German splits the day three ways by origin: **Uhr** (Latin) for the hours,
+**Mittag/Mitternacht** (native) for its pivots.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Mittag" (noon), "Mitternacht" (midnight)]
+- [YOU SAY: break them — "Mitte (middle) + Tag (day)", "Mitte + Nacht (night)"]
+- [YOU SAY: "Mitternacht / mid-night" — the same Germanic compound]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *Mittag* and *Mitternacht* literally mean, and from what native
+word? ("Mid-day" / "mid-night"; from *Mitte* "middle" + *Tag/Nacht*.) How does this
+differ from *Uhr*? (*Uhr* is a **Latin loan**; these are **native** compounds.) What
+English word is *Mitternacht* the twin of? (*Midnight*.) Next chapter builds on this
+toward months and family.

--- a/code/learning/human-languages/german/lessons/GE-C08-uhr.md
+++ b/code/learning/human-languages/german/lessons/GE-C08-uhr.md
@@ -1,0 +1,71 @@
+---
+id: GE-C08-uhr
+chapter: 8
+type: word
+headword: Uhr
+gloss: clock / o'clock — and a Latin word inside German
+concept_tag: GE-TIME-HOUR
+prerequisites: [GE-C06-zahlen-1-5]
+sounds: [vowel-u-long, r-final]
+roots: [hora-latin]
+etymology_hook: "Uhr ← Latin hōra 'hour' — a LATIN LOANWORD, unlike German's native numbers and day-gods; the same hōra behind French heure and English hour"
+est_minutes: 5
+reviews_of: [GE-C06-zahlen-1-5, GE-C07-wochentage-2]
+---
+
+# Uhr — the clock, and a Roman word in the German day
+
+## Warm-up
+
+[PAUSE 2s] Something new happens here. German's numbers were homegrown (*eins,
+zwei*), and its weekdays were Germanic gods (*Donnerstag*). But its word for the
+**clock** — **Uhr** — is **borrowed from Latin**. Time-keeping came to the German
+world with Roman and monastic clocks, and the Latin word rode in with them.
+
+## Sounds you'll need
+
+- `vowel-u-long` — **Uhr** = *oor*, a long *u* then a soft *r*: one syllable.
+
+## The word, taken apart — a Latin loan among Germanic natives
+
+**Uhr** comes from Latin **hōra**, "hour" — the *same word* that became French
+*heure*, Italian *ora*, and English *hour*. German took it in (through medieval
+Latin/Low German *ūr(e)*) and made it *Uhr*.
+
+That's the striking part: three layers of the German day, three different origins —
+
+| what | German | origin |
+|---|---|---|
+| the **numbers** | *eins, zwei, drei* | **native Germanic** (twins of English) |
+| the **weekdays** | *Montag, Donnerstag* | **Germanic gods** (Latin *months*) |
+| the **clock** | **Uhr** | **Latin loan** (*hōra*) |
+
+German kept its own numbers and gods, but for the *machine that measures hours*, it
+reached for Rome. (German also has a native word, **Stunde**, "an hour's span" — but
+for clock-reading, "o'clock," it's *Uhr*.)
+
+## Grammar Lens: "Es ist … Uhr"
+
+To tell the time, German says **es ist** ("it is") + the number + **Uhr**:
+
+> **Es ist ein Uhr.** — "It is one o'clock."
+> **Es ist zwei Uhr.** — "It is two o'clock."
+> **Es ist zehn Uhr.** — "It is ten o'clock."
+
+**Uhr** doesn't add a plural here (not "*zwei Uhren*" for the time) — it works like
+English **o'clock**: *zwei Uhr* = "two o'clock." (*Uhren*, plural, means "clocks"
+the objects.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Uhr" — *oor*]
+- [YOU SAY: "Es ist ein Uhr, zwei Uhr, drei Uhr"]
+- [YOU SAY: "Uhr / heure / hour" — all from Latin *hōra*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does *Uhr* come from, and why is that notable? (Latin **hōra** — a
+loanword, unlike German's native numbers and Germanic day-gods.) Two French/English
+cousins of *Uhr*? (*heure*, *hour*.) How does German say "it is three o'clock"? (*Es
+ist drei Uhr*.) Next: **Mittag** and **Mitternacht** — noon and midnight.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -47,12 +47,16 @@ Spanish and French where a contrast helps. The recurring decoder is the
   "mid-week" exception where the Church dropped Woden, mirroring English keeping
   *Wednesday*) → Samstag/Sonntag (*Samstag* ← *Sabbat*, the Sabbath, **not** Saturn,
   twin of Spanish *sábado*; *Sonntag* = Sun's day = *Sunday*). **Authored.**
+- **Ch. 8 — Time & the clock**: Uhr (clock/o'clock ← Latin *hōra* — the **standout
+  Latin loanword** in a Germanic system of native numbers & day-gods; *es ist zwei
+  Uhr*) → Mittag/Mitternacht (noon/midnight, **native** compounds *Mitte* + *Tag* /
+  *Nacht*, unlike the borrowed *Uhr*). **Authored.**
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 8+ | Cases (der→den→dem), time & the clock, family, food, sprechen & irregular verbs — following the shared theme order |
+| 9+ | Cases (der→den→dem), months & seasons, family, food, sprechen & irregular verbs — following the shared theme order |
 
 The **du / Sie** lesson (Ch. 2) completes the formal/informal set across the
 languages: Spanish *tú/usted* (from "your grace"), French *tu/vous* (the

--- a/code/learning/human-languages/gujarati/lessons/GU-C03-vandho-nahi.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C03-vandho-nahi.md
@@ -4,7 +4,7 @@ chapter: 3
 type: phrase
 headword: વાંધો નહીં
 gloss: no problem / it's okay / you're welcome
-concept_tag: YOURE-WELCOME
+concept_tag: COURTESY-YOUREWELCOME
 prerequisites: [GU-C01-haa-naa, GU-C01-aabhaar]
 sounds: [nasal-aa, no-top-line]
 roots: [na-negative]

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 8 — Time & the clock
+
+- **Chapter 8 authored** (`IT-C08-ora`, `-mezzogiorno-mezzanotte`): telling the
+  time, atom-first, reviewing Ch.6–7 via `reviews_of`.
+- **ora** ← Latin *hōra* ← Greek *hṓrā* — the **closest of the sisters to Latin**
+  (French wore it to *heure*; Italian barely touched *hōra → ora*). The Italian
+  twist: time is told with the **feminine article**, the word *ore* left implied —
+  *è l'una* (one, singular) but *sono le due* ("they are the two [hours]").
+- **mezzogiorno / mezzanotte** — noon/midnight = *mezzo/mezza* ("half/middle," ←
+  *medius*, cousin of French *mi-*) + *giorno* (← *diurnum*, root of *journal/
+  journey*) / *notte* (← *noctem*). *mezza*notte is feminine (for *notte*),
+  *mezzo*giorno masculine (for *giorno*) — the gender system again.
+- Taxonomy: namespaced `IT-TIME-HOUR`, `IT-TIME-NOON-MIDNIGHT`.
+
 ## Chapter 7 — Days of the week
 
 - **Chapter 7 authored** (`IT-C07-giorni-1`, `-giorni-2`): the seven days,

--- a/code/learning/human-languages/italian/lessons/IT-C08-mezzogiorno-mezzanotte.md
+++ b/code/learning/human-languages/italian/lessons/IT-C08-mezzogiorno-mezzanotte.md
@@ -1,0 +1,63 @@
+---
+id: IT-C08-mezzogiorno-mezzanotte
+chapter: 8
+type: word
+headword: mezzogiorno, mezzanotte
+gloss: noon and midnight — "mid-day" and "mid-night"
+concept_tag: IT-TIME-NOON-MIDNIGHT
+prerequisites: [IT-C08-ora]
+sounds: [double-zz, gli-none]
+roots: [medius-latin, diurnum-noctem-latin]
+etymology_hook: "mezzogiorno = mezzo + giorno ('mid-day'), mezzanotte = mezza + notte ('mid-night'); mezzo ← medius, twin of French midi/minuit"
+est_minutes: 4
+reviews_of: [IT-C08-ora, IT-C07-giorni-2]
+---
+
+# mezzogiorno and mezzanotte — Italy's noon and midnight
+
+## Warm-up
+
+[PAUSE 2s] The two unnumbered hours. **mezzogiorno** (noon) and **mezzanotte**
+(midnight) are, like their French cousins, the **middle** of the day and the night —
+built from *mezzo* "half/middle" plus *giorno* "day" and *notte* "night."
+
+## Sounds you'll need
+
+- `double-zz` — **mezzo** = *MED-dzo*, the doubled *zz* a hard "ts/dz" — lean on it.
+
+## The two words, taken apart
+
+The front piece is **mezzo/mezza**, "half, middle," from Latin **medius** (cousin
+of English *medium, mid*, and of French *mi-* in *midi*):
+
+| Italian | = | ← Latin | literally |
+|---|---|---|---|
+| **mezzogiorno** | *mezzo* + *giorno* | *medius* + *diurnum* | "**mid**-**day**" (noon) |
+| **mezzanotte** | *mezza* + *notte* | *media* + *noctem* | "**mid**-**night**" (midnight) |
+
+- **mezzogiorno** = "mid-day." *giorno* ("day") is from Latin *diurnum* ("of the
+  day") — the same root as English *journal* and *journey* (a day's travel). So noon
+  is "the middle of the day-span."
+- **mezzanotte** = "mid-night." *notte* ("night") ← *noctem*, twin of English
+  *night* and French *nuit*. *mezza* is the **feminine** "half" (agreeing with the
+  feminine *notte*), where *mezzo* is masculine (with *giorno*) — the article
+  system you just met, again.
+
+To use them, they *are* the hour:
+
+> **È mezzogiorno.** — "It is noon." **È mezzanotte.** — "It is midnight."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mezzogiorno" (noon), "mezzanotte" (midnight)]
+- [YOU SAY: break them — "mezzo (middle) + giorno (day)", "mezza + notte (night)"]
+- [YOU SAY: "È mezzogiorno. È mezzanotte." — singular *è*, no number]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *mezzogiorno* and *mezzanotte* literally mean? ("Mid-day" and
+"mid-night.") What is *mezzo/mezza* from, and its French cousin? (Latin *medius*;
+French *mi-* in *midi/minuit*.) Why *mezza*notte but *mezzo*giorno? (*mezza* is
+feminine for *notte*, *mezzo* masculine for *giorno*.) Next chapter builds on this
+toward months and family.

--- a/code/learning/human-languages/italian/lessons/IT-C08-ora.md
+++ b/code/learning/human-languages/italian/lessons/IT-C08-ora.md
@@ -1,0 +1,63 @@
+---
+id: IT-C08-ora
+chapter: 8
+type: word
+headword: ora
+gloss: hour / o'clock — telling the time with the feminine article
+concept_tag: IT-TIME-HOUR
+prerequisites: [IT-C06-numeri-1-5]
+sounds: [open-o, r-single]
+roots: [hora-latin, hora-greek]
+etymology_hook: "ora ← Latin hōra ← Greek hṓrā → hour; time is told with the feminine article: 'sono le due' = 'it is the two [hours]'"
+est_minutes: 5
+reviews_of: [IT-C06-numeri-1-5, IT-C07-giorni-2]
+---
+
+# ora — the hour, told with "le"
+
+## Warm-up
+
+[PAUSE 2s] Italian's word for "hour" is **ora**, straight from Latin **hōra** (which
+Rome took from Greek *hṓrā*, "a time of day"). Telling the time in Italian has one
+neat twist: you use the **feminine article** and let *ore* ("hours") stay implied.
+
+## Sounds you'll need
+
+- `open-o` — **ora** = *OH-ra*, open *o*, single tapped *r*.
+
+## The word, taken apart
+
+**ora** ← Latin **hōra** ← Greek **hṓrā**. It's the closest of the sisters to the
+Latin: French wore it to *heure*, but Italian barely touched it — *hōra → ora*
+(Italian dropped the silent Latin *h-* in spelling, too). Same word as English
+*hour*, and as German's borrowed *Uhr*.
+
+## Grammar Lens: "è l'una" but "sono le due"
+
+Here's the twist. Italian tells the time with the **feminine article** (because
+*ora/ore* is feminine), and the verb agrees with the number:
+
+> **È l'una.** — "It is one o'clock." (singular: *è* "it is" + *l'una* = "the one
+> [hour]")
+> **Sono le due.** — "It is two o'clock." (plural: *sono* "they are" + *le due* =
+> "the two [hours]")
+> **Sono le dieci.** — "It is ten o'clock."
+
+Literally "**they are** the two [hours]" — Italian counts the hours as feminine
+things and drops the word *ore* entirely; the article **le** carries it. Only
+**one o'clock** is singular (*è l'una*); from two on, it's *sono le …*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ora" — *OH-ra*]
+- [YOU SAY: "è l'una … sono le due, sono le tre, sono le quattro"]
+- [YOU SAY: "ora / heure / Uhr / hour" — all Latin *hōra*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What word is *ora* from, and its sisters? (Latin *hōra* ← Greek *hṓrā*;
+French *heure*, German *Uhr*, English *hour*.) Why "*sono le* due" but "*è l'*una"?
+(Plural hours take *sono le …*; one o'clock is singular *è l'una*.) What word does
+the *le* stand in for? (*ore*, "hours" — feminine.) Next: **mezzogiorno** and
+**mezzanotte** — noon and midnight.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -43,12 +43,15 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   accented *-dì* ← *diēs* kept audible; three-sister lines *lunedì/lunes/lundi*;
   *giovedì* = Giove/Jupiter) → sabato/domenica (*Sabbatum* / *diēs Dominica* "Lord's
   day," twins of Spanish *sábado/domingo*). **Authored.**
+- **Ch. 8 — Time & the clock**: ora (hour ← *hōra* ← Greek *hṓrā*; the **feminine
+  article** twist — *è l'una* but *sono le due*) → mezzogiorno/mezzanotte
+  (noon/midnight; *mezzo/mezza* ← *medius* + *giorno/notte*). **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 8+ | Time & the clock, months, family, food — following the shared theme order |
+| 9+ | Months & seasons, family, food — following the shared theme order |
 
 Note: Italian's formal "you" is **Lei** — literally "she" (a 3rd-person
 politeness, like German *Sie*), a different mechanism from Spanish *usted* (a

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 8 — Time & the clock
+
+- **Chapter 8 authored** (`PT-C08-hora`, `-meio-dia-meia-noite`): telling the
+  time, atom-first, reviewing Ch.6–7 via `reviews_of`.
+- **hora** ← Latin *hōra* ← Greek *hṓrā* → *hour* (silent *h-* kept, as in English).
+  Unlike Italian, Portuguese keeps **horas** explicit: *é uma hora* (singular) /
+  *são duas horas* (plural), reusing the *é/são* split and the *dois/**duas***
+  gender from the numbers.
+- **meio-dia / meia-noite** — noon/midnight = *meio/meia* ("half/middle," ←
+  *medius/media*) + *dia* / *noite*. The payoff: *noite* ← *noctem* carries the
+  **ct→it shift** taught in the numbers chapter (*noctem → noite*, exactly like
+  *octō → oito*) — a direct callback. *meia*-noite feminine, *meio*-dia masculine.
+- Taxonomy: namespaced `PT-TIME-HOUR`, `PT-TIME-NOON-MIDNIGHT`.
+
 ## Chapter 7 — Days of the week
 
 - **Chapter 7 authored** (`PT-C07-dias-1`, `-dias-2`): the seven days, atom-first,

--- a/code/learning/human-languages/portuguese/lessons/PT-C08-hora.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C08-hora.md
@@ -1,0 +1,63 @@
+---
+id: PT-C08-hora
+chapter: 8
+type: word
+headword: hora
+gloss: hour / o'clock — telling the time
+concept_tag: PT-TIME-HOUR
+prerequisites: [PT-C06-numeros-1-5]
+sounds: [silent-h, open-o]
+roots: [hora-latin, hora-greek]
+etymology_hook: "hora ← Latin hōra ← Greek hṓrā → hour; 'são duas horas' keeps 'horas' explicit and plural"
+est_minutes: 5
+reviews_of: [PT-C06-numeros-1-5, PT-C07-dias-2]
+---
+
+# hora — the hour, said in full
+
+## Warm-up
+
+[PAUSE 2s] Portuguese "hour" is **hora**, from Latin **hōra** (← Greek *hṓrā*) — the
+same word behind Spanish *hora*, French *heure*, and English *hour*. And unlike
+Italian, which hides the word, Portuguese keeps **horas** right out loud.
+
+## Sounds you'll need
+
+- `silent-h` — the **h** of *hora* is silent (as everywhere in Portuguese): say
+  *OH-ra*.
+
+## The word, taken apart
+
+**hora** ← Latin **hōra** ← Greek **hṓrā**, "a time of day." Portuguese kept the
+Latin spelling's silent *h-*, exactly as English *hour* does. Line the sisters up:
+*hora / hora / heure / Uhr / hour* — one Roman word (itself Greek-born) fanned across
+five languages.
+
+## Grammar Lens: "é uma hora" but "são duas horas"
+
+Portuguese states the word **horas** in full, and the verb agrees with the number:
+
+> **É uma hora.** — "It is one o'clock." (singular: *é* "it is" + *uma hora*)
+> **São duas horas.** — "It is two o'clock." (plural: *são* "they are" + *duas
+> horas*)
+> **São dez horas.** — "It is ten o'clock."
+
+Literally "**they are** two **hours**." Two things to notice, both from earlier
+chapters: the verb is **é** (one) vs **são** (two or more), like Italian *è/sono*;
+and **two** still shows gender — *duas* horas (feminine, agreeing with *horas*),
+the *dois/duas* split you met in the numbers.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hora" — *OH-ra*, silent h]
+- [YOU SAY: "é uma hora … são duas horas, são três horas"]
+- [YOU SAY: "duas horas" — feminine *duas*, not *dois*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What word is *hora* from, and its Spanish twin? (Latin *hōra* ← Greek
+*hṓrā*; Spanish *hora*.) Why "*são duas* horas" but "*é uma* hora"? (Plural takes
+*são*; one o'clock is singular *é*.) Why *duas* and not *dois*? (*Horas* is feminine —
+the *dois/duas* gender split.) Next: **meio-dia** and **meia-noite** — noon and
+midnight.

--- a/code/learning/human-languages/portuguese/lessons/PT-C08-meio-dia-meia-noite.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C08-meio-dia-meia-noite.md
@@ -1,0 +1,58 @@
+---
+id: PT-C08-meio-dia-meia-noite
+chapter: 8
+type: word
+headword: meio-dia, meia-noite
+gloss: noon and midnight — "mid-day" and "mid-night"
+concept_tag: PT-TIME-NOON-MIDNIGHT
+prerequisites: [PT-C08-hora]
+sounds: [diphthong-ei, nasal-none]
+roots: [medius-latin, noctem-latin]
+etymology_hook: "meio-dia = meio + dia ('mid-day'), meia-noite = meia + noite ('mid-night'); noite ← noctem shows the ct→it shift from the numbers chapter (oito)"
+est_minutes: 4
+reviews_of: [PT-C08-hora, PT-C06-numeros-6-10, PT-C07-dias-2]
+---
+
+# meio-dia and meia-noite — noon and midnight
+
+## Warm-up
+
+[PAUSE 2s] The two named hours. **meio-dia** (noon) and **meia-noite** (midnight)
+are the **middle** of the day and the night — and *meia-noite* hides a sound-shift
+you already met back in the numbers.
+
+## The two words, taken apart
+
+The front piece is **meio/meia**, "half, middle," from Latin **medius/media**
+(cousin of English *mid, medium* and of Spanish *medio*):
+
+| Portuguese | = | ← Latin | literally |
+|---|---|---|---|
+| **meio-dia** | *meio* + *dia* | *medius* + *diēs* | "**mid**-**day**" (noon) |
+| **meia-noite** | *meia* + *noite* | *media* + *noctem* | "**mid**-**night**" (midnight) |
+
+- **meio-dia** = "mid-day." *dia* ("day") ← *diēs*; *meio* is masculine (agreeing
+  with the masculine *dia*).
+- **meia-noite** = "mid-night." *meia* is **feminine** (for the feminine *noite*) —
+  the *meio/meia* gender pair, like the *dois/duas* you know. And look at **noite**:
+  it comes from Latin **noctem**, and the *-ct-* became *-it-* — *noctem → noite* —
+  the **very same ct→it shift** that turned *octō* into *oito* ("8") in the numbers
+  chapter. Spot *-it-* and you can often guess a Latin *-ct-* underneath.
+
+To use them, they *are* the hour:
+
+> **É meio-dia.** — "It is noon." **É meia-noite.** — "It is midnight."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "meio-dia" (noon), "meia-noite" (midnight)]
+- [YOU SAY: break them — "meio (middle) + dia (day)", "meia + noite (night)"]
+- [YOU SAY: the shift — "noite ← noctem, like oito ← octō"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *meio-dia* and *meia-noite* literally mean? ("Mid-day" and
+"mid-night.") Why *meia*-noite but *meio*-dia? (*meia* feminine for *noite*, *meio*
+masculine for *dia*.) What earlier sound-shift is inside *noite*? (*ct→it*: *noctem
+→ noite*, like *octō → oito*.) Next chapter builds on this toward months and family.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -46,12 +46,16 @@ French.
   planet-gods (Bishop Martinho de Braga, 6th c.) → sábado/domingo (*Sabbatum* /
   *diēs Dominica*; *domingo* counted first, so Monday is *segunda* "second").
   **Authored.**
+- **Ch. 8 — Time & the clock**: hora (hour ← *hōra* ← Greek *hṓrā*; *horas* kept
+  explicit — *é uma hora* / *são duas horas*, with the *dois/duas* gender) →
+  meio-dia/meia-noite (noon/midnight; *noite* ← *noctem* shows the **ct→it** shift
+  from the numbers, like *oito*). **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 8+ | Time & the clock, months, family, food — following the shared theme order |
+| 9+ | Months & seasons, family, food — following the shared theme order |
 
 Note: Portuguese's polite "you" is **você** (← *vossa mercê*, "your mercy") — the
 same "your grace" mechanism as Spanish *usted*, worn down differently. Worth

--- a/code/learning/human-languages/sanskrit/lessons/SA-C03-na-cinta.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C03-na-cinta.md
@@ -4,7 +4,7 @@ chapter: 3
 type: phrase
 headword: न चिन्ता
 gloss: no worry / it's nothing / you're welcome
-concept_tag: YOURE-WELCOME
+concept_tag: COURTESY-YOUREWELCOME
 prerequisites: [SA-C01-am-na, SA-C01-dhanyavada]
 sounds: [inherent-a, nt-conjunct]
 roots: [na-negative, cint-think]


### PR DESCRIPTION
Parallel **time & the clock** chapters across the four non-Spanish tracks. Atom-first, two lessons each (the hour-word + noon/midnight), ~4–5 min, reviewing Ch.6–7 via `reviews_of`. The unifying thread: **heure / Uhr / ora / hora all descend from Latin *hōra* ← Greek *hṓrā*** — one word, five languages (with English *hour*), each with a distinct angle:

| Track | The angle |
|---|---|
| **French** | *heure* ← *hōra* (silent-h + liaison, *il est deux heures*); *midi/minuit* ← *medius diēs* / *media nox* ("mid-day"/"mid-night") |
| **German** | **The standout** — *Uhr* is a **Latin loanword** (← *hōra*) in a Germanic system whose numbers & day-gods are *native*; *Mittag/Mitternacht* swing back to native compounds (*Mitte* + *Tag/Nacht*) |
| **Italian** | *ora*, closest to Latin; the **feminine-article twist** (*è l'una* but *sono le due*); *mezzo/mezza* ← *medius* |
| **Portuguese** | *horas* kept explicit (*são duas horas*, *dois/duas* gender); *meia-noite*'s *noite* ← *noctem* is the **ct→it shift** from the numbers chapter (like *oito* ← *octō*) — a direct callback |

**Three-layer German story** deepens across chapters: numbers *native*, weekdays *Germanic gods* (Latin months), clock *Latin loan* (*Uhr*). Correct prefixes (FR-, **GE-**, IT-, PT-); namespaced `{FR,GE,IT,PT}-TIME-HOUR / -TIME-NOON-MIDNIGHT`; four roadmaps + CHANGELOGs advanced to "Next = Ch.9 (months/seasons)".

## Also: fixes red main (8th & 9th Indic tracks)
**Gujarati** `GU-C03-vandho-nahi` and **Sanskrit** `SA-C03-na-cinta` both carried the **retired** `concept_tag: YOURE-WELCOME`. Retagged both to canonical `COURTESY-YOUREWELCOME`. Must ride here because this PR edits `taxonomy.json`, which retriggers that suite. That's now **9 tracks** hit by this recurring pattern (Hindi → Tamil → Telugu → Kannada → Punjabi → Malayalam → Bengali → Gujarati → Sanskrit) — root-cause fix tracked in a separate task.

## Verification
- `human-language-data` suite: **38 / 38 pass** (was 3 failing on origin/main due to the Gujarati+Sanskrit tags).
- Security-reviewed (subagent): markdown + JSON only — no scripts, URLs, secrets, or injection; taxonomy.json validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)