### PR TITLE
feat(hl): Chapter 11 food (bread, water, wine) for FR/GE/IT/PT

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -240,6 +240,8 @@
       "IT-SEASONS": "primavera/estate/autunno/inverno (primavera='prima vera' first green; stagione ← statiō 'a standing')",
       "IT-FAMILY-PARENTS": "padre/madre (father/mother; closest to Latin pater/māter, -t-→-d-; padre = English loan; genitori 'parents' ← genitor 'begetter'; parenti=relatives false friend)",
       "IT-FAMILY-SIBLINGS": "fratello/sorella (brother/sister; frāter/soror + diminutive -ello/-ella = 'little brother/sister'; → fraternal/sorority)",
+      "IT-FOOD-BREAD": "pane (bread; closest to Latin pānis; → companion 'one you share bread with', pantry; companatico = 'what you eat WITH bread')",
+      "IT-FOOD-DRINKS": "acqua/vino (water/wine; acqua KEPT Latin aqua whole, -cq- doubled, vs French eau; vino ← vīnum → wine/vine/vinegar)",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
@@ -256,6 +258,8 @@
       "FR-SEASONS": "printemps/été/automne/hiver (printemps='prime temps' first time; hiver ← hibernum → hibernate)",
       "FR-FAMILY-PARENTS": "père/mère (father/mother ← pater/māter; same PIE as English father/mother via Grimm's law p→f/t→th; → paternal/maternal)",
       "FR-FAMILY-SIBLINGS": "frère/sœur (brother/sister ← frāter/soror; → fraternal/friar, sorority; œ ligature spells soror worn down)",
+      "FR-FOOD-BREAD": "pain (bread ← pānis; nasal -ain; → companion 'one you share bread with', company, pantry)",
+      "FR-FOOD-DRINKS": "eau/vin (water/wine; eau ← aqua worn to a bare 'oh' — most eroded of all, vs English aquatic; vin ← vīnum → wine/vine/vinegar)",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
@@ -272,6 +276,8 @@
       "GE-SEASONS": "Frühling/Sommer/Herbst/Winter (NATIVE Germanic, unlike Latin months; Herbst = English HARVEST; Frühling ← früh 'early')",
       "GE-FAMILY-PARENTS": "Vater/Mutter (father/mother; INHERITED Germanic, NOT Latin loans like the months; Grimm's law twins of English father/mother, V=f)",
       "GE-FAMILY-SIBLINGS": "Bruder/Schwester (brother/sister; Germanic twins of English brother/sister; Geschwister 'siblings' via collective ge-)",
+      "GE-FOOD-BREAD": "Brot (bread; INHERITED Germanic twin of English bread, NOT Latin pānis; introduces the neuter das + capitalized nouns)",
+      "GE-FOOD-DRINKS": "Wasser/Wein (water/wine; Wasser NATIVE Germanic twin of water; but Wein is an ANCIENT Latin loan ← vīnum, borrowed with the vine — like English wine)",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
       "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
       "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
@@ -286,7 +292,9 @@
       "PT-MONTHS": "janeiro…dezembro (março=Mars; -eiro ending ← -arius like feira; setembro…dezembro = Latin 7-10 = sete/dez)",
       "PT-SEASONS": "primavera/verão/outono/inverno (verão ← veranum ← vēr 'spring' — summer grew from spring!; outono ← autumnus au→ou)",
       "PT-FAMILY-PARENTS": "pai/mãe (father/mother; most worn-down of the sisters — pater→pae→pai, māter→mãe nasal, -t- vanished; os pais 'parents' lit. 'the fathers'; o país=country)",
-      "PT-FAMILY-SIBLINGS": "irmão/irmã (brother/sister; NOT from frāter but germānus 'of the same stock' — frāter germānus 'full brother'; = ES hermano; cousins germane/German)"
+      "PT-FAMILY-SIBLINGS": "irmão/irmã (brother/sister; NOT from frāter but germānus 'of the same stock' — frāter germānus 'full brother'; = ES hermano; cousins germane/German)",
+      "PT-FOOD-BREAD": "pão (bread ← pānis, worn to one nasal syllable pānis→pão — same erosion as pai; plural pães; → companion/pantry)",
+      "PT-FOOD-DRINKS": "água/vinho (water/wine; água KEPT aqua's body vs French eau; vinho ← vīnum with signature -nh- = Spanish ñ → wine/vine/vinegar)"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Chapter 11 — Food (bread, water, wine)
+
+- **Chapter 11 authored** (`FR-C11-pain`, `-eau-vin`): the everyday table trio,
+  atom-first, reviewing Ch.10/Ch.1 via `reviews_of`.
+- **pain** ("bread") ← *pānis* — with the payoff that a **companion** is literally
+  "one you **share bread** with" (*com-* + *pānis*); also *company*, *pantry*.
+- **eau / vin** — **eau** ("water") is French's **most eroded** loan from Latin:
+  *aqua → eau*, worn down to a bare vowel "oh" (three silent letters for one
+  sound), while English kept the loud original in *aquatic/aquarium*. **vin** ←
+  *vīnum* held its shape → *wine/vine/vinegar/vintage*.
+- Taxonomy: namespaced `FR-FOOD-BREAD`, `FR-FOOD-DRINKS`.
+
 ## Chapter 10 — Family
 
 - **Chapter 10 authored** (`FR-C10-parents`, `-freres-soeurs`): the immediate

--- a/code/learning/human-languages/french/lessons/FR-C11-eau-vin.md
+++ b/code/learning/human-languages/french/lessons/FR-C11-eau-vin.md
@@ -1,0 +1,57 @@
+---
+id: FR-C11-eau-vin
+chapter: 11
+type: word
+headword: l'eau, le vin
+gloss: water and wine — eau, the most eroded Latin word of all
+concept_tag: FR-FOOD-DRINKS
+prerequisites: [FR-C11-pain]
+sounds: [o-eau, nasal-in]
+roots: [aqua-latin, vinum-latin]
+etymology_hook: "eau ← aqua — worn down so far almost nothing is left (aqua→eue→eau, just 'oh'); vin ← vīnum → wine, vine, vinegar, vintage; French drank the vowels out of aqua"
+est_minutes: 5
+reviews_of: [FR-C11-pain, FR-C10-parents]
+---
+
+# l'eau, le vin — water and wine
+
+## Warm-up
+
+[PAUSE 2s] The two drinks of the French table — and one of them, **eau**, is the
+single most **worn-down** word French took from Latin. It began as *aqua* and
+ended as a bare "**oh**."
+
+## l'eau (water) — Latin aqua, dissolved
+
+- **l'eau** ("water") ← Latin **aqua**. Watch the erosion: *aqua → ewe → eaue →
+  eau*, until only the vowel sound **"oh"** remains — three silent letters *e-a-u*
+  spelling one sound. It even takes *l'* (not *le/la*) because it starts with a
+  vowel. French quite literally **drank the consonants out of *aqua*.**
+
+The **original** *aqua*, though, is loud in English — because English borrowed the
+Latin word **whole**: **aquatic, aquarium, aqueduct, aqualung**, and Italian
+**acqua** (which barely changed). So *l'eau* and *aquarium* are the far ends of the
+same word.
+
+## le vin (wine) — Latin vīnum, kept
+
+- **le vin** ("wine") ← Latin **vīnum** (nasal *vɛ̃*). Unlike *eau*, this one held
+  its shape — and English shares it: **wine** itself is *vīnum* borrowed into old
+  Germanic, plus **vine, vinegar** (*vin* + *aigre*, "sour wine"), **vintage,
+  vineyard, vinyl**. Wine mattered enough to keep its name across every border.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "l'eau, le vin" — *eau* = "oh"; *vin* nasal]
+- [YOU SAY: the erosion — "*aqua* → *eau*, worn to one vowel"]
+- [YOU SAY: "eau ↔ aquarium; vin → wine, vinegar"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "water" and "wine" with articles. (**l'eau, le vin**.) What Latin
+word became *eau*, and what's left of it? (*aqua* — worn down to just the sound
+**"oh"**.) Where did the *loud* version of *aqua* survive? (**English** —
+aquatic/aquarium; and Italian *acqua*.) Name an English cousin of *vin*.
+(wine/vine/vinegar/vintage.) Next chapter: ordering and asking for these at a
+table.

--- a/code/learning/human-languages/french/lessons/FR-C11-pain.md
+++ b/code/learning/human-languages/french/lessons/FR-C11-pain.md
@@ -1,0 +1,53 @@
+---
+id: FR-C11-pain
+chapter: 11
+type: word
+headword: le pain
+gloss: bread — and the "companion" who shares it
+concept_tag: FR-FOOD-BREAD
+prerequisites: [FR-C10-freres-soeurs, FR-C01-bonjour]
+sounds: [nasal-in, silent-final]
+roots: [panis-latin]
+etymology_hook: "pain ← Latin pānis 'bread' → companion (com + pānis, 'one you share bread with'), company, pantry; the nasal -ain"
+est_minutes: 4
+reviews_of: [FR-C10-freres-soeurs, FR-C01-bonjour]
+---
+
+# le pain — bread, and the people you share it with
+
+## Warm-up
+
+[PAUSE 2s] Food at last. **le pain** ("bread") is the heart of the French table —
+and its Latin root hides one of the loveliest word-stories in English: your
+**companion** is, literally, someone you **share bread** with.
+
+## Taken apart
+
+- **le pain** ("bread") ← Latin **pānis** — the nasal vowel *-ain* (*pɛ̃*), with a
+  silent final *-n*. Masculine: *le* pain.
+
+## The "bread" family in English
+
+The root **pān-** ("bread") feeds a surprising table of English words:
+
+- **companion / company** ← *com-* ("with") + *pānis* — "one you **break bread
+  with**." A *company* was first a group sharing meals.
+- **pantry** — the room where the *bread* (and food) is kept.
+- **pannier** — a *bread*-basket, now the bag over a bike or donkey.
+
+So *le pain* is the same root as *companion* — French kept the bread, English kept
+the friendship built on it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "le pain" — nasal *-ain*, silent *-n*]
+- [YOU SAY: "un pain, du pain" ("a loaf, some bread")]
+- [YOU SAY: "pain → companion, pantry" — the share-bread family]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "bread" with its article. (**le pain**.) What Latin word is it
+from? (*pānis*.) What does *companion* literally mean, from this root? ("One you
+**share bread with**" — *com-* + *pānis*.) Next: **l'eau** and **le vin** — water
+and wine.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -59,6 +59,11 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   **frère/sœur** (← *frāter/soror* → fraternal/friar, sorority; the **œ** ligature
   spells worn-down *soror*). **Authored.**
 
+- **Ch. 11 — Food (bread, water, wine)**: **pain** (← *pānis* → **companion**
+  "one you share bread with", pantry) → **eau/vin** (**eau** ← *aqua*, the **most
+  eroded** word French took from Latin — worn to a bare "oh," vs English *aquatic*;
+  **vin** ← *vīnum* → wine/vine/vinegar). **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Chapter 11 — Food (bread, water, wine)
+
+- **Chapter 11 authored** (`GE-C11-brot`, `-wasser-wein`): the everyday table
+  trio, atom-first, reviewing Ch.10/Ch.1 via `reviews_of`.
+- **Brot** ("bread") — **inherited Germanic**, the direct twin of English *bread*
+  (NOT the Latin *pānis* the Romance sisters use); introduces the **neuter das**
+  (completing *der/die/das*) and the rule that German **capitalizes all nouns**.
+- **Wasser / Wein** — the native-vs-borrowed pair: **Wasser** ("water," *w*=*v*) is
+  a native Germanic twin of *water*, but **Wein** ("wine," *ei*="eye") is an
+  **ancient Latin loan** ← *vīnum*, taken with the grapevine Rome carried north —
+  which is exactly why *Wein*, English *wine*, and *vīnum* all match (one loan, not
+  three cousins).
+- Taxonomy: namespaced `GE-FOOD-BREAD`, `GE-FOOD-DRINKS`.
+
 ## Chapter 10 — Family
 
 - **Chapter 10 authored** (`GE-C10-eltern`, `-geschwister`): the immediate family,

--- a/code/learning/human-languages/german/lessons/GE-C11-brot.md
+++ b/code/learning/human-languages/german/lessons/GE-C11-brot.md
@@ -1,0 +1,52 @@
+---
+id: GE-C11-brot
+chapter: 11
+type: word
+headword: das Brot
+gloss: bread — inherited Germanic, the twin of English bread
+concept_tag: GE-FOOD-BREAD
+prerequisites: [GE-C10-geschwister, GE-C01-hallo]
+sounds: [long-o, r-uvular]
+roots: [germanic-braudam]
+etymology_hook: "Brot is INHERITED Germanic (← *braudam), the direct twin of English bread — NOT the Latin pānis the Romance sisters use; and it introduces the third gender, das (neuter)"
+est_minutes: 5
+reviews_of: [GE-C10-geschwister, GE-C01-hallo]
+---
+
+# das Brot — bread, and the third gender
+
+## Warm-up
+
+[PAUSE 2s] Where the Romance sisters all say a version of Latin *pānis* (French
+*pain*, Italian *pane*), German goes its **own Germanic way**: **Brot** — the
+direct twin of English **bread**. And it brings a new grammatical face: the
+**neuter** article, **das**.
+
+## Taken apart
+
+- **das Brot** ("bread") ← old Germanic **\*braudam** — the same word that became
+  English **bread**. No Latin here: this is a **native** word, like *Vater* and
+  *Wasser*, from the Germanic core the two languages share.
+
+## The third gender — das
+
+You have met **der** (masculine, *der Vater*) and **die** (feminine, *die
+Mutter*). German has a **third**: **das**, the **neuter** — and *Brot* is one:
+**das Brot**. (German nouns are also always **capitalized** — *Brot*, *Vater*,
+*Wasser* — a rule no other language here follows.) So the article set is now
+complete: **der / die / das**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "das Brot" — long *o*, the neuter *das*]
+- [YOU SAY: the twin test — "**Brot / bread** — both Germanic, no Latin"]
+- [YOU SAY: the three genders — "der Vater, die Mutter, das Brot"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "bread" with its article. (**das Brot**.) Why is it *not* from
+Latin *pānis* like French *pain*? (It is **inherited Germanic** — the twin of
+English **bread**.) What gender does *das* mark, and what are the other two?
+(**Neuter** — with *der* masculine and *die* feminine.) Next: **Wasser** and
+**Wein** — and a split between native and borrowed.

--- a/code/learning/human-languages/german/lessons/GE-C11-wasser-wein.md
+++ b/code/learning/human-languages/german/lessons/GE-C11-wasser-wein.md
@@ -1,0 +1,58 @@
+---
+id: GE-C11-wasser-wein
+chapter: 11
+type: word
+headword: das Wasser, der Wein
+gloss: water and wine — one native Germanic, one ancient Latin loan
+concept_tag: GE-FOOD-DRINKS
+prerequisites: [GE-C11-brot]
+sounds: [w-as-v, ai-as-eye]
+roots: [germanic-watar, vinum-latin]
+etymology_hook: "Wasser is INHERITED Germanic (Grimm's-law twin of English water); but Wein — like English wine — is an ANCIENT Latin loan (vīnum), borrowed when Rome brought the vine north; native vs borrowed, side by side"
+est_minutes: 5
+reviews_of: [GE-C11-brot, GE-C10-eltern]
+---
+
+# das Wasser, der Wein — one word Germans always had, one Rome brought
+
+## Warm-up
+
+[PAUSE 2s] Two drinks, two very different histories. **Wasser** is a word Germanic
+speakers have **always had**; **Wein** is one Rome **carried north** with the
+grapevine. Side by side, they show the difference between an *inherited* word and
+an ancient *loan*.
+
+## das Wasser (water) — native Germanic
+
+- **das Wasser** ("water") — the **w** is pronounced **v** (*VAH-ser*). It is the
+  Grimm's-law twin of English **water**: same Germanic root **\*watar**, same core
+  meaning, both native. Like *Brot* and *Vater*, no Latin needed — and neuter,
+  **das** Wasser.
+
+## der Wein (wine) — an ancient Latin loan
+
+- **der Wein** ("wine") — the **ei** is said "**eye**" (*vine*). Here is the twist:
+  *Wein* is **not** a native Germanic word. It was **borrowed from Latin *vīnum***
+  in Roman times, when the legions brought **viticulture** north of the Alps. The
+  Germanic tribes took the drink *and its name* — which is exactly why **English
+  wine, German Wein, and Latin vīnum** all match: they are one **loan**, not three
+  cousins. (Masculine: *der* Wein.)
+
+**The lesson in one line:** *Wasser* is a word Germans **always had**; *Wein* is a
+word Rome **gave** them — the vine came with a vocabulary.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "das Wasser" (*v-*), "der Wein" (*-ein* = "eye")]
+- [YOU SAY: "Wasser / water — native twins"; "Wein / wine / vīnum — one Latin loan"]
+- [YOU SAY: the split — "Wasser native, Wein borrowed with the grapevine"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "water" and "wine" with articles and correct sounds. (**das
+Wasser** — *v-* — **der Wein** — "vine".) Which is inherited Germanic, and which
+is a Latin loan? (*Wasser* **native** — twin of *water*; *Wein* **borrowed** from
+*vīnum*, with the vine.) Why do *Wein* and English *wine* match so exactly? (Both
+borrowed the **same Latin word**, *vīnum*.) Next chapter: asking for these at the
+table.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -63,6 +63,12 @@ Spanish and French where a contrast helps. The recurring decoder is the
   via the collective **ge-**). The standout: family is native where the months were
   borrowed. **Authored.**
 
+- **Ch. 11 — Food (bread, water, wine)**: **Brot** (**inherited Germanic** twin of
+  English *bread*, NOT Latin *pānis*; introduces the neuter **das** + capitalized
+  nouns) → **Wasser/Wein** — the native-vs-borrowed split: **Wasser** a native
+  Germanic twin of *water*, but **Wein** an **ancient Latin loan** (← *vīnum*),
+  borrowed with the grapevine, which is why *Wein/wine/vīnum* all match. **Authored.**
+
 ## Planned
 
 | Chapter | Theme |

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Chapter 11 — Food (bread, water, wine)
+
+- **Chapter 11 authored** (`IT-C11-pane`, `-acqua-vino`): the everyday table trio,
+  atom-first, reviewing Ch.10/Ch.1 via `reviews_of`.
+- **pane** ("bread") — **closest to Latin** *pānis*; the **companion** payoff
+  (*com-* + *pānis*, "one you share bread with"), plus the purely Italian
+  **companatico** — "whatever you eat **with** bread."
+- **acqua / vino** — **acqua** ("water") **kept** Latin *aqua* almost whole (even
+  doubling *-cq-*), a sharp contrast with French *eau* worn to a single vowel;
+  **vino** ← *vīnum* → *wine/vine/vinegar*.
+- Taxonomy: namespaced `IT-FOOD-BREAD`, `IT-FOOD-DRINKS`.
+
 ## Chapter 10 — Family
 
 - **Chapter 10 authored** (`IT-C10-genitori`, `-fratello-sorella`): the immediate

--- a/code/learning/human-languages/italian/lessons/IT-C11-acqua-vino.md
+++ b/code/learning/human-languages/italian/lessons/IT-C11-acqua-vino.md
@@ -1,0 +1,52 @@
+---
+id: IT-C11-acqua-vino
+chapter: 11
+type: word
+headword: l'acqua, il vino
+gloss: water and wine — acqua kept Latin's whole aqua, where French wore it to eau
+concept_tag: IT-FOOD-DRINKS
+prerequisites: [IT-C11-pane]
+sounds: [double-cq, v-clear]
+roots: [aqua-latin, vinum-latin]
+etymology_hook: "acqua kept Latin aqua almost whole (the -cq- doubles the sound) — the loud original French wore down to eau; vino ← vīnum → wine/vine/vinegar/vintage"
+est_minutes: 5
+reviews_of: [IT-C11-pane, IT-C10-genitori]
+---
+
+# l'acqua, il vino — water and wine, close to the source
+
+## Warm-up
+
+[PAUSE 2s] The Italian table's two drinks — and a neat contrast with French.
+Where French dissolved Latin *aqua* into a bare **eau** ("oh"), Italian kept it
+almost **whole**: **acqua**, with the *aqua* still ringing in it.
+
+## l'acqua (water) — Latin aqua, preserved
+
+- **l'acqua** ("water") ← Latin **aqua**. Italian barely moved it — it even
+  **doubles** the sound with **-cq-** (*AH-kwa*), holding onto the hard *qu* that
+  French threw away. Set them side by side: Latin *aqua* → Italian **acqua** (kept)
+  vs French **eau** (worn to a vowel). English borrowed the same loud original for
+  **aquatic, aquarium, aqueduct**. Takes *l'* before the vowel.
+
+## il vino (wine) — Latin vīnum
+
+- **il vino** ("wine") ← Latin **vīnum** — clean and close, like everything Italian.
+  The same word travelled into English as **wine**, and gives **vine, vinegar,
+  vintage, vineyard, vinyl**. Masculine: *il* vino.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "l'acqua, il vino" — *acqua* with the doubled *-cq-*]
+- [YOU SAY: the contrast — "Latin *aqua* → Italian **acqua** (kept), French **eau**
+  (worn away)"]
+- [YOU SAY: "acqua ↔ aquarium; vino → wine, vinegar"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "water" and "wine" with articles. (**l'acqua, il vino**.) How does
+Italian *acqua* differ from French *eau*, from the same *aqua*? (Italian **kept**
+it — even doubling *-cq-*; French wore it to a single vowel.) Name an English
+cousin of each. (*acqua* → aquatic/aquarium; *vino* → wine/vinegar.) Next chapter:
+asking for these at a table.

--- a/code/learning/human-languages/italian/lessons/IT-C11-pane.md
+++ b/code/learning/human-languages/italian/lessons/IT-C11-pane.md
@@ -1,0 +1,50 @@
+---
+id: IT-C11-pane
+chapter: 11
+type: word
+headword: il pane
+gloss: bread — closest to Latin pānis, and the "companion" who shares it
+concept_tag: IT-FOOD-BREAD
+prerequisites: [IT-C10-fratello-sorella, IT-C01-ciao]
+sounds: [e-open, n-single]
+roots: [panis-latin]
+etymology_hook: "pane sits closest to Latin pānis; the root gives companion (com + pānis, 'one you share bread with'), company, pantry; Italy's companatico is 'whatever you eat WITH bread'"
+est_minutes: 4
+reviews_of: [IT-C10-fratello-sorella, IT-C01-ciao]
+---
+
+# il pane — bread, and its companions
+
+## Warm-up
+
+[PAUSE 2s] **il pane** ("bread") — and, true to form, Italian keeps it **closest
+to Latin**: *pānis → pane*, barely touched. Its root carries the same warm story
+as the French *pain*: a **companion** is one you **share bread** with.
+
+## Taken apart
+
+- **il pane** ("bread") ← Latin **pānis** — masculine, *il* pane; the plural is
+  *i pani*.
+
+## The "bread" family
+
+- **companion / company** ← *com-* ("with") + *pānis* — "one you **break bread
+  with**."
+- **pantry**, **pannier** (a bread-basket).
+- And a purely Italian gem: **companatico** — the word for "**whatever you eat with
+  bread**" (cheese, salami, anything on it). The bread is the given; the
+  *companatico* is what joins it — the same *com- + pānis* idea, alive in one Italian
+  word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "il pane" — open *e*; plural "i pani"]
+- [YOU SAY: "pane → companion, companatico" — bread and what joins it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "bread" with its article. (**il pane**.) What Latin word, and how
+much did Italian change it? (*pānis* — barely: *pānis → pane*.) What does
+*companatico* mean, and how does it use the bread-root? ("What you eat **with**
+bread" — *com-* "with" + *pānis*.) Next: **l'acqua** and **il vino**.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -56,6 +56,11 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   *parenti*=relatives false friend) → **fratello/sorella** (← *frāter/soror* + the
   diminutive *-ello/-ella*, "little brother/sister"). **Authored.**
 
+- **Ch. 11 — Food (bread, water, wine)**: **pane** (closest to Latin *pānis* →
+  **companion**, *companatico* "what you eat with bread") → **acqua/vino** —
+  **acqua** **kept** Latin *aqua* whole (doubled *-cq-*), the loud original French
+  wore down to *eau*; **vino** ← *vīnum* → wine/vine/vinegar. **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Chapter 11 — Food (bread, water, wine)
+
+- **Chapter 11 authored** (`PT-C11-pao`, `-agua-vinho`): the everyday table trio,
+  atom-first, reviewing Ch.10/Ch.1 via `reviews_of`.
+- **pão** ("bread") ← *pānis*, worn to a single **nasal** syllable (*pānis → pão*)
+  — the **same nasalizing erosion** that made *pai* from *pater* and *mãe* from
+  *māter*; tricky plural **pães**. Root still gives *companion/pantry*.
+- **água / vinho** — **água** ("water") **kept** *aqua*'s body (unlike French
+  *eau*); **vinho** ("wine") ← *vīnum* carries Portuguese's signature **-nh-** (the
+  palatal *ny*, = Spanish **ñ**, met before in *amanhã*) → *wine/vine/vinegar*.
+- Taxonomy: namespaced `PT-FOOD-BREAD`, `PT-FOOD-DRINKS`.
+
 ## Chapter 10 — Family
 
 - **Chapter 10 authored** (`PT-C10-pais`, `-irmaos`): the immediate family,

--- a/code/learning/human-languages/portuguese/lessons/PT-C11-agua-vinho.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C11-agua-vinho.md
@@ -1,0 +1,52 @@
+---
+id: PT-C11-agua-vinho
+chapter: 11
+type: word
+headword: a água, o vinho
+gloss: water and wine — água keeps aqua's shape; vinho shows the -nh- for Latin -n-
+concept_tag: PT-FOOD-DRINKS
+prerequisites: [PT-C11-pao]
+sounds: [nasal-none, nh-palatal]
+roots: [aqua-latin, vinum-latin]
+etymology_hook: "água kept aqua's body (where French wore it to eau); vinho ← vīnum, with Portuguese's signature -nh- (= Spanish ñ, French/Italian gn) → wine/vine/vinegar"
+est_minutes: 5
+reviews_of: [PT-C11-pao, PT-C10-pais]
+---
+
+# a água, o vinho — water and wine
+
+## Warm-up
+
+[PAUSE 2s] Two drinks, two more sound-stories. Portuguese kept **água** close to
+Latin *aqua* (unlike French, which dissolved it to *eau*), and it stamps **vinho**
+with its signature spelling — the **-nh-**.
+
+## a água (water) — Latin aqua, kept
+
+- **a água** ("water") ← Latin **aqua**. Portuguese held its body — *aqua → água*
+  — where French wore it down to a single vowel (*eau*). The accent on **á** marks
+  the stress. It's **feminine**: *a* água. English kept the loud original in
+  **aquatic, aquarium, aqueduct**.
+
+## o vinho (wine) — Latin vīnum, with -nh-
+
+- **o vinho** ("wine") ← Latin **vīnum**. The **-nh-** is Portuguese's palatal *ny*
+  sound — the **same sound** as Spanish **ñ** (*viño*→*vinho*), French/Italian
+  **gn**, and the *nh* you already met in *amanhã* ("tomorrow"). One sound, four
+  spellings across the sisters. The word still gives English **wine, vine, vinegar,
+  vintage**. Masculine: *o* vinho.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "a água, o vinho" — stress the *á*; *-nh-* = palatal *ny*]
+- [YOU SAY: the contrast — "*aqua* → **água** (kept), French **eau** (worn away)"]
+- [YOU SAY: "the *nh* of *vinho* = Spanish *ñ*, met before in *amanhã*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "water" and "wine" with articles. (**a água, o vinho**.) How does
+*água* compare with French *eau*, from the same *aqua*? (Portuguese **kept** the
+body; French wore it to a vowel.) What sound is the **-nh-** in *vinho*, and its
+Spanish twin? (A palatal *ny* — Spanish **ñ**.) Next chapter: asking for these at a
+table.

--- a/code/learning/human-languages/portuguese/lessons/PT-C11-pao.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C11-pao.md
@@ -1,0 +1,52 @@
+---
+id: PT-C11-pao
+chapter: 11
+type: word
+headword: o pão
+gloss: bread — pānis worn to a single nasal syllable, just like pai
+concept_tag: PT-FOOD-BREAD
+prerequisites: [PT-C10-irmaos, PT-C01-ola]
+sounds: [nasal-ao, p-clear]
+roots: [panis-latin]
+etymology_hook: "pão ← pānis, worn to one nasal syllable (pānis→pãe→pão) — the same nasalizing erosion that made pai from pater; the root still gives companion, pantry"
+est_minutes: 4
+reviews_of: [PT-C10-irmaos, PT-C10-pais]
+---
+
+# o pão — bread, worn down to a hum
+
+## Warm-up
+
+[PAUSE 2s] **o pão** ("bread") — and Portuguese does to it exactly what it did to
+"father." Just as *pater* eroded to the one-syllable **pai**, Latin *pānis* wore
+down to the single **nasal** syllable **pão** ("**powng**"). Same word as French
+*pain* and Italian *pane*, taken furthest.
+
+## Taken apart
+
+- **o pão** ("bread") ← Latin **pānis**. The intervocalic *-n-* dissolved and left
+  its **nasality** behind on the vowel: *pānis → pãe → pão*, the tilde marking the
+  hum — the identical process behind **pai** (← *pater*) and **mãe** (← *māter*)
+  from the family chapter. Masculine: *o* pão; the plural is the tricky **pães**.
+
+## The "bread" family — still there
+
+Even worn to a hum, the root keeps its English relatives: **companion / company**
+(*com-* + *pānis*, "one you **share bread with**"), **pantry**, **pannier**. So
+*pão* and *companion* are the near-vanished and the well-preserved ends of one
+Latin word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "o pão" — fully nasal, "powng"; plural "pães"]
+- [YOU SAY: the parallel — "*pater* → **pai**, *pānis* → **pão** — same nasal
+  erosion"]
+- [YOU SAY: "pão → companion, pantry"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give "bread" with its article. (**o pão**.) What Latin word is it from,
+and what happened to it? (*pānis* — worn to a single **nasal** syllable, *pānis →
+pão*.) Which family word followed the *same* erosion? (**pai**, ← *pater* — and
+*mãe* ← *māter*.) Next: **a água** and **o vinho** — water and wine.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -61,6 +61,11 @@ French.
   "of the same stock," from *frāter germānus* "full brother," **not** *frāter*; = ES
   *hermano*; cousins *germane*/*German*). **Authored.**
 
+- **Ch. 11 — Food (bread, water, wine)**: **pão** (← *pānis*, worn to one **nasal**
+  syllable *pānis→pão* — the same erosion as *pai*; plural *pães*) → **água/vinho**
+  — **água** **kept** *aqua*'s body (vs French *eau*); **vinho** ← *vīnum* with the
+  signature **-nh-** (= Spanish *ñ*) → wine/vine/vinegar. **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |


### PR DESCRIPTION
## What

The everyday-table trio — **bread, water, wine** — authored in parallel across the four Latin-script sisters (**8 lessons**), each atom-first and reviewing Ch.10/Ch.1 via `reviews_of`. Shared threads: *pānis* → **companion** ("one you break bread with"); the erosion contrast on *aqua*; *vīnum* → wine/vine/vinegar. Each track lands a **distinct angle**:

| Track | Angle |
|---|---|
| **French** | *pain* ← *pānis* → companion/pantry; **eau** is French's **most eroded** loan — *aqua* worn to a bare "oh" (three silent letters, one sound) vs English *aquatic*; *vin* ← *vīnum* |
| **German** | **Brot** is **inherited Germanic** (twin of *bread*, NOT *pānis*), introduces the **neuter das** + capitalized nouns; then the native-vs-borrowed split — **Wasser** native (twin of *water*) but **Wein** an **ancient Latin loan** (← *vīnum*, with the grapevine), so *Wein/wine/vīnum* all match |
| **Italian** | *pane* closest to Latin → **companion** + **companatico** ("what you eat *with* bread"); **acqua** **kept** *aqua* whole (doubled *-cq-*) vs French *eau*; *vino* ← *vīnum* |
| **Portuguese** | **pão** ← *pānis* worn to one **nasal** syllable — the same erosion as *pai/mãe*; *água* kept *aqua*'s body; *vinho* ← *vīnum* with the signature **-nh-** (= Spanish *ñ*) |

The German native-vs-Latin thread continues: *Brot/Wasser* native, but *Wein* an ancient loan — the vine came with a vocabulary.

## Housekeeping
- Taxonomy: namespaced `{FR,GE,IT,PT}-FOOD-BREAD/-DRINKS`.
- Each track's `roadmap.md` (Ch.11 authored) and `CHANGELOG.md`.
- Suite **38/38**; `taxonomy.json` valid JSON; no retired `concept_tag`s; security-reviewed (Markdown + JSON only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)