### PR TITLE
feat(adj-tables): RS-5e — per-row provenance, so an answer cites the row it selected

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -412,7 +412,13 @@ table_decl   = "table" IDENT LBRACE { use_decl } columns_decl { table_row } { an
 
 columns_decl = "columns" IDENT { COMMA IDENT } ;
 
-table_row    = "row" LPAREN row_item { COMMA row_item } RPAREN ;
+# A row may carry its OWN provenance block (ADJ-TABLES RS-5e), overriding the
+# table envelope field-by-field for that row — so a lookup cites the span that
+# defends the row it actually SELECTED, not the table's first sentence. The block
+# is BRACED deliberately: a table's envelope is written AFTER its rows, so a bare
+# trailing annotation would be ambiguous (last row's? or the table's?). LBRACE
+# disambiguates, and a row with no block inherits the envelope exactly as before.
+table_row    = "row" LPAREN row_item { COMMA row_item } RPAREN [ LBRACE { annotation } RBRACE ] ;
 
 row_item     = NUMBER | IDENT | STRING ;
 

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.14.0] — 2026-07-18 — table answers now cite the row that produced them (ADJ-TABLES RS-5e)
+
+### Changed
+
+- **A table-backed answer's `citations` now quote the span defending *that row*** — not the table's
+  single envelope. Ask the shipped `environment/air-quality-index` table for AQI 120 and the answer
+  cites *"Orange Unhealthy for Sensitive Groups 101 to 150 …"*; previously it cited the `0 → good`
+  sentence regardless of which band was selected. This holds for **exact** recall and **range**
+  lookup alike, and flows through the proof DAG's `via_facts` the same way.
+- **No CLI source changed.** Each row already lowered to its own `Fact`, and the citation path
+  already cited *the fact that produced the answer*; adj-lang 0.55.0 simply gives that fact the
+  row's provenance. The version bump records the observable change in emitted citations.
+- Tables whose rows carry no provenance block are byte-for-byte unchanged.
+
 ## [0.13.0] — 2026-07-18 — RS-5c: range / bracket lookup answers (ADJ-TABLES)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/tests/rs5e_row_provenance_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5e_row_provenance_e2e.rs
@@ -1,0 +1,188 @@
+//! End-to-end tests for ADJ-TABLES RS-5e — PER-ROW provenance on a `table` —
+//! driven through the built CLI binary.
+//!
+//! ## What is being fixed
+//!
+//! A table carries one `source`/`locator`/`trust` envelope. With six bands and one
+//! envelope, EVERY answer — in every band — quoted the SAME sentence. That is an
+//! accounting error: the audit trail asserts a fact and cites a span that does not
+//! defend it. A range lookup makes it glaring (the selected row is explicit in the
+//! audit), but exact lookup was equally mis-cited.
+//!
+//! RS-5e lets a row carry its own `{ … }` block, folded OVER the envelope field by
+//! field. Five things are proven:
+//!
+//!   (a) RANGE lookup cites the span of the row it SELECTED — not the envelope's.
+//!   (b) EXACT lookup likewise cites its own row's span.
+//!   (c) INHERITANCE: a row that writes only `source` keeps the table's `locator`
+//!       and `trust` (so the common case stays terse — one span per row, one
+//!       locator for the page).
+//!   (d) OVERRIDE: a row may also override `trust`, and only that row changes.
+//!   (e) BACKWARD COMPATIBILITY: a table whose rows write no block behaves exactly
+//!       as before — every row inherits the whole envelope.
+
+use std::path::Path;
+use std::process::Command;
+
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs5e_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+fn write(dir: &Path, name: &str, src: &str) {
+    std::fs::write(dir.join(name), src).unwrap();
+}
+
+/// A breakpoint table whose rows each carry their OWN defending span, while
+/// sharing the table's `locator` and (mostly) its `trust`.
+const PER_ROW_TABLE: &str = r#"
+table aqi {
+    columns min_aqi, category
+    row (0, good)                             { source "Green   Good   0 to 50" }
+    row (51, moderate)                        { source "Yellow   Moderate   51 to 100" }
+    row (101, unhealthy_for_sensitive_groups) { source "Orange   Unhealthy for Sensitive Groups   101 to 150" }
+    row (301, hazardous)                      { source "Maroon   Hazardous   301 and higher"  trust consensus }
+    source  "The AQI includes six color-coded categories, each corresponding to a range of index values."
+    locator "https://www.airnow.gov/aqi/aqi-basics/"
+    trust   authoritative
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// (a) Range lookup cites the SELECTED row — the heart of the fix.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn range_lookup_cites_the_selected_rows_own_span_not_the_table_envelope() {
+    let dir = scratch("range");
+    let src = format!("{PER_ROW_TABLE}\n? lookup aqi min_aqi = 120 mode range give category\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI should succeed; stderr={err}");
+    assert!(
+        out.contains("\"category\":\"unhealthy_for_sensitive_groups\""),
+        "wrong band: {out}"
+    );
+    // The answer must quote the span that defends THIS band …
+    assert!(
+        out.contains("Orange   Unhealthy for Sensitive Groups   101 to 150"),
+        "answer must cite the selected row's span: {out}"
+    );
+    // … and must NOT fall back to the table's framing sentence.
+    assert!(
+        !out.contains("six color-coded categories"),
+        "the envelope's span must not be cited for a row that has its own: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Exact lookup cites its own row too — this was never range-specific.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn exact_lookup_cites_the_matching_rows_own_span() {
+    let dir = scratch("exact");
+    let src = format!("{PER_ROW_TABLE}\n? aqi(51, $Category)\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, _e) = run(&dir.join("case.adj"));
+    assert!(ok);
+    assert!(out.contains("\"Category\":\"moderate\""), "bad bind: {out}");
+    assert!(
+        out.contains("Yellow   Moderate   51 to 100"),
+        "exact lookup must cite its own row's span: {out}"
+    );
+    assert!(
+        !out.contains("six color-coded categories"),
+        "envelope span must not be cited here: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) A row that writes only `source` inherits locator + trust.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_row_that_writes_only_source_inherits_the_tables_locator_and_trust() {
+    let dir = scratch("inherit");
+    let src = format!("{PER_ROW_TABLE}\n? lookup aqi min_aqi = 75 mode range give category\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, _e) = run(&dir.join("case.adj"));
+    assert!(ok);
+    assert!(out.contains("Yellow   Moderate   51 to 100"), "own span: {out}");
+    // Inherited from the envelope — the row wrote neither.
+    assert!(
+        out.contains("airnow.gov/aqi/aqi-basics"),
+        "locator must be inherited: {out}"
+    );
+    assert!(
+        out.contains("\"trust\":\"authoritative\""),
+        "trust must be inherited: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) A row may override `trust`, and ONLY that row changes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_row_can_override_trust_without_affecting_its_siblings() {
+    let dir = scratch("override");
+    // The 301 row downgrades itself to `consensus`; the 51 row does not.
+    let src = format!(
+        "{PER_ROW_TABLE}\n\
+         ? lookup aqi min_aqi = 400 mode range give category\n\
+         ? lookup aqi min_aqi = 75 mode range give category\n"
+    );
+    write(&dir, "case.adj", &src);
+    let (ok, out, _e) = run(&dir.join("case.adj"));
+    assert!(ok);
+    assert!(out.contains("\"trust\":\"consensus\""), "row override missing: {out}");
+    assert!(
+        out.contains("\"trust\":\"authoritative\""),
+        "sibling row must keep the inherited tier: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (e) Backward compatibility — no row blocks means the old behaviour exactly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_table_with_no_row_blocks_still_inherits_the_envelope_everywhere() {
+    let dir = scratch("compat");
+    let src = r#"
+table bands {
+    columns min_v, label
+    row (0, low)
+    row (10, high)
+    source  "One sentence defending the whole table."
+    locator "https://example.test/bands"
+    trust   consensus
+}
+
+? lookup bands min_v = 12 mode range give label
+"#;
+    write(&dir, "case.adj", src);
+    let (ok, out, _e) = run(&dir.join("case.adj"));
+    assert!(ok);
+    assert!(out.contains("\"label\":\"high\""), "bad band: {out}");
+    assert!(
+        out.contains("One sentence defending the whole table."),
+        "a row with no block must inherit the envelope: {out}"
+    );
+    assert!(out.contains("\"trust\":\"consensus\""), "tier inherited: {out}");
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.55.0] — 2026-07-18
+
+### Added — RS-5e: per-row provenance on a `table` (ADJ-TABLES)
+
+**A table row can now carry the span that defends *it*.** Until now a `table` had ONE
+`source`/`locator`/`trust` envelope, so every answer — in every band, from every row — quoted the
+same sentence. That is an accounting error, not a cosmetic one: the audit trail asserted a fact and
+cited a span that did not support it. The RS-5c range lookup made it glaring (the selected row is
+explicit in the audit), but exact lookup had always been mis-cited the same way.
+
+- **Grammar**: `table_row` gains an optional `[ LBRACE { annotation } RBRACE ]` block. The braces
+  are deliberate — a table's envelope is written *after* its rows, so a bare trailing annotation
+  would be ambiguous (last row's, or the table's?). `LBRACE` disambiguates. Regenerated
+  `_parser_grammar.rs`.
+- **AST**: `TableRow` gains `annotations: Vec<Annotation>`.
+- **Lower**: new `row_provenance()` folds a row's block **over** the envelope *field by field*, so a
+  row supplies only what differs — usually just its own `source` span — and inherits the shared
+  `locator`/`trust`. Corroborating `cites` are appended. Duplicate keys inside one row block stay a
+  clean `DuplicateAnnotation`.
+- **No renderer change was needed**, which is the elegant part: each row already lowered to its
+  **own** `Fact`, and every citation path (exact recall, range lookup, the proof DAG's `via_facts`)
+  already cites *the fact that produced the answer*. Giving that fact the row's provenance was the
+  entire fix.
+- **Backward compatible**: a row with no block inherits the whole envelope, exactly as before, so
+  every table authored pre-RS-5e is unchanged.
+
 ## [0.54.0] — 2026-07-18
 
 ### Added — RS-5c: range / bracket lookup over a `table` read as a step function (ADJ-TABLES)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -654,8 +654,13 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"row_item"#.to_string() },
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+                        GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+                    ] }) },
             ] },
-            line_number: 415,
+            line_number: 421,
         },
         GrammarRule {
             name: r#"row_item"#.to_string(),
@@ -664,7 +669,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 417,
+            line_number: 423,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -672,7 +677,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 433,
+            line_number: 439,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -682,7 +687,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
             ] },
-            line_number: 445,
+            line_number: 451,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -690,7 +695,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 451,
+            line_number: 457,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -698,7 +703,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 452,
+            line_number: 458,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -706,7 +711,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 453,
+            line_number: 459,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -716,7 +721,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 454,
+            line_number: 460,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -727,7 +732,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 456,
+            line_number: 462,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -751,7 +756,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 478,
+            line_number: 484,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1057,7 +1057,12 @@ fn adapt_table(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
                         }
                     }
                 }
-                rows.push(crate::ast::TableRow { cells });
+                // ADJ-TABLES RS-5e: the row's OWN `{ … }` provenance block, if it
+                // wrote one. `collect_annotations` walks this row node's direct
+                // `annotation` children — the braces keep them scoped to the row,
+                // so the table's trailing envelope is never absorbed here.
+                let annotations = collect_annotations(row_node)?;
+                rows.push(crate::ast::TableRow { cells, annotations });
             }
         }
     }

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -562,6 +562,19 @@ pub struct FormulaStep {
 pub struct TableRow {
     /// The row's cells, in column order.
     pub cells: Vec<TableCell>,
+    /// This row's OWN provenance block (ADJ-TABLES RS-5e), if it wrote one. Empty
+    /// for a row that inherits the table's envelope wholesale (the pre-RS-5e
+    /// behaviour, and still the common case for a table whose every row is
+    /// defended by the same sentence).
+    ///
+    /// When non-empty these annotations override the table envelope **field by
+    /// field** for this row — so a row can supply just the `source` span that
+    /// defends *it* and keep the table's shared `locator`/`trust`. The point is
+    /// that a lookup answer cites the span supporting **the row it selected**,
+    /// not the table's first sentence: with one envelope, a six-band table made
+    /// every answer in every band quote the same cell, which is an accounting
+    /// error the moment the selected row is explicit (as a range lookup makes it).
+    pub annotations: Vec<Annotation>,
 }
 
 /// A single table cell (ADJ-TABLES RS-5). One of the three GROUND term kinds the

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -791,7 +791,15 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                         });
                     }
                     let args: Vec<CoreTerm> = row.cells.iter().map(lower_cell).collect();
-                    kb.add_fact(Fact::certain(compound(name, args)).with_provenance(prov.clone()));
+                    // ADJ-TABLES RS-5e: each row already becomes its OWN `Fact`, and
+                    // every citation path (exact recall, range lookup, the proof
+                    // DAG's `via_facts`) cites *the fact that produced the answer* —
+                    // so stamping the ROW's provenance here is the whole fix, with no
+                    // renderer change. A row that wrote its own `{ … }` block
+                    // overrides the envelope field-by-field; a row without one gets
+                    // the envelope unchanged (pre-RS-5e behaviour).
+                    let row_prov = row_provenance(&prov, &row.annotations)?;
+                    kb.add_fact(Fact::certain(compound(name, args)).with_provenance(row_prov));
                 }
             }
             // ---- import (MYCIN-2026 M3) ----
@@ -1266,6 +1274,75 @@ fn lower_cmp_op(op: CmpOp) -> EngineCmpOp {
         CmpOp::Lt => EngineCmpOp::Lt,
         CmpOp::Eq => EngineCmpOp::Eq,
     }
+}
+
+/// Fold a table row's OWN `{ … }` provenance block over the table's envelope
+/// (ADJ-TABLES RS-5e), producing the provenance stamped on *that row's* fact.
+///
+/// ## Why a row needs its own provenance
+///
+/// A table carries one `source`/`locator`/`trust` envelope. With six bands and one
+/// envelope, **every** answer — in every band — quotes the same sentence. That is an
+/// accounting error: the audit trail asserts a fact and cites a span that does not
+/// defend it. A range lookup makes it glaring (the selected row is explicit in the
+/// audit), but it was equally wrong for exact lookup all along.
+///
+/// ## Override, don't replace
+///
+/// The row's fields are folded **over** the envelope rather than replacing it, so a
+/// row supplies only what differs — usually just the `source` span of its own cell —
+/// and inherits the shared `locator` and `trust`. That keeps the common case terse
+/// (one `source` per row, one `locator` for the page) and means an empty block is
+/// exactly the old behaviour. Corroborating `cites` are *appended* to the envelope's,
+/// since they are additional independent support, not a correction.
+///
+/// Duplicate keys **within one row block** are the same clean error they are anywhere
+/// else (`source` twice in one block is a typo, not an override of itself).
+fn row_provenance(
+    table: &Provenance,
+    row_annotations: &[Annotation],
+) -> Result<Provenance, LowerError> {
+    if row_annotations.is_empty() {
+        return Ok(table.clone());
+    }
+    let mut prov = table.clone();
+    let (mut saw_source, mut saw_locator, mut saw_trust) = (false, false, false);
+    for a in row_annotations {
+        match a {
+            Annotation::Source(s) => {
+                if saw_source {
+                    return Err(LowerError::DuplicateAnnotation { name: "source" });
+                }
+                saw_source = true;
+                prov.source = s.clone();
+            }
+            Annotation::Locator(s) => {
+                if saw_locator {
+                    return Err(LowerError::DuplicateAnnotation { name: "locator" });
+                }
+                saw_locator = true;
+                prov.locator = Some(s.clone());
+            }
+            Annotation::Trust(name) => {
+                if saw_trust {
+                    return Err(LowerError::DuplicateAnnotation { name: "trust" });
+                }
+                saw_trust = true;
+                prov.trust_tier = match name {
+                    TrustTierName::Consensus => TrustTier::Consensus,
+                    TrustTierName::Authoritative => TrustTier::Authoritative,
+                    TrustTierName::Empirical => TrustTier::Empirical,
+                    TrustTierName::Inferred => TrustTier::Inferred,
+                    TrustTierName::Unattributed => TrustTier::Unattributed,
+                };
+            }
+            Annotation::Cites { source, locator } => {
+                prov.corroborations
+                    .push(Citation::new(source.clone(), locator.clone()));
+            }
+        }
+    }
+    Ok(prov)
 }
 
 fn annotations_to_provenance(annotations: &[Annotation]) -> Result<Provenance, LowerError> {

--- a/code/specs/ADJ-TABLES.md
+++ b/code/specs/ADJ-TABLES.md
@@ -64,9 +64,29 @@ Grammar (added to the `statement` alternation; see [ADJ01 grammar](ADJ01-adjudic
 ```
 table_decl   = "table" IDENT LBRACE { use_decl } columns_decl { table_row } { annotation } RBRACE ;
 columns_decl = "columns" IDENT { COMMA IDENT } ;
-table_row    = "row" LPAREN row_item { COMMA row_item } RPAREN ;
+table_row    = "row" LPAREN row_item { COMMA row_item } RPAREN [ LBRACE { annotation } RBRACE ] ;
 row_item     = NUMBER | IDENT | STRING ;
 ```
+
+**Per-row provenance (RS-5e).** A row may carry its **own** `{ … }` annotation block, which
+overrides the table envelope *field by field* for that row — so a row can supply just the span
+that defends **it** and inherit the shared `locator`/`trust`:
+
+```
+table air_quality_index {
+    columns min_aqi, category
+    row (0,   good)     { source "Green   Good   0 to 50" }
+    row (51,  moderate) { source "Yellow   Moderate   51 to 100" }
+    source  "The AQI includes six color-coded categories, each corresponding to a range of index values."
+    locator "https://www.airnow.gov/aqi/aqi-basics/"
+    trust   authoritative
+}
+```
+
+The block is **braced deliberately**: a table's envelope is conventionally written *after* its
+rows, so a bare trailing annotation would be ambiguous — the parser could not tell whether it
+belonged to the last row or to the table. `LBRACE` disambiguates, and a row with no block behaves
+exactly as before (inherits the whole envelope), so every existing table is unchanged.
 
 - **`use <dict>`** (optional): vocabulary-check column entities against a `dictionary`, as a
   `rulebook`/`formulabook` does.
@@ -142,6 +162,18 @@ value columns; a non-numeric column is a compile/lookup error.
   `annotations_to_provenance` surface used by `relate`, `rule`, `prior`, `contributes`, and
   `formula`. Trust tiers are the existing five (`consensus`/`authoritative`/`empirical`/
   `inferred`/`unattributed`).
+- **Per-row override (RS-5e).** A row's own `{ … }` block overrides the envelope *field by field*
+  for that row, so the answer cites **the span that defends the row actually selected** — not the
+  table's first sentence. This closes a real accounting gap: a six-band table with one envelope
+  made every answer, in every band, cite the *same* sentence. A range lookup made it glaring,
+  because the selected row is explicit in the audit; but it affected every multi-row table.
+  Mechanically it is nearly free — each row already lowers to its **own** `Fact`, and every
+  citation path (exact recall, range lookup, the proof DAG's `via_facts`) already cites *the fact
+  that produced the answer*. Giving that fact the row's provenance is the whole fix; no renderer
+  changes.
+- This is what makes the audit trail honest at the table level: *every asserted fact quotes the
+  byte span that supports **it***. A row without a block still inherits the envelope, so tables
+  authored before RS-5e keep working unchanged.
 - Every lookup answer (exact, range, or interpolated) carries the table's citation. For
   interpolated answers the derivation records the two bracketing rows it combined — the answer
   remains auditable to the source rows, honouring *hallucination is an accounting failure;
@@ -172,12 +204,13 @@ per conversion, one table cites the NIST page once and every conversion is audit
 |-------|------|--------|
 | RS-5a | this spec | **this PR** |
 | RS-5b | grammar + AST + adapter + lower; rows→relations; **exact lookup** e2e; shipped NIST table | **this PR** |
-| RS-5c | **range/bracket** lookup tactic (reuses the exact `BigRational` order) + e2e (inline BMI bands) | **this PR** |
+| RS-5c | **range/bracket** lookup tactic (reuses the exact `BigRational` order) + e2e (inline BMI bands) | shipped |
+| RS-5e | **per-row provenance** — a row's `{ … }` block overrides the envelope; the answer cites the SELECTED row's span | **this PR** |
 | RS-5d | **interpolated** lookup tactic (new, on `BigRational`) + e2e (nomogram) | follow-up |
 
-**Explicitly deferred:** per-row provenance (table-level only for now); multi-key composite
-lookup beyond positional binding; typed/dimensioned columns (columns are untyped atoms/numbers
-today). These are additive and do not change the row-as-relation core.
+**Explicitly deferred:** multi-key composite lookup beyond positional binding; typed/dimensioned
+columns (columns are untyped atoms/numbers today). These are additive and do not change the
+row-as-relation core. (*Per-row provenance was deferred at RS-5b and is now delivered by RS-5e.*)
 
 ---
 

--- a/code/specs/data/adj-facts-stdlib/environment/air-quality-index.adj
+++ b/code/specs/data/adj-facts-stdlib/environment/air-quality-index.adj
@@ -134,10 +134,13 @@
 % than a closed interval. The 0 floor is grounded in the "0 to 50" span, which
 % is why anything below 0 abstains: the source's domain starts there.
 %
-% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
-% `trust` below hold the single cleanest span: the AirNow statement that fixes
-% the first breakpoint row (0 → good). Every OTHER row's per-fact source and
-% verbatim span is listed above, so each band remains independently checkable.
+% Each of those six spans is machine-attached to the row it defends (ADJ-TABLES
+% RS-5e per-row provenance), so a lookup answer quotes the band it actually
+% selected: ask for AQI 120 and the citation is the "Orange … 101 to 150" span,
+% not the table's framing sentence. The table-level `source` below is the
+% FRAMING claim — that the AQI has exactly these six categories — which is what
+% defends the table as a whole; `locator` and `trust` are shared, and every row
+% inherits them rather than restating them.
 % All spans are from the same EPA / AirNow page — AirNow is run by the U.S.
 % Environmental Protection Agency and the AQI is EPA's own index, a primary U.S.
 % government source — so `trust authoritative`.
@@ -148,14 +151,38 @@
 table air_quality_index {
     columns min_aqi, category
 
-    row (0, good)                              % "Green   Good   0 to 50"
-    row (51, moderate)                         % "Yellow   Moderate   51 to 100"
-    row (101, unhealthy_for_sensitive_groups)  % "Orange   Unhealthy for Sensitive Groups   101 to 150"
-    row (151, unhealthy)                       % "Red   Unhealthy   151 to 200"
-    row (201, very_unhealthy)                  % "Purple   Very Unhealthy   201 to 300"
-    row (301, hazardous)                       % "Maroon   Hazardous   301 and higher" (open top band)
+    % ADJ-TABLES RS-5e — PER-ROW PROVENANCE. Each row carries the span that
+    % defends IT, so a lookup answer quotes the band it actually selected: ask
+    % for AQI 120 and the citation is the "Orange … 101 to 150" row, not the
+    % table's framing sentence. Before RS-5e a table had one envelope, so every
+    % answer in every band quoted the same cell — an accounting error the range
+    % lookup made glaring by naming the selected row in the audit.
+    % None of these rows restates `locator`/`trust`: they all come from the one
+    % AirNow page at one tier, and a row inherits every field it does not write.
+    row (0, good) {
+        source "Green Good 0 to 50 Air quality is satisfactory, and air pollution poses little or no risk."
+    }
+    row (51, moderate) {
+        source "Yellow Moderate 51 to 100 Air quality is acceptable. However, there may be a risk for some people, particularly those who are unusually sensitive to air pollution."
+    }
+    row (101, unhealthy_for_sensitive_groups) {
+        source "Orange Unhealthy for Sensitive Groups 101 to 150 Members of sensitive groups may experience health effects. The general public is less likely to be affected."
+    }
+    row (151, unhealthy) {
+        source "Red Unhealthy 151 to 200 Some members of the general public may experience health effects; members of sensitive groups may experience more serious health effects."
+    }
+    row (201, very_unhealthy) {
+        source "Purple Very Unhealthy 201 to 300 Health alert: The risk of health effects is increased for everyone."
+    }
+    row (301, hazardous) {
+        % The open top band is grounded in this span's "301 and higher".
+        source "Maroon Hazardous 301 and higher Health warning of emergency conditions: everyone is more likely to be affected."
+    }
 
-    source "Green Good 0 to 50 Air quality is satisfactory, and air pollution poses little or no risk."
+    % The table-level envelope now carries the FRAMING span — what defends the
+    % table as a whole, namely that the AQI has exactly these six categories —
+    % plus the shared locator and trust tier every row above inherits.
+    source "The AQI includes six color-coded categories, each corresponding to a range of index values."
     locator "https://www.airnow.gov/aqi/aqi-basics/"
     trust authoritative
 }


### PR DESCRIPTION
## The bug this fixes

An ADJ `table` carried **one** `source`/`locator`/`trust` envelope. So every answer — in every band, from every row — quoted the **same sentence**.

That is an accounting error, not a cosmetic one: the audit trail asserted a fact and cited a span that did not defend it. Ask the shipped AQI table for 120 and it answered `unhealthy_for_sensitive_groups` while citing *"Green Good 0 to 50 …"*.

The RS-5c range lookup made this **glaring** (the selected row is now explicit in the audit), but exact lookup had been mis-cited the same way all along, across every multi-row table in the facts stdlib.

## The fix

A row may carry its own **braced** provenance block, folded **over** the envelope *field by field* — so it supplies only what differs (usually just its own span) and inherits the shared `locator`/`trust`:

```
row (101, unhealthy_for_sensitive_groups) {
    source "Orange Unhealthy for Sensitive Groups 101 to 150 …"
}
```

**Why braced:** a table's envelope is conventionally written *after* its rows, so a bare trailing annotation would be ambiguous — last row's, or the table's? `LBRACE` disambiguates. (The security review independently confirmed the scoping holds in both directions and that a malformed block is a hard parse error, never silent re-attribution.)

**No renderer changed** — the elegant part. Each row already lowered to its **own** `Fact`, and every citation path (exact recall, range lookup, the proof DAG's `via_facts`) already cites *the fact that produced the answer*. Giving that fact the row's provenance was the entire fix.

## Verified live, on the shipped artifact

This PR also backfills `environment/air-quality-index` with its six per-row spans, closing in code the limitation I documented in #8669's body:

| query | answer | now cites |
|---|---|---|
| AQI 120 | `unhealthy_for_sensitive_groups` | "Orange Unhealthy for Sensitive Groups 101 to 150 …" |
| AQI 210 | `very_unhealthy` | "Purple Very Unhealthy 201 to 300 …" |

Both previously cited the `0 → good` sentence.

## Backward compatibility

A row with no block inherits the whole envelope exactly as before — every pre-RS-5e table is byte-identical. **`cli_golden` and all 162 suites pass unchanged.**

## Verification

- `cargo test -p adj-lang -p adj-lang-cli` — **162 suites ok, 0 failed**.
- 5 new `rs5e_row_provenance_e2e` tests: range cites the selected row (and *not* the envelope); exact cites its own row; `locator`/`trust` inheritance; per-row `trust` override affecting only that row; no-block backward compatibility.
- `/security-review` **PASSED** — no unwraps/panics, correct per-block duplicate detection, no unbounded `corroborations` growth, regenerated parser table is mechanical-only, new spans are pure ASCII with no JSON breakout.

## Why this ordering

This is the correctness prerequisite for **RS-4** (the first-class audit trail — `? why` step-by-step reasoning with `adj-verify`). There is no point building a step-by-step "why" on top of citations that point at the wrong row.

Bumps: adj-lang 0.54.0 → 0.55.0, adj-lang-cli 0.13.0 → 0.14.0 (no CLI source changed; the bump records the observable change in emitted citations). ADJ-TABLES.md §2/§4/§6 updated; per-row provenance moves out of "explicitly deferred".

🤖 Generated with [Claude Code](https://claude.com/claude-code)