### PR TITLE
feat(hl): Arabic Ch.1 writing set — break the script apart and draw سلام

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Chapter 1 — Writing set (break the script apart and draw it)
+
+- **Writing lessons added** (`AR-W01-direction-and-alif`,
+  `AR-W02-joining-sin-lam`, `AR-W03-dots-mim-ba-salam`): a `writing`-type
+  companion to the Ch. 1 greetings, matching the Russian/Cyrillic writing set —
+  the hand-writing track the script-writing-visualizer app renders. Anchored on
+  the real Ch. 1 word **سلام** (*salām*, the "peace" inside *as-salāmu ʿalaykum*).
+  No `concept_tag` (writing lessons are exempt from the concept join).
+- **W01 — direction + abjad + alif**: leads with the two big surprises before
+  any stroke — Arabic runs **right-to-left** (the older habit, shared with
+  Hebrew/Phoenician) and is an **abjad** (short vowels normally unwritten; the
+  word *abjad* = *a-b-j-d* recited, exactly like *alphabet* = *alpha-beta*).
+  Then **ا** (*alif*), one clean downstroke, one of the six non-joining letters.
+  Cousin payoff: *alif* ← Phoenician **ʾālep** ("ox") → Greek *alpha* → Latin **A**.
+- **W02 — cursive joining**: the biggest difference from Latin/Cyrillic print —
+  a letter wears up to **four coats** (isolated/initial/medial/final). Taught on
+  **ل** (*lām* ← *lāmed*, cousin of **L**) and **س** (*sīn* ← *shin* "tooth" —
+  the shape *is* teeth), plus the obligatory **لا** *lām-alif* ligature and the
+  joined pair **سل**.
+- **W03 — dots as a piece + first whole word**: the truth-table of the shared
+  bowl skeleton (ح/ب/ن/ت/ث differ **only by dots**), so the dot under **ب** is
+  what draws the letter, not decoration. Teaches **ب** (*bāʾ* ← *bēt* "house" →
+  **B**) and **م** (*mīm* ← *mem* "water" → **M**), then **assembles سلام**
+  right-to-left — including the pen-lift after *alif*. Payoff: *ʾālep*/*bēt*/*mem*
+  = ox/house/water = **A**/**B**/**M** — Arabic, Greek, and Latin are one family
+  tree.
+
 ## Chapter 2 — Introducing Yourself
 
 - New chapter around the introduction dialogue (*ismī … / mā ismuka?*),

--- a/code/learning/human-languages/arabic/lessons/AR-W01-direction-and-alif.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W01-direction-and-alif.md
@@ -1,0 +1,83 @@
+---
+id: AR-W01-direction-and-alif
+chapter: 1
+type: writing
+headword: "ا"
+gloss: two surprises before the first stroke — Arabic runs right-to-left and hides its short vowels — then writing alif (ā)
+romanization: "alif"
+prerequisites: [AR-C01-salam]
+sounds: [arabic-alif, long-a]
+roots: [phoenician-aleph]
+est_minutes: 4
+reviews_of: [AR-C01-salam, AR-C01-marhaba]
+---
+
+# ا (alif) — the first stroke, and two rules that change everything
+
+## Warm-up
+
+[PAUSE 2s] Before you draw a single line, two facts about Arabic will feel
+strange — and both are freeing once you know them. You have already **read**
+Arabic in *سلام* (*salām*, "peace") and *مرحبا* (*marḥaban*, "hello"); now you
+learn to **write** it, one piece at a time.
+
+## Surprise 1 — Arabic runs right-to-left
+
+English marches **left → right**. Arabic marches **right → left**. The pen
+starts on the **right edge** of the word and moves **toward the left**. So in
+*سلام*, the letter you meet **first** (rightmost) is *س* (s), and the letter you
+meet **last** (leftmost) is *م* (m) — the exact reverse of the reading order your
+eye is trained on.
+
+This is not exotic for its own sake: Arabic, Hebrew, and the old Phoenician
+alphabet **all** ran right-to-left. It is the older habit; left-to-right (Greek,
+Latin, and everything downstream) is the newcomer that flipped direction.
+
+## Surprise 2 — the short vowels are usually invisible (an *abjad*)
+
+Look again at *سلām*: three consonants (s-l-m) and the vowels *a...a* are barely
+there. Arabic is an **abjad** — the letters are **consonants**, and the short
+vowels ("a, i, u") are normally **left out**, the way you can still read "*bld a
+hs*" as "build a house." (The word *abjad* is just the first four letters —
+*a-b-j-d* — recited in order, exactly like saying "*ABC*"; the Latin *alphabet*
+is the same trick on *alpha-beta*.) When a beginner's book *does* mark the
+vowels, it uses tiny **ḥarakāt** — small dashes above or below — but everyday
+text goes without.
+
+So the skeleton you learn to draw is the **consonants**. That's the whole word.
+
+## ا (alif) — one clean downstroke
+
+Meet **alif**, the first letter — and mercifully the simplest shape in the whole
+script. Break it apart — there is only *one piece*:
+
+1. **the upright** — a single tall **vertical** stroke, drawn top-to-bottom.
+
+That's it. No dots, no curve, no tail. If you can draw a capital **I** without
+its serifs, you can draw **alif**.
+
+**The cousin payoff.** *alif* comes from Phoenician **ʾālep** ("ox") — the very
+same ancestor that became Greek **alpha** and your Latin **A**. Three scripts,
+one great-grandparent: the letter that starts *alphabet*, *alpha*, and *abjad*
+is the letter you just drew.
+
+**The one rule to remember:** alif is one of six letters that **do not join to
+the letter after them**. So even in the middle of a word, alif forces a little
+**break** — the pen lifts. You will feel that break when you write *سلام* two
+lessons from now.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Arabic runs **right to left**" while sliding a finger right → left
+  across *سلام*]
+- [YOU WRITE: **ا** — one top-to-bottom vertical — three times]
+- [YOU SAY: "alif — from *ʾālep*, the ox — cousin of **A**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which edge of a word does your pen start on? (The **right**.) What
+does an *abjad* leave out? (The **short vowels** — the letters are consonants.)
+Draw **alif**: how many strokes, and does it join to the next letter? (**One**
+vertical; **no** — it forces a break.) You have written the first letter of the
+Arabic alphabet — and met the ox that also gave you *A*.

--- a/code/learning/human-languages/arabic/lessons/AR-W02-joining-sin-lam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W02-joining-sin-lam.md
@@ -1,0 +1,89 @@
+---
+id: AR-W02-joining-sin-lam
+chapter: 1
+type: writing
+headword: "س، ل"
+gloss: the big idea — letters JOIN and change shape by position — taught on sin (s) and lam (l), plus the لا ligature
+romanization: "sīn, lām"
+prerequisites: [AR-W01-direction-and-alif]
+sounds: [arabic-sin, arabic-lam]
+roots: [phoenician-shin, phoenician-lamed]
+est_minutes: 5
+reviews_of: [AR-W01-direction-and-alif, AR-C01-salam, AR-C01-as-salamu-alaykum]
+---
+
+# س and ل — how Arabic letters hold hands
+
+## Warm-up
+
+[PAUSE 2s] Last lesson: one lonely stroke (alif) that refuses to join. Now the
+rule that makes Arabic **cursive** — most letters **do** join, and when they
+join they **change shape**. This is the single biggest difference from the Latin
+and Cyrillic printing you know, and once it clicks, the script reads like
+handwriting instead of a code.
+
+## The big idea — four shapes, one letter
+
+In English print, an *n* is an *n* wherever it sits. In Arabic, a letter wears up
+to **four coats** depending on where it stands in the word:
+
+- **isolated** — standing alone.
+- **initial** — first in a joined run (a little "reach" leftward to the next).
+- **medial** — joined on **both** sides.
+- **final** — last in a run (joined only on the right).
+
+They are the **same letter** — think *cursive English*, where the *a* in "cat"
+links differently than an *a* standing alone. The core skeleton never changes;
+only the connectors at the edges do.
+
+## ل (lām) — the tall hook
+
+**lām** ("l") is easy to spot: a **tall upright** that dives into a **bowl**
+curving up at the base. Break it apart — *upright, then base-bowl*:
+
+1. **the upright** — a tall vertical.
+2. **the base bowl** — a curve scooping up at the bottom.
+
+Its four coats keep that tall spine; only the tail changes. **lām** comes from
+Phoenician **lāmed** ("ox-goad") — the same ancestor as Greek **lambda** and
+your Latin **L**.
+
+## س (sīn) — the three teeth
+
+**sīn** ("s") is three little **teeth** (small humps) followed by a **bowl** that
+trails below the line. Break it apart — *teeth, then trailing bowl*:
+
+1. **the three teeth** — three quick humps in a row.
+2. **the trailing bowl** — a dip that scoops below the baseline.
+
+**sīn** is from Phoenician **shin** ("tooth") — and the shape really is a row of
+teeth. (Remember the "tooth" name; next lesson its cousin **shīn** ش will be the
+*same* teeth with **three dots** added on top.)
+
+## Joining them — the لا you will need
+
+Now watch two letters hold hands. Write **lām** then **alif** and they fuse into
+one obligatory **ligature**, **لا** — a slanted stroke crossing the upright.
+Every Arabic hand writes *lām-alif* this way; you cannot leave them apart. And
+**سل** (*sīn* reaching into *lām*) is the first joined pair of *سلام* — the
+teeth flow straight into the tall hook.
+
+- **سل** = *sīn* (initial, reaching left) + *lām*.
+- **لا** = *lām* + *alif* — the fixed ligature.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "same letter, four coats — isolated, initial, medial, final"]
+- [YOU WRITE: **ل** (tall upright + base bowl), then **س** (three teeth + bowl)]
+- [YOU WRITE: the join **سل**, then the ligature **لا** — "lām and alif always fuse"]
+- [YOU SAY: "*sīn* from *shin*, tooth; *lām* from *lāmed*, cousin of **L**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How many shapes can one Arabic letter wear, and what decides which?
+(Up to **four** — its **position** in the joined run.) What Phoenician word names
+**sīn**, and what does the shape look like? (**shin** — a **tooth**; and *sīn* is
+a row of teeth.) When *lām* meets *alif*, what happens? (They **must** fuse into
+the ligature **لا**.) You can now write three of the four letters in *سلām* — one
+to go.

--- a/code/learning/human-languages/arabic/lessons/AR-W03-dots-mim-ba-salam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W03-dots-mim-ba-salam.md
@@ -1,0 +1,92 @@
+---
+id: AR-W03-dots-mim-ba-salam
+chapter: 1
+type: writing
+headword: "م، ب"
+gloss: dots as a real piece — mim (m) and ba (b) — then assembling the whole word سلام (salām)
+romanization: "mīm, bāʾ"
+prerequisites: [AR-W02-joining-sin-lam]
+sounds: [arabic-mim, arabic-ba]
+roots: [phoenician-mem, phoenician-bet]
+est_minutes: 5
+reviews_of: [AR-W02-joining-sin-lam, AR-W01-direction-and-alif, AR-C01-salam]
+---
+
+# م، ب — the dots that tell letters apart, and your first whole word
+
+## Warm-up
+
+[PAUSE 2s] The finish line. Two more letters — **م** (m) and **ب** (b) — and then
+you assemble **سلام** (*salām*, "peace") from right to left, the same word buried
+inside the greeting *as-salāmu ʿalaykum*. Along the way, the cleverest idea in
+Arabic handwriting: **the dots are a piece you draw**.
+
+## Dots are not decoration — they *are* the letter
+
+Many Arabic letters share **one skeleton** and differ **only by dots**. You met
+*sīn*'s teeth last lesson; add **three dots above** and the same teeth become
+**shīn** (ش, "sh"). The bowl-shape works the same way:
+
+| skeleton | no dot | one dot below | one dot above | two above | three above |
+|---|---|---|---|---|---|
+| the bowl | ح (ḥ) | **ب** (b) | **ن** (n) | ت (t) | ث (th) |
+
+So when you draw **ب**, the **dot below** is not a flourish — it is the one thing
+that stops the letter being an *n*, a *t*, or a *th*. Draw the dot as
+deliberately as the stroke.
+
+## ب (bāʾ) — a boat with one dot below
+
+Break it apart — *bowl, then the dot*:
+
+1. **the bowl** — a shallow boat-shaped dish sitting on the line.
+2. **one dot BELOW** — placed under the belly of the boat.
+
+**bāʾ** is from Phoenician **bēt** ("house") — the ancestor of Greek **beta** and
+your Latin **B**. The very word *alpha-bet* is *ʾālep* + *bēt*: the **ox** and the
+**house** you have now both drawn.
+
+## م (mīm) — a little head on a tail
+
+Break it apart — *round head, then tail*:
+
+1. **the round head** — a small closed loop.
+2. **the tail** — a stroke dropping straight down (when *mīm* ends a word, as in
+   *salām*).
+
+**mīm** is from Phoenician **mem** ("water") — sibling of Greek **mu** and Latin
+**M**. Four scripts, one drop of water.
+
+## Assemble — سلام, right to left
+
+Now write the whole word. Start at the **right** and move **left**, remembering
+which letters join and which break:
+
+1. **س** (*sīn*) — three teeth, **reaching left** into…
+2. **ل** (*lām*) — the tall hook; and *lām* + *alif* **fuse** into…
+3. **لا** — the obligatory ligature (the slanted alif across the upright).
+4. **[break]** — *alif* **does not join** what follows (the rule from Lesson 1),
+   so the pen **lifts**…
+5. **م** (*mīm*) — standing free at the left end, its tail dropping below the line.
+
+Read back right-to-left: **س · ل · ا · م** = *s · l · ā · m* = **سلام**. Vowels
+unwritten, consonants doing all the work — a real Arabic word in your own hand.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **ب** — boat + one dot below — then say "the dot makes it *b*, not
+  *n*"]
+- [YOU WRITE: **م** — round head + dropping tail]
+- [YOU WRITE: **سلام**, right to left — "teeth, hook, the لا fuse, lift, mīm"]
+- [YOU SAY: "*bēt* the house → *B*; *mem* the water → *M*; *ʾālep* the ox → *A*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is the **dot** under **ب** not optional? (It is the only thing
+separating *b* from *n*, *t*, *th* — same skeleton, different dots.) In **سلام**,
+where does the pen **lift**, and why? (After **alif** — alif never joins the
+letter after it.) Name the Phoenician meanings behind **A**, **B**, and **M**.
+(**ox**, **house**, **water** — *ʾālep*, *bēt*, *mem*.) You can now hand-write
+every letter in **سلام** — and you have seen that the Arabic, Greek, and Latin
+alphabets are the same family tree wearing different clothes.

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -23,6 +23,13 @@ word lessons — never as a gated reading course.
   tasharrafnā → practice. Root-and-suffix engine; the **zero copula** (shared
   with the Dravidian tracks); "you" split by **gender**, not register.
 
+- **Ch. 1 — Writing set** (`AR-W01`–`AR-W03`, `writing` type): the
+  "break-it-apart-and-draw-it" companion to the greetings, rendered by the
+  script-writing-visualizer app (parallel to the Cyrillic `RU-W*` set). Right-to-
+  left and *abjad* taught first, then the cursive four-coats rule, dots-as-a-piece,
+  and the assembly of a whole word — **سلام** — from *sīn/lām/alif/mīm*. Ties the
+  Arabic letters back to their Phoenician ancestors (*ʾālep/bēt/mem* = **A/B/M**).
+
 ## Planned
 
 | Chapter | Theme |


### PR DESCRIPTION
## What

A `writing`-type companion to the Arabic Chapter 1 greetings (`AR-W01/02/03`), mirroring the Cyrillic `RU-W*` set — the hand-writing track the **script-writing-visualizer** app renders. Anchored on the real Ch.1 word **سلام** (*salām*), the "peace" inside *as-salāmu ʿalaykum*. `writing` lessons carry **no `concept_tag`** (exempt from the concept join).

## The three lessons (atom-first, ~4–5 min each, chained via `reviews_of`)

| Lesson | Fresh teaching point |
|---|---|
| **W01 — direction + abjad + alif** | Leads with the two surprises *before any stroke*: Arabic runs **right-to-left** (the older habit — shared with Hebrew/Phoenician) and is an **abjad** (short vowels normally unwritten; *abjad* = *a-b-j-d* recited, exactly like *alphabet* = *alpha-beta*). Then **ا**, one downstroke, a non-joining letter. |
| **W02 — cursive joining** | The **four coats** a letter wears (isolated/initial/medial/final) — the biggest break from Latin/Cyrillic print. Taught on **ل** (*lām*) and **س** (*sīn* ← *shin* "tooth" — the shape *is* teeth), plus the obligatory **لا** ligature and the joined pair **سل**. |
| **W03 — dots-as-a-piece + first whole word** | The shared bowl-skeleton truth-table (ح/ب/ن/ت/ث differ **only by dots**), so the dot under **ب** *is* the letter. Teaches **ب** and **م**, then **assembles سلام** right-to-left — including the pen-lift after *alif*. |

## Unifying deep thread

Arabic letters share the **Phoenician ancestor** with the learner's own Latin/Greek/Cyrillic letters: *ʾālep / bēt / mem* = **ox / house / water** = **A / B / M**. The "foreign" script is a long-lost cousin, not a code.

## Housekeeping
- Updates `arabic/CHANGELOG.md` and `arabic/roadmap.md` (Ch.1 writing set authored).
- Suite **38/38**; no retired `concept_tag`s in the curriculum; security-reviewed (Markdown/prose only — no scripts, links, or secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)