### PR TITLE
feat(gradient-descent): add Haskell port

### DIFF
--- a/code/packages/haskell/gradient-descent/BUILD
+++ b/code/packages/haskell/gradient-descent/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/gradient-descent/BUILD_windows
+++ b/code/packages/haskell/gradient-descent/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/gradient-descent/CHANGELOG.md
+++ b/code/packages/haskell/gradient-descent/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - 2026-07-19
+
+- Add a pure stochastic-gradient-descent update matching the ML02 contract.
+- Reject empty and length-mismatched weight and gradient vectors explicitly.
+- Cover reference values, learning-rate behavior, input preservation, and all
+  validation paths with package-native tests.

--- a/code/packages/haskell/gradient-descent/README.md
+++ b/code/packages/haskell/gradient-descent/README.md
@@ -1,0 +1,22 @@
+# gradient-descent
+
+Pure Haskell implementation of the ML02 stochastic-gradient-descent update.
+
+## API
+
+`sgd weights gradients learningRate` returns a new vector containing
+`weight - learningRate * gradient` for every pair of elements. It returns
+`Left` when the vectors are empty or have different lengths.
+
+The package accepts already-computed gradients as plain values, so it does not
+need a runtime dependency on `loss-functions` or a matrix library.
+
+## Dependencies
+
+The library depends only on `base`. Tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/gradient-descent/cabal.project
+++ b/code/packages/haskell/gradient-descent/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/gradient-descent/gradient-descent.cabal
+++ b/code/packages/haskell/gradient-descent/gradient-descent.cabal
@@ -1,0 +1,31 @@
+cabal-version: 3.0
+name:          gradient-descent
+version:       0.1.0
+synopsis:      Pure stochastic gradient descent updates
+description:   Dependency-free ML02 stochastic gradient descent with explicit vector validation.
+category:      Math
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  GradientDescent
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    GradientDescentSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , gradient-descent
+                    , hspec == 2.*
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/gradient-descent/src/GradientDescent.hs
+++ b/code/packages/haskell/gradient-descent/src/GradientDescent.hs
@@ -1,0 +1,18 @@
+-- | Pure gradient-descent optimizers for machine-learning examples.
+module GradientDescent
+    ( sgd
+    ) where
+
+-- | Apply one stochastic-gradient-descent update.
+--
+-- The result is a newly constructed vector whose elements are
+-- @weight - learningRate * gradient@. Empty vectors and mismatched vector
+-- lengths are rejected explicitly.
+sgd :: [Double] -> [Double] -> Double -> Either String [Double]
+sgd weights gradients learningRate
+    | null weights = Left "Weights and gradients must have the same non-zero length"
+    | length weights /= length gradients =
+        Left "Weights and gradients must have the same non-zero length"
+    | otherwise = Right $ zipWith update weights gradients
+  where
+    update weight gradient = weight - learningRate * gradient

--- a/code/packages/haskell/gradient-descent/test/GradientDescentSpec.hs
+++ b/code/packages/haskell/gradient-descent/test/GradientDescentSpec.hs
@@ -1,0 +1,72 @@
+module GradientDescentSpec (spec) where
+
+import Control.Monad (zipWithM_)
+import Data.Either (isLeft)
+import GradientDescent (sgd)
+import Test.Hspec
+
+tolerance :: Double
+tolerance = 1e-12
+
+shouldBeCloseTo :: Double -> Double -> Expectation
+actual `shouldBeCloseTo` expected =
+    abs (actual - expected) `shouldSatisfy` (<= tolerance)
+
+shouldBeCloseList :: [Double] -> [Double] -> Expectation
+actual `shouldBeCloseList` expected = do
+    length actual `shouldBe` length expected
+    zipWithM_ shouldBeCloseTo actual expected
+
+rightValue :: Show error => Either error value -> IO value
+rightValue result = case result of
+    Left err -> expectationFailure (show err) >> error "unreachable"
+    Right value -> pure value
+
+spec :: Spec
+spec = do
+    describe "sgd" $ do
+        it "matches the shared ML02 parity vector" $ do
+            result <- rightValue $ sgd [1.0, -0.5, 2.0] [0.1, -0.2, 0.0] 0.1
+            result `shouldBeCloseList` [0.99, -0.48, 2.0]
+
+        it "updates every element independently" $ do
+            result <- rightValue $ sgd [4.0, 3.0, 2.0, 1.0] [1.0, 2.0, 3.0, 4.0] 0.25
+            result `shouldBeCloseList` [3.75, 2.5, 1.25, 0.0]
+
+        it "supports a singleton vector" $ do
+            result <- rightValue $ sgd [2.0] [0.75] 0.4
+            result `shouldBeCloseList` [1.7]
+
+        it "leaves weights unchanged at a zero learning rate" $ do
+            result <- rightValue $ sgd [1.0, -2.0, 3.5] [100.0, -50.0, 7.0] 0.0
+            result `shouldBeCloseList` [1.0, -2.0, 3.5]
+
+        it "moves in the gradient direction for a negative learning rate" $ do
+            result <- rightValue $ sgd [1.0, -1.0] [0.5, -0.25] (-2.0)
+            result `shouldBeCloseList` [2.0, -1.5]
+
+        it "handles positive, negative, and zero gradients" $ do
+            result <- rightValue $ sgd [0.0, 0.0, 0.0] [2.0, -3.0, 0.0] 0.5
+            result `shouldBeCloseList` [-1.0, 1.5, 0.0]
+
+        it "does not mutate the input values" $ do
+            let weights = [3.0, 5.0]
+                gradients = [1.0, 2.0]
+            _ <- rightValue $ sgd weights gradients 0.5
+            weights `shouldBe` [3.0, 5.0]
+            gradients `shouldBe` [1.0, 2.0]
+
+    describe "input validation" $ do
+        it "rejects two empty vectors" $
+            sgd [] [] 0.1 `shouldSatisfy` isLeft
+
+        it "rejects a missing gradient" $
+            sgd [1.0] [] 0.1
+                `shouldBe` Left "Weights and gradients must have the same non-zero length"
+
+        it "rejects extra gradients" $
+            sgd [1.0] [0.1, 0.2] 0.1 `shouldSatisfy` isLeft
+
+        it "uses the shared validation message" $ do
+            sgd [] [] 0.1
+                `shouldBe` Left "Weights and gradients must have the same non-zero length"

--- a/code/packages/haskell/gradient-descent/test/Spec.hs
+++ b/code/packages/haskell/gradient-descent/test/Spec.hs
@@ -1,0 +1,5 @@
+import GradientDescentSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -119,11 +119,11 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
 `matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
-ports:
+ports, followed by the Haskell `gradient-descent` port:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 293 |
+| Present in 10-15 languages | 172 | 292 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 705 | 9,870 |
@@ -180,7 +180,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 18 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 17 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -546,6 +546,15 @@ nonzero rotation, positive and negative tight-bound extrema, zero sweep, the
 quarter-circle magic controls, segmentation, and continuity. The package now
 spans 12 implementation lanes, reduces the high-consensus backlog to 293 slots,
 and leaves 18 gaps in the Haskell lane.
+
+The seventeenth Haskell high-consensus slice is complete: `gradient-descent`
+now provides the dependency-free ML02 stochastic-gradient-descent update with
+explicit rejection of empty and length-mismatched vectors. Its package-native
+suite exercises 11 examples with 100% expression and alternative coverage,
+including the shared parity vector, singleton and multi-element inputs, zero
+and negative learning rates, mixed gradient signs, input preservation, and all
+validation paths. The package now spans 11 implementation lanes, reduces the
+high-consensus backlog to 292 slots, and leaves 17 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell ML02 `gradient-descent` package with the `sgd` update and explicit non-empty, equal-length vector validation
- add Cabal metadata, build entry points, documentation, changelog, and 11 package-native Hspec examples
- refresh the package-parity roadmap from 293 to 292 high-consensus missing slots and from 18 to 17 Haskell gaps

## Why this slice

After the merged `arc2d` port, `gradient-descent` was the smallest unblocked Haskell high-consensus leaf. It is dependency-free beyond `base`, follows a shared language-neutral contract, and does not require the later ML training stack.

## Validation

- `stack test gradient-descent --coverage`: 11 examples pass; 100% expression and alternative coverage
- `stack sdist ... --test-tarball`: source archive builds and all 11 examples pass in isolation
- `python code/scripts/tests/test_package_parity_report.py -v`: 6 tests pass
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: 292 high-consensus missing slots, 17 Haskell gaps, zero collisions, zero unknown buckets
- `git diff --check`

## Remaining parity work

The high-consensus core has 292 missing slots. Haskell has 17 remaining high-consensus gaps; the loop will select the next smallest dependency-safe leaf after this PR is reviewed and merged.
