### PR TITLE
feat(hl): Spanish Ch.15 — completing the preterite

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -227,6 +227,8 @@
       "ES-VERB-VENIR": "venir — 'to come' (doubly irregular: -go yo-form vengo + e→ie stem-change vienes/viene; ← venīre → adventure/event/convene; twin of tener)",
       "ES-PRETERITE-SER-IR": "the preterite of ser AND ir — one shared set fui/fuiste/fue/fuimos/fueron (← Latin fuī, a 2nd 'be' root = English be/future); context decides: fui a=went, fui X=was",
       "ES-PRETERITE-AR": "the regular -ar preterite — hablé/hablaste/habló/hablamos/hablaron (← Latin perfect -āvī; accent marks the final stress, hablo→habló; hablamos present=preterite)",
+      "ES-PRETERITE-ER-IR": "the regular -er/-ir preterite — comí/comiste/comió/comimos/comieron, viví/viviste/vivió (ONE shared set, unlike the present where -er/-ir differ; ← Latin perfect -ī/-istī/-it, -istī→-iste nearly intact; vivimos present=preterite but comemos≠comimos)",
+      "ES-PRETERITE-STRONG": "the strong preterites — tener→tuve, hacer→hice, estar→estuve (stress moves OFF the ending onto the stem, TUve/HIce, hence NO written accent, the reverse of hablé/habló; yo ending -e not -é; hizo c→z; ← Latin strong perfects tenuī/fēcī/stetī, inherited not rebuilt)",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -308,6 +310,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, CH14-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, CH14-PRACTICE, CH15-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Chapter 15 — Completing the preterite
+
+- **Chapter 15 authored** (`ES-C15-comer-vivir-preterite`, `-preterite-fuertes`,
+  `-practice`): finishes the everyday past tense opened in Ch.14, reviewing
+  Ch.4/7/8/12/14 via `reviews_of`.
+- **the regular -er/-ir preterite** (`ES-C15-comer-vivir-preterite`):
+  *comí/comiste/comió/comimos/comieron*, *viví/viviste/vivió*. The point worth
+  making explicit — **-er and -ir share ONE set of preterite endings**, though in
+  the **present** they pull apart (*comemos* vs *vivimos*): two conjugations
+  **merge** in the past, a genuine simplification. ← Latin perfect *-ī/-istī/-it*,
+  where *-istī* → *-iste* survives almost intact. Trap kept from Ch.14: *vivimos*
+  is present **and** preterite, but *comemos* ≠ *comimos*.
+- **the strong preterites** (`ES-C15-preterite-fuertes`): *tener→tuve*,
+  *hacer→hice*, *estar→estuve*. The stress moves **off** the ending and back into
+  the **stem** (*TUve*, *HIce*) — so the written accent **vanishes**, the exact
+  reverse of Ch.14's *hablÉ/hablÓ*; the *yo* ending is **-e**, not *-é*. Also
+  *hizo*'s **c→z** (the letter changes so the sound won't). Etymology: these are
+  Latin's **strong perfects** (*tenuī*, *fēcī*, *stetī*) inherited whole instead of
+  rebuilt — irregular precisely because they were too common to be re-made; *tuv-*
+  and *estuv-* even share the *-uv-* shape.
+- **practice** — the full five-row map (*-ar*, *-er*, *-ir*, strong, *ser/ir*) and
+  a single diagnostic: **where does the stress land?** Ending → regular, accent on
+  *yo*/*él*; stem → strong, no accent. Re-drills the tense-ambiguous *nosotros*
+  forms and *fui* = "I was"/"I went."
+- Taxonomy: namespaced `ES-PRETERITE-ER-IR`, `ES-PRETERITE-STRONG`; practice label
+  `CH15-PRACTICE`.
+
 ## Chapter 14 — The preterite (the first past tense)
 
 - **Chapter 14 authored** (`ES-C14-ser-ir-preterite`, `-hablar-preterite`,

--- a/code/learning/human-languages/spanish/lessons/ES-C15-comer-vivir-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-comer-vivir-preterite.md
@@ -1,0 +1,70 @@
+---
+id: ES-C15-comer-vivir-preterite
+chapter: 15
+type: word
+headword: comí, viví
+gloss: the regular -er/-ir preterite — where two conjugations collapse into one
+concept_tag: ES-PRETERITE-ER-IR
+prerequisites: [ES-C14-hablar-preterite, ES-C07-comer, ES-C07-vivir]
+sounds: [stress-final, accent-acute]
+roots: [latin-perfect-i]
+etymology_hook: "the -er and -ir preterites are IDENTICAL (-í/-iste/-ió/-imos/-ieron) though their presents differ — two conjugations merging into one; ← Latin perfect -ī/-istī/-it, with -istī → -iste still plainly visible"
+est_minutes: 5
+reviews_of: [ES-C14-hablar-preterite, ES-C07-comer, ES-C07-vivir]
+---
+
+# comí, viví — two conjugations become one
+
+## Warm-up
+
+[PAUSE 2s] You have the *-ar* past (*hablé*). Now the other two. And here Spanish
+does you a **favour** it never does in the present tense: **-er** and **-ir**
+verbs take the **exact same** preterite endings. Learn one set, get both.
+
+## One set of endings
+
+Drop *-er* or *-ir*, add: **-í, -iste, -ió, -imos, -ieron**.
+
+| | comer ("to eat") | vivir ("to live") |
+|---|---|---|
+| yo | **comí** | **viví** |
+| tú | **comiste** | **viviste** |
+| él/ella/usted | **comió** | **vivió** |
+| nosotros | **comimos** | **vivimos** |
+| ellos/ustedes | **comieron** | **vivieron** |
+
+Look down the two columns: **the endings are identical**. That is not true in the
+present, where *-er* and *-ir* pull apart (*com**e**mos* vs *viv**i**mos*). In the
+past, the two conjugations **merge**.
+
+The accent works exactly as in Chapter 14: it marks the **stressed final vowel** —
+**comí**, **comió**. Stress at the end = the past.
+
+## Where they come from
+
+These endings are worn-down Latin **perfect** forms — *-ī, -istī, -it*. The middle
+one barely changed at all: Latin **-istī** → Spanish **-iste** (*comiste*,
+*viviste*). Two thousand years, one dropped vowel.
+
+## One trap
+
+For **-ir** verbs, *nosotros* is the **same** in present and preterite —
+*vivimos* means both "we live" and "we lived" (just like *hablamos* from Chapter
+14). But for **-er** verbs it differs: *comemos* (we eat) vs *comimos* (we ate).
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "comí, comiste, comió, comimos, comieron"]
+- [YOU SAY: "viví, viviste, vivió, vivimos, vivieron" — hear the same endings]
+- [YOU SAY: the contrast — "comemos / comimos differ; vivimos / vivimos don't"]
+- [YOU SAY: "Ayer comí paella" ("Yesterday I ate paella")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the five *-er/-ir* preterite endings. (*-í, -iste, -ió, -imos,
+-ieron*.) What's the favour Spanish does here? (**-er and -ir share one set** —
+though their **presents** differ.) Which Latin ending is still almost intact?
+(**-istī → -iste**.) Which *nosotros* form is ambiguous, and which isn't?
+(*Vivimos* is; *comemos/comimos* are **distinct**.) Next: the **strong**
+preterites, where the accent disappears entirely.

--- a/code/learning/human-languages/spanish/lessons/ES-C15-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-practice.md
@@ -1,0 +1,72 @@
+---
+id: ES-C15-practice
+chapter: 15
+type: practice-mix
+headword: (practice)
+gloss: the whole preterite — -ar, -er/-ir, and strong, told apart by where the stress lands
+concept_tag: CH15-PRACTICE
+prerequisites: [ES-C15-comer-vivir-preterite, ES-C15-preterite-fuertes]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C15-comer-vivir-preterite, ES-C15-preterite-fuertes, ES-C14-practice]
+---
+
+# Practice — three families, one question
+
+## Warm-up
+
+[PAUSE 2s] You now have the **entire** everyday past tense. Three families — and
+one question sorts them: **where does the stress land?**
+
+## The whole map
+
+| | yo | tú | él/ella | nosotros | ellos |
+|---|---|---|---|---|---|
+| -ar *hablar* | habl**é** | habl**aste** | habl**ó** | habl**amos** | habl**aron** |
+| -er *comer* | com**í** | com**iste** | com**ió** | com**imos** | com**ieron** |
+| -ir *vivir* | viv**í** | viv**iste** | viv**ió** | viv**imos** | viv**ieron** |
+| strong *tener* | **tuve** | **tuviste** | **tuvo** | **tuvimos** | **tuvieron** |
+| ser / ir | **fui** | **fuiste** | **fue** | **fuimos** | **fueron** |
+
+Two things to notice:
+
+1. Rows 2 and 3 are the **same** — *-er* and *-ir* merged.
+2. Only rows 1–3 carry accents, and only on *yo* and *él*. Those are exactly the
+   forms where **the stress is on the ending**.
+
+## The stress test
+
+Read any preterite and ask: is the loud syllable the **last** one?
+
+- **Yes** → regular. Accent on *yo* and *él/ella* (*hablé, hablÓ, comí, comió*).
+- **No, it's the stem** → **strong**. No accent (*TUve, HIce, ESTUvo*).
+
+## Drill — past or present?
+
+Some forms live in both tenses. Decide by context:
+
+| form | could be | which? |
+|---|---|---|
+| *hablamos* | we speak / we spoke | either — context decides |
+| *vivimos* | we live / we lived | either — context decides |
+| *comemos* / *comimos* | we eat / we ate | **distinct** — the vowel tells you |
+| *fui* | I was / I went | either — *ser* and *ir* share it |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: yo-forms across all five rows — "hablé, comí, viví, tuve, fui"]
+- [YOU SAY: "Ayer hablé con mi madre y comí en casa"]
+- [YOU SAY: "Hice la comida" ("I made the food") — stem stress, no accent]
+- [YOU SAY: "Fui al mercado" ("I went to the market")]
+- [YOU SAY: the diagnostic aloud — "last syllable loud → accent; stem loud → none"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which two rows are identical? (**-er and -ir**.) Which forms take a
+written accent? (*Yo* and *él/ella* of the **regular** verbs only.) What single
+test separates regular from strong? (**Where the stress lands** — ending vs
+stem.) Which form means both "I was" and "I went"? (***Fui***.) Which *nosotros*
+forms are tense-ambiguous? (*Hablamos*, *vivimos* — but **not** *comimos*.) Next
+chapter: talking about the past that **kept going** — the imperfect.

--- a/code/learning/human-languages/spanish/lessons/ES-C15-preterite-fuertes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-preterite-fuertes.md
@@ -1,0 +1,83 @@
+---
+id: ES-C15-preterite-fuertes
+chapter: 15
+type: word
+headword: tuve, hice, estuve
+gloss: the strong preterites — where the stress moves off the ending and the accent disappears
+concept_tag: ES-PRETERITE-STRONG
+prerequisites: [ES-C15-comer-vivir-preterite, ES-C08-tener, ES-C12-hacer, ES-C04-estar]
+sounds: [stress-stem, spelling-c-z]
+roots: [latin-perfect-strong]
+etymology_hook: "'strong' = the stress lives in the STEM, not the ending — TUve, HIce, so no written accent, the exact reverse of hablÉ/hablÓ; these are the Latin strong perfects (tenuī, fēcī, stetī) inherited whole instead of rebuilt"
+est_minutes: 5
+reviews_of: [ES-C15-comer-vivir-preterite, ES-C14-hablar-preterite, ES-C08-tener, ES-C12-hacer]
+---
+
+# tuve, hice, estuve — the strong preterites
+
+## Warm-up
+
+[PAUSE 2s] Everything so far pushed the stress **to the end**: habl**É**,
+com**Í**, com**IÓ**. Now meet the verbs that do the **opposite**. They pull the
+stress **back into the stem** — and so they lose their accent marks entirely.
+Spanish calls them *pretéritos fuertes*, "**strong**" preterites: strong because
+the **stem** carries the weight.
+
+## Three of them, all verbs you know
+
+The stem changes, then one shared set of endings: **-e, -iste, -o, -imos, -ieron**.
+
+| | tener → **tuv-** | hacer → **hic-** | estar → **estuv-** |
+|---|---|---|---|
+| yo | **tuve** | **hice** | **estuve** |
+| tú | **tuviste** | **hiciste** | **estuviste** |
+| él/ella/usted | **tuvo** | **hizo** | **estuvo** |
+| nosotros | **tuvimos** | **hicimos** | **estuvimos** |
+| ellos/ustedes | **tuvieron** | **hicieron** | **estuvieron** |
+
+## The accent rule, inverted
+
+Compare the *yo* and *él* forms across the three families:
+
+| family | yo | él/ella | stressed syllable | accent? |
+|---|---|---|---|---|
+| -ar (hablar) | habl**é** | habl**ó** | the **ending** | **yes** |
+| -er/-ir (comer) | com**í** | com**ió** | the **ending** | **yes** |
+| **strong** (tener) | **TU**ve | **TU**vo | the **stem** | **no** |
+
+Say them out loud back to back: *hablÓ* … *TUvo*. The written accent isn't
+decoration — it's telling you **where the stress went**. No accent on a strong
+preterite because the stress never left the stem.
+
+Note the *yo* ending too: **-e**, not *-é* (*tuve*, not *tuvé*).
+
+## One spelling swerve
+
+*Hacer* gives **hizo**, not *hico* — Spanish swaps **c → z** before **o** to keep
+the sound the same. The letter changes so the pronunciation won't.
+
+## Why these are irregular
+
+Because they're **old**. Latin had two ways to build a perfect, and these verbs
+kept the "strong" one, inherited whole rather than rebuilt: *tenuī* → **tuve**,
+*fēcī* → **hice**, *stetī/stāre* → **estuve**. The regular *-ar/-er/-ir* patterns
+are the tidy replacements that spread later; the strong verbs are the most-used
+ones, worn smooth by frequency and never re-made. Notice *tuv-* and *estuv-* even
+share the same **-uv-** shape.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tuve, tuviste, tuvo, tuvimos, tuvieron"]
+- [YOU SAY: "hice, hiciste, hizo" — hear the **z**]
+- [YOU SAY: the contrast pair — "hablÓ … TUvo"]
+- [YOU SAY: "Ayer estuve en casa" ("Yesterday I was at home")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why "strong"? (The **stem** carries the stress.) So why no accent
+marks? (Because the stress **never reaches the ending** — the accent only ever
+marked that.) What's the *yo* ending? (**-e**, not *-é*.) Why *hizo* and not
+*hico*? (**c → z** before **o**, to protect the sound.) Where do they come from?
+(Latin's **strong perfects** — *tenuī*, *fēcī* — inherited, not rebuilt.) Next:
+all three families side by side.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -103,8 +103,20 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   the **accent** carries the tense, *hablo→habló*; *hablamos* present=preterite) →
   practice switching present↔past. **Authored.**
 
-Next: **Ch. 15** — more of the past (regular *-er/-ir* preterite, *tener/hacer*
-irregular preterites) and everyday description, building toward real conversation.
+- **Ch. 15 — Completing the preterite**: the **regular -er/-ir preterite**
+  *comí/comiste/comió/comimos/comieron*, *viví/viviste/vivió* — where *-er* and
+  *-ir* take **one shared set** of endings though their **presents** differ (←
+  Latin perfect *-ī/-istī/-it*, with *-istī* → *-iste* nearly intact; *vivimos* is
+  present=preterite, but *comemos* ≠ *comimos*) → the **strong preterites**
+  *tuve/hice/estuve*, where the stress moves **off** the ending onto the stem
+  (*TUve*, *HIce*) so the written accent **disappears** — the exact reverse of
+  *hablÉ/hablÓ*, plus *hizo*'s c→z; they are the Latin **strong perfects**
+  (*tenuī*, *fēcī*, *stetī*) inherited whole rather than rebuilt → practice
+  sorting all three families by the single question *where does the stress land?*
+  **Authored.**
+
+Next: **Ch. 16** — the **imperfect**, the past that kept going, and its contrast
+with the preterite; then everyday description, building toward real conversation.
 From here the course hands over rules, not phrases. Grammar accumulates piece by
 piece. The theme skeleton below plans the wider road.
 


### PR DESCRIPTION
Finishes the everyday past tense opened in Ch.14, in three tiny lessons.

**`ES-C15-comer-vivir-preterite`** — the regular **-er/-ir** preterite
(*comí/comiste/comió/comimos/comieron*, *viví/viviste/vivió*). The point worth
making explicit: **-er and -ir share ONE set of preterite endings**, though in the
**present** they pull apart (*comemos* vs *vivimos*) — two conjugations **merge**
in the past, a genuine simplification. ← Latin perfect *-ī/-istī/-it*, where
*-istī* → *-iste* survives almost intact. Keeps Ch.14's trap: *vivimos* is present
**and** preterite, but *comemos* ≠ *comimos*.

**`ES-C15-preterite-fuertes`** — the **strong** preterites *tener→tuve*,
*hacer→hice*, *estar→estuve*. The stress moves **off** the ending and back into the
**stem** (*TUve*, *HIce*), so the written accent **vanishes** — the exact reverse of
Ch.14's *hablÉ/hablÓ*; the *yo* ending is **-e**, not *-é*. Plus *hizo*'s **c→z**
(the letter changes so the sound won't). Etymology: these are Latin's **strong
perfects** (*tenuī*, *fēcī*, *stetī*) inherited whole instead of rebuilt — irregular
precisely because they were too common to be re-made; *tuv-* and *estuv-* even share
the *-uv-* shape.

**`ES-C15-practice`** — the full five-row map (*-ar*, *-er*, *-ir*, strong, *ser/ir*)
sorted by one diagnostic: **where does the stress land?** Ending → regular, accent on
*yo*/*él*; stem → strong, no accent.

Taxonomy: namespaced `ES-PRETERITE-ER-IR`, `ES-PRETERITE-STRONG`; practice label
`CH15-PRACTICE`. Spanish roadmap (Ch.15 authored, Next Ch.16 = the imperfect) and
CHANGELOG updated.

Suite green at **38/38**; retired-concept-tag sweep clean across the whole curriculum.
Security-reviewed: PASS, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)