### PR TITLE
feat(maple-to-semantic-ir): fifth and final SIR23 frontend, closing HML01 Stream B's language list

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -269,6 +269,7 @@ members = [
     "maple-parser",
     "maple-runtime",
     "maple-repl",
+    "maple-to-semantic-ir",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/maple-to-semantic-ir/BUILD
+++ b/code/packages/rust/maple-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p maple-to-semantic-ir -- --nocapture

--- a/code/packages/rust/maple-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/maple-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p maple-to-semantic-ir -- --nocapture

--- a/code/packages/rust/maple-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/maple-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,195 @@
+# Changelog
+
+## [0.1.0] - 2026-07-20
+
+### Added
+
+- Initial `maple-to-semantic-ir` frontend crate (HML01 Stream B), the
+  **fifth and final** to target SIR23 (symbolic-expression/pattern
+  domain), sibling to `wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`,
+  `derive-to-semantic-ir`, and `reduce-to-semantic-ir`: `compile`/
+  `compile_source` lowering `coding-adventures-maple-parser`'s
+  `GrammarASTNode` CST into a `semantic_ir::Module`. Closes Stream B's
+  currently-tracked language list — every math-CAS language HML01 names
+  today now has a shipped SIR23 frontend.
+- Design: retargets `maple-runtime`'s own `lower_node` rule-name dispatch
+  (which already lowers this exact CST to `symbolic_ir::IRNode`) onto
+  `semantic_ir::Expr`'s SIR23 vocabulary (`SymSymbol`/`SymApply`)
+  instead — much of the shape is a direct copy of
+  `reduce-to-semantic-ir`'s own lowering (`maple-runtime`'s own module
+  doc comment says so explicitly: both languages are "surface operators +
+  `head(args)` calls" with no pattern/rewrite-rule vocabulary in this
+  subset).
+- **Scope boundary, disclosed from day one, verified empirically against
+  `code/grammars/maple/maple.grammar` and `maple.tokens`** (not just
+  trusted from `maple-runtime`'s own doc comment, per this repo's
+  verify-before-implementing discipline): Maple's grammar has no
+  pattern-matching or rewrite-rule syntax at all (no `_`/blank, no `->`/
+  `:>` rule arrow — Maple DOES have an `ARROW` token, but it appears in
+  exactly one production, `arrow_def`, MA09 §3's function-definition
+  spelling, never as a pattern-rule arrow — no `/.`/`//.` replacement,
+  and no `STRING` token at all) — this crate therefore only ever
+  constructs `Expr::SymSymbol`/`Expr::SymApply` (plus reused
+  `IntLit`/`FloatLit`), never `Expr::StrLit`,
+  `SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll`, and
+  never observes `Feature::PatternMatching`. This also means
+  `measure_depth_iterative`/`drop_iterative` only need a match arm for
+  `Expr::SymApply` — `If`/`Assign`/`Define`/`Set` are all `SymApply` with
+  a different head symbol or bracket, not new `Expr` variants.
+- **A REAL structural difference from Reduce: the dispatch is genuinely
+  SPLIT, not blindly copied.** `reduce.grammar`'s `expr = if_expr |
+  group_expr | assignment` sits at the top of Reduce's expression
+  grammar, so `if`/`:=` are reachable from *every* `expr` position.
+  `maple.grammar` draws a hard line Reduce's own grammar does not:
+  `statement = if_expr | assignment` sits in its OWN nonterminal, never
+  reachable from `expr` at all. This crate's `lower_node` is still one
+  shared dispatch table (mirroring `maple-runtime::lower::lower_node`'s
+  own single `match`, not two separate Rust functions), but the
+  grammar's own reachability graph is what enforces the real divide:
+  `lower_if`/`lower_assignment` are only ever reached from the top-level
+  statement loop, never nested inside an arithmetic/comparison/logical
+  operand. Regression tests confirm `x := if a then 1 end if;` and `a :=
+  b := 5;` both fail to compile (syntax errors), matching
+  `maple-parser`'s own identically-named regression tests.
+- **Assignment is deliberately NARROWER than Reduce's/Derive's own
+  call-shaped-LHS disambiguation**: `assignment = NAME ASSIGN ( arrow_def
+  | expr ) | expr` — the LHS is a bare `NAME` token, full stop. Maple's
+  `f(x) := expr` spelling means something narrower in real Maple (a
+  remember-table patch onto an existing procedure, MA09 §1/§4) than
+  Reduce's/Derive's general-definition idiom of the identical shape, so
+  `maple.grammar` makes it fail to *parse* at all — confirmed by a
+  regression test (`remember_table_spelling_is_rejected`). This crate
+  never needs "is the LHS call-shaped" logic. Instead, a SEPARATE
+  `arrow_def`/`arrow_params` production (`f := (x, y) -> x + y` / `f :=
+  x -> x^2`) is the general-purpose function-definition spelling —
+  `lower_arrow_def`/`lower_arrow_params` lower it to `Define[f,
+  List[params...], body]`, the same `Define` shape Derive's/Reduce's own
+  (differently-spelled) definitions already use. Zero/one/multiple
+  parameter arrow-definitions all covered by dedicated tests.
+- **`if`/`elif`/`else` right-folds, mirroring Macsyma's elif chain, NOT
+  Reduce's simpler 2-or-3-child `if`**: `if_expr = "if" expr "then"
+  statement { "elif" expr "then" statement } [ "else" statement ] ( "end"
+  "if" | "fi" )` — `lower_if` retargets `maple-runtime::lower_if`'s exact
+  collect-pairs-then-fold-right-to-left logic. Because Maple requires an
+  explicit close for every `if_expr`, there is no dangling-else ambiguity
+  the way Reduce's `if`/`else` chain has to resolve by convention. A new
+  `check_elif_chain_length` guard (mirroring `check_chain_length`'s
+  reasoning) bounds `elif`-arm count before the fold runs, since
+  `maple-parser`'s own doc comment confirms the `{ "elif" ... }`
+  repetition is a flat EBNF shape (zero parser-stack cost regardless of
+  width) — the fold itself is what builds an N-deep tree.
+- **`Set` — a canonical head genuinely new to this repo (MA09 §5)**:
+  Maple is the first language here with two distinct bracketed aggregate
+  literals — `[a, b, c]` (ordered → `List`, a shared existing head) and
+  `{a, b, c}` (unordered → `Set`). `symbolic-vm`'s shared handler table
+  has no handler for `Set` (confirmed by `maple-runtime`'s own doc
+  comment) — reused the identical local-`pub-const` pattern
+  `reduce-to-semantic-ir`/`reduce-runtime` established for their own new
+  `COMPOUND_EXPRESSION`/`CONS`/… constants, spelled to match
+  `maple-runtime`'s own `SET` constant.
+- **`diff`/`int` bridge to `D`/`Integrate`** — a plain two-entry surface-
+  name bridge table, mirroring `maple-runtime::surface_head_to_ir`'s
+  identical table exactly (no calculus reimplementation).
+- **Booleans — the first literal `true`/`false` TOKENS in this CAS
+  family**: neither Derive's nor Reduce's grammar has a dedicated boolean
+  literal token. `maple.grammar`'s `atom` rule is the first to include
+  `"true"`/`"false"` as their own alternatives — bridged to the shared
+  backend's pre-bound `True`/`False` symbols, the same bridge
+  `macsyma-compiler::lower_token` already uses. **Verified directly**
+  that `symbolic-ir` exports no `TRUE`/`FALSE` constants (`grep -n
+  '"True"\|"False"\|pub const TRUE\|pub const FALSE'
+  symbolic-ir/src/lib.rs` finds nothing but a stray test literal) — uses
+  bare string literals, matching `maple-runtime`'s own bridge.
+- **`postfix` is NOT chainable — verified, no guard invented for a
+  non-existent risk**: `maple.grammar`'s `postfix = atom [ LPAREN
+  [arglist] RPAREN ] ;` has a single OPTIONAL call suffix (confirmed
+  directly against the grammar file), unlike Reduce's/Derive's REPEATED
+  `{ LPAREN [arglist] RPAREN }` chain — `f(x)(y)` is not valid Maple
+  syntax in this subset at all. A regression test
+  (`postfix_call_is_not_chainable`) confirms `compile_source` rejects it
+  as a parse error. No `check_postfix_chain_length`-equivalent guard
+  exists anywhere in this crate — the axis it would guard is
+  structurally impossible here, not merely bounded by a cap.
+- The `;`-vs-`:` statement terminator is deliberately NOT tracked — MA09
+  §3's own statement-separator row calls it "a display flag on the
+  surrounding session, not an IR node." Unlike `maple-runtime`'s own
+  `LoweredStatement`/`Display` REPL-rendering types, this frontend just
+  emits every statement as a plain `Stmt::ExprStmt`, mirroring how
+  neither `derive-to-semantic-ir` nor `reduce-to-semantic-ir` replicate
+  their own native runtimes' prompt/display machinery either.
+- Recursion-depth hardening applied from day one, proactively carried
+  over from `wolfram-to-semantic-ir`'s, `macsyma-to-semantic-ir`'s,
+  `derive-to-semantic-ir`'s, and `reduce-to-semantic-ir`'s own
+  security-review history, even though neither `maple-parser` nor
+  `maple-runtime` (the retarget source) applies any of these guards
+  themselves:
+  - `MAX_EXPR_DEPTH` (256), the same value and reasoning as the sibling
+    SIR23 frontends, kept for family-wide consistency even though
+    `maple-parser`'s own cap (150) is lower than `derive-parser`'s (200)
+    — this constant bounds a different axis (this crate's own
+    chain-folding budget) than the parser's CST-nesting cap.
+  - `check_chain_length` caps every flat operator-chain fold
+    (`additive`/`multiplicative`/`logical_or`/`logical_and`) before any
+    tree is built — confirmed these ARE flat EBNF repetitions (not
+    right-recursion) directly against `maple-parser`'s own
+    `MAX_RULE_DEPTH` doc comment.
+  - `check_elif_chain_length` — new to this crate (see above).
+  - `check_apply_arg_count` caps `arglist` element counts (shared by
+    call arguments, list literals, and set literals) **and**
+    `arrow_params`'s flat parameter-name count — a defense-in-depth
+    allocation-size backstop, mirrors `reduce-to-semantic-ir`'s
+    identical reuse of this one guard across multiple flat-`Vec`
+    productions.
+  - `measure_depth_iterative`/`drop_iterative` — the authoritative,
+    construction-composition-independent iterative depth check and
+    iterative teardown, run once per top-level statement.
+  - **No additional lowering-side guard is needed** for Maple's six
+    genuinely self-referential (right-recursive or prefix-recursive)
+    productions — parenthesised `group` nesting, list-/set-literal
+    nesting, a `not`-prefix chain, a unary-minus-prefix chain, the power
+    (`^`) chain, and nested `if`/`end if` (or `fi`) — since
+    `maple-parser`'s own `MAX_RULE_DEPTH` (150; binding constraint
+    measured at a 218-rule-frame `not`-chain floor, ~31.2% margin)
+    already bounds how deep any of these can nest in the CST this crate
+    ever receives. Verified with dedicated regression tests: a
+    5,000-level deep parenthesised expression, a 5,000-level deep `not`
+    chain, and a 5,000-level deep nested-`if`/`end if` chain are all
+    cleanly rejected (by the parser, surfaced as a clean `Err` through
+    `compile_source`), never crash.
+- `Feature::Floats` regression avoided proactively: `number_literal_expr`
+  is an instance method (not a free function) specifically so every
+  `FloatLit`-constructing branch can call `self.observed.add(Feature::
+  Floats)` immediately — this is a confirmed, previously-shipped bug in
+  both `matlab-to-semantic-ir` and `wolfram-to-semantic-ir`.
+- `compile_source` needs no worker-thread stack enlargement, unlike
+  `wolfram-to-semantic-ir::compile_source`: `maple-parser`'s own
+  `MAX_RULE_DEPTH` (150) is already documented safe on a bare default
+  (~2 MiB) stack with comfortable margin (~31.2% below its own measured
+  crash floor) — mirrors `macsyma-to-semantic-ir`'s/`derive-to-semantic-
+  ir`'s/`reduce-to-semantic-ir`'s simpler `compile_source` shape.
+- `tests/e2e_node.rs` — written directly against the *current* SIR23 JS
+  backend state (real `__Sir.Symbolic.*` codegen, confirmed by reading
+  `reduce-to-semantic-ir`'s current test bodies, not module doc
+  comments) — compiles and runs representative Maple programs
+  (arithmetic, an arrow-definition+call, assignment, lists/sets, `if`/
+  `elif`/`else`, boolean literals, `diff`/`int` calls, a multi-statement
+  program) through `node`, including the `Set` construct with no
+  shared-VM evaluation handler — proving the SIR23 codegen path accepts
+  and executes it as pure data construction regardless of runtime
+  evaluability.
+- 86 tests: 66 unit tests over exact `Expr` shapes for every grammar
+  production plus statement/expression-split syntax-error regressions
+  (chained assignment, the remember-table spelling, `if` as an
+  assignment RHS, chained postfix application) and DoS-guard regressions
+  (flat-chain, a wide list/set literal, a wide `arrow_params` list, a
+  wide `elif` chain, a deeply parenthesised expression, a deep `not`
+  chain, a deep nested-`if` chain, and exact-boundary cases) and the
+  `Feature::Floats` regression, 11 validator/capability-acceptance
+  tests (including the no-shared-VM-handler `Set` construct), 8 e2e
+  `node`-execution tests (skip cleanly if `node` is unavailable), 1
+  doctest.
+- Adds `maple-to-semantic-ir` to `code/packages/rust/Cargo.toml`'s
+  workspace `members` and marks it done in
+  `HML01-math-to-semantic-ir.md`'s language list and Stream B rollout
+  note — this is the LAST entry in Stream B's previously-tracked
+  language list, so the rollout note's framing is updated accordingly.

--- a/code/packages/rust/maple-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/maple-to-semantic-ir/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "maple-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "Maple CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Fifth and final frontend to target SIR23, sibling to wolfram-to-semantic-ir, macsyma-to-semantic-ir, derive-to-semantic-ir, and reduce-to-semantic-ir."
+
+[dependencies]
+semantic-ir = { path = "../semantic-ir" }
+coding-adventures-maple-parser = { path = "../maple-parser" }
+# The reusable canonical head-name constants (`ADD`/`SUB`/`MUL`/…) so the
+# surface→canonical bridging table stays typo-proof and in lockstep with
+# the native `maple-runtime`'s own identical table.
+symbolic-ir = { path = "../symbolic-ir" }
+# The parser emits a generic `parser::grammar_parser::GrammarASTNode`
+# whose leaf tokens are `lexer::token::Token`; we walk both directly.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+
+[dev-dependencies]
+# Used by tests/test_validator.rs (confirms the JS backend accepts every
+# module this frontend produces, all of which use SIR23 nodes) and
+# tests/e2e_node.rs (actually runs the compiled JS through `node`).
+semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/maple-to-semantic-ir/README.md
+++ b/code/packages/rust/maple-to-semantic-ir/README.md
@@ -1,0 +1,215 @@
+# maple-to-semantic-ir
+
+Maple CST → narrow-waist Semantic IR. The **fifth and final** frontend to
+target [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+symbolic-expression/pattern-matching domain extension of the SIR10
+narrow-waist IR (Stream B of
+[HML01](../../../specs/HML01-math-to-semantic-ir.md)) — sibling to
+`wolfram-to-semantic-ir` (the first), `macsyma-to-semantic-ir` (the
+second), `derive-to-semantic-ir` (the third), and `reduce-to-semantic-ir`
+(the fourth). This closes Stream B's tracked language list — every
+math-CAS language HML01 currently names now has a SIR23 frontend.
+
+## Where this fits
+
+```
+Maple source
+   │
+   ▼  coding_adventures_maple_parser::try_parse_maple(src)
+parser::grammar_parser::GrammarASTNode   (generic CST)
+   │
+   ▼  maple_to_semantic_ir::compile
+semantic_ir::Module                      (per SIR10 + SIR23)
+```
+
+## Usage
+
+```rust
+use maple_to_semantic_ir::compile_source;
+
+let module = compile_source("1 + 2;\n", "demo")?;
+```
+
+`compile_source` parses and lowers directly, with no worker-thread stack
+enlargement — like `macsyma-to-semantic-ir`/`derive-to-semantic-ir`/
+`reduce-to-semantic-ir` (and unlike `wolfram-to-semantic-ir::
+compile_source`), `maple-parser`'s own `MAX_RULE_DEPTH` (150) is already
+documented safe on a bare default (~2 MiB) stack with comfortable margin:
+that crate's own doc comment measures SIX independent recursion shapes in
+*rule-frame* terms and finds the binding constraint is a `not`-prefix
+chain's floor of 218 rule frames — 150 sits about 31.2% below that floor,
+a comparable margin to `reduce-parser`'s own ~28.5%. `compile` (taking an
+already-parsed `GrammarASTNode`) is pure lowering, exactly like every
+sibling frontend's `compile`.
+
+## Design: retargeting `maple-runtime`
+
+`maple-runtime` already walks this exact CST and compiles it to
+`symbolic_ir::IRNode` — this crate's dispatch table is a direct retarget
+of that lowering's own rule-name dispatch onto `semantic_ir::Expr`'s
+SIR23 vocabulary (`SymSymbol`/`SymApply`) instead. Every construct —
+arithmetic, comparisons, logic, lists, sets, `if`/`elif`/`else`,
+assignment, arrow-operator definitions — lowers to symbolic *data*,
+mirroring `symbolic_ir::IRNode`'s "everything is one apply-tree" design.
+See `src/lower.rs`'s module doc comment for the full reasoning and the
+node-by-node mapping.
+
+### A REAL structural difference from Reduce: the dispatch is SPLIT
+
+`reduce.grammar`'s `expr = if_expr | group_expr | assignment` sits at the
+very top of Reduce's expression grammar, so `if`/`:=` are reachable from
+*every* position an `expr` can appear. `maple.grammar` draws a hard line
+Reduce's own grammar does not: `statement = if_expr | assignment` sits in
+its OWN nonterminal, never reachable from `expr` at all — `expr` itself
+is just `logical_or` (Chapter 3 "Maple Expressions"), with no alternative
+that ever leads back to `if_expr`/`assignment` (Chapter 5 "Maple
+Statements"). This crate's `lower_node` is still one shared dispatch
+table (mirroring `maple-runtime::lower::lower_node`'s own single `match`,
+not two separate Rust functions) — but the grammar's own reachability
+graph is what enforces the real divide: `lower_if`/`lower_assignment` are
+only ever reached via the top-level statement loop, never nested inside
+an arithmetic/comparison/logical operand the way Reduce's can be. `x :=
+if a then 1 else 2 end if;` and `a := b := c;` are both syntax errors in
+Maple's grammar.
+
+### Assignment: bare `NAME` LHS only, plus a new `arrow_def`/`arrow_params`
+
+`assignment = NAME ASSIGN ( arrow_def | expr ) | expr` — deliberately
+NARROWER than Reduce's/Derive's own call-shaped-LHS disambiguation:
+Maple's identical-looking `f(x) := expr` means something narrower in real
+Maple (a remember-table patch onto an existing procedure, MA09 §1/§4)
+than Reduce's/Derive's general-definition idiom, so `maple.grammar` makes
+`f(x) := expr` fail to *parse* at all — this crate never needs to check
+whether the LHS is call-shaped. Instead, Maple has a SEPARATE production,
+`arrow_def = arrow_params ARROW expr` (`f := (x, y) -> x + y` / `f := x
+-> x^2`), for general function definition — `lower_arrow_def` lowers this
+to `Define[f, List[params...], body]`, the same `Define` shape Derive's/
+Reduce's own (differently-spelled) definitions already use.
+
+### `if`/`elif`/`else` — a right-fold, mirroring Macsyma's elif chain
+
+`if_expr = "if" expr "then" statement { "elif" expr "then" statement } [
+"else" statement ] ( "end" "if" | "fi" )` — unlike Reduce's simpler
+2-or-3-child `if` (no `elseif` repetition at all), Maple's flat `{ "elif"
+... }` EBNF repetition folds right-to-left into nested `If` applications,
+the same shape Macsyma's own elif-chain fold uses. Because Maple requires
+an explicit close (`end if` or `fi`) for every `if_expr`, there is no
+dangling-else ambiguity the way Reduce's `if`/`else` chain has to resolve
+by convention.
+
+### `Set` — a canonical head genuinely new to this repo (MA09 §5)
+
+Maple is the first language here with TWO distinct bracketed aggregate
+literals — `[a, b, c]` (ordered → `List`, a shared existing head) and
+`{a, b, c}` (unordered → `Set`, MA09 §3/§5). `symbolic-vm`'s shared
+handler table has no handler for `Set` — so `SET` is a `pub const`
+defined LOCALLY in this crate, exactly the pattern
+`reduce-to-semantic-ir`/`reduce-runtime` used for their own new
+`COMPOUND_EXPRESSION`/`CONS`/`FIRST`/… constants (not added to shared
+`symbolic-ir`, since it's not a `Backend`-agnostic canonical head).
+
+### `diff`/`int` — thin bridges to the shared `D`/`Integrate` handlers
+
+Same idea as Derive's `DIF`/`INT` bridge, just lowercase surface spelling
+(MA09 §3: Maple's builtin names are conventionally lowercase). A plain
+name→canonical-head bridge table entry, no new logic — MA09 §3 documents
+no other function-call bridge for this subset (list/set construction
+already has literal syntax; elementary-function names like `sin` are
+deliberately not bridged, same as Reduce).
+
+### Booleans — the first literal `true`/`false` tokens in this CAS family
+
+Neither Derive's nor Reduce's grammar has a dedicated boolean literal
+token — `maple.grammar`'s `atom` rule is the first to include `"true"`/
+`"false"` as their own alternatives. These bridge to the shared backend's
+pre-bound `True`/`False` symbols, the same bridge `macsyma-compiler`
+already uses for its own boolean keywords. `symbolic-ir` exports no
+`TRUE`/`FALSE` constants (verified directly), so this uses bare string
+literals, matching `maple-runtime`'s own bridge.
+
+### `postfix` is NOT chainable
+
+`maple.grammar`'s `postfix = atom [ LPAREN [ arglist ] RPAREN ] ;` has a
+single OPTIONAL call suffix — `f(x)(y)` is not valid Maple syntax in this
+subset at all (confirmed by a regression test asserting `compile_source`
+rejects it as a parse error), unlike Reduce's/Derive's REPEATED `{
+LPAREN [arglist] RPAREN }` chain. So there is no
+`check_postfix_chain_length`-equivalent guard anywhere in this crate —
+the axis it would guard is structurally impossible here, not merely
+bounded by a cap.
+
+### `;`-vs-`:` is a runtime/session concept, not something this frontend tracks
+
+MA09 §3's own statement-separator row is explicit this is "a display flag
+on the surrounding session, not an IR node" — `maple-runtime`'s own
+`LoweredStatement`/`Display` types exist only for its REPL's
+result-printing decision. This SIR23 frontend has no interactive-session
+concept at all (mirrors how neither `derive-to-semantic-ir` nor
+`reduce-to-semantic-ir` replicate their own native runtimes' prompt/
+display machinery either) — every statement lowers to a plain
+`Stmt::ExprStmt`, and the `;`/`:` distinction is ignored entirely.
+
+### Recursion-depth hardening
+
+Carried over proactively from `wolfram-to-semantic-ir`'s (four rounds of
+security review), `macsyma-to-semantic-ir`'s, `derive-to-semantic-ir`'s,
+and `reduce-to-semantic-ir`'s established pattern, even though neither
+`maple-parser` nor `maple-runtime` applies any of these guards themselves:
+
+- `MAX_EXPR_DEPTH` (256) bounds this crate's own lowering recursion,
+  independent of `maple-parser`'s own grammar-nesting guard (150).
+- `check_chain_length` caps every flat, same-precedence operator-chain
+  fold (`additive`/`multiplicative`/`logical_or`/`logical_and`) before
+  any tree is built.
+- `check_elif_chain_length` caps the `elif`-arm count in an `if_expr`
+  before the right-fold runs — the same "flat repetition folds into a
+  deep tree" shape, applied to the construct genuinely new relative to
+  Reduce's simpler `if`.
+- **No `check_postfix_chain_length`-equivalent guard** — see above for
+  why: chained application is structurally impossible in this grammar.
+- `check_apply_arg_count` caps `arglist` element counts (shared by call
+  arguments, list literals, and set literals) AND `arrow_params`'s flat
+  parameter-name count — flat-`Vec` allocation-size backstops, not stack
+  guards.
+- `measure_depth_iterative`/`drop_iterative` — the authoritative,
+  construction-composition-independent iterative depth check and
+  iterative teardown, run once per top-level statement.
+
+Maple's six genuinely self-referential (right-recursive or
+prefix-recursive) productions — parenthesised nesting, list-/set-literal
+nesting, a `not`-prefix chain, a unary-minus-prefix chain, the power
+(`^`) chain, and nested `if`/`end if` (or `fi`) — need no additional
+lowering-side guard beyond the ordinary recursion-depth parameter:
+`maple-parser`'s own `MAX_RULE_DEPTH` (150) already bounds how deep any
+of these can nest in the CST this crate ever receives.
+
+Also carried over proactively: every branch that constructs a `FloatLit`
+calls `self.observed.add(Feature::Floats)` immediately — a confirmed,
+previously-shipped bug in both `matlab-to-semantic-ir` and
+`wolfram-to-semantic-ir` (their number-literal helpers were free
+functions with no access to the feature-tracking state).
+
+### Testing
+
+- `tests/test_lower.rs` — unit tests asserting exact `Expr` shapes for
+  every grammar production (arithmetic, comparisons including `<>`,
+  logic, `if`/`elif`/`else`/`end if`/`fi`, arrow-definitions with
+  zero/one/multiple parameters, `List`-vs-`Set` distinction, boolean
+  literals, `diff`/`int` bridging), regression tests for every
+  statement/expression-split syntax error (chained assignment, the
+  remember-table spelling, `if` as an assignment RHS, chained postfix
+  application), plus DoS-guard regression tests (flat operator chains, a
+  wide list/set literal, a wide `arrow_params` list, a wide `elif`
+  chain, a deeply parenthesised expression, a deep `not` chain, a deep
+  nested-`if` chain — all confirmed to fail cleanly, never crash), and
+  exact-boundary tests.
+- `tests/test_validator.rs` — every lowered module passes
+  `semantic_ir::validate` (manifest declares exactly the SIR23 features
+  used, never `Feature::PatternMatching`) and is **accepted** by
+  `semantic-ir-to-javascript`'s capability check, including the `Set`
+  construct with no shared-VM evaluation handler.
+- `tests/e2e_node.rs` — compiles and runs representative Maple programs
+  (arithmetic, an arrow-definition+call, assignment, lists/sets,
+  `if`/`elif`/`else`, boolean literals, `diff`/`int` calls, a
+  multi-statement program) through `node`, proving the SIR23 codegen
+  path is genuinely executable end-to-end, not just statically accepted.

--- a/code/packages/rust/maple-to-semantic-ir/required_capabilities.json
+++ b/code/packages/rust/maple-to-semantic-ir/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/maple-to-semantic-ir",
+  "capabilities": [],
+  "justification": "Pure computation over an in-memory GrammarASTNode and semantic_ir::Module. No filesystem, network, process, DOM, or environment access needed — like macsyma-to-semantic-ir/derive-to-semantic-ir/reduce-to-semantic-ir (and unlike wolfram-to-semantic-ir), this crate does not even spawn a worker thread (see src/lib.rs's compile_source doc comment for why)."
+}

--- a/code/packages/rust/maple-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/maple-to-semantic-ir/src/lib.rs
@@ -1,0 +1,82 @@
+//! # maple-to-semantic-ir
+//!
+//! Maple CST → narrow-waist Semantic IR, **v0.1.0**.
+//!
+//! This is the **fifth and final** frontend to target
+//! [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+//! symbolic-expression/pattern-matching domain extension of the SIR10
+//! narrow-waist IR (Stream B of
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)) — sibling to
+//! `wolfram-to-semantic-ir` (the first), `macsyma-to-semantic-ir` (the
+//! second), `derive-to-semantic-ir` (the third), and
+//! `reduce-to-semantic-ir` (the fourth). It consumes the generic
+//! `GrammarASTNode` CST produced by the `coding-adventures-maple-parser`
+//! crate and emits a [`semantic_ir::Module`]. See `lower.rs`'s module doc
+//! comment for the full scope, the "retarget `maple-runtime`, not start
+//! from scratch" design note, the statement-vs-expression dispatch split
+//! `maple.grammar` forces (unlike Reduce's unified `expr` production), the
+//! new `Set` head, and the no-pattern-matching scope boundary (Maple's
+//! grammar has no pattern or rewrite-rule syntax in this subset).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Maple source
+//!    │
+//!    ▼  coding_adventures_maple_parser::try_parse_maple(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  maple_to_semantic_ir::compile
+//! semantic_ir::Module                      (per SIR10 + SIR23)
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use maple_to_semantic_ir::compile_source;
+//! let module = compile_source("1 + 2;\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+
+mod lower;
+pub use lower::{compile, MapleLowerError};
+
+/// Parse `source` as Maple and lower it into a [`semantic_ir::Module`] in
+/// one step, mirroring every other `-to-semantic-ir` frontend's
+/// `compile_source` convenience wrapper.
+///
+/// Like `derive-to-semantic-ir::compile_source`,
+/// `macsyma-to-semantic-ir::compile_source`, and
+/// `reduce-to-semantic-ir::compile_source` (and unlike
+/// `wolfram-to-semantic-ir::compile_source`, which spawns an
+/// enlarged-stack worker thread because Wolfram's 20-rule precedence
+/// cascade makes its own parser's `MAX_RULE_DEPTH` unsafe on a bare
+/// stack), this function needs no worker thread at all:
+/// `coding_adventures_maple_parser`'s own `MAX_RULE_DEPTH` (150) is
+/// already documented — see that crate's `src/lib.rs` doc comment — as
+/// safe on a bare default (~2 MiB) stack with comfortable margin. That doc
+/// comment measures SIX independent recursion shapes (parenthesised
+/// nesting, list/set-literal nesting, a `not`-prefix chain, a unary-minus
+/// chain, a power (`^`) chain, and a nested `if`/`end if` chain) in
+/// *rule-frame* terms and finds the binding constraint is the `not`-chain's
+/// floor of 218 rule frames — `150` sits about 31.2% below that floor, a
+/// comparable margin to `reduce-parser`'s own ~28.5%, `apl-parser`'s
+/// ~26.5%, `j-parser`'s ~30%, and `derive-parser`'s ~33%. Its own test
+/// suite directly confirms input thousands of levels/links past the cap
+/// still fails cleanly with a `Result::Err` on a bare default-stack
+/// thread, never a crash. So this crate mirrors
+/// `macsyma-to-semantic-ir`'s (and `derive-to-semantic-ir`'s /
+/// `reduce-to-semantic-ir`'s) simple, worker-thread-free `compile_source`
+/// shape rather than `wolfram-to-semantic-ir`'s.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, MapleLowerError> {
+    let tree =
+        coding_adventures_maple_parser::try_parse_maple(source).map_err(|msg| MapleLowerError {
+            message: format!("parse error: {msg}"),
+            line: 1,
+            column: 1,
+        })?;
+    compile(&tree, module_name)
+}

--- a/code/packages/rust/maple-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/maple-to-semantic-ir/src/lower.rs
@@ -1,0 +1,1386 @@
+//! The lowering pass from `coding_adventures_maple_parser`'s generic
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **v0.1.0**.
+//!
+//! This is the **fifth and final** frontend to target
+//! [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+//! symbolic-expression/pattern-matching domain extension of the SIR10
+//! narrow-waist IR (Stream B of
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)). The first,
+//! `wolfram-to-semantic-ir`, and the second, `macsyma-to-semantic-ir`, are
+//! this crate's design templates for the "everything is data" decision —
+//! read `wolfram-to-semantic-ir::lower`'s module doc comment first. The
+//! fourth, `reduce-to-semantic-ir`, is the closest sibling (both languages
+//! are "surface operators + `head(args)` calls" with no pattern/
+//! rewrite-rule vocabulary) — everything below assumes that context and
+//! only calls out where Maple's grammar genuinely differs.
+//!
+//! # Retargeting `maple-runtime`, not starting from scratch
+//!
+//! `maple-runtime` already walks this exact CST and compiles it to
+//! `symbolic_ir::IRNode` (`Symbol`/`Integer`/`Float`/`Apply` — see that
+//! crate's `src/lower.rs`, in particular its module doc comment). This
+//! crate's job is the same mechanical retarget `reduce-to-semantic-ir`
+//! already did for `reduce-runtime`: walk the same CST, dispatch on the
+//! same rule names `maple-runtime::lower::lower_node` already uses, and
+//! construct `semantic_ir::Expr::{SymSymbol,SymApply}` wherever that
+//! lowering constructs `symbolic_ir::IRNode::{Symbol,Apply}`. Literals
+//! (`Integer`/`Float`) reuse SIR10/SIR16's `IntLit`/`FloatLit` directly —
+//! Maple has no `STRING` token at all (`maple.tokens`'s `escapes: none`),
+//! so, like Reduce and Derive, this crate never constructs `Expr::StrLit`
+//! either.
+//!
+//! # A REAL structural difference from Reduce: the dispatch is SPLIT
+//!
+//! `reduce.grammar`'s `expr = if_expr | group_expr | assignment` sits at
+//! the very TOP of Reduce's expression grammar, so `if`/`<<...>>`/`:=` are
+//! reachable from *every* position an `expr` can appear — nested inside an
+//! arithmetic operand, a function argument, anywhere. `maple.grammar`
+//! draws a hard line Reduce's own grammar does not (see that grammar's own
+//! "statements vs. expressions" design-decision comment, reused here only
+//! by reference, not copied): `statement = if_expr | assignment` sits in
+//! its OWN nonterminal, never reachable from `expr` at all. `expr` itself
+//! is just `logical_or` — Chapter 3 "Maple Expressions" — with no
+//! alternative that ever leads back to `if_expr`/`assignment` — Chapter 5
+//! "Maple Statements".
+//!
+//! Concretely, this crate's [`Lowerer::lower_node`] is still ONE dispatch
+//! table (mirroring `maple-runtime::lower::lower_node`'s own single
+//! `match`, not two separate Rust functions) — but the grammar's own
+//! reachability graph, not a Rust-level split, is what enforces the real
+//! divide: [`Lowerer::lower_if`] and [`Lowerer::lower_assignment`] are
+//! only ever reached via `lower_node`'s own `"if_expr"`/`"assignment"`
+//! match arms, which in turn are only ever reached from
+//! [`Lowerer::lower_file`]'s top-level statement loop (`statement_line`/
+//! `statement`) — never nested inside an arithmetic/comparison/logical
+//! operand the way Reduce's can be. `x := if a then 1 else 2 end if;` and
+//! `a := b := c;` are both syntax errors in Maple's grammar (confirmed
+//! directly against `maple.grammar`, not just trusted from
+//! `maple-runtime`'s doc comment) — so no `Assign`/`Define` node can ever
+//! appear nested inside another `SymApply`'s argument list the way
+//! Reduce's `If`/`CompoundExpression` can. This crate's dispatch table
+//! reflects that same shape by simply retargeting `maple-runtime`'s own
+//! rule-name arms one-for-one, rather than blindly copying
+//! `reduce-to-semantic-ir`'s unified-reachability dispatch.
+//!
+//! # Scope (v0.1.0) — no pattern-matching or rewrite-rule syntax at all
+//!
+//! **Verified empirically against `maple.grammar`/`maple.tokens`
+//! (`code/grammars/maple/`), not just trusted from `maple-runtime`'s own
+//! doc comment**, exactly mirroring `reduce-to-semantic-ir`'s own
+//! verification discipline: grepping both files for pattern-syntax tokens
+//! (`_` blank, `->`/`:>` rule arrows, `/.`/`//.` replacement operators)
+//! finds none — `maple.tokens` declares no such token, and `maple.grammar`
+//! DOES have an `ARROW` (`->`) token, but it appears in exactly ONE
+//! production, `arrow_def = arrow_params ARROW expr` (MA09 §3's
+//! general-purpose function-definition spelling, `f := x -> x^2`), never
+//! as a pattern-rule arrow the way Wolfram's `->`/`:>` are. This confirms
+//! `maple-runtime`'s own claim ("no pattern/rewrite-rule vocabulary in
+//! this subset — MA09 §4 defers `patmatch`/`match`, ordinary library
+//! calls, not surface grammar") is accurate for the grammar as it
+//! currently ships.
+//!
+//! This crate therefore **only ever constructs [`Expr::SymSymbol`] and
+//! [`Expr::SymApply`]** (plus the reused `IntLit`/`FloatLit` literal
+//! nodes) — it never constructs `SymPatternBlank`/`SymPatternNamed`/
+//! `SymRule`/`SymReplaceAll`, and it never observes
+//! `Feature::PatternMatching`. One concrete consequence, mirroring
+//! `reduce-to-semantic-ir`'s identical note: [`measure_depth_iterative`]/
+//! [`drop_iterative`] below only need a match arm for [`Expr::SymApply`]
+//! (recursing into `head` and `args`) — every other `Expr` variant is a
+//! leaf for this crate's purposes. `If`/`Assign`/`Define`/`Set` all lower
+//! to *this same* `SymApply` variant (only the head symbol's name or the
+//! bracket differs), so this holds even though this crate covers the
+//! full statement/expression split.
+//!
+//! # Assignment: a bare `NAME` LHS, never a call shape — plus a genuinely
+//! new `arrow_def`/`arrow_params` path
+//!
+//! `assignment = NAME ASSIGN ( arrow_def | expr ) | expr` — deliberately
+//! NARROWER than `reduce-to-semantic-ir::lower_assignment`'s
+//! `SymApply{head: SymSymbol(_), ..}`-shaped disambiguation.
+//! `maple.grammar`'s own "assignment's left-hand side" design-decision
+//! comment explains why: Maple's identical-looking `f(x) := expr`
+//! spelling means something NARROWER and DIFFERENT in real Maple (a
+//! remember-table specific-value patch onto an ALREADY-EXISTING
+//! procedure, MA09 §1/§4) than Reduce's/Derive's own general-definition
+//! idiom of the same shape — so `maple.grammar` makes `f(x) := expr` fail
+//! to *parse* at all, and this crate's [`Lowerer::lower_assignment`] never
+//! needs to distinguish "was the LHS call-shaped" the way Reduce's/
+//! Derive's own `lower_assignment` does. By the time `lower_node`
+//! dispatches to [`Lowerer::lower_assignment`], a genuine `assignment`
+//! node always has the 3-child `[NAME, ASSIGN, (arrow_def | expr)]` shape
+//! — the bare-`expr` alternative dissolves away (via [`unwrap_single`])
+//! before ever reaching this function; [`Lowerer::lower_first_node`]'s
+//! fallback there is defensive only, mirroring `maple-runtime::
+//! lower_assignment`'s identical defensive shape.
+//!
+//! Instead, Maple has a SEPARATE production, `arrow_def = arrow_params
+//! ARROW expr` (MA09 §3's own two worked spellings: `f := (x, y) -> x + y`
+//! and `f := x -> x^2`), for general function definition —
+//! [`Lowerer::lower_arrow_def`] lowers this to `Define[f, List[params...],
+//! body]`, the same `Define` shape Derive's/Reduce's own
+//! (differently-spelled) general-definition idioms already use.
+//! [`Lowerer::lower_arrow_params`] collects every `NAME` token among the
+//! node's children in order — `arrow_params = NAME | LPAREN [ NAME {
+//! COMMA NAME } ] RPAREN` — both the bare-single-parameter and the
+//! parenthesised-list shapes reduce to the identical "collect NAME
+//! tokens" walk, so there is no need to branch on which alternative
+//! matched; the `LPAREN`/`COMMA`/`RPAREN` tokens present in the
+//! parenthesised form are harmlessly filtered out. Zero parameters (`()
+//! -> e`) falls out of the optional inner list for free.
+//!
+//! # `if`/`elif`/`else` — a right-fold, mirroring Macsyma's elif chain,
+//! NOT Reduce's simpler 2-or-3-child `if`
+//!
+//! `if_expr = "if" expr "then" statement { "elif" expr "then" statement }
+//! [ "else" statement ] ( "end" "if" | "fi" )` — unlike Reduce's `if_expr
+//! = "if" expr "then" expr [ "else" expr ]` (a plain 2-or-3-children
+//! count, since Reduce's grammar has no `elseif` repetition at all), Maple
+//! has a flat `{ "elif" expr "then" statement }` EBNF repetition that must
+//! be folded right-to-left into nested `If` applications — the *same*
+//! shape `macsyma-runtime`'s own elif-chain fold already handles for
+//! Macsyma, and the *same* fold [`maple-runtime::lower_if`] already
+//! implements, retargeted directly here.
+//!
+//! Because Maple requires an explicit close (`end if` or `fi`) for every
+//! `if_expr`, there is no dangling-else ambiguity the way Reduce's
+//! `if`/`else` chain has: a nested `if_expr` inside a branch must run all
+//! the way to its OWN close before the outer `if_expr`'s own `elif`/
+//! `else`/close is ever reached — structurally only one place an outer
+//! `else` can attach, by construction. Every child *node* of an `if_expr`
+//! (ignoring the keyword tokens — `Group`/`Alternation` splice whichever
+//! branch matched directly into the parent `Sequence`, they never
+//! synthesize a wrapper node, confirmed directly against
+//! `maple-parser`'s compiled grammar) appears in strict alternating
+//! `(cond, body)` pairs, with one optional trailing lone `body` node for a
+//! final `else` — [`Lowerer::lower_if`] collects `child_nodes` in order
+//! and walks it two at a time (an odd-length list signals a trailing
+//! `else`), exactly mirroring `maple-runtime::lower_if`'s identical
+//! collection-and-fold logic, retargeted onto `semantic_ir::Expr`.
+//!
+//! The `{ "elif" ... }` repetition is a FLAT list of sibling children (not
+//! right-recursive — confirmed directly against `maple-parser`'s own
+//! `MAX_RULE_DEPTH` doc comment, which measures every `{ x }` EBNF
+//! repetition in this grammar as costing zero native parser stack
+//! regardless of width), so folding N `elif` arms right-to-left still
+//! builds an N-deep nested `If` `Expr` tree — [`Lowerer::
+//! check_elif_chain_length`] bounds `elif`-arm count before any fold
+//! happens, the same "flat CST repetition folds into a deep tree" DoS
+//! shape [`Lowerer::check_chain_length`] already guards for
+//! `additive`/`multiplicative`/`logical_or`/`logical_and`.
+//!
+//! # `Set` — a canonical head genuinely new to this repo (MA09 §5)
+//!
+//! Maple is the first language in this repo with **two** distinct
+//! bracketed aggregate literals: `[a, b, c]` (ordered, `List` — a shared,
+//! already-existing head every CAS-family sibling here reuses) and `{a,
+//! b, c}` (unordered, `Set` — MA09 §3/§5). `symbolic-vm`'s shared handler
+//! table has no handler for a `Set` head (confirmed by `maple-runtime`'s
+//! own doc comment, which greps `symbolic_vm::handlers::
+//! build_handler_table` directly) — so [`SET`] is a `pub const` defined
+//! LOCALLY in this crate, exactly the same pattern
+//! `reduce-to-semantic-ir`/`reduce-runtime` used for their own new
+//! `COMPOUND_EXPRESSION`/`CONS`/`FIRST`/… constants (a locally-defined
+//! `pub const`, not added to shared `symbolic-ir`, since it's not a
+//! `Backend`-agnostic canonical head), spelled to match `maple-runtime`'s
+//! own identically-named constant. This is largely moot for this crate:
+//! it never evaluates anything (the "everything is data" design every
+//! SIR23 frontend shares), so a `SymApply{head: "Set", ...}` node is
+//! valid, executable SIR23 data regardless of whether any *runtime*
+//! currently has a handler for it.
+//!
+//! # `diff`/`int` — thin bridges to already-shared calculus handlers
+//!
+//! `diff(f, x)`/`int(f, x)` bridge to the canonical `D`/`Integrate` heads
+//! — the same idea as Derive's `DIF`/`INT` bridge and
+//! `maple-runtime::surface_head_to_ir`'s own identical table, just
+//! lowercase surface spelling (MA09 §3: Maple's builtin names are
+//! conventionally lowercase, unlike Derive's uppercase convention). A
+//! plain name→canonical-head bridge table entry, no new logic — unlike
+//! `reduce-to-semantic-ir`'s much larger list-accessor bridge table, MA09
+//! §3 documents no function-call spelling for list/set construction
+//! (Maple already has literal `[...]`/`{...}` syntax for both) and this
+//! subset deliberately does not bridge elementary-function names (`sin`,
+//! `log`, …) either.
+//!
+//! # Booleans — the first literal `true`/`false` TOKENS in this CAS family
+//!
+//! Neither `derive.grammar`'s nor `reduce.grammar`'s own grammar has a
+//! dedicated boolean literal token (their booleans only arise from
+//! comparison/logic results) — `maple.grammar`'s `atom` rule is the first
+//! to include `"true"`/`"false"` as their own alternatives (MA09 §3,
+//! citing the `type/truefalseFAIL` Help page). `maple-runtime::
+//! lower_token` bridges these to the shared backend's pre-bound `True`/
+//! `False` symbols (`symbolic_vm::backend::BaseBackend::new` pre-binds
+//! exactly those two names) — the same bridge `macsyma-compiler::
+//! lower_token` already uses for its own boolean keywords (`"KEYWORD" if
+//! token.value == "true" => Ok(sym("True"))`). [`Lowerer::lower_token`]
+//! retargets this exact bridge. **Verified directly against
+//! `symbolic-ir/src/lib.rs`** (per this repo's verify-before-implementing
+//! discipline, not assumed): that crate exports no `TRUE`/`FALSE`
+//! constants at all (`grep -n '"True"\|"False"\|pub const TRUE\|pub
+//! const FALSE'` turns up nothing but a stray test literal) — every
+//! sibling CAS-family lowering that needs these two names uses bare
+//! string literals, so this crate does too (`self.sym_symbol("True"
+//! .to_string(), span)`), rather than inventing constants no shared crate
+//! defines.
+//!
+//! # The `;`-vs-`:` statement terminator is a runtime/session concept,
+//! not something this frontend replicates
+//!
+//! `maple-runtime`'s own `LoweredStatement`/`Display` types tag every
+//! lowered statement with whether `MapleSession`'s evaluation loop should
+//! print a `Display` line — MA09 §3's own statement-separator row is
+//! explicit this is "a display flag on the surrounding session, not an IR
+//! node." This SIR23 frontend has no interactive-session/display concept
+//! at all (mirrors how neither `derive-to-semantic-ir` nor
+//! `reduce-to-semantic-ir` replicate their own native runtimes' prompt/
+//! display machinery either) — [`Lowerer::lower_file`] just emits each
+//! statement's lowered `Expr` as a plain `Stmt::ExprStmt`, exactly like
+//! every sibling SIR23 frontend, and ignores the `;`/`:` distinction
+//! entirely. No `LoweredStatement`-with-display-flag type exists here —
+//! that shape is specific to REPL rendering, out of scope for this crate.
+//!
+//! # `postfix` is NOT chainable — no `check_postfix_chain_length`-
+//! equivalent guard exists here at all
+//!
+//! `reduce-to-semantic-ir`'s (and `derive-to-semantic-ir`'s) `postfix`
+//! production is `atom { LPAREN [ arglist ] RPAREN }` — a REPEATED call
+//! suffix, so `f(x)(y)(z)…` parses and needs a chain-length guard before
+//! lowering folds it into a deep nested-application tree.
+//! `maple.grammar`'s own `postfix = atom [ LPAREN [ arglist ] RPAREN ] ;`
+//! (verified directly against the grammar file, not assumed) has a single
+//! OPTIONAL suffix — `[ ... ]`, not `{ ... }` — so `f(x)(y)` is not valid
+//! Maple in this subset at all: after the first `(x)` is consumed,
+//! `postfix`'s own production has nowhere left to attach a second call
+//! group, and the leftover `(y)` fails whatever comes next (confirmed by
+//! this crate's own `postfix_call_is_not_chainable` regression test,
+//! which asserts `compile_source` rejects `f(x)(y);\n` as a parse error).
+//! [`Lowerer::lower_postfix`] therefore has no chain-counting loop and no
+//! analogous guard at all — the axis `check_postfix_chain_length` bounds
+//! in the sibling crates is structurally impossible here, not merely
+//! bounded by a cap.
+//!
+//! # Recursion-depth hardening — carried over proactively, not discovered
+//!
+//! `wolfram-to-semantic-ir`'s `CHANGELOG.md` documents four rounds of
+//! security review that each found a real, adversarially-confirmed native
+//! stack-overflow gap, and every sibling SIR23 frontend since
+//! (`macsyma-to-semantic-ir`, `derive-to-semantic-ir`,
+//! `reduce-to-semantic-ir`) carries every one of those hardening
+//! mechanisms over from day one rather than rediscovering them. This
+//! crate does the same, even though neither `maple-parser` nor
+//! `maple-runtime` (the retarget source) applies any of these guards
+//! themselves — they are a `*-to-semantic-ir`-frontend-specific defense,
+//! not part of the native pipeline:
+//!
+//! - [`MAX_EXPR_DEPTH`] bounds this crate's own CST-walking recursion.
+//! - [`Lowerer::check_chain_length`] caps every flat, same-precedence
+//!   operator-chain fold (`additive`/`multiplicative`/`logical_or`/
+//!   `logical_and`) before any tree is built — `maple-parser`'s own
+//!   `MAX_RULE_DEPTH` doc comment confirms these ARE flat EBNF
+//!   repetitions in this grammar (not right-recursion), costing zero
+//!   native parser stack regardless of width.
+//! - [`Lowerer::check_elif_chain_length`] caps the `elif`-arm count in an
+//!   `if_expr` before [`Lowerer::lower_if`]'s right-fold runs — the same
+//!   "flat repetition folds into a deep tree" shape, applied to the one
+//!   construct genuinely new relative to Reduce's simpler `if`.
+//! - **No `check_postfix_chain_length`-equivalent guard exists** — see
+//!   the section above for why: `postfix`'s single OPTIONAL call suffix
+//!   makes chained application structurally impossible in this grammar.
+//! - [`Lowerer::check_apply_arg_count`] caps `arglist` element counts
+//!   (shared by a call's arguments, `list_literal`, and `set_literal`)
+//!   AND `arrow_params`' flat parameter-name count — flat-`Vec`
+//!   allocation-size backstops, not stack guards.
+//! - [`measure_depth_iterative`] is the authoritative,
+//!   construction-composition-independent check: an iterative (never
+//!   recursive) walk of an already-built `Expr`, called once per
+//!   top-level statement in [`Lowerer::lower_file`].
+//! - [`drop_iterative`] tears down a tree [`measure_depth_iterative`] just
+//!   rejected, using an explicit work stack rather than the ordinary
+//!   recursive `Drop` glue, for the same reason every sibling SIR23
+//!   frontend documents (detecting an oversized tree and then letting it
+//!   drop normally just relocates the same stack overflow from "walking
+//!   forward" to "walking backward").
+//!
+//! Maple's six genuinely *self-referential* (right-recursive or
+//! prefix-recursive) productions — parenthesised `group` nesting,
+//! list-/set-literal nesting, a `not`-prefix chain, a unary-minus-prefix
+//! chain, the power (`^`) chain, and nested `if`/`end if` (or `fi`) — need
+//! NO additional lowering-side guard beyond the ordinary `depth`
+//! parameter threaded through [`Lowerer::lower_node`]: `maple-parser`'s
+//! own `MAX_RULE_DEPTH` (150) already bounds how deep any of these can
+//! nest in the CST this crate ever receives (measured directly in that
+//! crate's own doc comment across all six shapes independently — the
+//! binding constraint is the `not`-chain's floor of 218 rule frames, a
+//! ~31.2% margin below the 150 cap). This mirrors exactly why
+//! `reduce-to-semantic-ir` needs no explicit guard on its own five
+//! self-referential productions either — the risk there is bounded by the
+//! parser, not by this module.
+//!
+//! # `compile` vs. `compile_source`
+//!
+//! This module's [`compile`] is pure lowering over an already-parsed
+//! tree — see `src/lib.rs`'s `compile_source` doc comment for why, like
+//! `macsyma-to-semantic-ir`/`derive-to-semantic-ir`/
+//! `reduce-to-semantic-ir` (and unlike `wolfram-to-semantic-ir`), this
+//! crate's `compile_source` does not need to spawn an enlarged-stack
+//! worker thread: `maple-parser`'s own `MAX_RULE_DEPTH` (150) is already
+//! documented safe on a bare default (~2 MiB) stack with comfortable
+//! margin.
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+};
+use symbolic_ir::{
+    ADD, AND, ASSIGN, D, DEFINE, DIV, EQUAL, GREATER, GREATER_EQUAL, IF, INTEGRATE, LESS,
+    LESS_EQUAL, LIST, MUL, NEG, NOT, NOT_EQUAL, OR, POW, SUB,
+};
+
+/// The canonical head for a Maple set literal `{a, b, c}` (MA09 §3/§5).
+///
+/// Not exported by `symbolic-ir` (see the module doc comment's "`Set`"
+/// section) — defined locally, spelled to match `maple-runtime::lower`'s
+/// own identically-named constant, so the one place this crate needs the
+/// spelling has a name, not a repeated string literal.
+pub const SET: &str = "Set";
+
+/// Maximum expression-nesting depth for *this crate's own* lowering
+/// recursion — distinct from (and independent of) `maple-parser`'s own
+/// `MAX_RULE_DEPTH` grammar-nesting guard (150), which bounds the CST this
+/// crate walks. Mirrors `wolfram-to-semantic-ir`'s, `macsyma-to-semantic-
+/// ir`'s, `derive-to-semantic-ir`'s, and `reduce-to-semantic-ir`'s
+/// identically-named, identically-valued guard — kept at 256 for
+/// consistency across the whole SIR23 frontend family rather than
+/// inventing a new value, even though `maple-parser`'s own cap (150) is
+/// lower: this constant bounds a DIFFERENT axis (this crate's own
+/// chain-folding/tree-depth budget, exercised by e.g. a long flat `+`
+/// chain that parses as ONE CST node regardless of nesting depth), not
+/// the CST-nesting axis `maple-parser`'s own cap already bounds.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// Synthetic file name used for all spans (the CST does not carry the
+/// original path).
+const FILE: &str = "<maple>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during Maple → SIR lowering.
+///
+/// Mirrors `ReduceLowerError`/`DeriveLowerError`/`MacsymaLowerError`/
+/// `WolframLowerError`'s shape exactly (`message` + 1-based
+/// `line`/`column`) so tooling can treat every SIR frontend uniformly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MapleLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for MapleLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MapleLowerError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for MapleLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Maple CST (rooted at the `program` rule) into a SIR
+/// module.
+///
+/// This function does **not** itself guard against native stack overflow
+/// on deeply-nested input beyond its own [`MAX_EXPR_DEPTH`] cap — it
+/// trusts `tree` was already parsed under a suitable guard
+/// (`maple-parser`'s own `MAX_RULE_DEPTH`). See `src/lib.rs`'s
+/// `compile_source` doc comment for why no worker-thread stack
+/// enlargement is needed here.
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, MapleLowerError> {
+    Lowerer::new(module_name).lower_file(tree)
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// The lowering pass's only mutable state: the module name (fixed at
+/// construction) and the set of SIR features observed while lowering
+/// (used to build the manifest so it declares *exactly* what the module
+/// emits — see `semantic-ir/src/validator.rs`'s `check_expr`, the ground
+/// truth this must match node-kind-for-node-kind).
+///
+/// Like every sibling SIR23 frontend's `Lowerer`, there is no per-function
+/// name-resolution context here at all: under the "everything is data"
+/// design inherited from `maple-runtime` (see the module doc comment),
+/// there are no host variables, parameters, or scopes to resolve — even
+/// an arrow-definition's formal parameters lower to plain `SymSymbol`s
+/// inside a `List`, not to bound names. This lowerer is a near-stateless
+/// recursive descent over the CST.
+struct Lowerer {
+    module_name: String,
+    observed: FeatureManifest,
+}
+
+impl Lowerer {
+    fn new(module_name: &str) -> Self {
+        Self {
+            module_name: module_name.to_string(),
+            observed: FeatureManifest::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program = { statement_line } [ statement ] ;`
+    // `statement_line = statement ( SEMI | COLON ) ;`
+    // -------------------------------------------------------------------
+
+    /// Like `reduce-to-semantic-ir::lower_file`, Maple's grammar adds an
+    /// OPTIONAL final bare `statement` outside the repetition (so a
+    /// source file need not end with a trailing `;`/`:`) — the identical
+    /// shape `maple.grammar`'s own `program` comment documents (reused
+    /// nearly verbatim from `reduce.grammar`'s own comment, per that
+    /// grammar file's own note). The `;`-vs-`:` display distinction is
+    /// deliberately NOT tracked here — see the module doc comment's
+    /// "statement terminator" section.
+    fn lower_file(&mut self, program: &GrammarASTNode) -> Result<Module, MapleLowerError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        let mut stmts: Vec<Stmt> = Vec::new();
+        for child in child_nodes(program) {
+            let statement_node = match child.rule_name.as_str() {
+                "statement_line" => child_nodes(child).find(|n| n.rule_name == "statement"),
+                "statement" => Some(child),
+                _ => None,
+            };
+            let Some(statement_node) = statement_node else {
+                continue;
+            };
+            let expr = self.lower_node(statement_node, 0)?;
+            if measure_depth_iterative(&expr).is_none() {
+                let err = self.err_at(
+                    statement_node,
+                    format!("expression tree too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+                );
+                drop_iterative(expr);
+                return Err(err);
+            }
+            let span = expr.span().clone();
+            stmts.push(Stmt::ExprStmt { expr, span });
+        }
+
+        let span = Span::point(FILE, 1, 1);
+        let main = Function {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit { span: span.clone() },
+                span: span.clone(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: span.clone(),
+        };
+
+        let metadata = Metadata::new()
+            .with_source_language("maple")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION);
+
+        Ok(Module {
+            name: self.module_name.clone(),
+            manifest: self.observed.clone(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![main],
+            globals: vec![],
+            metadata,
+            span,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // Dispatch
+    // -------------------------------------------------------------------
+
+    /// Lower a single arbitrary node, one level deeper than `depth`.
+    ///
+    /// One shared dispatch table — mirroring `maple-runtime::lower::
+    /// lower_node`'s own single `match` exactly (see the module doc
+    /// comment's "dispatch is SPLIT" section for why this is still
+    /// correct despite the grammar's statement/expression divide: the
+    /// divide is enforced by *reachability*, not by two Rust functions).
+    /// Most grammar rules are "transparent wrappers" — a precedence level
+    /// that did not apply its own operator still emits its own node with
+    /// a single child, and so does `statement = if_expr | assignment`
+    /// once it has committed to one alternative. [`unwrap_single`] peels
+    /// those away so we dispatch on the first rule that genuinely shapes
+    /// the tree.
+    fn lower_node(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        match unwrap_single(node) {
+            Unwrapped::Token(token) => self.lower_token(token),
+            Unwrapped::Node(node) => match node.rule_name.as_str() {
+                "program" => Err(self.err_at(node, "nested program node is not an expression".to_string())),
+                "statement_line" | "statement" | "expr" => self.lower_first_node(node, depth),
+                "if_expr" => self.lower_if(node, depth),
+                "assignment" => self.lower_assignment(node, depth),
+                "logical_or" => self.lower_logical_chain(node, depth, OR),
+                "logical_and" => self.lower_logical_chain(node, depth, AND),
+                "logical_not" => self.lower_logical_not(node, depth),
+                "comparison" => self.lower_comparison(node, depth),
+                "additive" | "multiplicative" => self.lower_binary_chain(node, depth),
+                "unary" => self.lower_unary(node, depth),
+                "power" => self.lower_power(node, depth),
+                "postfix" => self.lower_postfix(node, depth),
+                "atom" => self.lower_atom(node, depth),
+                "arglist" => Err(self.err_at(
+                    node,
+                    "an arglist cannot be lowered as a scalar expression".to_string(),
+                )),
+                "list_literal" => self.lower_list_literal(node, depth),
+                "set_literal" => self.lower_set_literal(node, depth),
+                "group" => self.lower_group(node, depth),
+                other => Err(self.err_at(node, format!("no lowering for rule `{other}`"))),
+            },
+        }
+    }
+
+    /// Lower a raw token (a literal or a bare symbol). `and`/`or`/`not`/
+    /// `if`/`then`/`elif`/`else`/`end`/`fi` are always consumed by their
+    /// own grammar rule before reaching here as a bare leaf token (they
+    /// are matched by literal spelling inside `if_expr`/`logical_and`/
+    /// `logical_or`/`logical_not`'s own productions) — so, mirroring
+    /// `maple-runtime::lower_token`, this only ever needs `NUMBER`/
+    /// `NAME`/the two boolean `KEYWORD` arms.
+    fn lower_token(&mut self, token: &Token) -> Result<Expr, MapleLowerError> {
+        let span = self.token_span(token);
+        match token_type(token) {
+            "NUMBER" => Ok(self.number_literal_expr(&token.value, span)),
+            "NAME" => Ok(self.sym_symbol(token.value.clone(), span)),
+            // See the module doc comment's "Booleans" section — the
+            // shared backend pre-binds exactly these two symbol names,
+            // and `symbolic-ir` exports no `TRUE`/`FALSE` constant
+            // (verified directly), so this uses bare string literals,
+            // matching `maple-runtime`'s/`macsyma-compiler`'s own bridge.
+            "KEYWORD" if token.value == "true" => Ok(self.sym_symbol("True".to_string(), span)),
+            "KEYWORD" if token.value == "false" => Ok(self.sym_symbol("False".to_string(), span)),
+            other => Err(MapleLowerError {
+                message: format!("unexpected token `{other}` = {:?}", token.value),
+                line: token.line,
+                column: token.column,
+            }),
+        }
+    }
+
+    /// `if_expr = "if" expr "then" statement { "elif" expr "then"
+    /// statement } [ "else" statement ] ( "end" "if" | "fi" )` — see the
+    /// module doc comment's "if/elif/else" section for the full
+    /// right-fold explanation. Retargets `maple-runtime::lower_if`'s
+    /// exact collection-and-fold logic onto `semantic_ir::Expr`, with
+    /// [`Self::check_elif_chain_length`] added as this crate's own
+    /// proactive DoS guard (the native runtime does not need one, since
+    /// it evaluates eagerly and never builds an unbounded tree ahead of
+    /// use the way this frontend's pure-data lowering does).
+    fn lower_if(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let nodes: Vec<&GrammarASTNode> = child_nodes(node).collect();
+        if nodes.len() < 2 {
+            return Err(self.err_at(node, "if_expr must have at least one branch".to_string()));
+        }
+        let has_else = nodes.len() % 2 == 1;
+        let branch_count = if has_else { (nodes.len() - 1) / 2 } else { nodes.len() / 2 };
+        self.check_elif_chain_length(node, branch_count)?;
+
+        let mut branches = Vec::with_capacity(branch_count);
+        for i in 0..branch_count {
+            let cond = self.lower_node(nodes[2 * i], depth + 1)?;
+            let body = self.lower_node(nodes[2 * i + 1], depth + 1)?;
+            branches.push((cond, body));
+        }
+        let else_body = if has_else {
+            Some(self.lower_node(nodes[nodes.len() - 1], depth + 1)?)
+        } else {
+            None
+        };
+
+        let span = self.span_of(node);
+        // Fold right-to-left: the innermost branch's "else slot" is the
+        // final `else` body if present, otherwise absent (a bare 2-arg
+        // `If`); every earlier `elif` branch wraps the accumulated
+        // result as its own 3-arg `If`'s else-slot.
+        let mut acc = else_body;
+        for (cond, body) in branches.into_iter().rev() {
+            acc = Some(match acc {
+                Some(prev) => self.sym_apply(
+                    self.sym_symbol_bare(IF, span.clone()),
+                    vec![cond, body, prev],
+                    span.clone(),
+                ),
+                None => self.sym_apply(self.sym_symbol_bare(IF, span.clone()), vec![cond, body], span.clone()),
+            });
+        }
+        acc.ok_or_else(|| self.err_at(node, "if_expr produced no branches".to_string()))
+    }
+
+    /// `assignment = NAME ASSIGN ( arrow_def | expr ) | expr` — see the
+    /// module doc comment's "Assignment" section for why this LHS is a
+    /// bare `NAME` token, full stop, unlike Reduce's/Derive's own
+    /// call-shaped-LHS disambiguation. By the time `lower_node` dispatches
+    /// here (via `unwrap_single`), a genuine `assignment` node always has
+    /// the 3-child `[NAME, ASSIGN, (arrow_def | expr)]` shape — the
+    /// bare-`expr` alternative dissolves away before ever reaching this
+    /// function. [`Self::lower_first_node`]'s fallback is defensive only,
+    /// mirroring `maple-runtime::lower_assignment`'s identical shape.
+    fn lower_assignment(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let is_assign_form = node.children.len() == 3
+            && as_token(&node.children[1]).is_some_and(|t| token_type(t) == "ASSIGN");
+        if !is_assign_form {
+            return self.lower_first_node(node, depth);
+        }
+        let name = match as_token(&node.children[0]) {
+            Some(t) if token_type(t) == "NAME" => t.value.clone(),
+            _ => return Err(self.err_at(node, "assignment lhs must be a bare NAME".to_string())),
+        };
+        let span = self.span_of(node);
+        match &node.children[2] {
+            ASTNodeOrToken::Node(n) if n.rule_name == "arrow_def" => self.lower_arrow_def(name, n, depth + 1),
+            rhs => {
+                let value = self.lower_child(rhs, depth + 1)?;
+                Ok(self.sym_apply(
+                    self.sym_symbol_bare(ASSIGN, span.clone()),
+                    vec![self.sym_symbol_bare(name, span.clone()), value],
+                    span,
+                ))
+            }
+        }
+    }
+
+    /// `arrow_def = arrow_params ARROW expr` — MA09 §3's general-purpose
+    /// function-definition spelling, `f := (x, y) -> e` / `f := x -> e`.
+    /// Lowers to `Define[f, List[params...], body]`, mirroring
+    /// `derive-to-semantic-ir`'s/`reduce-to-semantic-ir`'s identical
+    /// `Define` shape for their own (differently-spelled) definition
+    /// idioms — see the module doc comment's "Assignment" section.
+    fn lower_arrow_def(
+        &mut self,
+        name: String,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, MapleLowerError> {
+        if node.children.len() != 3 {
+            return Err(self.err_at(node, "malformed arrow_def node".to_string()));
+        }
+        let params_node = as_node(&node.children[0])
+            .ok_or_else(|| self.err_at(node, "arrow_def is missing its parameter list".to_string()))?;
+        let params = self.lower_arrow_params(params_node)?;
+        let body = self.lower_child(&node.children[2], depth)?;
+        let span = self.span_of(node);
+        let params_list = self.sym_apply(self.sym_symbol_bare(LIST, span.clone()), params, span.clone());
+        Ok(self.sym_apply(
+            self.sym_symbol_bare(DEFINE, span.clone()),
+            vec![self.sym_symbol_bare(name, span.clone()), params_list, body],
+            span,
+        ))
+    }
+
+    /// `arrow_params = NAME | LPAREN [ NAME { COMMA NAME } ] RPAREN` — a
+    /// single bare parameter needs no parentheses, two-or-more do, and
+    /// `()` (zero parameters) falls out of the optional inner list for
+    /// free. Both shapes are handled uniformly by simply collecting every
+    /// `NAME` token among the node's children in order — the
+    /// `LPAREN`/`COMMA`/`RPAREN` tokens present in the parenthesised form
+    /// are harmlessly filtered out, mirroring `maple-runtime::
+    /// lower_arrow_params`'s identical logic. A flat `Vec`, not a folded
+    /// tree, so [`Self::check_apply_arg_count`] bounds its length as an
+    /// allocation-size backstop only, not a stack-recursion guard.
+    fn lower_arrow_params(&mut self, node: &GrammarASTNode) -> Result<Vec<Expr>, MapleLowerError> {
+        let names: Vec<&Token> = node
+            .children
+            .iter()
+            .filter_map(as_token)
+            .filter(|t| token_type(t) == "NAME")
+            .collect();
+        self.check_apply_arg_count(node, names.len())?;
+        let mut params = Vec::with_capacity(names.len());
+        for t in names {
+            let span = self.token_span(t);
+            params.push(self.sym_symbol(t.value.clone(), span));
+        }
+        Ok(params)
+    }
+
+    /// `logical_or`/`logical_and` — fold operands into an n-ary `Or`/`And`
+    /// `SymApply` (a single flat apply carrying every operand at this
+    /// precedence level, not a nested binary chain — safe to fold n-ary
+    /// because every step in one chain shares the SAME operator).
+    /// Mirrors `maple-runtime::lower_logical_chain`/`reduce-to-semantic-
+    /// ir::lower_logical_chain` exactly, with [`Self::check_chain_length`]
+    /// added proactively.
+    fn lower_logical_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        head: &str,
+    ) -> Result<Expr, MapleLowerError> {
+        self.check_chain_length(node)?;
+        let operands = self.lower_child_nodes(node, depth + 1)?;
+        match operands.len() {
+            0 => Err(self.err_at(node, "empty logical chain".to_string())),
+            1 => Ok(operands.into_iter().next().unwrap()),
+            _ => {
+                let span = self.span_of(node);
+                Ok(self.sym_apply(self.sym_symbol_bare(head, span.clone()), operands, span))
+            }
+        }
+    }
+
+    /// `logical_not = "not" logical_not | comparison ;`
+    ///
+    /// `and`/`or`/`not`/`if`/`then`/`elif`/`else`/`end`/`fi` are all
+    /// matched in the grammar as `maple.tokens`' own `KEYWORD` token type
+    /// (promoted from `NAME` by exact lowercase spelling — MA09 §3), so —
+    /// mirroring `maple-runtime::lower_logical_not`'s identical check —
+    /// this checks the token's literal *value*, not `effective_type_name()`
+    /// (every keyword shares that one type name).
+    fn lower_logical_not(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let has_not = node
+            .children
+            .iter()
+            .any(|c| as_token(c).is_some_and(|t| t.value == "not"));
+        if !has_not {
+            return self.lower_first_node(node, depth);
+        }
+        let inner = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, "`not` with no operand".to_string()))?;
+        let operand = self.lower_node(inner, depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(NOT, span.clone()), vec![operand], span))
+    }
+
+    /// `comparison = additive [ ( EQ | NEQ | LESS | GREATER | LE | GE )
+    /// additive ] ;` — a single (non-chained) comparison, per MA09 §3's
+    /// own disclosed simplification (reusing `reduce.grammar`'s own
+    /// "flat, non-chaining tier" precedent rather than re-deriving one —
+    /// see `maple.grammar`'s own design-decision comment). `=` is Maple's
+    /// *equation* operator (`Equal`), never assignment — `:=` alone owns
+    /// that role. Unlike Reduce's word-keyword `neq`, Maple's not-equal
+    /// is the symbolic `NEQ` (`<>`) token TYPE, so — unlike
+    /// `reduce-to-semantic-ir::comparison_head`'s value-based check for
+    /// `neq` — every arm here is purely type-based.
+    fn lower_comparison(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let Some(op_index) = node
+            .children
+            .iter()
+            .position(|c| as_token(c).is_some_and(|t| comparison_head(t).is_some()))
+        else {
+            return self.lower_first_node(node, depth);
+        };
+        if op_index == 0 || op_index + 1 >= node.children.len() {
+            return Err(self.err_at(node, "malformed comparison node".to_string()));
+        }
+        let head = comparison_head(as_token(&node.children[op_index]).unwrap()).unwrap();
+        let lhs = self.lower_child(&node.children[op_index - 1], depth + 1)?;
+        let rhs = self.lower_child(&node.children[op_index + 1], depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(head, span.clone()), vec![lhs, rhs], span))
+    }
+
+    /// `additive`/`multiplicative` — a left-associative binary chain of
+    /// `+`/`-`/`*`/`/`. Must fold pairwise (not n-ary, unlike the logical
+    /// chains) since a single chain can mix operators: `a - b - c` folds
+    /// left into `Sub(Sub(a, b), c)`; `a + b - c` into `Sub(Add(a, b),
+    /// c)`. Mirrors `maple-runtime::lower_binary_chain`/`reduce-to-
+    /// semantic-ir::lower_binary_chain` exactly (identical grammar
+    /// shape). [`Self::check_chain_length`] guards the fold, same
+    /// reasoning as [`Self::lower_logical_chain`]'s.
+    fn lower_binary_chain(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        self.check_chain_length(node)?;
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty binary chain".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            let head = as_token(op_child)
+                .and_then(|t| binary_head(token_type(t)))
+                .ok_or_else(|| self.err_at(node, "expected a binary operator".to_string()))?;
+            let rhs = children
+                .next()
+                .ok_or_else(|| self.err_at(node, "binary operator with no right operand".to_string()))?;
+            let rhs_expr = self.lower_child(rhs, depth + 1)?;
+            let span = self.span_of(node);
+            result = self.sym_apply(self.sym_symbol_bare(head, span.clone()), vec![result, rhs_expr], span);
+        }
+        Ok(result)
+    }
+
+    /// `unary = MINUS unary | power ;` — MA09 §3 lists only unary `-` (no
+    /// unary `+`, matching Reduce's/Derive's identical asymmetry) — a
+    /// leading `-` is `Neg`; otherwise it is the inner `power`. Genuinely
+    /// self-referential (prefix-recursive), bounded by `maple-parser`'s
+    /// own depth cap — see the module doc comment's recursion-hardening
+    /// section for why no additional chain-length guard is needed here.
+    fn lower_unary(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        match node.children.len() {
+            1 => self.lower_child(&node.children[0], depth + 1),
+            2 => {
+                let operand = self.lower_child(&node.children[1], depth + 1)?;
+                let span = self.span_of(node);
+                Ok(self.sym_apply(self.sym_symbol_bare(NEG, span.clone()), vec![operand], span))
+            }
+            _ => Err(self.err_at(node, "malformed unary node".to_string())),
+        }
+    }
+
+    /// `power = postfix [ CARET unary ] ;` — right-associative `^`.
+    /// Unlike `reduce-to-semantic-ir::lower_power` (which accepts either
+    /// `CARET` or `POW`, since Reduce's manual documents both as one
+    /// tier), Maple's own grammar has no `**` synonym at all (MA09 §3/§4;
+    /// `maple.tokens` has no `POW` token), so this only ever matches
+    /// `CARET` — mirroring `maple-runtime::lower_power`'s identical
+    /// single-token acceptance.
+    fn lower_power(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        match node.children.len() {
+            1 => self.lower_child(&node.children[0], depth + 1),
+            3 => {
+                let is_caret = as_token(&node.children[1]).is_some_and(|t| token_type(t) == "CARET");
+                if !is_caret {
+                    return Err(self.err_at(node, "malformed power node: expected CARET".to_string()));
+                }
+                let lhs = self.lower_child(&node.children[0], depth + 1)?;
+                let rhs = self.lower_child(&node.children[2], depth + 1)?;
+                let span = self.span_of(node);
+                Ok(self.sym_apply(self.sym_symbol_bare(POW, span.clone()), vec![lhs, rhs], span))
+            }
+            _ => Err(self.err_at(node, "malformed power node".to_string())),
+        }
+    }
+
+    /// `postfix = atom [ LPAREN [ arglist ] RPAREN ] ;` — a single
+    /// OPTIONAL call suffix, deliberately narrower than Reduce's/Derive's
+    /// REPEATED `{ LPAREN [arglist] RPAREN }` chain. See the module doc
+    /// comment's "postfix is NOT chainable" section: because at most one
+    /// call suffix can ever appear, there is no
+    /// `check_postfix_chain_length`-equivalent guard anywhere in this
+    /// function — the axis it would guard is structurally impossible in
+    /// this grammar.
+    ///
+    /// The head runs through [`Self::build_application`] so `diff`/`int`
+    /// become the IR heads `symbolic-vm` already has handlers for; any
+    /// other head (a user-defined function, or a builtin this subset
+    /// doesn't bridge, like `sin`/`solve`/`piecewise`) passes through
+    /// unchanged and stays a harmless unevaluated symbolic call — mirrors
+    /// `maple-runtime::lower_postfix`'s identical head-bridging step.
+    fn lower_postfix(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let base = self.lower_child(
+            node.children
+                .first()
+                .ok_or_else(|| self.err_at(node, "postfix has no base".to_string()))?,
+            depth + 1,
+        )?;
+
+        let has_call = node
+            .children
+            .get(1)
+            .and_then(as_token)
+            .is_some_and(|t| token_type(t) == "LPAREN");
+        if !has_call {
+            return Ok(base);
+        }
+
+        let args = node
+            .children
+            .get(2)
+            .and_then(as_node)
+            .filter(|n| n.rule_name == "arglist")
+            .map(|n| self.lower_arglist(n, depth + 1))
+            .transpose()?
+            .unwrap_or_default();
+        self.check_apply_arg_count(node, args.len())?;
+        Ok(self.build_application(base, args, node))
+    }
+
+    /// Apply `head` to `args`, bridging a lowercase builtin surface
+    /// function name (`diff`, `int`) to its canonical IR head via
+    /// [`standard_function`] — mirrors `maple-runtime::lower_postfix`'s
+    /// `canonical_head` step exactly. There is no associative n-ary
+    /// left-fold here (unlike Wolfram's `build_application`): Maple has
+    /// no explicit-head-application sugar analogous to Wolfram's
+    /// `Plus[1, 2, 3]`, so this is a plain wrap.
+    fn build_application(&mut self, head: Expr, args: Vec<Expr>, node: &GrammarASTNode) -> Expr {
+        let span = self.span_of(node);
+        let canonical_head = match &head {
+            Expr::SymSymbol { name, span: head_span } => standard_function(name)
+                .map(|c| self.sym_symbol_bare(c, head_span.clone()))
+                .unwrap_or_else(|| head.clone()),
+            _ => head,
+        };
+        self.sym_apply(canonical_head, args, span)
+    }
+
+    /// `arglist = expr { COMMA expr } ;` — lower each comma-separated
+    /// argument. An arglist is a flat `Vec`, not a folded tree, so it has
+    /// no stack-recursion risk analogous to the binary-chain rules — the
+    /// caller applies [`Self::check_apply_arg_count`] to bound its raw
+    /// length as a modest defense-in-depth cap on allocation size.
+    fn lower_arglist(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Vec<Expr>, MapleLowerError> {
+        self.lower_child_nodes(node, depth)
+    }
+
+    /// `atom = NUMBER | NAME | "true" | "false" | list_literal |
+    /// set_literal | group ;` In practice [`unwrap_single`] already
+    /// dissolves a single-child `atom` node before `lower_node`'s
+    /// dispatch ever sees rule_name `"atom"` (every alternative here
+    /// matches to exactly one child), so this function mirrors
+    /// `maple-runtime::lower_atom`'s identical defensive shape rather
+    /// than being load-bearing for the common case.
+    fn lower_atom(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        if let Some(child) = child_nodes(node).next() {
+            if matches!(child.rule_name.as_str(), "list_literal" | "set_literal" | "group") {
+                return self.lower_node(child, depth + 1);
+            }
+        }
+        let tokens: Vec<&Token> = node.children.iter().filter_map(as_token).collect();
+        match tokens.as_slice() {
+            [single] => self.lower_token(single),
+            _ => Err(self.err_at(
+                node,
+                format!(
+                    "unrecognised atom token shape: {:?}",
+                    tokens.iter().map(|t| &t.value).collect::<Vec<_>>()
+                ),
+            )),
+        }
+    }
+
+    /// `list_literal = LBRACKET [ arglist ] RBRACKET ;` — MA09 §3's `[a,
+    /// b, c]` (square brackets, ordered, duplicates kept). Lowers to
+    /// `List[...]`, the shared, already-handled head every CAS-family
+    /// sibling in this repo reuses — mirrors `maple-runtime::
+    /// lower_list_literal`'s identical logic.
+    fn lower_list_literal(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let args = match child_nodes(node).find(|n| n.rule_name == "arglist") {
+            Some(arglist_node) => self.lower_arglist(arglist_node, depth + 1)?,
+            None => vec![],
+        };
+        self.check_apply_arg_count(node, args.len())?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(LIST, span.clone()), args, span))
+    }
+
+    /// `set_literal = LBRACE [ arglist ] RBRACE ;` — MA09 §3's `{a, b,
+    /// c}` (curly braces, unordered, duplicates removed *in real Maple*).
+    /// Lowers to the new [`SET`] head — see the module doc comment's
+    /// "`Set`" section for the disclosed evaluation-time gap (this
+    /// frontend never evaluates anything, so the gap is moot here; only
+    /// the *shape* matters for pure data construction/codegen). Mirrors
+    /// `maple-runtime::lower_set_literal`'s identical logic, differing
+    /// from [`Self::lower_list_literal`] only in which head/bracket.
+    fn lower_set_literal(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let args = match child_nodes(node).find(|n| n.rule_name == "arglist") {
+            Some(arglist_node) => self.lower_arglist(arglist_node, depth + 1)?,
+            None => vec![],
+        };
+        self.check_apply_arg_count(node, args.len())?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(SET, span.clone()), args, span))
+    }
+
+    /// `group = LPAREN expr RPAREN ;` — grouping only.
+    fn lower_group(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let inner = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty group `( )`".to_string()))?;
+        self.lower_node(inner, depth + 1)
+    }
+
+    // -------------------------------------------------------------------
+    // Small constructors (each observes the feature the validator's own
+    // `check_expr` requires for that node kind -- see `semantic-ir/src/
+    // validator.rs`, the ground truth this must match exactly).
+    // -------------------------------------------------------------------
+
+    fn sym_symbol(&mut self, name: String, span: Span) -> Expr {
+        self.observed.add(Feature::SymbolicExpr);
+        Expr::SymSymbol { name, span }
+    }
+
+    /// Build a `SymSymbol` for a *head* name, or any other
+    /// internally-constructed symbol that is always immediately wrapped
+    /// in a [`Self::sym_apply`] call — which itself observes the
+    /// feature — so this helper does not need to (identical shape to
+    /// [`Self::sym_symbol`], named separately only so call sites make
+    /// their intent legible; mirrors every sibling SIR23 frontend's
+    /// identically-named helper).
+    fn sym_symbol_bare(&self, name: impl Into<String>, span: Span) -> Expr {
+        Expr::SymSymbol {
+            name: name.into(),
+            span,
+        }
+    }
+
+    fn sym_apply(&mut self, head: Expr, args: Vec<Expr>, span: Span) -> Expr {
+        self.observed.add(Feature::SymbolicExpr);
+        Expr::SymApply {
+            head: Box::new(head),
+            args,
+            span,
+        }
+    }
+
+    /// Parse a `NUMBER` lexeme into an `IntLit` or `FloatLit` (a `.`,
+    /// `e`, or `E` means a real; otherwise an integer, matching
+    /// `maple-runtime::lower::lower_number`'s identical rule — the
+    /// `maple.tokens` `NUMBER` regex is identical to Reduce's/Derive's/
+    /// Macsyma's own). An integer lexeme too large for `i64` falls back
+    /// to a float rather than silently truncating.
+    ///
+    /// **Must** be an instance method, not a free function: every branch
+    /// that constructs a `FloatLit` calls `self.observed.add(Feature::
+    /// Floats)` immediately. This is a confirmed, previously-shipped bug
+    /// in both `matlab-to-semantic-ir` and `wolfram-to-semantic-ir` (their
+    /// number-literal helpers were free functions with no access to
+    /// `observed`, so a float-literal-only module failed
+    /// `semantic_ir::validate()`), fixed proactively in
+    /// `macsyma-to-semantic-ir`/`derive-to-semantic-ir`/
+    /// `reduce-to-semantic-ir` and carried forward here.
+    fn number_literal_expr(&mut self, text: &str, span: Span) -> Expr {
+        if text.contains('.') || text.contains('e') || text.contains('E') {
+            self.observed.add(Feature::Floats);
+            Expr::FloatLit {
+                value: text.parse::<f64>().unwrap_or(0.0),
+                span,
+            }
+        } else {
+            match text.parse::<i64>() {
+                Ok(v) => Expr::IntLit { value: v, span },
+                Err(_) => {
+                    self.observed.add(Feature::Floats);
+                    Expr::FloatLit {
+                        value: text.parse::<f64>().unwrap_or(0.0),
+                        span,
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Guards
+    // -------------------------------------------------------------------
+
+    /// Reject a same-precedence operator chain (`additive`/
+    /// `multiplicative`/`logical_or`/`logical_and`) with more than
+    /// `MAX_EXPR_DEPTH` operands.
+    ///
+    /// Maple's grammar, like Wolfram's, Macsyma's, Derive's, and Reduce's,
+    /// collapses a flat run of same-precedence operators into ONE CST
+    /// node with many children rather than nesting through parens, so a
+    /// long unparenthesized chain (`1 + 1 + ... + 1`, thousands of terms)
+    /// never trips the ordinary grammar-nesting depth guard
+    /// (`maple-parser`'s `MAX_RULE_DEPTH`, which counts *nesting*, not
+    /// the length of one flat repetition — confirmed directly in that
+    /// crate's own doc comment). But folding N operands
+    /// left-associatively still builds an N-deep *binary* `Expr` tree,
+    /// and that tree's own depth is what every later recursive pass over
+    /// it pays for regardless of how cheaply each fold step was.
+    fn check_chain_length(&self, node: &GrammarASTNode) -> Result<(), MapleLowerError> {
+        let operand_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .count();
+        if operand_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "expression chain too long ({operand_count} operands, exceeds \
+                     {MAX_EXPR_DEPTH})"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Reject an `if_expr` with more than `MAX_EXPR_DEPTH` total branches
+    /// (the initial `if` branch plus every `elif` branch). See the module
+    /// doc comment's "if/elif/else" section: the `{ "elif" ... }`
+    /// repetition is a flat CST shape (zero parser-stack cost regardless
+    /// of width), but [`Self::lower_if`]'s right-fold still builds a
+    /// `branch_count`-deep nested `If` `Expr` tree — the identical DoS
+    /// shape [`Self::check_chain_length`] guards for the flat operator
+    /// chains, applied here to the one construct genuinely new relative
+    /// to `reduce-to-semantic-ir`'s simpler 2-or-3-child `if`.
+    fn check_elif_chain_length(&self, node: &GrammarASTNode, branch_count: usize) -> Result<(), MapleLowerError> {
+        if branch_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("if/elif chain too long ({branch_count} branches, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Cap the argument count of a single `f(…)` application, the
+    /// element count of a `[…]`/`{…}` list/set literal, or the parameter
+    /// count of an `arrow_def`'s `arrow_params`. None of these fold into
+    /// a nested tree (all stay a flat `Vec<Expr>`), so this is not a
+    /// stack-recursion guard — it is a modest defense-in-depth cap on a
+    /// single allocation's size, using the same `MAX_EXPR_DEPTH` bound
+    /// for consistency rather than inventing new constants per call site
+    /// (mirrors `reduce-to-semantic-ir::check_apply_arg_count`'s
+    /// identical reuse across `arglist`/`list_literal`/`group_expr`).
+    fn check_apply_arg_count(&self, node: &GrammarASTNode, count: usize) -> Result<(), MapleLowerError> {
+        if count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("too many arguments ({count}, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // Small helpers
+    // -------------------------------------------------------------------
+
+    fn lower_first_node(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, MapleLowerError> {
+        let child = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, format!("`{}` has no expression child", node.rule_name)))?;
+        self.lower_node(child, depth + 1)
+    }
+
+    fn lower_child(&mut self, child: &ASTNodeOrToken, depth: usize) -> Result<Expr, MapleLowerError> {
+        match child {
+            ASTNodeOrToken::Node(node) => self.lower_node(node, depth),
+            ASTNodeOrToken::Token(token) => self.lower_token(token),
+        }
+    }
+
+    fn lower_child_nodes(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Vec<Expr>, MapleLowerError> {
+        child_nodes(node).map(|n| self.lower_node(n, depth)).collect()
+    }
+
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        Span::new(
+            FILE,
+            node.start_line.unwrap_or(1),
+            node.start_column.unwrap_or(1),
+            node.end_line.unwrap_or(node.start_line.unwrap_or(1)),
+            node.end_column.unwrap_or(node.start_column.unwrap_or(1)),
+        )
+    }
+
+    fn token_span(&self, token: &Token) -> Span {
+        Span::point(FILE, token.line, token.column)
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> MapleLowerError {
+        MapleLowerError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers (no `&mut self` needed)
+// ---------------------------------------------------------------------------
+
+/// Collect the *node* children of `node` (dropping tokens).
+fn child_nodes(node: &GrammarASTNode) -> impl Iterator<Item = &GrammarASTNode> {
+    node.children.iter().filter_map(as_node)
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+/// Map an arithmetic token type to its canonical IR head — the exact
+/// heads `symbolic_vm::handlers::build_handler_table` wires and
+/// `maple-runtime::lower` itself already uses. Note `TIMES`, matching
+/// `maple.tokens`'s own spelling of the multiplication token (same as
+/// Reduce's/Derive's `TIMES`, not Macsyma's `STAR`).
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a comparison token to its canonical IR head. Every comparison
+/// operator in this subset is a symbolic (punctuation) token TYPE —
+/// unlike Reduce's `neq` keyword (matched by literal *value*), Maple
+/// spells not-equal `<>` (`NEQ`), so no value-based check is needed
+/// alongside the type-based ones — mirrors `maple-runtime::
+/// comparison_head`'s identical purely-type-based table.
+fn comparison_head(token: &Token) -> Option<&'static str> {
+    match token_type(token) {
+        "EQ" => Some(EQUAL),
+        "NEQ" => Some(NOT_EQUAL),
+        "LESS" => Some(LESS),
+        "GREATER" => Some(GREATER),
+        "LE" => Some(LESS_EQUAL),
+        "GE" => Some(GREATER_EQUAL),
+        _ => None,
+    }
+}
+
+/// Bridge a Maple *surface* builtin call-head name to the canonical IR
+/// head it's already implemented under. Per the module doc comment's
+/// "diff/int" section, this subset's *only* such bridge is calculus
+/// (`diff`→`D`, `int`→`Integrate`) — mirrors `maple-runtime::
+/// surface_head_to_ir`'s identical two-entry table exactly. A head not
+/// in this table (a user-defined function, or any of MA09 §4's deferred
+/// `cas-*` surface, e.g. `sin`/`solve`/`piecewise`) is returned
+/// unchanged, so it stays a harmless unevaluated symbolic call.
+fn standard_function(name: &str) -> Option<&'static str> {
+    match name {
+        "diff" => Some(D),
+        "int" => Some(INTEGRATE),
+        _ => None,
+    }
+}
+
+/// Measure `expr`'s true tree depth **iteratively**, using an explicit
+/// heap-allocated work stack rather than native recursion, so calling
+/// this can never itself overflow the stack no matter how deep `expr`
+/// already is. Building a deeply-nested `Box`-based tree only costs heap
+/// space (each construction step is O(1) stack); the risk this guards
+/// against is only in *walking* it recursively afterward.
+///
+/// Returns `None` as soon as the depth is certain to exceed
+/// `MAX_EXPR_DEPTH`, `Some(depth)` otherwise.
+///
+/// Only needs a match arm for [`Expr::SymApply`] (recursing into `head`
+/// and `args`) — every other `Expr` variant is a leaf for this crate's
+/// purposes, since (per the module doc comment's scope note) this crate
+/// can never construct a `SymPatternBlank`/`SymPatternNamed`/`SymRule`/
+/// `SymReplaceAll` node in the first place (Maple's grammar has no
+/// pattern-matching or rewrite-rule syntax at all). `If`/`Assign`/
+/// `Define`/`Set` are all `SymApply` with a different head symbol or
+/// bracket, not new `Expr` variants, so this one match arm already
+/// covers them.
+///
+/// This is the authoritative depth check every other guard in this file
+/// (`MAX_EXPR_DEPTH`'s recursion-depth parameter, [`Lowerer::
+/// check_chain_length`], [`Lowerer::check_elif_chain_length`]) is only
+/// an early, cheap approximation of — those guards are each scoped to
+/// one grammar node and do not compose across nested `(...)` boundaries
+/// (see `wolfram-to-semantic-ir`'s `CHANGELOG.md` for the security-review
+/// finding this mirrors). Called once per top-level statement in
+/// [`Lowerer::lower_file`], so no tree this crate hands to a caller can
+/// ever actually exceed `MAX_EXPR_DEPTH`, regardless of how its
+/// construction was composed.
+fn measure_depth_iterative(expr: &Expr) -> Option<usize> {
+    let mut stack: Vec<(&Expr, usize)> = vec![(expr, 0)];
+    let mut max_depth = 0;
+    while let Some((node, d)) = stack.pop() {
+        if d > MAX_EXPR_DEPTH {
+            return None;
+        }
+        max_depth = max_depth.max(d);
+        if let Expr::SymApply { head, args, .. } = node {
+            stack.push((head, d + 1));
+            for a in args {
+                stack.push((a, d + 1));
+            }
+        }
+    }
+    Some(max_depth)
+}
+
+/// Tear down a rejected, pathologically-deep `Expr` tree **iteratively**,
+/// so freeing it can never itself overflow the stack — unlike simply
+/// letting `expr` fall out of scope, which invokes `Expr`/`Box<Expr>`'s
+/// ordinary *recursive* compiler-derived `Drop` glue. `wolfram-to-
+/// semantic-ir`'s security-review history confirmed this is a real,
+/// exploitable crash (empirically, via an isolated subprocess) — moving a
+/// pathologically deep tree past [`measure_depth_iterative`]'s detection
+/// only to then let it drop normally just relocates the same native stack
+/// overflow from "walking the tree forward" to "walking it backward".
+///
+/// The technique: take ownership of `expr`, and for the one nested
+/// recursive field this crate's trees can ever have (`SymApply`'s
+/// `head`/`args`), *move* those fields out onto an explicit heap-
+/// allocated work stack instead of leaving them in place to be dropped as
+/// part of the outer match's scrutinee. Only needs the `Expr::SymApply`
+/// arm for the same scope reason [`measure_depth_iterative`] documents.
+fn drop_iterative(expr: Expr) {
+    let mut stack: Vec<Expr> = vec![expr];
+    while let Some(node) = stack.pop() {
+        if let Expr::SymApply { head, args, .. } = node {
+            stack.push(*head);
+            stack.extend(args);
+        }
+        // `node`'s own shell drops here — shallowly, since its only
+        // nested `Expr` field (if any) was already moved out onto
+        // `stack` above.
+    }
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with
+/// structure (or a leaf token). A precedence-cascade rule that did not
+/// apply its operator still emits its own node with exactly one child —
+/// this skips straight to the rule that actually matters (mirrors
+/// `maple-runtime::unwrap_single`/`reduce-to-semantic-ir::unwrap_single`
+/// exactly — the shared `parser::GrammarParser` engine's node shape is
+/// identical across every grammar built on it).
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}

--- a/code/packages/rust/maple-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/maple-to-semantic-ir/tests/e2e_node.rs
@@ -1,0 +1,150 @@
+//! End-to-end round-trip: Maple → SIR → JavaScript → `node`.
+//!
+//! Mirrors `reduce-to-semantic-ir`'s (and `derive-to-semantic-ir`'s /
+//! `wolfram-to-semantic-ir`'s / `macsyma-to-semantic-ir`'s) own
+//! `tests/e2e_node.rs` harnesses: lower a Maple program to SIR with this
+//! crate, validate the module, emit JavaScript with the merged
+//! `semantic-ir-to-javascript` backend (a dev-dependency), write it to a
+//! temp file, and **execute it with `node`**.
+//!
+//! # Why these tests check "runs cleanly", not a printed value
+//!
+//! See `wolfram-to-semantic-ir/tests/e2e_node.rs`'s own module doc
+//! comment for the full explanation — the same "everything is symbolic
+//! data" design applies here (`lower.rs`'s module doc comment): a Maple
+//! program never produces a host-language computed value through this
+//! pipeline, so there is no `disp`-equivalent stdout to assert on. These
+//! tests prove instead that every one of these programs compiles to
+//! JavaScript that `node` actually executes without throwing — genuine,
+//! executable confirmation that the SIR23 codegen `semantic-ir-to-
+//! javascript` implements handles the shapes this frontend emits,
+//! including the construct with no `symbolic-vm` evaluation handler at
+//! all (the `Set` head — see `tests/test_validator.rs`'s own module doc
+//! comment for why that gap is moot for pure data construction/codegen).
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use maple_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_via_node(name: &str, src: &str) {
+    let module = compile_source(src, "prog").expect("lowering should succeed");
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    let artifact = semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("maple_sir_e2e_{name}_{}.js", std::process::id()));
+    // See `matlab-to-semantic-ir`'s / `reduce-to-semantic-ir`'s identical
+    // helper for why `create_new` (not `std::fs::write`) is used here: it
+    // fails loudly on an existing path (including a symlink) instead of
+    // silently following/truncating through it. Each test uses a unique
+    // name+PID, so this should never legitimately collide.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes()).expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn plain_arithmetic_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping plain_arithmetic_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("arithmetic", "1 + 2 * 3;\n");
+}
+
+#[test]
+fn an_arrow_definition_and_call_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping an_arrow_definition_and_call_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node("arrow_def_call", "h := x -> x^2;\nh(3);\n");
+}
+
+#[test]
+fn assignment_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping assignment_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("assignment", "x := 5;\ny := x + 1;\n");
+}
+
+#[test]
+fn lists_and_sets_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping lists_and_sets_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node("lists_sets", "[1, 2, 3];\n{1, 2, 3};\n");
+}
+
+#[test]
+fn if_elif_else_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping if_elif_else_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node(
+        "if_elif_else",
+        "if x > 0 then 1 elif x < 0 then -1 else 0 end if;\nif x then y end if;\n",
+    );
+}
+
+#[test]
+fn boolean_literals_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping boolean_literals_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node("booleans", "true;\nfalse;\ntrue and false;\nnot true;\n");
+}
+
+#[test]
+fn diff_and_int_calls_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping diff_and_int_calls_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node("diff_int", "diff(x^2, x);\nint(x, x);\n");
+}
+
+#[test]
+fn a_complex_multi_statement_program_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_complex_multi_statement_program_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node(
+        "complex",
+        "f := x -> x^2;\ng := (x, y) -> f(x) + y;\nresult := g(3, 1);\n[result, f(2)];\n{result, f(2)};\nif result > 0 then result else 0 end if;\n",
+    );
+}

--- a/code/packages/rust/maple-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/maple-to-semantic-ir/tests/test_lower.rs
@@ -1,0 +1,706 @@
+//! Unit tests asserting exact `Expr` shapes produced by
+//! `maple_to_semantic_ir::compile_source` — one per grammar production,
+//! mirroring `reduce-to-semantic-ir`'s (and `derive-to-semantic-ir`'s /
+//! `wolfram-to-semantic-ir`'s / `macsyma-to-semantic-ir`'s) own
+//! `tests/test_lower.rs` structure. Many individual cases are adapted
+//! directly from `maple-runtime`'s own `#[cfg(test)]` module (the retarget
+//! source), just asserting `semantic_ir::Expr` shapes instead of
+//! `symbolic_ir::IRNode` ones.
+
+use maple_to_semantic_ir::compile_source;
+use semantic_ir::{Expr, Feature, Module, Stmt};
+
+/// Lower a single-statement source to its one top-level `Expr`.
+fn lower_one(src: &str) -> Expr {
+    let module = compile_source(src, "test").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let main = module
+        .functions
+        .iter()
+        .find(|f| f.name == "main")
+        .expect("no main function");
+    assert_eq!(
+        main.body.stmts.len(),
+        1,
+        "expected exactly one statement for {src:?}, got {}",
+        main.body.stmts.len()
+    );
+    match &main.body.stmts[0] {
+        Stmt::ExprStmt { expr, .. } => expr.clone(),
+        other => panic!("expected an ExprStmt, got {other:?}"),
+    }
+}
+
+fn manifest_has(module: &Module, feature: Feature) -> bool {
+    module.manifest.iter().any(|f| f == feature)
+}
+
+fn sym(name: &str) -> Expr {
+    Expr::SymSymbol {
+        name: name.to_string(),
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn int(v: i64) -> Expr {
+    Expr::IntLit {
+        value: v,
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn apply(head: Expr, args: Vec<Expr>) -> Expr {
+    Expr::SymApply {
+        head: Box::new(head),
+        args,
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+/// Equality that ignores spans (every helper above uses a synthetic span;
+/// real lowered spans point at real source positions) — recursively zero
+/// out spans on both sides before comparing.
+fn assert_shape_eq(actual: Expr, expected: Expr) {
+    assert_eq!(strip_spans(actual), strip_spans(expected));
+}
+
+fn strip_spans(expr: Expr) -> Expr {
+    let z = semantic_ir::Span::synthetic();
+    match expr {
+        Expr::IntLit { value, .. } => Expr::IntLit { value, span: z },
+        Expr::FloatLit { value, .. } => Expr::FloatLit { value, span: z },
+        Expr::StrLit { value, .. } => Expr::StrLit { value, span: z },
+        Expr::SymSymbol { name, .. } => Expr::SymSymbol { name, span: z },
+        Expr::SymApply { head, args, .. } => Expr::SymApply {
+            head: Box::new(strip_spans(*head)),
+            args: args.into_iter().map(strip_spans).collect(),
+            span: z,
+        },
+        other => other,
+    }
+}
+
+// --- literals ---------------------------------------------------------
+
+#[test]
+fn integer_and_real_literals() {
+    assert_shape_eq(lower_one("42;\n"), int(42));
+    assert_shape_eq(
+        lower_one("1.5;\n"),
+        Expr::FloatLit {
+            value: 1.5,
+            span: semantic_ir::Span::synthetic(),
+        },
+    );
+}
+
+#[test]
+fn bare_symbol_is_symbolic_data() {
+    let module = compile_source("foo;\n", "test").unwrap();
+    assert!(manifest_has(&module, Feature::SymbolicExpr));
+    assert_shape_eq(lower_one("foo;\n"), sym("foo"));
+}
+
+#[test]
+fn bare_trailing_statement_with_no_terminator_lowers() {
+    // `program = { statement_line } [ statement ]` -- the optional final
+    // bare statement outside the repetition (no trailing `;`/`:`).
+    assert_shape_eq(lower_one("42"), int(42));
+}
+
+#[test]
+fn colon_terminator_is_not_distinguished_from_semicolon() {
+    // The `;`-vs-`:` display distinction is a runtime/session concept,
+    // not something this frontend tracks -- both lower identically to a
+    // plain `Stmt::ExprStmt` (see lower.rs's module doc comment).
+    assert_shape_eq(lower_one("42:\n"), int(42));
+}
+
+// --- booleans (the first literal true/false TOKENS in this CAS family) ---
+
+#[test]
+fn boolean_literals_bridge_to_the_shared_true_false_symbols() {
+    assert_shape_eq(lower_one("true;\n"), sym("True"));
+    assert_shape_eq(lower_one("false;\n"), sym("False"));
+}
+
+// --- arithmetic: REAL heads (Add/Sub/Mul/Div/Pow/Neg) ---------------------
+
+#[test]
+fn additive_lowers_to_add_apply() {
+    assert_shape_eq(lower_one("1 + 2;\n"), apply(sym("Add"), vec![int(1), int(2)]));
+}
+
+#[test]
+fn subtraction_is_left_associative() {
+    assert_shape_eq(
+        lower_one("a - b - c;\n"),
+        apply(sym("Sub"), vec![apply(sym("Sub"), vec![sym("a"), sym("b")]), sym("c")]),
+    );
+}
+
+#[test]
+fn mixed_additive_chain_folds_left_by_operator() {
+    // a + b - c  ->  Sub(Add(a, b), c)
+    assert_shape_eq(
+        lower_one("a + b - c;\n"),
+        apply(sym("Sub"), vec![apply(sym("Add"), vec![sym("a"), sym("b")]), sym("c")]),
+    );
+}
+
+#[test]
+fn multiplication_requires_explicit_star_and_lowers_to_mul() {
+    assert_shape_eq(lower_one("a * b;\n"), apply(sym("Mul"), vec![sym("a"), sym("b")]));
+}
+
+#[test]
+fn division_lowers_to_div() {
+    assert_shape_eq(lower_one("a / b;\n"), apply(sym("Div"), vec![sym("a"), sym("b")]));
+}
+
+#[test]
+fn power_operator_lowers_to_pow() {
+    assert_shape_eq(lower_one("a ^ b;\n"), apply(sym("Pow"), vec![sym("a"), sym("b")]));
+}
+
+#[test]
+fn power_is_right_associative() {
+    assert_shape_eq(
+        lower_one("a ^ b ^ c;\n"),
+        apply(sym("Pow"), vec![sym("a"), apply(sym("Pow"), vec![sym("b"), sym("c")])]),
+    );
+}
+
+#[test]
+fn unary_minus_lowers_to_neg_not_times_negative_one() {
+    // -x^2  ->  Neg(Pow(x, 2)) -- binds looser than power.
+    assert_shape_eq(
+        lower_one("-x^2;\n"),
+        apply(sym("Neg"), vec![apply(sym("Pow"), vec![sym("x"), int(2)])]),
+    );
+}
+
+// --- comparisons (all symbolic, punctuation-spelled -- no `neq` keyword) --
+
+#[test]
+fn eq_lowers_to_equal_not_assign() {
+    // `=` is Maple's equation operator, never assignment.
+    assert_shape_eq(lower_one("x = 4;\n"), apply(sym("Equal"), vec![sym("x"), int(4)]));
+}
+
+#[test]
+fn every_comparison_operator_lowers_to_its_head() {
+    assert_shape_eq(lower_one("a < b;\n"), apply(sym("Less"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a > b;\n"), apply(sym("Greater"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a <= b;\n"), apply(sym("LessEqual"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(
+        lower_one("a >= b;\n"),
+        apply(sym("GreaterEqual"), vec![sym("a"), sym("b")]),
+    );
+    // `<>` -- Maple's symbolic not-equal, unlike Reduce's word `neq`.
+    assert_shape_eq(lower_one("a <> b;\n"), apply(sym("NotEqual"), vec![sym("a"), sym("b")]));
+}
+
+// --- logic: lowercase keywords -----------------------------------------
+
+#[test]
+fn boolean_keywords_lower_to_and_or_not() {
+    assert_shape_eq(lower_one("a and b;\n"), apply(sym("And"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a or b;\n"), apply(sym("Or"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("not a;\n"), apply(sym("Not"), vec![sym("a")]));
+}
+
+#[test]
+fn logical_or_chain_folds_n_ary_not_nested_binary() {
+    // a or b or c  ->  Or(a, b, c) -- a flat n-ary apply, not Or(Or(a,b),c).
+    assert_shape_eq(
+        lower_one("a or b or c;\n"),
+        apply(sym("Or"), vec![sym("a"), sym("b"), sym("c")]),
+    );
+}
+
+#[test]
+fn uppercase_keyword_spellings_are_not_special_cased() {
+    // maple.tokens' keywords are lowercase-only -- AND uppercase lexes as
+    // an ordinary NAME.
+    assert_shape_eq(lower_one("AND;\n"), sym("AND"));
+}
+
+// --- grouping --------------------------------------------------------------
+
+#[test]
+fn grouping_parens_lower_transparently() {
+    assert_shape_eq(
+        lower_one("(1 + 2) * 3;\n"),
+        apply(sym("Mul"), vec![apply(sym("Add"), vec![int(1), int(2)]), int(3)]),
+    );
+}
+
+// --- function application (single OPTIONAL call suffix, never chained) ----
+
+#[test]
+fn function_application_of_unknown_head_passes_through() {
+    assert_shape_eq(lower_one("f(a, b);\n"), apply(sym("f"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("f();\n"), apply(sym("f"), vec![]));
+}
+
+#[test]
+fn nested_function_calls_lower_correctly() {
+    assert_shape_eq(
+        lower_one("log(exp(x));\n"),
+        apply(sym("log"), vec![apply(sym("exp"), vec![sym("x")])]),
+    );
+}
+
+#[test]
+fn postfix_call_is_not_chainable() {
+    // f(x)(y) is a SYNTAX ERROR in this subset -- maple.grammar's own
+    // `postfix = atom [ LPAREN [ arglist ] RPAREN ]` allows at most ONE
+    // call suffix (unlike Reduce's/Derive's repeated `{ ... }` chain).
+    assert!(compile_source("f(x)(y);\n", "test").is_err());
+}
+
+// --- diff/int bridge to D/Integrate (MA09 §2/§5) --------------------------
+
+#[test]
+fn diff_bridges_to_d() {
+    assert_shape_eq(
+        lower_one("diff(x^2, x);\n"),
+        apply(sym("D"), vec![apply(sym("Pow"), vec![sym("x"), int(2)]), sym("x")]),
+    );
+}
+
+#[test]
+fn int_bridges_to_integrate() {
+    assert_shape_eq(
+        lower_one("int(x, x);\n"),
+        apply(sym("Integrate"), vec![sym("x"), sym("x")]),
+    );
+}
+
+#[test]
+fn elementary_function_names_are_not_bridged() {
+    // Unlike diff/int -- MA09 §2/§5 names only the calculus bridge, so
+    // `sin` stays lowercase and unresolved.
+    assert_shape_eq(lower_one("sin(x);\n"), apply(sym("sin"), vec![sym("x")]));
+}
+
+// --- assignment / arrow-operator definition: pure data, no host binding ---
+
+#[test]
+fn variable_assignment_lowers_to_assign() {
+    assert_shape_eq(lower_one("x := 5;\n"), apply(sym("Assign"), vec![sym("x"), int(5)]));
+    let module = compile_source("x := 5;\n", "test").unwrap();
+    assert!(manifest_has(&module, Feature::SymbolicExpr));
+}
+
+#[test]
+fn arrow_definition_with_two_params_lowers_to_define() {
+    assert_shape_eq(
+        lower_one("f := (x, y) -> x + y;\n"),
+        apply(
+            sym("Define"),
+            vec![
+                sym("f"),
+                apply(sym("List"), vec![sym("x"), sym("y")]),
+                apply(sym("Add"), vec![sym("x"), sym("y")]),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn arrow_definition_with_one_bare_param_lowers_to_define() {
+    assert_shape_eq(
+        lower_one("f := x -> x^2;\n"),
+        apply(
+            sym("Define"),
+            vec![
+                sym("f"),
+                apply(sym("List"), vec![sym("x")]),
+                apply(sym("Pow"), vec![sym("x"), int(2)]),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn arrow_definition_with_zero_params_lowers_to_define_with_empty_list() {
+    assert_shape_eq(
+        lower_one("f := () -> 5;\n"),
+        apply(sym("Define"), vec![sym("f"), apply(sym("List"), vec![]), int(5)]),
+    );
+}
+
+#[test]
+fn plain_assignment_of_a_variable_does_not_produce_define() {
+    assert_shape_eq(lower_one("f := x;\n"), apply(sym("Assign"), vec![sym("f"), sym("x")]));
+}
+
+#[test]
+fn remember_table_spelling_is_rejected() {
+    // f(x) := e (Maple's narrower remember-table spelling, MA09 §1/§4)
+    // fails to PARSE in this subset -- the grammar's assignment LHS is a
+    // bare NAME token, full stop. See lower.rs's module doc comment.
+    assert!(compile_source("f(x) := 5;\n", "test").is_err());
+}
+
+#[test]
+fn chained_assignment_is_rejected() {
+    // a := b := c is a syntax error here -- unlike Reduce's own
+    // self-referential `assignment = logical_or [ ASSIGN assignment ]`,
+    // Maple's RHS of `NAME ASSIGN (...)` is `arrow_def | expr`, and
+    // `expr` never reaches back to `assignment`.
+    assert!(compile_source("a := b := 5;\n", "test").is_err());
+}
+
+// --- `if`/`elif`/`else`/`end if` (MA09 §3) ---------------------------------
+
+#[test]
+fn if_then_end_if_lowers_to_two_arg_if() {
+    assert_shape_eq(
+        lower_one("if a > 0 then 1 end if;\n"),
+        apply(sym("If"), vec![apply(sym("Greater"), vec![sym("a"), int(0)]), int(1)]),
+    );
+}
+
+#[test]
+fn if_then_else_end_if_lowers_to_three_arg_if() {
+    assert_shape_eq(
+        lower_one("if a > 0 then 1 else -1 end if;\n"),
+        apply(
+            sym("If"),
+            vec![
+                apply(sym("Greater"), vec![sym("a"), int(0)]),
+                int(1),
+                apply(sym("Neg"), vec![int(1)]),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn fi_closing_spelling_lowers_identically_to_end_if() {
+    let end_if = lower_one("if a > 0 then 1 else -1 end if;\n");
+    let fi = lower_one("if a > 0 then 1 else -1 fi;\n");
+    assert_shape_eq(end_if, fi);
+}
+
+#[test]
+fn elif_chain_desugars_to_nested_if() {
+    // if a then 1 elif b then 2 else 3 end if
+    //   -> If(a, 1, If(b, 2, 3))
+    assert_shape_eq(
+        lower_one("if a then 1 elif b then 2 else 3 end if;\n"),
+        apply(
+            sym("If"),
+            vec![sym("a"), int(1), apply(sym("If"), vec![sym("b"), int(2), int(3)])],
+        ),
+    );
+}
+
+#[test]
+fn elif_chain_with_no_final_else_leaves_the_innermost_if_two_armed() {
+    // if a then 1 elif b then 2 end if -> If(a, 1, If(b, 2))
+    assert_shape_eq(
+        lower_one("if a then 1 elif b then 2 end if;\n"),
+        apply(sym("If"), vec![sym("a"), int(1), apply(sym("If"), vec![sym("b"), int(2)])]),
+    );
+}
+
+#[test]
+fn multiple_elif_arms_fold_right_to_left() {
+    assert_shape_eq(
+        lower_one("if a then 1 elif b then 2 elif c then 3 else 4 end if;\n"),
+        apply(
+            sym("If"),
+            vec![
+                sym("a"),
+                int(1),
+                apply(
+                    sym("If"),
+                    vec![
+                        sym("b"),
+                        int(2),
+                        apply(sym("If"), vec![sym("c"), int(3), int(4)]),
+                    ],
+                ),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn if_can_branch_to_an_assignment() {
+    assert_shape_eq(
+        lower_one("if a then x := 1 else x := 2 end if;\n"),
+        apply(
+            sym("If"),
+            vec![
+                sym("a"),
+                apply(sym("Assign"), vec![sym("x"), int(1)]),
+                apply(sym("Assign"), vec![sym("x"), int(2)]),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn nested_if_resolves_unambiguously() {
+    // if a then if b then c end if else d end if
+    //   -> If(a, If(b, c), d)
+    assert_shape_eq(
+        lower_one("if a then if b then c end if else d end if;\n"),
+        apply(sym("If"), vec![sym("a"), apply(sym("If"), vec![sym("b"), sym("c")]), sym("d")]),
+    );
+}
+
+#[test]
+fn if_is_not_usable_as_an_assignment_rhs() {
+    // Unlike Reduce's own expression-shaped `if`, Maple's `if_expr` sits
+    // in its own `statement` nonterminal, never reachable from `expr` --
+    // `x := if a then 1 end if;` is a syntax error.
+    assert!(compile_source("x := if a then 1 end if;\n", "test").is_err());
+}
+
+// --- lists / sets (MA09 §3/§5) ---------------------------------------------
+
+#[test]
+fn square_bracket_list_literal_lowers_to_list() {
+    assert_shape_eq(
+        lower_one("[a, b, c];\n"),
+        apply(sym("List"), vec![sym("a"), sym("b"), sym("c")]),
+    );
+}
+
+#[test]
+fn empty_list_literal_lowers_to_empty_list() {
+    assert_shape_eq(lower_one("[];\n"), apply(sym("List"), vec![]));
+}
+
+#[test]
+fn curly_brace_set_literal_lowers_to_the_new_set_head() {
+    assert_shape_eq(
+        lower_one("{a, b, c};\n"),
+        apply(sym("Set"), vec![sym("a"), sym("b"), sym("c")]),
+    );
+}
+
+#[test]
+fn empty_set_literal_lowers_to_empty_set() {
+    assert_shape_eq(lower_one("{};\n"), apply(sym("Set"), vec![]));
+}
+
+#[test]
+fn list_and_set_are_genuinely_distinct_heads_for_the_same_elements() {
+    let list = lower_one("[a, b];\n");
+    let set = lower_one("{a, b};\n");
+    assert_ne!(strip_spans(list.clone()), strip_spans(set.clone()));
+    assert_shape_eq(list, apply(sym("List"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(set, apply(sym("Set"), vec![sym("a"), sym("b")]));
+}
+
+// --- multi-statement programs ------------------------------------------------
+
+#[test]
+fn multi_statement_program_lowers_each_line() {
+    let module = compile_source("x := 1; y := 2; x + y;\n", "test").unwrap();
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 3);
+    let Stmt::ExprStmt { expr: first, .. } = &main.body.stmts[0] else {
+        panic!("expected ExprStmt");
+    };
+    assert_shape_eq(first.clone(), apply(sym("Assign"), vec![sym("x"), int(1)]));
+    let Stmt::ExprStmt { expr: third, .. } = &main.body.stmts[2] else {
+        panic!("expected ExprStmt");
+    };
+    assert_shape_eq(third.clone(), apply(sym("Add"), vec![sym("x"), sym("y")]));
+}
+
+#[test]
+fn semicolon_and_colon_terminated_statements_both_lower() {
+    let module = compile_source("x := 1: y := 2;\n", "test").unwrap();
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 2);
+}
+
+#[test]
+fn a_small_maple_program_compiles() {
+    let module = compile_source("f := x -> x*x; f(5); [1, 2, 3];\n", "test").unwrap();
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 3);
+    assert!(matches!(main.body.value, Expr::NilLit { .. }));
+}
+
+// --- error cases --------------------------------------------------------------
+
+#[test]
+fn a_syntax_error_is_reported_as_a_lower_error() {
+    assert!(compile_source("1 +;\n", "test").is_err());
+}
+
+// --- SIR23 hardening bug carried over from wolfram-to-semantic-ir /
+// macsyma-to-semantic-ir / derive-to-semantic-ir / reduce-to-semantic-ir's
+// shipped history: `FloatLit` must observe `Feature::Floats` -------------
+
+#[test]
+fn float_literal_module_validates_and_declares_floats() {
+    let module = compile_source("1.5;\n", "test").unwrap();
+    assert!(
+        manifest_has(&module, Feature::Floats),
+        "a float-literal-only module must declare Feature::Floats"
+    );
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "float-literal module failed semantic_ir::validate: {:?}",
+        report.issues
+    );
+}
+
+// --- recursion-depth / chain-length guards (DoS hardening) -----------------
+//
+// These prove `compile_source` cleanly rejects (not crashes on) input far
+// past `MAX_EXPR_DEPTH` (256) or `maple-parser`'s own `MAX_RULE_DEPTH`
+// (150). Scaled to ~3,000 terms/branches/elements -- comfortably past both
+// caps while staying fast to parse -- mirroring `reduce-to-semantic-ir`'s
+// own scale.
+
+fn additive_chain_source(terms: usize) -> String {
+    format!("{};\n", (0..terms).map(|_| "1").collect::<Vec<_>>().join(" + "))
+}
+
+fn multiplicative_chain_source(terms: usize) -> String {
+    format!("{};\n", (0..terms).map(|_| "1").collect::<Vec<_>>().join(" * "))
+}
+
+fn logical_or_chain_source(terms: usize) -> String {
+    format!("{};\n", (0..terms).map(|_| "a").collect::<Vec<_>>().join(" or "))
+}
+
+fn logical_and_chain_source(terms: usize) -> String {
+    format!("{};\n", (0..terms).map(|_| "a").collect::<Vec<_>>().join(" and "))
+}
+
+fn wide_list_literal_source(elems: usize) -> String {
+    format!("[{}];\n", (0..elems).map(|_| "1").collect::<Vec<_>>().join(", "))
+}
+
+fn wide_set_literal_source(elems: usize) -> String {
+    format!("{{{}}};\n", (0..elems).map(|_| "1").collect::<Vec<_>>().join(", "))
+}
+
+fn wide_arrow_params_source(params: usize) -> String {
+    let names: Vec<String> = (0..params).map(|i| format!("p{i}")).collect();
+    format!("f := ({}) -> 1;\n", names.join(", "))
+}
+
+fn wide_elif_chain_source(arms: usize) -> String {
+    let mut src = String::from("if a then 1 ");
+    for _ in 0..arms {
+        src.push_str("elif a then 1 ");
+    }
+    src.push_str("end if;\n");
+    src
+}
+
+#[test]
+fn a_huge_flat_additive_chain_is_rejected_cleanly_not_crashed() {
+    assert!(compile_source(&additive_chain_source(3_000), "test").is_err());
+}
+
+#[test]
+fn a_huge_flat_multiplicative_chain_is_rejected_cleanly_not_crashed() {
+    assert!(compile_source(&multiplicative_chain_source(3_000), "test").is_err());
+}
+
+#[test]
+fn a_huge_flat_logical_or_chain_is_rejected_cleanly_not_crashed() {
+    assert!(compile_source(&logical_or_chain_source(3_000), "test").is_err());
+}
+
+#[test]
+fn a_huge_flat_logical_and_chain_is_rejected_cleanly_not_crashed() {
+    assert!(compile_source(&logical_and_chain_source(3_000), "test").is_err());
+}
+
+#[test]
+fn a_wide_list_literal_past_the_cap_is_rejected_cleanly_not_crashed() {
+    assert!(compile_source(&wide_list_literal_source(3_000), "test").is_err());
+}
+
+#[test]
+fn a_wide_set_literal_past_the_cap_is_rejected_cleanly_not_crashed() {
+    assert!(compile_source(&wide_set_literal_source(3_000), "test").is_err());
+}
+
+#[test]
+fn a_wide_arrow_params_list_past_the_cap_is_rejected_cleanly_not_crashed() {
+    assert!(compile_source(&wide_arrow_params_source(3_000), "test").is_err());
+}
+
+#[test]
+fn a_wide_elif_chain_past_the_cap_is_rejected_cleanly_not_crashed() {
+    assert!(compile_source(&wide_elif_chain_source(3_000), "test").is_err());
+}
+
+#[test]
+fn a_deeply_parenthesised_expression_is_rejected_cleanly() {
+    let nesting = 5_000;
+    let src = format!("{}0{};\n", "(".repeat(nesting), ")".repeat(nesting));
+    // `maple-parser`'s own `MAX_RULE_DEPTH` trips first on input this
+    // deep; either way this must be a clean Err, never a crash (the
+    // surrounding test process itself is the proof: if this overflowed
+    // the stack, the whole test binary would abort, not fail one
+    // assertion).
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_deeply_nested_not_chain_is_rejected_cleanly() {
+    // `logical_not`'s own right-recursive `"not" logical_not` continuation
+    // is bounded by `maple-parser`'s own `MAX_RULE_DEPTH` (150; the
+    // `not`-chain floor is 218 rule frames, the binding constraint across
+    // all six of that crate's own measured recursion shapes), NOT by any
+    // lowering-side guard in this crate -- see lower.rs's module doc
+    // comment.
+    let levels = 5_000;
+    let src = format!("{}a;\n", "not ".repeat(levels));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_deeply_nested_if_end_if_chain_is_rejected_cleanly() {
+    // Nested `if`/`end if` (each nested inside a `then`-branch) is
+    // likewise bounded by `maple-parser`'s own depth cap, not a
+    // lowering-side guard.
+    let levels = 5_000;
+    let src = format!("{}5{};\n", "if 1 then ".repeat(levels), " end if".repeat(levels));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn an_additive_chain_at_exactly_the_cap_still_compiles() {
+    // MAX_EXPR_DEPTH is 256; 256 operands is exactly at the cap (255
+    // operators), one more trips it.
+    assert!(compile_source(&additive_chain_source(256), "test").is_ok());
+    assert!(compile_source(&additive_chain_source(257), "test").is_err());
+}
+
+#[test]
+fn a_list_literal_at_exactly_the_cap_still_compiles() {
+    assert!(compile_source(&wide_list_literal_source(256), "test").is_ok());
+    assert!(compile_source(&wide_list_literal_source(257), "test").is_err());
+}
+
+#[test]
+fn a_set_literal_at_exactly_the_cap_still_compiles() {
+    assert!(compile_source(&wide_set_literal_source(256), "test").is_ok());
+    assert!(compile_source(&wide_set_literal_source(257), "test").is_err());
+}
+
+#[test]
+fn an_elif_chain_at_exactly_the_cap_still_compiles() {
+    // 256 branches total means the initial `if` plus 255 `elif` arms.
+    assert!(compile_source(&wide_elif_chain_source(255), "test").is_ok());
+    assert!(compile_source(&wide_elif_chain_source(256), "test").is_err());
+}

--- a/code/packages/rust/maple-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/maple-to-semantic-ir/tests/test_validator.rs
@@ -1,0 +1,152 @@
+//! Structural verification of lowered modules: every module this frontend
+//! produces must pass the shared SIR validator (confirming the manifest
+//! declares exactly the SIR23 features the module actually uses — the
+//! same ground truth `semantic-ir/src/validator.rs`'s `check_expr`
+//! enforces node kind for node kind), and every module must be
+//! **accepted** by the JS backend.
+//!
+//! `semantic-ir-to-javascript` already has real SIR23 codegen
+//! (`SymApply`/`SymSymbol`/… lower to calls into the inlined
+//! `__Sir.Symbolic.*` runtime, ported from `sir-runtime-symbolic` — HML01
+//! Stream B rollout items 6-7), confirmed directly by reading
+//! `reduce-to-semantic-ir`'s own *current* `tests/test_validator.rs` and
+//! `tests/e2e_node.rs` bodies (which themselves note the same discipline
+//! against `wolfram-to-semantic-ir`/`macsyma-to-semantic-ir`/
+//! `derive-to-semantic-ir`) rather than trusting any crate's module doc
+//! comment on faith. This file is written directly against that current,
+//! already-shipped behaviour.
+//!
+//! The new `Set` head (MA09 §3/§5) has no evaluation *handler* in the
+//! shared `symbolic-vm` (see `lower.rs`'s module doc comment's "`Set`"
+//! section) — but that is a runtime-evaluation concern, not a SIR
+//! validation or backend-*acceptance* one: it is an ordinary `SymApply`
+//! node with an unusual head *name*, and the JS backend's SIR23 codegen
+//! handles any `SymApply`/`SymSymbol` shape uniformly regardless of head
+//! spelling (it does not special-case individual head names at all,
+//! confirmed by reading `semantic-ir-to-javascript`'s SIR23 `match` arms
+//! directly). So a `Set` literal is still expected to validate and be
+//! accepted here.
+
+use maple_to_semantic_ir::compile_source;
+use semantic_ir::backend::Backend;
+use semantic_ir::Feature;
+use semantic_ir_to_javascript::JavaScriptBackend;
+
+fn assert_valid(src: &str) -> semantic_ir::Module {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for `{src}`: {:?}",
+        report.issues
+    );
+    module
+}
+
+fn assert_js_backend_accepts(module: &semantic_ir::Module) {
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a module using only SIR23 features \
+         (codegen for them has been implemented since HML01 Stream B rollout item 7): {errors:?}"
+    );
+}
+
+#[test]
+fn bare_arithmetic_validates_and_declares_symbolic_expr() {
+    let module = assert_valid("1 + 2;\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_bare_symbol_alone_validates_and_declares_symbolic_expr() {
+    let module = assert_valid("x;\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn an_arrow_definition_and_call_validates() {
+    let module = assert_valid("h := x -> x*x;\nh(3);\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    // Confirms the disclosed scope boundary: Maple's grammar has no
+    // pattern-matching syntax in this subset, so this feature is never
+    // observed, even for a function-definition construct.
+    assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn assignment_is_pure_data_and_still_validates() {
+    let module = assert_valid("x := 5;\ny := x + 1;\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn lists_and_sets_both_validate_as_symbolic_data() {
+    let module = assert_valid("[1, 2, 3];\n{1, 2, 3};\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_set_literal_alone_validates_despite_no_shared_vm_handler() {
+    // `Set` has no evaluation handler in the shared `symbolic-vm` (see
+    // lower.rs's module doc comment) -- still expected to validate/be
+    // accepted, since this is a structural concern (an ordinary SymApply
+    // node), not an evaluation one.
+    let module = assert_valid("{1, 2, 3};\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn if_elif_else_expression_validates() {
+    let module = assert_valid("if x > 0 then 1 elif x < 0 then -1 else 0 end if;\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn boolean_literals_validate() {
+    let module = assert_valid("true;\nfalse;\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn diff_and_int_calls_validate() {
+    let module = assert_valid("diff(x^2, x);\nint(x, x);\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_float_literal_module_validates_and_declares_floats() {
+    // A BARE float literal alone (no arithmetic wrapping it) emits no
+    // SIR23 node at all -- it is just a plain SIR16 `FloatLit`, which the
+    // JS backend has always accepted on its own, so it alone wouldn't
+    // exercise the `Feature::SymbolicExpr` manifest assertion this test
+    // also makes. Pairing it with a genuine symbolic construct keeps this
+    // test consistent with the rest of the file while still confirming
+    // `Feature::Floats` is declared.
+    let module = assert_valid("1.5;\nx + 1;\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::Floats));
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_complex_multi_statement_program_validates_end_to_end() {
+    let module = assert_valid(
+        "f := x -> x*x;\ng := (x, y) -> f(x) + y;\nresult := g(3, 1);\n[result, f(2)];\n{result, f(2)};\nif result > 0 then result else 0 end if;\n",
+    );
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_accepts(&module);
+}

--- a/code/specs/HML01-math-to-semantic-ir.md
+++ b/code/specs/HML01-math-to-semantic-ir.md
@@ -196,6 +196,42 @@ pub fn compile_source(source: &str, module_name: &str)
   anything), confirmed structurally accepted by the JS backend's
   head-name-agnostic `SymApply` codegen regardless. Also round-trips
   through `node` from v0.1.0.
+- **`maple-to-semantic-ir`** (✅ v0.1.0 shipped) — walks the
+  `maple-parser` CST using the same rule-name dispatch already proven in
+  `maple-runtime` (`"assignment"`, `"arrow_def"`, `"if_expr"`,
+  `"postfix"`, `"set_literal"`, …), emits SIR23 nodes. Same "everything is
+  symbolic data" design as the other four (this grammar has no
+  pattern-matching syntax in this subset either, verified directly
+  against `maple.grammar`/`maple.tokens` — the `ARROW` token exists but
+  only for `arrow_def`, never a pattern-rule arrow — not just trusted
+  from `maple-runtime`'s own doc comment). Much of the lowering is a
+  direct copy of `reduce-to-semantic-ir`'s shape (both languages are
+  "surface operators + `head(args)` calls" with no pattern vocabulary),
+  but `maple.grammar` draws a REAL structural line Reduce's grammar does
+  not: `statement = if_expr | assignment` sits in its own nonterminal,
+  never reachable from `expr` at all, so `if`/`:=` can never nest inside
+  an arithmetic/comparison/logical operand the way Reduce's can
+  (`x := if a then 1 end if;` and `a := b := c;` are both syntax errors).
+  Assignment's left-hand side is a bare `NAME` token only — Maple's
+  `f(x) := expr` means a narrower remember-table patch in real Maple
+  (MA09 §1/§4), so the grammar rejects it outright rather than pushing an
+  interpretation question onto this frontend — general function
+  definition instead uses a dedicated `arrow_def`/`arrow_params`
+  production (`f := (x, y) -> x + y`) lowering to the same `Define` shape
+  Derive/Reduce use. `if`/`elif`/`else` right-folds like Macsyma's own
+  elif chain (unlike Reduce's simpler 2-or-3-child `if`), guarded by a
+  new `check_elif_chain_length`. Introduces `Set` (`{a,b,c}`, unordered)
+  as a canonical head genuinely new to this repo — Maple is the first
+  language here with two distinct bracketed aggregate literals (`[a,b,c]`
+  → shared `List`, `{a,b,c}` → new local `Set`) — plus the first literal
+  `true`/`false` boolean TOKENS in this CAS family (bridged to the shared
+  backend's pre-bound `True`/`False` symbols). `postfix` is deliberately
+  NOT chainable (`f(x)(y)` fails to parse), so this is the first SIR23
+  frontend needing no `check_postfix_chain_length`-equivalent guard at
+  all. Also round-trips through `node` from v0.1.0. **This closes Stream
+  B's previously-tracked language list** — every math-CAS language this
+  spec names (Wolfram, Macsyma, Maxima, Derive, Reduce, Maple) now has a
+  shipped SIR23 frontend.
 - **`apl-to-semantic-ir`** (✅ v0.1.0 shipped, MA-4f) — the first Stream A
   frontend beyond MATLAB/Octave, confirming the array/matrix domain
   generalizes past the language it was designed against; emits SIR22 nodes
@@ -273,17 +309,19 @@ array operands, and a hard crash on `× ÷ ⌈ ⌊`), all still open — see tha
 crate's `CHANGELOG.md`. J's own oracle tests remain an open follow-on item.
 All items through JS/TS backend codegen are shipped.
 
-**Stream B (symbolic/CAS, backs Wolfram/Macsyma/Maxima/Derive/Reduce and
-future Maple):** `SIR23` spec → `semantic-ir` core additions →
+**Stream B (symbolic/CAS, backs Wolfram/Macsyma/Maxima/Derive/Reduce/
+Maple):** `SIR23` spec → `semantic-ir` core additions →
 `wolfram-to-semantic-ir` → `macsyma-to-semantic-ir` → `maxima-to-semantic-ir`
-→ `derive-to-semantic-ir` → `reduce-to-semantic-ir` → `sir-runtime-symbolic`
-→ JS/TS backend codegen → golden/oracle tests (in progress — real
-`node`-execution proof shipped for `wolfram-to-semantic-ir`,
-`macsyma-to-semantic-ir`, `derive-to-semantic-ir`, and
-`reduce-to-semantic-ir` via each crate's `tests/e2e_node.rs`; a true
-oracle diff against each language's native runtime remains open;
-`maple-to-semantic-ir` remains an open follow-on item).
-All items through JS/TS backend codegen are shipped.
+→ `derive-to-semantic-ir` → `reduce-to-semantic-ir` → `maple-to-semantic-ir`
+→ `sir-runtime-symbolic` → JS/TS backend codegen → golden/oracle tests (in
+progress — real `node`-execution proof shipped for `wolfram-to-semantic-ir`,
+`macsyma-to-semantic-ir`, `derive-to-semantic-ir`, `reduce-to-semantic-ir`,
+and `maple-to-semantic-ir` via each crate's `tests/e2e_node.rs`; a true
+oracle diff against each language's native runtime remains the one open
+item). **All five frontends this stream's own language list names are now
+shipped** — `maple-to-semantic-ir` was the last open follow-on item and is
+done as of this crate landing. All items through JS/TS backend codegen are
+shipped.
 
 The streams touch disjoint crates except `semantic-ir` core and the two JS
 backends — a short serialization point, not a merge of the whole effort.


### PR DESCRIPTION
## Summary

Completes the Semantic-IR frontend gap: after `derive-to-semantic-ir` (#8653) and `reduce-to-semantic-ir` (#8657), this PR adds `maple-to-semantic-ir`, the last remaining language. **Every math-CAS language HML01 names — Wolfram, Macsyma, Maxima, Derive, Reduce, Maple — now has a shipped SIR23 frontend.**

- New crate `maple-to-semantic-ir` — retargets `maple-runtime`'s existing `symbolic_ir::IRNode` lowering onto `semantic_ir::Expr`'s SIR23 vocabulary, mirroring `reduce-to-semantic-ir`'s closest-sibling shape.
- **Scope boundary, verified empirically** against `maple.grammar`/`maple.tokens`: no pattern-matching syntax — the `ARROW` token exists but only for `arrow_def` (function definition), never a pattern-rule arrow. The crate only ever constructs `SymSymbol`/`SymApply`, never declares `Feature::PatternMatching`.
- **A real structural difference from Reduce**: `statement = if_expr | assignment` sits in its own nonterminal, never reachable from `expr` — so `if`/`:=` can never nest inside an arithmetic/comparison/logical operand the way Reduce's can (`x := if a then 1 end if;` and `a := b := c;` are both syntax errors, confirmed by regression tests).
- **Assignment's LHS is a bare `NAME` token only** — Maple's `f(x) := expr` means a narrower remember-table patch in real Maple, so the grammar rejects it outright rather than pushing an interpretation question onto this frontend. General function definition instead uses a dedicated `arrow_def`/`arrow_params` production (`f := (x, y) -> x + y`), lowering to the same `Define` shape Derive/Reduce use.
- **`if`/`elif`/`else` right-folds** like Macsyma's own elif chain (unlike Reduce's simpler 2-or-3-child `if`), guarded by a new `check_elif_chain_length`.
- **Introduces `Set`** (`{a,b,c}`, unordered) as a canonical head genuinely new to this repo — Maple is the first language here with two distinct bracketed aggregate literals (`[a,b,c]` → shared `List`, `{a,b,c}` → new local `Set`, since `symbolic-vm` has no shared handler for it).
- **First literal `true`/`false` boolean tokens** in this CAS family (bridged to the shared backend's pre-bound `True`/`False` symbols; verified `symbolic-ir` exports no `TRUE`/`FALSE` constants, so bare string literals are used, matching the sibling crates' precedent).
- **`postfix` is deliberately not chainable** (`f(x)(y)` fails to parse, verified directly against the grammar) — the first SIR23 frontend needing no `check_postfix_chain_length`-equivalent guard at all.
- Recursion-depth hardening carried over proactively (`MAX_EXPR_DEPTH`, chain/elif-chain/arg-count guards, iterative `measure_depth_iterative`/`drop_iterative`).
- `tests/e2e_node.rs` ships real, executing `node` round-trip tests from v0.1.0.
- Updates `code/specs/HML01-math-to-semantic-ir.md`'s language list and Stream B rollout note, marking the stream's tracked language list fully shipped.

## Test plan

- [x] `cargo test -p maple-to-semantic-ir` — 86 tests pass (66 unit, 11 validator/capability, 8 e2e `node`-execution, 1 doctest).
- [x] `cargo clippy -p maple-to-semantic-ir --all-targets -- -D warnings` — clean.
- [x] `cargo build --workspace` — excluding four confirmed pre-existing, environment/platform-specific failures unrelated to this change (`os-kernel` targets UEFI, `paint-vm-direct2d`/`paint-vm-gdi` require Windows, `font-parser-python` fails to link against this host's Python C API — a native-FFI linker-setup issue, not a code regression), the entire remaining workspace builds cleanly.
- [x] `/security-review` — PASSED, no vulnerabilities found. Given the diff size, the reviewer used direct repository access rather than a pasted diff, and specifically verified: the elif-chain right-fold's index arithmetic is provably in-bounds for any valid branch count, the "postfix is not chainable" claim against the actual grammar production, the arrow-params argument-count guard has no gap, every self-referential lowering function threads `depth` correctly, and the iterative depth-measure/teardown pair is structurally identical to the four already-reviewed sibling crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)