### PR TITLE
feat(hl): Arabic Ch.3 writing set — a second dots-family, and writing your reply

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Chapter 3 — Writing set (a second dots-family, and writing your reply)
+
+- **Writing lessons added** (`AR-W07-hook-family-ha-kha`, `AR-W08-kaf-and-ra`,
+  `AR-W09-khayr-bikhayr`): a `writing`-type companion continuing the AR-W01–06
+  track, building toward the "how are you?" **reply**. No `concept_tag` (writing
+  lessons are exempt from the concept join). Anchor: **خير** (*khayr*, "good") —
+  the word already inside the Ch. 1 greeting **صباح الخير** (*ṣabāḥ al-khayr*).
+- **W07 — the hook-and-tail dots-family**: the bowl-family trick reborn on a
+  **new skeleton** — one curvy hook-and-tail body gives **ح** (*ḥāʾ*, no dot),
+  **خ** (*khāʾ*, one dot above), **ج** (*jīm*, one dot below). Phoenician tie-back:
+  *ḥēth*→**H**, *gīml*→**C/G**. Note that *خير* opens with *خ*.
+- **W08 — kāf & rā**: **ك** (*kāf*, an angular body + inner stroke; *kaph* "palm"
+  →**K**) and **ر** (*rā*; *rēsh* "head" →**R**) — the latter another **non-joiner**
+  like *alif*, so the pen lifts after it.
+- **W09 — assemble خير → بخير**: writes **خير** (*khāʾ·yāʾ·rā*, "good"; root
+  **kh-y-r**), then prefixes **بـ** (*bi-*, "in/with") for **بخير** (*bi-khayr*,
+  "well," literally "in goodness") — the everyday answer to *kayfa ḥāluk?*. A
+  greeting and its reply are now both hand-writable.
+
 ## Chapter 2 — Writing set (the dots family, your name, and the hidden vowels)
 
 - **Writing lessons added** (`AR-W04-dots-family-nun-ta`, `AR-W05-ya-and-my-name`,

--- a/code/learning/human-languages/arabic/lessons/AR-W07-hook-family-ha-kha.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W07-hook-family-ha-kha.md
@@ -1,0 +1,69 @@
+---
+id: AR-W07-hook-family-ha-kha
+chapter: 3
+type: writing
+headword: "ح، خ، ج"
+gloss: a second dots-family on a new skeleton — the hook-and-tail body ḥāʾ, khāʾ, jīm
+romanization: "ḥāʾ, khāʾ, jīm"
+prerequisites: [AR-W06-harakat-and-hamza]
+sounds: [arabic-ha-deep, arabic-kha, arabic-jim]
+roots: [phoenician-heth, phoenician-giml]
+est_minutes: 5
+reviews_of: [AR-W06-harakat-and-hamza, AR-W04-dots-family-nun-ta, AR-C01-sabah-al-khayr]
+---
+
+# ح، خ، ج — the dots trick, on a brand-new body
+
+## Warm-up
+
+[PAUSE 2s] Back in Lesson 4 you learned a whole family of letters that share one
+**bowl** and differ only by dots. Arabic does the *same trick* on a **second**
+skeleton — a curvy **hook-and-tail body** — giving three more common letters. Learn
+the body once; the dots do the rest, exactly as before.
+
+## The hook-and-tail family
+
+Every letter here is the **same shape**: a rounded **hook** at the top flowing into
+a **tail that drops below the line**. Only the dot changes:
+
+| letter | sound | the dot |
+|---|---|---|
+| **ح** *ḥāʾ* | ḥ — a deep, breathy "h" (from the throat) | **no** dot |
+| **خ** *khāʾ* | kh — like the *ch* in Scottish "lo**ch**" | **one** dot **above** |
+| **ج** *jīm* | j — as in "**j**am" | **one** dot **below** |
+
+It is the bowl-family idea reborn: one skeleton, the dots deciding everything. Say
+the dial — **no dot / above / below → ḥ / kh / j**.
+
+## Draw them
+
+- **ح** (*ḥāʾ*) — the hook body, then the descending tail; **no dot**. From
+  Phoenician **ḥēth** ("fence") — the ancestor of Latin **H**.
+- **خ** (*khāʾ*) — the **same** body, plus **one dot above**. (Arabic built *khāʾ*
+  from *ḥāʾ* by adding the dot — no separate Latin cousin, but you already know the
+  shape.)
+- **ج** (*jīm*) — the same body, plus **one dot below**. From Phoenician **gīml**
+  ("camel") — the great-grandparent of Greek *gamma* and Latin **C/G**.
+
+## Where you've seen it — خير
+
+You have already read **خير** (*khayr*, "good/well") inside the Chapter 1 greeting
+**صباح الخير** (*ṣabāḥ al-khayr*, "good morning"). It **opens with خ** — the
+hook-body plus one dot above. You now know the first letter of a word you've been
+saying since Lesson… one.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: the same hook-and-tail body three times, then dot them — ح (none),
+  خ (above), ج (below)]
+- [YOU SAY: the dial — "no dot, above, below — ḥ, kh, j"]
+- [YOU SAY: "خ opens خير — the 'good' in *ṣabāḥ al-khayr*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do **ح, خ, ج** share, and what tells them apart? (One
+**hook-and-tail body**; the **dots** — none / above / below.) Which sound is *خ*,
+and where's its dot? (**kh**, like *loch*; **one above**.) Which Chapter 1 word
+opens with *خ*? (**خير**, in *ṣabāḥ al-khayr*.) Next: **ك** (*kāf*) and **ر**
+(*rā*) — the last letters you need to write it.

--- a/code/learning/human-languages/arabic/lessons/AR-W08-kaf-and-ra.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W08-kaf-and-ra.md
@@ -1,0 +1,61 @@
+---
+id: AR-W08-kaf-and-ra
+chapter: 3
+type: writing
+headword: "ك، ر"
+gloss: two more letters — kāf (k), and rā (r), another non-joiner like alif
+romanization: "kāf, rā"
+prerequisites: [AR-W07-hook-family-ha-kha]
+sounds: [arabic-kaf, arabic-ra]
+roots: [phoenician-kaph, phoenician-resh]
+est_minutes: 4
+reviews_of: [AR-W07-hook-family-ha-kha, AR-W01-direction-and-alif]
+---
+
+# ك and ر — an angular k, and an r that won't hold hands
+
+## Warm-up
+
+[PAUSE 2s] Two more shapes, and then — next lesson — you can write **خير**. Meet
+**ك** (*kāf*, "k") and **ر** (*rā*, "r"). One is angular and new; the other
+revisits a rule you learned on the very first day.
+
+## ك (kāf) — the angular k
+
+Break it apart:
+
+1. **the body** — an **angular upright**, bending like an open corner (not a curve
+   — a hard angle).
+2. **the inner stroke** — a small *hamza*-like flick tucked **inside** the angle.
+
+**ك** is *kāf*, a clean "k." From Phoenician **kaph** ("palm of the hand") — the
+ancestor of Greek *kappa* and Latin **K**. It joins its neighbours, changing shape
+by position like the other connectors.
+
+## ر (rā) — the little downward curve that breaks
+
+Break it apart — there's just *one piece*:
+
+1. **the curve** — a short stroke that **curves down below the baseline** and
+   stops. No dot, no loop.
+
+**ر** is *rā*, "r." From Phoenician **rēsh** ("head") — ancestor of Greek *rho* and
+Latin **R**. And here is the important rule: like **alif** (Lesson 1), **rā does
+not join to the letter after it** — it is one of the **six non-joiners**. So *rā*
+forces the pen to **lift**, just as *alif* did in *سلام*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **ك** — angular body + the inner flick]
+- [YOU WRITE: **ر** — one short downward curve below the line]
+- [YOU SAY: "*rā*, like *alif*, **breaks** — no joining the next letter"]
+- [YOU SAY: "*kaph* → K, *rēsh* → R — the Phoenician cousins again"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Describe **ك**: angular or curved, and what sits inside? (**Angular**
+body with a small **inner stroke**.) What Latin letters descend from *kāf* and *rā*?
+(**K** and **R**.) What rule does **ر** share with **alif**? (It is a **non-joiner**
+— the pen **lifts** after it.) Next: you assemble **خير** — and answer "how are
+you?"

--- a/code/learning/human-languages/arabic/lessons/AR-W09-khayr-bikhayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W09-khayr-bikhayr.md
@@ -1,0 +1,61 @@
+---
+id: AR-W09-khayr-bikhayr
+chapter: 3
+type: writing
+headword: "خير"
+gloss: assembling خير (khayr, "good/well") and بخير (bi-khayr, "well") — the answer to "how are you?"
+romanization: "khayr, bi-khayr"
+prerequisites: [AR-W08-kaf-and-ra]
+sounds: [arabic-khayr]
+roots: [semitic-kh-y-r]
+est_minutes: 5
+reviews_of: [AR-W08-kaf-and-ra, AR-W07-hook-family-ha-kha, AR-C01-sabah-al-khayr]
+---
+
+# خير and بخير — writing "good," and how you say you're well
+
+## Warm-up
+
+[PAUSE 2s] Everything comes together. With **خ** (Lesson 7), **ي** (Lesson 5), and
+**ر** (Lesson 8), you can now write **خير** (*khayr*, "good") — the word hiding in
+every "good morning" you've greeted with — and then **بخير** (*bi-khayr*, "well"),
+the everyday answer to "how are you?"
+
+## Assemble خير — right to left
+
+Write it starting on the **right**, moving **left**:
+
+1. **خ** (*khāʾ*) — the hook-body with **one dot above**, **reaching left** into…
+2. **ي** (*yāʾ*) — joined in the middle (its two dots below), flowing into…
+3. **ر** (*rā*) — the little down-curve. Remember Lesson 8: *rā* is a **non-joiner**,
+   so it simply ends the word — but *yāʾ* **does** join into it from the right.
+
+Read back, right to left: **خ · ي · ر** = *kh · ī · r* = **خير**, "good." (The root
+**kh–y–r** means "good, best, choice" across Semitic — the same three consonants
+carry the meaning, vowels laid on top, just like Arabic always works.)
+
+## Then بخير — "(I'm) well"
+
+Glue **بـ** (*bi-*, "in / with") onto the front — *bāʾ* from Lesson 3, its one dot
+below — and it joins straight into the *khāʾ*:
+
+- **بخير** = *bāʾ · khāʾ · yāʾ · rā* = **bi-khayr**, literally "**in goodness**" —
+  what you say when someone asks *kayfa ḥāluk?* ("how are you?"). "*Al-ḥamdu lillāh,
+  bi-khayr*" — "Praise God, (I'm) well."
+
+You have now written a **real reply** in a real conversation, in your own hand.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **خير**, right to left — "khāʾ (dot above), yāʾ, rā — lift"]
+- [YOU WRITE: **بخير** — add *bi-* on the right: "bāʾ joins into khāʾ"]
+- [YOU SAY: "the root **kh-y-r** = good; *bi-khayr* = 'in goodness' = 'I'm well'"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Spell **خير** letter by letter, right to left. (*khāʾ · yāʾ · rā* —
+"good.") Which letter ends it, and does anything join *after* it? (**rā** — **no**,
+it's a non-joiner; the pen lifts.) What does **بخير** literally mean, and when do
+you say it? ("**In goodness**" — the answer to "how are you?", *kayfa ḥāluk?*.) You
+can now hand-write a greeting *and* its reply — the Arabic script is yours.

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -39,6 +39,15 @@ word lessons — never as a gated reading course.
   marks) and the **hamza** — the showpiece being that a single *fatḥa*/*kasra*
   flips **أنتَ** ("you," m.) to **أنتِ** ("you," f.).
 
+- **Ch. 3 — Writing set** (`AR-W07`–`AR-W09`, `writing` type): builds toward the
+  reply *bi-khayr* ("well"). Introduces a **second dots-family** — the
+  hook-and-tail body **ح/خ/ج** (no-dot/above/below → ḥ/kh/j), a structural rhyme
+  with the Ch. 2 bowl-family — then **ك** (*kāf*) and **ر** (*rā*, another
+  non-joiner like *alif*), and assembles **خير → بخير** ("good" → "well," lit. "in
+  goodness"). The anchor **خير** is the word already hiding in the Ch. 1 greeting
+  *ṣabāḥ al-khayr*, so a greeting and its reply are now both hand-writable.
+  Phoenician cousins continue: *ḥēth*→H, *gīml*→C/G, *kaph*→K, *rēsh*→R.
+
 ## Planned
 
 | Chapter | Theme |


### PR DESCRIPTION
## What

Extends the Arabic writing track (`AR-W07/08/09`, `writing` type, **no `concept_tag`**) toward the "how are you?" **reply**, continuing `AR-W01–06`. Anchored on **خير** (*khayr*, "good") — the word already hiding in the Ch.1 greeting **صباح الخير** (*ṣabāḥ al-khayr*, "good morning").

## The three lessons

| Lesson | Content |
|---|---|
| **W07 — the hook-and-tail dots-family** | The bowl-family trick reborn on a **new skeleton**: one curvy hook-and-tail body gives **ح** (*ḥāʾ*, no dot), **خ** (*khāʾ*, one dot above), **ج** (*jīm*, one dot below). Phoenician tie-back: *ḥēth*→**H**, *gīml*→**C/G**. |
| **W08 — kāf & rā** | **ك** (*kāf*, angular body + inner stroke; *kaph* "palm"→**K**) and **ر** (*rā*; *rēsh* "head"→**R**) — the latter another **non-joiner** like *alif*, so the pen lifts. |
| **W09 — assemble خير → بخير** | Writes **خير** (*khāʾ·yāʾ·rā*, "good"; Semitic root **kh-y-r**), then prefixes **بـ** (*bi-*, "in/with") for **بخير** (*bi-khayr*, "well," literally "in goodness") — the everyday answer to *kayfa ḥāluk?*. |

The structural payoff: the hook-body family (ح/خ/ج) **rhymes** with the Ch.2 bowl-family (ب/ن/ت/ث) — same "one skeleton, dots decide" logic on a different shape. And a **greeting and its reply are now both hand-writable**.

## Housekeeping
- Updates `arabic/CHANGELOG.md` and `roadmap.md` (Ch.3 writing set authored).
- Suite **38/38**; all three lessons carry **no `concept_tag`**; no retired tags; security-reviewed (Markdown only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)