### PR TITLE
feat(hl): Spanish Ch.14 — the preterite (the first past tense)

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -225,6 +225,8 @@
       "ES-VERB-PONER": "poner — 'to put/place' (-go yo-form pongo; ← pōnere → position/compose/deposit/postpone; poner la mesa 'set the table', ponerse 'put on/become')",
       "ES-VERB-SALIR": "salir — 'to leave/go out' (-go yo-form salgo; ← salīre 'to leap' → salient/sally/salmon/somersault; la salida 'the exit')",
       "ES-VERB-VENIR": "venir — 'to come' (doubly irregular: -go yo-form vengo + e→ie stem-change vienes/viene; ← venīre → adventure/event/convene; twin of tener)",
+      "ES-PRETERITE-SER-IR": "the preterite of ser AND ir — one shared set fui/fuiste/fue/fuimos/fueron (← Latin fuī, a 2nd 'be' root = English be/future); context decides: fui a=went, fui X=was",
+      "ES-PRETERITE-AR": "the regular -ar preterite — hablé/hablaste/habló/hablamos/hablaron (← Latin perfect -āvī; accent marks the final stress, hablo→habló; hablamos present=preterite)",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -298,6 +300,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, CH14-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 14 — The preterite (the first past tense)
+
+- **Chapter 14 authored** (`ES-C14-ser-ir-preterite`, `-hablar-preterite`,
+  `-practice`): the course's **first past tense**, the everyday **preterite** —
+  reviewing Ch.6/9/10/13 via `reviews_of`.
+- **ser & ir — one shared preterite** (`ES-C14-ser-ir-preterite`):
+  *fui/fuiste/fue/fuimos/fueron* serves **both** verbs, so *fui* = "I **was**" **and**
+  "I **went**," disambiguated only by **context** (*fui a Madrid* = went; *fui
+  profesor* = was). The etymology: *fuī* is the perfect of a **second** Latin "be"
+  root (PIE *\*bʰuH-* "become," cousin of English *be/been/future/physics*) grafted
+  onto *sum/es/est* (**suppletion**, like *go/went*); *ir* then borrowed it after
+  Latin's own past of *īre* wore away — so **"to be" and "to go" merged in the past.**
+- **the regular -ar preterite** (`ES-C14-hablar-preterite`):
+  *hablé/hablaste/habló/hablamos/hablaron* ← Latin perfect *-āvī* (*amāvī→amé*), the
+  *-āv-* dissolving to leave a **stressed final vowel** the accent now marks. The
+  key insight: the **accent carries the tense** (*HAblo* "I speak" vs *hablÓ* "s/he
+  spoke"); plus the *hablamos* present=preterite trap (context / *ayer* disambiguates).
+- **practice** — switches present↔past, drills the accent-flip, and the *ser*-vs-*ir*
+  reading of *fui/fue*.
+- Taxonomy: namespaced `ES-PRETERITE-SER-IR`, `ES-PRETERITE-AR`; practice label
+  `CH14-PRACTICE`.
+
 ## Chapter 13 — Completing the -go club
 
 - **Chapter 13 authored** (`ES-C13-poner`, `-salir`, `-venir`, `-practice`):

--- a/code/learning/human-languages/spanish/lessons/ES-C14-hablar-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-hablar-preterite.md
@@ -1,0 +1,72 @@
+---
+id: ES-C14-hablar-preterite
+chapter: 14
+type: word
+headword: hablé
+gloss: the regular -ar preterite — hablé, hablaste, habló — and why the accent matters
+concept_tag: ES-PRETERITE-AR
+prerequisites: [ES-C14-ser-ir-preterite, ES-C06-hablar]
+sounds: [stress-final, accent-acute]
+roots: [latin-perfect-avi]
+etymology_hook: "the -ar preterite endings -é/-aste/-ó/-amos/-aron ← Latin perfect -āvī/-āvistī/-āvit (amāvī → amé); the written accent on hablé/habló marks the stress Latin put on that final vowel"
+est_minutes: 5
+reviews_of: [ES-C14-ser-ir-preterite, ES-C06-hablar]
+---
+
+# hablé — the regular past, built on an accent
+
+## Warm-up
+
+[PAUSE 2s] *Fui* was irregular; now the **pattern** that covers thousands of verbs.
+Take any regular **-ar** verb, drop the *-ar*, and add the **preterite endings**.
+The whole tense hangs on one small mark: the **accent**.
+
+## Sounds you'll need
+
+- `accent-acute` — the written **´** marks the **stressed** vowel: **habl-É**,
+  **habl-Ó**. Say the stress at the very end and the past tense announces itself.
+
+## The regular -ar preterite
+
+Drop *-ar* from **hablar** ("to speak") and add:
+
+| yo | **hablé** | (accent on é) |
+| tú | **hablaste** | |
+| él/ella/usted | **habló** | (accent on ó) |
+| nosotros | **hablamos** | (no accent) |
+| ellos/ustedes | **hablaron** | |
+
+Compare it with the **present** you learned in Chapter 6 — *hablo, hablas, habla*
+— and the difference is almost entirely **where the stress lands**: *HABlo* (I
+speak, now) vs *hablÉ* (I spoke, done). The accent is not decoration; it **carries
+the tense**.
+
+## Where the endings come from
+
+These endings are worn-down Latin **perfect** forms. Latin *amāvī* ("I loved")
+→ *amé*; *amāvistī* → *amaste*; *amāvit* → *amó*. The *-āv-* dissolved and left the
+**stressed final vowel** that Spanish now crowns with an accent. So *hablé* is
+*(fabulāvī)* with the middle chewed away — the same erosion you've watched all
+along, applied to a whole tense.
+
+## One trap — hablamos
+
+**hablamos** is the **same** in present and preterite ("we speak" / "we spoke").
+Only **context** — or a time-word like *ayer* ("yesterday") — tells them apart:
+*hablamos ayer* = "we spoke yesterday."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the set — "hablé, hablaste, habló, hablamos, hablaron" — hit the end]
+- [YOU SAY: present vs past — "hablo / hablé", "habla / habló" — the accent flips it]
+- [YOU SAY: "Ayer hablé con María" ("Yesterday I spoke with María")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the *-ar* preterite of *hablar*. (*Hablé, hablaste, habló,
+hablamos, hablaron*.) What single feature separates *hablo* (present) from *habló*
+(preterite)? (The **accent** — where the **stress** falls.) Which form is
+identical in present and preterite, and what disambiguates it? (*Hablamos* —
+**context** / a time-word like *ayer*.) Next: **practice** — past vs present, side
+by side.

--- a/code/learning/human-languages/spanish/lessons/ES-C14-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-practice.md
@@ -1,0 +1,64 @@
+---
+id: ES-C14-practice
+chapter: 14
+type: practice-mix
+headword: (practice)
+gloss: past vs present — fui, hablé, and the forms that look the same
+concept_tag: CH14-PRACTICE
+prerequisites: [ES-C14-ser-ir-preterite, ES-C14-hablar-preterite]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C14-ser-ir-preterite, ES-C14-hablar-preterite, ES-C13-practice]
+---
+
+# Practice — the preterite, past against present
+
+## Warm-up
+
+[PAUSE 2s] This chapter gave you the **past**: the shared *ser/ir* preterite
+(*fui*) and the regular *-ar* pattern (*hablé*). Time to switch between now and
+then without stumbling.
+
+## Drill 1 — say the two paradigms
+
+[PAUSE 1s]
+- **fui** (ser/ir): fui · fuiste · fue · fuimos · fueron.
+- **hablé** (regular -ar): hablé · hablaste · habló · hablamos · hablaron.
+
+## Drill 2 — the accent flips the tense
+
+[PAUSE 1s] Say each **present** form, then its **preterite** twin — the stress
+jumps to the end:
+
+- **hablo** (I speak) → **hablé** (I spoke)
+- **habla** (s/he speaks) → **habló** (s/he spoke)
+- **trabajo** (I work) → **trabajé** (I worked)
+
+[PAUSE 2s] What one thing changed? (The **accent** — the stressed syllable moved
+to the **end**.)
+
+## Drill 3 — ser or ir? (context decides)
+
+[PAUSE 1s] For each *fui/fue*, say whether it's "to be" or "to go":
+
+- "**Fui** a la escuela." → ? (**ir** — "I **went**.")
+- "**Fui** estudiante." → ? (**ser** — "I **was** a student.")
+- "Ella **fue** muy amable." → ? (**ser** — "She **was** very kind.")
+- "Ellos **fueron** a España." → ? (**ir** — "They **went**.")
+
+## Drill 4 — put it to use
+
+[PAUSE 1s] Say each out loud:
+
+- "**Ayer hablé con mi madre.**" — "Yesterday I spoke with my mother."
+- "**Fui al mercado y compré pan.**" — "I went to the market and bought bread."
+- "**Fuimos amigos.**" — "We were friends."
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which two verbs share the preterite *fui/fue*? (**ser** and **ir**.)
+How does the accent change *hablo* into *habló*? (It moves the **stress to the
+end** — present → preterite.) In "**Fui a casa**," be/go? (**Go** — *ir*.) You can
+now speak in the **past** — the course has crossed from "what is" to "what
+happened."

--- a/code/learning/human-languages/spanish/lessons/ES-C14-ser-ir-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-ser-ir-preterite.md
@@ -1,0 +1,73 @@
+---
+id: ES-C14-ser-ir-preterite
+chapter: 14
+type: word
+headword: fui
+gloss: the preterite (past) — and the astonishing fact that "I was" and "I went" are the same word
+concept_tag: ES-PRETERITE-SER-IR
+prerequisites: [ES-C13-venir, ES-C09-ser, ES-C10-ir]
+sounds: [diphthong-ui, stress-final]
+roots: [fui-latin]
+etymology_hook: "fui ← Latin fuī 'I have been' (perfect of a second 'be' root — cousin of English BE, future, physics); ser AND ir share this ONE preterite, so fui = 'I was' AND 'I went', context deciding"
+est_minutes: 5
+reviews_of: [ES-C13-venir, ES-C09-ser, ES-C10-ir]
+---
+
+# fui — the past tense arrives, and two verbs become one
+
+## Warm-up
+
+[PAUSE 2s] A big moment: your **first past tense**. Spanish's everyday past is the
+**preterite** — "I spoke, I went, I was." And it opens with the strangest, most
+memorable fact in the whole language: the verbs **ser** ("to be") and **ir** ("to
+go") have the **exact same preterite**. *Fui* means both "**I was**" *and* "**I
+went**."
+
+## Sounds you'll need
+
+- `stress-final` — the preterite loves the **final** syllable: *fui*, *fue*
+  (one-syllable), then *fuiste*, *fuimos*, *fueron*.
+
+## The shared forms
+
+| | ser / ir (same!) |
+|---|---|
+| yo | **fui** |
+| tú | **fuiste** |
+| él/ella/usted | **fue** |
+| nosotros | **fuimos** |
+| ellos/ustedes | **fueron** |
+
+One set of forms, **two verbs**. There is no separate past for "to go" — Spanish
+just reuses "to be."
+
+## Why? A tale of two "be" verbs
+
+**fui** comes from Latin **fuī**, "I have been" — but here is the twist: Latin had
+*two* roots for "to be." The present *sum/es/est* (→ *soy/eres/es*) came from PIE
+**\*es-**; the perfect **fuī** came from a *different* root, PIE **\*bʰuH-**, "to
+grow, become" — the very root of English **be**, **been**, and (through Greek and
+Latin) **future** and **physics**. Spanish stitched the two roots into one verb —
+that's **suppletion**, like English *go/went*.
+
+Then *ir* ("to go") borrowed *fuī* too, because Latin's own past of *īre* had
+worn away. So **"to be" and "to go" merged in the past** — and only **context**
+tells them apart:
+
+- **Fui a Madrid.** — "I **went** to Madrid." (movement → *ir*)
+- **Fui profesor.** — "I **was** a teacher." (state → *ser*)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the set — "fui, fuiste, fue, fuimos, fueron" — stress the end]
+- [YOU SAY: the two meanings — "Fui a casa" (I went) vs "Fui feliz" (I was happy)]
+- [YOU SAY: "same form, context decides — ser and ir share one past"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What tense is *fui*, and which **two** verbs does it belong to? (The
+**preterite** — both **ser** and **ir**.) Give all five forms. (*Fui, fuiste, fue,
+fuimos, fueron*.) In "**Fui a España**," is it *ser* or *ir*, and how do you know?
+(*Ir* — "I **went**"; the *a* + place signals movement.) Next: the **regular** -ar
+preterite — *hablé, hablaste*.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -95,10 +95,18 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   twin of *tener*) → practice recapping all six (*tengo/hago/digo/pongo/salgo/
   vengo*). **Authored.**
 
-Next: **Ch. 14** — everyday description and more high-frequency irregulars (the
-*ir/ser* preterite), building toward real conversation. From here the course hands
-over rules, not phrases. Grammar accumulates piece by piece. The theme skeleton
-below plans the wider road.
+- **Ch. 14 — The preterite (the first past tense)**: the biggest tense-jump so far.
+  **ser & ir share ONE preterite** — *fui/fuiste/fue/fuimos/fueron* (← Latin *fuī*,
+  a second "be" root, cousin of English *be/future*), so *fui* means both "I was"
+  and "I went," context deciding (*fui a X* = went; *fui X* = was) → the **regular
+  -ar preterite** *hablé/hablaste/habló/hablamos/hablaron* (← Latin perfect *-āvī*;
+  the **accent** carries the tense, *hablo→habló*; *hablamos* present=preterite) →
+  practice switching present↔past. **Authored.**
+
+Next: **Ch. 15** — more of the past (regular *-er/-ir* preterite, *tener/hacer*
+irregular preterites) and everyday description, building toward real conversation.
+From here the course hands over rules, not phrases. Grammar accumulates piece by
+piece. The theme skeleton below plans the wider road.
 
 ## Theme Skeleton (planning only)
 


### PR DESCRIPTION
## What

Spanish **Chapter 14** (`ES-C14-ser-ir-preterite/hablar-preterite/practice`) — the course's **first past tense**, the everyday **preterite**. A major milestone: the curriculum crosses from "what is" to "what happened." Reviews Ch.6/9/10/13.

## The lessons

| Lesson | Content |
|---|---|
| **ser & ir — one shared preterite** | *fui/fuiste/fue/fuimos/fueron* serves **both** verbs, so **fui = "I was" *and* "I went"**, told apart only by context (*fui a Madrid* = went; *fui profesor* = was). The etymology: *fuī* is the perfect of a **second** Latin "be" root (PIE *\*bʰuH-* "become," cousin of English *be/future/physics*) grafted onto *sum/es/est* — **suppletion**, like *go/went* — and *ir* borrowed it after Latin's own past of *īre* wore away, so **"to be" and "to go" merged in the past.** |
| **the regular -ar preterite** | *hablé/hablaste/habló/hablamos/hablaron* ← Latin perfect *-āvī* (*amāvī→amé*). The key insight: the **accent carries the tense** — *HAblo* "I speak" vs *hablÓ* "s/he spoke"; plus the *hablamos* present=preterite trap. |
| **practice** | Switches present↔past, drills the accent-flip, and the *ser*-vs-*ir* reading of *fui/fue*. |

## Housekeeping
- Taxonomy: namespaced `ES-PRETERITE-SER-IR`, `ES-PRETERITE-AR` + `CH14-PRACTICE`.
- `spanish/CHANGELOG.md` (Ch.14) and `roadmap.md` (Ch.14 authored, Next = Ch.15).
- Suite **38/38**; `taxonomy.json` valid; no retired `concept_tag`s; security-reviewed (Markdown + JSON only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)