### PR TITLE
fix(sir): is_a? / case-when with a class constant — worked on Python alone

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## 0.7.0 — lift a class CONSTANT to its name for `is_a?` / `when SomeClass`
+
+`case x when Integer` and `x.is_a?(Integer)` compiled on **Python alone**. Both
+lower to `is_a?`, and both passed the class as a bare `Const` `VarRef`. Only
+Python's backend could cope: Go and Rust REJECT a constant reference at emit
+("cannot lower a constant reference" — a `Const` is accepted only as an
+exception class in `raise Foo`), and JavaScript emitted an undefined reference
+that blew up at run time. Ruby type-dispatch is ordinary code, so this was a
+large hole rather than an exotic one.
+
+Both sites now surface the class as a `StrLit` of its NAME — exactly the
+convention `lower_class_pattern` (Phase FC) already documented and used
+("so no constant declaration is required and no `Constants` feature is pulled
+in"):
+
+- `when SomeClass` in a `case`.
+- A direct `x.is_a?(C)` / `x.kind_of?(C)` / `x.instance_of?(C)` call.
+
+Every backend's `is_a?` compares class NAMES, so the name is the honest thing
+to hand them, and no backend needs general constant-reference support. All four
+running backends (Python, JavaScript, Go, Rust) now agree.
+
 ## [0.6.3] - 2026-07-03
 
 ### Fixed (FC — sequential local assignments: `x = a` where `a` is an earlier local)

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1893,15 +1893,41 @@ impl Lowerer {
             //     which dispatches Range→membership, Regexp→match, else `==`.
             // The `case_eq` floor is `==`, so plain literals keep their old
             // behaviour.
-            let cmp = if matches!(
-                val,
+            let const_class_name = match &val {
                 Expr::VarRef {
+                    name,
                     scope: Scope::Const,
                     ..
-                }
-            ) {
+                } => Some(name.clone()),
+                _ => None,
+            };
+            let cmp = if let Some(class_name) = const_class_name {
                 self.features_used.insert(Feature::Classes);
-                // The synthetic `"is_a?"` method-name is a string literal.
+                // Both the synthetic `"is_a?"` method-name AND the CLASS NAME
+                // are string literals.  Surfacing the class as a `StrLit` of
+                // its name — rather than passing the `Const` `VarRef` through —
+                // is the same convention `lower_class_pattern` (Phase FC)
+                // already uses, and it is what makes `when SomeClass` portable:
+                // a bare constant reference is not lowerable by the Go or Rust
+                // backends (they accept a `Const` only as an exception class in
+                // `raise Foo`), and JavaScript emitted an undefined reference
+                // that blew up at run time — so `when Integer` used to work on
+                // Python alone.  The backends' `is_a?` all compare class NAMES,
+                // so the name is the honest thing to hand them.
+                //
+                // LIMITATION (pre-existing, but now SILENT rather than loud):
+                // this arm treats ANY `Const` as a class pattern, whereas
+                // Ruby's `when FOO` is `FOO === x` — for a non-class constant
+                // (`FOO = "root"`) that means `==`.  Such a `when` lowers to an
+                // `is_a?` against the constant's NAME and is therefore always
+                // false, a fail-open shape for a deny-list.  Before this lift
+                // it at least failed to COMPILE on Go/Rust; that accidental
+                // signal is gone, so it is called out here.  Likewise a
+                // namespaced `Foo::Bar` lifts to the qualified string, which
+                // will not match a class registered under its simple name.
+                // Telling a class constant from a value constant needs
+                // const-binding knowledge the lowerer does not have — the
+                // honest fix is a resolved constant table.
                 self.features_used.insert(Feature::Strings);
                 Expr::BuiltinCall {
                     name: "__method__".to_string(),
@@ -1911,7 +1937,10 @@ impl Lowerer {
                             value: "is_a?".to_string(),
                             span: span.clone(),
                         },
-                        val,
+                        Expr::StrLit {
+                            value: class_name,
+                            span: span.clone(),
+                        },
                     ],
                     effects: EffectSet::PURE,
                     span: span.clone(),
@@ -9677,6 +9706,34 @@ impl Lowerer {
                 span,
             });
         }
+
+        // The reflection predicates take a CLASS as their argument, and every
+        // backend's `is_a?` compares class NAMES.  Lift a bare `Const`
+        // argument to a `StrLit` of its name here — the same convention
+        // `lower_class_pattern` (Phase FC) and `when SomeClass` use — so no
+        // backend needs general constant-reference support.  Without this,
+        // `x.is_a?(Integer)` was rejected at EMIT by the Go and Rust backends
+        // (they lower a `Const` only as an exception class in `raise Foo`) and
+        // produced an undefined reference at run time on JavaScript, leaving
+        // the whole family working on Python alone.
+        let is_reflection_predicate = matches!(
+            method_name.as_str(),
+            "is_a?" | "kind_of?" | "instance_of?"
+        );
+        let args = if is_reflection_predicate {
+            args.into_iter()
+                .map(|a| match a {
+                    Expr::VarRef {
+                        name,
+                        scope: Scope::Const,
+                        span,
+                    } => Expr::StrLit { value: name, span },
+                    other => other,
+                })
+                .collect()
+        } else {
+            args
+        };
 
         // Pack as BuiltinCall("__method__", [receiver, StrLit(method),
         // ...args]) — see apply_dot_chain doc for rationale.

--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.35.0 — implement `is_a?` / `kind_of?` / `instance_of?`
+
+These were listed in `_sir_responds_to` but **never implemented**, so
+`respond_to?(:is_a?)` answered `true` while an actual call fell through to
+`NoMethodError` and killed the program. (`class` was already implemented; the
+predicates were not.)
+
+`_sir_object_method` gains the three arms, reusing the existing
+`_sir_ruby_class_name`. `is_a?`/`kind_of?` honour ancestry — the built-in
+surface (`Integer`/`Float` are `Numeric` and `Comparable`, `String` is
+`Comparable`, `Object`/`BasicObject` match everything) plus, for a user
+instance, its superclass chain (`_sir_is_ancestor_or_self`) and any module
+mixed in along it. `instance_of?` is an exact class match.
+
+Transitive module matching (Ruby MRO: `C` includes `M`, `M` includes `N` ⇒
+`c.is_a?(N)`) uses an ITERATIVE worklist rather than recursion, because
+include-graph depth is shaped by the source — the same design the JavaScript
+and Rust backends use. Cyclic and self-including graphs terminate.
+
+The class argument arrives as a NAME (ruby-to-semantic-ir 0.7.0 lifts a
+`Const` to a `StrLit`), so no constant-reference support is needed.
+
+Two adjacent fixes found while reviewing the above:
+- `_sir_ruby_class_name` now recognises `*SirError`. A raised/caught exception
+  is not a `*SirInstance`, so it fell to the `Object` default — `rescue => e;
+  e.class` said `Object` and `e.is_a?(StandardError)` was FALSE for every
+  exception, silently skipping a handler guarded that way, even though
+  `_sir_ancestry` holds the whole exception hierarchy. `_sir_value_is_a` walks
+  ancestry for `*SirError` too.
+- The `==` / `!=` object arms indexed `args[0]` with no length check, so a
+  zero-argument `x.==()` PANICKED and killed the program. Both are guarded.
+
 ## 0.34.0 — Ruby `Integer#/` floors toward −∞ (SIR21 §E3)
 
 The inline `__sir` runtime's `_sir_divide` truncated integer division toward

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1389,6 +1389,14 @@ func _sir_ruby_class_name(v Value) string {
 	if inst, ok := v.(*SirInstance); ok {
 		return inst.Class
 	}
+	// A raised/caught exception is a *SirError, NOT a *SirInstance — it carries
+	// its class tag the same way.  Without this it fell to the "Object" default,
+	// so `rescue => e; e.class` said "Object" and `e.is_a?(StandardError)` was
+	// FALSE for every exception — silently skipping a handler guarded that way,
+	// even though `_sir_ancestry` holds the whole exception hierarchy.
+	if se, ok := v.(*SirError); ok {
+		return se.Class
+	}
 	switch t := v.(type) {
 	case bool:
 		if t {
@@ -1416,12 +1424,37 @@ func _sir_object_method(recv Value, name string, args []Value) (Value, bool) {
 	switch name {
 	case "nil?":
 		return recv == nil, true
+	// Guard `args[0]`: a zero-argument `x.==()` would otherwise index an empty
+	// slice and PANIC, killing the program.  Ruby raises ArgumentError; the
+	// never-crash floor here is to compare against nil.
 	case "==":
+		if len(args) == 0 {
+			return recv == nil, true
+		}
 		return _sir_value_eq(recv, args[0]), true
 	case "!=":
+		if len(args) == 0 {
+			return recv != nil, true
+		}
 		return !_sir_value_eq(recv, args[0]), true
 	case "class":
 		return _sir_ruby_class_name(recv), true
+	// `is_a?`/`kind_of?` honour ancestry; `instance_of?` is an EXACT class
+	// match.  These were listed in `_sir_responds_to` but never IMPLEMENTED,
+	// so `respond_to?(:is_a?)` answered true while an actual call fell through
+	// to `NoMethodError` and killed the program.  The class argument arrives
+	// as a NAME (the frontend lifts a `Const` to a `StrLit`), so no
+	// constant-reference support is needed here.
+	case "is_a?", "kind_of?", "instance_of?":
+		if len(args) == 0 {
+			return false, true
+		}
+		target := _sir_method_name(args[0])
+		actual := _sir_ruby_class_name(recv)
+		if name == "instance_of?" {
+			return actual == target, true
+		}
+		return _sir_value_is_a(recv, actual, target), true
 	case "to_s":
 		return _sir_ruby_to_s(recv), true
 	case "inspect":
@@ -3981,6 +4014,68 @@ func _sir_class_of_thrown(r any) string {
 		return se.Class
 	}
 	return "StandardError"
+}
+
+// Ruby `is_a?`: the receiver's own class, a BUILT-IN ancestor (`Integer` and
+// `Float` are `Numeric` and `Comparable`; `String` is `Comparable`), the
+// universal `Object`/`BasicObject`, or — for a user instance — its superclass
+// chain plus any module mixed in along it.
+func _sir_value_is_a(recv Value, actual string, target string) bool {
+	if actual == target || target == "Object" || target == "BasicObject" {
+		return true
+	}
+	switch actual {
+	case "Integer", "Float":
+		if target == "Numeric" || target == "Comparable" {
+			return true
+		}
+	case "String":
+		if target == "Comparable" {
+			return true
+		}
+	}
+	// A user instance — or an exception, which is a *SirError carrying the same
+	// kind of class tag — also matches its superclass chain and any module
+	// mixed in along it.  Exceptions matter here: `_sir_ancestry` holds the
+	// built-in hierarchy, so `e.is_a?(StandardError)` resolves through it.
+	switch recv.(type) {
+	case *SirInstance, *SirError:
+		return _sir_is_ancestor_or_self(actual, target) ||
+			_sir_includes_module_transitively(actual, target)
+	}
+	return false
+}
+
+// Does `owner` reach `target` through the modules mixed into it or into any of
+// its ancestors?  Ruby's MRO is TRANSITIVE — `class C; include M; end` where
+// `module M; include N; end` makes `c.is_a?(N)` true.
+//
+// Deliberately ITERATIVE (an explicit worklist, not recursion): include-graph
+// depth is shaped by the source, so a recursive walk could exhaust the stack on
+// a long chain.  `seen` expands each module at most once and `chain` guards a
+// cyclic ancestry edge, so any graph terminates.
+func _sir_includes_module_transitively(owner string, target string) bool {
+	seen := make(map[string]bool)
+	work := []string{owner}
+	for len(work) > 0 {
+		cur := work[len(work)-1]
+		work = work[:len(work)-1]
+		chain := make(map[string]bool)
+		for cur != "" && !chain[cur] {
+			chain[cur] = true
+			for _, m := range _sir_included_modules[cur] {
+				if m == target {
+					return true
+				}
+				if !seen[m] {
+					seen[m] = true
+					work = append(work, m)
+				}
+			}
+			cur = _sir_ancestry[cur]
+		}
+	}
+	return false
 }
 
 // True iff `actual` is `target` or descends from it via `_sir_ancestry`.

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.18.0] - `is_a?` / `case-when` frontier across the backends
+
+Adds `is_a_and_case_when_match_ruby_on_every_backend` — the `is_a?` family and
+`case x when SomeClass`, whose class argument is a bare CONSTANT in the source.
+
+This previously compiled on Python alone: Go and Rust rejected the constant
+reference at emit, and JavaScript blew up at run time. With the frontend now
+lifting the constant to its name (ruby-to-semantic-ir 0.7.0) and Go implementing
+the predicates (semantic-ir-to-go 0.35.0), all four running backends agree —
+so it is a live cross-backend assertion, not a per-backend guard.
+
 ## [0.17.0] - Reflection frontier goes cross-backend (Rust arm closed)
 
 `tests/reflection.rs` grows from a per-backend guard into a live **all-backend**

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/tests/reflection.rs
+++ b/code/packages/rust/sir-conformance/tests/reflection.rs
@@ -133,3 +133,54 @@ fn class_reflection_matches_ruby_on_every_backend() {
     }
     assert!(ran > 0, "no backend toolchain available — reflection proved nothing");
 }
+
+/// `(ruby source, expected output)` — the `is_a?` family and `case/when
+/// SomeClass`, whose class argument is a bare CONSTANT in the source.
+const IS_A_CASES: &[(&str, &str)] = &[
+    ("puts(7.is_a?(Integer))\n", "#t"),
+    ("puts(7.is_a?(String))\n", "#f"),
+    ("puts(7.kind_of?(Numeric))\n", "#t"),
+    ("puts(7.instance_of?(Integer))\n", "#t"),
+    ("puts(7.instance_of?(Numeric))\n", "#f"),
+    ("case 7\nwhen Integer\n  puts(\"int\")\nend\n", "int"),
+    ("case \"s\"\nwhen Integer\n  puts(\"int\")\nelse\n  puts(\"other\")\nend\n", "other"),
+];
+
+/// The `is_a?` frontier. A bare constant (`Integer`, `MyClass`) as the class
+/// argument used to reach the backends as a `Const` reference, which only
+/// Python could cope with: Go and Rust REJECTED the program at emit ("cannot
+/// lower a constant reference"), and JavaScript emitted an undefined reference
+/// that blew up at run time. Since `when SomeClass` lowers to `is_a?`, that
+/// meant ordinary Ruby type-dispatch compiled on exactly one backend.
+///
+/// The frontend now lifts the constant to a `StrLit` of its NAME — the
+/// convention `lower_class_pattern` already used — so no backend needs general
+/// constant-reference support, and every backend's `is_a?` (which compares
+/// class names) just works.
+#[test]
+fn is_a_and_case_when_match_ruby_on_every_backend() {
+    let mut ran = 0usize;
+    for &(src, expected) in IS_A_CASES {
+        for &target in Target::all() {
+            match run_source("is_a_frontier", src, target) {
+                RunOutcome::Ran(out) => {
+                    assert_eq!(
+                        out, expected,
+                        "\nIS_A FRONTIER: backend {} gave `{}` = {out}, Ruby says {expected}\n",
+                        target.tag(),
+                        src.trim(),
+                    );
+                    ran += 1;
+                }
+                RunOutcome::Failed(msg) => panic!(
+                    "IS_A FRONTIER: backend {} failed on `{}`: {}",
+                    target.tag(),
+                    src.trim(),
+                    msg.lines().next().unwrap_or("")
+                ),
+                RunOutcome::Skipped(_) => {}
+            }
+        }
+    }
+    assert!(ran > 0, "no backend toolchain available — is_a? proved nothing");
+}


### PR DESCRIPTION
## The bug

`case x when Integer` and `x.is_a?(Integer)` compiled on **exactly one backend**.

Both lower to `is_a?`, and both passed the class as a bare `Const` reference. Only Python coped:

| | before |
|---|---|
| Python | ✅ |
| JavaScript | ❌ undefined reference, crashes at runtime |
| Go | ❌ rejected at emit — *"cannot emit a constant reference `Integer`"* |
| Rust | ❌ rejected at emit — *"cannot lower a constant reference"* |

Ruby type-dispatch is ordinary code, so this was a large hole rather than an exotic one — `when SomeClass` is everyday Ruby.

## The fix — the frontend already had the right convention

`lower_class_pattern` (Phase FC) documents it explicitly: surface the class as a `StrLit` of its **name** *"so no constant declaration is required and no `Constants` feature is pulled in."* The `when` arm and the direct-call path just weren't following it.

Both now do. Every backend's `is_a?` compares class **names**, so the name is the honest thing to hand them — and no backend needs general constant-reference support. **This alone fixed JavaScript and Rust.**

That exposed the next layer: **Go declared `is_a?`/`kind_of?`/`instance_of?` in `_sir_responds_to` but never implemented them** — so `respond_to?(:is_a?)` answered `true` while an actual call fell through to `NoMethodError` and killed the program. Implemented in `_sir_object_method`, reusing the existing `_sir_ruby_class_name`, honouring ancestry (built-in surface plus a user instance's superclass chain and mixed-in modules), with an **iterative worklist** for transitive module matching — include depth is source-shaped, so recursion there is a stack hazard (same design as the JS and Rust backends).

**All four running backends now agree**, pinned by a new cross-backend frontier test.

## Two adjacent Go bugs, found by security review

- **`_sir_ruby_class_name` didn't recognise `*SirError`.** A caught exception fell to the `Object` default, so `e.class` said `Object` and **`e.is_a?(StandardError)` was `false` for every exception** — silently skipping a handler guarded that way, even though `_sir_ancestry` holds the whole exception hierarchy.
- **`==` / `!=` indexed `args[0]` unguarded**, so a zero-argument `x.==()` **panicked** and killed the program.

## Documented limitation (called out in-code, not silently accepted)

The `when` arm treats *any* `Const` as a class pattern, but Ruby's `when FOO` is `FOO === x` — for a non-class constant (`FOO = "root"`) that means `==`. Such a `when` lowers to an `is_a?` against the name and is always false, a fail-open shape. It was already wrong; before this lift it at least failed to *compile* on Go/Rust, and that accidental signal is now gone — so it's spelled out at the site. Distinguishing a class constant from a value constant needs a resolved constant table the lowerer doesn't have.

## Verification
- New `is_a_and_case_when_match_ruby_on_every_backend` cross-backend frontier: `is_a?`, `kind_of?`, `instance_of?` (positive **and** negative), and `case/when` hitting and falling through to `else`.
- Frontend suite (427), Go backend suite, JS backend suite, and reflection conformance (5/5) all green.
- Two rounds of security review; every finding is either fixed above or documented in-code.

## Known, out of scope (measured, not assumed)
- Implicit-self `is_a?(Foo)` fails on **all four** backends identically at module validation (`direct call to unknown function`) — that's implicit-self dispatch not being lowered at all, a separate frontend feature, failing loudly and uniformly.
- `e.class` inside a rescue still diverges: **Python → `Object`**, **Rust → `String`** (it binds the message, not the error object). JS and Go are correct as of this PR. Fixing those two is my next piece of work.

## Versions
`ruby-to-semantic-ir` 0.6.3 → **0.7.0** · `semantic-ir-to-go` 0.34.0 → **0.35.0** · `sir-conformance` 0.17.0 → **0.18.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)