### PR TITLE
feat(hl): Arabic Ch.2 writing set — the dots family, "my name", and the hidden vowels

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Chapter 2 — Writing set (the dots family, your name, and the hidden vowels)
+
+- **Writing lessons added** (`AR-W04-dots-family-nun-ta`, `AR-W05-ya-and-my-name`,
+  `AR-W06-harakat-and-hamza`): a `writing`-type companion to the Ch. 2
+  self-introduction words, extending the Ch. 1 set (AR-W01–03). No `concept_tag`
+  (writing lessons are exempt from the concept join). Chapter-2 anchors: **أنت**
+  (*anta/anti*) and **اسمي** (*ismī*, "my name").
+- **W04 — the bowl-skeleton dots-family, finished**: turns Lesson 3's hint into a
+  truth-table — the *same* boat-bowl gives **ب** (1 dot below), **ن** (1 above),
+  **ت** (2 above), **ث** (3 above); the dots do all the work. Anchored on **أنت**,
+  which is *alif · nūn · tāʾ*. Phoenician tie-back: *nun*/*taw* → **N**/**T**.
+- **W05 — yāʾ + "my name"**: teaches **ي** (two dots below — closing the
+  below/above dial) as a **triple-threat** (consonant *y*, long vowel *ī*, and the
+  possessive **-ī** "my"; Phoenician *yod* "hand" → *iota* → **I/J**), then
+  **assembles اسم → اسمي** ("name" → "my name") entirely from letters taught in
+  W01–05.
+- **W06 — the ḥarakāt & the hamza**: pays off W01's *abjad* claim by showing the
+  optional short-vowel marks (*fatḥa* above = a, *kasra* below = i, *ḍamma* above =
+  u; + *sukūn*/*shadda*). The showpiece: **أنتَ** ("you," m.) vs **أنتِ** ("you,"
+  f.) differ by a **single mark** (*fatḥa* vs *kasra*) — the Ch. 2 gender split is
+  one dash. Also introduces the **hamza** (**ء**, glottal stop) riding an *alif*
+  seat (**أ**).
+
 ## Chapter 1 — Writing set (break the script apart and draw it)
 
 - **Writing lessons added** (`AR-W01-direction-and-alif`,

--- a/code/learning/human-languages/arabic/lessons/AR-W04-dots-family-nun-ta.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W04-dots-family-nun-ta.md
@@ -1,0 +1,74 @@
+---
+id: AR-W04-dots-family-nun-ta
+chapter: 2
+type: writing
+headword: "ن، ت، ث"
+gloss: the bowl skeleton finished — nūn, tāʾ, thāʾ, where only the dots differ
+romanization: "nūn, tāʾ, thāʾ"
+prerequisites: [AR-W03-dots-mim-ba-salam]
+sounds: [arabic-nun, arabic-ta, arabic-tha]
+roots: [phoenician-nun, phoenician-taw]
+est_minutes: 5
+reviews_of: [AR-W03-dots-mim-ba-salam, AR-C02-anta-anti, AR-C02-ism]
+---
+
+# ن، ت، ث — one bowl, four dot-patterns
+
+## Warm-up
+
+[PAUSE 2s] In Lesson 3 you drew **ب** (*bāʾ*) — a boat-bowl with **one dot
+below** — and met the idea that the **dots make the letter**. Now the promised
+payoff: the *same* bowl, with the dots moved and multiplied, gives you three more
+common letters. Learn the bowl once; the dots do the rest.
+
+## The bowl family — a truth-table
+
+Every letter here is the **same shallow boat-bowl** you already draw for *bāʾ*.
+Only the dots change:
+
+| letter | sound | the dots |
+|---|---|---|
+| **ب** *bāʾ* | b | one dot **below** (from Lesson 3) |
+| **ن** *nūn* | n | one dot **above** |
+| **ت** *tāʾ* | t | **two** dots above |
+| **ث** *thāʾ* | th | **three** dots above |
+| (ح *ḥāʾ*) | ḥ | **no** dot (a bigger hook — Lesson 3's cousin) |
+
+Read it as a dial: **below → 1 above → 2 above → 3 above**. The pen-stroke is
+identical each time; your only real decision is *how many dots, and on which
+side*.
+
+## Draw them
+
+- **ن** (*nūn*) — the bowl, then **one dot above**. (*nūn* sits a little deeper
+  than *bāʾ* when it stands alone, but joined, it is the shared skeleton + one
+  dot.) From Phoenician **nun**, "fish" — ancestor of Greek *nu* and Latin **N**.
+- **ت** (*tāʾ*) — the bowl, then **two dots above**. From Phoenician **taw**,
+  "mark" — the great-grandparent of Latin **T** (and the word *tattoo*-like "mark"
+  survives in *taw* meaning a cross-mark).
+- **ث** (*thāʾ*) — the bowl, then **three dots above** (drawn as a little
+  triangle of dots).
+
+## Where you have seen them — أنت
+
+The Chapter 2 word **أنت** (*anta / anti*, "you") is built from exactly these: an
+*alif* (with a small **hamza** seat you will meet in Lesson 6), then **ن** (*nūn*,
+one dot above) joined to **ت** (*tāʾ*, two dots above). So *أنت* is, in dots,
+"bowl-with-one-above, bowl-with-two-above" — you can now read the skeleton of a
+real word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: the same bowl four times, then dot them — ب (1 below), ن (1 above),
+  ت (2 above), ث (3 above)]
+- [YOU SAY: the dial — "below, one above, two above, three above — b, n, t, th"]
+- [YOU WRITE: the joined pair **نت** (*nūn*→*tāʾ*), the core of *أنت*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What single feature separates **ب, ن, ت, ث**? (**The dots** — same
+bowl; one below / one above / two above / three above.) Which two of them build
+the Chapter 2 word **أنت** ("you")? (**ن** *nūn* and **ت** *tāʾ*.) What Latin
+letters descend from *nūn* and *taw*? (**N** and **T**.) Next: **ي** (*yāʾ*), the
+two-dots-below letter — and your name.

--- a/code/learning/human-languages/arabic/lessons/AR-W05-ya-and-my-name.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W05-ya-and-my-name.md
@@ -1,0 +1,73 @@
+---
+id: AR-W05-ya-and-my-name
+chapter: 2
+type: writing
+headword: "ي"
+gloss: yāʾ — two dots below, a consonant that doubles as the long vowel ī and the suffix "my" — then writing اسمي
+romanization: "yāʾ"
+prerequisites: [AR-W04-dots-family-nun-ta]
+sounds: [arabic-ya, long-i]
+roots: [phoenician-yod]
+est_minutes: 5
+reviews_of: [AR-W04-dots-family-nun-ta, AR-C02-ism, AR-C02-ii-my]
+---
+
+# ي (yāʾ) — the last dot-letter, and "my name"
+
+## Warm-up
+
+[PAUSE 2s] One more member of the bowl family, and it is a **triple threat**:
+**ي** (*yāʾ*) is a consonant *y*, **and** the long vowel **ī**, **and** the little
+suffix **-ī** meaning "**my**." With it you can finally write a whole Chapter 2
+phrase in your own hand: **اسمي** ("my name").
+
+## ي (yāʾ) — two dots below
+
+Break it apart:
+
+1. **the body** — the boat-bowl (standing alone) or a tooth (when joined).
+2. **two dots BELOW** — the mark that completes the bowl-family dial: *bāʾ* had one
+   below, *yāʾ* has **two** below.
+
+So the full "below/above" set is now closed: **ب** one-below, **ي** two-below;
+**ن** one-above, **ت** two-above, **ث** three-above. *Yāʾ* comes from Phoenician
+**yod**, "hand" — the ancestor of Greek *iota* and Latin **I / J** (and the reason
+we say "not one **iota**," the smallest letter).
+
+## Its three jobs
+
+- **consonant y** — as in *yawm* ("day").
+- **long vowel ī** — a *seat* for the "ee" sound.
+- **the suffix ـي "my"** — the Chapter 2 possessive. Glue *-ī* onto a noun and it
+  becomes "my ___," exactly as *ism* ("name") + *-ī* → *ismī* ("my name").
+
+## Assemble — first اسم, then اسمي
+
+You already know every letter of **اسم** (*ism*, "name") from Lessons 1–3:
+**ا** (alif) · **س** (sīn) · **م** (mīm). Write it right-to-left:
+
+1. **ا** (*alif*) — the upright; it **does not join** forward, so the pen lifts.
+2. **س** (*sīn*) — three teeth, joining into…
+3. **م** (*mīm*) — round head + tail. → **اسم**.
+
+Now add **ي** for "my." *Mīm* joins forward to *yāʾ*, giving **اسمي** (*ismī*):
+
+- **اسمي** = *alif · sīn · mīm · yāʾ* = *i-s-m-ī* = "**my name**."
+
+Read it back, right to left, and you have written a phrase you will say every time
+you introduce yourself.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **ي** — body + **two dots below**]
+- [YOU SAY: the closed dial — "ب one-below, ي two-below; ن/ت/ث one/two/three above"]
+- [YOU WRITE: **اسم** (ism), then extend to **اسمي** (ismī, "my name")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Where do *yāʾ*'s dots sit, and how many? (**Two, below.**) Name *yāʾ*'s
+**three** jobs. (Consonant *y*; long vowel *ī*; the suffix *-ī* "**my**.") Spell
+**اسمي** letter by letter, right to left. (*alif · sīn · mīm · yāʾ* — "my name.")
+Next: the little **vowel marks** — and how one of them flips *أنت* from "you (m.)"
+to "you (f.)."

--- a/code/learning/human-languages/arabic/lessons/AR-W06-harakat-and-hamza.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W06-harakat-and-hamza.md
@@ -1,0 +1,80 @@
+---
+id: AR-W06-harakat-and-hamza
+chapter: 2
+type: writing
+headword: "َ ِ ُ"
+gloss: the abjad's optional vowel marks (ḥarakāt) and the hamza — where one tiny mark flips anta to anti
+romanization: "fatḥa, kasra, ḍamma; hamza"
+prerequisites: [AR-W05-ya-and-my-name]
+sounds: [arabic-harakat, arabic-hamza]
+roots: [abjad-vowels]
+est_minutes: 5
+reviews_of: [AR-W05-ya-and-my-name, AR-W01-direction-and-alif, AR-C02-anta-anti]
+---
+
+# َ ِ ُ and ء — the little marks the abjad usually hides
+
+## Warm-up
+
+[PAUSE 2s] Way back in Lesson 1 you learned Arabic is an **abjad**: the short
+vowels are **usually left out**. This lesson shows the marks that a beginner's
+book *does* print when it wants to be clear — the **ḥarakāt** — and one of them
+delivers the neatest payoff in the whole set: the difference between "you (m.)"
+and "you (f.)" is a **single dash**.
+
+## The ḥarakāt — three short-vowel marks
+
+These are small marks written **around** a consonant, not letters in their own
+right. On the letter *bāʾ* (**ب**):
+
+| mark | name | where | sound | example |
+|---|---|---|---|---|
+| **َ** | *fatḥa* | a slash **above** | "a" | **بَ** = *ba* |
+| **ِ** | *kasra* | a slash **below** | "i" | **بِ** = *bi* |
+| **ُ** | *ḍamma* | a tiny *wāw* **above** | "u" | **بُ** = *bu* |
+
+Two more you will see: **ْ** *sukūn* (a small circle = "no vowel here") and **ّ**
+*shadda* (a small *w* = "double this consonant"). In everyday text they all vanish
+— the reader supplies them from knowing the word — but they are the abjad's
+"training wheels," and the tail on *shukran* (**شكرًا**) is one of them.
+
+## The payoff — أنتَ vs أنتِ
+
+Here is why the marks matter. The Chapter 2 word **أنت** ("you") is the *same*
+consonant skeleton for a man and a woman — *alif · nūn · tāʾ*. What splits them is
+a single ḥaraka on the final **ت**:
+
+- **أنتَ** — *tāʾ* + **fatḥa** (the "a" slash above) = **anta**, "you" to a **man**.
+- **أنتِ** — *tāʾ* + **kasra** (the "i" slash below) = **anti**, "you" to a
+  **woman**.
+
+One dash up or down carries the whole gender distinction you learned in the
+introductions chapter. Leave the mark off — as normal Arabic does — and **أنت**
+serves both, the reader deciding from context.
+
+## The hamza — the glottal catch (ء)
+
+Look at the start of **أنت**: that little hook on top of the *alif* — **أ** — is a
+**hamza** (**ء**), the sign for a **glottal stop** (the catch in the middle of
+English "uh-oh"). It rides on a "seat," most often an *alif*, and marks a real
+consonant sound, not a vowel. So *alif* has two lives: a long "aa," or — wearing a
+hamza — a glottal-stop seat.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: on **ب** — *fatḥa* above (*ba*), *kasra* below (*bi*), *ḍamma* above
+  (*bu*)]
+- [YOU SAY: the flip — "أنتَ *anta* (man, slash above) vs أنتِ *anti* (woman, slash
+  below)"]
+- [YOU SAY: "the hamza **ء** on **أ** = a glottal stop, the catch in 'uh-oh'"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are the **ḥarakāt**, and does everyday text show them? (The short-
+**vowel marks** — *fatḥa/kasra/ḍamma*; normally **left off**, since Arabic is an
+abjad.) Which mark, and where, turns *anta* into *anti*? (A *kasra* — the "i"
+slash — **below** the final *tāʾ*, instead of the *fatḥa* above.) What does a
+**hamza** (**ء**) stand for? (A **glottal stop** — the catch in "uh-oh" — riding
+on a seat like *alif*.) You have now met Arabic's consonants, its joining, its
+dots, **and** its hidden vowels — the whole machine.

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -30,6 +30,15 @@ word lessons — never as a gated reading course.
   and the assembly of a whole word — **سلام** — from *sīn/lām/alif/mīm*. Ties the
   Arabic letters back to their Phoenician ancestors (*ʾālep/bēt/mem* = **A/B/M**).
 
+- **Ch. 2 — Writing set** (`AR-W04`–`AR-W06`, `writing` type): the writing
+  companion to the self-introduction words. Completes the **bowl-skeleton
+  dots-family** as a truth-table (ب/ن/ت/ث — one-below/one-above/two/three, + ي
+  two-below), teaches **ي** (*yāʾ*: consonant *y*, long vowel *ī*, and the "-ī my"
+  suffix) and assembles **اسم → اسمي** ("name" → "my name") from already-known
+  letters, then pays off Ch. 1's *abjad* idea with the **ḥarakāt** (short-vowel
+  marks) and the **hamza** — the showpiece being that a single *fatḥa*/*kasra*
+  flips **أنتَ** ("you," m.) to **أنتِ** ("you," f.).
+
 ## Planned
 
 | Chapter | Theme |


### PR DESCRIPTION
## What

Extends the Arabic writing track (`AR-W04/05/06`, `writing` type, **no `concept_tag`**) as a companion to the Ch.2 self-introduction words, continuing the Ch.1 set (`AR-W01–03`). Anchored on the real Ch.2 words **أنت** (*anta/anti*, "you") and **اسمي** (*ismī*, "my name").

## The three lessons (atom-first, chained via `reviews_of`)

| Lesson | Content |
|---|---|
| **W04 — the dots family, finished** | Turns W03's hint into a **truth-table**: the *same* boat-bowl gives **ب** (1 dot below), **ن** (1 above), **ت** (2 above), **ث** (3 above) — the dots do all the work. Anchored on **أنت** = *alif·nūn·tāʾ*. Phoenician tie-back: *nun/taw* → **N/T**. |
| **W05 — yāʾ + "my name"** | Teaches **ي** (two dots below — closing the below/above dial) as a **triple-threat**: consonant *y*, long vowel *ī*, and the possessive **-ī** "my" (*yod* "hand" → *iota* → **I/J**). Then **assembles اسم → اسمي** ("name" → "my name") from already-known letters. |
| **W06 — the hidden vowels** | Pays off W01's *abjad* claim with the **ḥarakāt** (*fatḥa* above=a, *kasra* below=i, *ḍamma* above=u; + *sukūn/shadda*). **Showpiece:** **أنتَ** ("you," m.) vs **أنتِ** ("you," f.) differ by a **single mark** — the Ch.2 gender split is one dash. Also introduces the **hamza** (**ء**, glottal stop) on an *alif* seat (**أ**). |

## Housekeeping
- Updates `arabic/CHANGELOG.md` and `roadmap.md` (Ch.2 writing set authored).
- Suite **38/38**; all three lessons carry **no `concept_tag`**; no retired tags; security-reviewed (Markdown only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)