### PR TITLE
feat(sir-rust): Ruby type reflection — .class no longer crashes the program

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.37.0 — Ruby type reflection: `.class`, `is_a?`, `kind_of?`, `instance_of?`
+
+`.class` **crashed the program**. The backend already had the full class-name
+mapping (`ruby_class_name`: `NilClass`, `TrueClass`/`FalseClass`, `Integer`,
+`Float`, `String`, `Symbol`, `Array`, `Hash`, `Pair`, `Proc`, a user instance's
+own tag, `Object`) — but it was documented as being "for a `NoMethodError`
+message and nothing else" and was never dispatched. So `7.class` resolved no
+method, raised `NoMethodError`, and — unrescued — surfaced as a panic that
+killed the process (exit 101). Measured: Python and Go answered `.class`; Rust
+aborted.
+
+- `object_method` gains `class`, `is_a?`, `kind_of?` and `instance_of?`, so
+  every receiver answers, reusing the existing `ruby_class_name`.
+- `is_a?`/`kind_of?` honour ancestry — the built-in surface (`Integer` and
+  `Float` are `Numeric` and `Comparable`, `String` is `Comparable`,
+  `Object`/`BasicObject` match everything) plus, for a user instance, its
+  superclass chain (the same cycle-guarded `is_ancestor_or_self` walk `rescue`
+  matching uses) and any module mixed in along it. `instance_of?` is an exact
+  class match.
+- Transitive module matching (Ruby's MRO: `C` includes `M`, `M` includes `N` ⇒
+  `c.is_a?(N)`) uses an ITERATIVE worklist rather than recursion, because
+  include-graph depth is shaped by the source — the same design the JavaScript
+  backend uses. Cyclic and self-including graphs terminate.
+- The class argument arrives as a NAME string (the frontend lowers a class
+  pattern to its name), so no constant-reference support is needed.
+- `responds_to` reports all four universally, matching the Go and JavaScript
+  backends, keeping `respond_to?` honest.
+
+This closes the Rust arm of the cross-backend reflection frontier — the
+`sir-conformance` guard is now a live all-backend assertion rather than
+per-backend.
+
 ## 0.36.0 — Ruby `Integer#/` floors toward −∞ (SIR21 §E3)
 
 The inline `__sir` runtime's `divide` truncated integer division toward zero

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1452,8 +1452,89 @@ pub const RUNTIME: &str = r##"mod __sir {
                 Some(b @ Value::Closure(_)) => Some(apply_closure(b, vec![recv.clone()])),
                 _ => Some(recv.clone()),
             },
+            // Type reflection on ANY receiver: `7.class` → "Integer",
+            // `7.0.class` → "Float", `obj.class` → its own class tag.  This
+            // reuses `ruby_class_name`, which until now existed ONLY to build a
+            // `NoMethodError` message — so `.class` raised `NoMethodError`
+            // (surfacing as an unrescued panic) even though the mapping was
+            // sitting right there.
+            "class" => Some(Value::Str(Rc::from(ruby_class_name(recv).as_str()))),
+            // `is_a?`/`kind_of?` honour ancestry; `instance_of?` is an EXACT
+            // class match.  The class argument arrives as a NAME — the frontend
+            // lowers a class pattern to its name string — so no constant-
+            // reference support is required here.
+            "is_a?" | "kind_of?" | "instance_of?" => {
+                let target = args.first().map(method_name).unwrap_or_default();
+                let actual = ruby_class_name(recv);
+                Some(Value::Bool(if name == "instance_of?" {
+                    actual == target
+                } else {
+                    value_is_a(recv, &actual, &target)
+                }))
+            }
             _ => None,
         }
+    }
+
+    // Ruby `is_a?`: the receiver's own class, a BUILT-IN ancestor (`Integer`
+    // and `Float` are `Numeric` and `Comparable`; `String` is `Comparable`),
+    // the universal `Object`/`BasicObject`, or — for a user instance — its
+    // superclass chain (the same cycle-guarded walk `rescue` matching uses)
+    // plus any module mixed in along that chain.
+    fn value_is_a(recv: &Value, actual: &str, target: &str) -> bool {
+        if actual == target || target == "Object" || target == "BasicObject" {
+            return true;
+        }
+        let builtin: &[&str] = match actual {
+            "Integer" | "Float" => &["Numeric", "Comparable"],
+            "String" => &["Comparable"],
+            _ => &[],
+        };
+        if builtin.contains(&target) {
+            return true;
+        }
+        if matches!(recv, Value::Instance(_)) {
+            return is_ancestor_or_self(actual, target)
+                || includes_module_transitively(actual, target);
+        }
+        false
+    }
+
+    // Does `owner` reach `target` through the modules mixed into it or into any
+    // of its ancestors?  Ruby's MRO is TRANSITIVE — `class C; include M; end`
+    // where `module M; include N; end` makes `c.is_a?(N)` true.
+    //
+    // Deliberately ITERATIVE (an explicit worklist, not recursion): include-graph
+    // depth is shaped by the source, so a recursive walk could exhaust the stack
+    // on a long chain.  `seen` expands each module at most once and `chain`
+    // guards a cyclic ancestry edge, so any graph terminates.
+    fn includes_module_transitively(owner: &str, target: &str) -> bool {
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut work: Vec<String> = vec![owner.to_string()];
+        while let Some(start) = work.pop() {
+            let mut cur = start;
+            let mut chain: std::collections::HashSet<String> = std::collections::HashSet::new();
+            loop {
+                if !chain.insert(cur.clone()) {
+                    break; // cyclic ancestry edge — stop this chain.
+                }
+                if let Some(mods) = INCLUDED_MODULES.with(|t| t.borrow().get(&cur).cloned()) {
+                    for m in mods {
+                        if m == target {
+                            return true;
+                        }
+                        if seen.insert(m.clone()) {
+                            work.push(m);
+                        }
+                    }
+                }
+                match super_of(&cur) {
+                    Some(next) => cur = next,
+                    None => break,
+                }
+            }
+        }
+        false
     }
 
     // Does dispatch on `recv` resolve `name`?  Mirrors the Python reference's
@@ -1468,6 +1549,9 @@ pub const RUNTIME: &str = r##"mod __sir {
             name,
             "to_s" | "respond_to?" | "send" | "__send__" | "public_send" | "tap"
                 | "then" | "yield_self"
+                // Type reflection answers on every receiver (matching the Go
+                // and JavaScript backends).
+                | "class" | "is_a?" | "kind_of?" | "instance_of?"
         ) {
             return true;
         }

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.17.0] - Reflection frontier goes cross-backend (Rust arm closed)
+
+`tests/reflection.rs` grows from a per-backend guard into a live **all-backend**
+assertion, `class_reflection_matches_ruby_on_every_backend`: every backend that
+runs a case must produce the same Ruby class-name string, failing by name the
+day one diverges.
+
+That was gated on the Rust arm, which previously **panicked at runtime**
+(exit 101) because `.class` was undispatched; `semantic-ir-to-rust` 0.37.0
+implements it. Adds `rust_class_reflection_is_ruby_faithful` alongside the
+existing JavaScript and Go granular guards. Python, Go, JavaScript and Rust all
+answer; C does not yet emit reflection and skips.
+
 ## [0.16.0] - Type-reflection conformance: `.class` across the backends
 
 Adds `tests/reflection.rs` — every backend must reproduce Ruby's class-NAME

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/tests/reflection.rs
+++ b/code/packages/rust/sir-conformance/tests/reflection.rs
@@ -11,14 +11,15 @@
 //! | Python     | ✅ |
 //! | Go         | ✅ (`_sir_ruby_class_name`) |
 //! | JavaScript | ✅ **as of this change** — previously raised `NoMethodError` |
-//! | Rust       | ❌ **panics at runtime** (exit 101) — tracked separately |
+//! | Rust       | ✅ **as of this change** — previously panicked at runtime (exit 101) |
 //! | C          | not yet emitted (skips) |
 //! | Ruby       | ✅ (the reference; skips without a `ruby` toolchain) |
 //!
-//! Because the Rust arm still crashes, this is a **per-backend** guard in the
-//! style of `division.rs`'s `python_division_is_ruby_floor_faithful` rather
-//! than an all-backend frontier; it locks the arms that are closed and will
-//! grow into a cross-backend assertion once Rust's `.class` is implemented.
+//! With the Rust arm now closed, the guard has grown from per-backend into a
+//! **cross-backend** assertion: [`class_reflection_matches_ruby_on_every_backend`]
+//! holds every backend that runs to the same class-name strings, exactly like
+//! `division.rs`'s frontier. The per-backend tests remain as granular guards
+//! that name the offending backend directly when one regresses.
 //!
 //! The JavaScript arm is the interesting one: JS numbers are all `f64`, so
 //! `7` and `7.0` are the SAME value there. Distinguishing `Integer` from
@@ -84,4 +85,51 @@ fn go_class_reflection_is_ruby_faithful() {
     if ran == 0 {
         eprintln!("note: `go` unavailable — Go reflection not proved");
     }
+}
+
+/// The Rust arm, **closed by this change**. Rust already had the class-name
+/// mapping (`ruby_class_name`) but used it ONLY to build a `NoMethodError`
+/// message — `.class` itself was undispatched, so it raised, and the unrescued
+/// raise surfaced as a process-killing panic (exit 101).
+#[test]
+fn rust_class_reflection_is_ruby_faithful() {
+    let ran = assert_class_names_on(Target::Rust, "Rust `.class`");
+    if ran == 0 {
+        eprintln!("note: `rustc` unavailable — Rust reflection not proved");
+    }
+}
+
+/// The frontier: **every** backend that runs a case must produce the same
+/// Ruby class name. Now that Python, Go, JavaScript and Rust all answer, this
+/// is a live cross-backend assertion — it fails, naming the backend, the day
+/// one diverges. Backends without a toolchain (or that do not yet emit
+/// reflection, e.g. C) report `Skipped` and are not asserted.
+#[test]
+fn class_reflection_matches_ruby_on_every_backend() {
+    let mut ran = 0usize;
+    for &(src, expected) in CASES {
+        for &target in Target::all() {
+            match run_source("reflection_all", src, target) {
+                RunOutcome::Ran(out) => {
+                    assert_eq!(
+                        out, expected,
+                        "\nREFLECTION FRONTIER: backend {} gave `{}` = {out}, Ruby says {expected}\n",
+                        target.tag(),
+                        src.trim(),
+                    );
+                    ran += 1;
+                }
+                // A backend that emits reflection but crashes on it is a
+                // frontier failure, not a skip — surface it by name.
+                RunOutcome::Failed(msg) => panic!(
+                    "REFLECTION FRONTIER: backend {} failed on `{}`: {}",
+                    target.tag(),
+                    src.trim(),
+                    msg.lines().next().unwrap_or("")
+                ),
+                RunOutcome::Skipped(_) => {}
+            }
+        }
+    }
+    assert!(ran > 0, "no backend toolchain available — reflection proved nothing");
 }


### PR DESCRIPTION
## What

`.class` **killed the process** on the Rust backend. `puts(7.class)` compiled fine, then aborted with exit 101.

Root cause is a neat one: the backend **already had** the complete class-name mapping —

```rust
fn ruby_class_name(v: &Value) -> String {   // NilClass, Integer, Float, String, Symbol, Array, Hash, Pair, Proc, …
```

— but it was documented as *"for a `NoMethodError` message and nothing else"* and was **never dispatched**. So `.class` resolved no method, raised `NoMethodError`, and the unrescued raise surfaced as a panic that took the whole program down.

Measured across backends before this change: Python ✅, Go ✅, JavaScript ✅ (fixed in #8672), **Rust ❌ aborts**.

## How

- `object_method` gains `class`, `is_a?`, `kind_of?`, `instance_of?` — every receiver answers, reusing the existing `ruby_class_name`.
- **`is_a?`/`kind_of?` honour ancestry**: the built-in surface (`Integer`/`Float` are `Numeric` and `Comparable`, `String` is `Comparable`, `Object`/`BasicObject` match everything), plus — for a user instance — its superclass chain (the *same* cycle-guarded `is_ancestor_or_self` walk `rescue` matching uses) and any module mixed in along it. **`instance_of?`** is an exact match.
- **Transitive module matching** (Ruby's MRO: `C` includes `M`, `M` includes `N` ⇒ `c.is_a?(N)`) uses an **iterative worklist, not recursion** — include-graph depth is shaped by the source, so recursion there is a stack hazard. Same design as the JS backend. Self-including, mutually-including, and cyclic-ancestry graphs all terminate.
- The class argument arrives as a **name string**, so no constant-reference support is needed.
- `responds_to` reports all four universally (matching Go and JS), keeping `respond_to?` honest.

## The reflection frontier is now cross-backend

With the Rust arm closed, the `sir-conformance` guard added in #8672 **graduates from per-backend to a live all-backend assertion** — `class_reflection_matches_ruby_on_every_backend` holds every backend that runs to the same class-name strings and fails *by name* the day one diverges.

| | `.class` |
|---|---|
| Python | ✅ |
| Go | ✅ |
| JavaScript | ✅ (#8672) |
| **Rust** | ✅ **this PR** |
| C | skips — doesn't emit reflection yet |

## Verification
- Reflection conformance **4/4 green across all backends** (445s), including the new cross-backend frontier and a Rust-specific granular guard.
- Full `semantic-ir-to-rust` suite green — no regressions.
- Security-reviewed clean (termination on adversarial include graphs, panic-safety of the new arms, and `respond_to?` honesty all checked explicitly).

## Versions
`semantic-ir-to-rust` 0.36.0 → **0.37.0** · `sir-conformance` 0.16.0 → **0.17.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)