### PR TITLE
Add Haskell point2d package

### DIFF
--- a/code/packages/haskell/point2d/BUILD
+++ b/code/packages/haskell/point2d/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/point2d/BUILD_windows
+++ b/code/packages/haskell/point2d/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/point2d/CHANGELOG.md
+++ b/code/packages/haskell/point2d/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0 - 2026-07-19
+
+- Add immutable G2D00 `Point` and `Rect` values.
+- Add vector arithmetic, products, norms, interpolation, perpendiculars, and
+  direction angles through the existing pure Haskell `trig` package.
+- Add half-open containment, union, strict positive-area intersection, and
+  symmetric rectangle expansion.
+- Add package-native coverage for construction, vector geometry, empty and
+  negative rectangles, boundary behavior, and set operations.

--- a/code/packages/haskell/point2d/README.md
+++ b/code/packages/haskell/point2d/README.md
@@ -1,0 +1,28 @@
+# point2d (Haskell)
+
+Pure Haskell implementation of the G2D00 two-dimensional geometry primitives.
+The package provides immutable points/vectors and axis-aligned rectangles
+without calling a native graphics library.
+
+## API
+
+- `Point` stores an `(x, y)` coordinate pair.
+- `origin`, `add`, `subtract`, `scale`, and `negate` provide vector arithmetic.
+- `dot`, `cross`, `magnitude`, `normalize`, `distance`, `lerp`,
+  `perpendicular`, and `angle` provide vector geometry.
+- `Rect` stores an origin and extent.
+- `rectFromPoints`, `zeroRect`, `minPoint`, `maxPoint`, and `center` construct
+  and inspect rectangles.
+- `isEmpty`, `containsPoint`, `union`, `intersection`, and `expandBy` provide
+  half-open AABB predicates and set operations.
+
+`magnitude` and `angle` compose the existing pure Haskell `trig` package.
+Rectangle containment uses `[x, x + width) x [y, y + height)`, so the top and
+left edges are included while the right and bottom edges are excluded.
+
+## Development
+
+```sh
+cabal test all
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/point2d/cabal.project
+++ b/code/packages/haskell/point2d/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../trig

--- a/code/packages/haskell/point2d/point2d.cabal
+++ b/code/packages/haskell/point2d/point2d.cabal
@@ -1,0 +1,33 @@
+cabal-version: 3.0
+name:          point2d
+version:       0.1.0
+synopsis:      Immutable 2D points, vectors, and axis-aligned rectangles
+description:   Pure G2D00 point and vector arithmetic together with immutable half-open axis-aligned rectangle geometry.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Point2D
+    build-depends:    base >=4.14 && <5
+                    , trig >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Point2DSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , point2d
+                    , trig >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/point2d/src/Point2D.hs
+++ b/code/packages/haskell/point2d/src/Point2D.hs
@@ -1,0 +1,202 @@
+-- | Immutable 2D points, vectors, and axis-aligned rectangles.
+module Point2D
+    ( Point (..)
+    , Rect (..)
+    , origin
+    , add
+    , subtract
+    , scale
+    , negate
+    , dot
+    , cross
+    , magnitude
+    , magnitudeSquared
+    , normalize
+    , distance
+    , distanceSquared
+    , lerp
+    , perpendicular
+    , angle
+    , rectFromPoints
+    , zeroRect
+    , minPoint
+    , maxPoint
+    , center
+    , isEmpty
+    , containsPoint
+    , union
+    , intersection
+    , expandBy
+    ) where
+
+import qualified Prelude as P
+import Prelude hiding (negate, subtract)
+import qualified Trig
+
+-- | A position or vector in the Cartesian plane.
+data Point = Point
+    { pointX :: Double
+    , pointY :: Double
+    }
+    deriving (Eq, Show)
+
+-- | An axis-aligned rectangle represented by its top-left corner and extent.
+data Rect = Rect
+    { rectX :: Double
+    , rectY :: Double
+    , rectWidth :: Double
+    , rectHeight :: Double
+    }
+    deriving (Eq, Show)
+
+-- | The additive identity @(0, 0)@.
+origin :: Point
+origin = Point 0.0 0.0
+
+-- | Add two points component by component.
+add :: Point -> Point -> Point
+add left right =
+    Point
+        (pointX left + pointX right)
+        (pointY left + pointY right)
+
+-- | Subtract the second point from the first component by component.
+subtract :: Point -> Point -> Point
+subtract left right =
+    Point
+        (pointX left - pointX right)
+        (pointY left - pointY right)
+
+-- | Multiply both components by a scalar.
+scale :: Point -> Double -> Point
+scale point factor = Point (pointX point * factor) (pointY point * factor)
+
+-- | Return the additive inverse of a point.
+negate :: Point -> Point
+negate point = Point (P.negate (pointX point)) (P.negate (pointY point))
+
+-- | Compute the scalar dot product.
+dot :: Point -> Point -> Double
+dot left right = pointX left * pointX right + pointY left * pointY right
+
+-- | Compute the scalar two-dimensional cross product.
+cross :: Point -> Point -> Double
+cross left right = pointX left * pointY right - pointY left * pointX right
+
+-- | Compute Euclidean length through the shared pure 'Trig.sqrt'.
+magnitude :: Point -> Double
+magnitude point =
+    case Trig.sqrt (magnitudeSquared point) of
+        Right value -> value
+        Left _ -> 0.0
+
+-- | Compute squared Euclidean length without a square root.
+magnitudeSquared :: Point -> Double
+magnitudeSquared point = pointX point * pointX point + pointY point * pointY point
+
+-- | Return a unit vector, or 'origin' when the magnitude is effectively zero.
+normalize :: Point -> Point
+normalize point
+    | size < 1e-12 = origin
+    | otherwise = Point (pointX point / size) (pointY point / size)
+  where
+    size = magnitude point
+
+-- | Compute Euclidean distance between two points.
+distance :: Point -> Point -> Double
+distance left right = magnitude (subtract left right)
+
+-- | Compute squared Euclidean distance between two points.
+distanceSquared :: Point -> Point -> Double
+distanceSquared left right = magnitudeSquared (subtract left right)
+
+-- | Linearly interpolate without clamping the interpolation factor.
+lerp :: Point -> Point -> Double -> Point
+lerp start end amount =
+    Point
+        (pointX start + amount * (pointX end - pointX start))
+        (pointY start + amount * (pointY end - pointY start))
+
+-- | Rotate a vector 90 degrees counterclockwise.
+perpendicular :: Point -> Point
+perpendicular point = Point (P.negate (pointY point)) (pointX point)
+
+-- | Return the direction in radians in the range @(-pi, pi]@.
+angle :: Point -> Double
+angle point = Trig.atan2 (pointY point) (pointX point)
+
+-- | Construct a rectangle from top-left and bottom-right corner points.
+rectFromPoints :: Point -> Point -> Rect
+rectFromPoints minimumPoint maximumPoint =
+    Rect
+        (pointX minimumPoint)
+        (pointY minimumPoint)
+        (pointX maximumPoint - pointX minimumPoint)
+        (pointY maximumPoint - pointY minimumPoint)
+
+-- | The empty rectangle at the origin.
+zeroRect :: Rect
+zeroRect = Rect 0.0 0.0 0.0 0.0
+
+-- | Return the rectangle's top-left corner.
+minPoint :: Rect -> Point
+minPoint rect = Point (rectX rect) (rectY rect)
+
+-- | Return the rectangle's bottom-right corner.
+maxPoint :: Rect -> Point
+maxPoint rect =
+    Point
+        (rectX rect + rectWidth rect)
+        (rectY rect + rectHeight rect)
+
+-- | Return the rectangle's center.
+center :: Rect -> Point
+center rect =
+    Point
+        (rectX rect + rectWidth rect / 2.0)
+        (rectY rect + rectHeight rect / 2.0)
+
+-- | A rectangle is empty when either extent is non-positive.
+isEmpty :: Rect -> Bool
+isEmpty rect = rectWidth rect <= 0.0 || rectHeight rect <= 0.0
+
+-- | Test the half-open region @[x, x + width) x [y, y + height)@.
+containsPoint :: Rect -> Point -> Bool
+containsPoint rect point =
+    rectX rect <= pointX point
+        && pointX point < rectX rect + rectWidth rect
+        && rectY rect <= pointY point
+        && pointY point < rectY rect + rectHeight rect
+
+-- | Return the smallest rectangle that contains both inputs.
+-- Empty rectangles act as the identity value.
+union :: Rect -> Rect -> Rect
+union left right
+    | isEmpty left = right
+    | isEmpty right = left
+    | otherwise = Rect minimumX minimumY (maximumX - minimumX) (maximumY - minimumY)
+  where
+    minimumX = min (rectX left) (rectX right)
+    minimumY = min (rectY left) (rectY right)
+    maximumX = max (rectX left + rectWidth left) (rectX right + rectWidth right)
+    maximumY = max (rectY left + rectHeight left) (rectY right + rectHeight right)
+
+-- | Return the positive-area overlap, or 'Nothing' for disjoint or touching rectangles.
+intersection :: Rect -> Rect -> Maybe Rect
+intersection left right
+    | overlapWidth <= 0.0 || overlapHeight <= 0.0 = Nothing
+    | otherwise = Just (Rect overlapX overlapY overlapWidth overlapHeight)
+  where
+    overlapX = max (rectX left) (rectX right)
+    overlapY = max (rectY left) (rectY right)
+    overlapWidth = min (rectX left + rectWidth left) (rectX right + rectWidth right) - overlapX
+    overlapHeight = min (rectY left + rectHeight left) (rectY right + rectHeight right) - overlapY
+
+-- | Move every edge outward by an amount; negative amounts shrink the rectangle.
+expandBy :: Rect -> Double -> Rect
+expandBy rect amount =
+    Rect
+        (rectX rect - amount)
+        (rectY rect - amount)
+        (rectWidth rect + 2.0 * amount)
+        (rectHeight rect + 2.0 * amount)

--- a/code/packages/haskell/point2d/test/Point2DSpec.hs
+++ b/code/packages/haskell/point2d/test/Point2DSpec.hs
@@ -1,0 +1,137 @@
+module Point2DSpec (spec) where
+
+import Point2D
+import Prelude hiding (negate, subtract)
+import Test.Hspec
+import qualified Trig
+
+epsilon :: Double
+epsilon = 1e-9
+
+shouldApprox :: Double -> Double -> Expectation
+shouldApprox actual expected = abs (actual - expected) `shouldSatisfy` (< epsilon)
+
+shouldBePoint :: Point -> Point -> Expectation
+shouldBePoint actual expected = do
+    pointX actual `shouldApprox` pointX expected
+    pointY actual `shouldApprox` pointY expected
+
+shouldBeRect :: Rect -> Rect -> Expectation
+shouldBeRect actual expected = do
+    rectX actual `shouldApprox` rectX expected
+    rectY actual `shouldApprox` rectY expected
+    rectWidth actual `shouldApprox` rectWidth expected
+    rectHeight actual `shouldApprox` rectHeight expected
+
+spec :: Spec
+spec = do
+    describe "Point construction and arithmetic" $ do
+        it "constructs the origin" $
+            origin `shouldBe` Point 0.0 0.0
+        it "stores coordinates" $ do
+            pointX (Point 3.0 (-5.0)) `shouldBe` 3.0
+            pointY (Point 3.0 (-5.0)) `shouldBe` (-5.0)
+        it "adds component by component" $
+            add (Point 1.0 2.0) (Point 3.0 4.0) `shouldBe` Point 4.0 6.0
+        it "subtracts component by component" $
+            subtract (Point 5.0 7.0) (Point 2.0 3.0) `shouldBe` Point 3.0 4.0
+        it "scales by positive, zero, and negative factors" $ do
+            scale (Point 3.0 4.0) 2.0 `shouldBePoint` Point 6.0 8.0
+            scale (Point 3.0 4.0) 0.0 `shouldBePoint` origin
+            scale (Point 3.0 4.0) (-1.0) `shouldBePoint` Point (-3.0) (-4.0)
+        it "negates both coordinates" $
+            negate (Point 3.0 (-4.0)) `shouldBe` Point (-3.0) 4.0
+
+    describe "Point vector geometry" $ do
+        it "computes perpendicular and parallel dot products" $ do
+            dot (Point 1.0 0.0) (Point 0.0 1.0) `shouldBe` 0.0
+            dot (Point 3.0 0.0) (Point 5.0 0.0) `shouldBe` 15.0
+        it "computes signed cross products" $ do
+            cross (Point 1.0 0.0) (Point 0.0 1.0) `shouldBe` 1.0
+            cross (Point 0.0 1.0) (Point 1.0 0.0) `shouldBe` (-1.0)
+        it "computes magnitude and squared magnitude" $ do
+            magnitude (Point 3.0 4.0) `shouldApprox` 5.0
+            magnitude origin `shouldBe` 0.0
+            magnitudeSquared (Point 3.0 4.0) `shouldBe` 25.0
+        it "normalizes non-zero vectors" $ do
+            let unit = normalize (Point 3.0 4.0)
+            unit `shouldBePoint` Point 0.6 0.8
+            magnitude unit `shouldApprox` 1.0
+        it "normalizes zero and near-zero vectors to the origin" $ do
+            normalize origin `shouldBe` origin
+            normalize (Point 1e-14 0.0) `shouldBe` origin
+        it "computes distance and squared distance" $ do
+            distance origin (Point 3.0 4.0) `shouldApprox` 5.0
+            distanceSquared origin (Point 3.0 4.0) `shouldBe` 25.0
+        it "interpolates endpoints, midpoints, and extrapolation" $ do
+            let start = Point 1.0 2.0
+                end = Point 5.0 6.0
+            lerp start end 0.0 `shouldBePoint` start
+            lerp start end 1.0 `shouldBePoint` end
+            lerp start end 0.5 `shouldBePoint` Point 3.0 4.0
+            lerp start end 2.0 `shouldBePoint` Point 9.0 10.0
+        it "rotates counterclockwise and negates after two rotations" $ do
+            perpendicular (Point 1.0 0.0) `shouldBePoint` Point 0.0 1.0
+            perpendicular (Point 0.0 1.0) `shouldBePoint` Point (-1.0) 0.0
+            perpendicular (perpendicular (Point 3.0 4.0))
+                `shouldBePoint` negate (Point 3.0 4.0)
+        it "returns angles on every axis" $ do
+            angle (Point 1.0 0.0) `shouldApprox` 0.0
+            angle (Point 0.0 1.0) `shouldApprox` Trig.halfPi
+            abs (angle (Point (-1.0) 0.0)) `shouldApprox` Trig.piValue
+            angle (Point 0.0 (-1.0)) `shouldApprox` (-Trig.halfPi)
+
+    describe "Rect construction and accessors" $ do
+        it "stores origin and extent" $
+            Rect 1.0 2.0 10.0 5.0 `shouldBe` Rect 1.0 2.0 10.0 5.0
+        it "constructs from corner points" $
+            rectFromPoints (Point 1.0 2.0) (Point 11.0 7.0)
+                `shouldBeRect` Rect 1.0 2.0 10.0 5.0
+        it "constructs the zero rectangle" $
+            zeroRect `shouldBe` Rect 0.0 0.0 0.0 0.0
+        it "returns minimum, maximum, and center points" $ do
+            let rect = Rect 2.0 3.0 8.0 4.0
+            minPoint rect `shouldBePoint` Point 2.0 3.0
+            maxPoint rect `shouldBePoint` Point 10.0 7.0
+            center rect `shouldBePoint` Point 6.0 5.0
+
+    describe "Rect predicates" $ do
+        it "recognizes zero, negative, and positive areas" $ do
+            isEmpty zeroRect `shouldBe` True
+            isEmpty (Rect 0.0 0.0 (-1.0) 5.0) `shouldBe` True
+            isEmpty (Rect 0.0 0.0 5.0 (-1.0)) `shouldBe` True
+            isEmpty (Rect 0.0 0.0 5.0 5.0) `shouldBe` False
+        it "contains interior and top-left points" $ do
+            let rect = Rect 0.0 0.0 10.0 10.0
+            containsPoint rect (Point 5.0 5.0) `shouldBe` True
+            containsPoint rect (Point 0.0 0.0) `shouldBe` True
+        it "excludes right, bottom, and exterior points" $ do
+            let rect = Rect 0.0 0.0 10.0 10.0
+            containsPoint rect (Point 10.0 5.0) `shouldBe` False
+            containsPoint rect (Point 5.0 10.0) `shouldBe` False
+            containsPoint rect (Point (-1.0) 5.0) `shouldBe` False
+            containsPoint rect (Point 5.0 (-1.0)) `shouldBe` False
+
+    describe "Rect set operations" $ do
+        it "unites non-overlapping rectangles" $
+            union (Rect 0.0 0.0 5.0 5.0) (Rect 10.0 10.0 5.0 5.0)
+                `shouldBeRect` Rect 0.0 0.0 15.0 15.0
+        it "treats an empty rectangle as the union identity on either side" $ do
+            let rect = Rect 1.0 2.0 5.0 5.0
+            union rect zeroRect `shouldBe` rect
+            union zeroRect rect `shouldBe` rect
+        it "returns a positive-area intersection" $
+            intersection (Rect 0.0 0.0 10.0 10.0) (Rect 5.0 5.0 10.0 10.0)
+                `shouldBe` Just (Rect 5.0 5.0 5.0 5.0)
+        it "rejects disjoint and edge-touching intersections" $ do
+            intersection (Rect 0.0 0.0 5.0 5.0) (Rect 10.0 10.0 5.0 5.0)
+                `shouldBe` Nothing
+            intersection (Rect 0.0 0.0 5.0 5.0) (Rect 5.0 0.0 5.0 5.0)
+                `shouldBe` Nothing
+            intersection (Rect 0.0 0.0 5.0 5.0) (Rect 0.0 5.0 5.0 5.0)
+                `shouldBe` Nothing
+        it "expands and shrinks symmetrically" $ do
+            expandBy (Rect 1.0 1.0 8.0 8.0) 1.0
+                `shouldBeRect` Rect 0.0 0.0 10.0 10.0
+            expandBy (Rect 0.0 0.0 10.0 10.0) (-1.0)
+                `shouldBeRect` Rect 1.0 1.0 8.0 8.0

--- a/code/packages/haskell/point2d/test/Spec.hs
+++ b/code/packages/haskell/point2d/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified Point2DSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec Point2DSpec.spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -117,12 +117,13 @@ ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
 `scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
-`matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, and `deflate`
+`matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`, and
+`point2d`
 ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 297 |
+| Present in 10-15 languages | 172 | 296 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 705 | 9,870 |
@@ -168,7 +169,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 297
+The 172 packages present in at least ten implementation languages need 296
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -179,7 +180,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 22 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 21 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -501,6 +502,16 @@ literal-only and match-heavy streams, binary round trips, parameter validation,
 and malformed headers, tables, prefixes, backreferences, and output lengths.
 The package now spans 13 implementation lanes, reduces the high-consensus
 backlog to 297 slots, and leaves 22 gaps in the Haskell lane.
+
+The thirteenth Haskell high-consensus slice is complete: `point2d` now provides
+immutable G2D00 point/vector arithmetic and half-open axis-aligned rectangle
+geometry on top of the existing pure Haskell `trig` package. Its package-native
+suite exercises construction, products, norms, normalization, distance,
+interpolation, axis angles, empty and negative extents, boundary containment,
+union, strict positive-area intersection, and symmetric expansion. The package
+now spans 12 implementation lanes, reduces the high-consensus backlog to 296
+slots, leaves 21 gaps in the Haskell lane, and unlocks the dependent `affine2d`,
+`bezier2d`, and `arc2d` graphics wave.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `point2d` package covering points, vectors, and immutable axis-aligned rectangles
- use the native Haskell `trig` package for square roots and angles, preserving dependency parity without foreign-language bridges
- cover vector arithmetic, normalization, interpolation, half-open containment, rectangle union/intersection, and symmetric expansion
- refresh the package-parity roadmap to 296 high-consensus missing slots and 21 remaining Haskell gaps

## Why

`point2d` was a dependency-safe Haskell gap in the high-consensus package set. Filling it raises the package to 12 implementation lanes and unlocks future Haskell ports of `affine2d`, `bezier2d`, and `arc2d`.

## Validation

- `stack test point2d --coverage` — 27 examples, 0 failures, 99% expression coverage
- `stack sdist ... --test-tarball` — package and `trig` dependency tests pass; Cabal common-mistake check is clean
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py' -v` — 6 tests pass
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 0 collisions and 0 unknown language buckets
- `git diff --check`
