### PR TITLE
Add Haskell Codabar port

### DIFF
--- a/code/packages/haskell/codabar/BUILD
+++ b/code/packages/haskell/codabar/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/codabar/BUILD_windows
+++ b/code/packages/haskell/codabar/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/codabar/CHANGELOG.md
+++ b/code/packages/haskell/codabar/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Validate body-only and explicitly guarded Codabar input.
+- Support configurable `A`-`D` start and stop symbols.
+- Encode all 20 standard symbols with exact binary patterns.
+- Expand attributed start, data, stop, and inter-character-gap runs.
+- Emit backend-neutral paint scenes through the shared 1D barcode geometry.

--- a/code/packages/haskell/codabar/README.md
+++ b/code/packages/haskell/codabar/README.md
@@ -1,0 +1,30 @@
+# codabar (Haskell)
+
+Pure Codabar barcode encoding for the Haskell package lane. Body-only input is
+wrapped in `A ... A` by default, callers can choose any `A`-`D` start and stop
+pair, and fully guarded input such as `B40156D` is preserved.
+
+```haskell
+import CodingAdventures.Codabar
+
+example = drawCodabar
+  "40156"
+  (CodabarGuards 'B' 'D')
+  defaultPaintBarcode1DOptions
+```
+
+The package supports digits `0`-`9`, punctuation `- $ : / . +`, and the four
+guard symbols `A B C D`. Guards are restricted to the two outer positions.
+The API exposes normalized data, typed per-symbol encodings, and the complete
+attributed run stream.
+
+Rendering delegates to `barcode-layout-1d`, which supplies validated quiet-zone
+geometry, rectangle-only paint instructions, and shared scene metadata. Human-
+readable text remains explicitly unsupported until the Haskell lane has a text
+shaping backend.
+
+## Development
+
+```sh
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/codabar/cabal.project
+++ b/code/packages/haskell/codabar/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../barcode-layout-1d ../paint-instructions

--- a/code/packages/haskell/codabar/codabar.cabal
+++ b/code/packages/haskell/codabar/codabar.cabal
@@ -1,0 +1,39 @@
+cabal-version: 3.0
+name:          codabar
+version:       0.1.0
+synopsis:      Pure Codabar barcode encoder
+description:   Validated guards, all 20 standard symbols, attributed runs, and backend-neutral paint scenes.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.Codabar
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , paint-instructions >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CodabarSpec
+    hs-source-dirs:   test
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , codabar
+                    , containers >=0.6 && <0.8
+                    , hspec ==2.*
+                    , paint-instructions >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/codabar/src/CodingAdventures/Codabar.hs
+++ b/code/packages/haskell/codabar/src/CodingAdventures/Codabar.hs
@@ -1,0 +1,239 @@
+-- | Pure Codabar barcode encoding.
+module CodingAdventures.Codabar
+  ( EncodedCodabarSymbol (..)
+  , CodabarGuards (..)
+  , CodabarError (..)
+  , Barcode1DError (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , PaintScene (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , defaultCodabarGuards
+  , normalizeCodabar
+  , encodeCodabar
+  , expandCodabarRuns
+  , layoutCodabar
+  , drawCodabar
+  , version
+  ) where
+
+import CodingAdventures.BarcodeLayout1D
+  ( Barcode1DError (..)
+  , Barcode1DRenderConfig (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , PaintBarcode1DOptions (..)
+  , defaultBarcode1DRenderConfig
+  , defaultBinaryPatternOptions
+  , defaultPaintBarcode1DOptions
+  , layoutBarcode1D
+  , runsFromBinaryPattern
+  )
+import CodingAdventures.PaintInstructions (PaintScene (..))
+import Data.Aeson (toJSON)
+import Data.Bifunctor (first)
+import Data.Char (toUpper)
+import qualified Data.Map.Strict as Map
+
+-- | Package version shared with the established implementations.
+version :: String
+version = "0.1.0"
+
+-- | Start and stop symbols used when the payload does not provide its own.
+data CodabarGuards = CodabarGuards
+  { codabarStartGuard :: Char
+  , codabarStopGuard :: Char
+  } deriving (Eq, Show)
+
+-- | The standard default wraps body data in @A ... A@.
+defaultCodabarGuards :: CodabarGuards
+defaultCodabarGuards = CodabarGuards 'A' 'A'
+
+-- | One normalized symbol and its fully expanded binary module pattern.
+data EncodedCodabarSymbol = EncodedCodabarSymbol
+  { encodedCodabarCharacter :: Char
+  , encodedCodabarPattern :: String
+  , encodedCodabarSourceIndex :: Int
+  , encodedCodabarRole :: Barcode1DRunRole
+  } deriving (Eq, Show)
+
+-- | Checked failures from guard, body, or shared layout validation.
+data CodabarError
+  = InvalidCodabarBodyCharacter Char
+  | InvalidCodabarGuard Char
+  | CodabarLayoutError Barcode1DError
+  deriving (Eq)
+
+instance Show CodabarError where
+  show (InvalidCodabarBodyCharacter character) =
+    "Invalid Codabar body character " ++ show [character]
+  show (InvalidCodabarGuard character) =
+    "Invalid Codabar guard " ++ show [character]
+      ++ "; expected A, B, C, or D"
+  show (CodabarLayoutError layoutError) = show layoutError
+
+codabarPatterns :: Map.Map Char String
+codabarPatterns = Map.fromList
+  [ ('0', "101010011")
+  , ('1', "101011001")
+  , ('2', "101001011")
+  , ('3', "110010101")
+  , ('4', "101101001")
+  , ('5', "110101001")
+  , ('6', "100101011")
+  , ('7', "100101101")
+  , ('8', "100110101")
+  , ('9', "110100101")
+  , ('-', "101001101")
+  , ('$', "101100101")
+  , (':', "1101011011")
+  , ('/', "1101101011")
+  , ('.', "1101101101")
+  , ('+', "1011011011")
+  , ('A', "1011001001")
+  , ('B', "1001001011")
+  , ('C', "1010010011")
+  , ('D', "1010011001")
+  ]
+
+-- | Uppercase input, preserve valid explicit guards, or insert configured
+-- guards around a body-only payload.
+normalizeCodabar :: String -> CodabarGuards -> Either CodabarError String
+normalizeCodabar input guards = case explicitBody normalized of
+  Just body -> validateBody body >> Right normalized
+  Nothing -> do
+      validateGuard (codabarStartGuard guards)
+      validateGuard (codabarStopGuard guards)
+      validateBody normalized
+      Right (codabarStartGuard guards : normalized ++ [codabarStopGuard guards])
+  where
+    normalized = map toUpper input
+
+-- | Encode normalized body data and its two guards.
+encodeCodabar
+  :: String
+  -> CodabarGuards
+  -> Either CodabarError [EncodedCodabarSymbol]
+encodeCodabar input guards = normalizeCodabar input guards >>= encodeNormalized
+
+-- | Expand every symbol into shared runs with one-module inter-character gaps.
+expandCodabarRuns
+  :: String
+  -> CodabarGuards
+  -> Either CodabarError [Barcode1DRun]
+expandCodabarRuns input guards = do
+  encoded <- encodeCodabar input guards
+  expandEncoded encoded
+
+-- | Render Codabar through the shared backend-neutral 1D geometry.
+layoutCodabar
+  :: String
+  -> CodabarGuards
+  -> PaintBarcode1DOptions
+  -> Either CodabarError PaintScene
+layoutCodabar input guards options = do
+  normalized <- normalizeCodabar input guards
+  encoded <- encodeNormalized normalized
+  runs <- expandEncoded encoded
+  first CodabarLayoutError
+    (layoutBarcode1D runs (codabarOptions normalized options))
+
+-- | Compatibility alias matching the shared public API name.
+drawCodabar
+  :: String
+  -> CodabarGuards
+  -> PaintBarcode1DOptions
+  -> Either CodabarError PaintScene
+drawCodabar = layoutCodabar
+
+isGuard :: Char -> Bool
+isGuard character = character `elem` "ABCD"
+
+explicitBody :: String -> Maybe String
+explicitBody normalized = case normalized of
+  firstCharacter : rest -> case reverse rest of
+    stopCharacter : reversedBody
+      | isGuard firstCharacter && isGuard stopCharacter ->
+          Just (reverse reversedBody)
+    _ -> Nothing
+  [] -> Nothing
+
+validateGuard :: Char -> Either CodabarError ()
+validateGuard character
+  | isGuard character = Right ()
+  | otherwise = Left (InvalidCodabarGuard character)
+
+validateBody :: String -> Either CodabarError ()
+validateBody [] = Right ()
+validateBody (character : rest)
+  | Map.member character codabarPatterns && not (isGuard character) =
+      validateBody rest
+  | otherwise = Left (InvalidCodabarBodyCharacter character)
+
+encodeNormalized :: String -> Either CodabarError [EncodedCodabarSymbol]
+encodeNormalized normalized = traverse encodeOne indexed
+  where
+    encodedLength = length normalized
+    indexed = zip [0 :: Int ..] normalized
+    encodeOne (sourceIndex, character) = case Map.lookup character codabarPatterns of
+      Nothing -> Left (InvalidCodabarBodyCharacter character)
+      Just patternText -> Right EncodedCodabarSymbol
+        { encodedCodabarCharacter = character
+        , encodedCodabarPattern = patternText
+        , encodedCodabarSourceIndex = sourceIndex
+        , encodedCodabarRole = roleFor encodedLength sourceIndex
+        }
+
+roleFor :: Int -> Int -> Barcode1DRunRole
+roleFor encodedLength sourceIndex
+  | sourceIndex == 0 = Start
+  | sourceIndex == encodedLength - 1 = Stop
+  | otherwise = Data
+
+expandEncoded
+  :: [EncodedCodabarSymbol]
+  -> Either CodabarError [Barcode1DRun]
+expandEncoded encoded = concat <$> traverse expandOne indexed
+  where
+    encodedLength = length encoded
+    indexed = zip [0 :: Int ..] encoded
+    expandOne (encodedIndex, symbol) = do
+      symbolRuns <- first CodabarLayoutError
+        (runsFromBinaryPattern
+          (encodedCodabarPattern symbol)
+          (defaultBinaryPatternOptions
+            [encodedCodabarCharacter symbol]
+            (encodedCodabarSourceIndex symbol)
+            (encodedCodabarRole symbol)))
+      let gap
+            | encodedIndex < encodedLength - 1 =
+                [ Barcode1DRun
+                    { runColor = Space
+                    , runModules = 1
+                    , runSourceLabel = [encodedCodabarCharacter symbol]
+                    , runSourceIndex = encodedCodabarSourceIndex symbol
+                    , runRole = InterCharacterGap
+                    }
+                ]
+            | otherwise = []
+      Right (symbolRuns ++ gap)
+
+codabarOptions
+  :: String
+  -> PaintBarcode1DOptions
+  -> PaintBarcode1DOptions
+codabarOptions normalized options = options
+  { optionsLabel = Just (maybe defaultLabel id (optionsLabel options))
+  , optionsMetadata = Map.insert "encodedText" (toJSON normalized)
+      (Map.insert "stop" (toJSON (take 1 (reverse normalized)))
+        (Map.insert "start" (toJSON (take 1 normalized))
+          (Map.insert "symbology" (toJSON ("codabar" :: String))
+            (optionsMetadata options))))
+  }
+  where
+    defaultLabel = "Codabar barcode for " ++ normalized

--- a/code/packages/haskell/codabar/test/CodabarSpec.hs
+++ b/code/packages/haskell/codabar/test/CodabarSpec.hs
@@ -1,0 +1,177 @@
+module CodabarSpec (spec) where
+
+import CodingAdventures.Codabar
+import CodingAdventures.PaintInstructions (PaintInstruction (..))
+import Data.Aeson (toJSON)
+import Data.List (nub, sort)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "metadata and defaults" $ do
+    it "reports the shared package version" $
+      version `shouldBe` "0.1.0"
+
+    it "uses A guards by default" $
+      defaultCodabarGuards `shouldBe` CodabarGuards 'A' 'A'
+
+  describe "normalizeCodabar" $ do
+    it "wraps body data in A guards by default" $
+      normalizeCodabar "40156" defaultCodabarGuards `shouldBe` Right "A40156A"
+
+    it "uppercases and preserves explicit guards" $
+      normalizeCodabar "b40156d" defaultCodabarGuards `shouldBe` Right "B40156D"
+
+    it "inserts distinct configured guards" $
+      normalizeCodabar "40156" (CodabarGuards 'B' 'D') `shouldBe` Right "B40156D"
+
+    it "accepts an empty body" $
+      normalizeCodabar "" defaultCodabarGuards `shouldBe` Right "AA"
+
+    it "rejects invalid configured guards educationally" $ do
+      normalizeCodabar "0" (CodabarGuards 'X' 'A') `shouldBe`
+        Left (InvalidCodabarGuard 'X')
+      normalizeCodabar "0" (CodabarGuards 'A' 'X') `shouldBe`
+        Left (InvalidCodabarGuard 'X')
+      show (InvalidCodabarGuard 'X') `shouldBe`
+        "Invalid Codabar guard \"X\"; expected A, B, C, or D"
+
+    it "rejects unsupported and embedded guard characters" $ do
+      normalizeCodabar "40*56" defaultCodabarGuards `shouldBe`
+        Left (InvalidCodabarBodyCharacter '*')
+      normalizeCodabar "40A56" defaultCodabarGuards `shouldBe`
+        Left (InvalidCodabarBodyCharacter 'A')
+      normalizeCodabar "A40156" defaultCodabarGuards `shouldBe`
+        Left (InvalidCodabarBodyCharacter 'A')
+      show (InvalidCodabarBodyCharacter '*') `shouldBe`
+        "Invalid Codabar body character \"*\""
+
+  describe "encodeCodabar" $ do
+    it "marks the outer symbols and source indices" $ do
+      encoded <- expectRight (encodeCodabar "40156" defaultCodabarGuards)
+      map encodedCodabarCharacter encoded `shouldBe` "A40156A"
+      map encodedCodabarSourceIndex encoded `shouldBe` [0 .. 6]
+      map encodedCodabarRole encoded `shouldBe`
+        [Start, Data, Data, Data, Data, Data, Stop]
+
+    it "uses the exact shared reference patterns" $ do
+      encoded <- expectRight (encodeCodabar "0+" defaultCodabarGuards)
+      map encodedCodabarPattern encoded `shouldBe`
+        ["1011001001", "101010011", "1011011011", "1011001001"]
+
+    it "contains all 20 standard symbols" $ do
+      body <- expectRight
+        (encodeCodabar "0123456789-$:/.+" defaultCodabarGuards)
+      guardB <- expectRight (encodeCodabar "BB" defaultCodabarGuards)
+      guardsCD <- expectRight (encodeCodabar "CD" defaultCodabarGuards)
+      let symbols = map encodedCodabarCharacter (body ++ guardB ++ guardsCD)
+      sort (nub symbols) `shouldBe` sort "0123456789-$:/.+ABCD"
+
+    it "encodes empty input as only two guards" $
+      fmap (map encodedCodabarCharacter)
+        (encodeCodabar "" defaultCodabarGuards) `shouldBe` Right "AA"
+
+  describe "expandCodabarRuns" $ do
+    it "expands one data symbol with two inter-character gaps" $ do
+      runs <- expectRight (expandCodabarRuns "0" defaultCodabarGuards)
+      length runs `shouldBe` 23
+      map runRole (take 7 runs) `shouldBe` replicate 7 Start
+      runs !! 7 `shouldBe` Barcode1DRun Space 1 "A" 0 InterCharacterGap
+      map runRole (take 7 (drop 8 runs)) `shouldBe` replicate 7 Data
+      runs !! 15 `shouldBe` Barcode1DRun Space 1 "0" 1 InterCharacterGap
+      map runRole (drop 16 runs) `shouldBe` replicate 7 Stop
+
+    it "uses exact shared module counts and alternating colors" $ do
+      one <- expectRight (expandCodabarRuns "0" defaultCodabarGuards)
+      sample <- expectRight (expandCodabarRuns "40156" defaultCodabarGuards)
+      empty <- expectRight (expandCodabarRuns "" defaultCodabarGuards)
+      sum (map runModules one) `shouldBe` 31
+      sum (map runModules sample) `shouldBe` 71
+      sum (map runModules empty) `shouldBe` 21
+      map runColor one `shouldBe` take (length one) (cycle [Bar, Space])
+
+    it "preserves custom start and stop attribution" $ do
+      runs <- expectRight (expandCodabarRuns "0" (CodabarGuards 'B' 'D'))
+      map runSourceLabel (take 7 runs) `shouldBe` replicate 7 "B"
+      map runSourceLabel (drop 16 runs) `shouldBe` replicate 7 "D"
+
+    it "propagates validation failures" $
+      expandCodabarRuns "@" defaultCodabarGuards `shouldBe`
+        Left (InvalidCodabarBodyCharacter '@')
+
+  describe "layoutCodabar" $ do
+    it "renders through the shared default geometry" $ do
+      scene <- expectRight
+        (layoutCodabar "0" defaultCodabarGuards defaultPaintBarcode1DOptions)
+      psWidth scene `shouldBe` 204
+      psHeight scene `shouldBe` 120
+      psBg scene `shouldBe` "#ffffff"
+      length (psInstructions scene) `shouldBe` 12
+      map prX (take 2 (psInstructions scene)) `shouldBe` [40, 48]
+
+    it "records normalized data, guards, label, and inferred symbols" $ do
+      scene <- expectRight
+        (layoutCodabar "40156" defaultCodabarGuards defaultPaintBarcode1DOptions)
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("codabar" :: String))
+      Map.lookup "start" (psMeta scene) `shouldBe` Just (toJSON ("A" :: String))
+      Map.lookup "stop" (psMeta scene) `shouldBe` Just (toJSON ("A" :: String))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("A40156A" :: String))
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Codabar barcode for A40156A" :: String))
+      Map.lookup "symbolCount" (psMeta scene) `shouldBe` Just (toJSON (7 :: Int))
+
+    it "preserves custom rendering, labels, and caller metadata" $ do
+      let config = defaultBarcode1DRenderConfig
+            { configModuleWidth = 2
+            , configBarHeight = 50
+            , configQuietZoneModules = 5
+            , configForeground = "navy"
+            , configBackground = "transparent"
+            }
+          options = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = config
+            , optionsLabel = Just "Library label"
+            , optionsMetadata = Map.fromList
+                [ ("batch", toJSON (7 :: Int))
+                , ("encodedText", toJSON ("wrong" :: String))
+                , ("start", toJSON ("wrong" :: String))
+                , ("stop", toJSON ("wrong" :: String))
+                , ("symbology", toJSON ("wrong" :: String))
+                ]
+            }
+      scene <- expectRight (layoutCodabar "0" (CodabarGuards 'B' 'D') options)
+      (psWidth scene, psHeight scene, psBg scene) `shouldBe` (82, 50, "transparent")
+      map prFill (psInstructions scene) `shouldBe` replicate 12 "navy"
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Library label" :: String))
+      Map.lookup "batch" (psMeta scene) `shouldBe` Just (toJSON (7 :: Int))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("B0D" :: String))
+      Map.lookup "start" (psMeta scene) `shouldBe` Just (toJSON ("B" :: String))
+      Map.lookup "stop" (psMeta scene) `shouldBe` Just (toJSON ("D" :: String))
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("codabar" :: String))
+
+    it "supports the draw alias" $
+      drawCodabar "0" defaultCodabarGuards defaultPaintBarcode1DOptions
+        `shouldBe`
+          layoutCodabar "0" defaultCodabarGuards defaultPaintBarcode1DOptions
+
+    it "wraps shared layout validation failures" $ do
+      let invalidGeometry = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = defaultBarcode1DRenderConfig
+                { configModuleWidth = 0 }
+            }
+          humanText = defaultPaintBarcode1DOptions
+            { optionsHumanReadableText = Just "A0A" }
+      layoutCodabar "0" defaultCodabarGuards invalidGeometry `shouldBe`
+        Left (CodabarLayoutError (InvalidRenderConfiguration "moduleWidth" 0))
+      layoutCodabar "0" defaultCodabarGuards humanText `shouldBe`
+        Left (CodabarLayoutError HumanReadableTextUnsupported)
+
+expectRight :: Show error => Either error value -> IO value
+expectRight (Right value) = pure value
+expectRight (Left err) = fail ("unexpected error: " ++ show err)

--- a/code/packages/haskell/codabar/test/Spec.hs
+++ b/code/packages/haskell/codabar/test/Spec.hs
@@ -1,0 +1,5 @@
+import CodabarSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -121,11 +121,11 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
 `type-checker-protocol` ports, and the Haskell `paint-vm-ascii`,
-`barcode-layout-1d`, `itf`, and `code39` ports:
+`barcode-layout-1d`, `itf`, `code39`, and `codabar` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 286 |
+| Present in 10-15 languages | 172 | 285 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 710 | 9,940 |
@@ -182,7 +182,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 11 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 10 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -627,6 +627,18 @@ counts, semantic attribution, empty payloads, customized paint output,
 metadata precedence, aliases, and both local and shared validation paths. The
 package now spans 12 implementation lanes, reduces the high-consensus backlog
 to 286 slots, and leaves 11 gaps in the Haskell lane.
+
+The twenty-fourth Haskell high-consensus slice is complete: `codabar` now
+provides the pure configurable-guard encoder unlocked by `barcode-layout-1d`.
+It accepts body-only or explicitly guarded input, validates configurable `A`-`D`
+start and stop choices, exposes all 20 typed binary symbol patterns, and emits
+attributed start, data, stop, and inter-character-gap runs through the shared
+paint geometry. Its package-native suite exercises guard insertion and
+preservation, educational errors, the complete symbol table, exact module
+counts, semantic attribution, empty payloads, customized paint output,
+metadata precedence, aliases, and both local and shared validation paths. The
+package now spans 12 implementation lanes, reduces the high-consensus backlog
+to 285 slots, and leaves 10 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell Codabar package with validated configurable or explicit `A`-`D` guards and all 20 standard symbol patterns
- expose typed symbol encodings, attributed start/data/stop/gap runs, and backend-neutral scenes through `barcode-layout-1d`
- add package-native documentation, metadata, build entrypoints, and 21 Codabar examples
- update the parity roadmap from 286 to 285 high-consensus missing slots and from 11 to 10 Haskell high-consensus gaps

## Why

Codabar was the smallest dependency-safe leaf remaining in the Haskell high-consensus backlog. The already-merged Haskell `barcode-layout-1d` package supplies its complete geometry and paint dependency chain, so this port adds no external implementation dependency.

## Validation

- `cabal test all --enable-coverage` — 67 examples passed across Codabar and its two local dependencies
- Codabar coverage: 97% expressions, 90% alternatives
- `cabal check`
- `cabal sdist` to an external temporary directory
- `python code/scripts/tests/test_package_parity_report.py` — 6 tests passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- asserted 285 high-consensus missing slots, 10 Haskell gaps, 12 Codabar lanes, zero collisions, and zero unknown buckets
- `git diff --check origin/main...HEAD`
