### PR TITLE
feat(facts): environment/air-quality-index — first shipped RANGE table (RS-5c)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_aqi_range_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_aqi_range_e2e.rs
@@ -1,0 +1,186 @@
+//! End-to-end test for the environment FACTS library
+//! (`adj-facts-stdlib/environment/air-quality-index.adj`) driven through the
+//! built CLI. This is the first SHIPPED facts table that is a RANGE table
+//! (ADJ-TABLES RS-5c) rather than an exact lookup: its rows are the EPA AQI
+//! BREAKPOINTS, keyed by each band's minimum index value, and a query for an
+//! arbitrary AQI selects the row whose key is the greatest one `<=` the queried
+//! value. The test proves, against the shipped artifact:
+//!
+//!   (a) a MID-BAND value (75) binds `moderate` with the EPA / AirNow citation
+//!       at `authoritative` trust, and the audit names the matched breakpoint
+//!       (51) — i.e. which bracket it fell into;
+//!   (b) an EXACT breakpoint (101) selects the band that STARTS there,
+//!       `unhealthy_for_sensitive_groups` — boundaries are not rounded down
+//!       across a health threshold — and the open top band still answers (480 →
+//!       `hazardous`, the source's "301 and higher");
+//!   (c) a BELOW-DOMAIN value (-5) has no breakpoint `<=` it and honestly
+//!       ABSTAINS rather than fabricating a category.
+//!
+//! 0 model calls throughout.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsaqi_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Copy the SHIPPED table beside an entry program so the `import` resolves —
+/// the test therefore exercises the artifact we actually ship, not a copy of
+/// the table inlined into the test source (which could silently drift).
+fn place_at(dir: &Path) {
+    let src = facts_stdlib().join("environment/air-quality-index.adj");
+    std::fs::copy(&src, dir.join("air-quality-index.adj"))
+        .expect("copy shipped air-quality-index.adj");
+}
+
+fn write(dir: &Path, name: &str, src: &str) {
+    std::fs::write(dir.join(name), src).unwrap();
+}
+
+fn run(program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// (a) Mid-band value — 75 is inside 51..100, brackets down to the 51 row.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn environment_aqi_mid_band_binds_category_with_epa_citation_and_matched_breakpoint() {
+    let dir = scratch("midband");
+    place_at(&dir);
+    write(
+        &dir,
+        "case.adj",
+        "import \"air-quality-index.adj\"\n\
+         ? lookup air_quality_index min_aqi = 75 mode range give category\n",
+    );
+
+    let (ok, out, err) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(out.contains("\"lookups\""), "expected a lookups section: {out}");
+
+    // No row is literally 75; the greatest key <= 75 is 51 → moderate.
+    assert!(
+        out.contains("\"category\":\"moderate\""),
+        "AQI 75 falls in the 51..100 band → moderate: {out}"
+    );
+    assert!(
+        out.contains("\"min_aqi\":\"51\""),
+        "audit must name the matched breakpoint (51), i.e. which bracket it fell in: {out}"
+    );
+
+    // The answer travels with the EPA / AirNow citation, at the trust tier a
+    // primary U.S. government source earns.
+    assert!(
+        out.contains("airnow.gov/aqi/aqi-basics"),
+        "answer must carry the EPA / AirNow locator: {out}"
+    );
+    assert!(
+        out.contains("\"trust\":\"authoritative\""),
+        "EPA / AirNow is a primary U.S. government source → authoritative: {out}"
+    );
+    assert!(
+        out.contains("\"abstained\":false"),
+        "a bracket hit is not an abstention: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Exact breakpoint, and the open top band.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn environment_aqi_exact_breakpoint_selects_that_band_and_top_band_is_open() {
+    let dir = scratch("boundary");
+    place_at(&dir);
+
+    // 101 is exactly a breakpoint: the greatest key <= 101 is 101 itself, so it
+    // binds the band that STARTS at 101 — NOT `moderate` below it. This is the
+    // point the source's prose calls the turn to unhealthy air.
+    write(
+        &dir,
+        "exact.adj",
+        "import \"air-quality-index.adj\"\n\
+         ? lookup air_quality_index min_aqi = 101 mode range give category\n",
+    );
+    let (ok, out, err) = run(&dir.join("exact.adj"));
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(
+        out.contains("\"category\":\"unhealthy_for_sensitive_groups\""),
+        "an exact breakpoint selects the band it starts, not the one below: {out}"
+    );
+    assert!(
+        out.contains("\"min_aqi\":\"101\""),
+        "matched key should be the breakpoint itself: {out}"
+    );
+    assert!(
+        !out.contains("\"category\":\"moderate\""),
+        "101 must not round down into the moderate band: {out}"
+    );
+
+    // The source writes the last band open-ended ("301 and higher"), so a bad
+    // wildfire-smoke day of 480 is still grounded as hazardous.
+    write(
+        &dir,
+        "top.adj",
+        "import \"air-quality-index.adj\"\n\
+         ? lookup air_quality_index min_aqi = 480 mode range give category\n",
+    );
+    let (ok2, out2, _e2) = run(&dir.join("top.adj"));
+    assert!(ok2);
+    assert!(
+        out2.contains("\"category\":\"hazardous\""),
+        "above the last breakpoint the top band is open → hazardous: {out2}"
+    );
+    assert!(
+        out2.contains("\"min_aqi\":\"301\""),
+        "the open top band's breakpoint is 301: {out2}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) Below the domain — honest abstention.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn environment_aqi_below_domain_abstains_rather_than_fabricating_a_category() {
+    let dir = scratch("below");
+    place_at(&dir);
+    write(
+        &dir,
+        "case.adj",
+        "import \"air-quality-index.adj\"\n\
+         ? lookup air_quality_index min_aqi = -5 mode range give category\n",
+    );
+
+    let (ok, out, err) = run(&dir.join("case.adj"));
+    assert!(ok, "an abstention is a normal answer, not a crash; stderr={err}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "the AQI domain starts at 0 — below it there is no breakpoint <= the value: {out}"
+    );
+    assert!(
+        !out.contains("\"category\":\""),
+        "an abstention binds no band — a negative AQI is not 'extra good' air: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -114,6 +114,7 @@ per rotation, in parallel):
 | `meteorology/` | Beaufort wind force number → the name the source gives it (0 → calm, 6 → strong_breeze, 12 → hurricane) | NWS Beaufort Wind Scale (authoritative) |
 | `meteorology/` | precipitation type → defining physical form (snow → ice_crystals, sleet → frozen_raindrops, hail → balls_of_ice) | NOAA National Weather Service (authoritative) |
 | `meteorology/` | Saffir-Simpson hurricane category → the damage descriptor NHC uses (1 → some_damage, 3 → devastating_damage, 5 → catastrophic_damage) | NOAA/NHC Saffir-Simpson Hurricane Wind Scale (authoritative) |
+| `environment/` | **RANGE table** — AQI value → EPA level of concern, keyed by band minimum (0 → good, 51 → moderate, 101 → unhealthy_for_sensitive_groups, 301 → hazardous, open top band) | EPA AirNow "AQI Basics" (authoritative) |
 | `geography/` | common landform → defining descriptor (mountain → projects_above_surroundings, plateau → flat_elevated, canyon → deep_narrow) | USGS Feature Type Thesaurus (authoritative) |
 | `geography/` | globe reference line → what it marks (equator → zero_degrees_latitude, prime_meridian → zero_degrees_longitude, tropic_of_cancer → northernmost_sun_overhead) | NOAA National Ocean Service / NESDIS (authoritative) |
 | … | *geography, physical constants, …* | *(expanding)* |

--- a/code/specs/data/adj-facts-stdlib/environment/air-quality-index.adj
+++ b/code/specs/data/adj-facts-stdlib/environment/air-quality-index.adj
@@ -1,0 +1,161 @@
+% ============================================================================
+% air-quality-index — the U.S. EPA Air Quality Index (AQI) breakpoints: each
+% band's MINIMUM index value → the "Level of Concern" category the source names
+% for that band (adj-facts-stdlib, ENVIRONMENT).
+% ============================================================================
+% Every other table in this library is an EXACT lookup: you hand it a key that
+% is literally a row (`category_3`, `hydrogen`, `tuesday`) and it hands back
+% that row's value. The AQI is not shaped like that. When the monitor near you
+% reports an AQI of 75, there is no row labelled 75 — 75 lives INSIDE a band,
+% and what you actually want to know is which band swallowed it. The AQI is a
+% STEP FUNCTION over the whole number line: it is flat across a band, then
+% jumps at a breakpoint, then is flat again.
+%
+% So this table is stored as its BREAKPOINTS. Each `row` is keyed by the
+% MINIMUM index value of a band — 0, 51, 101, 151, 201, 301 — and carries the
+% category that band is called. A query for 75 does NOT ask "is there a row
+% named 75?"; it asks "which breakpoint is the greatest one still `<=` 75?".
+% That is 51, so the answer is `moderate`. This is the ADJ-TABLES RS-5c RANGE /
+% BRACKET lookup, and this library is the first shipped facts table to use it:
+%
+%     ? lookup air_quality_index min_aqi = 75 mode range give category
+%                                                          % moderate
+%
+% Read the keyword form literally — `lookup`, `mode`, `give` are all keywords:
+%
+%     ? lookup <table> <key_col> = <number> mode range give <value_col>
+%              ^^^^^^^ ^^^^^^^^^   ^^^^^^^^           ^^^^^      ^^^^^^^^^
+%              which    the        the value          bracket    which column
+%              table    numeric    you are            select,    to hand back
+%                       key col    classifying        not exact
+%
+% The key column MUST be numeric. That is what makes "greatest key `<=` n" a
+% meaningful question at all: you cannot bracket-search a column of atoms, and
+% the engine rejects an attempt to do so rather than guessing an ordering.
+%
+% The six EPA bands, as a truth table. The `min_aqi` column is what is STORED;
+% the "band" column is the interval that key implies (it runs up to just below
+% the next breakpoint) and is shown here only to make the step visible:
+%
+%     min_aqi   band (implied)    category                          source's colour
+%     -------   ---------------   -------------------------------   ---------------
+%           0   0 to 50           good                              Green
+%          51   51 to 100         moderate                          Yellow
+%         101   101 to 150        unhealthy_for_sensitive_groups    Orange
+%         151   151 to 200        unhealthy                         Red
+%         201   201 to 300        very_unhealthy                    Purple
+%         301   301 and higher    hazardous                         Maroon
+%
+% Note that the interval column is DERIVED, not stored. Storing `0 to 50` as a
+% pair would duplicate 51 in two places (as the top of one band and the bottom
+% of the next) and let them drift apart. Storing only the minima makes the bands
+% contiguous by construction: there is no gap between 50 and 51 to fall into,
+% because 51 IS the next step. The top band is deliberately OPEN — the source
+% says "301 and higher", so an AQI of 480 (a bad wildfire-smoke day) is still
+% `hazardous`; there is no upper breakpoint to fall off.
+%
+% Boundaries are EXACT, not fuzzy. A query for exactly 101 is not "near" the
+% orange band, it IS the orange band: the greatest key `<=` 101 is 101 itself,
+% so it binds `unhealthy_for_sensitive_groups`, not `moderate`. This matters,
+% because 101 is precisely the point where the source's prose says air quality
+% turns unhealthy ("When AQI values are above 100, air quality is unhealthy: at
+% first for certain sensitive groups of people"), and a table that rounded the
+% boundary the wrong way would put a real health threshold on the wrong side.
+%
+% HONEST ABSTENTION BELOW THE DOMAIN. The AQI starts at 0. There is no
+% breakpoint below 0, so a query for -5 has NO key `<=` it, and the engine
+% ABSTAINS — it reports that the value is below the table's domain rather than
+% inventing a category for it. This is the correct answer, not a failure: a
+% negative AQI is not "extra good air", it is not an AQI at all. The same
+% honesty that makes the exact-lookup tables abstain on a key they do not have
+% makes the range table abstain below its floor:
+%
+%     ? lookup air_quality_index min_aqi = -5 mode range give category
+%                                                          % abstains
+%
+% Contrast the two edges deliberately. ABOVE the top breakpoint the table does
+% NOT abstain, because the source explicitly wrote an open-ended band ("301 and
+% higher") — the answer is grounded. BELOW the bottom breakpoint it DOES
+% abstain, because the source's domain simply starts at 0 and says nothing about
+% what lies beneath it. The table answers exactly what its source covers, and
+% only that.
+%
+% The `category` value of every row is the source's own "Levels of Concern"
+% wording collapsed to a single snake_case atom, with no editorial rewording:
+% "Good" → `good`, "Moderate" → `moderate`, "Unhealthy for Sensitive Groups" →
+% `unhealthy_for_sensitive_groups`, "Unhealthy" → `unhealthy`, "Very Unhealthy"
+% → `very_unhealthy`, "Hazardous" → `hazardous`. In particular the third band
+% keeps the full four-word phrase rather than being shortened to something
+% tidier like `sensitive`, because the distinction the source is drawing there
+% is exactly that it is unhealthy for SOME people and not yet for everyone.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — all six breakpoint→category
+% pairs were read out of the fetched EPA / AirNow "Air Quality Index (AQI)
+% Basics" page, from the table titled "AQI Basics for Ozone and Particle
+% Pollution", and any band whose category wording or numeric range could not be
+% verified there would have been dropped). All six spans come from the SAME
+% primary source, https://www.airnow.gov/aqi/aqi-basics/ :
+%
+%   framing (why the table has exactly six steps)
+%     "The U.S. Air Quality Index (AQI) is EPA's tool for communicating about
+%      outdoor air quality and health. The AQI includes six color-coded
+%      categories, each corresponding to a range of index values."
+%
+%   0 → good
+%     "Green   Good   0 to 50   Air quality is satisfactory, and air pollution
+%      poses little or no risk."
+%
+%   51 → moderate
+%     "Yellow   Moderate   51 to 100   Air quality is acceptable. However, there
+%      may be a risk for some people, particularly those who are unusually
+%      sensitive to air pollution."
+%
+%   101 → unhealthy_for_sensitive_groups
+%     "Orange   Unhealthy for Sensitive Groups   101 to 150   Members of
+%      sensitive groups may experience health effects. The general public is
+%      less likely to be affected."
+%
+%   151 → unhealthy
+%     "Red   Unhealthy   151 to 200   Some members of the general public may
+%      experience health effects; members of sensitive groups may experience
+%      more serious health effects."
+%
+%   201 → very_unhealthy
+%     "Purple   Very Unhealthy   201 to 300   Health alert: The risk of health
+%      effects is increased for everyone."
+%
+%   301 → hazardous
+%     "Maroon   Hazardous   301 and higher   Health warning of emergency
+%      conditions: everyone is more likely to be affected."
+%
+% The open top band is grounded in that last span's "301 and higher" — the
+% source writes no upper bound, which is why the 301 row is an open step rather
+% than a closed interval. The 0 floor is grounded in the "0 to 50" span, which
+% is why anything below 0 abstains: the source's domain starts there.
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single cleanest span: the AirNow statement that fixes
+% the first breakpoint row (0 → good). Every OTHER row's per-fact source and
+% verbatim span is listed above, so each band remains independently checkable.
+% All spans are from the same EPA / AirNow page — AirNow is run by the U.S.
+% Environmental Protection Agency and the AQI is EPA's own index, a primary U.S.
+% government source — so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table air_quality_index {
+    columns min_aqi, category
+
+    row (0, good)                              % "Green   Good   0 to 50"
+    row (51, moderate)                         % "Yellow   Moderate   51 to 100"
+    row (101, unhealthy_for_sensitive_groups)  % "Orange   Unhealthy for Sensitive Groups   101 to 150"
+    row (151, unhealthy)                       % "Red   Unhealthy   151 to 200"
+    row (201, very_unhealthy)                  % "Purple   Very Unhealthy   201 to 300"
+    row (301, hazardous)                       % "Maroon   Hazardous   301 and higher" (open top band)
+
+    source "Green Good 0 to 50 Air quality is satisfactory, and air pollution poses little or no risk."
+    locator "https://www.airnow.gov/aqi/aqi-basics/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/environment/air-quality-index.query.adj
+++ b/code/specs/data/adj-facts-stdlib/environment/air-quality-index.query.adj
@@ -1,0 +1,37 @@
+% ============================================================================
+% air-quality-index.query.adj — a worked RANGE (bracket) recall over the
+% environment air-quality-index library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "the AQI here is 75 — how
+% bad is that?": it states no air-quality fact of its own — it only `import`s
+% the grounded breakpoint table and asks range lookups. The engine selects, for
+% each queried value, the breakpoint row whose `min_aqi` is the GREATEST key
+% still `<=` that value, and returns that row's `category` together with the
+% table's source/locator/trust.
+%
+% The queries below walk the three behaviours that matter for a step function:
+%
+%   * INSIDE a band (75, 260) — no row is literally 75, so the lookup brackets
+%     down to the 51 breakpoint and answers `moderate`.
+%   * EXACTLY ON a breakpoint (101, 0) — the greatest key `<=` 101 is 101
+%     itself, so it binds the band that STARTS there
+%     (`unhealthy_for_sensitive_groups`), not the band below it. Boundaries are
+%     exact; nothing is rounded across a health threshold.
+%   * OFF the ends — 480 is above the last breakpoint and is still answered
+%     (`hazardous`), because the source wrote that band open-ended as "301 and
+%     higher". But -5 is BELOW the smallest key, has no breakpoint `<=` it, and
+%     honestly ABSTAINS: a negative AQI is not exceptionally clean air, it is
+%     not an AQI at all, and the engine never invents a category for it.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli air-quality-index.query.adj
+% ============================================================================
+
+import "air-quality-index.adj"
+
+? lookup air_quality_index min_aqi = 75 mode range give category    % inside 51..100 → moderate
+? lookup air_quality_index min_aqi = 101 mode range give category   % exactly on a breakpoint → unhealthy_for_sensitive_groups
+? lookup air_quality_index min_aqi = 0 mode range give category     % the very floor of the domain → good
+? lookup air_quality_index min_aqi = 260 mode range give category   % inside 201..300 → very_unhealthy
+? lookup air_quality_index min_aqi = 480 mode range give category   % above the last breakpoint, open band → hazardous
+? lookup air_quality_index min_aqi = -5 mode range give category    % below the domain → abstains


### PR DESCRIPTION
## What

The **first grounded facts library that is a RANGE/bracket table** rather than an exact lookup — exercising the RS-5c tactic merged in #8544. All 52 existing facts libraries are exact-key lookups; this is the first shipped step function.

Rows are the **EPA AQI breakpoints**, keyed by each band's minimum index value. A query for an arbitrary AQI selects the row whose key is the greatest one `<=` the queried value:

```
? lookup air_quality_index min_aqi = 75 mode range give category   → moderate  (bracket 51)
```

| key (band min) | category | verbatim source cell |
|---|---|---|
| 0 | `good` | "Green   Good   0 to 50" |
| 51 | `moderate` | "Yellow   Moderate   51 to 100" |
| 101 | `unhealthy_for_sensitive_groups` | "Orange   Unhealthy for Sensitive Groups   101 to 150" |
| 151 | `unhealthy` | "Red   Unhealthy   151 to 200" |
| 201 | `very_unhealthy` | "Purple   Very Unhealthy   201 to 300" |
| 301 | `hazardous` | "Maroon   Hazardous   301 and higher" (open top band) |

Only band **minima** are stored; intervals are derived — so `51` cannot drift from "one past 50", it *is* the next step rather than a second copy of the boundary.

Both edges are **grounded, not assumed**: above the last breakpoint the table still answers (480 → `hazardous`) because the source literally says "301 and higher"; below 0 it **abstains**, since no breakpoint is `<=` a negative value and the source's domain starts at 0.

**Source:** EPA/AirNow ["AQI Basics"](https://www.airnow.gov/aqi/aqi-basics/) — the AQI is EPA's own index, primary U.S. government. **Trust: authoritative.**

## Known limitation (tracked, pre-existing — please read)

An ADJ `table` carries **one** `source`/`locator`/`trust` envelope, so *every* answer cites the envelope's span (the `0 → good` sentence) whatever band it lands in. Each row's own verbatim span is in the literate header and independently checkable, but is **not machine-attached to its row**.

This is the existing table-level convention across the whole facts stdlib, not something introduced here — the range lookup merely makes it **visible**, because the selected row is now explicit in the audit. Per-row table provenance (ADJ-TABLES §6, deferred at RS-5b) is the **next substrate item**, so these rows will inherit correct per-row citations without any change to this data.

## Also in flight (not in this PR)

A `geology/earthquake-magnitude` range table was built alongside this one but is **deliberately held back**: four of its six bands could only be grounded in a transcription of a PNG figure, not a byte-quotable text span, so `adj-verify` could never re-confirm them. Shipping a partial step function would be worse (a 2-row table classifies a 6.4 quake as `minor`). It is queued for re-grounding against a text source.

## Verification

- `cargo test -p adj-lang-cli --test facts_aqi_range_e2e` — 3 passed, 0 failed. The test imports the **shipped** `.adj` (copy-beside-entry) so the artifact itself is under test, not an inlined duplicate that could drift.
- Asserts: mid-band 75 → `moderate` with the AirNow citation + `"trust":"authoritative"` + matched breakpoint 51; exact breakpoint 101 → `unhealthy_for_sensitive_groups` (boundaries not rounded down across a health threshold); open top band 480 → `hazardous`; below-domain −5 → `"abstained":true`.
- `/security-review` **PASSED** — no vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)