### PR TITLE
feat(hl): Arabic Ch.4 — farewells, and the root that closes the circle

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## Chapter 4 — Farewells (and the root that closes the circle)
+
+- **Chapter 4 authored** (`AR-C04-maa-with`, `-al-salama`, `-maa-salama`,
+  `-ila-liqaa`, `-practice`): the **word** lessons for **مع السلامة**, which
+  `AR-W12` had already taught the learner to hand-write — the same gap-filling
+  move as Ch. 3. Completes the greet → introduce → ask → **part** arc.
+- **مع** (*maʿa*, "with") — the first preposition met that does **not** attach,
+  in explicit contrast to *al-*, *bi-* and *li-* from Chapters 1 and 3; and
+  distinguished from *bi-* by sense (*bi-khayr* = "**in** goodness" vs *maʿa* =
+  "**accompanied by**"). ← Semitic *\*ʿimma*, cousin of Hebrew **ʿim** — the
+  *salām/shalom* and *ism/shem* pairing for a third time, presented as systematic
+  rather than coincidental.
+- **السلامة** (*as-salāma*) — **not a new word**. It is Ch. 1's *salām* run
+  through the ***faʿāla*** pattern, which converts a thing into **the state of
+  being** that thing (peace → safety/soundness), plus *al-* in front and the
+  feminine **ة** behind. Reactivates two already-taught rules: **س** is a **sun
+  letter** so *al-* assimilates (*as-salāma*), and *tāʾ marbūṭa* marks the
+  feminine, as Arabic abstract nouns usually are.
+- **مع السلامة** — the assembly, and the chapter's point: the **first greeting**
+  (*as-salāmu ʿalaykum*) and the **last farewell** are built on the **same root
+  s–l–m**, so Arabic opens and closes a conversation with one idea. Set beside
+  English **goodbye** ← "***God be with ye***" — both languages hinge their
+  farewell on "**with**" — plus Spanish *adiós* / French *adieu* ("to God"): four
+  languages, one instinct.
+- **إلى اللقاء** (*ilā l-liqāʾ*, "until the meeting," root **l–q–y**) — whose
+  "until + a future point" shape is exactly Spanish *hasta luego / hasta mañana*.
+  The payoff: ***hasta*** is **itself an Arabic loanword** (← *ḥattā*), one of the
+  rare borrowed **function** words among al-Andalus's ~4000 — so Spanish didn't
+  just copy the pattern, it borrowed the word that builds it. **Honest letter
+  note**: **ق** (*qāf*) and **ى** (*alif maqṣūra*) are outside
+  `data/scripts/arabic.json`'s letter set, so the lesson says to read them now and
+  draw them later — *alif maqṣūra* is framed via the already-taught dots principle
+  (yāʾ's body, no dots, long *ā*).
+- **practice** — the full four-chapter dialogue with a literal-translation column
+  showing that **no line contains a verb "to be,"** a **root ledger** (s–l–m,
+  s–m–w, ḥ–w–l, kh–y–r, ḥ–m–d, l–q–y — six roots carry the whole conversation),
+  and the attaching-pieces table (*al-*, *bi-*, *li-*, *-ī*, *-ka/-ki*) with *maʿa*
+  as the one that doesn't.
+- Taxonomy: canonical `FAREWELL`, `FAREWELL-LATER`, `REVIEW`; namespaced
+  `AR-PREP-WITH`, `AR-WORD-SALAMA`. Roadmap: Ch. 4 authored and removed from the
+  planned table.
+
 ## Chapter 3 — Responding (how are you, and two ways to answer)
 
 - **Chapter 3 authored** (`AR-C03-kayfa`, `-hal`, `-kayfa-haluka`, `-bi-khayr`,

--- a/code/learning/human-languages/arabic/lessons/AR-C04-al-salama.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C04-al-salama.md
@@ -1,0 +1,73 @@
+---
+id: AR-C04-al-salama
+chapter: 4
+type: word
+headword: السلامة
+gloss: "the safety — Chapter 1's salām, plus a pattern and a feminine ending"
+romanization: as-salāma
+concept_tag: AR-WORD-SALAMA
+prerequisites: [AR-C04-maa-with, AR-C01-salam, AR-C01-al]
+sounds: [sun-letter-assimilation, ta-marbuta]
+roots: [semitic-s-l-m]
+etymology_hook: "salāma is salām run through the faʿāla pattern, which turns a thing into the STATE of that thing — peace → safety/soundness; the ة (tāʾ marbūṭa) marks it feminine, as Arabic abstract nouns usually are, and س is a sun letter so al- assimilates to as-"
+est_minutes: 4
+reviews_of: [AR-C04-maa-with, AR-C01-salam, AR-C01-al, AR-W11-ha-and-ta-marbuta]
+---
+
+# السلامة (as-salāma) — "the safety"
+
+## Warm-up
+
+[PAUSE 2s] This looks like a long new word. It isn't. It is **one word you
+learned in Chapter 1** with a piece added at each end.
+
+## Taking it apart
+
+| piece | what it is | met in |
+|---|---|---|
+| **الـ** | *al-*, "the" | Ch. 1 |
+| **سلام** | *salām*, "peace" | Ch. 1 — the very first word |
+| **ة** | *tāʾ marbūṭa*, feminine ending | writing Lesson 11 |
+
+→ **السلامة** = *al-* + *salām* + *-a* = "**the safety**."
+
+Every letter is one you have already written by hand.
+
+## The pattern that changed the meaning
+
+Arabic doesn't just add endings — it pours a root into a **shape**. Here the root
+**s–l–m** goes into the pattern *faʿāla*, which turns a thing into **the state of
+being that thing**:
+
+| word | meaning |
+|---|---|
+| **salām** | peace |
+| **salāma** | safety, soundness, wellbeing — *the state of being at peace* |
+
+Same three consonants, one new shape, a new but related word. This is the engine
+Chapter 1 promised, working in front of you.
+
+## Two small rules, both already learned
+
+**1. The sun letter.** *S* (**س**) is a **sun letter**, so the *l* of *al-*
+assimilates to it: written **الس**, but said **as-**salāma, not *al-salāma*. The
+same thing happens in **الس**لام عليكم — the greeting you have said since Chapter 1.
+
+**2. The feminine ة.** *Tāʾ marbūṭa* marks *salāma* as **feminine**. Arabic
+abstract nouns very often are.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "*as-salāma*" — with the doubled *s*, not *al-s*]
+- [YOU SAY: the build — "*salām* … *salāma* … *as-salāma*"]
+- [YOU SAY: the pattern — "peace → **the state of** peace"]
+- [YOU WRITE: **السلامة**]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What three pieces make **السلامة**? (***al-*** + ***salām*** +
+***ة***.) What did the *faʿāla* pattern do to the meaning? (Turned "peace" into
+"**the state of** being at peace" — safety.) Why is it *as-salāma* and not
+*al-salāma*? (**س** is a **sun letter**; the *l* assimilates.) What does the **ة**
+tell you? (The word is **feminine**.) Next: put *maʿa* in front of it.

--- a/code/learning/human-languages/arabic/lessons/AR-C04-ila-liqaa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C04-ila-liqaa.md
@@ -1,0 +1,92 @@
+---
+id: AR-C04-ila-liqaa
+chapter: 4
+type: phrase
+headword: إلى اللقاء
+gloss: "see you — literally 'until the meeting', the structure Spanish borrowed a word for"
+romanization: ilā l-liqāʾ
+concept_tag: FAREWELL-LATER
+prerequisites: [AR-C04-maa-salama, AR-C01-al]
+sounds: [hamza, alif-maqsura]
+roots: [semitic-l-q-y]
+etymology_hook: "'until the meeting' is exactly the Spanish hasta luego / hasta mañana shape — and hasta ITSELF is an Arabic loan (ḥattā), so Spanish borrowed the very word that builds this kind of farewell; liqāʾ ← root l-q-y 'to meet'"
+est_minutes: 4
+reviews_of: [AR-C04-maa-salama, AR-C01-al, AR-W06-harakat-and-hamza]
+---
+
+# إلى اللقاء (ilā l-liqāʾ) — "see you"
+
+## Warm-up
+
+[PAUSE 2s] The other everyday farewell — and the one with a surprise waiting in
+the Spanish track.
+
+## A note on the letters
+
+*(Skim if you read Arabic.)* Two pieces here are **beyond what the writing track
+has covered**, so read them for now and draw them later:
+
+- **ق** (*qāf*) — a *k* made far back against the soft palate, deeper than **ك**
+  (*kāf*). It is **not** in the letter set you have been writing from.
+- **ى** in **إلى** — this is *alif maqṣūra*, "shortened alif": it wears **yāʾ's
+  skeleton with no dots** and is pronounced as a long *ā*. You already know from
+  writing Lessons 4–5 that dots are what separate letters sharing a body; this is
+  that same principle, taken one step further.
+
+The rest — **ا ل ء** — you have written.
+
+## The two pieces
+
+| piece | meaning |
+|---|---|
+| **إلى** *ilā* | "to, until" |
+| **اللقاء** *al-liqāʾ* | "the meeting" |
+
+→ **إلى اللقاء** = "**until the meeting**."
+
+**لقاء** (*liqāʾ*) comes from the root **l–q–y**, "**to meet**." The final **ء**
+is the *hamza* from writing Lesson 6 — a glottal stop, a real consonant here, not
+decoration.
+
+Note **ل** is a sun letter too, so *al-liqāʾ* doubles the *l*, just as *as-salāma*
+doubled the *s*.
+
+## The Spanish surprise
+
+Spanish says goodbye like this:
+
+> *hasta luego* — "**until** later"
+> *hasta mañana* — "**until** tomorrow"
+
+Same shape as *ilā l-liqāʾ*: **"until" + a future point**. But it goes further —
+Spanish ***hasta*** is itself an **Arabic loanword**, from ***ḥattā*** ("until").
+Of the roughly four thousand Arabic words Spanish took during the eight centuries
+of al-Andalus, most are nouns; *hasta* is one of the rare borrowed **function
+words**.
+
+So Spanish did not merely copy the pattern — it borrowed the very word that
+builds it.
+
+| language | farewell | shape |
+|---|---|---|
+| Arabic | *ilā l-liqāʾ* | until + the meeting |
+| Spanish | *hasta luego* | **until** (← *ḥattā*) + later |
+| French | *à bientôt* | to + soon |
+| Italian | *a presto* | to + soon |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "*ilā l-liqāʾ*" — double the *l*]
+- [YOU SAY: the two farewells — "*maʿa s-salāma* · *ilā l-liqāʾ*"]
+- [YOU SAY: the loan — "*hasta* ← *ḥattā*"]
+- [YOU SAY: the root — "**l · q · y** — to meet"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **إلى اللقاء** literally say? ("**Until the meeting**.")
+What root is *liqāʾ* from? (**l–q–y**, "to meet".) Which two letters here has the
+writing track **not** reached? (**ق** *qāf*, and **ى** *alif maqṣūra*.) What is
+*alif maqṣūra*? (**Yāʾ's body with no dots**, pronounced long *ā*.) Which Spanish
+word for "until" came from Arabic? (***Hasta*** ← ***ḥattā***.) Next: practise
+the whole conversation, hello to goodbye.

--- a/code/learning/human-languages/arabic/lessons/AR-C04-maa-salama.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C04-maa-salama.md
@@ -1,0 +1,81 @@
+---
+id: AR-C04-maa-salama
+chapter: 4
+type: phrase
+headword: مع السلامة
+gloss: "goodbye — literally 'with safety', closing the course on the root that opened it"
+romanization: maʿa s-salāma
+concept_tag: FAREWELL
+prerequisites: [AR-C04-al-salama, AR-C04-maa-with]
+sounds: [sun-letter-assimilation, ayn-throat]
+roots: [semitic-s-l-m]
+etymology_hook: "the greeting (as-salāmu ʿalaykum) and the farewell (maʿa s-salāma) are built from the SAME root s-l-m — Arabic opens and closes a conversation with one idea; and English 'goodbye' is worn down from 'God be WITH ye', so both languages hinge their farewell on the word 'with'"
+est_minutes: 4
+reviews_of: [AR-C04-al-salama, AR-C04-maa-with, AR-C01-as-salamu-alaykum, AR-W12-maa-salama]
+---
+
+# مع السلامة (maʿa s-salāma) — "goodbye"
+
+## Warm-up
+
+[PAUSE 2s] Put the last two lessons together and the farewell falls out. You have
+already **hand-written** this phrase; now it means something.
+
+## The assembly
+
+> **مع** (*maʿa*, "with") + **السلامة** (*as-salāma*, "the safety")
+> → **مع السلامة** — "**with safety**."
+
+Said as one run: *maʿa s-salāma* — the *a* of *maʿa* swallows the *al-*'s vowel,
+and the sun-letter rule doubles the *s*.
+
+It is not "goodbye" in the English sense of a plain sign-off. It is a **wish**:
+*go in safety*.
+
+## The circle closes
+
+Look at what Chapter 1 opened with and what Chapter 4 closes with:
+
+| | phrase | root |
+|---|---|---|
+| first greeting | **السلام عليكم** *as-salāmu ʿalaykum* | **s–l–m** |
+| last farewell | **مع السلامة** *maʿa s-salāma* | **s–l–m** |
+
+**The same three consonants.** Arabic begins and ends a conversation with one
+idea — peace, safety, wholeness. The root engine you met in the very first lesson
+has been running the whole time; here it simply comes back round.
+
+The family, one more time: *salām* (peace), *salāma* (safety), *islām*
+(submission, i.e. entering peace), *muslim* (one who does so).
+
+## English does the same trick
+
+**Goodbye** looks like a single word. It is worn down from ***God be with ye***.
+So the English farewell is also built on "**with**" — you are being commended to
+something protective as you go.
+
+| language | farewell | literally |
+|---|---|---|
+| Arabic | *maʿa s-salāma* | "**with** safety" |
+| English | *goodbye* | "God be **with** ye" |
+| Spanish | *adiós* | "to God" |
+| French | *adieu* | "to God" |
+
+Four languages, one instinct: as someone leaves, hand them over to safekeeping.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "*maʿa s-salāma*"]
+- [YOU SAY: the bookend — "*as-salāmu ʿalaykum* … *maʿa s-salāma*"]
+- [YOU SAY: the root aloud — "**s · l · m**"]
+- [YOU SAY: "goodbye ← God be **with** ye"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **مع السلامة** literally mean? ("**With safety**.") What
+root is it built on, and where have you met that root before? (**s–l–m** — the
+Chapter 1 greeting *as-salāmu ʿalaykum*, and *salām* itself.) So what does Arabic
+open and close a conversation with? (**The same idea** — peace/safety.) What is
+English *goodbye* worn down from? ("**God be with ye**.") Next: a second farewell,
+and a word Spanish borrowed.

--- a/code/learning/human-languages/arabic/lessons/AR-C04-maa-with.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C04-maa-with.md
@@ -1,0 +1,74 @@
+---
+id: AR-C04-maa-with
+chapter: 4
+type: word
+headword: مع
+gloss: with
+romanization: maʿa
+concept_tag: AR-PREP-WITH
+prerequisites: [AR-C03-practice, AR-W10-ayn]
+sounds: [rtl-known-letters, ayn-throat]
+roots: [semitic-imma]
+etymology_hook: "maʿa ← Semitic *ʿimma, cousin of Hebrew ʿim 'with' — the same family pairing as salām/shalom; and 'with' is the hinge of farewells in more languages than Arabic: English goodbye is worn down from 'God be WITH ye'"
+est_minutes: 3
+reviews_of: [AR-C03-practice, AR-W10-ayn, AR-C01-salam]
+---
+
+# مع (maʿa) — "with"
+
+## Warm-up
+
+[PAUSE 2s] Two letters, both already yours, and a word that will carry the whole
+chapter.
+
+## The letters
+
+*(Skim if you read Arabic.)* **م** (*mīm*) from Lesson 3 of the writing set, and
+**ع** (*ʿayn*) from Lesson 10 — the throat sound whose Phoenician ancestor meant
+"**eye**," and which the Greeks recycled into the vowel **O**.
+
+Right to left: **م · ع** → *maʿa*. The *ʿayn* is not a vowel; it is a
+constriction deep in the throat. Take your time with it.
+
+## The word
+
+**مع** (*maʿa*) = "**with**, together with."
+
+It is a **preposition**, and unlike **الـ** (*al-*) or **بـ** (*bi-*) from
+Chapter 3, it is a **free-standing word** — it does not glue onto the next one.
+Compare:
+
+| | attaches? |
+|---|---|
+| **الـ** *al-* "the" | yes |
+| **بـ** *bi-* "in/with" | yes |
+| **لـ** *li-* "to" | yes |
+| **مع** *maʿa* "with" | **no** |
+
+So Arabic has *two* words touching on "with": the one-letter **بـ** (*bi-*,
+"in/by means of," as in *bi-khayr*) and the full word **مع** (*maʿa*,
+"accompanied by"). *Bi-khayr* is "**in** goodness"; *maʿa* is standing **next
+to** something.
+
+## The Semitic cousin
+
+*maʿa* ← Semitic *\*ʿimma*, and its Hebrew cousin is **עִם** (*ʿim*), "with." The
+same pairing you met with **salām / shalom** in Chapter 1 and **ism / shem** in
+Chapter 2. Three chapters, three cousins — the family resemblance is systematic,
+not a coincidence.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "*maʿa*" — the *ʿayn* from the throat]
+- [YOU SAY: the contrast — "*bi-khayr* **in** goodness · *maʿa* **with**"]
+- [YOU SAY: the cousin — "*maʿa* · Hebrew *ʿim*"]
+- [YOU WRITE: **مع** — mīm joining into ʿayn]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **مع** mean? ("**With**.") Does it attach to the next word,
+like *al-* and *bi-*? (**No** — it stands alone.) What is the difference between
+*bi-* and *maʿa*? (*Bi-* = "**in**/by means of"; *maʿa* = "**accompanied by**".)
+What is its Hebrew cousin? (***ʿim***.) Next: the word it goes with — and you
+already know most of it.

--- a/code/learning/human-languages/arabic/lessons/AR-C04-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C04-practice.md
@@ -1,0 +1,80 @@
+---
+id: AR-C04-practice
+chapter: 4
+type: practice
+headword: (dialogue)
+gloss: Chapter 4 recap — a whole conversation, hello to goodbye
+concept_tag: REVIEW
+prerequisites: [AR-C04-maa-salama, AR-C04-ila-liqaa]
+sounds: []
+roots: []
+est_minutes: 5
+reviews_of: [AR-C04-maa-with, AR-C04-al-salama, AR-C04-maa-salama, AR-C04-ila-liqaa, AR-C03-practice, AR-C02-practice, AR-C01-practice]
+---
+
+# Practice — the whole conversation
+
+## Warm-up
+
+[PAUSE 2s] Four chapters. Greet, introduce, ask after someone, part. Here it all
+is in one piece.
+
+## The full exchange
+
+| | Arabic | literally |
+|---|---|---|
+| A | **السلام عليكم** | peace [be] upon you |
+| B | **وعليكم السلام** | and upon you, peace |
+| A | **ما اسمك؟** | what [is] your name? |
+| B | **اسمي …، تشرفنا.** | my name [is] …, we are honoured |
+| A | **كيف حالك؟** | how [is] your state? |
+| B | **الحمد لله، بخير.** | the praise [is] to God — in goodness |
+| A | **مع السلامة** | with safety |
+| B | **إلى اللقاء** | until the meeting |
+
+Read the right-hand column top to bottom. **Not one line contains a verb "to
+be."** The zero copula has held for four chapters.
+
+## The root ledger
+
+Everything you have learned sits on a handful of three-consonant roots:
+
+| root | meaning | words you know |
+|---|---|---|
+| **s–l–m** | peace, safety | *salām*, *as-salāmu ʿalaykum*, *salāma*, *maʿa s-salāma* |
+| **s–m–w** | name | *ism*, *ismī*, *ismuka* |
+| **ḥ–w–l** | to turn | *ḥāl*, *kayfa ḥāluka* |
+| **kh–y–r** | good | *ṣabāḥ al-khayr*, *bi-khayr* |
+| **ḥ–m–d** | to praise | *al-ḥamdu lillāh*, *Muḥammad* |
+| **l–q–y** | to meet | *liqāʾ*, *ilā l-liqāʾ* |
+
+Six roots. A whole conversation.
+
+## The small attaching pieces
+
+| piece | job | example |
+|---|---|---|
+| **الـ** *al-* | the | *al-khayr* |
+| **بـ** *bi-* | in / by | *bi-khayr* |
+| **لـ** *li-* | to | *lillāh* |
+| **ـي** *-ī* | my | *ismī* |
+| **ـك** *-ka / -ki* | your (m./f.) | *ismuka, ḥāluki* |
+
+And **مع** *maʿa*, the one that **doesn't** attach.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the full dialogue, both parts, addressing a **man**]
+- [YOU SAY: it again to a **woman** — every *-ka* becomes *-ki*]
+- [YOU WRITE: **مع السلامة** — every letter is one you have drawn]
+- [YOU SAY: the bookend — "**السلام** to open, **السلامة** to close"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give a complete greeting-to-farewell exchange. (The dialogue above.)
+Which root opens **and** closes it? (**s–l–m**.) Which piece of the chapter
+doesn't glue onto the next word? (**مع** *maʿa*.) What single word is absent from
+every literal translation? (**"Is"** — the zero copula.) Which Spanish word came
+from Arabic *ḥattā*? (***Hasta***.) You can now hold — and hand-write — a short
+Arabic conversation from beginning to end.

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -40,6 +40,25 @@ word lessons — never as a gated reading course.
   **Muḥammad** ("the much-praised") → practice running the full greet-ask-answer
   exchange. **Authored.**
 
+- **Ch. 4 — Farewells**: the word lessons for the phrase `AR-W12` already taught
+  the learner to **hand-write**. **مع** (*maʿa*, "with") — the first preposition
+  that does **not** attach, unlike *al-*, *bi-*, *li-*; ← Semitic *\*ʿimma*, cousin
+  of Hebrew *ʿim* (the *salām/shalom*, *ism/shem* pairing a third time) → **السلامة**
+  (*as-salāma*) — **not a new word**: Ch. 1's *salām* poured into the ***faʿāla***
+  pattern, which turns a thing into **the state of** that thing (peace → safety),
+  plus *al-* and the feminine **ة**, with **س** as a sun letter doubling the *s* →
+  **مع السلامة** ("with safety"), whose root **s–l–m** is the **same one the course
+  opened on** in *as-salāmu ʿalaykum*, so Arabic begins and ends a conversation
+  with one idea — set beside English **goodbye** ← "*God be **with** ye*," which
+  hinges on "with" too → **إلى اللقاء** (*ilā l-liqāʾ*, "until the meeting," root
+  **l–q–y**), whose "until + a future point" shape is exactly Spanish *hasta
+  luego* — and ***hasta*** is itself the **Arabic loan** *ḥattā*, so Spanish
+  borrowed the very word that builds this farewell → practice: the full
+  greet-introduce-ask-part dialogue, a **root ledger** of the six roots that carry
+  it, and the attaching-pieces table. **Authored.** (Honest note in the lesson:
+  **ق** *qāf* and **ى** *alif maqṣūra* are beyond the writing track's letter set,
+  so they are read, not drawn.)
+
 - **Ch. 1 — Writing set** (`AR-W01`–`AR-W03`, `writing` type): the
   "break-it-apart-and-draw-it" companion to the greetings, rendered by the
   script-writing-visualizer app (parallel to the Cyrillic `RU-W*` set). Right-to-
@@ -80,7 +99,6 @@ word lessons — never as a gated reading course.
 
 | Chapter | Theme |
 |---|---|
-| 4 | Farewells: *maʿa s-salāma* ("with safety"), *ilā l-liqāʾ* — the **word** lessons for the farewell already hand-written in `AR-W12` |
 | 5+ | Numbers, the pattern system (verb forms I–X), family, food — always with the root engine and the Spanish-loanword thread |
 
 Note: Arabic marks **gender on "you"** (*anta* to a man, *anti* to a woman) —

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -194,6 +194,8 @@
     "examples": {
       "AR-WORD-HAL": "ḥāl — 'state, condition' (← root ḥ-w-l 'to TURN/change', so a state is how things have turned; cf. ḥawla 'around', taḥwīl 'transformation', ḥawl 'a year' = one full turn — contrast Spanish estar ← stāre 'to STAND')",
       "AR-PRAISE-GOD": "al-ḥamdu lillāh — 'praise be to God', the everyday reply to kayfa ḥāluka; al- + ḥamd + li- + allāh (itself al- + ilāh 'THE god', cousin of Hebrew El/Elohim). Root ḥ-m-d 'praise' also yields the names Aḥmad and Muḥammad ('the much-praised')",
+      "AR-PREP-WITH": "maʿa — 'with, accompanied by' (← Semitic *ʿimma, cousin of Hebrew ʿim, the salām/shalom pairing again). The one preposition so far that does NOT attach: contrast al-, bi-, li-, which all glue onto the next word. Distinct from bi- 'in/by means of' (bi-khayr = IN goodness)",
+      "AR-WORD-SALAMA": "salāma — 'safety, soundness' = Ch.1's salām poured into the faʿāla pattern, which turns a thing into the STATE of that thing (peace → being at peace); ة marks it feminine, as Arabic abstract nouns usually are; س is a sun letter so al-salāma is said as-salāma",
       "ES-VERB-LLAMAR": "llamar — 'to call' (the Spanish naming verb)",
       "ES-SE-LLAMA": "se llama — 'he/she calls himself' (3rd-person of llamar)",
       "ES-WORD-MUCHO": "mucho — 'much / a lot'",


### PR DESCRIPTION
The **word** lessons for **مع السلامة**, which `AR-W12` already taught the learner to
hand-write — the same gap-filling move as Ch.3. Completes the greet → introduce → ask →
**part** arc.

**`AR-C04-maa-with`** — **مع** (*maʿa*, "with"), the first preposition met that does
**not** attach, in explicit contrast to *al-*, *bi-* and *li-*, and distinguished from
*bi-* by sense (*bi-khayr* = "**in** goodness" vs *maʿa* = "**accompanied by**"). ←
Semitic *\*ʿimma*, cousin of Hebrew **ʿim** — the *salām/shalom* and *ism/shem* pairing
for a third time, presented as systematic rather than coincidental.

**`AR-C04-al-salama`** — **السلامة** is **not a new word**. It's Ch.1's *salām* run
through the ***faʿāla*** pattern, which converts a thing into **the state of being** that
thing (peace → safety/soundness), plus *al-* in front and the feminine **ة** behind.
Reactivates two already-taught rules: **س** is a **sun letter** so *al-* assimilates
(*as-salāma*), and *tāʾ marbūṭa* marks the feminine, as Arabic abstract nouns usually are.

**`AR-C04-maa-salama`** — the assembly, and the chapter's point: the **first greeting**
(*as-salāmu ʿalaykum*) and the **last farewell** are built on the **same root s–l–m**, so
Arabic opens and closes a conversation with one idea. Set beside English **goodbye** ←
"***God be with ye***" — both languages hinge their farewell on "**with**" — plus Spanish
*adiós* / French *adieu* ("to God"): four languages, one instinct.

**`AR-C04-ila-liqaa`** — **إلى اللقاء** ("until the meeting," root **l–q–y**), whose
"until + a future point" shape is exactly Spanish *hasta luego*. The payoff: ***hasta*** is
**itself an Arabic loanword** (← *ḥattā*), one of the rare borrowed **function** words
among al-Andalus's ~4000 — so Spanish didn't just copy the pattern, it borrowed the word
that builds it. **Honest letter note**: **ق** (*qāf*) and **ى** (*alif maqṣūra*) are
outside `data/scripts/arabic.json`'s letter set, so the lesson says to read them now and
draw them later — *alif maqṣūra* framed via the already-taught dots principle (yāʾ's body,
no dots, long *ā*).

**`AR-C04-practice`** — the full four-chapter dialogue, whose literal-translation column
shows that **no line contains a verb "to be"**; a **root ledger** (*s–l–m, s–m–w, ḥ–w–l,
kh–y–r, ḥ–m–d, l–q–y* — six roots carry the whole conversation); and the attaching-pieces
table, with *maʿa* as the one that doesn't.

Taxonomy: canonical `FAREWELL`, `FAREWELL-LATER`, `REVIEW`; namespaced `AR-PREP-WITH`,
`AR-WORD-SALAMA`. Roadmap: Ch.4 authored and removed from the planned table.

Suite green at **38/38**; retired-concept-tag sweep clean across the whole curriculum.
Security-reviewed: PASS, no findings — including a byte-level bidi/zero-width Unicode scan
(no overrides, isolates, or invisible characters; directionality left entirely to the
natural Unicode bidi algorithm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)