### PR TITLE
Add Haskell Code 39 port

### DIFF
--- a/code/packages/haskell/code39/BUILD
+++ b/code/packages/haskell/code39/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/code39/BUILD_windows
+++ b/code/packages/haskell/code39/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/code39/CHANGELOG.md
+++ b/code/packages/haskell/code39/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Normalize lowercase input and validate the complete standard Code 39 alphabet.
+- Encode all 44 symbols with explicit narrow and wide patterns.
+- Expand typed start, data, stop, and inter-character-gap runs.
+- Emit backend-neutral paint scenes through the shared 1D barcode geometry.

--- a/code/packages/haskell/code39/README.md
+++ b/code/packages/haskell/code39/README.md
@@ -1,0 +1,26 @@
+# code39 (Haskell)
+
+Pure Code 39 barcode encoding for the Haskell package lane. Lowercase letters
+are normalized to uppercase, spaces are preserved, and input is restricted to
+the standard alphanumeric and punctuation alphabet. The `*` symbol is reserved
+for the start and stop markers inserted by the encoder.
+
+```haskell
+import CodingAdventures.Code39
+
+example = drawCode39 "hello-123" defaultPaintBarcode1DOptions
+```
+
+The package exposes normalized data, typed per-character encodings, and the
+complete attributed run stream. Rendering delegates to `barcode-layout-1d`,
+which supplies validated quiet-zone geometry, rectangle-only paint
+instructions, and shared scene metadata.
+
+V1 deliberately excludes extended ASCII mode and the optional modulo-43
+checksum.
+
+## Development
+
+```sh
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/code39/cabal.project
+++ b/code/packages/haskell/code39/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../barcode-layout-1d ../paint-instructions

--- a/code/packages/haskell/code39/code39.cabal
+++ b/code/packages/haskell/code39/code39.cabal
@@ -1,0 +1,39 @@
+cabal-version: 3.0
+name:          code39
+version:       0.1.0
+synopsis:      Pure Code 39 barcode encoder
+description:   Validated Code 39 symbols, narrow and wide runs, and backend-neutral paint scenes.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.Code39
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , paint-instructions >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Code39Spec
+    hs-source-dirs:   test
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , code39
+                    , containers >=0.6 && <0.8
+                    , hspec ==2.*
+                    , paint-instructions >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/code39/src/CodingAdventures/Code39.hs
+++ b/code/packages/haskell/code39/src/CodingAdventures/Code39.hs
@@ -1,0 +1,217 @@
+-- | Pure Code 39 barcode encoding.
+module CodingAdventures.Code39
+  ( EncodedCharacter (..)
+  , Code39Error (..)
+  , Barcode1DError (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , PaintScene (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , normalizeCode39
+  , encodeCode39Char
+  , encodeCode39
+  , expandCode39Runs
+  , layoutCode39
+  , drawCode39
+  , version
+  ) where
+
+import CodingAdventures.BarcodeLayout1D
+  ( Barcode1DError (..)
+  , Barcode1DRenderConfig (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , PaintBarcode1DOptions (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , defaultWidthPatternOptions
+  , layoutBarcode1D
+  , runsFromWidthPattern
+  )
+import CodingAdventures.PaintInstructions (PaintScene (..))
+import Data.Aeson (toJSON)
+import Data.Bifunctor (first)
+import Data.Char (toUpper)
+import qualified Data.Map.Strict as Map
+
+-- | Package version shared with the established implementations.
+version :: String
+version = "0.1.0"
+
+-- | One normalized character and its nine-element width pattern.
+data EncodedCharacter = EncodedCharacter
+  { encodedCharacterValue :: Char
+  , encodedCharacterIsStartStop :: Bool
+  , encodedCharacterPattern :: String
+  } deriving (Eq, Show)
+
+-- | Checked failures from input validation or shared layout validation.
+data Code39Error
+  = InvalidCode39Character Char
+  | ReservedCode39StartStop
+  | Code39LayoutError Barcode1DError
+  deriving (Eq)
+
+instance Show Code39Error where
+  show (InvalidCode39Character character) =
+    "Invalid character: " ++ show [character] ++ " is not supported by Code 39"
+  show ReservedCode39StartStop =
+    "Input must not contain \"*\" because it is reserved for start/stop"
+  show (Code39LayoutError layoutError) = show layoutError
+
+code39Patterns :: Map.Map Char String
+code39Patterns = Map.fromList
+  [ ('0', "bwbWBwBwb")
+  , ('1', "BwbWbwbwB")
+  , ('2', "bwBWbwbwB")
+  , ('3', "BwBWbwbwb")
+  , ('4', "bwbWBwbwB")
+  , ('5', "BwbWBwbwb")
+  , ('6', "bwBWBwbwb")
+  , ('7', "bwbWbwBwB")
+  , ('8', "BwbWbwBwb")
+  , ('9', "bwBWbwBwb")
+  , ('A', "BwbwbWbwB")
+  , ('B', "bwBwbWbwB")
+  , ('C', "BwBwbWbwb")
+  , ('D', "bwbwBWbwB")
+  , ('E', "BwbwBWbwb")
+  , ('F', "bwBwBWbwb")
+  , ('G', "bwbwbWBwB")
+  , ('H', "BwbwbWBwb")
+  , ('I', "bwBwbWBwb")
+  , ('J', "bwbwBWBwb")
+  , ('K', "BwbwbwbWB")
+  , ('L', "bwBwbwbWB")
+  , ('M', "BwBwbwbWb")
+  , ('N', "bwbwBwbWB")
+  , ('O', "BwbwBwbWb")
+  , ('P', "bwBwBwbWb")
+  , ('Q', "bwbwbwBWB")
+  , ('R', "BwbwbwBWb")
+  , ('S', "bwBwbwBWb")
+  , ('T', "bwbwBwBWb")
+  , ('U', "BWbwbwbwB")
+  , ('V', "bWBwbwbwB")
+  , ('W', "BWBwbwbwb")
+  , ('X', "bWbwBwbwB")
+  , ('Y', "BWbwBwbwb")
+  , ('Z', "bWBwBwbwb")
+  , ('-', "bWbwbwBwB")
+  , ('.', "BWbwbwBwb")
+  , (' ', "bWBwbwBwb")
+  , ('$', "bWbWbWbwb")
+  , ('/', "bWbWbwbWb")
+  , ('+', "bWbwbWbWb")
+  , ('%', "bwbWbWbWb")
+  , ('*', "bWbwBwBwb")
+  ]
+
+-- | Uppercase letters, preserve spaces, and reject unsupported input.
+normalizeCode39 :: String -> Either Code39Error String
+normalizeCode39 input = validate normalized >> Right normalized
+  where
+    normalized = map toUpper input
+    validate [] = Right ()
+    validate (character : rest)
+      | character == '*' = Left ReservedCode39StartStop
+      | Map.notMember character code39Patterns = Left (InvalidCode39Character character)
+      | otherwise = validate rest
+
+-- | Look up one exact standard Code 39 symbol.
+encodeCode39Char :: Char -> Either Code39Error EncodedCharacter
+encodeCode39Char character = case Map.lookup character code39Patterns of
+  Nothing -> Left (InvalidCode39Character character)
+  Just patternText -> Right EncodedCharacter
+    { encodedCharacterValue = character
+    , encodedCharacterIsStartStop = character == '*'
+    , encodedCharacterPattern = widthPattern patternText
+    }
+
+-- | Normalize data and insert the standard start and stop markers.
+encodeCode39 :: String -> Either Code39Error [EncodedCharacter]
+encodeCode39 input = normalizeCode39 input >>= encodeNormalized
+
+-- | Expand every symbol into alternating bar and space runs with narrow gaps.
+expandCode39Runs :: String -> Either Code39Error [Barcode1DRun]
+expandCode39Runs input = do
+  encoded <- encodeCode39 input
+  expandEncoded encoded
+
+-- | Render Code 39 through the shared backend-neutral 1D geometry.
+layoutCode39
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either Code39Error PaintScene
+layoutCode39 input options = do
+  normalized <- normalizeCode39 input
+  encoded <- encodeNormalized normalized
+  runs <- expandEncoded encoded
+  first Code39LayoutError
+    (layoutBarcode1D runs (code39Options normalized options))
+
+-- | Compatibility alias matching the shared public API name.
+drawCode39
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either Code39Error PaintScene
+drawCode39 = layoutCode39
+
+widthPattern :: String -> String
+widthPattern = map widthMarker
+  where
+    widthMarker element
+      | element == 'B' || element == 'W' = 'W'
+      | otherwise = 'N'
+
+encodeNormalized :: String -> Either Code39Error [EncodedCharacter]
+encodeNormalized normalized =
+  traverse encodeCode39Char ('*' : normalized ++ "*")
+
+expandEncoded :: [EncodedCharacter] -> Either Code39Error [Barcode1DRun]
+expandEncoded encoded = concat <$> traverse expandOne indexed
+  where
+    encodedLength = length encoded
+    indexed = zip [0 :: Int ..] encoded
+    expandOne (sourceIndex, encodedCharacter) = do
+      symbolRuns <- first Code39LayoutError (runsFromWidthPattern
+        (encodedCharacterPattern encodedCharacter)
+        (defaultWidthPatternOptions
+          [encodedCharacterValue encodedCharacter]
+          sourceIndex
+          (roleFor encodedLength sourceIndex encodedCharacter)))
+      let gap
+            | sourceIndex < encodedLength - 1 =
+                [ Barcode1DRun
+                    { runColor = Space
+                    , runModules = 1
+                    , runSourceLabel = [encodedCharacterValue encodedCharacter]
+                    , runSourceIndex = sourceIndex
+                    , runRole = InterCharacterGap
+                    }
+                ]
+            | otherwise = []
+      Right (symbolRuns ++ gap)
+
+roleFor :: Int -> Int -> EncodedCharacter -> Barcode1DRunRole
+roleFor encodedLength sourceIndex encodedCharacter
+  | not (encodedCharacterIsStartStop encodedCharacter) = Data
+  | sourceIndex == 0 = Start
+  | sourceIndex == encodedLength - 1 = Stop
+  | otherwise = Guard
+
+code39Options :: String -> PaintBarcode1DOptions -> PaintBarcode1DOptions
+code39Options normalized options = options
+  { optionsLabel = Just (maybe defaultLabel id (optionsLabel options))
+  , optionsMetadata = Map.insert "encodedText" (toJSON normalized)
+      (Map.insert "symbology" (toJSON ("code39" :: String)) (optionsMetadata options))
+  }
+  where
+    defaultLabel
+      | null normalized = "Code 39 barcode"
+      | otherwise = "Code 39 barcode for " ++ normalized

--- a/code/packages/haskell/code39/test/Code39Spec.hs
+++ b/code/packages/haskell/code39/test/Code39Spec.hs
@@ -1,0 +1,162 @@
+module Code39Spec (spec) where
+
+import CodingAdventures.Code39
+import CodingAdventures.PaintInstructions (PaintInstruction (..))
+import Data.Aeson (toJSON)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "metadata" $ do
+    it "reports the shared package version" $
+      version `shouldBe` "0.1.0"
+
+  describe "normalizeCode39" $ do
+    it "uppercases letters while preserving digits, punctuation, and spaces" $
+      normalizeCode39 "hello-123 $/+%" `shouldBe` Right "HELLO-123 $/+%"
+
+    it "accepts empty input for a start/stop-only barcode" $
+      normalizeCode39 "" `shouldBe` Right ""
+
+    it "rejects the reserved start/stop marker" $ do
+      normalizeCode39 "A*B" `shouldBe` Left ReservedCode39StartStop
+      show ReservedCode39StartStop `shouldBe`
+        "Input must not contain \"*\" because it is reserved for start/stop"
+
+    it "rejects unsupported ASCII and Unicode characters educationally" $ do
+      normalizeCode39 "ABC@123" `shouldBe` Left (InvalidCode39Character '@')
+      normalizeCode39 "CAFÉ" `shouldBe` Left (InvalidCode39Character 'É')
+      show (InvalidCode39Character '@') `shouldBe`
+        "Invalid character: \"@\" is not supported by Code 39"
+
+  describe "encodeCode39Char" $ do
+    it "encodes the shared A reference pattern" $
+      encodeCode39Char 'A' `shouldBe` Right
+        (EncodedCharacter 'A' False "WNNNNWNNW")
+
+    it "recognizes the inserted start and stop symbol" $
+      encodeCode39Char '*' `shouldBe` Right
+        (EncodedCharacter '*' True "NWNNWNWNN")
+
+    it "rejects characters that have not been normalized" $
+      encodeCode39Char 'a' `shouldBe` Left (InvalidCode39Character 'a')
+
+    it "contains all 44 standard patterns with exactly three wide elements" $ do
+      encoded <- traverse (expectRight . encodeCode39Char) standardAlphabet
+      length encoded `shouldBe` 44
+      map (length . encodedCharacterPattern) encoded `shouldBe` replicate 44 9
+      map (length . filter (== 'W') . encodedCharacterPattern) encoded
+        `shouldBe` replicate 44 3
+
+  describe "encodeCode39" $ do
+    it "wraps normalized data in start and stop markers" $ do
+      encoded <- expectRight (encodeCode39 "a-1")
+      map encodedCharacterValue encoded `shouldBe` "*A-1*"
+      map encodedCharacterIsStartStop encoded `shouldBe`
+        [True, False, False, False, True]
+
+    it "encodes empty input as only the two delimiters" $
+      fmap (map encodedCharacterValue) (encodeCode39 "") `shouldBe` Right "**"
+
+  describe "expandCode39Runs" $ do
+    it "expands one data character into three symbols and two gaps" $ do
+      runs <- expectRight (expandCode39Runs "A")
+      length runs `shouldBe` 29
+      map runRole (take 9 runs) `shouldBe` replicate 9 Start
+      runs !! 9 `shouldBe` Barcode1DRun Space 1 "*" 0 InterCharacterGap
+      map runRole (take 9 (drop 10 runs)) `shouldBe` replicate 9 Data
+      runs !! 19 `shouldBe` Barcode1DRun Space 1 "A" 1 InterCharacterGap
+      map runRole (drop 20 runs) `shouldBe` replicate 9 Stop
+
+    it "alternates five bars and four spaces inside every symbol" $ do
+      runs <- expectRight (expandCode39Runs "A")
+      let symbolRuns = take 9 runs
+      map runColor symbolRuns `shouldBe` take 9 (cycle [Bar, Space])
+      length (filter ((== Bar) . runColor) symbolRuns) `shouldBe` 5
+      map runModules (take 9 (drop 10 runs)) `shouldBe`
+        [3, 1, 1, 1, 1, 3, 1, 1, 3]
+
+    it "uses exact shared module counts" $ do
+      one <- expectRight (expandCode39Runs "A")
+      empty <- expectRight (expandCode39Runs "")
+      sum (map runModules one) `shouldBe` 47
+      sum (map runModules empty) `shouldBe` 31
+      length empty `shouldBe` 19
+
+    it "propagates validation failures" $
+      expandCode39Runs "A@" `shouldBe` Left (InvalidCode39Character '@')
+
+  describe "layoutCode39" $ do
+    it "renders through the shared default geometry" $ do
+      scene <- expectRight (layoutCode39 "A" defaultPaintBarcode1DOptions)
+      psWidth scene `shouldBe` 268
+      psHeight scene `shouldBe` 120
+      psBg scene `shouldBe` "#ffffff"
+      length (psInstructions scene) `shouldBe` 15
+      map prX (take 2 (psInstructions scene)) `shouldBe` [40, 56]
+
+    it "records normalized data, label, and inferred symbols" $ do
+      scene <- expectRight (layoutCode39 "ab" defaultPaintBarcode1DOptions)
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("code39" :: String))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("AB" :: String))
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Code 39 barcode for AB" :: String))
+      Map.lookup "symbolCount" (psMeta scene) `shouldBe` Just (toJSON (4 :: Int))
+
+    it "uses a concise label for empty input" $ do
+      scene <- expectRight (layoutCode39 "" defaultPaintBarcode1DOptions)
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Code 39 barcode" :: String))
+
+    it "preserves custom rendering, labels, and metadata" $ do
+      let config = defaultBarcode1DRenderConfig
+            { configModuleWidth = 2
+            , configBarHeight = 50
+            , configQuietZoneModules = 5
+            , configForeground = "navy"
+            , configBackground = "transparent"
+            }
+          options = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = config
+            , optionsLabel = Just "Inventory label"
+            , optionsMetadata = Map.fromList
+                [ ("batch", toJSON (7 :: Int))
+                , ("encodedText", toJSON ("wrong" :: String))
+                , ("symbology", toJSON ("wrong" :: String))
+                ]
+            }
+      scene <- expectRight (layoutCode39 "a" options)
+      (psWidth scene, psHeight scene, psBg scene) `shouldBe` (114, 50, "transparent")
+      map prFill (psInstructions scene) `shouldBe` replicate 15 "navy"
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Inventory label" :: String))
+      Map.lookup "batch" (psMeta scene) `shouldBe` Just (toJSON (7 :: Int))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe` Just (toJSON ("A" :: String))
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("code39" :: String))
+
+    it "supports the draw alias" $
+      drawCode39 "A" defaultPaintBarcode1DOptions `shouldBe`
+        layoutCode39 "A" defaultPaintBarcode1DOptions
+
+    it "wraps shared layout validation failures" $ do
+      let invalidGeometry = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = defaultBarcode1DRenderConfig
+                { configModuleWidth = 0 }
+            }
+          humanText = defaultPaintBarcode1DOptions
+            { optionsHumanReadableText = Just "A" }
+      layoutCode39 "A" invalidGeometry `shouldBe`
+        Left (Code39LayoutError (InvalidRenderConfiguration "moduleWidth" 0))
+      layoutCode39 "A" humanText `shouldBe`
+        Left (Code39LayoutError HumanReadableTextUnsupported)
+
+standardAlphabet :: String
+standardAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%*"
+
+expectRight :: Show error => Either error value -> IO value
+expectRight (Right value) = pure value
+expectRight (Left err) = fail ("unexpected error: " ++ show err)

--- a/code/packages/haskell/code39/test/Spec.hs
+++ b/code/packages/haskell/code39/test/Spec.hs
@@ -1,0 +1,5 @@
+import Code39Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -121,11 +121,11 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
 `type-checker-protocol` ports, and the Haskell `paint-vm-ascii`,
-`barcode-layout-1d`, and `itf` ports:
+`barcode-layout-1d`, `itf`, and `code39` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 287 |
+| Present in 10-15 languages | 172 | 286 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 710 | 9,940 |
@@ -182,7 +182,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 12 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 11 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -615,6 +615,18 @@ complete digit table, source attribution, exact module geometry, customized
 paint output, metadata precedence, aliases, and both local and shared
 validation paths. The package now spans 12 implementation lanes, reduces the
 high-consensus backlog to 287 slots, and leaves 12 gaps in the Haskell lane.
+
+The twenty-third Haskell high-consensus slice is complete: `code39` now
+provides the pure linear-barcode encoder unlocked by `barcode-layout-1d`. It
+normalizes lowercase input, validates the complete standard alphabet, protects
+the reserved delimiter, exposes all 44 typed narrow/wide symbol patterns, and
+emits attributed start, data, stop, and inter-character-gap runs through the
+shared paint geometry. Its package-native suite exercises normalization,
+educational errors, the complete symbol table, exact patterns and module
+counts, semantic attribution, empty payloads, customized paint output,
+metadata precedence, aliases, and both local and shared validation paths. The
+package now spans 12 implementation lanes, reduces the high-consensus backlog
+to 286 slots, and leaves 11 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell Code 39 encoder on top of `barcode-layout-1d`
- expose normalization, typed per-symbol patterns, attributed narrow/wide runs, educational validation errors, and paint-scene metadata
- cover the complete 44-symbol standard table and update the package-parity roadmap

## Why

`code39` was the smallest remaining dependency-safe Haskell high-consensus gap after the shared linear-barcode geometry and ITF ports merged. This adds a total, platform-neutral implementation without external runtime dependencies and continues the newly unlocked 1D barcode family.

## Validation

- `cabal test all --enable-coverage` (21 Code 39, 18 barcode-layout, and 28 paint-instructions examples)
- 98% expression and 89% alternative coverage for `CodingAdventures.Code39`
- `cabal check`
- `cabal sdist` with the artifact written outside the repository
- `python code/scripts/tests/test_package_parity_report.py` (6 tests)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
  - high-consensus missing slots: 287 to 286
  - Haskell high-consensus gaps: 12 to 11
  - canonical collisions: 0
  - unknown language buckets: 0
- `git diff --check`
