### PR TITLE
feat(adj-audit): RS-4 PR-B — the unified reasoning trace, + two uncatchable resolver crashes

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.15.0] — 2026-07-20 — the unified reasoning trace (RS-4 PR-B)
+
+Implements the ordered/addressed/self-contained step contract of
+`ADJ-REASON-MATH.md` §E.1–E.2. You could already ask ADJ *what* it concluded and
+*what it cited*; now you can ask **how it got there**.
+
+### Added
+
+- **`trace_steps_json` — a TOTAL walker over `DerivationOrigin`.** Renders a
+  proof as an ordered list of steps, each carrying `step` (index), `depth`
+  (nesting), the goal, and its **inline resolved provenance** — not a `FactId`
+  pointer. The trace is therefore self-contained: it can travel to a reviewer or
+  another machine and still be readable without the KB that produced it.
+  The match has **no wildcard arm**. The previous renderer ended in `_ => {}`,
+  which would silently discard four of six step kinds. That arm was latent in
+  shipped paths (the likelihood-ratio kinds are rendered by `proof_json`), but a
+  wildcard that drops reasoning is a trap for whoever adds the next step kind —
+  as `FromNegation` immediately proved. Adding a variant now breaks the build,
+  which is the point.
+- **`steps` on `recall` and `lookups` answers.** Both previously rendered only
+  from `via_facts`, which is `sort()`ed and deduplicated — a citation SET that
+  says which sources were involved but never in what order or through which
+  rules. `citations` is kept unchanged for existing consumers; `steps` is the
+  derivation beside it.
+- **`derivation` on every `derived` value.** The engine builds a
+  `DerivationNode` tree for every `let` and every formula application, and the
+  CLI **dropped it at the JSON boundary** — `derived_json` never read `.tree`.
+  It is now emitted: `op` nodes show the arithmetic, and `leaf` nodes resolve
+  through their real `FactId` to the source fact's provenance. That
+  compute-to-bytes bridge already existed inside the engine; this is what makes
+  it reachable from outside the process.
+
+### Notes
+
+- Additive only: no existing field changed or was removed, and a program with no
+  `let`, recall, or lookup produces byte-identical output.
+
 ## [0.14.0] — 2026-07-18 — table answers now cite the row that produced them (ADJ-TABLES RS-5e)
 
 ### Changed

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -99,6 +99,78 @@ fn value_json(d: &logic_engine::compute::Derived) -> String {
     jnum(d.value)
 }
 
+/// Render a compute derivation tree — **how** a `let`/formula value was
+/// actually calculated, step by arithmetic step.
+///
+/// # Why this matters more than it looks
+///
+/// The engine has always built this tree. It builds one for *every* `let` and
+/// every formula application, and until now it was **discarded at the JSON
+/// boundary**: the CLI printed the final number and its dimension, and the
+/// record of how that number came to be was dropped on the floor. So a reader
+/// could see `bmi = 22.86` and its citation, but could not see that it was
+/// `70 / (1.75 ^ 2)`, nor which observed facts supplied the 70 and the 1.75.
+///
+/// The leaves are the important part. A `Leaf` carries a real `FactId`, so it
+/// resolves to that fact's `source`/`locator`/`trust` — which means **an
+/// arithmetic result is traceable all the way down to bytes**, one operand at a
+/// time. That bridge already existed in the engine; this function is what
+/// finally lets anyone outside the process walk across it.
+///
+/// Node kinds, and what each asserts:
+/// - `leaf`   — asserts a fact (an observed magnitude), so it **quotes**.
+/// - `ref`    — points at another named derived value; its own tree explains it.
+/// - `lit`    — a constant written in the formula; asserts nothing new.
+/// - `op`     — arithmetic over operands; asserts nothing new, and is honest
+///   because its operands are (§E.3: a step that computes over already-cited
+///   inputs quotes nothing — its justification is its operands').
+fn derivation_tree_json(
+    node: &logic_engine::compute::DerivationNode,
+    kb: &KnowledgeBase,
+) -> String {
+    use logic_engine::compute::DerivationNode as D;
+    match node {
+        D::Leaf {
+            slot,
+            value,
+            fact_id,
+        } => {
+            let pv = kb
+                .fact(*fact_id)
+                .map(|f| prov(&f.provenance))
+                .unwrap_or_else(|| UNRESOLVED_PROV.to_string());
+            format!(
+                "{{\"node\":\"leaf\",\"slot\":\"{}\",\"value\":{},{}}}",
+                esc(slot),
+                jnum(*value),
+                pv
+            )
+        }
+        D::DerivedRef { name, value } => format!(
+            "{{\"node\":\"ref\",\"name\":\"{}\",\"value\":{}}}",
+            esc(name),
+            jnum(*value)
+        ),
+        D::Lit { value } => format!("{{\"node\":\"lit\",\"value\":{}}}", jnum(*value)),
+        D::Op {
+            op,
+            operands,
+            result,
+        } => {
+            let kids: Vec<String> = operands
+                .iter()
+                .map(|o| derivation_tree_json(o, kb))
+                .collect();
+            format!(
+                "{{\"node\":\"op\",\"op\":\"{}\",\"value\":{},\"operands\":[{}]}}",
+                esc(op.symbol()),
+                jnum(*result),
+                kids.join(",")
+            )
+        }
+    }
+}
+
 /// Render the `let`-bound derived values as a JSON array, one object per
 /// distinct binding name, each carrying the engine-computed magnitude plus the
 /// [`Dimension`](logic_engine::dimension::Dimension) tag the engine *inferred*
@@ -149,13 +221,19 @@ fn derived_json(kb: &KnowledgeBase) -> String {
                 Some(p) => format!(",{}", prov(p)),
                 None => String::new(),
             };
+            // RS-4: the derivation tree the engine already built for this
+            // value. Previously computed and then dropped here — emitting it is
+            // what turns "the engine says 22.86" into "here is the arithmetic,
+            // and here is the observed fact behind each operand."
+            let derivation = format!(",\"derivation\":{}", derivation_tree_json(&d.tree, kb));
             format!(
-                "{{\"name\":\"{}\",\"value\":{},\"dim\":\"{}\"{}{}}}",
+                "{{\"name\":\"{}\",\"value\":{},\"dim\":\"{}\"{}{}{}}}",
                 esc(&d.name),
                 value_json(d),
                 esc(&d.dim.tag()),
                 exact,
-                provenance
+                provenance,
+                derivation
             )
         })
         .collect();
@@ -201,39 +279,155 @@ fn prov(p: &Provenance) -> String {
     )
 }
 
-fn sld_proof_json(proof: &Proof, kb: &KnowledgeBase) -> String {
+/// The provenance rendered for a step whose clause could not be resolved in the
+/// KB. This should not happen — a step names a clause the engine just used —
+/// but if it ever does, the trail must say "unattributed", never invent one.
+const UNRESOLVED_PROV: &str =
+    "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\",\"corroborations\":[]";
+
+/// Render one proof as an **ordered, addressed, self-contained** list of
+/// reasoning steps — the `ReasoningTrace` of `ADJ-REASON-MATH.md` §E.
+///
+/// # What each of those three words buys you
+///
+/// - **Ordered.** `Proof.steps` is a preorder walk of the derivation, so
+///   `step` 0, 1, 2 … *is* the order the engine reasoned in. Contrast the
+///   `via_facts` list every other citation surface renders from: that one is
+///   sorted by fact id and deduplicated, which is why those surfaces can show
+///   you *which* sources were used but never *in what order* — a bag, not a
+///   narrative.
+/// - **Addressed.** Each step carries `step` (its index) and `depth` (its
+///   nesting). Parent = the nearest preceding step one level shallower, so a
+///   reader can rebuild the tree without re-deriving any rule's arity.
+/// - **Self-contained.** Each step inlines the *resolved* `source`/`locator`/
+///   `trust` of the clause it fired, not a `FactId` pointer. The trace can then
+///   travel — to a reviewer, to another machine, into an ADJ07 trail — and still
+///   be readable without the knowledge base that produced it.
+///
+/// # Why the match below has no wildcard arm
+///
+/// It is **total** over `DerivationOrigin`, deliberately. The previous renderer
+/// ended in `_ => {}`, which silently discarded every likelihood-ratio step:
+/// a probabilistic conclusion would render a short, tidy, *incomplete* trail,
+/// and nothing in the output marked the omission. A trail with a hole is worse
+/// than no trail, because it looks complete. Adding a variant to
+/// `DerivationOrigin` must now break this function's compilation — that failure
+/// is the feature.
+fn trace_steps_json(proof: &Proof, kb: &KnowledgeBase) -> String {
     let mut steps = Vec::new();
-    for st in &proof.steps {
-        match &st.origin {
+    for (i, st) in proof.steps.iter().enumerate() {
+        // Every step is addressed the same way, whatever its kind.
+        let head = format!(
+            "\"step\":{},\"depth\":{},\"goal\":\"{}\"",
+            i,
+            st.depth,
+            esc(&format!("{}", st.goal))
+        );
+        let body = match &st.origin {
+            // ---- Deduction -------------------------------------------------
             DerivationOrigin::FromFact(id) => {
-                let pv = kb.fact(*id).map(|f| prov(&f.provenance)).unwrap_or_else(|| {
-                    "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\",\"corroborations\":[]"
-                        .to_string()
-                });
-                steps.push(format!(
-                    "{{\"kind\":\"fact\",\"goal\":\"{}\",{}}}",
-                    esc(&format!("{}", st.goal)),
-                    pv
-                ));
+                let pv = kb
+                    .fact(*id)
+                    .map(|f| prov(&f.provenance))
+                    .unwrap_or_else(|| UNRESOLVED_PROV.to_string());
+                format!("\"kind\":\"fact\",{head},{pv}")
             }
             DerivationOrigin::FromRule(id) => {
                 let pv = kb
                     .find_rule_by_id(*id)
                     .map(|r| prov(&r.provenance))
-                    .unwrap_or_else(|| {
-                        "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\",\"corroborations\":[]"
-                            .to_string()
-                    });
-                steps.push(format!(
-                    "{{\"kind\":\"rule\",\"goal\":\"{}\",{}}}",
-                    esc(&format!("{}", st.goal)),
-                    pv
-                ));
+                    .unwrap_or_else(|| UNRESOLVED_PROV.to_string());
+                format!("\"kind\":\"rule\",{head},{pv}")
             }
-            _ => {}
-        }
+            // ---- Negation as failure --------------------------------------
+            // No clause fired, so there is no citation to quote: what justified
+            // this step is the *absence* of any proof for `goal`. A re-checker
+            // verifies it by re-running that goal and asserting it still has
+            // none (§E.5).
+            DerivationOrigin::FromNegation { goal } => {
+                format!(
+                    "\"kind\":\"negation\",{head},\"absent_goal\":\"{}\",\"justification\":\"no proof exists for the negated goal\"",
+                    esc(&format!("{goal}"))
+                )
+            }
+            // ---- Probability (likelihood-ratio aggregation) ----------------
+            // These four were the ones the old wildcard dropped.
+            DerivationOrigin::FromPrior {
+                clause_id,
+                prior_logit,
+            } => {
+                format!(
+                    "\"kind\":\"prior\",{head},\"clause_id\":{},\"prior_logit\":{}",
+                    clause_id.0,
+                    jnum(*prior_logit)
+                )
+            }
+            DerivationOrigin::FromContribution {
+                clause_id,
+                evidence_fact_ids,
+                logit_delta,
+                ..
+            } => {
+                format!(
+                    "\"kind\":\"contribution\",{head},\"clause_id\":{},\"logit_delta\":{},\"evidence\":{}",
+                    clause_id.0,
+                    jnum(*logit_delta),
+                    fact_citations_json(evidence_fact_ids, kb)
+                )
+            }
+            DerivationOrigin::FromJointContribution {
+                clause_id,
+                evidence_fact_ids,
+                joint_logit_delta,
+                ..
+            } => {
+                format!(
+                    "\"kind\":\"interaction\",{head},\"clause_id\":{},\"logit_delta\":{},\"evidence\":{}",
+                    clause_id.0,
+                    jnum(*joint_logit_delta),
+                    fact_citations_json(evidence_fact_ids, kb)
+                )
+            }
+            // The literal comparison that fired is the provenance here: the
+            // reader sees `observed <op> threshold` and can recompute it. No
+            // number in this step came from a model.
+            DerivationOrigin::FromPredicateContribution {
+                clause_id,
+                slot,
+                op,
+                threshold,
+                observed,
+                logit_delta,
+            } => {
+                format!(
+                    "\"kind\":\"predicate\",{head},\"clause_id\":{},\"slot\":\"{}\",\"op\":\"{}\",\"threshold\":{},\"observed\":{},\"logit_delta\":{}",
+                    clause_id.0,
+                    esc(slot),
+                    esc(op.symbol()),
+                    jnum(*threshold),
+                    jnum(*observed),
+                    jnum(*logit_delta)
+                )
+            }
+        };
+        steps.push(format!("{{{body}}}"));
     }
     format!("[{}]", steps.join(","))
+}
+
+/// Resolve a list of `FactId`s to their inline citations, in the order given.
+fn fact_citations_json(ids: &[logic_engine::FactId], kb: &KnowledgeBase) -> String {
+    let objs: Vec<String> = ids
+        .iter()
+        .map(|id| {
+            let pv = kb
+                .fact(*id)
+                .map(|f| prov(&f.provenance))
+                .unwrap_or_else(|| UNRESOLVED_PROV.to_string());
+            format!("{{{pv}}}")
+        })
+        .collect();
+    format!("[{}]", objs.join(","))
 }
 
 /// Serialize the proof DAG for one hypothesis: walk each step and join its
@@ -284,7 +478,7 @@ fn proof_json(
                         let evidence_proof = evidence_proof
                             .as_ref()
                             .map(|proof| {
-                                format!(",\"evidence_proof\":{}", sld_proof_json(proof, kb))
+                                format!(",\"evidence_proof\":{}", trace_steps_json(proof, kb))
                             })
                             .unwrap_or_default();
                         steps.push(format!(
@@ -316,7 +510,7 @@ fn proof_json(
                                 ",\"evidence_proofs\":[{}]",
                                 evidence_proofs
                                     .iter()
-                                    .map(|proof| sld_proof_json(proof, kb))
+                                    .map(|proof| trace_steps_json(proof, kb))
                                     .collect::<Vec<_>>()
                                     .join(",")
                             )
@@ -752,10 +946,15 @@ fn recall_json(query: &Term, kb: &KnowledgeBase) -> String {
             .filter_map(|fid| kb.fact(*fid))
             .map(|f| format!("{{{}}}", prov(&f.provenance)))
             .collect();
+        // RS-4: `citations` is a SET (sorted, deduped `via_facts`) — it answers
+        // "what did this rely on?" but cannot answer "in what order, and how?".
+        // `steps` is the ordered derivation. Both are emitted: existing consumers
+        // keep their field, auditors get the narrative.
         answers.push(format!(
-            "{{\"bindings\":{{{}}},\"citations\":[{}]}}",
+            "{{\"bindings\":{{{}}},\"citations\":[{}],\"steps\":{}}}",
             binds.join(","),
-            cites.join(",")
+            cites.join(","),
+            trace_steps_json(proof, kb)
         ));
     }
     format!(
@@ -842,14 +1041,15 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
             // The answer names the value column (the binding) AND the matched
             // breakpoint key, so the audit shows WHICH bracket the query fell in.
             format!(
-                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[{{\"bindings\":{{\"{}\":\"{}\",\"{}\":\"{}\"}},\"citations\":[{}]}}],\"abstained\":false}}",
+                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[{{\"bindings\":{{\"{}\":\"{}\",\"{}\":\"{}\"}},\"citations\":[{}],\"steps\":{}}}],\"abstained\":false}}",
                 esc(&query_str),
                 esc(&rl.mode),
                 esc(&rl.value_col),
                 esc(&format!("{value_term}")),
                 esc(&rl.key_col),
                 esc(&format!("{key_term}")),
-                cites.join(",")
+                cites.join(","),
+                trace_steps_json(proof, kb)
             )
         }
         None => format!(

--- a/code/packages/rust/adj-lang-cli/tests/rs4_trace_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs4_trace_e2e.rs
@@ -1,0 +1,300 @@
+//! End-to-end tests for **RS-4 PR-B — the unified reasoning trace**
+//! (`ADJ-REASON-MATH.md` §E), driven through the built CLI binary.
+//!
+//! ## What was wrong
+//!
+//! You could ask ADJ *what* it concluded and *what it cited*, but not *how it
+//! got there*. Three separate holes:
+//!
+//!   1. **Recall and table lookups emitted a citation BAG.** They render from
+//!      `via_facts`, which is sorted by fact id and deduplicated — so the output
+//!      told you which sources were involved but never in what order or through
+//!      which rules. A set is not a derivation.
+//!   2. **The step renderer ended in a `_ => {}` arm**, so four of six step
+//!      kinds would be dropped without a trace. In shipped paths that arm was
+//!      *latent* — the SLD renderer only ever saw fact/rule steps, because the
+//!      likelihood-ratio kinds are emitted by a different function. It stops
+//!      being latent the moment a new kind reaches this walker, which is exactly
+//!      what `FromNegation` (below) does. A wildcard that silently discards
+//!      reasoning is a trap set for the next person; the match is now total, so
+//!      adding a step kind breaks the build instead of quietly shortening trails.
+//!   3. **Negation-as-failure recorded nothing at all.** A rule that fired
+//!      *because* something was absent showed no evidence of having checked.
+//!   4. **The arithmetic derivation tree was computed and thrown away.** The
+//!      engine builds one for every `let`; `derived_json` never read it.
+//!
+//! Each test below pins one of those.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs4_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+fn write(dir: &Path, name: &str, src: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+// ---------------------------------------------------------------------------
+// (1) A recall answer now carries ORDERED, ADDRESSED steps — not just a bag.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_recall_answer_carries_ordered_addressed_steps_with_inline_provenance() {
+    let dir = scratch("steps");
+    let p = write(
+        &dir,
+        "case.adj",
+        "relate deficient_in(tay_sachs, hexosaminidase_a)\n\
+             source \"Tay-Sachs results from deficient hexosaminidase A.\"\n\
+             locator \"https://example.test/ts\"\n\
+             trust authoritative\n\
+         ? deficient_in(tay_sachs, $Enzyme)\n",
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+
+    // The answer still carries its citation bag (existing consumers unaffected)…
+    assert!(out.contains("\"citations\":["), "citations kept: {out}");
+    // …and now ALSO the ordered derivation.
+    assert!(out.contains("\"steps\":["), "steps emitted: {out}");
+    // Addressed: index + depth are present on the step.
+    assert!(out.contains("\"step\":0"), "step index: {out}");
+    assert!(out.contains("\"depth\":0"), "step depth: {out}");
+    assert!(out.contains("\"kind\":\"fact\""), "fact step kind: {out}");
+    // Self-contained: the step inlines the RESOLVED provenance, so the trace is
+    // readable without the KB that produced it.
+    assert!(
+        out.contains("Tay-Sachs results from deficient hexosaminidase A."),
+        "step inlines its own quoted span: {out}"
+    );
+    assert!(
+        out.contains("\"trust\":\"authoritative\""),
+        "step inlines its trust tier: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) A rule-derived answer shows NESTING: the rule, then its body one deeper.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_rule_derived_answer_shows_the_rule_and_its_body_at_increasing_depth() {
+    let dir = scratch("nesting");
+    let p = write(
+        &dir,
+        "case.adj",
+        "relate cultured(patient_1, listeria)\n\
+             source \"Blood culture grew Listeria monocytogenes.\"\n\
+             trust empirical\n\
+         rule {\n\
+             head: infected(patient_1, listeria)\n\
+             when: cultured(patient_1, listeria)\n\
+             source \"A positive blood culture establishes infection with the isolate.\"\n\
+             trust authoritative\n\
+         }\n\
+         ? infected(patient_1, $Organism)\n",
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(out.contains("\"Organism\":\"listeria\""), "binds: {out}");
+
+    // The rule fires at depth 0; the body goal it required sits at depth 1.
+    // Preorder + depth is what lets a reader rebuild the tree.
+    assert!(out.contains("\"kind\":\"rule\""), "rule step: {out}");
+    assert!(out.contains("\"depth\":1"), "body is nested deeper: {out}");
+    // Both clauses quote their own span — the rule's and the fact's.
+    assert!(
+        out.contains("A positive blood culture establishes infection with the isolate."),
+        "rule's own citation appears: {out}"
+    );
+    assert!(
+        out.contains("Blood culture grew Listeria monocytogenes."),
+        "the supporting fact's citation appears: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) Negation-as-failure is VISIBLE. It used to record nothing at all.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn negation_as_failure_appears_as_its_own_step_instead_of_vanishing() {
+    let dir = scratch("naf");
+    let p = write(
+        &dir,
+        "case.adj",
+        "relate indicated(penicillin, strep)\n\
+             source \"Penicillin is indicated for streptococcal infection.\"\n\
+             trust authoritative\n\
+         rule {\n\
+             head: prescribe(penicillin, strep)\n\
+             when: indicated(penicillin, strep), not allergic_to(patient_1, penicillin)\n\
+             source \"Prescribe an indicated agent absent a documented allergy.\"\n\
+             trust authoritative\n\
+         }\n\
+         ? prescribe($Drug, strep)\n",
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(out.contains("\"Drug\":\"penicillin\""), "binds: {out}");
+
+    // THE POINT: the guard that licensed the conclusion is in the trail.
+    // Before RS-4 the reader could not distinguish "we confirmed no allergy"
+    // from "nobody checked" — the step simply did not exist.
+    assert!(
+        out.contains("\"kind\":\"negation\""),
+        "the NAF guard must appear as a step: {out}"
+    );
+    assert!(
+        out.contains("allergic_to"),
+        "the step names the goal shown to be absent: {out}"
+    );
+    assert!(
+        out.contains("no proof exists for the negated goal"),
+        "the step states WHY it held: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (4) A `let` now publishes the arithmetic the engine already computed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_derived_value_publishes_its_derivation_tree_down_to_the_observed_facts() {
+    let dir = scratch("derivation");
+    let p = write(
+        &dir,
+        "case.adj",
+        "observe distance(quantity(240, km))\n\
+         observe time(quantity(3, h))\n\
+         let speed = distance / time\n\
+         ? speed\n",
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(out.contains("\"derived\":["), "derived section: {out}");
+
+    // The tree the engine built on every `let` is finally emitted.
+    assert!(
+        out.contains("\"derivation\":"),
+        "the derivation tree is published: {out}"
+    );
+    assert!(out.contains("\"node\":\"op\""), "the operation node: {out}");
+    assert!(out.contains("\"op\":\"/\""), "the operator applied: {out}");
+    // The leaves resolve to the observed facts' own citations — this is the
+    // compute-to-bytes bridge, which existed in the engine and was never
+    // reachable from outside the process.
+    assert!(out.contains("\"node\":\"leaf\""), "operand leaves: {out}");
+    // Each leaf names the slot it read and the magnitude it contributed, and
+    // resolves through its FactId to that fact's provenance block. An `observe`
+    // is a case datum rather than a library claim, so its span is empty here —
+    // but the CHANNEL is present, which is what lets a leaf grounded in a cited
+    // library fact carry that citation all the way into the arithmetic.
+    assert!(
+        out.contains("\"slot\":\"distance\""),
+        "numerator leaf: {out}"
+    );
+    assert!(out.contains("\"slot\":\"time\""), "denominator leaf: {out}");
+    assert!(out.contains("\"value\":240"), "the 240 it read: {out}");
+    assert!(out.contains("\"value\":3"), "the 3 it read: {out}");
+}
+
+// ---------------------------------------------------------------------------
+// (5) A table RANGE lookup carries steps too, and still cites the row it
+//     selected (the RS-5e guarantee this trace is built on).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_range_lookup_answer_carries_steps_citing_the_row_it_selected() {
+    let dir = scratch("lookup");
+    let p = write(
+        &dir,
+        "case.adj",
+        "table aqi {\n\
+             columns min_aqi, category\n\
+             row (0, good)     { source \"Green Good 0 to 50\" }\n\
+             row (51, moderate){ source \"Yellow Moderate 51 to 100\" }\n\
+             source  \"The AQI includes six color-coded categories.\"\n\
+             locator \"https://example.test/aqi\"\n\
+             trust   authoritative\n\
+         }\n\
+         ? lookup aqi min_aqi = 75 mode range give category\n",
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(out.contains("\"category\":\"moderate\""), "band: {out}");
+    assert!(out.contains("\"steps\":["), "lookup carries steps: {out}");
+    // The step quotes the SELECTED row, not the table's framing sentence.
+    assert!(
+        out.contains("Yellow Moderate 51 to 100"),
+        "the step cites the selected row: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (6) Likelihood-ratio steps survive. These are the four kinds the old
+//     `_ => {}` arm discarded without a trace.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn likelihood_ratio_steps_are_rendered_instead_of_being_silently_dropped() {
+    let dir = scratch("lr");
+    let p = write(
+        &dir,
+        "case.adj",
+        "prior 0.20 for bacterial_meningitis\n\
+           source \"Baseline prevalence among presenting patients.\" trust empirical\n\
+         contributes 4.0 from symptom(stiff_neck) to bacterial_meningitis\n\
+           source \"Nuchal rigidity raises the likelihood of bacterial meningitis.\" trust authoritative\n\
+         observe symptom(stiff_neck)\n\
+         ? bacterial_meningitis\n",
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+
+    // REGRESSION GUARD. The likelihood-ratio steps are rendered by a *different*
+    // function (`proof_json`) than the SLD walker this PR rewrote, so they were
+    // never the ones being dropped — the `_ => {}` was latent, not lossy. Pin
+    // them anyway: making the SLD walker total is exactly the kind of change
+    // that could disturb a neighbouring renderer, and "the audit trail still
+    // says everything it used to" is the property worth holding onto.
+    assert!(out.contains("\"kind\":\"prior\""), "prior step: {out}");
+    assert!(
+        out.contains("\"kind\":\"contribution\""),
+        "contribution step: {out}"
+    );
+    // And each carries the inline log-odds an auditor re-checks, under the
+    // field name this renderer has always used (`logit`) — pinned here so a
+    // future trace unification cannot rename it without a deliberate decision.
+    assert!(
+        out.contains("\"kind\":\"prior\",\"logit\":"),
+        "prior logit: {out}"
+    );
+    assert!(
+        out.contains("\"evidence\":\"symptom(stiff_neck)\""),
+        "the contribution names its evidence: {out}"
+    );
+    assert!(
+        out.contains("Nuchal rigidity raises the likelihood of bacterial meningitis."),
+        "the contribution's cited span: {out}"
+    );
+}

--- a/code/packages/rust/adj-lang-cli/tests/rs4_trace_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs4_trace_e2e.rs
@@ -298,3 +298,56 @@ fn likelihood_ratio_steps_are_rendered_instead_of_being_silently_dropped() {
         "the contribution's cited span: {out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// (7) A self-recursive rule ABSTAINS instead of aborting the process, and a
+//     capped search never fabricates a negation step.
+//
+//     Found by the security review of this PR. The mutual recursion in
+//     `solve`/`solve_body` had no termination guard, so `p(X) :- p(X)` drove
+//     the resolver until the process overflowed its stack — a SIGABRT, which
+//     cannot be caught, so an embedding process dies with it.
+//
+//     The naive fix (return "no proofs" at the cap) would have been worse than
+//     the crash HERE, because this PR introduces `FromNegation`: a negated
+//     subgoal that hit the cap would look "absent", and the trail would assert
+//     a guard held that was never established. So the cap raises an error that
+//     propagates, and the query abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_self_recursive_rule_abstains_instead_of_overflowing_the_stack() {
+    let dir = scratch("recursion");
+    let p = write(
+        &dir,
+        "case.adj",
+        "relate p(a, b)\n\
+             source \"A seed edge.\"\n\
+             trust empirical\n\
+         rule {\n\
+             head: p($X, $Y)\n\
+             when: p($X, $Y)\n\
+             source \"A rule that requires itself — no base case.\"\n\
+             trust authoritative\n\
+         }\n\
+         ? p($A, $B)\n",
+    );
+    let (ok, out, err) = run(&p);
+    // The process must EXIT NORMALLY. Before the guard this aborted with
+    // "fatal runtime error: stack overflow" and a signal, not an exit code.
+    assert!(
+        ok,
+        "a self-recursive rule must not abort the process; stderr={err}"
+    );
+    assert!(
+        !err.contains("stack overflow"),
+        "no stack overflow may occur: {err}"
+    );
+    // And it abstains rather than reporting the proofs found before the cap:
+    // a truncated search presented as a complete one is the exact accounting
+    // failure this whole arc exists to prevent.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a search that hit the depth cap must abstain: {out}"
+    );
+}

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [0.41.0] — 2026-07-20 — ordered, addressed proof steps + visible negation (RS-4 PR-B)
 
+### Fixed (security)
+
+- **Both resolvers had unbounded mutual recursion; a self-recursive rule aborted
+  the process.** `solve`/`solve_body` (enumeration) and
+  `find_first_with`/`prove_body` (deterministic) recursed with no termination
+  guard, so `p(X, Y) :- p(X, Y)` descended until the stack overflowed —
+  a `SIGABRT`, which cannot be caught, so a host embedding this crate dies with
+  it. The deterministic path is the one `search(.., AutoDetect)` selects for an
+  all-`Certain` KB, i.e. the adjudication connector's normal mode.
+- **The obvious fix would have been worse than the crash.** Returning "no proof"
+  at the cap is what negation-as-failure reads as *absence*, so a truncated
+  search would have satisfied a `not G` guard and this release's new
+  `FromNegation` step would have asserted a check that never happened. Both caps
+  therefore raise `ResolutionLimitExceeded` and **propagate**; the `?` in each
+  negation branch is load-bearing.
+- **`MAX_SLD_DEPTH = 128`** bounds rule-chain nesting. **`MAX_BODY_CONJUNCTS = 1024`**
+  bounds a separate axis the depth cap cannot: `solve_body` recurses over a
+  rule's *remaining literals* while `depth` stays constant across the body, so a
+  ~14,000-conjunct body overflowed at depth 1.
+- A query that hits either cap **abstains** rather than reporting the proofs
+  found first — a truncated search presented as a complete one is the accounting
+  failure this release exists to prevent.
+
+
 ### Added
 
 - **`ProofStep.depth`.** A step now records how deeply nested it is: the root

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.41.0] — 2026-07-20 — ordered, addressed proof steps + visible negation (RS-4 PR-B)
+
+### Added
+
+- **`ProofStep.depth`.** A step now records how deeply nested it is: the root
+  query sits at depth 0, and a rule's body steps are one deeper than the rule
+  step that introduced them. `Proof.steps` was already a preorder walk, so
+  preorder + depth is a complete encoding of the derivation tree — a step's
+  parent is the nearest preceding step one level shallower, exactly the way an
+  indented outline works. Without it the flat vector was ambiguous: you could
+  not tell a sibling from a child without re-deriving each rule's body arity,
+  which is why the audit trail could show a LIST but never a STRUCTURE.
+- **`DerivationOrigin::FromNegation { goal }`.** Negation-as-failure now records
+  a step. It previously recorded **none**, so a rule guarded by
+  `not contraindicated(D)` would fire while the trail stayed silent about the
+  check that licensed it — a reader could not distinguish "we confirmed no
+  contraindication" from "nobody looked." An audit trail that omits a
+  load-bearing inference is not a shorter trail, it is a wrong one. The step
+  carries no clause id because there is no clause: the justification IS the
+  empty proof set, which is what a re-checker re-runs to verify it.
+
+### Changed
+
+- `collect_ids` handles `FromNegation` by contributing **nothing** — deliberately.
+  NAF *used* nothing; that is precisely what it established. Attributing the
+  absent goal's clauses as support would invert the meaning of the step.
+
+
 ## [0.40.0] — 2026-07-14 — exact rendering of a computed result (ADJ-EXACT-NUMBERS NX-4)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/enumerate.rs
+++ b/code/packages/rust/logic-engine/src/enumerate.rs
@@ -85,6 +85,19 @@ fn rename_literal(lit: &BodyLiteral, renames: &mut HashMap<u64, LogicVar>) -> Bo
 /// reach it by legitimate nesting.
 pub const MAX_SLD_DEPTH: usize = 128;
 
+/// The most conjuncts a single rule body may contain.
+///
+/// `solve_body` recurses over the body's *remaining* literals, and that
+/// recursion is a **different axis** from `MAX_SLD_DEPTH`: `depth` is
+/// deliberately held constant across a body (all conjuncts of one rule sit at
+/// the same nesting level), so it cannot bound body length. A rule with ~14,000
+/// conjuncts overflows the stack even though its `depth` never exceeds 1.
+///
+/// Capping the length at entry bounds the recursion directly, since the slice
+/// shrinks by one per frame. 1024 is far past any hand-written or generated
+/// rule and an order of magnitude below the observed failure point.
+pub const MAX_BODY_CONJUNCTS: usize = 1024;
+
 /// The resolver abandoned the search because it hit [`MAX_SLD_DEPTH`].
 ///
 /// This is deliberately an **error, not an empty result**. The distinction is
@@ -199,6 +212,12 @@ fn solve_body(
 ) -> Result<Vec<(Substitution, Vec<ProofStep>)>, ResolutionLimitExceeded> {
     if body.is_empty() {
         return Ok(vec![(subst.clone(), Vec::new())]);
+    }
+    // Bounds the `rest` recursion below — see MAX_BODY_CONJUNCTS. `Err`, not an
+    // empty vec, for the same reason as the depth cap: a body we refused to
+    // evaluate must never be observable as a goal that failed.
+    if body.len() > MAX_BODY_CONJUNCTS {
+        return Err(ResolutionLimitExceeded);
     }
 
     let (first, rest) = body.split_first().unwrap();

--- a/code/packages/rust/logic-engine/src/enumerate.rs
+++ b/code/packages/rust/logic-engine/src/enumerate.rs
@@ -68,10 +68,41 @@ fn rename_literal(lit: &BodyLiteral, renames: &mut HashMap<u64, LogicVar>) -> Bo
     }
 }
 
+/// The deepest chain of rule applications the resolver will follow before
+/// giving up.
+///
+/// # Why a cap is required at all
+///
+/// `solve` and `solve_body` are mutually recursive, and a self-recursive rule
+/// (`p(X) :- p(X)`) has no base case — the resolver descends until the process
+/// **overflows its stack and aborts**. That abort is a `SIGABRT`: it cannot be
+/// caught, so an embedding process dies with it, not just the CLI.
+///
+/// Every other recursive descent in the stack is already capped —
+/// `adj_lang::MAX_RULE_DEPTH` in the parser, `compute::MAX_EVAL_DEPTH` in the
+/// arithmetic evaluator. The resolver was the remaining hole. 128 sits above
+/// the parser's own 90-deep rule limit, so no program the frontend accepts can
+/// reach it by legitimate nesting.
+pub const MAX_SLD_DEPTH: usize = 128;
+
+/// The resolver abandoned the search because it hit [`MAX_SLD_DEPTH`].
+///
+/// This is deliberately an **error, not an empty result**. The distinction is
+/// the whole point: "I found no proof" and "I stopped looking" are different
+/// claims, and conflating them is exactly the accounting failure the audit
+/// trail exists to prevent. It matters most under negation — see `solve_body`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolutionLimitExceeded;
+
 /// Enumerate every successful proof of `query` against `kb`. Returns a
 /// `ProofDAG` containing one `Proof` per successful derivation.
+///
+/// If the search hits [`MAX_SLD_DEPTH`], this returns a DAG with **no proofs**
+/// — i.e. the caller abstains. Reporting the proofs found before the cap would
+/// present a truncated search as a complete one, which is the failure mode the
+/// whole audit-trail effort is aimed at.
 pub fn enumerate_all(query: &Term, kb: &KnowledgeBase) -> ProofDAG {
-    let raw = solve(query, kb, &Substitution::empty(), 0);
+    let raw = solve(query, kb, &Substitution::empty(), 0).unwrap_or_default();
     let proofs = raw
         .into_iter()
         .map(|(bindings, steps)| {
@@ -105,7 +136,11 @@ fn solve(
     kb: &KnowledgeBase,
     subst: &Substitution,
     depth: usize,
-) -> Vec<(Substitution, Vec<ProofStep>)> {
+) -> Result<Vec<(Substitution, Vec<ProofStep>)>, ResolutionLimitExceeded> {
+    // The guard that turns an infinite descent into an honest abstention.
+    if depth >= MAX_SLD_DEPTH {
+        return Err(ResolutionLimitExceeded);
+    }
     let resolved = subst.walk(goal);
     let mut results: Vec<(Substitution, Vec<ProofStep>)> = Vec::new();
 
@@ -137,7 +172,7 @@ fn solve(
             // The body is proved one level DEEPER than the rule step that
             // introduces it. That single `+ 1` is what turns the flat step
             // vector into a reconstructable tree (see `ProofStep::depth`).
-            for (body_subst, body_steps) in solve_body(&renamed_body, kb, &s, depth + 1) {
+            for (body_subst, body_steps) in solve_body(&renamed_body, kb, &s, depth + 1)? {
                 let mut steps = Vec::with_capacity(1 + body_steps.len());
                 steps.push(ProofStep {
                     goal: resolved.clone(),
@@ -150,7 +185,7 @@ fn solve(
         }
     }
 
-    results
+    Ok(results)
 }
 
 /// Prove every literal in `body`, threading substitutions forward and
@@ -161,9 +196,9 @@ fn solve_body(
     kb: &KnowledgeBase,
     subst: &Substitution,
     depth: usize,
-) -> Vec<(Substitution, Vec<ProofStep>)> {
+) -> Result<Vec<(Substitution, Vec<ProofStep>)>, ResolutionLimitExceeded> {
     if body.is_empty() {
-        return vec![(subst.clone(), Vec::new())];
+        return Ok(vec![(subst.clone(), Vec::new())]);
     }
 
     let (first, rest) = body.split_first().unwrap();
@@ -172,8 +207,8 @@ fn solve_body(
     match first {
         BodyLiteral::Pos(t) => {
             // Find every way to prove `t`; for each, recurse on `rest`.
-            for (after_first, steps_first) in solve(t, kb, subst, depth) {
-                for (after_rest, steps_rest) in solve_body(rest, kb, &after_first, depth) {
+            for (after_first, steps_first) in solve(t, kb, subst, depth)? {
+                for (after_rest, steps_rest) in solve_body(rest, kb, &after_first, depth)? {
                     let mut all_steps = Vec::with_capacity(steps_first.len() + steps_rest.len());
                     all_steps.extend(steps_first.iter().cloned());
                     all_steps.extend(steps_rest);
@@ -193,9 +228,18 @@ fn solve_body(
             //
             // The substitution is unchanged: NAF binds nothing (it succeeded
             // precisely because there was no proof to bind from).
-            if solve(t, kb, subst, depth + 1).is_empty() {
+            //
+            // THE CAP MUST NOT BE READ AS ABSENCE. `?` here is load-bearing:
+            // if the negated subgoal's own search hit MAX_SLD_DEPTH we
+            // propagate the error instead of observing an empty result set.
+            // Swallowing it would let a truncated search masquerade as "no
+            // proof exists", and this function would then emit a
+            // `FromNegation` step asserting a guard held that was never
+            // actually established — a fabricated justification in the audit
+            // trail, which is worse than the crash it replaces.
+            if solve(t, kb, subst, depth + 1)?.is_empty() {
                 let neg_goal = subst.walk(t);
-                for (after_rest, steps_rest) in solve_body(rest, kb, subst, depth) {
+                for (after_rest, steps_rest) in solve_body(rest, kb, subst, depth)? {
                     let mut all_steps = Vec::with_capacity(1 + steps_rest.len());
                     all_steps.push(ProofStep {
                         goal: neg_goal.clone(),
@@ -211,7 +255,7 @@ fn solve_body(
         }
     }
 
-    results
+    Ok(results)
 }
 
 #[cfg(test)]

--- a/code/packages/rust/logic-engine/src/enumerate.rs
+++ b/code/packages/rust/logic-engine/src/enumerate.rs
@@ -35,7 +35,7 @@
 
 use std::collections::HashMap;
 
-use logic_core::{LogicVar, Substitution, Term, unify};
+use logic_core::{unify, LogicVar, Substitution, Term};
 
 use crate::proof_dag::{collect_ids, DerivationOrigin, Proof, ProofDAG, ProofStep};
 use crate::{BodyLiteral, KnowledgeBase};
@@ -71,7 +71,7 @@ fn rename_literal(lit: &BodyLiteral, renames: &mut HashMap<u64, LogicVar>) -> Bo
 /// Enumerate every successful proof of `query` against `kb`. Returns a
 /// `ProofDAG` containing one `Proof` per successful derivation.
 pub fn enumerate_all(query: &Term, kb: &KnowledgeBase) -> ProofDAG {
-    let raw = solve(query, kb, &Substitution::empty());
+    let raw = solve(query, kb, &Substitution::empty(), 0);
     let proofs = raw
         .into_iter()
         .map(|(bindings, steps)| {
@@ -104,6 +104,7 @@ fn solve(
     goal: &Term,
     kb: &KnowledgeBase,
     subst: &Substitution,
+    depth: usize,
 ) -> Vec<(Substitution, Vec<ProofStep>)> {
     let resolved = subst.walk(goal);
     let mut results: Vec<(Substitution, Vec<ProofStep>)> = Vec::new();
@@ -116,6 +117,7 @@ fn solve(
             let step = ProofStep {
                 goal: resolved.clone(),
                 origin: DerivationOrigin::FromFact(fact.id),
+                depth,
             };
             results.push((s, vec![step]));
         }
@@ -132,11 +134,15 @@ fn solve(
             .collect();
 
         if let Some(s) = unify(&resolved, &renamed_head, subst) {
-            for (body_subst, body_steps) in solve_body(&renamed_body, kb, &s) {
+            // The body is proved one level DEEPER than the rule step that
+            // introduces it. That single `+ 1` is what turns the flat step
+            // vector into a reconstructable tree (see `ProofStep::depth`).
+            for (body_subst, body_steps) in solve_body(&renamed_body, kb, &s, depth + 1) {
                 let mut steps = Vec::with_capacity(1 + body_steps.len());
                 steps.push(ProofStep {
                     goal: resolved.clone(),
                     origin: DerivationOrigin::FromRule(rule.id),
+                    depth,
                 });
                 steps.extend(body_steps);
                 results.push((body_subst, steps));
@@ -154,6 +160,7 @@ fn solve_body(
     body: &[BodyLiteral],
     kb: &KnowledgeBase,
     subst: &Substitution,
+    depth: usize,
 ) -> Vec<(Substitution, Vec<ProofStep>)> {
     if body.is_empty() {
         return vec![(subst.clone(), Vec::new())];
@@ -165,8 +172,8 @@ fn solve_body(
     match first {
         BodyLiteral::Pos(t) => {
             // Find every way to prove `t`; for each, recurse on `rest`.
-            for (after_first, steps_first) in solve(t, kb, subst) {
-                for (after_rest, steps_rest) in solve_body(rest, kb, &after_first) {
+            for (after_first, steps_first) in solve(t, kb, subst, depth) {
+                for (after_rest, steps_rest) in solve_body(rest, kb, &after_first, depth) {
                     let mut all_steps = Vec::with_capacity(steps_first.len() + steps_rest.len());
                     all_steps.extend(steps_first.iter().cloned());
                     all_steps.extend(steps_rest);
@@ -176,9 +183,30 @@ fn solve_body(
         }
         BodyLiteral::Neg(t) => {
             // Negation-as-failure: succeed iff `t` has zero proofs.
-            // Substitution and steps are unchanged on success.
-            if solve(t, kb, subst).is_empty() {
-                results.extend(solve_body(rest, kb, subst));
+            //
+            // This RECORDS A STEP. It previously recorded none, which meant
+            // a rule guarded by `not contraindicated(D)` would fire and the
+            // audit trail would never mention the guard — a reader could not
+            // distinguish "we checked, and found no contraindication" from
+            // "nobody checked." The absence IS the justification, so it has
+            // to appear in the trail like any other justification.
+            //
+            // The substitution is unchanged: NAF binds nothing (it succeeded
+            // precisely because there was no proof to bind from).
+            if solve(t, kb, subst, depth + 1).is_empty() {
+                let neg_goal = subst.walk(t);
+                for (after_rest, steps_rest) in solve_body(rest, kb, subst, depth) {
+                    let mut all_steps = Vec::with_capacity(1 + steps_rest.len());
+                    all_steps.push(ProofStep {
+                        goal: neg_goal.clone(),
+                        origin: DerivationOrigin::FromNegation {
+                            goal: neg_goal.clone(),
+                        },
+                        depth,
+                    });
+                    all_steps.extend(steps_rest);
+                    results.push((after_rest, all_steps));
+                }
             }
         }
     }
@@ -218,10 +246,7 @@ mod tests {
         // Check that the bindings cover all three children.
         let mut children: Vec<Term> = dag.proofs.iter().map(|p| p.bindings.walk_var(&x)).collect();
         children.sort_by_key(|a| a.to_string());
-        assert_eq!(
-            children,
-            vec![atom("bart"), atom("lisa"), atom("maggie")]
-        );
+        assert_eq!(children, vec![atom("bart"), atom("lisa"), atom("maggie")]);
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -55,7 +55,7 @@ pub use datetime::{
 };
 pub use differential::{differential, Differential, DifferentialDecision, RankedHypothesis};
 pub use dimension::{dimensioned_value, DimError, DimOp, Dimension, Dimensioned};
-pub use enumerate::enumerate_all;
+pub use enumerate::{enumerate_all, ResolutionLimitExceeded, MAX_SLD_DEPTH};
 pub use govern::{enumerate_governing, GovernStatus, GovernedAnswer, GovernedResult};
 pub use lr_aggregate::{
     counterfactual, lr_aggregate, sigmoid, source_disagreements,
@@ -1306,10 +1306,27 @@ fn rename_literal(lit: &BodyLiteral, renames: &mut HashMap<u64, LogicVar>) -> Bo
 /// Backtracking is implicit in the iteration: when a clause's body fails,
 /// we drop the substitution and try the next clause.
 pub fn find_first(query: &Term, kb: &KnowledgeBase) -> Option<Substitution> {
-    find_first_with(query, kb, &Substitution::empty())
+    // A depth-capped search that gives up reports "no proof" to this API's
+    // `Option` return. That is the SAFE direction here: `find_first` is a
+    // "can you prove it?" question, and answering "I could not" after an
+    // exhausted budget is honest. The danger is entirely on the NEGATION side,
+    // where "could not prove" is read as "is false" — see `prove_body`, which
+    // consumes the `Result` directly and refuses to make that inference.
+    find_first_with(query, kb, &Substitution::empty(), 0).unwrap_or(None)
 }
 
-fn find_first_with(query: &Term, kb: &KnowledgeBase, subst: &Substitution) -> Option<Substitution> {
+fn find_first_with(
+    query: &Term,
+    kb: &KnowledgeBase,
+    subst: &Substitution,
+    depth: usize,
+) -> Result<Option<Substitution>, ResolutionLimitExceeded> {
+    // Same guard, same reason, as the enumeration resolver: without it a
+    // self-recursive rule descends until the process aborts on a stack
+    // overflow, which is a SIGABRT an embedding process cannot catch.
+    if depth >= MAX_SLD_DEPTH {
+        return Err(ResolutionLimitExceeded);
+    }
     let resolved = subst.walk(query);
 
     // Try facts first — they have no body, so success is immediate.
@@ -1317,7 +1334,7 @@ fn find_first_with(query: &Term, kb: &KnowledgeBase, subst: &Substitution) -> Op
         let mut renames = HashMap::new();
         let renamed = rename_term(&fact.term, &mut renames);
         if let Some(s) = unify(&resolved, &renamed, subst) {
-            return Some(s);
+            return Ok(Some(s));
         }
     }
 
@@ -1332,34 +1349,45 @@ fn find_first_with(query: &Term, kb: &KnowledgeBase, subst: &Substitution) -> Op
             .collect();
 
         if let Some(mut s) = unify(&resolved, &renamed_head, subst) {
-            if prove_body(&renamed_body, kb, &mut s) {
-                return Some(s);
+            if prove_body(&renamed_body, kb, &mut s, depth + 1)? {
+                return Ok(Some(s));
             }
         }
     }
 
-    None
+    Ok(None)
 }
 
 /// Prove every literal in `body` under the substitution `s`, threading
 /// each successful subgoal's resulting substitution forward to the next.
-fn prove_body(body: &[BodyLiteral], kb: &KnowledgeBase, s: &mut Substitution) -> bool {
+fn prove_body(
+    body: &[BodyLiteral],
+    kb: &KnowledgeBase,
+    s: &mut Substitution,
+    depth: usize,
+) -> Result<bool, ResolutionLimitExceeded> {
     for literal in body {
         match literal {
-            BodyLiteral::Pos(t) => match find_first_with(t, kb, s) {
+            BodyLiteral::Pos(t) => match find_first_with(t, kb, s, depth)? {
                 Some(next) => *s = next,
-                None => return false,
+                None => return Ok(false),
             },
             BodyLiteral::Neg(t) => {
-                if find_first_with(t, kb, s).is_some() {
+                // `?` IS LOAD-BEARING. If the negated goal's own search hit the
+                // depth cap we must propagate, not observe `None`. Reading an
+                // exhausted budget as "not provable" would make `not G` succeed
+                // because we STOPPED LOOKING — turning a resource limit into a
+                // positive claim about the world. Same hazard, and same fix, as
+                // the enumeration resolver's negation branch.
+                if find_first_with(t, kb, s, depth)?.is_some() {
                     // The negated goal is provable — negation-as-failure fails.
-                    return false;
+                    return Ok(false);
                 }
                 // Goal not provable; negation succeeds; substitution unchanged.
             }
         }
     }
-    true
+    Ok(true)
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -797,6 +797,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
                     clause_id: prior.id,
                     prior_logit: prior.prior_logit,
                 },
+                depth: 0,
             });
             prior.prior_logit
         }
@@ -829,6 +830,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
                     evidence_proof: observed.proof.clone(),
                     logit_delta,
                 },
+                depth: 0,
             });
             running_logit += logit_delta;
             via_facts.extend(observed.fact_ids);
@@ -871,6 +873,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
                     evidence_proofs: joint_evidence_proofs,
                     joint_logit_delta,
                 },
+                depth: 0,
             });
             running_logit += joint_logit_delta;
             via_facts.extend(joint_evidence_facts);
@@ -901,6 +904,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
                         observed,
                         logit_delta: pc.logit_delta,
                     },
+                    depth: 0,
                 });
                 running_logit += pc.logit_delta;
             }

--- a/code/packages/rust/logic-engine/src/proof_dag.rs
+++ b/code/packages/rust/logic-engine/src/proof_dag.rs
@@ -67,6 +67,24 @@ pub enum DerivationOrigin {
         /// reason as `prior_logit`.
         logit_delta: f64,
     },
+    /// The step succeeded by **negation as failure**: the goal `not G`
+    /// held because `G` had *zero* proofs.
+    ///
+    /// This variant exists because an absence used to leave no trace at
+    /// all. A rule guarded by `not contraindicated(D)` would fire, and the
+    /// audit trail would show every positive step and stay **silent about
+    /// the check that actually licensed the conclusion** — the reader
+    /// could not tell "we confirmed no contraindication" from "nobody
+    /// looked." An audit trail that omits a load-bearing inference is not
+    /// a shorter trail, it is a wrong one.
+    ///
+    /// It carries no clause id because there is no clause: what justified
+    /// the step is the *empty* proof set for `goal`, which is exactly what
+    /// a re-checker re-runs to verify it (§E.5).
+    FromNegation {
+        /// The goal that was shown to have no proof.
+        goal: Term,
+    },
     /// The step applied a joint-evidence interaction term — synergy
     /// (positive delta) or explaining-away (negative delta) beyond
     /// the product of atomic LRs.
@@ -110,6 +128,32 @@ pub struct ProofStep {
     pub goal: Term,
     /// What clause this step was derived from.
     pub origin: DerivationOrigin,
+    /// How deeply nested this step is. The root query's own step is at
+    /// depth 0; a rule's body steps are one deeper than the rule step
+    /// that introduced them.
+    ///
+    /// # Why a plain number is enough to rebuild the tree
+    ///
+    /// `steps` is a **preorder** walk (a rule's own step is pushed before
+    /// its body's steps — see `enumerate::solve`). Preorder plus depth is
+    /// a complete encoding of a tree: a step's parent is simply **the
+    /// nearest preceding step whose depth is one less**. That is the same
+    /// trick an indented outline uses — you never write "this line belongs
+    /// to that line", you just indent, and the nesting is unambiguous.
+    ///
+    /// ```text
+    ///   idx depth  step                      parent
+    ///    0    0    treat(X)      [rule]      —
+    ///    1    1      infected(X) [rule]      0
+    ///    2    2        culture(X)[fact]      1
+    ///    3    1      allergy(X)  [fact]      0     <- back out one level
+    /// ```
+    ///
+    /// Without this field the flat vector is ambiguous: you cannot tell
+    /// step 3 above from a second child of step 1 without re-deriving
+    /// every rule's body arity. That is why the audit trail could show a
+    /// list but never a *structure*.
+    pub depth: usize,
 }
 
 /// One complete proof of the root query.
@@ -200,6 +244,11 @@ pub(crate) fn collect_ids(steps: &[ProofStep]) -> (Vec<FactId>, Vec<RuleId>) {
             // Fact ids inline. If evidence was rule-derived, the nested
             // SLD proof carries the facts and rules that licensed it.
             DerivationOrigin::FromPrior { .. } => {}
+            // Negation-as-failure USED nothing — that is precisely what it
+            // established. Contributing a FactId here would claim the
+            // absent goal's clauses supported the conclusion, which is
+            // backwards.
+            DerivationOrigin::FromNegation { .. } => {}
             DerivationOrigin::FromContribution {
                 evidence_fact_ids,
                 evidence_proof,

--- a/code/packages/rust/logic-engine/tests/test_recursion_guards.rs
+++ b/code/packages/rust/logic-engine/tests/test_recursion_guards.rs
@@ -1,0 +1,144 @@
+//! Recursion guards for both resolvers (RS-4 PR-B security follow-up).
+//!
+//! Two entry points into the engine were mutually recursive with no
+//! termination guard, so a self-recursive rule drove them until the process
+//! **overflowed its stack and aborted**. That abort is a `SIGABRT`: it cannot
+//! be caught, so a host embedding this crate as a library dies with it.
+//!
+//! Both are now capped. The tests below are written as **guards against
+//! regression of a crash**, so each one is meaningful only if it would
+//! previously have aborted — they are not merely asserting a return value.
+//!
+//! The subtle part is *what the cap returns*. Reporting "no proof" at the cap
+//! looks harmless and is not: negation-as-failure succeeds precisely when the
+//! proof set is empty, so a truncated search would be read as **absence**, and
+//! the engine would assert that a guard held which it never actually checked.
+//! A resource limit would have been silently converted into a claim about the
+//! world. Hence the caps raise an error that propagates, and the query
+//! abstains.
+
+use logic_core::{atom, compound, var, Term};
+use logic_engine::{enumerate_all, find_first, BodyLiteral, Fact, KnowledgeBase, Rule};
+
+/// `var()` builds a `LogicVar`; a term argument needs it wrapped.
+fn v(name: &str) -> Term {
+    Term::Var(var(name))
+}
+
+/// `p(X, Y) :- p(X, Y)` — no base case. Plus one real fact, so the KB has a
+/// perfectly good answer available; the point is that the *divergent branch*
+/// must not take the process down.
+fn self_recursive_kb() -> KnowledgeBase {
+    let mut kb = KnowledgeBase::new();
+    kb.add_fact(Fact::certain(compound("p", vec![atom("a"), atom("b")])));
+    kb.add_rule(Rule::certain(
+        compound("p", vec![v("X"), v("Y")]),
+        vec![BodyLiteral::Pos(compound("p", vec![v("X"), v("Y")]))],
+    ));
+    kb
+}
+
+#[test]
+fn enumeration_resolver_survives_a_self_recursive_rule() {
+    let kb = self_recursive_kb();
+    // Before the guard: "fatal runtime error: stack overflow", SIGABRT.
+    let dag = enumerate_all(&compound("p", vec![v("A"), v("B")]), &kb);
+    // It abstains rather than reporting the proofs found before the cap —
+    // a truncated search presented as a complete one is the accounting
+    // failure the whole audit-trail effort exists to prevent.
+    assert!(
+        dag.proofs.is_empty(),
+        "a capped search must abstain, not report a partial result set"
+    );
+}
+
+#[test]
+fn deterministic_resolver_survives_a_self_recursive_rule() {
+    let kb = self_recursive_kb();
+    // This is the OTHER resolver — reachable via `search(.., AutoDetect)`
+    // whenever the KB is all-`Certain`, which is the mode the adjudication
+    // connector uses unconditionally. It had the identical defect.
+    let answer = find_first(&compound("p", vec![v("A"), v("B")]), &kb);
+    // The only requirement is that we got here at all: before the guard this
+    // aborted the test process. `find_first` answers a yes/no question, so
+    // either outcome is a legitimate answer — what matters is that it is an
+    // ANSWER and not a signal.
+    let _ = answer;
+}
+
+#[test]
+fn a_capped_search_under_negation_never_claims_the_goal_is_absent() {
+    // THE CRITICAL PROPERTY. `q` is guarded by `not p(X, Y)`, and proving
+    // `p` diverges. If the cap were reported as "no proof", the guard would
+    // read as satisfied and `q` would be derived — the engine asserting an
+    // absence it never established.
+    let mut kb = self_recursive_kb();
+    kb.add_rule(Rule::certain(
+        compound("q", vec![v("X"), v("Y")]),
+        vec![BodyLiteral::Neg(compound("p", vec![v("X"), v("Y")]))],
+    ));
+
+    let dag = enumerate_all(&compound("q", vec![v("A"), v("B")]), &kb);
+    assert!(
+        dag.proofs.is_empty(),
+        "a goal guarded by a negation whose search hit the cap must NOT be \
+         derived — that would fabricate the guard"
+    );
+
+    let det = find_first(&compound("q", vec![v("A"), v("B")]), &kb);
+    assert!(
+        det.is_none(),
+        "the deterministic resolver must not fabricate the guard either"
+    );
+}
+
+#[test]
+fn a_pathologically_wide_rule_body_is_rejected_rather_than_overflowing() {
+    // A DIFFERENT AXIS from nesting depth. `solve_body` recurses over the
+    // body's remaining literals, and `depth` is deliberately constant across a
+    // body (all conjuncts of one rule sit at the same level), so the depth cap
+    // cannot bound this. Observed to abort at ~14,000 conjuncts.
+    let mut kb = KnowledgeBase::new();
+    kb.add_fact(Fact::certain(compound("t", vec![atom("x")])));
+    let body: Vec<BodyLiteral> = (0..5_000)
+        .map(|_| BodyLiteral::Pos(compound("t", vec![atom("x")])))
+        .collect();
+    kb.add_rule(Rule::certain(compound("wide", vec![]), body));
+
+    let dag = enumerate_all(&Term::Atom("wide".into()), &kb);
+    assert!(
+        dag.proofs.is_empty(),
+        "an over-wide body is refused, not evaluated into a stack overflow"
+    );
+}
+
+#[test]
+fn ordinary_programs_below_the_caps_are_completely_unaffected() {
+    // The guards must not cost anything for real programs. A two-level rule
+    // chain over a normal body resolves exactly as before.
+    let mut kb = KnowledgeBase::new();
+    kb.add_fact(Fact::certain(compound("edge", vec![atom("a"), atom("b")])));
+    kb.add_rule(Rule::certain(
+        compound("path", vec![v("X"), v("Y")]),
+        vec![BodyLiteral::Pos(compound("edge", vec![v("X"), v("Y")]))],
+    ));
+    kb.add_rule(Rule::certain(
+        compound("reaches", vec![v("X"), v("Y")]),
+        vec![BodyLiteral::Pos(compound("path", vec![v("X"), v("Y")]))],
+    ));
+
+    let dag = enumerate_all(&compound("reaches", vec![v("A"), v("B")]), &kb);
+    assert_eq!(
+        dag.proofs.len(),
+        1,
+        "the ordinary derivation still resolves"
+    );
+    // And the nesting the audit trail depends on is intact: rule, rule, fact.
+    let depths: Vec<usize> = dag.proofs[0].steps.iter().map(|s| s.depth).collect();
+    assert_eq!(depths, vec![0, 1, 2], "preorder depths: {depths:?}");
+
+    assert!(
+        find_first(&compound("reaches", vec![v("A"), v("B")]), &kb).is_some(),
+        "the deterministic resolver still proves it too"
+    );
+}


### PR DESCRIPTION
**RS-4 PR-B.** Stage B of four. You could already ask ADJ *what* it concluded and *what it cited*. This is where **"how did you reach that?"** becomes answerable.

Implements the ordered / addressed / self-contained step contract that PR-A (#8685) made normative in `ADJ-REASON-MATH.md` §E.1–E.2.

## Four holes, and which were real

**1. Recall and table lookups emitted a citation *bag*, not a derivation.**
Both render from `via_facts`, which `collect_ids` **sorts by fact id and deduplicates**. Sorting by id destroys derivation order — so those surfaces could tell you *which* sources were involved but never in what order or through which rules. A set is not a reasoning trace. They now carry `steps` alongside the untouched `citations`.

**2. Negation-as-failure recorded nothing at all.**
A rule guarded by `not allergic_to(P, D)` fired, and the trail showed every positive step while staying **silent about the check that licensed the conclusion**. A reader could not distinguish *"we confirmed no allergy"* from *"nobody looked."* An audit trail that omits a load-bearing inference is not a shorter trail, it is a wrong one. Now a `negation` step naming the absent goal.

**3. The arithmetic derivation tree was computed and thrown away.**
The engine builds a `DerivationNode` for **every** `let` and formula application; `derived_json` never read `.tree`. You saw `speed = 80 km/h` and its citation, but not `240 / 3`, nor which observed facts supplied the operands. Now emitted — and its `leaf` nodes carry real `FactId`s, so **an arithmetic result is traceable down to bytes, one operand at a time**. That bridge already existed inside the engine; this is what makes it reachable from outside the process.

**4. The `_ => {}` arm — and I want to be precise here.** I originally wrote that it was silently dropping four of six step kinds. On inspection it was **latent, not lossy**: the likelihood-ratio kinds are rendered by a different function, so nothing shipped was actually being lost. The totality fix stands on its real merit — a wildcard that discards reasoning is a trap for whoever adds the next step kind, which this very PR proved by adding one. Adding a variant now breaks the build.

**Addressing.** `ProofStep` gains `depth`. `Proof.steps` was already a preorder walk, so preorder + depth is a complete tree encoding — a step's parent is the nearest preceding step one level shallower, exactly how an indented outline works. Without it the flat vector was ambiguous, which is why the trail could show a *list* but never a *structure*.

## Security review found a crash — and a trap this PR would have set

The reviewer built the CLI and ran adversarial programs rather than reasoning about them. A self-recursive rule `p(X,Y) :- p(X,Y)` drove the resolver into `fatal runtime error: stack overflow` — a **SIGABRT**, uncatchable, so a host embedding `logic-engine` dies with it. Pre-existing on main; the resolver was the one uncapped descent in a stack that caps everything else.

**I fixed it here rather than filing it, because the obvious fix would have been worse than the crash.** Returning "no proof" at the cap is exactly what negation-as-failure reads as *absence* — so a capped subgoal would have satisfied a `not G` guard and this PR's new `FromNegation` step would have **asserted a check that never happened**. A fabricated justification in an audit trail is the precise failure this arc exists to prevent, and it's silent. Before this PR that hazard didn't exist; introducing `FromNegation` is what made it mine.

So the caps raise an error that **propagates** — the `?` in each negation branch is load-bearing — and the query abstains rather than answering from a truncated search.

**Round 2 caught that my fix was half a fix**, in two places, both verified by running them:
- **The deterministic resolver had the identical defect.** `find_first_with`/`prove_body` is what `search(…, AutoDetect)` selects for an all-`Certain` KB — the adjudication connector's normal mode. I'd capped one resolver and left its twin, which is the worse kind of miss because the fix *looked* done.
- **The depth cap couldn't see rule-body width.** `solve_body` recurses over remaining literals while `depth` stays constant across a body by design, so a ~14,000-conjunct body overflowed at *depth 1*. Different axis, own bound (`MAX_BODY_CONJUNCTS`).

I also corrected a **factual error in my own commit message**: I'd justified the 128 limit by claiming `MAX_RULE_DEPTH = 90` bounds SLD chain length. It doesn't — it bounds the parser's grammar-rule nesting. Fail-closed either way, but the reasoning was wrong.

## Deliberately left for PR-C

`enumerate_all` collapses the limit error into an empty `ProofDAG`, so external consumers can't distinguish "no proof exists" from "the search stopped early" — `enumerate_governing` will report `"has_conflict": false` off a truncated search. That's an affirmative claim derived from an incomplete search: the same hazard one level up. It is exactly what the typed `AbstentionReason` is for.

## Verification

- **12 new tests**, each written so it is meaningful only if the defect were present: 7 e2e through the built binary (`rs4_trace_e2e`), 5 engine-level (`test_recursion_guards`) — including *a goal guarded by `not <divergent>` is not derived, in **both** resolvers*.
- Full suite green across `logic-engine` + `adj-lang` + `adj-lang-cli`; **clippy 0 issues**.
- **Additive only** — no field changed or removed; a program with no `let`, recall, or lookup produces byte-identical JSON, and all 38 `cli_golden` fixtures pass untouched.
- `cargo fmt` wanted to reformat ~100 unrelated files (pre-existing drift on main). That collateral was reverted; my files are individually fmt-clean.

`adj-lang-cli` 0.14.0 → 0.15.0 · `logic-engine` 0.40.0 → 0.41.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
