### PR TITLE
feat(hl): Ch.14 "to have" + age for French, German, Italian, Portuguese

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -254,6 +254,8 @@
       "IT-NUM-17-20": "diciassette…venti (17-20; at 17 the ORDER FLIPS — sedici 'six-ten' but diciassette 'ten-and-seven'; venti ← vīgintī)",
       "IT-COLOUR-BLACK-WHITE": "nero, bianco — nero ← Latin niger (→ denigrate), but bianco ← Germanic *blank 'shining', likely via the LOMBARDS (→ Lombardia), displacing Latin albus, which survives in alba 'dawn' / albume",
       "IT-COLOUR-RED-BLUE": "rosso, blu (+ azzurro) — rosso ← russus ← PIE *h₁rewdʰ-, cousin (not loan) of red/rot/rouge; blu is a SECOND Germanic loan (*blāo); azzurro ← Arabic lāzaward 'lapis lazuli' ← Persian lāžward, l- lost as if an article → English azure; gli Azzurri",
+      "IT-VERB-HAVE": "avere — 'to have' (ho/hai/ha/abbiamo/avete/hanno; ← habēre → habit/inhabit/exhibit/prohibit). Home of Italian's ONLY silent letter: the h in ho/hai/ha/hanno is never pronounced and exists purely to keep them apart in WRITING from o 'or', ai 'to the', a 'to', anno 'YEAR'",
+      "IT-AGE": "quanti anni hai? / ho venti anni — age via avere ('have years'), never essere; anno ← annus → annual/anniversary, with a held double n. The silent-h payoff lands here: hanno ('they have') and anno ('year') are homophones that co-occur in age sentences",
       "FR-VERB-APPELER": "(s')appeler — 'to call (oneself)'",
       "FR-VERB-ALLER": "aller — 'to go' (suppletive: ambulāre/vādere/īre); drives 'comment ça va?'",
       "FR-VERB-PARLER": "parler — 'to speak' (← parabolāre; the big regular -er verb / present tense)",
@@ -276,6 +278,8 @@
       "FR-NUM-17-20": "dix-sept…vingt (17-20; at 17 French GIVES UP fusing and goes transparent 'ten-seven', the order flipping too; vingt ← vīgintī → vigesimal)",
       "FR-COLOUR-BLACK-WHITE": "noir, blanc — noir ← Latin niger, but blanc ← FRANKISH *blank 'shining', a Germanic word borrowed INTO Romance (the reverse of the usual flow); Latin albus survives only as aube 'dawn' / aubépine / album",
       "FR-COLOUR-RED-BLUE": "rouge, bleu — rouge ← rubeus ← PIE *h₁rewdʰ-, a true cousin of English red / German rot; bleu is a SECOND Germanic loan (*blāo), which English then borrowed BACK from French as 'blue'; azur ← Arabic lāzaward. Bleu-blanc-rouge: two of three are loans",
+      "FR-VERB-HAVE": "avoir — 'to have' (j'ai/tu as/il a/nous avons/vous avez/ils ont; the three singular forms ai/as/a are HOMOPHONES). ← habēre, the SAME root as Ch.5's habiter (← habitāre, habēre's frequentative) and English habit/inhabit/exhibit/prohibit; habeō wore down to j'ai, a single vowel sound. Elision: j'ai not je ai",
+      "FR-AGE": "quel âge as-tu? / j'ai vingt ans — age via avoir ('have years'), never être, and ans is obligatory; an ← annus → annual/anniversary. Liaison wakes the silent t of vingt: vin-t-an",
       "DE-VERB-HEISSEN": "heißen — 'to be called'",
       "DE-VERB-GEHEN": "gehen — 'to go' (= English go); drives 'wie geht es dir?'",
       "GE-VERB-WOHNEN": "wohnen — 'to live/dwell' (← wonēn → English 'wont'); first weak verb / present tense",
@@ -298,6 +302,8 @@
       "GE-NUM-13-20": "dreizehn…zwanzig (13-20; digit + zehn with NO exceptions, mirroring English -teen which IS ten; zwanzig ← twaintig 'two tens'; German never breaks, unlike Romance)",
       "GE-COLOUR-BLACK-WHITE": "schwarz, weiß — both NATIVE Germanic: schwarz ← *swartaz (English 'swarthy'; kin to Latin sordēs → sordid), weiß ← *hwītaz = English white (note ß after a long vowel; Swiss 'weiss'). German's own blank 'shiny' is the word Romance borrowed for WHITE (blanc/bianco/branco) — Germanic lending INTO Latin's daughters",
       "GE-COLOUR-RED-BLUE": "rot, blau — rot ← *raudaz ← PIE *h₁rewdʰ-, cousin by DESCENT of Latin ruber → rouge/rosso; blau ← *blēwaz, the SECOND German colour word borrowed into Romance (bleu/blu), with English taking 'blue' from French rather than from Germanic",
+      "GE-VERB-HAVE": "haben — 'to have' (habe/hast/hat/haben/habt/haben; du hast + er hat DROP the b, exactly as English have→has). THE FALSE COGNATE: haben ← Germanic *habjaną ← PIE *kap- 'to seize', whose Latin child is capere (capture/captive) — while Latin habēre (→ avoir/avere) descends from *gʰabʰ-, whose English child is GIVE. Identical sound and sense, opposite ancestry",
+      "GE-AGE": "wie alt bist du? / ich bin zwanzig Jahre alt — the one everyday slot where German REFUSES haben: age takes sein, word-for-word the English sentence, siding with English against all four Romance sisters (which all 'have' their years). Jahr ← *jēra = year; alt ← *aldaz = old (Latin cousin alere 'nourish' → adult)",
       "PT-WORD-TUDO": "tudo — 'everything / all' (← Latin tōtus); the heart of 'tudo bem?'",
       "PT-VERB-FALAR": "falar — 'to speak' (← fabulārī = Spanish hablar, but PT kept f-); the regular -ar present",
       "PT-VERB-MORAR": "morar — 'to live/dwell' (← morārī 'to linger' → moratorium; not habitāre)",
@@ -318,7 +324,9 @@
       "PT-NUM-11-15": "onze…quinze (11-15; only FIVE fused teens — fewer than any sister; -ze = decem as in dez/dezembro; catorze keeps the c-)",
       "PT-NUM-16-20": "dezesseis…vinte (16-20; PT breaks EARLIEST at 16, rebuilding as dez + e + seis = literally 'ten AND six', the 'and' still audible; vinte ← vīgintī)",
       "PT-COLOUR-BLACK-WHITE": "preto, branco — PT keeps TWO blacks: literary negro ← niger, and everyday preto ← Latin pressus 'pressed, dense' (dense→thick→dark; cf. press/compress). branco ← Germanic *blank 'shining', with the Portuguese l→r swap (blanc→branco, plaza→praça); albus survives in alvorada/alva 'dawn'",
-      "PT-COLOUR-RED-BLUE": "vermelho, azul — vermelho ← vermiculus 'LITTLE WORM', the kermes scale insect crushed for scarlet dye, so the dye's name became the colour's (→ English vermilion; vermis → vermin); PT alone skips the ancient *h₁rewdʰ- red root (kept only in rubro/ruivo). azul ← Arabic lāzaward 'lapis lazuli' ← Persian lāžward, l- lost as if an article → azure — the al-Andalus thread reaching a basic colour"
+      "PT-COLOUR-RED-BLUE": "vermelho, azul — vermelho ← vermiculus 'LITTLE WORM', the kermes scale insect crushed for scarlet dye, so the dye's name became the colour's (→ English vermilion; vermis → vermin); PT alone skips the ancient *h₁rewdʰ- red root (kept only in rubro/ruivo). azul ← Arabic lāzaward 'lapis lazuli' ← Persian lāžward, l- lost as if an article → azure — the al-Andalus thread reaching a basic colour",
+      "PT-VERB-HAVE": "ter — 'to have' (tenho/tens/tem/temos/têm; -nh- as in vinho; the CIRCUMFLEX alone separates tem 'he has' from têm 'they have'). THE IBERIAN SWAP: PT and ES alone took tenēre 'to HOLD' (→ tenant/retain/maintain/tenacious/tenure) for 'have', while FR/IT kept habēre — and PT's own habēre survivor, haver, was demoted to an auxiliary and to há 'there is'. The two verbs swapped jobs",
+      "PT-AGE": "quantos anos tens? / tenho vinte anos — age via ter, never ser; given ter ← tenēre this literally says 'I HOLD twenty years', the most physical version of the idiom. ano ← annus, where PT SIMPLIFIED the -nn- to n while Spanish PALATALIZED it to ñ (año) — one Latin word, two Iberian outcomes, and the origin of ñ itself"
     }
   },
   "practiceTags": {

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 14 — avoir, and having your years
+
+- **Chapter 14 authored** (`FR-C14-avoir`, `-age`): the verb the rest of the
+  course is built on, reviewing Ch.5/9/12/13 via `reviews_of`.
+- **avoir** (`FR-C14-avoir`): *j'ai/tu as/il a/nous avons/vous avez/ils ont* —
+  with the observation that the three singular forms are **homophones** (*ai · as
+  · a*), so only the pronoun tells you who. Etymology: ← *habēre*, and the payoff
+  is that Chapter 5 already taught this root — **habiter** ← *habitāre* is
+  *habēre*'s frequentative, "to keep having a place," so *avoir* and *habiter* are
+  the same word twice. English took the family whole: *habit* (what you have
+  regularly), *inhabit*, *exhibit* ("hold out"), *prohibit* ("hold back"). Plus how
+  far it wore down — Latin *habeō* → **j'ai**, a single vowel sound, French's usual
+  erosion (cf. *aqua* → *eau*).
+- **j'ai vingt ans** (`FR-C14-age`): age takes **avoir**, never *être*, and *ans*
+  is **obligatory** where English drops "years old." *An* ← *annus* →
+  *annual/anniversary/annals*. Includes **liaison** — the silent *t* of *vingt*
+  wakes up before a vowel: *vin-t-an*. Closes on the five-language table:
+  **French, Spanish, Italian and Portuguese all *have* their years; German and
+  English *are* theirs** — age as possession vs age as identity.
+- Sets up the compound past: *avoir* is the auxiliary the *passé composé* needs.
+- Taxonomy: namespaced `FR-VERB-HAVE`, `FR-AGE`.
+
 ## Chapter 13 — Colours
 
 - **Chapter 13 authored** (`FR-C13-noir-blanc`, `-rouge-bleu`): the **borrowing**

--- a/code/learning/human-languages/french/lessons/FR-C14-age.md
+++ b/code/learning/human-languages/french/lessons/FR-C14-age.md
@@ -1,0 +1,73 @@
+---
+id: FR-C14-age
+chapter: 14
+type: phrase
+headword: j'ai vingt ans
+gloss: "age — French HAS its years, it doesn't BE them"
+concept_tag: FR-AGE
+prerequisites: [FR-C14-avoir, FR-C12-nombres-17-20]
+sounds: [liaison-z, nasal-an]
+roots: [latin-annus]
+etymology_hook: "Romance says 'I HAVE twenty years' (j'ai vingt ans = Spanish tengo veinte años, Italian ho venti anni) where English and German say 'I AM twenty years old' — age as possession vs age as identity; an ← annus → annual/anniversary"
+est_minutes: 4
+reviews_of: [FR-C14-avoir, FR-C12-nombres-17-20, FR-C09-mois]
+---
+
+# j'ai vingt ans — having your years
+
+## Warm-up
+
+[PAUSE 2s] Ask a French speaker their age and the answer uses **avoir**. Not "I
+am twenty" — "**I have twenty years**." English can't do this; Spanish and
+Italian do exactly the same thing.
+
+## The phrase
+
+> **Quel âge as-tu ?** — "What age do you **have**?"
+> **J'ai vingt ans.** — "I **have** twenty years."
+
+Two things to notice:
+
+1. The verb is **avoir**, never *être*. *Je suis vingt ans* is simply wrong.
+2. **ans** is compulsory. English drops it ("I'm twenty"); French cannot.
+
+## an ← annus
+
+**an** ("year") ← Latin ***annus***, which gives English **annual**,
+**anniversary**, **annals**, and *per annum*. You have already met its
+descendants: Chapter 9's month names came from the same calendar.
+
+Careful with the sound: **an** is **nasal**, and in *vingt ans* the silent *t* of
+*vingt* **wakes up** and links — *vin-**t**-an*. That's **liaison**, French's
+habit of reviving a dead consonant when a vowel follows.
+
+## Who else does it this way
+
+| language | "I am 20" |
+|---|---|
+| French | *j'**ai** vingt **ans*** — **have** |
+| Spanish | *t**engo** veinte **años*** — **have** |
+| Italian | *h**o** venti **anni*** — **have** |
+| Portuguese | *t**enho** vinte **anos*** — **have** |
+| German | *ich **bin** zwanzig Jahre alt* — **be** |
+| English | *I **am** twenty* — **be** |
+
+A clean split: **Romance has its years; Germanic is its years.** Age as
+something you **carry** versus age as something you **are**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Quel âge as-tu ?"]
+- [YOU SAY: "J'ai vingt ans" — with the liaison, *vin-t-an*]
+- [YOU SAY: your own age, using Ch. 12's numbers]
+- [YOU SAY: the split — "French **a** ses ans; English **is** its years"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which verb does French use for age? (***Avoir*** — never *être*.) What
+does *j'ai vingt ans* literally say? ("I **have** twenty years.") Can you drop
+*ans*? (**No** — French requires it.) Where does *an* come from? (Latin
+***annus*** → *annual, anniversary*.) What happens to the *t* of *vingt* before
+*ans*? (It **links** — liaison.) Which languages side with English here?
+(**German** — and only German, of the five.)

--- a/code/learning/human-languages/french/lessons/FR-C14-avoir.md
+++ b/code/learning/human-languages/french/lessons/FR-C14-avoir.md
@@ -1,0 +1,74 @@
+---
+id: FR-C14-avoir
+chapter: 14
+type: word
+headword: avoir
+gloss: to have — the most worn-down verb in French, and a root you already met
+concept_tag: FR-VERB-HAVE
+prerequisites: [FR-C13-rouge-bleu, FR-C05-habiter]
+sounds: [elision-j-ai, liaison]
+roots: [latin-habere]
+etymology_hook: "avoir ← Latin habēre — the SAME root as habiter from Ch.5 (habitāre was habēre's frequentative, 'to keep having a place'), and as English habit / inhabit / exhibit / prohibit; habeō wore all the way down to j'ai, one sound"
+est_minutes: 5
+reviews_of: [FR-C13-rouge-bleu, FR-C05-habiter, FR-C05-parler]
+---
+
+# avoir — "to have"
+
+## Warm-up
+
+[PAUSE 2s] The verb French leans on hardest. It's irregular, it's everywhere,
+and — you have already met its root without knowing it.
+
+## The forms
+
+| | | |
+|---|---|---|
+| j'**ai** | nous **avons** | |
+| tu **as** | vous **avez** | |
+| il/elle **a** | ils/elles **ont** | |
+
+Say the singular column: **ai, as, a** — three forms, and they all sound the
+**same**. The written endings differ; your ear can't tell them apart. Only the
+pronoun tells you who.
+
+Note **j'ai**, not *je ai*: before a vowel, *je* loses its **e**. That's the
+**elision** you already do in *l'eau* (Ch. 11).
+
+## The root you already own
+
+**avoir** ← Latin ***habēre***. And in Chapter 5 you learned **habiter** ("to
+live somewhere") ← ***habitāre*** — which is just *habēre* run through a
+"keep doing it" pattern: *to keep having a place*. **Same root, both verbs.**
+
+The family in English is large because English borrowed it whole:
+
+| English word | inside it |
+|---|---|
+| **habit** | what you *have* regularly |
+| **inhabit** | to *have* a place — = *habiter* |
+| **exhibit** | to *hold* out |
+| **prohibit** | to *hold* back |
+
+## How far it wore down
+
+Latin ***habeō*** ("I have") → French **j'ai**. Four syllables of Latin reduced
+to a **single vowel sound**. French does this more than any of its sisters —
+compare Italian *ho*, Spanish *he*, and Chapter 11's *aqua* → **eau**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "j'ai, tu as, il a, nous avons, vous avez, ils ont"]
+- [YOU SAY: the three that sound alike — "ai · as · a"]
+- [YOU SAY: "J'ai un frère" ("I have a brother") — Ch. 10's family]
+- [YOU SAY: the root pair — "avoir · habiter"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the six forms of *avoir*. (*J'ai, tu as, il a, nous avons, vous
+avez, ils ont*.) Which three sound identical? (**Ai, as, a**.) What root is
+*avoir* from? (Latin ***habēre***.) Which verb from Chapter 5 shares it?
+(**Habiter** ← *habitāre*.) Why is it *j'ai* and not *je ai*? (**Elision** — *je*
+drops its *e* before a vowel.) Next: what French does with *avoir* that English
+would never do.

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -80,6 +80,19 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   borrowed **back** from French. Payoff: of *bleu-blanc-rouge*, **two of three are
   loanwords**. **Authored.**
 
+- **Ch. 14 — *avoir*, and having your years**: **avoir** — irregular and
+  everywhere (*j'ai/tu as/il a/nous avons/vous avez/ils ont*), where the three
+  singular forms are **homophones** and only the pronoun disambiguates; ←
+  *habēre*, which is the **same root as Ch. 5's *habiter*** (*habitāre* is
+  *habēre*'s frequentative, "to keep having a place") and as English
+  *habit/inhabit/exhibit/prohibit*; *habeō* wore all the way down to **j'ai**, a
+  single vowel → **j'ai vingt ans** — age takes **avoir**, never *être*, and *ans*
+  is obligatory (*an* ← *annus* → *annual/anniversary*), with **liaison** waking
+  the silent *t* of *vingt* (*vin-t-an*). The cross-language payoff: **French,
+  Spanish, Italian and Portuguese all *have* their years; German and English *are*
+  theirs.** **Authored.** (Also the prerequisite for the compound past — *avoir* is
+  the auxiliary the *passé composé* is built on.)
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Chapter 14 — haben, and being your years
+
+- **Chapter 14 authored** (`GE-C14-haben`, `-alter`): the workhorse verb plus the
+  one everyday place German won't use it, reviewing Ch.5/9/10/12/13 via
+  `reviews_of`.
+- **haben** (`GE-C14-haben`): *habe/hast/hat/haben/habt/haben*, where *du hast*
+  and *er hat* **drop the b** — precisely as English *have* → *ha**s*** (and
+  archaic *hast*), one shortcut the two languages inherited together. The
+  showpiece is a **false cognate**: *haben* ← Germanic *\*habjaną* ← PIE *\*kap-*
+  "to **seize**," whose Latin child is ***capere*** (→ *capture, captive, capable,
+  accept*) — while Latin ***habēre*** (which gave French *avoir* and Italian
+  *avere*) descends from *\*gʰabʰ-*, whose English descendant is **give**. The two
+  words that look most alike and mean the same thing come from **opposite**
+  ancestries; German *haben* is kin to *capture*, Latin *habēre* to *give*.
+- **ich bin zwanzig Jahre alt** (`GE-C14-alter`): the one everyday slot where
+  German **refuses** *haben* — age takes **sein**, producing word-for-word the
+  English sentence, and shortening the same way (*ich bin zwanzig*). *Jahr* ←
+  *\*jēra* = **year**; *alt* ← *\*aldaz* = **old**, with the Latin cousin *alere*
+  "to nourish, grow" behind English *adult*. Closes on the five-language table:
+  **all four Romance sisters *have* their years; German sides with English and
+  *is* its years** — and does so even though it borrowed its month names from
+  Latin (Ch.9).
+- Sets up the *Perfekt*, which is built on *haben*.
+- Taxonomy: namespaced `GE-VERB-HAVE`, `GE-AGE`.
+
 ## Chapter 13 — Colours
 
 - **Chapter 13 authored** (`GE-C13-schwarz-weiss`, `-rot-blau`): German as the

--- a/code/learning/human-languages/german/lessons/GE-C14-alter.md
+++ b/code/learning/human-languages/german/lessons/GE-C14-alter.md
@@ -1,0 +1,76 @@
+---
+id: GE-C14-alter
+chapter: 14
+type: phrase
+headword: ich bin zwanzig Jahre alt
+gloss: "age — the one place German refuses haben, siding with English against every Romance sister"
+concept_tag: GE-AGE
+prerequisites: [GE-C14-haben, GE-C12-zahlen-13-20]
+sounds: [long-a, ch-ich]
+roots: [germanic-jera, germanic-alda]
+etymology_hook: "German+English say 'I AM twenty years old' where French/Spanish/Italian/Portuguese all say 'I HAVE twenty years' — age as identity vs age as possession; Jahr ← *jēra = English year, alt ← *aldaz = English old (and 'adult', from Latin's cousin alere 'to nourish')"
+est_minutes: 4
+reviews_of: [GE-C14-haben, GE-C12-zahlen-13-20, GE-C09-jahreszeiten]
+---
+
+# ich bin zwanzig Jahre alt — being your years
+
+## Warm-up
+
+[PAUSE 2s] You just learned **haben**. Here is the everyday sentence where German
+**won't** let you use it — and where German and English stand alone against all
+four Romance languages.
+
+## The phrase
+
+> **Wie alt bist du?** — literally "**How old** are you?"
+> **Ich bin zwanzig Jahre alt.** — "I **am** twenty years old."
+
+Word for word, that is the **English sentence**. Not a coincidence — both
+languages inherited the same way of saying it.
+
+You can shorten it to **Ich bin zwanzig**, exactly as English drops "years old."
+
+## The words
+
+| word | ← | English twin |
+|---|---|---|
+| **Jahr** | Germanic *\*jēra* | **year** |
+| **alt** | Germanic *\*aldaz* | **old** |
+
+*Alt* has a Latin cousin too: *alere*, "to nourish, grow" — which gives English
+**adult** ("grown up") and **old** itself. Growing and ageing, one idea.
+
+Note **Jahre** is the plural (Ch. 9's *Jahreszeiten*, "year's-times" = seasons,
+already had it), and German capitalises it as a noun.
+
+## The split, laid out
+
+| language | how age works | literally |
+|---|---|---|
+| **German** | *ich **bin** … Jahre alt* | I **am** … |
+| **English** | *I **am** twenty* | I **am** … |
+| French | *j'**ai** vingt ans* | I **have** … |
+| Spanish | *t**engo** veinte años* | I **have** … |
+| Italian | *h**o** venti anni* | I **have** … |
+| Portuguese | *t**enho** vinte anos* | I **have** … |
+
+**Romance has its years; Germanic is its years.** Age as something you carry
+versus age as something you are — and German, which borrowed its months from
+Latin (Ch. 9), keeps its **own** logic here.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Wie alt bist du?"]
+- [YOU SAY: "Ich bin zwanzig Jahre alt"]
+- [YOU SAY: your own age, using Ch. 12's numbers]
+- [YOU SAY: the contrast — "ich **bin** … / j'**ai** …"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which verb does German use for age? (**Sein** — *bin* — **not**
+*haben*.) What does *wie alt* literally ask? ("**How old**.") What are *Jahr* and
+*alt* in English? (**Year** and **old** — direct twins.) Which languages say "I
+**have** twenty years"? (**All four Romance ones** — French, Spanish, Italian,
+Portuguese.) So who does German side with? (**English**, alone.)

--- a/code/learning/human-languages/german/lessons/GE-C14-haben.md
+++ b/code/learning/human-languages/german/lessons/GE-C14-haben.md
@@ -1,0 +1,78 @@
+---
+id: GE-C14-haben
+chapter: 14
+type: word
+headword: haben
+gloss: to have — identical to Latin habēre in sound and sense, and unrelated to it
+concept_tag: GE-VERB-HAVE
+prerequisites: [GE-C13-rot-blau, GE-C05-machen]
+sounds: [long-a, final-t]
+roots: [germanic-habjana]
+etymology_hook: "haben ← Germanic *habjaną (= English have), from PIE *kap- 'to seize' — the SAME root as Latin capere (capture/captive). Latin habēre only LOOKS like it: it descends from *gʰabʰ-, whose English child is GIVE. A textbook false cognate — same sound, same meaning, opposite ancestry"
+est_minutes: 5
+reviews_of: [GE-C13-rot-blau, GE-C05-machen, GE-C10-geschwister]
+---
+
+# haben — "to have"
+
+## Warm-up
+
+[PAUSE 2s] German's workhorse verb, the twin of English *have* — and the source
+of the best false cognate in this whole course.
+
+## The forms
+
+| | | |
+|---|---|---|
+| ich **habe** | wir **haben** | |
+| du **hast** | ihr **habt** | |
+| er/sie **hat** | sie/Sie **haben** | |
+
+Mostly regular, with **two irregulars**: *du hast* and *er hat* **drop the b**.
+English does the identical thing — *have* but *ha**s***, *hast* in older English.
+Two languages, one shortcut, inherited together.
+
+## The trap: haben is not habēre
+
+Look at these two verbs:
+
+| | verb | meaning |
+|---|---|---|
+| German | **haben** | to have |
+| Latin | **habēre** | to have |
+
+Same consonants, same meaning. **They are not related.** It is a coincidence —
+one of the most famous in linguistics.
+
+- **haben** ← Germanic *\*habjaną* ← PIE *\*kap-* "**to seize**." That root's
+  Latin child is ***capere*** — which gives English **capture, captive,
+  capable, accept**.
+- **habēre** ← PIE *\*gʰabʰ-*, whose English descendant is… **give**.
+
+So German *haben* is a cousin of **capture**, and Latin *habēre* — the source of
+French *avoir* and Italian *avere* — is a cousin of **give**. The two words that
+look most alike come from **opposite** directions.
+
+## Using it
+
+German nouns are capitalised and take their gender (Ch. 10, 11):
+
+> **Ich habe einen Bruder.** — "I have a brother."
+> **Wir haben Brot und Wein.** — Chapter 11's food, now possessed.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ich habe, du hast, er hat, wir haben, ihr habt, sie haben"]
+- [YOU SAY: the dropped **b** — "habe … ha**st** … ha**t**"]
+- [YOU SAY: "Ich habe eine Schwester" — Ch. 10's family]
+- [YOU SAY: the false pair — "**haben** kin to *capture*; **habēre** kin to *give*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the forms of *haben*. (*Habe, hast, hat, haben, habt, haben*.)
+Which two drop the **b**, and which English forms match? (*Du hast*, *er hat* —
+English *has/hast*.) Is *haben* related to Latin *habēre*? (**No** — a
+coincidence.) What is each one actually related to? (*Haben* → **capture** (via
+*capere*); *habēre* → **give**.) Next: the one everyday thing German **refuses**
+to use *haben* for.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -88,6 +88,20 @@ Spanish and French where a contrast helps. The recurring decoder is the
   *blu*), and English took *blue* from **French** rather than from Germanic.
   **Authored.**
 
+- **Ch. 14 — *haben*, and being your years**: **haben** (*habe/hast/hat/haben/
+  habt/haben*), where *du hast* and *er hat* **drop the b** exactly as English
+  *have* → *ha**s***. The showpiece is a **false cognate**: *haben* ← Germanic
+  *\*habjaną* ← PIE *\*kap-* "to **seize**," whose Latin child is ***capere***
+  (*capture/captive/accept*) — while Latin ***habēre*** (the source of *avoir* and
+  *avere*) descends from *\*gʰabʰ-*, whose English child is **give**. The two
+  words that look most alike, mean the same thing, and come from **opposite**
+  directions → **ich bin zwanzig Jahre alt** — the one everyday slot where German
+  **refuses** *haben*: age takes **sein**, word for word the English sentence
+  (*Jahr* ← *\*jēra* = *year*; *alt* ← *\*aldaz* = *old*). The split: **all four
+  Romance sisters *have* their years; German sides with English and *is* its
+  years.** **Authored.** (Also the prerequisite for the *Perfekt*, built on
+  *haben*.)
+
 ## Planned
 
 | Chapter | Theme |

--- a/code/learning/human-languages/italian/CHANGELOG.md
+++ b/code/learning/human-languages/italian/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Chapter 14 — avere, and having your years
+
+- **Chapter 14 authored** (`IT-C14-avere`, `-eta`): the workhorse verb and the
+  language's only silent letter, reviewing Ch.5/9/10/11/12/13 via `reviews_of`.
+- **avere** (`IT-C14-avere`): *ho/hai/ha/abbiamo/avete/hanno* ← *habēre*, the same
+  source as French *avoir*, and English's *habit/inhabit/exhibit/prohibit*. The
+  chapter's real subject is the **silent h**: Italian discarded the Latin *h*
+  almost everywhere (*homō* → *uomo*, *herba* → *erba*), but kept it in exactly
+  these four forms because without it they collide with **o** ("or"), **ai** ("to
+  the"), **a** ("to") and **anno** ("**year**"). The letter is never pronounced and
+  survives **only so the eye can tell the words apart** — spelling doing a job
+  sound cannot. Also notes *abbiamo*'s **bb** as the old *habē-* resurfacing while
+  *ho* wore down to one vowel.
+- **ho venti anni** (`IT-C14-eta`): age via *avere*, never *essere*; *anno* ←
+  *annus* → *annual/anniversary*, with a genuinely held **double n**. The silent
+  *h* then pays off inside this very chapter — ***hanno*** ("they have") and
+  ***anno*** ("year") are **homophones** that co-occur in age sentences, which is
+  exactly why the letter was worth keeping. Closes on the five-language table:
+  **Romance has its years; Germanic is its years.**
+- Sets up the *passato prossimo*, which is built on *avere*.
+- Taxonomy: namespaced `IT-VERB-HAVE`, `IT-AGE`.
+
 ## Chapter 13 — Colours
 
 - **Chapter 13 authored** (`IT-C13-nero-bianco`, `-rosso-blu`): two colours from two

--- a/code/learning/human-languages/italian/lessons/IT-C14-avere.md
+++ b/code/learning/human-languages/italian/lessons/IT-C14-avere.md
@@ -1,0 +1,76 @@
+---
+id: IT-C14-avere
+chapter: 14
+type: word
+headword: avere
+gloss: to have — and Italy's only silent letter, which exists purely to prevent confusion
+concept_tag: IT-VERB-HAVE
+prerequisites: [IT-C13-rosso-blu, IT-C05-parlare]
+sounds: [silent-h, double-n]
+roots: [latin-habere]
+etymology_hook: "avere ← habēre (→ habit/inhabit/exhibit/prohibit). Italian dropped the Latin h everywhere EXCEPT here: ho/hai/ha/hanno keep a silent h purely to distinguish them from o 'or', ai 'to the', a 'to', anno 'YEAR' — spelling doing a job sound can't"
+est_minutes: 5
+reviews_of: [IT-C13-rosso-blu, IT-C05-parlare, IT-C11-acqua-vino]
+---
+
+# avere — "to have"
+
+## Warm-up
+
+[PAUSE 2s] Italian's workhorse verb — and the home of the language's **only
+silent letter**, which is there for a reason worth knowing.
+
+## The forms
+
+| | | |
+|---|---|---|
+| **ho** | **abbiamo** | |
+| **hai** | **avete** | |
+| **ha** | **hanno** | |
+
+Look at which forms carry an **h**: *ho, hai, ha, hanno*. And which don't:
+*abbiamo, avete*.
+
+## The silent h, and why it survives
+
+Italian threw the Latin **h** away almost completely — it is never pronounced,
+and *uomo* (← *homō*) and *erba* (← *herba*) simply dropped it.
+
+But in *avere* it stayed, because without it these words would collide:
+
+| with h | without h | meaning |
+|---|---|---|
+| **ho** — I have | **o** | "or" |
+| **hai** — you have | **ai** | "to the" |
+| **ha** — he/she has | **a** | "to" |
+| **hanno** — they have | **anno** | "**year**" |
+
+Four minimal pairs, all extremely common. The **h** is silent, does nothing to
+the sound, and is kept **only so your eye can tell the words apart**. Spelling
+doing a job pronunciation can't — hold onto *hanno* vs *anno*; it comes back in
+the next lesson.
+
+## The root
+
+**avere** ← Latin ***habēre***, the same source as French *avoir*. English took
+it as a whole family: **habit** (what you have regularly), **inhabit**,
+**exhibit** ("hold out"), **prohibit** ("hold back").
+
+Note *abbiamo* — the **bb** is the old *habē-* resurfacing in the *noi* form,
+while *ho* wore down to a single vowel.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ho, hai, ha, abbiamo, avete, hanno"]
+- [YOU SAY: "Ho un fratello" ("I have a brother") — Ch. 10's family]
+- [YOU SAY: the pair — "**hanno** they have · **anno** a year"]
+- [YOU SAY: "Abbiamo pane e vino" — Ch. 11's food]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give the six forms. (*Ho, hai, ha, abbiamo, avete, hanno*.) Which
+carry an **h**? (*Ho, hai, ha, hanno*.) Is it pronounced? (**No** — never.) Then
+why is it there? (To keep them apart from **o, ai, a, anno** in **writing**.)
+What root is *avere* from? (Latin ***habēre*** → *habit/inhabit/exhibit*.) Next:
+*anno* takes centre stage.

--- a/code/learning/human-languages/italian/lessons/IT-C14-eta.md
+++ b/code/learning/human-languages/italian/lessons/IT-C14-eta.md
@@ -1,0 +1,80 @@
+---
+id: IT-C14-eta
+chapter: 14
+type: phrase
+headword: ho venti anni
+gloss: "age — Italian HAS its years, and the last lesson's silent h finally earns its keep"
+concept_tag: IT-AGE
+prerequisites: [IT-C14-avere, IT-C12-numeri-17-20]
+sounds: [double-n, final-stress-a]
+roots: [latin-annus, latin-aetas]
+etymology_hook: "ho venti anni = 'I HAVE twenty years' like French/Spanish/Portuguese, against German/English 'I AM'; anno ← annus → annual/anniversary — and here hanno ('they have') vs anno ('year') stops being a curiosity and becomes a sentence you must spell right"
+est_minutes: 4
+reviews_of: [IT-C14-avere, IT-C12-numeri-17-20, IT-C09-mesi]
+---
+
+# ho venti anni — having your years
+
+## Warm-up
+
+[PAUSE 2s] Italian states age with **avere**, not *essere*. And the silent **h**
+from last lesson stops being trivia here — it becomes the difference between two
+real sentences.
+
+## The phrase
+
+> **Quanti anni hai?** — "How many years do you **have**?"
+> **Ho venti anni.** — "I **have** twenty years."
+
+*Essere* is wrong here. *Sono venti anni* does not mean "I am twenty."
+
+## anno ← annus
+
+**anno** ("year") ← Latin ***annus*** → English **annual**, **anniversary**,
+**annals**, *per annum*. Chapter 9's months and seasons came from the same
+calendar vocabulary.
+
+Note the **double n**: *a-nno*, held. Italian's double consonants are real
+length, not decoration.
+
+## The h earns its keep
+
+Now put the last lesson to work:
+
+| sentence | meaning |
+|---|---|
+| **Hanno venti anni.** | "**They have** twenty years." |
+| **anno** | "**year**" |
+
+*Hanno* and *anno* sound **exactly the same**. Only the silent **h** tells them
+apart — and in a sentence about years, both words show up at once. That is
+precisely why Italian kept a letter it never pronounces.
+
+## Who has, who is
+
+| language | |
+|---|---|
+| Italian | *h**o** venti anni* — **have** |
+| French | *j'**ai** vingt ans* — **have** |
+| Spanish | *t**engo** veinte años* — **have** |
+| Portuguese | *t**enho** vinte anos* — **have** |
+| German | *ich **bin** zwanzig Jahre alt* — **be** |
+| English | *I **am** twenty* — **be** |
+
+**Romance has its years; Germanic is its years.**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Quanti anni hai?"]
+- [YOU SAY: "Ho venti anni" — hold the **nn**]
+- [YOU SAY: your own age, using Ch. 12's numbers]
+- [YOU SAY: the pair aloud — "**hanno** … **anno**" — identical sound]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which verb does Italian use for age? (***Avere***, never *essere*.)
+What does *ho venti anni* literally say? ("I **have** twenty years.") Where does
+*anno* come from? (Latin ***annus*** → *annual/anniversary*.) What separates
+*hanno* from *anno*? (**Only the silent h** — they sound identical.) Which two
+languages say "I **am**" instead? (**German and English**.)

--- a/code/learning/human-languages/italian/roadmap.md
+++ b/code/learning/human-languages/italian/roadmap.md
@@ -77,6 +77,18 @@ and Italian's habit of keeping final vowels Latin's other children dropped.
   article → English **azure** — so Italy's teams, **gli Azzurri**, are named after a
   blue stone mined in Afghanistan. **Authored.**
 
+- **Ch. 14 — *avere*, and having your years**: **avere** (*ho/hai/ha/abbiamo/
+  avete/hanno*) ← *habēre*, the same source as French *avoir* (→ English
+  *habit/inhabit/exhibit/prohibit*). It houses **Italian's only silent letter**:
+  the **h** of *ho/hai/ha/hanno* is never pronounced and survives **purely to keep
+  them apart in writing** from *o* ("or"), *ai* ("to the"), *a* ("to") and *anno*
+  ("**year**") — spelling doing a job sound cannot → **ho venti anni**, age via
+  *avere* and never *essere* (*anno* ← *annus* → *annual/anniversary*, with a held
+  **double n**). The silent *h* then earns its keep in this very chapter:
+  ***hanno*** ("they have") and ***anno*** ("year") are **homophones** that turn up
+  in the same sentence. **Authored.** (Also the prerequisite for the *passato
+  prossimo*.)
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |

--- a/code/learning/human-languages/portuguese/CHANGELOG.md
+++ b/code/learning/human-languages/portuguese/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Chapter 14 — ter, and holding your years
+
+- **Chapter 14 authored** (`PT-C14-ter`, `-idade`): the workhorse verb, and the
+  place Portuguese and Spanish broke ranks with the rest of Romance — reviewing
+  Ch.5/9/10/11/12/13 via `reviews_of`.
+- **ter** (`PT-C14-ter`): *tenho/tens/tem/temos/têm*, with the **-nh-** already met
+  in *vinho* and *amanhã*, and a **circumflex** that alone separates *tem* ("he
+  has") from *têm* ("**they** have") — an accent doing **grammar**, not sound. The
+  chapter's subject is the **Iberian swap**: Portuguese and Spanish **alone** took
+  Latin ***tenēre*** "to **hold**" as their everyday word for *have*, while French
+  and Italian kept *habēre* — and Portuguese's own *habēre* survivor, **haver**,
+  was **demoted** to an auxiliary and to *há* ("there is"). The two verbs swapped
+  jobs on the peninsula. English kept the *tenēre* family as borrowings: *tenant*
+  (one who **holds** land), *retain*, *maintain*, *tenacious*, *tenure*, *contain*.
+- **tenho vinte anos** (`PT-C14-idade`): age via *ter*, never *ser* — and because
+  *ter* came from "to hold," the sentence literally says "**I hold twenty
+  years**," the most physical version of the idiom in the five languages. *Ano* ←
+  *annus* then shows the **two Iberian outcomes of Latin -nn-**: Portuguese
+  **simplified** it to a plain *n*, Spanish **palatalized** it into **ñ** (*año*) —
+  which is where the *ñ* came from in the first place. Closes on the layered table:
+  Germanic **is** its years, French and Italian **have** them, Iberian Romance
+  **holds** them.
+- Taxonomy: namespaced `PT-VERB-HAVE`, `PT-AGE`.
+
 ## Chapter 13 — Colours
 
 - **Chapter 13 authored** (`PT-C13-preto-branco`, `-vermelho-azul`): the strangest

--- a/code/learning/human-languages/portuguese/lessons/PT-C14-idade.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C14-idade.md
@@ -1,0 +1,79 @@
+---
+id: PT-C14-idade
+chapter: 14
+type: phrase
+headword: tenho vinte anos
+gloss: "age — Portuguese HOLDS its years, and annus loses its double n"
+concept_tag: PT-AGE
+prerequisites: [PT-C14-ter, PT-C12-numeros-16-20]
+sounds: [nasal-anos, plural-s]
+roots: [latin-annus, latin-aetas]
+etymology_hook: "tenho vinte anos literally 'I HOLD twenty years' (ter ← tenēre), the strongest form of the Romance have-your-age idiom; ano ← annus simplified the -nn- where Spanish palatalized it to año — one Latin word, two Iberian outcomes"
+est_minutes: 4
+reviews_of: [PT-C14-ter, PT-C12-numeros-16-20, PT-C09-meses]
+---
+
+# tenho vinte anos — holding your years
+
+## Warm-up
+
+[PAUSE 2s] Portuguese states age with **ter**. And since *ter* came from "to
+**hold**," the sentence is, at the root, "**I hold twenty years**" — the most
+physical version of this idea in any of the five languages.
+
+## The phrase
+
+> **Quantos anos tens?** — "How many years do you **have**?"
+> **Tenho vinte anos.** — "I **have** twenty years."
+
+*Ser* is wrong here. And **anos** can't be dropped, unlike English "I'm twenty."
+
+## ano ← annus, minus one n
+
+**ano** ("year") ← Latin ***annus*** → English **annual**, **anniversary**,
+**annals**.
+
+Now compare the two Iberian sisters:
+
+| Latin | Portuguese | Spanish |
+|---|---|---|
+| *annus* | **ano** | **año** |
+
+The Latin **-nn-** went two ways: Portuguese **simplified** it to a plain *n*,
+Spanish **palatalized** it into **ñ**. Same word, same peninsula, two outcomes —
+and this is exactly where Spanish's *ñ* came from in the first place: doubled
+Latin *n*.
+
+Careful: keep *ano* distinct from *ânus*. The stress and the circumflex do the
+work.
+
+## Who has, who is
+
+| language | | literally |
+|---|---|---|
+| Portuguese | *t**enho** vinte anos* | I **hold** … |
+| Spanish | *t**engo** veinte años* | I **hold** … |
+| French | *j'**ai** vingt ans* | I **have** … |
+| Italian | *h**o** venti anni* | I **have** … |
+| German | *ich **bin** zwanzig Jahre alt* | I **am** … |
+| English | *I **am** twenty* | I **am** … |
+
+Three layers: Germanic **is** its years, French and Italian **have** them, and
+Iberian Romance **holds** them.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Quantos anos tens?"]
+- [YOU SAY: "Tenho vinte anos"]
+- [YOU SAY: your own age, using Ch. 12's numbers]
+- [YOU SAY: the sister pair — "**ano** … **año**" — one Latin *annus*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which verb does Portuguese use for age? (***Ter***, never *ser*.)
+Given *ter*'s root, what does the sentence literally say? ("I **hold** twenty
+years.") Where does *ano* come from? (Latin ***annus***.) What did Portuguese and
+Spanish each do with the **-nn-**? (PT **simplified** it to *n*; ES
+**palatalized** it to **ñ**.) Which two languages say "I **am**" instead?
+(**German and English**.)

--- a/code/learning/human-languages/portuguese/lessons/PT-C14-ter.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C14-ter.md
@@ -1,0 +1,74 @@
+---
+id: PT-C14-ter
+chapter: 14
+type: word
+headword: ter
+gloss: to have — where Portuguese and Spanish broke ranks with the rest of Romance
+concept_tag: PT-VERB-HAVE
+prerequisites: [PT-C13-vermelho-azul, PT-C05-falar]
+sounds: [nasal-em, circumflex-tem]
+roots: [latin-tenere]
+etymology_hook: "PT and ES alone use tenēre 'to HOLD' (→ tenant/retain/tenacious) for 'have', while French/Italian kept habēre; Portuguese does have haver ← habēre, but demoted it to an auxiliary — two verbs swapped jobs on the Iberian peninsula"
+est_minutes: 5
+reviews_of: [PT-C13-vermelho-azul, PT-C05-falar, PT-C10-irmaos]
+---
+
+# ter — "to have"
+
+## Warm-up
+
+[PAUSE 2s] Every Romance language needs a word for "have." French and Italian
+took one from Latin; **Portuguese and Spanish took a different one entirely** —
+and it didn't originally mean "have" at all.
+
+## The forms
+
+| | |
+|---|---|
+| (eu) | **tenho** |
+| (tu) | **tens** |
+| (ele/ela/você) | **tem** |
+| (nós) | **temos** |
+| (vocês/eles) | **têm** |
+
+Two things to watch:
+
+- **tenho** — the **-nh-** (Portuguese's palatal *ny*, = Spanish **ñ**), already
+  met in *vinho* (Ch. 11) and *amanhã*.
+- **tem** vs **têm** — "he has" vs "**they** have". They sound nearly alike; the
+  **circumflex** marks the plural. An accent doing grammar, not sound.
+
+## The Iberian swap
+
+**ter** ← Latin ***tenēre***, "**to hold**" — not "to have."
+
+| language | "to have" | ← Latin |
+|---|---|---|
+| French | *avoir* | *habēre* |
+| Italian | *avere* | *habēre* |
+| **Portuguese** | **ter** | ***tenēre*** "to hold" |
+| **Spanish** | **tener** | ***tenēre*** "to hold" |
+
+Portuguese *does* still have **haver** (← *habēre*) — but it got demoted to an
+auxiliary and to *há* ("there is"). So on the Iberian peninsula the two verbs
+**swapped jobs**: "hold" moved up to mean *have*, and "have" moved down to a
+grammar word.
+
+English kept the *tenēre* family as borrowings: **tenant** (one who *holds*
+land), **retain**, **maintain**, **tenacious**, **tenure**, **contain**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tenho, tens, tem, temos, têm"]
+- [YOU SAY: the **-nh-** — "te**nh**o", like *vi**nh**o*]
+- [YOU SAY: "Tenho um irmão" ("I have a brother") — Ch. 10's family]
+- [YOU SAY: the hold-family — "ter · tenant · retain · tenacious"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did *ter*'s Latin source mean? (***Tenēre*** — "to **hold**".)
+Which other language made the same swap? (**Spanish**, *tener*.) What happened to
+Portuguese's *habēre* verb? (It became **haver** — an auxiliary, and *há* "there
+is".) What separates *tem* from *têm*? (The **circumflex** — singular vs plural.)
+Next: the question *ter* is used for that English would never use "have" for.

--- a/code/learning/human-languages/portuguese/roadmap.md
+++ b/code/learning/human-languages/portuguese/roadmap.md
@@ -85,6 +85,20 @@ French.
   colour. Payoff: **not one** of the four is a plain inherited Latin colour word.
   **Authored.**
 
+- **Ch. 14 — *ter*, and holding your years**: **ter** (*tenho/tens/tem/temos/
+  têm*), with the **-nh-** already met in *vinho* and a **circumflex** that alone
+  separates *tem* ("he has") from *têm* ("**they** have") — an accent doing
+  grammar, not sound. The chapter's point is the **Iberian swap**: Portuguese and
+  Spanish **alone** took Latin ***tenēre*** "to **hold**" (→ English
+  *tenant/retain/maintain/tenacious/tenure*) as their word for *have*, while French
+  and Italian kept *habēre* — and Portuguese's own *habēre* survivor, **haver**,
+  was **demoted** to an auxiliary and to *há* ("there is"). The two verbs swapped
+  jobs → **tenho vinte anos**, age via *ter* and never *ser*, which given the root
+  literally says "**I hold twenty years**" — the most physical version of the
+  idiom. And *ano* ← *annus* shows the two Iberian outcomes of Latin **-nn-**:
+  Portuguese **simplified** it to *n*, Spanish **palatalized** it into **ñ**
+  (*año*) — which is where *ñ* came from in the first place. **Authored.**
+
 ## Planned (mirrors the Spanish theme sequence)
 
 | Chapter | Theme |


### PR DESCRIPTION
**Scope note:** the queued plan was the compound past (*passé composé* / *Perfekt* /
*passato prossimo*). On checking, **none of the four tracks had taught "to have" yet** —
so the compound past couldn't be built atom-first. This chapter teaches the missing
auxiliary instead, exactly as the Spanish pilot taught *tener* (Ch.8) before anything
leaned on it. The past tense follows in Ch.15, now with its prerequisite in place.

Each language gets the verb plus the **age idiom**, which splits the five languages
cleanly.

**French** (`FR-C14-avoir`, `-age`) — *j'ai/tu as/il a/…*, whose three singular forms are
**homophones**, so only the pronoun disambiguates. *Avoir* ← *habēre* — the **same root
as Ch.5's *habiter*** (*habitāre* is *habēre*'s frequentative, "to keep having a place"),
and as English *habit/inhabit/exhibit/prohibit*; Latin *habeō* wore down to **j'ai**, a
single vowel. Then *j'ai vingt ans*: **avoir never *être***, *ans* obligatory, and
**liaison** waking the silent *t* of *vingt* (*vin-t-an*).

**German** (`GE-C14-haben`, `-alter`) — *habe/hast/hat/…*, where *du hast* and *er hat*
**drop the b** exactly as English *have* → *ha**s***. The showpiece is a **false
cognate**: *haben* ← Germanic *\*habjaną* ← PIE *\*kap-* "to **seize**," whose Latin child
is ***capere*** (*capture/captive*) — while Latin ***habēre***, the source of *avoir* and
*avere*, descends from *\*gʰabʰ-*, whose English child is **give**. Identical sound and
sense, **opposite ancestry**. Then the one everyday slot where German **refuses** *haben*:
*ich bin zwanzig Jahre alt*, word for word the English sentence.

**Italian** (`IT-C14-avere`, `-eta`) — *ho/hai/ha/abbiamo/avete/hanno*, and the language's
**only silent letter**. Italian discarded the Latin *h* nearly everywhere (*homō* →
*uomo*, *herba* → *erba*) but kept it in these four forms because without it they collide
with **o** "or", **ai** "to the", **a** "to" and **anno** "**year**". It is never
pronounced and survives **only so the eye can separate them** — and the payoff lands in
the same chapter: ***hanno*** and ***anno*** are homophones that co-occur in age sentences.

**Portuguese** (`PT-C14-ter`, `-idade`) — *tenho/tens/tem/temos/têm*, with *-nh-* from
*vinho* and a **circumflex** that alone separates *tem* "he has" from *têm* "they have" —
an accent doing **grammar**, not sound. The **Iberian swap**: PT and ES **alone** took
*tenēre* "to **hold**" (→ *tenant/retain/tenacious/tenure*) for "have" while FR/IT kept
*habēre*, and Portuguese's own *haver* was **demoted** to an auxiliary and to *há* "there
is". So *tenho vinte anos* literally says "**I hold twenty years**." *Ano* ← *annus* also
shows the two Iberian outcomes of **-nn-**: PT **simplified** to *n*, Spanish
**palatalized** to **ñ** — which is where *ñ* came from.

**The cross-language payoff**, closing every age lesson: **Germanic *is* its years, French
and Italian *have* them, Iberian Romance *holds* them.**

Taxonomy: namespaced `{FR,GE,IT,PT}-VERB-HAVE` and `-AGE`. All four roadmaps (Ch.14
authored) and CHANGELOGs updated.

Suite green at **38/38**; retired-concept-tag sweep clean across the whole curriculum.
Security-reviewed: PASS, no findings (its one editorial note — a gap in the PT
conjugation table — is fixed; the table now matches the track's 5-form paradigm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)