### PR TITLE
fix(sql): ORDER BY alias no longer inherits an unrelated column COLLATE

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.59 — ORDER BY alias no longer borrows a column's COLLATE
+
+`SELECT x AS c FROM t ORDER BY c` sorted case-insensitively when the table
+happened to contain an unrelated `c TEXT COLLATE NOCASE` column — the ORDER BY
+key resolved the bare name against the base table instead of the output list, so
+the alias inherited a collating sequence from a column the query never used.
+Now the collation follows what the alias stands for: `x AS c ... ORDER BY c` is
+byte order, `c AS y ... ORDER BY y` still folds NOCASE. Verified against
+bundled real SQLite with all three shapes (shadowing alias, alias of a collated
+column, and a genuine collated-column reference as a control).
+
 ## 0.5.58 — DISTINCT honours a column's declared COLLATE
 
 `SELECT DISTINCT c` on a column declared `COLLATE NOCASE` now dedupes

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.58"
+version = "0.5.59"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1719,6 +1719,18 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT c AS y FROM t ORDER BY y",
     },
+    // Duplicate output aliases: SQLite's alias resolution returns the FIRST
+    // select-list match (no ambiguity error for ORDER BY), so this sorts by `x`
+    // (BINARY, 'P' before 'p') and NOT by the NOCASE `y`. Pins the first-wins
+    // rule that the precomputed alias map must preserve (`or_insert`).
+    Case {
+        id: "order_by_duplicate_alias_first_wins",
+        setup: &[
+            "CREATE TABLE t (x TEXT, y TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES('p','B'),('P','a')",
+        ],
+        query: "SELECT x AS c, y AS c FROM t ORDER BY c",
+    },
     // The same table's BINARY column is NOT folded — all four values are distinct.
     // (Guards against over-applying the collation to every column.)
     Case {

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1684,6 +1684,41 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT DISTINCT c FROM t GROUP BY x ORDER BY 1",
     },
+    // An ORDER BY key that names an OUTPUT ALIAS must use that expression's
+    // collation, not the collation of a base-table column that happens to share
+    // the name. Here `c` is an alias for the BINARY column `x`, so the sort is
+    // byte order ('P' before 'p') even though the table also has a NOCASE column
+    // literally called `c`. Previously the ORDER BY collation pass resolved the
+    // bare name `c` straight against the base table and sorted case-insensitively.
+    Case {
+        id: "order_by_alias_shadowing_collated_column",
+        setup: &[
+            "CREATE TABLE t (x TEXT, c TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES('p','z'),('P','z')",
+        ],
+        query: "SELECT x AS c FROM t ORDER BY c",
+    },
+    // Control: a genuine reference to the NOCASE column still sorts
+    // case-insensitively ('a' before 'B'), so the fix must not over-correct.
+    Case {
+        id: "order_by_real_collated_column_still_folds",
+        setup: &[
+            "CREATE TABLE t (c TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES('B'),('a')",
+        ],
+        query: "SELECT c FROM t ORDER BY c",
+    },
+    // Conversely, an alias STANDING FOR the NOCASE column does carry its
+    // collation ('a' before 'B') — the collation follows what the alias means,
+    // so the fix must not simply drop collation for every aliased key.
+    Case {
+        id: "order_by_alias_of_collated_column",
+        setup: &[
+            "CREATE TABLE t (c TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES('B'),('a')",
+        ],
+        query: "SELECT c AS y FROM t ORDER BY y",
+    },
     // The same table's BINARY column is NOT folded — all four values are distinct.
     // (Guards against over-applying the collation to every column.)
     Case {

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this package will be documented in this file.
 
 ### Fixed
 
+- **The ORDER BY alias lookup is precomputed, not scanned per key.** The first
+  cut of the fix below scanned `output_columns` for every sort key, which is
+  O(keys × columns) with both dimensions attacker-controlled — the exact shape
+  the sibling collation-map precompute 500 lines earlier was written to avoid
+  (a wide `SELECT x AS a1, …` with many NON-matching keys never short-circuits).
+  `plan_order_by` now builds a lowercased alias → expression map once, and skips
+  building it entirely when there is no collation context. FIRST alias wins on a
+  duplicate (`or_insert`), matching SQLite's `resolveAsName`: `SELECT x AS c,
+  y AS c … ORDER BY c` binds to `x`. Caught by security review before push.
+
 - **An ORDER BY key naming an output ALIAS no longer inherits an unrelated
   column's `COLLATE`.** `plan_order_item` resolved a bare ORDER BY name straight
   against the base table, so `SELECT x AS c FROM t ORDER BY c` — where `x` is

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.28] - Unreleased
+
+### Fixed
+
+- **An ORDER BY key naming an output ALIAS no longer inherits an unrelated
+  column's `COLLATE`.** `plan_order_item` resolved a bare ORDER BY name straight
+  against the base table, so `SELECT x AS c FROM t ORDER BY c` — where `x` is
+  BINARY but the table also has a `c TEXT COLLATE NOCASE` — sorted
+  case-insensitively, silently borrowing the collating sequence of a column the
+  query never referenced. The key now resolves through the output list first:
+  when an UNQUALIFIED name matches an output alias, the collation comes from what
+  that alias STANDS FOR. So `x AS c ... ORDER BY c` is byte order, while
+  `c AS y ... ORDER BY y` still folds NOCASE — the collation follows the
+  expression, not the label. A qualified name (`t.c`) is always the column and is
+  unaffected, as is an explicit `COLLATE` on the key, which still wins outright.
+  Found while testing DISTINCT collation; same name-shadowing trap, different
+  code path.
+
 ## [0.2.27] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.27"
+version = "0.2.28"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1066,9 +1066,32 @@ fn plan_order_by(
             collations,
         }
     });
+    // Same reasoning for the output ALIAS lookup an unqualified key needs (see
+    // `plan_order_item`): scanning `output_columns` per key would be
+    // O(keys × columns) with both dimensions attacker-controlled — a wide
+    // `SELECT x AS a1, …` with many non-matching ORDER BY keys never
+    // short-circuits. Build the map once instead.
+    //
+    // FIRST alias wins on a duplicate (`or_insert`, not `insert`): SQLite's
+    // `resolveAsName` returns the first select-list match and raises no
+    // ambiguity error for ORDER BY, so `SELECT x AS c, y AS c … ORDER BY c`
+    // binds to `x`. Keys are lowercased to match the collation map's convention.
+    // Skipped entirely when there is no collation context, since the result
+    // would be discarded.
+    let alias_exprs: std::collections::HashMap<String, &SqlExpr> = if order_ctx.is_some() {
+        let mut m = std::collections::HashMap::new();
+        for oc in output_columns {
+            if let Some(a) = oc.alias.as_deref() {
+                m.entry(a.to_ascii_lowercase()).or_insert(&oc.expr);
+            }
+        }
+        m
+    } else {
+        std::collections::HashMap::new()
+    };
     find_nodes(order_clause, "order_item")
         .iter()
-        .map(|item| plan_order_item(item, order_ctx.as_ref(), output_columns))
+        .map(|item| plan_order_item(item, order_ctx.as_ref(), output_columns, &alias_exprs))
         .collect()
 }
 
@@ -1458,6 +1481,10 @@ fn plan_order_item(
     item: &GrammarASTNode,
     collate_ctx: Option<&OrderCollateCtx>,
     output_columns: &[OutputColumn],
+    // Lowercased output alias -> the expression it stands for, precomputed once
+    // in `plan_order_by` so alias lookup stays O(1) per key rather than
+    // O(output columns).
+    alias_exprs: &std::collections::HashMap<String, &SqlExpr>,
 ) -> Result<SortKey, PlanError> {
     // The first child Node is the expression; check for ASC/DESC tokens.
     let expr_node = item
@@ -1574,14 +1601,12 @@ fn plan_order_item(
         // inherited an unrelated column's collating sequence. Only an
         // UNQUALIFIED name can be an alias; `t.c` always means the column.
         let via_alias = match &expr {
-            SqlExpr::Column { table: None, name } => output_columns.iter().find(|oc| {
-                oc.alias
-                    .as_deref()
-                    .is_some_and(|a| a.eq_ignore_ascii_case(name))
-            }),
+            SqlExpr::Column { table: None, name } => {
+                alias_exprs.get(&name.to_ascii_lowercase()).copied()
+            }
             _ => None,
         };
-        let source = via_alias.map_or(&expr, |oc| &oc.expr);
+        let source = via_alias.unwrap_or(&expr);
         collate_ctx.and_then(|ctx| resolve_column_collation(source, ctx))
     };
 

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1561,7 +1561,28 @@ fn plan_order_item(
     let collation = if has_explicit_collate {
         collation
     } else {
-        collate_ctx.and_then(|ctx| resolve_column_collation(&expr, ctx))
+        // A bare ORDER BY name may be an OUTPUT ALIAS rather than a base-table
+        // column. When it is, the collation comes from what the alias STANDS FOR,
+        // never from a base-table column that merely shares the name:
+        //
+        //   CREATE TABLE t (x TEXT, c TEXT COLLATE NOCASE);
+        //   SELECT x AS c FROM t ORDER BY c;   -- byte order: `c` here IS `x`
+        //   SELECT c AS y FROM t ORDER BY y;   -- NOCASE: `y` stands for `c`
+        //
+        // Previously the name was resolved straight against the base table, so
+        // the first query sorted case-insensitively — the alias silently
+        // inherited an unrelated column's collating sequence. Only an
+        // UNQUALIFIED name can be an alias; `t.c` always means the column.
+        let via_alias = match &expr {
+            SqlExpr::Column { table: None, name } => output_columns.iter().find(|oc| {
+                oc.alias
+                    .as_deref()
+                    .is_some_and(|a| a.eq_ignore_ascii_case(name))
+            }),
+            _ => None,
+        };
+        let source = via_alias.map_or(&expr, |oc| &oc.expr);
+        collate_ctx.and_then(|ctx| resolve_column_collation(source, ctx))
     };
 
     Ok(SortKey {


### PR DESCRIPTION
Follows #8681 (DISTINCT collate), now merged. Last of the lane-3 collation cluster.

## The bug

`SELECT x AS c FROM t ORDER BY c` sorted **case-insensitively** whenever the table happened to also contain an unrelated `c TEXT COLLATE NOCASE` column. `plan_order_item` resolved the bare ORDER BY name straight against the base table, so the alias silently borrowed the collating sequence of a column the query never referenced.

## The rule

The collation follows what the alias **stands for**, not the label. Each row verified against real `sqlite3` and pinned by an oracle case:

| query (`c` is NOCASE, `x` is BINARY) | sorts | why |
|---|---|---|
| `x AS c … ORDER BY c` | byte order (`P`, `p`) | `c` here *is* `x` — the name is irrelevant |
| `c AS y … ORDER BY y` | NOCASE (`a`, `B`) | `y` stands for the collated `c` |
| `c … ORDER BY c` | NOCASE (`a`, `B`) | **control** — must not over-correct |
| `x AS c, y AS c … ORDER BY c` | byte order | duplicate alias: SQLite's `resolveAsName` takes the FIRST match |

That third row matters: the naive fix ("aliased keys get no collation") passes the first two and silently breaks it. The fourth pins first-wins semantics.

A qualified name (`t.c`) can never be an alias and is untouched; an explicit `COLLATE` on the key still wins outright.

## Second commit: a DoS-hygiene regression, caught by security review

My first cut scanned `output_columns` for every sort key — **O(keys × columns)**, both dimensions attacker-controlled, and a non-matching key never short-circuits. That is precisely the shape the sibling collation-map precompute 500 lines earlier in the same file was written to avoid ("both dimensions attacker-controlled… keeps planning linear"). I had reintroduced a hazard the file already documented.

`plan_order_by` now builds the lowercased alias → expression map once and skips it entirely when there is no collation context. First-wins preserved via `or_insert` — easy to regress to last-wins when moving a linear scan to a `HashMap`, hence the duplicate-alias oracle case above.

## Tests

4 new differential-oracle cases against bundled real SQLite (the table above). sql-planner 78 and all mini-sqlite suites green; clippy clean on the changed lib.

Version bumps: sql-planner 0.2.28, mini-sqlite 0.5.59 (+ CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
