### PR TITLE
feat(hl): Chapter 9 months & seasons for French, German, Italian, Portuguese

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -230,6 +230,8 @@
       "IT-DAYS-WEEKEND": "sabato/domenica (Sat/Sun; ← Sabbatum / diēs Dominica 'Lord's day'; = ES sábado/domingo)",
       "IT-TIME-HOUR": "ora (hour ← hōra ← Greek hṓrā; time via feminine article: è l'una / sono le due)",
       "IT-TIME-NOON-MIDNIGHT": "mezzogiorno/mezzanotte (noon/midnight; mezzo/mezza ← medius + giorno/notte)",
+      "IT-MONTHS": "gennaio…dicembre (closest to Latin; marzo=Mars=martedì; settembre…dicembre = Latin 7-10; luglio/agosto = Julius/Augustus)",
+      "IT-SEASONS": "primavera/estate/autunno/inverno (primavera='prima vera' first green; stagione ← statiō 'a standing')",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
@@ -242,6 +244,8 @@
       "FR-DAYS-WEEKEND": "samedi/dimanche (Sat/Sun; samedi ← Sabbatum, dimanche ← diēs Dominica 'Lord's day'; di- moved to front)",
       "FR-TIME-HOUR": "heure (hour ← hōra ← Greek hṓrā; silent h + liaison; il est deux heures)",
       "FR-TIME-NOON-MIDNIGHT": "midi/minuit (noon/midnight ← medius diēs / media nox; mi- 'middle' + di/nuit)",
+      "FR-MONTHS": "janvier…décembre (Roman gods/emperors: janvier←Janus, mars←Mars=mardi, juillet←Julius; septembre…décembre = Latin 7-10)",
+      "FR-SEASONS": "printemps/été/automne/hiver (printemps='prime temps' first time; hiver ← hibernum → hibernate)",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
@@ -254,6 +258,8 @@
       "GE-DAYS-WEEKEND": "Samstag/Sonntag (Sat/Sun; Samstag ← Sabbat/shabbāt NOT Saturn = ES sábado; Sonntag = Sun's day = Sunday)",
       "GE-TIME-HOUR": "Uhr (clock/o'clock ← Latin hōra — a LATIN LOAN, unlike native numbers/day-gods; es ist zwei Uhr)",
       "GE-TIME-NOON-MIDNIGHT": "Mittag/Mitternacht (noon/midnight; NATIVE compounds Mitte+Tag / Mitte+Nacht, vs Latin-loaned Uhr)",
+      "GE-MONTHS": "Januar…Dezember (LATIN loans like Uhr — März←Mars=Dienstag's Tiw; September…Dezember = Latin 7-10; vs native numbers)",
+      "GE-SEASONS": "Frühling/Sommer/Herbst/Winter (NATIVE Germanic, unlike Latin months; Herbst = English HARVEST; Frühling ← früh 'early')",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
       "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
       "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
@@ -264,7 +270,9 @@
       "PT-DAYS-WEEKDAYS": "segunda/terça/quarta/quinta/sexta(-feira) (Mon-Fri; UNIQUE numbered feira days ← fēria 'feast-day'; ordinals of dois…seis; Church dropped planet-gods)",
       "PT-DAYS-WEEKEND": "sábado/domingo (Sat/Sun; ← Sabbatum / diēs Dominica; domingo counted 1st → Monday='segunda' 2nd)",
       "PT-TIME-HOUR": "hora (hour ← hōra ← Greek hṓrā; horas explicit: é uma hora / são duas horas)",
-      "PT-TIME-NOON-MIDNIGHT": "meio-dia/meia-noite (noon/midnight; meio/meia ← medius; noite ← noctem shows ct→it like oito)"
+      "PT-TIME-NOON-MIDNIGHT": "meio-dia/meia-noite (noon/midnight; meio/meia ← medius; noite ← noctem shows ct→it like oito)",
+      "PT-MONTHS": "janeiro…dezembro (março=Mars; -eiro ending ← -arius like feira; setembro…dezembro = Latin 7-10 = sete/dez)",
+      "PT-SEASONS": "primavera/verão/outono/inverno (verão ← veranum ← vēr 'spring' — summer grew from spring!; outono ← autumnus au→ou)"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Chapter 9 — Months & seasons
+
+- **Chapter 9 authored** (`FR-C09-mois`, `-saisons`): the calendar year, atom-first,
+  reviewing Ch.6–8 via `reviews_of`.
+- **The months** are a parade of Roman gods and emperors: *janvier* ← Janus (the
+  two-faced god of beginnings), *février* ← the *Februa* purification, *mai* ← Maia,
+  *juin* ← Juno, with **two big payoffs** — *mars* is the **same Mars** behind
+  *mardi* (Tuesday), and *septembre–décembre* still mean the Latin **7–10** learned
+  in the numbers chapter (the Roman year began in March; *juillet/août* ← Julius/
+  Augustus were inserted and shifted the count).
+- **The seasons**: *printemps* = *prime* + *temps*, "the **first time / prime
+  season**"; *été* ← *aestas* "heat"; *automne* ← *autumnus*; *hiver* ← *hibernum*
+  "wintry" (cousin of English **hibernate**). Plus the *au printemps* / *en été…*
+  preposition split.
+- Taxonomy: namespaced `FR-MONTHS`, `FR-SEASONS`.
+
 ## Chapter 8 — Time & the clock
 
 - **Chapter 8 authored** (`FR-C08-heure`, `-midi-minuit`): telling the time,

--- a/code/learning/human-languages/french/lessons/FR-C09-mois.md
+++ b/code/learning/human-languages/french/lessons/FR-C09-mois.md
@@ -1,0 +1,64 @@
+---
+id: FR-C09-mois
+chapter: 9
+type: word
+headword: les mois
+gloss: the months — a parade of Roman gods and emperors
+concept_tag: FR-MONTHS
+prerequisites: [FR-C06-nombres-6-10, FR-C07-jours-1]
+sounds: [nasal-an, silent-final]
+roots: [latin-months, roman-gods]
+etymology_hook: "the French months are Roman gods and emperors: janvier←Janus, mars←Mars (= mardi!), juillet←Julius Caesar; septembre–décembre still mean Latin 7–10"
+est_minutes: 5
+reviews_of: [FR-C06-nombres-6-10, FR-C07-jours-1]
+---
+
+# les mois — the calendar's gods and Caesars
+
+## Warm-up
+
+[PAUSE 2s] The twelve French months are a **procession of Roman gods and
+emperors**, almost unchanged from Latin. Two things you already know pay off here:
+*mars* is the war-god you met in *mardi*, and *septembre–décembre* are the Latin
+numbers 7–10 from the counting chapter.
+
+## The months, taken apart
+
+| French | ← Latin | who / what |
+|---|---|---|
+| **janvier** | *Januarius* | **Janus**, the two-faced god of doors & beginnings — looking back at the old year, forward to the new |
+| **février** | *Februarius* | *Februa*, the Roman **purification** festival |
+| **mars** | *Martius* | **Mars**, the war-god — *the same Mars as* **mardi** (Tuesday)! |
+| **avril** | *Aprilis* | perhaps *aperire* "to **open**" (buds opening) |
+| **mai** | *Maius* | **Maia**, goddess of growth |
+| **juin** | *Junius* | **Juno**, queen of the gods |
+| **juillet** | *Julius* | **Julius Caesar** (he inserted this month) |
+| **août** | *Augustus* | the emperor **Augustus** (he inserted this one) |
+| **septembre** | *september* | "**7th**" (*septem*) |
+| **octobre** | *october* | "**8th**" (*octo*) |
+| **novembre** | *november* | "**9th**" (*novem*) |
+| **décembre** | *december* | "**10th**" (*decem*) |
+
+Two payoffs land at once:
+
+- **mars = Mars = mardi.** The month and the weekday honour the *same* war-god —
+  *Martius* (his month) and *Martis diēs* (his day). Spot one, you know the other.
+- **The 7–10 months.** *Septembre* through *décembre* still carry *septem, octo,
+  novem, decem* — because the old Roman year began in **March**, so September really
+  was the 7th month. Then **Julius** and **Augustus** shoved two months in
+  (*juillet, août*), and the counting slid out of place — but the names stuck.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "janvier, février, mars, avril, mai, juin, juillet, août,
+  septembre, octobre, novembre, décembre"]
+- [YOU SAY: the tie-back — "mars / mardi — both Mars, the war-god"]
+- [YOU SAY: "septembre = 7, décembre = 10" — the old March-start year]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which god links *mars* and *mardi*? (**Mars**, the war-god — his month
+and his day.) Why is *décembre* Latin for "ten"? (The Roman year began in March.)
+Which two months are named for **people**, not gods? (*Juillet* — Julius Caesar;
+*août* — Augustus.) Next: the **seasons**.

--- a/code/learning/human-languages/french/lessons/FR-C09-saisons.md
+++ b/code/learning/human-languages/french/lessons/FR-C09-saisons.md
@@ -1,0 +1,57 @@
+---
+id: FR-C09-saisons
+chapter: 9
+type: word
+headword: les saisons
+gloss: the seasons — spring, summer, autumn, winter
+concept_tag: FR-SEASONS
+prerequisites: [FR-C09-mois]
+sounds: [nasal-in, vowel-e]
+roots: [latin-seasons]
+etymology_hook: "printemps = 'first-time' (prime + temps); été ← aestas; automne ← autumnus; hiver ← hibernum 'wintry' — the four seasons, each from Latin"
+est_minutes: 4
+reviews_of: [FR-C09-mois, FR-C08-heure]
+---
+
+# les saisons — the four seasons
+
+## Warm-up
+
+[PAUSE 2s] Four words for the turning year. **printemps, été, automne, hiver** —
+each traces to Latin, and the first one is a small poem: *printemps* means, almost
+literally, "**the first time**."
+
+## The four seasons, taken apart
+
+| French | ← Latin | literally |
+|---|---|---|
+| **le printemps** (spring) | *prīmum tempus* | "the **first time / prime season**" (*prime* + *temps* "time") |
+| **l'été** (summer) | *aestas / aestātem* | "heat, the hot season" (cousin of *estival*, *aestival*) |
+| **l'automne** (autumn) | *autumnus* | "autumn" — the same word English borrowed (the *m* stayed, the *n* went silent) |
+| **l'hiver** (winter) | *hībernum (tempus)* | "the **wintry** season" (cousin of *hibernate* — to winter through) |
+
+- **printemps** = *prime* + *temps* ("time/weather"): the year's *first* season, its
+  "prime time." (Older French used *primevère* — the same *prima vera* "first
+  spring" that Italian keeps as *primavera*.)
+- **été** ← *aestas*, "heat" — summer as the hot season; English *estival* means "of
+  summer."
+- **hiver** ← *hībernum*, "wintry" — and English **hibernate** is literally "to
+  spend the winter." Same root, one a season, one a bear's sleep.
+
+To say "in": **au printemps** but **en été / en automne / en hiver** (only spring
+takes *au*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "le printemps, l'été, l'automne, l'hiver"]
+- [YOU SAY: unpack them — "printemps = prime + temps (first time)", "hiver ~
+  hibernate"]
+- [YOU SAY: "au printemps, en été, en hiver" — the little prepositions]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name the four French seasons. (*Printemps, été, automne, hiver*.) What
+does *printemps* literally mean? ("The **first time / prime season**.") Which
+English word is *hiver* the cousin of? (*Hibernate* — to winter through, ←
+*hībernum*.) Next chapter builds on this toward family and food.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -49,12 +49,16 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
 - **Ch. 8 — Time & the clock**: heure (← *hōra* ← Greek *hṓrā* → *hour*; *il est
   deux heures*, silent-h liaison) → midi/minuit (noon/midnight ← *medius diēs* /
   *media nox* — "mid-day"/"mid-night"). **Authored.**
+- **Ch. 9 — Months & seasons**: the twelve months as a parade of Roman gods/emperors
+  (janvier ← Janus, **mars ← Mars = mardi**, juillet/août ← Julius/Augustus;
+  septembre–décembre = the Latin **7–10** from the numbers) → the four seasons
+  (printemps = "prime temps" first-time; hiver ← *hibernum* → hibernate). **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 9+ | Months & seasons, family, food — following the Spanish theme order, with the Spanish cousin supplied for contrast |
+| 10+ | Family, food, the body — following the Spanish theme order, with the Spanish cousin supplied for contrast |
 
 The *tu/vous* lesson (Ch. 2) is the French counterpart to Spanish *tú/usted*:
 same formal/informal split, but French makes the formal from the **plural**

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 9 — Months & seasons
+
+- **Chapter 9 authored** (`GE-C09-monate`, `-jahreszeiten`): the calendar year,
+  atom-first, reviewing Ch.6–8 via `reviews_of`.
+- **The native-vs-Latin split deepens** (numbers native, weekday-gods Germanic,
+  clock *Uhr* Latin — now): the **months are Latin loans** (Januar ← Janus, *März*
+  ← Mars = *Dienstag*'s Tiw, September–Dezember = Latin 7–10), reaching for Rome
+  just as *Uhr* did — while German's own numbers stay *sieben, acht, neun, zehn*.
+- **The seasons swing back to native Germanic**: *Frühling* ← *früh* "early" (the
+  early-season); *Sommer/Winter* = the plain twins of English *summer/winter*; and
+  the surprise, **Herbst = English harvest** — the same Germanic reaping-word, which
+  English narrowed to the *act* while taking Latin *autumn* for the season.
+- Taxonomy: namespaced `GE-MONTHS`, `GE-SEASONS`.
+
 ## Chapter 8 — Time & the clock
 
 - **Chapter 8 authored** (`GE-C08-uhr`, `-mittag-mitternacht`): telling the time,

--- a/code/learning/human-languages/german/lessons/GE-C09-jahreszeiten.md
+++ b/code/learning/human-languages/german/lessons/GE-C09-jahreszeiten.md
@@ -1,0 +1,59 @@
+---
+id: GE-C09-jahreszeiten
+chapter: 9
+type: word
+headword: die Jahreszeiten
+gloss: the seasons — native Germanic, unlike the Latin months
+concept_tag: GE-SEASONS
+prerequisites: [GE-C09-monate]
+sounds: [ch-none, umlaut-ue]
+roots: [germanic-seasons]
+etymology_hook: "German seasons are NATIVE: Frühling (← früh 'early'), Sommer (= English summer), Herbst (= English HARVEST!), Winter (= English winter) — unlike the Latin-loaned months"
+est_minutes: 4
+reviews_of: [GE-C09-monate, GE-C08-mittag-mitternacht]
+---
+
+# die Jahreszeiten — the seasons go native
+
+## Warm-up
+
+[PAUSE 2s] The months were Latin. The **seasons** swing back to **native German** —
+and one of them, *Herbst*, is the same word as English **harvest**. The word for
+"season" itself is transparent: **Jahres-zeit** = "year-time."
+
+## The four seasons, taken apart
+
+| German | = | English twin |
+|---|---|---|
+| **der Frühling** (spring) | *früh* "early" + *-ling* | *early*-season (from *früh*, cousin of English *early*) |
+| **der Sommer** (summer) | native Germanic | **summer** |
+| **der Herbst** (autumn) | native Germanic | **harvest** |
+| **der Winter** (winter) | native Germanic | **winter** |
+
+All four are homegrown Germanic, and three are the plain twins of English *summer,
+winter,* and — the surprise — **harvest**:
+
+- **Frühling** is built from **früh** ("early") — literally the "early-season," the
+  year's first. (German also uses *Lenz*, an old poetic word for spring.)
+- **Herbst ↔ harvest.** They're the same Germanic word: the **reaping** season.
+  English kept *harvest* but narrowed it to the *act* of gathering and reached for
+  Latin-derived *autumn* for the season; German kept the old word for the season
+  itself. Two languages, one word, split in meaning.
+
+So the German year splits cleanly: **Latin** for the months (like *Uhr*, the clock),
+**native Germanic** for the seasons (like the numbers and *Mittag/Mitternacht*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "der Frühling, der Sommer, der Herbst, der Winter"]
+- [YOU SAY: the twins — "Sommer/summer, Winter/winter, Herbst/**harvest**"]
+- [YOU SAY: "Frühling = früh (early) + -ling — the early season"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are German seasons native or Latin, unlike the months? (**Native**
+Germanic.) What English word is *Herbst* the twin of, and what happened to it?
+(**Harvest** — English narrowed it to the reaping act and took *autumn* from Latin
+for the season.) What is *Frühling* built from? (*früh* "early" — the early season.)
+Next chapter builds on this toward family and food.

--- a/code/learning/human-languages/german/lessons/GE-C09-monate.md
+++ b/code/learning/human-languages/german/lessons/GE-C09-monate.md
@@ -1,0 +1,67 @@
+---
+id: GE-C09-monate
+chapter: 9
+type: word
+headword: die Monate
+gloss: the months — Latin loans, like the clock-word Uhr
+concept_tag: GE-MONTHS
+prerequisites: [GE-C06-zahlen-6-10, GE-C08-uhr]
+sounds: [vowel-ae, ch-none]
+roots: [latin-months]
+etymology_hook: "German's months are Latin loans (Januar←Janus, März←Mars, like mardi!) — the same reach-for-Rome that gave it Uhr, while its numbers and seasons stay native"
+est_minutes: 5
+reviews_of: [GE-C06-zahlen-6-10, GE-C07-wochentage-1, GE-C08-uhr]
+---
+
+# die Monate — Rome's calendar in German
+
+## Warm-up
+
+[PAUSE 2s] Here's the German pattern again. Its numbers are homegrown (*eins,
+zwei*), its weekday-gods are Germanic (*Donnerstag*). But its **months** — like its
+clock-word **Uhr** — are **borrowed straight from Latin**. Time-reckoning, again,
+came to the German world from Rome.
+
+## The months, taken apart
+
+| German | ← Latin | who / what |
+|---|---|---|
+| **Januar** | *Januarius* | **Janus**, god of doors & beginnings |
+| **Februar** | *Februarius* | the *Februa* purification festival |
+| **März** | *Martius* | **Mars**, the war-god — the same Mars as English *Tuesday* / French *mardi* |
+| **April** | *Aprilis* | perhaps *aperire* "to open" |
+| **Mai** | *Maius* | **Maia**, goddess of growth |
+| **Juni** | *Junius* | **Juno**, queen of the gods |
+| **Juli** | *Julius* | **Julius Caesar** |
+| **August** | *Augustus* | the emperor **Augustus** |
+| **September** | *september* | "**7th**" (*septem*) |
+| **Oktober** | *october* | "**8th**" (*octo*) |
+| **November** | *november* | "**9th**" (*novem*) |
+| **Dezember** | *december* | "**10th**" (*decem*) |
+
+Two familiar payoffs:
+
+- **März = Mars.** German borrowed the Roman war-god's month whole — the same god
+  behind English *March* and, as *Tuesday* (Tiw = Mars), behind German's own
+  *Dienstag*. The god came in twice, once by name, once by translation.
+- **September–Dezember = 7–10.** Even in German, these keep the Latin numbers
+  *septem…decem* (the Roman year began in March). So German's *own* numbers are
+  *sieben, acht, neun, zehn* — but its *month* names count in Latin.
+
+Three layers of the German calendar, three origins: **numbers** native, **weekdays**
+Germanic gods, **months** (and the clock, *Uhr*) Latin.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "Januar, Februar, März … November, Dezember"]
+- [YOU SAY: "März = Mars = Dienstag's god (Tiw)"]
+- [YOU SAY: "September = 7, Dezember = 10 — Latin numbers in German months"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are German month names native or borrowed, and like which other German
+word? (Borrowed from **Latin** — like the clock-word *Uhr*.) What links *März* to
+*Dienstag*? (The war-god **Mars** = Germanic *Tiw*.) Why is *Dezember* Latin for
+"ten"? (The Roman year began in March.) Next: the **seasons** — where German goes
+native again.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -51,12 +51,17 @@ Spanish and French where a contrast helps. The recurring decoder is the
   Latin loanword** in a Germanic system of native numbers & day-gods; *es ist zwei
   Uhr*) → Mittag/Mitternacht (noon/midnight, **native** compounds *Mitte* + *Tag* /
   *Nacht*, unlike the borrowed *Uhr*). **Authored.**
+- **Ch. 9 — Months & seasons**: the **native-vs-Latin split deepens** — the months
+  are **Latin loans** (Januar ← Janus, *März* ← Mars = Dienstag's Tiw; September–
+  Dezember = Latin 7–10), like the clock-word *Uhr*, while the **seasons stay
+  native** (Frühling ← *früh* "early"; *Herbst* = English **harvest**; Sommer/Winter
+  = English twins). **Authored.**
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 9+ | Cases (der→den→dem), months & seasons, family, food, sprechen & irregular verbs — following the shared theme order |
+| 10+ | Cases (der→den→dem), family, food, the body, sprechen & irregular verbs — following the shared theme order |
 
 The **du / Sie** lesson (Ch. 2) completes the formal/informal set across the
 languages: Spanish *tú/usted* (from "your grace"), French *tu/vous* (the

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 9 — Months & seasons
+
+- **Chapter 9 authored** (`IT-C09-mesi`, `-stagioni`): the calendar year, atom-first,
+  reviewing Ch.6–8 via `reviews_of`, with Spanish twins supplied.
+- **The months, closest to Latin** of the sisters (*gennaio* keeps *Januarius*'s
+  *-aio*; *ottobre* echoes *otto*): the god/emperor parade (Janus, Mars, Maia, Juno,
+  Julius, Augustus), with the payoffs — *marzo* is the **same Mars** as *martedì*,
+  and *settembre–dicembre* are the Latin **7–10** (Roman year began in March).
+- **The seasons**: *primavera* = *prima vera*, "**first spring / first green**"
+  (from Latin *vēr*); *estate* ← *aestas*; *autunno* ← *autumnus*; *inverno* ←
+  *hibernum*. Even *stagione* is Latin *statiō*, "a standing" — a *station* of the
+  year.
+- Taxonomy: namespaced `IT-MONTHS`, `IT-SEASONS`.
+
 ## Chapter 8 — Time & the clock
 
 - **Chapter 8 authored** (`IT-C08-ora`, `-mezzogiorno-mezzanotte`): telling the

--- a/code/learning/human-languages/italian/lessons/IT-C09-mesi.md
+++ b/code/learning/human-languages/italian/lessons/IT-C09-mesi.md
@@ -1,0 +1,63 @@
+---
+id: IT-C09-mesi
+chapter: 9
+type: word
+headword: i mesi
+gloss: the months — the Roman calendar, barely worn down
+concept_tag: IT-MONTHS
+prerequisites: [IT-C06-numeri-6-10, IT-C07-giorni-1]
+sounds: [double-gg, c-before-i]
+roots: [latin-months, roman-gods]
+etymology_hook: "Italy kept the months closest to Latin: gennaio←Januarius, marzo←Mars (= martedì!), settembre–dicembre = the Latin 7–10 you learned as numbers"
+est_minutes: 5
+reviews_of: [IT-C06-numeri-6-10, IT-C07-giorni-1]
+---
+
+# i mesi — Rome's own months
+
+## Warm-up
+
+[PAUSE 2s] Sitting next to Rome, Italian kept the month names **closest to Latin**
+of all the sisters — the same procession of gods and Caesars, barely worn. And two
+things you know pay off: *marzo* is the war-god of *martedì*, and *settembre–
+dicembre* are the Latin numbers 7–10.
+
+## The months, taken apart
+
+| Italian | ← Latin | who / what | Spanish twin |
+|---|---|---|---|
+| **gennaio** | *Januarius* | **Janus**, god of beginnings | *enero* |
+| **febbraio** | *Februarius* | the *Februa* purification | *febrero* |
+| **marzo** | *Martius* | **Mars** — the god of **martedì**! | *marzo* |
+| **aprile** | *Aprilis* | *aperire* "to open" | *abril* |
+| **maggio** | *Maius* | **Maia**, growth-goddess | *mayo* |
+| **giugno** | *Junius* | **Juno**, queen of gods | *junio* |
+| **luglio** | *Julius* | **Julius Caesar** | *julio* |
+| **agosto** | *Augustus* | emperor **Augustus** | *agosto* |
+| **settembre** | *september* | "**7th**" (*septem*) | *septiembre* |
+| **ottobre** | *october* | "**8th**" (*octo*) | *octubre* |
+| **novembre** | *november* | "**9th**" (*novem*) | *noviembre* |
+| **dicembre** | *december* | "**10th**" (*decem*) | *diciembre* |
+
+The Italian tells: *gennaio* kept the *-aio* of *Januarius*, and *settembre/ottobre*
+keep the doubled/assimilated look (*ottobre*, like *otto*). And two payoffs land:
+
+- **marzo = Mars = martedì.** The month and Tuesday honour the *same* war-god —
+  *Martius* and *Martedì*. One unlocks the other.
+- **settembre…dicembre = 7…10.** Still the Latin numbers, because the Roman year
+  began in **March**; then *luglio* (Julius) and *agosto* (Augustus) were inserted
+  and shifted the count.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "gennaio, febbraio, marzo … novembre, dicembre"]
+- [YOU SAY: "marzo / martedì — both Mars"]
+- [YOU SAY: "settembre = 7, dicembre = 10"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which god links *marzo* and *martedì*? (**Mars**.) Why is *dicembre*
+Latin for "ten"? (The Roman year began in March.) Which two months honour real
+**people**? (*Luglio* — Julius; *agosto* — Augustus.) Next: the **stagioni**, the
+seasons.

--- a/code/learning/human-languages/italian/lessons/IT-C09-stagioni.md
+++ b/code/learning/human-languages/italian/lessons/IT-C09-stagioni.md
@@ -1,0 +1,53 @@
+---
+id: IT-C09-stagioni
+chapter: 9
+type: word
+headword: le stagioni
+gloss: the seasons — and "primavera," the first green
+concept_tag: IT-SEASONS
+prerequisites: [IT-C09-mesi]
+sounds: [double-none, open-e]
+roots: [latin-seasons]
+etymology_hook: "primavera = prima vera 'first spring/green'; estate ← aestas; autunno ← autumnus; inverno ← hibernum; even 'stagione' is Latin statiō, a 'standing' of the year"
+est_minutes: 4
+reviews_of: [IT-C09-mesi, IT-C08-ora]
+---
+
+# le stagioni — the four seasons
+
+## Warm-up
+
+[PAUSE 2s] The word for "season," **stagione**, is itself a small lesson: it's Latin
+**statiō**, a "standing" — a fixed *station* of the year (cousin of English
+*station, stage*). And the loveliest of the four, **primavera**, means the "**first
+green**."
+
+## The four seasons, taken apart
+
+| Italian | ← Latin | literally |
+|---|---|---|
+| **la primavera** (spring) | *prīma vēra* | "**first spring / first green**" (*prima* "first" + *vera* ← *ver* "spring") |
+| **l'estate** (summer) | *aestas / aestātem* | "the heat, the hot season" |
+| **l'autunno** (autumn) | *autumnus* | "autumn" (twin of English *autumn*) |
+| **l'inverno** (winter) | *hibernum* | "the wintry season" (cousin of *hibernate*) |
+
+- **primavera** = *prima* + *vera*: the "first spring." Latin *vēr* was the word for
+  spring; Italian (and Spanish, and Portuguese) built "prima-vera," the year's
+  *first* season — the same idea French once had in *primevère*.
+- **estate** ← *aestas*, "heat." **autunno** ← *autumnus*, the same word English
+  borrowed. **inverno** ← *hibernum* "wintry" — English **hibernate** is "to spend
+  the *inverno*."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "la primavera, l'estate, l'autunno, l'inverno"]
+- [YOU SAY: "primavera = prima + vera (first green)"; "inverno ~ hibernate"]
+- [YOU SAY: "stagione ← statiō — a 'standing' of the year, like station"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name the four Italian seasons. (*Primavera, estate, autunno, inverno*.)
+What does *primavera* literally mean? ("**First spring / first green**.") What Latin
+word is *stagione* from, and its English cousin? (*Statiō* "a standing"; *station*.)
+Next chapter builds on this toward family and food.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -46,12 +46,16 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
 - **Ch. 8 — Time & the clock**: ora (hour ← *hōra* ← Greek *hṓrā*; the **feminine
   article** twist — *è l'una* but *sono le due*) → mezzogiorno/mezzanotte
   (noon/midnight; *mezzo/mezza* ← *medius* + *giorno/notte*). **Authored.**
+- **Ch. 9 — Months & seasons**: the months **closest to Latin** (gennaio ← Januarius,
+  **marzo ← Mars = martedì**, luglio/agosto ← Julius/Augustus; settembre–dicembre =
+  Latin **7–10**) → the seasons (primavera = "prima vera" first-green; *stagione* ←
+  *statiō* "a standing"; inverno ← *hibernum*). **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 9+ | Months & seasons, family, food — following the shared theme order |
+| 10+ | Family, food, the body — following the shared theme order |
 
 Note: Italian's formal "you" is **Lei** — literally "she" (a 3rd-person
 politeness, like German *Sie*), a different mechanism from Spanish *usted* (a

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Chapter 9 — Months & seasons
+
+- **Chapter 9 authored** (`PT-C09-meses`, `-estacoes`): the calendar year, atom-first,
+  reviewing Ch.6–8 via `reviews_of`, with Spanish twins supplied.
+- **The months** (the *-eiro* ending ← *-arius*, the same suffix as *feira*): the
+  god/emperor parade, with the payoffs — *março* is **Mars**, and *setembro–dezembro*
+  are the Latin **7–10** you can hear in *sete/dez* (Roman year began in March;
+  *julho/agosto* ← Julius/Augustus were inserted).
+- **The seasons**, with a twist: *primavera* = "**first spring**" (*prima* + *vēr*),
+  and **verão** ("summer") also grew from *vēr* "spring" — via *vēranum*
+  "spring-like/warm," so Portuguese's summer-word literally came from *spring*.
+  *outono* ← *autumnus* shows the *au→ou* softening (cf. *oito/noite*); *inverno* ←
+  *hibernum*.
+- Taxonomy: namespaced `PT-MONTHS`, `PT-SEASONS`.
+
 ## Chapter 8 — Time & the clock
 
 - **Chapter 8 authored** (`PT-C08-hora`, `-meio-dia-meia-noite`): telling the

--- a/code/learning/human-languages/portuguese/lessons/PT-C09-estacoes.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C09-estacoes.md
@@ -1,0 +1,57 @@
+---
+id: PT-C09-estacoes
+chapter: 9
+type: word
+headword: as estações
+gloss: the seasons — and verão, a "summer" that came from "spring"
+concept_tag: PT-SEASONS
+prerequisites: [PT-C09-meses]
+sounds: [nasal-ao, open-e]
+roots: [latin-seasons]
+etymology_hook: "primavera = 'first green'; verão ← veranum 'spring-like' — Portuguese's word for SUMMER literally grew out of 'spring'; outono ← autumnus (ct→ut); inverno ← hibernum"
+est_minutes: 4
+reviews_of: [PT-C09-meses, PT-C08-hora]
+---
+
+# as estações — the seasons, and a shifting summer
+
+## Warm-up
+
+[PAUSE 2s] Four seasons — and a small mystery in one of them. Portuguese's word for
+**summer**, *verão*, didn't come from a "heat" word like French *été*. It grew out
+of the word for **spring**. Here's how.
+
+## The four seasons, taken apart
+
+| Portuguese | ← Latin | literally |
+|---|---|---|
+| **a primavera** (spring) | *prīma vēra* | "**first spring / first green**" (*prima* + *ver* "spring") |
+| **o verão** (summer) | *vēranum (tempus)* | "the **spring-like / warm** season" (← *vēr* "spring"!) |
+| **o outono** (autumn) | *autumnus* | "autumn" (*ct/tumn* → *ut*: *autumnus → outono*) |
+| **o inverno** (winter) | *hibernum* | "the wintry season" (cousin of *hibernate*) |
+
+The twist is in the first two, both born from Latin **vēr**, "spring":
+
+- **primavera** = *prima* + *ver*: "the **first** spring / first green" — the year's
+  opening season (shared with Spanish and Italian).
+- **verão** ← *vēranum*, which meant "**spring-like**, of the growing season."
+  Warmth crept forward on the calendar, and the word slid with it — so Portuguese's
+  "summer" literally *grew out of* "spring." (Spanish did the same: *verano*.)
+
+And **outono** ← *autumnus* shows a familiar Portuguese move: the *au…t* smoothed to
+**ou**, the same softening you saw in *oito* and *noite*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "a primavera, o verão, o outono, o inverno"]
+- [YOU SAY: the twist — "verão ← veranum ← ver (spring): summer from spring"]
+- [YOU SAY: "inverno ~ hibernate"; "outono ← autumnus"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name the four Portuguese seasons. (*Primavera, verão, outono, inverno*.)
+What's surprising about *verão*'s origin? (It comes from *vēr* "**spring**" — the
+summer-word grew out of the spring-word.) What does *primavera* literally mean?
+("**First spring / first green**.") Next chapter builds on this toward family and
+food.

--- a/code/learning/human-languages/portuguese/lessons/PT-C09-meses.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C09-meses.md
@@ -1,0 +1,62 @@
+---
+id: PT-C09-meses
+chapter: 9
+type: word
+headword: os meses
+gloss: the months — Roman gods, emperors, and the numbers 7–10
+concept_tag: PT-MONTHS
+prerequisites: [PT-C06-numeros-6-10, PT-C07-dias-1]
+sounds: [nasal-none, open-e]
+roots: [latin-months, roman-gods]
+etymology_hook: "janeiro←Januarius (Janus), março←Mars, julho←Julius Caesar; setembro–dezembro still mean Latin 7–10 (the numbers you learned)"
+est_minutes: 5
+reviews_of: [PT-C06-numeros-6-10, PT-C07-dias-1]
+---
+
+# os meses — the gods and numbers of the calendar
+
+## Warm-up
+
+[PAUSE 2s] The Portuguese months are the Roman procession of gods and Caesars,
+worn down the Portuguese way. And two things you know pay off: *março* is the
+war-god, and *setembro–dezembro* are the Latin numbers 7–10.
+
+## The months, taken apart
+
+| Portuguese | ← Latin | who / what | Spanish twin |
+|---|---|---|---|
+| **janeiro** | *Januarius* | **Janus**, god of beginnings | *enero* |
+| **fevereiro** | *Februarius* | the *Februa* purification | *febrero* |
+| **março** | *Martius* | **Mars**, the war-god | *marzo* |
+| **abril** | *Aprilis* | *aperire* "to open" | *abril* |
+| **maio** | *Maius* | **Maia**, growth-goddess | *mayo* |
+| **junho** | *Junius* | **Juno**, queen of gods | *junio* |
+| **julho** | *Julius* | **Julius Caesar** | *julio* |
+| **agosto** | *Augustus* | emperor **Augustus** | *agosto* |
+| **setembro** | *september* | "**7th**" (*septem*) | *septiembre* |
+| **outubro** | *october* | "**8th**" (*octo*) | *octubre* |
+| **novembro** | *november* | "**9th**" (*novem*) | *noviembre* |
+| **dezembro** | *december* | "**10th**" (*decem*) | *diciembre* |
+
+Portuguese tells: *janeiro/fevereiro* kept the *-eiro* ending (← *-arius*, the same
+suffix in *feira*), and *setembro/dezembro* echo the numbers *sete/dez* you learned.
+Two payoffs:
+
+- **março = Mars.** The war-god's month, the same Mars behind English *March*.
+- **setembro…dezembro = 7…10.** Still the Latin numbers, because the Roman year
+  began in **March**; then *julho* (Julius) and *agosto* (Augustus) were inserted
+  and pushed the count down two.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the twelve — "janeiro, fevereiro, março … novembro, dezembro"]
+- [YOU SAY: "março = Mars, the war-god"]
+- [YOU SAY: "setembro = 7 (sete), dezembro = 10 (dez)"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which god is *março* named for? (**Mars**, the war-god.) Why is
+*dezembro* Latin for "ten"? (The Roman year began in March.) Which two months honour
+real **people**? (*Julho* — Julius; *agosto* — Augustus.) Next: the **estações**,
+the seasons.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -50,12 +50,16 @@ French.
   explicit — *é uma hora* / *são duas horas*, with the *dois/duas* gender) →
   meio-dia/meia-noite (noon/midnight; *noite* ← *noctem* shows the **ct→it** shift
   from the numbers, like *oito*). **Authored.**
+- **Ch. 9 — Months & seasons**: the months (**março ← Mars**, julho/agosto ←
+  Julius/Augustus; setembro–dezembro = Latin **7–10** = *sete/dez*) → the seasons,
+  with the twist that **verão** ("summer") ← *veranum* ← *vēr* "**spring**" — the
+  summer-word grew out of spring; *outono* ← *autumnus* (au→ou). **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |
 |---|---|
-| 9+ | Months & seasons, family, food — following the shared theme order |
+| 10+ | Family, food, the body — following the shared theme order |
 
 Note: Portuguese's polite "you" is **você** (← *vossa mercê*, "your mercy") — the
 same "your grace" mechanism as Spanish *usted*, worn down differently. Worth


### PR DESCRIPTION
Parallel **months & seasons** chapters across the four non-Spanish tracks. Atom-first, two lessons each (the twelve months + the four seasons), ~4–5 min, reviewing Ch.6–8 via `reviews_of`. **Two big payoffs the learner already set up:** *marzo/mars/März/março* = the **same Mars** behind Tuesday (days chapter), and *September–December* = the Latin **7–10** from the numbers chapter.

| Track | The angle |
|---|---|
| **French** | The god/emperor parade (*janvier*←Janus, *mars*←Mars, *juillet/août*←Julius/Augustus); *printemps* = "prime temps" first-time; *hiver* ← *hibernum* → **hibernate** |
| **German** | **The standout** — the native-vs-Latin split *deepens*: months are **Latin loans** (like *Uhr*; *März*←Mars=*Dienstag*'s Tiw) while the **seasons stay native Germanic** (*Herbst* = English **harvest**; *Frühling*←*früh*; *Sommer/Winter* = English twins) |
| **Italian** | Months closest to Latin (*gennaio*, *ottobre* echoes *otto*); *primavera* = "prima vera" first green; *stagione* ← *statiō* "a standing" |
| **Portuguese** | *março*=Mars; *-eiro* ending ← *-arius* (like *feira*); the twist that **verão** ("summer") ← *veranum* ← *vēr* "**spring**" — summer grew from spring; *outono* ← *autumnus* (au→ou) |

The German native-vs-Latin thread now spans four chapters: numbers *native* → weekday-gods *Germanic* → clock+months *Latin loan* → seasons *native again*. Correct prefixes (FR-, **GE-**, IT-, PT-); namespaced `{FR,GE,IT,PT}-MONTHS/-SEASONS`; four roadmaps + CHANGELOGs advanced to "Next = Ch.10 (family/food)".

## Verification
- `human-language-data` suite: **38 / 38 pass**. Main **clean on retired tags** (three cycles running — the root-cause task appears to have landed).
- Security-reviewed (subagent): markdown + JSON only — no scripts, URLs, secrets, or injection; taxonomy.json validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)