### PR TITLE
feat(c-to-semantic-ir): control flow & comparisons (SIR27 milestone 2)

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Milestone 2 — control flow & comparisons
+
+- Comparisons `< > <= >= == !=` (with the usual arithmetic conversions on their
+  operands).  As a condition they lower to a SIR bool directly; as a **value**
+  they lower to `If(cmp, 1, 0)`, restoring C's int-typed `0`/`1`.
+- `if`/`else` → an `Expr::If` evaluated as a statement; `while` → `Stmt::While`;
+  `for` desugars to `init; while (cond) { body; step }`; re-assignment `x = e`
+  → `Stmt::Assign` (RHS converted to `x`'s declared type).
+- The **C-vs-SIR truthiness bridge**: a non-comparison condition `e` becomes
+  `!=(e, 0)` (C treats `0` as false; SIR treats it as truthy), so `while (n)`
+  terminates correctly.
+- Manifest now declares `Loops` + `MutableBindings`.
+- Early `return` (anywhere but the function's last statement) is a clean,
+  positioned error — SIR functions yield a block value with no early exit.
+- Conformance corpus grows with control-flow programs (accumulator `for`,
+  `while` countdown, `if/else` min, factorial, **uint8 wraparound accumulated in
+  a loop → 232**, comparison-as-value, equality branch) — all byte-identical
+  across reference `clang -fwrapv`, emitted Ruby, and emitted C.
+
 - Tests: `tests/three_way_conformance.rs` — a three-way conformance corpus that,
   for each milestone-1 C program, asserts byte-identical stdout across (1)
   reference C compiled `clang -fwrapv`, (2) emitted Ruby run with `ruby`, and (3)

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -70,6 +70,71 @@ mod tests {
         );
     }
 
+    // ── milestone 2: control flow & comparisons ─────────────────────────────
+
+    #[test]
+    fn while_loop_lowers_to_sir_while_with_bool_cond() {
+        let m = lower("int main(void) { int32_t i = 0; while (i < 3) { i = i + 1; } return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("(while"), "no while stmt:\n{text}");
+        // The condition is the comparison builtin directly (already a bool),
+        // not wrapped in a `!= 0`.
+        assert!(text.contains("(builtin-call <"), "no `<` cond:\n{text}");
+        assert!(text.contains("(assign i local"), "no reassign:\n{text}");
+    }
+
+    #[test]
+    fn for_loop_desugars_to_while_with_trailing_step() {
+        let m = lower(
+            "int main(void) { uint32_t s = 0; for (int i = 1; i <= 3; i = i + 1) { s = s + i; } return 0; }",
+        );
+        let text = semantic_ir::print_module(&m);
+        assert!(
+            text.contains("(while"),
+            "for did not desugar to while:\n{text}"
+        );
+        // init `i` is bound before the loop; the step reassigns it inside.
+        assert!(text.contains("(let* i "), "no loop-var init:\n{text}");
+        assert!(text.contains("(assign i local"), "no step assign:\n{text}");
+    }
+
+    #[test]
+    fn bare_int_condition_gets_ne_zero() {
+        // `while (n)` — a non-comparison condition — must become `!= 0`, since
+        // SIR treats 0 as truthy (C treats it as false).
+        let m = lower("int main(void) { int32_t n = 2; while (n) { n = n - 1; } return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(
+            text.contains("(builtin-call != (effects pure) (var-ref n local) (int 0))"),
+            "condition not bridged via != 0:\n{text}"
+        );
+    }
+
+    #[test]
+    fn comparison_as_value_is_if_one_else_zero() {
+        // `int c = a > b;` — the comparison is used as a value, so it is
+        // `If(cmp, 1, 0)` (C's int-typed 0/1 result).
+        let m = lower("int main(void) { int a = 5; int b = 3; int c = a > b; return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("(if (builtin-call >"), "no if-int:\n{text}");
+    }
+
+    #[test]
+    fn early_return_is_a_clean_error() {
+        // A `return` that is not the function's last statement has no SIR
+        // representation (no early exit) and must error, not miscompile.
+        let err = compile_source(
+            "int f(int x) { if (x == 0) { return 1; } return 0; }",
+            "test",
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("early `return`"),
+            "wrong error: {}",
+            err.message
+        );
+    }
+
     // ── end-to-end helpers ──────────────────────────────────────────────────
 
     fn run_ruby(m: &semantic_ir::Module) -> Option<String> {

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -8,9 +8,17 @@
 //! SIR arithmetic stays exact, the `Convert` after each width-bounded operation
 //! is what reproduces C's fixed-width overflow at every step (see SIR27).
 //!
-//! Milestone 1: functions, typed integer arithmetic/bitwise, casts,
-//! declarations & assignments, `printf`, and `return`.  Control flow and
-//! comparisons (which involve C-vs-SIR truthiness) land in a later milestone.
+//! Milestone 1: functions, typed integer `+`/`-`/`*`, casts, declarations,
+//! `printf`, and a trailing `return`.
+//!
+//! Milestone 2 (this revision) adds **comparisons and control flow** —
+//! `< > <= >= == !=`, `if`/`else`, `while`, `for`, and re-assignment — bridging
+//! the C-vs-SIR *truthiness mismatch* (C: `0` is false and a comparison yields
+//! `int` `0`/`1`; SIR: only nil/false are falsy and comparisons yield `bool`).
+//! A C condition lowers to a SIR bool (`!=(e, 0)`, or the comparison builtin
+//! directly), and a comparison used as a value lowers back to an int via
+//! `If(cmp, 1, 0)`.  Early `return` (anywhere but the function's last statement)
+//! stays deferred: SIR functions yield their block value, with no early exit.
 
 use std::collections::HashMap;
 
@@ -226,6 +234,27 @@ fn builtin(name: &str, args: Vec<Expr>) -> Expr {
     }
 }
 
+/// A block that is just a value expression (no statements) — the branches of a
+/// value-producing `If`, and the shape a nested `{ }` block reduces to.
+fn value_block(value: Expr) -> Block {
+    Block {
+        stmts: vec![],
+        value,
+        span: sp(),
+    }
+}
+
+/// Turn a SIR **bool** `cond` into the C **int** `0`/`1` it denotes as a value:
+/// `If(cond, 1, 0)`.  This restores C's rule that a comparison has type `int`.
+fn if_int(cond: Expr) -> Expr {
+    Expr::If {
+        cond: Box::new(cond),
+        then_branch: Box::new(value_block(int_lit(1))),
+        else_branch: Box::new(value_block(int_lit(0))),
+        span: sp(),
+    }
+}
+
 // ── The lowerer ──────────────────────────────────────────────────────────────
 
 struct Lowerer {
@@ -266,6 +295,11 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
         Feature::SizedIntegers,
         Feature::Unsigned,
         Feature::WrappingArithmetic,
+        // Milestone 2: `while`/`for` → `Stmt::While` (Loops); re-assignment →
+        // `Stmt::Assign` (MutableBindings).  `Expr::If` and the comparison
+        // builtins need no feature of their own (core control flow / intrinsics).
+        Feature::Loops,
+        Feature::MutableBindings,
     ]);
 
     let module = Module {
@@ -384,52 +418,38 @@ impl Lowerer {
     }
 
     /// Lower a `compound_stmt` as a function body: statements, then the value of
-    /// a trailing `return` (SIR functions return their block's value).
+    /// a trailing `return` (SIR functions return their block's value).  A
+    /// `return` anywhere but the last position has no SIR representation (no
+    /// early exit) and is a positioned error.
     fn lower_body(
         &mut self,
         body: &GrammarASTNode,
         ret: Option<IntSpec>,
     ) -> Result<Block, CLowerError> {
+        let items: Vec<&GrammarASTNode> = child_nodes(body)
+            .into_iter()
+            .filter(|x| x.rule_name == "block_item")
+            .collect();
         let mut stmts = Vec::new();
         let mut value = Expr::NilLit { span: sp() };
-        for item in child_nodes(body) {
-            if item.rule_name != "block_item" {
-                continue;
-            }
+        let last = items.len().saturating_sub(1);
+        for (i, item) in items.iter().enumerate() {
             let inner = peel_block_item(item);
             match inner.rule_name.as_str() {
                 "declaration" => stmts.push(self.lower_declaration(inner)?),
                 "statement" => {
                     let s = peel(inner);
-                    match s.rule_name.as_str() {
-                        "return_stmt" => {
-                            // Milestone 1: the return supplies the block value.
-                            value = match first_node(s, "expr") {
-                                Some(e) => {
-                                    let (ex, ty) = self.lower_expr(e)?;
-                                    match ret {
-                                        Some(rt) => convert_to(ex, ty, rt),
-                                        None => ex,
-                                    }
-                                }
-                                None => Expr::NilLit { span: sp() },
-                            };
-                        }
-                        "expr_stmt" => {
-                            if let Some(e) = first_node(s, "expr") {
-                                let (ex, _) = self.lower_expr(e)?;
-                                stmts.push(Stmt::ExprStmt {
-                                    expr: ex,
-                                    span: sp(),
-                                });
-                            }
-                        }
-                        other => {
+                    if s.rule_name == "return_stmt" {
+                        if i != last {
                             return err(
-                                format!("statement `{other}` not supported in milestone 1"),
+                                "early `return` is not supported yet (a `return` may appear \
+                                 only as the function's last statement)",
                                 s,
-                            )
+                            );
                         }
+                        value = self.lower_return(s, ret)?;
+                    } else {
+                        self.lower_stmt(s, &mut stmts)?;
                     }
                 }
                 other => return err(format!("block item `{other}` unsupported"), inner),
@@ -442,12 +462,367 @@ impl Lowerer {
         })
     }
 
+    /// The value a trailing `return e;` (or bare `return;`) supplies, converted
+    /// to the function's declared return type.
+    fn lower_return(
+        &mut self,
+        s: &GrammarASTNode,
+        ret: Option<IntSpec>,
+    ) -> Result<Expr, CLowerError> {
+        Ok(match first_node(s, "expr") {
+            Some(e) => {
+                let (ex, ty) = self.lower_expr(e)?;
+                match ret {
+                    Some(rt) => convert_to(ex, ty, rt),
+                    None => ex,
+                }
+            }
+            None => Expr::NilLit { span: sp() },
+        })
+    }
+
+    // ── statements (milestone 2) ─────────────────────────────────────────────
+
+    /// Lower one *statement-kind* node (already peeled from `statement`),
+    /// appending the resulting SIR statement(s) to `out`.
+    fn lower_stmt(&mut self, s: &GrammarASTNode, out: &mut Vec<Stmt>) -> Result<(), CLowerError> {
+        match s.rule_name.as_str() {
+            "compound_stmt" => {
+                // A nested `{ … }` block: splice its statements in (v1 shares one
+                // flat symbol table — no per-block scoping).
+                let inner = self.lower_block_items(s)?;
+                out.extend(inner);
+            }
+            "expr_stmt" => {
+                if let Some(e) = first_node(s, "expr") {
+                    self.lower_expr_stmt(e, out)?;
+                }
+            }
+            "if_stmt" => self.lower_if(s, out)?,
+            "while_stmt" => self.lower_while(s, out)?,
+            "for_stmt" => self.lower_for(s, out)?,
+            "return_stmt" => {
+                return err(
+                    "early `return` is not supported yet (a `return` may appear \
+                     only as the function's last statement)",
+                    s,
+                )
+            }
+            other => return err(format!("statement `{other}` not supported"), s),
+        }
+        Ok(())
+    }
+
+    /// Lower every `block_item` of a `compound_stmt` into a flat `Vec<Stmt>`.
+    fn lower_block_items(&mut self, compound: &GrammarASTNode) -> Result<Vec<Stmt>, CLowerError> {
+        let mut out = Vec::new();
+        for item in child_nodes(compound) {
+            if item.rule_name != "block_item" {
+                continue;
+            }
+            let inner = peel_block_item(item);
+            match inner.rule_name.as_str() {
+                "declaration" => out.push(self.lower_declaration(inner)?),
+                "statement" => {
+                    let s = peel(inner);
+                    self.lower_stmt(s, &mut out)?;
+                }
+                other => return err(format!("block item `{other}` unsupported"), inner),
+            }
+        }
+        Ok(out)
+    }
+
+    /// Lower a loop/branch body (`statement`, possibly a `compound_stmt`) to a
+    /// SIR `Block` with a nil value — control-flow bodies are evaluated for
+    /// their effects, not a value.
+    fn lower_void_block(&mut self, stmt: &GrammarASTNode) -> Result<Block, CLowerError> {
+        let s = peel(stmt);
+        let stmts = if s.rule_name == "compound_stmt" {
+            self.lower_block_items(s)?
+        } else {
+            let mut v = Vec::new();
+            self.lower_stmt(s, &mut v)?;
+            v
+        };
+        Ok(Block {
+            stmts,
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        })
+    }
+
+    /// An expression used as a statement: an assignment `x = e` becomes
+    /// `Stmt::Assign`, anything else a bare `ExprStmt` (evaluated for effect).
+    fn lower_expr_stmt(
+        &mut self,
+        expr_node: &GrammarASTNode,
+        out: &mut Vec<Stmt>,
+    ) -> Result<(), CLowerError> {
+        let p = peel(expr_node);
+        if p.rule_name == "assignment" && child_tokens(p).iter().any(|t| t.value == "=") {
+            out.push(self.lower_assignment(p)?);
+        } else {
+            let (ex, _) = self.lower_expr(expr_node)?;
+            out.push(Stmt::ExprStmt {
+                expr: ex,
+                span: sp(),
+            });
+        }
+        Ok(())
+    }
+
+    /// `x = e` → `Stmt::Assign` with the RHS converted to `x`'s declared type.
+    /// The LHS must be a bare, already-declared name (the only lvalue in v1).
+    fn lower_assignment(&mut self, n: &GrammarASTNode) -> Result<Stmt, CLowerError> {
+        let nodes = child_nodes(n);
+        let lhs = nodes.first().copied().ok_or_else(|| CLowerError {
+            message: "assignment without a left-hand side".into(),
+            line: n.start_line.unwrap_or(0),
+            column: n.start_column.unwrap_or(0),
+        })?;
+        let name = child_tokens(peel(lhs))
+            .iter()
+            .find(|t| t.effective_type_name() == "NAME")
+            .map(|t| t.value.clone())
+            .ok_or_else(|| CLowerError {
+                message: "assignment target is not a plain variable".into(),
+                line: n.start_line.unwrap_or(0),
+                column: n.start_column.unwrap_or(0),
+            })?;
+        let (ty, scope) = self.vars.get(&name).copied().ok_or_else(|| CLowerError {
+            message: format!("assignment to undeclared variable `{name}`"),
+            line: n.start_line.unwrap_or(0),
+            column: n.start_column.unwrap_or(0),
+        })?;
+        let rhs = nodes.get(1).copied().ok_or_else(|| CLowerError {
+            message: "assignment without a right-hand side".into(),
+            line: n.start_line.unwrap_or(0),
+            column: n.start_column.unwrap_or(0),
+        })?;
+        let (e, et) = self.lower_expr(rhs)?;
+        Ok(Stmt::Assign {
+            name,
+            scope,
+            value: convert_to(e, et, ty),
+            span: sp(),
+        })
+    }
+
+    /// `if (c) S1 [else S2]` → an `If` expression evaluated as a statement.
+    fn lower_if(&mut self, s: &GrammarASTNode, out: &mut Vec<Stmt>) -> Result<(), CLowerError> {
+        let cond_node = first_node(s, "expr").ok_or_else(|| CLowerError {
+            message: "`if` without a condition".into(),
+            line: s.start_line.unwrap_or(0),
+            column: s.start_column.unwrap_or(0),
+        })?;
+        let cond = self.lower_cond(cond_node)?;
+        let branches: Vec<&GrammarASTNode> = child_nodes(s)
+            .into_iter()
+            .filter(|x| x.rule_name == "statement")
+            .collect();
+        let then_branch =
+            self.lower_void_block(branches.first().ok_or_else(|| CLowerError {
+                message: "`if` without a body".into(),
+                line: s.start_line.unwrap_or(0),
+                column: s.start_column.unwrap_or(0),
+            })?)?;
+        let else_branch = match branches.get(1) {
+            Some(e) => self.lower_void_block(e)?,
+            None => Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: sp() },
+                span: sp(),
+            },
+        };
+        out.push(Stmt::ExprStmt {
+            expr: Expr::If {
+                cond: Box::new(cond),
+                then_branch: Box::new(then_branch),
+                else_branch: Box::new(else_branch),
+                span: sp(),
+            },
+            span: sp(),
+        });
+        Ok(())
+    }
+
+    /// `while (c) S` → `Stmt::While`.
+    fn lower_while(&mut self, s: &GrammarASTNode, out: &mut Vec<Stmt>) -> Result<(), CLowerError> {
+        let cond_node = first_node(s, "expr").ok_or_else(|| CLowerError {
+            message: "`while` without a condition".into(),
+            line: s.start_line.unwrap_or(0),
+            column: s.start_column.unwrap_or(0),
+        })?;
+        let cond = self.lower_cond(cond_node)?;
+        let body_node = first_node(s, "statement").ok_or_else(|| CLowerError {
+            message: "`while` without a body".into(),
+            line: s.start_line.unwrap_or(0),
+            column: s.start_column.unwrap_or(0),
+        })?;
+        let body = self.lower_void_block(body_node)?;
+        out.push(Stmt::While {
+            cond,
+            body,
+            span: sp(),
+        });
+        Ok(())
+    }
+
+    /// `for (init; cond; step) S` desugars to `init; while (cond) { S; step }`.
+    /// Children are walked in order, bucketed by the two `;` separators.
+    fn lower_for(&mut self, s: &GrammarASTNode, out: &mut Vec<Stmt>) -> Result<(), CLowerError> {
+        let (mut init, mut cond, mut step, mut body) = (None, None, None, None);
+        let mut semicolons = 0;
+        for child in &s.children {
+            match child {
+                ASTNodeOrToken::Token(t) if t.value == ";" => semicolons += 1,
+                ASTNodeOrToken::Token(_) => {}
+                ASTNodeOrToken::Node(x) => match x.rule_name.as_str() {
+                    "for_clause" => init = Some(x),
+                    "statement" => body = Some(x),
+                    "expr" if semicolons == 1 => cond = Some(x),
+                    "expr" => step = Some(x),
+                    _ => {}
+                },
+            }
+        }
+
+        // init clause: a declaration (`int i = 0`) or an expression (`i = 0`).
+        if let Some(fc) = init {
+            let inner = child_nodes(fc)
+                .into_iter()
+                .next()
+                .ok_or_else(|| CLowerError {
+                    message: "empty `for` init clause".into(),
+                    line: fc.start_line.unwrap_or(0),
+                    column: fc.start_column.unwrap_or(0),
+                })?;
+            if inner.rule_name == "init_declarator" {
+                out.push(self.lower_init_declarator(inner)?);
+            } else {
+                self.lower_expr_stmt(inner, out)?;
+            }
+        }
+
+        // condition: absent means `true` (an unconditional loop).
+        let cond_expr = match cond {
+            Some(c) => self.lower_cond(c)?,
+            None => Expr::BoolLit {
+                value: true,
+                span: sp(),
+            },
+        };
+
+        // body then the step expression, all inside the loop.
+        let body_node = body.ok_or_else(|| CLowerError {
+            message: "`for` without a body".into(),
+            line: s.start_line.unwrap_or(0),
+            column: s.start_column.unwrap_or(0),
+        })?;
+        let mut body_block = self.lower_void_block(body_node)?;
+        if let Some(st) = step {
+            self.lower_expr_stmt(st, &mut body_block.stmts)?;
+        }
+        out.push(Stmt::While {
+            cond: cond_expr,
+            body: body_block,
+            span: sp(),
+        });
+        Ok(())
+    }
+
+    // ── conditions & comparisons (milestone 2) ───────────────────────────────
+
+    /// Lower a C condition expression to a SIR **bool**, bridging truthiness.
+    /// A syntactic comparison yields a bool directly; any other integer
+    /// expression `e` becomes `!=(e, 0)` (C: non-zero is true; SIR: 0 is truthy,
+    /// so the explicit compare is required).
+    fn lower_cond(&mut self, node: &GrammarASTNode) -> Result<Expr, CLowerError> {
+        let n = peel(node);
+        if matches!(n.rule_name.as_str(), "equality" | "relational") && child_nodes(n).len() >= 2 {
+            self.lower_compare_bool(n)
+        } else {
+            let (e, _t) = self.lower_expr(node)?;
+            Ok(builtin("!=", vec![e, int_lit(0)]))
+        }
+    }
+
+    /// Lower an `equality`/`relational` node to a SIR bool.  Left-associative:
+    /// an intermediate comparison result feeds the next as an `int` `0`/`1`
+    /// (matching C's chained-comparison semantics), and the final step is the
+    /// bool we return.
+    fn lower_compare_bool(&mut self, n: &GrammarASTNode) -> Result<Expr, CLowerError> {
+        let mut acc: Option<(Expr, IntSpec)> = None;
+        let mut pending_op: Option<String> = None;
+        let mut last_bool: Option<Expr> = None;
+        for c in &n.children {
+            match c {
+                ASTNodeOrToken::Node(operand) => {
+                    let (e, t) = self.lower_expr(operand)?;
+                    match acc.take() {
+                        None => acc = Some((e, t)),
+                        Some((le, lt)) => {
+                            let op = pending_op.take().ok_or_else(|| CLowerError {
+                                message: "comparison operands with no operator between them".into(),
+                                line: n.start_line.unwrap_or(0),
+                                column: n.start_column.unwrap_or(0),
+                            })?;
+                            let b = self.compare(&op, le, lt, e, t)?;
+                            last_bool = Some(b.clone());
+                            acc = Some((if_int(b), i32_spec()));
+                        }
+                    }
+                }
+                ASTNodeOrToken::Token(t) => pending_op = Some(t.value.clone()),
+            }
+        }
+        last_bool.ok_or_else(|| CLowerError {
+            message: "comparison without an operator".into(),
+            line: n.start_line.unwrap_or(0),
+            column: n.start_column.unwrap_or(0),
+        })
+    }
+
+    /// Emit a comparison builtin, applying the usual arithmetic conversions to
+    /// the operands first (like arithmetic).  The result is a SIR bool.
+    fn compare(
+        &self,
+        op: &str,
+        le: Expr,
+        lt: IntSpec,
+        re: Expr,
+        rt: IntSpec,
+    ) -> Result<Expr, CLowerError> {
+        let lp = promote(lt);
+        let rp = promote(rt);
+        let le = convert_to(le, lt, lp);
+        let re = convert_to(re, rt, rp);
+        let c = common_type(lp, rp);
+        let le = convert_to(le, lp, c);
+        let re = convert_to(re, rp, c);
+        match op {
+            "<" | ">" | "<=" | ">=" | "==" | "!=" => Ok(builtin(op, vec![le, re])),
+            other => Err(CLowerError {
+                message: format!("comparison operator `{other}` unsupported"),
+                line: 0,
+                column: 0,
+            }),
+        }
+    }
+
     fn lower_declaration(&mut self, decl: &GrammarASTNode) -> Result<Stmt, CLowerError> {
         let init = first_node(decl, "init_declarator").ok_or_else(|| CLowerError {
             message: "declaration without declarator".into(),
             line: decl.start_line.unwrap_or(0),
             column: decl.start_column.unwrap_or(0),
         })?;
+        self.lower_init_declarator(init)
+    }
+
+    /// Lower an `init_declarator` (`T name [= expr]`) to a `LetStarBinding`.
+    /// Shared by ordinary declarations and `for`-init clauses.
+    fn lower_init_declarator(&mut self, init: &GrammarASTNode) -> Result<Stmt, CLowerError> {
         let ts = first_node(init, "type_spec").ok_or_else(|| CLowerError {
             message: "declaration without a type specifier".into(),
             line: init.start_line.unwrap_or(0),
@@ -487,15 +862,19 @@ impl Lowerer {
             "additive" | "multiplicative" | "shift" | "bit_and" | "bit_or" | "bit_xor" => {
                 self.lower_binary(n)
             }
+            // A comparison used as a *value* has type `int` in C (0 or 1), so it
+            // lowers to `If(cmp, 1, 0)` — restoring the integer from the bool.
+            "equality" | "relational" if child_nodes(n).len() >= 2 => {
+                let b = self.lower_compare_bool(n)?;
+                Ok((if_int(b), i32_spec()))
+            }
             "cast" => self.lower_cast(n),
             "unary" => self.lower_unary(n),
             "postfix" => self.lower_postfix(n),
             "primary" => self.lower_primary(n),
-            // Comparison / logical / assignment operators are deferred.
-            other => err(
-                format!("expression `{other}` not supported in milestone 1"),
-                n,
-            ),
+            // Logical `&& ||`, unary `!`, and assignment-as-subexpression remain
+            // deferred (assignment is handled in statement position).
+            other => err(format!("expression `{other}` not yet supported"), n),
         }
     }
 

--- a/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
+++ b/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
@@ -254,6 +254,57 @@ fn corpus() -> Vec<Case> {
                    int add(int a, int b) { return a + b; }\n\
                    int main(void) { printf(\"%d\\n\", add(2, 3)); return 0; }",
         },
+        // ── milestone 2: control flow & comparisons ──────────────────────────
+        Case {
+            label: "for-loop accumulator sum(1..100) → 5050",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { uint32_t sum = 0; \
+                   for (int i = 1; i <= 100; i = i + 1) { sum = sum + i; } \
+                   printf(\"%u\\n\", sum); return 0; }",
+        },
+        Case {
+            label: "while countdown sum(5..1) → 15",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { int32_t i = 5; int32_t acc = 0; \
+                   while (i > 0) { acc = acc + i; i = i - 1; } \
+                   printf(\"%d\\n\", acc); return 0; }",
+        },
+        Case {
+            label: "if/else min(7,3) → 3",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int min(int a, int b) { int r = 0; \
+                   if (a < b) { r = a; } else { r = b; } return r; }\n\
+                   int main(void) { printf(\"%d\\n\", min(7, 3)); return 0; }",
+        },
+        Case {
+            label: "factorial loop 10! → 3628800",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { uint32_t f = 1; \
+                   for (int i = 1; i <= 10; i = i + 1) { f = f * i; } \
+                   printf(\"%u\\n\", f); return 0; }",
+        },
+        Case {
+            // The headline of milestone 2: fixed-width wraparound survives loop
+            // mutation — `x = x + 100` on a uint8_t, ten times, wraps every step.
+            label: "uint8 wraparound accumulated in a loop → 232",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { uint8_t x = 0; \
+                   for (int i = 0; i < 10; i = i + 1) { x = x + 100; } \
+                   printf(\"%d\\n\", x); return 0; }",
+        },
+        Case {
+            label: "comparison as a value (5 > 3) → 1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { int a = 5; int b = 3; int c = a > b; \
+                   printf(\"%d\\n\", c); return 0; }",
+        },
+        Case {
+            label: "equality branch classify(0) → 100",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int classify(int x) { int r = 0; \
+                   if (x == 0) { r = 100; } else { r = 200; } return r; }\n\
+                   int main(void) { printf(\"%d\\n\", classify(0)); return 0; }",
+        },
     ]
 }
 

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.4.0 — control flow, mutation & the rest of the comparisons (SIR16)
+
+Accepts `Feature::Loops` and `Feature::MutableBindings`, and:
+
+- Renders `Stmt::While` as a portable `for (;;) { SirValue c; c = <cond>; if
+  (!_sir_truthy(c)) break; <body> }` — the condition is re-evaluated each
+  iteration, so it may be compound.
+- Renders `Stmt::Assign` (re-binding an already-declared `SirValue`).
+- Adds the missing comparison builtins `<=`, `>=`, `==`, `!=` (runtime helpers
+  `_sir_le`/`_sir_ge`/`_sir_ne`; previously only `<`/`>`/`=` were lowered, so a
+  `<=` reached `_sir_unknown_builtin` and failed).
+- **Portability fix:** user functions named `min`/`max` are now escaped (trailing
+  `_`).  `<stdlib.h>` on MSVC/UCRT defines `min`/`max` as function-like macros,
+  so `SirValue min(SirValue a, SirValue b)` expanded to garbage under clang-cl /
+  MSVC — now they compile on all three compilers.
+
 ## 0.3.0 — lower unary minus (`neg` builtin) — negative literals no longer skip
 
 Ruby lowers unary minus (`-x`) to `BuiltinCall("neg", [x])`, but the v0 C

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -314,10 +314,32 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 let _ = writeln!(out, "{pad}(void){tmp};");
             }
         }
-        // SIR16+ statements (Assign / loops / index-set / class / try) are not
-        // accepted in v0; the capability check rejects such modules before
-        // emit, so these are unreachable here.
-        other => unreachable!("v0 C backend reached unsupported statement: {other:?}"),
+        // SIR16 re-binding: the target `SirValue` is already declared (by an
+        // earlier `LetStarBinding`), so this reuses `emit_assign` (which handles
+        // a simple value or a compound `If`/`Convert`).
+        Stmt::Assign { name, value, .. } => {
+            let n = sanitize_ident(name);
+            emit_assign(out, &n, value, indent);
+        }
+        // SIR16 loop.  Portable shape that re-evaluates a possibly-compound
+        // condition every iteration:
+        //   for (;;) { SirValue c; <c = cond>; if (!_sir_truthy(c)) break; <body> }
+        Stmt::While { cond, body, .. } => {
+            let _ = writeln!(out, "{pad}for (;;) {{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let ctmp = format!("_sir_w{}", fresh_id());
+            let _ = writeln!(out, "{ipad}SirValue {ctmp};");
+            emit_assign(out, &ctmp, cond, inner);
+            let _ = writeln!(out, "{ipad}if (!_sir_truthy({ctmp})) break;");
+            for st in &body.stmts {
+                emit_stmt(out, st, inner);
+            }
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // Other SIR16+ statements (ForRange/ForEach/index-set/class/try) are not
+        // accepted; the capability check rejects such modules before emit.
+        other => unreachable!("C backend reached unsupported statement: {other:?}"),
     }
 }
 
@@ -804,6 +826,11 @@ fn fixed_helper(name: &str) -> Option<(&'static str, usize)> {
         "case_eq" => ("_sir_case_eq", 2),
         "<" => ("_sir_lt", 2),
         ">" => ("_sir_gt", 2),
+        // Milestone 2 comparisons (the C frontend emits the operator spellings).
+        "<=" => ("_sir_le", 2),
+        ">=" => ("_sir_ge", 2),
+        "==" => ("_sir_eq", 2),
+        "!=" => ("_sir_ne", 2),
         "cons" => ("_sir_cons", 2),
         "car" => ("_sir_car", 1),
         "cdr" => ("_sir_cdr", 1),
@@ -848,6 +875,7 @@ pub fn sanitize_ident(s: &str) -> String {
         out.push('_');
     }
     if is_c_keyword(&out)
+        || is_reserved_macro(&out)
         || out.starts_with("_sir")
         || out == "main"
         || out == "user_main"
@@ -856,6 +884,16 @@ pub fn sanitize_ident(s: &str) -> String {
         out.push('_');
     }
     out
+}
+
+/// Standard-library / platform *function-like macros* that are not C keywords
+/// but would wreck a same-named function definition.  `<stdlib.h>` on MSVC/UCRT
+/// (and `<windows.h>`) define `min`/`max` as macros, so `SirValue min(SirValue
+/// a, SirValue b)` expands to garbage under clang-cl / MSVC — a portability trap
+/// the three-compiler mandate must dodge.  Escaping them (a trailing `_`) keeps
+/// a user function called `min` compiling everywhere.
+fn is_reserved_macro(s: &str) -> bool {
+    matches!(s, "min" | "max")
 }
 
 fn is_c_keyword(s: &str) -> bool {

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -66,6 +66,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::SizedIntegers,
     Feature::Unsigned,
     Feature::WrappingArithmetic,
+    // ── SIR16 control flow / mutation ────────────────────────────────
+    // `Stmt::While` renders as a portable `for (;;) { … if (!truthy) break; }`
+    // (the condition is re-evaluated each iteration, so it may be compound);
+    // `Stmt::Assign` re-binds an already-declared `SirValue`.  Both are needed by
+    // the C frontend's milestone-2 `if`/`while`/`for` lowering.
+    Feature::Loops,
+    Feature::MutableBindings,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -286,6 +286,14 @@ SirValue _sir_gt(SirValue a, SirValue b) {
     if (a.tag == SIR_STR && b.tag == SIR_STR) return _sir_bool(strcmp(a.as.s, b.as.s) > 0);
     return _sir_bool(_sir_as_num(a) > _sir_as_num(b));
 }
+SirValue _sir_le(SirValue a, SirValue b) {
+    if (a.tag == SIR_STR && b.tag == SIR_STR) return _sir_bool(strcmp(a.as.s, b.as.s) <= 0);
+    return _sir_bool(_sir_as_num(a) <= _sir_as_num(b));
+}
+SirValue _sir_ge(SirValue a, SirValue b) {
+    if (a.tag == SIR_STR && b.tag == SIR_STR) return _sir_bool(strcmp(a.as.s, b.as.s) >= 0);
+    return _sir_bool(_sir_as_num(a) >= _sir_as_num(b));
+}
 
 int _sir_value_eq(SirValue a, SirValue b) {
     if (_sir_is_num(a) && _sir_is_num(b)) {
@@ -305,6 +313,7 @@ int _sir_value_eq(SirValue a, SirValue b) {
     }
 }
 SirValue _sir_eq(SirValue a, SirValue b) { return _sir_bool(_sir_value_eq(a, b)); }
+SirValue _sir_ne(SirValue a, SirValue b) { return _sir_bool(!_sir_value_eq(a, b)); }
 
 /* Ruby `===` (case subsumption).  For the v0 value set — no classes, ranges, or
  * regexps yet — `pattern === value` reduces to structural equality, so `case`
@@ -476,6 +485,10 @@ SirValue _sir_builtin_dispatch(SirValue *caps, SirValue *args, int argc) {
     if (strcmp(name, "=") == 0)        return _sir_eq(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "<") == 0)        return _sir_lt(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, ">") == 0)        return _sir_gt(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "<=") == 0)       return _sir_le(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, ">=") == 0)       return _sir_ge(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "==") == 0)       return _sir_eq(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "!=") == 0)       return _sir_ne(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "cons") == 0)     return _sir_cons(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "car") == 0)      return _sir_car(_sir_arg(args, argc, 0));
     if (strcmp(name, "cdr") == 0)      return _sir_cdr(_sir_arg(args, argc, 0));

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -114,9 +114,11 @@ fn self_contained_no_external_headers() {
 
 #[test]
 fn unaccepted_feature_is_rejected_cleanly() {
-    // `while` declares Feature::Loops, which the v0 backend does not accept.
-    let m = lower_ruby("i = 0\nwhile i < 3\n  i = i + 1\nend\nputs i");
-    let err = compile(&m).expect_err("v0 rejects loops");
+    // An array literal declares Feature::Sequences, which this backend does not
+    // accept (loops and mutation are now accepted, so a `while` no longer
+    // exercises the rejection path — an array still does).
+    let m = lower_ruby("puts [1, 2, 3]");
+    let err = compile(&m).expect_err("backend rejects Sequences");
     assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
 }
 

--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.3.0 — control flow & mutation (SIR16)
+
+Accepts `Feature::Loops` and `Feature::MutableBindings`, and renders the two
+statements the C frontend's milestone-2 `if`/`while`/`for` produce:
+
+- `Stmt::While { cond, body }` → Ruby `while sir_truthy(<cond>) … end` (the
+  condition, already a bool, is re-tested each iteration).
+- `Stmt::Assign { name, value }` → `name = value` (Ruby locals are mutable).
+
+`Expr::If` and the comparison builtins were already rendered, so a C `for`-loop
+now round-trips to running Ruby.
+
 ## 0.2.0 — render SIR26 integer conversions
 
 Accepts `Feature::Conversions` (plus the SIR21 type-implied `SizedIntegers`,

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -205,9 +205,25 @@ fn emit_stmt(s: &Stmt) -> String {
             format!("{} = {}", sanitize_ident(name), emit_expr(value))
         }
         Stmt::ExprStmt { expr, .. } => emit_expr(expr),
-        // SIR16+ statements are not accepted in v0; the capability check rejects
-        // such modules before emit, so these are unreachable.
-        other => unreachable!("v0 Ruby backend reached unsupported statement: {other:?}"),
+        // SIR16 re-binding: Ruby locals are mutable, so this is a plain `=`.
+        Stmt::Assign { name, value, .. } => {
+            format!("{} = {}", sanitize_ident(name), emit_expr(value))
+        }
+        // SIR16 loop: Ruby's `while` re-tests the (already-bool) condition each
+        // iteration.  The body's statements run for effect; its value is nil and
+        // is discarded (a loop yields nothing).
+        Stmt::While { cond, body, .. } => {
+            let mut s = format!("while sir_truthy({})\n", emit_expr(cond));
+            for st in &body.stmts {
+                s.push_str(&emit_stmt(st));
+                s.push('\n');
+            }
+            s.push_str("end");
+            s
+        }
+        // Other SIR16+ statements (ForRange/ForEach/index-set/class/try) are not
+        // accepted; the capability check rejects such modules before emit.
+        other => unreachable!("Ruby backend reached unsupported statement: {other:?}"),
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -63,6 +63,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::SizedIntegers,
     Feature::Unsigned,
     Feature::WrappingArithmetic,
+    // ── SIR16 control flow / mutation ────────────────────────────────
+    // `Stmt::While` (loops) and `Stmt::Assign` (re-binding) render as Ruby's
+    // native `while … end` and `name = value` — Ruby is fully mutable and
+    // expression-oriented, so these are direct.  The C frontend's milestone-2
+    // `if`/`while`/`for` lower to these plus `Expr::If` (which needs no feature).
+    Feature::Loops,
+    Feature::MutableBindings,
 ];
 
 impl Backend for RubyBackend {

--- a/code/specs/SIR27-c-to-semantic-ir.md
+++ b/code/specs/SIR27-c-to-semantic-ir.md
@@ -122,6 +122,57 @@ narrows to u8 → `300 → 44`.  The Ruby backend renders
 `c = sir_u8(sir_i32(sir_i32(a) + sir_i32(b)))`; the C backend renders the
 equivalent `_sir_convert(...)` chain; both agree with `clang -fwrapv`.
 
+## Control flow & comparisons (milestone 2)
+
+Milestone 1 delivered typed `+`/`-`/`*`, casts, declarations, `printf`, and a
+trailing `return`.  Milestone 2 adds **comparisons and control flow**, whose one
+subtlety is a **truthiness mismatch** between the two languages:
+
+- In **C**, a condition is an integer: `0` is false, any non-zero is true, and a
+  comparison (`a < b`) yields an `int` that is `0` or `1`.
+- In **SIR**, only `nil`/`false` are falsy — **`0` is truthy** — and a comparison
+  builtin yields a `bool`.
+
+So the lowering must bridge in two directions:
+
+1. **C condition → SIR bool** (used by `if`/`while`/`for`).  `lower_cond(e)`:
+   - if `e` is syntactically a comparison (`relational`/`equality`), lower it to
+     the SIR comparison builtin directly — that already yields a `bool`;
+   - otherwise `e` is an integer expression, so emit `!=(e, 0)` — the SIR bool
+     that is true exactly when C would treat `e` as true.  This is what stops
+     `while (x)` from looping forever on `x == 0` (which SIR would call truthy).
+
+2. **C comparison as an r-value → SIR int** (`int b = a < c;`).  A comparison has
+   type `int` in C, so when its result is *used as a value* it lowers to
+   `If(cmp, 1, 0)` typed `i32` — restoring C's `0`/`1`.  (`If`'s two branches are
+   the SIR blocks `{1}` and `{0}`.)
+
+Both comparison forms apply the **usual arithmetic conversions** to their
+operands first (promote, then common type), exactly like arithmetic — so
+`(uint8_t)200 < (uint8_t)100` compares the promoted `int` values, matching C.
+
+**Statements added:**
+
+| C | SIR |
+|---|---|
+| `if (c) S1 else S2` | `ExprStmt(If{ lower_cond(c), block(S1), block(S2) })` |
+| `while (c) S` | `Stmt::While{ lower_cond(c), block(S) }` (feature `Loops`) |
+| `for (init; c; step) S` | desugars to `init; While{ c′, block(S; step) }` |
+| `x = e;` | `Stmt::Assign{ x, scope, Convert{type(x)}(e) }` (feature `MutableBindings`) |
+
+`for` desugars to the `while` form: the init clause (a declaration or an
+expression) is emitted before the loop, the step expression is appended to the
+end of the loop body, and an absent condition becomes `true`.  A nested `{ … }`
+block is spliced into the enclosing statement list (v1 does not model per-block
+scopes; the flat symbol table is shared).
+
+**Early `return` is still out of scope.**  SIR functions yield their block's
+*value* — there is no early-return statement — so `return` is accepted **only as
+the function's last statement** (where it supplies that value).  A `return`
+inside an `if`/`while`/`for` body is a clear, positioned error rather than a
+silent miscompile; lifting it into nested `If` values is a later milestone.
+Logical `&& ||`, unary `!`, bitwise, and `/`/`%` also remain deferred.
+
 ## Pipeline
 
 ```text


### PR DESCRIPTION
## Milestone 2 of the C → SIR → Ruby initiative

Extends the C-subset slice from straight-line integer arithmetic to **real control flow**, so a C `for`-loop now round-trips to running Ruby *and* portable C. Spans the frontend and both backends.

### Frontend (`c-to-semantic-ir`)
- **Comparisons** `< > <= >= == !=` (usual arithmetic conversions on operands). As a condition → a SIR bool directly; as a **value** (`int c = a > b`) → `If(cmp, 1, 0)`, restoring C's int-typed `0`/`1`.
- **`if`/`else`** → `Expr::If` as a statement; **`while`** → `Stmt::While`; **`for`** desugars to `init; while (cond) { body; step }`; **`x = e`** → `Stmt::Assign` (RHS converted to `x`'s type).
- **The C-vs-SIR truthiness bridge:** a non-comparison condition `e` becomes `!=(e, 0)` — C treats `0` as false, SIR treats it as truthy — so `while (n)` terminates correctly.
- **Early `return`** (not the last statement) is a clean positioned error: SIR functions yield a block value, with no early exit. (A later milestone can lift it into nested `If` values.)

### Backends (needed to *run* the new statements)
- **`semantic-ir-to-ruby` 0.3.0** — accept `Loops`/`MutableBindings`; render `Stmt::While` (`while sir_truthy(cond) … end`) and `Stmt::Assign`.
- **`semantic-ir-to-c` 0.4.0** — accept `Loops`/`MutableBindings`; render `Stmt::While` as a portable `for(;;){ c = cond; if(!_sir_truthy(c)) break; body }` and `Stmt::Assign`; add the missing comparison builtins `<= >= == !=` (`_sir_le`/`_sir_ge`/`_sir_ne`).
- **Portability fix:** user functions named `min`/`max` are escaped — `<stdlib.h>` on MSVC/UCRT defines them as macros, which wrecked `SirValue min(...)` under clang-cl/MSVC.

### Verified locally (the payoff)
A **19-program three-way conformance corpus** is byte-identical across reference `clang -fwrapv`, emitted Ruby (`ruby` 3.4), and emitted C. The seven control-flow programs also compile + run identically on **clang + gcc + MSVC**:

| program | result |
|---|---|
| accumulator `for` sum(1..100) | 5050 |
| `while` countdown | 15 |
| `if/else` min(7,3) | 3 |
| factorial 10! | 3628800 |
| **uint8 wraparound accumulated in a loop** | **232** |
| comparison as a value (5 > 3) | 1 |
| equality branch classify(0) | 100 |

The uint8-in-a-loop case is the headline: fixed-width wraparound survives loop mutation, still identical across all three languages.

Full `c-to-semantic-ir`, both backends, and `sir-conformance` test suites pass. Security review passed (static name-switch dispatch preserved; all identifiers routed through `sanitize_ident`; malformed C returns positioned errors, not panics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)