### PR TITLE
feat(hl): Chapter 10 family (parents & siblings) for FR/GE/IT/PT

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -235,6 +235,8 @@
       "IT-TIME-NOON-MIDNIGHT": "mezzogiorno/mezzanotte (noon/midnight; mezzo/mezza ← medius + giorno/notte)",
       "IT-MONTHS": "gennaio…dicembre (closest to Latin; marzo=Mars=martedì; settembre…dicembre = Latin 7-10; luglio/agosto = Julius/Augustus)",
       "IT-SEASONS": "primavera/estate/autunno/inverno (primavera='prima vera' first green; stagione ← statiō 'a standing')",
+      "IT-FAMILY-PARENTS": "padre/madre (father/mother; closest to Latin pater/māter, -t-→-d-; padre = English loan; genitori 'parents' ← genitor 'begetter'; parenti=relatives false friend)",
+      "IT-FAMILY-SIBLINGS": "fratello/sorella (brother/sister; frāter/soror + diminutive -ello/-ella = 'little brother/sister'; → fraternal/sorority)",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
@@ -249,6 +251,8 @@
       "FR-TIME-NOON-MIDNIGHT": "midi/minuit (noon/midnight ← medius diēs / media nox; mi- 'middle' + di/nuit)",
       "FR-MONTHS": "janvier…décembre (Roman gods/emperors: janvier←Janus, mars←Mars=mardi, juillet←Julius; septembre…décembre = Latin 7-10)",
       "FR-SEASONS": "printemps/été/automne/hiver (printemps='prime temps' first time; hiver ← hibernum → hibernate)",
+      "FR-FAMILY-PARENTS": "père/mère (father/mother ← pater/māter; same PIE as English father/mother via Grimm's law p→f/t→th; → paternal/maternal)",
+      "FR-FAMILY-SIBLINGS": "frère/sœur (brother/sister ← frāter/soror; → fraternal/friar, sorority; œ ligature spells soror worn down)",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
@@ -263,6 +267,8 @@
       "GE-TIME-NOON-MIDNIGHT": "Mittag/Mitternacht (noon/midnight; NATIVE compounds Mitte+Tag / Mitte+Nacht, vs Latin-loaned Uhr)",
       "GE-MONTHS": "Januar…Dezember (LATIN loans like Uhr — März←Mars=Dienstag's Tiw; September…Dezember = Latin 7-10; vs native numbers)",
       "GE-SEASONS": "Frühling/Sommer/Herbst/Winter (NATIVE Germanic, unlike Latin months; Herbst = English HARVEST; Frühling ← früh 'early')",
+      "GE-FAMILY-PARENTS": "Vater/Mutter (father/mother; INHERITED Germanic, NOT Latin loans like the months; Grimm's law twins of English father/mother, V=f)",
+      "GE-FAMILY-SIBLINGS": "Bruder/Schwester (brother/sister; Germanic twins of English brother/sister; Geschwister 'siblings' via collective ge-)",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
       "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
       "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
@@ -275,7 +281,9 @@
       "PT-TIME-HOUR": "hora (hour ← hōra ← Greek hṓrā; horas explicit: é uma hora / são duas horas)",
       "PT-TIME-NOON-MIDNIGHT": "meio-dia/meia-noite (noon/midnight; meio/meia ← medius; noite ← noctem shows ct→it like oito)",
       "PT-MONTHS": "janeiro…dezembro (março=Mars; -eiro ending ← -arius like feira; setembro…dezembro = Latin 7-10 = sete/dez)",
-      "PT-SEASONS": "primavera/verão/outono/inverno (verão ← veranum ← vēr 'spring' — summer grew from spring!; outono ← autumnus au→ou)"
+      "PT-SEASONS": "primavera/verão/outono/inverno (verão ← veranum ← vēr 'spring' — summer grew from spring!; outono ← autumnus au→ou)",
+      "PT-FAMILY-PARENTS": "pai/mãe (father/mother; most worn-down of the sisters — pater→pae→pai, māter→mãe nasal, -t- vanished; os pais 'parents' lit. 'the fathers'; o país=country)",
+      "PT-FAMILY-SIBLINGS": "irmão/irmã (brother/sister; NOT from frāter but germānus 'of the same stock' — frāter germānus 'full brother'; = ES hermano; cousins germane/German)"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Chapter 10 — Family
+
+- **Chapter 10 authored** (`FR-C10-parents`, `-freres-soeurs`): the immediate
+  family, atom-first, reviewing Ch.9/Ch.1 via `reviews_of`.
+- **père / mère** ← *pater / māter* ← PIE *\*ph₂tḗr / \*méh₂tēr*. Taught as the
+  **same inherited words** as English *father / mother*, split only by **Grimm's
+  law** (*p → f*, *t → th*) — French kept Latin's *p*, English shifted it. Root
+  payoff: paternal/patron, maternal/matron.
+- **frère / sœur** ← *frāter / soror* → fraternal/friar, sorority; the **œ**
+  ligature is introduced as the fused vowel spelling worn-down *soror*.
+- Taxonomy: namespaced `FR-FAMILY-PARENTS`, `FR-FAMILY-SIBLINGS`.
+
 ## Chapter 9 — Months & seasons
 
 - **Chapter 9 authored** (`FR-C09-mois`, `-saisons`): the calendar year, atom-first,

--- a/code/learning/human-languages/french/lessons/FR-C10-freres-soeurs.md
+++ b/code/learning/human-languages/french/lessons/FR-C10-freres-soeurs.md
@@ -1,0 +1,57 @@
+---
+id: FR-C10-freres-soeurs
+chapter: 10
+type: word
+headword: le frère, la sœur
+gloss: brother and sister — frater and soror, behind fraternal and sorority
+concept_tag: FR-FAMILY-SIBLINGS
+prerequisites: [FR-C10-parents]
+sounds: [oe-ligature, e-grave]
+roots: [frater-latin, soror-latin]
+etymology_hook: "frère ← frater (→ fraternal, friar, fraternity), sœur ← soror (→ sorority, sorority); the œ ligature spells the worn-down soror"
+est_minutes: 4
+reviews_of: [FR-C10-parents, FR-C09-saisons]
+---
+
+# le frère, la sœur — brother and sister
+
+## Warm-up
+
+[PAUSE 2s] With parents in hand, the next pair: **frère** ("brother") and
+**sœur** ("sister"). Both are straight from Latin, and both hand English a whole
+family of words.
+
+## Taken apart
+
+- **le frère** ("brother") ← Latin **frāter** ← PIE **\*bʰréh₂tēr** (the same PIE
+  root that, through Grimm's law *bʰ → b*, gave English **brother**).
+- **la sœur** ("sister") ← Latin **soror**. The odd-looking **œ** (an *o* and *e*
+  fused into one letter) spells the vowel that *soror* wore down to — *soror →
+  seror → sœur*.
+
+## The English cousins
+
+- **frère** → **fraternal, fraternity, fraternize**, and — softened in old French
+  — **friar** (a "brother" in a religious order).
+- **sœur** → **sorority, sororal**; and a *sister* in a convent is still called a
+  **sœur**. (English *sister* comes from the *same* PIE root *\*swésōr*, by the
+  Germanic road — Latin *soror* and English *sister* are cousins.)
+
+So the four family words now form a set: **père, mère, frère, sœur** — each one a
+key to a Latin-through-English word (**pat**ernal, **mat**ernal, **frat**ernal,
+**soror**ity).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: all four — "le père, la mère, le frère, la sœur"]
+- [YOU SAY: "frère → fraternal, friar; sœur → sorority"]
+- [YOU SAY: spell it — "s-œ-u-r, the *œ* is one letter"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "brother" and "sister" with articles. (**le frère, la sœur**.)
+What Latin words are they from? (*frāter*, *soror*.) An English cousin of each?
+(*frère* → fraternal/friar; *sœur* → sorority.) What is unusual about spelling
+*sœur*? (The **œ** ligature — *o* and *e* fused into one letter.) Next chapter:
+building sentences about your family.

--- a/code/learning/human-languages/french/lessons/FR-C10-parents.md
+++ b/code/learning/human-languages/french/lessons/FR-C10-parents.md
@@ -1,0 +1,63 @@
+---
+id: FR-C10-parents
+chapter: 10
+type: word
+headword: le père, la mère
+gloss: father and mother — the PIE root behind paternal and maternal
+concept_tag: FR-FAMILY-PARENTS
+prerequisites: [FR-C09-saisons, FR-C01-bonjour]
+sounds: [nasal-none, e-grave]
+roots: [pater-latin, mater-latin]
+etymology_hook: "père ← pater, mère ← mater — the same PIE *ph2tēr/*méh2tēr that split into English father/mother (Grimm's law p→f, t→th) and Latin paternal/maternal"
+est_minutes: 5
+reviews_of: [FR-C09-saisons, FR-C01-bonjour]
+---
+
+# le père, la mère — the oldest words in the family
+
+## Warm-up
+
+[PAUSE 2s] The words for "father" and "mother" are among the **oldest words we
+can reconstruct** — older than Latin, older than Rome. French kept them almost
+bare: **père** and **mère**. And they are secretly the *same words* as English
+**father** and **mother**.
+
+## Taken apart
+
+- **le père** ("father") ← Latin **pater** ← PIE **\*ph₂tḗr**.
+- **la mère** ("mother") ← Latin **māter** ← PIE **\*méh₂tēr**.
+
+Note the articles: *le* père (masculine), *la* mère (feminine) — the gender
+you have been tracking since Chapter 1.
+
+## The English connection (one sound-law)
+
+French took *pater/māter* straight from Latin. **English** took the *same* PIE
+words down a different road, through **Grimm's law**, which turned Latin's **p →
+f** and **t → th**:
+
+| PIE | Latin / French | English |
+|---|---|---|
+| \*ph₂tḗr | *pater* → **père** | **f**a**th**er |
+| \*méh₂tēr | *māter* → **mère** | **m**o**th**er |
+
+So *père* and *father* are not lookalikes borrowed late — they are the **same
+inherited word**, one keeping the *p*, the other shifting it to *f*. The Latin
+root also gives English its "of a parent" adjectives: **paternal, paternity,
+patron** and **maternal, maternity, matron, matter** (*māter* → *materia*,
+"stuff a tree-mother makes").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "le père, la mère" — note *le / la*, the genders]
+- [YOU SAY: the sound-law — "*père* keeps *p*, *father* shifts to *f*; same word"]
+- [YOU SAY: "père → paternal; mère → maternal"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "father" and "mother" with their articles. (**le père, la
+mère**.) What one sound-change makes *père* into English *father*? (Grimm's law:
+**p → f** — and **t → th**.) Name an English cousin of each. (*père* →
+paternal/patron; *mère* → maternal/matron.) Next: **le frère, la sœur** — brother
+and sister.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -54,6 +54,11 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   septembre–décembre = the Latin **7–10** from the numbers) → the four seasons
   (printemps = "prime temps" first-time; hiver ← *hibernum* → hibernate). **Authored.**
 
+- **Ch. 10 — Family**: **père/mère** (← *pater/māter* — the same PIE words as English
+  *father/mother*, split by **Grimm's law** *p→f, t→th*; → paternal/maternal) →
+  **frère/sœur** (← *frāter/soror* → fraternal/friar, sorority; the **œ** ligature
+  spells worn-down *soror*). **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Chapter 10 — Family
+
+- **Chapter 10 authored** (`GE-C10-eltern`, `-geschwister`): the immediate family,
+  atom-first, reviewing Ch.9/Ch.1 via `reviews_of` — and the **mirror image of the
+  months chapter**.
+- **der Vater / die Mutter** — taught as **inherited Germanic** words (NOT Latin
+  loans like the months), the Grimm's-law twins of English *father / mother*: the
+  *V* of *Vater* is pronounced *f*, and German/English agree (*f-*, *m-*) precisely
+  because both are Germanic, while French/Latin sit across Grimm's line. The
+  standout thread: **family is native where the calendar was borrowed**.
+- **der Bruder / die Schwester** — Germanic twins of *brother / sister*; plus
+  **die Geschwister** ("siblings"), built with the **collective ge-** prefix that
+  English lacks.
+- Taxonomy: namespaced `GE-FAMILY-PARENTS`, `GE-FAMILY-SIBLINGS`.
+
 ## Chapter 9 — Months & seasons
 
 - **Chapter 9 authored** (`GE-C09-monate`, `-jahreszeiten`): the calendar year,

--- a/code/learning/human-languages/german/lessons/GE-C10-eltern.md
+++ b/code/learning/human-languages/german/lessons/GE-C10-eltern.md
@@ -1,0 +1,70 @@
+---
+id: GE-C10-eltern
+chapter: 10
+type: word
+headword: der Vater, die Mutter
+gloss: father and mother — Grimm's law makes them twins of English father/mother
+concept_tag: GE-FAMILY-PARENTS
+prerequisites: [GE-C09-jahreszeiten, GE-C01-hallo]
+sounds: [v-as-f, umlaut-u]
+roots: [pie-pater, pie-mater, grimms-law]
+etymology_hook: "Vater/Mutter aren't borrowed from Latin like the German months — they're inherited Germanic cousins of English father/mother, and Grimm's law (p→f, t→th→d) is written right on their faces"
+est_minutes: 5
+reviews_of: [GE-C09-jahreszeiten, GE-C01-hallo]
+---
+
+# der Vater, die Mutter — the family that proves Grimm's law
+
+## Warm-up
+
+[PAUSE 2s] Back in the months chapter, German **borrowed** its calendar from
+Latin (*Januar, März*…). Family is the **opposite** story: **Vater** and
+**Mutter** are **not** borrowed — they are *inherited* Germanic words, blood
+cousins of English **father** and **mother**. And the sound-law that links them,
+**Grimm's law**, is written right on their faces.
+
+## Taken apart
+
+- **der Vater** ("father") — note the spelling **V**, but it is pronounced **f**
+  (*FAH-ter*). ← PIE **\*ph₂tḗr**.
+- **die Mutter** ("mother"). ← PIE **\*méh₂tēr**.
+
+Articles: *der* Vater (masculine), *die* Mutter (feminine).
+
+## Grimm's law, on display
+
+Grimm's law is the great sound-shift that split the **Germanic** languages
+(English, German, Dutch…) off from the rest. Watch what it did to the *same* PIE
+words that Latin kept as *pater/māter*:
+
+| PIE | Latin (French) | Germanic (English / German) |
+|---|---|---|
+| \*ph₂tḗr | *pater* (père) | **f**ather / **V**ater (*V* = *f*) |
+| \*méh₂tēr | *māter* (mère) | **m**other / **M**utter |
+
+- **p → f**: Latin kept the *p* (*pater*); Germanic turned it to *f* — English
+  **f**ather, German **V**ater (the *V* is just an old spelling of that *f* sound).
+- **t → th → d**: the middle consonant became English *th* (mo**th**er) and then,
+  in German's later shift, *d/t* (Mu**tt**er).
+
+So German and English **agree** here (both *f-*, both *m-*) precisely because they
+are **both Germanic** — while French/Latin sit on the other side of Grimm's line.
+The month names were Latin tourists; **Vater** and **Mutter** are natives.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "der Vater, die Mutter" — *Vater* with an **f** sound]
+- [YOU SAY: the twin test — "**V**ater / **f**ather, **M**utter / **m**other —
+  both Germanic"]
+- [YOU SAY: contrast — "German months = Latin (Januar); German family = Germanic
+  (Vater)"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "father" and "mother" with articles, minding the pronunciation.
+(**der Vater** — *f* sound — **die Mutter**.) Why do German *Vater* and English
+*father* match, while French *père* differs? (German & English are both
+**Germanic** — Grimm's law shifted *p → f* in both; French kept Latin's *p*.) How
+does this chapter contrast with the months chapter? (Months were **borrowed** from
+Latin; family is **inherited** Germanic.) Next: **Bruder** and **Schwester**.

--- a/code/learning/human-languages/german/lessons/GE-C10-geschwister.md
+++ b/code/learning/human-languages/german/lessons/GE-C10-geschwister.md
@@ -1,0 +1,61 @@
+---
+id: GE-C10-geschwister
+chapter: 10
+type: word
+headword: der Bruder, die Schwester
+gloss: brother and sister — again Germanic twins of the English words
+concept_tag: GE-FAMILY-SIBLINGS
+prerequisites: [GE-C10-eltern]
+sounds: [sch-sh, umlaut-none]
+roots: [pie-bhrater, pie-swesor]
+etymology_hook: "Bruder/Schwester are the Germanic cousins of English brother/sister (same PIE *bʰréh₂tēr, *swésōr); Geschwister 'siblings' bundles them with the ge- collective prefix"
+est_minutes: 4
+reviews_of: [GE-C10-eltern, GE-C09-jahreszeiten]
+---
+
+# der Bruder, die Schwester — and the word for "siblings"
+
+## Warm-up
+
+[PAUSE 2s] The parent pair proved German and English are Germanic twins. The
+sibling pair does it again: **Bruder** ("brother") and **Schwester** ("sister")
+are the near-identical cousins of the English words — no translation really
+needed, just an ear for the German sounds.
+
+## Taken apart
+
+- **der Bruder** ("brother") ← PIE **\*bʰréh₂tēr** — the same root as Latin
+  *frāter* (French *frère*), but here kept with a **b-** (Grimm's law changed
+  *bʰ → b*), exactly like English **b**rother.
+- **die Schwester** ("sister") ← PIE **\*swésōr**. The German **sch** spells an
+  *sh* sound; strip it back and *Schwester* is English **s**ister and Latin
+  **s**oror, all one root.
+
+## The collective — Geschwister
+
+German has a tidy word English lacks: **die Geschwister** = "**siblings**,"
+brothers-and-sisters together. It is built with the **ge-** prefix, an old
+**collective** marker ("a set of…") on *Schwester* — the same *ge-* that bundles
+mountains into a *Gebirge* ("range") and lets German gather a family in one word.
+
+The four family words now stand as a Germanic set beside the Romance ones:
+
+| German | English | (Romance cousin) |
+|---|---|---|
+| Vater / Mutter | father / mother | père / mère |
+| Bruder / Schwester | brother / sister | frère / sœur |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "der Bruder, die Schwester" — *Schw-* = *shv*]
+- [YOU SAY: the twin test — "**B**ruder / **b**rother, **Schw**ester / **s**ister"]
+- [YOU SAY: "die Geschwister — the *ge-* bundles them into 'siblings'"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "brother" and "sister" with articles. (**der Bruder, die
+Schwester**.) Why do they match English so closely? (Both **Germanic** — same PIE
+roots, no Grimm's-law gap between them.) What does **Geschwister** mean, and what
+does the **ge-** do? ("**Siblings**"; *ge-* is a **collective** prefix, "a set
+of.") Next chapter: putting the family into sentences.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -57,6 +57,12 @@ Spanish and French where a contrast helps. The recurring decoder is the
   native** (Frühling ← *früh* "early"; *Herbst* = English **harvest**; Sommer/Winter
   = English twins). **Authored.**
 
+- **Ch. 10 — Family**: the mirror of the months — **Vater/Mutter** are **inherited
+  Germanic** (NOT Latin loans), Grimm's-law twins of English *father/mother* (*V* = *f*)
+  → **Bruder/Schwester** (Germanic twins of *brother/sister*; **Geschwister** "siblings"
+  via the collective **ge-**). The standout: family is native where the months were
+  borrowed. **Authored.**
+
 ## Planned
 
 | Chapter | Theme |

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 10 — Family
+
+- **Chapter 10 authored** (`IT-C10-genitori`, `-fratello-sorella`): the immediate
+  family, atom-first, reviewing Ch.9/Ch.1 via `reviews_of`.
+- **padre / madre** — the sisters' **closest to Latin** *pater / māter* (only the
+  *-t-* softened to *-d-*); *padre* is the very word English borrowed for a priest.
+  **i genitori** ("parents") ← *genitor* "**begetter**" (*gignere* "beget") →
+  genesis/gene/progenitor; with the **false-friend** warning that *parenti* means
+  **relatives**, not "parents."
+- **fratello / sorella** — Italian rebuilt "brother/sister" with its **diminutive**
+  *-ello / -ella* ("little brother/sister"), keeping the *frat- / soror-* roots
+  (→ fraternal, sorority).
+- Taxonomy: namespaced `IT-FAMILY-PARENTS`, `IT-FAMILY-SIBLINGS`.
+
 ## Chapter 9 — Months & seasons
 
 - **Chapter 9 authored** (`IT-C09-mesi`, `-stagioni`): the calendar year, atom-first,

--- a/code/learning/human-languages/italian/lessons/IT-C10-fratello-sorella.md
+++ b/code/learning/human-languages/italian/lessons/IT-C10-fratello-sorella.md
@@ -1,0 +1,51 @@
+---
+id: IT-C10-fratello-sorella
+chapter: 10
+type: word
+headword: il fratello, la sorella
+gloss: brother and sister — frater/soror plus Italy's favourite little-endings
+concept_tag: IT-FAMILY-SIBLINGS
+prerequisites: [IT-C10-genitori]
+sounds: [double-ll, r-tap]
+roots: [frater-latin, soror-latin]
+etymology_hook: "fratello ← frater + the diminutive -ellus, sorella ← soror + -ella; Italian rebuilt 'brother/sister' as 'little brother/little sister', keeping frat-/soror- (→ fraternal, sorority)"
+est_minutes: 4
+reviews_of: [IT-C10-genitori, IT-C09-stagioni]
+---
+
+# il fratello, la sorella — brother and sister, with a little-ending
+
+## Warm-up
+
+[PAUSE 2s] Here Italian does something charming. Where French kept *frère* and
+*sœur* bare, Italian rebuilt "brother" and "sister" with its beloved
+**diminutive** endings — literally "**little brother**" and "**little sister**" —
+and those forms became the everyday words.
+
+## Taken apart
+
+- **il fratello** ("brother") ← Latin **frāter** + the diminutive **-ellus** →
+  *fraterellus* → *fratello*, once "little brother."
+- **la sorella** ("sister") ← Latin **soror** + the diminutive **-ella** →
+  *sorella*, once "little sister."
+
+The root still shows: **frat-** and **soror-**, the same roots English turns into
+**frat**ernal, **frat**ernity, **friar** and **soror**ity, **soror**al. Italian
+just wrapped them in the affectionate *-ello/-ella* that also gives *fratello*'s
+cousins across the language (*-ello* on *poverello* "poor little one," *-ella* on
+countless names).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: all four — "il padre, la madre, il fratello, la sorella"]
+- [YOU SAY: the build — "*frater* + *-ello* → fratello, 'little brother'"]
+- [YOU SAY: "fratello → fraternal; sorella → sorority"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "brother" and "sister" with articles. (**il fratello, la
+sorella**.) What did Italian **add** to Latin *frāter/soror* to make them?
+(A **diminutive** ending, *-ello / -ella* — "little brother/sister.") Name an
+English cousin of each root. (*frat-* → fraternal/friar; *soror-* → sorority.)
+Next chapter: sentences about the family.

--- a/code/learning/human-languages/italian/lessons/IT-C10-genitori.md
+++ b/code/learning/human-languages/italian/lessons/IT-C10-genitori.md
@@ -1,0 +1,60 @@
+---
+id: IT-C10-genitori
+chapter: 10
+type: word
+headword: il padre, la madre
+gloss: father and mother — Italian keeps them closest to Latin pater/mater
+concept_tag: IT-FAMILY-PARENTS
+prerequisites: [IT-C09-stagioni, IT-C01-ciao]
+sounds: [d-single, r-tap]
+roots: [pater-latin, mater-latin]
+etymology_hook: "padre/madre sit closest of the sisters to Latin pater/mater; padre is the very word English borrowed as 'padre'; genitori 'parents' ← genitor 'begetter' (→ genital, progenitor, genesis)"
+est_minutes: 5
+reviews_of: [IT-C09-stagioni, IT-C01-ciao]
+---
+
+# il padre, la madre — closest to Latin
+
+## Warm-up
+
+[PAUSE 2s] Italian, as ever, stays nearest to Rome. Its **padre** ("father") and
+**madre** ("mother") barely moved from Latin **pater** and **māter** — Latin just
+softened the *-t-* to *-d-*. If you know the Latin, you nearly know the Italian.
+
+## Taken apart
+
+- **il padre** ("father") ← Latin **pater** (*-t- → -d-*).
+- **la madre** ("mother") ← Latin **māter** (*-t- → -d-*).
+
+Articles: *il* padre (masculine), *la* madre (feminine).
+
+**English already borrowed one of these whole:** a **padre** is what English (and
+Spanish-influenced) speakers call a priest or military chaplain — *padre* itself,
+untouched.
+
+## The word for "parents" — genitori
+
+Italian "parents" is **i genitori** — not from *parens* but from Latin **genitor**,
+"the **begetter**," from *gignere* "to beget/bring forth." That root *gen-* "give
+birth to" is everywhere in English: **genital, progenitor, genesis, generate,
+genus, gene**. So *i genitori* are literally "the begetters." (Beware the **false
+friend**: Italian *parenti* means **relatives** in general, *not* "parents"!)
+
+The Latin-through-English adjective family still comes from *pater/māter*:
+**pat**ernal, **mat**ernal — the same roots as French *père/mère* and, by Grimm's
+law, English *father/mother*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "il padre, la madre" — soft *-d-* where Latin had *-t-*]
+- [YOU SAY: "i genitori = the parents; *genitor* = begetter → genesis, gene"]
+- [YOU SAY: the false-friend warning — "*parenti* = relatives, NOT parents"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "father" and "mother" with articles. (**il padre, la madre**.)
+What single sound did Latin *pater/māter* soften to? (The *-t-* became **-d-**.)
+What does **genitori** literally mean, and name an English cousin. ("The
+**begetters**"; genesis/gene/progenitor.) What does the false friend *parenti*
+mean? (**Relatives**, not parents.) Next: **fratello** and **sorella**.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -51,6 +51,11 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   Latin **7–10**) → the seasons (primavera = "prima vera" first-green; *stagione* ←
   *statiō* "a standing"; inverno ← *hibernum*). **Authored.**
 
+- **Ch. 10 — Family**: **padre/madre** (closest to Latin *pater/māter*, *-t-→-d-*;
+  *padre* = the English loan; **genitori** "parents" ← *genitor* "begetter" → genesis;
+  *parenti*=relatives false friend) → **fratello/sorella** (← *frāter/soror* + the
+  diminutive *-ello/-ella*, "little brother/sister"). **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 10 — Family
+
+- **Chapter 10 authored** (`PT-C10-pais`, `-irmaos`): the immediate family,
+  atom-first, reviewing Ch.9/Ch.1 via `reviews_of` — with **two Iberian twists**.
+- **pai / mãe** — the **most worn-down** parents of any sister: Latin *pater / māter*
+  lost the intervocalic *-t-* entirely (*pater → pae → pai*; *mãe* went nasal). The
+  masculine plural **os pais** means "the parents" (literally "the fathers"), with a
+  spelling-trap note vs *o país* ("the country").
+- **irmão / irmã** — the surprise: **not** from *frāter* but from Latin **germānus**
+  "of the same stock" (*frāter germānus* "full brother," the *frāter* later dropped).
+  Ties to the English cousins **germane** and **German** (the people-name), and to
+  the identical Spanish swap *hermano / hermana*.
+- Taxonomy: namespaced `PT-FAMILY-PARENTS`, `PT-FAMILY-SIBLINGS`.
+
 ## Chapter 9 — Months & seasons
 
 - **Chapter 9 authored** (`PT-C09-meses`, `-estacoes`): the calendar year, atom-first,

--- a/code/learning/human-languages/portuguese/lessons/PT-C10-irmaos.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C10-irmaos.md
@@ -1,0 +1,67 @@
+---
+id: PT-C10-irmaos
+chapter: 10
+type: word
+headword: o irmão, a irmã
+gloss: brother and sister — NOT from frater, but from germanus "of the same stock"
+concept_tag: PT-FAMILY-SIBLINGS
+prerequisites: [PT-C10-pais]
+sounds: [nasal-ao, nasal-a]
+roots: [germanus-latin]
+etymology_hook: "the Iberian surprise: irmão/irmã come NOT from frater but from Latin germanus 'genuine, of the same parents' (frater germanus 'full brother') — the same word as 'germane' and the people-name 'German'; Spanish did the identical swap (hermano/hermana)"
+est_minutes: 5
+reviews_of: [PT-C10-pais, PT-C09-estacoes]
+---
+
+# o irmão, a irmã — the brother who isn't a "frater"
+
+## Warm-up
+
+[PAUSE 2s] Every other track in this course builds "brother" from Latin *frāter*
+(French *frère*, Italian *fratello*). Portuguese — and Spanish with it — does
+something completely different, and it is one of the best etymologies in the whole
+language.
+
+## Taken apart
+
+- **o irmão** ("brother") and **a irmã** ("sister") come **not** from *frāter* but
+  from Latin **germānus**, meaning "**genuine, of the same stock, born of the same
+  parents.**"
+- The Romans said **frāter germānus** — a "**full** brother," one sharing both
+  parents, as opposed to a half-brother. Over time Iberian speakers **dropped the
+  *frāter*** and kept the adjective: *(frāter) germānus → irmão*. So a Portuguese
+  brother is literally a "**full-blood** one."
+
+Articles: *o* irmão (masc.), *a* irmã (fem.); the masculine plural **os irmãos**
+covers a mixed set ("siblings"), exactly as *os pais* did for parents.
+
+## The astonishing cousins of germanus
+
+That same *germānus* "of the same stock" fans out in English:
+
+- **germane** — "relevant, closely related" (originally "having the same
+  parents").
+- **German** — the **people-name**! The Romans called the tribes across the Rhine
+  *Germani*, plausibly "the genuine/kindred ones." So *irmão* ("brother") and
+  *German* (the nation) spring from one Latin word for **kinship**.
+
+Spanish made the **identical** swap — *hermano / hermana* — so Portuguese *irmão*
+and Spanish *hermano* are twins, both meaning "full-blood brother," both leaving
+*frāter* behind (kept only in bookish *fraternal / fraterno*).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "o irmão, a irmã" — both nasal endings]
+- [YOU SAY: the origin — "*frāter germānus* → drop *frāter* → **irmão**, 'full
+  brother'"]
+- [YOU SAY: the cousins — "germano → germane, and *German* the people"]
+- [YOU SAY: the twin — "Portuguese *irmão* = Spanish *hermano*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "brother" and "sister" with articles. (**o irmão, a irmã**.) What
+Latin word are they from — and what did it mean? (**germānus** — "genuine, of the
+same parents"; from *frāter germānus*, "full brother.") Name two English cousins
+of *germānus*. (**germane**; **German**, the people-name.) What is the Spanish
+twin of *irmão*? (*hermano*.) Next chapter: sentences about the whole family.

--- a/code/learning/human-languages/portuguese/lessons/PT-C10-pais.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C10-pais.md
@@ -1,0 +1,62 @@
+---
+id: PT-C10-pais
+chapter: 10
+type: word
+headword: o pai, a mãe
+gloss: father and mother — the most worn-down of all: pater→pai, mater→mãe
+concept_tag: PT-FAMILY-PARENTS
+prerequisites: [PT-C09-estacoes, PT-C01-ola]
+sounds: [nasal-ae, diphthong-ai]
+roots: [pater-latin, mater-latin]
+etymology_hook: "Portuguese wore pater/māter down further than any sister — to one-syllable pai and nasal mãe (the intervocalic -t- vanished, pater→pae→pai); os pais means both 'the parents' and, literally, 'the fathers'"
+est_minutes: 5
+reviews_of: [PT-C09-estacoes, PT-C01-ola]
+---
+
+# o pai, a mãe — the family words worn to the bone
+
+## Warm-up
+
+[PAUSE 2s] Every Romance sister descends from *pater* and *māter*, but
+**Portuguese wore them down the furthest**. Italian kept *padre/madre*; French
+*père/mère*; Portuguese dissolved the middle consonant entirely, leaving the
+one-syllable **pai** and the nasal **mãe**.
+
+## Taken apart
+
+- **o pai** ("father") ← Latin **pater**. Portuguese dropped the intervocalic
+  **-t-** completely: *pater → pae → pai*. The same disappearing-*-t-* you saw in
+  Ch.1's *noite* is here taken all the way to a bare diphthong.
+- **a mãe** ("mother") ← Latin **māter**. Same loss of *-t-*, and the *a* soaked
+  up a nasal from the lost *-n-*/*-m-* environment → the tilde vowel **ã**
+  (*mãe* = "mahng-ee," nasal).
+
+Articles: *o* pai (masculine), *a* mãe (feminine).
+
+## The plural trick — os pais
+
+Portuguese says **os pais** for "**the parents**" — but literally it is "the
+**fathers**." Like Spanish *los padres*, the masculine plural **covers a mixed
+group**: one father + one mother = *os pais*. (And mind the spelling twin: **o
+país** — with an accent — means "the **country**"; *os pais* / *os países* are a
+classic pair to keep straight.)
+
+The learned adjectives, borrowed back from Latin, still show the old root:
+**pat**ernal, **mat**ernal — so *pai* and *paternal* are the worn-down and the
+dressed-up versions of the same word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "o pai, a mãe" — *mãe* fully nasal]
+- [YOU SAY: the erosion — "*pater* → *pae* → **pai**; the *-t-* vanished"]
+- [YOU SAY: "os pais = the parents (lit. 'the fathers'); mind *o país* = country"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "father" and "mother" with articles. (**o pai, a mãe**.) What
+happened to the *-t-* of *pater/māter* in Portuguese? (It **vanished** — *pater →
+pae → pai*.) What does **os pais** mean literally and in use? (Literally "the
+fathers"; in use, "**the parents**.") What word does *o país* (accented) mean?
+(The **country** — a spelling trap.) Next: **o irmão, a irmã** — and a surprise
+about where "brother" comes from.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -55,6 +55,12 @@ French.
   with the twist that **verão** ("summer") ← *veranum* ← *vēr* "**spring**" — the
   summer-word grew out of spring; *outono* ← *autumnus* (au→ou). **Authored.**
 
+- **Ch. 10 — Family**: the most worn-down parents of all — **pai/mãe** (← *pater/māter*,
+  the *-t-* vanished: *pater→pae→pai*, *mãe* nasal; *os pais* "parents" = lit. "the
+  fathers"; mind *o país*=country) → the Iberian surprise **irmão/irmã** (← *germānus*
+  "of the same stock," from *frāter germānus* "full brother," **not** *frāter*; = ES
+  *hermano*; cousins *germane*/*German*). **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |


### PR DESCRIPTION
## What

The immediate-family chapter, authored in parallel across the four Latin-script sisters (**8 lessons**). Each is atom-first and reviews Ch.9/Ch.1 via `reviews_of`. Every track shares the deep PIE thread — *pater/māter* behind all of them — but lands a **distinct angle**:

| Track | Angle |
|---|---|
| **French** | The clean set: *père/mère* ← *pater/māter*, *frère/sœur* ← *frāter/soror*. Teaches *père*/*father* as the **same inherited PIE word** split by Grimm's law (*p→f, t→th*); → paternal/fraternal/sorority; the **œ** ligature. |
| **German** | **The standout** — the *mirror* of the months chapter. *Vater/Mutter* are **inherited Germanic** (not Latin loans), Grimm's-law twins of English *father/mother* (*V*=*f*); *Bruder/Schwester*; **Geschwister** "siblings" via the collective **ge-**. Family is *native* where the months were *borrowed*. |
| **Italian** | Closest to Latin (*padre/madre*, *-t-→-d-*; *padre* = the English loan); **genitori** ← *genitor* "begetter" → genesis, with the *parenti*=**relatives** false friend; *fratello/sorella* built with the diminutive *-ello/-ella*. |
| **Portuguese** | Two Iberian twists — *pai/mãe* the **most worn-down** parents (*pater→pae→pai*, *-t-* gone; *os pais* lit. "the fathers"), and the surprise that **irmão/irmã** come from *germānus* "of the same stock" (*frāter germānus* "full brother"), **not** *frāter* — cousins *germane*/*German*, = ES *hermano*. |

## Housekeeping
- Taxonomy: namespaced `{FR,GE,IT,PT}-FAMILY-PARENTS/-SIBLINGS`.
- Each track's `roadmap.md` (Ch.10 authored) and `CHANGELOG.md`.
- Suite **38/38**; `taxonomy.json` valid JSON; no retired `concept_tag`s; security-reviewed (Markdown + JSON only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)