### PR TITLE
feat(hl-spanish): Chapter 11 — querer/poder and the stem-change boot

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -215,6 +215,10 @@
       "ES-VERB-IR": "ir — 'to go' (most suppletive: infinitive ← īre, present voy/vas/va/vamos/van ← vādere → invade/evade; go/went trick)",
       "ES-NEAR-FUTURE": "ir a + infinitive — the 'going-to' future (voy a hablar = I'm going to speak); a ← ad; mirrors English/French",
       "ES-POSSESSIVE": "mi/tu/su (+ mis/tus/sus) — possessives ← meus/tuus/suus → my/thy; agree in NUMBER not gender; tu 'your' vs tú 'you'",
+      "ES-VERB-QUERER": "querer — 'to want/love' (e→ie stem-changer: quiero/quieres…queremos; ← quaerere 'seek' → query/quest/conquer)",
+      "ES-VERB-PODER": "poder — 'to be able/can' (o→ue stem-changer: puedo/puedes…podemos; ← potēre → power/potent/possible; poder+inf)",
+      "ES-STEM-CHANGES": "e→ie & o→ue stem-changes — one sound-law (stressed short e/o broke: terra→tierra, porta→puerta); the 'boot' (all but nosotros)",
+      "ES-POSSESSIVE-OUR": "nuestro/vuestro — 'our/your-pl' (← noster/voster → Paternoster); agree in BOTH gender & number, unlike mi/tu/su",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -264,6 +268,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Chapter 11 — Wants, ability, and the stem-change boot
+
+- **Chapter 11 authored** (`ES-C11-querer`, `-poder`, `-stem-changes`, `-nuestro`,
+  `-practice`): the two most useful modal-ish verbs plus the stem-change rule that
+  governs a whole class of Spanish verbs — reviewing Ch.8–10 via `reviews_of`.
+- **querer** ("to want/love") — the **e→ie** stem-changer (*quiero/quieres/quiere/
+  queremos/quieren*), ← *quaerere* "to seek" (→ query/quest/question/inquire/require/
+  conquer/exquisite) — the same *e→ie* crack first met in *tener* (Ch.8).
+- **poder** ("to be able/can") — the **o→ue** stem-changer (*puedo/puedes/puede/
+  podemos/pueden*), ← *potēre* (→ **power**/potent/possible/potential), with *poder*
+  + infinitive for ability (*puedo hablar*).
+- **The stem-change rule made explicit**: one sound-law — short **stressed** Latin
+  *e* broke to *ie*, short stressed *o* to *ue* — in nouns too (*terra→tierra*,
+  *porta→puerta*; *septem→siete*, *novem→nueve*), producing the **"boot"** (all
+  forms crack but *nosotros/vosotros*).
+- **nuestro/vuestro** ("our/your-pl", ← *noster/voster* → Paternoster/nostrum) — the
+  possessive that agrees in **gender AND number** (four forms), contrasted with
+  *mi/tu/su* (number only); itself an *o→ue* fossil (*noster→nuestro*).
+- Taxonomy: namespaced `ES-VERB-QUERER`, `ES-VERB-PODER`, `ES-STEM-CHANGES`,
+  `ES-POSSESSIVE-OUR`; practice label `CH11-PRACTICE`.
+
 ## Chapter 10 — The near future and possessives
 
 - **Chapter 10 authored** (`ES-C10-ir`, `-ir-a-futuro`, `-mi-tu-su`, `-practice`):

--- a/code/learning/human-languages/spanish/lessons/ES-C11-nuestro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-nuestro.md
@@ -1,0 +1,63 @@
+---
+id: ES-C11-nuestro
+chapter: 11
+type: word
+headword: nuestro
+gloss: our (and vuestro, "your"-plural) — the possessive that agrees fully
+concept_tag: ES-POSSESSIVE-OUR
+prerequisites: [ES-C10-mi-tu-su]
+sounds: [diphthong-ue]
+roots: [noster-latin]
+etymology_hook: "nuestro ← Latin noster 'our' (paternoster = 'our father'); vuestro ← voster; unlike mi/tu/su these agree in BOTH gender and number"
+est_minutes: 4
+reviews_of: [ES-C10-mi-tu-su, ES-C11-poder]
+---
+
+# nuestro — "our," the possessive that agrees fully
+
+## Warm-up
+
+[PAUSE 2s] In Chapter 10 you met *mi/tu/su* — possessives that change only for
+**number** (*mis, tus, sus*). **nuestro** ("our") is different: it agrees in **both
+gender and number**, like an ordinary *-o/-a* adjective. It's the fullest-flexing
+of the possessives.
+
+## The word, taken apart
+
+**nuestro** comes from Latin **noster**, *"our."* You've heard it without knowing:
+the **Paternoster** is the "**Our** Father," and a **nostrum** is literally "**our**
+thing" (a quack's secret remedy). Its partner **vuestro** ("your," to a group) is
+from **voster/vester**.
+
+Notice the stem-change fossil: *noster → nuestro* shows the same **o→ue** break you
+just learned (short stressed *o* → *ue*). The possessive cracks exactly like
+*puerta* and *puedo*.
+
+## Grammar Lens: four forms, agreeing like -o/-a
+
+Where *mi* had two forms (*mi/mis*), **nuestro** has **four** — masculine/feminine
+× singular/plural:
+
+| | singular | plural |
+|---|---|---|
+| **masc.** | **nuestro** libro | **nuestros** libros |
+| **fem.** | **nuestra** casa | **nuestras** casas |
+
+So it's *nuestro coche* ("our car," masc.) but *nuestra casa* ("our house," fem.) —
+you match the noun in both gender and number, just like *bueno/buena/buenos/buenas*.
+*vuestro* does the same (*vuestro/vuestra/vuestros/vuestras*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nuestro, nuestra, nuestros, nuestras" — the full set]
+- [YOU SAY: match a noun — "nuestro coche, nuestra casa, nuestros amigos"]
+- [YOU SAY: "nuestro" then "Paternoster / nostrum" — the *noster* "our" family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin word is *nuestro* from, and one English echo? (*noster* "our";
+*Paternoster* / *nostrum*.) How does *nuestro* differ from *mi/tu/su*? (It agrees in
+**gender and number** — four forms — not just number.) Give "our house" and "our
+car." (*Nuestra casa*; *nuestro coche*.) Next: **practice** — pull the chapter
+together.

--- a/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
@@ -1,0 +1,76 @@
+---
+id: ES-C11-poder
+chapter: 11
+type: word
+headword: poder
+gloss: to be able / can — a stem-changing verb, o→ue
+concept_tag: ES-VERB-PODER
+prerequisites: [ES-C11-querer, ES-C06-hablar]
+sounds: [diphthong-ue, r-tap]
+roots: [potere-latin]
+etymology_hook: "poder ← Latin potēre 'to be able' → power, potent, possible, potential; the stressed o breaks to ue (puedo) — the second stem-change pattern"
+est_minutes: 5
+reviews_of: [ES-C11-querer, ES-C10-ir-a-futuro]
+---
+
+# poder — "to be able," and the o→ue crack
+
+## Warm-up
+
+[PAUSE 2s] *querer* broke *e → ie*. Now meet the **other** stem-change: *o → ue*.
+The verb is **poder**, "to be able / can" — and once you have *querer* (want) and
+*poder* (can), you can say almost anything you *want to* or *can* do.
+
+## Sounds you'll need
+
+- `diphthong-ue` — the stem breaks to **-ue-** under stress: **puedo** = *PWE-do*
+  (a *w*-glide).
+
+## The word, taken apart
+
+**poder** comes from Latin **potēre** (from *posse*), *"to be able, to have
+power."* It's literally the verb *power* — and the family shows it:
+
+- **power** itself (English took it through Old French *poeir* ← *potēre*).
+- **potent, potential, omnipotent** ("all-powerful"), **possible** ("able to be"),
+  **posse** ("(those) able" to be summoned).
+
+So *puedo* and *power* are the same word — one a Spanish verb, the other its English
+noun.
+
+## Grammar Lens: the o→ue stem-change
+
+*poder* is a stem-changer of the **o→ue** kind: the stressed stem *o* breaks to
+**ue**, in the same **boot** shape (all forms but *nosotros/vosotros*):
+
+| yo | **puedo** | (o → ue) |
+| tú | **puedes** | (o → ue) |
+| él/ella/usted | **puede** | (o → ue) |
+| nosotros | **podemos** | (plain *o* — unstressed) |
+| ellos/ustedes | **pueden** | (o → ue) |
+
+Just like *querer*, only *podemos* keeps the plain vowel. (Other *o→ue* verbs you'll
+meet: *dormir* "sleep" → *duermo*, *volver* "return" → *vuelvo*.)
+
+## Grammar Lens: poder + infinitive ("I can …")
+
+Point *poder* at an **infinitive** to say what you're able to do — just like *ir a*
++ infinitive, but for ability:
+
+> **Puedo hablar** español. — "I can speak Spanish."
+> **¿Puedes** venir? — "Can you come?"
+> **No puedo** — "I can't."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "poder" then "puedo, puedes, puede, podemos, pueden" — the *ue* crack]
+- [YOU SAY: "Puedo hablar español"; "¿Puedes venir?"]
+- [YOU SAY: "poder / power" — the same Latin *potēre*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *poder* from, and its English twin? (*potēre* "to be
+able"; *power*.) Give its five forms. (*Puedo, puedes, puede, podemos, pueden*.)
+How do you say "I can speak"? (*Puedo hablar* — *poder* + infinitive.) Next: the two
+cracks (e→ie and o→ue) side by side.

--- a/code/learning/human-languages/spanish/lessons/ES-C11-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-practice.md
@@ -1,0 +1,80 @@
+---
+id: ES-C11-practice
+chapter: 11
+type: practice-mix
+headword: (practice)
+gloss: wanting, being able, and the stem-change boot
+concept_tag: CH11-PRACTICE
+prerequisites: [ES-C11-querer, ES-C11-poder, ES-C11-stem-changes, ES-C11-nuestro]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C11-querer, ES-C11-poder, ES-C11-nuestro, ES-C10-practice]
+---
+
+# Practice — querer, poder, and the boot
+
+## Warm-up
+
+[PAUSE 2s] Two power-verbs and a rule this chapter: **querer** (want, e→ie),
+**poder** (can, o→ue), and the **stem-change boot** that shapes them both — plus
+**nuestro**, the fully-agreeing "our." Drill the cracks until *quiero/puedo* come
+without thinking.
+
+## Conjugate both boots, out loud
+
+[PAUSE 1s]
+- **querer** (e→ie): **quiero · quieres · quiere · queremos · quieren** (only
+  *queremos* stays plain).
+- **poder** (o→ue): **puedo · puedes · puede · podemos · pueden** (only *podemos*
+  stays plain).
+
+## Chain the verbs (want to / can + infinitive)
+
+[PAUSE 1s]
+- **Quiero** hablar español. — "I want to speak Spanish."
+- **Puedo** hablar un poco. — "I can speak a little."
+- **¿Quieres** comer? — "Do you want to eat?" · **¿Puedes** venir? — "Can you come?"
+- **Vamos a** poder — "we're going to be able to" (reusing the near future from
+  Ch.10).
+
+## nuestro, agreeing
+
+[PAUSE 1s]
+- **nuestra casa** (fem.), **nuestro coche** (masc.), **nuestros amigos** (masc.
+  pl.) — match gender *and* number, unlike *mi/tu/su*.
+
+## Say something real
+
+> — ¿Qué **quieres** hacer? — **Quiero** ir a un café con **nuestros** amigos. ¿**Puedes**
+> venir? — Sí, **puedo**. **Podemos** ir ahora.
+
+Every tool of the chapter: *quiero* (want, e→ie), *puedes/puedo/podemos* (can,
+o→ue), *nuestros* (our, agreeing), and *ir a* from Ch.10.
+
+## What you've built this chapter
+
+- **querer** (want, ← *quaerere* "seek" → query/quest/conquer) — the **e→ie**
+  stem-changer.
+- **poder** (can, ← *potēre* → power/potent/possible) — the **o→ue** stem-changer,
+  and *poder* + infinitive for ability.
+- **the boot**: one sound-law (short stressed *e→ie*, *o→ue*; *tierra*, *puerta*)
+  cracking all forms but *nosotros/vosotros*.
+- **nuestro/vuestro** (← *noster/voster* → Paternoster) — the possessive that agrees
+  in **gender and number**, four forms.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: conjugate *querer* and *poder* fully, back to back]
+- [YOU SAY: chain three — "Quiero comer," "Puedo hablar," "¿Quieres venir?"]
+- [YOU SAY: "nuestra casa, nuestro coche" — the agreeing possessive]
+
+[REPEAT x2] "¿Qué quieres hacer? — Quiero … . ¿Puedes …? — Sí, puedo."
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the *yo* of *querer* and *poder*. (*Quiero, puedo*.) Which form of
+each stays plain, and why? (*Queremos/podemos* — the stress is on the ending.) How
+does *nuestro* agree, versus *mi/tu/su*? (Gender **and** number — four forms.) Next
+chapter carries the grammar forward — the course now runs on rules.

--- a/code/learning/human-languages/spanish/lessons/ES-C11-querer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-querer.md
@@ -1,0 +1,73 @@
+---
+id: ES-C11-querer
+chapter: 11
+type: word
+headword: querer
+gloss: to want (and to love) — a stem-changing verb, e→ie
+concept_tag: ES-VERB-QUERER
+prerequisites: [ES-C08-tener, ES-C06-hablar]
+sounds: [diphthong-ie, r-tap]
+roots: [quaerere-latin]
+etymology_hook: "querer ← Latin quaerere 'to seek, ask' → query, quest, question, inquire, require, conquer; the stressed e breaks to ie (quiero) — the same crack you met in tener"
+est_minutes: 5
+reviews_of: [ES-C08-tener, ES-C10-practice]
+---
+
+# querer — "to want," and the e→ie crack again
+
+## Warm-up
+
+[PAUSE 2s] Back in Chapter 8, *tener* cracked its stem: *tienes*, with the vowel
+breaking *e → ie*. That wasn't a one-off — it's a whole **class** of Spanish verbs.
+Here's the most useful of them: **querer**, "to want" (and, of a person, "to
+love").
+
+## Sounds you'll need
+
+- `diphthong-ie` — the stem breaks to **-ie-** under stress: **quiero** = *KYE-ro*.
+
+## The word, taken apart
+
+**querer** comes from Latin **quaerere**, *"to seek, to ask, to want."* Seeking and
+wanting are the same impulse at the root — and that root is a treasure-house of
+English:
+
+- **query, quest, question** — a seeking.
+- with prefixes: **inquire** (*in-* "into"), **require** (*re-* "back"), **acquire**
+  (*ad-* "toward"), **conquer** (*con-* "thoroughly seek/win"), **exquisite**
+  ("sought out"), **quorum** ("of whom" the seeking needs enough).
+
+So when you say *quiero*, you're using the same "seek" root as *question* and
+*conquer*.
+
+## Grammar Lens: the e→ie stem-change (the "boot")
+
+*querer* is a **stem-changing verb**: when the stem vowel *e* is **stressed**, it
+breaks to **ie** — exactly the pattern *tener* showed you.
+
+| yo | **quiero** | (e → ie) |
+| tú | **quieres** | (e → ie) |
+| él/ella/usted | **quiere** | (e → ie) |
+| nosotros | **queremos** | (plain *e* — unstressed) |
+| ellos/ustedes | **quieren** | (e → ie) |
+
+Only *queremos* keeps the plain *e*, because there the stress falls on the ending,
+not the stem. Shade in the forms that change — yo/tú/él…/ellos — and they draw a
+**boot** shape around the *nosotros/vosotros* gap. That "boot" is the signature of
+every stem-changer.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "querer" then the set — "quiero, quieres, quiere, queremos, quieren" —
+  hear the *ie* crack in, and drop out for *queremos*]
+- [YOU SAY: "Quiero un café" ("I want a coffee"); "Quiero café, por favor"]
+- [YOU SAY: "querer" then English "query, quest, conquer" — the seek-family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *querer* from, and two English cousins? (*quaerere*
+"to seek"; query/quest/conquer.) Give its five present forms. (*Quiero, quieres,
+quiere, queremos, quieren*.) Which form keeps the plain *e*, and why? (*Queremos* —
+the stress is on the ending, not the stem.) Next: **poder**, with a *different*
+crack, o→ue.

--- a/code/learning/human-languages/spanish/lessons/ES-C11-stem-changes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-stem-changes.md
@@ -1,0 +1,67 @@
+---
+id: ES-C11-stem-changes
+chapter: 11
+type: phrase
+headword: e→ie, o→ue
+gloss: the stem-change patterns, side by side — the "boot"
+concept_tag: ES-STEM-CHANGES
+prerequisites: [ES-C11-querer, ES-C11-poder]
+sounds: [diphthong-ie, diphthong-ue]
+roots: [latin-stressed-vowel-breaking]
+etymology_hook: "why the vowels crack: Latin's short stressed e and o 'broke' into ie and ue in Spanish (terra→tierra, porta→puerta) — the same law that shapes the stem-changers"
+est_minutes: 4
+reviews_of: [ES-C11-querer, ES-C11-poder, ES-C08-tener]
+---
+
+# e→ie and o→ue — one rule, two vowels
+
+## Warm-up
+
+[PAUSE 2s] You've now seen both stem-changes: *querer → quiero* (e→ie) and *poder →
+puedo* (o→ue). They aren't two random quirks — they're **one sound-law**, and
+knowing it turns a "memorize each verb" chore into a pattern you can predict.
+
+## The rule: stressed short vowels broke
+
+In the leap from Latin to Spanish, a **short, stressed *e*** broke into **ie**, and
+a **short, stressed *o*** broke into **ue**. It happened in ordinary nouns too, not
+just verbs:
+
+| Latin | Spanish | break |
+|---|---|---|
+| *terra* | *tierra* ("earth") | e → ie |
+| *septem* | *siete* ("seven") | e → ie |
+| *porta* | *puerta* ("door") | o → ue |
+| *novem* | *nueve* ("nine") | o → ue |
+
+(You already met *siete* and *nueve* in the numbers — now you know *why* they have
+that glide.) In verbs, the stem vowel is stressed in the "boot" forms and unstressed
+in *nosotros/vosotros* — so it breaks in the boot and stays plain outside it.
+
+## The boot, for both patterns
+
+| | e→ie (*querer*) | o→ue (*poder*) |
+|---|---|---|
+| yo | qu**ie**ro | p**ue**do |
+| tú | qu**ie**res | p**ue**des |
+| él/ella/ud | qu**ie**re | p**ue**de |
+| **nosotros** | qu**e**remos | p**o**demos |
+| ellos/uds | qu**ie**ren | p**ue**den |
+
+Same shape both times: the four "corner" forms crack, the *nosotros* form stays
+plain — the boot. *tener* (→ *tienes*), from Chapter 8, was your first taste; now
+you own the whole rule.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the pairs — "querer/quiero (e→ie), poder/puedo (o→ue)"]
+- [YOU SAY: the noun echoes — "terra→tierra, porta→puerta"]
+- [YOU SAY: conjugate both boots, noticing *queremos*/*podemos* stay plain]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What single sound-law lies behind e→ie and o→ue? (Short **stressed**
+Latin *e* and *o* broke into *ie* and *ue*.) Which persons crack, and which stays
+plain? (The "boot" — all but *nosotros/vosotros*.) Give a *noun* that shows each
+break. (*tierra* ← *terra*; *puerta* ← *porta*.) Next: **nuestro** — "our."

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -72,10 +72,18 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   **number** not gender; *tu* vs *tú*) → practice. **Authored** — the course now
   runs on rules, not phrases.
 
-Next: **Ch. 11** — *querer/poder* (stem-changing verbs; wants & ability) and more
-possessives (*nuestro*), building toward everyday description. From here the course
-hands over rules, not phrases. Grammar accumulates piece by piece. The theme
-skeleton below plans the wider road.
+- **Ch. 11 — Wants, ability, and the stem-change boot**: **querer** ("to want," ←
+  *quaerere* "seek" → query/quest/conquer; the **e→ie** stem-changer) → **poder**
+  ("to be able," ← *potēre* → power/potent/possible; the **o→ue** stem-changer, +
+  *poder* + infinitive) → the two cracks side by side (one sound-law: stressed short
+  *e→ie*, *o→ue*; *tierra*, *puerta*; the "boot") → **nuestro/vuestro** (← *noster/
+  voster* → Paternoster; agrees in **gender and number**, unlike *mi/tu/su*) →
+  practice. **Authored.**
+
+Next: **Ch. 12** — the rest of the high-frequency verbs (*hacer, decir, ir*
+irregulars) and more description, building toward everyday conversation. From here
+the course hands over rules, not phrases. Grammar accumulates piece by piece. The
+theme skeleton below plans the wider road.
 
 ## Theme Skeleton (planning only)
 


### PR DESCRIPTION
Spanish **Chapter 11**: the two most useful modal-ish verbs, plus the **stem-change rule** that governs a whole class of Spanish verbs. Atom-first, each 3–5 min, reviewing Ch.8–10 via `reviews_of`, deep etymology throughout.

## Lessons (`ES-C11-*`)
- **querer** ("to want/love") — the **e→ie** stem-changer (*quiero/quieres/quiere/queremos/quieren*), ← *quaerere* "to seek" (→ query/quest/question/inquire/require/**conquer**/exquisite); the same *e→ie* crack first met in *tener* (Ch.8).
- **poder** ("to be able/can") — the **o→ue** stem-changer (*puedo/puedes/puede/podemos/pueden*), ← *potēre* (→ **power**/potent/possible/potential), + *poder* + infinitive for ability.
- **stem-changes** — the rule made explicit: **one sound-law** (short *stressed* Latin *e→ie*, *o→ue*) seen in nouns too (*terra→tierra*, *porta→puerta*; *siete*, *nueve*), producing the **"boot"** (all forms crack but *nosotros/vosotros*).
- **nuestro/vuestro** ("our/your-pl", ← *noster/voster* → **Paternoster**/nostrum) — the possessive that agrees in **gender AND number** (four forms), vs *mi/tu/su* (number only); itself an *o→ue* fossil (*noster→nuestro*).
- **practice** — drills both boots, verb+infinitive chaining, and *nuestro* agreement.

## Data / taxonomy
- Namespaced concepts: `ES-VERB-QUERER`, `ES-VERB-PODER`, `ES-STEM-CHANGES`, `ES-POSSESSIVE-OUR`; `CH11-PRACTICE` added to the practice-tag note.
- Roadmap advanced (Ch.11 authored; **Next = Ch.12**); Spanish CHANGELOG updated.

## Verification
- `human-language-data` suite: **38 / 38 pass**. Main was **clean on retired tags** this cycle — no red-main fix needed (possibly the root-cause task landed).
- Security-reviewed (subagent): markdown + JSON only — no scripts, URLs, secrets, or injection; taxonomy.json validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)