### PR TITLE
Add Haskell affine2d package

### DIFF
--- a/code/packages/haskell/affine2d/BUILD
+++ b/code/packages/haskell/affine2d/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/affine2d/BUILD_windows
+++ b/code/packages/haskell/affine2d/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/affine2d/CHANGELOG.md
+++ b/code/packages/haskell/affine2d/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0 - 2026-07-19
+
+- Add the immutable G2D01 six-scalar `Affine` value.
+- Add translation, rotation, centered rotation, scaling, and skew factories
+  through the existing pure Haskell `point2d` and `trig` packages.
+- Add ordered composition, point and vector application, determinant, checked
+  inversion, tolerance predicates, and graphics-array conversion.
+- Add package-native coverage for every required G2D01 behavior, including
+  non-commutativity, singular matrices, centered rotation, and vector handling.

--- a/code/packages/haskell/affine2d/README.md
+++ b/code/packages/haskell/affine2d/README.md
@@ -1,0 +1,35 @@
+# affine2d (Haskell)
+
+Pure Haskell implementation of the G2D01 two-dimensional affine
+transformation matrix. The package uses the standard SVG/Canvas six-scalar
+representation `[a, b, c, d, e, f]`:
+
+```text
+x' = a*x + c*y + e
+y' = b*x + d*y + f
+```
+
+## API
+
+- `Affine` is an immutable value containing the six matrix components.
+- `identity`, `translate`, `rotate`, `rotateAround`, `scale`, `scaleUniform`,
+  `skewX`, and `skewY` construct common transforms.
+- `multiply` applies its right transform first; `thenTransform` gives readable
+  left-to-right sequencing (`then` is a Haskell keyword).
+- `applyToPoint` includes translation while `applyToVector` applies only the
+  linear portion.
+- `determinant` and `invert` expose area scaling and checked inversion.
+- `isIdentity`, `isTranslationOnly`, and `toArray` support renderer fast paths
+  and graphics API interop.
+
+Rotation and skew compose the existing pure Haskell `trig` package, while
+points come from the pure Haskell `point2d` package. Inversion rejects matrices
+whose determinant magnitude is below `1e-12`; predicates use the G2D01
+`1e-10` tolerance.
+
+## Development
+
+```sh
+cabal test all
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/affine2d/affine2d.cabal
+++ b/code/packages/haskell/affine2d/affine2d.cabal
@@ -1,0 +1,35 @@
+cabal-version: 3.0
+name:          affine2d
+version:       0.1.0
+synopsis:      Immutable two-dimensional affine transformation matrices
+description:   Pure G2D01 affine matrix construction, composition, application, inversion, and classification.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Affine2D
+    build-depends:    base >=4.14 && <5
+                    , point2d >=0.1 && <0.2
+                    , trig >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Affine2DSpec
+    hs-source-dirs:   test
+    build-depends:    affine2d
+                    , base >=4.14 && <5
+                    , hspec == 2.*
+                    , point2d >=0.1 && <0.2
+                    , trig >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/affine2d/cabal.project
+++ b/code/packages/haskell/affine2d/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../point2d ../trig

--- a/code/packages/haskell/affine2d/src/Affine2D.hs
+++ b/code/packages/haskell/affine2d/src/Affine2D.hs
@@ -1,0 +1,167 @@
+-- | Immutable two-dimensional affine transformation matrices.
+module Affine2D
+    ( Affine (..)
+    , identity
+    , translate
+    , rotate
+    , rotateAround
+    , scale
+    , scaleUniform
+    , skewX
+    , skewY
+    , thenTransform
+    , multiply
+    , applyToPoint
+    , applyToVector
+    , determinant
+    , invert
+    , isIdentity
+    , isTranslationOnly
+    , toArray
+    ) where
+
+import Point2D (Point (..))
+import qualified Trig
+
+-- | A G2D01 matrix stored in SVG and Canvas order @[a, b, c, d, e, f]@.
+--
+-- The implicit homogeneous matrix is:
+--
+-- @
+-- [ a c e ]
+-- [ b d f ]
+-- [ 0 0 1 ]
+-- @
+data Affine = Affine
+    { affineA :: Double
+    , affineB :: Double
+    , affineC :: Double
+    , affineD :: Double
+    , affineE :: Double
+    , affineF :: Double
+    }
+    deriving (Eq, Show)
+
+-- | The transform that leaves every point unchanged.
+identity :: Affine
+identity = Affine 1.0 0.0 0.0 1.0 0.0 0.0
+
+-- | Construct a pure translation.
+translate :: Double -> Double -> Affine
+translate tx ty = Affine 1.0 0.0 0.0 1.0 tx ty
+
+-- | Construct a counterclockwise rotation by an angle in radians.
+rotate :: Double -> Affine
+rotate radians = Affine cosine sine (-sine) cosine 0.0 0.0
+  where
+    cosine = Trig.cos radians
+    sine = Trig.sin radians
+
+-- | Construct a counterclockwise rotation about an arbitrary center.
+rotateAround :: Point -> Double -> Affine
+rotateAround rotationCenter radians =
+    thenTransform
+        (thenTransform
+            (translate (-pointX rotationCenter) (-pointY rotationCenter))
+            (rotate radians))
+        (translate (pointX rotationCenter) (pointY rotationCenter))
+
+-- | Construct a non-uniform scale.
+scale :: Double -> Double -> Affine
+scale sx sy = Affine sx 0.0 0.0 sy 0.0 0.0
+
+-- | Construct a uniform scale.
+scaleUniform :: Double -> Affine
+scaleUniform factor = scale factor factor
+
+-- | Construct a horizontal shear by an angle in radians.
+skewX :: Double -> Affine
+skewX radians = Affine 1.0 0.0 (Trig.tan radians) 1.0 0.0 0.0
+
+-- | Construct a vertical shear by an angle in radians.
+skewY :: Double -> Affine
+skewY radians = Affine 1.0 (Trig.tan radians) 0.0 1.0 0.0 0.0
+
+-- | Compose transforms in readable order: apply the first, then the second.
+-- The G2D01 name is adapted because @then@ is a Haskell keyword.
+thenTransform :: Affine -> Affine -> Affine
+thenTransform first next = multiply next first
+
+-- | Matrix multiplication. The right transform is applied first.
+multiply :: Affine -> Affine -> Affine
+multiply self other =
+    Affine
+        (affineA self * affineA other + affineC self * affineB other)
+        (affineB self * affineA other + affineD self * affineB other)
+        (affineA self * affineC other + affineC self * affineD other)
+        (affineB self * affineC other + affineD self * affineD other)
+        (affineA self * affineE other + affineC self * affineF other + affineE self)
+        (affineB self * affineE other + affineD self * affineF other + affineF self)
+
+-- | Apply the full transform to a position, including translation.
+applyToPoint :: Affine -> Point -> Point
+applyToPoint matrix point =
+    Point
+        (affineA matrix * pointX point + affineC matrix * pointY point + affineE matrix)
+        (affineB matrix * pointX point + affineD matrix * pointY point + affineF matrix)
+
+-- | Apply only the linear part to a direction vector.
+applyToVector :: Affine -> Point -> Point
+applyToVector matrix vector =
+    Point
+        (affineA matrix * pointX vector + affineC matrix * pointY vector)
+        (affineB matrix * pointX vector + affineD matrix * pointY vector)
+
+-- | Return the signed area scaling factor of the linear part.
+determinant :: Affine -> Double
+determinant matrix =
+    affineA matrix * affineD matrix - affineB matrix * affineC matrix
+
+-- | Return the inverse, or 'Nothing' when the matrix is numerically singular.
+invert :: Affine -> Maybe Affine
+invert matrix
+    | abs det < 1e-12 = Nothing
+    | otherwise =
+        Just
+            (Affine
+                (affineD matrix / det)
+                ((-affineB matrix) / det)
+                ((-affineC matrix) / det)
+                (affineA matrix / det)
+                ((affineC matrix * affineF matrix - affineD matrix * affineE matrix) / det)
+                ((affineB matrix * affineE matrix - affineA matrix * affineF matrix) / det))
+  where
+    det = determinant matrix
+
+-- | Test whether all six components are within G2D01 epsilon of identity.
+isIdentity :: Affine -> Bool
+isIdentity matrix =
+    abs (affineA matrix - 1.0) < epsilon
+        && abs (affineB matrix) < epsilon
+        && abs (affineC matrix) < epsilon
+        && abs (affineD matrix - 1.0) < epsilon
+        && abs (affineE matrix) < epsilon
+        && abs (affineF matrix) < epsilon
+  where
+    epsilon = 1e-10
+
+-- | Test whether the matrix contains no rotation, scale, or shear.
+isTranslationOnly :: Affine -> Bool
+isTranslationOnly matrix =
+    abs (affineA matrix - 1.0) < epsilon
+        && abs (affineB matrix) < epsilon
+        && abs (affineC matrix) < epsilon
+        && abs (affineD matrix - 1.0) < epsilon
+  where
+    epsilon = 1e-10
+
+-- | Return components in SVG and Canvas order.
+toArray :: Affine -> [Double]
+toArray matrix =
+    [ affineA matrix
+    , affineB matrix
+    , affineC matrix
+    , affineD matrix
+    , affineE matrix
+    , affineF matrix
+    ]

--- a/code/packages/haskell/affine2d/test/Affine2DSpec.hs
+++ b/code/packages/haskell/affine2d/test/Affine2DSpec.hs
@@ -1,0 +1,119 @@
+module Affine2DSpec (spec) where
+
+import Affine2D
+import Point2D (Point (..))
+import Test.Hspec
+import qualified Trig
+
+epsilon :: Double
+epsilon = 1e-9
+
+shouldApprox :: Double -> Double -> Expectation
+shouldApprox actual expected = abs (actual - expected) `shouldSatisfy` (< epsilon)
+
+shouldBePoint :: Point -> Point -> Expectation
+shouldBePoint actual expected = do
+    pointX actual `shouldApprox` pointX expected
+    pointY actual `shouldApprox` pointY expected
+
+shouldBeAffine :: Affine -> Affine -> Expectation
+shouldBeAffine actual expected =
+    mapM_ (uncurry shouldApprox) (zip (toArray actual) (toArray expected))
+
+spec :: Spec
+spec = do
+    describe "Affine construction and factories" $ do
+        it "constructs identity in standard component order" $ do
+            identity `shouldBe` Affine 1.0 0.0 0.0 1.0 0.0 0.0
+            toArray identity `shouldBe` [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        it "exposes all six immutable components" $ do
+            let matrix = Affine 1.0 2.0 3.0 4.0 5.0 6.0
+            affineA matrix `shouldBe` 1.0
+            affineB matrix `shouldBe` 2.0
+            affineC matrix `shouldBe` 3.0
+            affineD matrix `shouldBe` 4.0
+            affineE matrix `shouldBe` 5.0
+            affineF matrix `shouldBe` 6.0
+        it "leaves points unchanged under identity" $
+            applyToPoint identity (Point 3.0 4.0) `shouldBePoint` Point 3.0 4.0
+        it "translates positions" $
+            applyToPoint (translate 3.0 4.0) (Point 1.0 1.0)
+                `shouldBePoint` Point 4.0 5.0
+        it "does not translate vectors" $
+            applyToVector (translate 99.0 99.0) (Point 1.0 (-2.0))
+                `shouldBePoint` Point 1.0 (-2.0)
+        it "rotates 90 degrees counterclockwise" $
+            applyToPoint (rotate Trig.halfPi) (Point 1.0 0.0)
+                `shouldBePoint` Point 0.0 1.0
+        it "treats a full rotation as identity" $
+            isIdentity (rotate Trig.twoPi) `shouldBe` True
+        it "rotates around a fixed center" $ do
+            let matrix = rotateAround (Point 5.0 5.0) Trig.halfPi
+            applyToPoint matrix (Point 5.0 5.0) `shouldBePoint` Point 5.0 5.0
+            applyToPoint matrix (Point 6.0 5.0) `shouldBePoint` Point 5.0 6.0
+        it "scales independently and uniformly" $ do
+            applyToPoint (scale 2.0 3.0) (Point 1.0 1.0)
+                `shouldBePoint` Point 2.0 3.0
+            applyToPoint (scaleUniform 5.0) (Point 2.0 3.0)
+                `shouldBePoint` Point 10.0 15.0
+        it "skews on both axes" $ do
+            applyToPoint (skewX (Trig.piValue / 4.0)) (Point 0.0 1.0)
+                `shouldBePoint` Point 1.0 1.0
+            applyToPoint (skewY (Trig.piValue / 4.0)) (Point 1.0 0.0)
+                `shouldBePoint` Point 1.0 1.0
+
+    describe "Affine composition" $ do
+        it "multiplies by identity on either side" $ do
+            let matrix = translate 3.0 4.0
+            multiply matrix identity `shouldBeAffine` matrix
+            multiply identity matrix `shouldBeAffine` matrix
+        it "combines two quarter turns into a half turn" $
+            multiply (rotate Trig.halfPi) (rotate Trig.halfPi)
+                `shouldBeAffine` rotate Trig.piValue
+        it "applies the right matrix first" $
+            applyToPoint
+                (multiply (translate 10.0 0.0) (scaleUniform 2.0))
+                (Point 1.0 1.0)
+                `shouldBePoint` Point 12.0 2.0
+        it "thenTransform composes in readable left-to-right order" $
+            applyToPoint
+                (thenTransform (scaleUniform 2.0) (translate 10.0 0.0))
+                (Point 1.0 1.0)
+                `shouldBePoint` Point 12.0 2.0
+        it "demonstrates non-commutativity" $ do
+            let point = Point 1.0 0.0
+                translateAfterRotate = multiply (translate 10.0 0.0) (rotate Trig.halfPi)
+                rotateAfterTranslate = multiply (rotate Trig.halfPi) (translate 10.0 0.0)
+            applyToPoint translateAfterRotate point `shouldBePoint` Point 10.0 1.0
+            applyToPoint rotateAfterTranslate point `shouldBePoint` Point 0.0 11.0
+
+    describe "Determinant and inversion" $ do
+        it "reports identity, translation, scale, and rotation determinants" $ do
+            determinant identity `shouldBe` 1.0
+            determinant (translate 5.0 3.0) `shouldBe` 1.0
+            determinant (scale 2.0 3.0) `shouldBe` 6.0
+            determinant (rotate (Trig.piValue / 3.0)) `shouldApprox` 1.0
+        it "inverts identity exactly" $
+            invert identity `shouldBe` Just identity
+        it "multiplies a transform by its inverse to identity" $ do
+            let matrix = thenTransform (scale 2.0 3.0) (thenTransform (rotate 0.4) (translate 3.0 (-7.0)))
+            case invert matrix of
+                Nothing -> expectationFailure "expected matrix to be invertible"
+                Just inverse -> isIdentity (multiply matrix inverse) `shouldBe` True
+        it "rejects zero and near-singular scales" $ do
+            invert (scale 0.0 1.0) `shouldBe` Nothing
+            invert (scale 1e-13 1.0) `shouldBe` Nothing
+
+    describe "Affine predicates" $ do
+        it "recognizes identity within tolerance" $ do
+            isIdentity identity `shouldBe` True
+            isIdentity (Affine (1.0 + 1e-11) 1e-11 (-1e-11) (1.0 - 1e-11) 1e-11 (-1e-11))
+                `shouldBe` True
+        it "rejects visible translation and scale as identity" $ do
+            isIdentity (translate 0.001 0.0) `shouldBe` False
+            isIdentity (scale 2.0 1.0) `shouldBe` False
+        it "recognizes only the pure-translation linear block" $ do
+            isTranslationOnly identity `shouldBe` True
+            isTranslationOnly (translate 5.0 3.0) `shouldBe` True
+            isTranslationOnly (rotate 0.1) `shouldBe` False
+            isTranslationOnly (scale 2.0 1.0) `shouldBe` False

--- a/code/packages/haskell/affine2d/test/Spec.hs
+++ b/code/packages/haskell/affine2d/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified Affine2DSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec Affine2DSpec.spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -117,13 +117,13 @@ ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
 ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
 `scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
-`matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`, and
-`point2d`
+`matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
+`point2d`, and `affine2d`
 ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 296 |
+| Present in 10-15 languages | 172 | 295 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 705 | 9,870 |
@@ -169,7 +169,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 296
+The 172 packages present in at least ten implementation languages need 295
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -180,7 +180,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 21 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 20 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -512,6 +512,16 @@ union, strict positive-area intersection, and symmetric expansion. The package
 now spans 12 implementation lanes, reduces the high-consensus backlog to 296
 slots, leaves 21 gaps in the Haskell lane, and unlocks the dependent `affine2d`,
 `bezier2d`, and `arc2d` graphics wave.
+
+The fourteenth Haskell high-consensus slice is complete: `affine2d` now
+provides the immutable G2D01 six-scalar matrix, all standard factories,
+ordered composition, separate point and vector application, determinant,
+checked inversion, tolerance predicates, and SVG/Canvas component ordering.
+It composes the existing pure Haskell `point2d` and `trig` packages and covers
+centered rotation, skew, non-commutativity, singularity thresholds, and inverse
+round trips in its package-native suite. The package now spans 12 implementation
+lanes, reduces the high-consensus backlog to 295 slots, and leaves 20 gaps in
+the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `affine2d` package implementing the immutable G2D01 six-scalar transform matrix
- compose the native Haskell `point2d` and `trig` packages for point/vector application, rotation, centered rotation, scaling, and skew
- provide ordered matrix composition, determinant, checked inversion, tolerance predicates, and SVG/Canvas component ordering
- refresh the package-parity roadmap to 295 high-consensus missing slots and 20 remaining Haskell gaps

## Why

The merged Haskell `point2d` port unlocked the dependency-safe G2D01 geometry layer. Filling `affine2d` raises the package to 12 implementation lanes and keeps the Haskell graphics wave moving toward `bezier2d` and `arc2d`.

## Validation

- `stack test affine2d --coverage` — 22 examples, 0 failures, 100% expression and alternative coverage
- `stack sdist ... --test-tarball` — 17 `trig`, 27 `point2d`, and 22 `affine2d` examples pass; Cabal common-mistake check is clean
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py' -v` — 6 tests pass
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 0 collisions and 0 unknown language buckets
- `git diff --check`
