### PR TITLE
feat(hl): Spanish Ch.13 — poner, salir, venir, completing the -go club

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -222,6 +222,9 @@
       "ES-VERB-HACER": "hacer — 'to do/make' (-go yo-form hago, like tengo; ← facere → fact/factory/perfect; f→h softening; weather: hace calor)",
       "ES-VERB-DECIR": "decir — 'to say/tell' (doubly irregular: -go yo-form digo + e→i stem-change dices/dice; ← dīcere → dictate/diction/verdict)",
       "ES-YO-GO": "the -go club — verbs whose yo-form grows a hard g (tengo/hago/digo/pongo/salgo/vengo); yo-only, a closed Latin-inherited set of high-frequency verbs",
+      "ES-VERB-PONER": "poner — 'to put/place' (-go yo-form pongo; ← pōnere → position/compose/deposit/postpone; poner la mesa 'set the table', ponerse 'put on/become')",
+      "ES-VERB-SALIR": "salir — 'to leave/go out' (-go yo-form salgo; ← salīre 'to leap' → salient/sally/salmon/somersault; la salida 'the exit')",
+      "ES-VERB-VENIR": "venir — 'to come' (doubly irregular: -go yo-form vengo + e→ie stem-change vienes/viene; ← venīre → adventure/event/convene; twin of tener)",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -287,6 +290,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Chapter 13 — Completing the -go club
+
+- **Chapter 13 authored** (`ES-C13-poner`, `-salir`, `-venir`, `-practice`):
+  closes the *-go* club opened in Ch.12, reviewing Ch.8/11/12 via `reviews_of`.
+- **poner** ("to put/place") — plain *-go* yo-form **pongo**; ← *pōnere* →
+  position/compose/deposit/postpone/component; everyday *poner la mesa* ("set the
+  table") and reflexive *ponerse* ("put on / become").
+- **salir** ("to leave/go out") — *-go* yo-form **salgo**; ← *salīre* "**to
+  leap**" → salient/sally/somersault, and *salmō* "the leaper" (**salmon**); *la
+  salida* = "the **exit**." Notes that English *exit* is the rival *exīre*, not
+  this leaping root.
+- **venir** ("to come") — the **doubly irregular** finale: *-go* yo-form
+  **vengo** **and** the **e→ie** stem-change (*vienes/viene/vienen*, *venimos*
+  escaping the boot) — the exact mirror of *tener*. ← *venīre* →
+  adventure/event/convene/invent/avenue/souvenir.
+- **practice** — the full six-member roll-call (*tengo/hago/digo/pongo/salgo/
+  vengo*), sorted into plain-*-go* / *-go*+e→i / *-go*+e→ie, plus the *tener*↔*venir*
+  boot twins.
+- Taxonomy: namespaced `ES-VERB-PONER`, `ES-VERB-SALIR`, `ES-VERB-VENIR`; practice
+  label `CH13-PRACTICE`.
+
 ## Chapter 12 — Doing, making, saying, and the -go club
 
 - **Chapter 12 authored** (`ES-C12-hacer`, `-decir`, `-yo-go`, `-practice`): two

--- a/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
@@ -1,0 +1,72 @@
+---
+id: ES-C13-poner
+chapter: 13
+type: word
+headword: poner
+gloss: to put / to place — a -go yo-form, pongo
+concept_tag: ES-VERB-PONER
+prerequisites: [ES-C12-yo-go, ES-C12-hacer]
+sounds: [g-hard, r-tap]
+roots: [ponere-latin]
+etymology_hook: "poner ← Latin pōnere 'to put, place' → position, compose, deposit, component, opponent, postpone; the -go yo-form pongo joins tengo/hago/digo"
+est_minutes: 5
+reviews_of: [ES-C12-yo-go, ES-C12-hacer, ES-C08-tener]
+---
+
+# poner — "to put," and the club gains a member
+
+## Warm-up
+
+[PAUSE 2s] In Chapter 12 you met the **-go club** — *tengo, hago, digo* — and
+three members "to come": *pongo, salgo, vengo*. Here is the first of them.
+**poner** ("to put / to place") is a plain *-er* verb everywhere **except** the
+*yo*-form, which grows the familiar **g**: **pongo**.
+
+## Sounds you'll need
+
+- `g-hard` — the *g* in **pongo** is the hard *-go* you now know from *tengo*.
+
+## The word, taken apart
+
+**poner** comes from Latin **pōnere**, *"to put, to place, to set down"* — and its
+stem **pon-/pos-** ("place") is one of the busiest roots in English:
+
+- **position, pose, posit** — a placing.
+- with prefixes: **compose** ("place together"), **deposit** ("place down"),
+  **expose** ("place out"), **oppose / opponent** ("place against"), **propose**
+  ("place forward"), **postpone** ("place after"), **component**, **deposit**.
+
+So *poner* and *position* share the same "place" root — you are putting something
+in its *pōnere*.
+
+## Grammar Lens: the -go yo-form
+
+Only the **yo**-form is irregular — it takes the **g** — the rest is a regular
+*-er* present:
+
+| yo | **pongo** | (-go, like tengo) |
+| tú | pones | (regular) |
+| él/ella/usted | pone | (regular) |
+| nosotros | ponemos | (regular) |
+| ellos/ustedes | ponen | (regular) |
+
+**The everyday payoff:** *poner la mesa* ("to set the table"), *poner música*
+("to put on music"), and the reflexive **ponerse** — "to put on (clothes)" or
+"to become" (*me pongo* nervioso, "I get nervous").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "poner" then the set — "**pongo**, pones, pone, ponemos, ponen" — the
+  *g* only in *pongo*]
+- [YOU SAY: "Pongo la mesa" ("I set the table"); "Me pongo el abrigo" ("I put on
+  the coat")]
+- [YOU SAY: "poner" then English "position, compose, deposit" — the place-family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What Latin verb is *poner* from, and two English cousins? (*pōnere*
+"to place"; position/compose/deposit — any two.) Give its *yo*-form and the club
+it joins. (**pongo** — the *-go* club, with *tengo/hago/digo*.) What does *poner
+la mesa* mean? ("To **set the table**.") Next: **salir** — another *-go* verb,
+and a leaping etymology.

--- a/code/learning/human-languages/spanish/lessons/ES-C13-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-practice.md
@@ -1,0 +1,73 @@
+---
+id: ES-C13-practice
+chapter: 13
+type: practice-mix
+headword: (practice)
+gloss: the whole -go club, complete — tengo, hago, digo, pongo, salgo, vengo
+concept_tag: CH13-PRACTICE
+prerequisites: [ES-C13-poner, ES-C13-salir, ES-C13-venir]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C13-poner, ES-C13-salir, ES-C13-venir, ES-C12-practice]
+---
+
+# Practice — the -go club, complete
+
+## Warm-up
+
+[PAUSE 2s] Chapter 12 opened the **-go club** with *tengo, hago, digo*; this
+chapter closed it with *pongo, salgo, vengo*. All six in one place now — say them
+until the *yo*-forms are automatic.
+
+## Drill 1 — the full roll-call
+
+[PAUSE 1s] Say each infinitive, then its *yo*-form:
+
+- **tener** → **tengo** · **hacer** → **hago** · **decir** → **digo**
+- **poner** → **pongo** · **salir** → **salgo** · **venir** → **vengo**
+
+[PAUSE 2s] What do all six *yo*-forms share? (The **-go**.) In which form only?
+(The **yo**-form — the rest is regular, plus any stem-change.)
+
+## Drill 2 — the three kinds
+
+[PAUSE 1s] Sort the club by *how* irregular:
+
+- **plain -go** (regular otherwise): *hago, pongo, salgo*.
+- **-go + e→i** (the decir type): *digo* (dices/dice).
+- **-go + e→ie** (the boot twins): *tengo* (tienes), *vengo* (vienes).
+
+## Drill 3 — run the two boot verbs
+
+[PAUSE 1s] Say *tener* and *venir* full — they are mirror twins:
+
+- **tener**: tengo · tienes · tiene · tenemos · tienen.
+- **venir**: vengo · vienes · viene · venimos · vienen.
+
+Only *tenemos / venimos* keep the plain *e* — the **boot**.
+
+## Drill 4 — put it to use
+
+[PAUSE 1s] Say each out loud:
+
+- "**Vengo de casa y pongo la mesa.**" — "I come from home and set the table."
+- "**Salgo a las ocho.**" — "I leave at eight."
+- "**¿Qué haces? — Hago la cena.**" — "What are you doing? — I'm making dinner."
+- "**Digo que sí.**" — "I say yes."
+
+## Drill 5 — the root families (say the cousin)
+
+[PAUSE 1s] One English cousin each:
+
+- *poner* ← *pōnere* → ? (**position / compose / deposit**.)
+- *salir* ← *salīre* → ? (**salient / salmon / somersault**.)
+- *venir* ← *venīre* → ? (**adventure / event / convene**.)
+
+## Wrap-up Recall
+
+[PAUSE 3s] Recite the six *yo*-forms of the club. (**tengo, hago, digo, pongo,
+salgo, vengo**.) Which two are the *e→ie* "boot" twins? (**tener** and **venir**.)
+Which single verb is *-go* **and** *e→i*? (**decir** — *digo/dices*.) You now hold
+the whole irregular *-go* corner of Spanish — its oldest, most-used verbs, mastered
+as one pattern.

--- a/code/learning/human-languages/spanish/lessons/ES-C13-salir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-salir.md
@@ -1,0 +1,67 @@
+---
+id: ES-C13-salir
+chapter: 13
+type: word
+headword: salir
+gloss: to leave / to go out — a -go yo-form, salgo, from a root that means "to leap"
+concept_tag: ES-VERB-SALIR
+prerequisites: [ES-C13-poner]
+sounds: [g-hard, l-clear]
+roots: [salire-latin]
+etymology_hook: "salir ← Latin salīre 'to leap, jump' → sally, salient, somersault, salmon (the leaping fish); the -go yo-form salgo joins pongo/tengo — 'going out' as an old 'leaping out'"
+est_minutes: 5
+reviews_of: [ES-C13-poner, ES-C12-yo-go]
+---
+
+# salir — "to go out," from a verb that meant "to leap"
+
+## Warm-up
+
+[PAUSE 2s] The second *-go* verb: **salir** ("to leave, to go out"). Same story
+as *poner* — regular *-ir* everywhere but the *yo*-form, which grows the **g**:
+**salgo**. But its **origin** is a delight: *salir* comes from a Latin verb for
+**leaping**.
+
+## The word, taken apart
+
+**salir** comes from Latin **salīre**, *"to leap, to jump, to spring"* — and over
+time "leaping out" softened into simply "going out." The leap survives across
+English:
+
+- **salient** ("leaping out," so: prominent, sticking out), **sally** ("a sudden
+  rush out"), **somersault** (*sopra* + *saltus*, "a leap over").
+- with prefixes: **assail / assault** ("leap at"), **resilient** ("leap back"),
+  **result** ("leap back out"), **insult** ("leap upon").
+- and the **salmon** — *salīre* gave Latin *salmō*, "the **leaper**," for the fish
+  that leaps upstream.
+
+So every time you say *salgo* ("I go out"), you are using the old "**leap**" verb
+behind *salient* and *salmon*.
+
+## Grammar Lens: the -go yo-form
+
+| yo | **salgo** | (-go, like pongo/tengo) |
+| tú | sales | (regular) |
+| él/ella/usted | sale | (regular) |
+| nosotros | salimos | (regular) |
+| ellos/ustedes | salen | (regular) |
+
+**The everyday payoff:** *salir de casa* ("to leave the house"), *salir con*
+alguien ("to go out with someone" — to date), and *la salida* ("the **exit**" —
+the sign you'll read at every station). Note: English *exit* is from a **different**
+Latin verb, *exīre* ("go out"); Spanish chose the *leaping* one.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "salir" then the set — "**salgo**, sales, sale, salimos, salen"]
+- [YOU SAY: "Salgo de casa" ("I leave the house"); "la salida" ("the exit")]
+- [YOU SAY: "salir" then English "salient, salmon, somersault" — the leap-family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did *salir*'s Latin root *salīre* originally mean? ("To **leap /
+jump**.") Name two English cousins. (salient/sally/somersault/salmon — any two.)
+Give the *yo*-form and the sign it hides. (**salgo**; *la salida* = the **exit**.)
+Next: **venir** — the last *-go* verb, and the trickiest, because it *also* cracks
+its stem.

--- a/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
@@ -1,0 +1,79 @@
+---
+id: ES-C13-venir
+chapter: 13
+type: word
+headword: venir
+gloss: to come — doubly irregular, vengo + e→ie, completing the -go club
+concept_tag: ES-VERB-VENIR
+prerequisites: [ES-C13-salir, ES-C11-querer]
+sounds: [g-hard, diphthong-ie]
+roots: [venire-latin]
+etymology_hook: "venir ← Latin venīre 'to come' → adventure, convene, event, invent, avenue, souvenir; doubly irregular like decir — the -go yo-form vengo AND the e→ie stem-change (vienes/viene), completing the club"
+est_minutes: 5
+reviews_of: [ES-C13-salir, ES-C13-poner, ES-C11-querer, ES-C12-decir]
+---
+
+# venir — "to come," the last club member, cracked *and* g-grown
+
+## Warm-up
+
+[PAUSE 2s] The sixth and final member of the **-go club**: **venir** ("to come").
+And like *decir* back in Chapter 12, it is **doubly irregular** — it stacks the
+**-go** *yo*-form **and** a stem-change. Learn *venir* and the whole system you've
+been building since *tener* clicks shut.
+
+## Sounds you'll need
+
+- `g-hard` — the *-go* of **vengo**.
+- `diphthong-ie` — the stressed stem *e* breaks to **ie**: **vienes** = *vee-EH-nes*.
+
+## The word, taken apart
+
+**venir** comes from Latin **venīre**, *"to come"* — a root **ven-/vent-** that
+comes *toward* English from every direction:
+
+- **adventure** (*ad-venīre*, "what **comes to** you"), **event** ("what comes
+  out"), **convene / convention** ("come together"), **invent** ("come upon"),
+  **prevent** ("come before"), **intervene**, **revenue** ("what **comes back**"),
+  **avenue** ("a coming-toward"), and **souvenir** (French, "a thing that **comes
+  to mind**").
+
+## Grammar Lens: two irregularities at once
+
+**(1) The -go yo-form**, like *pongo/salgo/tengo*: **vengo**.
+**(2) The e→ie stem-change**, like *querer/tener*: the stressed stem breaks to
+*ie* — the "boot" again.
+
+| yo | **vengo** | (-go form) |
+| tú | **vienes** | (e → ie) |
+| él/ella/usted | **viene** | (e → ie) |
+| nosotros | venimos | (plain *e* — unstressed) |
+| ellos/ustedes | **vienen** | (e → ie) |
+
+*Venimos* alone keeps the plain *e* (stress on the ending), drawing the **boot**;
+everything inside it cracks to *ie*, and the *yo* corner carries the *-go*. This
+is the exact shape of *tener* (*tengo / tienes*) — *venir* is its mirror twin.
+
+## The club is complete
+
+You have now met all six: **tengo · hago · digo · pongo · salgo · vengo**. Three
+plain *-go* (poner, salir, hacer), one *-go* + *e→i* (decir), two *-go* + *e→ie*
+(tener, venir). The corner is closed.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "venir" then the set — "**vengo**, vienes, viene, venimos, vienen" —
+  the *g* in *vengo*, the *ie* through the boot, plain *e* in *venimos*]
+- [YOU SAY: "Vengo de España" ("I come from Spain"); "¿Vienes?" ("Are you
+  coming?")]
+- [YOU SAY: "venir" then English "adventure, convene, event" — the come-family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name *venir*'s **two** irregularities. (The *-go* *yo*-form **vengo**,
+and the **e→ie** stem-change.) Which form escapes the boot, and why? (*venimos* —
+stress on the ending.) What Latin verb, and two English cousins? (*venīre*;
+adventure/event/convene — any two.) Which earlier verb is *venir*'s exact twin?
+(**tener** — *tengo/tienes* = *vengo/vienes*.) Next: **practice** — the whole
+*-go* club at once.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -87,10 +87,18 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   the **-go club** (*tengo/hago/digo/pongo/salgo/vengo* — yo-only, a closed
   Latin-inherited set of the oldest, most-used verbs) → practice. **Authored.**
 
-Next: **Ch. 13** — more everyday description and the remaining high-frequency
-irregulars (*ir* preterite, *poner/salir/venir* completing the *-go* club), building
-toward real conversation. From here the course hands over rules, not phrases.
-Grammar accumulates piece by piece. The theme skeleton below plans the wider road.
+- **Ch. 13 — Completing the -go club**: **poner** ("to put," ← *pōnere* →
+  position/compose/deposit; the *-go* yo-form *pongo*; *poner la mesa*) → **salir**
+  ("to leave/go out," ← *salīre* "to leap" → salient/salmon/somersault; *salgo*;
+  *la salida* "the exit") → **venir** ("to come," ← *venīre* → adventure/event/
+  convene; **doubly** irregular — *-go* *vengo* **and** *e→ie* *vienes*, the mirror
+  twin of *tener*) → practice recapping all six (*tengo/hago/digo/pongo/salgo/
+  vengo*). **Authored.**
+
+Next: **Ch. 14** — everyday description and more high-frequency irregulars (the
+*ir/ser* preterite), building toward real conversation. From here the course hands
+over rules, not phrases. Grammar accumulates piece by piece. The theme skeleton
+below plans the wider road.
 
 ## Theme Skeleton (planning only)
 


### PR DESCRIPTION
## What

Closes the **-go verb club** opened in Chapter 12 (`ES-C13-poner/salir/venir/practice`) — the payoff the Ch.12 *yo-go* lesson promised. Each models the ES-C12 shape and reviews Ch.8/11/12 via `reviews_of`.

## The lessons

| Lesson | Content |
|---|---|
| **poner** ("to put/place") | Plain *-go* yo-form **pongo**; ← *pōnere* → position/compose/deposit/postpone; *poner la mesa*, *ponerse*. |
| **salir** ("to leave/go out") | *-go* yo-form **salgo**; ← *salīre* "**to leap**" → salient/sally/somersault, and *salmō* "the leaper" (**salmon**); *la salida* = "the exit." |
| **venir** ("to come") | The **doubly irregular** finale — *-go* yo-form **vengo** **and** the **e→ie** stem-change (*vienes/viene*, *venimos* escaping the boot), the exact mirror of *tener*. ← *venīre* → adventure/event/convene/souvenir. |
| **practice** | Full six-member roll-call (*tengo/hago/digo/pongo/salgo/vengo*), sorted plain-*go* / *-go*+e→i (*decir*) / *-go*+e→ie (*tener*, *venir* boot twins). |

The club is now **complete**: three plain *-go*, one *-go*+e→i, two *-go*+e→ie — the oldest, most-used irregular verbs mastered as one pattern.

## Housekeeping
- Taxonomy: namespaced `ES-VERB-PONER/SALIR/VENIR` + `CH13-PRACTICE`.
- `spanish/CHANGELOG.md` (Ch.13) and `roadmap.md` (Ch.13 authored, Next = Ch.14).
- Suite **38/38**; `taxonomy.json` valid; no retired `concept_tag`s; security-reviewed (Markdown + JSON only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)