### PR TITLE
feat(hl-russian): Cyrillic writing lessons II — complete the letters of привет

### DIFF
--- a/code/learning/human-languages/russian/CHANGELOG.md
+++ b/code/learning/human-languages/russian/CHANGELOG.md
@@ -30,6 +30,12 @@
   - `RU-W03-new-shapes-b-d` — writing **б** (b) and **д** (d, ← Greek delta), two
     shapes with no Latin disguise; contrasts б vs в (the top flag + one belly vs
     two bellies).
+  - `RU-W04-privet-letters-p-i` — writing **п** (p, ← Greek pi Π) and **и** (ee,
+    the quiet false friend — a *backwards* Latin N: its diagonal **rises** where
+    N's falls); contrasts п (top bar) vs н (middle bar).
+  - `RU-W05-privet-letters-e-t` — writing **е** (ye, an *iotated* honest vowel) and
+    **т** (t, ← Greek tau); **completes every letter of привет** (п·р·и·в·е·т), so
+    the learner can hand-write their first Russian word end to end.
 - Stroke data is the canonical `data/scripts/cyrillic.json` the companion
   `script-writing-visualizer` app renders, so the lessons and the app agree.
 

--- a/code/learning/human-languages/russian/lessons/RU-W04-privet-letters-p-i.md
+++ b/code/learning/human-languages/russian/lessons/RU-W04-privet-letters-p-i.md
@@ -1,0 +1,67 @@
+---
+id: RU-W04-privet-letters-p-i
+chapter: 1
+type: writing
+headword: "п, и"
+gloss: writing п (p) and и (ee) — two more letters of привет
+romanization: "p, i"
+prerequisites: [RU-W01-false-friends-v-r]
+sounds: [cyrillic-new-shapes, cyrillic-false-friends]
+roots: [greek-pi]
+est_minutes: 4
+reviews_of: [RU-W01-false-friends-v-r, RU-C01-privet]
+---
+
+# п and и — filling in привет
+
+## Warm-up
+
+[PAUSE 2s] You can already hand-write the *в* and the *р* of *привет*. Now take
+two more of its letters: **п** ("p") and **и** ("ee"). One is an honest Greek
+shape; the other is a **quiet false friend** — it looks like a Latin *N*.
+
+## п ("p") — the Greek gate
+
+**п** is Greek **pi** (Π), the letter mathematicians write for 3.14…. It's an
+honest letter: it looks like a little gateway and says **"p."**
+
+Break it apart — *two verticals joined by a top bar*:
+
+1. **the left vertical** — a downstroke.
+2. **the top bar** — a short horizontal across the top.
+3. **the right vertical** — a second downstroke, parallel to the first.
+
+A doorway shape: two posts and a lintel. (Don't confuse it with **н** — that one's
+bar sits in the **middle**, this one's sits on **top**.)
+
+## и ("ee") — the backwards N
+
+**и** says **"ee"** (as in *meet*) — a vowel. But watch out: it looks almost
+exactly like a **Latin N with the diagonal reversed**. That's the quiet trap — your
+eye reads "N," but it's a vowel.
+
+Break it apart — *two verticals joined by a rising diagonal*:
+
+1. **the left vertical** — a downstroke.
+2. **the diagonal** — from the **bottom** of the left vertical **up** to the top of
+   the right (rising left-to-right — the mirror of Latin *N*, whose diagonal
+   **falls**).
+3. **the right vertical** — a downstroke.
+
+So the tell between *и* and Latin *N* is which way the diagonal leans: **и** rises,
+*N* falls. (Later you'll meet **й** — an *и* with a little breve on top, "ee-y.")
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: trace п — "left post, top bar, right post" — sound "p"]
+- [YOU SAY: trace и — "left post, rising diagonal, right post" — sound "ee"]
+- [YOU WRITE: the start of *привет* — п · р · и · … — three letters down]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Draw **п** — what sound and which Greek letter? ("p"; Greek **pi** Π.)
+Draw **и** — what sound, and how do you tell it from Latin *N*? ("ee"; its diagonal
+**rises** left-to-right, where *N*'s falls.) Which letter has its bar on top, п or
+н? (п — top bar; н — middle bar.) Next: **е** and **т**, and you'll have all of
+*привет*.

--- a/code/learning/human-languages/russian/lessons/RU-W05-privet-letters-e-t.md
+++ b/code/learning/human-languages/russian/lessons/RU-W05-privet-letters-e-t.md
@@ -1,0 +1,69 @@
+---
+id: RU-W05-privet-letters-e-t
+chapter: 1
+type: writing
+headword: "е, т"
+gloss: writing е (ye) and т (t) — completing привет
+romanization: "e, t"
+prerequisites: [RU-W04-privet-letters-p-i]
+sounds: [cyrillic-honest, e-ye]
+roots: [greek-tau]
+est_minutes: 4
+reviews_of: [RU-W04-privet-letters-p-i, RU-C01-privet]
+---
+
+# е and т — the last two letters of привет
+
+## Warm-up
+
+[PAUSE 2s] The finish line. **е** and **т** are two of Cyrillic's most **honest**
+letters — they look like their Latin twins *and* sound close to them. Learn these
+and you can hand-write the whole of *привет* from memory.
+
+## е ("ye") — the honest vowel
+
+**е** looks like a Latin **e** and sounds close to one — with a small twist: at the
+start of a syllable it carries a **y**-glide, "**ye**" (as in *yes*). So *привет*
+ends *…v-**ye**-t*. (Letters that add a *y*-onset like this are called *iotated* —
+*е, ё, ю, я* are the family; you'll meet the others in Chapter 2.)
+
+Break it apart — *a curve, then a middle bar* (exactly like writing a Latin *e*):
+
+1. **the curve** — start top-right, sweep left, curl down and round.
+2. **the middle bar** — the short horizontal that closes the *e*.
+
+No trap here: what you see is what you get.
+
+## т ("t") — Greek tau, honest too
+
+**т** is Greek **tau** (τ), and it looks and sounds like Latin **T**: a crossbar on
+a stem. (In *handwriting* Russians often make lowercase *т* look like an *m* with a
+bar over it, but the printed citation form is the clean T-shape you see here.)
+
+Break it apart — *a central downstroke, then a top bar*:
+
+1. **the downstroke** — a vertical stem.
+2. **the top bar** — a horizontal across the top, centred on the stem.
+
+## Now write the whole word
+
+You now own every letter of **привет**:
+
+> **п** (p) · **р** (r) · **и** (ee) · **в** (v) · **е** (ye) · **т** (t) = *privét*
+
+Two of them are false friends (**р**=r, **в**=v), one is a quiet one (**и**=ee), and
+three are honest (**п, е, т**). Write it slowly, naming each letter's sound.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: trace е — "curve, middle bar" — sound "ye"]
+- [YOU SAY: trace т — "downstroke, top bar" — sound "t", Greek tau]
+- [YOU WRITE: the full word — *привет* — start to finish, from memory]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Draw **е** — what sound, and what does *iotated* mean? ("Ye"; it carries
+a *y*-onset.) Draw **т** — what sound and which Greek letter? ("t"; Greek **tau**.)
+Spell out the letters of *привет* with their sounds. (п-р-и-в-е-т = p-r-i-v-ye-t.)
+You can now hand-write your first Russian word end to end.

--- a/code/learning/human-languages/russian/roadmap.md
+++ b/code/learning/human-languages/russian/roadmap.md
@@ -22,8 +22,11 @@ Chapter 1 words introduced — component strokes + stroke order, from the canoni
 - `RU-W01` — **в** (v ← beta) and **р** (r ← rho), the two false friends in *привет*.
 - `RU-W02` — **с** (s ← sigma) and **н** (n, the *H*-look-alike), completing в·р·с·н.
 - `RU-W03` — **б** (b) and **д** (d ← delta), two shapes with no Latin disguise
-  (and how б differs from в). More letters get a writing lesson as later chapters
-  introduce them (я э ю ч ш ь in Ch.2).
+  (and how б differs from в).
+- `RU-W04` — **п** (p ← pi) and **и** (ee, the backwards-N quiet false friend).
+- `RU-W05` — **е** (ye, iotated) and **т** (t ← tau), which **completes every
+  letter of привет** — the learner can now hand-write the whole word. More letters
+  get a writing lesson as later chapters introduce them (я э ю ч ш ь in Ch.2).
 
 ## Chapter 2 — Introducing yourself *(planned)*
 


### PR DESCRIPTION
Extends the Russian hand-writing strand (RU-W01/02/03) with the **remaining letters of *привет***, so the learner can now write the whole word end to end. Two `writing`-type lessons (no `concept_tag`; exempt from the cross-language join), each broken into component strokes with a stroke order, from the canonical `cyrillic.json` the companion `script-writing-visualizer` app renders.

## Lessons
- **RU-W04-privet-letters-p-i** — writing **п** (p, ← Greek *pi* Π; the top-bar "gateway", vs *н*'s middle bar) and **и** (ee, the **quiet false friend** — a *backwards* Latin N: its diagonal **rises** where N's falls).
- **RU-W05-privet-letters-e-t** — writing **е** (ye, an *iotated* honest vowel) and **т** (t, ← Greek *tau*). **Completes every letter of привет** (п·р·и·в·е·т = p-r-i-v-ye-t): two false friends (р/в), one quiet one (и), three honest (п/е/т).

The learner has now met all six letters of *привет* twice — read inline in Ch.1, and now hand-formed — and can write their first Russian word from memory.

## Verification
- No `taxonomy.json` change (writing lessons carry no `concept_tag`).
- `human-language-data` suite: **38 / 38 pass** (main was clean on retired tags this cycle — no red-main fix needed).
- Security-reviewed (subagent): pure markdown lesson content — no scripts, URLs, secrets, or injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)