### PR TITLE
Add Haskell paint-vm-ascii port

### DIFF
--- a/code/packages/haskell/paint-vm-ascii/BUILD
+++ b/code/packages/haskell/paint-vm-ascii/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/paint-vm-ascii/BUILD_windows
+++ b/code/packages/haskell/paint-vm-ascii/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/paint-vm-ascii/CHANGELOG.md
+++ b/code/packages/haskell/paint-vm-ascii/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add configurable terminal-cell scaling with shared 8-by-16 defaults.
+- Render visible filled rectangles with clipping and whitespace trimming.
+- Reject unsupported path instructions explicitly.
+- Validate scales, scene dimensions, and rectangle geometry without throwing exceptions.

--- a/code/packages/haskell/paint-vm-ascii/README.md
+++ b/code/packages/haskell/paint-vm-ascii/README.md
@@ -1,0 +1,31 @@
+# paint-vm-ascii (Haskell)
+
+A pure terminal backend for backend-neutral `PaintScene` values. It converts
+scene coordinates into character cells and draws visible filled rectangles
+with Unicode full-block characters.
+
+```haskell
+import CodingAdventures.PaintInstructions
+import CodingAdventures.PaintVmAscii
+
+scene = (emptyScene 16 16 "transparent")
+  { psInstructions = [makeRect 0 0 8 16 "#000000"] }
+
+main = putStrLn (either show id (renderDefault scene))
+```
+
+`AsciiOptions` defaults to an 8-by-16 scene-unit character cell. Output rows
+and trailing blank rows are trimmed, and drawing is clipped to the scene-sized
+buffer. Empty, `transparent`, and `none` fills are ignored.
+
+The current Haskell paint IR exposes rectangles and paths. This backend
+supports rectangles and returns `UnsupportedInstruction "path"` for paths,
+so unsupported vector geometry cannot silently disappear from the output.
+
+## Development
+
+Run the tests from this directory:
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/paint-vm-ascii/cabal.project
+++ b/code/packages/haskell/paint-vm-ascii/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../paint-instructions

--- a/code/packages/haskell/paint-vm-ascii/paint-vm-ascii.cabal
+++ b/code/packages/haskell/paint-vm-ascii/paint-vm-ascii.cabal
@@ -1,0 +1,33 @@
+cabal-version: 3.0
+name:          paint-vm-ascii
+version:       0.1.0
+synopsis:      Terminal renderer for backend-neutral paint scenes
+description:   Pure terminal rendering of PaintInstructions scenes with configurable character-cell scaling.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.PaintVmAscii
+    build-depends:    base >=4.14 && <5
+                    , paint-instructions >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    PaintVmAsciiSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , hspec == 2.*
+                    , paint-instructions >=0.1 && <0.2
+                    , paint-vm-ascii
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/paint-vm-ascii/src/CodingAdventures/PaintVmAscii.hs
+++ b/code/packages/haskell/paint-vm-ascii/src/CodingAdventures/PaintVmAscii.hs
@@ -1,0 +1,135 @@
+-- | A small, pure terminal backend for 'PaintScene' values.
+--
+-- Scene coordinates are divided by a configurable horizontal and vertical
+-- scale to obtain character-cell coordinates. Filled rectangles are drawn
+-- with full-block characters and output is trimmed for terminal use.
+module CodingAdventures.PaintVmAscii
+  ( AsciiOptions (..)
+  , PaintVmAsciiError (..)
+  , defaultAsciiOptions
+  , render
+  , renderDefault
+  , version
+  ) where
+
+import Control.Monad (foldM)
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd)
+import CodingAdventures.PaintInstructions
+  ( PaintInstruction (..)
+  , PaintScene (..)
+  )
+
+-- | Package version, shared with the other language implementations.
+version :: String
+version = "0.1.0"
+
+-- | How scene coordinates map to terminal character cells.
+data AsciiOptions = AsciiOptions
+  { scaleX :: Int
+  , scaleY :: Int
+  } deriving (Eq, Show)
+
+-- | The cross-language default uses cells that are eight scene units wide
+-- and sixteen scene units tall.
+defaultAsciiOptions :: AsciiOptions
+defaultAsciiOptions = AsciiOptions
+  { scaleX = 8
+  , scaleY = 16
+  }
+
+-- | Errors that can be reported without partial functions or exceptions.
+data PaintVmAsciiError
+  = InvalidScaleX Int
+  | InvalidScaleY Int
+  | InvalidSceneDimensions Double Double
+  | InvalidRectangleGeometry Double Double Double Double
+  | UnsupportedInstruction String
+  deriving (Eq, Show)
+
+-- | Render with 'defaultAsciiOptions'.
+renderDefault :: PaintScene -> Either PaintVmAsciiError String
+renderDefault scene = render scene defaultAsciiOptions
+
+-- | Render a scene as terminal-friendly text.
+--
+-- The renderer supports the rectangle instruction available in every paint
+-- IR implementation. Haskell's other current instruction, 'PaintPath', is
+-- rejected explicitly so a caller never mistakes a partial rendering for a
+-- complete one.
+render :: PaintScene -> AsciiOptions -> Either PaintVmAsciiError String
+render scene options
+  | scaleX options <= 0 = Left (InvalidScaleX (scaleX options))
+  | scaleY options <= 0 = Left (InvalidScaleY (scaleY options))
+  | not (validDimension (psWidth scene) && validDimension (psHeight scene)) =
+      Left (InvalidSceneDimensions (psWidth scene) (psHeight scene))
+  | otherwise = do
+      let columns = ceiling (psWidth scene / fromIntegral (scaleX options))
+          rows = ceiling (psHeight scene / fromIntegral (scaleY options))
+          buffer = replicate rows (replicate columns ' ')
+      rendered <- foldM (renderInstruction options) buffer (psInstructions scene)
+      pure (bufferText rendered)
+
+validDimension :: Double -> Bool
+validDimension value = value >= 0 && not (isNaN value || isInfinite value)
+
+renderInstruction
+  :: AsciiOptions
+  -> [String]
+  -> PaintInstruction
+  -> Either PaintVmAsciiError [String]
+renderInstruction options buffer instruction = case instruction of
+  PaintRect {}
+    | validRectangle instruction -> Right (renderRectangle options instruction buffer)
+    | otherwise -> Left (InvalidRectangleGeometry
+        (prX instruction) (prY instruction) (prW instruction) (prH instruction))
+  PaintPath {} -> Left (UnsupportedInstruction "path")
+
+validRectangle :: PaintInstruction -> Bool
+validRectangle rectangle =
+  validCoordinate (prX rectangle)
+    && validCoordinate (prY rectangle)
+    && validDimension (prW rectangle)
+    && validDimension (prH rectangle)
+
+validCoordinate :: Double -> Bool
+validCoordinate value = not (isNaN value || isInfinite value)
+
+renderRectangle :: AsciiOptions -> PaintInstruction -> [String] -> [String]
+renderRectangle options rectangle buffer
+  | not (visiblePaint (prFill rectangle)) = buffer
+  | otherwise =
+      [ if rowIndex >= firstRow && rowIndex <= lastRow
+          then paintColumns firstColumn lastColumn row
+          else row
+      | (rowIndex, row) <- zip [0 ..] buffer
+      ]
+  where
+    firstColumn = toCell (prX rectangle) (scaleX options)
+    firstRow = toCell (prY rectangle) (scaleY options)
+    lastColumn = toCell (prX rectangle + prW rectangle) (scaleX options)
+    lastRow = toCell (prY rectangle + prH rectangle) (scaleY options)
+
+toCell :: Double -> Int -> Int
+toCell coordinate scale = round (coordinate / fromIntegral scale)
+
+paintColumns :: Int -> Int -> String -> String
+paintColumns firstColumn lastColumn row =
+  [ if column >= firstColumn && column <= lastColumn then '\x2588' else cell
+  | (column, cell) <- zip [0 ..] row
+  ]
+
+visiblePaint :: String -> Bool
+visiblePaint paint = trimmed /= "" && trimmed /= "transparent" && trimmed /= "none"
+  where
+    trimmed = trim paint
+
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace
+
+bufferText :: [String] -> String
+bufferText = joinLines . dropWhileEnd null . map (dropWhileEnd (== ' '))
+
+joinLines :: [String] -> String
+joinLines [] = ""
+joinLines rows = foldr1 (\row rest -> row ++ "\n" ++ rest) rows

--- a/code/packages/haskell/paint-vm-ascii/test/PaintVmAsciiSpec.hs
+++ b/code/packages/haskell/paint-vm-ascii/test/PaintVmAsciiSpec.hs
@@ -1,0 +1,94 @@
+module PaintVmAsciiSpec (spec) where
+
+import CodingAdventures.PaintInstructions
+  ( PaintInstruction
+  , PaintScene (..)
+  , emptyScene
+  , makePath
+  , makeRect
+  )
+import CodingAdventures.PaintVmAscii
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "metadata" $ do
+    it "reports the shared package version" $
+      version `shouldBe` "0.1.0"
+
+    it "uses the shared default cell scaling" $
+      defaultAsciiOptions `shouldBe` AsciiOptions 8 16
+
+  describe "render" $ do
+    it "renders a filled rectangle inclusively" $ do
+      let scene = withInstructions (emptyScene 4 3 "#ffffff")
+            [makeRect 0 0 2 1 "#000000"]
+      render scene (AsciiOptions 1 1) `shouldBe` Right "███\n███"
+
+    it "uses painter order while clipping rectangles to the buffer" $ do
+      let scene = withInstructions (emptyScene 3 2 "transparent")
+            [ makeRect (-2) (-2) 3 3 "red"
+            , makeRect 2 1 4 4 "blue"
+            ]
+      render scene (AsciiOptions 1 1) `shouldBe` Right "██\n███"
+
+    it "skips empty and transparent fills after trimming whitespace" $ do
+      let scene = withInstructions (emptyScene 3 2 "transparent")
+            [ makeRect 0 0 2 1 ""
+            , makeRect 0 0 2 1 " transparent "
+            , makeRect 0 0 2 1 "none"
+            ]
+      render scene (AsciiOptions 1 1) `shouldBe` Right ""
+
+    it "maps coordinates through the default scale" $ do
+      let scene = withInstructions (emptyScene 16 32 "transparent")
+            [makeRect 8 16 0 0 "black"]
+      renderDefault scene `shouldBe` Right "\n █"
+
+    it "uses nearest-even rounding at half-cell boundaries" $ do
+      let scene = withInstructions (emptyScene 4 1 "transparent")
+            [makeRect 0.5 0 1 0 "black"]
+      render scene (AsciiOptions 1 1) `shouldBe` Right "███"
+
+    it "renders a zero-sized scene as empty text" $
+      renderDefault (emptyScene 0 0 "transparent") `shouldBe` Right ""
+
+    it "rejects paths instead of returning an incomplete rendering" $ do
+      let scene = withInstructions (emptyScene 10 10 "transparent")
+            [makePath [] "black"]
+      renderDefault scene `shouldBe` Left (UnsupportedInstruction "path")
+
+    it "rejects non-positive horizontal scales" $ do
+      let scene = emptyScene 1 1 "transparent"
+      render scene (AsciiOptions 0 1) `shouldBe` Left (InvalidScaleX 0)
+      render scene (AsciiOptions (-1) 1) `shouldBe` Left (InvalidScaleX (-1))
+
+    it "rejects non-positive vertical scales" $ do
+      let scene = emptyScene 1 1 "transparent"
+      render scene (AsciiOptions 1 0) `shouldBe` Left (InvalidScaleY 0)
+      render scene (AsciiOptions 1 (-1)) `shouldBe` Left (InvalidScaleY (-1))
+
+    it "rejects negative and non-finite scene dimensions" $ do
+      renderDefault (emptyScene (-1) 1 "transparent")
+        `shouldBe` Left (InvalidSceneDimensions (-1) 1)
+      renderDefault (emptyScene (0 / 0) 1 "transparent")
+        `shouldSatisfy` isInvalidDimensions
+      renderDefault (emptyScene (1 / 0) 1 "transparent")
+        `shouldBe` Left (InvalidSceneDimensions (1 / 0) 1)
+
+    it "rejects invalid rectangle geometry" $ do
+      let negativeSize = withInstructions (emptyScene 2 2 "transparent")
+            [makeRect 0 0 (-1) 1 "black"]
+          infiniteCoordinate = withInstructions (emptyScene 2 2 "transparent")
+            [makeRect (1 / 0) 0 1 1 "black"]
+      renderDefault negativeSize
+        `shouldBe` Left (InvalidRectangleGeometry 0 0 (-1) 1)
+      renderDefault infiniteCoordinate
+        `shouldBe` Left (InvalidRectangleGeometry (1 / 0) 0 1 1)
+
+withInstructions :: PaintScene -> [PaintInstruction] -> PaintScene
+withInstructions scene instructions = scene { psInstructions = instructions }
+
+isInvalidDimensions :: Either PaintVmAsciiError String -> Bool
+isInvalidDimensions (Left (InvalidSceneDimensions width height)) = isNaN width && height == 1
+isInvalidDimensions _ = False

--- a/code/packages/haskell/paint-vm-ascii/test/Spec.hs
+++ b/code/packages/haskell/paint-vm-ascii/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Test.Hspec (hspec)
+import qualified PaintVmAsciiSpec
+
+main :: IO ()
+main = hspec PaintVmAsciiSpec.spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -120,11 +120,11 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
-`type-checker-protocol` ports:
+`type-checker-protocol` ports, and the Haskell `paint-vm-ascii` port:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 290 |
+| Present in 10-15 languages | 172 | 289 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 709 | 9,926 |
@@ -170,7 +170,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 290
+The 172 packages present in at least ten implementation languages need 289
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -181,7 +181,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 15 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 14 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -578,6 +578,17 @@ state, with 100% alternative and 99% expression coverage. The package now
 spans 11 implementation lanes, reduces the high-consensus backlog to 290
 slots, leaves 15 gaps in the Haskell lane, and establishes the shared contract
 needed by later typed-frontend ports.
+
+The twentieth Haskell high-consensus slice is complete: `paint-vm-ascii` now
+provides a pure terminal renderer for the shared `paint-instructions` IR. It
+maps scene coordinates through configurable character-cell scales, clips
+visible filled rectangles into the scene buffer, trims terminal whitespace,
+and rejects paths explicitly rather than returning incomplete output. Its
+package-native suite exercises 13 examples covering shared defaults, filled
+rectangles, clipping, transparent paints, default scaling, half-cell rounding,
+zero-sized scenes, unsupported paths, invalid scales, scene dimensions, and
+rectangle geometry. The package now spans 11 implementation lanes, reduces the
+high-consensus backlog to 289 slots, and leaves 14 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `paint-vm-ascii` package backed by the existing `paint-instructions` IR
- render visible filled rectangles with configurable character-cell scaling, clipping, and terminal whitespace trimming
- reject unsupported paths and invalid geometry explicitly
- update the package-parity roadmap from 15 to 14 Haskell high-consensus gaps and from 290 to 289 missing high-consensus slots

## Impact

This closes the smallest dependency-safe Haskell graphics gap. The package now spans 11 implementation languages and composes only the existing Haskell `paint-instructions` package.

## Validation

- `cabal test paint-vm-ascii:spec --offline` — 13 examples, 0 failures
- `cabal check` — no errors or warnings
- `cabal sdist .` — source tarball generated successfully outside the repository
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py -v` — 6 tests passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 0 collisions, 0 unknown buckets
- `git diff --check`
