### PR TITLE
feat(hl): Spanish Ch.16 — the imperfect, and choosing between the two pasts

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -231,6 +231,8 @@
       "ES-PRETERITE-AR": "the regular -ar preterite — hablé/hablaste/habló/hablamos/hablaron (← Latin perfect -āvī; accent marks the final stress, hablo→habló; hablamos present=preterite)",
       "ES-PRETERITE-ER-IR": "the regular -er/-ir preterite — comí/comiste/comió/comimos/comieron, viví/viviste/vivió (ONE shared set, unlike the present where -er/-ir differ; ← Latin perfect -ī/-istī/-it, -istī→-iste nearly intact; vivimos present=preterite but comemos≠comimos)",
       "ES-PRETERITE-STRONG": "the strong preterites — tener→tuve, hacer→hice, estar→estuve (stress moves OFF the ending onto the stem, TUve/HIce, hence NO written accent, the reverse of hablé/habló; yo ending -e not -é; hizo c→z; ← Latin strong perfects tenuī/fēcī/stetī, inherited not rebuilt)",
+      "ES-IMPERFECT": "the imperfect — hablaba/hablabas/hablaba/hablábamos/hablaban and comía/vivía (the ongoing/habitual past; -er and -ir share ONE set a THIRD time). ← Latin -ābam / -ēbam, the b surviving whole in -aba but wearing away in -ēbam→-ía. Accents do two different jobs: hablábamos = stress 3 syllables back; comía = breaking the diphthong into co-mí-a. yo and él forms are IDENTICAL, so Spanish often un-drops yo here — a pro-drop exception",
+      "ES-IMPERFECT-IRREGULARS": "the only THREE irregular imperfects in the language — ser→era (← eram, same es- root as soy/es and English is/are), ir→iba (← ībam), ver→veía (barely irregular: keeps an -e- from older veer). PAYOFF: iba is the ONE tense where ir uses its OWN Latin verb īre — its present came from vādere and its preterite from fuī, so ir is stitched from THREE different Latin verbs",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -320,6 +322,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, CH14-PRACTICE, CH15-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, CH14-PRACTICE, CH15-PRACTICE, CH16-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## Chapter 16 — The imperfect, and choosing between the two pasts
+
+- **Chapter 16 authored** (`ES-C16-imperfecto`, `-tres-irregulares`,
+  `-practice`): the second past tense, and the first genuinely **new distinction**
+  (rather than new forms) the course has asked for — reviewing Ch.6/7/9/10/14/15
+  via `reviews_of`.
+- **the regular imperfect** (`ES-C16-imperfecto`): *hablaba/hablabas/hablaba/
+  hablábamos/hablaban*, *comía/vivía* — the ongoing-or-habitual past, and the
+  **most regular tense in the language**, deliberately framed as relief after
+  Ch.15's strong preterites. **-er and -ir share one set a third time.**
+  Etymology: ← Latin *-ābam* / *-ēbam*, where the **b survived whole** in *-aba*
+  but **wore away** in *-ēbam → -ea → -ía* — one Latin ending, two fates in one
+  language. The two accents do **different jobs**: *hablábamos* marks stress three
+  syllables back (the only accented *-ar* form), while *comía* **breaks the
+  diphthong** so *co-mí-a* is three syllables (every *-er/-ir* form needs it). And
+  a **pro-drop exception**: *yo* and *él* forms are identical, so Spanish — which
+  normally drops pronouns (Ch.6) — puts *yo* back when the ending stops doing its
+  job.
+- **the three irregulars** (`ES-C16-tres-irregulares`): *ser→era*, *ir→iba*,
+  *ver→veía* — **three verbs, not three families**, the complete inventory for the
+  whole language; *ver* barely counts, keeping an extra *-e-* from older *veer*.
+  The chapter's payoff is **ir**: its present comes from *vādere* (Ch.10), its
+  preterite from *fuī* (Ch.14), and the **imperfect is the one tense where *ir*
+  uses its own original verb, *īre*** — so *ir* is stitched together from **three
+  different Latin verbs**, with *ir* and *iba* the last surviving pieces of the
+  real one. *Era* ← *eram*, the same *es-* root as *soy/es* and English *is/are*
+  (Ch.9), which *ser* then abandons for *fuī* in the preterite: *era* vs *fue*.
+- **practice** — **preterite vs imperfect**, the aspect contrast English marks only
+  lexically and never with an ending. Framed as **point vs line**: the imperfect
+  sets the background and the preterite interrupts it (*hablaba cuando llegó*),
+  plus the verbs where the choice changes the **meaning** — *sabía* "knew" vs
+  *supe* "**found out**"; *conocía* "knew" vs *conocí* "**met**"; *tenía* "had" vs
+  *tuve* "**got**"; *quería* "wanted" vs *quise* "tried" / *no quise* "**refused**"
+  — all one consistent logic: the preterite marks the **instant the state began**.
+- Taxonomy: namespaced `ES-IMPERFECT`, `ES-IMPERFECT-IRREGULARS`; practice label
+  `CH16-PRACTICE`.
+
 ## Chapter 15 — Completing the preterite
 
 - **Chapter 15 authored** (`ES-C15-comer-vivir-preterite`, `-preterite-fuertes`,

--- a/code/learning/human-languages/spanish/lessons/ES-C16-imperfecto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-imperfecto.md
@@ -1,0 +1,83 @@
+---
+id: ES-C16-imperfecto
+chapter: 16
+type: word
+headword: hablaba, comía
+gloss: the imperfect — the past that kept going, and the most regular tense in Spanish
+concept_tag: ES-IMPERFECT
+prerequisites: [ES-C15-practice, ES-C07-comer, ES-C07-vivir]
+sounds: [accent-acute, hiatus-ia]
+roots: [latin-abam-ebam]
+etymology_hook: "-aba ← Latin -ābam, -ía ← -ēbam (the b wore away in the -er/-ir set but survives whole in -ar); -er and -ir share ONE set a third time; the accent on -ía breaks the diphthong so i and a are two syllables"
+est_minutes: 5
+reviews_of: [ES-C15-practice, ES-C15-comer-vivir-preterite, ES-C06-hablar, ES-C07-comer]
+---
+
+# hablaba, comía — the past that kept going
+
+## Warm-up
+
+[PAUSE 2s] The preterite told you a past thing **finished**. The **imperfect**
+tells you a past thing was **going on** — "I **was speaking**," "I **used to
+speak**." And after Chapter 15's strong verbs, here is the good news: this is the
+**most regular tense in the language**.
+
+## Two sets, and you can guess the second
+
+Drop the ending, add:
+
+| | -ar (hablar) | -er / -ir (comer, vivir) |
+|---|---|---|
+| yo | habl**aba** | com**ía** / viv**ía** |
+| tú | habl**abas** | com**ías** |
+| él/ella/usted | habl**aba** | com**ía** |
+| nosotros | habl**ábamos** | com**íamos** |
+| ellos/ustedes | habl**aban** | com**ían** |
+
+**-er and -ir share one set again** — the third time now (preterite, and here).
+Two conjugations, one pattern.
+
+## The accents, and why
+
+Two different jobs:
+
+- **hablábamos** — the stress falls **three syllables back**, so it must be
+  written. Only this one form in the *-ar* set takes an accent.
+- **comía** — the accent **splits the vowels**. Without it, *ia* would be one
+  syllable (like *piano*); with it, *co-mí-a* is three. **Every** form in the
+  *-er/-ir* set needs it.
+
+## Where they come from
+
+| Spanish | ← Latin |
+|---|---|
+| habl**aba** | *-ābam* |
+| com**ía** | *-ēbam* |
+
+Same Latin ending, two fates: the **b** survived whole in *-aba*, but wore away
+in the other set (*-ēbam → -ea → -ía*). One sound, two outcomes, in the same
+language.
+
+## One trap, and a broken rule
+
+*Yo hablaba* and *él hablaba* are **identical**. So Spanish, which normally
+**drops** its pronouns (Chapter 6), often puts *yo* back in the imperfect — the
+ending stopped doing its job, so the pronoun steps in.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hablaba, hablabas, hablaba, hablábamos, hablaban"]
+- [YOU SAY: "comía, comías, comía, comíamos, comían"]
+- [YOU SAY: "co-mí-a" — three syllables, not two]
+- [YOU SAY: "Cuando era niño, hablaba español en casa"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the imperfect express? (A past action **going on** or
+**habitual** — "was doing," "used to do.") Which two conjugations share a set?
+(**-er and -ir**, again.) Why does *comía* need an accent? (To **break the
+diphthong** — *co-mí-a*, three syllables.) Which *-ar* form takes one, and why?
+(**Hablábamos** — the stress is three syllables back.) Why does Spanish put *yo*
+back here? (*Yo* and *él* forms are **identical**.) Next: the only three
+irregular verbs in the whole tense.

--- a/code/learning/human-languages/spanish/lessons/ES-C16-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-practice.md
@@ -1,0 +1,86 @@
+---
+id: ES-C16-practice
+chapter: 16
+type: practice-mix
+headword: (practice)
+gloss: preterite vs imperfect — the distinction English doesn't grammatically make
+concept_tag: CH16-PRACTICE
+prerequisites: [ES-C16-imperfecto, ES-C16-tres-irregulares]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [ES-C16-imperfecto, ES-C16-tres-irregulares, ES-C15-practice, ES-C14-practice]
+---
+
+# Practice — two pasts, one choice
+
+## Warm-up
+
+[PAUSE 2s] You now have **both** past tenses. English marks this difference only
+sometimes, and never with an ending — so this is a genuinely **new distinction**
+to think in, not just new forms to learn.
+
+## The split
+
+| | preterite | imperfect |
+|---|---|---|
+| what it does | a **completed** event | an **ongoing** or **habitual** state |
+| shape of time | a **point** | a **line** |
+| English | "I ate" | "I **was** eating" / "I **used to** eat" |
+| typical clues | *ayer, una vez, de repente* | *siempre, todos los días, mientras* |
+
+**Comí** = the meal happened and ended. **Comía** = I was in the middle of it, or
+I did it regularly.
+
+## Background and interruption
+
+The classic pairing — the imperfect sets the scene, the preterite breaks it:
+
+> **Hablaba** con María cuando **llegó** Juan.
+> *(I was talking to María when Juan arrived.)*
+
+The talking is the **line**; the arriving is the **point** that lands on it. Swap
+the tenses and the sentence stops making sense.
+
+## Verbs that change meaning
+
+With a few verbs the choice doesn't just shift the shape of time — it changes
+**what the word means**:
+
+| verb | imperfect (state) | preterite (the moment it started) |
+|---|---|---|
+| saber | *sabía* — I **knew** | *supe* — I **found out** |
+| conocer | *conocía* — I **knew** (a person) | *conocí* — I **met** |
+| tener | *tenía* — I **had** | *tuve* — I **got, received** |
+| querer | *quería* — I **wanted** | *quise* — I **tried**; *no quise* — I **refused** |
+
+The logic is consistent: the imperfect gives you the state; the preterite gives
+you the **instant the state began**. Knowing → the moment of finding out.
+
+## Drill — which tense?
+
+[PAUSE 2s] Decide before reading the answer.
+
+| sentence | tense |
+|---|---|
+| "Every summer we **went** to Spain." | imperfect (*íbamos*) — habitual |
+| "Yesterday we **went** to Spain." | preterite (*fuimos*) — one event |
+| "She **was** tall." | imperfect (*era*) — a lasting state |
+| "The concert **was** yesterday." | preterite (*fue*) — a bounded event |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Comía cuando llamaste" ("I was eating when you called")]
+- [YOU SAY: the pair — "*sabía* I knew … *supe* I found out"]
+- [YOU SAY: "Cuando era niño, iba a la playa todos los veranos"]
+- [YOU SAY: the test aloud — "**line** → imperfect; **point** → preterite"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Preterite or imperfect for a **habit**? (**Imperfect**.) Which tense
+sets the background, and which interrupts it? (Imperfect **sets**, preterite
+**interrupts**.) What's the difference between *conocía* and *conocí*? ("I
+**knew** someone" vs "I **met** them.") How many irregular imperfects were there?
+(**Three**.) Give the one-word test. ("**Line** or **point**?") Next chapter:
+talking about what **will** happen.

--- a/code/learning/human-languages/spanish/lessons/ES-C16-tres-irregulares.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-tres-irregulares.md
@@ -1,0 +1,79 @@
+---
+id: ES-C16-tres-irregulares
+chapter: 16
+type: word
+headword: era, iba, veía
+gloss: the only three irregular imperfects in the entire language
+concept_tag: ES-IMPERFECT-IRREGULARS
+prerequisites: [ES-C16-imperfecto, ES-C09-ser, ES-C10-ir]
+sounds: [accent-acute, stress-antepenultimate]
+roots: [latin-eram, latin-ibam, latin-videre]
+etymology_hook: "iba ← Latin ībam — the imperfect is the ONE tense where ir uses its own original verb īre; its present came from vādere and its preterite from fuī, so ir's three tenses come from THREE different Latin verbs"
+est_minutes: 5
+reviews_of: [ES-C16-imperfecto, ES-C09-ser, ES-C10-ir, ES-C14-ser-ir-preterite]
+---
+
+# era, iba, veía — all three of them
+
+## Warm-up
+
+[PAUSE 2s] Chapter 15 handed you a pile of strong preterites to memorise. Here is
+the compensation: the imperfect has **three** irregular verbs. Not three
+families — **three verbs**, in the whole language.
+
+## The complete list
+
+| | ser → **era** | ir → **iba** | ver → **veía** |
+|---|---|---|---|
+| yo | **era** | **iba** | **veía** |
+| tú | **eras** | **ibas** | **veías** |
+| él/ella/usted | **era** | **iba** | **veía** |
+| nosotros | **éramos** | **íbamos** | **veíamos** |
+| ellos/ustedes | **eran** | **iban** | **veían** |
+
+That is the entire irregular inventory. Every other verb in Spanish — thousands
+of them — takes the regular endings from the last lesson.
+
+*Ver* barely counts: it just keeps an extra **-e-** from its older form *veer*,
+then conjugates normally (*ve-* + *-ía*).
+
+## ir's third Latin verb
+
+Now the best thing in the chapter. Track where *ir*'s tenses come from:
+
+| tense | form | ← Latin verb |
+|---|---|---|
+| present | *voy, vas, va* | ***vādere*** "to advance" (Ch. 10) |
+| preterite | *fui, fuiste, fue* | ***fuī***, from *esse* (Ch. 14) |
+| **imperfect** | ***iba, ibas, iba*** | ***īre*** — **its own infinitive** |
+
+Spanish *ir* is stitched together from **three different Latin verbs**, and the
+imperfect is the **one place** the original *īre* survives conjugated. The
+infinitive *ir* and the imperfect *iba* are the last two pieces of the real verb;
+everything else was borrowed from elsewhere.
+
+## era
+
+**era** ← Latin ***eram***, from the same *es-* root as *ser*, *soy*, *es* — and
+as English **is** and **are** (Chapter 9). So *ser* uses that ancient root in the
+present and the imperfect, but jumps to *fuī* in the preterite: *era* vs *fue*.
+
+Note the accents: **éramos**, **íbamos** — stress three syllables back, exactly
+like *hablábamos*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "era, eras, era, éramos, eran"]
+- [YOU SAY: "iba, ibas, iba, íbamos, iban"]
+- [YOU SAY: "Cuando era niño, iba a la escuela" ("When I was a child, I used to go to school")]
+- [YOU SAY: the three sources — "voy ← *vādere* · fui ← *fuī* · iba ← *īre*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How many irregular imperfects are there? (**Three** — *ser, ir, ver*.)
+Which one hardly counts, and why? (*Ver* — it just keeps an extra **-e-** from
+*veer*.) Where does *iba* come from? (**Latin *īre*** — *ir*'s **own** verb, and
+the only tense that kept it.) So how many Latin verbs is *ir* built from?
+(**Three** — *vādere*, *fuī*, *īre*.) Which two forms take a written accent?
+(**Éramos, íbamos** — stress three back.) Next: choosing between the two pasts.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -115,8 +115,25 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   sorting all three families by the single question *where does the stress land?*
   **Authored.**
 
-Next: **Ch. 16** — the **imperfect**, the past that kept going, and its contrast
-with the preterite; then everyday description, building toward real conversation.
+- **Ch. 16 — The imperfect, and choosing between the two pasts**: the **regular
+  imperfect** *hablaba…hablábamos* / *comía…comíamos* — the ongoing-or-habitual
+  past, and the **most regular tense in the language**, with **-er and -ir sharing
+  one set a third time** (← Latin *-ābam* / *-ēbam*, the *b* surviving whole in
+  *-aba* but wearing away in *-ēbam → -ía*); the two accent jobs (*hablábamos* =
+  stress three syllables back; *comía* = **breaking the diphthong** into
+  *co-mí-a*); and a **pro-drop exception** — *yo* and *él* forms are identical, so
+  Spanish puts *yo* back → the **only three irregular imperfects in the entire
+  language**: *ser→era*, *ir→iba*, *ver→veía* (which barely counts). The payoff:
+  ***iba* ← Latin *īre*** is the **one tense where *ir* uses its own verb** — its
+  present came from *vādere* (Ch. 10) and its preterite from *fuī* (Ch. 14), so
+  *ir* is stitched together from **three different Latin verbs** → practice on the
+  **aspect** contrast English doesn't grammatically mark: **point vs line**,
+  imperfect setting the background and preterite interrupting it, plus the verbs
+  where the choice changes the **meaning** (*sabía* "knew" vs *supe* "found out";
+  *conocía* "knew" vs *conocí* "met"). **Authored.**
+
+Next: **Ch. 17** — the **future** and the conditional; then everyday description,
+building toward real conversation.
 From here the course hands over rules, not phrases. Grammar accumulates piece by
 piece. The theme skeleton below plans the wider road.
 


### PR DESCRIPTION
The second past tense — and the first genuinely **new distinction** the course asks for,
rather than just new forms.

**`ES-C16-imperfecto`** — the regular imperfect (*hablaba…hablábamos*, *comía…comíamos*):
the ongoing-or-habitual past, and the **most regular tense in the language**, deliberately
framed as relief after Ch.15's strong preterites. **-er and -ir share one set a third
time.** ← Latin *-ābam* / *-ēbam*, where the **b survived whole** in *-aba* but **wore
away** in *-ēbam → -ea → -ía*: one Latin ending, two fates inside one language. The two
accents do **different jobs** — *hablábamos* marks stress three syllables back (the only
accented *-ar* form), while *comía* **breaks the diphthong** so *co-mí-a* is three
syllables (every *-er/-ir* form needs it). And a **pro-drop exception**: *yo* and *él*
forms are identical, so Spanish — which normally drops pronouns (Ch.6) — puts *yo* back
when the ending stops doing its job.

**`ES-C16-tres-irregulares`** — *ser→era*, *ir→iba*, *ver→veía*. **Three verbs, not three
families** — the complete inventory for the whole language; *ver* barely counts, keeping
an extra *-e-* from older *veer*. The payoff is **ir**: its present comes from *vādere*
(Ch.10), its preterite from *fuī* (Ch.14), and the **imperfect is the one tense where
*ir* uses its own original verb, *īre*** — so *ir* is stitched together from **three
different Latin verbs**, with *ir* and *iba* the last surviving pieces of the real one.
*Era* ← *eram*, the same *es-* root as *soy/es* and English *is/are* (Ch.9), which *ser*
then abandons for *fuī* in the preterite: *era* vs *fue*.

**`ES-C16-practice`** — **preterite vs imperfect**, the aspect contrast English marks only
lexically and never with an ending. Framed as **point vs line**: the imperfect sets the
background and the preterite interrupts it (*hablaba cuando llegó*), plus the verbs where
the choice changes the **meaning** — *sabía* "knew" vs *supe* "**found out**"; *conocía*
"knew" vs *conocí* "**met**"; *tenía* "had" vs *tuve* "**got**"; *quería* "wanted" vs
*quise* "tried" / *no quise* "**refused**" — one consistent logic: the preterite marks the
**instant the state began**.

Taxonomy: namespaced `ES-IMPERFECT`, `ES-IMPERFECT-IRREGULARS`; practice label
`CH16-PRACTICE`. Spanish roadmap (Ch.16 authored, Next Ch.17 = the future and conditional)
and CHANGELOG updated.

Suite green at **38/38**; retired-concept-tag sweep clean across the whole curriculum.
Security-reviewed: PASS, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)