### PR TITLE
Add Haskell Code 128 port

### DIFF
--- a/code/packages/haskell/code128/BUILD
+++ b/code/packages/haskell/code128/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/code128/BUILD_windows
+++ b/code/packages/haskell/code128/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/code128/CHANGELOG.md
+++ b/code/packages/haskell/code128/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Validate printable ASCII input for Code Set B.
+- Encode the complete 107-symbol table with Start B, modulo-103 checksum, and stop.
+- Expand attributed start, data, check, and stop runs.
+- Emit backend-neutral paint scenes through the shared 1D barcode geometry.

--- a/code/packages/haskell/code128/README.md
+++ b/code/packages/haskell/code128/README.md
@@ -1,0 +1,27 @@
+# code128 (Haskell)
+
+Pure Code 128 encoding for the Haskell package lane. V1 implements Code Set B
+for printable ASCII, including the required Start B symbol, weighted modulo-103
+checksum, and stop pattern.
+
+```haskell
+import CodingAdventures.Code128
+
+example = drawCode128 "Code 128" defaultPaintBarcode1DOptions
+```
+
+The API exposes validated input, character values, all 107 standard patterns,
+typed per-symbol encodings, and the complete attributed run stream. Automatic
+Code Set A/C switching, FNC behavior, GS1-128, and Code Set C compaction remain
+outside the V1 contract.
+
+Rendering delegates to `barcode-layout-1d`, which supplies validated quiet-zone
+geometry, rectangle-only paint instructions, and shared scene metadata. Human-
+readable text remains explicitly unsupported until the Haskell lane has a text
+shaping backend.
+
+## Development
+
+```sh
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/code128/cabal.project
+++ b/code/packages/haskell/code128/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../barcode-layout-1d ../paint-instructions

--- a/code/packages/haskell/code128/code128.cabal
+++ b/code/packages/haskell/code128/code128.cabal
@@ -1,0 +1,39 @@
+cabal-version: 3.0
+name:          code128
+version:       0.1.0
+synopsis:      Pure Code 128 Code Set B encoder
+description:   Validated Code Set B symbols, modulo-103 checksums, attributed runs, and backend-neutral paint scenes.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.Code128
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , paint-instructions >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Code128Spec
+    hs-source-dirs:   test
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , code128
+                    , containers >=0.6 && <0.8
+                    , hspec ==2.*
+                    , paint-instructions >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/code128/src/CodingAdventures/Code128.hs
+++ b/code/packages/haskell/code128/src/CodingAdventures/Code128.hs
@@ -1,0 +1,237 @@
+-- | Pure Code 128 Code Set B encoding.
+module CodingAdventures.Code128
+  ( EncodedCode128Symbol (..)
+  , Code128Error (..)
+  , Barcode1DError (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , PaintScene (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , normalizeCode128B
+  , code128BValue
+  , code128Pattern
+  , computeCode128Checksum
+  , encodeCode128B
+  , expandCode128Runs
+  , layoutCode128
+  , drawCode128
+  , version
+  ) where
+
+import CodingAdventures.BarcodeLayout1D
+  ( Barcode1DError (..)
+  , Barcode1DRenderConfig (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , PaintBarcode1DOptions (..)
+  , defaultBarcode1DRenderConfig
+  , defaultBinaryPatternOptions
+  , defaultPaintBarcode1DOptions
+  , layoutBarcode1D
+  , runsFromBinaryPattern
+  )
+import CodingAdventures.PaintInstructions (PaintScene (..))
+import Data.Aeson (toJSON)
+import Data.Bifunctor (first)
+import Data.Char (ord)
+import qualified Data.Map.Strict as Map
+
+-- | Package version shared with the established implementations.
+version :: String
+version = "0.1.0"
+
+-- | One control, data, checksum, or stop symbol and its module pattern.
+data EncodedCode128Symbol = EncodedCode128Symbol
+  { encodedCode128Label :: String
+  , encodedCode128Value :: Int
+  , encodedCode128Pattern :: String
+  , encodedCode128SourceIndex :: Int
+  , encodedCode128Role :: Barcode1DRunRole
+  } deriving (Eq, Show)
+
+-- | Checked failures from input, table lookup, or shared layout validation.
+data Code128Error
+  = InvalidCode128Character Char
+  | InvalidCode128Value Int
+  | Code128LayoutError Barcode1DError
+  deriving (Eq)
+
+instance Show Code128Error where
+  show (InvalidCode128Character character) =
+    "Invalid Code 128 Code Set B character " ++ show [character]
+      ++ "; expected printable ASCII (32-126)"
+  show (InvalidCode128Value value) =
+    "Invalid Code 128 symbol value " ++ show value ++ "; expected 0-106"
+  show (Code128LayoutError layoutError) = show layoutError
+
+startB :: Int
+startB = 104
+
+stop :: Int
+stop = 106
+
+-- | The complete Code 128 pattern table, values 0 through 106.
+code128Patterns :: [String]
+code128Patterns =
+  [ "11011001100", "11001101100", "11001100110", "10010011000"
+  , "10010001100", "10001001100", "10011001000", "10011000100"
+  , "10001100100", "11001001000", "11001000100", "11000100100"
+  , "10110011100", "10011011100", "10011001110", "10111001100"
+  , "10011101100", "10011100110", "11001110010", "11001011100"
+  , "11001001110", "11011100100", "11001110100", "11101101110"
+  , "11101001100", "11100101100", "11100100110", "11101100100"
+  , "11100110100", "11100110010", "11011011000", "11011000110"
+  , "11000110110", "10100011000", "10001011000", "10001000110"
+  , "10110001000", "10001101000", "10001100010", "11010001000"
+  , "11000101000", "11000100010", "10110111000", "10110001110"
+  , "10001101110", "10111011000", "10111000110", "10001110110"
+  , "11101110110", "11010001110", "11000101110", "11011101000"
+  , "11011100010", "11011101110", "11101011000", "11101000110"
+  , "11100010110", "11101101000", "11101100010", "11100011010"
+  , "11101111010", "11001000010", "11110001010", "10100110000"
+  , "10100001100", "10010110000", "10010000110", "10000101100"
+  , "10000100110", "10110010000", "10110000100", "10011010000"
+  , "10011000010", "10000110100", "10000110010", "11000010010"
+  , "11001010000", "11110111010", "11000010100", "10001111010"
+  , "10100111100", "10010111100", "10010011110", "10111100100"
+  , "10011110100", "10011110010", "11110100100", "11110010100"
+  , "11110010010", "11011011110", "11011110110", "11110110110"
+  , "10101111000", "10100011110", "10001011110", "10111101000"
+  , "10111100010", "11110101000", "11110100010", "10111011110"
+  , "10111101110", "11101011110", "11110101110", "11010000100"
+  , "11010010000", "11010011100", "1100011101011"
+  ]
+
+-- | Preserve valid Code Set B text and reject everything outside printable
+-- ASCII.
+normalizeCode128B :: String -> Either Code128Error String
+normalizeCode128B input = traverse validate input
+  where
+    validate character
+      | characterCode >= 32 && characterCode <= 126 = Right character
+      | otherwise = Left (InvalidCode128Character character)
+      where
+        characterCode = ord character
+
+-- | Map one printable ASCII character to its Code Set B value.
+code128BValue :: Char -> Either Code128Error Int
+code128BValue character = do
+  _ <- normalizeCode128B [character]
+  Right (ord character - 32)
+
+-- | Look up any regular, control, start, or stop pattern by numeric value.
+code128Pattern :: Int -> Either Code128Error String
+code128Pattern value
+  | value < 0 || value > stop = Left (InvalidCode128Value value)
+  | otherwise = case drop value code128Patterns of
+      patternText : _ -> Right patternText
+      [] -> Left (InvalidCode128Value value)
+
+-- | Compute the required weighted modulo-103 checksum for Code Set B values.
+computeCode128Checksum :: [Int] -> Int
+computeCode128Checksum values =
+  (startB + sum (zipWith (*) [1 :: Int ..] values)) `mod` 103
+
+-- | Encode input as Start B, zero or more data symbols, checksum, and stop.
+encodeCode128B :: String -> Either Code128Error [EncodedCode128Symbol]
+encodeCode128B input = do
+  normalized <- normalizeCode128B input
+  encodeNormalized normalized
+
+-- | Expand each symbol into alternating shared barcode runs.
+expandCode128Runs :: String -> Either Code128Error [Barcode1DRun]
+expandCode128Runs input = encodeCode128B input >>= expandEncoded
+
+-- | Render Code 128 through the shared backend-neutral 1D geometry.
+layoutCode128
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either Code128Error PaintScene
+layoutCode128 input options = do
+  normalized <- normalizeCode128B input
+  encoded <- encodeNormalized normalized
+  runs <- expandEncoded encoded
+  let checksum = computeCode128Checksum
+        [ encodedCode128Value symbol
+        | symbol <- encoded
+        , encodedCode128Role symbol == Data
+        ]
+  first Code128LayoutError
+    (layoutBarcode1D runs (code128Options normalized checksum options))
+
+-- | Compatibility alias matching the shared public API name.
+drawCode128
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either Code128Error PaintScene
+drawCode128 = layoutCode128
+
+encodeNormalized :: String -> Either Code128Error [EncodedCode128Symbol]
+encodeNormalized normalized = do
+  dataSymbols <- traverse encodeData (zip [0 :: Int ..] normalized)
+  startPattern <- code128Pattern startB
+  let checksum = computeCode128Checksum (map encodedCode128Value dataSymbols)
+  checksumPattern <- code128Pattern checksum
+  stopPattern <- code128Pattern stop
+  Right
+    ( EncodedCode128Symbol "Start B" startB startPattern (-1) Start
+    : dataSymbols
+      ++ [ EncodedCode128Symbol
+            ("Checksum " ++ show checksum)
+            checksum
+            checksumPattern
+            (length normalized)
+            Check
+         , EncodedCode128Symbol
+            "Stop"
+            stop
+            stopPattern
+            (length normalized + 1)
+            Stop
+         ]
+    )
+  where
+    encodeData (sourceIndex, character) = do
+      value <- code128BValue character
+      patternText <- code128Pattern value
+      Right EncodedCode128Symbol
+        { encodedCode128Label = [character]
+        , encodedCode128Value = value
+        , encodedCode128Pattern = patternText
+        , encodedCode128SourceIndex = sourceIndex
+        , encodedCode128Role = Data
+        }
+
+expandEncoded
+  :: [EncodedCode128Symbol]
+  -> Either Code128Error [Barcode1DRun]
+expandEncoded encoded = concat <$> traverse expandOne encoded
+  where
+    expandOne symbol = first Code128LayoutError
+      (runsFromBinaryPattern
+        (encodedCode128Pattern symbol)
+        (defaultBinaryPatternOptions
+          (encodedCode128Label symbol)
+          (encodedCode128SourceIndex symbol)
+          (encodedCode128Role symbol)))
+
+code128Options
+  :: String
+  -> Int
+  -> PaintBarcode1DOptions
+  -> PaintBarcode1DOptions
+code128Options normalized checksum options = options
+  { optionsLabel = Just (maybe defaultLabel id (optionsLabel options))
+  , optionsMetadata = Map.insert "encodedText" (toJSON normalized)
+      (Map.insert "checksum" (toJSON checksum)
+        (Map.insert "codeSet" (toJSON ("B" :: String))
+          (Map.insert "symbology" (toJSON ("code128" :: String))
+            (optionsMetadata options))))
+  }
+  where
+    defaultLabel = "Code 128 barcode for " ++ normalized

--- a/code/packages/haskell/code128/test/Code128Spec.hs
+++ b/code/packages/haskell/code128/test/Code128Spec.hs
@@ -1,0 +1,185 @@
+module Code128Spec (spec) where
+
+import CodingAdventures.Code128
+import CodingAdventures.PaintInstructions (PaintInstruction (..))
+import Data.Aeson (toJSON)
+import Data.List (nub)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "metadata and defaults" $ do
+    it "reports the shared package version" $
+      version `shouldBe` "0.1.0"
+
+    it "uses the shared render defaults" $ do
+      configModuleWidth defaultBarcode1DRenderConfig `shouldBe` 4
+      configQuietZoneModules defaultBarcode1DRenderConfig `shouldBe` 10
+
+  describe "normalizeCode128B" $ do
+    it "accepts printable ASCII boundaries and empty input" $ do
+      normalizeCode128B "" `shouldBe` Right ""
+      normalizeCode128B " ~" `shouldBe` Right " ~"
+
+    it "rejects control, delete, and non-ASCII characters educationally" $ do
+      normalizeCode128B "bad\ninput" `shouldBe`
+        Left (InvalidCode128Character '\n')
+      normalizeCode128B ['\DEL'] `shouldBe`
+        Left (InvalidCode128Character '\DEL')
+      normalizeCode128B "caf\233" `shouldBe`
+        Left (InvalidCode128Character '\233')
+      show (InvalidCode128Character '\n') `shouldBe`
+        "Invalid Code 128 Code Set B character \"\\n\"; expected printable ASCII (32-126)"
+
+  describe "Code Set B values and patterns" $ do
+    it "maps printable ASCII to values 0 through 94" $ do
+      code128BValue ' ' `shouldBe` Right 0
+      code128BValue 'A' `shouldBe` Right 33
+      code128BValue '~' `shouldBe` Right 94
+      code128BValue '\n' `shouldBe` Left (InvalidCode128Character '\n')
+
+    it "contains all 107 distinct standard patterns" $ do
+      patterns <- expectRight (traverse code128Pattern [0 .. 106])
+      length patterns `shouldBe` 107
+      length (nub patterns) `shouldBe` 107
+      map length (take 106 patterns) `shouldBe` replicate 106 11
+      length (last patterns) `shouldBe` 13
+
+    it "uses exact reference patterns for data, Start B, and stop" $ do
+      code128Pattern 0 `shouldBe` Right "11011001100"
+      code128Pattern 64 `shouldBe` Right "10100001100"
+      code128Pattern 104 `shouldBe` Right "11010010000"
+      code128Pattern 106 `shouldBe` Right "1100011101011"
+
+    it "rejects values outside the complete table" $ do
+      code128Pattern (-1) `shouldBe` Left (InvalidCode128Value (-1))
+      code128Pattern 107 `shouldBe` Left (InvalidCode128Value 107)
+      show (InvalidCode128Value 107) `shouldBe`
+        "Invalid Code 128 symbol value 107; expected 0-106"
+
+  describe "computeCode128Checksum" $ do
+    it "matches the classic Code 128 example" $
+      computeCode128Checksum [35, 79, 68, 69, 0, 17, 18, 24] `shouldBe` 64
+
+    it "includes Start B for an empty payload" $
+      computeCode128Checksum [] `shouldBe` 1
+
+  describe "encodeCode128B" $ do
+    it "adds Start B, data, checksum, and stop with source attribution" $ do
+      encoded <- expectRight (encodeCode128B "Code 128")
+      map encodedCode128Value encoded `shouldBe`
+        [104, 35, 79, 68, 69, 0, 17, 18, 24, 64, 106]
+      map encodedCode128SourceIndex encoded `shouldBe` [-1 .. 9]
+      map encodedCode128Role encoded `shouldBe`
+        [Start, Data, Data, Data, Data, Data, Data, Data, Data, Check, Stop]
+      encodedCode128Label (head encoded) `shouldBe` "Start B"
+      encodedCode128Label (encoded !! 9) `shouldBe` "Checksum 64"
+      encodedCode128Label (last encoded) `shouldBe` "Stop"
+
+    it "encodes empty input as start, checksum, and stop" $ do
+      encoded <- expectRight (encodeCode128B "")
+      map encodedCode128Value encoded `shouldBe` [104, 1, 106]
+      map encodedCode128SourceIndex encoded `shouldBe` [-1, 0, 1]
+      map encodedCode128Role encoded `shouldBe` [Start, Check, Stop]
+
+    it "propagates input validation failures" $
+      encodeCode128B "A\n" `shouldBe` Left (InvalidCode128Character '\n')
+
+  describe "expandCode128Runs" $ do
+    it "expands six runs per regular symbol and seven for stop" $ do
+      runs <- expectRight (expandCode128Runs "Hi")
+      length runs `shouldBe` 31
+      sum (map runModules runs) `shouldBe` 57
+      map runRole (take 6 runs) `shouldBe` replicate 6 Start
+      map runRole (take 6 (drop 6 runs)) `shouldBe` replicate 6 Data
+      map runRole (take 6 (drop 12 runs)) `shouldBe` replicate 6 Data
+      map runRole (take 6 (drop 18 runs)) `shouldBe` replicate 6 Check
+      map runRole (drop 24 runs) `shouldBe` replicate 7 Stop
+
+    it "preserves exact labels, indices, and global color alternation" $ do
+      runs <- expectRight (expandCode128Runs "Hi")
+      map runSourceLabel (take 6 runs) `shouldBe` replicate 6 "Start B"
+      map runSourceIndex (take 6 (drop 6 runs)) `shouldBe` replicate 6 0
+      map runSourceLabel (drop 24 runs) `shouldBe` replicate 7 "Stop"
+      map runColor runs `shouldBe` take (length runs) (cycle [Bar, Space])
+
+    it "propagates validation failures" $
+      expandCode128Runs "\233" `shouldBe` Left (InvalidCode128Character '\233')
+
+  describe "layoutCode128" $ do
+    it "renders exact default geometry through the shared layer" $ do
+      scene <- expectRight (layoutCode128 "A" defaultPaintBarcode1DOptions)
+      psWidth scene `shouldBe` 264
+      psHeight scene `shouldBe` 120
+      psBg scene `shouldBe` "#ffffff"
+      length (psInstructions scene) `shouldBe` 13
+      map prX (take 2 (psInstructions scene)) `shouldBe` [40, 52]
+
+    it "records encoded data, code set, checksum, label, and symbols" $ do
+      scene <- expectRight
+        (layoutCode128 "Code 128" defaultPaintBarcode1DOptions)
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("code128" :: String))
+      Map.lookup "codeSet" (psMeta scene) `shouldBe`
+        Just (toJSON ("B" :: String))
+      Map.lookup "checksum" (psMeta scene) `shouldBe` Just (toJSON (64 :: Int))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("Code 128" :: String))
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Code 128 barcode for Code 128" :: String))
+      Map.lookup "symbolCount" (psMeta scene) `shouldBe` Just (toJSON (11 :: Int))
+
+    it "preserves custom rendering and caller metadata with standard keys authoritative" $ do
+      let config = defaultBarcode1DRenderConfig
+            { configModuleWidth = 2
+            , configBarHeight = 50
+            , configQuietZoneModules = 5
+            , configForeground = "navy"
+            , configBackground = "transparent"
+            }
+          options = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = config
+            , optionsLabel = Just "Library label"
+            , optionsMetadata = Map.fromList
+                [ ("batch", toJSON (7 :: Int))
+                , ("encodedText", toJSON ("wrong" :: String))
+                , ("codeSet", toJSON ("wrong" :: String))
+                , ("checksum", toJSON ((-1) :: Int))
+                , ("symbology", toJSON ("wrong" :: String))
+                ]
+            }
+      scene <- expectRight (layoutCode128 "A" options)
+      (psWidth scene, psHeight scene, psBg scene) `shouldBe`
+        (112, 50, "transparent")
+      map prFill (psInstructions scene) `shouldBe` replicate 13 "navy"
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Library label" :: String))
+      Map.lookup "batch" (psMeta scene) `shouldBe` Just (toJSON (7 :: Int))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("A" :: String))
+      Map.lookup "codeSet" (psMeta scene) `shouldBe`
+        Just (toJSON ("B" :: String))
+      Map.lookup "checksum" (psMeta scene) `shouldBe` Just (toJSON (34 :: Int))
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("code128" :: String))
+
+    it "supports the draw alias" $
+      drawCode128 "A" defaultPaintBarcode1DOptions `shouldBe`
+        layoutCode128 "A" defaultPaintBarcode1DOptions
+
+    it "wraps shared layout validation failures" $ do
+      let invalidGeometry = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = defaultBarcode1DRenderConfig
+                { configModuleWidth = 0 }
+            }
+          humanText = defaultPaintBarcode1DOptions
+            { optionsHumanReadableText = Just "A" }
+      layoutCode128 "A" invalidGeometry `shouldBe`
+        Left (Code128LayoutError (InvalidRenderConfiguration "moduleWidth" 0))
+      layoutCode128 "A" humanText `shouldBe`
+        Left (Code128LayoutError HumanReadableTextUnsupported)
+
+expectRight :: Show error => Either error value -> IO value
+expectRight (Right value) = pure value
+expectRight (Left err) = fail ("unexpected error: " ++ show err)

--- a/code/packages/haskell/code128/test/Spec.hs
+++ b/code/packages/haskell/code128/test/Spec.hs
@@ -1,0 +1,5 @@
+import Code128Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,7 +105,7 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 19, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
+on July 20, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
 `binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
 `skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
 the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
@@ -121,16 +121,16 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
 `type-checker-protocol` ports, and the Haskell `paint-vm-ascii`,
-`barcode-layout-1d`, `itf`, `code39`, and `codabar` ports:
+`barcode-layout-1d`, `itf`, `code39`, `codabar`, and `code128` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 285 |
+| Present in 10-15 languages | 172 | 284 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 710 | 9,940 |
+| Present in one language | 712 | 9,968 |
 
-The loop must not start by attempting 9,940 singleton ports. It should finish
+The loop must not start by attempting 9,968 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -182,7 +182,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 10 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 9 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -639,6 +639,17 @@ counts, semantic attribution, empty payloads, customized paint output,
 metadata precedence, aliases, and both local and shared validation paths. The
 package now spans 12 implementation lanes, reduces the high-consensus backlog
 to 285 slots, and leaves 10 gaps in the Haskell lane.
+
+The twenty-fifth Haskell high-consensus slice is complete: `code128` now
+provides the pure Code Set B encoder unlocked by `barcode-layout-1d`. It
+validates printable ASCII, exposes the complete 107-pattern symbol table,
+computes the required weighted modulo-103 checksum, and emits attributed start,
+data, check, and stop runs through the shared paint geometry. Its package-native
+suite exercises ASCII boundaries, educational errors, the complete pattern
+table, reference values and checksums, empty payloads, exact module geometry,
+customized paint output, metadata precedence, aliases, and both local and shared
+validation paths. The package now spans 12 implementation lanes, reduces the
+high-consensus backlog to 284 slots, and leaves 9 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell Code 128 V1 implementation for printable ASCII Code Set B
- expose typed symbol/error structures, all 107 standard patterns, modulo-103 checksums, and attributed start/data/check/stop runs
- render through the shared `barcode-layout-1d` and `paint-instructions` packages with authoritative symbology, code-set, checksum, and encoded-text metadata
- refresh the parity roadmap to 284 high-consensus gaps overall and 9 remaining in Haskell

## Why this slice

`code128` is the smallest remaining dependency-safe Haskell high-consensus leaf. Its only package dependencies, `barcode-layout-1d` and `paint-instructions`, are already merged, so this port advances the barcode family without introducing a temporary dependency gap.

## Validation

- `cabal test all --enable-coverage` — 67 examples passed: 21 Code 128, 18 barcode layout, and 28 paint instructions
- Code 128 coverage: 98% expressions (323/329), 77% alternatives (7/9)
- `cabal check`
- `cabal sdist` with the archive generated outside the repository
- all 107 Haskell patterns compared byte-for-byte with the established Python table
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'` — 6 tests passed
- parity reporter Markdown, JSON collision guard, and CSV outputs
- `git diff --cached --check`

## Remaining parity work

The Haskell high-consensus queue is now: `barcode-1d`, `brotli`, `ean-13`, `event-loop`, `http-core`, `http1`, `sql-csv-source`, `upc-a`, and `zstd`.

This slice is portable pure computation; no package was classified as native, wrapper, web-only, target-specific, or not applicable.