### PR TITLE
Add Haskell bezier2d package

### DIFF
--- a/code/packages/haskell/bezier2d/BUILD
+++ b/code/packages/haskell/bezier2d/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/bezier2d/BUILD_windows
+++ b/code/packages/haskell/bezier2d/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/bezier2d/CHANGELOG.md
+++ b/code/packages/haskell/bezier2d/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0 - 2026-07-19
+
+- Add immutable G2D02 quadratic and cubic Bezier values.
+- Add de Casteljau evaluation and exact subdivision.
+- Add unnormalized derivatives, adaptive polyline flattening, and tight
+  derivative-root bounding boxes.
+- Add exact quadratic-to-cubic degree elevation.
+- Add package-native tests covering the complete required G2D02 behavior and
+  degenerate bounding-box cases.

--- a/code/packages/haskell/bezier2d/README.md
+++ b/code/packages/haskell/bezier2d/README.md
@@ -1,0 +1,30 @@
+# bezier2d (Haskell)
+
+Pure Haskell implementation of G2D02 quadratic and cubic Bezier curves. The
+package composes the existing `point2d` package and uses de Casteljau's
+algorithm for numerically stable curve evaluation and subdivision.
+
+## API
+
+- `QuadraticBezier` and `CubicBezier` are immutable control-point records.
+- `evaluateQuadratic` and `evaluateCubic` evaluate points with de Casteljau's
+  algorithm.
+- `derivativeQuadratic` and `derivativeCubic` return unnormalized tangent
+  vectors.
+- `splitQuadratic` and `splitCubic` produce exact left and right sub-curves.
+- `toPolylineQuadratic` and `toPolylineCubic` adaptively flatten curves using
+  the G2D02 midpoint error criterion.
+- `boundingBoxQuadratic` and `boundingBoxCubic` compute tight bounds from
+  interior derivative roots as well as endpoints.
+- `elevate` converts a quadratic exactly into an equivalent cubic.
+
+All computations are pure. The only package dependency is `point2d`; square
+roots needed by cubic bounding boxes use Haskell's standard floating-point
+arithmetic.
+
+## Development
+
+```sh
+cabal test all
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/bezier2d/bezier2d.cabal
+++ b/code/packages/haskell/bezier2d/bezier2d.cabal
@@ -1,0 +1,33 @@
+cabal-version: 3.0
+name:          bezier2d
+version:       0.1.0
+synopsis:      Quadratic and cubic Bezier curve geometry
+description:   Pure G2D02 evaluation, differentiation, splitting, adaptive flattening, tight bounds, and degree elevation for quadratic and cubic Bezier curves.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Bezier2D
+    build-depends:    base >=4.14 && <5
+                    , point2d >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Bezier2DSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , bezier2d
+                    , hspec == 2.*
+                    , point2d >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/bezier2d/cabal.project
+++ b/code/packages/haskell/bezier2d/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../point2d ../trig

--- a/code/packages/haskell/bezier2d/src/Bezier2D.hs
+++ b/code/packages/haskell/bezier2d/src/Bezier2D.hs
@@ -1,0 +1,217 @@
+-- | Pure quadratic and cubic Bezier curve geometry.
+module Bezier2D
+    ( QuadraticBezier (..)
+    , CubicBezier (..)
+    , evaluateQuadratic
+    , derivativeQuadratic
+    , splitQuadratic
+    , toPolylineQuadratic
+    , boundingBoxQuadratic
+    , elevate
+    , evaluateCubic
+    , derivativeCubic
+    , splitCubic
+    , toPolylineCubic
+    , boundingBoxCubic
+    ) where
+
+import Point2D (Point (..), Rect (..))
+import qualified Point2D
+
+-- | A quadratic Bezier with two on-curve endpoints and one control point.
+data QuadraticBezier = QuadraticBezier
+    { quadraticP0 :: Point
+    , quadraticP1 :: Point
+    , quadraticP2 :: Point
+    }
+    deriving (Eq, Show)
+
+-- | A cubic Bezier with two on-curve endpoints and two control points.
+data CubicBezier = CubicBezier
+    { cubicP0 :: Point
+    , cubicP1 :: Point
+    , cubicP2 :: Point
+    , cubicP3 :: Point
+    }
+    deriving (Eq, Show)
+
+-- | Evaluate a quadratic curve with two levels of de Casteljau interpolation.
+evaluateQuadratic :: QuadraticBezier -> Double -> Point
+evaluateQuadratic curve amount = Point2D.lerp firstLevel secondLevel amount
+  where
+    firstLevel = Point2D.lerp (quadraticP0 curve) (quadraticP1 curve) amount
+    secondLevel = Point2D.lerp (quadraticP1 curve) (quadraticP2 curve) amount
+
+-- | Return the unnormalized quadratic tangent vector at a parameter value.
+derivativeQuadratic :: QuadraticBezier -> Double -> Point
+derivativeQuadratic curve amount =
+    Point2D.scale (Point2D.lerp firstDifference secondDifference amount) 2.0
+  where
+    firstDifference = Point2D.subtract (quadraticP1 curve) (quadraticP0 curve)
+    secondDifference = Point2D.subtract (quadraticP2 curve) (quadraticP1 curve)
+
+-- | Split a quadratic into exact left and right sub-curves.
+splitQuadratic :: QuadraticBezier -> Double -> (QuadraticBezier, QuadraticBezier)
+splitQuadratic curve amount =
+    ( QuadraticBezier (quadraticP0 curve) firstLevel midpoint
+    , QuadraticBezier midpoint secondLevel (quadraticP2 curve)
+    )
+  where
+    firstLevel = Point2D.lerp (quadraticP0 curve) (quadraticP1 curve) amount
+    secondLevel = Point2D.lerp (quadraticP1 curve) (quadraticP2 curve) amount
+    midpoint = Point2D.lerp firstLevel secondLevel amount
+
+-- | Adaptively flatten a quadratic curve using the G2D02 midpoint criterion.
+toPolylineQuadratic :: QuadraticBezier -> Double -> [Point]
+toPolylineQuadratic curve tolerance
+    | midpointError <= tolerance = [quadraticP0 curve, quadraticP2 curve]
+    | otherwise = leftPoints ++ drop 1 rightPoints
+  where
+    chordMidpoint = Point2D.lerp (quadraticP0 curve) (quadraticP2 curve) 0.5
+    curveMidpoint = evaluateQuadratic curve 0.5
+    midpointError = Point2D.distance chordMidpoint curveMidpoint
+    (left, right) = splitQuadratic curve 0.5
+    leftPoints = toPolylineQuadratic left tolerance
+    rightPoints = toPolylineQuadratic right tolerance
+
+-- | Compute the tight axis-aligned bounds of a quadratic curve.
+boundingBoxQuadratic :: QuadraticBezier -> Rect
+boundingBoxQuadratic curve = boundsOfPoints candidates
+  where
+    xRoot = quadraticExtremum
+        (pointX (quadraticP0 curve))
+        (pointX (quadraticP1 curve))
+        (pointX (quadraticP2 curve))
+    yRoot = quadraticExtremum
+        (pointY (quadraticP0 curve))
+        (pointY (quadraticP1 curve))
+        (pointY (quadraticP2 curve))
+    roots = maybeToList xRoot ++ maybeToList yRoot
+    candidates = quadraticP0 curve : quadraticP2 curve : map (evaluateQuadratic curve) roots
+
+-- | Elevate a quadratic exactly to a cubic representation.
+elevate :: QuadraticBezier -> CubicBezier
+elevate curve = CubicBezier start firstControl secondControl end
+  where
+    start = quadraticP0 curve
+    control = quadraticP1 curve
+    end = quadraticP2 curve
+    firstControl = Point2D.add (Point2D.scale start (1.0 / 3.0)) (Point2D.scale control (2.0 / 3.0))
+    secondControl = Point2D.add (Point2D.scale control (2.0 / 3.0)) (Point2D.scale end (1.0 / 3.0))
+
+-- | Evaluate a cubic curve with three levels of de Casteljau interpolation.
+evaluateCubic :: CubicBezier -> Double -> Point
+evaluateCubic curve amount = Point2D.lerp secondLeft secondRight amount
+  where
+    firstLeft = Point2D.lerp (cubicP0 curve) (cubicP1 curve) amount
+    firstMiddle = Point2D.lerp (cubicP1 curve) (cubicP2 curve) amount
+    firstRight = Point2D.lerp (cubicP2 curve) (cubicP3 curve) amount
+    secondLeft = Point2D.lerp firstLeft firstMiddle amount
+    secondRight = Point2D.lerp firstMiddle firstRight amount
+
+-- | Return the unnormalized cubic tangent vector at a parameter value.
+derivativeCubic :: CubicBezier -> Double -> Point
+derivativeCubic curve amount = Point2D.scale weighted 3.0
+  where
+    complement = 1.0 - amount
+    firstDifference = Point2D.subtract (cubicP1 curve) (cubicP0 curve)
+    secondDifference = Point2D.subtract (cubicP2 curve) (cubicP1 curve)
+    thirdDifference = Point2D.subtract (cubicP3 curve) (cubicP2 curve)
+    weighted =
+        Point2D.add
+            (Point2D.scale firstDifference (complement * complement))
+            (Point2D.add
+                (Point2D.scale secondDifference (2.0 * complement * amount))
+                (Point2D.scale thirdDifference (amount * amount)))
+
+-- | Split a cubic into exact left and right sub-curves.
+splitCubic :: CubicBezier -> Double -> (CubicBezier, CubicBezier)
+splitCubic curve amount =
+    ( CubicBezier (cubicP0 curve) firstLeft secondLeft midpoint
+    , CubicBezier midpoint secondRight firstRight (cubicP3 curve)
+    )
+  where
+    firstLeft = Point2D.lerp (cubicP0 curve) (cubicP1 curve) amount
+    firstMiddle = Point2D.lerp (cubicP1 curve) (cubicP2 curve) amount
+    firstRight = Point2D.lerp (cubicP2 curve) (cubicP3 curve) amount
+    secondLeft = Point2D.lerp firstLeft firstMiddle amount
+    secondRight = Point2D.lerp firstMiddle firstRight amount
+    midpoint = Point2D.lerp secondLeft secondRight amount
+
+-- | Adaptively flatten a cubic curve using the G2D02 midpoint criterion.
+toPolylineCubic :: CubicBezier -> Double -> [Point]
+toPolylineCubic curve tolerance
+    | midpointError <= tolerance = [cubicP0 curve, cubicP3 curve]
+    | otherwise = leftPoints ++ drop 1 rightPoints
+  where
+    chordMidpoint = Point2D.lerp (cubicP0 curve) (cubicP3 curve) 0.5
+    curveMidpoint = evaluateCubic curve 0.5
+    midpointError = Point2D.distance chordMidpoint curveMidpoint
+    (left, right) = splitCubic curve 0.5
+    leftPoints = toPolylineCubic left tolerance
+    rightPoints = toPolylineCubic right tolerance
+
+-- | Compute the tight axis-aligned bounds of a cubic curve.
+boundingBoxCubic :: CubicBezier -> Rect
+boundingBoxCubic curve = boundsOfPoints candidates
+  where
+    xRoots = cubicExtrema
+        (pointX (cubicP0 curve))
+        (pointX (cubicP1 curve))
+        (pointX (cubicP2 curve))
+        (pointX (cubicP3 curve))
+    yRoots = cubicExtrema
+        (pointY (cubicP0 curve))
+        (pointY (cubicP1 curve))
+        (pointY (cubicP2 curve))
+        (pointY (cubicP3 curve))
+    candidates = cubicP0 curve : cubicP3 curve : map (evaluateCubic curve) (xRoots ++ yRoots)
+
+quadraticExtremum :: Double -> Double -> Double -> Maybe Double
+quadraticExtremum first control end
+    | abs denominator <= epsilon = Nothing
+    | parameter > 0.0 && parameter < 1.0 = Just parameter
+    | otherwise = Nothing
+  where
+    denominator = first - 2.0 * control + end
+    parameter = (first - control) / denominator
+
+cubicExtrema :: Double -> Double -> Double -> Double -> [Double]
+cubicExtrema first firstControl secondControl end
+    | abs quadraticCoefficient <= epsilon = linearRoots
+    | discriminant < 0.0 = []
+    | otherwise = filter insideUnitInterval [rootPlus, rootMinus]
+  where
+    quadraticCoefficient = -3.0 * first + 9.0 * firstControl - 9.0 * secondControl + 3.0 * end
+    linearCoefficient = 6.0 * first - 12.0 * firstControl + 6.0 * secondControl
+    constantCoefficient = -3.0 * first + 3.0 * firstControl
+    discriminant = linearCoefficient * linearCoefficient - 4.0 * quadraticCoefficient * constantCoefficient
+    rootDistance = sqrt discriminant
+    denominator = 2.0 * quadraticCoefficient
+    rootPlus = (-linearCoefficient + rootDistance) / denominator
+    rootMinus = (-linearCoefficient - rootDistance) / denominator
+    linearRoots
+        | abs linearCoefficient <= epsilon = []
+        | insideUnitInterval linearRoot = [linearRoot]
+        | otherwise = []
+    linearRoot = -constantCoefficient / linearCoefficient
+
+insideUnitInterval :: Double -> Bool
+insideUnitInterval parameter = parameter > 0.0 && parameter < 1.0
+
+boundsOfPoints :: [Point] -> Rect
+boundsOfPoints points = Rect minimumX minimumY (maximumX - minimumX) (maximumY - minimumY)
+  where
+    xs = map pointX points
+    ys = map pointY points
+    minimumX = minimum xs
+    maximumX = maximum xs
+    minimumY = minimum ys
+    maximumY = maximum ys
+
+maybeToList :: Maybe value -> [value]
+maybeToList Nothing = []
+maybeToList (Just value) = [value]
+
+epsilon :: Double
+epsilon = 1e-12

--- a/code/packages/haskell/bezier2d/test/Bezier2DSpec.hs
+++ b/code/packages/haskell/bezier2d/test/Bezier2DSpec.hs
@@ -1,0 +1,131 @@
+module Bezier2DSpec (spec) where
+
+import Bezier2D
+import Point2D (Point (..), Rect (..))
+import Test.Hspec
+
+epsilon :: Double
+epsilon = 1e-9
+
+shouldApprox :: Double -> Double -> Expectation
+shouldApprox actual expected = abs (actual - expected) `shouldSatisfy` (< epsilon)
+
+shouldBePoint :: Point -> Point -> Expectation
+shouldBePoint actual expected = do
+    pointX actual `shouldApprox` pointX expected
+    pointY actual `shouldApprox` pointY expected
+
+shouldBeRect :: Rect -> Rect -> Expectation
+shouldBeRect actual expected = do
+    rectX actual `shouldApprox` rectX expected
+    rectY actual `shouldApprox` rectY expected
+    rectWidth actual `shouldApprox` rectWidth expected
+    rectHeight actual `shouldApprox` rectHeight expected
+
+quadratic :: QuadraticBezier
+quadratic = QuadraticBezier (Point 0.0 0.0) (Point 1.0 2.0) (Point 2.0 0.0)
+
+cubic :: CubicBezier
+cubic = CubicBezier (Point 0.0 0.0) (Point 1.0 2.0) (Point 3.0 2.0) (Point 4.0 0.0)
+
+spec :: Spec
+spec = do
+    describe "QuadraticBezier" $ do
+        it "stores immutable control points" $ do
+            quadraticP0 quadratic `shouldBe` Point 0.0 0.0
+            quadraticP1 quadratic `shouldBe` Point 1.0 2.0
+            quadraticP2 quadratic `shouldBe` Point 2.0 0.0
+        it "evaluates both endpoints" $ do
+            evaluateQuadratic quadratic 0.0 `shouldBePoint` quadraticP0 quadratic
+            evaluateQuadratic quadratic 1.0 `shouldBePoint` quadraticP2 quadratic
+        it "evaluates the known midpoint" $
+            evaluateQuadratic quadratic 0.5 `shouldBePoint` Point 1.0 1.0
+        it "returns the endpoint derivatives" $ do
+            derivativeQuadratic quadratic 0.0 `shouldBePoint` Point 2.0 4.0
+            derivativeQuadratic quadratic 1.0 `shouldBePoint` Point 2.0 (-4.0)
+        it "splits into exact reparameterized halves" $ do
+            let amount = 0.25
+                (left, right) = splitQuadratic quadratic amount
+            quadraticP0 left `shouldBePoint` quadraticP0 quadratic
+            quadraticP2 left `shouldBePoint` evaluateQuadratic quadratic amount
+            quadraticP0 right `shouldBePoint` evaluateQuadratic quadratic amount
+            quadraticP2 right `shouldBePoint` quadraticP2 quadratic
+            evaluateQuadratic left 0.5 `shouldBePoint` evaluateQuadratic quadratic (amount * 0.5)
+            evaluateQuadratic right 0.5 `shouldBePoint` evaluateQuadratic quadratic (amount + (1.0 - amount) * 0.5)
+        it "flattens a straight quadratic to its endpoints" $ do
+            let straight = QuadraticBezier (Point 0.0 0.0) (Point 1.0 0.0) (Point 2.0 0.0)
+            toPolylineQuadratic straight 0.1 `shouldBe` [Point 0.0 0.0, Point 2.0 0.0]
+        it "subdivides a curved quadratic without duplicate joins" $ do
+            let coarse = toPolylineQuadratic quadratic 2.0
+                fine = toPolylineQuadratic quadratic 0.01
+            length coarse `shouldBe` 2
+            length fine `shouldSatisfy` (> length coarse)
+            head fine `shouldBePoint` quadraticP0 quadratic
+            last fine `shouldBePoint` quadraticP2 quadratic
+            and (zipWith (/=) fine (drop 1 fine)) `shouldBe` True
+        it "computes a tight interior-extremum bounding box" $
+            boundingBoxQuadratic quadratic `shouldBeRect` Rect 0.0 0.0 2.0 1.0
+        it "ignores roots outside the parameter interval" $ do
+            let monotone = QuadraticBezier (Point 0.0 0.0) (Point 2.0 2.0) (Point 3.0 3.0)
+            boundingBoxQuadratic monotone `shouldBeRect` Rect 0.0 0.0 3.0 3.0
+        it "elevates exactly to a cubic" $ do
+            let elevated = elevate quadratic
+            cubicP0 elevated `shouldBePoint` quadraticP0 quadratic
+            cubicP3 elevated `shouldBePoint` quadraticP2 quadratic
+            mapM_ (\amount -> evaluateCubic elevated amount `shouldBePoint` evaluateQuadratic quadratic amount)
+                [0.0, 0.25, 0.5, 0.75, 1.0]
+
+    describe "CubicBezier" $ do
+        it "stores immutable control points" $ do
+            cubicP0 cubic `shouldBe` Point 0.0 0.0
+            cubicP1 cubic `shouldBe` Point 1.0 2.0
+            cubicP2 cubic `shouldBe` Point 3.0 2.0
+            cubicP3 cubic `shouldBe` Point 4.0 0.0
+        it "evaluates both endpoints" $ do
+            evaluateCubic cubic 0.0 `shouldBePoint` cubicP0 cubic
+            evaluateCubic cubic 1.0 `shouldBePoint` cubicP3 cubic
+        it "matches the worked symmetric midpoint" $
+            evaluateCubic cubic 0.5 `shouldBePoint` Point 2.0 1.5
+        it "returns the endpoint derivatives" $ do
+            derivativeCubic cubic 0.0 `shouldBePoint` Point 3.0 6.0
+            derivativeCubic cubic 1.0 `shouldBePoint` Point 3.0 (-6.0)
+        it "splits into exact reparameterized halves" $ do
+            let amount = 0.4
+                (left, right) = splitCubic cubic amount
+            cubicP0 left `shouldBePoint` cubicP0 cubic
+            cubicP3 left `shouldBePoint` evaluateCubic cubic amount
+            cubicP0 right `shouldBePoint` evaluateCubic cubic amount
+            cubicP3 right `shouldBePoint` cubicP3 cubic
+            evaluateCubic left 0.5 `shouldBePoint` evaluateCubic cubic (amount * 0.5)
+            evaluateCubic right 0.5 `shouldBePoint` evaluateCubic cubic (amount + (1.0 - amount) * 0.5)
+        it "flattens a straight cubic to its endpoints" $ do
+            let straight = CubicBezier (Point 0.0 0.0) (Point 1.0 0.0) (Point 2.0 0.0) (Point 3.0 0.0)
+            toPolylineCubic straight 0.1 `shouldBe` [Point 0.0 0.0, Point 3.0 0.0]
+        it "uses tighter tolerances for finer curved polylines" $ do
+            let arch = CubicBezier (Point 0.0 0.0) (Point 0.0 10.0) (Point 10.0 10.0) (Point 10.0 0.0)
+                coarse = toPolylineCubic arch 8.0
+                fine = toPolylineCubic arch 0.05
+            length coarse `shouldBe` 2
+            length fine `shouldSatisfy` (> length coarse)
+            head fine `shouldBePoint` Point 0.0 0.0
+            last fine `shouldBePoint` Point 10.0 0.0
+        it "computes exact symmetric arch bounds through a linear derivative root" $ do
+            let arch = CubicBezier (Point 0.0 0.0) (Point 0.0 10.0) (Point 10.0 10.0) (Point 10.0 0.0)
+            boundingBoxCubic arch `shouldBeRect` Rect 0.0 0.0 10.0 7.5
+        it "handles two roots per axis and contains sampled points" $ do
+            let looping = CubicBezier (Point 0.0 0.0) (Point 2.0 3.0) (Point (-1.0) 3.0) (Point 1.0 0.0)
+                bounds = boundingBoxCubic looping
+                samples = map (evaluateCubic looping . (/ 20.0) . fromIntegral) ([0 .. 20] :: [Int])
+                contains point =
+                    pointX point >= rectX bounds - epsilon
+                        && pointX point <= rectX bounds + rectWidth bounds + epsilon
+                        && pointY point >= rectY bounds - epsilon
+                        && pointY point <= rectY bounds + rectHeight bounds + epsilon
+            all contains samples `shouldBe` True
+        it "handles constant derivatives and a negative discriminant" $ do
+            let increasing = CubicBezier (Point 0.0 0.0) (Point 1.0 0.0) (Point 2.0 0.0) (Point 4.0 0.0)
+            boundingBoxCubic increasing `shouldBeRect` Rect 0.0 0.0 4.0 0.0
+        it "ignores a degenerate linear root outside the parameter interval" $ do
+            let monotone = CubicBezier (Point 0.0 0.0) (Point 2.0 2.0) (Point 3.0 3.0) (Point 3.0 3.0)
+                bounds = boundingBoxCubic monotone
+            bounds `shouldBeRect` Rect 0.0 0.0 3.0 3.0

--- a/code/packages/haskell/bezier2d/test/Spec.hs
+++ b/code/packages/haskell/bezier2d/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified Bezier2DSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec Bezier2DSpec.spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -118,12 +118,12 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
 `scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
 `matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
-`point2d`, and `affine2d`
+`point2d`, `affine2d`, and `bezier2d`
 ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 295 |
+| Present in 10-15 languages | 172 | 294 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 705 | 9,870 |
@@ -169,7 +169,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 295
+The 172 packages present in at least ten implementation languages need 294
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -180,7 +180,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 20 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 19 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -522,6 +522,18 @@ centered rotation, skew, non-commutativity, singularity thresholds, and inverse
 round trips in its package-native suite. The package now spans 12 implementation
 lanes, reduces the high-consensus backlog to 295 slots, and leaves 20 gaps in
 the Haskell lane.
+
+The fifteenth Haskell high-consensus slice is complete: `bezier2d` now
+provides immutable G2D02 quadratic and cubic curves, numerically stable de
+Casteljau evaluation and exact splitting, unnormalized derivatives, adaptive
+polyline flattening, tight derivative-root bounds, and exact quadratic degree
+elevation. It composes only the existing pure Haskell `point2d` package. Its
+package-native suite exercises 21 examples with 100% expression and
+alternative coverage, including exact reparameterized splits, tolerance-driven
+subdivision, both quadratic extrema paths, and full, linear, constant, and
+negative-discriminant cubic derivative cases. The package now spans 12
+implementation lanes, reduces the high-consensus backlog to 294 slots, leaves
+19 gaps in the Haskell lane, and unlocks the dependent `arc2d` port.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell G2D02 `bezier2d` package for immutable quadratic and cubic curves
- implement de Casteljau evaluation and splitting, derivatives, adaptive polyline flattening, tight derivative-root bounds, and exact quadratic degree elevation
- update the package-parity roadmap to 294 remaining high-consensus slots and 19 Haskell gaps

## Why this slice

The completed Haskell `point2d` package makes `bezier2d` the smallest dependency-safe graphics port. It is also the direct prerequisite for the remaining `arc2d` package, so this slice advances the Haskell high-consensus lane without creating a temporary broken dependency graph.

## Validation

- `stack test bezier2d --coverage`: 21 examples, 0 failures, 100% package expression and alternative coverage
- `stack sdist --test-tarball`: passed Cabal package checks and all local dependency tests (`trig` 17, `point2d` 27, `affine2d` 22, `bezier2d` 21)
- `python code/scripts/tests/test_package_parity_report.py`: 6 tests passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: 172 high-consensus packages, 294 missing slots, 19 Haskell gaps, 12 `bezier2d` lanes, zero collisions, zero unknown language buckets
- `git diff --check`

## Remaining work

The Haskell high-consensus lane has 19 gaps. `arc2d` is now unblocked as the next graphics dependency.
