### PR TITLE
feat(hl): Chapter 12 numbers 11–20 for FR/GE/IT/PT

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -244,6 +244,8 @@
       "IT-FAMILY-SIBLINGS": "fratello/sorella (brother/sister; frāter/soror + diminutive -ello/-ella = 'little brother/sister'; → fraternal/sorority)",
       "IT-FOOD-BREAD": "pane (bread; closest to Latin pānis; → companion 'one you share bread with', pantry; companatico = 'what you eat WITH bread')",
       "IT-FOOD-DRINKS": "acqua/vino (water/wine; acqua KEPT Latin aqua whole, -cq- doubled, vs French eau; vino ← vīnum → wine/vine/vinegar)",
+      "IT-NUM-11-16": "undici…sedici (11-16; digit + -dici, and -dici is still visibly Latin decem = dieci — clearer than French's worn-down -ze)",
+      "IT-NUM-17-20": "diciassette…venti (17-20; at 17 the ORDER FLIPS — sedici 'six-ten' but diciassette 'ten-and-seven'; venti ← vīgintī)",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
@@ -262,6 +264,8 @@
       "FR-FAMILY-SIBLINGS": "frère/sœur (brother/sister ← frāter/soror; → fraternal/friar, sorority; œ ligature spells soror worn down)",
       "FR-FOOD-BREAD": "pain (bread ← pānis; nasal -ain; → companion 'one you share bread with', company, pantry)",
       "FR-FOOD-DRINKS": "eau/vin (water/wine; eau ← aqua worn to a bare 'oh' — most eroded of all, vs English aquatic; vin ← vīnum → wine/vine/vinegar)",
+      "FR-NUM-11-16": "onze…seize (11-16; the six Latin fusions ūndecim…sēdecim; shared -ze = decem 'ten', the same ten as dix/décembre)",
+      "FR-NUM-17-20": "dix-sept…vingt (17-20; at 17 French GIVES UP fusing and goes transparent 'ten-seven', the order flipping too; vingt ← vīgintī → vigesimal)",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
@@ -280,6 +284,8 @@
       "GE-FAMILY-SIBLINGS": "Bruder/Schwester (brother/sister; Germanic twins of English brother/sister; Geschwister 'siblings' via collective ge-)",
       "GE-FOOD-BREAD": "Brot (bread; INHERITED Germanic twin of English bread, NOT Latin pānis; introduces the neuter das + capitalized nouns)",
       "GE-FOOD-DRINKS": "Wasser/Wein (water/wine; Wasser NATIVE Germanic twin of water; but Wein is an ANCIENT Latin loan ← vīnum, borrowed with the vine — like English wine)",
+      "GE-NUM-11-12": "elf/zwölf (11-12; ← ainlif/twalif, -lif = 'leave' → 'ONE/TWO left over' after ten fingers; the exact inherited twins of English eleven/twelve)",
+      "GE-NUM-13-20": "dreizehn…zwanzig (13-20; digit + zehn with NO exceptions, mirroring English -teen which IS ten; zwanzig ← twaintig 'two tens'; German never breaks, unlike Romance)",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
       "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
       "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
@@ -296,7 +302,9 @@
       "PT-FAMILY-PARENTS": "pai/mãe (father/mother; most worn-down of the sisters — pater→pae→pai, māter→mãe nasal, -t- vanished; os pais 'parents' lit. 'the fathers'; o país=country)",
       "PT-FAMILY-SIBLINGS": "irmão/irmã (brother/sister; NOT from frāter but germānus 'of the same stock' — frāter germānus 'full brother'; = ES hermano; cousins germane/German)",
       "PT-FOOD-BREAD": "pão (bread ← pānis, worn to one nasal syllable pānis→pão — same erosion as pai; plural pães; → companion/pantry)",
-      "PT-FOOD-DRINKS": "água/vinho (water/wine; água KEPT aqua's body vs French eau; vinho ← vīnum with signature -nh- = Spanish ñ → wine/vine/vinegar)"
+      "PT-FOOD-DRINKS": "água/vinho (water/wine; água KEPT aqua's body vs French eau; vinho ← vīnum with signature -nh- = Spanish ñ → wine/vine/vinegar)",
+      "PT-NUM-11-15": "onze…quinze (11-15; only FIVE fused teens — fewer than any sister; -ze = decem as in dez/dezembro; catorze keeps the c-)",
+      "PT-NUM-16-20": "dezesseis…vinte (16-20; PT breaks EARLIEST at 16, rebuilding as dez + e + seis = literally 'ten AND six', the 'and' still audible; vinte ← vīgintī)"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Chapter 12 — Numbers 11–20
+
+- **Chapter 12 authored** (`FR-C12-nombres-11-16`, `-17-20`): the teens, atom-first,
+  reviewing Ch.6/Ch.11 via `reviews_of`.
+- **onze–seize** — the six numbers French inherited **already fused** from Latin
+  (*ūndecim, duodecim … sēdecim*). The shared **-ze** is *decem* ("ten") worn thin —
+  the **same ten** the learner already knows in **dix** and **décembre** (Ch.9).
+  Each word's front is its Chapter 6 digit (*deux→dou-*, *six→sei-*).
+- **dix-sept–vingt** — the **seam**: at 17 French **abandons** the fusion and goes
+  transparent, *dix-sept* = plainly "ten-seven" — and the **order flips** with it
+  (digit-first *seize* → ten-first *dix-sept*). Notes that Latin itself wobbled here
+  (*duodēvīgintī*, "two-from-twenty"), a subtraction all the sisters dropped.
+  *vingt* ← *vīgintī* → English **vigesimal**, and the seed of *quatre-vingts*.
+- Taxonomy: namespaced `FR-NUM-11-16`, `FR-NUM-17-20`.
+
 ## Chapter 11 — Food (bread, water, wine)
 
 - **Chapter 11 authored** (`FR-C11-pain`, `-eau-vin`): the everyday table trio,

--- a/code/learning/human-languages/french/lessons/FR-C12-nombres-11-16.md
+++ b/code/learning/human-languages/french/lessons/FR-C12-nombres-11-16.md
@@ -1,0 +1,56 @@
+---
+id: FR-C12-nombres-11-16
+chapter: 12
+type: word
+headword: onze — seize
+gloss: 11–16, the six fused numbers French inherited whole from Latin
+concept_tag: FR-NUM-11-16
+prerequisites: [FR-C06-nombres-6-10, FR-C11-eau-vin]
+sounds: [nasal-on, z-voiced]
+roots: [latin-decim]
+etymology_hook: "onze…seize ← Latin ūndecim, duodecim … sēdecim — 'one-ten, two-ten … six-ten'; the -ze is a worn-down decem ('ten'), the same ten hiding in dix and décembre"
+est_minutes: 5
+reviews_of: [FR-C06-nombres-6-10, FR-C11-eau-vin]
+---
+
+# onze → seize — six numbers welded together
+
+## Warm-up
+
+[PAUSE 2s] You can count to ten. Now the teens — and they are **not** built the
+way you'd guess. French didn't say "ten-one, ten-two." It inherited six numbers
+already **fused** in Latin, and they came through almost unrecognisable.
+
+## The six fusions
+
+| | French | ← Latin | literally |
+|---|---|---|---|
+| 11 | **onze** | *ūndecim* | "one-ten" |
+| 12 | **douze** | *duodecim* | "two-ten" |
+| 13 | **treize** | *trēdecim* | "three-ten" |
+| 14 | **quatorze** | *quattuordecim* | "four-ten" |
+| 15 | **quinze** | *quīndecim* | "five-ten" |
+| 16 | **seize** | *sēdecim* | "six-ten" |
+
+Look at the ending they all share: **-ze**. That is Latin **decem** ("ten"),
+worn down to almost nothing — the **same ten** you already know in **dix** (10)
+and **décembre** (the old 10th month, from Chapter 9). One root, three disguises.
+
+And the front of each word is the digit you learned in Chapter 6: *un→on-*,
+*deux→dou-*, *trois→trei-*, *quatre→quator-*, *cinq→quin-*, *six→sei-*. Say them
+slowly and the small number surfaces.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "onze, douze, treize, quatorze, quinze, seize"]
+- [YOU SAY: hear the ten — "-ze = *decem* = dix"]
+- [YOU SAY: the digit inside — "**deux** → **dou**ze, **six** → **sei**ze"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count 11 to 16. (*Onze, douze, treize, quatorze, quinze, seize*.)
+What does the shared **-ze** ending come from? (Latin **decem**, "ten" — the same
+ten as *dix* and *décembre*.) Is 13 built as "ten-three" or "three-ten"? ("**Three-
+ten**" — *trēdecim*, the digit first.) Next: at **17**, French suddenly changes
+its mind.

--- a/code/learning/human-languages/french/lessons/FR-C12-nombres-17-20.md
+++ b/code/learning/human-languages/french/lessons/FR-C12-nombres-17-20.md
@@ -1,0 +1,58 @@
+---
+id: FR-C12-nombres-17-20
+chapter: 12
+type: word
+headword: dix-sept — vingt
+gloss: 17–20 — the seam where French gives up fusing and just says "ten-seven"
+concept_tag: FR-NUM-17-20
+prerequisites: [FR-C12-nombres-11-16]
+sounds: [liaison-t, nasal-in]
+roots: [latin-decim, viginti-latin]
+etymology_hook: "at 17 French abandons the Latin fusion and goes transparent: dix-sept = literally 'ten-seven' — you can watch the language change strategy mid-count; vingt ← vīgintī → English vigesimal"
+est_minutes: 5
+reviews_of: [FR-C12-nombres-11-16, FR-C06-nombres-6-10]
+---
+
+# dix-sept → vingt — where French changes its mind
+
+## Warm-up
+
+[PAUSE 2s] Here is something you can *watch happen*. Up to **seize** (16), French
+used the old welded-together Latin numbers. Then, at **17**, it simply **gives
+up** — and starts saying the numbers plainly, the way a child would.
+
+## The seam
+
+| | French | how it's built |
+|---|---|---|
+| 16 | **seize** | one fused word (← *sēdecim*) |
+| **17** | **dix-sept** | **"ten-seven"** — two words, plainly |
+| 18 | **dix-huit** | "ten-eight" |
+| 19 | **dix-neuf** | "ten-nine" |
+| 20 | **vingt** | ← *vīgintī* |
+
+Notice the **order flips too**. In *seize*, the digit came **first** ("six-ten").
+In *dix-sept*, the **ten comes first** ("ten-seven"). At exactly 17, French
+switched both its **strategy** and its **direction** — a visible seam in the
+counting system. (Latin itself wobbled here: it had *septendecim* for 17, but for
+18 and 19 it counted *down* from twenty — *duodēvīgintī*, "two-from-twenty." The
+sisters all abandoned that subtraction trick.)
+
+**vingt** (20) ← Latin **vīgintī**, the root behind English **vigesimal**
+("counting by twenties") — and the reason French later builds *quatre-vingts*
+(80 = "four twenties").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: 16→20 — "seize, dix-sept, dix-huit, dix-neuf, vingt"]
+- [YOU SAY: the seam — "*seize* = six-ten (fused); *dix-sept* = ten-seven (plain)"]
+- [YOU SAY: the whole run, 11 to 20]
+
+## Wrap-up Recall
+
+[PAUSE 3s] At which number does French stop fusing? (At **17** — *seize* is
+fused, *dix-sept* is plain "ten-seven".) What **two** things change at that seam?
+(The **strategy** — fused → transparent — and the **order**, digit-first →
+ten-first.) What English word comes from *vingt*'s root? (**Vigesimal**, from
+*vīgintī*.) Next chapter: putting numbers to work.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -64,6 +64,12 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   eroded** word French took from Latin — worn to a bare "oh," vs English *aquatic*;
   **vin** ← *vīnum* → wine/vine/vinegar). **Authored.**
 
+- **Ch. 12 — Numbers 11–20**: **onze–seize**, the six Latin fusions (*ūndecim…
+  sēdecim*; the shared **-ze** is *decem* "ten," the same ten as *dix* and
+  *décembre*) → **dix-sept–vingt**, where French **gives up fusing** and goes
+  transparent ("ten-seven"), **flipping the order** at the same seam; *vingt* ←
+  *vīgintī* → **vigesimal**. **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Chapter 12 — Numbers 11–20
+
+- **Chapter 12 authored** (`GE-C12-elf-zwoelf`, `-zahlen-13-20`): the teens,
+  atom-first, reviewing Ch.6/Ch.11 via `reviews_of`.
+- **elf / zwölf** — the showpiece: ← *ainlif / twalif*, where **-lif** means "**to
+  leave, remain**," so they literally say "**one left over**" and "**two left
+  over**" — left over from your **ten fingers**. English *eleven/twelve* are not
+  merely similar but **the same inherited words**, which is why both languages share
+  the oddity. Extends the Germanic-twin thread from *Vater/father*, *Wasser/water*.
+- **dreizehn–zwanzig** — then the pattern turns perfectly regular: **digit + zehn**,
+  no exceptions, exactly mirroring English *-teen* (which **is** *ten*: *thir-teen* =
+  "three-ten"). *Sechzehn/siebzehn* clip a sound just as English clipped
+  *three→thir-*, *five→fif-*; *zwanzig* ← *twaintig* "two tens" (= English *-ty*).
+- **The contrast made explicit**: the Romance sisters all **break** their teens
+  pattern partway (PT at 16, FR/IT at 17); **German never breaks** — two leftovers,
+  then one clean rule to twenty, with English marching alongside the whole way.
+- Taxonomy: namespaced `GE-NUM-11-12`, `GE-NUM-13-20`.
+
 ## Chapter 11 — Food (bread, water, wine)
 
 - **Chapter 11 authored** (`GE-C11-brot`, `-wasser-wein`): the everyday table

--- a/code/learning/human-languages/german/lessons/GE-C12-elf-zwoelf.md
+++ b/code/learning/human-languages/german/lessons/GE-C12-elf-zwoelf.md
@@ -1,0 +1,62 @@
+---
+id: GE-C12-elf-zwoelf
+chapter: 12
+type: word
+headword: elf, zwölf
+gloss: 11 and 12 — literally "one left over" and "two left over," the exact twins of eleven and twelve
+concept_tag: GE-NUM-11-12
+prerequisites: [GE-C06-zahlen-6-10, GE-C11-wasser-wein]
+sounds: [umlaut-oe, f-final]
+roots: [germanic-ainlif, germanic-twalif]
+etymology_hook: "elf ← ainlif, zwölf ← twalif — the -lif is 'leave/remain', so they mean 'ONE left [over ten]' and 'TWO left'; English eleven/twelve are the same words, same meaning — you counted ten fingers and had one left"
+est_minutes: 5
+reviews_of: [GE-C06-zahlen-6-10, GE-C11-wasser-wein]
+---
+
+# elf und zwölf — "one left over," "two left over"
+
+## Warm-up
+
+[PAUSE 2s] Why are English **eleven** and **twelve** so strange — why not
+"oneteen, twoteen"? German has the identical oddity (**elf**, **zwölf**), and
+because the two languages are Germanic twins, learning one *explains* the other.
+The answer is one of the best number-stories anywhere.
+
+## The words, taken apart
+
+- **elf** (11) ← old Germanic **ainlif** = **ain** ("one") + **lif**.
+- **zwölf** (12) ← **twalif** = **twa** ("two") + **lif**.
+
+And **-lif** means "**to leave, to remain**." So:
+
+- **elf** = "**one left over**"
+- **zwölf** = "**two left over**"
+
+Left over from **what**? From **ten** — from your ten fingers. You count to ten,
+you run out of fingers, and you have **one left**. Eleven is literally the
+leftover.
+
+**English says exactly the same thing**: *eleven* ← *ain-lif*, *twelve* ←
+*twa-lif*. Not similar words — *the same words*, inherited side by side. (You met
+this Germanic-twin pattern with *Vater/father* and *Wasser/water*; here it reaches
+even the counting.)
+
+## And then it stops
+
+The leftover-trick covers only **two** numbers. From **13** on, German turns
+completely regular — and so does English. That's the next lesson.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "elf, zwölf" — *zwölf* with the rounded **ö**]
+- [YOU SAY: the meaning — "one **left over**, two **left over** — after ten fingers"]
+- [YOU SAY: the twins — "elf/eleven, zwölf/twelve — same word, both Germanic"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do **elf** and **zwölf** literally mean? ("**One left over**" and
+"**two left over**" — *-lif* = "remain".) Left over from what? (From **ten** — the
+ten fingers you just counted.) Why do English *eleven/twelve* look equally odd?
+(They are the **same inherited Germanic words**.) Next: 13 to 20, where German
+becomes perfectly regular.

--- a/code/learning/human-languages/german/lessons/GE-C12-zahlen-13-20.md
+++ b/code/learning/human-languages/german/lessons/GE-C12-zahlen-13-20.md
@@ -1,0 +1,68 @@
+---
+id: GE-C12-zahlen-13-20
+chapter: 12
+type: word
+headword: dreizehn — zwanzig
+gloss: 13–20 — perfectly regular digit+zehn compounds, step for step with English
+concept_tag: GE-NUM-13-20
+prerequisites: [GE-C12-elf-zwoelf]
+sounds: [zehn-ts, ig-final]
+roots: [germanic-tehun, germanic-twaintig]
+etymology_hook: "dreizehn…neunzehn = digit + zehn, the exact mirror of English thir-teen…nine-teen (-teen IS ten); zwanzig ← twaintig 'two-tens' = English twenty; German never breaks the pattern, unlike the Romance sisters"
+est_minutes: 5
+reviews_of: [GE-C12-elf-zwoelf, GE-C06-zahlen-6-10]
+---
+
+# dreizehn → zwanzig — the pattern that never breaks
+
+## Warm-up
+
+[PAUSE 2s] After the two leftovers (*elf, zwölf*), German settles into a rule so
+regular you can generate every number without being taught it. And **English does
+the identical thing** — because *-teen* **is** *ten*.
+
+## The rule: digit + zehn
+
+| | German | English | build |
+|---|---|---|---|
+| 13 | **dreizehn** | thirteen | drei + zehn |
+| 14 | **vierzehn** | fourteen | vier + zehn |
+| 15 | **fünfzehn** | fifteen | fünf + zehn |
+| 16 | **sechzehn** | sixteen | sechs + zehn (the *s* drops) |
+| 17 | **siebzehn** | seventeen | sieben + zehn (shortened) |
+| 18 | **achtzehn** | eighteen | acht + zehn |
+| 19 | **neunzehn** | nineteen | neun + zehn |
+| 20 | **zwanzig** | twenty | ← *twaintig*, "**two tens**" |
+
+Every one is **your Chapter 6 digit + zehn** — and the English column is the same
+compound with *-teen* (which is just **ten** again: *thir-teen* = "three-ten").
+Only two small wearings-down: *sech(s)zehn* and *sieb(en)zehn* clip a sound for
+easier speech, exactly as English *thir-* and *fif-* did to *three* and *five*.
+
+**zwanzig** (20) ← **twaintig**, "two tens" — the *-zig* is another form of *ten*,
+matching English *twen-ty* (*-ty* = ten as well).
+
+## The contrast worth noticing
+
+The Romance sisters all **break** their pattern partway through the teens
+(Portuguese at 16, French and Italian at 17, swapping to "ten-and-six" style).
+**German never breaks.** Two leftovers, then one clean rule all the way to twenty
+— and English marches beside it the entire distance.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: 13→20 — "dreizehn, vierzehn, fünfzehn, sechzehn, siebzehn, achtzehn,
+  neunzehn, zwanzig"]
+- [YOU SAY: each beside its English twin — "dreizehn / thirteen, vierzehn /
+  fourteen…"]
+- [YOU SAY: the whole run, elf to zwanzig]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What's the rule from 13 to 19? (**Digit + zehn** — no exceptions.)
+Which two clip a sound, and what's the English parallel? (*Sechzehn* and
+*siebzehn*; English clipped *three→thir-*, *five→fif-*.) What does **zwanzig**
+literally mean? ("**Two tens**" — *-zig*, like English *-ty*.) How does this differ
+from the Romance sisters? (**They break** their pattern in the teens; German
+doesn't.) Next chapter: numbers in use.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -69,6 +69,13 @@ Spanish and French where a contrast helps. The recurring decoder is the
   Germanic twin of *water*, but **Wein** an **ancient Latin loan** (← *vīnum*),
   borrowed with the grapevine, which is why *Wein/wine/vīnum* all match. **Authored.**
 
+- **Ch. 12 — Numbers 11–20**: **elf/zwölf** (← *ainlif/twalif*, *-lif* = "leave" →
+  "**one/two left over**" after ten fingers — the exact inherited twins of English
+  *eleven/twelve*) → **dreizehn–zwanzig**, digit + *zehn* with **no exceptions**,
+  mirroring English *-teen* (which **is** ten); *zwanzig* ← *twaintig* "two tens."
+  The contrast: the Romance sisters all **break** their teens pattern; German
+  **never does**. **Authored.**
+
 ## Planned
 
 | Chapter | Theme |

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Chapter 12 — Numbers 11–20
+
+- **Chapter 12 authored** (`IT-C12-numeri-11-16`, `-17-20`): the teens, atom-first,
+  reviewing Ch.6/Ch.11 via `reviews_of`.
+- **undici–sedici** — Italian keeps the Latin fusions **most legibly**: the shared
+  **-dici** is still visibly *decem* ("ten"), the very word the learner says as
+  **dieci**. Set against the sisters, the clarity is the point — Latin *sēdecim* →
+  Italian **sedici** (ten audible) vs French **seize** (worn to *-ze*) vs Portuguese
+  **dezesseis** (rebuilt entirely).
+- **diciassette–venti** — the **reversal**: at 17 Italian turns the count around,
+  *se-dici* ("six-ten") becoming *dici-assette* ("**ten**-and-seven"), the ten
+  jumping to the front; the linking sounds (*diciAssette*, *diciANnove*) are just
+  Italian smoothing the joint. *venti* ← *vīgintī*.
+- Includes the three-sister table of **where each breaks** — Portuguese 16, French
+  and Italian 17 — one inherited Latin system, three different seams.
+- Taxonomy: namespaced `IT-NUM-11-16`, `IT-NUM-17-20`.
+
 ## Chapter 11 — Food (bread, water, wine)
 
 - **Chapter 11 authored** (`IT-C11-pane`, `-acqua-vino`): the everyday table trio,

--- a/code/learning/human-languages/italian/lessons/IT-C12-numeri-11-16.md
+++ b/code/learning/human-languages/italian/lessons/IT-C12-numeri-11-16.md
@@ -1,0 +1,58 @@
+---
+id: IT-C12-numeri-11-16
+chapter: 12
+type: word
+headword: undici — sedici
+gloss: 11–16 — Italian keeps Latin's fusions so clearly you can still read the "ten" in them
+concept_tag: IT-NUM-11-16
+prerequisites: [IT-C06-numeri-6-10, IT-C11-acqua-vino]
+sounds: [c-soft-dici, double-consonant]
+roots: [latin-decim]
+etymology_hook: "undici…sedici ← ūndecim…sēdecim, with -dici still visibly Latin decem ('ten') — clearer than French's worn-down -ze; and dieci (10) sits right there beside it"
+est_minutes: 5
+reviews_of: [IT-C06-numeri-6-10, IT-C11-acqua-vino]
+---
+
+# undici → sedici — the ten you can still see
+
+## Warm-up
+
+[PAUSE 2s] True to form, Italian keeps the teens **closest to Latin** — so close
+that the word for "ten" is still sitting in plain sight inside each one. Where
+French wore *decem* down to a bare **-ze**, Italian kept **-dici**.
+
+## The six fusions
+
+| | Italian | ← Latin | build |
+|---|---|---|---|
+| 11 | **undici** | *ūndecim* | un + dici |
+| 12 | **dodici** | *duodecim* | do + dici |
+| 13 | **tredici** | *trēdecim* | tre + dici |
+| 14 | **quattordici** | *quattuordecim* | quattor + dici |
+| 15 | **quindici** | *quīndecim* | quin + dici |
+| 16 | **sedici** | *sēdecim* | se + dici |
+
+Every one is **digit + -dici**, and **-dici** is Latin **decem**, "ten" — the same
+ten you say as **dieci** (10). Compare the sisters and Italian's clarity jumps
+out:
+
+- Latin *sēdecim* → Italian **sedici** (ten still audible) · French **seize**
+  (ten worn to a *-ze*) · Portuguese **dezesseis** (rebuilt from scratch).
+
+The digits are your Chapter 6 numbers barely changed: *tre→tre-*, *quattro→
+quattor-*, *cinque→quin-*, *sei→se-*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "undici, dodici, tredici, quattordici, quindici, sedici"]
+- [YOU SAY: the ten inside — "-dici = *decem* = **dieci**"]
+- [YOU SAY: the three-sister line — "sedici / seize / dezesseis, one Latin word"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count 11 to 16 in Italian. (*Undici, dodici, tredici, quattordici,
+quindici, sedici*.) What is the **-dici** in every one? (Latin **decem**, "ten" —
+the same as *dieci*.) Which order are they built in — digit first or ten first?
+(**Digit first**: *tre*-dici = "three-ten".) Next: at **17**, Italian flips *both*
+its strategy **and** its direction.

--- a/code/learning/human-languages/italian/lessons/IT-C12-numeri-17-20.md
+++ b/code/learning/human-languages/italian/lessons/IT-C12-numeri-17-20.md
@@ -1,0 +1,69 @@
+---
+id: IT-C12-numeri-17-20
+chapter: 12
+type: word
+headword: diciassette — venti
+gloss: 17–20 — Italian flips the order at 17: the ten jumps to the FRONT
+concept_tag: IT-NUM-17-20
+prerequisites: [IT-C12-numeri-11-16]
+sounds: [double-ss, c-soft-dici]
+roots: [latin-decim, viginti-latin]
+etymology_hook: "at 17 Italian reverses itself — sedici is 'six-ten' but diciassette is 'ten-and-seven' (dici + e + sette); the same ten, moved to the front, mid-count; venti ← vīgintī"
+est_minutes: 5
+reviews_of: [IT-C12-numeri-11-16, IT-C06-numeri-6-10]
+---
+
+# diciassette → venti — the count turns around
+
+## Warm-up
+
+[PAUSE 2s] Watch the language change direction. Through **sedici** (16), Italian
+put the **digit first** and the ten last. At **17**, it turns the whole thing
+around and puts the **ten first** — and it keeps the *-dici* right there so you
+can see it happen.
+
+## The reversal
+
+| | Italian | build | order |
+|---|---|---|---|
+| 16 | **sedici** | *se* + *dici* | **six-ten** |
+| **17** | **diciassette** | *dici* + *(a)* + *sette* | **ten-and-seven** |
+| 18 | **diciotto** | *dici* + *otto* | ten-eight |
+| 19 | **diciannove** | *dici* + *(an)* + *nove* | ten-nine |
+| 20 | **venti** | ← *vīgintī* | — |
+
+Same building blocks — *dici* ("ten") and your Chapter 6 digits — but from 17 the
+**ten leads**. The little linking sounds (*diciAssette*, *diciANnove*) are just
+Italian smoothing the joint, the doubling it loves.
+
+## All three sisters break — at different numbers
+
+This "give up fusing, go transparent" seam happens in every Romance sister, but
+**not at the same place**:
+
+| language | fuses up to | goes transparent at |
+|---|---|---|
+| **Portuguese** | *quinze* (15) | **16** — *dezesseis* |
+| **French** | *seize* (16) | **17** — *dix-sept* |
+| **Italian** | *sedici* (16) | **17** — *diciassette* |
+
+Three languages, one inherited Latin system, three different breaking points. (And
+German, you may recall, never breaks at all.)
+
+**venti** (20) ← *vīgintī*, the same root as French *vingt* and English
+**vigesimal**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: 16→20 — "sedici, diciassette, diciotto, diciannove, venti"]
+- [YOU SAY: the turn — "*se*-dici (six-ten) → *dici*-assette (ten-seven)"]
+- [YOU SAY: the whole run, undici to venti]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What changes between *sedici* and *diciassette*? (The **order** — the
+**ten moves to the front**; digit-first becomes ten-first.) Where do the three
+Romance sisters break? (**Portuguese at 16**, **French and Italian at 17**.) What
+Latin word gives *venti*? (*vīgintī* — like French *vingt*, English *vigesimal*.)
+Next chapter: numbers in use.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -61,6 +61,12 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   **acqua** **kept** Latin *aqua* whole (doubled *-cq-*), the loud original French
   wore down to *eau*; **vino** ← *vīnum* → wine/vine/vinegar. **Authored.**
 
+- **Ch. 12 — Numbers 11–20**: **undici–sedici**, where the *-dici* is still visibly
+  Latin *decem* (= *dieci*) — clearer than French's worn-down *-ze* → **diciassette–
+  venti**, where Italian **flips the order** at 17 (*se*-*dici* "six-ten" becomes
+  *dici*-*assette* "ten-and-seven"). Includes the three-sister comparison of *where*
+  each breaks: PT at 16, FR and IT at 17. **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Chapter 12 — Numbers 11–20
+
+- **Chapter 12 authored** (`PT-C12-numeros-11-15`, `-16-20`): the teens, atom-first,
+  reviewing Ch.6/Ch.11 via `reviews_of`.
+- **onze–quinze** — Portuguese kept only **five** fused teens, **fewer than any
+  sister**. The shared **-ze** is *decem* ("ten") worn thin, the same ten inside
+  **dez** and **dezembro** (Ch.9); *catorze* keeps the *c-* where French says
+  *quatorze* and Spanish *catorce*.
+- **dezesseis–vinte** — the distinctive move: Portuguese **breaks earliest of all,
+  at 16**, and rebuilds from living words — *dez* + **e** + *seis* = literally
+  "**ten AND six**," with the **and still audible** (*dezoito* swallows it before
+  the vowel of *oito*). Nothing to memorise, only to assemble.
+- Includes the three-sister comparison — **PT breaks at 16**, French and Italian at
+  17 — and the note that German never breaks at all. *vinte* ← *vīgintī*.
+- Taxonomy: namespaced `PT-NUM-11-15`, `PT-NUM-16-20`.
+
 ## Chapter 11 — Food (bread, water, wine)
 
 - **Chapter 11 authored** (`PT-C11-pao`, `-agua-vinho`): the everyday table trio,

--- a/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-11-15.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-11-15.md
@@ -1,0 +1,59 @@
+---
+id: PT-C12-numeros-11-15
+chapter: 12
+type: word
+headword: onze — quinze
+gloss: 11–15 — the only five teens Portuguese kept fused; it breaks earliest of all
+concept_tag: PT-NUM-11-15
+prerequisites: [PT-C06-numeros-6-10, PT-C11-agua-vinho]
+sounds: [nasal-on, z-voiced]
+roots: [latin-decim]
+etymology_hook: "onze…quinze ← ūndecim…quīndecim, the -ze a worn-down decem ('ten'); Portuguese keeps only FIVE fused teens — fewer than any sister — then rebuilds from 16 on"
+est_minutes: 5
+reviews_of: [PT-C06-numeros-6-10, PT-C11-agua-vinho]
+---
+
+# onze → quinze — the short list
+
+## Warm-up
+
+[PAUSE 2s] Portuguese inherited the same welded Latin teens as its sisters — but
+it kept **fewer of them than anyone**. Just **five**. After *quinze* (15), it
+starts over with a completely different, much plainer method.
+
+## The five fusions
+
+| | Portuguese | ← Latin | build |
+|---|---|---|---|
+| 11 | **onze** | *ūndecim* | "one-ten" |
+| 12 | **doze** | *duodecim* | "two-ten" |
+| 13 | **treze** | *trēdecim* | "three-ten" |
+| 14 | **catorze** | *quattuordecim* | "four-ten" |
+| 15 | **quinze** | *quīndecim* | "five-ten" |
+
+The shared **-ze** is Latin **decem** ("ten") worn thin — the same ten inside
+**dez** (10) and **dezembro** (the old 10th month, from Chapter 9). The digit sits
+at the front: *dois→do-*, *três→tre-*, *quatro→cator-*, *cinco→quin-*.
+
+Note **catorze** — Portuguese kept the *c-* where Spanish says *catorce* and
+French *quatorze*; three worn-down versions of one Latin *quattuordecim*.
+
+## And that's where it stops
+
+*Quinze* is the **last** fused number. From **16** Portuguese does something none
+of its sisters do so early — the next lesson.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "onze, doze, treze, catorze, quinze"]
+- [YOU SAY: the ten inside — "-ze = *decem* = **dez**"]
+- [YOU SAY: the digit inside — "**três** → **tre**ze, **cinco** → **quin**ze"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count 11 to 15. (*Onze, doze, treze, catorze, quinze*.) What is the
+**-ze**? (Latin **decem**, "ten" — as in *dez*, *dezembro*.) How many fused teens
+does Portuguese keep, and is that more or fewer than its sisters? (**Five** —
+**fewer**; French and Italian keep six.) Next: **16**, where Portuguese starts
+building numbers a brand-new way.

--- a/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-16-20.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C12-numeros-16-20.md
@@ -1,0 +1,71 @@
+---
+id: PT-C12-numeros-16-20
+chapter: 12
+type: word
+headword: dezesseis — vinte
+gloss: 16–20 — Portuguese breaks earliest, and rebuilds numbers as "ten AND six"
+concept_tag: PT-NUM-16-20
+prerequisites: [PT-C12-numeros-11-15]
+sounds: [double-ss, nasal-in]
+roots: [latin-decem, viginti-latin]
+etymology_hook: "dezesseis = dez + e + seis, literally 'TEN AND SIX' — Portuguese rebuilt its upper teens from live words, keeping the 'and' (e) visible; it breaks at 16, earlier than any sister"
+est_minutes: 5
+reviews_of: [PT-C12-numeros-11-15, PT-C06-numeros-6-10]
+---
+
+# dezesseis → vinte — built from scratch, with the "and" still showing
+
+## Warm-up
+
+[PAUSE 2s] At **16**, Portuguese stops inheriting and starts **building**. And it
+does it more openly than any sister: it glues together the living words for "ten,"
+"and," and the digit — and leaves the **and** right there in the middle where you
+can hear it.
+
+## Ten AND six
+
+| | Portuguese | build | literally |
+|---|---|---|---|
+| 15 | **quinze** | (fused, inherited) | "five-ten" |
+| **16** | **dezesseis** | **dez + e + seis** | **"ten and six"** |
+| 17 | **dezessete** | dez + e + sete | "ten and seven" |
+| 18 | **dezoito** | dez + oito | "ten eight" |
+| 19 | **dezenove** | dez + e + nove | "ten and nine" |
+| 20 | **vinte** | ← *vīgintī* | — |
+
+Every one begins with **dez** ("ten," Chapter 6) and most keep **e** ("and") — so
+*dezesseis* is transparently a little sentence: *ten-and-six*. (*Dezoito* swallows
+the *e* before the vowel of *oito*.) You already know every ingredient; nothing
+here needs memorising, only assembling.
+
+## Portuguese breaks earliest
+
+All three Romance sisters give up fusing partway through the teens — but
+Portuguese gives up **first**:
+
+| language | last fused | goes transparent at |
+|---|---|---|
+| **Portuguese** | *quinze* (15) | **16** — *dezesseis* |
+| French | *seize* (16) | 17 — *dix-sept* |
+| Italian | *sedici* (16) | 17 — *diciassette* |
+
+One inherited Latin system, three different breaking points — and Portuguese is
+the boldest rebuilder. (German, by contrast, never breaks at all.)
+
+**vinte** (20) ← *vīgintī*, the same root as French *vingt*, Italian *venti*, and
+English **vigesimal**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: 15→20 — "quinze, dezesseis, dezessete, dezoito, dezenove, vinte"]
+- [YOU SAY: hear the sentence — "*dez* **e** *seis* — ten AND six"]
+- [YOU SAY: the whole run, onze to vinte]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **dezesseis** literally spell out? ("**Ten and six**" — *dez*
++ *e* + *seis*.) At which number does Portuguese break, and how does that compare
+with French and Italian? (At **16** — **earlier**; they break at 17.) Why does
+*dezoito* have no *e*? (It's **swallowed** before the vowel of *oito*.) Next
+chapter: numbers in use.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -66,6 +66,12 @@ French.
   — **água** **kept** *aqua*'s body (vs French *eau*); **vinho** ← *vīnum* with the
   signature **-nh-** (= Spanish *ñ*) → wine/vine/vinegar. **Authored.**
 
+- **Ch. 12 — Numbers 11–20**: **onze–quinze**, only **five** fused teens (fewer than
+  any sister; *-ze* = *decem*, as in *dez*/*dezembro*) → **dezesseis–vinte**, where
+  Portuguese **breaks earliest of all — at 16** — and rebuilds transparently as
+  *dez* + **e** + *seis*, "**ten AND six**," the *and* still audible. *vinte* ←
+  *vīgintī*. **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |


### PR DESCRIPTION
## What

The teens, authored in parallel across the four Latin-script sisters (**8 lessons**), each atom-first and reviewing Ch.6/Ch.11 via `reviews_of`.

The chapter is built around one comparative question: **where does each language stop inheriting Latin's fused teens and start building them transparently?** Every track breaks at a different number — and German never breaks at all.

| Track | Angle |
|---|---|
| **French** | *onze–seize* are the six Latin fusions (shared **-ze** = *decem*, the same ten as *dix*/*décembre*). At **17** French **gives up** — *dix-sept* is plainly "ten-seven" — and the **order flips** with it |
| **German** | **The showpiece**: *elf/zwölf* ← *ainlif/twalif*, where **-lif** = "leave" — so they mean "**one/two left over**" (after your ten fingers). English *eleven/twelve* are the **same inherited words**, which is why both languages share the oddity. Then digit+*zehn*, no exceptions, mirroring English *-teen* (which **is** ten) |
| **Italian** | Keeps the fusions most legibly (*-dici* still visibly *decem* = *dieci*). At **17** it **reverses** — *se-dici* "six-ten" becomes *dici-assette* "**ten**-and-seven" |
| **Portuguese** | Keeps only **five** fused teens (fewest of any sister) and **breaks earliest, at 16** — rebuilding from living words as *dez* + **e** + *seis* = literally "**ten AND six**," the *and* still audible |

**The payoff table** (taught in three of the four tracks): Portuguese breaks at 16, French and Italian at 17, German never — one inherited Latin system, three different seams.

## Housekeeping
- Taxonomy: namespaced `{FR,GE,IT}-NUM-11-16/-17-20` and `PT-NUM-11-15/-16-20`.
- Each track's `roadmap.md` (Ch.12 authored) and `CHANGELOG.md`.
- Suite **38/38**; `taxonomy.json` valid (structure **and** duplicate-key verified); no retired `concept_tag`s; security-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)