### PR TITLE
Add Haskell arc2d package

### DIFF
--- a/code/packages/haskell/arc2d/CHANGELOG.md
+++ b/code/packages/haskell/arc2d/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 - 2026-07-19
+
+- Add SVG endpoint and center representations for elliptical arcs.
+- Add W3C endpoint-to-center conversion with radius correction and flag logic.
+- Add evaluation, tangents, exact rotated-ellipse arc bounds, and cubic Bezier
+  approximation through the pure Haskell geometry dependency chain.
+- Add package-native tests for degenerate cases, sweep choices, radius scaling,
+  rotation, tight bounds, cubic segmentation, continuity, and control points.

--- a/code/packages/haskell/arc2d/README.md
+++ b/code/packages/haskell/arc2d/README.md
@@ -1,0 +1,24 @@
+# arc2d (Haskell)
+
+Pure Haskell implementation of G2D03 elliptical arcs. It supports both SVG
+endpoint form and center form, including the W3C endpoint-to-center conversion.
+
+## API
+
+- `SvgArc` stores SVG `A` command parameters; `toCenterArc` performs the W3C
+  conversion with radius correction and degeneracy guards.
+- `CenterArc` supports parametric evaluation, unnormalized tangents, exact
+  rotated-ellipse arc bounds, and cubic Bezier approximation.
+- `evaluateSvgArc` and `boundingBoxSvgArc` treat degenerate arcs as line
+  segments, while `toCubicBeziersSvg` returns an empty list for them.
+
+All angular and square-root operations use the repository's pure Haskell
+`trig` package. Points, rectangles, and cubic curves come from `point2d` and
+`bezier2d`.
+
+## Development
+
+```sh
+cabal test all
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/arc2d/arc2d.cabal
+++ b/code/packages/haskell/arc2d/arc2d.cabal
@@ -1,0 +1,37 @@
+cabal-version: 3.0
+name:          arc2d
+version:       0.1.0
+synopsis:      Elliptical arcs in SVG endpoint and center forms
+description:   Pure G2D03 SVG endpoint-to-center conversion, evaluation, tangents, tight bounds, and cubic Bezier approximation for elliptical arcs.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Arc2D
+    build-depends:    base >=4.14 && <5
+                    , bezier2d >=0.1 && <0.2
+                    , point2d >=0.1 && <0.2
+                    , trig >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Arc2DSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , arc2d
+                    , bezier2d >=0.1 && <0.2
+                    , hspec == 2.*
+                    , point2d >=0.1 && <0.2
+                    , trig >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/arc2d/cabal.project
+++ b/code/packages/haskell/arc2d/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../point2d ../bezier2d ../trig

--- a/code/packages/haskell/arc2d/src/Arc2D.hs
+++ b/code/packages/haskell/arc2d/src/Arc2D.hs
@@ -1,0 +1,246 @@
+-- | Pure elliptical arc geometry in SVG endpoint and center forms.
+module Arc2D
+    ( SvgArc (..)
+    , CenterArc (..)
+    , toCenterArc
+    , evaluateCenterArc
+    , tangentCenterArc
+    , boundingBoxCenterArc
+    , toCubicBeziersCenter
+    , toCubicBeziersSvg
+    , evaluateSvgArc
+    , boundingBoxSvgArc
+    ) where
+
+import Bezier2D (CubicBezier (..))
+import Data.Either (fromRight)
+import Data.Fixed (mod')
+import Point2D (Point (..), Rect (..))
+import qualified Point2D
+import qualified Trig
+
+-- | An elliptical arc in SVG endpoint form.
+data SvgArc = SvgArc
+    { svgFrom :: Point
+    , svgTo :: Point
+    , svgRx :: Double
+    , svgRy :: Double
+    , svgRotation :: Double
+    , svgLargeArc :: Bool
+    , svgSweep :: Bool
+    }
+    deriving (Eq, Show)
+
+-- | An elliptical arc in center form.
+data CenterArc = CenterArc
+    { arcCenter :: Point
+    , arcRx :: Double
+    , arcRy :: Double
+    , arcStartAngle :: Double
+    , arcSweepAngle :: Double
+    , arcRotation :: Double
+    }
+    deriving (Eq, Show)
+
+-- | Convert SVG endpoint form to center form with the W3C algorithm.
+-- Degenerate endpoint arcs and effectively zero radii return 'Nothing'.
+toCenterArc :: SvgArc -> Maybe CenterArc
+toCenterArc arc
+    | Point2D.distanceSquared start end < pointEpsilonSquared = Nothing
+    | abs (svgRx arc) < radiusEpsilon = Nothing
+    | abs (svgRy arc) < radiusEpsilon = Nothing
+    | otherwise = Just CenterArc
+        { arcCenter = Point centerX centerY
+        , arcRx = correctedRx
+        , arcRy = correctedRy
+        , arcStartAngle = startAngle
+        , arcSweepAngle = correctedSweep
+        , arcRotation = rotation
+        }
+  where
+    start = svgFrom arc
+    end = svgTo arc
+    rotation = svgRotation arc
+    cosineRotation = Trig.cos rotation
+    sineRotation = Trig.sin rotation
+    deltaX = (pointX start - pointX end) / 2.0
+    deltaY = (pointY start - pointY end) / 2.0
+    localX = cosineRotation * deltaX + sineRotation * deltaY
+    localY = negate sineRotation * deltaX + cosineRotation * deltaY
+    initialRx = abs (svgRx arc)
+    initialRy = abs (svgRy arc)
+    lambda = square (localX / initialRx) + square (localY / initialRy)
+    radiusScale = if lambda > 1.0 then squareRoot lambda else 1.0
+    correctedRx = initialRx * radiusScale
+    correctedRy = initialRy * radiusScale
+    rxSquared = square correctedRx
+    rySquared = square correctedRy
+    localXSquared = square localX
+    localYSquared = square localY
+    numerator = rxSquared * rySquared
+        - rxSquared * localYSquared
+        - rySquared * localXSquared
+    denominator = rxSquared * localYSquared + rySquared * localXSquared
+    centerFactor = squareRoot (max 0.0 (numerator / denominator))
+    centerSign = if svgLargeArc arc == svgSweep arc then -1.0 else 1.0
+    centerLocalX = centerSign * centerFactor * correctedRx * localY / correctedRy
+    centerLocalY = centerSign * centerFactor * negate (correctedRy * localX / correctedRx)
+    midpointX = (pointX start + pointX end) / 2.0
+    midpointY = (pointY start + pointY end) / 2.0
+    centerX = cosineRotation * centerLocalX - sineRotation * centerLocalY + midpointX
+    centerY = sineRotation * centerLocalX + cosineRotation * centerLocalY + midpointY
+    unitStartX = (localX - centerLocalX) / correctedRx
+    unitStartY = (localY - centerLocalY) / correctedRy
+    unitEndX = (negate localX - centerLocalX) / correctedRx
+    unitEndY = (negate localY - centerLocalY) / correctedRy
+    startAngle = angleBetween 1.0 0.0 unitStartX unitStartY
+    rawSweep = angleBetween unitStartX unitStartY unitEndX unitEndY
+    correctedSweep
+        | not (svgSweep arc) && rawSweep > 0.0 = rawSweep - Trig.twoPi
+        | svgSweep arc && rawSweep < 0.0 = rawSweep + Trig.twoPi
+        | otherwise = rawSweep
+
+-- | Evaluate a center-form arc at a normalized parameter.
+evaluateCenterArc :: CenterArc -> Double -> Point
+evaluateCenterArc arc amount = pointAtAngle arc angle
+  where
+    angle = arcStartAngle arc + amount * arcSweepAngle arc
+
+-- | Return the unnormalized derivative with respect to the normalized parameter.
+tangentCenterArc :: CenterArc -> Double -> Point
+tangentCenterArc arc amount = Point worldX worldY
+  where
+    angle = arcStartAngle arc + amount * arcSweepAngle arc
+    localX = negate (arcRx arc) * Trig.sin angle * arcSweepAngle arc
+    localY = arcRy arc * Trig.cos angle * arcSweepAngle arc
+    cosineRotation = Trig.cos (arcRotation arc)
+    sineRotation = Trig.sin (arcRotation arc)
+    worldX = cosineRotation * localX - sineRotation * localY
+    worldY = sineRotation * localX + cosineRotation * localY
+
+-- | Compute tight axis-aligned bounds from the endpoints and rotated-ellipse extrema.
+boundingBoxCenterArc :: CenterArc -> Rect
+boundingBoxCenterArc arc = boundsOfPoints (map (pointAtAngle arc) includedAngles)
+  where
+    rotation = arcRotation arc
+    xExtremum = Trig.atan2
+        (negate (arcRy arc) * Trig.sin rotation)
+        (arcRx arc * Trig.cos rotation)
+    yExtremum = Trig.atan2
+        (arcRy arc * Trig.cos rotation)
+        (arcRx arc * Trig.sin rotation)
+    extrema =
+        [ xExtremum
+        , xExtremum + Trig.piValue
+        , yExtremum
+        , yExtremum + Trig.piValue
+        ]
+    includedAngles =
+        arcStartAngle arc
+            : arcStartAngle arc + arcSweepAngle arc
+            : filter (angleOnArc arc) extrema
+
+-- | Approximate a center-form arc with cubic Beziers of at most 90 degrees.
+toCubicBeziersCenter :: CenterArc -> [CubicBezier]
+toCubicBeziersCenter arc = map segment ([0 .. segmentCount - 1] :: [Int])
+  where
+    segmentCount = max 1 (ceiling (abs (arcSweepAngle arc) / Trig.halfPi))
+    segmentSweep = arcSweepAngle arc / fromIntegral segmentCount
+    magic = (4.0 / 3.0) * Trig.tan (segmentSweep / 4.0)
+    segment index = CubicBezier
+        (worldPoint startLocal)
+        (worldPoint firstControlLocal)
+        (worldPoint secondControlLocal)
+        (worldPoint endLocal)
+      where
+        startAngle = arcStartAngle arc + fromIntegral index * segmentSweep
+        endAngle = startAngle + segmentSweep
+        startLocal = localPoint arc startAngle
+        endLocal = localPoint arc endAngle
+        startTangent = localAngleTangent arc startAngle
+        endTangent = localAngleTangent arc endAngle
+        firstControlLocal = Point2D.add startLocal (Point2D.scale startTangent magic)
+        secondControlLocal = Point2D.subtract endLocal (Point2D.scale endTangent magic)
+    worldPoint = rotateTranslate (arcCenter arc) (arcRotation arc)
+
+-- | Convert an endpoint-form arc to cubics, or return an empty list if degenerate.
+toCubicBeziersSvg :: SvgArc -> [CubicBezier]
+toCubicBeziersSvg = maybe [] toCubicBeziersCenter . toCenterArc
+
+-- | Evaluate an endpoint-form arc, falling back to its line segment when degenerate.
+evaluateSvgArc :: SvgArc -> Double -> Point
+evaluateSvgArc arc amount =
+    maybe
+        (Point2D.lerp (svgFrom arc) (svgTo arc) amount)
+        (`evaluateCenterArc` amount)
+        (toCenterArc arc)
+
+-- | Bound an endpoint-form arc, falling back to its line segment when degenerate.
+boundingBoxSvgArc :: SvgArc -> Rect
+boundingBoxSvgArc arc =
+    maybe
+        (boundsOfPoints [svgFrom arc, svgTo arc])
+        boundingBoxCenterArc
+        (toCenterArc arc)
+
+pointAtAngle :: CenterArc -> Double -> Point
+pointAtAngle arc angle = rotateTranslate (arcCenter arc) (arcRotation arc) (localPoint arc angle)
+
+localPoint :: CenterArc -> Double -> Point
+localPoint arc angle = Point (arcRx arc * Trig.cos angle) (arcRy arc * Trig.sin angle)
+
+localAngleTangent :: CenterArc -> Double -> Point
+localAngleTangent arc angle = Point
+    (negate (arcRx arc) * Trig.sin angle)
+    (arcRy arc * Trig.cos angle)
+
+rotateTranslate :: Point -> Double -> Point -> Point
+rotateTranslate center rotation local = Point
+    (cosineRotation * pointX local - sineRotation * pointY local + pointX center)
+    (sineRotation * pointX local + cosineRotation * pointY local + pointY center)
+  where
+    cosineRotation = Trig.cos rotation
+    sineRotation = Trig.sin rotation
+
+angleOnArc :: CenterArc -> Double -> Bool
+angleOnArc arc angle
+    | abs sweep >= Trig.twoPi - angleEpsilon = True
+    | sweep >= 0.0 = normalizeAngle (angle - start) <= sweep + angleEpsilon
+    | otherwise = normalizeAngle (start - angle) <= negate sweep + angleEpsilon
+  where
+    start = arcStartAngle arc
+    sweep = arcSweepAngle arc
+
+normalizeAngle :: Double -> Double
+normalizeAngle angle = angle `mod'` Trig.twoPi
+
+angleBetween :: Double -> Double -> Double -> Double -> Double
+angleBetween firstX firstY secondX secondY =
+    Trig.atan2
+        (firstX * secondY - firstY * secondX)
+        (firstX * secondX + firstY * secondY)
+
+boundsOfPoints :: [Point] -> Rect
+boundsOfPoints points = Rect minimumX minimumY (maximumX - minimumX) (maximumY - minimumY)
+  where
+    xs = map pointX points
+    ys = map pointY points
+    minimumX = minimum xs
+    maximumX = maximum xs
+    minimumY = minimum ys
+    maximumY = maximum ys
+
+squareRoot :: Double -> Double
+squareRoot = fromRight 0.0 . Trig.sqrt
+
+square :: Double -> Double
+square value = value * value
+
+pointEpsilonSquared :: Double
+pointEpsilonSquared = 1e-20
+
+radiusEpsilon :: Double
+radiusEpsilon = 1e-10
+
+angleEpsilon :: Double
+angleEpsilon = 1e-12

--- a/code/packages/haskell/arc2d/test/Arc2DSpec.hs
+++ b/code/packages/haskell/arc2d/test/Arc2DSpec.hs
@@ -1,0 +1,171 @@
+module Arc2DSpec (spec) where
+
+import Arc2D
+import Bezier2D (CubicBezier (..), evaluateCubic)
+import Data.Maybe (fromJust)
+import Point2D (Point (..), Rect (..))
+import qualified Point2D
+import Test.Hspec
+import qualified Trig
+
+epsilon :: Double
+epsilon = 1e-8
+
+shouldApprox :: Double -> Double -> Expectation
+shouldApprox actual expected = abs (actual - expected) `shouldSatisfy` (< epsilon)
+
+shouldBePoint :: Point -> Point -> Expectation
+shouldBePoint actual expected = do
+    pointX actual `shouldApprox` pointX expected
+    pointY actual `shouldApprox` pointY expected
+
+shouldBeRect :: Rect -> Rect -> Expectation
+shouldBeRect actual expected = do
+    rectX actual `shouldApprox` rectX expected
+    rectY actual `shouldApprox` rectY expected
+    rectWidth actual `shouldApprox` rectWidth expected
+    rectHeight actual `shouldApprox` rectHeight expected
+
+quarterCircle :: CenterArc
+quarterCircle = CenterArc Point2D.origin 1.0 1.0 0.0 Trig.halfPi 0.0
+
+quarterSvg :: SvgArc
+quarterSvg = SvgArc (Point 1.0 0.0) (Point 0.0 1.0) 1.0 1.0 0.0 False True
+
+spec :: Spec
+spec = do
+    describe "CenterArc" $ do
+        it "stores center-form parameters" $ do
+            arcCenter quarterCircle `shouldBe` Point2D.origin
+            arcRx quarterCircle `shouldBe` 1.0
+            arcRy quarterCircle `shouldBe` 1.0
+            arcStartAngle quarterCircle `shouldBe` 0.0
+            arcSweepAngle quarterCircle `shouldBe` Trig.halfPi
+            arcRotation quarterCircle `shouldBe` 0.0
+        it "evaluates quarter-circle endpoints and midpoint" $ do
+            evaluateCenterArc quarterCircle 0.0 `shouldBePoint` Point 1.0 0.0
+            evaluateCenterArc quarterCircle 0.5 `shouldBePoint` Point (Trig.sqrt 0.5 `rightOr` 0.0) (Trig.sqrt 0.5 `rightOr` 0.0)
+            evaluateCenterArc quarterCircle 1.0 `shouldBePoint` Point 0.0 1.0
+        it "evaluates a full circle midpoint" $
+            evaluateCenterArc (CenterArc Point2D.origin 2.0 2.0 0.0 Trig.twoPi 0.0) 0.5
+                `shouldBePoint` Point (-2.0) 0.0
+        it "applies center offset and ellipse rotation" $ do
+            let arc = CenterArc (Point 5.0 3.0) 2.0 1.0 0.0 Trig.halfPi Trig.halfPi
+            evaluateCenterArc arc 0.0 `shouldBePoint` Point 5.0 5.0
+            evaluateCenterArc arc 1.0 `shouldBePoint` Point 4.0 3.0
+        it "returns tangents in both sweep directions" $ do
+            tangentCenterArc quarterCircle 0.0 `shouldBePoint` Point 0.0 Trig.halfPi
+            let clockwise = CenterArc Point2D.origin 1.0 1.0 0.0 (negate Trig.halfPi) 0.0
+            tangentCenterArc clockwise 0.0 `shouldBePoint` Point 0.0 (negate Trig.halfPi)
+        it "rotates tangent vectors without translating them" $ do
+            let arc = CenterArc (Point 20.0 30.0) 2.0 1.0 0.0 Trig.halfPi Trig.halfPi
+            tangentCenterArc arc 0.0 `shouldBePoint` Point (negate Trig.halfPi) 0.0
+        it "computes tight axis-aligned quarter-circle bounds" $
+            boundingBoxCenterArc quarterCircle `shouldBeRect` Rect 0.0 0.0 1.0 1.0
+        it "computes exact full rotated-ellipse bounds" $ do
+            let arc = CenterArc Point2D.origin 3.0 1.0 0.0 Trig.twoPi (Trig.piValue / 4.0)
+                xRadius = Trig.sqrt 5.0 `rightOr` 0.0
+            boundingBoxCenterArc arc `shouldBeRect` Rect (negate xRadius) (negate xRadius) (2.0 * xRadius) (2.0 * xRadius)
+        it "handles negative sweeps when selecting bounds extrema" $ do
+            let arc = CenterArc Point2D.origin 2.0 1.0 0.0 (negate Trig.halfPi) 0.0
+            boundingBoxCenterArc arc `shouldBeRect` Rect 0.0 (-1.0) 2.0 1.0
+        it "bounds a zero-sweep arc as one point" $
+            boundingBoxCenterArc (CenterArc (Point 1.0 2.0) 3.0 4.0 0.0 0.0 0.0)
+                `shouldBeRect` Rect 4.0 2.0 0.0 0.0
+        it "creates one cubic with the quarter-circle magic controls" $ do
+            let curves = toCubicBeziersCenter quarterCircle
+                curve = head curves
+                magic = (4.0 / 3.0) * Trig.tan (Trig.piValue / 8.0)
+            length curves `shouldBe` 1
+            cubicP0 curve `shouldBePoint` Point 1.0 0.0
+            cubicP1 curve `shouldBePoint` Point 1.0 magic
+            cubicP2 curve `shouldBePoint` Point magic 1.0
+            cubicP3 curve `shouldBePoint` Point 0.0 1.0
+            evaluateCubic curve 0.5 `shouldBePointWithin` (Point (Trig.sqrt 0.5 `rightOr` 0.0) (Trig.sqrt 0.5 `rightOr` 0.0), 3e-4)
+        it "splits full circles into four continuous cubics" $ do
+            let curves = toCubicBeziersCenter (CenterArc Point2D.origin 1.0 1.0 0.0 Trig.twoPi 0.0)
+            length curves `shouldBe` 4
+            mapM_ (uncurry shouldJoin) (zip curves (drop 1 curves))
+            cubicP3 (last curves) `shouldBePoint` cubicP0 (head curves)
+        it "splits a 91-degree arc into two cubics" $
+            length (toCubicBeziersCenter (CenterArc Point2D.origin 1.0 1.0 0.0 (Trig.radians 91.0) 0.0))
+                `shouldBe` 2
+        it "represents a zero sweep with one degenerate cubic" $ do
+            let curves = toCubicBeziersCenter (CenterArc Point2D.origin 2.0 1.0 0.0 0.0 0.0)
+                curve = head curves
+            length curves `shouldBe` 1
+            cubicP0 curve `shouldBePoint` Point 2.0 0.0
+            cubicP1 curve `shouldBePoint` Point 2.0 0.0
+            cubicP2 curve `shouldBePoint` Point 2.0 0.0
+            cubicP3 curve `shouldBePoint` Point 2.0 0.0
+
+    describe "SvgArc" $ do
+        it "stores endpoint-form parameters" $ do
+            svgFrom quarterSvg `shouldBe` Point 1.0 0.0
+            svgTo quarterSvg `shouldBe` Point 0.0 1.0
+            svgRx quarterSvg `shouldBe` 1.0
+            svgRy quarterSvg `shouldBe` 1.0
+            svgRotation quarterSvg `shouldBe` 0.0
+            svgLargeArc quarterSvg `shouldBe` False
+            svgSweep quarterSvg `shouldBe` True
+        it "rejects coincident endpoints and each zero-radius case" $ do
+            toCenterArc (SvgArc Point2D.origin Point2D.origin 1.0 1.0 0.0 False True) `shouldBe` Nothing
+            toCenterArc (SvgArc Point2D.origin (Point 1.0 0.0) 1e-11 1.0 0.0 False True) `shouldBe` Nothing
+            toCenterArc (SvgArc Point2D.origin (Point 1.0 0.0) 1.0 1e-11 0.0 False True) `shouldBe` Nothing
+        it "converts the unit quarter circle" $ do
+            let arc = fromJust (toCenterArc quarterSvg)
+            arcCenter arc `shouldBePoint` Point2D.origin
+            arcRx arc `shouldApprox` 1.0
+            arcRy arc `shouldApprox` 1.0
+            arcSweepAngle arc `shouldApprox` Trig.halfPi
+        it "accepts negative radii by taking their absolute values" $ do
+            let arc = fromJust (toCenterArc quarterSvg {svgRx = -1.0, svgRy = -1.0})
+            arcRx arc `shouldApprox` 1.0
+            arcRy arc `shouldApprox` 1.0
+        it "scales radii that are too small to join the endpoints" $ do
+            let arc = SvgArc (Point 0.0 0.0) (Point 10.0 0.0) 0.1 0.1 0.0 False True
+                centerArc = fromJust (toCenterArc arc)
+            arcRx centerArc `shouldApprox` 5.0
+            arcRy centerArc `shouldApprox` 5.0
+        it "honors clockwise and counterclockwise sweep flags" $ do
+            let counterclockwise = fromJust (toCenterArc quarterSvg)
+                clockwise = fromJust (toCenterArc quarterSvg {svgSweep = False})
+            arcSweepAngle counterclockwise `shouldSatisfy` (> 0.0)
+            arcSweepAngle clockwise `shouldSatisfy` (< 0.0)
+        it "wraps a positive raw angle into a large clockwise sweep" $ do
+            let arc = fromJust (toCenterArc quarterSvg {svgLargeArc = True, svgSweep = False})
+            arcSweepAngle arc `shouldSatisfy` (< negate Trig.piValue)
+        it "honors the large-arc flag" $ do
+            let endpoint = Point (negate (Trig.cos 0.3)) (Trig.sin 0.3)
+                base = SvgArc (Point 1.0 0.0) endpoint 1.0 1.0 0.0 False True
+                smallArc = fromJust (toCenterArc base)
+                largeArc = fromJust (toCenterArc base {svgLargeArc = True})
+            abs (arcSweepAngle smallArc) `shouldSatisfy` (< Trig.piValue)
+            abs (arcSweepAngle largeArc) `shouldSatisfy` (> Trig.piValue)
+        it "preserves endpoints through nonzero rotation conversion" $ do
+            let arc = SvgArc (Point 2.0 1.0) (Point (-1.0) 2.0) 3.0 1.5 (Trig.piValue / 4.0) False True
+                centerArc = fromJust (toCenterArc arc)
+            evaluateCenterArc centerArc 0.0 `shouldBePoint` svgFrom arc
+            evaluateCenterArc centerArc 1.0 `shouldBePoint` svgTo arc
+        it "delegates evaluation, cubics, and tight bounds" $ do
+            evaluateSvgArc quarterSvg 0.0 `shouldBePoint` svgFrom quarterSvg
+            evaluateSvgArc quarterSvg 1.0 `shouldBePoint` svgTo quarterSvg
+            boundingBoxSvgArc quarterSvg `shouldBeRect` Rect 0.0 0.0 1.0 1.0
+            let curves = toCubicBeziersSvg quarterSvg
+                centerArc = fromJust (toCenterArc quarterSvg)
+            curves `shouldBe` toCubicBeziersCenter centerArc
+        it "uses line fallbacks for degenerate endpoint arcs" $ do
+            let arc = SvgArc (Point 4.0 2.0) (Point (-2.0) 8.0) 0.0 2.0 0.0 False True
+            evaluateSvgArc arc 0.25 `shouldBePoint` Point 2.5 3.5
+            boundingBoxSvgArc arc `shouldBeRect` Rect (-2.0) 2.0 6.0 6.0
+            toCubicBeziersSvg arc `shouldBe` []
+
+rightOr :: Either error value -> value -> value
+rightOr result fallback = either (const fallback) id result
+
+shouldJoin :: CubicBezier -> CubicBezier -> Expectation
+shouldJoin left right = cubicP3 left `shouldBePoint` cubicP0 right
+
+shouldBePointWithin :: Point -> (Point, Double) -> Expectation
+shouldBePointWithin actual (expected, tolerance) =
+    Point2D.distance actual expected `shouldSatisfy` (< tolerance)

--- a/code/packages/haskell/arc2d/test/Spec.hs
+++ b/code/packages/haskell/arc2d/test/Spec.hs
@@ -1,0 +1,5 @@
+import qualified Arc2DSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec Arc2DSpec.spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -118,12 +118,12 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
 `scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
 `matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
-`point2d`, `affine2d`, and `bezier2d`
+`point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 294 |
+| Present in 10-15 languages | 172 | 293 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 705 | 9,870 |
@@ -169,7 +169,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 294
+The 172 packages present in at least ten implementation languages need 293
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -180,7 +180,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 19 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 18 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -534,6 +534,18 @@ subdivision, both quadratic extrema paths, and full, linear, constant, and
 negative-discriminant cubic derivative cases. The package now spans 12
 implementation lanes, reduces the high-consensus backlog to 294 slots, leaves
 19 gaps in the Haskell lane, and unlocks the dependent `arc2d` port.
+
+The sixteenth Haskell high-consensus slice is complete: `arc2d` now provides
+G2D03 SVG endpoint and center arc forms, W3C endpoint-to-center conversion,
+parametric evaluation, unnormalized tangents, analytic bounds for rotated
+ellipse arcs, and cubic Bezier approximation. It composes the existing pure
+Haskell `point2d`, `bezier2d`, and `trig` packages. Its package-native suite
+exercises 25 examples with 99% expression and 100% alternative coverage,
+including degeneracy thresholds, both sweep corrections, radius scaling,
+nonzero rotation, positive and negative tight-bound extrema, zero sweep, the
+quarter-circle magic controls, segmentation, and continuity. The package now
+spans 12 implementation lanes, reduces the high-consensus backlog to 293 slots,
+and leaves 18 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## What changed

- add a pure Haskell `arc2d` package implementing G2D03 SVG endpoint and center arc forms
- implement the W3C endpoint-to-center conversion, line fallbacks for degenerate arcs, analytic rotated-ellipse bounds, tangents, and cubic Bezier approximation
- add package metadata, documentation, and 25 package-native examples
- refresh the parity roadmap from 294 to 293 high-consensus gaps and from 19 to 18 Haskell gaps

## Why

`arc2d` was the next smallest dependency-safe Haskell parity gap after `point2d` and `bezier2d`. This completes the first coherent pure-Haskell 2D geometry dependency chain through G2D03.

## Validation

- `stack test arc2d --coverage` — 25 examples passed; 99% expression and 100% alternative coverage
- `stack sdist --test-tarball` — rebuilt and passed the isolated source archives plus the local `trig`, `point2d`, and `bezier2d` dependency graph
- `python code/scripts/tests/test_package_parity_report.py` — 6 tests passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 293 high-consensus gaps, 18 Haskell gaps, 12 `arc2d` lanes, zero collisions, zero unknown buckets
- `git diff --check`
