### PR TITLE
feat(sql): i64::MIN div/mod overflow + integer % semantics

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.55 — `i64::MIN` div/mod overflow + integer `%`
+
+Two `%` / `/` edge cases now match SQLite. **`i64::MIN` overflow:**
+`0x8000000000000000 / -1` promotes to REAL (`9.2233720369e18`) instead of
+erroring, mirroring the `+`/`-`/`*` overflow promotion, and
+`0x8000000000000000 % -1` returns INTEGER `0` (its true remainder). **Integer
+`%`:** SQLite's modulo is an integer operation — both operands are truncated
+toward zero to 64-bit integers before the remainder is taken, and the result is
+REAL only if an operand was REAL. So `7.5 % 2` is now `1.0` (7 % 2), not `1.5`
+(fmod); `10.9 % 3.9` is `1.0` (10 % 3); a real divisor that truncates to zero
+(`5 % 0.9`) is NULL. Division (`/`) is unchanged — it stays true real division
+(`7.5 / 2` = 3.75). Implemented in `sql-vm`'s `Div`/`Mod` arms; verified against
+bundled real SQLite in the differential oracle.
+
 ## 0.5.54 — Hexadecimal integer literals
 
 `SELECT 0x1F` now works (was a parse error). SQLite hex integer literals like

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.54"
+version = "0.5.55"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1641,6 +1641,29 @@ const CASES: &[Case] = &[
         setup: &[],
         query: "SELECT 9223372036854775807 + 1 AS a, typeof(9223372036854775807 + 1) AS at, -9223372036854775807 - 2 AS b, 9223372036854775807 * 2 AS c, -(-9223372036854775808) AS d, 100 + 200 AS e, typeof(100 + 200) AS et",
     },
+    // Division overflow also promotes to REAL: `i64::MIN / -1` has no `i64`
+    // representation, so SQLite yields `9223372036854775808.0` (real). The only
+    // `i64` overflow modulo can hit is `i64::MIN % -1`, whose remainder is 0
+    // (integer). `i64::MIN` is written as `0x8000000000000000` (hex literals,
+    // added last cycle) since the decimal `9223372036854775808` is itself a REAL.
+    // Previously mini errored ("integer overflow in division/modulo").
+    Case {
+        id: "div_mod_i64_min_overflow",
+        setup: &[],
+        query: "SELECT 0x8000000000000000 / -1 AS a, typeof(0x8000000000000000 / -1) AS at, 0x8000000000000000 % -1 AS b, typeof(0x8000000000000000 % -1) AS bt",
+    },
+    // SQLite's `%` is an INTEGER operation, unlike `/`: both operands are
+    // truncated toward zero to 64-bit integers before the remainder is taken, and
+    // the result is REAL only if an operand was REAL. So `7.5 % 2` = `1.0` (7 % 2,
+    // rendered real), NOT `1.5` (fmod); `10.9 % 3.9` = `1.0` (10 % 3); a real
+    // divisor that truncates to zero (`5 % 0.9`) is NULL; `-7.5 % 2` = `-1.0`.
+    // Division by contrast stays true real division (`7.5 / 2` = 3.75). Previously
+    // mini used fmod for the float cases (`7.5 % 2` gave 1.5).
+    Case {
+        id: "modulo_integer_truncation",
+        setup: &[],
+        query: "SELECT 7.5 % 2 AS a, typeof(7.5 % 2) AS at, 10.9 % 3.9 AS b, -7.5 % 2 AS c, (5 % 0.9) IS NULL AS d, 7.5 / 2 AS e, 7 % 2 AS f, typeof(7 % 2) AS ft",
+    },
     // Binary arithmetic applies NUMERIC affinity to text/blob operands, matching
     // SQLite: `'5'+0` = 5 (integer), `'5.5'+0` = 5.5 (real), `'abc'+1` = 1 (no
     // numeric prefix → 0), `'12abc'+0` = 12, and `'10'-'3'` = 7 (both coerced).

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.31] - Unreleased
+
+### Changed
+
+- **`i64::MIN` division/modulo overflow now matches SQLite instead of erroring.**
+  `i64::MIN / -1` has no `i64` representation, so it now PROMOTES to REAL
+  (`9223372036854775808.0`), mirroring the existing `+`/`-`/`*` overflow
+  promotion. `i64::MIN % -1` (the only overflow `%` can hit) returns INTEGER `0`,
+  its true remainder. Both previously surfaced a `VmError` ("integer overflow in
+  division/modulo").
+- **`%` is now an INTEGER operation, matching SQLite.** Both operands are
+  converted to 64-bit integers (numeric affinity, then truncation toward zero,
+  with out-of-range reals clamped to the i64 bounds via Rust's saturating
+  `as i64` float cast) before the remainder is taken; the result is REAL only if
+  an operand carried REAL affinity. So `7.5 % 2` is now `1.0` (7 % 2), not `1.5`
+  (fmod), and `10.9 % 3.9` is `1.0` (10 % 3). A real divisor that truncates to
+  zero (`5 % 0.9`) is NULL, as before. Division (`/`) is unchanged — it stays
+  true real division (`7.5 / 2` = 3.75).
+
 ## [0.4.30] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.30"
+version = "0.4.31"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1989,10 +1989,10 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
         //
         // Integer arithmetic uses checked variants so overflow is detected rather
         // than panicking (debug) or silently wrapping (release). For `+`/`-`/`*`
-        // an overflow PROMOTES the operation to REAL (see `checked_int_binop`),
-        // matching SQLite; only `/` and `%` still surface the rare `i64::MIN`
-        // overflow as a VmError (a follow-up). Float arithmetic wraps naturally
-        // (IEEE 754 semantics).
+        // and `/` an overflow PROMOTES the operation to REAL (see
+        // `checked_int_binop` and the `Div` arm), matching SQLite; the only i64
+        // overflow `%` can hit is `i64::MIN % -1`, whose remainder is 0. Float
+        // arithmetic wraps naturally (IEEE 754 semantics).
         BinaryOp::Add => checked_int_binop(l, r, i64::checked_add, |a, b| a + b),
         BinaryOp::Sub => checked_int_binop(l, r, i64::checked_sub, |a, b| a - b),
         BinaryOp::Mul => checked_int_binop(l, r, i64::checked_mul, |a, b| a * b),
@@ -2008,9 +2008,14 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
                 (_, SqlValue::Int(0)) => Ok(SqlValue::Null),
                 (_, SqlValue::Float(f)) if *f == 0.0 => Ok(SqlValue::Null),
                 (SqlValue::Int(a), SqlValue::Int(b)) => {
-                    a.checked_div(*b).map(SqlValue::Int).ok_or_else(|| {
-                        VmError::TypeMismatch("integer overflow in division".to_string())
-                    })
+                    // `checked_div` is `None` only for `i64::MIN / -1` (the zero
+                    // divisor was handled above), which overflows i64. SQLite
+                    // PROMOTES that to REAL — `-9223372036854775808 / -1` is
+                    // `9223372036854775808.0` — mirroring the +/-/* overflow
+                    // promotion, so fall back to the widened float quotient.
+                    Ok(a.checked_div(*b)
+                        .map(SqlValue::Int)
+                        .unwrap_or_else(|| SqlValue::Float(*a as f64 / *b as f64)))
                 }
                 (SqlValue::Float(a), SqlValue::Float(b)) => Ok(SqlValue::Float(a / b)),
                 (SqlValue::Int(a), SqlValue::Float(b)) => Ok(SqlValue::Float(*a as f64 / b)),
@@ -2022,20 +2027,39 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
             }
         }
         BinaryOp::Mod => {
-          // Numeric affinity applies first (`'7' % 3` = 1); then modulo by zero
-          // is NULL in SQLite (`5%0`, `5.5%0`, `5%0.0`), not an error.
+          // SQLite's `%` is fundamentally an INTEGER operation, unlike `/`: both
+          // operands are first converted to 64-bit integers (numeric affinity,
+          // then truncation TOWARD ZERO — `7.5`→7, `-7.5`→-7 — with out-of-range
+          // reals clamped to the i64 bounds, exactly what Rust's `as i64` float
+          // cast does), the integer remainder is taken, and the RESULT is REAL
+          // when either operand was REAL and INTEGER otherwise. So `7.5 % 2` is
+          // `1.0` (7 % 2 = 1, rendered real), NOT `1.5` (which is what `fmod`
+          // would give). Modulo by zero is NULL — including a real divisor that
+          // truncates to zero, e.g. `5 % 0.9` — never an error.
           let (l, r) = (coerce_arith(l), coerce_arith(r));
-          match (&l, &r) {
-            (_, SqlValue::Int(0)) => Ok(SqlValue::Null),
-            (_, SqlValue::Float(f)) if *f == 0.0 => Ok(SqlValue::Null),
-            (SqlValue::Int(a), SqlValue::Int(b)) => {
-                a.checked_rem(*b).map(SqlValue::Int).ok_or_else(|| {
-                    VmError::TypeMismatch("integer overflow in modulo".to_string())
-                })
+          // `coerce_arith` leaves only Int/Float for numeric operands; map each to
+          // an i64 (truncating floats), remembering whether either side was REAL.
+          let to_i64 = |v: &SqlValue| -> Option<i64> {
+              match v {
+                  SqlValue::Int(n) => Some(*n),
+                  SqlValue::Float(f) => Some(*f as i64),
+                  _ => None,
+              }
+          };
+          match (to_i64(&l), to_i64(&r)) {
+            (Some(_), Some(0)) => Ok(SqlValue::Null),
+            (Some(a), Some(b)) => {
+                // `checked_rem` is `None` only for `i64::MIN % -1` (the zero
+                // divisor is handled above); the true remainder there is 0, since
+                // -1 divides evenly. So the fallback is 0, never an error.
+                let m = a.checked_rem(b).unwrap_or(0);
+                // REAL if either operand carried REAL affinity, else INTEGER.
+                if matches!(l, SqlValue::Float(_)) || matches!(r, SqlValue::Float(_)) {
+                    Ok(SqlValue::Float(m as f64))
+                } else {
+                    Ok(SqlValue::Int(m))
+                }
             }
-            (SqlValue::Float(a), SqlValue::Float(b)) => Ok(SqlValue::Float(a % b)),
-            (SqlValue::Int(a), SqlValue::Float(b)) => Ok(SqlValue::Float(*a as f64 % b)),
-            (SqlValue::Float(a), SqlValue::Int(b)) => Ok(SqlValue::Float(a % *b as f64)),
             _ => Err(VmError::TypeMismatch(format!(
                 "cannot mod {:?} by {:?}", l.type_name(), r.type_name()
             ))),
@@ -3564,6 +3588,43 @@ mod tests {
         assert_eq!(bin(BinaryOp::Mod, t("7"), int(3)), int(1));
         // NULL still short-circuits to NULL (handled before coercion).
         assert_eq!(bin(BinaryOp::Add, t("5"), null()), null());
+    }
+
+    #[test]
+    fn test_div_mod_i64_min_overflow() {
+        // `i64::MIN / -1` overflows i64 → SQLite promotes to REAL. `i64::MIN % -1`
+        // overflows Rust's `%` but its true remainder is 0 (integer).
+        let bin = |op: BinaryOp, l: SqlValue, r: SqlValue| eval_binary(&op, l, r).unwrap();
+        assert_eq!(
+            bin(BinaryOp::Div, int(i64::MIN), int(-1)),
+            SqlValue::Float(9223372036854775808.0)
+        );
+        assert_eq!(bin(BinaryOp::Mod, int(i64::MIN), int(-1)), int(0));
+        // Non-overflowing div/mod are unchanged.
+        assert_eq!(bin(BinaryOp::Div, int(7), int(2)), int(3));
+        assert_eq!(bin(BinaryOp::Mod, int(7), int(3)), int(1));
+        assert_eq!(bin(BinaryOp::Div, int(-7), int(2)), int(-3));
+    }
+
+    #[test]
+    fn test_modulo_integer_truncation() {
+        // SQLite's `%` truncates both operands to i64 (toward zero) before taking
+        // the remainder; the result is REAL iff an operand was REAL. So `7.5 % 2`
+        // is `1.0` (7 % 2), NOT `1.5` (fmod).
+        let bin = |op: BinaryOp, l: SqlValue, r: SqlValue| eval_binary(&op, l, r).unwrap();
+        let f = SqlValue::Float;
+        assert_eq!(bin(BinaryOp::Mod, f(7.5), int(2)), f(1.0)); // 7 % 2 = 1
+        assert_eq!(bin(BinaryOp::Mod, f(10.9), f(3.9)), f(1.0)); // 10 % 3 = 1
+        assert_eq!(bin(BinaryOp::Mod, f(-7.5), int(2)), f(-1.0)); // -7 % 2 = -1
+        assert_eq!(bin(BinaryOp::Mod, int(7), f(2.5)), f(1.0)); // 7 % 2 = 1, real
+        assert_eq!(bin(BinaryOp::Mod, int(7), int(2)), int(1)); // pure int stays int
+        // A real divisor that truncates to zero is NULL, like an integer zero.
+        assert_eq!(bin(BinaryOp::Mod, int(5), f(0.9)), null());
+        // Out-of-range real dividend clamps to i64::MAX before the remainder
+        // (matching SQLite's `doubleToInt64`): 9223372036854775807 % 2 = 1.
+        assert_eq!(bin(BinaryOp::Mod, f(1e19), int(2)), f(1.0));
+        // Division, by contrast, stays true real division.
+        assert_eq!(bin(BinaryOp::Div, f(7.5), int(2)), f(3.75));
     }
 
     #[test]


### PR DESCRIPTION
## What

Fixes two `%` / `/` arithmetic edge cases in mini-sqlite to match real SQLite.

**`i64::MIN` overflow** (previously errored `"integer overflow in division/modulo"`):
- `0x8000000000000000 / -1` → promotes to **REAL** `9223372036854775808.0` (mirrors the `+`/`-`/`*` overflow promotion)
- `0x8000000000000000 % -1` → **INTEGER `0`** (its true remainder — the only i64 overflow `%` can hit)

**Integer `%`:** SQLite's modulo is fundamentally an *integer* operation, unlike `/`. Both operands are now truncated toward zero to i64 (with out-of-range reals clamped to the i64 bounds, matching `doubleToInt64`) before the remainder is taken, and the result is REAL only if an operand was REAL:
- `7.5 % 2` → `1.0` (7 % 2), not `1.5` (fmod)
- `10.9 % 3.9` → `1.0` (10 % 3)
- `5 % 0.9` → `NULL` (divisor truncates to 0)
- Division stays true real division: `7.5 / 2` → `3.75`

## How

Both changes are in `sql-vm`'s `eval_binary` `Div`/`Mod` arms:
- `Div` Int/Int: `checked_div` is `None` only for `i64::MIN / -1` (zero divisor handled above) → fall back to the widened float quotient.
- `Mod`: coerce operands, map each to i64 via a saturating `as i64` cast, route truncated-to-zero divisors to NULL, and take `checked_rem(...).unwrap_or(0)` (the `unwrap_or` absorbs `i64::MIN % -1`). Result is REAL iff either coerced operand was Float.

## Tests

- 1 new **differential-oracle** case pair (`div_mod_i64_min_overflow`, `modulo_integer_truncation`) — verified against bundled real SQLite. `i64::MIN` is expressed via the `0x8000000000000000` hex literal added last cycle (the decimal `9223372036854775808` is itself a REAL).
- 2 `sql-vm` unit tests covering `i64::MIN` overflow, truncation (incl. the `1e19` saturating clamp) and the real-divisor-to-zero NULL.
- Full `sql-vm` (110) + `mini-sqlite` suites green; `cargo clippy` clean on the changed lib.

## Security

Inline review: **clean** — no panicking path (saturating `f64 as i64` cast + `checked_div`/`checked_rem`; the float fallback never sees a zero divisor), result-type rule matches SQLite's `OP_Remainder`, no ReDoS/loops.

Version bumps: sql-vm 0.4.30→0.4.31, mini-sqlite 0.5.54→0.5.55 (+ CHANGELOGs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
