### PR TITLE
feat(human-languages): Marathi Chapters 2–5 — introductions to first verbs

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -31,7 +31,7 @@ Every track shares the same shape:
 | [Portuguese](./portuguese/README.md) | Romance / Latin | Chapter 1 (Greetings) authored (lessons + book) |
 | [Arabic](./arabic/README.md) | Semitic / Arabic (vendored font) | Chapters 1-2 authored (script inline) |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | Chapters 1-2 authored (lessons + book) |
-| [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapter 1 (Greetings) authored (lessons + book) |
+| [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapters 1-5 authored (lessons + book) |
 | [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
 | [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapter 1 (Greetings) authored (lessons + book) |
 | [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-5 authored (new track, script inline) |

--- a/code/learning/human-languages/marathi/CHANGELOG.md
+++ b/code/learning/human-languages/marathi/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Chapters 2–5 — introductions, how-are-you, farewells, first verbs
+
+Brings Marathi to Chapter 5 parity with the leading tracks (~26 new deep
+lessons + four book chapters), mirroring the Indic template. Every atom traced to
+its root; the script stays inline. Book recompiles clean with XeLaTeX (0 missing
+characters, 0 undefined references), rasterized and visually QA'd.
+
+- **Chapter 2 — Introducing Yourself** (`lessons/MR-C02-*`): nāv (Sanskrit
+  *nāman* → English *name*; the Marathi *m→v* softening), mājhaṁ (three-gender
+  agreement), **āhe** (the copula, from *ásti*/√as, and it goes **last**),
+  "mājhaṁ nāv … āhe", tū/tumhī (courtesy-by-plural), kāy ("what," the *k-*
+  family), "tumchaṁ nāv kāy āhe?", ānand ("joy"), practice.
+- **Chapter 3 — How Are You** (`lessons/MR-C03-*`): kasā/kaśī/kasaṁ (gendered
+  "how"), "tumhī kase āhāt?", mī (*aham* → Latin *ego*, English *I*), "mī barā
+  āhe" (Ch1 *baraṁ* now gendered), **kāhī harkat nāhī** (*harkat* ← Arabic — the
+  Deccan Perso-Arabic layer), practice.
+- **Chapter 4 — Farewells** (`lessons/MR-C04-*`): punhā (Sanskrit *punar*), bheṭū
+  (the "we" in the *-ū* ending), "punhā bheṭū", "udyā bheṭū" (Marathi keeps
+  *udyā* tomorrow ≠ *kāl* yesterday), kāḷjī ghyā (the retroflex **ळ**; *ghyā*
+  resp. / *ghe* fam.), practice.
+- **Chapter 5 — The First Verbs** (`lessons/MR-C05-*`): bolṇe (the *-ṇe*
+  infinitive; the **gendered present** *bolto/bolte* — Marathi's signature),
+  "mī marāṭhī bolto" (*marāṭhī* ← *Mahārāṣṭra* "great realm"), rāhṇe (postposition
+  *-āt* "in"), kām karṇe (√*kṛ* — root of *namaskār*, *karma*; *kām* ← *karma*),
+  practice.
+
+Concept tags reuse the universal HL01 ids (WORD-NAME, PRONOUN-MY/I/YOU, WORD-IS,
+QUESTION-WHAT/HOW, INTRO-*, STATE-HOW-ARE-YOU, WORD-WELL, COURTESY-YOUREWELCOME,
+FAREWELL-LATER/-TOMORROW); verbs and lexemes namespaced (MR-VERB-*, MR-WORD-*,
+MR-PHRASE-*). The thread throughout: gender on the **verb** in the present, the
+**three** genders, and the extra retroflex letter **ळ**.
+
 ## Chapter 1 — Greetings (Devanagari taught inline)
 
 - New Marathi track on the HL00 framework — Indo-Aryan, written in Devanagari

--- a/code/learning/human-languages/marathi/README.md
+++ b/code/learning/human-languages/marathi/README.md
@@ -21,9 +21,17 @@ book.
 ## Progress
 
 - **Chapter 1 — Greetings** ([`lessons/MR-C01-*`](./lessons/)): namaskār,
-  dhanyavād, ho, nāhī, baraṃ, yeto/yete (gendered farewell), practice. In the
-  book.
-- **Chapter 2 — Introducing Yourself** (planned): *mājhe nāv…*, *tū* / *tumhī*.
+  dhanyavād, ho, nāhī, baraṁ, yeto/yete (gendered farewell), practice.
+- **Chapter 2 — Introducing Yourself** ([`lessons/MR-C02-*`](./lessons/)): nāv,
+  mājhaṁ, āhe, "my name is…", tū/tumhī, kāy, "what's your name?", ānand.
+- **Chapter 3 — How Are You** ([`lessons/MR-C03-*`](./lessons/)): kasā, "tumhī
+  kase āhāt?", mī, "mī barā āhe", kāhī harkat nāhī.
+- **Chapter 4 — Farewells** ([`lessons/MR-C04-*`](./lessons/)): punhā, bheṭū,
+  "punhā bheṭū", "udyā bheṭū", kāḷjī ghyā.
+- **Chapter 5 — The First Verbs** ([`lessons/MR-C05-*`](./lessons/)): bolṇe, "mī
+  marāṭhī bolto", rāhṇe, kām karṇe.
+
+All five chapters are in the book.
 
 ## Book / fonts
 

--- a/code/learning/human-languages/marathi/book/book.tex
+++ b/code/learning/human-languages/marathi/book/book.tex
@@ -64,4 +64,12 @@ Released under CC~BY-SA~4.0.
 
 \input{chapters/ch01-greetings}
 
+\input{chapters/ch02-introductions}
+
+\input{chapters/ch03-responding}
+
+\input{chapters/ch04-farewells}
+
+\input{chapters/ch05-first-verbs}
+
 \end{document}

--- a/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
@@ -1,0 +1,160 @@
+\chapter{Introducing Yourself}
+\label{ch:introductions}
+
+Now a first real exchange --- giving your name, asking for someone else's, and
+saying you are glad to meet them:
+
+\begin{center}
+\mr{माझं नाव मीरा आहे.} \quad(\emph{m\=ajh\d{m} n\=av Mira \=ahe} --- ``My name is Mira.'')\\
+\mr{तुमचं नाव काय आहे?} \quad(\emph{tumch\d{m} n\=av k\=ay \=ahe} --- ``What is your name?'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/MR-C02-*.md}.}
+
+\section{\mr{नाव} \emph{(n\=av)} --- ``name,'' a word older than Europe}
+\label{lesson:naav}
+
+\begin{sounds}
+\mr{ना} (\emph{n\=a}) $+$ \mr{व} (\emph{va}) $\to$ \mr{नाव} \emph{n\=av}.
+\end{sounds}
+
+\begin{cousinweb}
+\mr{नाव} (\emph{n\=av}) $\leftarrow$ Sanskrit \mr{नामन्} (\emph{n\=aman},
+``name''). Watch the small Marathi shift: the Sanskrit \emph{-m-} softened to
+\emph{-v-}, so \emph{n\=am} became \textbf{n\=av} (Hindi kept the \emph{m}:
+\emph{n\=am}). That \emph{n\=aman} goes back to PIE \emph{*h\textsubscript{3}%
+n\'{o}mn\d{}} --- the same root as English \textbf{name} and \textbf{noun}, Latin
+\emph{n\=omen}, Greek \emph{onoma}. A cousin from before either language existed.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{A Marathi habit: soft consonants.} \emph{m}$\to$\emph{v} here is one of
+many softenings that distinguish Marathi from Hindi. Spot the shift and a
+Sanskrit word reads straight into Marathi.
+\end{grammarlens}
+
+\section{\mr{माझं} \emph{(m\=ajh\d{m})} --- ``my,'' and gender again}
+\label{lesson:majhe}
+
+\begin{sounds}
+\mr{मा} (\emph{m\=a}) $+$ \mr{झं} (\emph{jha} with the \emph{anusv\=ara} \mr{ं})
+$\to$ \emph{m\=ajh\d{m}}.
+\end{sounds}
+
+\begin{cousinweb}
+\mr{माझं} (\emph{m\=ajh\d{m}}, ``my'') sits on the first-person root \emph{ma-}
+--- the same root behind English \textbf{me}, \textbf{my}, \textbf{mine}, Latin
+\emph{meus}, Hindi \emph{mer\=a}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``My'' agrees in three genders.} \mr{माझा} (\emph{m\=ajh\=a}, m.) /
+\mr{माझी} (\emph{m\=ajh\=\i}, f.) / \mr{माझं} (\emph{m\=ajh\d{m}}, n.). The noun
+\emph{n\=av} (``name'') is \textbf{neuter}, so ``my name'' is \emph{m\=ajh\d{m}
+n\=av}. You met this gender idea already in the goodbye \emph{yeto/yete}; it runs
+through the whole language.
+\end{grammarlens}
+
+\section{\mr{आहे} \emph{(\=ahe)} --- ``is,'' and it comes last}
+\label{lesson:aahe}
+
+\begin{sounds}
+\mr{आ} (\emph{\=a}, the standalone long-\emph{\=a} vowel) $+$ \mr{हे} (\emph{he})
+$\to$ \mr{आहे} \emph{\=ahe}.
+\end{sounds}
+
+\begin{cousinweb}
+\mr{आहे} (\emph{\=ahe}, ``is'') descends from Sanskrit \mr{अस्ति} (\emph{ásti}),
+on the root \textbf{$\surd$as} (``to be''). That \emph{$\surd$as} / PIE
+\emph{*h\textsubscript{1}es-} is the ancestor of Latin \emph{est}, German
+\emph{ist}, and English \textbf{is} itself --- the oldest verb in the family,
+worn to \emph{\=ahe} in Marathi.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{The verb goes last.} Marathi is subject--object--verb: ``my name Mira
+\emph{is}.'' \emph{\=ahe} sits at the end, and it changes with the subject ---
+\emph{m\=\i\ \=ahe} (I am), \emph{t\=u \=ahes} (you are), \emph{tumh\=\i\ \=ah\=at}
+(you are, resp.), which you will use in the next chapter.
+\end{grammarlens}
+
+\section{\mr{माझं नाव \ldots आहे} --- ``my name is\ldots''}
+\label{lesson:majhe-naav-aahe}
+
+\mr{माझं} (my) $+$ \mr{नाव} (name) $+$ name $+$ \mr{आहे} (is) $=$ ``my name
+is\ldots'' \emph{M\=ajh\d{m} n\=av Arun \=ahe.} The \emph{m\=ajh\d{m}} is neuter
+to agree with \emph{n\=av}; the verb comes last.
+
+\section{\mr{तू} / \mr{तुम्ही} \emph{(t\=u / tumh\=\i)} --- ``you,'' familiar and respectful}
+\label{lesson:tu-tumhi}
+
+\begin{cousinweb}
+\mr{तू} (\emph{t\=u}, familiar ``you'') $\leftarrow$ Sanskrit \mr{त्वम्}
+(\emph{tvam}), PIE \emph{*t\=u} --- the root of English archaic \textbf{thou},
+Latin \emph{t\=u}, French \emph{tu}, Hindi \emph{t\=u}. \mr{तुम्ही}
+(\emph{tumh\=\i}, respectful) is grammatically \textbf{plural} --- honouring one
+person as many, exactly like French \emph{vous}; it takes the plural copula
+\emph{\=ah\=at}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{A choice of respect, every time.} \emph{t\=u} for a friend or child;
+\emph{tumh\=\i} for an elder, a stranger, anyone you show courtesy to. Marathi
+makes you pick with each address.
+\end{grammarlens}
+
+\section{\mr{काय} \emph{(k\=ay)} --- ``what''}
+\label{lesson:kaay}
+
+\begin{cousinweb}
+\mr{काय} (\emph{k\=ay}, ``what'') grows from the interrogative stem \emph{ka-},
+PIE \emph{*k\ensuremath{^w}o-} --- the root behind English \textbf{wh-} words and
+Latin \emph{qu-}. Marathi keeps the \emph{k-} plainly across its questions:
+\emph{k\=ay} (what), \emph{ko\d{n}} (who), \emph{ku\d{t}he} (where), \emph{k\=a}
+(why), \emph{kas\d{m}} (how). Hear that opening \emph{k-} and a question is
+coming.
+\end{cousinweb}
+
+\section{\mr{तुमचं नाव काय आहे?} --- ``what's your name?''}
+\label{lesson:tumche-naav-kaay-aahe}
+
+\mr{तुमचं} (\emph{tumch\d{m}}, ``your,'' neuter to match \emph{n\=av}) $+$
+\mr{नाव} $+$ \mr{काय} (what) $+$ \mr{आहे} (is) $=$ ``your name what is?'', verb
+last. The ``your'' set mirrors the ``my'' set: \emph{m\=ajh\d{m}} (my) /
+\emph{tumch\d{m}} (your, resp.) / \emph{tujh\d{m}} (your, familiar) --- all
+neuter here before \emph{n\=av}. To a friend: \mr{तुझं नाव काय आहे?}
+(\emph{tujh\d{m} n\=av k\=ay \=ahe?}).
+
+\section{\mr{भेटून आनंद झाला} \emph{(bhe\d{t}\=un \=anand jh\=al\=a)} --- ``a joy to meet you''}
+\label{lesson:anand}
+
+\begin{cousinweb}
+The warm close is \mr{भेटून आनंद झाला} --- literally ``having met [you], joy
+happened.'' \mr{आनंद} (\emph{\=anand}, ``joy, bliss'') is \textbf{Sanskrit} ---
+\emph{\=a-} (``fully'') $+$ \emph{nand} (``to rejoice'') --- the \emph{\=ananda}
+of \emph{sat-cit-\=ananda} and a common given name. And \emph{bhe\d{t}\=un} is
+built on \mr{भेटणे} (\emph{bhe\d{t}\d{n}e}, ``to meet''), the verb behind
+Chapter~4's \emph{punh\=a bhe\d{t}\=u}.
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Marathi & English \\
+\midrule
+\mr{माझं नाव मीरा आहे.} & My name is Mira. \\
+\mr{तुमचं नाव काय आहे?} & What's your name? \\
+\mr{माझं नाव अरुण आहे.} & My name is Arun. \\
+\mr{भेटून आनंद झाला.} & Pleased to meet you. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Every atom traced: \emph{n\=av} ($\to$ \emph{name}), \emph{m\=ajh\d{m}} ($\to$
+\emph{my}), \emph{k\=ay} ($\to$ \emph{what}), \emph{t\=u} ($\to$ \emph{thou}).
+And two Marathi distinctives came back: three genders (on \emph{m\=ajh\d{m}}) and
+the verb \emph{\=ahe} going \textbf{last}. Next chapter: \emph{tumh\=\i\ kase
+\=ah\=at?} (``how are you?'').

--- a/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
@@ -1,0 +1,102 @@
+\chapter{How Are You?}
+\label{ch:responding}
+
+The everyday exchange after hello:
+
+\begin{center}
+\mr{तुम्ही कसे आहात?} \quad(\emph{tumh\=\i\ kase \=ah\=at} --- ``How are you?'')\\
+\mr{मी बरा आहे, धन्यवाद.} \quad(\emph{m\=\i\ bar\=a \=ahe, dhanyav\=ad} --- ``I'm well, thank you.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/MR-C03-*.md}.}
+
+\section{\mr{कसा} / \mr{कशी} / \mr{कसं} \emph{(kas\=a / ka\'{s}\=\i\ / kas\d{m})} --- ``how''}
+\label{lesson:kasa}
+
+\begin{cousinweb}
+\mr{कसा} (\emph{kas\=a}, ``how'') is another \emph{k-} question, from PIE
+\emph{*k\ensuremath{^w}o-} --- the root behind English \textbf{how} (a \emph{wh-}
+word that lost its \emph{w}) and Latin \emph{quo-modo} (``in what way,'' $\to$
+Spanish \emph{c\'{o}mo}).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``How'' agrees with whom you ask.} \mr{कसा} (\emph{kas\=a}, to a man) /
+\mr{कशी} (\emph{ka\'{s}\=\i}, to a woman) / \mr{कसं} (\emph{kas\d{m}}, neuter). So
+``how are you?'' shifts shape with the person addressed.
+\end{grammarlens}
+
+\section{\mr{तुम्ही कसे आहात?} --- ``how are you?''}
+\label{lesson:tumhi-kase-aahat}
+
+\mr{तुम्ही} (\emph{tumh\=\i}, resp.\ ``you'') $+$ \mr{कसे} (\emph{kase}, ``how,''
+plural-agreeing) $+$ \mr{आहात} (\emph{\=ah\=at}, ``are,'' resp.) $=$ ``you how
+are?'', verb last. Because \emph{tumh\=\i} is grammatically plural, ``how''
+appears as \emph{kase} and the copula as \emph{\=ah\=at}. To a male friend:
+\mr{तू कसा आहेस?} (\emph{t\=u kas\=a \=ahes?}); to a female friend: \mr{तू कशी आहेस?}
+(\emph{t\=u ka\'{s}\=\i\ \=ahes?}).
+
+\section{\mr{मी} \emph{(m\=\i)} --- ``I''}
+\label{lesson:mi}
+
+\begin{cousinweb}
+\mr{मी} (\emph{m\=\i}, ``I'') descends from Sanskrit \mr{अहम्} (\emph{aham}),
+worn down to \emph{m\=\i}. That \emph{aham} is PIE
+\emph{*h\textsubscript{1}e\'{g}(H)om} --- the ancestor of Latin \textbf{ego} and
+English \textbf{I}. Note its family tie to last chapter's \emph{m\=ajh\d{m}}
+(``my''): the same first-person \emph{m-} thread, as English pairs \emph{I} with
+\emph{me/my}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``I am'' is \emph{m\=\i\ \=ahe}.} And ``I'm fine'' reaches back to
+Chapter~1's \emph{bar\d{m}} in its gendered form: \emph{m\=\i\ bar\=a \=ahe}
+(a man) / \emph{m\=\i\ bar\=\i\ \=ahe} (a woman).
+\end{grammarlens}
+
+\section{\mr{मी बरा आहे} --- ``I'm well, thank you''}
+\label{lesson:mi-bara-aahe}
+
+\mr{मी} (I) $+$ \mr{बरा} (\emph{bar\=a}, ``well'') $+$ \mr{आहे} (am) $=$ ``I am
+well.'' Chapter~1's \mr{बरं} (\emph{bar\d{m}}) was the bare \textbf{neuter}
+``okay''; describing a person it takes their gender: \emph{bar\=a} (m.) /
+\emph{bar\=\i} (f.). Add thanks: \emph{m\=\i\ bar\=a \=ahe, dhanyav\=ad}.
+
+\begin{grammarlens}
+\textbf{The copula changes with the subject.} \emph{m\=\i\ \=ahe} (I am), \emph{t\=u
+\=ahes} (you are), \emph{tumh\=\i\ \=ah\=at} (you are, resp.) --- one verb,
+reshaped for each person. Marathi marks \emph{who} on the verb itself.
+\end{grammarlens}
+
+\section{\mr{काही हरकत नाही} \emph{(k\=ah\=\i\ harkat n\=ah\=\i)} --- ``no problem''}
+\label{lesson:kaahi-harkat-nahi}
+
+\begin{cousinweb}
+\mr{काही} (\emph{k\=ah\=\i}, ``any'') $+$ \mr{हरकत} (\emph{harkat}, ``objection'')
+$+$ \mr{नाही} (\emph{n\=ah\=\i}, ``not'') $=$ ``[there is] no objection at all''
+--- Marathi's easy ``you're welcome / no problem.'' Two histories meet:
+\emph{n\=ah\=\i} rides PIE \emph{*ne} (English \textbf{no}, \textbf{not}), while
+\emph{harkat} is a \textbf{Perso-Arabic} loan (Arabic \emph{\d{h}arakah}) --- one
+of the many Persian and Arabic words Marathi absorbed under the Deccan
+sultanates. An Indo-European negative wrapped around an Arabic noun.
+\end{cousinweb}
+
+\section{The whole exchange}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Marathi & English \\
+\midrule
+\mr{तुम्ही कसे आहात?} & How are you? \\
+\mr{मी बरा आहे, धन्यवाद.} & I'm well, thank you. \\
+\mr{काही हरकत नाही.} & No problem / you're welcome. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Roots banked: \emph{kas\=a} (the \emph{k-} questions, gender-agreeing), \emph{m\=\i}
+(\emph{aham} $\to$ Latin \emph{ego}, English \emph{I}), \emph{bar\=a/bar\=\i}
+(now gendered), \emph{harkat} (Arabic, the Deccan trade-and-court layer). Next
+chapter: the farewells --- \emph{punh\=a bhe\d{t}\=u}.

--- a/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
@@ -1,0 +1,102 @@
+\chapter{Farewells}
+\label{ch:farewells}
+
+Chapter~1 gave you the quick \mr{येतो} (\emph{yeto}, ``I'll come again''). Its
+explicit companion:
+
+\begin{center}
+\mr{पुन्हा भेटू!} \quad(\emph{punh\=a bhe\d{t}\=u} --- ``We'll meet again!'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/MR-C04-*.md}.}
+
+\section{\mr{पुन्हा} \emph{(punh\=a)} --- ``again''}
+\label{lesson:punha}
+
+\begin{cousinweb}
+\mr{पुन्हा} (\emph{punh\=a}, ``again, back'') is from Sanskrit \mr{पुनर्}
+(\emph{punar}, ``again''), a cousin of Latin \emph{re-} (``back/again'') and the
+\emph{puna-} of \emph{punarjanma} (``rebirth''). To say a thing \emph{punh\=a} is
+to send it round once more.
+\end{cousinweb}
+
+\section{\mr{भेटू} \emph{(bhe\d{t}\=u)} --- ``(we'll) meet''}
+\label{lesson:bhetu}
+
+\begin{sounds}
+\mr{भे} (\emph{bhe}) $+$ \mr{टू} (\emph{\d{t}\=u}, the \textbf{retroflex} \mr{ट}
+\emph{\d{t}a} with the long-\emph{u}) $\to$ \emph{bhe\d{t}\=u}.
+\end{sounds}
+
+\begin{cousinweb}
+\mr{भेटू} (\emph{bhe\d{t}\=u}) is a form of \mr{भेटणे} (\emph{bhe\d{t}\d{n}e},
+``to meet''), a native Marathi verb (the stem \emph{bhe\d{t}-} also gives
+\emph{bhe\d{t}}, ``a meeting''). As \emph{bhe\d{t}\=u} it means ``let's / we'll
+meet'' --- the hopeful mood a goodbye wants.
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``We'' lives in the verb.} \emph{bhe\d{t}\=u} carries its own ``we/let's''
+in the \emph{-\=u} ending --- no separate word for ``we'' needed. Unlike the
+present (\emph{yeto/yete}), this future-wish form does \emph{not} split by gender.
+\end{grammarlens}
+
+\section{\mr{पुन्हा भेटू} --- ``see you again''}
+\label{lesson:punha-bhetu}
+
+\mr{पुन्हा} (again) $+$ \mr{भेटू} (we'll meet) $=$ ``\textbf{we'll meet again}''
+--- the explicit twin of Chapter~1's \emph{yeto}. Stack them for warmth:
+\mr{येतो, पुन्हा भेटू} (\emph{yeto, punh\=a bhe\d{t}\=u}). Neither word says
+``goodbye''; the parting is all return (Hindi \emph{phir milenge}, Bengali
+\emph{\=ashi}, Tamil \emph{p\=oy varugi\d{r}\=e\d{n}}).
+
+\section{\mr{उद्या भेटू} \emph{(udy\=a bhe\d{t}\=u)} --- ``see you tomorrow''}
+\label{lesson:udya-bhetu}
+
+\begin{cousinweb}
+\mr{उद्या} (\emph{udy\=a}, ``tomorrow'') $+$ \mr{भेटू} (we'll meet) $=$ ``we'll
+meet tomorrow.'' Unlike Hindi \emph{kal} (which means \emph{both} tomorrow and
+yesterday), Marathi keeps them apart: \emph{udy\=a} (tomorrow) vs.\ \mr{काल}
+(\emph{k\=al}, yesterday). The verb carries the future; the first word sets the
+day.
+\end{cousinweb}
+
+\section{\mr{काळजी घ्या} \emph{(k\=a\d{l}j\=\i\ ghy\=a)} --- ``take care''}
+\label{lesson:kalji-ghya}
+
+\begin{sounds}
+\mr{काळजी} carries \mr{ळ} (\emph{\d{l}a}), the \textbf{retroflex ``l''} Marathi
+keeps (Hindi dropped it): \mr{का}$+$\mr{ळ}$+$\mr{जी} $\to$ \emph{k\=a\d{l}j\=\i}.
+Then \mr{घ्या} (\emph{ghy\=a}, ``take,'' resp.).
+\end{sounds}
+
+\begin{cousinweb}
+\mr{काळजी} (\emph{k\=a\d{l}j\=\i}, ``care, concern'') $+$ \mr{घ्या} (\emph{ghy\=a},
+``take'') $=$ ``take care.'' Where \emph{punh\=a bhe\d{t}\=u} looks to the next
+meeting, this looks after the person in between --- ``mind yourself until then.''
+The respectful \mr{घ्या} (\emph{ghy\=a}) matches \emph{tumh\=\i}; to a friend,
+\mr{काळजी घे} (\emph{k\=a\d{l}j\=\i\ ghe}), matching \emph{t\=u}.
+\end{cousinweb}
+
+\section{The farewells}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Marathi & English \\
+\midrule
+\mr{येतो} / \mr{येते.} & I'll be going. (``come again'') \\
+\mr{पुन्हा भेटू.} & See you again. \\
+\mr{उद्या भेटू.} & See you tomorrow. \\
+\mr{काळजी घ्या.} & Take care. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Roots banked: \emph{punh\=a} (\emph{punar} ``again''), \emph{bhe\d{t}\d{n}e}
+(``to meet''; ``we'' in the ending), \emph{udy\=a} (tomorrow, kept apart from
+\emph{k\=al} yesterday), \emph{k\=a\d{l}j\=\i} (the retroflex \mr{ळ}). Every
+Marathi goodbye is a \textbf{return} or a caring wish --- never a bare
+``farewell.'' Next chapter: the first real verbs --- \emph{m\=\i\ mar\=a\d{t}h\=\i\
+bolto}.

--- a/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
@@ -1,0 +1,98 @@
+\chapter{The First Verbs}
+\label{ch:first-verbs}
+
+Until now, verbs of \emph{being} and \emph{meeting}. Now verbs that \emph{act}
+--- and sentences that move:
+
+\begin{center}
+\mr{मी मराठी बोलतो.} \quad(\emph{m\=\i\ mar\=a\d{t}h\=\i\ bolto} --- ``I speak Marathi.'')
+\end{center}
+
+\emph{Practice lessons: \texttt{lessons/MR-C05-*.md}.}
+
+\section{\mr{बोलणे} \emph{(bol\d{n}e)} --- ``to speak,'' your first full verb}
+\label{lesson:bolne}
+
+\begin{sounds}
+\mr{बो} (\emph{bo}) $+$ \mr{ल} (\emph{la}) $+$ \mr{णे} (\emph{\d{n}e}, the
+\textbf{retroflex} \mr{ण} \emph{\d{n}a}) $\to$ \emph{bol\d{n}e}.
+\end{sounds}
+
+\begin{cousinweb}
+\mr{बोलणे} (\emph{bol\d{n}e}, ``to speak'') is a native Indo-Aryan verb on the
+stem \emph{bol-} (the same \emph{bol-} as Hindi \emph{boln\=a}, Punjabi
+\emph{bol\d{n}\=a}). Its ending \mr{-णे} (\emph{-\d{n}e}) is Marathi's
+\textbf{infinitive}: \emph{bol-\d{n}e} ``to speak,'' \emph{bhe\d{t}-\d{n}e} ``to
+meet,'' \emph{ye-\d{n}e} ``to come.'' Strip \emph{-\d{n}e} for the stem
+(\emph{bol-}).
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{Stem $+$ gendered present ending.} \emph{m\=\i\ bolto} (a man speaks) /
+\emph{m\=\i\ bolte} (a woman speaks) --- the present tense splits by the speaker's
+gender, as \emph{yeto/yete} did. And it needs \textbf{no} separate ``am'': the
+one word does the work, at the end of the sentence.
+\end{grammarlens}
+
+\section{\mr{मी मराठी बोलतो} --- ``I speak Marathi''}
+\label{lesson:mi-marathi-bolto}
+
+\mr{मी} (I) $+$ \mr{मराठी} (\emph{mar\=a\d{t}h\=\i}, the object) $+$ \mr{बोलतो}
+(speak) --- ``I Marathi speak,'' verb last (a woman: \emph{m\=\i\ mar\=a\d{t}h\=\i\
+bolte}). The name \mr{मराठी} is ``[the language] of \mr{महाराष्ट्र}
+(\emph{Mah\=ar\=a\d{s}\d{t}ra})'' --- the ``great realm,'' \emph{mah\=a}
+(``great,'' cousin of Latin \emph{magnus}, English \emph{magnitude}) $+$
+\emph{r\=a\d{s}\d{t}ra} (``nation''). People \emph{Mar\=a\d{t}h\=a}, land
+\emph{Mah\=ar\=a\d{s}\d{t}ra}, tongue \emph{mar\=a\d{t}h\=\i} --- one root.
+
+\section{\mr{राहणे} \emph{(r\=ah\d{n}e)} --- ``to live, to stay''}
+\label{lesson:rahne}
+
+\begin{cousinweb}
+\mr{राहणे} (\emph{r\=ah\d{n}e}, ``to live, remain'') is from Sanskrit \emph{rah-}
+(``to remain,'' the same root as Hindi \emph{rahn\=a}): \emph{m\=\i\ pu\d{n}y\=at
+r\=ahto} (``I live in Pune'').
+\end{cousinweb}
+
+\begin{grammarlens}
+\textbf{``In'' comes after the noun.} \mr{पुण्यात} (\emph{pu\d{n}y\=at}) $=$
+\mr{पुणे} (\emph{Pu\d{n}e}, the city) $+$ \emph{-\=at} (``in''), glued to the
+noun's \emph{end}. Marathi uses \textbf{post}positions, verb last.
+\end{grammarlens}
+
+\section{\mr{काम करणे} \emph{(k\=am kar\d{n}e)} --- ``to work''}
+\label{lesson:kaam-karne}
+
+\begin{cousinweb}
+\mr{करणे} (\emph{kar\d{n}e}, ``to do, make'') is from Sanskrit \emph{$\surd$k\d{r}}
+(``to do''), PIE \emph{*k\ensuremath{^w}er-} --- the very root inside Chapter~1's
+\mr{नमस्कार} (\emph{namask\=ar} $=$ ``the \emph{making} of a bow'') and \mr{कर्म}
+(\emph{karma}, ``a thing \emph{done}''). And \mr{काम} (\emph{k\=am}, ``work'') is
+itself worn down from that \emph{karma}. Marathi builds compounds as \textbf{noun
+$+$ \mr{करणे}}: \mr{काम करणे} (\emph{k\=am kar\d{n}e}, ``work-do'' $=$ ``to
+work''), \emph{madat kar\d{n}e} (``to help''). Present, gendered: \emph{m\=\i\
+k\=am karto/karte} (``I work'').
+\end{cousinweb}
+
+\section{Sentences about yourself}
+\label{lesson:practice}
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Marathi & English \\
+\midrule
+\mr{मी मराठी बोलतो / बोलते.} & I speak Marathi. \\
+\mr{मी पुण्यात राहतो / राहते.} & I live in Pune. \\
+\mr{मी काम करतो / करते.} & I work. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+One engine: an infinitive in \emph{-\d{n}e}; a present of stem $+$ a
+\textbf{gendered} ending (\emph{-to} m.\ / \emph{-te} f.) that folds in the
+``am''; the verb last; ``in'' on the noun's tail. Roots banked: \emph{bol\d{n}e}
+(native), \emph{mar\=a\d{t}h\=\i} ($\leftarrow$ \emph{Mah\=ar\=a\d{s}\d{t}ra}
+``great realm''), \emph{r\=ah\d{n}e} (\emph{rah-} ``remain''), \emph{kar\d{n}e}
+(\emph{$\surd$k\d{r}} --- root of \emph{namask\=ar}, \emph{karma}; \emph{k\=am}
+$\leftarrow$ \emph{karma}). From here, Marathi only opens further.

--- a/code/learning/human-languages/marathi/lessons/MR-C02-aahe.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-aahe.md
@@ -1,0 +1,50 @@
+---
+id: MR-C02-aahe
+chapter: 2
+type: word
+headword: आहे
+gloss: is (āhe)
+concept_tag: WORD-IS
+prerequisites: [MR-C02-naav, MR-C02-majhe]
+sounds: [standalone-vowel-aa]
+roots: [asti]
+est_minutes: 4
+reviews_of: [MR-C02-naav, MR-C02-majhe]
+---
+
+# आहे (āhe) — "is"
+
+## Warm-up
+
+[PAUSE 2s] The little verb that finishes almost every Marathi sentence about
+what something **is** — and, in Marathi, it comes **last**.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **आ** (*ā*, the standalone long-*ā* vowel, used
+when a word begins with a vowel) + **हे** (*he*) → **आहे** *āhe*.
+
+## The word, taken apart
+
+**आहे** (*āhe*, "is") descends from Sanskrit **अस्ति** (*ásti*, "is"), on the
+root **√as** ("to be"). That same *√as* / PIE **\*h₁es-** is the ancestor of
+Latin *est*, German *ist*, and English **is** itself — the deepest, oldest verb
+in the family, worn down to *āhe* in Marathi.
+
+## Grammar Lens: the verb goes last
+
+Marathi is a **subject–object–verb** language: "my name Mira **is**." The
+copula **आहे** sits at the **end**, where English puts it in the middle. It
+changes with the subject — you will meet **आहेस** (*āhes*, "you are") and
+**आहात** (*āhāt*, "you are," respectful) in Chapter 3.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āhe" — is]
+- [YOU SAY: the English cousin from the same root ("is")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does *āhe* sit in a Marathi sentence, and what English word is
+its cousin? (At the **end**; English **is**, both from *√as*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C02-anand.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-anand.md
@@ -1,0 +1,51 @@
+---
+id: MR-C02-anand
+chapter: 2
+type: phrase
+headword: भेटून आनंद झाला
+gloss: pleased to meet you (bheṭūn ānand jhālā)
+concept_tag: INTRO-NICE-TO-MEET-YOU
+prerequisites: [MR-C02-tumche-naav-kaay-aahe]
+sounds: [anusvara]
+roots: [ananda]
+est_minutes: 4
+reviews_of: [MR-C02-majhe-naav-aahe]
+---
+
+# भेटून आनंद झाला (bheṭūn ānand jhālā) — "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] Names exchanged — now the warm close of a first meeting.
+
+## The phrase, assembled
+
+**भेटून** (*bheṭūn*, "having met") + **आनंद** (*ānand*, "joy") + **झाला**
+(*jhālā*, "happened") → literally **"having met [you], joy happened."** Marathi
+does not say "I am pleased"; it says the joy itself *occurred*.
+
+## The word, taken apart
+
+The heart of it is **आनंद** (*ānand*, "joy, bliss"), pure **Sanskrit**: **आ-**
+(*ā-*, "fully") + **नन्द** (*nand*, "to rejoice"). It is the *ānanda* of the
+scriptural phrase *sat-cit-ānanda* ("being–consciousness–bliss") — and one of the
+most common given names across India. So a Marathi speaker meets you and names
+the feeling **joy**.
+
+## Why it's said this way
+
+The verb **झाला** (*jhālā*, "happened/became") also carries gender — *jhālā* by
+default here for the event *ānand*. And **भेटून** (*bheṭūn*) is built on **भेटणे**
+(*bheṭṇe*, "to meet") — a verb you will meet again in Chapter 4's goodbye, *punhā
+bheṭū* ("we'll meet again").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bheṭūn ānand jhālā" — pleased to meet you]
+- [YOU SAY: what *ānand* literally means ("joy")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Literally, what does a Marathi speaker say when meeting you? ("Having
+met you, **joy** happened" — *bheṭūn ānand jhālā*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C02-kaay.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-kaay.md
@@ -1,0 +1,49 @@
+---
+id: MR-C02-kaay
+chapter: 2
+type: word
+headword: काय
+gloss: what (kāy)
+concept_tag: QUESTION-WHAT
+prerequisites: [MR-C02-tu-tumhi]
+sounds: [matra-aa]
+roots: [ka-interrogative]
+est_minutes: 3
+reviews_of: [MR-C02-naav]
+---
+
+# काय (kāy) — "what"
+
+## Warm-up
+
+[PAUSE 2s] One more atom before the question "what's your name?" — the word
+**what** itself.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **का** (*kā*) + **य** (*ya*) → **काय** *kāy*.
+
+## The word, taken apart
+
+**काय** (*kāy*, "what") grows from the ancient interrogative stem **ka-**, from
+PIE **\*kʷo-** — the very root behind English **wh-** words (*what, who, when,
+where, why*) and Latin *qu-* (*quis, quid*). Marathi keeps the **k-** plainly
+across its whole question family: **काय** (*kāy*, what), **कोण** (*koṇ*, who),
+**कुठे** (*kuṭhe*, where), **का** (*kā*, why), **कसं** (*kasaṁ*, how — Chapter 3).
+Learn to hear that opening **k-** and you can spot a Marathi question coming.
+
+## Why it's said this way
+
+English *wh-*, Latin *qu-*, and Marathi *k-* are three coats on one 5,000-year-old
+question-root — the family resemblance survives the different spellings.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kāy" — what]
+- [YOU SAY: three more Marathi *k-* questions (*koṇ, kuṭhe, kā*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do Marathi *kāy*, English *what*, and Latin *quid* share? (One
+PIE question-root **\*kʷo-**.)

--- a/code/learning/human-languages/marathi/lessons/MR-C02-majhe-naav-aahe.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-majhe-naav-aahe.md
@@ -1,0 +1,48 @@
+---
+id: MR-C02-majhe-naav-aahe
+chapter: 2
+type: phrase
+headword: माझं नाव … आहे
+gloss: my name is… (mājhaṁ nāv … āhe)
+concept_tag: INTRO-MY-NAME-IS
+prerequisites: [MR-C02-majhe, MR-C02-naav, MR-C02-aahe]
+sounds: []
+roots: [ma, naaman, asti]
+est_minutes: 3
+reviews_of: [MR-C02-majhe, MR-C02-naav, MR-C02-aahe]
+---
+
+# माझं नाव … आहे (mājhaṁ nāv … āhe) — "my name is…"
+
+## Warm-up
+
+[PAUSE 2s] Now assemble the three atoms you just met into your first full
+sentence about yourself.
+
+## The phrase, assembled
+
+**माझं** (*mājhaṁ*, my) + **नाव** (*nāv*, name) + **[your name]** + **आहे**
+(*āhe*, is) → **माझं नाव मीरा आहे** (*mājhaṁ nāv Mira āhe*) — "my name is Mira."
+
+Notice the shape:
+- **माझं** is neuter, agreeing with the neuter **नाव**.
+- The verb **आहे** comes **last** — "my name Mira is."
+
+A man or a woman says it the same way here; the gender lived in *mājhaṁ*
+(matching *nāv*), which is settled.
+
+## Why it's said this way
+
+Marathi drops nothing and reorders everything to English eyes: possessor, thing,
+value, then *is*. Learn this frame and you can swap in any name — or, later, any
+fact about yourself.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mājhaṁ nāv Mira āhe" — my name is Mira]
+- [YOU SAY: it with your own name in the blank]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Put "my name is Arun" into Marathi. (*mājhaṁ nāv Arun āhe.*)

--- a/code/learning/human-languages/marathi/lessons/MR-C02-majhe.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-majhe.md
@@ -1,0 +1,50 @@
+---
+id: MR-C02-majhe
+chapter: 2
+type: word
+headword: माझं
+gloss: my (mājhaṁ, neuter)
+concept_tag: PRONOUN-MY
+prerequisites: [MR-C02-naav]
+sounds: [inherent-a, anusvara]
+roots: [ma]
+est_minutes: 4
+reviews_of: [MR-C02-naav, MR-C01-yeto]
+---
+
+# माझं (mājhaṁ) — "my"
+
+## Warm-up
+
+[PAUSE 2s] "My name." The word for **my** — and it changes shape with the
+gender of what it owns.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **मा** (*mā*) + **झं** (*jhaṁ*, the झ *jha*
+with an *anusvara* **ं** for the light nasal) → **माझं** *mājhaṁ*.
+
+## The word, taken apart
+
+**माझं** (*mājhaṁ*, "my") sits on the first-person root **ma-** — the very root
+behind English **me, my, mine**, Latin *meus*, and Hindi *merā*. One tiny
+syllable, *ma*, marks "belonging to me" across the whole Indo-European family.
+
+## Grammar Lens: "my" agrees in three genders
+
+Marathi keeps **three** genders, and "my" picks its ending from the noun:
+**माझा** (*mājhā*, masculine) · **माझी** (*mājhī*, feminine) · **माझं**
+(*mājhaṁ*, neuter). The word **नाव** (*nāv*, "name") is **neuter**, so "my name"
+is **माझं नाव** (*mājhaṁ nāv*). You met this gender-agreement idea already with
+the goodbye *yeto/yete*; it runs through the whole language.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mājhā / mājhī / mājhaṁ" — the three genders of "my"]
+- [YOU SAY: "mājhaṁ nāv" — my name (neuter, to match *nāv*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is "my name" *mājhaṁ nāv* and not *mājhā nāv*? (*nāv* is neuter, so
+"my" takes the neuter form *mājhaṁ*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C02-naav.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-naav.md
@@ -1,0 +1,51 @@
+---
+id: MR-C02-naav
+chapter: 2
+type: word
+headword: नाव
+gloss: name (nāv)
+concept_tag: WORD-NAME
+prerequisites: [MR-C01-namaskar]
+sounds: [inherent-a, matra-aa]
+roots: [naaman]
+est_minutes: 4
+reviews_of: [MR-C01-namaskar]
+---
+
+# नाव (nāv) — "name"
+
+## Warm-up
+
+[PAUSE 2s] To introduce yourself you need one word first: **name**. In Marathi
+it is **नाव** (*nāv*) — and it is a very old word wearing a Marathi coat.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **ना** (*nā*, the न *na* with the **ा**
+long-*ā* stroke) + **व** (*va*) → **नाव** *nāv*. Two letters, read left to right.
+
+## The word, taken apart
+
+**नाव** (*nāv*) comes from Sanskrit **नामन्** (*nāman*, "name"). Watch the small
+Marathi sound-shift: the Sanskrit *-m-* softened to *-v-*, so *nām* became
+**nāv**. (Hindi kept the *m*: *nām*.) That Sanskrit *nāman* traces back to the
+same ancient root, **\*h₃nómn̥**, that gave English **name** and **noun**, Latin
+*nōmen*, Greek *onoma*. A cousin from before either language had a name for
+itself.
+
+## Why it's said this way
+
+Marathi softens many old Sanskrit consonants this way — *m* leaning to *v*, hard
+sounds going soft. Spotting the shift lets you read a Sanskrit word straight into
+its Marathi form.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nāv" — name]
+- [YOU SAY: the English cousin from the same root ("name")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is *nāv*, and what happened to the *m* of Sanskrit *nām*? ("Name";
+it softened to *v* — a Marathi sound-shift.)

--- a/code/learning/human-languages/marathi/lessons/MR-C02-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-practice.md
@@ -1,0 +1,53 @@
+---
+id: MR-C02-practice
+chapter: 2
+type: practice
+headword: (recap)
+gloss: Chapter 2 recap — introducing yourself
+concept_tag: REVIEW
+prerequisites: [MR-C02-anand]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [MR-C02-naav, MR-C02-majhe, MR-C02-aahe, MR-C02-majhe-naav-aahe, MR-C02-tu-tumhi, MR-C02-kaay, MR-C02-tumche-naav-kaay-aahe, MR-C02-anand]
+---
+
+# Chapter 2 recap — introducing yourself
+
+## Warm-up
+
+[PAUSE 2s] Run the whole first exchange, atom by atom, then whole.
+
+## The whole exchange
+
+| Marathi | English |
+|---|---|
+| माझं नाव मीरा आहे. | My name is Mira. |
+| तुमचं नाव काय आहे? | What's your name? |
+| माझं नाव अरुण आहे. | My name is Arun. |
+| भेटून आनंद झाला. | Pleased to meet you. |
+
+## Atoms banked this chapter
+
+- **नाव** (*nāv*) — name; Sanskrit *nāman* → English **name** (the *m* softened to
+  *v* in Marathi).
+- **माझं** (*mājhaṁ*) — my; root *ma-* → English **me/my**; three genders
+  *mājhā/mājhī/mājhaṁ*.
+- **आहे** (*āhe*) — is; Sanskrit *ásti* (√as) → English **is**; the verb comes
+  **last**.
+- **तू / तुम्ही** (*tū / tumhī*) — familiar / respectful "you"; *tū* → **thou**;
+  courtesy-by-plural.
+- **काय** (*kāy*) — what; PIE *\*kʷo-*, the *k-* question family.
+- **आनंद** (*ānand*) — joy; Sanskrit *ānanda*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full four-line exchange, both parts]
+- [YOU SAY: "my name is [you]" and "what's your name?" to a friend (*tujhaṁ*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two Marathi distinctives showed up again this chapter? (Three
+genders on *mājhaṁ*; the verb *āhe* going **last**.) Next chapter: *tumhī kase
+āhāt?* — "how are you?"

--- a/code/learning/human-languages/marathi/lessons/MR-C02-tu-tumhi.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-tu-tumhi.md
@@ -1,0 +1,53 @@
+---
+id: MR-C02-tu-tumhi
+chapter: 2
+type: word
+headword: तू / तुम्ही
+gloss: you (tū familiar / tumhī respectful)
+concept_tag: PRONOUN-YOU
+prerequisites: [MR-C02-majhe-naav-aahe]
+sounds: [matra-u, halant-conjunct]
+roots: [tvam]
+est_minutes: 4
+reviews_of: [MR-C02-aahe]
+---
+
+# तू / तुम्ही (tū / tumhī) — "you"
+
+## Warm-up
+
+[PAUSE 2s] Before you can ask someone *their* name, you need "you" — and Marathi
+gives you two, one warm, one respectful.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **तू** (*tū*, the त *ta* with the long-*u*
+stroke **ू**). And **तुम्ही** (*tumhī*): **तु** + **म्ही** (*mhī*, the म *ma* with
+a *halant* joining ह *ha*).
+
+## The word, taken apart
+
+**तू** (*tū*, familiar "you") comes from Sanskrit **त्वम्** (*tvam*), from PIE
+**\*tū** — the very root of English archaic **thou**, Latin *tū*, French *tu*,
+and Hindi *tū*. The respectful **तुम्ही** (*tumhī*) is grammatically **plural**:
+you honour one person by addressing them as many, exactly as French does with
+*vous*. It takes the plural verb **आहात** (*āhāt*), not *āhes*.
+
+## Grammar Lens: two "you"s, a choice of respect
+
+- **तू** (*tū*) — a friend, a child, someone close.
+- **तुम्ही** (*tumhī*) — an elder, a stranger, anyone you show courtesy to.
+
+Choosing between them is a small act of politeness Marathi makes you perform
+every time you speak to someone.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tū" (close) / "tumhī" (respectful)]
+- [YOU SAY: the English cousin of *tū* ("thou")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which "you" for a teacher, and why? (*tumhī* — the respectful plural,
+courtesy-by-plural like French *vous*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C02-tumche-naav-kaay-aahe.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-tumche-naav-kaay-aahe.md
@@ -1,0 +1,49 @@
+---
+id: MR-C02-tumche-naav-kaay-aahe
+chapter: 2
+type: phrase
+headword: तुमचं नाव काय आहे?
+gloss: what's your name? (tumchaṁ nāv kāy āhe?)
+concept_tag: INTRO-WHATS-YOUR-NAME
+prerequisites: [MR-C02-tu-tumhi, MR-C02-kaay, MR-C02-aahe, MR-C02-naav]
+sounds: []
+roots: [tvam, ka-interrogative, naaman, asti]
+est_minutes: 3
+reviews_of: [MR-C02-tu-tumhi, MR-C02-kaay, MR-C02-majhe-naav-aahe]
+---
+
+# तुमचं नाव काय आहे? (tumchaṁ nāv kāy āhe?) — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] Now turn the question outward — ask someone else's name.
+
+## The phrase, assembled
+
+**तुमचं** (*tumchaṁ*, "your," neuter to match *nāv*) + **नाव** (*nāv*, name) +
+**काय** (*kāy*, what) + **आहे** (*āhe*, is) → **तुमचं नाव काय आहे?** — literally
+"your name what is?", verb last.
+
+The "your" mirrors the "my" set you learned:
+- **माझं** (*mājhaṁ*) — my
+- **तुमचं** (*tumchaṁ*) — your (respectful, from *tumhī*)
+- **तुझं** (*tujhaṁ*) — your (familiar, from *tū*)
+
+All three are shown here in the neuter, agreeing with the neuter **नाव**.
+
+## Why it's said this way
+
+To a friend you would say **तुझं नाव काय आहे?** (*tujhaṁ nāv kāy āhe?*), swapping
+the respectful *tumchaṁ* for the familiar *tujhaṁ* — the same *tū / tumhī* choice
+of respect, now on the possessive.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tumchaṁ nāv kāy āhe?" — what's your name? (respectful)]
+- [YOU SAY: the familiar version (*tujhaṁ nāv kāy āhe?*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the respectful and familiar "your name" forms. (*tumchaṁ* /
+*tujhaṁ* — both neuter before *nāv*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C03-kaahi-harkat-nahi.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C03-kaahi-harkat-nahi.md
@@ -1,0 +1,55 @@
+---
+id: MR-C03-kaahi-harkat-nahi
+chapter: 3
+type: phrase
+headword: काही हरकत नाही
+gloss: no problem / you're welcome (kāhī harkat nāhī)
+concept_tag: COURTESY-YOUREWELCOME
+prerequisites: [MR-C03-mi-bara-aahe, MR-C01-nahi]
+sounds: []
+roots: [na-negative]
+est_minutes: 4
+reviews_of: [MR-C01-nahi, MR-C01-dhanyavad]
+---
+
+# काही हरकत नाही (kāhī harkat nāhī) — "no problem / you're welcome"
+
+## Warm-up
+
+[PAUSE 2s] When someone thanks you, Marathi's easy reply is not "you're welcome"
+but "there's **no objection** at all."
+
+## The phrase, assembled
+
+**काही** (*kāhī*, "any") + **हरकत** (*harkat*, "objection, trouble") + **नाही**
+(*nāhī*, "not/none") → "any objection there-is-not" ≈ **"no problem at all."**
+
+## The word, taken apart
+
+Two threads meet here:
+- **नाही** (*nāhī*, "not") is Chapter 1's "no," on the ancient negative **na-** —
+  PIE **\*ne**, the root of English **no, not, none** and Latin *nōn*.
+- **हरकत** (*harkat*, "objection, hindrance") is a **Perso-Arabic** loan (from
+  Arabic *ḥarakah*), one of the many words Marathi absorbed over centuries of
+  contact with Persian-speaking rulers and traders — the same trade-and-court
+  layer that colours all the languages of the Deccan.
+
+So the reply blends an Indo-European negative with an Arabic noun — a small map
+of Marathi's history in three words.
+
+## Why it's said this way
+
+Where English "thank you / you're welcome" trades politeness tokens, Marathi
+waves the thanks away: *don't mention it, there was no trouble.* The same
+gesture, a different picture.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "dhanyavād" → "kāhī harkat nāhī" — thanks → no problem]
+- [YOU SAY: the two histories inside it (*nāhī* ← PIE *ne; *harkat* ← Arabic)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two language families meet in *kāhī harkat nāhī*? (Indo-European
+*nāhī* ← *\*ne; Arabic *harkat*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C03-kasa.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C03-kasa.md
@@ -1,0 +1,52 @@
+---
+id: MR-C03-kasa
+chapter: 3
+type: word
+headword: कसा / कशी / कसं
+gloss: how (kasā m. / kaśī f. / kasaṁ n.)
+concept_tag: QUESTION-HOW
+prerequisites: [MR-C02-kaay]
+sounds: [inherent-a, anusvara]
+roots: [ka-interrogative]
+est_minutes: 4
+reviews_of: [MR-C02-kaay]
+---
+
+# कसा / कशी / कसं (kasā / kaśī / kasaṁ) — "how"
+
+## Warm-up
+
+[PAUSE 2s] The everyday "how are you?" needs one more *k-* question word —
+**how**. And, being an adjective-like word, it too carries gender.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **क** (*ka*) + **सा** (*sā*) → **कसा** *kasā*;
+**क** + **शी** (*śī*) → **कशी** *kaśī*; **क** + **सं** (*saṁ*) → **कसं** *kasaṁ*.
+
+## The word, taken apart
+
+**कसा** (*kasā*, "how") belongs to the same **k-** question family as *kāy*
+(what), *koṇ* (who), *kuṭhe* (where) — all from PIE **\*kʷo-**, the root behind
+English **how** (yes, *how* is a *wh-* word that lost its *w*-spelling) and Latin
+*quo-modo* ("in what way," which became Spanish *cómo*).
+
+## Grammar Lens: "how" agrees with who you ask
+
+Because it describes the person's state, *how* takes their gender:
+- **कसा** (*kasā*) — asking a **man**
+- **कशी** (*kaśī*) — asking a **woman**
+- **कसं** (*kasaṁ*) — asking about a neuter thing
+
+So "how are you?" changes shape with whom you address — you will see this in the
+next lesson.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kasā / kaśī / kasaṁ" — how, in three genders]
+- [YOU SAY: two cousins from the same root (English *how*, Spanish *cómo*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which "how" do you use asking a woman? (*kaśī* — feminine.)

--- a/code/learning/human-languages/marathi/lessons/MR-C03-mi-bara-aahe.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C03-mi-bara-aahe.md
@@ -1,0 +1,50 @@
+---
+id: MR-C03-mi-bara-aahe
+chapter: 3
+type: phrase
+headword: मी बरा आहे
+gloss: I'm well, thank you (mī barā āhe)
+concept_tag: WORD-WELL
+prerequisites: [MR-C03-mi, MR-C01-baram, MR-C01-dhanyavad]
+sounds: []
+roots: [asti]
+est_minutes: 3
+reviews_of: [MR-C01-baram, MR-C01-dhanyavad, MR-C03-mi]
+---
+
+# मी बरा आहे (mī barā āhe) — "I'm well, thank you"
+
+## Warm-up
+
+[PAUSE 2s] The answer to "how are you?" — and it reuses a word you already banked
+in Chapter 1.
+
+## The phrase, assembled
+
+**मी** (*mī*, I) + **बरा** (*barā*, "well/fine") + **आहे** (*āhe*, am) → **मी बरा
+आहे** — "I am well." Add thanks: **मी बरा आहे, धन्यवाद** (*mī barā āhe,
+dhanyavād*).
+
+Back in Chapter 1 you met **बरं** (*baraṁ*) standing alone as "okay/fine" — its
+**neuter** form. When it describes *you*, it takes your gender:
+- **बरा** (*barā*) — a man is well
+- **बरी** (*barī*) — a woman is well
+- **बरं** (*baraṁ*) — the bare "okay" (neuter)
+
+## Grammar Lens: the copula changes with the subject
+
+You now have three forms of *āhe* in play: **मी आहे** (*mī āhe*, I am), **तू
+आहेस** (*tū āhes*, you are, familiar), **तुम्ही आहात** (*tumhī āhāt*, you are,
+respectful). One verb, reshaped for each person — Marathi marks *who* on the verb
+itself.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mī barā āhe, dhanyavād" (man) / "mī barī āhe, dhanyavād" (woman)]
+- [YOU SAY: the three copula forms — *mī āhe, tū āhes, tumhī āhāt*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why does the Chapter-1 *baraṁ* become *barā* here? (It now describes a
+person, so it takes that person's gender.)

--- a/code/learning/human-languages/marathi/lessons/MR-C03-mi.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C03-mi.md
@@ -1,0 +1,52 @@
+---
+id: MR-C03-mi
+chapter: 3
+type: word
+headword: मी
+gloss: I (mī)
+concept_tag: PRONOUN-I
+prerequisites: [MR-C03-tumhi-kase-aahat]
+sounds: [matra-i]
+roots: [aham]
+est_minutes: 3
+reviews_of: [MR-C02-majhe]
+---
+
+# मी (mī) — "I"
+
+## Warm-up
+
+[PAUSE 2s] To answer "how are you?", you need to say **I**. In Marathi that is a
+single bright syllable: **मी** (*mī*).
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **मी** = **म** (*ma*) + the long-*ī* stroke
+**ी** → *mī*.
+
+## The word, taken apart
+
+**मी** (*mī*, "I") descends from Sanskrit **अहम्** (*aham*, "I"), which wore down
+over centuries to the short *mī*. That *aham* comes from PIE
+**\*h₁eǵ(H)om** — the ancestor of Latin **ego** and English **I**. And notice its
+family tie to last chapter's **माझं** (*mājhaṁ*, "my"): the same first-person
+**m-** thread runs through "I" and "my," just as English pairs **I** with
+**me/my**.
+
+## Grammar Lens: "I am" is *mī āhe*
+
+Pair **मी** with the copula **आहे**: **मी आहे** (*mī āhe*, "I am"). To answer
+that you are well, reach back to Chapter 1's **बरं** (*baraṁ*, "fine") in its
+gendered form: **मी बरा आहे** (*mī barā āhe*, a man) / **मी बरी आहे** (*mī barī
+āhe*, a woman) — "I am fine."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mī" — I; then "mī āhe" — I am]
+- [YOU SAY: "I am fine" for yourself (*mī barā/barī āhe*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What links *mī* ("I") and *mājhaṁ* ("my")? (The shared first-person
+**m-** root — as English links *I* with *me/my*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C03-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C03-practice.md
@@ -1,0 +1,49 @@
+---
+id: MR-C03-practice
+chapter: 3
+type: practice
+headword: (recap)
+gloss: Chapter 3 recap — how are you
+concept_tag: REVIEW
+prerequisites: [MR-C03-kaahi-harkat-nahi]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [MR-C03-kasa, MR-C03-tumhi-kase-aahat, MR-C03-mi, MR-C03-mi-bara-aahe, MR-C03-kaahi-harkat-nahi]
+---
+
+# Chapter 3 recap — how are you
+
+## Warm-up
+
+[PAUSE 2s] The whole everyday exchange, start to finish.
+
+## The whole exchange
+
+| Marathi | English |
+|---|---|
+| तुम्ही कसे आहात? | How are you? |
+| मी बरा आहे, धन्यवाद. | I'm well, thank you. |
+| काही हरकत नाही. | No problem / you're welcome. |
+
+## Atoms banked this chapter
+
+- **कसा / कशी / कसं** (*kasā/kaśī/kasaṁ*) — how; the *k-* question family,
+  gender-agreeing.
+- **मी** (*mī*) — I; Sanskrit *aham* → Latin **ego**, English **I**.
+- **बरा / बरी / बरं** (*barā/barī/baraṁ*) — well/fine, now gendered.
+- **काही हरकत नाही** (*kāhī harkat nāhī*) — no problem; *nāhī* ← PIE *\*ne*,
+  *harkat* ← Arabic.
+- Copula forms: **मी आहे / तू आहेस / तुम्ही आहात** — one verb, reshaped per person.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full three-line exchange]
+- [YOU SAY: "how are you?" and "I'm well" for your own gender]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the respectful "how are you?" and a full answer. (*tumhī kase
+āhāt?* — *mī barā/barī āhe, dhanyavād.*) Next chapter: the farewells — *punhā
+bheṭū.*

--- a/code/learning/human-languages/marathi/lessons/MR-C03-tumhi-kase-aahat.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C03-tumhi-kase-aahat.md
@@ -1,0 +1,49 @@
+---
+id: MR-C03-tumhi-kase-aahat
+chapter: 3
+type: phrase
+headword: तुम्ही कसे आहात?
+gloss: how are you? (tumhī kase āhāt?)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [MR-C03-kasa, MR-C02-tu-tumhi, MR-C02-aahe]
+sounds: []
+roots: [ka-interrogative, asti]
+est_minutes: 4
+reviews_of: [MR-C03-kasa, MR-C02-tu-tumhi, MR-C02-aahe]
+---
+
+# तुम्ही कसे आहात? (tumhī kase āhāt?) — "how are you?"
+
+## Warm-up
+
+[PAUSE 2s] The full courteous "how are you?" — assembled from words you already
+hold.
+
+## The phrase, assembled
+
+**तुम्ही** (*tumhī*, respectful "you") + **कसे** (*kase*, "how," plural-agreeing)
++ **आहात** (*āhāt*, "are," respectful) → **तुम्ही कसे आहात?** — "you how are?",
+verb last.
+
+Two agreements are at work:
+- Because **तुम्ही** is grammatically plural, "how" appears as **कसे** (*kase*,
+  the plural form of *kasā*), and the copula as **आहात** (*āhāt*).
+- To a single male friend: **तू कसा आहेस?** (*tū kasā āhes?*); to a female
+  friend: **तू कशी आहेस?** (*tū kaśī āhes?*).
+
+## Why it's said this way
+
+The respectful *tumhī … āhāt* is the safe default with anyone new. The gendered
+*kasā/kaśī* only appears in the familiar *tū* form — one more place Marathi's
+three genders surface in ordinary speech.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tumhī kase āhāt?" — how are you? (respectful)]
+- [YOU SAY: it to a female friend (*tū kaśī āhes?*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why *kase* and *āhāt* (not *kasā*, *āhes*) with *tumhī*? (*tumhī* is
+grammatically plural, so "how" and "are" take plural forms.)

--- a/code/learning/human-languages/marathi/lessons/MR-C04-bhetu.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C04-bhetu.md
@@ -1,0 +1,51 @@
+---
+id: MR-C04-bhetu
+chapter: 4
+type: word
+headword: भेटू
+gloss: (we'll) meet (bheṭū)
+concept_tag: MR-VERB-BHETNE
+prerequisites: [MR-C04-punha, MR-C02-anand]
+sounds: [matra-e, matra-u]
+roots: [bhet-meet]
+est_minutes: 4
+reviews_of: [MR-C02-anand]
+---
+
+# भेटू (bheṭū) — "(let's / we'll) meet"
+
+## Warm-up
+
+[PAUSE 2s] The other half of the goodbye: **meet**. You already brushed past it
+in *bheṭūn ānand jhālā* ("pleased to meet you").
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **भे** (*bhe*) + **टू** (*ṭū*, the retroflex ट
+*ṭa* with the long-*u* stroke) → **भेटू** *bheṭū*. Note the **retroflex ट**
+(*ṭa*) — the tongue curls back to the roof of the mouth.
+
+## The word, taken apart
+
+**भेटू** (*bheṭū*) is a form of the verb **भेटणे** (*bheṭṇe*, "to meet"). As
+**भेटू** it means "let's meet / (we) will meet" — the hopeful, forward-looking
+mood you want in a goodbye. It is a native Marathi verb (the *bheṭ-* stem also
+gives *bheṭ*, "a meeting, a visit").
+
+## Grammar Lens: one verb, first-person-plural wish
+
+**भेटू** carries a built-in "we/let's" — no separate word for "we" is needed, the
+verb form says it. This is the same **-ū** ending you'll feel in other
+"let's ___" verbs. Unlike the present tense (*yeto/yete*), this future-wish form
+does **not** split by gender — men and women both say *bheṭū*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bheṭū" — (we'll) meet]
+- [YOU SAY: the fuller verb it comes from (*bheṭṇe*, to meet)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *bheṭū* pack into one word? ("(we/let's) will meet" — the
+"we" lives in the verb ending.)

--- a/code/learning/human-languages/marathi/lessons/MR-C04-kalji-ghya.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C04-kalji-ghya.md
@@ -1,0 +1,52 @@
+---
+id: MR-C04-kalji-ghya
+chapter: 4
+type: phrase
+headword: काळजी घ्या
+gloss: take care (kāḷjī ghyā)
+concept_tag: MR-PHRASE-TAKE-CARE
+prerequisites: [MR-C04-udya-bhetu]
+sounds: [retroflex-la]
+roots: []
+est_minutes: 4
+reviews_of: [MR-C02-tu-tumhi]
+---
+
+# काळजी घ्या (kāḷjī ghyā) — "take care"
+
+## Warm-up
+
+[PAUSE 2s] One last, tender goodbye — the Marathi "take care," and with it a
+letter unique to Marathi's corner of Devanagari.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **काळजी** carries the letter **ळ** (*ḷa*) — a
+**retroflex "l,"** the tongue curled back. Standard Hindi dropped this sound;
+Marathi (like the Dravidian south and Gujarati) keeps it, and it appears in many
+everyday Marathi words. **का** + **ळ** + **जी** → *kāḷjī*. Then **घ्या** (*ghyā*,
+"take," respectful).
+
+## The phrase, assembled
+
+**काळजी** (*kāḷjī*, "care, concern") + **घ्या** (*ghyā*, "take," the respectful
+imperative) → **काळजी घ्या** — "take care." To a friend, the familiar imperative:
+**काळजी घे** (*kāḷjī ghe*).
+
+## Why it's said this way
+
+Where *punhā bheṭū* looks ahead to the next meeting, *kāḷjī ghyā* looks after the
+person in between — "mind yourself until then." The respectful **घ्या** (*ghyā*)
+matches the **तुम्ही** register from Chapter 2; the familiar **घे** (*ghe*)
+matches **तू**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kāḷjī ghyā" (respectful) / "kāḷjī ghe" (to a friend)]
+- [YOU SAY: the retroflex ळ (*ḷa*) Marathi keeps that Hindi lost]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which special Marathi letter sits in *kāḷjī*, and who else keeps it?
+(The retroflex **ळ** *ḷa*; also kept by the Dravidian languages and Gujarati.)

--- a/code/learning/human-languages/marathi/lessons/MR-C04-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C04-practice.md
@@ -1,0 +1,49 @@
+---
+id: MR-C04-practice
+chapter: 4
+type: practice
+headword: (recap)
+gloss: Chapter 4 recap — farewells
+concept_tag: REVIEW
+prerequisites: [MR-C04-kalji-ghya]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [MR-C04-punha, MR-C04-bhetu, MR-C04-punha-bhetu, MR-C04-udya-bhetu, MR-C04-kalji-ghya, MR-C01-yeto]
+---
+
+# Chapter 4 recap — farewells
+
+## Warm-up
+
+[PAUSE 2s] The parting words, together — none of them a bare "goodbye."
+
+## The farewells
+
+| Marathi | English |
+|---|---|
+| येतो / येते. | I'll be going. ("I come again") |
+| पुन्हा भेटू. | See you again. |
+| उद्या भेटू. | See you tomorrow. |
+| काळजी घ्या. | Take care. |
+
+## Atoms banked this chapter
+
+- **पुन्हा** (*punhā*) — again; Sanskrit *punar*.
+- **भेटू** (*bheṭū*) — (we'll) meet; the "we" lives in the verb; from *bheṭṇe*.
+- **उद्या** (*udyā*) — tomorrow (distinct from *kāl*, yesterday).
+- **काळजी घ्या** (*kāḷjī ghyā*) — take care; the retroflex **ळ** Marathi keeps.
+- Register: **घ्या** (*ghyā*, respectful) vs **घे** (*ghe*, familiar) — the
+  *tumhī / tū* choice again.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: all four farewells in a row]
+- [YOU SAY: a stacked goodbye — *yeto, punhā bheṭū, kāḷjī ghyā*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do every Marathi goodbye have in common? (None says "farewell" —
+each is a **return** or a caring wish.) Next chapter: the first real verbs —
+*mī marāṭhī bolto.*

--- a/code/learning/human-languages/marathi/lessons/MR-C04-punha-bhetu.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C04-punha-bhetu.md
@@ -1,0 +1,46 @@
+---
+id: MR-C04-punha-bhetu
+chapter: 4
+type: phrase
+headword: पुन्हा भेटू
+gloss: see you again (punhā bheṭū)
+concept_tag: FAREWELL-LATER
+prerequisites: [MR-C04-punha, MR-C04-bhetu, MR-C01-yeto]
+sounds: []
+roots: [punar, bhet-meet]
+est_minutes: 3
+reviews_of: [MR-C04-punha, MR-C04-bhetu, MR-C01-yeto]
+---
+
+# पुन्हा भेटू (punhā bheṭū) — "see you again"
+
+## Warm-up
+
+[PAUSE 2s] Assemble the two atoms into the standard warm goodbye.
+
+## The phrase, assembled
+
+**पुन्हा** (*punhā*, again) + **भेटू** (*bheṭū*, we'll meet) → **पुन्हा भेटू** —
+"we'll meet again." Two words, and the whole promise of return is spoken.
+
+This is the fuller, explicit twin of Chapter 1's **येतो** (*yeto*, "I'll come
+[again]"). Both refuse a final "farewell": one says *I'll come back*, the other
+*we'll meet again* — the subcontinent's shared goodbye-as-promise (Hindi *phir
+milenge*, Bengali *āshi*, Tamil *pōy varugiṟēṉ*).
+
+## Why it's said this way
+
+You can stack them for warmth: **येतो, पुन्हा भेटू** (*yeto, punhā bheṭū*) — "I'll
+be going; we'll meet again." Neither word contains "goodbye"; the parting is all
+return.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "punhā bheṭū" — see you again]
+- [YOU SAY: it stacked with the Chapter-1 goodbye (*yeto, punhā bheṭū*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *punhā bheṭū* literally promise? ("We'll meet **again**" —
+return, not farewell.)

--- a/code/learning/human-languages/marathi/lessons/MR-C04-punha.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C04-punha.md
@@ -1,0 +1,49 @@
+---
+id: MR-C04-punha
+chapter: 4
+type: word
+headword: पुन्हा
+gloss: again (punhā)
+concept_tag: MR-WORD-PUNHA
+prerequisites: [MR-C01-yeto]
+sounds: [halant-conjunct, matra-aa]
+roots: [punar]
+est_minutes: 3
+reviews_of: [MR-C01-yeto]
+---
+
+# पुन्हा (punhā) — "again"
+
+## Warm-up
+
+[PAUSE 2s] Chapter 1 gave you the goodbye *yeto* ("I'll come [again]"). Now the
+explicit word for **again**, to build the warm "see you again."
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **पु** (*pu*) + **न्हा** (*nhā*, the न *na*
+joined by a *halant* to ह *ha* with the long-*ā* stroke) → **पुन्हा** *punhā*.
+
+## The word, taken apart
+
+**पुन्हा** (*punhā*, "again") comes from Sanskrit **पुनर्** (*punar*, "again,
+back"). That *punar* is a genuine Indo-European cousin of Latin **re-** in the
+sense of "back/again," and it echoes in Hindi *phir* and the *puna-* of
+*punarjanma* ("rebirth"). To say a thing *punhā* is to send it round once more.
+
+## Why it's said this way
+
+Marathi's goodbyes lean on *again* and *meet* rather than on *farewell* — the
+parting is framed as a **return**, never an ending. This word is the hinge of
+that idea.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "punhā" — again]
+- [YOU SAY: its Sanskrit source (*punar*) and the *punarjanma* echo]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does *punhā* mean, and from what Sanskrit word? ("Again"; from
+*punar*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C04-udya-bhetu.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C04-udya-bhetu.md
@@ -1,0 +1,52 @@
+---
+id: MR-C04-udya-bhetu
+chapter: 4
+type: phrase
+headword: उद्या भेटू
+gloss: see you tomorrow (udyā bheṭū)
+concept_tag: FAREWELL-TOMORROW
+prerequisites: [MR-C04-punha-bhetu]
+sounds: [halant-conjunct, matra-aa]
+roots: [bhet-meet]
+est_minutes: 3
+reviews_of: [MR-C04-bhetu]
+---
+
+# उद्या भेटू (udyā bheṭū) — "see you tomorrow"
+
+## Warm-up
+
+[PAUSE 2s] Swap "again" for "tomorrow" and you have a dated goodbye.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **उ** (*u*, standalone vowel) + **द्या** (*dyā*,
+द *da* joined by a *halant* to य *ya* with the long-*ā* stroke) → **उद्या**
+*udyā*.
+
+## The phrase, assembled
+
+**उद्या** (*udyā*, "tomorrow") + **भेटू** (*bheṭū*, we'll meet) → **उद्या भेटू** —
+"we'll meet tomorrow."
+
+**उद्या** comes from Sanskrit **श्वः** (*śvaḥ*) by way of a later *udya-*; unlike
+Hindi's *kal* (which means *both* tomorrow and yesterday), Marathi keeps
+**tomorrow** and **yesterday** as two distinct words — *udyā* (tomorrow) vs.
+**काल** (*kāl*, yesterday). No ambiguity about which way time is pointing.
+
+## Why it's said this way
+
+Because *bheṭū* already carries the future wish, you simply front it with *when*:
+*udyā bheṭū* (tomorrow), *punhā bheṭū* (again). The verb does the tense; the first
+word sets the day.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "udyā bheṭū" — see you tomorrow]
+- [YOU SAY: the tomorrow/yesterday pair Marathi keeps apart (*udyā / kāl*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How does Marathi's *udyā* differ from Hindi's *kal*? (*udyā* is only
+"tomorrow"; Marathi uses a separate word *kāl* for "yesterday.")

--- a/code/learning/human-languages/marathi/lessons/MR-C05-bolne.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C05-bolne.md
@@ -1,0 +1,56 @@
+---
+id: MR-C05-bolne
+chapter: 5
+type: word
+headword: बोलणे
+gloss: to speak (bolṇe)
+concept_tag: MR-VERB-BOLNE
+prerequisites: [MR-C01-yeto, MR-C02-aahe]
+sounds: [matra-o, retroflex-na]
+roots: [bol-speak]
+est_minutes: 4
+reviews_of: [MR-C01-yeto]
+---
+
+# बोलणे (bolṇe) — "to speak"
+
+## Warm-up
+
+[PAUSE 2s] Until now, verbs of *being* and *meeting*. Here is your first verb of
+**doing** — to speak — and the pattern that runs every Marathi verb.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **बो** (*bo*) + **ल** (*la*) + **णे** (*ṇe*, the
+**retroflex** ण *ṇa* with the *-e* stroke) → **बोलणे** *bolṇe*.
+
+## The word, taken apart
+
+**बोलणे** (*bolṇe*, "to speak") is a native Indo-Aryan verb on the stem
+**bol-** — the same *bol-* as Hindi *bolnā* and Punjabi *bolṇā*. Its ending
+**-णे** (*-ṇe*) is the Marathi **infinitive** ("to ___"): *bol-ṇe* "to speak,"
+*bheṭ-ṇe* "to meet," *ye-ṇe* "to come." Strip *-ṇe* and you have the stem to
+build on: **bol-**.
+
+## Grammar Lens: stem + gendered present ending
+
+From the stem you build the present tense — and, as with *yeto/yete*, it splits
+by the speaker's gender:
+- **मी बोलतो** (*mī bolto*) — a man speaks
+- **मी बोलते** (*mī bolte*) — a woman speaks
+- (plural / respectful: **बोलतो / बोलता**)
+
+The verb still ends the sentence; the copula-less present tense is one word doing
+the work.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "bolṇe" — to speak; then the stem (*bol-*)]
+- [YOU SAY: "I speak" for your own gender (*mī bolto* / *mī bolte*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the Marathi infinitive ending, and how does the present split?
+(*-ṇe*; the present ending changes with the speaker's gender — *bolto* m. /
+*bolte* f.)

--- a/code/learning/human-languages/marathi/lessons/MR-C05-kaam-karne.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C05-kaam-karne.md
@@ -1,0 +1,51 @@
+---
+id: MR-C05-kaam-karne
+chapter: 5
+type: word
+headword: काम करणे
+gloss: to work (kām karṇe)
+concept_tag: MR-VERB-KARNE
+prerequisites: [MR-C05-rahne, MR-C01-namaskar]
+sounds: [matra-aa, retroflex-na]
+roots: [kr-do]
+est_minutes: 4
+reviews_of: [MR-C05-bolne, MR-C01-namaskar]
+---
+
+# काम करणे (kām karṇe) — "to work"
+
+## Warm-up
+
+[PAUSE 2s] Your third verb — **to work** — and it closes a circle back to
+Chapter 1's greeting.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **काम** (*kām*): **का** + **म** (*ma*). **करणे**
+(*karṇe*): **क** (*ka*) + **र** (*ra*) + **णे** (*ṇe*, retroflex).
+
+## The word, taken apart
+
+**करणे** (*karṇe*, "to do, make") is from Sanskrit **√कृ** (*kṛ*, "to do"), from
+PIE **\*kʷer-**. That is the very root hiding inside Chapter 1's **नमस्कार**
+(*namaskār* = "the **making** of a bow") and inside **कर्म** (*karma*, "a thing
+**done**"). And **काम** (*kām*, "work") is itself worn down from that same
+**कर्म** (*karma*). So "to work" is literally built twice from *doing*: **काम
+करणे** (*kām karṇe*) = "work-do."
+
+## Grammar Lens: noun + करणे makes a verb
+
+Marathi builds countless verbs as **noun + करणे**: *kām karṇe* (to work), *madat
+karṇe* (to help), *sevā karṇe* (to serve). Present tense, gendered: **मी काम
+करतो** (*mī kām karto*, m.) / **करते** (*karte*, f.) — "I work."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kām karṇe" — to work; then "mī kām karto/karte"]
+- [YOU SAY: the root it shares with *namaskār* and *karma* (*√kṛ*, "to do")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What links *karṇe*, *namaskār*, and *karma*? (All from *√kṛ*, "to do" —
+and *kām* "work" is worn-down *karma*.)

--- a/code/learning/human-languages/marathi/lessons/MR-C05-mi-marathi-bolto.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C05-mi-marathi-bolto.md
@@ -1,0 +1,51 @@
+---
+id: MR-C05-mi-marathi-bolto
+chapter: 5
+type: phrase
+headword: मी मराठी बोलतो
+gloss: I speak Marathi (gendered)
+concept_tag: MR-WORD-MARATHI
+prerequisites: [MR-C05-bolne, MR-C03-mi]
+sounds: [retroflex-tha]
+roots: [maharashtra]
+est_minutes: 5
+reviews_of: [MR-C05-bolne, MR-C03-mi]
+---
+
+# मी मराठी बोलतो (mī marāṭhī bolto) — "I speak Marathi"
+
+## Warm-up
+
+[PAUSE 2s] Your first full action-sentence — and it names the language itself.
+
+## The phrase, assembled
+
+**मी** (*mī*, I) + **मराठी** (*marāṭhī*, Marathi, the object) + **बोलतो**
+(*bolto*, speak) → "I Marathi speak," verb last.
+- A woman says **मी मराठी बोलते** (*mī marāṭhī bolte*).
+
+## The word, taken apart
+
+**मराठी** (*marāṭhī*) is "[the language] of **महाराष्ट्र** (*Mahārāṣṭra*)" — the
+"great kingdom/realm," *mahā* ("great," cousin of Latin *magnus* and English
+*magnitude*) + *rāṣṭra* ("nation, realm"). The people are the *Marāṭhā*, the land
+*Mahārāṣṭra*, and the tongue *marāṭhī* — all one root. It carries the same
+**retroflex** sounds you keep meeting: the ट (*ṭa*) of *marāṭhī*, the ळ of
+*kāḷjī*.
+
+## Why it's said this way
+
+The present tense needs no separate "am/do" — **बोलतो** alone says "I speak."
+Contrast Hindi, which adds a copula (*maiṁ hindī boltā **hūṁ***); Marathi folds
+the "am" into the verb ending. Cleaner, and gendered.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "mī marāṭhī bolto/bolte" — I speak Marathi]
+- [YOU SAY: the root of *marāṭhī* (*Mahārāṣṭra* = "great realm")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does the name *marāṭhī* come from? (*Mahārāṣṭra*, "great realm" —
+*mahā* "great" + *rāṣṭra* "nation.")

--- a/code/learning/human-languages/marathi/lessons/MR-C05-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C05-practice.md
@@ -1,0 +1,54 @@
+---
+id: MR-C05-practice
+chapter: 5
+type: practice
+headword: (recap)
+gloss: Chapter 5 recap — the first verbs
+concept_tag: REVIEW
+prerequisites: [MR-C05-kaam-karne]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [MR-C05-bolne, MR-C05-mi-marathi-bolto, MR-C05-rahne, MR-C05-kaam-karne]
+---
+
+# Chapter 5 recap — the first verbs
+
+## Warm-up
+
+[PAUSE 2s] Three verbs, one engine — sentences about yourself.
+
+## Sentences about yourself
+
+| Marathi | English |
+|---|---|
+| मी मराठी बोलतो / बोलते. | I speak Marathi. |
+| मी पुण्यात राहतो / राहते. | I live in Pune. |
+| मी काम करतो / करते. | I work. |
+
+## The engine, in one look
+
+- **Infinitive** ends in **-णे** (*-ṇe*): *bolṇe, rāhṇe, karṇe*.
+- **Present** = stem + a **gendered** ending — *-to* (m.) / *-te* (f.): *bolto/
+  bolte, rāhto/rāhte, karto/karte*. No separate "am" — the ending carries it.
+- **Verb goes last**; **"in"** attaches to the noun's end (*puṇyāt*).
+
+## Roots banked
+
+- **बोलणे** (*bolṇe*) — to speak (native *bol-*).
+- **मराठी** (*marāṭhī*) — from *Mahārāṣṭra*, "great realm."
+- **राहणे** (*rāhṇe*) — to live (Sanskrit *rah-*).
+- **करणे** (*karṇe*) — to do/work (√*kṛ* — root of *namaskār*, *karma*; *kām* ←
+  *karma*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: all three sentences for your own gender]
+- [YOU SAY: "I speak Marathi and I work" (*mī marāṭhī bolto āṇi kām karto*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What three things does the Marathi present tense fold into one word?
+(The action, the person, and their gender — no separate "am.") From here, Marathi
+only opens further.

--- a/code/learning/human-languages/marathi/lessons/MR-C05-rahne.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C05-rahne.md
@@ -1,0 +1,50 @@
+---
+id: MR-C05-rahne
+chapter: 5
+type: word
+headword: राहणे
+gloss: to live, to stay (rāhṇe)
+concept_tag: MR-VERB-RAHNE
+prerequisites: [MR-C05-bolne]
+sounds: [matra-aa, retroflex-na]
+roots: [rah-remain]
+est_minutes: 4
+reviews_of: [MR-C05-mi-marathi-bolto]
+---
+
+# राहणे (rāhṇe) — "to live, to stay"
+
+## Warm-up
+
+[PAUSE 2s] A second verb on the same engine — **to live** — and a first
+postposition to place yourself somewhere.
+
+## The letters in this word
+
+*(Skim if you read Devanagari.)* **रा** (*rā*) + **ह** (*ha*) + **णे** (*ṇe*,
+retroflex) → **राहणे** *rāhṇe*.
+
+## The word, taken apart
+
+**राहणे** (*rāhṇe*, "to live, remain, stay") is from Sanskrit **रह्** (*rah-*, "to
+remain") — the same root behind Hindi *rahnā*. Present tense, gendered as always:
+**मी पुण्यात राहतो** (*mī puṇyāt rāhto*, a man) / **राहते** (*rāhte*, a woman) — "I
+live in Pune."
+
+## Grammar Lens: "in" comes *after* the noun
+
+Look at **पुण्यात** (*puṇyāt*) = **पुणे** (*Puṇe*, the city) + **-ात** (*-āt*,
+"in"). Marathi glues "in" onto the **end** of the noun — a **post**position, not a
+preposition. Verb last, place-marker on the noun's tail: *mī puṇyāt rāhto*,
+"I in-Pune live."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rāhṇe" — to live; then "mī puṇyāt rāhto/rāhte"]
+- [YOU SAY: how "in" attaches (*Puṇe* + *-āt* → *puṇyāt*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where does "in" go in Marathi, and on what root is *rāhṇe*? (On the
+**end** of the noun (*-āt*); Sanskrit *rah-* "to remain.")

--- a/code/learning/human-languages/marathi/roadmap.md
+++ b/code/learning/human-languages/marathi/roadmap.md
@@ -13,18 +13,31 @@ extra letter ळ, and a Dravidian-flavoured everyday grammar. The script is taug
 
 ## Authored
 
-- **Ch. 1 — Greetings**: namaskār → dhanyavād → ho → nāhī → baraṃ → yeto/yete →
+- **Ch. 1 — Greetings**: namaskār → dhanyavād → ho → nāhī → baraṁ → yeto/yete →
   practice. Devanagari introduced through the words; Marathi's distinctives
   foregrounded.
+- **Ch. 2 — Introducing Yourself**: nāv → mājhaṁ → āhe → "my name is…" → tū/tumhī
+  → kāy → "what's your name?" → ānand → practice. The copula *āhe* going last;
+  three-gender agreement.
+- **Ch. 3 — How Are You**: kasā → "tumhī kase āhāt?" → mī → "mī barā āhe" → kāhī
+  harkat nāhī → practice. The *k-* questions; the Perso-Arabic *harkat*.
+- **Ch. 4 — Farewells**: punhā → bheṭū → "punhā bheṭū" → "udyā bheṭū" → kāḷjī ghyā
+  → practice. The future-wish *-ū*; the retroflex ळ.
+- **Ch. 5 — The First Verbs**: bolṇe → "mī marāṭhī bolto" → rāhṇe → kām karṇe →
+  practice. The *-ṇe* infinitive; the gendered present (*-to/-te*); postposition
+  *-āt*.
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 2 | Introducing yourself: *mājhe nāv…* ("my name"), *tū* / *tumhī* (familiar / respectful "you"), the three genders at the first noun |
-| 3 | Responding: *kase āhāt?* ("how are you"), *maja āhe* ("I'm well"), the verb *asaṇe* ("to be," *āhe*) |
-| 4 | The case-endings (Marathi's postpositions), numbers 1–10 |
-| 5+ | Gendered verbs deepened, family, food — always with the Hindi/Dravidian contrast thread |
+| 6 | Numbers 1–10 (native words + Devanagari digits १२३), counting, age |
+| 7 | Family (*āī*, *bābā*, *bhāū*, *bahīṇ*) and the honorific *-jī* / *-rāv* |
+| 8 | Food and the market — where the Perso-Arabic and Portuguese loans cluster |
+| 9+ | The case-endings deepened, past and future tenses (where gender returns on the verb), everyday sentences — always with the Hindi/Dravidian contrast thread |
 
 Note: Marathi marks "you" by **register** (*tū* familiar / *tumhī* respectful,
-also plural) — like the other Indo-Aryan and Romance tracks.
+also plural) — like the other Indo-Aryan and Romance tracks. Its signature is
+gender on the **verb** in the present tense (*yeto/yete*, *bolto/bolte*), the
+**three** genders, and the extra retroflex letter **ळ** — all now surfaced across
+Chapters 1–5.

--- a/code/learning/human-languages/marathi/session-map.md
+++ b/code/learning/human-languages/marathi/session-map.md
@@ -1,4 +1,4 @@
-# Session Map — Marathi Chapter 1 (Greetings)
+# Session Map — Marathi Chapters 1–5
 
 Same spaced-repetition schedule as the other tracks (a word from session *N*
 resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
@@ -20,7 +20,53 @@ word needs.
 | 6 | yeto | येतो / येते | "I'll be going" — gendered verb (m./f.); "promise of return" |
 | 7 | practice | (recap) | greetings + what makes Marathi its own (3 genders, ळ) |
 
+## Chapter 2 — Introducing Yourself
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 8 | naav | नाव | "name" ← Sanskrit *nāman* (English *name*); the *m→v* softening |
+| 9 | majhe | माझं | "my" ← *ma-* (English *me/my*); three genders *mājhā/mājhī/mājhaṁ* |
+| 10 | aahe | आहे | "is" ← Sanskrit *ásti* (√as, English *is*); the verb goes last |
+| 11 | majhe-naav-aahe | माझं नाव … आहे | "my name is…" assembled |
+| 12 | tu-tumhi | तू / तुम्ही | familiar / respectful "you"; *tū* → *thou*; courtesy-by-plural |
+| 13 | kaay | काय | "what"; the *k-* question family (PIE *\*kʷo-*) |
+| 14 | tumche-naav-kaay-aahe | तुमचं नाव काय आहे? | "what's your name?" assembled |
+| 15 | anand | भेटून आनंद झाला | "pleased to meet you" ← *ānand* "joy" |
+| 16 | practice | (recap) | the whole introduction exchange |
+
+## Chapter 3 — How Are You
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 17 | kasa | कसा / कशी / कसं | "how"; gender-agreeing *k-* question |
+| 18 | tumhi-kase-aahat | तुम्ही कसे आहात? | "how are you?"; plural agreement with *tumhī* |
+| 19 | mi | मी | "I" ← *aham* → Latin *ego*, English *I* |
+| 20 | mi-bara-aahe | मी बरा आहे | "I'm well"; Ch1 *baraṁ* now gendered *barā/barī* |
+| 21 | kaahi-harkat-nahi | काही हरकत नाही | "no problem"; *nāhī* ← PIE *ne, *harkat* ← Arabic |
+| 22 | practice | (recap) | the whole how-are-you exchange |
+
+## Chapter 4 — Farewells
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 23 | punha | पुन्हा | "again" ← Sanskrit *punar* |
+| 24 | bhetu | भेटू | "(we'll) meet"; the "we" lives in the *-ū* ending; ← *bheṭṇe* |
+| 25 | punha-bhetu | पुन्हा भेटू | "see you again" — the promise of return |
+| 26 | udya-bhetu | उद्या भेटू | "see you tomorrow"; *udyā* distinct from *kāl* (yesterday) |
+| 27 | kalji-ghya | काळजी घ्या | "take care"; the retroflex ळ; *ghyā* (resp.) / *ghe* (fam.) |
+| 28 | practice | (recap) | the farewells |
+
+## Chapter 5 — The First Verbs
+
+| Session | Lesson | Word | Root / hook |
+|---|---|---|---|
+| 29 | bolne | बोलणे | "to speak"; the *-ṇe* infinitive; gendered present *bolto/bolte* |
+| 30 | mi-marathi-bolto | मी मराठी बोलतो | "I speak Marathi"; *marāṭhī* ← *Mahārāṣṭra* "great realm" |
+| 31 | rahne | राहणे | "to live" ← Sanskrit *rah-*; the postposition *-āt* ("in") |
+| 32 | kaam-karne | काम करणे | "to work"; *karṇe* ← √*kṛ* (root of *namaskār*, *karma*) |
+| 33 | practice | (recap) | three verbs, one engine — sentences about yourself |
+
 ## Next
 
-Chapter 2 — introducing yourself: *mājhe nāv…* ("my name"), and Marathi's *tū* /
-*tumhī* (familiar / respectful "you"), with the three genders at the first noun.
+Chapter 6 — numbers 1–10 (words + Devanagari digits १२३), then family and food,
+then the case-endings and the tenses where gender returns on the verb.


### PR DESCRIPTION
Brings the **Marathi** (Devanagari) track to **Chapter 5** parity with the leading tracks — the last Indo-Aryan track still sitting at Chapter 1, completing the whole South-Asian family at Ch 5. ~26 new deep lessons + four book chapters, mirroring the Indic template. Every atom traced to its root; the script stays inline (no reading course).

## What's here

- **Ch2 Introducing Yourself** — nāv (Sanskrit *nāman* → English *name*; the Marathi **m→v** softening), mājhaṁ (three-gender agreement), **āhe** (the copula, from *ásti*/√as → English *is*, and it goes **last**), tū/tumhī (courtesy-by-plural), kāy (the *k-* question family), ānand ("joy").
- **Ch3 How Are You** — kasā/kaśī/kasaṁ (gendered "how"), "tumhī kase āhāt?", mī (*aham* → Latin *ego*, English *I*), "mī barā āhe" (Ch1 *baraṁ* now gendered), **kāhī harkat nāhī** (*harkat* ← Arabic — the Deccan Perso-Arabic layer).
- **Ch4 Farewells** — punhā (Sanskrit *punar*), bheṭū (the "we" lives in the *-ū* ending), "punhā bheṭū", "udyā bheṭū" (Marathi keeps *udyā* tomorrow ≠ *kāl* yesterday), kāḷjī ghyā (the retroflex **ळ**).
- **Ch5 The First Verbs** — bolṇe (the *-ṇe* infinitive; the **gendered present** *bolto/bolte* — Marathi's signature), "mī marāṭhī bolto" (*marāṭhī* ← *Mahārāṣṭra* "great realm"), rāhṇe (postposition *-āt*), kām karṇe (√*kṛ* — root of *namaskār*, *karma*; *kām* ← *karma*).

## Threads
Gender on the **verb** in the present tense, the **three** genders, and the extra retroflex letter **ळ** — Marathi's distinctives, carried from Ch1 through Ch5.

## Verification
- Concept tags reuse the universal HL01 ids (WORD-NAME, PRONOUN-*, WORD-IS, QUESTION-*, INTRO-*, STATE-HOW-ARE-YOU, WORD-WELL, COURTESY-YOUREWELCOME, FAREWELL-LATER/-TOMORROW); verbs/lexemes namespaced (MR-VERB-*, MR-WORD-*, MR-PHRASE-*).
- Book compiles clean with XeLaTeX (**0 missing characters, 0 undefined references**); rasterized and visually QA'd — complex conjuncts (*Mahārāṣṭra*'s ष्ट्र, *puṇyāt*, *karṇe*) render correctly.
- Infra updated: README, CHANGELOG, roadmap, session-map; track marked Chapters 1-5 in the human-languages README table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)