### PR TITLE
feat(scilab-parser): MA10 kickoff — scilab.grammar + scilab-parser crate (MA-10c)

### DIFF
--- a/code/grammars/scilab/scilab.grammar
+++ b/code/grammars/scilab/scilab.grammar
@@ -1,0 +1,354 @@
+# Scilab Language Grammar
+# ============================================================================
+#
+# Parses the token stream from `scilab-lexer` into a tree the (future)
+# `scilab-runtime` walks by rule name. See code/specs/MA10-scilab-language.md.
+#
+# THIS FILE IS FORKED FROM `code/grammars/matlab/matlab.grammar` at the
+# grammar-SOURCE level (copied, then diverged) — not a Rust-crate dependency;
+# `scilab-parser` does not depend on `matlab-parser` (MA10 §5). MA10 §1's
+# closing paragraph is the justification: matrix literals, ranges, and the
+# operator-precedence cascade are a legitimate MATLAB-family inheritance even
+# though the *language* (string `+`, its own `select`/`case`, the `then`/`do`
+# linker keywords, `$` vs. `end`, `endfunction`) genuinely is not MATLAB.
+#
+# PRECEDENCE (loosest → tightest) — MA10 §3's own 12-tier table, confirmed
+# tier-for-tier identical in relative order to matlab.grammar's own cascade
+# above (the concrete evidence for MA10 §1's "grammar shape transfers, the
+# language doesn't" claim):
+#   assignment  =
+#   ||                       (short-circuit or)
+#   &&                       (short-circuit and)
+#   |                        (elementwise or)
+#   &                        (elementwise and)
+#   == ~= <> < > <= >=       (comparison — BOTH not-equal spellings)
+#   :                        (colon — ranges a:b, a:b:c)
+#   + -                      (additive)
+#   * / \ .* ./ .\           (multiplicative, matrix AND elementwise — same level)
+#   + - ~                    (unary prefix)
+#   ^ .^                     (power, right-associative, binds tighter than unary minus)
+#   ' .' ( ) { } .           (postfix: transpose, call/index, cell-index, field)
+#   primary                  (literals, names, $ last-index, %const, [ ] matrices, { } cells)
+#
+# Left-associativity is encoded with `{ ... }` (repetition); right-associativity
+# (assignment, power) with `[ ... self ]` (optional self-recursion), exactly as
+# in matlab.grammar/r.grammar.
+#
+# THREE DIVERGENCES FROM matlab.grammar'S SHAPE (MA10 §3 "Parser differences")
+# ----------------------------------------------------------------------------
+# 1. `stmt_sep` — ONE new production, reused at SIX header sites (see its own
+#    comment below): if/elseif/select/case take an optional `then` linker;
+#    while/for take an optional `do` linker; every one of the six can instead
+#    be a bare comma or newline. No MATLAB equivalent exists at any of these
+#    six positions.
+# 2. `endfunction` is func_def's OWN closing keyword, textually distinct from
+#    the generic `end` production if_stmt/while_stmt/for_stmt/select_stmt all
+#    close with (MA10 §1 finding 7) — NOT unified into one production the way
+#    matlab.grammar's single "end" literal closes every block including
+#    functions.
+# 3. `$` (DOLLAR) replaces MATLAB's context-sensitive `end`-as-last-index
+#    trick entirely (see `primary`'s own comment below) — Scilab's lexer
+#    already resolved `$` to one unambiguous token (scilab-lexer has NO
+#    pre-parse "retag every bracket-interior `end`" hook at all, unlike
+#    matlab-parser), so this grammar needs no context-sensitive handling
+#    whatsoever: `$` is an ordinary `primary` alternative, ready to use.
+#
+# NO `switch`/`otherwise` (Scilab has neither spelling — its own multi-way
+# conditional is `select`/`case`/`else`, MA10 §1 finding 4), no `try`/`catch`/
+# `return`/`global`/`persistent` (none of those tokens exist in
+# `scilab.tokens` — MA10 §4 scopes them out), and no `lambda`/`@` production
+# (no AT token exists in `scilab.tokens` either — MA10 §4 never lists function
+# handles in scope).
+#
+# A KNOWN, EXPECTED `grammar-tools validate` (cross-check) FALSE POSITIVE:
+# ----------------------------------------------------------------------------
+# `primary`'s `STRING` reference below will be reported as "Grammar
+# references token 'STRING' which is not defined in the tokens file" by the
+# cross-validator — this is expected and does not indicate a bug. Unlike
+# `matlab.tokens` (whose `DQ_STRING = ... -> STRING` alias registers "STRING"
+# as a statically-known name the validator can see), `scilab.tokens`
+# *deliberately* leaves `DQ_STRING` un-aliased (see that file's own SECTION 2
+# header comment) so `scilab-lexer`'s own `collapse_dq_string_escapes`
+# post-tokenize hook can tell "still needs its `""` collapsed" apart from
+# "already a fully-decoded STRING." Both `STRING_PLACEHOLDER`- and
+# `DQ_STRING`-derived tokens are relabelled to `type_name = "STRING"` by
+# `scilab-lexer`'s own post-tokenize hooks (`restore_placeholders`,
+# `collapse_dq_string_escapes`) *before* any token ever reaches this grammar
+# — a purely runtime relabelling `grammar-tools`' static cross-validator has
+# no way to see, since it only reads the `.tokens` FILE TEXT, not
+# `scilab-lexer`'s Rust hook code. `parser::grammar_parser::GrammarParser`'s
+# own `match_token_reference` matches purely on a token's live `type_name`
+# field (confirmed directly in `parser/src/grammar_parser.rs`), so `STRING`
+# here is functionally correct at parse time regardless of what the static
+# validator can prove — referencing `STRING_PLACEHOLDER`/`DQ_STRING` instead
+# would be the one genuinely WRONG choice, since no token still carries
+# either of those type names by the time parsing begins (except a
+# deliberately-unresolved placeholder, scilab-lexer's own honest-failure
+# case for a corrupted index, which should fail to parse anyway). Fixing the
+# false positive at the source would require modifying `scilab.tokens`,
+# which MA-10c does not touch (MA-10b is already merged).
+
+# ============================================================================
+# Program and statements
+# ============================================================================
+
+program = { statement_line } ;
+
+# A statement plus its terminator. A bare terminator is a blank/separator line.
+# The terminator token (`;` vs newline/comma) is kept in the tree so a future
+# runtime can honour `;`-suppressed display — identical to matlab.grammar.
+statement_line = statement stmt_term
+               | statement
+               | stmt_term ;
+
+stmt_term = NEWLINE | SEMICOLON | COMMA ;
+
+statement = func_def
+          | if_stmt
+          | select_stmt
+          | for_stmt
+          | while_stmt
+          | break_stmt
+          | continue_stmt
+          | expr ;
+
+# A block body is a run of statement lines; it stops at the keyword that closes
+# its construct (`end`/`else`/`elseif`/`case`/`endfunction`), none of which can
+# begin a statement. Identical shape to matlab.grammar's own `block_body`.
+block_body = { statement_line } ;
+
+# ============================================================================
+# `stmt_sep` — the one new production this grammar adds relative to
+# matlab.grammar, reused at exactly SIX header sites below.
+#
+# MA10 §1 finding 4 / §3: `if`/`elseif` and `select`/`case` take an optional
+# `then` linker; `while`/`for` take an optional `do` linker; every one of the
+# six positions is individually replaceable by a bare comma or a newline —
+# help.scilab.org states the identical rule on each of the `then`/`do` pages
+# in near-identical wording: the linker "must be on the same line as" its
+# header, and "can be replaced by a carriage return or a comma."
+#
+# The load-bearing reading: `then`/`do`, when present, are ALTERNATIVES to
+# the punctuation, not an ADDITION on top of it — real Scilab accepts
+# `if x > 0 then y = 1, end` with NOTHING at all between `then` and `y`, the
+# same way `if x > 0, y = 1, end` needs nothing between the comma and `y`.
+# So this is a single REQUIRED (not optional) separator token that happens to
+# have four acceptable spellings, not two optional pieces stacked (an earlier,
+# rejected reading of help.scilab.org's wording would have modeled this as
+# `[ THEN | DO ] ( COMMA | NEWLINE )`, requiring punctuation even after an
+# explicit linker keyword — contradicted by the worked examples on those same
+# pages, none of which double up a keyword AND a comma before the body).
+#
+# `"then"`/`"do"` are quoted string LITERALS (matched by token VALUE), not
+# bare UPPERCASE TokenReferences — `scilab.tokens` has no dedicated THEN/DO
+# token TYPE at all; both are just two of the fourteen VALUES a shared
+# KEYWORD-typed token can carry (see `scilab.tokens`'s own `keywords:` block),
+# exactly the same convention every keyword literal elsewhere in this file
+# already uses (`"if"`, `"end"`, `"function"`, …) and matlab.grammar uses for
+# its own keywords.
+stmt_sep = "then" | "do" | COMMA | NEWLINE ;
+
+# Deliberate simplification, flagged for a reviewer: `stmt_sep` accepts BOTH
+# `THEN` and `DO` uniformly at all six sites below, rather than restricting
+# `if`/`elseif`/`select`/`case` to `THEN` only and `while`/`for` to `DO` only.
+# MA10 §3 states which linker is *idiomatic* at which site, not that the
+# other spelling is a *syntax error* there — and enforcing that narrower
+# cross-check would require six distinct nonterminals (or a parameterized
+# one) in place of the "one new rule, reused at multiple sites" shape §3
+# explicitly calls for (mirroring J's `verb_train` / APL's reduce-scan
+# productions — see MA06 §3). A future `scilab-runtime`/style-linter can
+# reject the idiomatically-wrong spelling at a later stage if desired; this
+# grammar's job is only to recognize where a header ends and a body begins.
+
+# ============================================================================
+# Control flow
+# ============================================================================
+
+# `if cond THEN|DO|,|<newline> body [elseif cond ...] [else body] end`
+if_stmt = "if" expr stmt_sep block_body { elseif_clause } [ else_clause ] "end" ;
+elseif_clause = "elseif" expr stmt_sep block_body ;
+
+# `else` takes NO linker keyword of its own (MA10 §3 never lists it among the
+# six `stmt_sep` sites) — shared unchanged between `if_stmt` and
+# `select_stmt` below, exactly like matlab.grammar's single `else_clause`.
+else_clause = "else" block_body ;
+
+# Scilab's OWN multi-way conditional (MA10 §1 finding 4) — replaces MATLAB's
+# `switch`/`otherwise` entirely; neither spelling exists in `scilab.tokens`.
+# `select` itself is one of the six `stmt_sep` sites (its own header, before
+# the first `case`, per MA10 §3's literal "if/elseif and select/case take
+# THEN" wording — four sites named there, not three, the fourth being
+# `select`'s own header) — there is no bare-statement `block_body` directly
+# under `select` the way `if`/`while`/`for` have one: a `select` body is
+# nothing but a run of `case_clause`s plus an optional trailing `else_clause`.
+select_stmt = "select" expr stmt_sep { case_clause } [ else_clause ] "end" ;
+case_clause = "case" expr stmt_sep block_body ;
+
+while_stmt = "while" expr stmt_sep block_body "end" ;
+
+for_stmt = "for" NAME EQ expr stmt_sep block_body "end" ;
+
+break_stmt = "break" ;
+continue_stmt = "continue" ;
+
+# ============================================================================
+# Function definitions
+#
+#   function out = name(a, b) … endfunction
+#   function [o1, o2] = name(a) … endfunction
+#   function name(a) … endfunction          (no return)
+#
+# `endfunction` is Scilab's OWN historically-mandated, still-preferred
+# function terminator (MA10 §1 finding 7) — kept as its OWN literal here,
+# textually separate from the generic `"end"` literal every other block
+# construct above closes with. Unlike matlab.grammar, where a single `"end"`
+# literal closes `if`/`for`/`while`/`switch`/`try`/`function` alike, this
+# grammar's `func_def` is the ONLY production that ever matches the
+# `endfunction` token, and no production anywhere in this file lets a bare
+# generic `"end"` close a function — so `function ... end` (using the
+# generic closer instead of `endfunction`) is a syntax error by construction,
+# not merely a style discouraged elsewhere.
+# ============================================================================
+
+func_def = "function" [ func_returns ] NAME [ LPAREN [ name_list ] RPAREN ] block_body "endfunction" ;
+func_returns = NAME EQ
+             | LBRACKET [ name_list ] RBRACKET EQ ;
+name_list = NAME { COMMA NAME } ;
+
+# ============================================================================
+# Expression precedence cascade (loosest → tightest)
+# ============================================================================
+
+expr = assignment ;
+
+# `=` is assignment (comparison is `==`); right-associative — unchanged from
+# matlab.grammar.
+assignment = logical_or [ EQ assignment ] ;
+
+logical_or  = logical_and { OR_OR logical_and } ;
+logical_and = bit_or { AND_AND bit_or } ;
+bit_or  = bit_and { PIPE bit_and } ;
+bit_and = comparison { AMP comparison } ;
+
+# Relational tier: BOTH not-equal spellings accepted here (MA10 §1 finding 6,
+# §3) — `NE` (`~=`, inherited from MATLAB) and `NE_ALT` (`<>`, Scilab's own,
+# real syntax with no MATLAB counterpart). scilab-lexer already lexes them as
+# two distinct token types (deliberately not aliased — see that crate's own
+# `scilab.tokens` header comment), so this is the one place they collapse
+# onto a single relational-operator production, exactly as that comment
+# promises ("the parser, not this lexer, is where the two spellings
+# collapse").
+comparison = colon_expr { ( EQ_EQ | NE | NE_ALT | LE | GE | LT | GT ) colon_expr } ;
+
+# The colon: `a:b` (range) or `a:b:c` (range with step). Binds looser than `+ -`
+# (so `1:n+1` is `1:(n+1)`) and tighter than comparison — unchanged from
+# matlab.grammar.
+colon_expr = additive [ COLON additive [ COLON additive ] ] ;
+
+additive = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+
+# Matrix and elementwise multiply/divide share one precedence level, same as
+# MATLAB. The Kronecker trigraphs (`.*.`/`./.`/`.\.`) are deliberately absent
+# (MA10 §4) — they are not tokens in `scilab.tokens` at all, so there is
+# nothing for this production to reference.
+multiplicative = unary { ( STAR | SLASH | BACKSLASH | ELEM_MUL | ELEM_RDIV | ELEM_LDIV ) unary } ;
+
+# Unary prefix. Looser than power, so `-2^2` is `-(2^2)` — unchanged from
+# matlab.grammar. (Scilab's own deprecated legacy `@`-for-`~` spelling, MA10
+# §1 finding 6, is out of scope — `@`/AT is not a token in `scilab.tokens`.)
+unary = ( PLUS | MINUS | TILDE ) unary
+      | power ;
+
+# Power, right-associative; the right operand is `unary` so `2^-3` parses —
+# unchanged from matlab.grammar. (Scilab's own deprecated legacy `**`
+# spelling for `^`, MA10 §1 finding 6, is out of scope — `a ** b` lexes as
+# two bare STAR tokens per scilab-lexer's own documented non-treatment, so
+# there is no `**` spelling for this production to reference either.)
+power = postfix [ ( CARET | ELEM_POW ) unary ] ;
+
+# Postfix (tightest): transpose, calls/indexing, cell indexing, field access —
+# unchanged from matlab.grammar. `A($)`/`A($-1)` reach this production the
+# same way `A(i)`/`A(i-1)` do: `$` is just an ordinary `primary` (see below),
+# so no special handling is needed at this tier at all.
+postfix = primary { transpose_suffix | call_suffix | cell_suffix | field_suffix } ;
+
+transpose_suffix = TRANSPOSE | ELEM_TRANSPOSE ;
+call_suffix  = LPAREN [ arg_list ] RPAREN ;
+cell_suffix  = LBRACE [ arg_list ] RBRACE ;
+field_suffix = DOT NAME ;
+
+# Index/call arguments: a lone `:` means "the whole dimension" (`A(:,k)`) —
+# unchanged from matlab.grammar. `arg`'s `expr` alternative already covers
+# `$`/`$-1` for free, since `$` is a `primary` (see below) and every tier
+# between `expr` and `primary` falls through unchanged when there is nothing
+# to the right of it to combine with.
+arg_list = arg { COMMA arg } ;
+arg = COLON | expr ;
+
+# ============================================================================
+# Primary expressions
+# ============================================================================
+
+# `$` (DOLLAR) sits here, as an ORDINARY primary alternative — the single
+# substitution MA10 §3 calls out relative to matlab.grammar's own `primary`.
+# MATLAB's `end`-as-last-index is context-SENSITIVE (matlab-parser's own
+# pre-parse hook must retag every bracket-interior `end` to a NAME before
+# this grammar ever runs, matlab.grammar's own header comment); Scilab's `$`
+# needs NONE of that, because scilab-lexer already lexes `$` as its own
+# always-unambiguous DOLLAR token in every position (confirmed directly by
+# scilab-lexer's own `last_index_dollar_is_a_value_before_transpose` test,
+# which treats `$` as an ordinary value on par with a closing bracket, and by
+# `dollar_last_index`, which shows `A($)`/`A($-1)` lexing with a plain
+# DOLLAR token, no retagging pass involved at all). Placing `$` at `primary`
+# — the SAME tier as `NUMBER`/`NAME` — rather than as some dedicated
+# indexing-only production is what makes `A($-1)` parse at all: `$` must be
+# able to serve as an ordinary operand to `additive`'s `MINUS` the same way
+# `NUMBER`/`NAME` can, and `primary` is the one tier every other tier in this
+# cascade already falls through to for an ordinary atom. A bare `$` (with no
+# enclosing indexing expression at all) is therefore also a legal `expr` by
+# the same construction — not excluded, since nothing about `primary`
+# requires being inside a `call_suffix`'s `arg_list` to be reachable, mirroring
+# how a bare `NUMBER` is equally reachable as a top-level statement.
+#
+# `PERCENT_CONST` is likewise a new `primary` alternative with no MATLAB
+# analogue (MA10 §3) — scilab-lexer's own `percent_constant_used_in_an_expression`
+# test (`r = %pi * 2`) confirms it composes with ordinary arithmetic the same
+# way `$` does, so it belongs at the identical tier for the identical reason.
+primary = NUMBER
+        | STRING
+        | PERCENT_CONST
+        | DOLLAR
+        | matrix_literal
+        | cell_literal
+        | group
+        | NAME ;
+
+group = LPAREN expr RPAREN ;
+
+# ============================================================================
+# Matrix and cell literals
+#
+#   [1 2 3]        a row (elements juxtaposed; whitespace was stripped by the
+#                  lexer, so adjacent expressions — with an optional comma —
+#                  are the columns)
+#   [1, 2, 3]      a row (explicit commas)
+#   [1 2; 3 4]     two rows (`;` or a newline separates rows; the lexer keeps
+#                  bracket-interior newlines for exactly this)
+#   { … }          a cell array, same shape
+#
+# Inherited near-verbatim from matlab.grammar (MA10 §3: "matrix literals,
+# ranges, and indexing are inherited almost unchanged") — the identical rule
+# MA10 §1's closing paragraph confirms Scilab keeps
+# (help.scilab.org/docs/2026.1.0/en_US/matrices.html states the same
+# space/comma-separates-columns, semicolon/newline-separates-rows rule
+# verbatim). No substitution is needed here at all; the ONE substitution
+# this grammar makes anywhere in the matrix/range/indexing surface is `$`
+# replacing `end`, already handled at `primary` above, not here.
+# ============================================================================
+
+matrix_literal = LBRACKET [ matrix_rows ] RBRACKET ;
+cell_literal = LBRACE [ matrix_rows ] RBRACE ;
+
+matrix_rows = matrix_row { row_sep matrix_row } [ row_sep ] ;
+row_sep = SEMICOLON | NEWLINE ;
+matrix_row = expr { [ COMMA ] expr } ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -271,6 +271,7 @@ members = [
     "maple-repl",
     "maple-to-semantic-ir",
     "scilab-lexer",
+    "scilab-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/scilab-parser/BUILD
+++ b/code/packages/rust/scilab-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-scilab-parser -- --nocapture

--- a/code/packages/rust/scilab-parser/BUILD_windows
+++ b/code/packages/rust/scilab-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-scilab-parser -- --nocapture

--- a/code/packages/rust/scilab-parser/CHANGELOG.md
+++ b/code/packages/rust/scilab-parser/CHANGELOG.md
@@ -1,0 +1,125 @@
+# Changelog
+
+## [0.1.0] - 2026-07-20
+
+### Added
+
+- Initial grammar-driven Rust Scilab parser (MA10 §6, task MA-10c).
+- `code/grammars/scilab/scilab.grammar`, forked from
+  `code/grammars/matlab/matlab.grammar` at the grammar-source level (copied,
+  then diverged) — this crate does not depend on `matlab-parser` (MA10 §5).
+  Matrix literals, ranges, and indexing are inherited near-verbatim; the
+  12-tier operator-precedence cascade (MA10 §3) is confirmed tier-for-tier
+  identical in relative order to MATLAB's own cascade.
+- Three parser-level divergences from `matlab.grammar` (MA10 §3):
+  1. `stmt_sep = "then" | "do" | COMMA | NEWLINE ;` — one new production,
+     reused at exactly six header sites (`if`, `elseif`, `select`, `case`,
+     `while`, `for`), each individually replaceable by a bare comma or
+     newline instead of the linker keyword. Modeled as a single
+     REQUIRED-but-flexible separator (not two optional pieces stacked),
+     since real Scilab's `then`/`do` replace the punctuation rather than
+     requiring it in addition.
+  2. `endfunction` kept as its own distinct closing production
+     (`func_def`'s only closer), textually separate from the generic `end`
+     `if_stmt`/`while_stmt`/`for_stmt`/`select_stmt` all reduce to (MA10 §1
+     finding 7) — a bare `end` cannot close a function by construction.
+  3. `$` (`DOLLAR`) replaces MATLAB's context-sensitive `end`-as-last-index
+     retagging hook entirely — added as an ordinary `primary` alternative
+     (the same tier as `NUMBER`/`NAME`), so `A($)`, `A($-1)`, and a bare `$`
+     all parse as an ordinary atom composing with arithmetic. `PERCENT_CONST`
+     (the eight `%`-prefixed special constants) is added at the identical
+     tier for the identical reason.
+- `select_stmt`/`case_clause` — Scilab's own multi-way conditional, replacing
+  MATLAB's `switch`/`otherwise` entirely (neither spelling exists in
+  `scilab.tokens`, MA10 §1 finding 4): `select expr stmt_sep { case_clause }
+  [ else_clause ] "end"`, `case_clause = "case" expr stmt_sep block_body`.
+  `select` shares the same `else_clause` production `if_stmt` uses.
+- No `try`/`catch`/`return`/`global`/`persistent`/lambda productions at all —
+  none of those tokens exist in `scilab.tokens` (MA10 §4 scopes them out).
+- A KNOWN, EXPECTED `grammar-tools validate` cross-check false positive:
+  `primary`'s `STRING` reference is reported as undefined because
+  `scilab.tokens` deliberately leaves `DQ_STRING` un-aliased (so its own
+  `collapse_dq_string_escapes` post-hook can tell the difference between "not
+  yet decoded" and "already STRING") — unlike `matlab.tokens`, which declares
+  `-> STRING` and registers the name statically. Both `STRING_PLACEHOLDER`-
+  and `DQ_STRING`-derived tokens are relabelled to `type_name = "STRING"` by
+  `scilab-lexer`'s own post-tokenize hooks before parsing begins, and
+  `GrammarParser::match_token_reference` matches purely on live `type_name`,
+  so `STRING` here is functionally correct despite the static validator's
+  false positive — documented at length in `scilab.grammar`'s own header
+  comment and this crate's own README rather than silently worked around
+  (fixing it at the source would require modifying the already-merged
+  `scilab.tokens`, out of scope for this PR).
+- A bespoke `MAX_RULE_DEPTH = 125` recursion-depth cap. Seven structurally
+  distinct self-referential shapes were measured independently
+  (parenthesised nesting, a flat right-recursive power (`^`) chain, a unary
+  prefix chain (`- - - … x` / `~ ~ ~ … x`), chained assignment
+  (`x=x=x=…=5`), deeply nested `if`/`end`, function-call/cell-index argument
+  nesting (`f(f(f(…)))`), and matrix-literal nesting), per MA10 §6's own
+  directive and the "measure, don't assume one shape's floor bounds the
+  others" methodology `apl-parser`/`j-parser`/`maple-parser` each
+  independently established — reinforced here by a security-review round
+  that caught two shapes (chained assignment, argument nesting) and a third
+  acknowledged-but-unmeasured shape (unary prefix) missing from the initial
+  four-shape survey. `select`/`end` shares the identical `statement ->
+  if_stmt` reachability as nested `if`, cell-index nesting shares
+  call-argument nesting's identical `arg_list`-mediated reachability, and
+  cell-literal nesting shares matrix-literal's identical shape, so none of
+  those three were separately measured (a provable rule-graph identity, not
+  an assumed shape resemblance). Every "flat chain of one operator"
+  production written with EBNF `{ x }` repetition costs zero native stack
+  regardless of width, confirmed by reading `parser::grammar_parser`'s own
+  `Repetition` implementation directly.
+- A genuine surprise once each shape's *nesting-count* crash floor was
+  converted into *rule-frame* terms (the units `MAX_RULE_DEPTH` actually
+  bounds): chained assignment tolerates far more nesting levels than the
+  power chain (162 vs. 101) yet has the *lower* rule-frame floor (179 safe /
+  180 crash, vs. 220/221) — each assignment link's persisting per-level cost
+  is a single rule-frame, cheaper in frame-count terms than every other
+  measured shape, yet its specific self-referential call path evidently
+  costs more native-stack bytes per crossing. Neither "the shape that
+  tolerates the fewest levels must bind" nor "parenthesised nesting binds,
+  since it does for nearly every sibling `*-parser` crate in this repo"
+  holds here — both would have shipped a cap unsafe specifically for chained
+  assignment. `125` sits about 30.2% below the binding 179 floor (comparable
+  to `reduce-parser`'s ~28.5%, `apl-parser`'s ~26.5%, `j-parser`'s ~30%,
+  `derive-parser`'s ~33%, `maple-parser`'s ~31.2%), and therefore safely
+  below all six other rule-frame floors (295, 220, 268, 289, 277, 219) too.
+  Full measurement tables and reasoning in `MAX_RULE_DEPTH`'s own doc comment
+  (`src/lib.rs`). Known, disclosed limitation: `while`/`for`/nested-`function`
+  bodies form the same `statement`-cycle shape as nested `if` (measured floor
+  268) but were not independently measured — they are structurally closer to
+  that shape than to the ones that turned out to diverge (chained assignment,
+  unary prefix), and 125 sits 143+ units below 268, so risk is assessed as
+  low, but this is a completeness gap for a future audit to close rather than
+  a claim of exhaustive coverage.
+- 55 tests + 1 doctest covering: every control-flow construct with and
+  without its linker keyword (`if`/`elseif`/`else`/`end`,
+  `select`/`case`/`else`/`end`, `while`/`end`, `for`/`end`), confirming a
+  bare comma/newline alone (no linker keyword at all) is also valid at every
+  one of the six `stmt_sep` sites; `function ... endfunction` (multiple
+  return values, no return value, no parameters at all, and a regression
+  confirming a bare `end` does NOT close a function); `switch`/`otherwise`
+  confirmed to remain ordinary syntax errors (Scilab has neither spelling);
+  the full precedence cascade (one test per tier boundary, from
+  `additive`/`multiplicative` up through `logical_or` being loosest, `unary`
+  binding looser than `power`, right-associative `power`, and postfix
+  transpose binding tightest); `$` as an ordinary expression atom (`A($)`,
+  `A($-1)` composing with `additive`, a bare `$` as a legal statement, and
+  `$` composing with a following transpose); `PERCENT_CONST` as a primary
+  (all eight constants); both not-equal spellings (`~=`/`<>`) reaching the
+  same `comparison` tier; matrix/cell literals and ranges (inherited,
+  confirmed still correct); and 4 depth-guard tests exercising all four
+  measured shapes at once (deep adversarial input on an enlarged-stack
+  thread returns a clean error for every shape, the cap trips before the
+  native stack would overflow even on a default-stack thread for every
+  shape, reasonable hand-written nesting for every shape stays well under
+  the cap, and an exact boundary test proving the measured real-input
+  headroom for every shape parses cleanly one level below the cap and trips
+  cleanly one level at the cap).
+- `code/grammars/scilab/scilab.grammar` validated with
+  `grammar-tools validate-grammar` (44 rules, clean) and cross-validated
+  against `code/grammars/scilab/scilab.tokens` with `grammar-tools validate`
+  (one known, expected, documented false positive on `STRING` — see above —
+  and two consequent "unused token" warnings for `STRING_PLACEHOLDER`/
+  `DQ_STRING`, which the grammar correctly never references directly).

--- a/code/packages/rust/scilab-parser/Cargo.toml
+++ b/code/packages/rust/scilab-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-scilab-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for the Scilab numerical/array frontend (MA10 MA-10c)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-scilab-lexer = { path = "../scilab-lexer" }

--- a/code/packages/rust/scilab-parser/README.md
+++ b/code/packages/rust/scilab-parser/README.md
@@ -1,0 +1,175 @@
+# coding-adventures-scilab-parser
+
+Scilab parser backed by `code/grammars/scilab/scilab.grammar`, compiled to
+Rust and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Where this fits
+
+This is the second crate of Scilab's frontend — MA-10c from
+[`MA10-scilab-language.md`](../../../specs/MA10-scilab-language.md), the spec
+that first established *why* Scilab needs its own frontend at all rather than
+a thin MATLAB-rewrite shim the way `octave-runtime` is (MA10 §1). The crate
+layout mirrors MA10 §6's rollout: `scilab-lexer` (MA-10b) → `scilab-parser`
+(this crate, MA-10c) → `scilab-runtime`/`scilab-repl` (MA-10d) →
+`scilab-to-semantic-ir` (MA-10e).
+
+`scilab.grammar` is **forked from** `code/grammars/matlab/matlab.grammar` at
+the grammar-**source** level (copied, then diverged) — this crate does
+**not** depend on `matlab-parser` at build time (MA10 §5). The grammar
+*shape* (matrix literals, ranges, the operator-precedence cascade, indexing)
+is a legitimate MATLAB-family inheritance; the *language* is not, which is
+why the fork happens at the text level rather than the Rust-crate level.
+
+## Scope
+
+Covers the MA10 §4-scoped first cut: dense-matrix arithmetic, matrix literals
+and ranges, comparisons (both not-equal spellings), logical operators,
+`$`-based last-index indexing, assignment, `if/elseif/else/end` and
+`select/case/else/end` (each with the optional `then` linker),
+`while/end`/`for/end` (each with the optional `do` linker), `break`/
+`continue`, `function ... endfunction`, and the eight `%`-prefixed special
+constants and single-/double-quoted strings as ordinary expression atoms.
+
+## Three things that are genuinely NOT MATLAB (MA10 §3)
+
+### 1. `stmt_sep` — one new production, reused at six header sites
+
+`if`/`elseif`/`select`/`case` take an optional `then` linker; `while`/`for`
+take an optional `do` linker — every one of the six is, per MA10 §1 finding
+4, individually replaceable by a bare comma or a newline. help.scilab.org's
+own wording ("can be replaced by a carriage return or a comma") is read as
+the linker keyword and the punctuation being ALTERNATIVES to each other, not
+two pieces stacked — real Scilab accepts `if x then y = 1, end` with nothing
+at all between `then` and `y`. So this collapses to one required (not
+optional), four-spelling production, reused at all six sites:
+
+```
+stmt_sep = "then" | "do" | COMMA | NEWLINE ;
+```
+
+mirroring the "one new rule, reused at multiple sites" shape J's own
+`verb_train` production takes (MA06 §3) or APL's reduce/scan operator
+productions. A deliberate, disclosed simplification: `stmt_sep` accepts
+*both* `then` and `do` uniformly at all six sites, rather than restricting
+which linker is idiomatic at which site — narrowing that would need six
+distinct nonterminals in place of one shared rule, and MA10 §3 states which
+spelling is idiomatic, not that the other is a syntax error there.
+
+### 2. `endfunction` is its own closing production, not unified with `end`
+
+Real Scilab's historical/still-preferred function terminator is
+`endfunction` (MA10 §1 finding 7) — `func_def` is the ONLY production in
+this grammar that ever matches the `endfunction` token, and no production
+anywhere lets a bare generic `"end"` close a function. `function ... end`
+(using the wrong closer) is therefore a **syntax error by construction**, not
+a discouraged style — confirmed by this crate's own
+`endfunction_is_required_not_generic_end` test.
+
+### 3. `$` replaces MATLAB's context-sensitive `end`-as-last-index trick
+
+MATLAB's `end`-as-last-index is context-**sensitive** — `matlab-parser`'s own
+pre-parse hook must retag every bracket-interior `end` to a `NAME` before its
+grammar ever runs (see `matlab.grammar`'s own header comment). Scilab's `$`
+needs **none** of that: `scilab-lexer` already lexes `$` as its own
+always-unambiguous `DOLLAR` token in every position, so this grammar simply
+adds `DOLLAR` as an ordinary `primary` alternative — the same tier as
+`NUMBER`/`NAME` — which is exactly what makes `A($-1)` parse at all (`$` must
+be usable as an ordinary operand to `additive`'s `MINUS`, the same way a
+`NUMBER` can). `PERCENT_CONST` (the eight `%`-prefixed special constants) is
+added at the identical tier for the identical reason.
+
+## No `switch`/`otherwise`/`try`/`catch`/`return`/`global`/`persistent`/`lambda`
+
+None of these tokens exist in `scilab.tokens` at all (MA10 §4 scopes them
+out) — Scilab's own multi-way conditional is `select`/`case`/`else` (MA10 §1
+finding 4), not `switch`/`otherwise`, so this grammar references neither
+spelling anywhere.
+
+## A known, expected `grammar-tools validate` false positive
+
+`primary`'s `STRING` reference is flagged by the cross-validator ("Grammar
+references token 'STRING' which is not defined in the tokens file") because
+`scilab.tokens` *deliberately* leaves `DQ_STRING` un-aliased (so its own
+`collapse_dq_string_escapes` post-hook can tell "still needs `""` collapsed"
+apart from "already decoded") — unlike `matlab.tokens`, which declares
+`DQ_STRING = ... -> STRING` and so registers "STRING" as a statically known
+name. Both `STRING_PLACEHOLDER`- and `DQ_STRING`-derived tokens are
+relabelled to `type_name = "STRING"` by `scilab-lexer`'s own post-tokenize
+hooks *before* any token reaches this grammar, and
+`parser::grammar_parser::GrammarParser`'s own `match_token_reference`
+matches purely on a token's live `type_name` — so `STRING` here is
+functionally correct at parse time regardless of what the static validator
+can prove. Fixing the false positive at the source would require modifying
+`scilab.tokens`, which this crate does not touch (MA-10b is already merged).
+See `scilab.grammar`'s own header comment for the full explanation.
+
+## Recursion-depth guard: seven shapes, measured independently
+
+`scilab.grammar` has seven structurally distinct self-referential recursion
+shapes — parenthesised nesting, a flat right-recursive power (`^`) chain, a
+unary prefix chain (`- - - … x` / `~ ~ ~ … x`), chained assignment
+(`x=x=x=…=5`), deeply nested `if`/`end` (`select`/`end` shares the identical
+`statement -> if_stmt` reachability, so it was not separately measured — a
+provable identity, not an assumed shape resemblance), function-call/cell-index
+argument nesting (`f(f(f(…)))`; cell-index nesting shares the identical
+`arg_list`-mediated reachability, so it was not separately measured either),
+and matrix-literal nesting (structurally distinct from parenthesised nesting:
+`matrix_literal` reaches `expr` through two extra rule-frames, `matrix_rows`
+then `matrix_row`, that `group` does not pay; cell-literal nesting shares this
+identical shape) — each measured independently (binary search, uncapped
+parser, default-stack worker thread, debug build, one fresh subprocess per
+data point), per [MA10](../../../specs/MA10-scilab-language.md) §6's own
+directive and the "measure, don't assume one shape's floor bounds the others"
+methodology `apl-parser`/`j-parser`/`maple-parser` each independently
+established — the initial four-shape survey missed chained assignment and
+argument nesting entirely and only reasoned about (rather than measured) the
+unary prefix chain, a gap a security-review pass caught and closed.
+
+The genuine surprise (mirroring `maple-parser`'s own): converting each
+shape's *nesting-count* crash floor into *rule-frame* terms (the units
+`MAX_RULE_DEPTH` actually bounds) shows chained assignment — which tolerates
+far more nesting levels (162) than parenthesised nesting (18), nested `if`
+(62), or matrix literals (15) — has the *lowest* rule-frame floor (179),
+lower even than the power chain's 220, despite the power chain crashing at
+far fewer levels (101). Neither "the shape that tolerates the fewest levels
+must bind" (matrix literals, wrong here) nor "parenthesised nesting binds,
+since it does for nearly every sibling `*-parser` crate in this repo" (also
+wrong — parens has a higher rule-frame floor, 295, than chained assignment
+here) holds in general. `MAX_RULE_DEPTH = 125` sits about 30.2% below the
+binding 179 floor, safely below all six other floors (295, 220, 268, 289,
+277, 219) too. Full measurement tables and reasoning in `MAX_RULE_DEPTH`'s
+own doc comment (`src/lib.rs`).
+
+**Known, disclosed limitation**: `while`/`for`/nested-`function` bodies form
+the same `statement`-cycle shape as nested `if` (measured floor 268) but were
+not independently measured — structurally closer to that shape than to the
+ones that turned out to diverge (chained assignment, unary prefix), and 125
+sits 143+ units below 268, so risk is assessed as low. This is a completeness
+gap for a future audit to close, not a claim of exhaustive coverage.
+
+## Usage
+
+```rust
+use coding_adventures_scilab_parser::parse_scilab;
+
+let ast = parse_scilab("x = %pi * 2\nif x > 0 then y = 1, end\n");
+assert_eq!(ast.rule_name, "program");
+```
+
+`parse_scilab` panics on a malformed source string; use `try_parse_scilab`
+for the `Result`-returning form, or `create_scilab_parser` directly if you
+need the raw `GrammarParser`.
+
+## Where this fits next
+
+`scilab-parser` is MA-10c of Scilab's frontend crates, consuming the token
+stream from `scilab-lexer` (MA-10b) against
+`code/grammars/scilab/scilab.grammar` to build the `GrammarASTNode` CST a
+future `scilab-runtime` (MA-10d, not yet started) will walk to evaluate over
+`array-runtime`'s `Array` value model plus a new `ScilabValue::{Num, Str}`
+enum (MA10 §2), and a future `scilab-to-semantic-ir` (MA-10e) will lower into
+[`SIR22`](../../../specs/SIR22-array-matrix-semantic-ir.md)'s array/matrix
+domain.

--- a/code/packages/rust/scilab-parser/required_capabilities.json
+++ b/code/packages/rust/scilab-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/scilab-parser",
+  "capabilities": [],
+  "justification": "Pure computation. The Scilab grammar is embedded as generated Rust code; tokenizing and parsing need no filesystem, network, or process access."
+}

--- a/code/packages/rust/scilab-parser/src/_grammar.rs
+++ b/code/packages/rust/scilab-parser/src/_grammar.rs
@@ -1,0 +1,494 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: scilab.grammar
+// Regenerate with: grammar-tools compile-grammar scilab.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
+            line_number: 95,
+        },
+        GrammarRule {
+            name: r#"statement_line"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"stmt_term"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"stmt_term"#.to_string() },
+            ] },
+            line_number: 100,
+        },
+        GrammarRule {
+            name: r#"stmt_term"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"SEMICOLON"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+            ] },
+            line_number: 104,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"func_def"#.to_string() },
+                GrammarElement::RuleReference { name: r#"if_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"select_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"for_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"while_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"break_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"continue_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 106,
+        },
+        GrammarRule {
+            name: r#"block_body"#.to_string(),
+            body: GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
+            line_number: 118,
+        },
+        GrammarRule {
+            name: r#"stmt_sep"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"then"#.to_string() },
+                GrammarElement::Literal { value: r#"do"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 149,
+        },
+        GrammarRule {
+            name: r#"if_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"if"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"stmt_sep"#.to_string() },
+                GrammarElement::RuleReference { name: r#"block_body"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"elseif_clause"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 168,
+        },
+        GrammarRule {
+            name: r#"elseif_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"elseif"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"stmt_sep"#.to_string() },
+                GrammarElement::RuleReference { name: r#"block_body"#.to_string() },
+            ] },
+            line_number: 169,
+        },
+        GrammarRule {
+            name: r#"else_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"else"#.to_string() },
+                GrammarElement::RuleReference { name: r#"block_body"#.to_string() },
+            ] },
+            line_number: 174,
+        },
+        GrammarRule {
+            name: r#"select_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"select"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"stmt_sep"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"case_clause"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 184,
+        },
+        GrammarRule {
+            name: r#"case_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"case"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"stmt_sep"#.to_string() },
+                GrammarElement::RuleReference { name: r#"block_body"#.to_string() },
+            ] },
+            line_number: 185,
+        },
+        GrammarRule {
+            name: r#"while_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"while"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"stmt_sep"#.to_string() },
+                GrammarElement::RuleReference { name: r#"block_body"#.to_string() },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 187,
+        },
+        GrammarRule {
+            name: r#"for_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"stmt_sep"#.to_string() },
+                GrammarElement::RuleReference { name: r#"block_body"#.to_string() },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 189,
+        },
+        GrammarRule {
+            name: r#"break_stmt"#.to_string(),
+            body: GrammarElement::Literal { value: r#"break"#.to_string() },
+            line_number: 191,
+        },
+        GrammarRule {
+            name: r#"continue_stmt"#.to_string(),
+            body: GrammarElement::Literal { value: r#"continue"#.to_string() },
+            line_number: 192,
+        },
+        GrammarRule {
+            name: r#"func_def"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"function"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"func_returns"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"name_list"#.to_string() }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"block_body"#.to_string() },
+                GrammarElement::Literal { value: r#"endfunction"#.to_string() },
+            ] },
+            line_number: 213,
+        },
+        GrammarRule {
+            name: r#"func_returns"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"name_list"#.to_string() }) },
+                    GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                ] },
+            ] },
+            line_number: 214,
+        },
+        GrammarRule {
+            name: r#"name_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 216,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+            line_number: 222,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 226,
+        },
+        GrammarRule {
+            name: r#"logical_or"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"OR_OR"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 228,
+        },
+        GrammarRule {
+            name: r#"logical_and"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"bit_or"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"AND_AND"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"bit_or"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 229,
+        },
+        GrammarRule {
+            name: r#"bit_or"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"bit_and"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"PIPE"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"bit_and"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 230,
+        },
+        GrammarRule {
+            name: r#"bit_and"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"AMP"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 231,
+        },
+        GrammarRule {
+            name: r#"comparison"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"colon_expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"EQ_EQ"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NE_ALT"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"colon_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 241,
+        },
+        GrammarRule {
+            name: r#"colon_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            ] }) },
+                    ] }) },
+            ] },
+            line_number: 246,
+        },
+        GrammarRule {
+            name: r#"additive"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 248,
+        },
+        GrammarRule {
+            name: r#"multiplicative"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"BACKSLASH"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"ELEM_MUL"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"ELEM_RDIV"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"ELEM_LDIV"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 254,
+        },
+        GrammarRule {
+            name: r#"unary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"TILDE"#.to_string() },
+                        ] }) },
+                    GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"power"#.to_string() },
+            ] },
+            line_number: 259,
+        },
+        GrammarRule {
+            name: r#"power"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"postfix"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"CARET"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"ELEM_POW"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 267,
+        },
+        GrammarRule {
+            name: r#"postfix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"primary"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"transpose_suffix"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"call_suffix"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"cell_suffix"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"field_suffix"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 273,
+        },
+        GrammarRule {
+            name: r#"transpose_suffix"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"TRANSPOSE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ELEM_TRANSPOSE"#.to_string() },
+            ] },
+            line_number: 275,
+        },
+        GrammarRule {
+            name: r#"call_suffix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arg_list"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 276,
+        },
+        GrammarRule {
+            name: r#"cell_suffix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arg_list"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 277,
+        },
+        GrammarRule {
+            name: r#"field_suffix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 278,
+        },
+        GrammarRule {
+            name: r#"arg_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"arg"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"arg"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 285,
+        },
+        GrammarRule {
+            name: r#"arg"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 286,
+        },
+        GrammarRule {
+            name: r#"primary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::TokenReference { name: r#"PERCENT_CONST"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOLLAR"#.to_string() },
+                GrammarElement::RuleReference { name: r#"matrix_literal"#.to_string() },
+                GrammarElement::RuleReference { name: r#"cell_literal"#.to_string() },
+                GrammarElement::RuleReference { name: r#"group"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 317,
+        },
+        GrammarRule {
+            name: r#"group"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 326,
+        },
+        GrammarRule {
+            name: r#"matrix_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"matrix_rows"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 349,
+        },
+        GrammarRule {
+            name: r#"cell_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"matrix_rows"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 350,
+        },
+        GrammarRule {
+            name: r#"matrix_rows"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"matrix_row"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"row_sep"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"matrix_row"#.to_string() },
+                    ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"row_sep"#.to_string() }) },
+            ] },
+            line_number: 352,
+        },
+        GrammarRule {
+            name: r#"row_sep"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"SEMICOLON"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 353,
+        },
+        GrammarRule {
+            name: r#"matrix_row"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"COMMA"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 354,
+        },
+    ],
+        version: 0,
+    }
+}

--- a/code/packages/rust/scilab-parser/src/lib.rs
+++ b/code/packages/rust/scilab-parser/src/lib.rs
@@ -1,0 +1,910 @@
+//! # Scilab Parser — building a syntax tree for Scilab (a subset).
+//!
+//! Turns the token stream from [`coding_adventures_scilab_lexer`] into a
+//! parse tree using the generic
+//! [`GrammarParser`](parser::grammar_parser::GrammarParser), driven by the
+//! embedded `scilab.grammar` (`src/_grammar.rs`). It hand-writes no parsing
+//! logic — a sibling of `maple-parser`/`matlab-parser`/`j-parser`. See
+//! `code/specs/MA10-scilab-language.md` (MA-10c).
+//!
+//! `scilab.grammar` is **forked from** `code/grammars/matlab/matlab.grammar`
+//! at the grammar-**source** level (copied, then diverged) — this crate does
+//! **not** depend on `matlab-parser` at build time (MA10 §5). The *shape* of
+//! MATLAB's grammar (matrix literals, ranges, the operator-precedence
+//! cascade, indexing) is a legitimate inheritance; three things genuinely are
+//! not MATLAB (MA10 §3 "Parser differences"), each documented at its own
+//! production in `scilab.grammar`:
+//!
+//! 1. `stmt_sep` — one new, reused production for the optional `then`/`do`
+//!    linker keyword at six header sites (`if`/`elseif`/`select`/`case`/
+//!    `while`/`for`), each individually replaceable by a bare comma or
+//!    newline instead.
+//! 2. `endfunction` is `func_def`'s own distinct closing keyword, never
+//!    unified with the generic `end` every other block construct closes
+//!    with (MA10 §1 finding 7).
+//! 3. `$` (`DOLLAR`) replaces MATLAB's context-sensitive `end`-as-last-index
+//!    trick with an ordinary, always-unambiguous `primary` alternative —
+//!    `scilab-parser` needs no pre-parse retagging hook at all, unlike
+//!    `matlab-parser`.
+//!
+//! ```text
+//! Scilab source
+//!    |
+//!    v
+//! coding_adventures_scilab_lexer::tokenize_scilab  ->  Vec<Token>
+//!    |
+//!    v
+//! parser::GrammarParser  (driven by the embedded scilab.grammar)
+//!    |
+//!    v
+//! GrammarASTNode  <- the tree a future scilab-runtime (MA-10d) walks
+//! ```
+
+use coding_adventures_scilab_lexer::{tokenize_scilab, try_tokenize_scilab};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+mod _grammar;
+
+/// Recursion-depth cap for the Scilab [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own `Result`-returning entry points ever get a chance to report
+/// anything).
+///
+/// # Seven recursion shapes, measured independently, per MA10 §6's directive
+///
+/// MA10 §6 (task MA-10c) requires measuring **this** grammar's own actual
+/// native-stack crash floor rather than assuming a sibling `*-parser`
+/// crate's numbers transfer — following the "measure, don't assume one
+/// shape's floor bounds the others" methodology `apl-parser`/`j-parser`'s
+/// own `CHANGELOG.md`s document, and the same six/five/four-shape survey
+/// `maple-parser`'s own `MAX_RULE_DEPTH` doc comment performs for Maple.
+/// `scilab.grammar` has (at least) seven structurally distinct
+/// self-referential shapes. The first four were measured when this constant
+/// was first introduced; shapes 5–7 close a gap a later security review
+/// flagged — `scilab.grammar`'s own header comment names `assignment` and
+/// `power` as the ONLY two "optional self-recursion" (`[ ... self ]`)
+/// productions in the whole file, yet only `power` had been measured, and
+/// two more genuinely distinct self-referential shapes (function/cell-index
+/// argument nesting, and the unary prefix chain this doc comment already
+/// *acknowledged* but never actually measured) were still open:
+///
+/// 1. **Parenthesised nesting**, `((((…5…))))` — `group -> expr ->
+///    assignment -> logical_or -> logical_and -> bit_or -> bit_and ->
+///    comparison -> colon_expr -> additive -> multiplicative -> unary ->
+///    power -> postfix -> primary -> group -> …` — cycles through the
+///    *entire* expression precedence cascade every nesting level (fifteen
+///    rule-frames: `group`, `expr`, `assignment`, `logical_or`,
+///    `logical_and`, `bit_or`, `bit_and`, `comparison`, `colon_expr`,
+///    `additive`, `multiplicative`, `unary`, `power`, `postfix`, `primary`,
+///    before the next `group`).
+/// 2. **A flat right-recursive dyadic chain**: the power operator, `1^1^1^
+///    … ^1` — chosen as the representative "flat chain" shape over a unary
+///    prefix chain (`- - - x` / `~ ~ ~ x`) because `power`'s own `[ ( CARET |
+///    ELEM_POW ) unary ]` continuation is the one production in this
+///    grammar that is genuinely *right-recursive through a dyadic operator*
+///    (cycling `power -> unary -> power -> …` once per `^`), matching the
+///    task brief's own suggested representative shape and mirroring
+///    `reduce-parser`/`maple-parser`'s identical choice of the power chain
+///    for this exact role — a prefix chain measures a different thing
+///    (repeated *unary* rule-frames, no dyadic operand on the right) and is
+///    not this grammar's most natural "flat chain" exemplar. (Shape 7 below
+///    measures that prefix chain too, for parity with `maple-parser`/
+///    `reduce-parser`, which measure both.)
+/// 3. **Deeply nested `if`/`end`**, `if 1 then if 1 then … 5 … end end` —
+///    `if_stmt`'s `block_body` is `{ statement_line }`, `statement_line`
+///    contains `statement`, and `statement`'s first alternative is
+///    `func_def | if_stmt | select_stmt | …`, so nesting an `if` inside its
+///    own body cycles `if_stmt -> block_body -> statement_line -> statement
+///    -> if_stmt -> …`. `select_stmt` shares the identical
+///    `statement -> if_stmt`-shaped reachability (`select_stmt`'s own
+///    `case_clause`'s `block_body` reaches `statement` exactly the same
+///    way), so nested `select`/`end` was not separately measured — confirmed
+///    by direct inspection of the rule graph (both `if_stmt`'s and
+///    `case_clause`'s bodies are the identical `block_body` production), not
+///    assumed by shape resemblance.
+///
+///    **Known, disclosed limitation**: `while_stmt`/`for_stmt`/`func_def`
+///    each also contain `block_body` directly (not through an extra
+///    `case_clause`-shaped wrapper the way `select_stmt` does) and so form
+///    the *same* `statement -> {while_stmt|for_stmt|func_def} -> block_body
+///    -> statement_line -> statement -> …` cycle nested `if` does — but,
+///    unlike `select_stmt`, this was not independently confirmed by a
+///    dedicated measurement, only by this same rule-graph argument. Given
+///    this file's own data shows near-identical per-level rule-frame cost
+///    does NOT reliably predict a shape's true native-stack floor (chained
+///    assignment's 179 vs. the unary-prefix chain's 219, despite both
+///    costing one persisting rule-frame per level — see shape 7 and the
+///    table below), treat this identity claim with appropriately less
+///    confidence than the measured shapes. Practical risk is assessed as
+///    low: these three are structurally closer to nested-`if` (rule-frame
+///    floor 268, comfortably above `MAX_RULE_DEPTH`) than to the two shapes
+///    that turned out to diverge, and 125 sits 143+ units below 268 — but a
+///    future audit should actually measure `while 1 do while 1 do … end
+///    end`, the analogous `for`, and nested `function … endfunction` rather
+///    than rely on this argument alone.
+/// 4. **Matrix-literal nesting**, `[[[[…5…]]]]` — structurally DISTINCT
+///    from parenthesised nesting, confirmed by direct inspection of the rule
+///    graph: `group = LPAREN expr RPAREN` wraps `expr` directly (zero extra
+///    frames), but `matrix_literal = LBRACKET [ matrix_rows ] RBRACKET`
+///    reaches `expr` through TWO extra rule-frames (`matrix_rows` then
+///    `matrix_row`) before an inner `expr` is reached — the same
+///    "one extra rule-frame per level" gap `maple-parser`'s own
+///    `list_literal` (via `arglist`) has relative to its `group`, doubled
+///    here since `matrix_literal` interposes two wrapper rules
+///    (`matrix_rows`, `matrix_row`) rather than one.
+/// 5. **Chained assignment**, `x=x=x=…=x` — `assignment`'s own `[ EQ
+///    assignment ]` continuation, the OTHER "optional self-recursion"
+///    production `scilab.grammar`'s header comment names alongside `power`.
+///    Unlike every shape above, `assignment`'s persisting per-level cost is
+///    exactly ONE rule-frame (`assignment` itself): its `logical_or`
+///    left-hand side dives through the entire twelve-frame cascade down to
+///    `primary` and back on every level, but that dive is a transient
+///    sibling call that fully returns *before* `[ EQ assignment ]` recurses,
+///    so it never accumulates — the same "primary returns before the next
+///    call, so it doesn't persist" shape `postfix`'s own suffix-repetition
+///    loop has (see shape 6). This is why chained assignment tolerates far
+///    more nesting than parens, nested-`if`, or matrix literals (see the
+///    nesting-count table below) despite being genuinely self-recursive.
+/// 6. **Nested function-call arguments**, `f(f(f(…5…)))` — `postfix`'s own
+///    suffix-repetition loop calls `primary` (matches the `NAME`, returns
+///    immediately — transient, does not persist) and then, on seeing
+///    `LPAREN`, `call_suffix -> arg_list -> arg -> expr -> …` down the full
+///    twelve-frame cascade and back into a NEW `postfix` invocation.
+///    Structurally distinct from every shape above — it re-enters `postfix`
+///    through a *suffix* repetition, not through `primary`'s own alternation
+///    the way `group`/`matrix_literal` do — and, like matrix-literal
+///    nesting, interposes THREE wrapper rule-frames per level
+///    (`call_suffix`, `arg_list`, `arg`) instead of `group`'s one, so its
+///    per-level rule-frame cost (see the ratio check below) lands close to
+///    matrix-literal nesting's own. `cell_suffix = LBRACE [ arg_list ]
+///    RBRACE` reaches `arg_list` the identical way (`A{A{A{…}}}` would cycle
+///    through the exact same `postfix -> cell_suffix -> arg_list -> arg ->
+///    expr -> … -> postfix` path), so nested cell-indexing was not
+///    separately measured — the same "identical reachability, confirmed by
+///    direct inspection, not assumed by shape resemblance" reasoning shape 3
+///    above already applies to `select_stmt`/`if_stmt`.
+/// 7. **A unary prefix chain**, `- - - … 5` (or `~ ~ ~ … 5`) — `unary`'s own
+///    `( PLUS | MINUS | TILDE ) unary` self-reference, ACKNOWLEDGED but never
+///    actually measured when this doc comment first justified picking the
+///    power chain as "the" representative flat-chain shape (see shape 2).
+///    `maple-parser`/`reduce-parser` measure both their power chain AND a
+///    unary/`not` prefix chain separately, and found the two can have very
+///    different rule-frame floors despite superficially similar "flat
+///    chain" shapes; measuring it here closes that parity gap. Like chained
+///    assignment (shape 5), `unary`'s persisting per-level cost is exactly
+///    ONE rule-frame (`unary` itself) — its base case, `power = postfix [
+///    ( CARET | ELEM_POW ) unary ]`, is a much SHALLOWER transient dive
+///    (`power -> postfix -> primary`, three frames) than assignment's own
+///    twelve-frame `logical_or` dive, which is why it tolerates even more
+///    nesting than chained assignment (202 vs. 162 — see the nesting-count
+///    table below) yet still binds at a meaningfully lower rule-frame floor
+///    than parens/nested-`if`/matrix-literal nesting (see the rule-frame
+///    table below).
+///
+/// Every "flat chain of one operator" production written with EBNF `{ x }`
+/// repetition (`logical_or`, `logical_and`, `bit_or`, `bit_and`,
+/// `comparison`, `additive`, `multiplicative`, `{ elseif_clause }`,
+/// `{ case_clause }`, `arg_list`, `name_list`, `matrix_rows`) costs *zero*
+/// native stack regardless of width — confirmed directly by reading
+/// [`parser::grammar_parser`]'s own `match_element` implementation (the
+/// `Repetition` arm is a plain `loop { ... }` where each iteration's
+/// `match_element` call returns before the next iteration begins, so the
+/// *native* call stack never grows with iteration count), the same
+/// engine-level fact every sibling `*-parser` crate's own `MAX_RULE_DEPTH`
+/// doc comment already establishes — not re-measured by a throwaway probe
+/// here, since it is a fact about the shared engine, not about this one
+/// grammar.
+///
+/// Measured with the same methodology every sibling `*-parser` crate uses:
+/// binary search, an *uncapped* `GrammarParser` (`max_depth = usize::MAX`,
+/// [`GrammarParser::new`]'s own default), a `std::thread::spawn` worker with
+/// the **default ~2 MiB stack** (no `stack_size` override), one fresh
+/// **subprocess per data point** (a real native-stack overflow calls
+/// `process::abort()`, which kills the whole process, not just the
+/// offending thread — an in-process loop cannot survive past the first
+/// crash to report a clean number), in a **debug** build (`cargo test`'s own
+/// default, since debug frames are meaningfully larger than release frames).
+///
+/// Nesting-count floors (parses safely up to N, crashes at N+1):
+///
+/// | Shape | Nesting-count floor |
+/// |---|---|
+/// | Parenthesised nesting | 18 safe / 19 crash |
+/// | Power (`^`) chain | 101 safe / 102 crash |
+/// | Nested `if`/`end` | 62 safe / 63 crash |
+/// | Matrix-literal nesting | 15 safe / 16 crash |
+/// | Chained assignment | 162 safe / 163 crash |
+/// | Nested function-call arguments | 16 safe / 17 crash |
+/// | Unary prefix chain | 202 safe / 203 crash |
+///
+/// # The binding constraint is a rule-frame floor, not a nesting-count one
+///
+/// Exactly as every sibling `*-parser` crate's own doc comment warns, the
+/// *nesting-count* floors above do not by themselves say which shape binds
+/// `MAX_RULE_DEPTH` — `self.depth` counts *named-rule* invocations, and
+/// different shapes cost a different number of rule-frames per nesting
+/// level. Converting each measured nesting-count floor into rule-frame terms
+/// (binary search over `with_max_depth` against a fixed 5000-level input —
+/// 2000 for nested `if`, since each level costs more source text — of each
+/// shape, so the *cap itself* — not the input's own finite length — is
+/// always what triggers first; same default ~2 MiB stack, same debug build):
+///
+/// | Shape | Nesting-count floor | Rule-frame floor |
+/// |---|---|---|
+/// | Parenthesised nesting | 18 safe / 19 crash | 295 safe / 296 crash |
+/// | Power (`^`) chain | 101 safe / 102 crash | 220 safe / 221 crash |
+/// | Nested `if`/`end` | 62 safe / 63 crash | 268 safe / 269 crash |
+/// | Matrix-literal nesting | 15 safe / 16 crash | 289 safe / 290 crash |
+/// | Chained assignment | 162 safe / 163 crash | **179 safe / 180 crash** |
+/// | Nested function-call arguments | 16 safe / 17 crash | 277 safe / 278 crash |
+/// | Unary prefix chain | 202 safe / 203 crash | 219 safe / 220 crash |
+///
+/// The lowest rule-frame floor is chained assignment's **179** — genuinely
+/// the binding shape here (this changed when shapes 5–7 were added; before
+/// then, the power chain's 220 was the lowest of the four measured, and
+/// `MAX_RULE_DEPTH` was 150). It is not the shape with the fewest tolerated
+/// nesting levels (nested function calls, at 16/17), not the shape that
+/// binds for most sibling `*-parser` crates in this repo (parenthesised
+/// nesting), and not even the power chain — the previous holder of "lowest
+/// floor despite tolerating the most levels" among the original four.
+/// Chained assignment's *persistent* per-level cost is exactly ONE
+/// rule-frame (`assignment` itself — see shape 5's own reasoning above) —
+/// cheaper in rule-frame-*count* terms than every other shape here,
+/// including the power chain's two (`power`, `unary`) — yet it reaches the
+/// native ceiling at a *lower total rule-frame count* (179) than the power
+/// chain (220) despite tolerating *more* nesting levels to get there (162
+/// vs. 101). The unary prefix chain (shape 7) has the identical
+/// one-rule-frame-per-level persistent cost and tolerates even *more*
+/// nesting (202) than chained assignment, yet its own rule-frame floor
+/// (219) sits close to the power chain's (220) rather than near chained
+/// assignment's (179) — so the two "cheapest per-frame-count" shapes here
+/// do NOT share a rule-frame floor either, despite an identical persisting
+/// frame-per-level count. This reinforces, more sharply than the original
+/// four-shape survey could, the standing warning every sibling `*-parser`
+/// crate's own doc comment gives: neither "the shape that tolerates the
+/// fewest nesting levels must bind" (nested function calls, wrong here) nor
+/// "parenthesised nesting binds, since it does for nearly every sibling
+/// crate in this repo" (also wrong) nor even "the shape with the fewest
+/// rule-frames per level must have the highest floor" (wrong — chained
+/// assignment and the unary prefix chain tie on rule-frames-per-level yet
+/// differ by 40 in their own rule-frame floors) holds in general; each
+/// grammar's own recursive shapes must be measured, not inferred by
+/// analogy, and not even inferred from a same-grammar sibling shape that
+/// merely *looks* similar. The per-level rule-frame costs are independently
+/// consistent with the raw floor ratios (295 / 18 ≈ 16.4 for parens, close
+/// to its own fifteen-frame-per-level count; 220 / 101 ≈ 2.18 for power,
+/// close to its own two-frame-per-level count; 268 / 62 ≈ 4.32 for nested
+/// `if`, close to its own four-frame-per-level count; 289 / 15 ≈ 19.3 for
+/// matrix literals, close to its own seventeen-frame-per-level count; 179 /
+/// 162 ≈ 1.10 for chained assignment, close to its own one-frame-per-level
+/// count; 277 / 16 ≈ 17.3 for nested function calls, close to matrix
+/// literals' own seventeen-frame-per-level count — expected, since both
+/// interpose three wrapper rule-frames per level relative to `group`'s one;
+/// 219 / 202 ≈ 1.08 for the unary prefix chain, close to its own
+/// one-frame-per-level count — small discrepancies are the constant
+/// top-level wrapping overhead, e.g. `program`/`statement_line`, paid once
+/// regardless of nesting depth), a useful sanity check that the measurement
+/// is behaving as the rule-graph analysis predicts, not an artifact of
+/// measurement noise.
+///
+/// `MAX_RULE_DEPTH` is set to **125** — about 30.2% below the binding
+/// chained-assignment rule-frame floor of 179 (a comparable margin to
+/// `reduce-parser`'s own ~28.5%, `apl-parser`'s ~26.5%, `j-parser`'s ~30%,
+/// `derive-parser`'s ~33%, `maple-parser`'s ~31.2%), and therefore safely
+/// below the other six rule-frame floors (219, 220, 268, 277, 289, 295) as
+/// well. This is DOWN from the original **150**, which sat only ~16.2%
+/// below 179 — comfortably safe in absolute terms (150 < 179), but not
+/// enough margin to match this repo's own 25–33% convention once chained
+/// assignment's lower floor was known, so the constant moved rather than
+/// leaving a thinner safety margin than every sibling crate uses.
+///
+/// Measured real-input headroom at `125` (using the CAPPED parser, i.e.
+/// [`create_scilab_parser`]/[`try_parse_scilab`], so no crash risk at all):
+/// parenthesised nesting parses cleanly up to 7 levels (8 trips the cap); a
+/// power chain parses cleanly up to 53 levels (54 trips); nested `if`s parse
+/// cleanly up to 27 levels (28 trips); matrix-literal nesting parses cleanly
+/// up to 6 levels (7 trips); chained assignment parses cleanly up to 108
+/// levels (109 trips); nested function-call arguments parse cleanly up to 6
+/// levels (7 trips); a unary prefix chain parses cleanly up to 107 levels
+/// (108 trips) — all comfortably beyond anything a hand-written Scilab
+/// program needs, and all seven independently confirmed not to crash a
+/// default-stack thread even thousands of levels past the cap (see this
+/// crate's tests).
+const MAX_RULE_DEPTH: usize = 125;
+
+/// Build a [`GrammarParser`] wired to the Scilab grammar for the already-
+/// tokenized `tokens`, with the recursion-depth guard ([`MAX_RULE_DEPTH`])
+/// enabled. The ONE place that constructs a capped Scilab [`GrammarParser`] --
+/// [`create_scilab_parser`] and [`try_parse_scilab`] both funnel through
+/// this, so a future change to the cap (or to how the parser is wired up)
+/// can never miss one of the two call sites.
+fn capped_scilab_parser(tokens: Vec<lexer::token::Token>) -> GrammarParser {
+    GrammarParser::new(tokens, _grammar::parser_grammar()).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Create a [`GrammarParser`] wired to the Scilab grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+pub fn create_scilab_parser(source: &str) -> GrammarParser {
+    capped_scilab_parser(tokenize_scilab(source))
+}
+
+/// Parse Scilab source text into a [`GrammarASTNode`] rooted at `program`.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_scilab`] to handle
+/// errors.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_scilab_parser::parse_scilab;
+/// let ast = parse_scilab("x = 5\n");
+/// assert_eq!(ast.rule_name, "program");
+/// ```
+pub fn parse_scilab(source: &str) -> GrammarASTNode {
+    create_scilab_parser(source)
+        .parse()
+        .unwrap_or_else(|e| panic!("Scilab parse failed: {e}"))
+}
+
+/// Parse Scilab source text, returning a `Result` instead of panicking.
+pub fn try_parse_scilab(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_scilab(source)?;
+    capped_scilab_parser(tokens)
+        .parse()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        node.rule_name == name
+            || node.children.iter().any(|c| match c {
+                ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                ASTNodeOrToken::Token(_) => false,
+            })
+    }
+
+    fn parses(src: &str) -> bool {
+        try_parse_scilab(src).is_ok()
+    }
+
+    #[test]
+    fn program_is_the_root() {
+        assert_eq!(parse_scilab("x = 5\n").rule_name, "program");
+    }
+
+    // --- Assignment, terminators --------------------------------------
+
+    #[test]
+    fn assignment_with_semicolon_suppresses_nothing_structurally() {
+        // The grammar keeps whichever terminator was used (`;` vs newline/
+        // comma) in the tree; a future runtime decides display suppression.
+        assert!(parses("x = 5;\n"));
+        assert!(parses("x = 5\n"));
+        assert!(parses("x = 5,\n"));
+    }
+
+    #[test]
+    fn bare_trailing_statement_with_no_terminator_parses() {
+        assert!(parses("x = 5"));
+    }
+
+    // --- if/elseif/else/end, with and without `then` -------------------
+
+    #[test]
+    fn if_end_with_newline_separator_no_then() {
+        let ast = parse_scilab("if x\n y = 1\nend\n");
+        assert!(contains_rule(&ast, "if_stmt"));
+    }
+
+    #[test]
+    fn if_end_with_comma_separator_no_then() {
+        let ast = parse_scilab("if x, y = 1, end\n");
+        assert!(contains_rule(&ast, "if_stmt"));
+    }
+
+    #[test]
+    fn if_end_with_then_linker() {
+        let ast = parse_scilab("if x then y = 1, end\n");
+        assert!(contains_rule(&ast, "if_stmt"));
+    }
+
+    #[test]
+    fn if_then_with_no_trailing_separator_before_body() {
+        // MA10's own reading: `then` REPLACES the comma/newline, it does not
+        // require one in addition -- `then y = 1` with nothing at all
+        // between the keyword and the first body statement must parse.
+        assert!(parses("if x then y = 1\nend\n"));
+    }
+
+    #[test]
+    fn elseif_and_else_with_and_without_then() {
+        let ast = parse_scilab("if x then y = 1\nelseif z, y = 2\nelse y = 3\nend\n");
+        assert!(contains_rule(&ast, "elseif_clause"));
+        assert!(contains_rule(&ast, "else_clause"));
+    }
+
+    #[test]
+    fn bare_end_does_not_close_a_function() {
+        // `endfunction` is required to close a function -- a generic `end`
+        // must NOT close it (MA10 §1 finding 7 / §3). Here a bare `end`
+        // closes the `if`, leaving the function itself unclosed, so the
+        // whole thing must fail to parse.
+        assert!(try_parse_scilab("function y = f(x)\n if x then y = 1\n end\nend\n").is_err());
+    }
+
+    // --- select/case/else/end, with and without `then` -----------------
+
+    #[test]
+    fn select_case_else_end_with_then() {
+        let ast =
+            parse_scilab("select x\n case 1 then y = 1\n case 2 then y = 2\n else y = 0\n end\n");
+        assert!(contains_rule(&ast, "select_stmt"));
+        assert!(contains_rule(&ast, "case_clause"));
+        assert!(contains_rule(&ast, "else_clause"));
+    }
+
+    #[test]
+    fn select_case_else_end_with_comma_no_then() {
+        let ast = parse_scilab("select x, case 1, y = 1, case 2, y = 2, else y = 0, end\n");
+        assert!(contains_rule(&ast, "select_stmt"));
+        assert!(contains_rule(&ast, "case_clause"));
+    }
+
+    #[test]
+    fn select_header_itself_accepts_bare_newline_separator() {
+        assert!(parses("select x\ncase 1 then y = 1\nend\n"));
+    }
+
+    #[test]
+    fn switch_and_otherwise_are_not_valid_scilab_constructs() {
+        // Scilab has neither spelling (MA10 §1 finding 4) -- `switch`/
+        // `otherwise` are ordinary NAMEs to the lexer, so this is just two
+        // bare names juxtaposed with no operator, a syntax error.
+        assert!(try_parse_scilab("switch x\n otherwise y = 1\n end\n").is_err());
+    }
+
+    // --- while/end and for/end, with and without `do` ------------------
+
+    #[test]
+    fn while_end_with_do_linker() {
+        let ast = parse_scilab("while x do y = 1, end\n");
+        assert!(contains_rule(&ast, "while_stmt"));
+    }
+
+    #[test]
+    fn while_end_with_comma_no_do() {
+        assert!(parses("while x, y = 1, end\n"));
+    }
+
+    #[test]
+    fn while_end_with_newline_no_do() {
+        assert!(parses("while x\n y = 1\nend\n"));
+    }
+
+    #[test]
+    fn for_end_with_do_linker() {
+        let ast = parse_scilab("for i = 1:10 do y = i, end\n");
+        assert!(contains_rule(&ast, "for_stmt"));
+    }
+
+    #[test]
+    fn for_end_with_newline_no_do() {
+        assert!(parses("for i = 1:10\n y = i\nend\n"));
+    }
+
+    #[test]
+    fn break_and_continue_parse_inside_loops() {
+        assert!(parses("while x do break, end\n"));
+        assert!(parses("for i = 1:10 do continue, end\n"));
+    }
+
+    // --- function ... endfunction ---------------------------------------
+
+    #[test]
+    fn function_with_single_return_and_params() {
+        let ast = parse_scilab("function y = f(x)\n y = x * 2\nendfunction\n");
+        assert!(contains_rule(&ast, "func_def"));
+        assert!(contains_rule(&ast, "func_returns"));
+    }
+
+    #[test]
+    fn function_with_multiple_returns() {
+        let ast = parse_scilab("function [a, b] = f(x)\n a = x\n b = x\nendfunction\n");
+        assert!(contains_rule(&ast, "func_def"));
+    }
+
+    #[test]
+    fn function_with_no_return_value() {
+        assert!(parses("function f(x)\n disp(x)\nendfunction\n"));
+    }
+
+    #[test]
+    fn function_with_no_parameters_at_all() {
+        // Parens themselves are optional in this grammar -- unchanged
+        // inheritance from matlab.grammar's own `func_def` shape.
+        assert!(parses("function y = f()\n y = 1\nendfunction\n"));
+    }
+
+    #[test]
+    fn endfunction_is_required_not_generic_end() {
+        assert!(try_parse_scilab("function y = f(x)\n y = x\nend\n").is_err());
+        assert!(parses("function y = f(x)\n y = x\nendfunction\n"));
+    }
+
+    // --- Precedence cascade: one test per tier boundary -----------------
+
+    #[test]
+    fn additive_and_multiplicative_precedence() {
+        // a + b * c -> a + (b*c)
+        let ast = parse_scilab("r = a + b * c\n");
+        assert!(contains_rule(&ast, "additive"));
+        assert!(contains_rule(&ast, "multiplicative"));
+    }
+
+    #[test]
+    fn colon_binds_looser_than_additive() {
+        // a:b+1 -> a:(b+1)
+        let ast = parse_scilab("r = a:b+1\n");
+        assert!(contains_rule(&ast, "colon_expr"));
+        assert!(contains_rule(&ast, "additive"));
+    }
+
+    #[test]
+    fn comparison_binds_looser_than_colon() {
+        let ast = parse_scilab("r = a:b == c:d\n");
+        assert!(contains_rule(&ast, "comparison"));
+        assert!(contains_rule(&ast, "colon_expr"));
+    }
+
+    #[test]
+    fn bit_and_binds_looser_than_comparison() {
+        let ast = parse_scilab("r = a == b & c == d\n");
+        assert!(contains_rule(&ast, "bit_and"));
+        assert!(contains_rule(&ast, "comparison"));
+    }
+
+    #[test]
+    fn bit_or_binds_looser_than_bit_and() {
+        let ast = parse_scilab("r = a & b | c & d\n");
+        assert!(contains_rule(&ast, "bit_or"));
+        assert!(contains_rule(&ast, "bit_and"));
+    }
+
+    #[test]
+    fn logical_and_binds_looser_than_bit_or() {
+        let ast = parse_scilab("r = a | b && c | d\n");
+        assert!(contains_rule(&ast, "logical_and"));
+        assert!(contains_rule(&ast, "bit_or"));
+    }
+
+    #[test]
+    fn logical_or_is_loosest_of_all() {
+        let ast = parse_scilab("r = a && b || c && d\n");
+        assert!(contains_rule(&ast, "logical_or"));
+        assert!(contains_rule(&ast, "logical_and"));
+    }
+
+    #[test]
+    fn unary_binds_looser_than_power() {
+        // -x^2 -> -(x^2)
+        let ast = parse_scilab("r = -x^2\n");
+        assert!(contains_rule(&ast, "unary"));
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn power_is_right_associative_by_shape() {
+        assert!(parses("r = 2^3^2\n"));
+        let ast = parse_scilab("r = 2^3^2\n");
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn postfix_transpose_binds_tightest_of_the_operators() {
+        let ast = parse_scilab("r = A' * B\n");
+        assert!(contains_rule(&ast, "postfix"));
+        assert!(contains_rule(&ast, "transpose_suffix"));
+    }
+
+    #[test]
+    fn grouping_parens_parse() {
+        assert!(parses("r = (1 + 2) * 3\n"));
+        assert!(contains_rule(&parse_scilab("r = (1 + 2) * 3\n"), "group"));
+    }
+
+    #[test]
+    fn assignment_is_right_associative_and_loosest() {
+        // `=` binds looser than everything in the expression cascade.
+        let ast = parse_scilab("x = a + b\n");
+        assert!(contains_rule(&ast, "assignment"));
+        assert!(contains_rule(&ast, "additive"));
+    }
+
+    // --- `$` last-index atom ---------------------------------------------
+
+    #[test]
+    fn dollar_bare_index() {
+        let ast = parse_scilab("r = A($)\n");
+        assert!(contains_rule(&ast, "primary"));
+    }
+
+    #[test]
+    fn dollar_minus_one_composes_with_arithmetic() {
+        // A($-1) -- $ must behave as an ordinary primary/atom so it can be
+        // the left operand of `additive`'s MINUS.
+        let ast = parse_scilab("r = A($-1)\n");
+        assert!(contains_rule(&ast, "additive"));
+    }
+
+    #[test]
+    fn bare_dollar_is_a_legal_expression_on_its_own() {
+        // Not just reachable inside an index -- `$` is an ordinary primary,
+        // so a bare `$` statement parses too.
+        assert!(parses("$\n"));
+    }
+
+    #[test]
+    fn dollar_composes_with_transpose() {
+        // Mirrors scilab-lexer's own `last_index_dollar_is_a_value_before_transpose`
+        // lexer test -- `A($)'` must parse as an index followed by a transpose.
+        assert!(parses("r = A($)'\n"));
+    }
+
+    // --- `PERCENT_CONST` as a primary --------------------------------------
+
+    #[test]
+    fn percent_const_used_as_a_primary() {
+        let ast = parse_scilab("r = %pi * 2\n");
+        assert!(contains_rule(&ast, "primary"));
+        assert!(contains_rule(&ast, "multiplicative"));
+    }
+
+    #[test]
+    fn every_percent_constant_parses_as_a_bare_expression() {
+        for name in ["%pi", "%e", "%i", "%inf", "%nan", "%eps", "%t", "%f"] {
+            assert!(parses(&format!("{name}\n")), "{name} should parse");
+        }
+    }
+
+    // --- Both not-equal spellings, same tier -------------------------------
+
+    #[test]
+    fn both_not_equal_spellings_reach_the_comparison_tier() {
+        let tilde_eq = parse_scilab("r = a ~= b\n");
+        let angle_eq = parse_scilab("r = a <> b\n");
+        assert!(contains_rule(&tilde_eq, "comparison"));
+        assert!(contains_rule(&angle_eq, "comparison"));
+    }
+
+    #[test]
+    fn all_comparison_operators_parse() {
+        for op in ["==", "~=", "<>", "<", ">", "<=", ">="] {
+            let src = format!("r = a {op} b\n");
+            assert!(parses(&src), "`{src}` should parse");
+        }
+    }
+
+    // --- Matrix/cell literals and ranges (inherited, confirm correct) ----
+
+    #[test]
+    fn matrix_literal_rows_and_columns() {
+        let ast = parse_scilab("A = [1 2; 3 4]\n");
+        assert!(contains_rule(&ast, "matrix_literal"));
+        assert!(contains_rule(&ast, "matrix_rows"));
+    }
+
+    #[test]
+    fn matrix_literal_with_explicit_commas() {
+        assert!(parses("A = [1, 2, 3]\n"));
+    }
+
+    #[test]
+    fn cell_literal_parses() {
+        let ast = parse_scilab("c = {1, 2, 3}\n");
+        assert!(contains_rule(&ast, "cell_literal"));
+    }
+
+    #[test]
+    fn range_two_and_three_argument_forms() {
+        assert!(parses("r = 1:10\n"));
+        assert!(parses("r = 1:2:10\n"));
+    }
+
+    #[test]
+    fn whole_dimension_colon_in_index() {
+        assert!(parses("r = A(:, 2)\n"));
+    }
+
+    #[test]
+    fn elementwise_operators_parse() {
+        assert!(parses("r = A .* B ./ C .^ D .\\ E\n"));
+        assert!(parses("r = A.'\n"));
+    }
+
+    #[test]
+    fn syntax_error_is_reported() {
+        assert!(try_parse_scilab("r = 1 +\n").is_err());
+        assert!(try_parse_scilab("r = (1 + 2\n").is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- exercises all seven
+    // independently-measured shapes documented on `MAX_RULE_DEPTH`.
+    // -------------------------------------------------------------------
+
+    fn nested_paren_source(n: usize) -> String {
+        format!("r = {}5{}\n", "(".repeat(n), ")".repeat(n))
+    }
+
+    fn power_chain_source(n: usize) -> String {
+        let mut s = String::from("r = 1");
+        for _ in 0..n {
+            s.push_str("^1");
+        }
+        s.push('\n');
+        s
+    }
+
+    fn nested_if_source(n: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str("if 1 then ");
+        }
+        s.push('5');
+        for _ in 0..n {
+            s.push_str(" end");
+        }
+        s.push('\n');
+        s
+    }
+
+    fn nested_matrix_source(n: usize) -> String {
+        format!("r = {}5{}\n", "[".repeat(n), "]".repeat(n))
+    }
+
+    /// Chained assignment, `r=r=r=...=r` -- `assignment`'s own `[ EQ
+    /// assignment ]` self-reference (shape 5 on `MAX_RULE_DEPTH`'s doc
+    /// comment).
+    fn assignment_chain_source(n: usize) -> String {
+        let mut s = String::from("r");
+        for _ in 0..n {
+            s.push_str("=r");
+        }
+        s.push('\n');
+        s
+    }
+
+    /// Nested function-call arguments, `r = f(f(f(...5...)))` -- `postfix ->
+    /// call_suffix -> arg_list -> arg -> expr -> ... -> postfix` (shape 6).
+    /// `cell_suffix` (`A{...}`) has the identical `arg_list`-mediated shape
+    /// and is not separately exercised here (see that shape's own reasoning
+    /// on `MAX_RULE_DEPTH`'s doc comment).
+    fn nested_call_source(n: usize) -> String {
+        format!("r = {}5{}\n", "f(".repeat(n), ")".repeat(n))
+    }
+
+    /// A unary prefix chain, `r = ---...-5` -- `unary`'s own `( PLUS | MINUS
+    /// | TILDE ) unary` self-reference (shape 7).
+    fn unary_prefix_chain_source(n: usize) -> String {
+        format!("r = {}5\n", "-".repeat(n))
+    }
+
+    /// Deeply-nested input, for every measured shape, must produce a
+    /// recoverable error, not overflow the native stack. Parses 5000
+    /// levels -- far past `MAX_RULE_DEPTH` -- on a worker thread with a
+    /// generous 32 MiB stack, so the *guard* is what stops the recursion,
+    /// not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow_for_every_shape() {
+        let sources = vec![
+            nested_paren_source(5000),
+            power_chain_source(5000),
+            nested_if_source(2000),
+            nested_matrix_source(5000),
+            assignment_chain_source(5000),
+            nested_call_source(5000),
+            unary_prefix_chain_source(5000),
+        ];
+        let handle = std::thread::Builder::new()
+            .name("scilab-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                for src in sources {
+                    let result = try_parse_scilab(&src);
+                    assert!(
+                        result.is_err(),
+                        "deeply-nested input must fail with an error, not parse or crash"
+                    );
+                }
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. Parses far-too-deep input, for every
+    /// shape, on a worker thread with **no** `stack_size` override (the
+    /// same ~2 MiB a default thread gets).
+    #[test]
+    fn test_cap_trips_before_overflow_on_default_stack_for_every_shape() {
+        let sources = vec![
+            nested_paren_source(5000),
+            power_chain_source(5000),
+            nested_if_source(2000),
+            nested_matrix_source(5000),
+            assignment_chain_source(5000),
+            nested_call_source(5000),
+            unary_prefix_chain_source(5000),
+        ];
+        let handle = std::thread::spawn(move || {
+            for src in sources {
+                let result = try_parse_scilab(&src);
+                assert!(result.is_err(), "deeply-nested input must error, not crash");
+            }
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// Reasonable, hand-writable nesting for every shape stays well under
+    /// the cap.
+    #[test]
+    fn test_reasonable_nesting_stays_under_the_cap_for_every_shape() {
+        assert!(try_parse_scilab(&nested_paren_source(3)).is_ok());
+        assert!(try_parse_scilab(&power_chain_source(5)).is_ok());
+        assert!(try_parse_scilab(&nested_if_source(3)).is_ok());
+        assert!(try_parse_scilab(&nested_matrix_source(3)).is_ok());
+        assert!(try_parse_scilab(&assignment_chain_source(5)).is_ok());
+        assert!(try_parse_scilab(&nested_call_source(3)).is_ok());
+        assert!(try_parse_scilab(&unary_prefix_chain_source(5)).is_ok());
+    }
+
+    /// Input that nests *exactly up to* `MAX_RULE_DEPTH`'s measured
+    /// real-input headroom for every shape still parses cleanly, and one
+    /// level deeper cleanly trips the cap. These exact boundary counts were
+    /// found empirically by binary-searching `try_parse_scilab` (the CAPPED
+    /// public API, `MAX_RULE_DEPTH = 125`) against increasing nesting counts
+    /// for each shape -- see `MAX_RULE_DEPTH`'s own doc comment ("Measured
+    /// real-input headroom at `125`"). Without this test, a future change to
+    /// the constant could silently move these boundaries without anyone
+    /// noticing, mirroring `maple-parser`/`j-parser`'s own per-shape
+    /// boundary tests.
+    #[test]
+    fn test_headroom_boundary_for_every_shape() {
+        assert!(try_parse_scilab(&nested_paren_source(7)).is_ok());
+        assert!(try_parse_scilab(&nested_paren_source(8)).is_err());
+
+        assert!(try_parse_scilab(&power_chain_source(53)).is_ok());
+        assert!(try_parse_scilab(&power_chain_source(54)).is_err());
+
+        assert!(try_parse_scilab(&nested_if_source(27)).is_ok());
+        assert!(try_parse_scilab(&nested_if_source(28)).is_err());
+
+        assert!(try_parse_scilab(&nested_matrix_source(6)).is_ok());
+        assert!(try_parse_scilab(&nested_matrix_source(7)).is_err());
+
+        assert!(try_parse_scilab(&assignment_chain_source(108)).is_ok());
+        assert!(try_parse_scilab(&assignment_chain_source(109)).is_err());
+
+        assert!(try_parse_scilab(&nested_call_source(6)).is_ok());
+        assert!(try_parse_scilab(&nested_call_source(7)).is_err());
+
+        assert!(try_parse_scilab(&unary_prefix_chain_source(107)).is_ok());
+        assert!(try_parse_scilab(&unary_prefix_chain_source(108)).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Second of four items standing up the new **Scilab** language frontend (per [`MA10-scilab-language.md`](code/specs/MA10-scilab-language.md)). Builds on the now-merged MA-10b lexer (#8674). This PR is **MA-10c only**: the parser grammar and crate. The runtime/REPL (MA-10d) and semantic-IR frontend (MA-10e) are separate follow-up PRs.

- `code/grammars/scilab/scilab.grammar` — forked from `matlab.grammar` at the grammar-source level (not a Rust-crate dependency on `matlab-parser`, per MA10 §5).
- `code/packages/rust/scilab-parser/` — new crate (`coding-adventures-scilab-parser`) wrapping the shared `GrammarParser`.

**Three parser divergences from MATLAB (MA10 §3):** a new `stmt_sep` production (one required separator with four acceptable spellings — `then`, `do`, comma, or newline — reused at all six `if`/`elseif`/`select`/`case`/`while`/`for` header sites); `endfunction` as `func_def`'s own distinct closing keyword, never unified with the generic `end`; `$` (DOLLAR) as an ordinary `primary` alternative replacing MATLAB's context-sensitive `end`-as-last-index trick entirely (no pre-parse retagging hook needed, unlike `matlab-parser`).

**Verification:**
- `cargo test -p coding-adventures-scilab-parser` — 55 tests + 1 doctest, all passing
- `cargo build --workspace` (excluding the 5 known pre-existing/environment-specific failures) — clean
- `cargo clippy -p coding-adventures-scilab-parser --all-targets -- -D warnings` — clean
- Two-round `/security-review`: round 1 flagged a MEDIUM finding (incomplete recursion-depth-cap measurement — see below); fixed, then a follow-up review caught two more LOW documentation-completeness gaps in the fix itself, also addressed; final review passed clean

## Security finding fixed during review

The recursion-depth-cap (`MAX_RULE_DEPTH`) doc comment initially measured four self-referential grammar shapes and set the cap to 150, ~31.8% below the lowest measured floor (220, from a `^` power-operator chain). Review caught that two more genuinely self-referential productions — chained assignment (`x=x=x=...`) and function-call/cell-index argument nesting — were never measured, and a third (a unary prefix chain) was reasoned about but never actually measured, unlike sibling `*-parser` crates in this repo that measure prefix chains and power chains separately.

Measuring all three closed a real gap: chained assignment turned out to have a **lower** rule-frame floor (179) than the previously-believed binding shape (power chain, 220) — confirming the concern was substantive. To be precise about severity: the old cap of 150 was never an active/exploitable overflow (150 < 179 already held), but it left a thinner-than-convention safety margin (~16.2%) than this repo's ~25-33% norm. `MAX_RULE_DEPTH` was lowered to **125** (~30.2% below the new floor of 179), the doc comment/README/CHANGELOG were rewritten to document all seven measured shapes, and tests were extended accordingly. A remaining low-risk, explicitly disclosed gap (three more shapes — `while`/`for`/nested-`function` bodies — share nested-`if`'s cycle shape by rule-graph argument but weren't independently measured) is called out in the doc comment, README, and CHANGELOG for a future audit to close.

## Test plan

- [x] `cargo test -p coding-adventures-scilab-parser`
- [x] `cargo clippy -p coding-adventures-scilab-parser --all-targets -- -D warnings`
- [x] `cargo build --workspace` (with documented pre-existing exclusions)
- [x] Security review: 2 rounds on the fix itself, final round clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)