### PR TITLE
Add Haskell UPC-A port

### DIFF
--- a/code/packages/haskell/upc-a/BUILD
+++ b/code/packages/haskell/upc-a/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/upc-a/BUILD_windows
+++ b/code/packages/haskell/upc-a/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/upc-a/CHANGELOG.md
+++ b/code/packages/haskell/upc-a/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Validate 11- and 12-digit ASCII UPC-A input.
+- Compute and verify the required modulo-10 check digit.
+- Encode the complete left/right digit tables and 95-module guard structure.
+- Emit attributed runs and backend-neutral paint scenes through the shared 1D geometry.

--- a/code/packages/haskell/upc-a/README.md
+++ b/code/packages/haskell/upc-a/README.md
@@ -1,0 +1,27 @@
+# upc-a (Haskell)
+
+Pure UPC-A encoding for the Haskell package lane. The package accepts an
+11-digit payload and computes its required check digit, or accepts a complete
+12-digit code and verifies the supplied check digit.
+
+```haskell
+import CodingAdventures.UpcA
+
+example = drawUpcA "03600029145" defaultPaintBarcode1DOptions
+```
+
+The API exposes typed left/right encodings, all twenty standard digit patterns,
+the modulo-10 checksum, normalized data, per-digit source attribution, and the
+complete 95-module run stream. UPC-E compression, supplements, GS1 application
+identifiers, and scanner-side decoding remain outside the V1 contract.
+
+Rendering delegates to `barcode-layout-1d`, which supplies validated quiet-zone
+geometry, explicit symbol spans, rectangle-only paint instructions, and shared
+scene metadata. Human-readable text remains explicitly unsupported until the
+Haskell lane has a text-shaping backend.
+
+## Development
+
+```sh
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/upc-a/cabal.project
+++ b/code/packages/haskell/upc-a/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../barcode-layout-1d ../paint-instructions

--- a/code/packages/haskell/upc-a/src/CodingAdventures/UpcA.hs
+++ b/code/packages/haskell/upc-a/src/CodingAdventures/UpcA.hs
@@ -1,0 +1,264 @@
+-- | Pure UPC-A barcode encoding.
+module CodingAdventures.UpcA
+  ( UpcAEncoding (..)
+  , EncodedUpcADigit (..)
+  , UpcAError (..)
+  , Barcode1DError (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , PaintScene (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , upcADigitPattern
+  , computeUpcACheckDigit
+  , normalizeUpcA
+  , encodeUpcA
+  , expandUpcARuns
+  , layoutUpcA
+  , drawUpcA
+  , version
+  ) where
+
+import CodingAdventures.BarcodeLayout1D
+  ( Barcode1DError (..)
+  , Barcode1DRenderConfig (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DSymbolDescriptor (..)
+  , Barcode1DSymbolRole (..)
+  , PaintBarcode1DOptions (..)
+  , defaultBarcode1DRenderConfig
+  , defaultBinaryPatternOptions
+  , defaultPaintBarcode1DOptions
+  , layoutBarcode1D
+  , runsFromBinaryPattern
+  )
+import CodingAdventures.PaintInstructions (PaintScene (..))
+import Data.Aeson (toJSON)
+import Data.Bifunctor (first)
+import Data.Char (ord)
+import Data.List (findIndex)
+import qualified Data.Map.Strict as Map
+
+-- | Package version shared with the established implementations.
+version :: String
+version = "0.1.0"
+
+-- | The side of the UPC-A symbol that supplies a digit's pattern.
+data UpcAEncoding = LeftEncoding | RightEncoding
+  deriving (Eq, Show)
+
+-- | One normalized digit and its seven-module pattern.
+data EncodedUpcADigit = EncodedUpcADigit
+  { encodedUpcADigit :: Char
+  , encodedUpcAEncoding :: UpcAEncoding
+  , encodedUpcAPattern :: String
+  , encodedUpcASourceIndex :: Int
+  , encodedUpcARole :: Barcode1DRunRole
+  } deriving (Eq, Show)
+
+-- | Checked failures from input, checksum, pattern, or shared layout rules.
+data UpcAError
+  = InvalidUpcACharacter Int Char
+  | InvalidUpcALength Int
+  | InvalidUpcACheckDigit Char Char
+  | UpcALayoutError Barcode1DError
+  deriving (Eq)
+
+instance Show UpcAError where
+  show (InvalidUpcACharacter index character) =
+    "Invalid UPC-A character " ++ show [character]
+      ++ " at index " ++ show index ++ "; expected an ASCII digit"
+  show (InvalidUpcALength actualLength) =
+    "Invalid UPC-A length " ++ show actualLength
+      ++ "; expected 11 payload digits or 12 complete digits"
+  show (InvalidUpcACheckDigit expected actual) =
+    "Invalid UPC-A check digit: expected " ++ [expected]
+      ++ " but received " ++ [actual]
+  show (UpcALayoutError layoutError) = show layoutError
+
+sideGuard :: String
+sideGuard = "101"
+
+centerGuard :: String
+centerGuard = "01010"
+
+leftPatterns :: [String]
+leftPatterns =
+  [ "0001101", "0011001", "0010011", "0111101", "0100011"
+  , "0110001", "0101111", "0111011", "0110111", "0001011"
+  ]
+
+rightPatterns :: [String]
+rightPatterns =
+  [ "1110010", "1100110", "1101100", "1000010", "1011100"
+  , "1001110", "1010000", "1000100", "1001000", "1110100"
+  ]
+
+-- | Look up one of the twenty standard seven-module digit patterns.
+upcADigitPattern :: UpcAEncoding -> Char -> Either UpcAError String
+upcADigitPattern encoding digit = do
+  value <- digitValue 0 digit
+  case drop value patterns of
+    patternText : _ -> Right patternText
+    [] -> Left (InvalidUpcACharacter 0 digit)
+  where
+    patterns = case encoding of
+      LeftEncoding -> leftPatterns
+      RightEncoding -> rightPatterns
+
+-- | Compute the modulo-10 check digit for exactly eleven payload digits.
+computeUpcACheckDigit :: String -> Either UpcAError Char
+computeUpcACheckDigit payload = do
+  validateDigits [11] payload
+  values <- traverse (uncurry digitValue) (zip [0 :: Int ..] payload)
+  let (oddValues, evenValues) = splitAlternating values
+      total = 3 * sum oddValues + sum evenValues
+  Right (toDigit ((10 - total `mod` 10) `mod` 10))
+
+-- | Append a missing check digit or verify the supplied twelfth digit.
+normalizeUpcA :: String -> Either UpcAError String
+normalizeUpcA input = do
+  validateDigits [11, 12] input
+  expected <- computeUpcACheckDigit (take 11 input)
+  case drop 11 input of
+    [] -> Right (input ++ [expected])
+    actual : _
+      | actual == expected -> Right input
+      | otherwise -> Left (InvalidUpcACheckDigit expected actual)
+
+-- | Encode the twelve normalized digits using six left and six right patterns.
+encodeUpcA :: String -> Either UpcAError [EncodedUpcADigit]
+encodeUpcA input = normalizeUpcA input >>= encodeNormalized
+
+-- | Expand the start, digits, center, and end into an attributed run stream.
+expandUpcARuns :: String -> Either UpcAError [Barcode1DRun]
+expandUpcARuns input = encodeUpcA input >>= expandEncoded
+
+-- | Render UPC-A through the shared backend-neutral 1D geometry.
+layoutUpcA
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either UpcAError PaintScene
+layoutUpcA input options = do
+  normalized <- normalizeUpcA input
+  encoded <- encodeNormalized normalized
+  runs <- expandEncoded encoded
+  let checkDigit = encodedUpcADigit (last encoded)
+  first UpcALayoutError
+    (layoutBarcode1D runs (upcAOptions normalized checkDigit encoded options))
+
+-- | Compatibility alias matching the shared public API name.
+drawUpcA
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either UpcAError PaintScene
+drawUpcA = layoutUpcA
+
+validateDigits :: [Int] -> String -> Either UpcAError ()
+validateDigits expectedLengths input = case findIndex (not . isAsciiDigit) input of
+  Just index -> Left (InvalidUpcACharacter index (input !! index))
+  Nothing
+    | length input `elem` expectedLengths -> Right ()
+    | otherwise -> Left (InvalidUpcALength (length input))
+
+isAsciiDigit :: Char -> Bool
+isAsciiDigit character = character >= '0' && character <= '9'
+
+digitValue :: Int -> Char -> Either UpcAError Int
+digitValue index character
+  | isAsciiDigit character = Right (ord character - ord '0')
+  | otherwise = Left (InvalidUpcACharacter index character)
+
+toDigit :: Int -> Char
+toDigit value = toEnum (ord '0' + value)
+
+splitAlternating :: [value] -> ([value], [value])
+splitAlternating values =
+  ( [value | (index, value) <- indexed, even index]
+  , [value | (index, value) <- indexed, odd index]
+  )
+  where
+    indexed = zip [0 :: Int ..] values
+
+encodeNormalized :: String -> Either UpcAError [EncodedUpcADigit]
+encodeNormalized normalized = traverse encodeOne (zip [0 :: Int ..] normalized)
+  where
+    encodeOne (sourceIndex, digit) = do
+      let encoding
+            | sourceIndex < 6 = LeftEncoding
+            | otherwise = RightEncoding
+          role
+            | sourceIndex == 11 = Check
+            | otherwise = Data
+      patternText <- upcADigitPattern encoding digit
+      Right EncodedUpcADigit
+        { encodedUpcADigit = digit
+        , encodedUpcAEncoding = encoding
+        , encodedUpcAPattern = patternText
+        , encodedUpcASourceIndex = sourceIndex
+        , encodedUpcARole = role
+        }
+
+expandEncoded :: [EncodedUpcADigit] -> Either UpcAError [Barcode1DRun]
+expandEncoded encoded = do
+  startRuns <- expandPattern "start" (-1) Guard sideGuard
+  leftRuns <- concat <$> traverse expandDigit (take 6 encoded)
+  middleRuns <- expandPattern "center" (-2) Guard centerGuard
+  rightRuns <- concat <$> traverse expandDigit (drop 6 encoded)
+  endRuns <- expandPattern "end" (-3) Guard sideGuard
+  Right (startRuns ++ leftRuns ++ middleRuns ++ rightRuns ++ endRuns)
+  where
+    expandDigit entry = expandPattern
+      [encodedUpcADigit entry]
+      (encodedUpcASourceIndex entry)
+      (encodedUpcARole entry)
+      (encodedUpcAPattern entry)
+
+expandPattern
+  :: String
+  -> Int
+  -> Barcode1DRunRole
+  -> String
+  -> Either UpcAError [Barcode1DRun]
+expandPattern label sourceIndex role patternText = first UpcALayoutError
+  (runsFromBinaryPattern patternText
+    (defaultBinaryPatternOptions label sourceIndex role))
+
+buildSymbols :: [EncodedUpcADigit] -> [Barcode1DSymbolDescriptor]
+buildSymbols encoded =
+  [Barcode1DSymbolDescriptor "start" 3 (-1) SymbolGuard]
+    ++ map digitDescriptor (take 6 encoded)
+    ++ [Barcode1DSymbolDescriptor "center" 5 (-2) SymbolGuard]
+    ++ map digitDescriptor (drop 6 encoded)
+    ++ [Barcode1DSymbolDescriptor "end" 3 (-3) SymbolGuard]
+  where
+    digitDescriptor entry = Barcode1DSymbolDescriptor
+      { descriptorLabel = [encodedUpcADigit entry]
+      , descriptorModules = 7
+      , descriptorSourceIndex = encodedUpcASourceIndex entry
+      , descriptorRole = if encodedUpcARole entry == Check
+          then SymbolCheck
+          else SymbolData
+      }
+
+upcAOptions
+  :: String
+  -> Char
+  -> [EncodedUpcADigit]
+  -> PaintBarcode1DOptions
+  -> PaintBarcode1DOptions
+upcAOptions normalized checkDigit encoded options = options
+  { optionsLabel = Just (maybe defaultLabel id (optionsLabel options))
+  , optionsMetadata = Map.insert "checkDigit" (toJSON [checkDigit])
+      (Map.insert "encodedText" (toJSON normalized)
+        (Map.insert "symbology" (toJSON ("upc-a" :: String))
+          (optionsMetadata options)))
+  , optionsSymbols = Just (buildSymbols encoded)
+  }
+  where
+    defaultLabel = "UPC-A barcode for " ++ normalized

--- a/code/packages/haskell/upc-a/test/Spec.hs
+++ b/code/packages/haskell/upc-a/test/Spec.hs
@@ -1,0 +1,5 @@
+import Test.Hspec (hspec)
+import UpcASpec (spec)
+
+main :: IO ()
+main = hspec spec

--- a/code/packages/haskell/upc-a/test/UpcASpec.hs
+++ b/code/packages/haskell/upc-a/test/UpcASpec.hs
@@ -1,0 +1,203 @@
+module UpcASpec (spec) where
+
+import CodingAdventures.PaintInstructions (PaintInstruction (..))
+import CodingAdventures.UpcA
+import Data.Aeson (toJSON)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "metadata" $ do
+    it "reports the shared package version" $
+      version `shouldBe` "0.1.0"
+
+  describe "upcADigitPattern" $ do
+    it "contains all ten exact left patterns" $
+      traverse (upcADigitPattern LeftEncoding) ['0' .. '9'] `shouldBe`
+        Right
+          [ "0001101", "0011001", "0010011", "0111101", "0100011"
+          , "0110001", "0101111", "0111011", "0110111", "0001011"
+          ]
+
+    it "contains all ten exact right patterns" $
+      traverse (upcADigitPattern RightEncoding) ['0' .. '9'] `shouldBe`
+        Right
+          [ "1110010", "1100110", "1101100", "1000010", "1011100"
+          , "1001110", "1010000", "1000100", "1001000", "1110100"
+          ]
+
+    it "rejects non-digit pattern lookups" $
+      upcADigitPattern LeftEncoding 'x' `shouldBe`
+        Left (InvalidUpcACharacter 0 'x')
+
+  describe "computeUpcACheckDigit" $ do
+    it "matches shared reference values" $ do
+      computeUpcACheckDigit "03600029145" `shouldBe` Right '2'
+      computeUpcACheckDigit "04210000526" `shouldBe` Right '4'
+      computeUpcACheckDigit "12345678901" `shouldBe` Right '2'
+      computeUpcACheckDigit "00000000000" `shouldBe` Right '0'
+
+    it "requires exactly eleven ASCII digits" $ do
+      computeUpcACheckDigit "123" `shouldBe` Left (InvalidUpcALength 3)
+      computeUpcACheckDigit "03600A29145" `shouldBe`
+        Left (InvalidUpcACharacter 5 'A')
+
+  describe "normalizeUpcA" $ do
+    it "appends a missing check digit" $
+      normalizeUpcA "03600029145" `shouldBe` Right "036000291452"
+
+    it "preserves a valid supplied check digit" $
+      normalizeUpcA "036000291452" `shouldBe` Right "036000291452"
+
+    it "rejects the wrong supplied check digit" $
+      normalizeUpcA "036000291453" `shouldBe`
+        Left (InvalidUpcACheckDigit '2' '3')
+
+    it "rejects empty, short, long, non-ASCII, and mixed input" $ do
+      normalizeUpcA "" `shouldBe` Left (InvalidUpcALength 0)
+      normalizeUpcA "1234567890" `shouldBe` Left (InvalidUpcALength 10)
+      normalizeUpcA "1234567890123" `shouldBe` Left (InvalidUpcALength 13)
+      normalizeUpcA "1234567890A" `shouldBe`
+        Left (InvalidUpcACharacter 10 'A')
+      normalizeUpcA "１２３４５６７８９０１" `shouldBe`
+        Left (InvalidUpcACharacter 0 '１')
+
+    it "shows educational errors" $ do
+      show (InvalidUpcACharacter 2 'x') `shouldBe`
+        "Invalid UPC-A character \"x\" at index 2; expected an ASCII digit"
+      show (InvalidUpcALength 4) `shouldBe`
+        "Invalid UPC-A length 4; expected 11 payload digits or 12 complete digits"
+      show (InvalidUpcACheckDigit '2' '3') `shouldBe`
+        "Invalid UPC-A check digit: expected 2 but received 3"
+
+  describe "encodeUpcA" $ do
+    it "encodes six left and six right digits with source attribution" $ do
+      encoded <- expectRight (encodeUpcA "03600029145")
+      map encodedUpcADigit encoded `shouldBe` "036000291452"
+      map encodedUpcASourceIndex encoded `shouldBe` [0 .. 11]
+      map encodedUpcAEncoding encoded `shouldBe`
+        replicate 6 LeftEncoding ++ replicate 6 RightEncoding
+      map encodedUpcARole encoded `shouldBe` replicate 11 Data ++ [Check]
+
+    it "uses the exact patterns for a reference code" $ do
+      encoded <- expectRight (encodeUpcA "03600029145")
+      map encodedUpcAPattern encoded `shouldBe`
+        [ "0001101", "0111101", "0101111", "0001101", "0001101", "0001101"
+        , "1101100", "1110100", "1100110", "1011100", "1001110", "1101100"
+        ]
+
+    it "produces identical records for computed and supplied checks" $
+      encodeUpcA "03600029145" `shouldBe` encodeUpcA "036000291452"
+
+  describe "expandUpcARuns" $ do
+    it "builds the exact 95-module guard and digit stream" $ do
+      encoded <- expectRight (encodeUpcA "03600029145")
+      runs <- expectRight (expandUpcARuns "03600029145")
+      let expected = "101"
+            ++ concatMap encodedUpcAPattern (take 6 encoded)
+            ++ "01010"
+            ++ concatMap encodedUpcAPattern (drop 6 encoded)
+            ++ "101"
+      modulesFromRuns runs `shouldBe` expected
+      length expected `shouldBe` 95
+      length runs `shouldBe` 59
+
+    it "attributes guards, data, and the check digit" $ do
+      runs <- expectRight (expandUpcARuns "03600029145")
+      map runRole (take 3 runs) `shouldBe` replicate 3 Guard
+      map runSourceLabel (take 3 runs) `shouldBe` replicate 3 "start"
+      map runRole (take 5 (drop 27 runs)) `shouldBe` replicate 5 Guard
+      map runSourceLabel (take 5 (drop 27 runs)) `shouldBe` replicate 5 "center"
+      map runRole (take 4 (drop 52 runs)) `shouldBe` replicate 4 Check
+      map runSourceLabel (take 4 (drop 52 runs)) `shouldBe` replicate 4 "2"
+      map runRole (drop 56 runs) `shouldBe` replicate 3 Guard
+      map runSourceLabel (drop 56 runs) `shouldBe` replicate 3 "end"
+
+    it "alternates colors across every symbol boundary" $ do
+      runs <- expectRight (expandUpcARuns "03600029145")
+      and (zipWith (/=) (map runColor runs) (drop 1 (map runColor runs)))
+        `shouldBe` True
+
+    it "propagates validation failures" $
+      expandUpcARuns "036000291453" `shouldBe`
+        Left (InvalidUpcACheckDigit '2' '3')
+
+  describe "layoutUpcA" $ do
+    it "renders the fixed module stream through shared default geometry" $ do
+      scene <- expectRight (layoutUpcA "03600029145" defaultPaintBarcode1DOptions)
+      psWidth scene `shouldBe` 460
+      psHeight scene `shouldBe` 120
+      psBg scene `shouldBe` "#ffffff"
+      length (psInstructions scene) `shouldBe` 30
+      map prX (take 2 (psInstructions scene)) `shouldBe` [40, 48]
+
+    it "records normalized data, checksum, label, and all fifteen symbols" $ do
+      scene <- expectRight (layoutUpcA "03600029145" defaultPaintBarcode1DOptions)
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("upc-a" :: String))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("036000291452" :: String))
+      Map.lookup "checkDigit" (psMeta scene) `shouldBe`
+        Just (toJSON ("2" :: String))
+      Map.lookup "contentModules" (psMeta scene) `shouldBe` Just (toJSON (95 :: Int))
+      Map.lookup "symbolCount" (psMeta scene) `shouldBe` Just (toJSON (15 :: Int))
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("UPC-A barcode for 036000291452" :: String))
+
+    it "preserves custom rendering, labels, and caller metadata" $ do
+      let config = defaultBarcode1DRenderConfig
+            { configModuleWidth = 2
+            , configBarHeight = 50
+            , configQuietZoneModules = 5
+            , configForeground = "navy"
+            , configBackground = "transparent"
+            }
+          options = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = config
+            , optionsLabel = Just "Library label"
+            , optionsMetadata = Map.fromList
+                [ ("batch", toJSON (7 :: Int))
+                , ("checkDigit", toJSON ("wrong" :: String))
+                , ("encodedText", toJSON ("wrong" :: String))
+                , ("symbology", toJSON ("wrong" :: String))
+                ]
+            }
+      scene <- expectRight (layoutUpcA "03600029145" options)
+      (psWidth scene, psHeight scene, psBg scene) `shouldBe` (210, 50, "transparent")
+      map prFill (psInstructions scene) `shouldBe` replicate 30 "navy"
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Library label" :: String))
+      Map.lookup "batch" (psMeta scene) `shouldBe` Just (toJSON (7 :: Int))
+      Map.lookup "checkDigit" (psMeta scene) `shouldBe`
+        Just (toJSON ("2" :: String))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("036000291452" :: String))
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("upc-a" :: String))
+
+    it "supports the draw alias" $
+      drawUpcA "03600029145" defaultPaintBarcode1DOptions `shouldBe`
+        layoutUpcA "03600029145" defaultPaintBarcode1DOptions
+
+    it "wraps shared layout validation failures" $ do
+      let invalidGeometry = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = defaultBarcode1DRenderConfig
+                { configModuleWidth = 0 }
+            }
+          humanText = defaultPaintBarcode1DOptions
+            { optionsHumanReadableText = Just "036000291452" }
+      layoutUpcA "03600029145" invalidGeometry `shouldBe`
+        Left (UpcALayoutError (InvalidRenderConfiguration "moduleWidth" 0))
+      layoutUpcA "03600029145" humanText `shouldBe`
+        Left (UpcALayoutError HumanReadableTextUnsupported)
+
+modulesFromRuns :: [Barcode1DRun] -> String
+modulesFromRuns = concatMap expandRun
+  where
+    expandRun run = replicate (runModules run)
+      (if runColor run == Bar then '1' else '0')
+
+expectRight :: Show error => Either error value -> IO value
+expectRight (Right value) = pure value
+expectRight (Left err) = fail ("unexpected error: " ++ show err)

--- a/code/packages/haskell/upc-a/upc-a.cabal
+++ b/code/packages/haskell/upc-a/upc-a.cabal
@@ -1,0 +1,39 @@
+cabal-version: 3.0
+name:          upc-a
+version:       0.1.0
+synopsis:      Pure UPC-A barcode encoder
+description:   Checked UPC-A normalization, modulo-10 checksums, attributed runs, and backend-neutral paint scenes.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.UpcA
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , paint-instructions >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    UpcASpec
+    hs-source-dirs:   test
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , hspec ==2.*
+                    , paint-instructions >=0.1 && <0.2
+                    , upc-a
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -121,11 +121,11 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
 `type-checker-protocol` ports, and the Haskell `paint-vm-ascii`,
-`barcode-layout-1d`, `itf`, `code39`, `codabar`, and `code128` ports:
+`barcode-layout-1d`, `itf`, `code39`, `codabar`, `code128`, and `upc-a` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 284 |
+| Present in 10-15 languages | 172 | 283 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 712 | 9,968 |
@@ -171,7 +171,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 288
+The 172 packages present in at least ten implementation languages need 283
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -182,7 +182,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 9 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 8 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -650,6 +650,19 @@ table, reference values and checksums, empty payloads, exact module geometry,
 customized paint output, metadata precedence, aliases, and both local and shared
 validation paths. The package now spans 12 implementation lanes, reduces the
 high-consensus backlog to 284 slots, and leaves 9 gaps in the Haskell lane.
+
+The twenty-sixth Haskell high-consensus slice is complete: `upc-a` now provides
+the pure retail-barcode encoder unlocked by `barcode-layout-1d`. It accepts
+11-digit payloads or validated 12-digit codes, computes the required modulo-10
+check digit, exposes all twenty left/right digit patterns, and emits the fixed
+95-module start, digit, center, and end structure with typed source attribution
+and explicit symbol spans. Its package-native suite exercises 23 examples with
+91% expression and 81% alternative coverage, including reference checksums,
+all standard patterns, computed and supplied checks, ASCII and length guards,
+exact module geometry, metadata precedence, aliases, and shared validation
+paths. The package now spans 12 implementation lanes, reduces the
+high-consensus backlog to 283 slots, leaves 8 gaps in the Haskell lane, and
+unlocks the dependent `ean-13` port.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell UPC-A encoder with typed ASCII/length/check-digit errors, all left/right digit patterns, and the fixed 95-module guard structure
- emit attributed runs and explicit symbol spans through the existing Haskell `barcode-layout-1d` and `paint-instructions` packages
- add package metadata, documentation, and 23 package-native examples covering validation, parity vectors, geometry, metadata, and shared failures
- refresh the package-parity roadmap to 283 high-consensus gaps overall and 8 remaining Haskell gaps

## Validation

- `cabal test all --enable-coverage` — 69 examples passed across UPC-A and its two shared dependencies
- UPC-A coverage — 91% expressions and 81% alternatives
- `cabal check`
- `cabal sdist all` with build and output directories outside the repository
- `python code/scripts/tests/test_package_parity_report.py` — 6 tests passed
- package parity report in Markdown, JSON, and CSV with `--fail-on-collisions`
- `git diff --check`
