### PR TITLE
Add Haskell EAN-13 port

### DIFF
--- a/code/packages/haskell/ean-13/BUILD
+++ b/code/packages/haskell/ean-13/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/ean-13/BUILD_windows
+++ b/code/packages/haskell/ean-13/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/ean-13/CHANGELOG.md
+++ b/code/packages/haskell/ean-13/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Validate 12- and 13-digit ASCII EAN-13 input.
+- Compute and verify the required modulo-10 check digit.
+- Select all ten leading-digit parity sequences and thirty L/G/R patterns.
+- Emit attributed 95-module runs and backend-neutral paint scenes through the shared 1D geometry.

--- a/code/packages/haskell/ean-13/README.md
+++ b/code/packages/haskell/ean-13/README.md
@@ -1,0 +1,29 @@
+# ean-13 (Haskell)
+
+Pure EAN-13 encoding for the Haskell package lane. The package accepts a
+12-digit payload and computes its required check digit, or accepts a complete
+13-digit code and verifies the supplied check digit.
+
+```haskell
+import CodingAdventures.Ean13
+
+example = drawEan13 "400638133393" defaultPaintBarcode1DOptions
+```
+
+The API exposes all thirty L/G/R digit patterns, every leading-digit parity
+sequence, normalized data, typed per-digit encodings, source attribution, and
+the complete 95-module run stream. The leading digit is represented indirectly
+through the six left-side parity choices, exactly as the symbology specifies.
+EAN-2/EAN-5 supplements, registry lookup, and scanner-side decoding remain
+outside the V1 contract.
+
+Rendering delegates to `barcode-layout-1d`, which supplies validated quiet-zone
+geometry, explicit symbol spans, rectangle-only paint instructions, and shared
+scene metadata. Human-readable text remains explicitly unsupported until the
+Haskell lane has a text-shaping backend.
+
+## Development
+
+```sh
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/ean-13/cabal.project
+++ b/code/packages/haskell/ean-13/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../barcode-layout-1d ../paint-instructions

--- a/code/packages/haskell/ean-13/ean13.cabal
+++ b/code/packages/haskell/ean-13/ean13.cabal
@@ -1,0 +1,39 @@
+cabal-version: 3.0
+name:          ean13
+version:       0.1.0
+synopsis:      Pure EAN-13 barcode encoder
+description:   Checked EAN-13 normalization, parity-selected digit patterns, attributed runs, and backend-neutral paint scenes.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.Ean13
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , paint-instructions >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Ean13Spec
+    hs-source-dirs:   test
+    build-depends:    aeson >=2.0 && <3
+                    , base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , containers >=0.6 && <0.8
+                    , ean13
+                    , hspec ==2.*
+                    , paint-instructions >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/ean-13/src/CodingAdventures/Ean13.hs
+++ b/code/packages/haskell/ean-13/src/CodingAdventures/Ean13.hs
@@ -1,0 +1,311 @@
+-- | Pure EAN-13 barcode encoding.
+module CodingAdventures.Ean13
+  ( Ean13Encoding (..)
+  , EncodedEan13Digit (..)
+  , Ean13Error (..)
+  , Barcode1DError (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , PaintScene (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , ean13DigitPattern
+  , computeEan13CheckDigit
+  , normalizeEan13
+  , leftParityPattern
+  , encodeEan13
+  , expandEan13Runs
+  , layoutEan13
+  , drawEan13
+  , version
+  ) where
+
+import CodingAdventures.BarcodeLayout1D
+  ( Barcode1DError (..)
+  , Barcode1DRenderConfig (..)
+  , Barcode1DRun (..)
+  , Barcode1DRunColor (..)
+  , Barcode1DRunRole (..)
+  , Barcode1DSymbolDescriptor (..)
+  , Barcode1DSymbolRole (..)
+  , PaintBarcode1DOptions (..)
+  , defaultBarcode1DRenderConfig
+  , defaultBinaryPatternOptions
+  , defaultPaintBarcode1DOptions
+  , layoutBarcode1D
+  , runsFromBinaryPattern
+  )
+import CodingAdventures.PaintInstructions (PaintScene (..))
+import Data.Aeson (toJSON)
+import Data.Bifunctor (first)
+import Data.Char (ord)
+import Data.List (findIndex)
+import qualified Data.Map.Strict as Map
+
+-- | Package version shared with the established implementations.
+version :: String
+version = "0.1.0"
+
+-- | The pattern family used for one visible EAN-13 digit.
+data Ean13Encoding = Ean13L | Ean13G | Ean13R
+  deriving (Eq, Show)
+
+-- | One visible digit and its selected seven-module pattern.
+data EncodedEan13Digit = EncodedEan13Digit
+  { encodedEan13Digit :: Char
+  , encodedEan13Encoding :: Ean13Encoding
+  , encodedEan13Pattern :: String
+  , encodedEan13SourceIndex :: Int
+  , encodedEan13Role :: Barcode1DRunRole
+  } deriving (Eq, Show)
+
+-- | Checked failures from input, checksum, pattern, or shared layout rules.
+data Ean13Error
+  = InvalidEan13Character Int Char
+  | InvalidEan13Length Int
+  | InvalidEan13CheckDigit Char Char
+  | Ean13LayoutError Barcode1DError
+  deriving (Eq)
+
+instance Show Ean13Error where
+  show (InvalidEan13Character index character) =
+    "Invalid EAN-13 character " ++ show [character]
+      ++ " at index " ++ show index ++ "; expected an ASCII digit"
+  show (InvalidEan13Length actualLength) =
+    "Invalid EAN-13 length " ++ show actualLength
+      ++ "; expected 12 payload digits or 13 complete digits"
+  show (InvalidEan13CheckDigit expected actual) =
+    "Invalid EAN-13 check digit: expected " ++ [expected]
+      ++ " but received " ++ [actual]
+  show (Ean13LayoutError layoutError) = show layoutError
+
+sideGuard :: String
+sideGuard = "101"
+
+centerGuard :: String
+centerGuard = "01010"
+
+leftPatterns :: [String]
+leftPatterns =
+  [ "0001101", "0011001", "0010011", "0111101", "0100011"
+  , "0110001", "0101111", "0111011", "0110111", "0001011"
+  ]
+
+evenPatterns :: [String]
+evenPatterns =
+  [ "0100111", "0110011", "0011011", "0100001", "0011101"
+  , "0111001", "0000101", "0010001", "0001001", "0010111"
+  ]
+
+rightPatterns :: [String]
+rightPatterns =
+  [ "1110010", "1100110", "1101100", "1000010", "1011100"
+  , "1001110", "1010000", "1000100", "1001000", "1110100"
+  ]
+
+leftParityEncodings :: [[Ean13Encoding]]
+leftParityEncodings =
+  [ replicate 6 Ean13L
+  , [Ean13L, Ean13L, Ean13G, Ean13L, Ean13G, Ean13G]
+  , [Ean13L, Ean13L, Ean13G, Ean13G, Ean13L, Ean13G]
+  , [Ean13L, Ean13L, Ean13G, Ean13G, Ean13G, Ean13L]
+  , [Ean13L, Ean13G, Ean13L, Ean13L, Ean13G, Ean13G]
+  , [Ean13L, Ean13G, Ean13G, Ean13L, Ean13L, Ean13G]
+  , [Ean13L, Ean13G, Ean13G, Ean13G, Ean13L, Ean13L]
+  , [Ean13L, Ean13G, Ean13L, Ean13G, Ean13L, Ean13G]
+  , [Ean13L, Ean13G, Ean13L, Ean13G, Ean13G, Ean13L]
+  , [Ean13L, Ean13G, Ean13G, Ean13L, Ean13G, Ean13L]
+  ]
+
+-- | Look up one of the thirty standard seven-module digit patterns.
+ean13DigitPattern :: Ean13Encoding -> Char -> Either Ean13Error String
+ean13DigitPattern encoding digit = do
+  value <- digitValue 0 digit
+  case drop value patterns of
+    patternText : _ -> Right patternText
+    [] -> Left (InvalidEan13Character 0 digit)
+  where
+    patterns = case encoding of
+      Ean13L -> leftPatterns
+      Ean13G -> evenPatterns
+      Ean13R -> rightPatterns
+
+-- | Compute the modulo-10 check digit for exactly twelve payload digits.
+computeEan13CheckDigit :: String -> Either Ean13Error Char
+computeEan13CheckDigit payload = do
+  validateDigits [12] payload
+  values <- traverse (uncurry digitValue) (zip [0 :: Int ..] payload)
+  let total = sum
+        [ value * if even index then 1 else 3
+        | (index, value) <- zip [0 :: Int ..] values
+        ]
+  Right (toDigit ((10 - total `mod` 10) `mod` 10))
+
+-- | Append a missing check digit or verify the supplied thirteenth digit.
+normalizeEan13 :: String -> Either Ean13Error String
+normalizeEan13 input = do
+  validateDigits [12, 13] input
+  expected <- computeEan13CheckDigit (take 12 input)
+  case drop 12 input of
+    [] -> Right (input ++ [expected])
+    actual : _
+      | actual == expected -> Right input
+      | otherwise -> Left (InvalidEan13CheckDigit expected actual)
+
+-- | Return the six L/G choices selected indirectly by the leading digit.
+leftParityPattern :: String -> Either Ean13Error String
+leftParityPattern input = do
+  normalized <- normalizeEan13 input
+  encodings <- parityForLeadingDigit (head normalized)
+  Right (map encodingMarker encodings)
+
+-- | Encode the twelve visible digits. The leading digit selects parity and
+-- occupies no modules of its own.
+encodeEan13 :: String -> Either Ean13Error [EncodedEan13Digit]
+encodeEan13 input = normalizeEan13 input >>= encodeNormalized
+
+-- | Expand the start, visible digits, center, and end into attributed runs.
+expandEan13Runs :: String -> Either Ean13Error [Barcode1DRun]
+expandEan13Runs input = encodeEan13 input >>= expandEncoded
+
+-- | Render EAN-13 through the shared backend-neutral 1D geometry.
+layoutEan13
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either Ean13Error PaintScene
+layoutEan13 input options = do
+  normalized <- normalizeEan13 input
+  parity <- leftParityPattern normalized
+  encoded <- encodeNormalized normalized
+  runs <- expandEncoded encoded
+  let checkDigit = encodedEan13Digit (last encoded)
+  first Ean13LayoutError
+    (layoutBarcode1D runs
+      (ean13Options normalized parity checkDigit encoded options))
+
+-- | Compatibility alias matching the shared public API name.
+drawEan13
+  :: String
+  -> PaintBarcode1DOptions
+  -> Either Ean13Error PaintScene
+drawEan13 = layoutEan13
+
+validateDigits :: [Int] -> String -> Either Ean13Error ()
+validateDigits expectedLengths input = case findIndex (not . isAsciiDigit) input of
+  Just index -> Left (InvalidEan13Character index (input !! index))
+  Nothing
+    | length input `elem` expectedLengths -> Right ()
+    | otherwise -> Left (InvalidEan13Length (length input))
+
+isAsciiDigit :: Char -> Bool
+isAsciiDigit character = character >= '0' && character <= '9'
+
+digitValue :: Int -> Char -> Either Ean13Error Int
+digitValue index character
+  | isAsciiDigit character = Right (ord character - ord '0')
+  | otherwise = Left (InvalidEan13Character index character)
+
+toDigit :: Int -> Char
+toDigit value = toEnum (ord '0' + value)
+
+parityForLeadingDigit :: Char -> Either Ean13Error [Ean13Encoding]
+parityForLeadingDigit leadingDigit = do
+  value <- digitValue 0 leadingDigit
+  case drop value leftParityEncodings of
+    encodings : _ -> Right encodings
+    [] -> Left (InvalidEan13Character 0 leadingDigit)
+
+encodingMarker :: Ean13Encoding -> Char
+encodingMarker encoding = case encoding of
+  Ean13L -> 'L'
+  Ean13G -> 'G'
+  Ean13R -> 'R'
+
+encodeNormalized :: String -> Either Ean13Error [EncodedEan13Digit]
+encodeNormalized normalized = do
+  parity <- parityForLeadingDigit (head normalized)
+  leftEncoded <- traverse encodeLeft
+    (zip3 [1 :: Int ..] (take 6 (drop 1 normalized)) parity)
+  rightEncoded <- traverse encodeRight
+    (zip [7 :: Int ..] (drop 7 normalized))
+  Right (leftEncoded ++ rightEncoded)
+  where
+    encodeLeft (sourceIndex, digit, encoding) =
+      encodeOne sourceIndex digit encoding Data
+    encodeRight (sourceIndex, digit) =
+      encodeOne sourceIndex digit Ean13R
+        (if sourceIndex == 12 then Check else Data)
+    encodeOne sourceIndex digit encoding role = do
+      patternText <- ean13DigitPattern encoding digit
+      Right EncodedEan13Digit
+        { encodedEan13Digit = digit
+        , encodedEan13Encoding = encoding
+        , encodedEan13Pattern = patternText
+        , encodedEan13SourceIndex = sourceIndex
+        , encodedEan13Role = role
+        }
+
+expandEncoded :: [EncodedEan13Digit] -> Either Ean13Error [Barcode1DRun]
+expandEncoded encoded = do
+  startRuns <- expandPattern "start" (-1) Guard sideGuard
+  leftRuns <- concat <$> traverse expandDigit (take 6 encoded)
+  middleRuns <- expandPattern "center" (-2) Guard centerGuard
+  rightRuns <- concat <$> traverse expandDigit (drop 6 encoded)
+  endRuns <- expandPattern "end" (-3) Guard sideGuard
+  Right (startRuns ++ leftRuns ++ middleRuns ++ rightRuns ++ endRuns)
+  where
+    expandDigit entry = expandPattern
+      [encodedEan13Digit entry]
+      (encodedEan13SourceIndex entry)
+      (encodedEan13Role entry)
+      (encodedEan13Pattern entry)
+
+expandPattern
+  :: String
+  -> Int
+  -> Barcode1DRunRole
+  -> String
+  -> Either Ean13Error [Barcode1DRun]
+expandPattern label sourceIndex role patternText = first Ean13LayoutError
+  (runsFromBinaryPattern patternText
+    (defaultBinaryPatternOptions label sourceIndex role))
+
+buildSymbols :: [EncodedEan13Digit] -> [Barcode1DSymbolDescriptor]
+buildSymbols encoded =
+  [Barcode1DSymbolDescriptor "start" 3 (-1) SymbolGuard]
+    ++ map digitDescriptor (take 6 encoded)
+    ++ [Barcode1DSymbolDescriptor "center" 5 (-2) SymbolGuard]
+    ++ map digitDescriptor (drop 6 encoded)
+    ++ [Barcode1DSymbolDescriptor "end" 3 (-3) SymbolGuard]
+  where
+    digitDescriptor entry = Barcode1DSymbolDescriptor
+      { descriptorLabel = [encodedEan13Digit entry]
+      , descriptorModules = 7
+      , descriptorSourceIndex = encodedEan13SourceIndex entry
+      , descriptorRole = if encodedEan13Role entry == Check
+          then SymbolCheck
+          else SymbolData
+      }
+
+ean13Options
+  :: String
+  -> String
+  -> Char
+  -> [EncodedEan13Digit]
+  -> PaintBarcode1DOptions
+  -> PaintBarcode1DOptions
+ean13Options normalized parity checkDigit encoded options = options
+  { optionsLabel = Just (maybe defaultLabel id (optionsLabel options))
+  , optionsMetadata = Map.insert "checkDigit" (toJSON [checkDigit])
+      (Map.insert "leftParity" (toJSON parity)
+        (Map.insert "leadingDigit" (toJSON (take 1 normalized))
+          (Map.insert "encodedText" (toJSON normalized)
+            (Map.insert "symbology" (toJSON ("ean-13" :: String))
+              (optionsMetadata options)))))
+  , optionsSymbols = Just (buildSymbols encoded)
+  }
+  where
+    defaultLabel = "EAN-13 barcode for " ++ normalized

--- a/code/packages/haskell/ean-13/test/Ean13Spec.hs
+++ b/code/packages/haskell/ean-13/test/Ean13Spec.hs
@@ -1,0 +1,237 @@
+module Ean13Spec (spec) where
+
+import CodingAdventures.Ean13
+import CodingAdventures.PaintInstructions (PaintInstruction (..))
+import Data.Aeson (toJSON)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "metadata" $ do
+    it "reports the shared package version" $
+      version `shouldBe` "0.1.0"
+
+  describe "ean13DigitPattern" $ do
+    it "contains all ten exact L patterns" $
+      traverse (ean13DigitPattern Ean13L) ['0' .. '9'] `shouldBe`
+        Right
+          [ "0001101", "0011001", "0010011", "0111101", "0100011"
+          , "0110001", "0101111", "0111011", "0110111", "0001011"
+          ]
+
+    it "contains all ten exact G patterns" $
+      traverse (ean13DigitPattern Ean13G) ['0' .. '9'] `shouldBe`
+        Right
+          [ "0100111", "0110011", "0011011", "0100001", "0011101"
+          , "0111001", "0000101", "0010001", "0001001", "0010111"
+          ]
+
+    it "contains all ten exact R patterns" $
+      traverse (ean13DigitPattern Ean13R) ['0' .. '9'] `shouldBe`
+        Right
+          [ "1110010", "1100110", "1101100", "1000010", "1011100"
+          , "1001110", "1010000", "1000100", "1001000", "1110100"
+          ]
+
+    it "rejects non-digit pattern lookups" $
+      ean13DigitPattern Ean13L 'x' `shouldBe`
+        Left (InvalidEan13Character 0 'x')
+
+  describe "computeEan13CheckDigit" $ do
+    it "matches shared reference values" $ do
+      computeEan13CheckDigit "400638133393" `shouldBe` Right '1'
+      computeEan13CheckDigit "590123412345" `shouldBe` Right '7'
+      computeEan13CheckDigit "978020137962" `shouldBe` Right '4'
+      computeEan13CheckDigit "000000000000" `shouldBe` Right '0'
+
+    it "requires exactly twelve ASCII digits" $ do
+      computeEan13CheckDigit "123" `shouldBe` Left (InvalidEan13Length 3)
+      computeEan13CheckDigit "40063813339A" `shouldBe`
+        Left (InvalidEan13Character 11 'A')
+
+  describe "normalizeEan13" $ do
+    it "appends a missing check digit" $
+      normalizeEan13 "400638133393" `shouldBe` Right "4006381333931"
+
+    it "preserves a valid supplied check digit" $
+      normalizeEan13 "4006381333931" `shouldBe` Right "4006381333931"
+
+    it "rejects the wrong supplied check digit" $
+      normalizeEan13 "4006381333932" `shouldBe`
+        Left (InvalidEan13CheckDigit '1' '2')
+
+    it "rejects empty, short, long, non-ASCII, and mixed input" $ do
+      normalizeEan13 "" `shouldBe` Left (InvalidEan13Length 0)
+      normalizeEan13 "12345678901" `shouldBe` Left (InvalidEan13Length 11)
+      normalizeEan13 "12345678901234" `shouldBe` Left (InvalidEan13Length 14)
+      normalizeEan13 "40063813339A" `shouldBe`
+        Left (InvalidEan13Character 11 'A')
+      normalizeEan13 "４００６３８１３３３９３" `shouldBe`
+        Left (InvalidEan13Character 0 '４')
+
+    it "shows educational errors" $ do
+      show (InvalidEan13Character 2 'x') `shouldBe`
+        "Invalid EAN-13 character \"x\" at index 2; expected an ASCII digit"
+      show (InvalidEan13Length 4) `shouldBe`
+        "Invalid EAN-13 length 4; expected 12 payload digits or 13 complete digits"
+      show (InvalidEan13CheckDigit '1' '2') `shouldBe`
+        "Invalid EAN-13 check digit: expected 1 but received 2"
+
+  describe "leftParityPattern" $ do
+    it "contains every standard leading-digit parity sequence" $
+      traverse parityFor ['0' .. '9'] `shouldBe`
+        Right
+          [ "LLLLLL", "LLGLGG", "LLGGLG", "LLGGGL", "LGLLGG"
+          , "LGGLLG", "LGGGLL", "LGLGLG", "LGLGGL", "LGGLGL"
+          ]
+
+    it "uses the reference leading digit and accepts a supplied check" $ do
+      leftParityPattern "400638133393" `shouldBe` Right "LGLLGG"
+      leftParityPattern "4006381333931" `shouldBe` Right "LGLLGG"
+
+  describe "encodeEan13" $ do
+    it "encodes only the twelve visible digits with source attribution" $ do
+      encoded <- expectRight (encodeEan13 "400638133393")
+      map encodedEan13Digit encoded `shouldBe` "006381333931"
+      map encodedEan13SourceIndex encoded `shouldBe` [1 .. 12]
+      map encodedEan13Encoding encoded `shouldBe`
+        [Ean13L, Ean13G, Ean13L, Ean13L, Ean13G, Ean13G]
+          ++ replicate 6 Ean13R
+      map encodedEan13Role encoded `shouldBe` replicate 11 Data ++ [Check]
+
+    it "uses exact parity-selected patterns for the reference code" $ do
+      encoded <- expectRight (encodeEan13 "400638133393")
+      map encodedEan13Pattern encoded `shouldBe`
+        [ "0001101", "0100111", "0101111", "0111101", "0001001", "0110011"
+        , "1000010", "1000010", "1000010", "1110100", "1000010", "1100110"
+        ]
+
+    it "produces identical records for computed and supplied checks" $
+      encodeEan13 "400638133393" `shouldBe` encodeEan13 "4006381333931"
+
+  describe "expandEan13Runs" $ do
+    it "builds the exact 95-module guard and visible-digit stream" $ do
+      encoded <- expectRight (encodeEan13 "400638133393")
+      runs <- expectRight (expandEan13Runs "400638133393")
+      let expected = "101"
+            ++ concatMap encodedEan13Pattern (take 6 encoded)
+            ++ "01010"
+            ++ concatMap encodedEan13Pattern (drop 6 encoded)
+            ++ "101"
+      modulesFromRuns runs `shouldBe` expected
+      length expected `shouldBe` 95
+      length runs `shouldBe` 59
+
+    it "attributes guards, visible data, and the check digit" $ do
+      runs <- expectRight (expandEan13Runs "400638133393")
+      map runRole (take 3 runs) `shouldBe` replicate 3 Guard
+      map runSourceLabel (take 3 runs) `shouldBe` replicate 3 "start"
+      map runRole (take 5 (drop 27 runs)) `shouldBe` replicate 5 Guard
+      map runSourceLabel (take 5 (drop 27 runs)) `shouldBe` replicate 5 "center"
+      map runRole (take 4 (drop 52 runs)) `shouldBe` replicate 4 Check
+      map runSourceLabel (take 4 (drop 52 runs)) `shouldBe` replicate 4 "1"
+      map runRole (drop 56 runs) `shouldBe` replicate 3 Guard
+      map runSourceLabel (drop 56 runs) `shouldBe` replicate 3 "end"
+      0 `shouldNotSatisfy` (\sourceIndex -> sourceIndex `elem` map runSourceIndex runs)
+
+    it "alternates colors across every symbol boundary" $ do
+      runs <- expectRight (expandEan13Runs "400638133393")
+      and (zipWith (/=) (map runColor runs) (drop 1 (map runColor runs)))
+        `shouldBe` True
+
+    it "propagates validation failures" $
+      expandEan13Runs "4006381333932" `shouldBe`
+        Left (InvalidEan13CheckDigit '1' '2')
+
+  describe "layoutEan13" $ do
+    it "renders the fixed module stream through shared default geometry" $ do
+      scene <- expectRight (layoutEan13 "400638133393" defaultPaintBarcode1DOptions)
+      psWidth scene `shouldBe` 460
+      psHeight scene `shouldBe` 120
+      psBg scene `shouldBe` "#ffffff"
+      length (psInstructions scene) `shouldBe` 30
+      map prX (take 2 (psInstructions scene)) `shouldBe` [40, 48]
+
+    it "records normalized data, parity, checksum, label, and fifteen symbols" $ do
+      scene <- expectRight (layoutEan13 "400638133393" defaultPaintBarcode1DOptions)
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("ean-13" :: String))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("4006381333931" :: String))
+      Map.lookup "leadingDigit" (psMeta scene) `shouldBe`
+        Just (toJSON ("4" :: String))
+      Map.lookup "leftParity" (psMeta scene) `shouldBe`
+        Just (toJSON ("LGLLGG" :: String))
+      Map.lookup "checkDigit" (psMeta scene) `shouldBe`
+        Just (toJSON ("1" :: String))
+      Map.lookup "contentModules" (psMeta scene) `shouldBe` Just (toJSON (95 :: Int))
+      Map.lookup "symbolCount" (psMeta scene) `shouldBe` Just (toJSON (15 :: Int))
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("EAN-13 barcode for 4006381333931" :: String))
+
+    it "preserves custom rendering, labels, and caller metadata" $ do
+      let config = defaultBarcode1DRenderConfig
+            { configModuleWidth = 2
+            , configBarHeight = 50
+            , configQuietZoneModules = 5
+            , configForeground = "navy"
+            , configBackground = "transparent"
+            }
+          options = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = config
+            , optionsLabel = Just "Library label"
+            , optionsMetadata = Map.fromList
+                [ ("batch", toJSON (7 :: Int))
+                , ("checkDigit", toJSON ("wrong" :: String))
+                , ("encodedText", toJSON ("wrong" :: String))
+                , ("leadingDigit", toJSON ("wrong" :: String))
+                , ("leftParity", toJSON ("wrong" :: String))
+                , ("symbology", toJSON ("wrong" :: String))
+                ]
+            }
+      scene <- expectRight (layoutEan13 "400638133393" options)
+      (psWidth scene, psHeight scene, psBg scene) `shouldBe` (210, 50, "transparent")
+      map prFill (psInstructions scene) `shouldBe` replicate 30 "navy"
+      Map.lookup "label" (psMeta scene) `shouldBe`
+        Just (toJSON ("Library label" :: String))
+      Map.lookup "batch" (psMeta scene) `shouldBe` Just (toJSON (7 :: Int))
+      Map.lookup "checkDigit" (psMeta scene) `shouldBe`
+        Just (toJSON ("1" :: String))
+      Map.lookup "encodedText" (psMeta scene) `shouldBe`
+        Just (toJSON ("4006381333931" :: String))
+      Map.lookup "leadingDigit" (psMeta scene) `shouldBe`
+        Just (toJSON ("4" :: String))
+      Map.lookup "leftParity" (psMeta scene) `shouldBe`
+        Just (toJSON ("LGLLGG" :: String))
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("ean-13" :: String))
+
+    it "supports the draw alias" $
+      drawEan13 "400638133393" defaultPaintBarcode1DOptions `shouldBe`
+        layoutEan13 "400638133393" defaultPaintBarcode1DOptions
+
+    it "wraps shared layout validation failures" $ do
+      let invalidGeometry = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = defaultBarcode1DRenderConfig
+                { configModuleWidth = 0 }
+            }
+          humanText = defaultPaintBarcode1DOptions
+            { optionsHumanReadableText = Just "4006381333931" }
+      layoutEan13 "400638133393" invalidGeometry `shouldBe`
+        Left (Ean13LayoutError (InvalidRenderConfiguration "moduleWidth" 0))
+      layoutEan13 "400638133393" humanText `shouldBe`
+        Left (Ean13LayoutError HumanReadableTextUnsupported)
+
+parityFor :: Char -> Either Ean13Error String
+parityFor leadingDigit = leftParityPattern ([leadingDigit] ++ replicate 11 '0')
+
+modulesFromRuns :: [Barcode1DRun] -> String
+modulesFromRuns = concatMap expandRun
+  where
+    expandRun run = replicate (runModules run)
+      (if runColor run == Bar then '1' else '0')
+
+expectRight :: Show error => Either error value -> IO value
+expectRight (Right value) = pure value
+expectRight (Left err) = fail ("unexpected error: " ++ show err)

--- a/code/packages/haskell/ean-13/test/Spec.hs
+++ b/code/packages/haskell/ean-13/test/Spec.hs
@@ -1,0 +1,5 @@
+import Ean13Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -121,11 +121,12 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
 `type-checker-protocol` ports, and the Haskell `paint-vm-ascii`,
-`barcode-layout-1d`, `itf`, `code39`, `codabar`, `code128`, and `upc-a` ports:
+`barcode-layout-1d`, `itf`, `code39`, `codabar`, `code128`, `upc-a`, and
+`ean-13` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 283 |
+| Present in 10-15 languages | 172 | 282 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 712 | 9,968 |
@@ -171,7 +172,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 283
+The 172 packages present in at least ten implementation languages need 282
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -182,7 +183,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 8 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 7 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -663,6 +664,19 @@ exact module geometry, metadata precedence, aliases, and shared validation
 paths. The package now spans 12 implementation lanes, reduces the
 high-consensus backlog to 283 slots, leaves 8 gaps in the Haskell lane, and
 unlocks the dependent `ean-13` port.
+
+The twenty-seventh Haskell high-consensus slice is complete: `ean-13` now
+provides the pure retail-barcode encoder unlocked by `barcode-layout-1d`. It
+accepts 12-digit payloads or validated 13-digit codes, computes the required
+weighted modulo-10 check digit, exposes all thirty L/G/R digit patterns and all
+ten leading-digit parity sequences, and emits the fixed 95-module guard and
+visible-digit structure with typed source attribution and explicit symbol
+spans. Its package-native suite exercises 26 examples with 92% expression and
+78% alternative coverage, including reference checksums, every standard digit
+and parity pattern, computed and supplied checks, ASCII and length guards,
+exact module geometry, metadata precedence, aliases, and shared validation
+paths. The package now spans 12 implementation lanes, reduces the
+high-consensus backlog to 282 slots, and leaves 7 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell EAN-13 encoder with typed L/G/R patterns, leading-digit parity selection, checksum validation, attributed 95-module runs, and backend-neutral rendering
- cover all thirty digit patterns, all ten parity sequences, reference checksums, validation failures, exact geometry, metadata, and shared layout errors in 26 package-native examples
- refresh the package-parity roadmap from the live reporter, reducing the high-consensus backlog to 282 slots and Haskell's remaining gaps to 7

The repository directory remains `ean-13` for cross-language parity discovery. The internal Cabal package name is `ean13` because Cabal package-name components cannot be numeric-only.

## Validation

- `cabal test all --enable-coverage` (26 EAN-13 examples plus 46 dependency examples)
- HPC: 92% expressions, 78% alternatives
- `cabal check`
- `cabal sdist all`
- `python code/scripts/tests/test_package_parity_report.py` (6 tests)
- package parity reporter in Markdown, JSON, and CSV with `--fail-on-collisions`
- `git diff --check`
- generated artifact scan (0 package-local artifact directories)
