### PR TITLE
fix(matlab-runtime): bound total element count against dimension-product overflow

### DIFF
--- a/code/packages/rust/matlab-runtime/CHANGELOG.md
+++ b/code/packages/rust/matlab-runtime/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-07-20
+
+### Security
+
+- **Fixed a dimension-product-overflow gap in every array-constructing/
+  -growing operation.** `count()` capped each dimension independently
+  (`1<<26`) but never their PRODUCT: `zeros(1<<26, 1<<26)`, `eye(1<<26)`,
+  repeated matrix self-concatenation (`A = [A A];` many times), and 2-D
+  indexing (`A(idx, idx)` with two independently-in-bounds index vectors)
+  could each still request an astronomical element count (up to ~4.5e15
+  elements, ~36 petabytes) before ever erroring — an allocation-aborting
+  denial of service, not a clean error. Found during security review of the
+  sibling `scilab-runtime` crate (MA-10d), which shares the identical
+  vulnerability class and was fixed the same way first.
+- Added `builtins::check_total_elements(name, rows, cols)` (uses
+  `checked_mul` so the multiplication itself cannot silently overflow) and
+  wired it into `dims()`, `eye()`, `hcat`, `vcat` (checked incrementally as
+  the result is built, not just once at the end — closes the
+  self-concatenation growth path), and `index_value`'s 2-D indexing arm.
+  `octave-runtime` inherits the fix automatically since it reuses this
+  crate's `Interpreter` directly.
+- Added regression tests: `constructor_rejects_an_astronomical_element_product`,
+  `matrix_self_concatenation_cannot_double_past_the_element_cap`,
+  `two_d_indexing_rejects_a_product_overflow`.
+
 ## [0.1.0] - 2026-06-16
 
 ### Added

--- a/code/packages/rust/matlab-runtime/Cargo.toml
+++ b/code/packages/rust/matlab-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-matlab-runtime"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Tree-walking evaluator for the MATLAB language over array-runtime"
 

--- a/code/packages/rust/matlab-runtime/src/builtins.rs
+++ b/code/packages/rust/matlab-runtime/src/builtins.rs
@@ -48,6 +48,7 @@ fn constructor(name: &str, args: &[MatValue], fill: f64) -> Result<MatValue, Str
 /// `eye(n)` → the `n×n` identity.
 fn eye(args: &[MatValue]) -> Result<MatValue, String> {
     let n = count(arg_num("eye", args, 0)?, "eye")?;
+    check_total_elements("eye", n, n)?;
     Ok(MatValue::Num(Array::eye(n)))
 }
 
@@ -89,13 +90,38 @@ fn unary(name: &str, args: &[MatValue], f: fn(f64) -> f64) -> Result<MatValue, S
 
 /// Interpret a constructor's arguments: `f(n)` → `(n, n)`, `f(r, c)` → `(r, c)`.
 fn dims(name: &str, args: &[MatValue]) -> Result<(usize, usize), String> {
-    match args {
+    let (r, c) = match args {
         [n] => {
             let n = count(n.as_num(name)?, name)?;
-            Ok((n, n))
+            (n, n)
         }
-        [r, c] => Ok((count(r.as_num(name)?, name)?, count(c.as_num(name)?, name)?)),
-        _ => Err(format!("{name}: expected 1 or 2 size arguments")),
+        [r, c] => (count(r.as_num(name)?, name)?, count(c.as_num(name)?, name)?),
+        _ => return Err(format!("{name}: expected 1 or 2 size arguments")),
+    };
+    // Each dimension alone is within `count()`'s own per-dimension cap, but
+    // their PRODUCT is not -- `zeros(1<<26, 1<<26)` would otherwise request
+    // an allocation of ~4.5e15 elements before this ever runs. Security
+    // regression, mirrors the fix already shipped in scilab-runtime.
+    check_total_elements(name, r, c)?;
+    Ok((r, c))
+}
+
+/// The total-element cap every array-constructing/-growing operation must
+/// enforce on its FINAL size -- not just on each dimension independently.
+/// Capping each dimension alone (as `count()` already does) does not bound
+/// their PRODUCT: two independently-in-bounds dimensions, or two
+/// independently-in-bounds index vectors used as `A(idx, idx)`, can still
+/// combine into an astronomical total. Uses `checked_mul` so the
+/// multiplication itself cannot silently overflow before the comparison
+/// runs.
+pub(crate) const MAX_TOTAL_ELEMENTS: usize = 1 << 26;
+
+pub(crate) fn check_total_elements(name: &str, rows: usize, cols: usize) -> Result<(), String> {
+    match rows.checked_mul(cols) {
+        Some(total) if total <= MAX_TOTAL_ELEMENTS => Ok(()),
+        _ => Err(format!(
+            "{name}: {rows}x{cols} exceeds the {MAX_TOTAL_ELEMENTS}-element limit"
+        )),
     }
 }
 

--- a/code/packages/rust/matlab-runtime/src/eval.rs
+++ b/code/packages/rust/matlab-runtime/src/eval.rs
@@ -352,6 +352,14 @@ impl Interpreter {
             [ri, ci] => {
                 let rows = dim_indices(ri, a.nrows(), "row")?;
                 let cols = dim_indices(ci, a.ncols(), "column")?;
+                // Each index vector's own length is bounded independently
+                // (by whatever constructed it) but nothing bounds their
+                // PRODUCT: `A(idx, idx)` with two independently-in-bounds
+                // index vectors can still request an astronomical result.
+                // Checked before `Vec::with_capacity`/`Array::from_shape`
+                // ever allocate. Security regression, mirrors
+                // scilab-runtime's fix.
+                crate::builtins::check_total_elements("indexing", rows.len(), cols.len())?;
                 let mut out = Vec::with_capacity(rows.len() * cols.len());
                 // Column-major output: iterate columns, then rows.
                 for &c in &cols {
@@ -634,6 +642,13 @@ fn hcat(cells: &[Array]) -> Result<Array, String> {
         if a.nrows() != nrows {
             return Err("horizontal concatenation: row counts must match".to_string());
         }
+        // `[A A]` repeated (e.g. `A = [A A];` many times) doubles the
+        // element count each time with no individually-large input --
+        // only the ACCUMULATED result grows exponentially. Checked
+        // incrementally, as the result is built, so the check fires
+        // before the oversized intermediate `cols`/`data` is ever
+        // allocated. Security regression, mirrors scilab-runtime's fix.
+        crate::builtins::check_total_elements("matrix literal", nrows, cols.len() + a.ncols())?;
         for c in 0..a.ncols() {
             cols.push((0..nrows).map(|r| a.get(r, c).unwrap()).collect());
         }
@@ -656,13 +671,19 @@ fn vcat(rows: &[Array]) -> Result<Array, String> {
         return Array::from_shape(vec![], vec![0, 0]);
     };
     let ncols = first.ncols();
-    let total_rows: usize = rows.iter().map(|a| a.nrows()).sum();
-    let mut data = vec![0.0; total_rows * ncols];
-    let mut row_off = 0;
+    let mut total_rows: usize = 0;
     for a in &rows {
         if a.ncols() != ncols {
             return Err("vertical concatenation: column counts must match".to_string());
         }
+        total_rows += a.nrows();
+        // See the matching comment in `hcat`: checked incrementally so the
+        // oversized `data` buffer is never allocated.
+        crate::builtins::check_total_elements("matrix literal", total_rows, ncols)?;
+    }
+    let mut data = vec![0.0; total_rows * ncols];
+    let mut row_off = 0;
+    for a in &rows {
         for c in 0..ncols {
             for r in 0..a.nrows() {
                 data[c * total_rows + (row_off + r)] = a.get(r, c).unwrap();

--- a/code/packages/rust/matlab-runtime/src/lib.rs
+++ b/code/packages/rust/matlab-runtime/src/lib.rs
@@ -219,6 +219,62 @@ mod tests {
     }
 
     #[test]
+    fn constructor_rejects_an_astronomical_element_product() {
+        // Security regression: each dimension alone (67,108,864) is within
+        // count()'s own per-dimension cap, but their PRODUCT (~4.5e15
+        // elements, ~36 petabytes) is not -- this must be a clean error, not
+        // an attempted allocation that aborts the process.
+        assert!(eval("zeros(67108864, 67108864)\n").is_err());
+        assert!(eval("eye(67108864)\n").is_err());
+        // A genuinely small, in-bounds construction still works.
+        assert!(eval("zeros(3, 4)\n").is_ok());
+    }
+
+    #[test]
+    fn matrix_self_concatenation_cannot_double_past_the_element_cap() {
+        // Security regression: `[A A]`/`[A; A]` repeated doubles the element
+        // count each time with no individually-large input -- only the
+        // ACCUMULATED result grows exponentially. 40 repetitions alone
+        // already reaches 2^40 elements; this must error out well before an
+        // attacker-reachable number of repetitions produces an
+        // allocation-aborting size.
+        let mut m = Interpreter::new();
+        m.feed("A = 1;\n").unwrap();
+        let mut last_ok = true;
+        for _ in 0..40 {
+            last_ok = m.feed("A = [A A];\n").is_ok();
+            if !last_ok {
+                break;
+            }
+        }
+        assert!(
+            !last_ok,
+            "40 doublings (up to 2^40 elements) must be rejected before completing"
+        );
+    }
+
+    #[test]
+    fn two_d_indexing_rejects_a_product_overflow() {
+        // Security regression: each index vector's own length is bounded
+        // independently (here, by `ones`'s own dimension cap) but nothing
+        // bounded their PRODUCT -- `A(idx, idx)` with two
+        // independently-in-bounds index vectors could still request an
+        // astronomical result. 8200x8200 (67,240,000 elements) exceeds the
+        // 1<<26 (67,108,864) total-element cap and must be rejected before
+        // any allocation is attempted.
+        let mut m = Interpreter::new();
+        m.feed("A = 0;\n").unwrap();
+        m.feed("idx = ones(1, 8200);\n").unwrap();
+        assert!(m.feed("B = A(idx, idx);\n").is_err());
+
+        // A genuinely small, in-bounds 2-D index still works.
+        let mut m2 = Interpreter::new();
+        m2.feed("A = 0;\n").unwrap();
+        m2.feed("idx2 = ones(1, 3);\n").unwrap();
+        assert!(m2.feed("B = A(idx2, idx2);\n").is_ok());
+    }
+
+    #[test]
     fn deeply_nested_input_errors_instead_of_crashing() {
         // Pathologically nested parentheses must be a clean error, not a stack
         // overflow that aborts the process.


### PR DESCRIPTION
## Summary

Ports a security fix from the sibling `scilab-runtime` crate (#8693, merged) into `matlab-runtime`, which shares the identical vulnerability class since `scilab-runtime`'s evaluator was originally modeled after this crate's. Tracked as follow-up task from that PR's security review.

**The gap**: `count()` capped each dimension independently (`1<<26`) but never checked their PRODUCT. Concretely:
- `zeros(1<<26, 1<<26)` / `eye(1<<26)` — each dimension alone passes the cap, but the constructed array would need ~4.5e15 elements (~36 petabytes).
- Repeated matrix self-concatenation (`A = [A A];` many times) — `hcat`/`vcat` here didn't even have a per-dimension check at all; only the accumulated result grows exponentially, with no single large input.
- 2-D indexing (`A(idx, idx)`) — two independently-in-bounds index vectors (each bounded by whatever constructed them) could still request an astronomical product.

Each of these is an allocation-aborting denial of service, not a clean error.

## Fix

- Added `builtins::check_total_elements(name, rows, cols)` using `checked_mul` (so the multiplication itself can't silently overflow before the comparison runs), cap `1<<26` total elements (matching the existing per-dimension convention).
- Wired into `dims()` and `eye()` (before allocating), and into `hcat`/`vcat` (checked incrementally as the result is built, so the check fires before the oversized intermediate buffer is ever allocated — closing the self-concatenation growth path).
- Wired into `index_value`'s 2-D indexing arm, before `Vec::with_capacity`/`Array::from_shape`.
- `octave-runtime` inherits the fix automatically — it's a pure text-rewriting shim that hands every statement to `matlab_runtime::Interpreter::feed` directly, with no parallel implementation of its own.
- Added 3 regression tests mirroring `scilab-runtime`'s: `constructor_rejects_an_astronomical_element_product`, `matrix_self_concatenation_cannot_double_past_the_element_cap`, `two_d_indexing_rejects_a_product_overflow`.
- Bumped to `0.1.1` with a CHANGELOG entry.

## Security review

One round, clean pass. The reviewer additionally verified: matrix multiplication (`A * B`) is a separate, untouched code path already independently guarded by `array-runtime`'s own 4 GiB output-tensor cap; and confirmed `octave-runtime` has no bypass path of its own.

## Test plan
- [x] `cargo test -p coding-adventures-matlab-runtime` (16 tests, including 3 new) — pass
- [x] `cargo test -p coding-adventures-octave-runtime -p coding-adventures-matlab-repl` (downstream consumers of the shared crate) — pass
- [x] `cargo clippy -p coding-adventures-matlab-runtime --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` (same exclusions as usual) — clean
- [x] Security review: 1 round, clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)