### PR TITLE
feat(hl): Arabic Ch.4 writing set — ʿayn, the feminine ending, and the farewell

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Chapter 4 — Writing set (ʿayn, the feminine ending, and the farewell)
+
+- **Writing lessons added** (`AR-W10-ayn`, `AR-W11-ha-and-ta-marbuta`,
+  `AR-W12-maa-salama`): closes the writing track (AR-W01–12) on the **farewell**.
+  No `concept_tag` (writing lessons are exempt from the concept join).
+- **W10 — ع (ʿayn)**: the sound English doesn't have and the letter people picture
+  when they picture Arabic — an open-mouth curve over a bowl. Opens a **third
+  dots-family** (skeleton shared with **غ** *ghayn*, one dot above), rhyming with
+  the Ch.2 bowl-family and the Ch.3 hook-family. **The surprise**: Phoenician
+  *ʿayin* meant "**eye**"; the Greeks had no throat-sound to use it for, so they
+  **repurposed** the sign as the vowel **omicron** — our **O**. The learner has
+  been saying this letter since Ch.1 in *as-salāmu **ʿ**alaykum*.
+- **W11 — ه and ة**: **ه** (*hāʾ*) as the most **shape-shifting** letter yet (its
+  loop wears four genuinely different coats — the Lesson-2 four-coats rule at its
+  extreme; *hē* → Greek epsilon → **E**). Then **ة** (*tāʾ marbūṭa*, "**tied
+  tāʾ**") shown as exactly what it is — *hāʾ*'s loop **plus tāʾ's two dots** from
+  Ch.2 — appearing only word-finally and marking the **feminine**.
+- **W12 — assemble مع السلامة**: the farewell, "**with safety**." The payoff is
+  that **السلامة** is not a new word — it is **سلام** *from Lesson 3* with **ال**
+  added in front and **ة** behind. Ties the greeting *as-salāmu ʿalaykum* and the
+  farewell *maʿa s-salāma* to the **same root s–l–m** (peace/safety): Arabic opens
+  and closes a conversation with one idea, and the learner can now write both.
+
 ## Chapter 3 — Writing set (a second dots-family, and writing your reply)
 
 - **Writing lessons added** (`AR-W07-hook-family-ha-kha`, `AR-W08-kaf-and-ra`,

--- a/code/learning/human-languages/arabic/lessons/AR-W10-ayn.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W10-ayn.md
@@ -1,0 +1,76 @@
+---
+id: AR-W10-ayn
+chapter: 4
+type: writing
+headword: "ع"
+gloss: ʿayn — the most Arabic sound of all, and the letter that became our O
+romanization: "ʿayn"
+prerequisites: [AR-W09-khayr-bikhayr]
+sounds: [arabic-ayn]
+roots: [phoenician-ayin]
+est_minutes: 5
+reviews_of: [AR-W09-khayr-bikhayr, AR-W07-hook-family-ha-kha, AR-C01-as-salamu-alaykum]
+---
+
+# ع (ʿayn) — the eye that became an O
+
+## Warm-up
+
+[PAUSE 2s] This is the letter people think of when they think "Arabic." **ع**
+(*ʿayn*) writes a sound made **deep in the throat** — one English simply does not
+have. And its history holds the best surprise in the whole alphabet: this
+consonant is the ancestor of our vowel **O**.
+
+## Draw it
+
+Break it apart — *an open curve, then a bowl*:
+
+1. **the open-mouth curve** on top — like a small **c** opening to the left.
+2. **the bowl below**, when *ʿayn* stands alone or ends a word — a scoop
+   underneath.
+
+Joined in the middle of a word it flattens into a little wedge; standing alone it
+shows the full curve-over-bowl. It is a **connector**, so it changes coat by
+position like *sīn* and *lām*.
+
+## A third dots-family
+
+You know the **bowl** family (ب/ن/ت/ث) from Lesson 4 and the **hook-and-tail**
+family (ح/خ/ج) from Lesson 7. *ʿayn* opens a **third**: its skeleton is shared
+with **غ** (*ghayn*), which is the **same shape plus one dot above**. Same trick,
+third time — by now you should expect it.
+
+## The surprise: ʿayn → O
+
+*ʿayn* comes from Phoenician **ʿayin**, meaning "**eye**" — and the oldest forms
+were drawn as one. When the **Greeks** borrowed the Phoenician alphabet, they had
+**no throat-sound** like *ʿ*. So they did what borrowers do with a sign they can't
+use: they **repurposed** it — and turned the eye-shaped letter into the vowel
+**omicron**, our **O**.
+
+So the round **O** you write is a Phoenician **eye**, and Arabic's *ʿayn* is the
+same sign that kept its original consonant job. (Compare the thread so far:
+*ʾālep*→**A**, *bēt*→**B**, *mem*→**M**, *kaph*→**K**, *rēsh*→**R** — and now
+*ʿayin*→**O**.)
+
+## Where you've heard it
+
+You have been *saying* this sound since Chapter 1: **السلام عليكم** (*as-salāmu
+**ʿ**alaykum*) — the *ʿ* in *ʿalaykum* is this letter. And the farewell you'll
+write two lessons from now, **مع السلامة**, opens with it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **ع** — the open curve, then the bowl beneath]
+- [YOU SAY: the sound, from the throat — as in *ʿalaykum*]
+- [YOU SAY: the family — "*ʿayn* ع, and *ghayn* غ = the same shape **plus one dot**"]
+- [YOU SAY: "*ʿayin* = **eye** → the Greeks made it **O**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Describe **ع**'s two pieces. (An **open-mouth curve** on top, a **bowl**
+below when isolated or final.) What did Phoenician *ʿayin* mean, and what letter
+did the Greeks turn it into? ("**Eye**"; they had no such sound, so they made it
+the vowel **O**.) Which letter shares its skeleton? (**غ** *ghayn* — one dot
+above.) Next: **ه** and the feminine ending **ة**.

--- a/code/learning/human-languages/arabic/lessons/AR-W11-ha-and-ta-marbuta.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W11-ha-and-ta-marbuta.md
@@ -1,0 +1,73 @@
+---
+id: AR-W11-ha-and-ta-marbuta
+chapter: 4
+type: writing
+headword: "ه، ة"
+gloss: hāʾ — the shape-shifting loop — and ة, the "tied tāʾ" that marks feminine words
+romanization: "hāʾ, tāʾ marbūṭa"
+prerequisites: [AR-W10-ayn]
+sounds: [arabic-ha-light, arabic-ta-marbuta]
+roots: [phoenician-he]
+est_minutes: 5
+reviews_of: [AR-W10-ayn, AR-W04-dots-family-nun-ta, AR-C02-anta-anti]
+---
+
+# ه and ة — the loop, and the ending that means "feminine"
+
+## Warm-up
+
+[PAUSE 2s] Two related shapes. **ه** (*hāʾ*) is a plain "h" — and the most
+**shape-shifting** letter you've met, wearing four genuinely different coats. Then
+**ة**, a letter built *out of* it, whose whole job is to say one grammatical
+thing: **this word is feminine**.
+
+## ه (hāʾ) — the loop that never looks the same
+
+Break it apart — there is really just *one piece*:
+
+1. **the loop** — a closed round body.
+
+But that loop **changes shape a lot by position** more than any letter so far:
+standing alone it's a neat circle-ish loop; at the start it opens out; in the
+middle it becomes a small figure-of-eight pinched in the centre; at the end it
+trails. Same letter, four faces — the four-coats rule from Lesson 2 taken to its
+extreme.
+
+From Phoenician **hē** — the ancestor of Greek *epsilon* and Latin **E**. (Another
+one for the family tree: *ʾālep*→A, *bēt*→B, *hē*→**E**, *mem*→M, *ʿayin*→O.)
+
+## ة (tāʾ marbūṭa) — the "tied tāʾ"
+
+Now look carefully at this:
+
+- **ه** = *hāʾ*'s loop, **no dots**.
+- **ة** = **the same loop + tāʾ's two dots above**.
+
+Its name says exactly what it is: **tāʾ marbūṭa**, "the **tied-up tāʾ**" — a **ت**
+(*tāʾ*, Lesson 4) whose ends have been **tied into a loop**. It appears **only at
+the end of a word**, and it is the standard mark of a **feminine** noun or
+adjective.
+
+You already know its partner: back in Lesson 4 you learned **ت** with **two dots
+above**. Put those same two dots on a *hāʾ* loop and you get the feminine ending.
+Nothing new to memorise — just two known pieces combined.
+
+**Where you've seen it:** the farewell **مع السلامة** (*maʿa s-salāma*) ends in
+**ة** — *salāma* is feminine. That's the next lesson.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **ه** — the loop; then try it isolated and final, feel it change]
+- [YOU WRITE: **ة** — the same loop, **plus tāʾ's two dots above**]
+- [YOU SAY: the name — "*tāʾ marbūṭa*, the **tied** tāʾ — it marks the feminine"]
+- [YOU SAY: "*hē* → Greek epsilon → Latin **E**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What makes **ه** unusual among the letters you've learned? (Its **loop
+changes shape** dramatically by position — four very different coats.) What is
+**ة** made of, and what does its name mean? (*hāʾ*'s loop **+ tāʾ's two dots**;
+"**tied tāʾ**".) What does **ة** tell you about a word, and where can it appear?
+(That it is **feminine**; only at the **end**.) Next: assembling the farewell
+**مع السلامة**.

--- a/code/learning/human-languages/arabic/lessons/AR-W12-maa-salama.md
+++ b/code/learning/human-languages/arabic/lessons/AR-W12-maa-salama.md
@@ -1,0 +1,79 @@
+---
+id: AR-W12-maa-salama
+chapter: 4
+type: writing
+headword: "مع السلامة"
+gloss: assembling the farewell maʿa s-salāma, "with safety" — built on the very first word you wrote
+romanization: "maʿa s-salāma"
+prerequisites: [AR-W11-ha-and-ta-marbuta]
+sounds: [arabic-ayn, arabic-ta-marbuta]
+roots: [semitic-s-l-m]
+est_minutes: 5
+reviews_of: [AR-W11-ha-and-ta-marbuta, AR-W10-ayn, AR-W03-dots-mim-ba-salam]
+---
+
+# مع السلامة — the goodbye, and a word you already know
+
+## Warm-up
+
+[PAUSE 2s] The closing move. **مع السلامة** (*maʿa s-salāma*) is how Arabic says
+goodbye — literally "**with safety**," *go in peace*. And the heart of it is a
+word you wrote **all the way back in Lesson 3**: **سلام**. Everything since has
+been leading here.
+
+## Part 1 — مع (maʿa, "with")
+
+Two letters, both known:
+
+1. **م** (*mīm*, Lesson 3) — round head, joining left into…
+2. **ع** (*ʿayn*, Lesson 10) — the open curve over its bowl, closing the word.
+
+→ **مع** = *maʿa*, "with."
+
+## Part 2 — السلامة (as-salāma, "the safety")
+
+Look at what this is made of:
+
+- **ال** — the **al-** ("the"), *alif* + *lām*, both from Lessons 1–2. You've read
+  it since Chapter 1 in **ال**خير and **ال**سلام عليكم.
+- **سلام** — **the exact word you assembled in Lesson 3**: *sīn · lām · alif ·
+  mīm*.
+- **ة** — the *tāʾ marbūṭa* from Lesson 11, marking *salāma* as **feminine**.
+
+So **السلامة** = *al-* + *salām* + *-a*. You are not learning a new word; you are
+**adding two edges** to one you already own.
+
+## The root s-l-m, one more time
+
+*salām*, *salāma*, *islām*, *muslim* — all from the Semitic root **s–l–m**,
+"peace, safety, wholeness." The greeting you learned first (**السلام عليكم**,
+"peace be upon you") and the farewell you learn last (**مع السلامة**, "with
+safety") come from the **same three consonants**. Arabic opens and closes a
+conversation with one idea.
+
+## Assemble it — right to left
+
+1. **م** then **ع** → **مع**
+2. lift; **ا** + **ل** (the *al-*), the *lām* joining into…
+3. **س · ل · ا** — and remember the **لا** ligature, and that *alif* **breaks**…
+4. **م**, then **ة** to close.
+
+→ **مع السلامة**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: **مع** — mīm into ʿayn]
+- [YOU WRITE: **السلامة** — "the *al-*, then your Lesson-3 word, then the feminine ة"]
+- [YOU SAY: "*maʿa s-salāma* — **with safety**"]
+- [YOU SAY: the bookend — "**السلام عليكم** to greet, **مع السلامة** to part —
+  same root **s-l-m**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **مع السلامة** literally mean? ("**With safety**.") Which
+earlier word sits inside **السلامة**, and what was added? (**سلام** from Lesson 3
+— plus **ال** in front and **ة** behind.) What does the final **ة** signal?
+(*salāma* is **feminine**.) What root ties the first greeting to the last
+farewell? (**s–l–m** — peace/safety.) You can now hand-write an Arabic
+conversation from hello to goodbye.

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -48,6 +48,17 @@ word lessons — never as a gated reading course.
   *ṣabāḥ al-khayr*, so a greeting and its reply are now both hand-writable.
   Phoenician cousins continue: *ḥēth*→H, *gīml*→C/G, *kaph*→K, *rēsh*→R.
 
+- **Ch. 4 — Writing set** (`AR-W10`–`AR-W12`, `writing` type): closes the
+  conversation. **ع** (*ʿayn*) — the signature throat-sound, a new shape, and a
+  **third** dots-family (skeleton shared with **غ**); its Phoenician ancestor
+  *ʿayin* meant "**eye**," and the Greeks, having no such sound, repurposed the
+  sign as the vowel **O**. Then **ه** (*hāʾ*, the most shape-shifting loop;
+  *hē*→**E**) and **ة** (*tāʾ marbūṭa*, "tied tāʾ" = *hāʾ*'s loop + *tāʾ*'s two
+  dots) marking the **feminine**. Finally assembles the farewell **مع السلامة**
+  ("with safety") — whose core **سلام** was already written in Lesson 3, so the
+  track ends where it began, on the root **s–l–m**: greeting and farewell from one
+  idea. The learner can now hand-write a conversation end to end.
+
 ## Planned
 
 | Chapter | Theme |


### PR DESCRIPTION
## What

Closes the Arabic writing track (**AR-W01–12**) on the **farewell**. Three `writing`-type lessons, **no `concept_tag`**. Only letters actually present in `data/scripts/arabic.json` are taught: **ع** and **ه** are full entries, and **ة** is presented as the related feminine ending exactly as **ه**'s own data note frames it.

## The three lessons

| Lesson | Content |
|---|---|
| **W10 — ع (ʿayn)** | The throat-sound English lacks and the letter people picture when they picture Arabic. Opens a **third dots-family** (skeleton shared with **غ**), rhyming with the Ch.2 bowl-family and Ch.3 hook-family. **The surprise:** Phoenician *ʿayin* meant "**eye**" — the Greeks had no such sound, so they **repurposed** the sign as the vowel *omicron*, our **O**. The learner has been *saying* this letter since Ch.1 in *as-salāmu **ʿ**alaykum*. |
| **W11 — ه and ة** | **ه** (*hāʾ*) as the most **shape-shifting** letter yet — its loop wears four genuinely different coats, the Lesson-2 four-coats rule at its extreme (*hē* → epsilon → **E**). Then **ة** (*tāʾ marbūṭa*, "**tied tāʾ**") shown as exactly what it is: *hāʾ*'s loop **plus tāʾ's two dots** from Ch.2 — word-final only, marking the **feminine**. |
| **W12 — assemble مع السلامة** | The payoff: **السلامة** is *not a new word* — it is **سلام**, written back in **Lesson 3**, with **ال** added in front and **ة** behind. |

## The closing thread

The greeting *as-salāmu ʿalaykum* and the farewell *maʿa s-salāma* come from the **same root s–l–m** (peace/safety) — Arabic opens and closes a conversation with one idea, and after twelve lessons the learner can **hand-write both**.

## Housekeeping
- Updates `arabic/CHANGELOG.md` and `roadmap.md` (Ch.4 writing set authored).
- Suite **38/38**; no retired `concept_tag`s; security-reviewed (Markdown only — full codepoint audit found **no bidi-override or zero-width characters**, worth checking given the heavy RTL content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)