### PR TITLE
feat(hl): Ch.13 colours for French, German, Italian, Portuguese

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -248,6 +248,8 @@
       "IT-FOOD-DRINKS": "acqua/vino (water/wine; acqua KEPT Latin aqua whole, -cq- doubled, vs French eau; vino ← vīnum → wine/vine/vinegar)",
       "IT-NUM-11-16": "undici…sedici (11-16; digit + -dici, and -dici is still visibly Latin decem = dieci — clearer than French's worn-down -ze)",
       "IT-NUM-17-20": "diciassette…venti (17-20; at 17 the ORDER FLIPS — sedici 'six-ten' but diciassette 'ten-and-seven'; venti ← vīgintī)",
+      "IT-COLOUR-BLACK-WHITE": "nero, bianco — nero ← Latin niger (→ denigrate), but bianco ← Germanic *blank 'shining', likely via the LOMBARDS (→ Lombardia), displacing Latin albus, which survives in alba 'dawn' / albume",
+      "IT-COLOUR-RED-BLUE": "rosso, blu (+ azzurro) — rosso ← russus ← PIE *h₁rewdʰ-, cousin (not loan) of red/rot/rouge; blu is a SECOND Germanic loan (*blāo); azzurro ← Arabic lāzaward 'lapis lazuli' ← Persian lāžward, l- lost as if an article → English azure; gli Azzurri",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
@@ -268,6 +270,8 @@
       "FR-FOOD-DRINKS": "eau/vin (water/wine; eau ← aqua worn to a bare 'oh' — most eroded of all, vs English aquatic; vin ← vīnum → wine/vine/vinegar)",
       "FR-NUM-11-16": "onze…seize (11-16; the six Latin fusions ūndecim…sēdecim; shared -ze = decem 'ten', the same ten as dix/décembre)",
       "FR-NUM-17-20": "dix-sept…vingt (17-20; at 17 French GIVES UP fusing and goes transparent 'ten-seven', the order flipping too; vingt ← vīgintī → vigesimal)",
+      "FR-COLOUR-BLACK-WHITE": "noir, blanc — noir ← Latin niger, but blanc ← FRANKISH *blank 'shining', a Germanic word borrowed INTO Romance (the reverse of the usual flow); Latin albus survives only as aube 'dawn' / aubépine / album",
+      "FR-COLOUR-RED-BLUE": "rouge, bleu — rouge ← rubeus ← PIE *h₁rewdʰ-, a true cousin of English red / German rot; bleu is a SECOND Germanic loan (*blāo), which English then borrowed BACK from French as 'blue'; azur ← Arabic lāzaward. Bleu-blanc-rouge: two of three are loans",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
@@ -288,6 +292,8 @@
       "GE-FOOD-DRINKS": "Wasser/Wein (water/wine; Wasser NATIVE Germanic twin of water; but Wein is an ANCIENT Latin loan ← vīnum, borrowed with the vine — like English wine)",
       "GE-NUM-11-12": "elf/zwölf (11-12; ← ainlif/twalif, -lif = 'leave' → 'ONE/TWO left over' after ten fingers; the exact inherited twins of English eleven/twelve)",
       "GE-NUM-13-20": "dreizehn…zwanzig (13-20; digit + zehn with NO exceptions, mirroring English -teen which IS ten; zwanzig ← twaintig 'two tens'; German never breaks, unlike Romance)",
+      "GE-COLOUR-BLACK-WHITE": "schwarz, weiß — both NATIVE Germanic: schwarz ← *swartaz (English 'swarthy'; kin to Latin sordēs → sordid), weiß ← *hwītaz = English white (note ß after a long vowel; Swiss 'weiss'). German's own blank 'shiny' is the word Romance borrowed for WHITE (blanc/bianco/branco) — Germanic lending INTO Latin's daughters",
+      "GE-COLOUR-RED-BLUE": "rot, blau — rot ← *raudaz ← PIE *h₁rewdʰ-, cousin by DESCENT of Latin ruber → rouge/rosso; blau ← *blēwaz, the SECOND German colour word borrowed into Romance (bleu/blu), with English taking 'blue' from French rather than from Germanic",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
       "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
       "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
@@ -306,7 +312,9 @@
       "PT-FOOD-BREAD": "pão (bread ← pānis, worn to one nasal syllable pānis→pão — same erosion as pai; plural pães; → companion/pantry)",
       "PT-FOOD-DRINKS": "água/vinho (water/wine; água KEPT aqua's body vs French eau; vinho ← vīnum with signature -nh- = Spanish ñ → wine/vine/vinegar)",
       "PT-NUM-11-15": "onze…quinze (11-15; only FIVE fused teens — fewer than any sister; -ze = decem as in dez/dezembro; catorze keeps the c-)",
-      "PT-NUM-16-20": "dezesseis…vinte (16-20; PT breaks EARLIEST at 16, rebuilding as dez + e + seis = literally 'ten AND six', the 'and' still audible; vinte ← vīgintī)"
+      "PT-NUM-16-20": "dezesseis…vinte (16-20; PT breaks EARLIEST at 16, rebuilding as dez + e + seis = literally 'ten AND six', the 'and' still audible; vinte ← vīgintī)",
+      "PT-COLOUR-BLACK-WHITE": "preto, branco — PT keeps TWO blacks: literary negro ← niger, and everyday preto ← Latin pressus 'pressed, dense' (dense→thick→dark; cf. press/compress). branco ← Germanic *blank 'shining', with the Portuguese l→r swap (blanc→branco, plaza→praça); albus survives in alvorada/alva 'dawn'",
+      "PT-COLOUR-RED-BLUE": "vermelho, azul — vermelho ← vermiculus 'LITTLE WORM', the kermes scale insect crushed for scarlet dye, so the dye's name became the colour's (→ English vermilion; vermis → vermin); PT alone skips the ancient *h₁rewdʰ- red root (kept only in rubro/ruivo). azul ← Arabic lāzaward 'lapis lazuli' ← Persian lāžward, l- lost as if an article → azure — the al-Andalus thread reaching a basic colour"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter 13 — Colours
+
+- **Chapter 13 authored** (`FR-C13-noir-blanc`, `-rouge-bleu`): the **borrowing**
+  chapter, reviewing Ch.11/12 via `reviews_of`.
+- **noir & blanc** (`FR-C13-noir-blanc`): *noir* ← Latin *niger* (→ *denigrate*) is
+  the expected inheritance — but **blanc is not from Latin *albus*** at all. It is
+  **Frankish *blank*** ("shining, gleaming"), a **Germanic** word borrowed **into**
+  French: the reverse of the usual Latin→Germanic flow, and it displaced *albus*
+  entirely, probably by being the more **vivid** option. *Albus* didn't die, it just
+  stopped being a colour: **aube** ("dawn"), *aubépine* ("white thorn"), *album*,
+  *albinos*.
+- **rouge & bleu** (`FR-C13-rouge-bleu`): *rouge* ← *rubeus* ← PIE ***h₁rewdʰ-***,
+  making *rouge*, English *red/rust/ruby* and German *rot* **cousins by descent**,
+  not borrowings — one of the oldest reconstructible colour words. *Bleu* is a
+  **second** Germanic loan (*blāo*), and English then borrowed **back** from French,
+  so *blue* is a Germanic word that came home in disguise; *azur* (← Arabic
+  *lāzaward*) noted alongside. Payoff: of **bleu-blanc-rouge**, **two of three are
+  loanwords**.
+- Taxonomy: namespaced `FR-COLOUR-BLACK-WHITE`, `FR-COLOUR-RED-BLUE`.
+
 ## Chapter 12 — Numbers 11–20
 
 - **Chapter 12 authored** (`FR-C12-nombres-11-16`, `-17-20`): the teens, atom-first,

--- a/code/learning/human-languages/french/lessons/FR-C13-noir-blanc.md
+++ b/code/learning/human-languages/french/lessons/FR-C13-noir-blanc.md
@@ -1,0 +1,69 @@
+---
+id: FR-C13-noir-blanc
+chapter: 13
+type: word
+headword: noir, blanc
+gloss: black and white — one word inherited from Latin, one borrowed from the Germanic neighbours
+concept_tag: FR-COLOUR-BLACK-WHITE
+prerequisites: [FR-C12-nombres-17-20]
+sounds: [nasal-an, silent-c]
+roots: [latin-niger, germanic-blank]
+etymology_hook: "noir ← Latin niger, but blanc is NOT from Latin albus — it's Frankish *blank 'shining', borrowed INTO French, the reverse of the usual flow; albus survives only in aube ('dawn') and album"
+est_minutes: 5
+reviews_of: [FR-C12-nombres-17-20, FR-C11-eau-vin]
+---
+
+# noir, blanc — one inherited, one borrowed
+
+## Warm-up
+
+[PAUSE 2s] Two colours, two completely different life stories. One walked
+straight down from Latin. The other was **borrowed from the Germanic
+neighbours** — and that direction, Germanic **into** Romance, is the opposite of
+what usually happens.
+
+## noir — the expected one
+
+**noir** ("black") ← Latin ***niger***. No surprises: *niger* → *negro/nero* in
+the sister languages, and into English in *denigrate* ("to blacken someone's
+name").
+
+## blanc — the imported one
+
+You'd expect Latin ***albus*** ("white"). It's not there. French says **blanc**,
+from **Frankish *blank*** — a Germanic word meaning "**shining, gleaming**." The
+Franks who gave France its name gave it its word for white too.
+
+Why did *albus* lose? Probably because *blank* was **vivid**: not just "white"
+but "bright, flashing." Colour words often get replaced by the more dramatic
+option.
+
+## Where albus went
+
+It didn't die — it stopped being a colour:
+
+| word | meaning | the white inside |
+|---|---|---|
+| **aube** | dawn | the sky going *white* |
+| **aubépine** | hawthorn | the "white thorn" |
+| *album* (Eng.) | album | a *blank white* tablet |
+| *albinos* (Eng.) | albino | white-skinned |
+
+So Latin's white is still all around you — just never where you'd look for it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "noir, blanc"]
+- [YOU SAY: "le vin blanc, le vin rouge" — wine you already know from Ch.11]
+- [YOU SAY: the pairing — "*noir* from Latin, *blanc* from the Franks"]
+- [YOU SAY: "l'**aube**" — and hear the old Latin white in it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which of the two is inherited from Latin? (**Noir** ← *niger*.) Where
+does **blanc** come from? (**Frankish *blank***, "shining" — a **Germanic** word
+borrowed **into** French.) Why is that direction surprising? (Latin usually lends
+**to** Germanic, not the other way.) Where did Latin *albus* end up? (In **aube**,
+"dawn," and *album* — no longer a colour.) Next: **red** and **blue**, and one
+more borrowing.

--- a/code/learning/human-languages/french/lessons/FR-C13-rouge-bleu.md
+++ b/code/learning/human-languages/french/lessons/FR-C13-rouge-bleu.md
@@ -1,0 +1,74 @@
+---
+id: FR-C13-rouge-bleu
+chapter: 13
+type: word
+headword: rouge, bleu
+gloss: red and blue — one ancient inherited root, and a second Germanic loan
+concept_tag: FR-COLOUR-RED-BLUE
+prerequisites: [FR-C13-noir-blanc]
+sounds: [uvular-r, vowel-eu]
+roots: [pie-rewdh, germanic-blao]
+etymology_hook: "rouge ← Latin rubeus, from the PIE root that also gave English red/ruby/rust — so rouge and red are cousins; bleu is a SECOND Germanic loan (*blāo), and English borrowed it back from French"
+est_minutes: 5
+reviews_of: [FR-C13-noir-blanc, FR-C12-nombres-17-20]
+---
+
+# rouge, bleu — an ancient word and a borrowed one
+
+## Warm-up
+
+[PAUSE 2s] Last lesson: one inherited colour, one borrowed. This lesson repeats
+the pattern — and shows that French's borrowing from Germanic wasn't a one-off.
+
+## rouge — very, very old
+
+**rouge** ← Latin ***rubeus*** ("reddish"). But *rubeus* itself descends from a
+root so old it predates Latin: PIE ***h₁rewdʰ-***. Its children are everywhere:
+
+| language | word |
+|---|---|
+| Latin | *ruber*, *rubeus* → **rouge**, *ruby*, *rubric* |
+| English | **red**, *rust*, *ruddy* |
+| German | **rot** |
+
+So *rouge* and *red* are not lookalikes — they are **actual cousins**, separated
+for maybe five thousand years. Red is one of humanity's oldest named colours.
+
+## bleu — borrowed, then lent onward
+
+**bleu** ← Frankish ***blāo***. Another **Germanic** word, borrowed exactly like
+*blanc*. And then something neat happened: **English took *bleu* from French** —
+so English *blue* is a Germanic word that went to France, changed clothes, and
+came back. German kept the original at home: **blau**.
+
+French also has **azur** (from the same source as Spanish *azul*, ultimately
+**Arabic** *lāzaward*, "lapis lazuli") — the poetic blue of the sky, and the
+*Côte d'Azur*.
+
+## The pattern of the chapter
+
+| colour | source |
+|---|---|
+| noir | Latin *niger* |
+| **blanc** | **Germanic** *blank* |
+| rouge | Latin *rubeus* (ancient PIE root) |
+| **bleu** | **Germanic** *blāo* |
+
+Half of French's basic colour vocabulary walked in from the north.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rouge, bleu"]
+- [YOU SAY: "le vin rouge" — Ch.11's wine, now with its colour]
+- [YOU SAY: "bleu, blanc, rouge" — the flag, all three learned]
+- [YOU SAY: the cousins — "rouge · red · rot"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are *rouge* and English *red* to each other? (**Cousins** — both
+from PIE ***h₁rewdʰ-***.) Where does **bleu** come from? (**Germanic *blāo*** —
+the second Germanic colour loan.) What did English do with it? (**Borrowed it
+back** from French as *blue*.) What are the three flag colours? (*Bleu, blanc,
+rouge* — and two of the three are **loanwords**.) Next chapter: describing what
+you see.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -70,6 +70,16 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   transparent ("ten-seven"), **flipping the order** at the same seam; *vingt* ←
   *vīgintī* → **vigesimal**. **Authored.**
 
+- **Ch. 13 — Colours**: the borrowing chapter. **noir/blanc** — *noir* ← *niger* as
+  expected, but **blanc is NOT from Latin *albus***: it's **Frankish *blank***
+  ("shining"), a **Germanic** word borrowed **into** Romance, the reverse of the
+  usual flow; *albus* survives only outside the colour slot, in **aube** ("dawn"),
+  *aubépine*, *album* → **rouge/bleu** — *rouge* ← *rubeus* ← PIE ***h₁rewdʰ-***, so
+  *rouge* and English *red* and German *rot* are **cousins by descent**, not
+  borrowings; *bleu* is a **second** Germanic loan (*blāo*), which English then
+  borrowed **back** from French. Payoff: of *bleu-blanc-rouge*, **two of three are
+  loanwords**. **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter 13 — Colours
+
+- **Chapter 13 authored** (`GE-C13-schwarz-weiss`, `-rot-blau`): German as the
+  **lender** rather than the borrower, reviewing Ch.11/12 via `reviews_of`.
+- **schwarz & weiß** (`GE-C13-schwarz-weiss`): both **native Germanic**, no Latin
+  anywhere. *Schwarz* ← *swartaz*, whose English cousin survives as **swarthy**, and
+  which is kin to Latin *sordēs* ("dirt") → *sordid* — black and grubby from one
+  idea. *Weiß* ← *hwītaz* = **exactly** English *white*; includes the **ß** rule
+  (sharp *s* after a long vowel; Swiss spelling *weiss*). The showpiece: German's own
+  **blank** ("shiny, polished, bare") is the very word Romance **borrowed** for
+  **white** — *blanc/bianco/branco* — while German kept the original meaning. This
+  reverses the direction seen in Ch.11 (*Wein* ← *vīnum*, *Fenster* ← *fenestra*).
+- **rot & blau** (`GE-C13-rot-blau`): *rot* ← *raudaz* ← PIE ***h₁rewdʰ-***, so *rot*
+  and French *rouge* are related **by descent, not borrowing** — they split millennia
+  before either language existed. *Blau* ← *blēwaz* is the **second** German colour
+  word Romance took (*bleu*, *blu*), and English took **blue from French** rather
+  than from its own Germanic stock. Closes with a four-row table of which words
+  Romance borrowed and which it already had a cousin for.
+- Taxonomy: namespaced `GE-COLOUR-BLACK-WHITE`, `GE-COLOUR-RED-BLUE`.
+
 ## Chapter 12 — Numbers 11–20
 
 - **Chapter 12 authored** (`GE-C12-elf-zwoelf`, `-zahlen-13-20`): the teens,

--- a/code/learning/human-languages/german/lessons/GE-C13-rot-blau.md
+++ b/code/learning/human-languages/german/lessons/GE-C13-rot-blau.md
@@ -1,0 +1,81 @@
+---
+id: GE-C13-rot-blau
+chapter: 13
+type: word
+headword: rot, blau
+gloss: red and blue — an ancient shared root, and a second word German lent to its neighbours
+concept_tag: GE-COLOUR-RED-BLUE
+prerequisites: [GE-C13-schwarz-weiss]
+sounds: [long-o, diphthong-au]
+roots: [pie-rewdh, germanic-blao]
+etymology_hook: "rot ← *raudaz ← PIE *h₁rewdʰ-, the same root as Latin ruber → French rouge — genuine cousins; and blau, like blank, was borrowed INTO Romance (bleu, blu), then English took blue back from French"
+est_minutes: 5
+reviews_of: [GE-C13-schwarz-weiss, GE-C12-zahlen-13-20]
+---
+
+# rot, blau — cousins and emigrants
+
+## Warm-up
+
+[PAUSE 2s] Two more native German colours. One is related to the French word for
+red — genuinely, not by borrowing. The other is a **second** German word the
+Romance languages took.
+
+## rot — an ancient cousin
+
+**rot** ← Proto-Germanic ***raudaz*** ← PIE ***h₁rewdʰ-***. That root is one of
+the oldest colour words we can reconstruct, and it went everywhere:
+
+| language | word |
+|---|---|
+| German | **rot** |
+| English | **red**, *rust*, *ruddy* |
+| Latin | *ruber*, *rubeus* → French **rouge**, *ruby*, *rubric* |
+
+So *rot* and *rouge* are **cousins**, not borrowings — they split apart thousands
+of years before either language existed. Red is the colour humans name first,
+after black and white.
+
+## blau — the second emigrant
+
+**blau** ← Proto-Germanic ***blēwaz***. Like *blank* in the last lesson, this word
+was **borrowed into Romance**:
+
+| language | "blue" |
+|---|---|
+| German | **blau** |
+| French | **bleu** |
+| Italian | **blu** |
+| English | **blue** — taken from **French**, not from German |
+
+English is the odd one here: it had Germanic *blāw* available but borrowed the
+French form instead. The word went Germanic → French → English, coming home in
+disguise.
+
+Portuguese went a different way entirely — its blue is **azul**, from **Arabic**.
+You'll meet that one in the Portuguese track.
+
+## The chapter in one table
+
+| German | source | did Romance borrow it? |
+|---|---|---|
+| schwarz | Germanic *swartaz* | no |
+| weiß | Germanic *hwītaz* | no — but *blank* went instead |
+| rot | Germanic *raudaz* | no — Latin had its **own** cousin |
+| blau | Germanic *blēwaz* | **yes** — *bleu*, *blu* |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rot, blau"]
+- [YOU SAY: "der Wein ist rot" — Chapter 11's wine again]
+- [YOU SAY: the cousins — "rot · red · rouge"]
+- [YOU SAY: all four — "schwarz, weiß, rot, blau"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is *rot* related to French *rouge* by **borrowing** or by **descent**?
+(**Descent** — both from PIE ***h₁rewdʰ-***.) Which two German colour words did
+Romance borrow? (***Blank*** → *blanc/bianco/branco*, and ***blau*** → *bleu/blu*.)
+Where did English get *blue* from? (**French** — the long way round.) Next
+chapter: putting colours onto the things you already name.

--- a/code/learning/human-languages/german/lessons/GE-C13-schwarz-weiss.md
+++ b/code/learning/human-languages/german/lessons/GE-C13-schwarz-weiss.md
@@ -1,0 +1,73 @@
+---
+id: GE-C13-schwarz-weiss
+chapter: 13
+type: word
+headword: schwarz, weiß
+gloss: black and white — both native Germanic, and one of them German lent to half of Europe
+concept_tag: GE-COLOUR-BLACK-WHITE
+prerequisites: [GE-C12-zahlen-13-20]
+sounds: [schw-cluster, eszett]
+roots: [germanic-swartaz, germanic-hweit]
+etymology_hook: "schwarz ← *swartaz (English 'swarthy'; cousin of Latin sordēs 'dirt' → sordid); weiß ← *hwītaz = English white — and German's own blank ('shiny') is the word French/Italian/Portuguese BORROWED for 'white'"
+est_minutes: 5
+reviews_of: [GE-C12-zahlen-13-20, GE-C11-brot-wasser]
+---
+
+# schwarz, weiß — and the word German lent away
+
+## Warm-up
+
+[PAUSE 2s] German's colour words are **home-grown** — no Latin here. But one of
+them has a sibling that emigrated: a German word for "shining" became the word
+for **white** in French, Italian and Portuguese.
+
+## schwarz
+
+**schwarz** ("black") ← Proto-Germanic ***swartaz***. Its English cousin survives
+in **swarthy** ("dark-complexioned"). Further back it's related to Latin
+***sordēs*** ("dirt") — the root of English **sordid**. Black and grubby, from
+one idea.
+
+## weiß
+
+**weiß** ("white") ← Proto-Germanic ***hwītaz*** = **exactly** English **white**.
+Same word, different spelling clothes.
+
+Note the **ß** (*Eszett*): it marks a sharp *s* after a long vowel. *Weiß* rhymes
+with English *vice*, not *vice-versa*'s second half. In Switzerland you'll see it
+written **weiss** — the letter is optional there.
+
+## The word that emigrated
+
+German also has **blank** — "shiny, polished, bare." That word, in its Frankish
+form ***blank*** ("shining"), was **borrowed into Romance**, where it pushed
+Latin's own *albus* out and became:
+
+| language | "white" |
+|---|---|
+| French | **blanc** |
+| Italian | **bianco** |
+| Portuguese | **branco** |
+| German | *blank* — still just "**shiny**" |
+
+This is the **reverse** of the usual flow. Latin normally lends **to** Germanic
+(*Fenster* ← *fenestra*, *Wein* ← *vīnum*, from Chapter 11). Here Germanic lent
+**to** Latin's daughters — and German kept the original meaning while they turned
+it into a colour.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "schwarz, weiß"]
+- [YOU SAY: "der Wein ist weiß" — Chapter 11's wine, coloured]
+- [YOU SAY: "weiß · white" — hear the same word]
+- [YOU SAY: "blank" — and remember: French made this one mean *white*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Are German's colour words borrowed from Latin? (**No** — both are
+native Germanic.) What English word is *schwarz*'s cousin? (**Swarthy** — and,
+further off, *sordid*.) What is *weiß* in English, letter for letter? (**White**.)
+Which German word became French *blanc*? (***Blank***, "shining" — Germanic
+lending **into** Romance for once.) Next: **rot** and **blau**, and one more word
+that travelled.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -76,6 +76,18 @@ Spanish and French where a contrast helps. The recurring decoder is the
   The contrast: the Romance sisters all **break** their teens pattern; German
   **never does**. **Authored.**
 
+- **Ch. 13 — Colours**: German as the **lender** for once. **schwarz/weiß** — both
+  **native Germanic**: *schwarz* ← *swartaz* (English **swarthy**; kin to Latin
+  *sordēs* → *sordid*), *weiß* ← *hwītaz* = **exactly** English *white* (with the
+  **ß** rule: sharp *s* after a long vowel, written *weiss* in Switzerland). The
+  showpiece: German's own **blank** ("shiny, polished") is the very word Romance
+  **borrowed** for **white** — *blanc/bianco/branco* — Germanic lending **into**
+  Latin's daughters, the reverse of *Fenster*/*Wein* → **rot/blau** — *rot* ←
+  *raudaz* ← PIE ***h₁rewdʰ-***, a cousin of *rouge/rosso* **by descent, not
+  borrowing**; *blau* is the **second** German colour word Romance took (*bleu*,
+  *blu*), and English took *blue* from **French** rather than from Germanic.
+  **Authored.**
+
 ## Planned
 
 | Chapter | Theme |

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Chapter 13 — Colours
+
+- **Chapter 13 authored** (`IT-C13-nero-bianco`, `-rosso-blu`): two colours from two
+  different peoples, reviewing Ch.11/12 via `reviews_of`.
+- **nero & bianco** (`IT-C13-nero-bianco`): *nero* ← Latin *niger* is Rome's own word,
+  barely changed. **Bianco** is not: it comes from Germanic ***blank*** ("shining"),
+  most likely carried in by the **Lombards**, the Germanic people who ruled the north
+  for two centuries and left their name on **Lombardia**. The loan won so completely
+  that Latin *albus* was pushed out of the colour slot, surviving as **alba**
+  ("dawn"), **albume** ("egg white"), and in place names.
+- **rosso & blu** (`IT-C13-rosso-blu`): *rosso* ← *russus* ← PIE ***h₁rewdʰ-***,
+  a **cousin** of *red/rot/rouge* rather than a borrowing (with a note on holding the
+  **double s** — *roso* ≠ *rosso*). *Blu* ← Germanic *blāo* confirms the chapter
+  pattern: Italian's **white and blue are both Germanic imports**. Then **azzurro** ←
+  Arabic ***lāzaward*** ("lapis lazuli") ← Persian *lāžward*, the initial *l-*
+  swallowed as if it were an article — the same journey that gave Spanish/Portuguese
+  *azul*, French *azur*, English **azure**. Payoff: **gli Azzurri** are named, at the
+  end of a long chain, after a blue stone mined in Afghanistan.
+- Taxonomy: namespaced `IT-COLOUR-BLACK-WHITE`, `IT-COLOUR-RED-BLUE`.
+
 ## Chapter 12 — Numbers 11–20
 
 - **Chapter 12 authored** (`IT-C12-numeri-11-16`, `-17-20`): the teens, atom-first,

--- a/code/learning/human-languages/italian/lessons/IT-C13-nero-bianco.md
+++ b/code/learning/human-languages/italian/lessons/IT-C13-nero-bianco.md
@@ -1,0 +1,66 @@
+---
+id: IT-C13-nero-bianco
+chapter: 13
+type: word
+headword: nero, bianco
+gloss: black and white — nero straight from Latin, bianco borrowed from the Germanic invaders
+concept_tag: IT-COLOUR-BLACK-WHITE
+prerequisites: [IT-C12-numeri-17-20]
+sounds: [open-e, palatal-bi]
+roots: [latin-niger, germanic-blank]
+etymology_hook: "nero ← niger, but bianco ← Germanic *blank 'shining' — brought by the Lombards and displacing Latin albus, which survives in alba ('dawn') and albume"
+est_minutes: 5
+reviews_of: [IT-C12-numeri-17-20, IT-C11-pane-acqua]
+---
+
+# nero, bianco — one Roman, one Lombard
+
+## Warm-up
+
+[PAUSE 2s] Italy's two most basic colours came from **two different peoples**.
+One is Rome's own word. The other arrived with the Germanic tribes who settled
+the peninsula after Rome fell.
+
+## nero — Rome's own
+
+**nero** ("black") ← Latin ***niger***. Straight inheritance, barely changed:
+*niger* → *nigrum* → *nero*. The same *niger* gives English *denigrate*, "to
+blacken."
+
+## bianco — the newcomer
+
+Latin's white was ***albus***. Italian doesn't use it. Instead: **bianco**, from
+Germanic ***blank*** — "**shining, gleaming**" — most likely carried in by the
+**Lombards**, the Germanic people who ruled northern Italy for two centuries and
+left their name on **Lombardia**.
+
+The same word became French *blanc* and Portuguese *branco*. Germanic lending
+**into** Romance is the reverse of the usual direction, and here the loan won so
+completely that Latin's own word was pushed out of the colour slot altogether.
+
+## Where albus went
+
+| word | meaning | the white inside |
+|---|---|---|
+| **alba** | dawn | the sky turning white |
+| **albume** | egg white | the white part |
+| **Albania**, *Alpi* | (place names) | "the white ones" |
+| *album* (Eng.) | album | a blank white tablet |
+
+Latin's white is still here — just doing other jobs.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nero, bianco"]
+- [YOU SAY: "il vino bianco, il vino rosso" — Ch.11's wine, coloured]
+- [YOU SAY: "il pane bianco" — Ch.11's bread]
+- [YOU SAY: "l'**alba**" — and hear Latin's forgotten white]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which colour is Rome's own? (**Nero** ← *niger*.) Where does **bianco**
+come from? (**Germanic *blank***, "shining" — likely via the **Lombards**.) Why is
+that surprising? (Latin normally lends **to** Germanic, not the reverse.) Where
+did *albus* survive? (In **alba**, "dawn," and **albume** — no longer a colour.)
+Next: **rosso** and **blu**, and one more traveller.

--- a/code/learning/human-languages/italian/lessons/IT-C13-rosso-blu.md
+++ b/code/learning/human-languages/italian/lessons/IT-C13-rosso-blu.md
@@ -1,0 +1,80 @@
+---
+id: IT-C13-rosso-blu
+chapter: 13
+type: word
+headword: rosso, blu
+gloss: red and blue — an ancient inherited root, a second Germanic loan, and the Arabic blue of the Azzurri
+concept_tag: IT-COLOUR-RED-BLUE
+prerequisites: [IT-C13-nero-bianco]
+sounds: [double-s, final-stress-u]
+roots: [pie-rewdh, germanic-blao, arabic-lazaward]
+etymology_hook: "rosso ← russus ← PIE *h₁rewdʰ-, cousin of English red and German rot; blu is a SECOND Germanic loan, while azzurro ← Arabic lāzaward 'lapis lazuli' → English azure — the colour Italy's teams are named for"
+est_minutes: 5
+reviews_of: [IT-C13-nero-bianco, IT-C12-numeri-17-20]
+---
+
+# rosso, blu — and the blue Italy plays in
+
+## Warm-up
+
+[PAUSE 2s] One very old word, one more Germanic loan — and a third blue that came
+all the way from Persia by way of Arabic.
+
+## rosso — very old indeed
+
+**rosso** ← Latin ***russus*** ("red"), from PIE ***h₁rewdʰ-***. That root is one
+of the oldest colour words we can reconstruct:
+
+| language | word |
+|---|---|
+| Italian | **rosso** |
+| French | **rouge** (← *rubeus*) |
+| English | **red**, *rust*, *ruby* |
+| German | **rot** |
+
+*Rosso* and *red* are **cousins**, not borrowings — separated for millennia.
+Note the **double s**: hold it. *Roso* and *rosso* are different words.
+
+## blu — the second Germanic loan
+
+**blu** ← Germanic ***blāo***, exactly like French *bleu*. Chapter pattern
+confirmed: **bianco** and **blu**, Italian's white and blue, are both **Germanic
+imports**.
+
+## azzurro — the Arabic blue
+
+Italian has a second blue, and it's the famous one: **azzurro**, from Arabic
+***lāzaward*** ("lapis lazuli"), itself from Persian ***lāžward***. The initial
+*l-* was swallowed — heard as an article and dropped — leaving *azur/azzurro*.
+The same journey gave Spanish and Portuguese **azul**, French **azur**, and
+English **azure**.
+
+Italy's national teams are **gli Azzurri**, "the blue ones" — named, at the end of
+a very long chain, after a **blue stone mined in Afghanistan**.
+
+## The chapter in one table
+
+| Italian | source |
+|---|---|
+| nero | Latin *niger* |
+| **bianco** | **Germanic** *blank* |
+| rosso | Latin *russus* (ancient PIE root) |
+| **blu** | **Germanic** *blāo* |
+| **azzurro** | **Arabic** *lāzaward* |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "rosso, blu, azzurro"]
+- [YOU SAY: "il vino rosso" — Chapter 11's wine]
+- [YOU SAY: the cousins — "rosso · red · rot · rouge"]
+- [YOU SAY: "gli Azzurri" — and think of the stone]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Is *rosso* related to English *red* by borrowing or descent?
+(**Descent** — PIE ***h₁rewdʰ-***.) Which two Italian colours are Germanic loans?
+(**Bianco** and **blu**.) Where does **azzurro** come from? (**Arabic
+*lāzaward***, "lapis lazuli" — via Persian; the *l-* was lost as if it were an
+article.) What are Italy's teams called? (**Gli Azzurri**.) Next chapter:
+attaching these colours to the nouns you know.

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -67,6 +67,16 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   *dici*-*assette* "ten-and-seven"). Includes the three-sister comparison of *where*
   each breaks: PT at 16, FR and IT at 17. **Authored.**
 
+- **Ch. 13 — Colours**: **nero/bianco** — *nero* ← *niger* straight from Rome, but
+  **bianco ← Germanic *blank*** ("shining"), most likely carried in by the
+  **Lombards** (who also named **Lombardia**); Latin *albus* was pushed out of the
+  colour slot and survives as **alba** ("dawn"), *albume*, *album* → **rosso/blu**
+  (+ **azzurro**) — *rosso* ← *russus* ← PIE ***h₁rewdʰ-***, a **cousin** of
+  *red/rot/rouge*; *blu* is the **second** Germanic loan; and **azzurro** ← Arabic
+  ***lāzaward*** ("lapis lazuli") ← Persian *lāžward*, the *l-* swallowed as if an
+  article → English **azure** — so Italy's teams, **gli Azzurri**, are named after a
+  blue stone mined in Afghanistan. **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Chapter 13 — Colours
+
+- **Chapter 13 authored** (`PT-C13-preto-branco`, `-vermelho-azul`): the strangest
+  colour set of the four tracks, reviewing Ch.11/12 via `reviews_of`.
+- **preto & branco** (`PT-C13-preto-branco`): Portuguese keeps **two blacks** —
+  literary **negro** ← *niger* (the expected inheritance, = French *noir*, Italian
+  *nero*), and the everyday **preto** ← Latin ***pressus*** ("pressed, compact"), a
+  colour named for how **dense** it is: dense → thick → dark (cf. *press*,
+  *pressure*, *compress*). **Branco** ← Germanic ***blank*** ("shining"), arriving
+  with the Suevi and Visigoths, and showing the Portuguese **l→r** signature
+  (*blanc-* → *branc-*, as *plaza* → *praça*); *albus* survives in **alvorada/alva**
+  ("dawn").
+- **vermelho & azul** (`PT-C13-vermelho-azul`): the chapter's payoff. Every other
+  Romance language builds "red" on PIE *h₁rewdʰ-*; Portuguese instead says
+  **vermelho** ← ***vermiculus***, "**little worm**" — the **kermes** scale insect
+  harvested off oak trees and crushed for scarlet dye, the **dye's name becoming the
+  colour's name** (→ English **vermilion**; *vermis* → *vermin*). The old root
+  survives only in *rubro* and *ruivo*. **Azul** ← Arabic ***lāzaward*** ("lapis
+  lazuli") ← Persian *lāžward*, the *l-* dropped as if it were the article — the
+  al-Andalus thread (first opened by Spanish *hasta*) reaching a **basic colour**.
+  Closing observation: **not one** of Portuguese's four basic colours is a plain
+  inherited Latin colour word.
+- Taxonomy: namespaced `PT-COLOUR-BLACK-WHITE`, `PT-COLOUR-RED-BLUE`.
+
 ## Chapter 12 — Numbers 11–20
 
 - **Chapter 12 authored** (`PT-C12-numeros-11-15`, `-16-20`): the teens, atom-first,

--- a/code/learning/human-languages/portuguese/lessons/PT-C13-preto-branco.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C13-preto-branco.md
@@ -1,0 +1,69 @@
+---
+id: PT-C13-preto-branco
+chapter: 13
+type: word
+headword: preto, branco
+gloss: black and white — Portuguese has TWO blacks, and its white is a Germanic loan
+concept_tag: PT-COLOUR-BLACK-WHITE
+prerequisites: [PT-C12-numeros-16-20]
+sounds: [closed-e, nasal-an]
+roots: [latin-pressus, latin-niger, germanic-blank]
+etymology_hook: "Portuguese keeps TWO blacks — negro ← niger and everyday preto ← Latin pressus 'pressed, dense' (dense → dark); branco is Germanic *blank 'shining', and Latin albus survives in alvorada ('dawn')"
+est_minutes: 5
+reviews_of: [PT-C12-numeros-16-20, PT-C11-pao-agua]
+---
+
+# preto, branco — two blacks and a borrowed white
+
+## Warm-up
+
+[PAUSE 2s] Portuguese does something the other Romance languages don't: it keeps
+**two words for black**, and the everyday one isn't the Latin one at all.
+
+## The two blacks
+
+| word | source | use |
+|---|---|---|
+| **negro** | Latin ***niger*** | literary, formal, fixed phrases |
+| **preto** | Latin ***pressus*** "pressed, dense" | the **everyday** colour word |
+
+*Negro* is the expected inheritance — the same *niger* that gave French *noir* and
+Italian *nero*. But day to day, Portuguese reaches for **preto**, from *pressus*
+("pressed together, compact"). Dense → thick → **dark**: a colour named for how
+**packed** it is, not for its shade.
+
+You already know *pressus*'s English children: *press*, *pressure*, *compress*.
+
+## branco — the Germanic import
+
+Latin's white, ***albus***, lost here too. Portuguese says **branco**, from
+Germanic ***blank*** ("shining") — the same loan that gave French *blanc* and
+Italian *bianco*, arriving with the Suevi and Visigoths who settled Iberia.
+
+Notice what Portuguese did to the shape: *blanc-* → **branc-**. The **l → r**
+swap is a Portuguese signature (compare *plaza* → **praça**, *blando* → *brando*).
+
+## Where albus went
+
+| word | meaning |
+|---|---|
+| **alvorada** | dawn (the sky going white) |
+| **alva** | white, dawn (poetic) |
+| *albumina*, *álbum* | (technical borrowings) |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "preto, branco"]
+- [YOU SAY: "o vinho branco" — Chapter 11's wine]
+- [YOU SAY: "o pão é branco" — Chapter 11's bread]
+- [YOU SAY: the l→r swap — "blanc → **branco**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What are Portuguese's two blacks? (**Negro** ← *niger*, literary; and
+**preto** ← *pressus* "pressed/dense," the everyday one.) Why would "pressed" mean
+black? (**Dense → thick → dark**.) Where does **branco** come from? (**Germanic
+*blank***, "shining" — borrowed **into** Romance.) What sound change shows in
+*branco*? (**l → r**, as in *praça*.) Next: **vermelho**, the strangest colour
+word in the language.

--- a/code/learning/human-languages/portuguese/lessons/PT-C13-vermelho-azul.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C13-vermelho-azul.md
@@ -1,0 +1,81 @@
+---
+id: PT-C13-vermelho-azul
+chapter: 13
+type: word
+headword: vermelho, azul
+gloss: red and blue — a red named after a worm, and a blue named after a stone
+concept_tag: PT-COLOUR-RED-BLUE
+prerequisites: [PT-C13-preto-branco]
+sounds: [lh-palatal, final-l]
+roots: [latin-vermiculus, arabic-lazaward]
+etymology_hook: "vermelho ← vermiculus 'little worm' — the kermes insect crushed for scarlet dye (→ English vermilion), so PT alone doesn't use the ancient red root; azul ← Arabic lāzaward 'lapis lazuli' → English azure"
+est_minutes: 5
+reviews_of: [PT-C13-preto-branco, PT-C12-numeros-16-20]
+---
+
+# vermelho, azul — a worm and a stone
+
+## Warm-up
+
+[PAUSE 2s] These two are the best etymologies in the whole chapter. Portuguese
+named its red after an **insect** and its blue after a **rock**.
+
+## vermelho — the little worm
+
+Every other Romance language builds "red" on the ancient root *h₁rewdʰ-*
+(*rouge*, *rosso*, Spanish *rojo*, and English *red*, German *rot*). Portuguese
+went its own way.
+
+**vermelho** ← Latin ***vermiculus***, "**little worm**" — the diminutive of
+*vermis*, "worm."
+
+Why? Because the finest red dye in the ancient Mediterranean came from **kermes**,
+a scale insect harvested off oak trees and crushed for its pigment. Dyers called
+the creature a "little worm," and eventually the **dye's name became the colour's
+name**.
+
+The same word gave English **vermilion**. And *vermis* gave English **vermin**.
+
+Portuguese does still keep the old root — in **rubro** (literary "red") and
+**ruivo** ("red-haired") — but the everyday word for red is a bug.
+
+## azul — the stone from the mountains
+
+**azul** ← Arabic ***lāzaward*** ← Persian ***lāžward***: **lapis lazuli**, the
+deep-blue stone mined for millennia in Afghanistan and ground into the most
+expensive pigment in the medieval world.
+
+The initial ***l-*** was lost — Spanish and Portuguese ears took it for the
+article *l'* and dropped it — leaving *azul*. The same journey produced French
+**azur**, Italian **azzurro**, and English **azure**.
+
+This is the **al-Andalus** thread again: eight centuries of Arabic in Iberia left
+Portuguese and Spanish thousands of words, and one of them is a basic colour.
+
+## The chapter in one table
+
+| Portuguese | source |
+|---|---|
+| preto | Latin *pressus* "pressed" |
+| **branco** | **Germanic** *blank* "shining" |
+| **vermelho** | Latin *vermiculus* "**little worm**" |
+| **azul** | **Arabic** *lāzaward* "**lapis lazuli**" |
+
+Not one of Portuguese's four basic colours is a plain inherited Latin colour word.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "vermelho, azul"]
+- [YOU SAY: "o vinho é vermelho… o vinho tinto" — note: **wine** is *tinto*, "dyed"]
+- [YOU SAY: "vermelho — vermilion — vermin"]
+- [YOU SAY: all four — "preto, branco, vermelho, azul"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **vermelho** literally come from? (***Vermiculus***, "**little
+worm**" — the **kermes** insect crushed for dye.) Which English word is its
+sibling? (**Vermilion**.) Where does **azul** come from? (**Arabic *lāzaward***,
+"**lapis lazuli**," via Persian — the *l-* lost as if an article.) What's odd
+about all four Portuguese colours? (**None** is a plain inherited Latin colour
+word.) Next chapter: describing what you see.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -72,6 +72,19 @@ French.
   *dez* + **e** + *seis*, "**ten AND six**," the *and* still audible. *vinte* ←
   *vīgintī*. **Authored.**
 
+- **Ch. 13 — Colours**: the strangest set of the four. **preto/branco** — Portuguese
+  keeps **two blacks**: literary *negro* ← *niger*, and the everyday **preto** ←
+  Latin ***pressus*** ("pressed, dense" → thick → **dark**; cf. *press/compress*);
+  **branco** ← Germanic ***blank*** with the Portuguese **l→r** swap (*blanc→branco*,
+  as *plaza→praça*), and *albus* survives in **alvorada/alva** ("dawn") →
+  **vermelho/azul** — **vermelho ← *vermiculus*, "little worm"**: the **kermes**
+  scale insect crushed for scarlet dye, the dye's name becoming the colour's (→
+  English **vermilion**; *vermis* → *vermin*), so Portuguese **alone** skips the
+  ancient red root, keeping it only in *rubro/ruivo*; and **azul** ← Arabic
+  ***lāzaward*** ("lapis lazuli") → **azure**, the al-Andalus thread reaching a basic
+  colour. Payoff: **not one** of the four is a plain inherited Latin colour word.
+  **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |


### PR DESCRIPTION
The parallel colour chapter, built around one throughline: **Romance did not inherit
its basic colour vocabulary from Latin — it borrowed it.**

**French** (`FR-C13-noir-blanc`, `-rouge-bleu`) — *noir* ← *niger* as expected, but
**blanc is not from Latin *albus***: it's **Frankish *blank*** ("shining"), a Germanic
word borrowed **into** Romance, the reverse of the usual flow. *Albus* survives only
outside the colour slot (**aube** "dawn," *aubépine*, *album*). *Rouge* ← *rubeus* ←
PIE ***h₁rewdʰ-***, so *rouge* / *red* / *rot* are cousins **by descent**, not
borrowings; *bleu* is a **second** Germanic loan, which English then borrowed **back**
from French. Payoff: of *bleu-blanc-rouge*, **two of three are loanwords**.

**German** (`GE-C13-schwarz-weiss`, `-rot-blau`) — German as the **lender**. *Schwarz*
← *swartaz* (English **swarthy**; kin to Latin *sordēs* → *sordid*); *weiß* ← *hwītaz*
= **exactly** English *white* (with the **ß** rule). The showpiece: German's own
**blank** ("shiny") is the very word Romance borrowed for **white**, while German kept
the original meaning — reversing Ch.11's *Wein* ← *vīnum*. *Rot* ← *raudaz*, a cousin
of *ruber* not a loan; *blau* is the second word Romance took.

**Italian** (`IT-C13-nero-bianco`, `-rosso-blu`) — *bianco* ← Germanic *blank*, likely
via the **Lombards** (who also named *Lombardia*); *albus* survives as **alba**,
*albume*. *Rosso* ← *russus*, cousin of *red/rot/rouge*. Then **azzurro** ← Arabic
***lāzaward*** "lapis lazuli" ← Persian *lāžward*, the *l-* swallowed as if an article
→ English **azure**: **gli Azzurri** are named after a blue stone mined in Afghanistan.

**Portuguese** (`PT-C13-preto-branco`, `-vermelho-azul`) — the strangest set. PT keeps
**two blacks**: literary *negro* ← *niger*, everyday **preto** ← *pressus* "pressed,
dense" (dense → thick → dark). *Branco* shows the Portuguese **l→r** swap. And
**vermelho ← *vermiculus*, "little worm"** — the **kermes** scale insect crushed for
scarlet dye, the dye's name becoming the colour's (→ **vermilion**; *vermis* →
*vermin*) — so PT **alone** skips the ancient red root. **Azul** ← Arabic *lāzaward*,
the al-Andalus thread reaching a basic colour. **Not one** of PT's four colours is a
plain inherited Latin colour word.

Taxonomy: namespaced `{FR,GE,IT,PT}-COLOUR-BLACK-WHITE` and `-RED-BLUE`. All four
roadmaps (Ch.13 authored) and CHANGELOGs updated.

Suite green at **38/38**; retired-concept-tag sweep clean across the whole curriculum.
Security-reviewed: PASS, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)