### PR TITLE
Add Haskell type-checker-protocol port

### DIFF
--- a/code/packages/haskell/type-checker-protocol/BUILD
+++ b/code/packages/haskell/type-checker-protocol/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/type-checker-protocol/BUILD_windows
+++ b/code/packages/haskell/type-checker-protocol/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/type-checker-protocol/CHANGELOG.md
+++ b/code/packages/haskell/type-checker-protocol/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0 - 2026-07-19
+
+- Add immutable diagnostic and type-check result values.
+- Add a functional checker wrapper for structurally compatible checker
+  functions.
+- Add pure generic hook registration and exact-before-wildcard dispatch.
+- Add reusable diagnostic collection, location handling, lifecycle reset, and
+  node-kind normalization.
+- Cover protocol, dispatch, fall-through, wildcard, argument, ordering, and
+  validation behavior with package-native tests.

--- a/code/packages/haskell/type-checker-protocol/README.md
+++ b/code/packages/haskell/type-checker-protocol/README.md
@@ -1,0 +1,48 @@
+# type-checker-protocol
+
+Pure Haskell implementation of the shared generic type-checker contract used by
+compiler frontends in this repository.
+
+## API
+
+- `TypeErrorDiagnostic` records an immutable message and one-based source
+  location.
+- `TypeCheckResult` carries the fully or partially typed AST and every
+  diagnostic collected during the pass; `ok` reports whether the list is empty.
+- `TypeChecker` wraps any function from an input AST to a typed result.
+- `GenericTypeChecker` supplies reusable phase/kind hook registration,
+  exact-before-wildcard dispatch, diagnostic accumulation, and lifecycle reset.
+- `HookResult` distinguishes a handled value from deliberate fall-through.
+
+The generic checker is explicitly threaded through hook functions. This keeps
+diagnostics and hook registration pure and makes a configured checker safely
+reusable across independent runs.
+
+## Example
+
+```haskell
+import TypeCheckerProtocol
+
+data Node = Node { nodeKind :: String, nodeText :: String }
+
+type Checker = GenericTypeChecker Node () Node
+
+literalHook :: Hook Node () Node
+literalHook node _ checker =
+    (Handled node { nodeText = "checked" }, checker)
+
+checker :: Checker
+checker =
+    registerHook "node" "literal" literalHook $
+        defaultGenericTypeChecker nodeKind
+```
+
+## Dependencies
+
+The library depends only on `base`. Tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/type-checker-protocol/cabal.project
+++ b/code/packages/haskell/type-checker-protocol/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/type-checker-protocol/src/TypeCheckerProtocol.hs
+++ b/code/packages/haskell/type-checker-protocol/src/TypeCheckerProtocol.hs
@@ -1,0 +1,210 @@
+-- | Shared pure contracts and dispatch helpers for language type checkers.
+module TypeCheckerProtocol
+    ( TypeErrorDiagnostic (..)
+    , TypeCheckResult (..)
+    , ok
+    , TypeChecker
+    , makeTypeChecker
+    , check
+    , HookResult (..)
+    , Hook
+    , GenericTypeChecker
+    , newGenericTypeChecker
+    , defaultGenericTypeChecker
+    , registerHook
+    , dispatch
+    , reportError
+    , resetErrors
+    , checkerErrors
+    , runGenericCheck
+    , normalizeKind
+    ) where
+
+import Data.List (dropWhileEnd)
+
+-- | A single type error at a one-based source location.
+data TypeErrorDiagnostic = TypeErrorDiagnostic
+    { message :: String
+    , line :: Int
+    , column :: Int
+    }
+    deriving (Eq, Ord, Show)
+
+-- | A fully or partially typed AST together with collected diagnostics.
+data TypeCheckResult ast = TypeCheckResult
+    { typedAst :: ast
+    , errors :: [TypeErrorDiagnostic]
+    }
+    deriving (Eq, Show)
+
+-- | Whether a type-checking pass completed without diagnostics.
+ok :: TypeCheckResult ast -> Bool
+ok = null . errors
+
+-- | A structurally compatible checker function.
+newtype TypeChecker astIn astOut = TypeChecker
+    { check :: astIn -> TypeCheckResult astOut
+    }
+
+-- | Wrap a checker function in the shared protocol type.
+makeTypeChecker :: (astIn -> TypeCheckResult astOut) -> TypeChecker astIn astOut
+makeTypeChecker = TypeChecker
+
+-- | The outcome of a hook invocation.
+--
+-- 'NotHandled' asks dispatch to continue to the next registered hook. A
+-- 'Handled' value stops the search immediately.
+data HookResult result
+    = NotHandled
+    | Handled result
+    deriving (Eq, Show)
+
+-- | A pure phase/kind hook. Hooks may return an updated checker so they can
+-- report diagnostics while dispatch continues.
+type Hook node argument result =
+    node ->
+    [argument] ->
+    GenericTypeChecker node argument result ->
+    (HookResult result, GenericTypeChecker node argument result)
+
+-- | Reusable state for node-driven type checkers.
+data GenericTypeChecker node argument result = GenericTypeChecker
+    { hookBuckets :: [(String, [Hook node argument result])]
+    , diagnostics :: [TypeErrorDiagnostic]
+    , nodeKindOf :: node -> String
+    , locateNode :: node -> (Int, Int)
+    }
+
+-- | Construct a checker with explicit node-kind and source-location helpers.
+newGenericTypeChecker ::
+    (node -> String) ->
+    (node -> (Int, Int)) ->
+    GenericTypeChecker node argument result
+newGenericTypeChecker kindOf locator =
+    GenericTypeChecker
+        { hookBuckets = []
+        , diagnostics = []
+        , nodeKindOf = kindOf
+        , locateNode = locator
+        }
+
+-- | Construct a checker whose diagnostics default to line 1, column 1.
+defaultGenericTypeChecker ::
+    (node -> String) ->
+    GenericTypeChecker node argument result
+defaultGenericTypeChecker kindOf = newGenericTypeChecker kindOf (const (1, 1))
+
+-- | Register a hook after existing hooks for the same phase and kind.
+--
+-- Kinds are normalized in the same way as node kinds. The literal @"*"@ is
+-- retained as the wildcard bucket.
+registerHook ::
+    String ->
+    String ->
+    Hook node argument result ->
+    GenericTypeChecker node argument result ->
+    GenericTypeChecker node argument result
+registerHook phase kind hook checker =
+    checker
+        { hookBuckets = insertHook key hook (hookBuckets checker)
+        }
+  where
+    normalizedKind
+        | kind == "*" = "*"
+        | otherwise = normalizeKind kind
+    key = phase ++ ":" ++ normalizedKind
+
+-- | Dispatch to exact-kind hooks first and wildcard hooks second.
+--
+-- Hooks within a bucket run in registration order. Diagnostics reported by a
+-- hook are retained even when that hook returns 'NotHandled'.
+dispatch ::
+    String ->
+    node ->
+    [argument] ->
+    GenericTypeChecker node argument result ->
+    (Maybe result, GenericTypeChecker node argument result)
+dispatch phase node arguments checker = dispatchKeys keys checker
+  where
+    exactKey = phase ++ ":" ++ normalizeKind (nodeKindOf checker node)
+    wildcardKey = phase ++ ":*"
+    keys = [exactKey, wildcardKey]
+
+    dispatchKeys [] current = (Nothing, current)
+    dispatchKeys (key : remainingKeys) current =
+        case lookup key (hookBuckets current) of
+            Nothing -> dispatchKeys remainingKeys current
+            Just hooks ->
+                case dispatchHooks hooks current of
+                    (Nothing, updated) -> dispatchKeys remainingKeys updated
+                    handled -> handled
+
+    dispatchHooks [] current = (Nothing, current)
+    dispatchHooks (hook : remainingHooks) current =
+        case hook node arguments current of
+            (NotHandled, updated) -> dispatchHooks remainingHooks updated
+            (Handled result, updated) -> (Just result, updated)
+
+-- | Add a diagnostic using the configured source locator.
+reportError ::
+    String ->
+    node ->
+    GenericTypeChecker node argument result ->
+    GenericTypeChecker node argument result
+reportError diagnosticMessage subject checker =
+    checker
+        { diagnostics =
+            diagnostics checker
+                ++ [TypeErrorDiagnostic diagnosticMessage sourceLine sourceColumn]
+        }
+  where
+    (sourceLine, sourceColumn) = locateNode checker subject
+
+-- | Remove diagnostics while preserving registered hooks and helper functions.
+resetErrors ::
+    GenericTypeChecker node argument result ->
+    GenericTypeChecker node argument result
+resetErrors checker = checker {diagnostics = []}
+
+-- | Return diagnostics in reporting order.
+checkerErrors ::
+    GenericTypeChecker node argument result ->
+    [TypeErrorDiagnostic]
+checkerErrors = diagnostics
+
+-- | Run a concrete traversal with a clean diagnostic lifecycle.
+--
+-- The traversal returns its typed or partially typed AST and updated checker.
+-- Hook configuration remains reusable because all state is immutable.
+runGenericCheck ::
+    (node -> GenericTypeChecker node argument result -> (typedAst, GenericTypeChecker node argument result)) ->
+    GenericTypeChecker node argument result ->
+    node ->
+    TypeCheckResult typedAst
+runGenericCheck run checker ast =
+    TypeCheckResult checkedAst (checkerErrors finished)
+  where
+    (checkedAst, finished) = run ast (resetErrors checker)
+
+-- | Normalize a node kind to ASCII alphanumerics separated by single
+-- underscores. Leading and trailing punctuation is discarded.
+normalizeKind :: String -> String
+normalizeKind = dropWhileEnd (== '_') . dropWhile (== '_') . collapse
+  where
+    collapse value = reverse (fst (foldl step ([], False) value))
+
+    step (characters, lastWasUnderscore) character
+        | isAsciiAlphaNumeric character = (character : characters, False)
+        | lastWasUnderscore = (characters, True)
+        | otherwise = ('_' : characters, True)
+
+    isAsciiAlphaNumeric character =
+        (character >= 'a' && character <= 'z')
+            || (character >= 'A' && character <= 'Z')
+            || (character >= '0' && character <= '9')
+
+insertHook :: String -> hook -> [(String, [hook])] -> [(String, [hook])]
+insertHook key hook [] = [(key, [hook])]
+insertHook key hook ((currentKey, hooks) : remaining)
+    | key == currentKey = (currentKey, hooks ++ [hook]) : remaining
+    | otherwise = (currentKey, hooks) : insertHook key hook remaining

--- a/code/packages/haskell/type-checker-protocol/test/Spec.hs
+++ b/code/packages/haskell/type-checker-protocol/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec (hspec)
+import TypeCheckerProtocolSpec (spec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/type-checker-protocol/test/TypeCheckerProtocolSpec.hs
+++ b/code/packages/haskell/type-checker-protocol/test/TypeCheckerProtocolSpec.hs
@@ -1,0 +1,204 @@
+module TypeCheckerProtocolSpec (spec) where
+
+import TypeCheckerProtocol
+import Test.Hspec
+
+data SimpleNode = SimpleNode
+    { nodeKind :: String
+    , nodeValue :: String
+    }
+    deriving (Eq, Show)
+
+data TypedNode = TypedNode
+    { typedKind :: String
+    , resolvedType :: String
+    }
+    deriving (Eq, Show)
+
+type Checker = GenericTypeChecker SimpleNode String SimpleNode
+
+goodChecker :: TypeChecker SimpleNode TypedNode
+goodChecker =
+    makeTypeChecker $ \node ->
+        TypeCheckResult (TypedNode (nodeKind node) "int") []
+
+badChecker :: TypeChecker SimpleNode TypedNode
+badChecker =
+    makeTypeChecker $ \node ->
+        TypeCheckResult
+            (TypedNode (nodeKind node) "error")
+            [TypeErrorDiagnostic ("Unknown kind: " ++ nodeKind node) 1 1]
+
+baseChecker :: Checker
+baseChecker = newGenericTypeChecker nodeKind locate
+  where
+    locate node
+        | nodeKind node == "origin" = (1, 1)
+        | otherwise = (7, 9)
+
+literalHook :: Hook SimpleNode String SimpleNode
+literalHook node arguments checker =
+    (Handled node {nodeValue = "checked" ++ concat arguments}, checker)
+
+brokenHook :: Hook SimpleNode String SimpleNode
+brokenHook node _ checker =
+    ( Handled node
+    , reportError ("bad node: " ++ nodeKind node) node checker
+    )
+
+decliningHook :: Hook SimpleNode String SimpleNode
+decliningHook _ _ checker = (NotHandled, checker)
+
+wildcardHook :: Hook SimpleNode String SimpleNode
+wildcardHook node _ checker =
+    (Handled node {nodeValue = "wildcard"}, checker)
+
+ruleChecker :: Checker
+ruleChecker =
+    registerHook "node" "broken" brokenHook $
+        registerHook "node" "literal" literalHook baseChecker
+
+runNode :: SimpleNode -> Checker -> (SimpleNode, Checker)
+runNode node checker =
+    case dispatch "node" node [] checker of
+        (Nothing, finished) -> (node, finished)
+        (Just typed, finished) -> (typed, finished)
+
+spec :: Spec
+spec = do
+    describe "diagnostics and results" $ do
+        it "constructs comparable ordered diagnostics" $ do
+            let diagnostic = TypeErrorDiagnostic "Type mismatch" 3 7
+            diagnostic `shouldBe` TypeErrorDiagnostic "Type mismatch" 3 7
+            diagnostic `shouldNotBe` TypeErrorDiagnostic "Type mismatch" 4 7
+            show diagnostic `shouldContain` "Type mismatch"
+            line diagnostic `shouldBe` 3
+            column diagnostic `shouldBe` 7
+            diagnostic `shouldSatisfy` (< TypeErrorDiagnostic "Type mismatch" 4 7)
+
+        it "reports success exactly when no diagnostics exist" $ do
+            let typed = TypedNode "literal" "int"
+            ok (TypeCheckResult typed []) `shouldBe` True
+            ok (TypeCheckResult typed [TypeErrorDiagnostic "bad" 1 1])
+                `shouldBe` False
+
+        it "preserves partial typed ASTs and diagnostic order" $ do
+            let typed = TypedNode "broken" "error"
+                first = TypeErrorDiagnostic "first" 1 1
+                second = TypeErrorDiagnostic "second" 2 5
+                result = TypeCheckResult typed [first, second]
+            typedAst result `shouldBe` typed
+            errors result `shouldBe` [first, second]
+            show result `shouldContain` "broken"
+            result `shouldBe` TypeCheckResult typed [first, second]
+
+    describe "type checker protocol" $ do
+        it "accepts checker functions with different outcomes" $ do
+            let good = check goodChecker (SimpleNode "literal" "42")
+                bad = check badChecker (SimpleNode "??" "")
+            ok good `shouldBe` True
+            typedKind (typedAst good) `shouldBe` "literal"
+            resolvedType (typedAst good) `shouldBe` "int"
+            ok bad `shouldBe` False
+            message (head (errors bad)) `shouldContain` "??"
+
+    describe "generic checker dispatch" $ do
+        it "dispatches exact node kinds through registered hooks" $ do
+            let result = runGenericCheck runNode ruleChecker (SimpleNode "literal" "before")
+            ok result `shouldBe` True
+            nodeValue (typedAst result) `shouldBe` "checked"
+
+        it "records errors through the configured source locator" $ do
+            let result = runGenericCheck runNode ruleChecker (SimpleNode "broken" "")
+            ok result `shouldBe` False
+            errors result
+                `shouldBe` [TypeErrorDiagnostic "bad node: broken" 7 9]
+
+        it "leaves unhandled node kinds unchanged" $ do
+            let original = SimpleNode "unknown" "unchanged"
+                result = runGenericCheck runNode ruleChecker original
+            typedAst result `shouldBe` original
+            ok result `shouldBe` True
+
+        it "tries hooks in registration order until one handles the node" $ do
+            let checker =
+                    registerHook "node" "literal" literalHook $
+                        registerHook "node" "literal" decliningHook baseChecker
+                result = runGenericCheck runNode checker (SimpleNode "literal" "")
+            nodeValue (typedAst result) `shouldBe` "checked"
+
+        it "tries exact hooks before wildcard hooks" $ do
+            let checker =
+                    registerHook "node" "literal" literalHook $
+                        registerHook "node" "*" wildcardHook baseChecker
+                exactResult = runGenericCheck runNode checker (SimpleNode "literal" "")
+                wildcardResult = runGenericCheck runNode checker (SimpleNode "other" "")
+            nodeValue (typedAst exactResult) `shouldBe` "checked"
+            nodeValue (typedAst wildcardResult) `shouldBe` "wildcard"
+
+        it "forwards dispatch arguments to hooks" $ do
+            let (result, finished) =
+                    dispatch
+                        "node"
+                        (SimpleNode "literal" "")
+                        ["!", "?"]
+                        ruleChecker
+            result `shouldBe` Just (SimpleNode "literal" "checked!?")
+            checkerErrors finished `shouldBe` []
+
+        it "retains diagnostics from hooks that deliberately fall through" $ do
+            let reportingDecline node _ current =
+                    (NotHandled, reportError "declined" node current)
+                configured =
+                    registerHook "node" "literal" literalHook $
+                        registerHook "node" "literal" reportingDecline baseChecker
+                result = runGenericCheck runNode configured (SimpleNode "literal" "")
+            nodeValue (typedAst result) `shouldBe` "checked"
+            errors result `shouldBe` [TypeErrorDiagnostic "declined" 7 9]
+
+        it "returns no value after the last hook declines" $ do
+            let checker = registerHook "node" "literal" decliningHook baseChecker
+                (result, finished) =
+                    dispatch "node" (SimpleNode "literal" "") [] checker
+            result `shouldBe` Nothing
+            checkerErrors finished `shouldBe` []
+
+        it "exposes comparable hook outcomes" $ do
+            (Handled "value" :: HookResult String) `shouldBe` Handled "value"
+            (NotHandled :: HookResult String) `shouldNotBe` Handled "value"
+            show (NotHandled :: HookResult String) `shouldBe` "NotHandled"
+
+    describe "diagnostic lifecycle" $ do
+        it "uses the default one-based location" $ do
+            let checker = defaultGenericTypeChecker nodeKind :: Checker
+                reported = reportError "bad" (SimpleNode "x" "") checker
+                (unhandled, _) = dispatch "node" (SimpleNode "x" "") [] checker
+            checkerErrors reported `shouldBe` [TypeErrorDiagnostic "bad" 1 1]
+            unhandled `shouldBe` Nothing
+
+        it "can derive locations from the reported subject" $ do
+            let reported = reportError "at origin" (SimpleNode "origin" "") baseChecker
+            checkerErrors reported `shouldBe` [TypeErrorDiagnostic "at origin" 1 1]
+
+        it "preserves reporting order and resets cleanly" $ do
+            let first = reportError "first" (SimpleNode "x" "") baseChecker
+                second = reportError "second" (SimpleNode "y" "") first
+            map message (checkerErrors second) `shouldBe` ["first", "second"]
+            checkerErrors (resetErrors second) `shouldBe` []
+
+        it "starts each generic check without stale diagnostics" $ do
+            let dirty = reportError "stale" (SimpleNode "x" "") ruleChecker
+                result = runGenericCheck runNode dirty (SimpleNode "literal" "")
+            ok result `shouldBe` True
+            errors result `shouldBe` []
+
+    describe "node kind normalization" $ do
+        it "collapses punctuation and trims separators" $ do
+            normalizeKind "expr:add" `shouldBe` "expr_add"
+            normalizeKind "  fn decl " `shouldBe` "fn_decl"
+            normalizeKind "a---b___c" `shouldBe` "a_b_c"
+
+        it "keeps ASCII case and digits while collapsing non-ASCII text" $ do
+            normalizeKind "Node42" `shouldBe` "Node42"
+            normalizeKind "lambda λ expr" `shouldBe` "lambda_expr"
+            normalizeKind "***" `shouldBe` ""

--- a/code/packages/haskell/type-checker-protocol/type-checker-protocol.cabal
+++ b/code/packages/haskell/type-checker-protocol/type-checker-protocol.cabal
@@ -1,0 +1,31 @@
+cabal-version: 3.0
+name:          type-checker-protocol
+version:       0.1.0
+synopsis:      Pure generic type-checker protocol and hook dispatch
+description:   Immutable diagnostics, typed results, checker functions, and dependency-free AST hook dispatch.
+category:      Compiler
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  TypeCheckerProtocol
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    TypeCheckerProtocolSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , type-checker-protocol
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -119,16 +119,17 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
 `matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
-ports, followed by the Haskell `gradient-descent` and `perceptron` ports:
+ports, followed by the Haskell `gradient-descent`, `perceptron`, and
+`type-checker-protocol` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 291 |
+| Present in 10-15 languages | 172 | 290 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 708 | 9,912 |
+| Present in one language | 709 | 9,926 |
 
-The loop must not start by attempting 9,870 singleton ports. It should finish
+The loop must not start by attempting 9,926 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -169,7 +170,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 291
+The 172 packages present in at least ten implementation languages need 290
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -180,7 +181,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 16 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 15 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -566,6 +567,18 @@ counts, and finite-value checks. The package now spans 11 implementation
 lanes, reduces the high-consensus backlog to 291 slots, and leaves 16 gaps in
 the Haskell lane.
 
+The nineteenth Haskell high-consensus slice is complete:
+`type-checker-protocol` now provides immutable diagnostics and typed results,
+a functional checker contract, and pure phase/kind hook dispatch with explicit
+fall-through, exact-before-wildcard precedence, source-location helpers, and
+clean diagnostic lifecycles. Its base-only package-native suite exercises 19
+examples covering checker outcomes, partial typed ASTs, normalization, hook
+ordering, wildcard and argument dispatch, error collection, and reusable
+state, with 100% alternative and 99% expression coverage. The package now
+spans 11 implementation lanes, reduces the high-consensus backlog to 290
+slots, leaves 15 gaps in the Haskell lane, and establishes the shared contract
+needed by later typed-frontend ports.
+
 Recommended family order:
 
 1. Leaf algorithms and data structures.
@@ -588,11 +601,11 @@ After the high-consensus set is complete:
 5. Add missing shared conformance fixtures before porting when current tests are
    language-specific and cannot prove equivalent behavior.
 
-This phase covers 122 package identities and 917 current missing slots.
+This phase covers 121 package identities and 911 current missing slots.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 501 Rust, 86 Python, and 83 TypeScript
+The singleton inventory is led by 514 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
 ### Likely portable Rust-led families


### PR DESCRIPTION
## Summary

- add a pure, base-only Haskell port of `type-checker-protocol`
- provide immutable diagnostics/results, a functional checker wrapper, and reusable phase/kind hook dispatch
- preserve registration ordering, explicit fall-through, exact-before-wildcard precedence, source locations, and clean diagnostic lifecycles
- update the package-parity roadmap and current inventory counts

## Why this port

This is the smallest dependency-safe remaining Haskell high-consensus gap. It also establishes the shared typed-frontend contract needed by later Haskell parser, checker, and compiler ports without adding a new runtime dependency.

## Validation

- `cabal test all` — 19 examples, 0 failures
- Cabal HPC — 100% alternatives, 99% expressions
- `cabal check` — no errors or warnings
- `cabal sdist all`, followed by a clean build and test from the generated tarball
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py -v` — 6 tests passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 0 identity collisions, 0 unknown language buckets
- `git diff --check`

## Parity impact

- `type-checker-protocol` now spans 11 implementation languages
- high-consensus missing slots: 291 -> 290
- remaining Haskell high-consensus gaps: 16 -> 15
- no non-portable package classifications were added
