### PR TITLE
feat(hl): Spanish Ch.12 — hacer, decir, and the -go verb club

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -219,6 +219,9 @@
       "ES-VERB-PODER": "poder — 'to be able/can' (o→ue stem-changer: puedo/puedes…podemos; ← potēre → power/potent/possible; poder+inf)",
       "ES-STEM-CHANGES": "e→ie & o→ue stem-changes — one sound-law (stressed short e/o broke: terra→tierra, porta→puerta); the 'boot' (all but nosotros)",
       "ES-POSSESSIVE-OUR": "nuestro/vuestro — 'our/your-pl' (← noster/voster → Paternoster); agree in BOTH gender & number, unlike mi/tu/su",
+      "ES-VERB-HACER": "hacer — 'to do/make' (-go yo-form hago, like tengo; ← facere → fact/factory/perfect; f→h softening; weather: hace calor)",
+      "ES-VERB-DECIR": "decir — 'to say/tell' (doubly irregular: -go yo-form digo + e→i stem-change dices/dice; ← dīcere → dictate/diction/verdict)",
+      "ES-YO-GO": "the -go club — verbs whose yo-form grows a hard g (tengo/hago/digo/pongo/salgo/vengo); yo-only, a closed Latin-inherited set of high-frequency verbs",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -276,6 +279,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 12 — Doing, making, saying, and the -go club
+
+- **Chapter 12 authored** (`ES-C12-hacer`, `-decir`, `-yo-go`, `-practice`): two
+  workhorse irregular verbs plus the pattern that unites their *yo*-forms —
+  reviewing Ch.8/10/11 via `reviews_of`.
+- **hacer** ("to do/make") — covers **both** English "do" and "make"; the Latin
+  **f→h** softening (*facere → hacer*, the same change as Ch.6 *hablar/hijo*), the
+  **-go** *yo*-form **hago** (echoing *tengo*), and the everyday weather idiom
+  *hace calor/frío/sol* ("it **makes** heat…"). Root payoff: *facere* →
+  fact/factory/perfect/manufacture/satisfy/affect.
+- **decir** ("to say/tell") — the **doubly irregular** verb: it stacks the **-go**
+  *yo*-form (**digo**) **and** an **e→i** stem-change (*dices/dice/dicen*, with
+  *decimos* escaping the boot). Root payoff: *dīcere* →
+  dictate/diction/dictionary/predict/verdict/contradict. Anchored on the learner's
+  most useful question, *¿Cómo se dice…?*
+- **-go club** (`ES-C12-yo-go`) — a pattern lesson: *tengo/hago/digo/pongo/salgo/
+  vengo* form a small, closed set whose *yo*-form grows a hard *g* (yo-only, the
+  rest regular). Framed as a Latin fossil kept by the oldest, most-used verbs —
+  three met (*tengo/hago/digo*), three flagged for Ch.13 (*pongo/salgo/vengo*).
+- Taxonomy: namespaced `ES-VERB-HACER`, `ES-VERB-DECIR`, `ES-YO-GO`; practice
+  label `CH12-PRACTICE`.
+
 ## Chapter 11 — Wants, ability, and the stem-change boot
 
 - **Chapter 11 authored** (`ES-C11-querer`, `-poder`, `-stem-changes`, `-nuestro`,

--- a/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
@@ -1,0 +1,79 @@
+---
+id: ES-C12-decir
+chapter: 12
+type: word
+headword: decir
+gloss: to say / to tell — doubly irregular, digo + e→i
+concept_tag: ES-VERB-DECIR
+prerequisites: [ES-C12-hacer, ES-C11-querer]
+sounds: [diphthong-none-i, g-hard]
+roots: [dicere-latin]
+etymology_hook: "decir ← Latin dīcere 'to say, tell' → dictate, diction, dictionary, predict, verdict, contradict; doubly irregular — the -go yo-form digo (like hago/tengo) AND the e→i stem-change (dices/dice)"
+est_minutes: 5
+reviews_of: [ES-C12-hacer, ES-C11-querer, ES-C11-stem-changes]
+---
+
+# decir — "to say," the verb with two irregularities at once
+
+## Warm-up
+
+[PAUSE 2s] **decir** ("to say / to tell") is the trickiest verb yet — and the most
+instructive, because it stacks **two** patterns you already know onto one word:
+the **-go** *yo*-form from *hacer/tener*, **and** a stem-change from Chapter 11.
+Learn *decir* and the whole system clicks together.
+
+## Sounds you'll need
+
+- `diphthong-none-i` — here the stressed stem *e* does **not** break to *ie*;
+  instead it **closes to i**: *digo, dices, dice*. A third kind of stem-change.
+
+## The word, taken apart
+
+**decir** comes from Latin **dīcere**, *"to say, to tell, to point out"* — and its
+root **dic-/dict-** ("say") runs straight through English:
+
+- **dictate, diction, dictionary, dictaphone** — all about *saying*.
+- with prefixes: **predict** ("say beforehand"), **contradict** ("say against"),
+  **verdict** ("a true saying"), **indicate** ("point out"), **dedicate**,
+  **edict**, **index**.
+
+So *decir* is the "say" root behind *dictionary* itself — the book of what words
+*say*.
+
+## Grammar Lens: two irregularities stacked
+
+**(1) The -go yo-form.** Like *hago* and *tengo*, the *yo*-form grows a **g**:
+**digo**.
+
+**(2) The e→i stem-change.** In the stressed forms, the stem *e* **closes to i** —
+not the *ie* of *querer*, but a tighter shift to plain **i**:
+
+| yo | **digo** | (-go form; stem also → i) |
+| tú | **dices** | (e → i) |
+| él/ella/usted | **dice** | (e → i) |
+| nosotros | **decimos** | (plain *e* — unstressed) |
+| ellos/ustedes | **dicen** | (e → i) |
+
+The **boot** shape returns: *decimos* alone keeps the plain *e*, because the stress
+falls on the ending. Everything inside the boot shifts to *i*; the *yo* corner
+also carries the *-go*.
+
+**The everyday payoff:** **¿Cómo se dice…?** — "How do you say…?", the single most
+useful question a learner owns. And **dime** ("tell me").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "decir" then the set — "**digo**, dices, dice, decimos, dicen" — the
+  *g* in *digo*, the *i* through the boot, the plain *e* in *decimos*]
+- [YOU SAY: "¿Cómo se dice 'coffee' en español?" — "Se dice 'café'."]
+- [YOU SAY: "decir" then English "dictate, predict, verdict" — the say-family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *decir* from, and three English cousins?
+(*dīcere*; dictate/diction/predict/verdict — any three.) Name its **two**
+irregularities. (The *-go* *yo*-form **digo**, and the **e→i** stem-change.) Which
+form keeps the plain *e*, and why? (*decimos* — stress on the ending, outside the
+boot.) How do you ask "How do you say…?" (**¿Cómo se dice…?**) Next: the whole
+**-go** family, side by side.

--- a/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
@@ -1,0 +1,79 @@
+---
+id: ES-C12-hacer
+chapter: 12
+type: word
+headword: hacer
+gloss: to do / to make — an irregular yo-form, hago
+concept_tag: ES-VERB-HACER
+prerequisites: [ES-C08-tener, ES-C06-hablar]
+sounds: [jota-h-silent, g-hard]
+roots: [facere-latin]
+etymology_hook: "hacer ← Latin facere 'to do, make' → fact, factory, affect, perfect, manufacture, satisfy; the f→h softening (facere→hacer, like Ch.6 hablar) and the -go yo-form hago (like tengo)"
+est_minutes: 5
+reviews_of: [ES-C08-tener, ES-C10-practice]
+---
+
+# hacer — "to do / to make," and the yo-form that grows a g
+
+## Warm-up
+
+[PAUSE 2s] One verb covers both English "do" **and** "make" in Spanish:
+**hacer**. It is one of the language's workhorses — and it hides two patterns you
+have already met: the **f→h** softening from Chapter 6, and a surprise **-go**
+ending in the *yo*-form, exactly like *tengo*.
+
+## Sounds you'll need
+
+- `jota-h-silent` — the **h** in *hacer* is **silent** (*a-THER* / *a-SER*). That
+  silent *h* is the ghost of a Latin **f**.
+
+## The word, taken apart
+
+**hacer** comes from Latin **facere**, *"to do, to make"* — and Spanish softened
+the Latin **f-** to a now-silent **h-**, the very same change that turned
+*fabulārī → hablar* and *filium → hijo* back in Chapter 6. The Latin *facere* is
+one of the richest roots in English:
+
+- **fact** ("a thing done"), **factory** ("a place of making"), **manufacture**
+  ("made by hand"), **feat**, **feature**.
+- with prefixes: **affect / effect** (*ad-/ex-* + *fac*), **perfect** ("thoroughly
+  done"), **satisfy** ("make enough"), **difficult** ("not easy to do"),
+  **benefit** ("do well").
+
+So *hacer* and *factory* are the same "make" root, one worn down in Spanish, one
+kept crisp in Latin-through-English.
+
+## Grammar Lens: the -go yo-form
+
+*hacer* is regular in most of its present tense — but the **yo**-form is
+irregular: it grows a **g**, giving **hago** (not *~~haço~~*). You have seen this
+exact move before: *tener → tengo*. It is a small, high-frequency club of "-go"
+verbs.
+
+| yo | **hago** | (irregular — grows a *g*) |
+| tú | haces | (regular) |
+| él/ella/usted | hace | (regular) |
+| nosotros | hacemos | (regular) |
+| ellos/ustedes | hacen | (regular) |
+
+**The everyday payoff — weather.** Spanish reports the weather with *hacer*,
+literally "it **makes**": **hace calor** ("it's hot" = "it makes heat"), **hace
+frío** ("it's cold"), **hace sol** ("it's sunny"). And the all-purpose question
+**¿Qué haces?** — "What are you doing?"
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hacer" then the set — "**hago**, haces, hace, hacemos, hacen" — hear
+  the *g* only in *hago*]
+- [YOU SAY: "¿Qué haces?" ("What are you doing?"); "Hago café" ("I make coffee")]
+- [YOU SAY: "Hace calor" / "Hace frío" — weather = "it makes…"]
+- [YOU SAY: "hacer" then English "fact, factory, perfect" — the make/do family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What two English verbs does *hacer* cover? ("**do**" and "**make**.")
+What Latin root, and two English cousins? (*facere*; fact/factory/perfect.) Give
+the *yo*-form, and the other verb it echoes. (**hago** — the *-go* club, like
+*tengo*.) How does Spanish say "it's hot"? (**Hace calor** — "it makes heat.")
+Next: **decir**, "to say" — a verb that cracks *and* grows a g.

--- a/code/learning/human-languages/spanish/lessons/ES-C12-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-practice.md
@@ -1,0 +1,65 @@
+---
+id: ES-C12-practice
+chapter: 12
+type: practice-mix
+headword: (practice)
+gloss: doing, making, saying — hacer, decir, and the -go club
+concept_tag: CH12-PRACTICE
+prerequisites: [ES-C12-hacer, ES-C12-decir, ES-C12-yo-go]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C12-hacer, ES-C12-decir, ES-C12-yo-go, ES-C11-practice]
+---
+
+# Practice — hacer, decir, and the -go club
+
+## Warm-up
+
+[PAUSE 2s] This chapter added two workhorse verbs — **hacer** ("do/make") and
+**decir** ("say") — and the **-go** club that unites their *yo*-forms with
+*tengo*. Time to make them automatic.
+
+## Drill 1 — the -go yo-forms
+
+[PAUSE 1s] Say the *yo*-form for each, then the *tú*-form (which drops the *g*):
+
+- **hacer** → yo **hago**, tú **haces**
+- **decir** → yo **digo**, tú **dices** (mind the *e→i*)
+- **tener** → yo **tengo**, tú **tienes** (mind the *e→ie*)
+
+[PAUSE 2s] What do all three *yo*-forms share? (The **-go**.) What happens to it
+in the *tú*-form? (It **drops** — the *-go* is *yo*-only.)
+
+## Drill 2 — say the full present
+
+[PAUSE 1s] Run each verb top to bottom:
+
+- **hacer**: hago · haces · hace · hacemos · hacen.
+- **decir**: digo · dices · dice · decimos · dicen — the **boot**: only *decimos*
+  keeps the plain *e*.
+
+## Drill 3 — put it to use
+
+[PAUSE 1s] Say each out loud:
+
+- "**¿Qué haces?**" — "What are you doing?"
+- "**Hago la tarea.**" — "I'm doing the homework."
+- "**¿Cómo se dice 'window'?**" — "How do you say 'window'?"
+- "**Hace frío hoy.**" — "It's cold today" (weather with *hacer* — "it makes
+  cold").
+
+## Drill 4 — the root families (say the cousin)
+
+[PAUSE 1s] Name an English cousin from the same Latin root:
+
+- **hacer** ← *facere* → ? (**fact / factory / perfect / manufacture** — any.)
+- **decir** ← *dīcere* → ? (**dictate / diction / predict / verdict** — any.)
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the *yo*-forms of *hacer*, *decir*, and *tener*. (**hago, digo,
+tengo** — the *-go* club.) In *decir*, which form escapes the *e→i* boot, and why?
+(*decimos* — stress on the ending.) How does Spanish say "it's hot"? (**Hace
+calor.**) You can now *do*, *make*, and *say* in Spanish — and you have seen that
+its most irregular verbs are its most-used, oldest words.

--- a/code/learning/human-languages/spanish/lessons/ES-C12-yo-go.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-yo-go.md
@@ -1,0 +1,70 @@
+---
+id: ES-C12-yo-go
+chapter: 12
+type: phrase
+headword: -go
+gloss: the "-go" verbs — a small club whose yo-form ends in -go
+concept_tag: ES-YO-GO
+prerequisites: [ES-C12-hacer, ES-C12-decir, ES-C08-tener]
+sounds: [g-hard]
+roots: [latin-velar-yo]
+etymology_hook: "the -go yo-forms (tengo, hago, digo, pongo, salgo, vengo) — a Latin-inherited club where the 1st-person present grows a hard g; learn the pattern once and every member follows"
+est_minutes: 4
+reviews_of: [ES-C12-hacer, ES-C12-decir, ES-C08-tener]
+---
+
+# The "-go" club — one irregular corner, many verbs
+
+## Warm-up
+
+[PAUSE 2s] You have now met three verbs whose **yo**-form ends in a surprising
+**-go**: *tener → **tengo***, *hacer → **hago***, *decir → **digo***. That is not
+three coincidences — it is a **club**. Learn the membership and you never have to
+re-learn the shape.
+
+## The pattern
+
+Most Spanish verbs build a tidy *yo*-form (*hablo, como, vivo*). But a small set
+of very common verbs **grow a hard *g*** in the *yo*-form only — the rest of the
+present tense behaves normally. You have two members already; here is the core
+club:
+
+| verb | meaning | **yo**-form | you've met it? |
+|---|---|---|---|
+| **tener** | to have | **tengo** | ✓ Chapter 8 |
+| **hacer** | to do/make | **hago** | ✓ this chapter |
+| **decir** | to say | **digo** | ✓ this chapter |
+| **poner** | to put | **pongo** | coming |
+| **salir** | to leave/go out | **salgo** | coming |
+| **venir** | to come | **vengo** | coming |
+
+Three you know, three to come — and every one follows the same rule: **-go in the
+*yo*-form, regular elsewhere** (with any stem-change stacked on top, as in
+*digo*).
+
+## Why the g? (a Latin fossil)
+
+The *g* is an inheritance. Latin's first-person forms and old sound-laws left a
+**velar** (a back-of-the-mouth *g/k*) clinging to these particular verbs; Spanish
+regularized it into a clean *-go*. You do not need the history to use them — but
+it explains why the club is closed and old: these are among the **most-used verbs
+in the language**, and the oldest, most-used words are exactly the ones that keep
+their irregularities (like English *am/was*, *go/went*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the three you know — "**tengo, hago, digo**" — feel the shared *-go*]
+- [YOU SAY: the three to come — "**pongo, salgo, vengo**" — same ending]
+- [YOU SAY: a mixed drill — "yo tengo, yo hago, yo digo" then "tú tienes, tú
+  haces, tú dices" — the *-go* is *yo*-only]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do *tengo*, *hago*, and *digo* share, and in which form only?
+(A **-go** ending, in the **yo**-form only.) Name three more members of the club.
+(*pongo, salgo, vengo* — from *poner, salir, venir*.) Are these verbs irregular
+everywhere? (No — **just the yo-form**; the rest is regular, plus any stem-change.)
+Why is the club old and closed? (These are the most-used, oldest verbs — the ones
+that keep their fossils.) Next: **practice** — put *hacer*, *decir*, and the *-go*
+club to work.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -80,10 +80,17 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   voster* → Paternoster; agrees in **gender and number**, unlike *mi/tu/su*) →
   practice. **Authored.**
 
-Next: **Ch. 12** — the rest of the high-frequency verbs (*hacer, decir, ir*
-irregulars) and more description, building toward everyday conversation. From here
-the course hands over rules, not phrases. Grammar accumulates piece by piece. The
-theme skeleton below plans the wider road.
+- **Ch. 12 — Doing, making, saying, and the -go club**: **hacer** ("to do/make,"
+  ← *facere* → fact/factory/perfect; f→h softening; the *-go* yo-form *hago*;
+  weather *hace calor*) → **decir** ("to say," ← *dīcere* → dictate/diction/verdict;
+  **doubly** irregular — *-go* yo-form *digo* **and** the **e→i** stem-change) →
+  the **-go club** (*tengo/hago/digo/pongo/salgo/vengo* — yo-only, a closed
+  Latin-inherited set of the oldest, most-used verbs) → practice. **Authored.**
+
+Next: **Ch. 13** — more everyday description and the remaining high-frequency
+irregulars (*ir* preterite, *poner/salir/venir* completing the *-go* club), building
+toward real conversation. From here the course hands over rules, not phrases.
+Grammar accumulates piece by piece. The theme skeleton below plans the wider road.
 
 ## Theme Skeleton (planning only)
 


### PR DESCRIPTION
## What

Spanish **Chapter 12** (`ES-C12-hacer/decir/yo-go/practice`) — two workhorse irregular verbs plus the pattern that unites their *yo*-forms with *tengo*. Models the existing ES-C11 verb-chapter shape; each lesson reviews Ch.8/10/11 via `reviews_of`.

## The lessons

| Lesson | Content |
|---|---|
| **hacer** ("to do/make") | Covers **both** English *do* and *make*; the Latin **f→h** softening (*facere → hacer*, the same change as Ch.6 *hablar/hijo*), the **-go** *yo*-form **hago** (echoing *tengo*), and the weather idiom *hace calor/frío/sol* ("it **makes** heat"). Root: *facere* → fact/factory/perfect/manufacture/affect. |
| **decir** ("to say/tell") | The **doubly irregular** verb — stacks the **-go** *yo*-form (**digo**) **and** an **e→i** stem-change (*dices/dice/dicen*, *decimos* escaping the boot). Root: *dīcere* → dictate/diction/predict/verdict. Anchored on *¿Cómo se dice…?* |
| **yo-go** | A pattern lesson: *tengo/hago/digo/pongo/salgo/vengo* form a closed set whose *yo*-form grows a hard *g* (yo-only, rest regular) — framed as a Latin fossil kept by the oldest, most-used verbs. Three met, three flagged for Ch.13. |
| **practice** | Drills the *-go* yo-forms, the *decir* boot, everyday use (*¿Qué haces?*, *hace frío*), and the root families. |

## Housekeeping
- Taxonomy: namespaced `ES-VERB-HACER`, `ES-VERB-DECIR`, `ES-YO-GO` + `CH12-PRACTICE` label.
- `spanish/CHANGELOG.md` (Ch.12) and `roadmap.md` (Ch.12 authored, Next = Ch.13).
- Suite **38/38**; no retired `concept_tag`s; security-reviewed (Markdown + JSON only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)