### PR TITLE
Add Haskell barcode-layout-1d port

### DIFF
--- a/code/packages/haskell/barcode-layout-1d/BUILD
+++ b/code/packages/haskell/barcode-layout-1d/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/barcode-layout-1d/BUILD_windows
+++ b/code/packages/haskell/barcode-layout-1d/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/barcode-layout-1d/CHANGELOG.md
+++ b/code/packages/haskell/barcode-layout-1d/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Add typed bar and space runs with semantic source roles.
+- Expand binary and configurable narrow/wide patterns.
+- Compute inferred or explicit symbol spans with validated quiet zones.
+- Emit metadata-rich bar rectangles through the shared paint IR.
+- Reject invalid geometry, non-alternating runs, and unsupported text output.

--- a/code/packages/haskell/barcode-layout-1d/README.md
+++ b/code/packages/haskell/barcode-layout-1d/README.md
@@ -1,0 +1,32 @@
+# barcode-layout-1d (Haskell)
+
+Pure shared geometry for linear barcode symbologies. Encoders provide an
+alternating stream of bar and space runs; this package validates those runs,
+computes symbol spans and quiet zones, and emits rectangle-only `PaintScene`
+values through the existing Haskell `paint-instructions` package.
+
+```haskell
+import CodingAdventures.BarcodeLayout1D
+
+example = do
+  runs <- runsFromBinaryPattern "101"
+    (defaultBinaryPatternOptions "start" (-1) Guard)
+  layoutBarcode1D runs defaultPaintBarcode1DOptions
+```
+
+The shared defaults use four scene units per module, 120-unit bars, and
+ten-module quiet zones on both sides. Run metadata is preserved on each bar
+rectangle, and the scene records its content and total module widths.
+
+Human-readable text is rejected explicitly until the Haskell paint stack has
+portable text metrics and glyph shaping. This prevents callers from receiving
+an incomplete scene that silently omits requested text.
+
+This package is the shared geometry foundation for the remaining
+Haskell Code 39, Codabar, ITF, UPC-A, EAN-13, and Code 128 ports.
+
+## Development
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/barcode-layout-1d/barcode-layout-1d.cabal
+++ b/code/packages/haskell/barcode-layout-1d/barcode-layout-1d.cabal
@@ -1,0 +1,37 @@
+cabal-version: 3.0
+name:          barcode-layout-1d
+version:       0.1.0
+synopsis:      Pure shared geometry for linear barcodes
+description:   Validated 1D barcode runs, symbol spans, quiet zones, and translation to the shared paint IR.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.BarcodeLayout1D
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , containers >=0.6 && <0.8
+                    , paint-instructions >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    BarcodeLayout1DSpec
+    hs-source-dirs:   test
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d
+                    , containers >=0.6 && <0.8
+                    , hspec ==2.*
+                    , paint-instructions >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/barcode-layout-1d/cabal.project
+++ b/code/packages/haskell/barcode-layout-1d/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../paint-instructions

--- a/code/packages/haskell/barcode-layout-1d/src/CodingAdventures/BarcodeLayout1D.hs
+++ b/code/packages/haskell/barcode-layout-1d/src/CodingAdventures/BarcodeLayout1D.hs
@@ -1,0 +1,476 @@
+-- | Pure geometry for linear barcodes.
+--
+-- Symbology packages turn their input into alternating 'Barcode1DRun'
+-- values. This module validates that run stream, computes quiet-zone and
+-- symbol geometry, and translates bars into the shared paint IR.
+module CodingAdventures.BarcodeLayout1D
+  ( Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DSymbolRole (..)
+  , Barcode1DRun (..)
+  , Barcode1DSymbolLayout (..)
+  , Barcode1DSymbolDescriptor (..)
+  , Barcode1DLayout (..)
+  , Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , RunsFromBinaryPatternOptions (..)
+  , RunsFromWidthPatternOptions (..)
+  , Barcode1DError (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , defaultBinaryPatternOptions
+  , defaultWidthPatternOptions
+  , totalModules
+  , computeBarcode1DLayout
+  , runsFromBinaryPattern
+  , runsFromWidthPattern
+  , layoutBarcode1D
+  , drawBarcode1D
+  , version
+  ) where
+
+import Data.Aeson (Value, toJSON)
+import Data.List (find, group)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
+import CodingAdventures.PaintInstructions
+  ( PaintInstruction (..)
+  , PaintScene (..)
+  )
+
+-- | Package version shared with the established implementations.
+version :: String
+version = "0.1.0"
+
+-- | Whether a run paints ink or advances through empty space.
+data Barcode1DRunColor = Bar | Space
+  deriving (Eq, Show)
+
+-- | The semantic role of a run in its source symbology.
+data Barcode1DRunRole
+  = Data
+  | Start
+  | Stop
+  | Guard
+  | Check
+  | InterCharacterGap
+  deriving (Eq, Show)
+
+-- | Symbol roles exclude gaps because gaps do not represent symbols.
+data Barcode1DSymbolRole
+  = SymbolData
+  | SymbolStart
+  | SymbolStop
+  | SymbolGuard
+  | SymbolCheck
+  deriving (Eq, Show)
+
+-- | One alternating bar or space measured in barcode modules.
+data Barcode1DRun = Barcode1DRun
+  { runColor :: Barcode1DRunColor
+  , runModules :: Int
+  , runSourceLabel :: String
+  , runSourceIndex :: Int
+  , runRole :: Barcode1DRunRole
+  } deriving (Eq, Show)
+
+-- | Inclusive/exclusive module span occupied by one encoded symbol.
+data Barcode1DSymbolLayout = Barcode1DSymbolLayout
+  { symbolLayoutLabel :: String
+  , symbolLayoutStartModule :: Int
+  , symbolLayoutEndModule :: Int
+  , symbolLayoutSourceIndex :: Int
+  , symbolLayoutRole :: Barcode1DSymbolRole
+  } deriving (Eq, Show)
+
+-- | Explicit symbol width supplied when run labels cannot infer boundaries.
+data Barcode1DSymbolDescriptor = Barcode1DSymbolDescriptor
+  { descriptorLabel :: String
+  , descriptorModules :: Int
+  , descriptorSourceIndex :: Int
+  , descriptorRole :: Barcode1DSymbolRole
+  } deriving (Eq, Show)
+
+-- | Complete module-space geometry for a barcode.
+data Barcode1DLayout = Barcode1DLayout
+  { layoutLeftQuietZoneModules :: Int
+  , layoutRightQuietZoneModules :: Int
+  , layoutContentModules :: Int
+  , layoutTotalModules :: Int
+  , layoutSymbolLayouts :: [Barcode1DSymbolLayout]
+  } deriving (Eq, Show)
+
+-- | Geometry and paint choices. These never change encoded data.
+data Barcode1DRenderConfig = Barcode1DRenderConfig
+  { configModuleWidth :: Double
+  , configBarHeight :: Double
+  , configQuietZoneModules :: Int
+  , configIncludeHumanReadableText :: Bool
+  , configTextFontSize :: Double
+  , configTextMargin :: Double
+  , configForeground :: String
+  , configBackground :: String
+  } deriving (Eq, Show)
+
+-- | Optional scene annotations and explicit symbol spans.
+data PaintBarcode1DOptions = PaintBarcode1DOptions
+  { optionsRenderConfig :: Barcode1DRenderConfig
+  , optionsHumanReadableText :: Maybe String
+  , optionsMetadata :: Map String Value
+  , optionsLabel :: Maybe String
+  , optionsSymbols :: Maybe [Barcode1DSymbolDescriptor]
+  } deriving (Eq, Show)
+
+-- | Source attribution attached to a binary-pattern run stream.
+data RunsFromBinaryPatternOptions = RunsFromBinaryPatternOptions
+  { binarySourceLabel :: String
+  , binarySourceIndex :: Int
+  , binaryRole :: Barcode1DRunRole
+  } deriving (Eq, Show)
+
+-- | Width-pattern markers, ratios, and source attribution.
+data RunsFromWidthPatternOptions = RunsFromWidthPatternOptions
+  { widthSourceLabel :: String
+  , widthSourceIndex :: Int
+  , widthRole :: Barcode1DRunRole
+  , widthNarrowModules :: Int
+  , widthWideModules :: Int
+  , widthNarrowMarker :: Char
+  , widthWideMarker :: Char
+  , widthStartingColor :: Barcode1DRunColor
+  } deriving (Eq, Show)
+
+-- | Checked failures returned by the pure API.
+data Barcode1DError
+  = EmptyPattern String
+  | UnsupportedBinaryToken Char
+  | UnsupportedWidthToken Char
+  | InvalidModuleCount String Int
+  | NonAlternatingRuns Int
+  | InvalidQuietZoneModules Int
+  | SymbolWidthMismatch Int Int
+  | InvalidRenderConfiguration String Double
+  | HumanReadableTextUnsupported
+  deriving (Eq, Show)
+
+-- | Shared rendering defaults from the barcode contract.
+defaultBarcode1DRenderConfig :: Barcode1DRenderConfig
+defaultBarcode1DRenderConfig = Barcode1DRenderConfig
+  { configModuleWidth = 4
+  , configBarHeight = 120
+  , configQuietZoneModules = 10
+  , configIncludeHumanReadableText = False
+  , configTextFontSize = 16
+  , configTextMargin = 8
+  , configForeground = "#000000"
+  , configBackground = "#ffffff"
+  }
+
+-- | Default scene options with no caller metadata or explicit symbols.
+defaultPaintBarcode1DOptions :: PaintBarcode1DOptions
+defaultPaintBarcode1DOptions = PaintBarcode1DOptions
+  { optionsRenderConfig = defaultBarcode1DRenderConfig
+  , optionsHumanReadableText = Nothing
+  , optionsMetadata = Map.empty
+  , optionsLabel = Nothing
+  , optionsSymbols = Nothing
+  }
+
+-- | Build the required attribution for a binary pattern.
+defaultBinaryPatternOptions
+  :: String -> Int -> Barcode1DRunRole -> RunsFromBinaryPatternOptions
+defaultBinaryPatternOptions label index role = RunsFromBinaryPatternOptions
+  { binarySourceLabel = label
+  , binarySourceIndex = index
+  , binaryRole = role
+  }
+
+-- | Build the standard 1:3 narrow/wide pattern configuration.
+defaultWidthPatternOptions
+  :: String -> Int -> Barcode1DRunRole -> RunsFromWidthPatternOptions
+defaultWidthPatternOptions label index role = RunsFromWidthPatternOptions
+  { widthSourceLabel = label
+  , widthSourceIndex = index
+  , widthRole = role
+  , widthNarrowModules = 1
+  , widthWideModules = 3
+  , widthNarrowMarker = 'N'
+  , widthWideMarker = 'W'
+  , widthStartingColor = Bar
+  }
+
+-- | Add the module widths in a run stream.
+totalModules :: [Barcode1DRun] -> Int
+totalModules = sum . map runModules
+
+-- | Coalesce a string of @0@ and @1@ modules into alternating runs.
+runsFromBinaryPattern
+  :: String
+  -> RunsFromBinaryPatternOptions
+  -> Either Barcode1DError [Barcode1DRun]
+runsFromBinaryPattern patternText options
+  | null patternText = Left (EmptyPattern "binary")
+  | Just token <- find (`notElem` "01") patternText =
+      Left (UnsupportedBinaryToken token)
+  | otherwise = Right (map makeRun (group patternText))
+  where
+    makeRun tokens = Barcode1DRun
+      { runColor = if head tokens == '1' then Bar else Space
+      , runModules = length tokens
+      , runSourceLabel = binarySourceLabel options
+      , runSourceIndex = binarySourceIndex options
+      , runRole = binaryRole options
+      }
+
+-- | Expand narrow/wide markers into alternating bar and space runs.
+runsFromWidthPattern
+  :: String
+  -> RunsFromWidthPatternOptions
+  -> Either Barcode1DError [Barcode1DRun]
+runsFromWidthPattern patternText options
+  | null patternText = Left (EmptyPattern "width")
+  | widthNarrowModules options <= 0 =
+      Left (InvalidModuleCount "narrowModules" (widthNarrowModules options))
+  | widthWideModules options <= 0 =
+      Left (InvalidModuleCount "wideModules" (widthWideModules options))
+  | Just token <- find unsupported patternText = Left (UnsupportedWidthToken token)
+  | otherwise = Right (zipWith makeRun [0 :: Int ..] patternText)
+  where
+    unsupported token =
+      token /= widthNarrowMarker options && token /= widthWideMarker options
+    makeRun index token = Barcode1DRun
+      { runColor = colorAt index (widthStartingColor options)
+      , runModules = if token == widthNarrowMarker options
+          then widthNarrowModules options
+          else widthWideModules options
+      , runSourceLabel = widthSourceLabel options
+      , runSourceIndex = widthSourceIndex options
+      , runRole = widthRole options
+      }
+
+colorAt :: Int -> Barcode1DRunColor -> Barcode1DRunColor
+colorAt index initial
+  | even index = initial
+  | initial == Bar = Space
+  | otherwise = Bar
+
+-- | Validate a run stream and compute quiet zones and symbol spans.
+computeBarcode1DLayout
+  :: [Barcode1DRun]
+  -> Int
+  -> Maybe [Barcode1DSymbolDescriptor]
+  -> Either Barcode1DError Barcode1DLayout
+computeBarcode1DLayout runs quietZone descriptors = do
+  validateRuns runs
+  if quietZone <= 0
+    then Left (InvalidQuietZoneModules quietZone)
+    else do
+      let content = totalModules runs
+      symbolLayouts <- case descriptors of
+        Just values -> explicitSymbolLayouts values content
+        Nothing -> Right (inferSymbolLayouts runs)
+      Right (Barcode1DLayout
+        { layoutLeftQuietZoneModules = quietZone
+        , layoutRightQuietZoneModules = quietZone
+        , layoutContentModules = content
+        , layoutTotalModules = quietZone + content + quietZone
+        , layoutSymbolLayouts = symbolLayouts
+        })
+
+validateRuns :: [Barcode1DRun] -> Either Barcode1DError ()
+validateRuns = go 0 Nothing
+  where
+    go _ _ [] = Right ()
+    go index previousColor (run : rest)
+      | runModules run <= 0 =
+          Left (InvalidModuleCount ("runs[" ++ show index ++ "].modules") (runModules run))
+      | previousColor == Just (runColor run) = Left (NonAlternatingRuns index)
+      | otherwise = go (index + 1) (Just (runColor run)) rest
+
+explicitSymbolLayouts
+  :: [Barcode1DSymbolDescriptor]
+  -> Int
+  -> Either Barcode1DError [Barcode1DSymbolLayout]
+explicitSymbolLayouts descriptors content = go 0 [] descriptors
+  where
+    go cursor layouts []
+      | cursor == content = Right (reverse layouts)
+      | otherwise = Left (SymbolWidthMismatch content cursor)
+    go cursor layouts (descriptor : rest)
+      | descriptorModules descriptor <= 0 =
+          Left (InvalidModuleCount
+            ("symbol " ++ show (descriptorLabel descriptor) ++ " modules")
+            (descriptorModules descriptor))
+      | otherwise =
+          let next = cursor + descriptorModules descriptor
+              layout = Barcode1DSymbolLayout
+                { symbolLayoutLabel = descriptorLabel descriptor
+                , symbolLayoutStartModule = cursor
+                , symbolLayoutEndModule = next
+                , symbolLayoutSourceIndex = descriptorSourceIndex descriptor
+                , symbolLayoutRole = descriptorRole descriptor
+                }
+          in go next (layout : layouts) rest
+
+inferSymbolLayouts :: [Barcode1DRun] -> [Barcode1DSymbolLayout]
+inferSymbolLayouts runs = reverse (finish finalCursor current layouts)
+  where
+    (finalCursor, current, layouts) = foldl step (0, Nothing, []) runs
+
+    step (cursor, active, completed) run =
+      let nextCursor = cursor + runModules run
+      in case symbolRoleFromRunRole (runRole run) of
+          Nothing -> (nextCursor, active, completed)
+          Just role
+            | sameSymbol active run role -> (nextCursor, active, completed)
+            | otherwise ->
+                ( nextCursor
+                , Just (runSourceLabel run, cursor, runSourceIndex run, role)
+                , finish cursor active completed
+                )
+
+    finish _ Nothing completed = completed
+    finish cursor (Just (label, startModule, sourceIndex, role)) completed =
+      Barcode1DSymbolLayout
+        { symbolLayoutLabel = label
+        , symbolLayoutStartModule = startModule
+        , symbolLayoutEndModule = cursor
+        , symbolLayoutSourceIndex = sourceIndex
+        , symbolLayoutRole = role
+        } : completed
+
+sameSymbol
+  :: Maybe (String, Int, Int, Barcode1DSymbolRole)
+  -> Barcode1DRun
+  -> Barcode1DSymbolRole
+  -> Bool
+sameSymbol Nothing _ _ = False
+sameSymbol (Just (label, _, sourceIndex, role)) run candidateRole =
+  label == runSourceLabel run
+    && sourceIndex == runSourceIndex run
+    && role == candidateRole
+
+symbolRoleFromRunRole :: Barcode1DRunRole -> Maybe Barcode1DSymbolRole
+symbolRoleFromRunRole role = case role of
+  Data -> Just SymbolData
+  Start -> Just SymbolStart
+  Stop -> Just SymbolStop
+  Guard -> Just SymbolGuard
+  Check -> Just SymbolCheck
+  InterCharacterGap -> Nothing
+
+runRoleName :: Barcode1DRunRole -> String
+runRoleName role = case role of
+  Data -> "data"
+  Start -> "start"
+  Stop -> "stop"
+  Guard -> "guard"
+  Check -> "check"
+  InterCharacterGap -> "inter-character-gap"
+
+-- | Translate barcode runs to rectangle-only paint instructions.
+layoutBarcode1D
+  :: [Barcode1DRun]
+  -> PaintBarcode1DOptions
+  -> Either Barcode1DError PaintScene
+layoutBarcode1D runs options = do
+  validateRenderConfig config
+  if configIncludeHumanReadableText config || isJust (optionsHumanReadableText options)
+    then Left HumanReadableTextUnsupported
+    else do
+      layout <- computeBarcode1DLayout
+        runs
+        (configQuietZoneModules config)
+        (optionsSymbols options)
+      let instructions = renderRuns config (layoutLeftQuietZoneModules layout) runs
+          sceneWidth = fromIntegral (layoutTotalModules layout) * configModuleWidth config
+          sceneHeight = configBarHeight config
+          sceneMetadata = Map.union
+            (standardMetadata options layout sceneWidth sceneHeight)
+            (optionsMetadata options)
+      Right PaintScene
+        { psWidth = sceneWidth
+        , psHeight = sceneHeight
+        , psInstructions = instructions
+        , psBg = configBackground config
+        , psMeta = sceneMetadata
+        }
+  where
+    config = optionsRenderConfig options
+
+-- | Alias matching the shared public API name.
+drawBarcode1D
+  :: [Barcode1DRun]
+  -> PaintBarcode1DOptions
+  -> Either Barcode1DError PaintScene
+drawBarcode1D = layoutBarcode1D
+
+validateRenderConfig :: Barcode1DRenderConfig -> Either Barcode1DError ()
+validateRenderConfig config = do
+  validatePositive "moduleWidth" (configModuleWidth config)
+  validatePositive "barHeight" (configBarHeight config)
+  if configQuietZoneModules config <= 0
+    then Left (InvalidQuietZoneModules (configQuietZoneModules config))
+    else Right ()
+  validatePositive "textFontSize" (configTextFontSize config)
+  validateNonNegative "textMargin" (configTextMargin config)
+
+validatePositive :: String -> Double -> Either Barcode1DError ()
+validatePositive name value
+  | finite value && value > 0 = Right ()
+  | otherwise = Left (InvalidRenderConfiguration name value)
+
+validateNonNegative :: String -> Double -> Either Barcode1DError ()
+validateNonNegative name value
+  | finite value && value >= 0 = Right ()
+  | otherwise = Left (InvalidRenderConfiguration name value)
+
+finite :: Double -> Bool
+finite value = not (isNaN value || isInfinite value)
+
+renderRuns
+  :: Barcode1DRenderConfig
+  -> Int
+  -> [Barcode1DRun]
+  -> [PaintInstruction]
+renderRuns config quietZone = reverse . snd . foldl renderRun (quietZone, [])
+  where
+    renderRun (cursor, instructions) run =
+      let next = cursor + runModules run
+          instruction = PaintRect
+            { prX = fromIntegral cursor * configModuleWidth config
+            , prY = 0
+            , prW = fromIntegral (runModules run) * configModuleWidth config
+            , prH = configBarHeight config
+            , prFill = configForeground config
+            , prMeta = Map.fromList
+                [ ("sourceLabel", toJSON (runSourceLabel run))
+                , ("sourceIndex", toJSON (runSourceIndex run))
+                , ("role", toJSON (runRoleName (runRole run)))
+                , ("moduleStart", toJSON cursor)
+                , ("moduleEnd", toJSON next)
+                ]
+            }
+      in if runColor run == Bar
+          then (next, instruction : instructions)
+          else (next, instructions)
+
+standardMetadata
+  :: PaintBarcode1DOptions
+  -> Barcode1DLayout
+  -> Double
+  -> Double
+  -> Map String Value
+standardMetadata options layout sceneWidth sceneHeight = Map.fromList
+  [ ("label", toJSON (maybe "1D barcode" id (optionsLabel options)))
+  , ("leftQuietZoneModules", toJSON (layoutLeftQuietZoneModules layout))
+  , ("rightQuietZoneModules", toJSON (layoutRightQuietZoneModules layout))
+  , ("contentModules", toJSON (layoutContentModules layout))
+  , ("totalModules", toJSON (layoutTotalModules layout))
+  , ("moduleWidthPx", toJSON (configModuleWidth (optionsRenderConfig options)))
+  , ("barHeightPx", toJSON (configBarHeight (optionsRenderConfig options)))
+  , ("sceneWidthPx", toJSON sceneWidth)
+  , ("sceneHeightPx", toJSON sceneHeight)
+  , ("symbolCount", toJSON (length (layoutSymbolLayouts layout)))
+  ]

--- a/code/packages/haskell/barcode-layout-1d/test/BarcodeLayout1DSpec.hs
+++ b/code/packages/haskell/barcode-layout-1d/test/BarcodeLayout1DSpec.hs
@@ -1,0 +1,223 @@
+module BarcodeLayout1DSpec (spec) where
+
+import CodingAdventures.BarcodeLayout1D
+import CodingAdventures.PaintInstructions (PaintInstruction (..), PaintScene (..))
+import Data.Aeson (toJSON)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "metadata and defaults" $ do
+    it "reports the shared package version" $
+      version `shouldBe` "0.1.0"
+
+    it "uses the shared render defaults" $
+      defaultBarcode1DRenderConfig `shouldBe` Barcode1DRenderConfig
+        { configModuleWidth = 4
+        , configBarHeight = 120
+        , configQuietZoneModules = 10
+        , configIncludeHumanReadableText = False
+        , configTextFontSize = 16
+        , configTextMargin = 8
+        , configForeground = "#000000"
+        , configBackground = "#ffffff"
+        }
+
+  describe "runsFromBinaryPattern" $ do
+    it "coalesces adjacent modules and preserves attribution" $ do
+      let options = defaultBinaryPatternOptions "start" (-1) Guard
+      runsFromBinaryPattern "110100" options `shouldBe` Right
+        [ Barcode1DRun Bar 2 "start" (-1) Guard
+        , Barcode1DRun Space 1 "start" (-1) Guard
+        , Barcode1DRun Bar 1 "start" (-1) Guard
+        , Barcode1DRun Space 2 "start" (-1) Guard
+        ]
+
+    it "rejects empty and non-binary patterns" $ do
+      let options = defaultBinaryPatternOptions "bad" 0 Data
+      runsFromBinaryPattern "" options `shouldBe` Left (EmptyPattern "binary")
+      runsFromBinaryPattern "10A1" options `shouldBe` Left (UnsupportedBinaryToken 'A')
+
+  describe "runsFromWidthPattern" $ do
+    it "expands narrow and wide markers with alternating colors" $ do
+      let options = defaultWidthPatternOptions "A" 0 Data
+      runsFromWidthPattern "NWNNW" options `shouldBe` Right
+        [ Barcode1DRun Bar 1 "A" 0 Data
+        , Barcode1DRun Space 3 "A" 0 Data
+        , Barcode1DRun Bar 1 "A" 0 Data
+        , Barcode1DRun Space 1 "A" 0 Data
+        , Barcode1DRun Bar 3 "A" 0 Data
+        ]
+
+    it "supports custom markers, ratios, and starting color" $ do
+      let options = (defaultWidthPatternOptions "B" 2 Check)
+            { widthNarrowModules = 2
+            , widthWideModules = 5
+            , widthNarrowMarker = 'n'
+            , widthWideMarker = 'w'
+            , widthStartingColor = Space
+            }
+      runsFromWidthPattern "nww" options `shouldBe` Right
+        [ Barcode1DRun Space 2 "B" 2 Check
+        , Barcode1DRun Bar 5 "B" 2 Check
+        , Barcode1DRun Space 5 "B" 2 Check
+        ]
+
+    it "rejects empty, invalid-marker, and non-positive-width patterns" $ do
+      let options = defaultWidthPatternOptions "bad" 0 Data
+      runsFromWidthPattern "" options `shouldBe` Left (EmptyPattern "width")
+      runsFromWidthPattern "NX" options `shouldBe` Left (UnsupportedWidthToken 'X')
+      runsFromWidthPattern "N" (options { widthNarrowModules = 0 })
+        `shouldBe` Left (InvalidModuleCount "narrowModules" 0)
+      runsFromWidthPattern "W" (options { widthWideModules = -1 })
+        `shouldBe` Left (InvalidModuleCount "wideModules" (-1))
+
+  describe "computeBarcode1DLayout" $ do
+    it "adds widths and quiet zones" $ do
+      let runs = sampleRuns
+      totalModules runs `shouldBe` 4
+      computeBarcode1DLayout runs 10 Nothing `shouldBe` Right (Barcode1DLayout
+        { layoutLeftQuietZoneModules = 10
+        , layoutRightQuietZoneModules = 10
+        , layoutContentModules = 4
+        , layoutTotalModules = 24
+        , layoutSymbolLayouts =
+            [ Barcode1DSymbolLayout "*" 0 2 0 SymbolStart
+            , Barcode1DSymbolLayout "A" 2 4 1 SymbolData
+            ]
+        })
+
+    it "groups adjacent runs from the same symbol" $ do
+      let runs =
+            [ Barcode1DRun Bar 1 "A" 0 Data
+            , Barcode1DRun Space 2 "A" 0 Data
+            , Barcode1DRun Bar 1 "B" 1 Check
+            ]
+      fmap layoutSymbolLayouts (computeBarcode1DLayout runs 5 Nothing) `shouldBe` Right
+        [ Barcode1DSymbolLayout "A" 0 3 0 SymbolData
+        , Barcode1DSymbolLayout "B" 3 4 1 SymbolCheck
+        ]
+
+    it "honors explicit symbol descriptors" $ do
+      let descriptors =
+            [ Barcode1DSymbolDescriptor "start" 2 (-1) SymbolGuard
+            , Barcode1DSymbolDescriptor "value" 2 0 SymbolData
+            ]
+      fmap layoutSymbolLayouts (computeBarcode1DLayout sampleRuns 10 (Just descriptors))
+        `shouldBe` Right
+          [ Barcode1DSymbolLayout "start" 0 2 (-1) SymbolGuard
+          , Barcode1DSymbolLayout "value" 2 4 0 SymbolData
+          ]
+
+    it "rejects invalid runs, quiet zones, and descriptors" $ do
+      computeBarcode1DLayout [Barcode1DRun Bar 0 "A" 0 Data] 10 Nothing
+        `shouldBe` Left (InvalidModuleCount "runs[0].modules" 0)
+      computeBarcode1DLayout
+        [Barcode1DRun Bar 1 "A" 0 Data, Barcode1DRun Bar 1 "B" 1 Data]
+        10 Nothing `shouldBe` Left (NonAlternatingRuns 1)
+      computeBarcode1DLayout [] 0 Nothing `shouldBe` Left (InvalidQuietZoneModules 0)
+      computeBarcode1DLayout sampleRuns 10
+        (Just [Barcode1DSymbolDescriptor "short" 3 0 SymbolData])
+        `shouldBe` Left (SymbolWidthMismatch 4 3)
+      computeBarcode1DLayout sampleRuns 10
+        (Just [Barcode1DSymbolDescriptor "bad" 0 0 SymbolData])
+        `shouldBe` Left (InvalidModuleCount "symbol \"bad\" modules" 0)
+
+    it "allows an empty content stream with quiet zones" $
+      computeBarcode1DLayout [] 3 Nothing `shouldBe` Right (Barcode1DLayout
+        { layoutLeftQuietZoneModules = 3
+        , layoutRightQuietZoneModules = 3
+        , layoutContentModules = 0
+        , layoutTotalModules = 6
+        , layoutSymbolLayouts = []
+        })
+
+  describe "layoutBarcode1D" $ do
+    it "emits rectangles only for bars at module-scaled coordinates" $ do
+      scene <- expectRight (layoutBarcode1D sampleRuns defaultPaintBarcode1DOptions)
+      psWidth scene `shouldBe` 96
+      psHeight scene `shouldBe` 120
+      psBg scene `shouldBe` "#ffffff"
+      psInstructions scene `shouldSatisfy` ((== 2) . length)
+      case psInstructions scene of
+        [firstBar, secondBar] -> do
+          (prX firstBar, prW firstBar) `shouldBe` (40, 4)
+          (prX secondBar, prW secondBar) `shouldBe` (48, 8)
+        _ -> expectationFailure "expected two bar rectangles"
+
+    it "preserves run and scene metadata with standard keys authoritative" $ do
+      let options = defaultPaintBarcode1DOptions
+            { optionsLabel = Just "Demo barcode"
+            , optionsMetadata = Map.fromList
+                [ ("symbology", toJSON ("demo" :: String))
+                , ("totalModules", toJSON (999 :: Int))
+                ]
+            }
+      scene <- expectRight (layoutBarcode1D sampleRuns options)
+      let firstBar = head (psInstructions scene)
+      Map.lookup "sourceLabel" (prMeta firstBar) `shouldBe` Just (toJSON ("*" :: String))
+      Map.lookup "moduleStart" (prMeta firstBar) `shouldBe` Just (toJSON (10 :: Int))
+      Map.lookup "moduleEnd" (prMeta firstBar) `shouldBe` Just (toJSON (11 :: Int))
+      Map.lookup "role" (prMeta firstBar) `shouldBe` Just (toJSON ("start" :: String))
+      Map.lookup "label" (psMeta scene) `shouldBe` Just (toJSON ("Demo barcode" :: String))
+      Map.lookup "symbology" (psMeta scene) `shouldBe` Just (toJSON ("demo" :: String))
+      Map.lookup "totalModules" (psMeta scene) `shouldBe` Just (toJSON (24 :: Int))
+
+    it "applies custom geometry and paint colors" $ do
+      let config = defaultBarcode1DRenderConfig
+            { configModuleWidth = 2.5
+            , configBarHeight = 50
+            , configQuietZoneModules = 2
+            , configForeground = "navy"
+            , configBackground = "transparent"
+            }
+      scene <- expectRight (layoutBarcode1D sampleRuns
+        (defaultPaintBarcode1DOptions { optionsRenderConfig = config }))
+      (psWidth scene, psHeight scene, psBg scene) `shouldBe` (20, 50, "transparent")
+      map prFill (psInstructions scene) `shouldBe` ["navy", "navy"]
+
+    it "supports the draw alias" $
+      drawBarcode1D sampleRuns defaultPaintBarcode1DOptions
+        `shouldBe` layoutBarcode1D sampleRuns defaultPaintBarcode1DOptions
+
+    it "rejects all non-finite and out-of-range render values" $ do
+      invalidConfig (defaultBarcode1DRenderConfig { configModuleWidth = 0 })
+        `shouldBe` Left (InvalidRenderConfiguration "moduleWidth" 0)
+      invalidConfig (defaultBarcode1DRenderConfig { configBarHeight = -1 })
+        `shouldBe` Left (InvalidRenderConfiguration "barHeight" (-1))
+      invalidConfig (defaultBarcode1DRenderConfig { configQuietZoneModules = 0 })
+        `shouldBe` Left (InvalidQuietZoneModules 0)
+      invalidConfig (defaultBarcode1DRenderConfig { configTextFontSize = 1 / 0 })
+        `shouldBe` Left (InvalidRenderConfiguration "textFontSize" (1 / 0))
+      invalidConfig (defaultBarcode1DRenderConfig { configTextMargin = -1 })
+        `shouldBe` Left (InvalidRenderConfiguration "textMargin" (-1))
+      invalidConfig (defaultBarcode1DRenderConfig { configTextMargin = 0 / 0 })
+        `shouldSatisfy` isInvalidTextMargin
+
+    it "rejects both text configuration paths until shaping exists" $ do
+      invalidConfig
+        (defaultBarcode1DRenderConfig { configIncludeHumanReadableText = True })
+        `shouldBe` Left HumanReadableTextUnsupported
+      layoutBarcode1D sampleRuns
+        (defaultPaintBarcode1DOptions { optionsHumanReadableText = Just "123" })
+        `shouldBe` Left HumanReadableTextUnsupported
+
+sampleRuns :: [Barcode1DRun]
+sampleRuns =
+  [ Barcode1DRun Bar 1 "*" 0 Start
+  , Barcode1DRun Space 1 "*" 0 InterCharacterGap
+  , Barcode1DRun Bar 2 "A" 1 Data
+  ]
+
+invalidConfig :: Barcode1DRenderConfig -> Either Barcode1DError PaintScene
+invalidConfig config = layoutBarcode1D sampleRuns
+  (defaultPaintBarcode1DOptions { optionsRenderConfig = config })
+
+isInvalidTextMargin :: Either Barcode1DError PaintScene -> Bool
+isInvalidTextMargin (Left (InvalidRenderConfiguration "textMargin" value)) = isNaN value
+isInvalidTextMargin _ = False
+
+expectRight :: Show error => Either error value -> IO value
+expectRight (Right value) = pure value
+expectRight (Left err) = fail ("unexpected error: " ++ show err)

--- a/code/packages/haskell/barcode-layout-1d/test/Spec.hs
+++ b/code/packages/haskell/barcode-layout-1d/test/Spec.hs
@@ -1,0 +1,5 @@
+import BarcodeLayout1DSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -120,11 +120,12 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
-`type-checker-protocol` ports, and the Haskell `paint-vm-ascii` port:
+`type-checker-protocol` ports, and the Haskell `paint-vm-ascii` and
+`barcode-layout-1d` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 289 |
+| Present in 10-15 languages | 172 | 288 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 709 | 9,926 |
@@ -170,7 +171,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 289
+The 172 packages present in at least ten implementation languages need 288
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -181,7 +182,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 14 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 13 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -589,6 +590,20 @@ rectangles, clipping, transparent paints, default scaling, half-cell rounding,
 zero-sized scenes, unsupported paths, invalid scales, scene dimensions, and
 rectangle geometry. The package now spans 11 implementation lanes, reduces the
 high-consensus backlog to 289 slots, and leaves 14 gaps in the Haskell lane.
+
+The twenty-first Haskell high-consensus slice is complete:
+`barcode-layout-1d` now provides the shared pure geometry layer for linear
+barcodes. It validates alternating bar/space runs, expands binary and
+narrow/wide patterns, computes inferred or explicit symbol spans and quiet
+zones, and emits metadata-rich rectangle-only scenes through the existing
+Haskell `paint-instructions` package. Its package-native suite exercises 18
+examples with 97% expression and 89% alternative coverage across shared
+defaults, both pattern families, custom ratios and markers, attribution,
+symbol inference and descriptors, empty content, rendering geometry and
+metadata, every validation family, and the deliberate text-shaping guard. The
+package now spans 12 implementation lanes, reduces the high-consensus backlog
+to 288 slots, leaves 13 gaps in the Haskell lane, and unlocks the dependent
+Code 39, Codabar, ITF, UPC-A, EAN-13, Code 128, and `barcode-1d` ports.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `barcode-layout-1d` package with typed bar/space runs, source roles, quiet-zone geometry, inferred and explicit symbol spans, and checked errors
- translate validated runs into metadata-rich rectangle-only `PaintScene` values through the existing Haskell `paint-instructions` package
- update the parity roadmap from 289 to 288 high-consensus gaps and from 14 to 13 Haskell gaps

## Why this slice is next

`barcode-layout-1d` is the smallest unblocked foundation in the remaining Haskell high-consensus queue. It is also the direct prerequisite for Code 39, Codabar, ITF, UPC-A, EAN-13, Code 128, and the higher `barcode-1d` pipeline, so landing it enables the dependency-shaped barcode wave without introducing temporary package-graph gaps.

## Validation

- `cabal test all --enable-coverage` — 18 package examples and 28 `paint-instructions` dependency examples passed; package coverage is 97% expressions and 89% alternatives
- `cabal check` — no errors or warnings
- `cabal sdist --output-directory <temp>` — source distribution created successfully outside the repository
- `python -m unittest discover -s code/scripts/tests -p test_package_parity_report.py -v` — 6 tests passed
- `python code/scripts/package_parity_report.py --format markdown --fail-on-collisions`
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 288 high-consensus gaps, 13 Haskell gaps, zero collisions, zero unknown buckets
- `git diff --check`

## Remaining Haskell high-consensus gaps

`barcode-1d`, `brotli`, `codabar`, `code128`, `code39`, `ean-13`, `event-loop`, `http-core`, `http1`, `itf`, `sql-csv-source`, `upc-a`, and `zstd`.

No packages are newly classified as non-portable in this slice.
