### PR TITLE
fix(sir-js): stack-overflow DoS in method dispatch (resolveMethod module search)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.45.0 — fix stack-overflow DoS in method dispatch (`resolveMethod`)
+
+**Any method call on an instance whose class has a deep `include` chain killed
+the program.** `resolveMethod`'s inner module search recursed once per level of
+the include graph, so a long chain exhausted the JS call stack —
+`RangeError: Maximum call stack size exceeded` (measured: fine at ~5k deep,
+fatal by ~9k). Because `resolveMethod` runs on EVERY method call to a
+`SirInstance`, this was not an exotic path: one deep mixin graph made every
+call on such an object crash. Reproduced end-to-end through `callMethod`.
+
+The module search is now an explicit STACK rather than recursion, keeping the
+JS stack at O(1) regardless of include-graph depth. The same shape the
+`is_a?` module walk already uses.
+
+**Method resolution order is preserved exactly.** The old walk visited a
+module's includes newest-first (`for (i = len-1; i >= 0; i--)`), fully
+exploring each subtree before the next sibling. A LIFO stack reproduces that
+by PUSHING children in ascending index order — they then pop newest-first, and
+a popped module's own children go on top so its subtree is exhausted before
+its older siblings. The shared `seen` set (checked on pop) still terminates a
+cyclic or repeated include.
+
+New `method_resolution_order_survives_the_iterative_module_search` exec-proof
+pins every ordering rule that must not change: a class's own method beats its
+modules; the most-recently-included module wins; a module's own includes are
+searched depth-first, newest-first, before an older sibling; and the
+superclass chain is consulted only after the whole subclass subtree misses.
+The deep-chain regression test now drives the REAL `callMethod` path (it
+previously had to route around this crash via the builtin form).
+
 ## 0.44.0 — Ruby type reflection: `.class`, `is_a?`, `kind_of?`, `instance_of?`
 
 The backend implemented NO type reflection: `7.class` compiled fine and then

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -2614,20 +2614,34 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // name))` — explicit data, never `[name]` / reflection.
   function resolveMethod(ownerTable, cls, name, topModules) {
     const seen = new Set();
-    // Search a MODULE `mod` (and, depth-first, its own included modules).
+    // Search a MODULE `start` (and, depth-first, its own included modules).
     // A module's methods always live in `methodTable` (instance methods).
-    function searchModule(mod) {
-      if (mod === undefined || mod === null || seen.has(mod)) {
-        return undefined;
-      }
-      seen.add(mod);
-      const own = methodTable.get(methodKey(mod, name));
-      if (own !== undefined) { return own; }
-      const mods = includedModules.get(mod);
-      if (mods !== undefined) {
-        for (let i = mods.length - 1; i >= 0; i--) {
-          const fn = searchModule(mods[i]);
-          if (fn !== undefined) { return fn; }
+    //
+    // ITERATIVE (an explicit stack), NOT recursion.  A module's include graph
+    // is shaped by the source program, so a long `include` chain used to
+    // recurse once per level and exhaust the JS call stack — and because
+    // `resolveMethod` runs on EVERY method call to an instance, that made ANY
+    // call on such an object die with `RangeError: Maximum call stack size
+    // exceeded` (measured: fine at ~5k deep, fatal by ~9k).
+    //
+    // MRO ORDER IS PRESERVED EXACTLY.  The old walk visited a module's
+    // includes newest-first (`for (i = len-1; i >= 0; i--)`), fully exploring
+    // each subtree before the next sibling.  A LIFO stack reproduces that if
+    // children are PUSHED in ascending index order — they then POP in
+    // descending order, and a popped module's own children go on top, so its
+    // subtree is exhausted before its older siblings.  `seen` is the same
+    // shared set, checked on pop, so a cyclic or repeated include terminates.
+    function searchModuleTree(start) {
+      const stack = [start];
+      while (stack.length > 0) {
+        const mod = stack.pop();
+        if (mod === undefined || mod === null || seen.has(mod)) { continue; }
+        seen.add(mod);
+        const own = methodTable.get(methodKey(mod, name));
+        if (own !== undefined) { return own; }
+        const mods = includedModules.get(mod);
+        if (mods !== undefined) {
+          for (let i = 0; i < mods.length; i++) { stack.push(mods[i]); }
         }
       }
       return undefined;
@@ -2644,7 +2658,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       const mods = topModules === undefined ? undefined : topModules.get(owner);
       if (mods !== undefined) {
         for (let i = mods.length - 1; i >= 0; i--) {
-          const fn = searchModule(mods[i]);
+          const fn = searchModuleTree(mods[i]);
           if (fn !== undefined) { return fn; }
         }
       }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -666,16 +666,15 @@ catch (err) { o.push("raised"); }                              // raised
 const native = new TypeError("internal");
 o.push(F.callMethod(native, "class"));                         // StandardError
 o.push(String(F.callMethod(native, "is_a?", "StandardError"))); // true
-// (5) a pathological include CHAIN must not exhaust the JS stack — the module
-//     walk behind `is_a?` is an explicit worklist, not recursion.  Driven
-//     through the BUILTIN form on purpose: `callMethod` on a SirInstance first
-//     consults `resolveMethod`, whose `searchModule` is recursive and blows
-//     the stack on a chain this deep — a PRE-EXISTING DoS in method dispatch,
-//     tracked separately and deliberately not exercised here.
+// (5) a pathological include CHAIN must not exhaust the JS stack — BOTH the
+//     module walk behind `is_a?` and `resolveMethod`'s own module search are
+//     explicit worklists, not recursion.  Driven through `callMethod` (the
+//     REAL dispatch path, which consults `resolveMethod` first) — that path
+//     used to die with `RangeError: Maximum call stack size exceeded`.
 for (let i = 0; i < 20000; i++) { F.includeModule("D" + i, "D" + (i + 1)); }
 const deep = new F.SirInstance("D0");
-o.push(String(F.builtins["is_a?"](deep, "D20000")));           // true, no overflow
-o.push(String(F.builtins["is_a?"](deep, "Nope")));             // false, no overflow
+o.push(String(F.callMethod(deep, "is_a?", "D20000")));         // true, no overflow
+o.push(String(F.callMethod(deep, "is_a?", "Nope")));           // false, no overflow
 console.log(o.join("|"));
 "#;
     if let Some(stdout) = run_runtime_snippet(snippet, "rbrefledge") {
@@ -684,6 +683,47 @@ console.log(o.join("|"));
             "ArgumentError|true|true|false|C|true|true|false|undefined|undefined|raised|\
              StandardError|true|true|false",
         );
+    }
+}
+
+#[test]
+fn method_resolution_order_survives_the_iterative_module_search() {
+    // `resolveMethod`'s module search became an explicit stack (it used to
+    // recurse and blow the JS stack on a deep `include` chain). MRO order is
+    // the thing that MUST NOT change, so pin every ordering rule:
+    //   1. a class's OWN method beats any module it includes;
+    //   2. the most-recently-included module wins over an earlier one;
+    //   3. a module's own includes are searched depth-first, newest-first,
+    //      BEFORE moving on to an older sibling module;
+    //   4. the superclass chain is consulted only after the whole subclass
+    //      subtree (class + its modules) misses.
+    let snippet = r#"
+const F = __Sir; const o = [];
+const m = (tag) => new F.Closure(() => tag);
+// 1. own method beats an included module
+F.defMethod("K1", "who", m("own")); F.includeModule("K1", "MA"); F.defMethod("MA", "who", m("MA"));
+o.push(F.callMethod(new F.SirInstance("K1"), "who"));            // own
+// 2. newest include wins (MB included after MA)
+F.includeModule("K2", "MA"); F.includeModule("K2", "MB"); F.defMethod("MB", "who", m("MB"));
+o.push(F.callMethod(new F.SirInstance("K2"), "who"));            // MB
+// 3. depth-first: MC's OWN include (MD) is searched before older sibling MA.
+//    K3 includes MA then MC; MC includes MD; only MD and MA define `who`.
+F.includeModule("K3", "MA"); F.includeModule("K3", "MC");
+F.includeModule("MC", "MD"); F.defMethod("MD", "who", m("MD"));
+o.push(F.callMethod(new F.SirInstance("K3"), "who"));            // MD (not MA)
+// 4. superclass only after the whole subclass subtree misses
+F.registerAncestry({ K4: "K4Base" });
+F.includeModule("K4", "ME");                                      // ME defines nothing
+F.defMethod("K4Base", "who", m("base"));
+o.push(F.callMethod(new F.SirInstance("K4"), "who"));            // base
+// ...but a module on the SUBCLASS still beats the superclass.
+F.registerAncestry({ K5: "K5Base" });
+F.includeModule("K5", "MA"); F.defMethod("K5Base", "who", m("base5"));
+o.push(F.callMethod(new F.SirInstance("K5"), "who"));            // MA
+console.log(o.join("|"));
+"#;
+    if let Some(stdout) = run_runtime_snippet(snippet, "mroorder") {
+        assert_eq!(stdout, "own|MB|MD|base|MA");
     }
 }
 


### PR DESCRIPTION
## The bug

**Any method call on an instance whose class has a deep `include` chain killed the program.**

`resolveMethod`'s inner `searchModule` recursed once per level of the include graph. Since `resolveMethod` runs on **every** method call to a `SirInstance`, one deep mixin graph made *every* call on such an object die with `RangeError: Maximum call stack size exceeded`. Measured: fine at ~5k deep, fatal by ~9k.

Reproduced end-to-end through the real `callMethod` path:

```js
for (let i = 0; i < 20000; i++) { F.includeModule("D" + i, "D" + (i + 1)); }
F.callMethod(new F.SirInstance("D0"), "is_a?", "D20000");   // RangeError, stack all searchModule
```

I found this while building `is_a?` (#8672) — my own module walk was already iterative, and this crash is what stopped the deep-chain test from using the real dispatch path.

## The fix

The module search is now an **explicit stack**, so the JS stack is O(1) regardless of include-graph depth — the same shape the `is_a?` walk uses.

Stack growth is bounded by the number of **edges** in the reachable include graph (each module is expanded at most once — `seen` is marked on pop, *before* children are pushed), so there's no small-source/large-stack amplification. Cycles, self-includes, diamonds and wide fan-out all terminate.

## MRO order is preserved *exactly* — the delicate part

This runs in the hottest dispatch path, and a wrong method resolving is worse than a crash. The transformation is order-identical, not merely similar:

- The old walk visited a module's includes **newest-first** (`for i = len-1 down to 0`), fully exploring each subtree before the next sibling.
- A LIFO stack reproduces that by **pushing children in ascending index order** — they pop newest-first, and a popped module's own children land on top of its un-popped older siblings, so its subtree is exhausted first.
- `seen` is tested at pop, which *is* the visit moment, so the visit sequence is identical by induction. Verified against a simple list, nested includes, a diamond, and a repeated module.

**No method is newly found or newly missed.**

## Verification

New `method_resolution_order_survives_the_iterative_module_search` exec-proof pins every ordering rule that must not change:

| rule | asserted |
|---|---|
| a class's own method beats its modules | `own` |
| most-recently-included module wins | `MB` |
| a module's own includes searched depth-first, newest-first, before an older sibling | `MD` |
| superclass consulted only after the whole subclass subtree misses | `base` |
| …but a subclass's module still beats the superclass | `MA` |

Plus: the 20k-deep regression test now drives the **real `callMethod` path** (it previously had to route around this crash via the builtin form). Full suite (248 tests, including the OOP/mixin exec-proofs that are the real MRO guards) green. Security-reviewed clean, including an independent proof of visit-order equivalence and the stack bound.

## Version
`semantic-ir-to-javascript` 0.44.0 → **0.45.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)