### PR TITLE
fix(security): reorder feed() size-check before buffer growth in reduce/derive/apl/j-repl

### DIFF
--- a/code/packages/rust/apl-repl/CHANGELOG.md
+++ b/code/packages/rust/apl-repl/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **`AplRepl::feed` now bounds `self.buffer` *before* growing it, not
+  after** — the previous order always ran `self.buffer.push_str(line)` (or
+  `push(' ')` + `push_str(line)` for a continuation) first and only then
+  checked `self.buffer.len() > MAX_CONTINUATION_BUFFER`, so a single,
+  caller-supplied `line` that was itself already oversized was fully
+  copied into `self.buffer` (an O(n) copy, possibly reallocating) before
+  the very check meant to bound it ever ran. Found while propagating
+  `maple-repl::MapleRepl::feed`'s identical `/security-review` fix (MP-4,
+  #8647) to this crate's sibling REPLs — this crate's own shipped
+  `read_bounded_line` never feeds `feed` a `line` longer than
+  `MAX_LINE_LEN`, but `feed` is a `pub fn` on a `pub struct`, so any other
+  embedder calling it directly with an attacker-supplied, unbounded `&str`
+  needed the same bound at this layer too, not just at the one shipped
+  call site. The buffer is now never grown past the cap; an oversized
+  `line` is rejected immediately (buffer cleared, same
+  `"...continuation limit; discarded"` message as before).
 - **`MAX_LINE_LEN` (64 KiB) caps a single physical line read from the input
   stream**, applied via the new `read_bounded_line` helper *before*
   `MAX_CONTINUATION_BUFFER`'s own check ever runs. `BufRead::read_line` has

--- a/code/packages/rust/apl-repl/src/lib.rs
+++ b/code/packages/rust/apl-repl/src/lib.rs
@@ -222,19 +222,39 @@ impl AplRepl {
                 "quit" | "exit" | "quit()" | "exit()" => return ReplResponse::Quit,
                 _ => {}
             }
+        }
+
+        // Bound the accumulation buffer BEFORE growing it: a stream that
+        // never balances (an endless run of open parens) must not buffer
+        // unbounded memory, and neither may a single caller-supplied `line`
+        // that is itself already oversized. Checking the size only after
+        // `push_str` would let an arbitrarily large `line` be copied into
+        // `self.buffer` (an O(n) copy, possibly reallocating) before the
+        // check meant to bound it ever ran — see `maple-repl::MapleRepl::
+        // feed`'s identical fix for the full rationale. `separator_len`
+        // accounts for the joining space this else-branch below adds when
+        // the buffer already holds a still-open continuation.
+        let separator_len = if self.buffer.is_empty() { 0 } else { 1 };
+        if self
+            .buffer
+            .len()
+            .saturating_add(separator_len)
+            .saturating_add(line.len())
+            > MAX_CONTINUATION_BUFFER
+        {
+            self.buffer.clear();
+            return ReplResponse::Output(format!(
+                "Error: statement exceeds the {MAX_CONTINUATION_BUFFER}-byte continuation limit; discarded\n"
+            ));
+        }
+
+        if separator_len == 0 {
             self.buffer.push_str(line);
         } else {
             // See this module's doc comment: joining with a space (not a
             // real '\n') keeps a still-open `(...)` on one logical line.
             self.buffer.push(' ');
             self.buffer.push_str(line);
-        }
-
-        if self.buffer.len() > MAX_CONTINUATION_BUFFER {
-            self.buffer.clear();
-            return ReplResponse::Output(format!(
-                "Error: statement exceeds the {MAX_CONTINUATION_BUFFER}-byte continuation limit; discarded\n"
-            ));
         }
 
         if paren_depth(&self.buffer) > 0 {

--- a/code/packages/rust/derive-repl/CHANGELOG.md
+++ b/code/packages/rust/derive-repl/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`DeriveRepl::feed` now bounds `self.buffer` *before* growing it, not
+  after** — the previous order always ran `self.buffer.push_str(line)` +
+  `push('\n')` first and only then checked `self.buffer.len() <=
+  MAX_INPUT_LEN`, so a single, caller-supplied `line` that was itself
+  already oversized was fully copied into `self.buffer` (an O(n) copy,
+  possibly reallocating) before the check meant to bound it ever ran, and
+  the oversized submission relied on `DeriveSession::feed`'s own internal
+  length guard to eventually reject it. Found while propagating
+  `maple-repl::MapleRepl::feed`'s identical `/security-review` fix (MP-4,
+  #8647) to this crate's sibling REPLs — this crate's own shipped
+  `read_bounded_line` never feeds `feed` a `line` longer than
+  `MAX_LINE_LEN`, but `feed` is a `pub fn` on a `pub struct`, so any other
+  embedder calling it directly with an attacker-supplied, unbounded `&str`
+  needed the same bound at this layer too, not just at the one shipped
+  call site. The buffer is now never grown past the cap; an oversized
+  `line` is rejected immediately (buffer cleared, `"input too large:
+  exceeds the {MAX_INPUT_LEN}-byte limit"`) without ever reaching
+  `DeriveSession::feed`. The numbered `#n: ` prompt still advances for a
+  rejected oversized submission exactly as it does for any other
+  submission — `self.input_index` increments in the new early-return path
+  too, preserving the existing `#1: ` → `#2: ` test expectation.
+
 ## [0.1.0] - 2026-07-13
 
 ### Added

--- a/code/packages/rust/derive-repl/src/lib.rs
+++ b/code/packages/rust/derive-repl/src/lib.rs
@@ -84,14 +84,37 @@ impl DeriveRepl {
                 _ => {}
             }
         }
+
+        // Bound the accumulation buffer BEFORE growing it: a stream that
+        // never balances (an endless run of open brackets) must not buffer
+        // unbounded memory, and neither may a single caller-supplied `line`
+        // that is itself already oversized. Checking the size only after
+        // `push_str` would let an arbitrarily large `line` be copied into
+        // `self.buffer` (an O(n) copy, possibly reallocating) before the
+        // check meant to bound it ever ran — see `maple-repl::MapleRepl::
+        // feed`'s identical fix for the full rationale.
+        if self
+            .buffer
+            .len()
+            .saturating_add(line.len())
+            .saturating_add(1)
+            > MAX_INPUT_LEN
+        {
+            self.buffer.clear();
+            // Still counts as a submitted (if rejected) statement, so the
+            // numbered prompt advances exactly as it would for any other
+            // submission — matching `#1: `/`#2: ` numbering even when the
+            // statement was too large to ever reach `self.session.feed`.
+            self.input_index += 1;
+            return ReplResponse::Output(format!(
+                "input too large: exceeds the {MAX_INPUT_LEN}-byte limit"
+            ));
+        }
+
         self.buffer.push_str(line);
         self.buffer.push('\n');
 
-        // Bound the accumulation buffer: a stream that never balances (an
-        // endless run of open brackets) must not buffer unbounded memory.
-        // Once over the size the session would reject anyway, submit so
-        // `feed` returns the clean "too large" error and resets.
-        if self.buffer.len() <= MAX_INPUT_LEN && is_incomplete(&self.buffer) {
+        if is_incomplete(&self.buffer) {
             return ReplResponse::NeedMore;
         }
 

--- a/code/packages/rust/j-repl/CHANGELOG.md
+++ b/code/packages/rust/j-repl/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **`JRepl::feed` now bounds `self.buffer` *before* growing it, not
+  after** — the previous order always ran `self.buffer.push_str(line)` (or
+  `push(' ')` + `push_str(line)` for a continuation) first and only then
+  checked `self.buffer.len() > MAX_CONTINUATION_BUFFER`, so a single,
+  caller-supplied `line` that was itself already oversized was fully
+  copied into `self.buffer` (an O(n) copy, possibly reallocating) before
+  the very check meant to bound it ever ran. Found while propagating
+  `maple-repl::MapleRepl::feed`'s identical `/security-review` fix (MP-4,
+  #8647) to this crate's sibling REPLs — this crate's own shipped
+  `read_bounded_line` never feeds `feed` a `line` longer than
+  `MAX_LINE_LEN`, but `feed` is a `pub fn` on a `pub struct`, so any other
+  embedder calling it directly with an attacker-supplied, unbounded `&str`
+  needed the same bound at this layer too, not just at the one shipped
+  call site. The buffer is now never grown past the cap; an oversized
+  `line` is rejected immediately (buffer cleared, same
+  `"...continuation limit; discarded"` message as before).
 - **`MAX_LINE_LEN` (64 KiB) caps a single physical line read from the input
   stream**, applied via the new `read_bounded_line` helper *before*
   `MAX_CONTINUATION_BUFFER`'s own check ever runs. `BufRead::read_line` has

--- a/code/packages/rust/j-repl/src/lib.rs
+++ b/code/packages/rust/j-repl/src/lib.rs
@@ -231,19 +231,39 @@ impl JRepl {
                 "quit" | "exit" | "quit()" | "exit()" => return ReplResponse::Quit,
                 _ => {}
             }
+        }
+
+        // Bound the accumulation buffer BEFORE growing it: a stream that
+        // never balances (an endless run of open parens) must not buffer
+        // unbounded memory, and neither may a single caller-supplied `line`
+        // that is itself already oversized. Checking the size only after
+        // `push_str` would let an arbitrarily large `line` be copied into
+        // `self.buffer` (an O(n) copy, possibly reallocating) before the
+        // check meant to bound it ever ran — see `maple-repl::MapleRepl::
+        // feed`'s identical fix for the full rationale. `separator_len`
+        // accounts for the joining space this else-branch below adds when
+        // the buffer already holds a still-open continuation.
+        let separator_len = if self.buffer.is_empty() { 0 } else { 1 };
+        if self
+            .buffer
+            .len()
+            .saturating_add(separator_len)
+            .saturating_add(line.len())
+            > MAX_CONTINUATION_BUFFER
+        {
+            self.buffer.clear();
+            return ReplResponse::Output(format!(
+                "Error: statement exceeds the {MAX_CONTINUATION_BUFFER}-byte continuation limit; discarded\n"
+            ));
+        }
+
+        if separator_len == 0 {
             self.buffer.push_str(line);
         } else {
             // See this module's doc comment: joining with a space (not a
             // real '\n') keeps a still-open `(...)` on one logical line.
             self.buffer.push(' ');
             self.buffer.push_str(line);
-        }
-
-        if self.buffer.len() > MAX_CONTINUATION_BUFFER {
-            self.buffer.clear();
-            return ReplResponse::Output(format!(
-                "Error: statement exceeds the {MAX_CONTINUATION_BUFFER}-byte continuation limit; discarded\n"
-            ));
         }
 
         if paren_depth(&self.buffer) > 0 {

--- a/code/packages/rust/reduce-repl/CHANGELOG.md
+++ b/code/packages/rust/reduce-repl/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`ReduceRepl::feed` now bounds `self.buffer` *before* growing it, not
+  after** — the previous order always ran `self.buffer.push_str(line)` +
+  `push('\n')` first and only then checked `self.buffer.len() <=
+  MAX_INPUT_LEN`, so a single, caller-supplied `line` that was itself
+  already oversized was fully copied into `self.buffer` (an O(n) copy,
+  possibly reallocating) before the check meant to bound it ever ran, and
+  the oversized submission relied on `ReduceSession::feed`'s own internal
+  length guard to eventually reject it. Found while propagating
+  `maple-repl::MapleRepl::feed`'s identical `/security-review` fix (MP-4,
+  #8647) to this crate's sibling REPLs — this crate's own shipped
+  `read_bounded_line` never feeds `feed` a `line` longer than
+  `MAX_LINE_LEN`, but `feed` is a `pub fn` on a `pub struct`, so any other
+  embedder calling it directly with an attacker-supplied, unbounded `&str`
+  needed the same bound at this layer too, not just at the one shipped
+  call site. The buffer is now never grown past the cap; an oversized
+  `line` is rejected immediately (buffer cleared, `"input too large:
+  exceeds the {MAX_INPUT_LEN}-byte limit"`) without ever reaching
+  `ReduceSession::feed`.
+
 ## [0.1.0] - 2026-07-18
 
 ### Added

--- a/code/packages/rust/reduce-repl/src/lib.rs
+++ b/code/packages/rust/reduce-repl/src/lib.rs
@@ -92,14 +92,32 @@ impl ReduceRepl {
                 _ => {}
             }
         }
+
+        // Bound the accumulation buffer BEFORE growing it: a stream that
+        // never balances (an endless run of open brackets) must not buffer
+        // unbounded memory, and neither may a single caller-supplied `line`
+        // that is itself already oversized. Checking the size only after
+        // `push_str` would let an arbitrarily large `line` be copied into
+        // `self.buffer` (an O(n) copy, possibly reallocating) before the
+        // check meant to bound it ever ran — see `maple-repl::MapleRepl::
+        // feed`'s identical fix for the full rationale.
+        if self
+            .buffer
+            .len()
+            .saturating_add(line.len())
+            .saturating_add(1)
+            > MAX_INPUT_LEN
+        {
+            self.buffer.clear();
+            return ReplResponse::Output(format!(
+                "input too large: exceeds the {MAX_INPUT_LEN}-byte limit"
+            ));
+        }
+
         self.buffer.push_str(line);
         self.buffer.push('\n');
 
-        // Bound the accumulation buffer: a stream that never balances (an
-        // endless run of open brackets) must not buffer unbounded memory.
-        // Once over the size the session would reject anyway, submit so
-        // `feed` returns the clean "too large" error and resets.
-        if self.buffer.len() <= MAX_INPUT_LEN && is_incomplete(&self.buffer) {
+        if is_incomplete(&self.buffer) {
             return ReplResponse::NeedMore;
         }
 


### PR DESCRIPTION
## Summary

`maple-repl`'s security review (MP-4, #8647) found and fixed a "push-before-size-check" ordering bug in `MapleRepl::feed`: the accumulation buffer's size cap was checked *after* the caller-supplied `line` was already appended via `push_str`, so a single already-oversized `line` would be fully copied into the buffer (an O(n) allocation/copy, possibly reallocating) before the check meant to bound it ever ran.

That review flagged the identical bug, unpatched, in all four sibling REPL crates. This PR propagates the same check-before-growth fix to each:

- **`reduce-repl` / `derive-repl`**: compute the prospective post-append length via `saturating_add` *before* `push_str`/`push('\n')`; reject immediately with the existing `"too large"`-class message if it would exceed `MAX_INPUT_LEN`, clearing the buffer without ever growing it past the cap. `derive-repl`'s numbered `#n:` prompt still advances on a rejected oversized submission (`self.input_index` increments in the new early-return path too), preserving its existing `#1: ` → `#2: ` test expectation.
- **`apl-repl` / `j-repl`**: same idea against `MAX_CONTINUATION_BUFFER`, correctly accounting for the joining-space byte the continuation branch adds when the buffer isn't empty, so the check is against the true post-append length.

## Test plan

- [x] `cargo test -p coding-adventures-reduce-repl -p coding-adventures-derive-repl -p coding-adventures-apl-repl -p coding-adventures-j-repl` — all 77 tests pass, including each crate's existing oversized-input regression test.
- [x] `cargo clippy -p coding-adventures-reduce-repl -p coding-adventures-derive-repl -p coding-adventures-apl-repl -p coding-adventures-j-repl --all-targets` — clean.
- [x] `/security-review` — PASSED, no vulnerabilities found (verified saturating-arithmetic safety, boundary/off-by-one behavior, separator-byte accounting in apl/j, and the `input_index` early-return path in derive-repl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)