### PR TITLE
Add Haskell ITF port

### DIFF
--- a/code/packages/haskell/itf/BUILD
+++ b/code/packages/haskell/itf/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/itf/BUILD_windows
+++ b/code/packages/haskell/itf/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/itf/CHANGELOG.md
+++ b/code/packages/haskell/itf/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Validate non-empty, even-length ASCII digit payloads.
+- Encode standard Interleaved 2 of 5 digit pairs and expose their patterns.
+- Expand start, data, and stop symbols through the shared 1D barcode layer.
+- Emit backend-neutral paint scenes with explicit symbol and pair metadata.

--- a/code/packages/haskell/itf/README.md
+++ b/code/packages/haskell/itf/README.md
@@ -1,0 +1,25 @@
+# itf (Haskell)
+
+Pure Interleaved 2 of 5 (ITF) barcode encoding for the Haskell package lane.
+The first digit in each pair controls bar widths, while the second controls
+space widths. Inputs must contain a non-empty, even number of ASCII digits.
+
+```haskell
+import CodingAdventures.Itf
+
+example = drawItf "123456" defaultPaintBarcode1DOptions
+```
+
+The encoder exposes normalized payloads, typed pair records, and the expanded
+run stream. Rendering delegates to `barcode-layout-1d`, so callers receive the
+same validated quiet-zone geometry, explicit symbol spans, rectangle-only
+paint instructions, and metadata as the other linear symbologies.
+
+V1 deliberately excludes ITF-14 bearer bars, GTIN packaging semantics, and
+automatic check-digit insertion.
+
+## Development
+
+```sh
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/itf/cabal.project
+++ b/code/packages/haskell/itf/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../barcode-layout-1d ../paint-instructions

--- a/code/packages/haskell/itf/itf.cabal
+++ b/code/packages/haskell/itf/itf.cabal
@@ -1,0 +1,39 @@
+cabal-version: 3.0
+name:          itf
+version:       0.1.0
+synopsis:      Pure Interleaved 2 of 5 barcode encoder
+description:   Validated ITF digit pairs, interleaved bar and space widths, and backend-neutral paint scenes.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.Itf
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , paint-instructions >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    ItfSpec
+    hs-source-dirs:   test
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , hspec ==2.*
+                    , itf
+                    , paint-instructions >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/itf/src/CodingAdventures/Itf.hs
+++ b/code/packages/haskell/itf/src/CodingAdventures/Itf.hs
@@ -1,0 +1,202 @@
+-- | Pure Interleaved 2 of 5 barcode encoding.
+module CodingAdventures.Itf
+  ( EncodedPair (..)
+  , ItfError (..)
+  , Barcode1DError (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , PaintScene (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , normalizeItf
+  , encodeItf
+  , expandItfRuns
+  , layoutItf
+  , drawItf
+  , version
+  ) where
+
+import CodingAdventures.BarcodeLayout1D
+  ( Barcode1DError (..)
+  , Barcode1DRenderConfig (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DSymbolDescriptor (..)
+  , Barcode1DSymbolRole (..)
+  , PaintBarcode1DOptions (..)
+  , defaultBarcode1DRenderConfig
+  , defaultBinaryPatternOptions
+  , defaultPaintBarcode1DOptions
+  , layoutBarcode1D
+  , runsFromBinaryPattern
+  )
+import CodingAdventures.PaintInstructions (PaintScene (..))
+import Data.Aeson (toJSON)
+import Data.Bifunctor (first)
+import qualified Data.Map.Strict as Map
+
+-- | Package version shared with the established implementations.
+version :: String
+version = "0.1.0"
+
+-- | The two digits and their fully expanded interleaved pattern.
+data EncodedPair = EncodedPair
+  { encodedPairDigits :: String
+  , encodedPairBarPattern :: String
+  , encodedPairSpacePattern :: String
+  , encodedPairBinaryPattern :: String
+  , encodedPairSourceIndex :: Int
+  } deriving (Eq, Show)
+
+-- | Checked failures from validation or the shared layout layer.
+data ItfError
+  = InvalidItfInput String
+  | ItfLayoutError Barcode1DError
+  deriving (Eq, Show)
+
+startPattern :: String
+startPattern = "1010"
+
+stopPattern :: String
+stopPattern = "11101"
+
+digitPatterns :: [String]
+digitPatterns =
+  [ "00110"
+  , "10001"
+  , "01001"
+  , "11000"
+  , "00101"
+  , "10100"
+  , "01100"
+  , "00011"
+  , "10010"
+  , "01010"
+  ]
+
+-- | Require a non-empty, even-length string of ASCII digits.
+normalizeItf :: String -> Either ItfError String
+normalizeItf input
+  | null input || any (not . isAsciiDigit) input =
+      Left (InvalidItfInput "ITF input must contain digits only")
+  | odd (length input) =
+      Left (InvalidItfInput "ITF input must contain an even number of digits")
+  | otherwise = Right input
+
+-- | Encode adjacent digits as interleaved bar and space widths.
+encodeItf :: String -> Either ItfError [EncodedPair]
+encodeItf input = encodeNormalized <$> normalizeItf input
+
+-- | Expand the start marker, digit pairs, and stop marker into shared runs.
+expandItfRuns :: String -> Either ItfError [Barcode1DRun]
+expandItfRuns input = do
+  pairs <- encodeItf input
+  runsForPairs pairs
+
+-- | Render ITF through the shared backend-neutral 1D barcode geometry.
+layoutItf
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either ItfError PaintScene
+layoutItf input options = do
+  normalized <- normalizeItf input
+  let pairs = encodeNormalized normalized
+  runs <- runsForPairs pairs
+  first ItfLayoutError (layoutBarcode1D runs (itfOptions normalized pairs options))
+
+-- | Compatibility alias matching the shared public API name.
+drawItf
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either ItfError PaintScene
+drawItf = layoutItf
+
+isAsciiDigit :: Char -> Bool
+isAsciiDigit character = character >= '0' && character <= '9'
+
+encodeNormalized :: String -> [EncodedPair]
+encodeNormalized = zipWith encodePair [0 :: Int ..] . pairsOfDigits
+
+pairsOfDigits :: String -> [String]
+pairsOfDigits [] = []
+pairsOfDigits (firstDigit : secondDigit : rest) =
+  [firstDigit, secondDigit] : pairsOfDigits rest
+pairsOfDigits _ = []
+
+encodePair :: Int -> String -> EncodedPair
+encodePair sourceIndex pair = EncodedPair
+  { encodedPairDigits = pair
+  , encodedPairBarPattern = barPattern
+  , encodedPairSpacePattern = spacePattern
+  , encodedPairBinaryPattern = interleavePatterns barPattern spacePattern
+  , encodedPairSourceIndex = sourceIndex
+  }
+  where
+    barPattern = digitPattern (head pair)
+    spacePattern = digitPattern (pair !! 1)
+
+digitPattern :: Char -> String
+digitPattern character = digitPatterns !! (fromEnum character - fromEnum '0')
+
+interleavePatterns :: String -> String -> String
+interleavePatterns bars spaces = concatMap expand (zip bars spaces)
+  where
+    expand (barMarker, spaceMarker) =
+      (if barMarker == '1' then "111" else "1")
+        ++ (if spaceMarker == '1' then "000" else "0")
+
+runsForPairs :: [EncodedPair] -> Either ItfError [Barcode1DRun]
+runsForPairs pairs = do
+  startRuns <- patternRuns startPattern "start" (-1) Start
+  pairRuns <- traverse runsForPair pairs
+  stopRuns <- patternRuns stopPattern "stop" (-2) Stop
+  Right (startRuns ++ concat pairRuns ++ stopRuns)
+
+runsForPair :: EncodedPair -> Either ItfError [Barcode1DRun]
+runsForPair pair = patternRuns
+  (encodedPairBinaryPattern pair)
+  (encodedPairDigits pair)
+  (encodedPairSourceIndex pair)
+  Data
+
+patternRuns
+  :: String
+  -> String
+  -> Int
+  -> Barcode1DRunRole
+  -> Either ItfError [Barcode1DRun]
+patternRuns patternText label sourceIndex role = first ItfLayoutError
+  (runsFromBinaryPattern patternText
+    (defaultBinaryPatternOptions label sourceIndex role))
+
+itfOptions
+  :: String
+  -> [EncodedPair]
+  -> PaintBarcode1DOptions
+  -> PaintBarcode1DOptions
+itfOptions normalized pairs options = options
+  { optionsLabel = Just (maybe defaultLabel id (optionsLabel options))
+  , optionsMetadata = Map.insert "pairCount" (toJSON (length pairs))
+      (Map.insert "symbology" (toJSON ("itf" :: String)) (optionsMetadata options))
+  , optionsSymbols = Just (symbolDescriptors pairs)
+  }
+  where
+    defaultLabel = "ITF barcode for " ++ normalized
+
+symbolDescriptors :: [EncodedPair] -> [Barcode1DSymbolDescriptor]
+symbolDescriptors pairs =
+  Barcode1DSymbolDescriptor "start" (length startPattern) (-1) SymbolStart
+    : map pairDescriptor pairs
+    ++ [Barcode1DSymbolDescriptor "stop" (length stopPattern) (-2) SymbolStop]
+
+pairDescriptor :: EncodedPair -> Barcode1DSymbolDescriptor
+pairDescriptor pair = Barcode1DSymbolDescriptor
+  { descriptorLabel = encodedPairDigits pair
+  , descriptorModules = length (encodedPairBinaryPattern pair)
+  , descriptorSourceIndex = encodedPairSourceIndex pair
+  , descriptorRole = SymbolData
+  }

--- a/code/packages/haskell/itf/test/ItfSpec.hs
+++ b/code/packages/haskell/itf/test/ItfSpec.hs
@@ -1,0 +1,157 @@
+module ItfSpec (spec) where
+
+import CodingAdventures.Itf
+import CodingAdventures.PaintInstructions (PaintInstruction (..))
+import Data.Aeson (toJSON)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "metadata" $ do
+    it "reports the shared package version" $
+      version `shouldBe` "0.1.0"
+
+  describe "normalizeItf" $ do
+    it "accepts non-empty even-length ASCII digits unchanged" $ do
+      normalizeItf "00" `shouldBe` Right "00"
+      normalizeItf "123456" `shouldBe` Right "123456"
+
+    it "rejects empty, non-ASCII, whitespace, and non-digit input" $ do
+      let expected = Left (InvalidItfInput "ITF input must contain digits only")
+      normalizeItf "" `shouldBe` expected
+      normalizeItf "12A4" `shouldBe` expected
+      normalizeItf "12 4" `shouldBe` expected
+      normalizeItf "１２" `shouldBe` expected
+
+    it "rejects odd-length digit input without padding" $
+      normalizeItf "12345" `shouldBe`
+        Left (InvalidItfInput "ITF input must contain an even number of digits")
+
+  describe "encodeItf" $ do
+    it "encodes the shared reference pair" $
+      encodeItf "12" `shouldBe` Right
+        [ EncodedPair
+            { encodedPairDigits = "12"
+            , encodedPairBarPattern = "10001"
+            , encodedPairSpacePattern = "01001"
+            , encodedPairBinaryPattern = "111010001010111000"
+            , encodedPairSourceIndex = 0
+            }
+        ]
+
+    it "preserves the complete standard digit table" $ do
+      pairs <- expectRight (encodeItf "00112233445566778899")
+      map encodedPairBarPattern pairs `shouldBe` digitTable
+      map encodedPairSpacePattern pairs `shouldBe` digitTable
+
+    it "assigns stable pair source indexes" $ do
+      pairs <- expectRight (encodeItf "123456")
+      map encodedPairDigits pairs `shouldBe` ["12", "34", "56"]
+      map encodedPairSourceIndex pairs `shouldBe` [0, 1, 2]
+      map (length . encodedPairBinaryPattern) pairs `shouldBe` [18, 18, 18]
+
+    it "propagates validation failures" $
+      encodeItf "123" `shouldBe`
+        Left (InvalidItfInput "ITF input must contain an even number of digits")
+
+  describe "expandItfRuns" $ do
+    it "emits standard start and stop patterns with semantic roles" $ do
+      runs <- expectRight (expandItfRuns "12")
+      take 4 runs `shouldBe`
+        [ Barcode1DRun Bar 1 "start" (-1) Start
+        , Barcode1DRun Space 1 "start" (-1) Start
+        , Barcode1DRun Bar 1 "start" (-1) Start
+        , Barcode1DRun Space 1 "start" (-1) Start
+        ]
+      drop (length runs - 3) runs `shouldBe`
+        [ Barcode1DRun Bar 3 "stop" (-2) Stop
+        , Barcode1DRun Space 1 "stop" (-2) Stop
+        , Barcode1DRun Bar 1 "stop" (-2) Stop
+        ]
+
+    it "interleaves first-digit bars with second-digit spaces" $ do
+      runs <- expectRight (expandItfRuns "12")
+      let dataRuns = filter ((== Data) . runRole) runs
+      map runModules dataRuns `shouldBe` [3, 1, 1, 3, 1, 1, 1, 1, 3, 3]
+      map runColor dataRuns `shouldBe` take 10 (cycle [Bar, Space])
+      map runSourceLabel dataRuns `shouldBe` replicate 10 "12"
+
+    it "produces the exact shared module and run counts" $ do
+      runs <- expectRight (expandItfRuns "123456")
+      sum (map runModules runs) `shouldBe` 63
+      length runs `shouldBe` 37
+
+    it "propagates input validation" $
+      expandItfRuns "abc" `shouldBe`
+        Left (InvalidItfInput "ITF input must contain digits only")
+
+  describe "layoutItf" $ do
+    it "renders through the shared default geometry" $ do
+      scene <- expectRight (layoutItf "12" defaultPaintBarcode1DOptions)
+      psWidth scene `shouldBe` 188
+      psHeight scene `shouldBe` 120
+      psBg scene `shouldBe` "#ffffff"
+      length (psInstructions scene) `shouldBe` 9
+      map prX (take 2 (psInstructions scene)) `shouldBe` [40, 48]
+
+    it "records symbology, pair count, label, and explicit symbols" $ do
+      scene <- expectRight (layoutItf "123456" defaultPaintBarcode1DOptions)
+      Map.lookup "symbology" (psMeta scene) `shouldBe` Just (toJSON ("itf" :: String))
+      Map.lookup "pairCount" (psMeta scene) `shouldBe` Just (toJSON (3 :: Int))
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("ITF barcode for 123456" :: String))
+      Map.lookup "symbolCount" (psMeta scene) `shouldBe` Just (toJSON (5 :: Int))
+      Map.lookup "contentModules" (psMeta scene) `shouldBe` Just (toJSON (63 :: Int))
+
+    it "preserves custom rendering, labels, and metadata" $ do
+      let config = defaultBarcode1DRenderConfig
+            { configModuleWidth = 2
+            , configBarHeight = 50
+            , configQuietZoneModules = 5
+            , configForeground = "navy"
+            , configBackground = "transparent"
+            }
+          options = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = config
+            , optionsLabel = Just "Warehouse pair"
+            , optionsMetadata = Map.fromList
+                [ ("batch", toJSON (7 :: Int))
+                , ("pairCount", toJSON (999 :: Int))
+                , ("symbology", toJSON ("wrong" :: String))
+                ]
+            }
+      scene <- expectRight (layoutItf "12" options)
+      (psWidth scene, psHeight scene, psBg scene) `shouldBe` (74, 50, "transparent")
+      map prFill (psInstructions scene) `shouldBe` replicate 9 "navy"
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Warehouse pair" :: String))
+      Map.lookup "batch" (psMeta scene) `shouldBe` Just (toJSON (7 :: Int))
+      Map.lookup "pairCount" (psMeta scene) `shouldBe` Just (toJSON (1 :: Int))
+      Map.lookup "symbology" (psMeta scene) `shouldBe` Just (toJSON ("itf" :: String))
+
+    it "supports the draw alias" $
+      drawItf "12" defaultPaintBarcode1DOptions `shouldBe`
+        layoutItf "12" defaultPaintBarcode1DOptions
+
+    it "wraps shared layout validation failures" $ do
+      let invalidGeometry = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = defaultBarcode1DRenderConfig
+                { configModuleWidth = 0 }
+            }
+          humanText = defaultPaintBarcode1DOptions
+            { optionsHumanReadableText = Just "12" }
+      layoutItf "12" invalidGeometry `shouldBe`
+        Left (ItfLayoutError (InvalidRenderConfiguration "moduleWidth" 0))
+      layoutItf "12" humanText `shouldBe`
+        Left (ItfLayoutError HumanReadableTextUnsupported)
+
+digitTable :: [String]
+digitTable =
+  [ "00110", "10001", "01001", "11000", "00101"
+  , "10100", "01100", "00011", "10010", "01010"
+  ]
+
+expectRight :: Show error => Either error value -> IO value
+expectRight (Right value) = pure value
+expectRight (Left err) = fail ("unexpected error: " ++ show err)

--- a/code/packages/haskell/itf/test/Spec.hs
+++ b/code/packages/haskell/itf/test/Spec.hs
@@ -1,0 +1,5 @@
+import ItfSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -120,17 +120,17 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
-`type-checker-protocol` ports, and the Haskell `paint-vm-ascii` and
-`barcode-layout-1d` ports:
+`type-checker-protocol` ports, and the Haskell `paint-vm-ascii`,
+`barcode-layout-1d`, and `itf` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 288 |
+| Present in 10-15 languages | 172 | 287 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 709 | 9,926 |
+| Present in one language | 710 | 9,940 |
 
-The loop must not start by attempting 9,926 singleton ports. It should finish
+The loop must not start by attempting 9,940 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -182,7 +182,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 13 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 12 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -605,6 +605,17 @@ package now spans 12 implementation lanes, reduces the high-consensus backlog
 to 288 slots, leaves 13 gaps in the Haskell lane, and unlocks the dependent
 Code 39, Codabar, ITF, UPC-A, EAN-13, Code 128, and `barcode-1d` ports.
 
+The twenty-second Haskell high-consensus slice is complete: `itf` now provides
+the pure Interleaved 2 of 5 encoder unlocked by `barcode-layout-1d`. It
+validates non-empty even-length ASCII digit payloads, exposes typed digit-pair
+patterns, interleaves first-digit bar widths with second-digit space widths,
+and emits explicit start, data, and stop symbol geometry plus authoritative
+symbology metadata. Its package-native suite exercises shared patterns, the
+complete digit table, source attribution, exact module geometry, customized
+paint output, metadata precedence, aliases, and both local and shared
+validation paths. The package now spans 12 implementation lanes, reduces the
+high-consensus backlog to 287 slots, and leaves 12 gaps in the Haskell lane.
+
 Recommended family order:
 
 1. Leaf algorithms and data structures.
@@ -631,7 +642,7 @@ This phase covers 121 package identities and 911 current missing slots.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 514 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 515 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
 ### Likely portable Rust-led families


### PR DESCRIPTION
## Summary

- add a pure Haskell Interleaved 2 of 5 encoder on top of `barcode-layout-1d`
- expose validated payloads, typed digit-pair patterns, attributed run streams, explicit symbol spans, and paint-scene metadata
- add package documentation, Cabal metadata, 17 package-native examples, and update the parity roadmap

## Why

`itf` was the smallest remaining dependency-safe Haskell high-consensus gap after the shared linear-barcode geometry package merged. This port closes that slot without external runtime dependencies and establishes the first concrete consumer of the new Haskell `barcode-layout-1d` layer.

## Validation

- `cabal test all --enable-coverage` (17 ITF, 18 barcode-layout, and 28 paint-instructions examples)
- 93% expression and 90% alternative coverage for `CodingAdventures.Itf`
- `cabal check`
- `cabal sdist` with the artifact written outside the repository
- `python code/scripts/tests/test_package_parity_report.py` (6 tests)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
  - high-consensus missing slots: 288 to 287
  - Haskell high-consensus gaps: 13 to 12
  - canonical collisions: 0
  - unknown language buckets: 0
- `git diff --check`
