### PR TITLE
Add Haskell perceptron package

### DIFF
--- a/code/packages/haskell/perceptron/BUILD
+++ b/code/packages/haskell/perceptron/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/perceptron/BUILD_windows
+++ b/code/packages/haskell/perceptron/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/perceptron/CHANGELOG.md
+++ b/code/packages/haskell/perceptron/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-19
+
+- Add a pure sigmoid/BCE perceptron with immutable training results.
+- Compose the existing Haskell matrix, loss, and activation packages.
+- Validate hyperparameters, feature shapes, label shapes, and finite values.
+- Cover AND-gate convergence, column labels, epoch-zero behavior, deterministic
+  refitting, prediction guards, and invalid inputs with package-native tests.

--- a/code/packages/haskell/perceptron/README.md
+++ b/code/packages/haskell/perceptron/README.md
@@ -1,0 +1,33 @@
+# perceptron
+
+Pure Haskell implementation of the repository's single-neuron binary
+classifier. It trains zero-initialized weights and bias with sigmoid activation,
+binary cross-entropy gradients, and full-batch gradient descent.
+
+## API
+
+- `new learningRate epochs` validates custom hyperparameters.
+- `defaultPerceptron` uses a learning rate of `0.1` and `2000` epochs.
+- `fit model features labels` returns a newly trained model.
+- `fitColumnLabels` accepts labels represented as one-column rows.
+- `predict model features` returns positive-class probabilities.
+
+Training performs updates for epoch zero through the configured epoch count,
+matching the established implementations. Every `fit` starts again from zero
+parameters. The Haskell API stays pure and therefore does not print periodic
+training progress.
+
+Feature rows must be non-empty, rectangular, finite, and contain at least one
+column. Labels must be finite and match the sample count. Prediction requires a
+trained model with the same feature width used for training.
+
+## Dependencies
+
+The implementation composes the repository's pure Haskell `matrix`,
+`loss-functions`, and `activation-functions` packages. Tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/perceptron/cabal.project
+++ b/code/packages/haskell/perceptron/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../activation-functions ../loss-functions ../matrix

--- a/code/packages/haskell/perceptron/perceptron.cabal
+++ b/code/packages/haskell/perceptron/perceptron.cabal
@@ -1,0 +1,34 @@
+cabal-version: 3.0
+name:          perceptron
+version:       0.1.0
+synopsis:      Pure single-neuron binary classifier
+description:   Sigmoid perceptron training with binary cross-entropy and explicit input validation.
+category:      Math
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  Perceptron
+    build-depends:    activation-functions >=0.1 && <0.2
+                    , base >=4.14 && <5
+                    , loss-functions >=0.1 && <0.2
+                    , matrix >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    PerceptronSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , perceptron
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/perceptron/src/Perceptron.hs
+++ b/code/packages/haskell/perceptron/src/Perceptron.hs
@@ -1,0 +1,125 @@
+-- | A pure single-neuron binary classifier.
+module Perceptron
+    ( Perceptron
+    , learningRate
+    , epochs
+    , weights
+    , bias
+    , new
+    , defaultPerceptron
+    , fit
+    , fitColumnLabels
+    , predict
+    ) where
+
+import ActivationFunctions (sigmoid, sigmoidDerivative)
+import LossFunctions (bceDerivative)
+import qualified Matrix as M
+
+-- | Model configuration and learned parameters.
+--
+-- A newly constructed model has no weights. 'fit' returns a new trained model
+-- rather than mutating the original value.
+data Perceptron = Perceptron
+    { learningRate :: Double
+    , epochs :: Int
+    , weights :: Maybe [Double]
+    , bias :: Double
+    }
+    deriving (Eq, Show)
+
+-- | Construct a model with validated hyperparameters.
+new :: Double -> Int -> Either String Perceptron
+new rate epochCount
+    | not (isFinite rate) = Left "Learning rate must be finite"
+    | epochCount < 0 = Left "Epochs must be non-negative"
+    | otherwise = Right (Perceptron rate epochCount Nothing 0.0)
+
+-- | A model configured with a learning rate of @0.1@ and @2000@ epochs.
+defaultPerceptron :: Perceptron
+defaultPerceptron = Perceptron 0.1 2000 Nothing 0.0
+
+-- | Fit a model against one scalar label per sample.
+--
+-- Training begins from zero weights and zero bias on every call. As in the
+-- other language implementations, epoch zero is an update, so a model with
+-- zero configured epochs performs one gradient step.
+fit :: Perceptron -> [[Double]] -> [Double] -> Either String Perceptron
+fit model featureRows labels = do
+    features <- validateFeatures featureRows
+    validateLabels (M.rows features) labels
+    initialWeights <- M.zeros (M.cols features) 1
+    (trainedWeights, trainedBias) <- train 0 initialWeights 0.0 features labels
+    pure
+        model
+            { weights = Just (map head (M.toRows trainedWeights))
+            , bias = trainedBias
+            }
+  where
+    train epoch currentWeights currentBias features trainingLabels = do
+        raw <- M.dot features currentWeights
+        let rawWithBias = M.addScalar raw currentBias
+            rawValues = map head (M.toRows rawWithBias)
+            predictions = map sigmoid rawValues
+        lossGradient <- bceDerivative trainingLabels predictions
+        let combinedGradient =
+                zipWith (*) lossGradient (map sigmoidDerivative rawValues)
+            biasGradient = sum combinedGradient
+        gradientColumn <- M.fromRows (map (: []) combinedGradient)
+        weightGradient <- M.dot (M.transpose features) gradientColumn
+        nextWeights <-
+            M.subtract
+                currentWeights
+                (M.scale weightGradient (learningRate model))
+        let nextBias = currentBias - learningRate model * biasGradient
+        if epoch == epochs model
+            then Right (nextWeights, nextBias)
+            else train (epoch + 1) nextWeights nextBias features trainingLabels
+
+-- | Fit a model against labels represented as one-column rows.
+fitColumnLabels :: Perceptron -> [[Double]] -> [[Double]] -> Either String Perceptron
+fitColumnLabels model featureRows labelRows = do
+    labels <- traverse flattenLabel labelRows
+    fit model featureRows labels
+  where
+    flattenLabel [value] = Right value
+    flattenLabel _ = Left "Column labels must have exactly one value per row"
+
+-- | Predict the positive-class probability for every sample.
+predict :: Perceptron -> [[Double]] -> Either String [Double]
+predict model featureRows = case weights model of
+    Nothing -> Left "Perceptron has not been trained yet. Call fit first"
+    Just learnedWeights -> do
+        features <- validateFeatures featureRows
+        if M.cols features /= length learnedWeights
+            then
+                Left
+                    ( "Feature width "
+                        ++ show (M.cols features)
+                        ++ " does not match trained width "
+                        ++ show (length learnedWeights)
+                    )
+            else do
+                weightColumn <- M.fromRows (map (: []) learnedWeights)
+                raw <- M.dot features weightColumn
+                pure $ map (sigmoid . (+ bias model) . head) (M.toRows raw)
+
+validateFeatures :: [[Double]] -> Either String M.Matrix
+validateFeatures [] = Left "Feature data must contain at least one sample"
+validateFeatures featureRows@(firstRow : remainingRows)
+    | null firstRow = Left "Samples must contain at least one feature"
+    | any ((/= length firstRow) . length) remainingRows =
+        Left "All samples must have the same number of features"
+    | any (not . isFinite) (concat featureRows) =
+        Left "Feature values must be finite"
+    | otherwise = M.fromRows featureRows
+
+validateLabels :: Int -> [Double] -> Either String ()
+validateLabels expectedRows labels
+    | null labels || length labels /= expectedRows =
+        Left "Labels must match the non-zero sample count"
+    | any (not . isFinite) labels = Left "Labels must be finite"
+    | otherwise = Right ()
+
+isFinite :: Double -> Bool
+isFinite value = not (isNaN value || isInfinite value)

--- a/code/packages/haskell/perceptron/test/PerceptronSpec.hs
+++ b/code/packages/haskell/perceptron/test/PerceptronSpec.hs
@@ -1,0 +1,111 @@
+module PerceptronSpec (spec) where
+
+import Control.Monad (zipWithM_)
+import Data.Either (isLeft)
+import Perceptron
+import Test.Hspec hiding (fit)
+
+andFeatures :: [[Double]]
+andFeatures =
+    [ [0.0, 0.0]
+    , [0.0, 1.0]
+    , [1.0, 0.0]
+    , [1.0, 1.0]
+    ]
+
+andLabels :: [Double]
+andLabels = [0.0, 0.0, 0.0, 1.0]
+
+rightValue :: Show error => Either error value -> IO value
+rightValue result = case result of
+    Left err -> expectationFailure (show err) >> error "unreachable"
+    Right value -> pure value
+
+shouldBeCloseTo :: Double -> Double -> Expectation
+actual `shouldBeCloseTo` expected =
+    abs (actual - expected) `shouldSatisfy` (<= 1e-12)
+
+shouldBeCloseList :: [Double] -> [Double] -> Expectation
+actual `shouldBeCloseList` expected = do
+    length actual `shouldBe` length expected
+    zipWithM_ shouldBeCloseTo actual expected
+
+spec :: Spec
+spec = do
+    describe "construction" $ do
+        it "provides the shared default hyperparameters" $ do
+            learningRate defaultPerceptron `shouldBe` 0.1
+            epochs defaultPerceptron `shouldBe` 2000
+            weights defaultPerceptron `shouldBe` Nothing
+            bias defaultPerceptron `shouldBe` 0.0
+
+        it "accepts finite custom hyperparameters" $ do
+            model <- rightValue $ new 0.8 5000
+            learningRate model `shouldBe` 0.8
+            epochs model `shouldBe` 5000
+
+        it "rejects non-finite learning rates" $ do
+            new (0.0 / 0.0) 10 `shouldSatisfy` isLeft
+            new (1.0 / 0.0) 10 `shouldSatisfy` isLeft
+
+        it "rejects negative epoch counts" $
+            new 0.1 (-1) `shouldBe` Left "Epochs must be non-negative"
+
+    describe "training and prediction" $ do
+        it "learns the shared AND-gate example" $ do
+            model <- rightValue $ new 0.8 5000
+            trained <- rightValue $ fit model andFeatures andLabels
+            predictions <- rightValue $ predict trained andFeatures
+            take 3 predictions `shouldSatisfy` all (< 0.2)
+            last predictions `shouldSatisfy` (> 0.7)
+            fmap length (weights trained) `shouldBe` Just 2
+
+        it "accepts one-column labels" $ do
+            model <- rightValue $ new 0.8 5000
+            trained <-
+                rightValue $
+                    fitColumnLabels model andFeatures (map (: []) andLabels)
+            predictions <- rightValue $ predict trained [[1.0, 1.0]]
+            head predictions `shouldSatisfy` (> 0.7)
+
+        it "performs one update when epochs is zero" $ do
+            model <- rightValue $ new 0.1 0
+            trained <- rightValue $ fit model [[1.0]] [1.0]
+            weights trained `shouldBe` Just [0.05]
+            bias trained `shouldBeCloseTo` 0.05
+            predictions <- rightValue $ predict trained [[1.0]]
+            predictions `shouldBeCloseList` [0.52497918747894]
+
+        it "starts every fit from zero parameters" $ do
+            model <- rightValue $ new 0.2 4
+            first <- rightValue $ fit model andFeatures andLabels
+            second <- rightValue $ fit first andFeatures andLabels
+            first `shouldBe` second
+
+        it "requires a trained model for prediction" $
+            predict defaultPerceptron [[0.0, 1.0]]
+                `shouldBe` Left "Perceptron has not been trained yet. Call fit first"
+
+        it "rejects prediction widths that differ from training" $ do
+            trained <- rightValue $ fit defaultPerceptron andFeatures andLabels
+            predict trained [[1.0]]
+                `shouldBe` Left "Feature width 1 does not match trained width 2"
+
+    describe "input validation" $ do
+        it "rejects empty, zero-width, and ragged feature data" $ do
+            fit defaultPerceptron [] [] `shouldSatisfy` isLeft
+            fit defaultPerceptron [[]] [0.0] `shouldSatisfy` isLeft
+            fit defaultPerceptron [[0.0], [1.0, 2.0]] [0.0, 1.0]
+                `shouldSatisfy` isLeft
+
+        it "rejects label counts that do not match the samples" $
+            fit defaultPerceptron [[0.0]] [0.0, 1.0]
+                `shouldBe` Left "Labels must match the non-zero sample count"
+
+        it "rejects multi-column label rows" $
+            fitColumnLabels defaultPerceptron [[0.0]] [[0.0, 1.0]]
+                `shouldBe` Left "Column labels must have exactly one value per row"
+
+        it "rejects non-finite features and labels" $ do
+            fit defaultPerceptron [[0.0 / 0.0]] [0.0] `shouldSatisfy` isLeft
+            fit defaultPerceptron [[0.0]] [1.0 / 0.0] `shouldSatisfy` isLeft

--- a/code/packages/haskell/perceptron/test/Spec.hs
+++ b/code/packages/haskell/perceptron/test/Spec.hs
@@ -1,0 +1,5 @@
+import PerceptronSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -119,14 +119,14 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
 `matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
-ports, followed by the Haskell `gradient-descent` port:
+ports, followed by the Haskell `gradient-descent` and `perceptron` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 292 |
+| Present in 10-15 languages | 172 | 291 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 705 | 9,870 |
+| Present in one language | 708 | 9,912 |
 
 The loop must not start by attempting 9,870 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
@@ -169,7 +169,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 293
+The 172 packages present in at least ten implementation languages need 291
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -180,7 +180,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 17 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 16 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -555,6 +555,16 @@ including the shared parity vector, singleton and multi-element inputs, zero
 and negative learning rates, mixed gradient signs, input preservation, and all
 validation paths. The package now spans 11 implementation lanes, reduces the
 high-consensus backlog to 292 slots, and leaves 17 gaps in the Haskell lane.
+
+The eighteenth Haskell high-consensus slice is complete: `perceptron` now
+provides a pure sigmoid/BCE single-neuron classifier that composes the existing
+Haskell `matrix`, `loss-functions`, and `activation-functions` packages. Its
+package-native suite exercises 14 examples covering shared AND-gate
+convergence, scalar and column labels, epoch-zero updates, deterministic
+refitting, prediction guards, hyperparameter validation, feature shapes, label
+counts, and finite-value checks. The package now spans 11 implementation
+lanes, reduces the high-consensus backlog to 291 slots, and leaves 16 gaps in
+the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `perceptron` package that composes the existing matrix, loss, and activation packages
- match the shared sigmoid/BCE training semantics, including zero initialization, inclusive epoch updates, column labels, and guarded prediction
- update the parity roadmap and regenerated counts to 291 high-consensus gaps overall and 16 in Haskell

## Validation

- `stack test perceptron --coverage --no-run-benchmarks` (14 examples, 0 failures; 96% expressions, 100% alternatives)
- `stack sdist . --test-tarball` (source archive and all four local Haskell package suites pass)
- `python code/scripts/tests/test_package_parity_report.py -v` (6 tests pass)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` (291 high-consensus gaps, 16 Haskell gaps, 0 collisions, 0 unknown buckets)
- `git diff --cached --check`
