### PR TITLE
feat(maple-runtime, maple-repl): MP-4 — evaluate Maple via the shared symbolic-vm backend

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -265,6 +265,8 @@ members = [
     "reduce-repl",
     "maple-lexer",
     "maple-parser",
+    "maple-runtime",
+    "maple-repl",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/maple-repl/BUILD
+++ b/code/packages/rust/maple-repl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maple-repl -- --nocapture

--- a/code/packages/rust/maple-repl/BUILD_windows
+++ b/code/packages/rust/maple-repl/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maple-repl -- --nocapture

--- a/code/packages/rust/maple-repl/CHANGELOG.md
+++ b/code/packages/rust/maple-repl/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## [0.1.0] - 2026-07-19
+
+### Added
+
+- Initial `maple-repl` crate (MA09 MP-4, front2 Wave 5): an interactive
+  Read-Eval-Print loop and the `maple` binary, wrapping a persistent
+  `MapleSession` (`maple-runtime`) — mirroring `reduce-repl`'s driver, per
+  MA09 §2/§5's explicit template pointer ("matching Reduce's own
+  unnumbered `reduce-repl`").
+- A **plain, non-numbered** prompt (`"> "`, continuation `"... "`) — MA09
+  §2/§5 are explicit that Maple's own session transcript has no
+  numbered-input convention the way Derive's `#n:` or Wolfram's `In[n]:=`
+  do, so no result is ever prefixed with an index.
+- `(`/`)`-, `[`/`]`- (Maple's *list* literal, MA09 §3 — square brackets,
+  not Reduce's curly braces), and `{`/`}`-aware (Maple's *set* literal, new
+  to this language) bracket-depth line continuation, carried forward from
+  `reduce-repl`'s identical shape.
+- **New continuation tracking beyond any sibling CAS-family REPL**: `if` /
+  `end if`|`fi` block-keyword balance. Real Maple's `if_expr` requires an
+  explicit closer (unlike REDUCE's `if`/`then`/`else`, which needs none),
+  so an entirely ordinary multi-line
+  ```text
+  if a > 0 then
+    1
+  else
+    -1
+  end if;
+  ```
+  would otherwise submit prematurely after the first line (no open
+  bracket) and fail to parse. The word-scanner tracks `"if"` (opens),
+  `"fi"` (closes), and the two-keyword `"end" "if"` sequence (closes as a
+  single unit, not double-counted) by exact lowercase spelling, mirroring
+  `maple.tokens`' own case-sensitive keyword rule; since this subset has no
+  comments or string literals (MA09 §4), the scanner needs no comment/
+  string-skipping state the way `matlab-repl`'s/`octave-repl`'s own
+  keyword-block trackers do.
+- Case-insensitive `QUIT`/`EXIT` to end the session, carried forward as a
+  REPL-level convenience (not a language feature — real Maple's own exit
+  is a library call, not a REPL keyword).
+- Bounded single-physical-line reads (`read_bounded_line`, 64 KiB cap),
+  carrying forward the `reduce-repl`/`derive-repl`/`j-repl`/`apl-repl`
+  `/security-review` fix ("cap unbounded single-line read before
+  continuation-buffer check") rather than reintroducing the same gap in a
+  new REPL.
+- The `maple` binary is declared directly in this crate's own `Cargo.toml`
+  (`[[bin]] name = "maple"`), **not** a separate `code/programs/rust/maple`
+  crate — verified against `reduce`/`derive`/`wolfram`'s own binaries,
+  none of which has a `code/programs/rust/` entry either; each `-repl`
+  crate is its own binary crate. See MA09 §5's own note on this.
+- 25 tests: prompt/continuation behaviour (parens, list brackets, set
+  braces, the new `if`/`end if`/`fi` block tracking including nested
+  `if`s), quit words, error recovery, persistent bindings, an end-to-end
+  Maple program, and the full `read_bounded_line` regression suite
+  (oversized line, exact-cap boundary, multi-chunk overflow drain,
+  multibyte-character straddle).

--- a/code/packages/rust/maple-repl/Cargo.toml
+++ b/code/packages/rust/maple-repl/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-maple-repl"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive REPL and `maple` binary for Maple (a subset)"
+license = "MIT"
+
+[dependencies]
+coding-adventures-maple-runtime = { path = "../maple-runtime" }
+
+[[bin]]
+name = "maple"
+path = "src/main.rs"

--- a/code/packages/rust/maple-repl/README.md
+++ b/code/packages/rust/maple-repl/README.md
@@ -1,0 +1,87 @@
+# coding-adventures-maple-repl
+
+An interactive Read-Eval-Print loop and the `maple` binary for Maple (a
+subset). Wraps a persistent
+[`coding_adventures_maple_runtime::MapleSession`](../maple-runtime) and adds
+the console behaviours an interactive Maple user expects. See
+[`code/specs/MA09-maple-language.md`](../../../specs/MA09-maple-language.md).
+
+## Usage
+
+```sh
+cargo run -p coding-adventures-maple-repl --bin maple
+```
+
+```text
+Maple (on the shared symbolic stack) — one statement per line, type QUIT to exit.
+> x := 5;
+5
+> x + 1;
+6
+> f := (x, y) -> x + y;
+f
+> f(2, 3);
+5
+> if x > 0 then
+...   1
+... else
+...   -1
+... end if;
+1
+> QUIT
+```
+
+## Behaviour
+
+- **A plain, non-numbered prompt (`> `)** — MA09 §2/§5 are explicit that
+  Maple's own session transcript has no numbered-input convention the way
+  Derive's `#n:` or Wolfram's `In[n]:=` do, matching
+  [Reduce](../reduce-repl)'s own unnumbered `reduce-repl` (the template
+  this crate follows most closely).
+- **Line continuation** — a statement is complete once `(`/`)`, `[`/`]`
+  (Maple's *list* literal, MA09 §3 — square brackets, not Reduce's curly
+  braces), and `{`/`}` (Maple's *set* literal, new to this language) are
+  all balanced, **and** any open `if` has reached its own `end if`/`fi`
+  closer. That last part is genuinely new relative to `reduce-repl`: real
+  Maple's `if_expr` requires an explicit close (REDUCE's own `if`/`then`/
+  `else` doesn't), so a plain multi-line
+  ```text
+  if a > 0 then
+    1
+  else
+    -1
+  end if;
+  ```
+  needs its own tracking, closer in spirit to `matlab-repl`'s/
+  `octave-repl`'s keyword-block continuation than to any other CAS-family
+  REPL here. Since this subset has no comments or string literals (MA09
+  §4), the word-scanner needs no comment/string-skipping state, unlike
+  those two.
+- **`QUIT`/`EXIT`** (case-insensitive) or Ctrl-D ends the session.
+- **Non-fatal errors** — a surface error (parse failure, a wrong-arity
+  `diff`/`int` call, …) prints and the session keeps working.
+
+## Security: bounded line reads
+
+`run` reads each physical line through a byte-oriented, cap-bounded
+`read_bounded_line` (64 KiB) rather than `BufRead::read_line` directly —
+carrying forward the exact fix `reduce-repl`/`derive-repl`/`j-repl`/
+`apl-repl` needed after their own `/security-review`: `read_line` has no
+length bound of its own, so a single, arbitrarily long line (no embedded
+newline) would be fully buffered in memory before `MapleRepl::feed`'s own
+size check ever ran. See the module doc comment for the full rationale
+(including the multibyte-character/cap-boundary edge case this fix also
+closes).
+
+## Tests
+
+```sh
+cargo test -p coding-adventures-maple-repl
+```
+
+Prompt/continuation behaviour (parens, list brackets, set braces, the new
+`if`/`end if`/`fi` block-keyword tracking including nested `if`s), quit
+words, error recovery, persistent bindings, an end-to-end Maple program,
+and the full `read_bounded_line` regression suite (oversized single line,
+exact-cap boundary, multi-chunk overflow drain, multibyte-character
+straddle).

--- a/code/packages/rust/maple-repl/required_capabilities.json
+++ b/code/packages/rust/maple-repl/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/maple-repl",
+  "capabilities": ["stdio"],
+  "justification": "An interactive console: the `maple` binary reads Maple source from stdin and writes results to stdout. No filesystem, network, or process access beyond standard streams."
+}

--- a/code/packages/rust/maple-repl/src/lib.rs
+++ b/code/packages/rust/maple-repl/src/lib.rs
@@ -107,15 +107,37 @@ impl MapleRepl {
                 _ => {}
             }
         }
+        // Bound the accumulation buffer BEFORE growing it: a stream that
+        // never balances (an endless run of open brackets, or an `if` with
+        // no closer) must not buffer unbounded memory, and neither may a
+        // single caller-supplied `line` that is itself already oversized.
+        // `/security-review` flagged an earlier draft that appended `line`
+        // via `push_str` first and checked the size second — that order
+        // would `push_str` an arbitrarily large `line` into `self.buffer`
+        // (an O(n) copy, possibly reallocating) before the very check meant
+        // to bound it ever ran. This crate's own `run()` loop never feeds
+        // `feed` a `line` longer than `read_bounded_line`'s 64 KiB-per-
+        // physical-line cap, but `feed` is a `pub fn` on a `pub struct`, so
+        // any other embedder calling it directly with an attacker-supplied,
+        // unbounded `&str` must be bounded here too, not just at the one
+        // shipped call site.
+        if self
+            .buffer
+            .len()
+            .saturating_add(line.len())
+            .saturating_add(1)
+            > MAX_INPUT_LEN
+        {
+            self.buffer.clear();
+            return ReplResponse::Output(format!(
+                "input too large: exceeds the {MAX_INPUT_LEN}-byte limit"
+            ));
+        }
+
         self.buffer.push_str(line);
         self.buffer.push('\n');
 
-        // Bound the accumulation buffer: a stream that never balances (an
-        // endless run of open brackets, or an `if` with no closer) must not
-        // buffer unbounded memory. Once over the size the session would
-        // reject anyway, submit so `feed` returns the clean "too large"
-        // error and resets.
-        if self.buffer.len() <= MAX_INPUT_LEN && is_incomplete(&self.buffer) {
+        if is_incomplete(&self.buffer) {
             return ReplResponse::NeedMore;
         }
 

--- a/code/packages/rust/maple-repl/src/lib.rs
+++ b/code/packages/rust/maple-repl/src/lib.rs
@@ -1,0 +1,580 @@
+//! # Maple REPL — an interactive Read-Eval-Print loop for Maple (a subset).
+//!
+//! [`MapleRepl`] wraps a persistent [`MapleSession`] (which reuses the
+//! entire shared symbolic stack) and adds the console behaviours an
+//! interactive Maple user expects. Mirrors `reduce-repl`'s driver closely
+//! (MA09 §5's own template pointer — "matching Reduce's own unnumbered
+//! `reduce-repl`"), with one genuine addition `reduce-repl`'s own
+//! continuation heuristic doesn't need:
+//!
+//! * **No numbered prompt.** Real Maple's own interactive session has no
+//!   `#n:`/`In[n]:=` numbered-history convention either (MA09 §5) — so the
+//!   prompt here is a fixed `"> "` (continuation: `"... "`), identical to
+//!   `reduce-repl`'s spelling.
+//! * **Line continuation tracks brackets *and* the `if` / `end if`|`fi`
+//!   block keywords.** `(`/`)`, `[`/`]` (Maple's list literal, MA09 §3 — not
+//!   Reduce's `{`/`}`), and `{`/`}` (Maple's *set* literal, new to this
+//!   language) are tracked exactly like `reduce-repl`'s bracket balance. But
+//!   unlike REDUCE's `if`/`then`/`else` (which needs no closing keyword at
+//!   all — it just ends at the next `;`/`$`), Maple's own `if_expr` requires
+//!   an explicit `end if` or `fi` closer (MA09 §3) — a genuinely new
+//!   continuation shape with no `reduce-repl` analogue, closer in spirit to
+//!   `matlab-repl`'s/`octave-repl`'s own keyword-block tracking (`if` ...
+//!   `end`) than to any other CAS-family REPL in this repo. Without this,
+//!   a completely ordinary multi-line `if a > 0 then\n  1\nelse\n  -1\nend
+//!   if;` typed interactively would submit prematurely after the first
+//!   line (no open bracket) and fail to parse — this tracker closes that
+//!   gap. `maple.tokens` has no comments or string literals in this subset
+//!   (MA09 §4), so — unlike `matlab-repl`'s/`octave-repl`'s own word
+//!   scanners — there is no comment/string state to skip over either,
+//!   keeping the scanner simple: accumulate a run of ASCII alphanumeric
+//!   characters into a word, and on each word boundary check it against
+//!   `"if"`/`"fi"`/`"end"` (matched by exact lowercase spelling, mirroring
+//!   `maple.tokens`' own case-sensitive keyword rule — an uppercase `IF`
+//!   lexes as an ordinary `NAME`, so the heuristic correctly ignores it
+//!   too). `end` alone is remembered as *pending* and only closes a block
+//!   when the very next word is `if` (Maple's two-keyword `end if` closer),
+//!   so it does not itself open a second block the way a bare `"if"` word
+//!   would.
+//! * **Quit / EOF** — `QUIT`, `EXIT` (case-insensitive convenience, mirroring
+//!   `reduce-repl`'s identical convenience even though real Maple's own exit
+//!   is a library call, `quit`/`done`/`stop`, not a REPL-level keyword), or
+//!   Ctrl-D end the session.
+//! * **Non-fatal errors** — a surface error prints and the session continues.
+//!
+//! This mirrors `reduce-repl`'s single-threaded driver, carrying forward its
+//! `read_bounded_line` fix verbatim: [`run`] reads each physical line
+//! through [`read_bounded_line`] (capped at [`MAX_LINE_LEN`]) rather than
+//! `BufRead::read_line` directly — see that function's own doc comment for
+//! the full rationale (unbounded `read_line`, and the multibyte-character/
+//! cap-boundary edge case).
+
+use coding_adventures_maple_runtime::{MapleSession, MAX_INPUT_LEN};
+use std::io::{BufRead, Write};
+
+/// What the REPL should do after being fed one physical line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplResponse {
+    /// A complete statement (or batch) was evaluated; here is its echo.
+    Output(String),
+    /// The buffer is not yet a complete statement — read another line.
+    NeedMore,
+    /// The user asked to leave.
+    Quit,
+}
+
+/// A persistent interactive Maple session.
+pub struct MapleRepl {
+    session: MapleSession,
+    buffer: String,
+}
+
+impl Default for MapleRepl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MapleRepl {
+    pub fn new() -> Self {
+        MapleRepl {
+            session: MapleSession::new(),
+            buffer: String::new(),
+        }
+    }
+
+    /// The prompt to print before reading the next physical line.
+    ///
+    /// A plain, non-numbered prompt (MA09 §5 — see the module doc
+    /// comment) — `"> "` for a fresh statement, `"... "` while one spans
+    /// multiple physical lines.
+    pub fn prompt(&self) -> String {
+        if self.buffer.is_empty() {
+            "> ".to_string()
+        } else {
+            "... ".to_string()
+        }
+    }
+
+    /// Feed one physical input line (without its trailing newline).
+    pub fn feed(&mut self, line: &str) -> ReplResponse {
+        // Quit words are only recognised at the start of a fresh statement,
+        // so an identifier named `QUIT`/`EXIT` mid-expression is never
+        // hijacked.
+        if self.buffer.is_empty() {
+            match line.trim() {
+                "QUIT" | "quit" | "Quit" | "EXIT" | "exit" | "Exit" => return ReplResponse::Quit,
+                _ => {}
+            }
+        }
+        self.buffer.push_str(line);
+        self.buffer.push('\n');
+
+        // Bound the accumulation buffer: a stream that never balances (an
+        // endless run of open brackets, or an `if` with no closer) must not
+        // buffer unbounded memory. Once over the size the session would
+        // reject anyway, submit so `feed` returns the clean "too large"
+        // error and resets.
+        if self.buffer.len() <= MAX_INPUT_LEN && is_incomplete(&self.buffer) {
+            return ReplResponse::NeedMore;
+        }
+
+        let src = std::mem::take(&mut self.buffer);
+        if src.trim().is_empty() {
+            return ReplResponse::Output(String::new());
+        }
+        match self.session.feed(&src) {
+            Ok(text) => ReplResponse::Output(text),
+            Err(e) => ReplResponse::Output(format!("Error: {e}\n")),
+        }
+    }
+
+    /// Is a statement currently spanning multiple lines?
+    pub fn is_continuing(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}
+
+/// Upper bound on a single *physical* line read from the input stream,
+/// applied in [`read_bounded_line`] before [`MapleRepl::feed`]'s own
+/// `MAX_INPUT_LEN` check ever runs. `BufRead::read_line` has no length bound
+/// of its own — it grows its buffer until it sees a `\n` or EOF — so without
+/// this, a single, arbitrarily long physical line (no embedded newline at
+/// all) is fully buffered in memory before `feed` ever gets a chance to
+/// reject anything. Mirrors `reduce-repl`'s/`derive-repl`'s/`j-repl`'s/
+/// `apl-repl`'s own `MAX_LINE_LEN` fix exactly (same value, same rationale).
+const MAX_LINE_LEN: u64 = 64 * 1024;
+
+/// Read one physical line, bounded to [`MAX_LINE_LEN`] bytes.
+///
+/// - `Ok(None)` — genuine end of input.
+/// - `Ok(Some(Ok(line)))` — an ordinary line. Includes a final, newline-less
+///   line at genuine EOF (same as `BufRead::read_line`'s own contract).
+/// - `Ok(Some(Err(())))` — a single physical line's true length exceeds the
+///   cap; the oversized remainder is fully drained and discarded so the next
+///   read always starts at a genuine line boundary.
+///
+/// Reads raw **bytes** (`read_until(b'\n', ..)`), not `BufRead::read_line`
+/// directly, deciding "oversized?" on the byte run *before* attempting UTF-8
+/// decoding — `Take` stops at an arbitrary byte offset with no notion of a
+/// character boundary, so a valid UTF-8 line whose true length only slightly
+/// exceeds the cap could have a multi-byte character straddle that exact
+/// offset, and validating on the byte run through `read_line` alone would
+/// misreport that as a decoding failure rather than an oversized line.
+/// Mirrors `reduce-repl::read_bounded_line`/`derive-repl::read_bounded_line`/
+/// `j-repl::read_bounded_line` exactly.
+fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
+    let mut buf: Vec<u8> = Vec::new();
+    // Explicit UFCS + an explicit reborrow (`&mut *reader`): `Read`/`BufRead`
+    // are implemented both for `R` itself and for `&mut R`, and ordinary
+    // autoref method resolution prefers the by-value `R` candidate even when
+    // the receiver is already a reference — silently trying to MOVE
+    // `*reader` instead of taking a bounded view of it. Naming the trait and
+    // the exact `&mut R` receiver explicitly removes that ambiguity.
+    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+    let read = limited.read_until(b'\n', &mut buf)?;
+    if read == 0 {
+        return Ok(None);
+    }
+    let hit_cap = buf.len() as u64 == MAX_LINE_LEN && buf.last() != Some(&b'\n');
+    if hit_cap {
+        // The initial capped read filled up with no newline in sight — keep
+        // reading further capped chunks (discarding them) until either a
+        // real `\n` is found (genuinely oversized) or a chunk comes back
+        // empty (a maximal-but-not-oversized line at genuine EOF).
+        let mut saw_more_data = false;
+        loop {
+            let mut chunk: Vec<u8> = Vec::new();
+            let mut limited: std::io::Take<&mut R> =
+                std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+            let n = limited.read_until(b'\n', &mut chunk)?;
+            if n == 0 {
+                if !saw_more_data {
+                    return match String::from_utf8(buf) {
+                        Ok(line) => Ok(Some(Ok(line))),
+                        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+                    };
+                }
+                break; // true EOF reached while draining real overflow
+            }
+            saw_more_data = true;
+            if chunk.last() == Some(&b'\n') {
+                break; // found the oversized line's real end
+            }
+        }
+        return Ok(Some(Err(())));
+    }
+    match String::from_utf8(buf) {
+        Ok(line) => Ok(Some(Ok(line))),
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+    }
+}
+
+/// Is the accumulated source *incomplete* — i.e. should the REPL keep
+/// reading?
+///
+/// A Maple statement (like Reduce's, unlike Derive's newline-terminated
+/// one) is terminated by `;`/`:`, and this subset's grammar tolerates a
+/// final statement with no terminator at all (`maple-parser`'s own
+/// `bare_trailing_statement_with_no_terminator_parses` test) — so this
+/// heuristic tracks bracket *and* `if`-block balance, not terminators,
+/// mirroring `reduce-repl::is_incomplete`'s "wait for balance, then submit
+/// the whole buffer" shape over Maple's own bracket vocabulary (`(`/`)`,
+/// `[`/`]` for lists, `{`/`}` for sets — MA09 §3), extended with the
+/// `if`/`end if`|`fi` block-keyword tracking this module's own doc comment
+/// explains (Maple's `if_expr`, unlike Reduce's, needs an explicit closer).
+///
+/// This is only a continuation *heuristic*: whatever is submitted still
+/// passes through [`MapleSession::feed`], which re-lexes with the real
+/// lexer and applies the size/complexity guards, so a mismatch can never
+/// crash — at worst it submits early or asks for one more line.
+fn is_incomplete(src: &str) -> bool {
+    let mut bracket: i32 = 0;
+    let mut blocks: i32 = 0;
+    let mut pending_end = false;
+    let mut word = String::new();
+
+    let flush = |word: &mut String, blocks: &mut i32, pending_end: &mut bool| {
+        if word.is_empty() {
+            return;
+        }
+        match word.as_str() {
+            "if" => {
+                if *pending_end {
+                    *blocks -= 1;
+                    *pending_end = false;
+                } else {
+                    *blocks += 1;
+                }
+            }
+            "fi" => {
+                *blocks -= 1;
+                *pending_end = false;
+            }
+            "end" => {
+                *pending_end = true;
+            }
+            _ => {
+                *pending_end = false;
+            }
+        }
+        word.clear();
+    };
+
+    for ch in src.chars() {
+        // maple.tokens' own NAME pattern is `[a-zA-Z][a-zA-Z0-9]*` — no
+        // underscore — so an ASCII-alphanumeric run is exactly a NAME or
+        // KEYWORD lexeme's shape (a NUMBER-leading run like `123abc` never
+        // equals `"if"`/`"fi"`/`"end"` anyway, so no separate digit-leading
+        // case needs to be excluded here).
+        if ch.is_ascii_alphanumeric() {
+            word.push(ch);
+            continue;
+        }
+        flush(&mut word, &mut blocks, &mut pending_end);
+        match ch {
+            '(' | '[' | '{' => bracket += 1,
+            ')' | ']' | '}' => bracket -= 1,
+            _ => {}
+        }
+    }
+    flush(&mut word, &mut blocks, &mut pending_end);
+
+    bracket > 0 || blocks > 0
+}
+
+/// Drive a full interactive Maple session over the given reader and writer.
+pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Result<()> {
+    let mut repl = MapleRepl::new();
+    writeln!(
+        writer,
+        "Maple (on the shared symbolic stack) — one statement per line, type QUIT to exit."
+    )?;
+
+    loop {
+        write!(writer, "{}", repl.prompt())?;
+        writer.flush()?;
+
+        let line = match read_bounded_line(&mut reader)? {
+            None => {
+                writeln!(writer)?;
+                break;
+            }
+            Some(Err(())) => {
+                writeln!(
+                    writer,
+                    "Error: line exceeds the {MAX_LINE_LEN}-byte limit; discarded"
+                )?;
+                writer.flush()?;
+                continue;
+            }
+            Some(Ok(line)) => line,
+        };
+        let line = line.strip_suffix('\n').unwrap_or(&line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        match repl.feed(line) {
+            ReplResponse::Output(text) => {
+                write!(writer, "{text}")?;
+                writer.flush()?;
+            }
+            ReplResponse::NeedMore => {}
+            ReplResponse::Quit => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_single_line_statement_evaluates_immediately() {
+        let mut r = MapleRepl::new();
+        assert!(matches!(r.feed("1 + 2*3;"), ReplResponse::Output(t) if t.contains('7')));
+    }
+
+    #[test]
+    fn continues_while_a_paren_is_open() {
+        let mut r = MapleRepl::new();
+        assert_eq!(r.feed("f := (x,"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("y) -> x + y;"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn continues_while_a_bracket_is_open() {
+        let mut r = MapleRepl::new();
+        assert_eq!(r.feed("[1,"), ReplResponse::NeedMore);
+        assert!(matches!(
+            r.feed("2, 3];"),
+            ReplResponse::Output(t) if t.contains("[1, 2, 3]")
+        ));
+    }
+
+    #[test]
+    fn continues_while_a_brace_is_open() {
+        let mut r = MapleRepl::new();
+        assert_eq!(r.feed("{1,"), ReplResponse::NeedMore);
+        assert!(matches!(
+            r.feed("2};"),
+            ReplResponse::Output(t) if t.contains("{1, 2}")
+        ));
+    }
+
+    #[test]
+    fn continues_across_a_multi_line_if_statement_until_end_if() {
+        let mut r = MapleRepl::new();
+        assert_eq!(r.feed("if 1 > 0 then"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("42"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("else"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("0"), ReplResponse::NeedMore);
+        assert!(matches!(
+            r.feed("end if;"),
+            ReplResponse::Output(t) if t.contains("42")
+        ));
+    }
+
+    #[test]
+    fn continues_across_a_multi_line_if_statement_closed_with_fi() {
+        let mut r = MapleRepl::new();
+        assert_eq!(r.feed("if 1 > 0 then"), ReplResponse::NeedMore);
+        assert!(matches!(
+            r.feed("42 else 0 fi;"),
+            ReplResponse::Output(t) if t.contains("42")
+        ));
+    }
+
+    #[test]
+    fn a_single_line_if_statement_does_not_need_continuation() {
+        let mut r = MapleRepl::new();
+        assert!(matches!(
+            r.feed("if 1 > 0 then 42 else 0 end if;"),
+            ReplResponse::Output(t) if t.contains("42")
+        ));
+    }
+
+    #[test]
+    fn nested_if_statements_balance_correctly() {
+        let mut r = MapleRepl::new();
+        assert_eq!(r.feed("if true then"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("if false then 1 end if"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("else 2 end if;"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn a_bare_comparison_does_not_perturb_bracket_or_block_tracking() {
+        let mut r = MapleRepl::new();
+        assert!(matches!(r.feed("1 < 2;"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn prompts_switch_between_input_and_continuation_with_no_numbering() {
+        let mut r = MapleRepl::new();
+        assert_eq!(r.prompt(), "> ");
+        assert_eq!(r.feed("f := ("), ReplResponse::NeedMore);
+        assert_eq!(r.prompt(), "... ", "continuation prompt while open");
+        assert!(r.is_continuing());
+        assert!(matches!(r.feed("x) -> x;"), ReplResponse::Output(_)));
+        assert_eq!(
+            r.prompt(),
+            "> ",
+            "prompt returns to the plain, non-numbered form"
+        );
+    }
+
+    #[test]
+    fn quit_words_leave_the_session() {
+        assert_eq!(MapleRepl::new().feed("QUIT"), ReplResponse::Quit);
+        assert_eq!(MapleRepl::new().feed("quit"), ReplResponse::Quit);
+        assert_eq!(MapleRepl::new().feed("EXIT"), ReplResponse::Quit);
+        assert_eq!(MapleRepl::new().feed("exit"), ReplResponse::Quit);
+    }
+
+    #[test]
+    fn an_error_is_printed_and_the_session_survives() {
+        let mut r = MapleRepl::new();
+        assert!(matches!(r.feed("1 +"), ReplResponse::Output(t) if t.contains("Error")));
+        assert!(matches!(r.feed("1 + 1;"), ReplResponse::Output(t) if t.contains('2')));
+    }
+
+    #[test]
+    fn bindings_persist_across_lines() {
+        let mut r = MapleRepl::new();
+        assert!(matches!(r.feed("x := 5;"), ReplResponse::Output(_)));
+        assert!(matches!(r.feed("x + 1;"), ReplResponse::Output(t) if t.contains('6')));
+    }
+
+    #[test]
+    fn an_unterminated_buffer_is_submitted_once_over_the_size_cap() {
+        let mut r = MapleRepl::new();
+        let big = "(".repeat(MAX_INPUT_LEN + 16);
+        match r.feed(&big) {
+            ReplResponse::Output(t) => assert!(t.contains("too large"), "got {t:?}"),
+            other => panic!("expected an over-size submission, got {other:?}"),
+        }
+        assert_eq!(r.prompt(), "> ");
+    }
+
+    #[test]
+    fn run_drives_a_session_to_eof() {
+        let input = b"1 + 2*3;\nQUIT\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains('7'), "expected 7 in session: {text:?}");
+        assert!(text.contains("> "), "expected the plain prompt: {text:?}");
+    }
+
+    #[test]
+    fn run_handles_bare_eof_without_quit() {
+        let input = b"2 + 2;\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        assert!(String::from_utf8(output).unwrap().contains('4'));
+    }
+
+    #[test]
+    fn blank_lines_are_harmless() {
+        let mut r = MapleRepl::new();
+        assert_eq!(r.feed(""), ReplResponse::Output(String::new()));
+        assert_eq!(r.prompt(), "> ", "a blank line does not change the prompt");
+    }
+
+    #[test]
+    fn a_maple_program_evaluates_end_to_end() {
+        let mut r = MapleRepl::new();
+        assert!(matches!(r.feed("f := x -> x*x;"), ReplResponse::Output(_)));
+        assert!(matches!(
+            r.feed("f(5);"),
+            ReplResponse::Output(t) if t.contains("25")
+        ));
+    }
+
+    // --- read_bounded_line: carried forward from reduce-repl/derive-repl/
+    //     j-repl/apl-repl (the /security-review fix, task #32) -------------
+
+    #[test]
+    fn read_bounded_line_rejects_a_line_exceeding_the_cap_without_buffering_it_whole() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 3);
+        let mut input = oversized.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        let _ = read_bounded_line(&mut input);
+    }
+
+    #[test]
+    fn read_bounded_line_at_exactly_the_cap_with_a_trailing_newline_is_not_oversized() {
+        let mut line = "+".repeat(MAX_LINE_LEN as usize - 1);
+        line.push('\n');
+        assert_eq!(line.len() as u64, MAX_LINE_LEN);
+        let mut input = line.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Ok(line)));
+    }
+
+    #[test]
+    fn read_bounded_line_treats_an_exactly_cap_sized_final_line_as_ordinary_not_oversized() {
+        let line = "+".repeat(MAX_LINE_LEN as usize);
+        let mut input = line.as_bytes();
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok(line.clone()))
+        );
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn read_bounded_line_fully_drains_a_line_spanning_multiple_cap_chunks() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1;\n");
+        let mut input = input.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("1+1;\n".to_string()))
+        );
+    }
+
+    #[test]
+    fn read_bounded_line_handles_a_multibyte_char_straddling_the_cap_boundary() {
+        let mut oversized: Vec<u8> = vec![b'a'; MAX_LINE_LEN as usize - 1];
+        oversized.extend_from_slice("é".as_bytes()); // 2-byte char, straddles the cap
+        oversized.push(b'\n');
+        let mut input = oversized.as_slice();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+    }
+
+    #[test]
+    fn run_reports_an_oversized_line_cleanly_and_keeps_the_session_alive() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 2);
+        let input = format!("{oversized}\n1+1;\nQUIT\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            text.contains("exceeds"),
+            "expected an oversized-line error, got: {text}"
+        );
+        assert!(
+            text.contains('2'),
+            "session must keep working after an oversized line, got: {text}"
+        );
+    }
+
+    #[test]
+    fn run_executes_the_correct_follow_up_statement_after_a_multi_chunk_oversized_line() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1;\nQUIT\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            text.contains("exceeds"),
+            "expected an oversized-line error, got: {text}"
+        );
+        assert!(
+            text.contains('2'),
+            "the real follow-up statement (1+1), not a fragment of the \
+             discarded line, must be what gets evaluated, got: {text}"
+        );
+    }
+}

--- a/code/packages/rust/maple-repl/src/main.rs
+++ b/code/packages/rust/maple-repl/src/main.rs
@@ -1,0 +1,20 @@
+//! The `maple` binary — an interactive prompt for Maple (a subset).
+//!
+//! Reads one physical line at a time (continuing across an open `(`/`)`,
+//! `[`/`]`, `{`/`}`, or an unclosed `if` until its `end if`/`fi`),
+//! evaluates over the reused shared symbolic stack, and echoes each
+//! *displayed* result — a plain, non-numbered read-eval-print loop (MA09
+//! §2/§5; unlike `derive`'s `#n:` worksheet convention). Type `QUIT`/`EXIT`
+//! (or Ctrl-D) to leave. All logic lives in
+//! [`coding_adventures_maple_repl::run`].
+
+use std::io;
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if let Err(e) = coding_adventures_maple_repl::run(stdin.lock(), stdout.lock()) {
+        eprintln!("maple: I/O error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/maple-runtime/BUILD
+++ b/code/packages/rust/maple-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maple-runtime -- --nocapture

--- a/code/packages/rust/maple-runtime/BUILD_windows
+++ b/code/packages/rust/maple-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-maple-runtime -- --nocapture

--- a/code/packages/rust/maple-runtime/CHANGELOG.md
+++ b/code/packages/rust/maple-runtime/CHANGELOG.md
@@ -1,0 +1,105 @@
+# Changelog
+
+## [0.1.0] - 2026-07-19
+
+### Added
+
+- Initial `maple-runtime` crate (MA09 MP-4, front2 Wave 5): lowers the
+  `maple-parser` (MP-3) `GrammarASTNode` CST into `symbolic_ir::IRNode` and
+  evaluates it via `symbolic_vm::VM` over the shared `SymbolicBackend` —
+  unchanged, no custom `Backend` — mirroring `derive-runtime`'s/
+  `reduce-runtime`'s identical reuse story for the other two Wave-5
+  CAS-family languages. The reuse claim was verified directly against
+  `symbolic_vm::handlers::build_handler_table` and
+  `symbolic_vm::backend::BaseBackend::new` (not assumed from either crate's
+  own spec prose, per the discipline MA08 §5 itself insists on after
+  disclosing its own earlier overclaim): every head this subset needs
+  (`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`, `Equal`/`NotEqual`/`Less`/`Greater`/
+  `LessEqual`/`GreaterEqual`, `And`/`Or`/`Not`, the held `Assign`/`Define`/
+  `If`, `List`, and — since `SymbolicBackend::new` always builds with
+  `simplify: true` — `D`/`Integrate`) is confirmed present and unchanged.
+- `lower` module: the full precedence-cascade lowering (`logical_or` down
+  to `atom`), the statement-vs-expression split `maple.grammar` draws
+  (`if_expr`/`assignment` reached only via `lower_node`'s own dispatch,
+  never nested inside an expression operand), the arrow-operator
+  (`f := (x, y) -> e` / `f := x -> e`) → `Define[name, List[params], body]`
+  bridge, the `diff`→`D`/`int`→`Integrate` calculus bridge (a thin surface
+  rename only — no calculus reimplemented), the `elif`-chain → nested-`If`
+  right-fold (`If[b, s1, If[b2, s2, s3]]`, per MA09 §3's own worked
+  example), and the new [`SET`] canonical head for `{a, b, c}` set literals
+  (defined locally to this crate, mirroring `reduce-runtime`'s own
+  treatment of its new `CompoundExpression`/`Cons`/list-accessor heads,
+  since no handler for `Set` exists anywhere in the shared table — no
+  language before Maple has asked for one).
+- **New**: `true`/`false` literal boolean tokens (MA09 §3 — the first CAS
+  family language in this repo with a dedicated boolean literal; Reduce's
+  and Derive's booleans arise only from comparison/logic results) bridge
+  to the shared backend's pre-bound `True`/`False` symbols, reusing
+  `macsyma-compiler::lower_token`'s exact `"KEYWORD" if token.value ==
+  "true"` precedent.
+- **New**: the `;`/`:` statement-terminator display-flag split (MA09 §3:
+  "`;` displays the result, `:` suppresses it ... a display flag on the
+  surrounding session, not an IR node"). `lower_program` returns
+  `LoweredStatement { node, display }` pairs rather than bare `IRNode`s —
+  every statement still evaluates (so a `:`-suppressed `x := 5:` really
+  binds `x`), but only `Display::Show` statements produce an `Output` line.
+- `printer` module: the inverse — canonical heads back to Maple surface
+  notation (infix arithmetic/comparison/logic, square-bracket `[a, b, c]`
+  lists, curly-brace `{a, b, c}` sets, `if ... then ... [elif ...] [else
+  ...] end if`, with a nested `If` in the else-slot folded back into an
+  `elif` continuation rather than a redundant second `if ... end if`), plus
+  the `diff`/`int` reverse-bridge for an unresolved `D`/`Integrate` result.
+- `MapleSession`/`eval`: a string-in/string-out facade mirroring
+  `reduce-runtime`'s session pattern, without a numbered-worksheet prefix —
+  MA09 §2/§5 are explicit that Maple's own session transcript has no
+  numbered-input convention either.
+- Robustness: `MAX_INPUT_LEN` (64 KiB) bounds total input;
+  `MAX_STATEMENT_TOKENS` (2000, measured against the real `maple-lexer`
+  token stream) closes the "long flat chain folds into a deep lowered
+  tree" vector `maple-parser`'s own `MAX_RULE_DEPTH` cannot cover (grammar
+  repetitions, not recursive rule calls, aren't bounded by that cap). Two
+  shapes are guarded: the additive/multiplicative left-fold chain (shared
+  with Reduce's/Derive's identical vector) and, genuinely new here (no
+  `reduce.grammar` analogue — REDUCE has no `elif`), a long `elif` chain
+  folding into a deeply nested `If` tree via `lower_if`'s own right-fold.
+  Unlike `reduce-runtime`'s identical-in-spirit guard, the token-count
+  reset on `SEMI`/`COLON` needs **no** bracket-nesting-depth tracking —
+  verified directly against `maple-parser`'s own compiled grammar
+  (`grep -n 'SEMI\|COLON'` hits exactly one production,
+  `statement_line`'s own terminator), so every `SEMI`/`COLON` in a valid
+  parse is unambiguously a genuine top-level statement boundary; this
+  subset has no bare compound-statement grouping construct the way
+  REDUCE's `<< ... >>` is (MA09 §4 defers bare expression sequences
+  entirely), so there is no way for a `;`/`:` to be lexically embedded
+  inside a nested operand the way REDUCE's guard has to defend against.
+  Evaluation runs on a 512 MiB-stack worker thread inside `catch_unwind`,
+  rebuilding the session after any caught panic (e.g. a wrong-arity
+  `diff(x)` call reaching `derivative_handler`'s own arity panic). Maple's
+  grammar-enforced bare-`NAME` `Assign`/`Define` left-hand side means,
+  unlike Reduce's, there is no malformed-`Assign`-lhs panic vector at all.
+- **Disclosed spec/reality gap** (documented in `crate::lower`'s and this
+  crate's own module doc comments, and this crate's README): grepping
+  `symbolic-vm::handlers::build_handler_table` confirms **no** handler
+  exists for the new `Set` head — MA09 §5's own disclosure that this is an
+  expected, not-yet-closed gap (real Maple's unordered/duplicate-removing
+  set semantics are not enforced at evaluation time; elements evaluate,
+  the call itself stays structurally correct but unevaluated), the same
+  "no handler, no crash" contract an undefined user function already has.
+- **Confirmed, not merely assumed**: `proc(...) ... end proc`
+  (block-structured procedures), `for`/`while` loops, and the remember-
+  table `f(x) := e` spelling are all rejected at **parse** time by the
+  already-merged `maple-parser` (MP-3) — this crate needs no special-case
+  rejection logic of its own; the parser's `Err` is forwarded as-is.
+- 104 tests total: `lower`/`printer` unit tests covering every row of MA09
+  §3's surface table, plus end-to-end session tests (arithmetic, persistent
+  bindings/functions, `if`/`elif`/`else` with both closing spellings, list/
+  set elementwise evaluation and the disclosed `Set` gap, the `;`/`:`
+  display-flag split, both robustness guards including the new elif-chain
+  regression, panic recovery, and explicit confirmation that the
+  out-of-scope constructs are cleanly rejected), plus a doctest on
+  `MapleSession::feed`.
+
+### No upstream `maple-lexer`/`maple-parser` changes
+
+No bug was found in the already-merged MP-2/MP-3 crates while integrating
+against them; neither crate was touched.

--- a/code/packages/rust/maple-runtime/Cargo.toml
+++ b/code/packages/rust/maple-runtime/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "coding-adventures-maple-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Maple runtime — lowers Maple syntax to symbolic-ir and evaluates via symbolic-vm (MP-4)"
+license = "MIT"
+
+[dependencies]
+# The MP-3 frontend: parses Maple source into a generic GrammarASTNode that
+# this crate lowers to symbolic-ir.
+coding-adventures-maple-parser = { path = "../maple-parser" }
+# The MP-2 lexer. Tokenized once up front (the lexer is iterative, so unlike
+# the parser it cannot stack-overflow) to measure per-statement token counts
+# from the *real* token stream, mirroring reduce-runtime/derive-runtime's
+# identical guard against a long flat operator/elif chain folding into a
+# deeply nested lowered tree (see MAX_STATEMENT_TOKENS's doc comment).
+coding-adventures-maple-lexer = { path = "../maple-lexer" }
+# The shared symbolic substrate: the term IR everything lowers to and the VM
+# that rewrites it.
+symbolic-ir = { path = "../symbolic-ir" }
+symbolic-vm = { path = "../symbolic-vm" }
+# The generic parser AST types (GrammarASTNode / ASTNodeOrToken) and the lexer
+# Token type the lowering walks.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/maple-runtime/README.md
+++ b/code/packages/rust/maple-runtime/README.md
@@ -1,0 +1,194 @@
+# coding-adventures-maple-runtime
+
+Evaluates Maple (a subset) by lowering the `maple-parser` (MP-3) CST into
+[`symbolic-ir`](../symbolic-ir) and running it through
+[`symbolic-vm`](../symbolic-vm)'s shared `SymbolicBackend` — the *same*
+rewrite engine Wolfram, Macsyma, Derive, and Reduce already drive,
+unchanged. See
+[`code/specs/MA09-maple-language.md`](../../../specs/MA09-maple-language.md).
+
+## Where this fits
+
+`maple-runtime` is MP-4 of the Maple frontend/runtime pipeline:
+
+```
+maple.tokens + maple-lexer     (MP-2)
+        │
+maple.grammar + maple-parser   (MP-3)
+        │
+maple-runtime                  (MP-4, this crate) ── crate::lower ──► symbolic_ir::IRNode
+        │                                              │
+        │                                       symbolic_vm::VM (SymbolicBackend)
+        │                                              │
+maple-repl                     (MP-4)  ◄── crate::printer ─┘
+```
+
+## No custom `Backend` — verified against the real handler table
+
+`SymbolicBackend` (built with `simplify: true`) already provides arithmetic
+(`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`), comparison (`Equal`/`Less`/`Greater`/
+`LessEqual`/`GreaterEqual`/`NotEqual`), logic (`And`/`Or`/`Not`), the held
+`Assign`/`Define`/`If` forms, `List`, and (since `SymbolicBackend::new`
+always builds with `simplify: true`) `D`/`Integrate` — so this crate adds
+**no new evaluation code**, only:
+
+- **`lower`** — Maple's surface `GrammarASTNode` (`statement`, `if_expr`,
+  `assignment`, `arrow_def`, `logical_or`, `comparison`, `additive`,
+  `postfix`, `atom`, …) → the canonical `IRNode` heads the VM dispatches,
+  including the `diff`→`D`/`int`→`Integrate` calculus bridge, the arrow-
+  operator (`f := (x, y) -> e`) → `Define` bridge, the `;`/`:` display-flag
+  split (tracked *alongside* the IR, never folded into it — MA09 §3's own
+  table calls this "a display flag on the surrounding session, not an IR
+  node"), and the `elif`-chain → nested-`If` desugar.
+- **`printer`** — the inverse: canonical `IRNode` → Maple surface notation
+  (infix `+`/`-`/`*`/`/`/`^`, `and`/`or`/`not`, square-bracket `[a, b, c]`
+  lists, curly-brace `{a, b, c}` sets, `if ... then ... [elif ...] [else
+  ...] end if`, with a nested-`If` in the else-slot folded back into an
+  `elif` rather than a second, redundant `if ... end if`).
+
+**`Set` — a canonical head new to this repo, and a disclosed gap.** Maple is
+the first language here with two distinct bracketed aggregate literals:
+`[a, b, c]` (`List`, already fully handled) and `{a, b, c}` (MA09 §3/§5).
+Grepping `symbolic_vm::handlers::build_handler_table` confirms **no**
+handler exists for a `Set` head — unsurprising, no language before Maple has
+asked for one. `Set` is defined *locally to this crate*
+(`coding_adventures_maple_runtime::SET`), exactly the way `reduce-runtime`
+defines its own new `CompoundExpression`/`Cons`/list-accessor heads rather
+than adding them to the shared `symbolic-ir`/`symbolic-vm` crates. `Set` is
+not a held head, so its elements *do* evaluate — but the call itself stays
+structurally correct, unevaluated: real Maple's unordered/duplicate-
+removing set semantics aren't enforced yet.
+
+```rust
+use coding_adventures_maple_runtime::MapleSession;
+
+let mut s = MapleSession::new();
+// Elements evaluate; the call stays a structurally-correct, unevaluated
+// Set(...) -- real Maple's dedup/unordered semantics aren't enforced yet.
+assert_eq!(s.feed("{1, 1, 2};\n").unwrap(), "{1, 1, 2}\n");
+```
+
+`diff`/`int` are thin calls into the already-shared `D`/`Integrate`
+handlers — the same ones Derive's `DIF`/`INT` and Wolfram's own
+`D`/`Integrate` call. This crate reimplements no calculus at all.
+
+## Usage
+
+```rust
+use coding_adventures_maple_runtime::MapleSession;
+
+let mut s = MapleSession::new();
+assert_eq!(s.feed("x := 5;\n").unwrap(), "5\n");
+assert_eq!(s.feed("x + 1;\n").unwrap(), "6\n");
+
+// The arrow operator is Maple's general-purpose function definition (MA09
+// §1/§3) -- NOT `f(x) := e` (that's real Maple's narrower remember-table
+// spelling, deliberately excluded, and doesn't even parse in this subset).
+s.feed("f := x -> x*x;\n").unwrap();
+assert_eq!(s.feed("f(5);\n").unwrap(), "25\n");
+
+// `:` suppresses the displayed line but the side effect still happens --
+// MA09 §3's own statement-separator row.
+assert_eq!(s.feed("y := 10:\n").unwrap(), "");
+assert_eq!(s.feed("y;\n").unwrap(), "10\n");
+```
+
+`coding_adventures_maple_runtime::eval(src)` is a one-shot convenience for
+callers that don't need a persistent session. Like `reduce-runtime`'s
+`Output` (and unlike Derive's/Wolfram's `#n:`/`In[n]:=` numbered worksheet),
+Maple's own session transcript has no numbered-input convention either
+(MA09 §2/§5), so every result line here is unprefixed plain text.
+
+## Why `Set` differs from `List` at the IR level
+
+Both `[a, b, c]` and `{a, b, c}` are, syntactically, just "bracket +
+comma-separated element list" — the same production shape every sibling
+CAS-family grammar in this repo already implements for its own single
+aggregate type. What makes them genuinely different is *evaluation*
+semantics, not syntax: `List` preserves order and duplicates (`List`'s
+handler is a pure passthrough once its elements are evaluated), while real
+Maple's `Set` is unordered with duplicates silently removed (`{x, y, y}`
+and `{y, x, y}` both produce `{x, y}`, per the Maple Help page's own worked
+example). Lowering both to the *same* head (`List`) would erase that
+distinction at the very first opportunity a future handler would need it —
+so `Set` gets its own canonical head from day one, even though no handler
+exists yet to enforce its semantics, so the *shape* is right for whenever
+that handler lands.
+
+## Why the arrow operator bridges to `Define`
+
+Maple's `f(x) := expr` — which is *exactly* Reduce's/Derive's own general
+function-definition spelling — means something narrower in real Maple: a
+remember-table patch onto an *already-existing* procedure (MA09 §1),
+confirmed against the Maple `remember` Help page ("you will not be able to
+substitute into it ... the way a real function normally would"). Real
+Maple's actual general-purpose definition mechanism is the arrow/functional
+operator, `f := (x, y) -> e` / `f := x -> e` (Help page
+`operators/functional`) — so *that* spelling, not `f(x) := e`, is this
+subset's bridge to the canonical `Define[name, List[params...], body]`
+head every CAS-family sibling here already reuses for its own (differently
+spelled) general-definition idiom. `maple-parser`'s own grammar enforces
+this at the syntax level too: `f(x) := expr` fails to *parse* at all in
+this subset (its `assignment` left-hand side is a bare `NAME` token, not a
+general call-shaped expression), so no Maple program here can accidentally
+mean the narrower remember-table thing.
+
+## Robustness
+
+`feed`/`eval_to_outputs` are the trust boundary for arbitrary Maple source.
+Two independent deep-recursion vectors are closed (see the crate doc
+comment for the full rationale):
+
+1. **Deeply nested source** (parenthesised, list/set-literal nesting,
+   `not`/unary-minus prefix chains, a flat `^` chain, or nested `if`/`end
+   if`/`fi`) — already rejected by `maple-parser`'s own `MAX_RULE_DEPTH`.
+2. **A long flat chain that folds into a deeply nested lowered tree** —
+   two shapes: `additive`/`multiplicative` (the same vector
+   `reduce-runtime`/`derive-runtime` already guard), and, genuinely new to
+   this grammar, a long `elif` chain (`lower_if` folds it into nested
+   `If`s). `MAX_STATEMENT_TOKENS` (measured against the real
+   `maple-lexer` token stream, reset **unconditionally** on every
+   `SEMI`/`COLON`) closes both. Unlike `reduce-runtime`'s own guard, no
+   bracket-nesting-depth tracking is needed here — verified directly
+   against `maple-parser`'s own compiled grammar that `SEMI`/`COLON` are
+   referenced in exactly one place (`statement_line`'s own terminator), so
+   every occurrence in a valid token stream is unambiguously a genuine
+   top-level statement boundary (this subset has no bare compound-statement
+   grouping construct the way REDUCE's `<< ... >>` is — MA09 §4 defers bare
+   expression sequences entirely).
+
+Evaluation itself runs on a worker thread with a large bounded stack inside
+`catch_unwind`, so a reused-handler panic (e.g. a wrong-arity `diff(x)`
+call) becomes a clean `Err` and the session is rebuilt rather than left
+corrupted. Maple's grammar-enforced bare-`NAME` `Assign`/`Define`
+left-hand side means, unlike Reduce's, there is no malformed-`Assign`-lhs
+panic vector at all in this crate.
+
+## Out-of-scope constructs are rejected at parse time (MA09 §4)
+
+`proc(...) ... end proc` (block-structured procedures) and `for`/`while`
+loops have no grammar production at all in `maple.grammar` — `proc`,
+`for`, `while`, `do` are ordinary `NAME` tokens, not reserved words, so
+`proc(x) x^2 end proc` parses only as far as the ordinary call `proc(x)`
+before failing to find a statement terminator, and `for i from 1 to 10 do
+...` parses only as far as the bare symbol `for`. Both surface as an
+ordinary parse `Err`, forwarded as-is — no special-casing needed in this
+crate at all, exactly like `reduce-runtime`'s identical "a parse error is
+returned, not panicked" contract.
+
+## Tests
+
+```sh
+cargo test -p coding-adventures-maple-runtime
+```
+
+104 tests: `lower`/`printer` unit tests covering every row of MA09 §3's
+surface table (arithmetic, comparison, logic, `if`/`elif`/`else`/`end
+if`/`fi`, lists, sets, the arrow-operator `Define` bridge, `diff`/`int`),
+plus end-to-end session tests (arithmetic, persistent bindings/functions,
+`if` with/without `else`, list/set elementwise evaluation and the
+disclosed `Set` gap, the `;`/`:` display-flag split, both robustness
+guards including the new elif-chain regression, panic recovery, and
+explicit confirmation that `proc`/`for`/`while` and the remember-table
+`f(x) := e` spelling are cleanly rejected at parse time), plus a doctest
+on `MapleSession::feed`.

--- a/code/packages/rust/maple-runtime/required_capabilities.json
+++ b/code/packages/rust/maple-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/maple-runtime",
+  "capabilities": [],
+  "justification": "Pure computation: parses Maple source, lowers it to symbolic-ir, evaluates with symbolic-vm, and formats the result string. No filesystem, network, or process access. (A bounded worker thread with a large stack is spawned per evaluation to contain deep-recursion stack overflows; this is in-process compute, not OS-level process spawning.)"
+}

--- a/code/packages/rust/maple-runtime/src/lib.rs
+++ b/code/packages/rust/maple-runtime/src/lib.rs
@@ -275,16 +275,20 @@ impl MapleSession {
                 MAX_INPUT_LEN
             ));
         }
-        // Guard 2: reject a long flat chain (arithmetic OR an elif chain)
-        // before it can fold into a stack-overflowing lowered tree (see the
-        // crate "Robustness" doc, point 2 — deeply *nested* source is
-        // already rejected by `maple-parser`'s own `MAX_RULE_DEPTH`, a
-        // *different* vector this guard does not need to re-cover).
-        check_statement_token_counts(src)?;
-
-        // Guard 3 + panics: the lowering, the VM evaluation, and the
-        // printer all run on a worker thread with a large bounded stack,
-        // and any unwinding panic from the reused symbolic stack is
+        // Guard 2 + panics: reject a long flat chain (arithmetic OR an elif
+        // chain) before it can fold into a stack-overflowing lowered tree
+        // (see the crate "Robustness" doc, point 2 — deeply *nested* source
+        // is already rejected by `maple-parser`'s own `MAX_RULE_DEPTH`, a
+        // *different* vector this guard does not need to re-cover). This
+        // check runs INSIDE the worker thread's `catch_unwind`, not on the
+        // caller thread — `/security-review` flagged an earlier draft that
+        // ran it before `std::thread::scope`, which would have let a
+        // hypothetical panic inside the tokenizer it calls unwind straight
+        // through `feed`/the REPL's `run` loop to `main`, contradicting this
+        // crate's own "one crafted statement can never abort the process"
+        // guarantee. Guard 3 + panics: the lowering, the VM evaluation, and
+        // the printer all run on the SAME worker thread with a large bounded
+        // stack, and any unwinding panic from the reused symbolic stack is
         // caught — mirroring `reduce-runtime`'s identical worker-thread
         // design (including its own `/security-review` fix: a thread-spawn
         // failure is folded into the ordinary `Err` path, never a
@@ -296,7 +300,10 @@ impl MapleSession {
             let handle = match std::thread::Builder::new()
                 .stack_size(EVAL_STACK_SIZE)
                 .spawn_scoped(scope, || {
-                    catch_unwind(AssertUnwindSafe(|| eval_source(vm, &src_owned)))
+                    catch_unwind(AssertUnwindSafe(|| {
+                        check_statement_token_counts(&src_owned)?;
+                        eval_source(vm, &src_owned)
+                    }))
                 }) {
                 Ok(handle) => handle,
                 Err(io_err) => {

--- a/code/packages/rust/maple-runtime/src/lib.rs
+++ b/code/packages/rust/maple-runtime/src/lib.rs
@@ -1,0 +1,713 @@
+//! # Maple runtime — lower Maple syntax to `symbolic-ir`, evaluate via `symbolic-vm`.
+//!
+//! This is the **MP-4** deliverable of the Maple-language lane (MA09 §2).
+//! MP-1 through MP-3 gave us a spec, a lexer, and a parser; this crate is the
+//! *runtime* that finally **evaluates** Maple source — by **reusing the
+//! shared symbolic substrate** rather than writing a bespoke interpreter,
+//! the same reuse story `derive-runtime`/`reduce-runtime` already
+//! demonstrated for the other two Wave-5 CAS-family languages:
+//!
+//! ```text
+//!   Maple source
+//!        │
+//!        ▼  coding_adventures_maple_parser::try_parse_maple  (MP-3)
+//!   GrammarASTNode  (surface tree: statement, if_expr, assignment, arrow_def,
+//!        │           logical_or, comparison, additive, postfix, …)
+//!        ▼  crate::lower                                        (this crate)
+//!   symbolic_ir::IRNode   (Add, Mul, Pow, Assign, Define, If, List, Set, …)
+//!        │
+//!        ▼  symbolic_vm::VM over SymbolicBackend, UNCHANGED
+//!   symbolic_ir::IRNode   (evaluated)
+//!        │
+//!        ▼  crate::printer
+//!   Maple surface string  (infix, [a,b,c], {a,b,c}, and/or/not, if...then...end if)
+//! ```
+//!
+//! ## No custom `Backend` needed — verified against the real handler table
+//!
+//! Per MA09 §2/§5, MP-4 reuses [`symbolic_vm::SymbolicBackend`] *unchanged*
+//! — no bespoke `Backend` the way `wolfram-runtime`/`macsyma-runtime` each
+//! layer their own list/string built-ins onto. This claim was checked
+//! directly against the source, not assumed from either crate's own spec
+//! prose (the exact discipline MA08 §5 itself insists on, after disclosing
+//! that its own *original* wording overclaimed a few heads as "already
+//! implemented"): grepping `symbolic_vm::handlers::build_handler_table`
+//! confirms handlers exist for `Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`,
+//! `Equal`/`NotEqual`/`Less`/`Greater`/`LessEqual`/`GreaterEqual`,
+//! `And`/`Or`/`Not`, `Assign`/`Define`/`If`, `List`, and — since
+//! `SymbolicBackend::new` always builds the table with `simplify: true`
+//! (`symbolic_vm::backends`) — `D`/`Integrate`. Grepping
+//! `symbolic_vm::backend::BaseBackend::new` confirms the held-heads set is
+//! exactly `{Assign, Define, If, Assume, Forget}` — every head this
+//! subset's `Assign`/`Define`/`If` lowering relies on being held (so
+//! `assign_handler`'s lhs, `define_handler`'s body, and `if_handler`'s
+//! not-taken branch never pre-evaluate) is confirmed present, unchanged.
+//!
+//! ## `Set` — the one genuinely new head, and the one disclosed gap
+//!
+//! Maple is the first language in this repo with **two** distinct bracketed
+//! aggregate literals — `[a, b, c]` (`List`, already fully handled) and
+//! `{a, b, c}` (`Set`, MA09 §3/§5). There is **no** handler for a `Set` head
+//! anywhere in the shared table (confirmed by the same grep above — no
+//! language before Maple has asked for one), so [`lower::SET`] is defined
+//! *locally to this crate* rather than added to `symbolic-ir`/`symbolic-vm`
+//! — mirroring `reduce-runtime`'s identical treatment of its own new
+//! `CompoundExpression`/`Cons`/list-accessor heads. `Set` is not a held
+//! head, so its elements evaluate (any `Assign` inside one still fires), but
+//! the call itself stays structurally correct-but-unevaluated: real Maple's
+//! unordered/duplicate-removing set semantics are **not yet enforced** —
+//! see [`lower`]'s own module doc comment for the full accounting. This is a
+//! disclosed gap, not a silent bug, ready for a future item to close by
+//! adding a real handler (to the shared table, or a narrowly-scoped Maple
+//! `Backend`) with no lowering change required.
+//!
+//! `diff`/`int` are thin calls into the already-shared `D`/`Integrate`
+//! handlers — the same ones Derive's `DIF`/`INT` and Wolfram's own
+//! `D`/`Integrate` already call — so this crate adds no calculus code of
+//! its own.
+//!
+//! ## Public contract
+//!
+//! [`MapleSession::feed`] is string-in / string-out. It evaluates a chunk of
+//! source (one or more `;`/`:`-terminated statements) and returns the
+//! surface rendering of each *displayed* result, one per line — MA09 §3's
+//! own statement-separator row is explicit that `;` displays and `:`
+//! suppresses ("a display flag on the surrounding session, not an IR node"),
+//! so [`lower::Display::Suppress`]-tagged statements still evaluate (side
+//! effects like `x := 5:` really do bind `x`) but contribute no output line.
+//! Like `reduce-runtime`'s own `ReduceSession` (and unlike Derive's/
+//! Wolfram's numbered worksheet convention), there is no `#n:`/`In[n]:=`
+//! prefix — real Maple's own interactive session has no equivalent either
+//! (MA09 §5). Bindings persist across calls, so an interactive `x := 5;`
+//! then `x + 1;` works.
+//!
+//! ## Robustness at the trust boundary
+//!
+//! `feed` takes arbitrary user text, so — exactly as in
+//! `reduce-runtime`/`derive-runtime`/`wolfram-runtime`/`maxima-runtime` — it
+//! is the trust boundary for the whole reused stack. Two layered guards
+//! close the two independent deep-recursion vectors (per the "depth caps
+//! don't compose across boundaries" lesson: a cap on one recursive walk
+//! does not protect a *different* recursive walk over the same or a derived
+//! tree):
+//!
+//! 1. **Deeply *nested* source** (parenthesised, list/set-literal nesting,
+//!    `not`/unary-minus prefix chains, a flat `^` chain, or nested
+//!    `if`/`end if`/`fi`) — already rejected by `maple-parser`'s own
+//!    `MAX_RULE_DEPTH`, before this crate's lowering/evaluation/printing
+//!    recursion (which walks the *same* already-shallow tree the parser
+//!    handed back) ever runs.
+//! 2. **A long *flat* chain that folds into a deeply *nested* lowered
+//!    tree.** `maple-parser`'s own `MAX_RULE_DEPTH` doc comment proves,
+//!    with an independent measurement per shape, that its EBNF
+//!    `{ x }`-repetition productions cost the parser *zero* native stack
+//!    regardless of width — so `MAX_RULE_DEPTH` does not (and structurally
+//!    cannot) bound a flat chain's length. Two shapes in this grammar fold a
+//!    flat repetition into a nested `Apply` tree at *lowering* time, not
+//!    parse time: [`lower::lower_binary_chain`] (`additive`/
+//!    `multiplicative` — the same vector `reduce-runtime`/`derive-runtime`
+//!    already guard) and, genuinely new to this grammar (no `reduce.grammar`
+//!    analogue — REDUCE has no `elif`), [`lower::lower_if`]'s own
+//!    right-to-left `elif`-chain fold. [`MAX_STATEMENT_TOKENS`], measured
+//!    against the **real** lexer token stream (so there is no separately-
+//!    maintained lexical model to diverge from and bypass), closes this
+//!    vector.
+//!
+//!    Unlike `reduce-runtime`'s identical-in-spirit guard — which must track
+//!    bracket *nesting depth* and only reset on a `;`/`$` at depth 0,
+//!    because REDUCE's `<< s1; s2; ... >>` group statement can embed a `;`
+//!    lexically *inside* a parenthesised construct that is itself just one
+//!    operand of a much larger enclosing chain — this crate's reset is
+//!    unconditional on every `SEMI`/`COLON` token. This is a genuine
+//!    grammar-shape difference, verified directly against
+//!    `maple-parser`'s own compiled grammar (`grep -n 'SEMI\|COLON'
+//!    coding-adventures-maple-parser/src/_grammar.rs`), not assumed by
+//!    resemblance to Reduce: `SEMI`/`COLON` are referenced in exactly ONE
+//!    place in the entire grammar — `statement_line`'s own terminator
+//!    alternation — so every `SEMI`/`COLON` token in a valid parse is
+//!    unambiguously a genuine top-level statement boundary; there is no
+//!    Maple construct (this subset has no bare compound-statement grouping
+//!    the way REDUCE's `<< ... >>` is — MA09 §4 defers bare expression
+//!    sequences entirely) that could ever embed one lexically inside a
+//!    nested operand.
+//! 3. **Unwinding panics** (e.g. a wrong-arity `diff(x)`/`int(f)` call
+//!    reaching `derivative_handler`/`integrate_handler`'s own arity panic —
+//!    Maple's grammar-enforced bare-`NAME` `Assign`/`Define` left-hand side
+//!    means, unlike Reduce's, there is no malformed-`Assign`-lhs panic
+//!    vector at all here). Evaluation runs inside [`catch_unwind`] on a
+//!    worker thread with a large bounded stack, and any panic becomes a
+//!    clean `Err(String)`; the session is rebuilt afterward (trading lost
+//!    bindings for a guaranteed-usable session next call), so one crafted
+//!    statement can never abort the process or wedge a session.
+//!
+//! ## Out-of-scope constructs (MA09 §4) are rejected at PARSE time, not here
+//!
+//! `proc(...) ... end proc` (block-structured procedures) and `for`/`while`
+//! loops are not represented anywhere in `maple.grammar` at all — `proc`,
+//! `for`, `while`, `do` are ordinary `NAME` tokens (not reserved words in
+//! `maple.tokens`), so `proc(x) x^2 end proc` parses only as far as the
+//! ordinary call `proc(x)` (ordinary function application, ambiguous with a
+//! ordinary function named `proc`), after which the leftover `x^2 end proc`
+//! has nowhere left to attach and `statement_line`'s own terminator check
+//! fails cleanly; similarly `for i from 1 to 10 do ... end do` parses only
+//! as far as the bare symbol `for`, after which `i` has nowhere to attach.
+//! Both therefore surface as an ordinary `try_parse_maple` `Err`, which this
+//! crate's own `eval_source` forwards as-is — no special-casing needed in
+//! this crate at all, exactly like `reduce-runtime`'s identical "a parse
+//! error is returned, not panicked" contract for its own out-of-scope
+//! constructs. See this crate's own test suite for confirmation that this
+//! is a genuine parse-time rejection, not silent mis-evaluation.
+
+mod lower;
+mod printer;
+
+pub use lower::{Display, LowerError, LoweredStatement, SET};
+pub use printer::print_maple;
+
+use coding_adventures_maple_lexer::try_tokenize_maple;
+use coding_adventures_maple_parser::try_parse_maple;
+use lower::lower_program;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use symbolic_vm::{SymbolicBackend, VM};
+
+/// Maximum length, in bytes, of a single source chunk handed to
+/// [`MapleSession::feed`].
+///
+/// A cheap first gate bounding per-call memory/time. 64 KiB is far beyond
+/// any realistic interactive submission.
+pub const MAX_INPUT_LEN: usize = 64 * 1024;
+
+/// Maximum number of lexer tokens allowed in any single statement (a run of
+/// tokens between two `SEMI`/`COLON` separators, or between a separator and
+/// the start/end of input).
+///
+/// See the crate doc comment's "Robustness" point 2 — this closes the
+/// long-flat-chain vector `maple-parser`'s own `MAX_RULE_DEPTH` does not
+/// (and cannot) cover. 2000 tokens in one statement is already absurd for a
+/// hand-written Maple program line, matching `reduce-runtime`'s/
+/// `derive-runtime`'s identical choice.
+pub const MAX_STATEMENT_TOKENS: usize = 2000;
+
+/// Stack size of the worker thread that runs evaluation and printing.
+///
+/// With the per-statement complexity cap bounding tree depth, this is
+/// generous headroom so the bounded-but-still-deep trees are built,
+/// evaluated, printed, and dropped well clear of any overflow, regardless of
+/// the caller's own stack.
+const EVAL_STACK_SIZE: usize = 512 * 1024 * 1024;
+
+/// A persistent Maple session.
+///
+/// Owns the [`VM`] (and through it the [`SymbolicBackend`] environment), so
+/// variable bindings (`x := 5`) and user-defined functions (`f := x -> x*x`)
+/// persist across calls to [`feed`](MapleSession::feed), exactly as in an
+/// interactive Maple session.
+pub struct MapleSession {
+    vm: VM,
+}
+
+impl Default for MapleSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One displayed result line from a [`MapleSession::feed`] call.
+///
+/// Only produced for `;`-terminated ([`Display::Show`]) statements — MA09
+/// §3's own statement-separator row (`:` suppresses). Maple's own session
+/// transcript has no numbered-input convention either (MA09 §2/§5), so —
+/// like `reduce-runtime::Output` and unlike `derive-runtime::Output`'s `#n`
+/// index — this carries only the rendered text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Output {
+    /// The result rendered in Maple surface notation.
+    pub text: String,
+}
+
+impl MapleSession {
+    /// Create a fresh session with an empty environment.
+    pub fn new() -> Self {
+        MapleSession {
+            vm: VM::new(Box::new(SymbolicBackend::new())),
+        }
+    }
+
+    /// Evaluate a chunk of Maple source and return the concatenated echo.
+    ///
+    /// Every *displayed* statement (`;`-terminated, or the optional final
+    /// terminator-less statement) produces one plain output line (no
+    /// numbering — see the module/[`Output`] doc comments); `:`-suppressed
+    /// statements still evaluate (so their side effects persist) but
+    /// contribute no line. Lines are concatenated in evaluation order, each
+    /// ending in a newline. A parse or lowering error is returned as `Err`
+    /// with the message.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use coding_adventures_maple_runtime::MapleSession;
+    /// let mut s = MapleSession::new();
+    /// assert_eq!(s.feed("1 + 2*3;\n").unwrap(), "7\n");
+    /// ```
+    pub fn feed(&mut self, src: &str) -> Result<String, String> {
+        let outputs = self.eval_to_outputs(src)?;
+        let mut out = String::new();
+        for o in outputs {
+            out.push_str(&o.text);
+            out.push('\n');
+        }
+        Ok(out)
+    }
+
+    /// Evaluate `src` and return the structured list of *displayed*
+    /// [`Output`]s (`:`-suppressed statements still evaluate for their side
+    /// effects, but contribute no `Output`).
+    ///
+    /// The lower-level cousin of [`feed`](MapleSession::feed) — a REPL that
+    /// wants to format its own prompt uses this and renders each `Output`.
+    pub fn eval_to_outputs(&mut self, src: &str) -> Result<Vec<Output>, String> {
+        // Guard 1: bound total input size (cheap memory/time gate).
+        if src.len() > MAX_INPUT_LEN {
+            return Err(format!(
+                "input too large: {} bytes exceeds the {}-byte limit",
+                src.len(),
+                MAX_INPUT_LEN
+            ));
+        }
+        // Guard 2: reject a long flat chain (arithmetic OR an elif chain)
+        // before it can fold into a stack-overflowing lowered tree (see the
+        // crate "Robustness" doc, point 2 — deeply *nested* source is
+        // already rejected by `maple-parser`'s own `MAX_RULE_DEPTH`, a
+        // *different* vector this guard does not need to re-cover).
+        check_statement_token_counts(src)?;
+
+        // Guard 3 + panics: the lowering, the VM evaluation, and the
+        // printer all run on a worker thread with a large bounded stack,
+        // and any unwinding panic from the reused symbolic stack is
+        // caught — mirroring `reduce-runtime`'s identical worker-thread
+        // design (including its own `/security-review` fix: a thread-spawn
+        // failure is folded into the ordinary `Err` path, never a
+        // caller-thread panic).
+        let vm = &mut self.vm;
+        let src_owned = src.to_string();
+        let mut panicked = false;
+        let result: Result<Vec<Output>, String> = std::thread::scope(|scope| {
+            let handle = match std::thread::Builder::new()
+                .stack_size(EVAL_STACK_SIZE)
+                .spawn_scoped(scope, || {
+                    catch_unwind(AssertUnwindSafe(|| eval_source(vm, &src_owned)))
+                }) {
+                Ok(handle) => handle,
+                Err(io_err) => {
+                    return Err(format!(
+                        "failed to spawn the Maple evaluation thread: {io_err}"
+                    ));
+                }
+            };
+            match handle.join() {
+                Ok(Ok(Ok(outputs))) => Ok(outputs),
+                Ok(Ok(Err(message))) => Err(message),
+                Ok(Err(payload)) | Err(payload) => {
+                    panicked = true;
+                    Err(panic_message(payload))
+                }
+            }
+        });
+
+        if panicked {
+            self.vm = VM::new(Box::new(SymbolicBackend::new()));
+        }
+        result
+    }
+}
+
+/// Evaluate every statement in `src`, returning the *displayed* outputs.
+/// Runs on the worker thread.
+fn eval_source(vm: &mut VM, src: &str) -> Result<Vec<Output>, String> {
+    // The parser's error string already carries a user-readable message
+    // (this is also where MA09 §4's out-of-scope constructs — `proc`,
+    // `for`/`while` — fail: see the crate doc comment's own section on
+    // this), so we forward it as-is.
+    let ast = try_parse_maple(src)?;
+    let statements = lower_program(&ast).map_err(|e| e.to_string())?;
+
+    let mut outputs = Vec::new();
+    for stmt in statements {
+        let result = vm.eval(stmt.node);
+        if matches!(stmt.display, lower::Display::Show) {
+            outputs.push(Output {
+                text: print_maple(&result),
+            });
+        }
+    }
+    Ok(outputs)
+}
+
+/// Reject input where any single statement lexes to too many tokens.
+///
+/// The count is taken from the **real** Maple lexer, the very one the
+/// parser consumes, so there is no separately-maintained lexical model to
+/// diverge from: a `SEMI`/`COLON` token (`;`/`:`) marks a statement boundary
+/// and resets the running count.
+///
+/// Unlike `reduce-runtime::check_statement_token_counts`, this reset is
+/// **unconditional** — no bracket-nesting depth needs to be tracked. See the
+/// crate doc comment's "Robustness" point 2 for the full, grep-verified
+/// argument: `SEMI`/`COLON` appear in exactly one place in the entire
+/// `maple.grammar` (`statement_line`'s own terminator), so every occurrence
+/// in a valid token stream is unambiguously a genuine top-level statement
+/// boundary — there is no Maple construct that could embed one lexically
+/// inside a nested operand the way REDUCE's `<< ... >>` group statement
+/// could.
+///
+/// If the lexer itself errors (an untokenizable character), we return
+/// `Ok(())` and let the parser surface the error uniformly — we never
+/// reject solely because the *checker* could not lex something.
+fn check_statement_token_counts(src: &str) -> Result<(), String> {
+    let tokens = match try_tokenize_maple(src) {
+        Ok(tokens) => tokens,
+        Err(_) => return Ok(()), // unlexable — let the parser surface it
+    };
+
+    let mut count: usize = 0;
+    for token in &tokens {
+        match token.effective_type_name() {
+            "SEMI" | "COLON" => {
+                count = 0;
+                continue;
+            }
+            _ => {}
+        }
+        count += 1;
+        if count > MAX_STATEMENT_TOKENS {
+            return Err(format!(
+                "statement too complex: more than {MAX_STATEMENT_TOKENS} tokens in one statement"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Evaluate `src` once on a fresh [`MapleSession`] and return its echo.
+///
+/// Convenience for callers that do not need persistent state.
+pub fn eval(src: &str) -> Result<String, String> {
+    MapleSession::new().feed(src)
+}
+
+/// Recover a human-readable message from a caught panic payload.
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        "Maple could not evaluate that input".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arithmetic_folds_to_an_integer() {
+        assert_eq!(eval("1 + 2*3;\n").unwrap(), "7\n");
+    }
+
+    #[test]
+    fn power_and_division() {
+        assert_eq!(eval("2^10;\n").unwrap(), "1024\n");
+        assert_eq!(eval("10 / 2;\n").unwrap(), "5\n");
+    }
+
+    #[test]
+    fn free_symbols_stay_symbolic() {
+        assert_eq!(eval("x + 0;\n").unwrap(), "x\n");
+    }
+
+    #[test]
+    fn assignment_persists_across_calls() {
+        let mut s = MapleSession::new();
+        assert_eq!(s.feed("x := 5;\n").unwrap(), "5\n");
+        assert_eq!(s.feed("x + 1;\n").unwrap(), "6\n");
+    }
+
+    #[test]
+    fn user_defined_arrow_function_end_to_end() {
+        let mut s = MapleSession::new();
+        s.feed("f := x -> x*x;\n").unwrap();
+        assert_eq!(s.feed("f(5);\n").unwrap(), "25\n");
+    }
+
+    #[test]
+    fn multi_parameter_arrow_function_end_to_end() {
+        let mut s = MapleSession::new();
+        s.feed("g := (x, y) -> x + y;\n").unwrap();
+        assert_eq!(s.feed("g(2, 3);\n").unwrap(), "5\n");
+    }
+
+    // --- Display suppression: `;` shows, `:` suppresses (MA09 §3) ----------
+
+    #[test]
+    fn colon_suppresses_output_but_side_effect_still_happens() {
+        let mut s = MapleSession::new();
+        assert_eq!(s.feed("x := 5:\n").unwrap(), "");
+        assert_eq!(s.feed("x + 1;\n").unwrap(), "6\n");
+    }
+
+    #[test]
+    fn semicolon_displays_output() {
+        assert_eq!(eval("x := 5;\n").unwrap(), "5\n");
+    }
+
+    #[test]
+    fn mixed_terminators_in_one_feed_only_display_the_semicolon_lines() {
+        let out = eval("1: 2; 3:\n").unwrap();
+        assert_eq!(out, "2\n");
+    }
+
+    // --- `if`/`elif`/`else`/`end if` (MA09 §3) -------------------------------
+
+    #[test]
+    fn if_selects_a_branch_via_the_held_handler() {
+        assert_eq!(eval("if 1 > 0 then 42 else 0 end if;\n").unwrap(), "42\n");
+        assert_eq!(eval("if 0 > 1 then 42 else 7 end if;\n").unwrap(), "7\n");
+    }
+
+    #[test]
+    fn if_with_no_else_returns_false_on_a_failing_condition() {
+        assert_eq!(eval("if 0 > 1 then 42 end if;\n").unwrap(), "false\n");
+    }
+
+    #[test]
+    fn fi_closing_spelling_evaluates_identically_to_end_if() {
+        assert_eq!(
+            eval("if 1 > 0 then 42 else 0 fi;\n").unwrap(),
+            eval("if 1 > 0 then 42 else 0 end if;\n").unwrap()
+        );
+    }
+
+    #[test]
+    fn elif_chain_evaluates_the_first_true_branch() {
+        assert_eq!(
+            eval("if false then 1 elif true then 2 else 3 end if;\n").unwrap(),
+            "2\n"
+        );
+    }
+
+    #[test]
+    fn if_unresolved_on_a_free_variable_prints_back_as_if_syntax() {
+        assert_eq!(
+            eval("if x > 0 then 1 else -1 end if;\n").unwrap(),
+            "if x > 0 then 1 else -1 end if\n"
+        );
+    }
+
+    // --- Lists / sets (MA09 §3/§5) --------------------------------------------
+
+    #[test]
+    fn list_literal_evaluates_elementwise() {
+        assert_eq!(eval("[1 + 1, 2*3, 2^3];\n").unwrap(), "[2, 6, 8]\n");
+    }
+
+    #[test]
+    fn list_assignment_persists_across_calls() {
+        let mut s = MapleSession::new();
+        assert_eq!(s.feed("v := [1, 2, 3];\n").unwrap(), "[1, 2, 3]\n");
+        assert_eq!(s.feed("v;\n").unwrap(), "[1, 2, 3]\n");
+    }
+
+    #[test]
+    fn set_literal_evaluates_its_elements_but_stays_structurally_unresolved() {
+        // Disclosed gap (crate/`lower` doc comments): no shared `Set`
+        // handler exists yet, so this must not crash or hang, and
+        // duplicates are NOT removed (real Maple's dedup semantics aren't
+        // enforced at evaluation time in this subset).
+        assert_eq!(eval("{1 + 1, 2*3};\n").unwrap(), "{2, 6}\n");
+        assert_eq!(eval("{1, 1, 2};\n").unwrap(), "{1, 1, 2}\n");
+    }
+
+    #[test]
+    fn set_assignment_persists_across_calls() {
+        let mut s = MapleSession::new();
+        assert_eq!(s.feed("v := {1, 2, 3};\n").unwrap(), "{1, 2, 3}\n");
+        assert_eq!(s.feed("v;\n").unwrap(), "{1, 2, 3}\n");
+    }
+
+    // --- Booleans / logic (MA09 §3) -------------------------------------------
+
+    #[test]
+    fn boolean_literals_evaluate() {
+        assert_eq!(eval("true;\n").unwrap(), "true\n");
+        assert_eq!(eval("false;\n").unwrap(), "false\n");
+    }
+
+    #[test]
+    fn boolean_logic_evaluates() {
+        assert_eq!(eval("1 > 0 and 2 > 1;\n").unwrap(), "true\n");
+        assert_eq!(eval("not (1 > 2);\n").unwrap(), "true\n");
+    }
+
+    #[test]
+    fn not_equal_operator_evaluates() {
+        assert_eq!(eval("1 <> 2;\n").unwrap(), "true\n");
+        assert_eq!(eval("1 <> 1;\n").unwrap(), "false\n");
+    }
+
+    // --- diff/int bridge to the shared D/Integrate handlers (MA09 §2/§5) ----
+
+    #[test]
+    fn diff_evaluates_via_the_shared_derivative_handler() {
+        assert_eq!(eval("diff(x^2, x);\n").unwrap(), "2*x\n");
+    }
+
+    #[test]
+    fn int_evaluates_via_the_shared_integrate_handler() {
+        assert_eq!(eval("int(x, x);\n").unwrap(), "1/2*x^2\n");
+    }
+
+    // --- Explicit `*` requirement (MA09 §3/§4) --------------------------------
+
+    #[test]
+    fn juxtaposition_without_an_operator_is_a_parse_error() {
+        assert!(eval("a b;\n").is_err());
+    }
+
+    // --- Out-of-scope constructs are rejected at parse time (MA09 §4) -------
+
+    #[test]
+    fn proc_block_structured_procedures_are_rejected() {
+        // `proc` is an ordinary NAME (no grammar production at all for
+        // block-structured procedures) -- `proc(x) x^2 end proc` parses
+        // only as far as the call `proc(x)`, then fails to find a
+        // SEMI/COLON terminator before `x^2`.
+        assert!(eval("proc(x) x^2 end proc;\n").is_err());
+        assert!(eval("proc() 1 end proc;\n").is_err());
+    }
+
+    #[test]
+    fn for_loops_are_rejected() {
+        assert!(eval("for i from 1 to 10 do i end do;\n").is_err());
+    }
+
+    #[test]
+    fn while_loops_are_rejected() {
+        assert!(eval("while x > 0 do x := x - 1 end do;\n").is_err());
+    }
+
+    #[test]
+    fn remember_table_spelling_is_rejected() {
+        // MA09 §1/§4: `f(x) := expr` is real Maple's narrower remember-table
+        // mechanism, deliberately excluded from this subset -- confirmed
+        // all the way through this crate's own `eval`, not just at the
+        // parser layer.
+        assert!(eval("f(x) := 1;\n").is_err());
+    }
+
+    // --- Robustness ------------------------------------------------------------
+
+    #[test]
+    fn a_parse_error_is_returned_not_panicked() {
+        let err = eval("1 +\n");
+        assert!(err.is_err(), "expected a clean Err, got {err:?}");
+    }
+
+    #[test]
+    fn session_recovers_after_a_parse_error() {
+        let mut s = MapleSession::new();
+        let _ = s.feed("1 +\n");
+        assert_eq!(s.feed("3 + 4;\n").unwrap(), "7\n");
+    }
+
+    #[test]
+    fn oversized_input_is_rejected_before_evaluation() {
+        let huge = format!("{}1;\n", "1+".repeat(MAX_INPUT_LEN));
+        assert!(huge.len() > MAX_INPUT_LEN);
+        let err = eval(&huge).unwrap_err();
+        assert!(err.contains("too large"), "got {err:?}");
+    }
+
+    #[test]
+    fn deeply_nested_parens_are_rejected_by_the_parsers_own_cap() {
+        // maple-parser's own MAX_RULE_DEPTH rejects this before the runtime
+        // ever sees a tree -- this test proves the session surfaces that as
+        // a clean Err (not a crash), not that this crate re-implements the
+        // cap.
+        let depth = 5000;
+        let src = format!("{}1{};\n", "(".repeat(depth), ")".repeat(depth));
+        assert!(src.len() <= MAX_INPUT_LEN, "stays under the length cap");
+        assert!(eval(&src).is_err());
+    }
+
+    #[test]
+    fn long_flat_additive_chain_is_rejected_by_the_statement_token_cap() {
+        // additive/multiplicative are grammar REPETITIONS, not recursive
+        // rule calls, so maple-parser's MAX_RULE_DEPTH does not bound
+        // chain length -- this is the vector MAX_STATEMENT_TOKENS closes.
+        let src = format!("{}1;\n", "1+".repeat(5_000));
+        assert!(src.len() <= MAX_INPUT_LEN);
+        assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn long_elif_chain_is_rejected_by_the_statement_token_cap() {
+        // Genuinely new relative to reduce-runtime/derive-runtime: an
+        // `elif` chain is ALSO a grammar repetition (not recursion), and
+        // `lower_if` folds it into a deeply nested `If(...)` tree, exactly
+        // the same shape of vector as the additive-chain case above.
+        let mut src = String::from("if false then 0\n");
+        for _ in 0..600 {
+            src.push_str("elif false then 0\n");
+        }
+        src.push_str("else 1 end if;\n");
+        assert!(
+            src.len() <= MAX_INPUT_LEN,
+            "the PoC must fit under the input-size cap on its own, so only \
+             the statement-token-count guard is what's actually being tested"
+        );
+        assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn moderate_chain_still_evaluates() {
+        let src = format!("{}1;\n", "1+".repeat(50));
+        assert_eq!(eval(&src).unwrap(), "51\n");
+    }
+
+    #[test]
+    fn a_wrong_arity_diff_call_is_caught_not_aborted() {
+        // `diff(x)` lowers to `D(x)` (1 arg) -- the reused
+        // `derivative_handler` *panics* on the wrong arity ("D expects 2
+        // arguments, got 1"). The worker-thread `catch_unwind` must convert
+        // that panic into a clean `Err`, and the session must remain usable
+        // afterward (the env is rebuilt).
+        let mut s = MapleSession::new();
+        assert!(
+            s.feed("diff(x);\n").is_err(),
+            "a wrong-arity diff call must return Err, never abort"
+        );
+        assert_eq!(s.feed("2 + 2;\n").unwrap(), "4\n");
+    }
+
+    #[test]
+    fn the_one_shot_eval_helper_matches_a_session() {
+        let one = eval("2 + 3;\n").unwrap();
+        let two = MapleSession::new().feed("2 + 3;\n").unwrap();
+        assert_eq!(one, two);
+    }
+
+    #[test]
+    fn empty_and_whitespace_input_yields_nothing() {
+        assert_eq!(eval("\n").unwrap(), "");
+    }
+
+    #[test]
+    fn a_small_maple_program_evaluates_end_to_end() {
+        let mut s = MapleSession::new();
+        s.feed("h := x -> x - 2*x;\n").unwrap();
+        let out = s.feed("h(5);\n").unwrap();
+        assert_eq!(out, "-5\n");
+    }
+}

--- a/code/packages/rust/maple-runtime/src/lower.rs
+++ b/code/packages/rust/maple-runtime/src/lower.rs
@@ -1,0 +1,1260 @@
+//! # Lowering — Maple syntax tree → `symbolic-ir`
+//!
+//! The MP-3 [`maple-parser`](coding_adventures_maple_parser) hands us a
+//! *generic* [`GrammarASTNode`] tree whose `rule_name`s mirror
+//! `maple.grammar` (`statement`, `if_expr`, `assignment`, `arrow_def`,
+//! `logical_or`, `comparison`, `additive`, `postfix`, `atom`, …). The parser
+//! deliberately does **no** semantic work — it just records which rule
+//! matched. This module is where Maple's *meaning* is assigned: every
+//! surface construct is **desugared** into the canonical
+//! [`symbolic_ir::IRNode`] head [`symbolic-vm`](symbolic_vm) already knows
+//! how to evaluate, per MA09 §3's table.
+//!
+//! ## Much of this mirrors `reduce-runtime::lower`'s shape — with one
+//! structural difference `reduce-parser` doesn't have
+//!
+//! Maple, like Reduce, is a "surface operators + `head(args)` calls"
+//! language with no pattern/rewrite-rule vocabulary in this subset (MA09 §4
+//! defers `patmatch`/`match` — they're ordinary library calls, not surface
+//! grammar). But `maple.grammar` draws a hard line REDUCE's own grammar does
+//! not: `statement = if_expr | assignment` sits in its own nonterminal,
+//! never reachable from `expr` (see `maple.grammar`'s own "statements vs.
+//! expressions" design-decision comment) — so, unlike
+//! `reduce-runtime::lower_node`'s single dispatch table covering both
+//! statement-shaped and expression-shaped rules uniformly, this module's
+//! dispatch mirrors that same split: [`lower_node`] handles the ordinary
+//! expression cascade (`logical_or` down to `atom`), while [`lower_if`] and
+//! [`lower_assignment`] are the two `statement`-only forms, reached only via
+//! `lower_node`'s own `"if_expr"`/`"assignment"` match arms (never nested
+//! inside an arithmetic/comparison/logical operand the way Reduce's
+//! `if_expr`/`assignment` can be).
+//!
+//! ## `Set` — a canonical head new to this repo (MA09 §5)
+//!
+//! Maple is the first language in this repo with **two** distinct bracketed
+//! aggregate literals: `[a, b, c]` (ordered, `List`) and `{a, b, c}`
+//! (unordered, `Set` — MA09 §3/§5). `symbolic-vm`'s shared handler table has
+//! no handler for a `Set` head (confirmed by grepping
+//! `symbolic_vm::handlers::build_handler_table` — see this crate's own
+//! README/CHANGELOG for the full accounting), so [`SET`] is defined *locally
+//! to this crate*, exactly the way `reduce-runtime::lower` defines its own
+//! new `COMPOUND_EXPRESSION`/`CONS`/`FIRST`/… constants rather than adding
+//! them to the shared `symbolic-ir` crate. `Set` is **not** a held head
+//! (unlike `Assign`/`Define`/`If`/`Assume`/`Forget` — see
+//! `symbolic_vm::backend::BaseBackend::new`), so its arguments *do* evaluate
+//! before the VM discovers there is no handler; `on_unknown_head`'s default
+//! fallback then leaves the call itself unevaluated — the *exact* same
+//! disclosed gap MA09 §5 documents by name ("this subset's `{a, b, c}` set
+//! literal lowers to the structurally-correct `Set[a, b, c]` ... but
+//! evaluates as an unresolved call today"). Real Maple's set semantics
+//! (unordered, duplicates silently removed) are therefore not yet enforced
+//! at evaluation time — only the *shape* is correct, ready for a future item
+//! that adds a real handler (to the shared table, or to a narrowly-scoped
+//! Maple `Backend`) without any lowering change at all.
+//!
+//! ## `diff`/`int` — thin bridges to already-shared calculus handlers
+//!
+//! `diff(f, x)` and `int(f, x)` bridge to the canonical `D`/`Integrate`
+//! heads — the *same* handlers Derive's `DIF`/`INT` and Wolfram's
+//! `D`/`Integrate` already call under their own names (confirmed by
+//! grepping `symbolic_vm::handlers::build_handler_table`: both are wired
+//! whenever `SymbolicBackend::new()` builds the table, which it always does
+//! with `simplify: true`). This crate reimplements no calculus — it is a
+//! surface-name bridge only, the same shape `derive-runtime::lower`'s own
+//! `"DIF" => D, "INT" => INTEGRATE` bridge uses. Multi-argument forms
+//! (`diff(f, x, y)`, `int(f, x, a, b)`) are out of this subset's scope
+//! (MA09 §4) — this lowering does not special-case argument counts at all,
+//! so a wrong-arity call simply reaches `derivative_handler`/
+//! `integrate_handler`'s own panic ("D expects 2 arguments, got N"), caught
+//! by [`crate`]'s own worker-thread `catch_unwind` boundary exactly like any
+//! other reused-handler panic.
+//!
+//! ## Booleans — the first literal `true`/`false` tokens in this CAS family
+//!
+//! Neither `reduce.grammar` nor `derive.grammar` has a dedicated boolean
+//! *literal* token (their booleans arise purely from comparison/logic
+//! results) — `maple.grammar`'s `atom` rule is the first to include `"true"`
+//! and `"false"` as their own alternatives (MA09 §3, citing the
+//! `type/truefalseFAIL` Help page). The established precedent for bridging a
+//! literal boolean keyword to the shared backend's pre-bound `True`/`False`
+//! symbols (`symbolic_vm::backend::BaseBackend::new` pre-binds exactly those
+//! two names) is `macsyma-compiler`'s own `lower_token`: `"KEYWORD" if
+//! token.value == "true" => Ok(sym("True"))` (and the `"false"` mirror) —
+//! [`lower_token`] below reuses that exact bridge.
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use symbolic_ir::{
+    apply, flt, int, sym, IRNode, ADD, AND, ASSIGN, DEFINE, DIV, D, EQUAL, GREATER, GREATER_EQUAL,
+    IF, INTEGRATE, LESS, LESS_EQUAL, LIST, MUL, NEG, NOT, NOT_EQUAL, OR, POW, SUB,
+};
+
+/// The canonical head for a Maple set literal `{a, b, c}` (MA09 §3/§5).
+///
+/// Not exported by `symbolic-ir` — see this module's own doc comment's
+/// "`Set`" section for the full accounting of why (no shared handler exists
+/// yet, mirroring `reduce-runtime::lower`'s identical treatment of its own
+/// new `COMPOUND_EXPRESSION`/`CONS`/list-accessor heads).
+pub const SET: &str = "Set";
+
+/// A failure while lowering the surface tree to IR. These are *structural*
+/// errors — a node shape the lowering did not expect — not user syntax
+/// errors (those are caught earlier by the parser).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LowerError {
+    message: String,
+}
+
+impl LowerError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// The human-readable message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl std::fmt::Display for LowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for LowerError {}
+
+/// One lowered top-level statement, tagged with whether its result should be
+/// displayed.
+///
+/// MA09 §3's own statement-separator row is explicit that the `;`-vs-`:`
+/// distinction is "a display flag on the surrounding session, not an IR
+/// node" — so, unlike every other surface construct in this module, the
+/// terminator choice is carried *alongside* the lowered [`IRNode`] rather
+/// than folded into it. [`crate::MapleSession`] evaluates every statement
+/// regardless (so `:`-suppressed side effects like `x := 5:` still bind
+/// `x`), but only renders a displayed line for `Display` statements.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoweredStatement {
+    pub node: IRNode,
+    pub display: Display,
+}
+
+/// Whether a lowered statement's evaluated result should be printed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Display {
+    /// `;`-terminated (or the optional final terminator-less statement,
+    /// kept displayed for interactive convenience — mirroring
+    /// `reduce-parser`'s/`macsyma-parser`'s identical trailing-statement
+    /// allowance).
+    Show,
+    /// `:`-terminated (MA09 §3 — Programming Guide §5.3).
+    Suppress,
+}
+
+/// Lower a parsed `program` node into one [`LoweredStatement`] per source
+/// statement.
+///
+/// `maple.grammar`'s root is `program = { statement_line } [ statement ]`:
+/// zero or more `;`/`:`-terminated `statement_line`s, plus an optional final
+/// bare `statement` with no terminator (so a source file need not end with
+/// one) — the identical shape `reduce.grammar`'s own `program` production
+/// documents, for the identical reason (see that grammar's own comment,
+/// reused verbatim by `maple.grammar`).
+pub fn lower_program(root: &GrammarASTNode) -> Result<Vec<LoweredStatement>, LowerError> {
+    if root.rule_name != "program" {
+        return Err(LowerError::new(format!(
+            "expected `program` root, got `{}`",
+            root.rule_name
+        )));
+    }
+    let mut statements = Vec::new();
+    for child in child_nodes(root) {
+        match child.rule_name.as_str() {
+            "statement_line" => {
+                let statement = child_nodes(child)
+                    .find(|n| n.rule_name == "statement")
+                    .ok_or_else(|| LowerError::new("statement_line has no statement"))?;
+                let display = match statement_terminator(child) {
+                    Some("COLON") => Display::Suppress,
+                    _ => Display::Show,
+                };
+                statements.push(LoweredStatement {
+                    node: lower_node(statement)?,
+                    display,
+                });
+            }
+            "statement" => statements.push(LoweredStatement {
+                node: lower_node(child)?,
+                display: Display::Show,
+            }),
+            _ => {}
+        }
+    }
+    Ok(statements)
+}
+
+/// Find the `SEMI`/`COLON` terminator token type of a `statement_line` node.
+fn statement_terminator(node: &GrammarASTNode) -> Option<&str> {
+    node.children.iter().find_map(as_token).map(token_type)
+}
+
+/// Lower a single arbitrary node.
+///
+/// Most grammar rules are "transparent wrappers" — `expr` is just
+/// `logical_or`, and every precedence tier that did not apply its own
+/// operator still emits its own node with a single child.
+/// [`unwrap_single`] peels those away so we dispatch on the first rule
+/// that genuinely shapes the tree.
+fn lower_node(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    match unwrap_single(node) {
+        Unwrapped::Token(token) => lower_token(token),
+        Unwrapped::Node(node) => match node.rule_name.as_str() {
+            "program" => Err(LowerError::new("nested program node is not an expression")),
+            "statement_line" | "statement" | "expr" => lower_first_node(node),
+            "if_expr" => lower_if(node),
+            "assignment" => lower_assignment(node),
+            "logical_or" => lower_logical_chain(node, OR),
+            "logical_and" => lower_logical_chain(node, AND),
+            "logical_not" => lower_logical_not(node),
+            "comparison" => lower_comparison(node),
+            "additive" | "multiplicative" => lower_binary_chain(node),
+            "unary" => lower_unary(node),
+            "power" => lower_power(node),
+            "postfix" => lower_postfix(node),
+            "atom" => lower_atom(node),
+            "arglist" => Err(LowerError::new(
+                "an arglist cannot be lowered as a scalar expression",
+            )),
+            "list_literal" => lower_list_literal(node),
+            "set_literal" => lower_set_literal(node),
+            "group" => lower_group(node),
+            other => Err(LowerError::new(format!("no lowering for rule `{other}`"))),
+        },
+    }
+}
+
+/// Lower a raw token (a literal or a bare symbol).
+///
+/// `"true"`/`"false"` are `KEYWORD` tokens (MA09 §3's own literal boolean
+/// alternatives in `atom`) bridged to the shared backend's pre-bound
+/// `True`/`False` symbols — see this module's own doc comment's "Booleans"
+/// section for the `macsyma-compiler` precedent this mirrors.
+fn lower_token(token: &Token) -> Result<IRNode, LowerError> {
+    match token_type(token) {
+        "NUMBER" => lower_number(&token.value),
+        "NAME" => Ok(sym(&token.value)),
+        "KEYWORD" if token.value == "true" => Ok(sym("True")),
+        "KEYWORD" if token.value == "false" => Ok(sym("False")),
+        other => Err(LowerError::new(format!(
+            "unexpected token `{other}` = {:?}",
+            token.value
+        ))),
+    }
+}
+
+/// Parse a `NUMBER` lexeme into an `Integer` or `Float` IR literal.
+///
+/// `maple.tokens`' `NUMBER` regex (`[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?`) is
+/// identical to Reduce's/Derive's/Macsyma's own, so a `.`, `e`, or `E` means
+/// it is a real; otherwise it is an integer. We reject an integer that
+/// overflows `i64` (the IR's integer width) rather than silently wrapping.
+fn lower_number(text: &str) -> Result<IRNode, LowerError> {
+    if text.contains('.') || text.contains('e') || text.contains('E') {
+        text.parse::<f64>()
+            .map(flt)
+            .map_err(|e| LowerError::new(format!("invalid real literal {text:?}: {e}")))
+    } else {
+        text.parse::<i64>()
+            .map(int)
+            .map_err(|e| LowerError::new(format!("invalid integer literal {text:?}: {e}")))
+    }
+}
+
+/// `if_expr = "if" expr "then" statement { "elif" expr "then" statement }
+/// [ "else" statement ] ( "end" "if" | "fi" )` — MA09 §3: each `elif`
+/// desugars to a nested `If`, folded right-to-left so the *innermost* If is
+/// either the final `else` body (if present) or a bare 2-arg `If` (if not) —
+/// exactly the shape the spec's own worked example describes: `If[b, s1,
+/// If[b2, s2, s3]]`.
+///
+/// Every child *node* of an `if_expr` (ignoring the `"if"`/`"then"`/
+/// `"elif"`/`"else"`/`"end"`/`"fi"` keyword tokens, confirmed by reading
+/// `maple-parser`'s own compiled grammar: `Group`/`Alternation` never
+/// synthesize a wrapper node, they splice whichever branch matched directly
+/// into the parent `Sequence`) appears in strict alternating
+/// `(cond, body)` pairs, with one optional trailing lone `body` node for a
+/// final `else` — so collecting `child_nodes` in order and walking it two
+/// at a time (with an odd-length list signalling a trailing `else`) recovers
+/// the whole chain without needing to distinguish `expr` nodes from
+/// `statement` nodes structurally.
+fn lower_if(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let nodes: Vec<&GrammarASTNode> = child_nodes(node).collect();
+    if nodes.len() < 2 {
+        return Err(LowerError::new("if_expr must have at least one branch"));
+    }
+    let has_else = nodes.len() % 2 == 1;
+    let branch_count = if has_else {
+        (nodes.len() - 1) / 2
+    } else {
+        nodes.len() / 2
+    };
+
+    let mut branches = Vec::with_capacity(branch_count);
+    for i in 0..branch_count {
+        let cond = lower_node(nodes[2 * i])?;
+        let body = lower_node(nodes[2 * i + 1])?;
+        branches.push((cond, body));
+    }
+    let else_body = if has_else {
+        Some(lower_node(nodes[nodes.len() - 1])?)
+    } else {
+        None
+    };
+
+    // Fold right-to-left: the innermost branch's "else slot" is the final
+    // `else` body if present, otherwise absent (a bare 2-arg `If`); every
+    // earlier `elif` branch wraps the accumulated result as its own 3-arg
+    // `If`'s else-slot.
+    let mut acc = else_body;
+    for (cond, body) in branches.into_iter().rev() {
+        acc = Some(match acc {
+            Some(prev) => apply(sym(IF), vec![cond, body, prev]),
+            None => apply(sym(IF), vec![cond, body]),
+        });
+    }
+    acc.ok_or_else(|| LowerError::new("if_expr produced no branches"))
+}
+
+/// `assignment = NAME ASSIGN ( arrow_def | expr ) | expr` — deliberately
+/// NARROWER than `reduce-runtime::lower_assignment`'s general
+/// `Apply(Symbol(_), _)`-shaped left-hand side: `maple.grammar`'s own
+/// "assignment's left-hand side" design-decision comment explains why the
+/// LHS here is a bare `NAME` *token*, full stop — `f(x) := expr` (Maple's
+/// narrower remember-table spelling, MA09 §1/§4) fails to *parse* at all in
+/// this subset, so this function never needs to distinguish "was the LHS a
+/// call" the way Reduce's/Derive's own `lower_assignment` does.
+///
+/// By the time `lower_node` dispatches here (via `unwrap_single`, which only
+/// stops descending once a node's own child count isn't exactly 1), a
+/// genuine `assignment` node always has the 3-child `[NAME, ASSIGN, (arrow_def
+/// | expr)]` shape — the bare-`expr` alternative dissolves away before ever
+/// reaching this function. The `lower_first_node` fallback below is
+/// defensive only, mirroring `reduce-runtime::lower_assignment`'s identical
+/// defensive shape.
+fn lower_assignment(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let is_assign_form = node.children.len() == 3
+        && as_token(&node.children[1]).is_some_and(|t| token_type(t) == "ASSIGN");
+    if !is_assign_form {
+        return lower_first_node(node);
+    }
+    let name = match as_token(&node.children[0]) {
+        Some(t) if token_type(t) == "NAME" => t.value.clone(),
+        _ => return Err(LowerError::new("assignment lhs must be a bare NAME")),
+    };
+    match &node.children[2] {
+        ASTNodeOrToken::Node(n) if n.rule_name == "arrow_def" => lower_arrow_def(name, n),
+        rhs => {
+            let value = lower_child(rhs)?;
+            Ok(apply(sym(ASSIGN), vec![sym(name), value]))
+        }
+    }
+}
+
+/// `arrow_def = arrow_params ARROW expr` — MA09 §3's general-purpose
+/// function-definition spelling, `f := (x, y) -> e` / `f := x -> e`. Lowers
+/// to `Define[f, List[params...], body]`, mirroring
+/// `derive-runtime`'s/`reduce-runtime`'s identical `Define` shape for their
+/// own (differently-spelled) general-definition idioms.
+fn lower_arrow_def(name: String, node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    if node.children.len() != 3 {
+        return Err(LowerError::new("malformed arrow_def node"));
+    }
+    let params_node = as_node(&node.children[0])
+        .ok_or_else(|| LowerError::new("arrow_def is missing its parameter list"))?;
+    let params = lower_arrow_params(params_node);
+    let body = lower_child(&node.children[2])?;
+    Ok(apply(
+        sym(DEFINE),
+        vec![sym(name), apply(sym(LIST), params), body],
+    ))
+}
+
+/// `arrow_params = NAME | LPAREN [ NAME { COMMA NAME } ] RPAREN` — a single
+/// bare parameter needs no parentheses, two-or-more do, and `()` (zero
+/// parameters) falls out of the optional inner list for free (MA09 §3's own
+/// note on `arrow_params`). Both shapes are handled uniformly by simply
+/// collecting every `NAME` token among the node's children in order — the
+/// `LPAREN`/`COMMA`/`RPAREN` tokens present in the parenthesised form are
+/// harmlessly filtered out, so there is no need to branch on which
+/// alternative matched.
+fn lower_arrow_params(node: &GrammarASTNode) -> Vec<IRNode> {
+    node.children
+        .iter()
+        .filter_map(as_token)
+        .filter(|t| token_type(t) == "NAME")
+        .map(|t| sym(t.value.clone()))
+        .collect()
+}
+
+/// `logical_or`/`logical_and` — fold the operands into an n-ary `Or`/`And`.
+/// Safe to fold n-ary (unlike `additive`/`multiplicative`) because every
+/// step in one chain shares the SAME operator (`logical_or = logical_and {
+/// "or" logical_and }` never mixes `or` and `and`) — mirrors
+/// `reduce-runtime::lower_logical_chain` exactly.
+fn lower_logical_chain(node: &GrammarASTNode, head: &str) -> Result<IRNode, LowerError> {
+    let operands = child_nodes(node)
+        .map(lower_node)
+        .collect::<Result<Vec<_>, _>>()?;
+    match operands.len() {
+        0 => Err(LowerError::new("empty logical chain")),
+        1 => Ok(operands.into_iter().next().unwrap()),
+        _ => Ok(apply(sym(head), operands)),
+    }
+}
+
+/// `logical_not = "not" logical_not | comparison`. A leading `not` wraps the
+/// operand; otherwise it is the inner comparison. `and`/`or`/`not` are all
+/// matched in the grammar as `maple.tokens`' own `KEYWORD` token type
+/// (promoted from `NAME` by exact lowercase spelling), so — mirroring
+/// `reduce-runtime::lower_logical_not`'s identical check — this checks the
+/// token's literal *value*, not its type name alone (every keyword shares
+/// that same type name).
+fn lower_logical_not(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let has_not = node
+        .children
+        .iter()
+        .any(|c| as_token(c).is_some_and(|t| t.value == "not"));
+    if !has_not {
+        return lower_first_node(node);
+    }
+    let inner = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new("`not` with no operand"))?;
+    Ok(apply(sym(NOT), vec![lower_node(inner)?]))
+}
+
+/// `comparison = additive [ ( EQ | NEQ | LESS | GREATER | LE | GE ) additive
+/// ]` — a single (non-chained) comparison, per MA09 §3's own disclosed
+/// simplification (the identical "one flat, non-chaining tier"
+/// simplification `reduce.grammar`'s own `comparison` rule already made,
+/// reused here rather than re-derived — see `maple.grammar`'s own "the
+/// comparison tier is flat and non-chaining" design-decision comment). `=`
+/// is Maple's *equation* operator (`Equal`), never assignment — `:=` alone
+/// owns that role. Unlike Reduce's `neq` word-keyword, Maple's not-equal is
+/// the symbolic `NEQ` (`<>`) token type, so no value-based disambiguation is
+/// needed here.
+fn lower_comparison(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let Some(op_index) = node
+        .children
+        .iter()
+        .position(|c| as_token(c).is_some_and(|t| comparison_head(t).is_some()))
+    else {
+        return lower_first_node(node);
+    };
+    if op_index == 0 || op_index + 1 >= node.children.len() {
+        return Err(LowerError::new("malformed comparison node"));
+    }
+    let head = comparison_head(as_token(&node.children[op_index]).unwrap()).unwrap();
+    Ok(apply(
+        sym(head),
+        vec![
+            lower_child(&node.children[op_index - 1])?,
+            lower_child(&node.children[op_index + 1])?,
+        ],
+    ))
+}
+
+/// `additive`/`multiplicative` — a left-associative chain of `+`/`-` or
+/// `*`/`/`. Must fold pairwise (not n-ary, unlike the logical chains) since a
+/// single chain can mix operators: `a - b - c` folds left into
+/// `Sub(Sub(a, b), c)`; `a + b - c` into `Sub(Add(a, b), c)`. Mirrors
+/// `reduce-runtime::lower_binary_chain` exactly (identical grammar shape).
+fn lower_binary_chain(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let mut children = node.children.iter();
+    let first = children
+        .next()
+        .ok_or_else(|| LowerError::new("empty binary chain"))?;
+    let mut result = lower_child(first)?;
+    while let Some(op_child) = children.next() {
+        let head = as_token(op_child)
+            .and_then(|t| binary_head(token_type(t)))
+            .ok_or_else(|| LowerError::new("expected a binary operator"))?;
+        let rhs = children
+            .next()
+            .ok_or_else(|| LowerError::new("binary operator with no right operand"))?;
+        result = apply(sym(head), vec![result, lower_child(rhs)?]);
+    }
+    Ok(result)
+}
+
+/// `unary = MINUS unary | power`. MA09 §3 lists only unary `-` (no unary
+/// `+`, matching `reduce.grammar`'s/`derive.grammar`'s identical asymmetry).
+fn lower_unary(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    if node.children.len() == 1 {
+        return lower_child(&node.children[0]);
+    }
+    let operand = lower_child(
+        node.children
+            .get(1)
+            .ok_or_else(|| LowerError::new("unary `-` with no operand"))?,
+    )?;
+    Ok(apply(sym(NEG), vec![operand]))
+}
+
+/// `power = postfix [ CARET unary ]` — right-associative `^`. Unlike
+/// `reduce-runtime::lower_power` (which accepts either `CARET` or `POW`,
+/// since Reduce's manual documents both as one tier), Maple's own grammar
+/// has no `**` synonym at all (MA09 §3/§4; `maple.tokens` has no `POW`
+/// token), so this only ever matches `CARET`.
+fn lower_power(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    match node.children.len() {
+        1 => lower_child(&node.children[0]),
+        3 => {
+            let is_caret =
+                as_token(&node.children[1]).is_some_and(|t| token_type(t) == "CARET");
+            if !is_caret {
+                return Err(LowerError::new("malformed power node: expected CARET"));
+            }
+            Ok(apply(
+                sym(POW),
+                vec![
+                    lower_child(&node.children[0])?,
+                    lower_child(&node.children[2])?,
+                ],
+            ))
+        }
+        _ => Err(LowerError::new("malformed power node")),
+    }
+}
+
+/// `postfix = atom [ LPAREN [ arglist ] RPAREN ]` — a single OPTIONAL call
+/// suffix, deliberately narrower than `reduce-runtime::lower_postfix`'s
+/// REPEATED `{ LPAREN [arglist] RPAREN }` chain (`maple.grammar`'s own "one
+/// call suffix, not a repeated chain" design-decision comment: MA09 §3
+/// documents no chained-call/array-subscript convention for Maple the way
+/// Reduce's manual does). One consequence worth noting for
+/// [`crate::MAX_STATEMENT_TOKENS`]'s own doc comment: Maple therefore has
+/// *no* "long chained postfix call `f(x)(x)(x)…`" deep-lowered-tree vector
+/// at all — that vector is structurally impossible in this grammar, not
+/// merely unlikely.
+///
+/// The head runs through [`canonical_head`] so `diff`/`int` become the IR
+/// heads `symbolic-vm` already has handlers for; any other head (a
+/// user-defined function, or a builtin this subset doesn't bridge, like
+/// `sin`/`solve`/`piecewise`) passes through unchanged and evaluates via the
+/// VM's ordinary "unknown head" fallback — the deferred `cas-*` surface
+/// (MA09 §4) simply parses and lowers as an ordinary, currently-unresolved
+/// call, exactly like any undefined user function.
+fn lower_postfix(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let base = lower_child(
+        node.children
+            .first()
+            .ok_or_else(|| LowerError::new("postfix has no base"))?,
+    )?;
+
+    let has_call = node
+        .children
+        .get(1)
+        .and_then(as_token)
+        .is_some_and(|t| token_type(t) == "LPAREN");
+    if !has_call {
+        return Ok(base);
+    }
+
+    let args = node
+        .children
+        .get(2)
+        .and_then(as_node)
+        .filter(|n| n.rule_name == "arglist")
+        .map(lower_arglist)
+        .transpose()?
+        .unwrap_or_default();
+    Ok(apply(canonical_head(base), args))
+}
+
+/// `arglist = expr { COMMA expr }` — lower each comma-separated argument.
+fn lower_arglist(node: &GrammarASTNode) -> Result<Vec<IRNode>, LowerError> {
+    child_nodes(node).map(lower_node).collect()
+}
+
+/// `atom = NUMBER | NAME | "true" | "false" | list_literal | set_literal |
+/// group`. In practice `unwrap_single` already dissolves a single-child
+/// `atom` node before `lower_node`'s dispatch ever sees rule_name `"atom"`
+/// (every alternative here matches to exactly one child), so this function
+/// mirrors `reduce-runtime::lower_atom`'s identical defensive shape rather
+/// than being load-bearing for the common case.
+fn lower_atom(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    if let Some(child) = child_nodes(node).next() {
+        if matches!(child.rule_name.as_str(), "list_literal" | "set_literal" | "group") {
+            return lower_node(child);
+        }
+    }
+    let tokens: Vec<&Token> = node.children.iter().filter_map(as_token).collect();
+    match tokens.as_slice() {
+        [single] => lower_token(single),
+        _ => Err(LowerError::new(format!(
+            "unrecognised atom token shape: {:?}",
+            tokens.iter().map(|t| &t.value).collect::<Vec<_>>()
+        ))),
+    }
+}
+
+/// `list_literal = LBRACKET [ arglist ] RBRACKET` — MA09 §3's `[a, b, c]`
+/// (square brackets, ordered, duplicates kept). Lowers to `List[...]`, the
+/// shared, already-handled head every CAS-family sibling in this repo
+/// reuses.
+fn lower_list_literal(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let args = child_nodes(node)
+        .find(|n| n.rule_name == "arglist")
+        .map(lower_arglist)
+        .transpose()?
+        .unwrap_or_default();
+    Ok(apply(sym(LIST), args))
+}
+
+/// `set_literal = LBRACE [ arglist ] RBRACE` — MA09 §3's `{a, b, c}` (curly
+/// braces, unordered, duplicates removed *in real Maple*). Lowers to the
+/// new [`SET`] head — see this module's own doc comment's "`Set`" section
+/// for the disclosed evaluation-time gap (arguments evaluate; the
+/// dedup/unordered semantics are not yet enforced, since no shared handler
+/// exists for this head).
+fn lower_set_literal(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let args = child_nodes(node)
+        .find(|n| n.rule_name == "arglist")
+        .map(lower_arglist)
+        .transpose()?
+        .unwrap_or_default();
+    Ok(apply(sym(SET), args))
+}
+
+/// `group = LPAREN expr RPAREN` — grouping only; lower the inner expression.
+fn lower_group(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let inner = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new("empty group `( )`"))?;
+    lower_node(inner)
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+fn lower_child(child: &ASTNodeOrToken) -> Result<IRNode, LowerError> {
+    match child {
+        ASTNodeOrToken::Node(node) => lower_node(node),
+        ASTNodeOrToken::Token(token) => lower_token(token),
+    }
+}
+
+/// Lower the first *node* child (ignoring tokens). Used by transparent-
+/// wrapper rules whose only meaningful content is a nested expression node.
+fn lower_first_node(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let child = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new(format!("`{}` has no expression child", node.rule_name)))?;
+    lower_node(child)
+}
+
+/// Map an arithmetic token type to its IR head.
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a comparison token to its IR head. Every comparison operator in this
+/// subset is a symbolic (punctuation) token type — unlike Reduce's `neq`
+/// keyword, Maple spells not-equal `<>` (`NEQ`), so no value-based check is
+/// needed alongside the type-based ones.
+fn comparison_head(token: &Token) -> Option<&'static str> {
+    match token_type(token) {
+        "EQ" => Some(EQUAL),
+        "NEQ" => Some(NOT_EQUAL),
+        "LESS" => Some(LESS),
+        "GREATER" => Some(GREATER),
+        "LE" => Some(LESS_EQUAL),
+        "GE" => Some(GREATER_EQUAL),
+        _ => None,
+    }
+}
+
+/// Bridge a Maple *surface* builtin call-head name to the canonical IR head
+/// it's already implemented under. Per MA09 §2's own MP-4 bullet, this
+/// subset's *only* such bridge is calculus (`diff`→`D`, `int`→`Integrate`) —
+/// unlike `reduce-runtime`'s equivalent table (which also bridges
+/// `list`/`first`/`second`/…), MA09 §3 documents no function-call spelling
+/// for list/set construction (Maple already has literal `[...]`/`{...}`
+/// syntax for both), and this subset deliberately does not bridge
+/// elementary-function names (`sin`, `log`, …) the way it does not for
+/// Reduce either — a head not in this table (a user-defined function, or
+/// any of MA09 §4's deferred `cas-*` surface) is returned unchanged, so it
+/// evaluates through the VM's ordinary user-function path and stays a
+/// harmless unevaluated symbolic call.
+fn canonical_head(head: IRNode) -> IRNode {
+    if let IRNode::Symbol(name) = &head {
+        if let Some(canonical) = surface_head_to_ir(name) {
+            return sym(canonical);
+        }
+    }
+    head
+}
+
+fn surface_head_to_ir(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "diff" => D,
+        "int" => INTEGRATE,
+        _ => return None,
+    })
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+/// Iterate a node's direct *node* children (skipping tokens).
+fn child_nodes(node: &GrammarASTNode) -> impl Iterator<Item = &GrammarASTNode> {
+    node.children.iter().filter_map(as_node)
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with structure
+/// (or a leaf token). A precedence-cascade rule that did not apply its
+/// operator still emits its own node with exactly one child, and so does an
+/// ordered-choice rule like `expr = logical_or` once it has committed to its
+/// one alternative — `unwrap_single` skips straight to the rule that
+/// actually matters. Mirrors `reduce-runtime::unwrap_single` exactly (the
+/// shared `parser::GrammarParser` engine's node shape is identical across
+/// every grammar built on it).
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_maple_parser::parse_maple;
+
+    /// Lower a single-statement source to its one `(IRNode, Display)` pair.
+    fn lower_one(src: &str) -> LoweredStatement {
+        let ast = parse_maple(src);
+        let mut stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 1, "expected exactly one statement for {src:?}");
+        stmts.pop().unwrap()
+    }
+
+    fn lower_one_node(src: &str) -> IRNode {
+        lower_one(src).node
+    }
+
+    #[test]
+    fn integer_and_real_literals() {
+        assert_eq!(lower_one_node("42;\n"), int(42));
+        assert_eq!(lower_one_node("1.5;\n"), flt(1.5));
+    }
+
+    #[test]
+    fn bare_symbol() {
+        assert_eq!(lower_one_node("foo;\n"), sym("foo"));
+    }
+
+    #[test]
+    fn bare_trailing_statement_with_no_terminator_lowers() {
+        let stmt = lower_one("42");
+        assert_eq!(stmt.node, int(42));
+        assert_eq!(stmt.display, Display::Show);
+    }
+
+    // --- Display flag: `;` shows, `:` suppresses (MA09 §3) ------------------
+
+    #[test]
+    fn semicolon_terminator_displays() {
+        assert_eq!(lower_one("1 + 1;\n").display, Display::Show);
+    }
+
+    #[test]
+    fn colon_terminator_suppresses() {
+        assert_eq!(lower_one("1 + 1:\n").display, Display::Suppress);
+    }
+
+    #[test]
+    fn mixed_terminators_in_one_program_are_tagged_independently() {
+        let ast = parse_maple("1: 2; 3:\n");
+        let stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 3);
+        assert_eq!(stmts[0].display, Display::Suppress);
+        assert_eq!(stmts[1].display, Display::Show);
+        assert_eq!(stmts[2].display, Display::Suppress);
+    }
+
+    // --- Booleans (MA09 §3) --------------------------------------------------
+
+    #[test]
+    fn boolean_literals_bridge_to_the_shared_true_false_symbols() {
+        assert_eq!(lower_one_node("true;\n"), sym("True"));
+        assert_eq!(lower_one_node("false;\n"), sym("False"));
+    }
+
+    // --- Arithmetic (MA09 §3) ------------------------------------------------
+
+    #[test]
+    fn additive_lowers_to_add() {
+        assert_eq!(
+            lower_one_node("1 + 2;\n"),
+            apply(sym(ADD), vec![int(1), int(2)])
+        );
+    }
+
+    #[test]
+    fn subtraction_lowers_to_sub_left_assoc() {
+        assert_eq!(
+            lower_one_node("a - b - c;\n"),
+            apply(
+                sym(SUB),
+                vec![apply(sym(SUB), vec![sym("a"), sym("b")]), sym("c")]
+            )
+        );
+    }
+
+    #[test]
+    fn mixed_additive_chain_folds_left_by_operator() {
+        assert_eq!(
+            lower_one_node("a + b - c;\n"),
+            apply(
+                sym(SUB),
+                vec![apply(sym(ADD), vec![sym("a"), sym("b")]), sym("c")]
+            )
+        );
+    }
+
+    #[test]
+    fn multiplication_requires_explicit_star_and_lowers_to_mul() {
+        assert_eq!(
+            lower_one_node("a * b;\n"),
+            apply(sym(MUL), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn division_lowers_to_div() {
+        assert_eq!(
+            lower_one_node("a / b;\n"),
+            apply(sym(DIV), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn power_operator_lowers_to_pow() {
+        assert_eq!(
+            lower_one_node("a ^ b;\n"),
+            apply(sym(POW), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn power_is_right_associative() {
+        assert_eq!(
+            lower_one_node("a ^ b ^ c;\n"),
+            apply(
+                sym(POW),
+                vec![sym("a"), apply(sym(POW), vec![sym("b"), sym("c")])]
+            )
+        );
+    }
+
+    #[test]
+    fn unary_minus_lowers_to_neg_and_binds_looser_than_power() {
+        assert_eq!(
+            lower_one_node("-x^2;\n"),
+            apply(sym(NEG), vec![apply(sym(POW), vec![sym("x"), int(2)])])
+        );
+    }
+
+    // --- Comparison / equation (MA09 §3) -------------------------------------
+
+    #[test]
+    fn eq_lowers_to_equal_not_assign() {
+        assert_eq!(
+            lower_one_node("x = 4;\n"),
+            apply(sym(EQUAL), vec![sym("x"), int(4)])
+        );
+    }
+
+    #[test]
+    fn every_comparison_operator_lowers_to_its_head() {
+        assert_eq!(
+            lower_one_node("a < b;\n"),
+            apply(sym(LESS), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one_node("a > b;\n"),
+            apply(sym(GREATER), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one_node("a <= b;\n"),
+            apply(sym(LESS_EQUAL), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one_node("a >= b;\n"),
+            apply(sym(GREATER_EQUAL), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one_node("a <> b;\n"),
+            apply(sym(NOT_EQUAL), vec![sym("a"), sym("b")])
+        );
+    }
+
+    // --- Logic (MA09 §3) ------------------------------------------------------
+
+    #[test]
+    fn boolean_keywords_lower_to_and_or_not() {
+        assert_eq!(
+            lower_one_node("a and b;\n"),
+            apply(sym(AND), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one_node("a or b;\n"),
+            apply(sym(OR), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one_node("not a;\n"),
+            apply(sym(NOT), vec![sym("a")])
+        );
+    }
+
+    #[test]
+    fn logical_or_chain_folds_n_ary() {
+        assert_eq!(
+            lower_one_node("a or b or c;\n"),
+            apply(sym(OR), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    // --- Grouping --------------------------------------------------------------
+
+    #[test]
+    fn grouping_parens_lower_transparently() {
+        assert_eq!(
+            lower_one_node("(1 + 2) * 3;\n"),
+            apply(
+                sym(MUL),
+                vec![apply(sym(ADD), vec![int(1), int(2)]), int(3)]
+            )
+        );
+    }
+
+    // --- Function application (MA09 §3) -----------------------------------
+
+    #[test]
+    fn function_application_of_unknown_head_passes_through() {
+        assert_eq!(
+            lower_one_node("f(a, b);\n"),
+            apply(sym("f"), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn nested_function_calls_lower_correctly() {
+        assert_eq!(
+            lower_one_node("log(exp(x));\n"),
+            apply(sym("log"), vec![apply(sym("exp"), vec![sym("x")])])
+        );
+    }
+
+    #[test]
+    fn call_with_no_arguments_lowers_to_an_empty_arg_apply() {
+        assert_eq!(lower_one_node("f();\n"), apply(sym("f"), vec![]));
+    }
+
+    // --- diff/int bridge to D/Integrate (MA09 §2/§5) ------------------------
+
+    #[test]
+    fn diff_bridges_to_d() {
+        assert_eq!(
+            lower_one_node("diff(x^2, x);\n"),
+            apply(sym(D), vec![apply(sym(POW), vec![sym("x"), int(2)]), sym("x")])
+        );
+    }
+
+    #[test]
+    fn int_bridges_to_integrate() {
+        assert_eq!(
+            lower_one_node("int(x, x);\n"),
+            apply(sym(INTEGRATE), vec![sym("x"), sym("x")])
+        );
+    }
+
+    #[test]
+    fn elementary_function_names_are_not_bridged() {
+        // Unlike diff/int -- MA09 §2/§5 names only the calculus bridge, so
+        // `sin` stays lowercase and unresolved (mirroring reduce-runtime's
+        // identical non-bridging of elementary function names).
+        assert_eq!(lower_one_node("sin(x);\n"), apply(sym("sin"), vec![sym("x")]));
+    }
+
+    // --- Assignment / arrow-operator definition (MA09 §3) --------------------
+
+    #[test]
+    fn variable_assignment_lowers_to_assign() {
+        assert_eq!(
+            lower_one_node("x := 5;\n"),
+            apply(sym(ASSIGN), vec![sym("x"), int(5)])
+        );
+    }
+
+    #[test]
+    fn arrow_definition_with_two_params_lowers_to_define() {
+        assert_eq!(
+            lower_one_node("f := (x, y) -> x + y;\n"),
+            apply(
+                sym(DEFINE),
+                vec![
+                    sym("f"),
+                    apply(sym(LIST), vec![sym("x"), sym("y")]),
+                    apply(sym(ADD), vec![sym("x"), sym("y")]),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn arrow_definition_with_one_bare_param_lowers_to_define() {
+        assert_eq!(
+            lower_one_node("f := x -> x^2;\n"),
+            apply(
+                sym(DEFINE),
+                vec![
+                    sym("f"),
+                    apply(sym(LIST), vec![sym("x")]),
+                    apply(sym(POW), vec![sym("x"), int(2)]),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn arrow_definition_with_zero_params_lowers_to_define_with_empty_list() {
+        assert_eq!(
+            lower_one_node("f := () -> 5;\n"),
+            apply(
+                sym(DEFINE),
+                vec![sym("f"), apply(sym(LIST), vec![]), int(5)]
+            )
+        );
+    }
+
+    #[test]
+    fn plain_assignment_of_a_variable_does_not_produce_define() {
+        assert_eq!(
+            lower_one_node("f := x;\n"),
+            apply(sym(ASSIGN), vec![sym("f"), sym("x")])
+        );
+    }
+
+    // --- `if`/`elif`/`else`/`end if` (MA09 §3) -------------------------------
+
+    #[test]
+    fn if_then_end_if_lowers_to_two_arg_if() {
+        assert_eq!(
+            lower_one_node("if a > 0 then 1 end if;\n"),
+            apply(
+                sym(IF),
+                vec![apply(sym(GREATER), vec![sym("a"), int(0)]), int(1)]
+            )
+        );
+    }
+
+    #[test]
+    fn if_then_else_end_if_lowers_to_three_arg_if() {
+        assert_eq!(
+            lower_one_node("if a > 0 then 1 else -1 end if;\n"),
+            apply(
+                sym(IF),
+                vec![
+                    apply(sym(GREATER), vec![sym("a"), int(0)]),
+                    int(1),
+                    apply(sym(NEG), vec![int(1)]),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn fi_closing_spelling_lowers_identically_to_end_if() {
+        let end_if = lower_one_node("if a > 0 then 1 else -1 end if;\n");
+        let fi = lower_one_node("if a > 0 then 1 else -1 fi;\n");
+        assert_eq!(end_if, fi);
+    }
+
+    #[test]
+    fn elif_chain_desugars_to_nested_if() {
+        // if a then 1 elif b then 2 else 3 end if
+        //   -> If(a, 1, If(b, 2, 3))
+        assert_eq!(
+            lower_one_node("if a then 1 elif b then 2 else 3 end if;\n"),
+            apply(
+                sym(IF),
+                vec![
+                    sym("a"),
+                    int(1),
+                    apply(sym(IF), vec![sym("b"), int(2), int(3)]),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn elif_chain_with_no_final_else_leaves_the_innermost_if_two_armed() {
+        // if a then 1 elif b then 2 end if -> If(a, 1, If(b, 2))
+        assert_eq!(
+            lower_one_node("if a then 1 elif b then 2 end if;\n"),
+            apply(
+                sym(IF),
+                vec![sym("a"), int(1), apply(sym(IF), vec![sym("b"), int(2)])]
+            )
+        );
+    }
+
+    #[test]
+    fn multiple_elif_arms_fold_right_to_left() {
+        assert_eq!(
+            lower_one_node("if a then 1 elif b then 2 elif c then 3 else 4 end if;\n"),
+            apply(
+                sym(IF),
+                vec![
+                    sym("a"),
+                    int(1),
+                    apply(
+                        sym(IF),
+                        vec![
+                            sym("b"),
+                            int(2),
+                            apply(sym(IF), vec![sym("c"), int(3), int(4)]),
+                        ]
+                    ),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn if_can_branch_to_an_assignment() {
+        assert_eq!(
+            lower_one_node("if a then x := 1 else x := 2 end if;\n"),
+            apply(
+                sym(IF),
+                vec![
+                    sym("a"),
+                    apply(sym(ASSIGN), vec![sym("x"), int(1)]),
+                    apply(sym(ASSIGN), vec![sym("x"), int(2)]),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn nested_if_resolves_unambiguously() {
+        // if a then if b then c end if else d end if
+        //   -> If(a, If(b, c), d)
+        assert_eq!(
+            lower_one_node("if a then if b then c end if else d end if;\n"),
+            apply(
+                sym(IF),
+                vec![sym("a"), apply(sym(IF), vec![sym("b"), sym("c")]), sym("d")]
+            )
+        );
+    }
+
+    // --- Lists / sets (MA09 §3/§5) --------------------------------------------
+
+    #[test]
+    fn square_bracket_list_literal_lowers_to_list() {
+        assert_eq!(
+            lower_one_node("[a, b, c];\n"),
+            apply(sym(LIST), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn empty_list_literal_lowers_to_empty_list() {
+        assert_eq!(lower_one_node("[];\n"), apply(sym(LIST), vec![]));
+    }
+
+    #[test]
+    fn curly_brace_set_literal_lowers_to_the_new_set_head() {
+        assert_eq!(
+            lower_one_node("{a, b, c};\n"),
+            apply(sym(SET), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn empty_set_literal_lowers_to_empty_set() {
+        assert_eq!(lower_one_node("{};\n"), apply(sym(SET), vec![]));
+    }
+
+    #[test]
+    fn list_and_set_are_genuinely_distinct_heads_for_the_same_elements() {
+        let list = lower_one_node("[a, b];\n");
+        let set = lower_one_node("{a, b};\n");
+        assert_ne!(list, set);
+        assert_eq!(list, apply(sym(LIST), vec![sym("a"), sym("b")]));
+        assert_eq!(set, apply(sym(SET), vec![sym("a"), sym("b")]));
+    }
+
+    // --- Multi-statement programs ---------------------------------------------
+
+    #[test]
+    fn multi_statement_program_lowers_each_line() {
+        let ast = parse_maple("x := 1; y := 2; x + y;\n");
+        let stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 3);
+        assert_eq!(stmts[0].node, apply(sym(ASSIGN), vec![sym("x"), int(1)]));
+        assert_eq!(stmts[1].node, apply(sym(ASSIGN), vec![sym("y"), int(2)]));
+        assert_eq!(stmts[2].node, apply(sym(ADD), vec![sym("x"), sym("y")]));
+    }
+
+    #[test]
+    fn a_small_maple_program_lowers_end_to_end() {
+        let ast = parse_maple("f := x -> x*x; f(5);\n");
+        let stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 2);
+        assert!(matches!(
+            &stmts[0].node,
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == DEFINE)
+        ));
+        assert_eq!(stmts[1].node, apply(sym("f"), vec![int(5)]));
+    }
+}

--- a/code/packages/rust/maple-runtime/src/printer.rs
+++ b/code/packages/rust/maple-runtime/src/printer.rs
@@ -1,0 +1,434 @@
+//! # Pretty-printing — `symbolic-ir` → Maple surface notation
+//!
+//! After evaluation the result is a [`symbolic_ir::IRNode`] whose heads are
+//! the IR's canonical names (`Add`, `Equal`, `List`, [`crate::lower::SET`],
+//! …). A Maple user expects to read it back in Maple's own notation — infix
+//! `+`/`*`/`^`, `and`/`or`/`not`, square-bracket `[a, b, c]` lists,
+//! curly-brace `{a, b, c}` sets, `f(…)` application, `if ... then ... [elif
+//! ... then ...] [else ...] end if`. This module is the inverse of
+//! [`crate::lower`]: it walks the result tree and renders the surface
+//! string, reversing the same head bridges `crate::lower` applies going in
+//! (mirroring `reduce-runtime::printer`'s identical role and shape).
+//!
+//! It is deliberately a **presentation** layer, not a re-parse: the output
+//! only needs to be readable and round-trippable for the heads this subset
+//! actually produces. Precedence is handled by parenthesising a child
+//! whenever its operator binds *looser* than the parent's.
+//!
+//! ## Precedence ladder (loosest → tightest, mirrors `maple.grammar`'s own
+//! cascade — MA09 §3)
+//!
+//! | Level | Constructs |
+//! |-------|------------|
+//! | — | (`if`/`elif`/`else`/`end if` is self-delimited by its own keywords, |
+//! |   | so it never needs surrounding parens — treated as atom-level; an |
+//! |   | `Assign`/`Define` result never reaches the printer at all, see below) |
+//! | 1 | `or` |
+//! | 2 | `and` |
+//! | 3 | `not` (prefix) / comparisons `=` `<>` `<` `<=` `>` `>=` |
+//! | 4 | `Add` `Sub` |
+//! | 5 | `Mul` `Div` |
+//! | 6 | unary `Neg` |
+//! | 7 | `Pow` |
+//! | 8 | atoms, `f(…)`, `[…]`, `{…}` |
+//!
+//! `Assign`/`Define` never appear in a printed *result*: `assign_handler`
+//! returns the bound *value* (not an `Assign(...)` node), and
+//! `define_handler` returns `Symbol(name)` — see `symbolic-vm`'s own
+//! `handlers.rs`. So, exactly like `reduce-runtime::printer`, this module
+//! has no rendering case for either head.
+//!
+//! ## `If` CAN still reach the printer, even though it's a *statement*
+//!
+//! Maple's `if_expr` is never usable as a *nested* expression (MA09/
+//! `maple.grammar`'s own "statements vs. expressions" design decision), but
+//! it is still a legitimate **top-level statement** whose evaluated result
+//! gets displayed — and `If` is a held head (`symbolic_vm::backend::
+//! BaseBackend::new`), so when the condition doesn't resolve to `True`/
+//! `False` (a free variable), `if_handler` rebuilds and returns the
+//! unevaluated `If(...)` node itself. [`render_if`] reconstructs Maple's own
+//! `if ... then ... [elif ... then ...] [else ...] end if` surface —
+//! folding a nested `If` in the else-slot back into an `elif` continuation
+//! (the exact reverse of [`crate::lower::lower_if`]'s own right-fold),
+//! rather than printing a redundant, less-readable `else if ... end if end
+//! if` — a deliberate presentation choice, not a re-parse requirement.
+
+use symbolic_ir::{
+    IRApply, IRNode, ADD, AND, DIV, D, EQUAL, GREATER, GREATER_EQUAL, IF, INTEGRATE, LESS,
+    LESS_EQUAL, LIST, MUL, NEG, NOT, NOT_EQUAL, OR, POW, SUB,
+};
+
+use crate::lower::SET;
+
+const PREC_LOWEST: u8 = 0;
+const PREC_OR: u8 = 1;
+const PREC_AND: u8 = 2;
+const PREC_NOT_CMP: u8 = 3;
+const PREC_ADD: u8 = 4;
+const PREC_MUL: u8 = 5;
+const PREC_NEG: u8 = 6;
+const PREC_POW: u8 = 7;
+const PREC_ATOM: u8 = 8;
+
+/// Render `node` as a Maple surface string.
+pub fn print_maple(node: &IRNode) -> String {
+    print_at(node, PREC_LOWEST)
+}
+
+/// Render `node`, wrapping it in parentheses if its own precedence is looser
+/// than `parent_prec` (so the surface string re-parses to the same tree).
+fn print_at(node: &IRNode, parent_prec: u8) -> String {
+    let (text, prec) = render(node);
+    if prec < parent_prec {
+        format!("({text})")
+    } else {
+        text
+    }
+}
+
+/// Render a node, returning its surface text and its own precedence level.
+fn render(node: &IRNode) -> (String, u8) {
+    match node {
+        IRNode::Integer(n) => (n.to_string(), PREC_ATOM),
+        IRNode::Float(v) => (format!("{v:?}"), PREC_ATOM),
+        IRNode::Rational(n, d) => (format!("{n}/{d}"), PREC_MUL),
+        IRNode::Str(s) => (format!("\"{s}\""), PREC_ATOM),
+        IRNode::Symbol(s) if s == "True" => ("true".to_string(), PREC_ATOM),
+        IRNode::Symbol(s) if s == "False" => ("false".to_string(), PREC_ATOM),
+        IRNode::Symbol(s) => (s.clone(), PREC_ATOM),
+        IRNode::Apply(app) => render_apply(app),
+    }
+}
+
+/// Render a compound `head(args)` node.
+fn render_apply(app: &IRApply) -> (String, u8) {
+    let head_name = match &app.head {
+        IRNode::Symbol(s) => Some(s.as_str()),
+        _ => None,
+    };
+    let args = &app.args;
+
+    if let Some(name) = head_name {
+        if let Some((op, prec)) = infix_binary(name) {
+            if args.len() == 2 {
+                let l = print_at(&args[0], prec);
+                let r = print_at(&args[1], prec);
+                return (format!("{l}{op}{r}"), prec);
+            }
+        }
+        // n-ary associative logic: And/Or flatten to a chain (mirrors how
+        // `lower_logical_chain` folds a homogeneous run flat rather than
+        // pairwise).
+        if let Some((op, prec)) = nary_logic(name) {
+            if args.len() >= 2 {
+                let parts: Vec<String> = args.iter().map(|a| print_at(a, prec)).collect();
+                return (parts.join(op), prec);
+            }
+            if args.len() == 1 {
+                return render(&args[0]);
+            }
+        }
+        match name {
+            POW if args.len() == 2 => {
+                // Right-associative and tighter than unary minus.
+                let base = print_at(&args[0], PREC_POW + 1);
+                let exp = print_at(&args[1], PREC_NEG);
+                return (format!("{base}^{exp}"), PREC_POW);
+            }
+            NEG if args.len() == 1 => {
+                let inner = print_at(&args[0], PREC_NEG);
+                return (format!("-{inner}"), PREC_NEG);
+            }
+            NOT if args.len() == 1 => {
+                let inner = print_at(&args[0], PREC_NOT_CMP);
+                return (format!("not {inner}"), PREC_NOT_CMP);
+            }
+            LIST => return (render_list(args), PREC_ATOM),
+            SET => return (render_set(args), PREC_ATOM),
+            IF if args.len() == 2 || args.len() == 3 => return (render_if(args), PREC_ATOM),
+            _ => {}
+        }
+
+        // Ordinary function application: `head(args…)`, bridging the
+        // canonical IR head back to Maple's surface spelling (the reverse
+        // of `crate::lower::canonical_head`); an unrecognised head (a
+        // user-defined function, or one of MA09 §4's deferred `cas-*`
+        // surface) is rendered as-typed/bridged-back but otherwise
+        // unchanged.
+        let surface = ir_head_to_surface(name).unwrap_or(name);
+        let parts: Vec<String> = args.iter().map(print_maple).collect();
+        return (format!("{surface}({})", parts.join(", ")), PREC_ATOM);
+    }
+
+    // A computed (non-symbol) head — render generically as `(head)(args…)`.
+    let head_text = print_at(&app.head, PREC_ATOM);
+    let parts: Vec<String> = args.iter().map(print_maple).collect();
+    (format!("{head_text}({})", parts.join(", ")), PREC_ATOM)
+}
+
+/// Binary infix arithmetic/comparison operators — `(surface, precedence)`.
+fn infix_binary(name: &str) -> Option<(&'static str, u8)> {
+    Some(match name {
+        ADD => (" + ", PREC_ADD),
+        SUB => (" - ", PREC_ADD),
+        MUL => ("*", PREC_MUL),
+        DIV => ("/", PREC_MUL),
+        EQUAL => (" = ", PREC_NOT_CMP),
+        NOT_EQUAL => (" <> ", PREC_NOT_CMP),
+        LESS => (" < ", PREC_NOT_CMP),
+        GREATER => (" > ", PREC_NOT_CMP),
+        LESS_EQUAL => (" <= ", PREC_NOT_CMP),
+        GREATER_EQUAL => (" >= ", PREC_NOT_CMP),
+        _ => return None,
+    })
+}
+
+/// n-ary logic operators — `(join-text, precedence)`.
+fn nary_logic(name: &str) -> Option<(&'static str, u8)> {
+    Some(match name {
+        AND => (" and ", PREC_AND),
+        OR => (" or ", PREC_OR),
+        _ => return None,
+    })
+}
+
+/// Render a `List(...)` node back to Maple's square-bracket syntax — the
+/// exact reverse of `crate::lower::lower_list_literal`.
+fn render_list(args: &[IRNode]) -> String {
+    let parts: Vec<String> = args.iter().map(print_maple).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+/// Render a `Set(...)` node back to Maple's curly-brace syntax — the exact
+/// reverse of `crate::lower::lower_set_literal`. Note this reflects
+/// whatever arguments the (unresolved, since no shared handler exists yet —
+/// see `crate::lower`'s own "Set" doc section) `Set` call was left holding:
+/// duplicates are NOT removed and order is NOT normalised, since real
+/// Maple's unordered/deduplicating set semantics aren't enforced at
+/// evaluation time in this subset.
+fn render_set(args: &[IRNode]) -> String {
+    let parts: Vec<String> = args.iter().map(print_maple).collect();
+    format!("{{{}}}", parts.join(", "))
+}
+
+/// Render an unresolved `If(cond, then[, else])` node back to Maple's
+/// `if ... then ... [elif ... then ...] [else ...] end if` surface — see
+/// this module's own doc comment's "`If` CAN still reach the printer"
+/// section. When the else-slot is itself another `If(...)` application
+/// (MA09 §3's own elif-desugaring, reversed), this folds it into an `elif`
+/// continuation instead of nesting a second, redundant `if ... end if`.
+fn render_if(args: &[IRNode]) -> String {
+    let mut out = String::from("if ");
+    out.push_str(&print_maple(&args[0]));
+    out.push_str(" then ");
+    out.push_str(&print_maple(&args[1]));
+
+    let mut tail: Option<&IRNode> = args.get(2);
+    while let Some(node) = tail {
+        if let IRNode::Apply(app) = node {
+            let is_if = matches!(&app.head, IRNode::Symbol(s) if s == IF);
+            if is_if && (app.args.len() == 2 || app.args.len() == 3) {
+                out.push_str(" elif ");
+                out.push_str(&print_maple(&app.args[0]));
+                out.push_str(" then ");
+                out.push_str(&print_maple(&app.args[1]));
+                tail = app.args.get(2);
+                continue;
+            }
+        }
+        out.push_str(" else ");
+        out.push_str(&print_maple(node));
+        break;
+    }
+    out.push_str(" end if");
+    out
+}
+
+/// The IR→surface head dictionary — the exact reverse of
+/// `crate::lower::surface_head_to_ir`. Kept as its own table (rather than
+/// derived at runtime) so each direction reads as a simple, directly
+/// checkable list. `List`/`Set` are handled specially above (bracket
+/// syntax, never the generic call form), so neither has an entry here.
+fn ir_head_to_surface(name: &str) -> Option<&'static str> {
+    Some(match name {
+        D => "diff",
+        INTEGRATE => "int",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symbolic_ir::{apply, flt, int, rat, sym};
+
+    #[test]
+    fn atoms_print_bare() {
+        assert_eq!(print_maple(&int(42)), "42");
+        assert_eq!(print_maple(&flt(1.5)), "1.5");
+        assert_eq!(print_maple(&rat(1, 3)), "1/3");
+        assert_eq!(print_maple(&sym("x")), "x");
+    }
+
+    #[test]
+    fn true_false_symbols_print_lowercase() {
+        assert_eq!(print_maple(&sym("True")), "true");
+        assert_eq!(print_maple(&sym("False")), "false");
+    }
+
+    #[test]
+    fn arithmetic_prints_infix() {
+        assert_eq!(
+            print_maple(&apply(sym(ADD), vec![sym("x"), int(1)])),
+            "x + 1"
+        );
+        assert_eq!(
+            print_maple(&apply(sym(MUL), vec![sym("x"), int(2)])),
+            "x*2"
+        );
+        assert_eq!(
+            print_maple(&apply(sym(DIV), vec![sym("x"), int(2)])),
+            "x/2"
+        );
+    }
+
+    #[test]
+    fn precedence_forces_parens_on_the_looser_child() {
+        let e = apply(
+            sym(MUL),
+            vec![apply(sym(ADD), vec![sym("a"), sym("b")]), sym("c")],
+        );
+        assert_eq!(print_maple(&e), "(a + b)*c");
+    }
+
+    #[test]
+    fn power_prints_caret_right_associative() {
+        let e = apply(
+            sym(POW),
+            vec![sym("a"), apply(sym(POW), vec![sym("b"), sym("c")])],
+        );
+        assert_eq!(print_maple(&e), "a^b^c");
+    }
+
+    #[test]
+    fn negation_and_not_print_prefix() {
+        assert_eq!(print_maple(&apply(sym(NEG), vec![sym("x")])), "-x");
+        assert_eq!(print_maple(&apply(sym(NOT), vec![sym("a")])), "not a");
+    }
+
+    #[test]
+    fn logic_chain_prints_flat() {
+        let e = apply(sym(OR), vec![sym("a"), sym("b"), sym("c")]);
+        assert_eq!(print_maple(&e), "a or b or c");
+    }
+
+    #[test]
+    fn comparisons_print_maple_spelling() {
+        assert_eq!(
+            print_maple(&apply(sym(EQUAL), vec![sym("x"), int(4)])),
+            "x = 4"
+        );
+        assert_eq!(
+            print_maple(&apply(sym(NOT_EQUAL), vec![sym("x"), int(4)])),
+            "x <> 4"
+        );
+        assert_eq!(
+            print_maple(&apply(sym(LESS_EQUAL), vec![sym("a"), sym("b")])),
+            "a <= b"
+        );
+    }
+
+    #[test]
+    fn user_function_call_prints_as_typed() {
+        assert_eq!(
+            print_maple(&apply(sym("f"), vec![sym("x"), sym("y")])),
+            "f(x, y)"
+        );
+    }
+
+    #[test]
+    fn list_prints_with_square_brackets() {
+        assert_eq!(
+            print_maple(&apply(sym(LIST), vec![int(1), int(2), int(3)])),
+            "[1, 2, 3]"
+        );
+    }
+
+    #[test]
+    fn empty_list_prints_as_empty_brackets() {
+        assert_eq!(print_maple(&apply(sym(LIST), vec![])), "[]");
+    }
+
+    #[test]
+    fn set_prints_with_curly_braces() {
+        assert_eq!(
+            print_maple(&apply(sym(SET), vec![int(1), int(2), int(3)])),
+            "{1, 2, 3}"
+        );
+    }
+
+    #[test]
+    fn empty_set_prints_as_empty_braces() {
+        assert_eq!(print_maple(&apply(sym(SET), vec![])), "{}");
+    }
+
+    #[test]
+    fn list_and_set_print_differently_for_the_same_elements() {
+        let list = apply(sym(LIST), vec![sym("a"), sym("b")]);
+        let set = apply(sym(SET), vec![sym("a"), sym("b")]);
+        assert_eq!(print_maple(&list), "[a, b]");
+        assert_eq!(print_maple(&set), "{a, b}");
+    }
+
+    #[test]
+    fn diff_and_int_bridge_back_to_lowercase_surface_names() {
+        assert_eq!(
+            print_maple(&apply(sym(D), vec![sym("f"), sym("x")])),
+            "diff(f, x)"
+        );
+        assert_eq!(
+            print_maple(&apply(sym(INTEGRATE), vec![sym("f"), sym("x")])),
+            "int(f, x)"
+        );
+    }
+
+    #[test]
+    fn unresolved_two_arg_if_prints_if_then_end_if() {
+        assert_eq!(
+            print_maple(&apply(sym(IF), vec![sym("a"), int(1)])),
+            "if a then 1 end if"
+        );
+    }
+
+    #[test]
+    fn unresolved_three_arg_if_prints_if_then_else_end_if() {
+        assert_eq!(
+            print_maple(&apply(sym(IF), vec![sym("a"), int(1), int(2)])),
+            "if a then 1 else 2 end if"
+        );
+    }
+
+    #[test]
+    fn nested_if_in_the_else_slot_folds_back_into_elif() {
+        // If(a, 1, If(b, 2, 3)) -> "if a then 1 elif b then 2 else 3 end if"
+        let e = apply(
+            sym(IF),
+            vec![
+                sym("a"),
+                int(1),
+                apply(sym(IF), vec![sym("b"), int(2), int(3)]),
+            ],
+        );
+        assert_eq!(print_maple(&e), "if a then 1 elif b then 2 else 3 end if");
+    }
+
+    #[test]
+    fn nested_if_with_no_final_else_folds_into_elif_with_no_trailing_else() {
+        // If(a, 1, If(b, 2)) -> "if a then 1 elif b then 2 end if"
+        let e = apply(
+            sym(IF),
+            vec![sym("a"), int(1), apply(sym(IF), vec![sym("b"), int(2)])],
+        );
+        assert_eq!(print_maple(&e), "if a then 1 elif b then 2 end if");
+    }
+}

--- a/code/specs/MA09-maple-language.md
+++ b/code/specs/MA09-maple-language.md
@@ -132,7 +132,7 @@ prefix (MATLAB's `ML-`, not `M-`), not overload it. This PR is a
   with an explicit `MAX_RULE_DEPTH` measured the same way
   `apl-parser`/`j-parser`/`derive-parser`/`reduce-parser` measured theirs
   (per [MA06](MA06-j-language.md) §6's precedent), rather than assumed.
-- **MP-4 — `maple-runtime` + `maple-repl`.** Lowers the parsed
+- **MP-4 — `maple-runtime` + `maple-repl`.** (✅ done) Lowers the parsed
   `GrammarASTNode` into `symbolic-ir`, evaluates with `symbolic-vm`'s shared
   `SymbolicBackend` — reused *unchanged*, with no custom `Backend` at all,
   the same reuse story `derive-runtime`/`reduce-runtime` already demonstrate
@@ -149,6 +149,22 @@ prefix (MATLAB's `ML-`, not `M-`), not overload it. This PR is a
   unnumbered `reduce-repl`) and the `maple` binary. `proc(...) ... end proc`
   block-structured procedures, `for`/`while` loops, and the rest of the
   `cas-*` surface under Maple names are **not** MP-4's scope — see §4.
+  **Every claim in this bullet held up unchanged once `maple-runtime`
+  actually landed** (unlike R-4's own two corrections, MA08 §2 — no
+  surface-table row here turned out to be wrong): §3's own table, checked
+  row by row against the shipped `crate::lower`/`crate::printer`, needed no
+  correction. `proc`/`for`/`while` and the remember-table `f(x) := e`
+  spelling are confirmed rejected at **parse** time by the already-merged
+  `maple-parser` itself (none of those keywords exist in `maple.tokens`, so
+  they lex as ordinary `NAME`s and the leftover tokens fail
+  `statement_line`'s own terminator check) — `maple-runtime` needed no
+  special-case rejection logic of its own, just to forward the parser's
+  `Err`. One disclosed addition beyond this spec's own text: `maple-repl`
+  tracks `if` / `end if`|`fi` block-keyword balance (in addition to bracket
+  balance) for its line-continuation heuristic — Maple's `if_expr`, unlike
+  Reduce's, requires an explicit closer, so an ordinary multi-line `if`
+  needed this to be usable interactively at all; see `maple-repl`'s own
+  README/CHANGELOG.
 
 ## §3 The supported surface (the grammar)
 
@@ -334,7 +350,7 @@ rules and block procedures.
 - **Frontend:** the grammar-tools framework, exactly as Macsyma/MATLAB/
   Wolfram/APL/J/Derive/Reduce use it. `maple.tokens`/`maple.grammar` compile
   to committed `_grammar.rs` in `maple-lexer`/`maple-parser` (MP-2/MP-3).
-- **Lowering + engine (MP-4):** the parsed tree lowers to
+- **Lowering + engine (MP-4, ✅ done, `maple-runtime`):** the parsed tree lowers to
   [`symbolic_ir::IRNode`](../packages/rust/symbolic-ir) (surface operators,
   `:=`, the arrow operator, and list/set literals → canonical `Add`/`Sub`/
   `Mul`/`Div`/`Pow`/`Neg`/`Equal`/`NotEqual`/`Less`/`Greater`/`LessEqual`/
@@ -383,12 +399,25 @@ rules and block procedures.
   handlers Derive's `DIF`/`INT` and Wolfram's `D`/`Integrate` already call
   under their own names — one function, four languages agreeing on its
   result, the same "reuse, not reimplementation" story §1 promises.
-- **REPL (MP-4):** a single-threaded driver mirroring
+- **REPL (MP-4, ✅ done, `maple-repl`):** a single-threaded driver mirroring
   `reduce-repl`/`derive-repl`/`wolfram-repl`/`maxima-repl`; a plain
   (non-numbered) read-eval-print loop, matching real Maple's own
   interactive-session convention (§5.3 "Statement Separators" — a
   `;`/`:`-terminated statement, no `#n:`/`In[n]:=` numbering), the same
   convention [MA08](MA08-reduce-language.md) documents for `reduce-repl`.
+  One addition beyond bracket balance: Maple's `if_expr` (unlike Reduce's)
+  requires an explicit `end if`/`fi` closer, so `maple-repl`'s own
+  continuation heuristic also tracks `if`/`end if`|`fi` block-keyword
+  balance — closer in spirit to `matlab-repl`'s/`octave-repl`'s own
+  keyword-block tracking than to any other CAS-family REPL in this repo.
+  The **`maple` binary itself is not a separate `code/programs/rust/maple`
+  crate** — verified directly against the sibling CAS-family languages
+  (`reduce`, `derive`, `wolfram`): none of them has a `code/programs/rust/`
+  entry either; each `-repl` crate's own `Cargo.toml` declares the binary
+  directly via `[[bin]] name = "..."`, and `maple-repl` follows that exact,
+  empirically-confirmed convention rather than the generic `code/programs/
+  rust/<name>` shape this repo's `CLAUDE.md` "Project Structure" section
+  describes for standalone programs in general.
 
 ## §6 References
 


### PR DESCRIPTION
## Summary

MP-4 (`code/specs/MA09-maple-language.md` §2) — the final Maple-language item after the spec (MP-1), lexer (MP-2), and parser (MP-3) already merged. Adds:

- **`maple-runtime`**: lowers `maple-parser`'s `GrammarASTNode` into `symbolic_ir::IRNode` and evaluates via `symbolic_vm`'s stock `SymbolicBackend`, reused **unchanged** — no Maple-specific `Backend` at all, the same reuse story `derive-runtime`/`reduce-runtime` already demonstrate. This was verified directly against the real handler table (not assumed from spec prose): every head this subset needs — arithmetic, comparisons, logic, the held `Assign`/`Define`/`If`, `List`, and `D`/`Integrate` — already exists in `symbolic_vm::handlers::build_handler_table`.
- **`Set`** — the one genuinely new head (Maple is the first language here with two distinct bracketed aggregate literals, `[a,b,c]` `List` vs `{a,b,c}` `Set`). No shared handler exists for it; it's defined locally to `maple-runtime` rather than added to `symbolic-ir`/`symbolic-vm`, mirroring `reduce-runtime`'s identical treatment of its own new heads. Disclosed gap: elements evaluate, but the `Set` call itself stays structurally correct-but-unevaluated (no unordered/dedup semantics yet) — a clean follow-on item, not a bug.
- **`maple-repl`**: an interactive, plain unnumbered REPL (no `#n:`/`In[n]:=` convention, matching `reduce-repl`'s own precedent — real Maple's interactive session has none either), plus the `maple` binary (declared directly in `maple-repl`'s own `Cargo.toml`, matching how `reduce`/`derive`/`wolfram`'s binaries are structured — none of them has a separate `code/programs/rust/<name>` crate).
- `diff`/`int` are thin bridges into the already-shared `D`/`Integrate` handlers (no calculus reimplemented). `if`/`elif`/`else`/`end if` desugars to nested `If` via a right-fold.

**Explicitly out of scope** (§4): `proc(...) ... end proc` block-structured procedures, `for`/`while` loops, and the remember-table `f(x) := e` spelling. None of these keywords exist in `maple.tokens`, so they fail to *parse* already — no special-case rejection logic needed in the runtime at all.

No changes to `maple-lexer`/`maple-parser`/`symbolic-vm`/`symbolic-ir` — this is a pure additive consumer of the existing shared substrate.

## Security review — 2 rounds, both MEDIUM findings fixed

Round 1 found two MEDIUM findings, both fixed in a follow-up commit:

1. **`check_statement_token_counts` ran on the caller thread**, before the `catch_unwind`-wrapped worker thread this crate's own docs claim contains every panic. A hypothetical panic inside the tokenizer it calls would have unwound past that boundary. Fixed: the guard now runs inside the same worker-thread `catch_unwind`.
2. **`MapleRepl::feed` appended the incoming line to its buffer before checking the `MAX_INPUT_LEN` cap.** The one shipped call site (`run()`, via `read_bounded_line`'s 64 KiB-per-line cap) wasn't exploitable, but `feed` is a `pub fn` any other embedder could call directly with an unbounded `&str`. Fixed: the size check now runs before `push_str`.

Round 2 confirmed both fixes are correct, found no new issues, and flagged (as a separate follow-up, tracked, not blocking this PR) that the identical push-before-check ordering bug exists unpatched in four sibling REPL crates (`reduce-repl`/`derive-repl`/`apl-repl`/`j-repl`) — out of scope for this PR since it doesn't touch those files.

## Test plan

- [x] `cargo test -p coding-adventures-maple-runtime -p coding-adventures-maple-repl`: 130 passed, 0 failed (104 + 25 unit tests + 1 doctest), both before and after the security fixes.
- [x] Downstream `symbolic-vm`/`symbolic-ir` consumers, all green (confirming zero shared-crate changes despite the new `Set` head being fully local to `maple-runtime`): `reduce-runtime` (85), `derive-runtime` (65), `wolfram-runtime` (347+85), `macsyma-runtime` (22+69).
- [x] `cargo clippy --all-targets` clean on both new crates.
- [x] Manually verified the `maple` binary end-to-end (`x := 5; x + 1;` → `6`).
- [x] Rebased cleanly on current `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)