### PR TITLE
feat(chief): add profile-gated host runtime

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -723,6 +723,7 @@ members = [
     "vault-import-export",
     "storage-fs",
     "chief-of-staff-tool-api",
+    "chief-of-staff-host-runtime",
     "chief-of-staff-smart-home-tools",
     "chief-of-staff-tool-audit-store",
     "context-store",

--- a/code/packages/rust/chief-of-staff-host-runtime/BUILD
+++ b/code/packages/rust/chief-of-staff-host-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-host-runtime -- --nocapture

--- a/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Added JSON host profiles with exact D18D tool allowlists, privilege ceilings,
+  capability coverage checks, catalog completeness validation, and an active
+  runtime wrapper for executable Chief jobs.

--- a/code/packages/rust/chief-of-staff-host-runtime/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host-runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "chief-of-staff-host-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Profile-gated D18D tool runtime for Chief of Staff hosts"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+coding-adventures-json-value = { path = "../json-value" }

--- a/code/packages/rust/chief-of-staff-host-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/README.md
@@ -1,0 +1,40 @@
+# chief-of-staff-host-runtime
+
+`chief-of-staff-host-runtime` turns reviewed host and orchestrator profiles into
+active D18D tool runtimes. Each host names its privilege ceiling, capability
+surface, and exact tool ids. The orchestrator profile requires one owner per
+tool and routes calls only to that host. Activation fails unless every
+allowlisted tool has been registered and every definition fits those bounds.
+
+This is the first production-shaped replacement for wiring an unrestricted
+`InMemoryToolRuntime` directly inside each Chief job. It deliberately does not
+spawn Deno yet; process supervision and host RPC can wrap the same active
+runtime without changing catalog policy.
+
+An orchestrator profile has this shape:
+
+```json
+{
+  "profile_id": "umbrella_today_v1",
+  "hosts": [
+    {
+      "host_id": "weather_fetcher",
+      "max_tier": "tier1",
+      "allowed_tools": ["weather.fetch_current"],
+      "capabilities": ["weather_api_read"]
+    },
+    {
+      "host_id": "file_writer",
+      "max_tier": "tier1",
+      "allowed_tools": ["file.write_text"],
+      "capabilities": ["filesystem_write"]
+    }
+  ]
+}
+```
+
+The Weather Agent end-to-end crate loads an orchestrator profile containing
+separate fetcher, classifier, and writer hosts. It registers each host catalog,
+activates the orchestrator runtime, and only then executes the scheduled
+pipeline. This preserves read/write separation instead of placing untrusted
+network ingestion and filesystem actuation in one host.

--- a/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
@@ -1,0 +1,774 @@
+//! Profile-gated D18D tool runtime for Chief of Staff hosts.
+
+#![forbid(unsafe_code)]
+
+use chief_of_staff_tool_api::{
+    validate_tool_id, InMemoryToolRuntime, PrivilegeTier, ToolApiError, ToolDefinition,
+    ToolExecutionTrace, ToolHandler, ToolInvocationRequest,
+};
+use coding_adventures_json_value::{parse as parse_json, JsonValue};
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostProfile {
+    pub profile_id: String,
+    pub host_id: String,
+    pub max_tier: PrivilegeTier,
+    pub allowed_tools: Vec<String>,
+    pub capabilities: Vec<String>,
+}
+
+impl HostProfile {
+    pub fn from_json(text: &str) -> Result<Self, HostRuntimeError> {
+        let value = parse_json(text)
+            .map_err(|error| HostRuntimeError::InvalidJson(error.message.to_string()))?;
+        let object = expect_object(&value, "$profile")?;
+        let profile = Self {
+            profile_id: required_string(object, "profile_id")?,
+            host_id: required_string(object, "host_id")?,
+            max_tier: parse_tier(&required_string(object, "max_tier")?)?,
+            allowed_tools: required_string_array(object, "allowed_tools")?,
+            capabilities: required_string_array(object, "capabilities")?,
+        };
+        profile.validate()?;
+        Ok(profile)
+    }
+
+    pub fn validate(&self) -> Result<(), HostRuntimeError> {
+        validate_label("profile_id", &self.profile_id)?;
+        validate_label("host_id", &self.host_id)?;
+        if self.allowed_tools.is_empty() {
+            return Err(HostRuntimeError::EmptyToolCatalog);
+        }
+
+        let mut tools = BTreeSet::new();
+        for tool_id in &self.allowed_tools {
+            validate_tool_id(tool_id).map_err(HostRuntimeError::ToolApi)?;
+            if !tools.insert(tool_id.clone()) {
+                return Err(HostRuntimeError::DuplicateTool(tool_id.clone()));
+            }
+        }
+
+        let mut capabilities = BTreeSet::new();
+        for capability in &self.capabilities {
+            validate_label("capability", capability)?;
+            if !capabilities.insert(capability.clone()) {
+                return Err(HostRuntimeError::DuplicateCapability(capability.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn allows_tool(&self, tool_id: &str) -> bool {
+        self.allowed_tools.iter().any(|allowed| allowed == tool_id)
+    }
+
+    pub fn has_capability(&self, capability: &str) -> bool {
+        self.capabilities
+            .iter()
+            .any(|declared| declared == capability)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrchestratorProfile {
+    pub profile_id: String,
+    pub hosts: Vec<HostProfile>,
+}
+
+impl OrchestratorProfile {
+    pub fn from_json(text: &str) -> Result<Self, HostRuntimeError> {
+        let value = parse_json(text)
+            .map_err(|error| HostRuntimeError::InvalidJson(error.message.to_string()))?;
+        let object = expect_object(&value, "$profile")?;
+        let profile_id = required_string(object, "profile_id")?;
+        validate_label("profile_id", &profile_id)?;
+        let JsonValue::Array(host_values) = required_value(object, "hosts")? else {
+            return Err(HostRuntimeError::InvalidField {
+                field: "hosts".to_string(),
+                message: "expected array".to_string(),
+            });
+        };
+        if host_values.is_empty() {
+            return Err(HostRuntimeError::EmptyHostCatalog);
+        }
+
+        let mut hosts = Vec::with_capacity(host_values.len());
+        let mut host_ids = BTreeSet::new();
+        let mut tool_owners = BTreeMap::new();
+        for (index, host_value) in host_values.iter().enumerate() {
+            let host_object = expect_object(host_value, &format!("hosts[{index}]"))?;
+            let host = HostProfile {
+                profile_id: profile_id.clone(),
+                host_id: required_string(host_object, "host_id")?,
+                max_tier: parse_tier(&required_string(host_object, "max_tier")?)?,
+                allowed_tools: required_string_array(host_object, "allowed_tools")?,
+                capabilities: required_string_array(host_object, "capabilities")?,
+            };
+            host.validate()?;
+            if !host_ids.insert(host.host_id.clone()) {
+                return Err(HostRuntimeError::DuplicateHost(host.host_id));
+            }
+            for tool_id in &host.allowed_tools {
+                if let Some(first_host) = tool_owners.insert(tool_id.clone(), host.host_id.clone())
+                {
+                    return Err(HostRuntimeError::DuplicateToolOwner {
+                        tool_id: tool_id.clone(),
+                        first_host,
+                        second_host: host.host_id.clone(),
+                    });
+                }
+            }
+            hosts.push(host);
+        }
+        Ok(Self { profile_id, hosts })
+    }
+
+    pub fn validate(&self) -> Result<(), HostRuntimeError> {
+        validate_label("profile_id", &self.profile_id)?;
+        if self.hosts.is_empty() {
+            return Err(HostRuntimeError::EmptyHostCatalog);
+        }
+        let mut host_ids = BTreeSet::new();
+        let mut tool_owners = BTreeMap::new();
+        for host in &self.hosts {
+            host.validate()?;
+            if host.profile_id != self.profile_id {
+                return Err(HostRuntimeError::InvalidField {
+                    field: "hosts.profile_id".to_string(),
+                    message: format!(
+                        "host '{}' belongs to profile '{}' instead of '{}'",
+                        host.host_id, host.profile_id, self.profile_id
+                    ),
+                });
+            }
+            if !host_ids.insert(host.host_id.clone()) {
+                return Err(HostRuntimeError::DuplicateHost(host.host_id.clone()));
+            }
+            for tool_id in &host.allowed_tools {
+                if let Some(first_host) = tool_owners.insert(tool_id.clone(), host.host_id.clone())
+                {
+                    return Err(HostRuntimeError::DuplicateToolOwner {
+                        tool_id: tool_id.clone(),
+                        first_host,
+                        second_host: host.host_id.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostProfileSummary {
+    pub profile_id: String,
+    pub host_id: String,
+    pub max_tier: PrivilegeTier,
+    pub allowed_tool_count: usize,
+    pub registered_tool_count: usize,
+    pub capability_count: usize,
+    pub active: bool,
+}
+
+pub struct HostProfileRuntime {
+    profile: HostProfile,
+    runtime: InMemoryToolRuntime,
+    registered_tools: BTreeSet<String>,
+}
+
+pub struct OrchestratorProfileRuntime {
+    profile_id: String,
+    hosts: BTreeMap<String, HostProfileRuntime>,
+    tool_owners: BTreeMap<String, String>,
+}
+
+impl OrchestratorProfileRuntime {
+    pub fn from_json(text: &str) -> Result<Self, HostRuntimeError> {
+        Self::new(OrchestratorProfile::from_json(text)?)
+    }
+
+    pub fn new(profile: OrchestratorProfile) -> Result<Self, HostRuntimeError> {
+        profile.validate()?;
+        let mut hosts = BTreeMap::new();
+        let mut tool_owners = BTreeMap::new();
+        for host in profile.hosts {
+            for tool_id in &host.allowed_tools {
+                tool_owners.insert(tool_id.clone(), host.host_id.clone());
+            }
+            hosts.insert(host.host_id.clone(), HostProfileRuntime::new(host)?);
+        }
+        Ok(Self {
+            profile_id: profile.profile_id,
+            hosts,
+            tool_owners,
+        })
+    }
+
+    pub fn register_handler<H>(
+        &mut self,
+        definition: ToolDefinition,
+        handler: H,
+    ) -> Result<(), HostRuntimeError>
+    where
+        H: ToolHandler + 'static,
+    {
+        let tool_id = definition.tool_id.clone();
+        let host_id = self
+            .tool_owners
+            .get(&tool_id)
+            .ok_or_else(|| HostRuntimeError::ToolNotAllowed(tool_id.clone()))?;
+        self.hosts
+            .get_mut(host_id)
+            .expect("validated orchestrator profile must retain each tool owner")
+            .register_handler(definition, handler)
+    }
+
+    pub fn summary(&self) -> OrchestratorProfileSummary {
+        let registered_tool_count = self
+            .hosts
+            .values()
+            .map(|host| host.registered_tools.len())
+            .sum();
+        OrchestratorProfileSummary {
+            profile_id: self.profile_id.clone(),
+            host_count: self.hosts.len(),
+            allowed_tool_count: self.tool_owners.len(),
+            registered_tool_count,
+            active: false,
+        }
+    }
+
+    pub fn activate(self) -> Result<ActiveOrchestratorRuntime, HostRuntimeError> {
+        let mut hosts = BTreeMap::new();
+        for (host_id, runtime) in self.hosts {
+            hosts.insert(host_id, runtime.activate()?);
+        }
+        Ok(ActiveOrchestratorRuntime {
+            profile_id: self.profile_id,
+            hosts,
+            tool_owners: self.tool_owners,
+        })
+    }
+}
+
+impl HostProfileRuntime {
+    pub fn from_json(text: &str) -> Result<Self, HostRuntimeError> {
+        Self::new(HostProfile::from_json(text)?)
+    }
+
+    pub fn new(profile: HostProfile) -> Result<Self, HostRuntimeError> {
+        profile.validate()?;
+        Ok(Self {
+            profile,
+            runtime: InMemoryToolRuntime::new(),
+            registered_tools: BTreeSet::new(),
+        })
+    }
+
+    pub fn profile(&self) -> &HostProfile {
+        &self.profile
+    }
+
+    pub fn register_handler<H>(
+        &mut self,
+        definition: ToolDefinition,
+        handler: H,
+    ) -> Result<(), HostRuntimeError>
+    where
+        H: ToolHandler + 'static,
+    {
+        let tool_id = definition.tool_id.clone();
+        if !self.profile.allows_tool(&tool_id) {
+            return Err(HostRuntimeError::ToolNotAllowed(tool_id));
+        }
+        if definition.required_tier > self.profile.max_tier {
+            return Err(HostRuntimeError::PrivilegeCeilingExceeded {
+                tool_id,
+                required: definition.required_tier,
+                maximum: self.profile.max_tier,
+            });
+        }
+        for capability in &definition.required_capabilities {
+            if !self.profile.has_capability(capability) {
+                return Err(HostRuntimeError::MissingCapability {
+                    tool_id: definition.tool_id.clone(),
+                    capability: capability.clone(),
+                });
+            }
+        }
+        self.runtime
+            .register_handler(definition, handler)
+            .map_err(HostRuntimeError::ToolApi)?;
+        self.registered_tools.insert(tool_id);
+        Ok(())
+    }
+
+    pub fn summary(&self) -> HostProfileSummary {
+        HostProfileSummary {
+            profile_id: self.profile.profile_id.clone(),
+            host_id: self.profile.host_id.clone(),
+            max_tier: self.profile.max_tier,
+            allowed_tool_count: self.profile.allowed_tools.len(),
+            registered_tool_count: self.registered_tools.len(),
+            capability_count: self.profile.capabilities.len(),
+            active: false,
+        }
+    }
+
+    pub fn activate(self) -> Result<ActiveHostToolRuntime, HostRuntimeError> {
+        let missing_tools = self
+            .profile
+            .allowed_tools
+            .iter()
+            .filter(|tool_id| !self.registered_tools.contains(*tool_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing_tools.is_empty() {
+            return Err(HostRuntimeError::CatalogIncomplete(missing_tools));
+        }
+        Ok(ActiveHostToolRuntime {
+            profile: self.profile,
+            runtime: self.runtime,
+            registered_tools: self.registered_tools,
+        })
+    }
+}
+
+pub struct ActiveHostToolRuntime {
+    profile: HostProfile,
+    runtime: InMemoryToolRuntime,
+    registered_tools: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrchestratorProfileSummary {
+    pub profile_id: String,
+    pub host_count: usize,
+    pub allowed_tool_count: usize,
+    pub registered_tool_count: usize,
+    pub active: bool,
+}
+
+pub struct ActiveOrchestratorRuntime {
+    profile_id: String,
+    hosts: BTreeMap<String, ActiveHostToolRuntime>,
+    tool_owners: BTreeMap<String, String>,
+}
+
+impl ActiveOrchestratorRuntime {
+    pub fn summary(&self) -> OrchestratorProfileSummary {
+        OrchestratorProfileSummary {
+            profile_id: self.profile_id.clone(),
+            host_count: self.hosts.len(),
+            allowed_tool_count: self.tool_owners.len(),
+            registered_tool_count: self
+                .hosts
+                .values()
+                .map(|host| host.registered_tools.len())
+                .sum(),
+            active: true,
+        }
+    }
+
+    pub fn host_for_tool(&self, tool_id: &str) -> Option<&str> {
+        self.tool_owners.get(tool_id).map(String::as_str)
+    }
+
+    pub fn invoke_with_events(
+        &self,
+        request: &ToolInvocationRequest,
+    ) -> Result<ToolExecutionTrace, HostRuntimeError> {
+        let host_id = self
+            .tool_owners
+            .get(&request.tool_id)
+            .ok_or_else(|| HostRuntimeError::ToolNotAllowed(request.tool_id.clone()))?;
+        Ok(self
+            .hosts
+            .get(host_id)
+            .expect("active orchestrator must retain each tool owner")
+            .invoke_with_events(request))
+    }
+}
+
+impl ActiveHostToolRuntime {
+    pub fn profile(&self) -> &HostProfile {
+        &self.profile
+    }
+
+    pub fn summary(&self) -> HostProfileSummary {
+        HostProfileSummary {
+            profile_id: self.profile.profile_id.clone(),
+            host_id: self.profile.host_id.clone(),
+            max_tier: self.profile.max_tier,
+            allowed_tool_count: self.profile.allowed_tools.len(),
+            registered_tool_count: self.registered_tools.len(),
+            capability_count: self.profile.capabilities.len(),
+            active: true,
+        }
+    }
+
+    pub fn invoke_with_events(&self, request: &ToolInvocationRequest) -> ToolExecutionTrace {
+        self.runtime.invoke_with_events(request)
+    }
+
+    pub fn definitions(&self) -> Vec<&ToolDefinition> {
+        self.runtime.list()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostRuntimeError {
+    InvalidJson(String),
+    MissingField(String),
+    InvalidField {
+        field: String,
+        message: String,
+    },
+    EmptyToolCatalog,
+    EmptyHostCatalog,
+    DuplicateHost(String),
+    DuplicateTool(String),
+    DuplicateToolOwner {
+        tool_id: String,
+        first_host: String,
+        second_host: String,
+    },
+    DuplicateCapability(String),
+    ToolNotAllowed(String),
+    PrivilegeCeilingExceeded {
+        tool_id: String,
+        required: PrivilegeTier,
+        maximum: PrivilegeTier,
+    },
+    MissingCapability {
+        tool_id: String,
+        capability: String,
+    },
+    CatalogIncomplete(Vec<String>),
+    ToolApi(ToolApiError),
+}
+
+impl Display for HostRuntimeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidJson(message) => write!(f, "invalid host profile JSON: {message}"),
+            Self::MissingField(field) => write!(f, "host profile is missing '{field}'"),
+            Self::InvalidField { field, message } => {
+                write!(f, "invalid host profile field '{field}': {message}")
+            }
+            Self::EmptyToolCatalog => f.write_str("host profile tool catalog cannot be empty"),
+            Self::EmptyHostCatalog => {
+                f.write_str("orchestrator profile host catalog cannot be empty")
+            }
+            Self::DuplicateHost(host_id) => write!(f, "duplicate profile host '{host_id}'"),
+            Self::DuplicateTool(tool_id) => write!(f, "duplicate profile tool '{tool_id}'"),
+            Self::DuplicateToolOwner {
+                tool_id,
+                first_host,
+                second_host,
+            } => write!(
+                f,
+                "tool '{tool_id}' is owned by both '{first_host}' and '{second_host}'"
+            ),
+            Self::DuplicateCapability(capability) => {
+                write!(f, "duplicate profile capability '{capability}'")
+            }
+            Self::ToolNotAllowed(tool_id) => {
+                write!(f, "tool '{tool_id}' is not allowlisted by the host profile")
+            }
+            Self::PrivilegeCeilingExceeded {
+                tool_id,
+                required,
+                maximum,
+            } => write!(
+                f,
+                "tool '{tool_id}' requires {required}, above host ceiling {maximum}"
+            ),
+            Self::MissingCapability {
+                tool_id,
+                capability,
+            } => write!(
+                f,
+                "tool '{tool_id}' requires undeclared host capability '{capability}'"
+            ),
+            Self::CatalogIncomplete(tool_ids) => write!(
+                f,
+                "host profile catalog is incomplete; missing {}",
+                tool_ids.join(", ")
+            ),
+            Self::ToolApi(error) => Display::fmt(error, f),
+        }
+    }
+}
+
+impl Error for HostRuntimeError {}
+
+fn expect_object<'a>(
+    value: &'a JsonValue,
+    field: &str,
+) -> Result<&'a [(String, JsonValue)], HostRuntimeError> {
+    match value {
+        JsonValue::Object(fields) => Ok(fields),
+        _ => Err(HostRuntimeError::InvalidField {
+            field: field.to_string(),
+            message: "expected object".to_string(),
+        }),
+    }
+}
+
+fn required_value<'a>(
+    object: &'a [(String, JsonValue)],
+    field: &str,
+) -> Result<&'a JsonValue, HostRuntimeError> {
+    object
+        .iter()
+        .find_map(|(name, value)| (name == field).then_some(value))
+        .ok_or_else(|| HostRuntimeError::MissingField(field.to_string()))
+}
+
+fn required_string(
+    object: &[(String, JsonValue)],
+    field: &str,
+) -> Result<String, HostRuntimeError> {
+    match required_value(object, field)? {
+        JsonValue::String(value) => Ok(value.clone()),
+        _ => Err(HostRuntimeError::InvalidField {
+            field: field.to_string(),
+            message: "expected string".to_string(),
+        }),
+    }
+}
+
+fn required_string_array(
+    object: &[(String, JsonValue)],
+    field: &str,
+) -> Result<Vec<String>, HostRuntimeError> {
+    let JsonValue::Array(values) = required_value(object, field)? else {
+        return Err(HostRuntimeError::InvalidField {
+            field: field.to_string(),
+            message: "expected array".to_string(),
+        });
+    };
+    values
+        .iter()
+        .map(|value| match value {
+            JsonValue::String(value) => Ok(value.clone()),
+            _ => Err(HostRuntimeError::InvalidField {
+                field: field.to_string(),
+                message: "expected an array of strings".to_string(),
+            }),
+        })
+        .collect()
+}
+
+fn parse_tier(value: &str) -> Result<PrivilegeTier, HostRuntimeError> {
+    match value {
+        "tier0" => Ok(PrivilegeTier::Tier0),
+        "tier1" => Ok(PrivilegeTier::Tier1),
+        "tier2" => Ok(PrivilegeTier::Tier2),
+        "tier3" => Ok(PrivilegeTier::Tier3),
+        _ => Err(HostRuntimeError::InvalidField {
+            field: "max_tier".to_string(),
+            message: "expected tier0, tier1, tier2, or tier3".to_string(),
+        }),
+    }
+}
+
+fn validate_label(field: &str, value: &str) -> Result<(), HostRuntimeError> {
+    if value.is_empty()
+        || value.chars().any(|character| {
+            !(character.is_ascii_alphanumeric() || character == '_' || character == '-')
+        })
+    {
+        return Err(HostRuntimeError::InvalidField {
+            field: field.to_string(),
+            message: "expected a non-empty ASCII label".to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_tool_api::{
+        JsonSchema, RequestedBy, ToolConcurrency, ToolHandlerOutput, ToolIdempotency,
+        ToolInvocationRequest, ToolSideEffects, ToolStability, ToolStreaming,
+    };
+
+    const PROFILE: &str = r#"{
+      "profile_id": "test_profile",
+      "host_id": "test_host",
+      "max_tier": "tier1",
+      "allowed_tools": ["demo.read"],
+      "capabilities": ["demo_read"]
+    }"#;
+
+    const ORCHESTRATOR_PROFILE: &str = r#"{
+      "profile_id": "demo_orchestrator",
+      "hosts": [
+        {
+          "host_id": "reader_host",
+          "max_tier": "tier1",
+          "allowed_tools": ["demo.read"],
+          "capabilities": ["demo_read"]
+        },
+        {
+          "host_id": "writer_host",
+          "max_tier": "tier1",
+          "allowed_tools": ["demo.write"],
+          "capabilities": ["demo_write"]
+        }
+      ]
+    }"#;
+
+    fn definition(tool_id: &str, tier: PrivilegeTier, capabilities: &[&str]) -> ToolDefinition {
+        ToolDefinition {
+            tool_id: tool_id.to_string(),
+            display_name: "Demo".to_string(),
+            description: "Demo tool".to_string(),
+            input_schema: JsonSchema::Object {
+                properties: vec![],
+                required: vec![],
+                allow_unknown_fields: false,
+            },
+            output_schema: Some(JsonSchema::String),
+            side_effects: ToolSideEffects::Read,
+            idempotency: ToolIdempotency::Always,
+            concurrency: ToolConcurrency::Safe,
+            streaming: ToolStreaming::None,
+            required_tier: tier,
+            required_capabilities: capabilities.iter().map(|value| value.to_string()).collect(),
+            preferred_lock_scope: None,
+            timeout_seconds: Some(5),
+            tags: vec!["demo".to_string()],
+            stability: ToolStability::Stable,
+        }
+    }
+
+    fn request(tool_id: &str) -> ToolInvocationRequest {
+        ToolInvocationRequest {
+            call_id: "call_1".to_string(),
+            tool_id: tool_id.to_string(),
+            arguments: JsonValue::Object(vec![]),
+            requested_by: RequestedBy::Agent,
+            session_id: Some("session_1".to_string()),
+            job_id: Some("job_1".to_string()),
+            agent_id: Some("agent_1".to_string()),
+            user_id: Some("user_1".to_string()),
+            requested_at: 100,
+            deadline_at: Some(200),
+            idempotency_key: Some("idem_1".to_string()),
+        }
+    }
+
+    #[test]
+    fn profile_activates_complete_allowlisted_catalog_and_invokes() {
+        let mut runtime = HostProfileRuntime::from_json(PROFILE).unwrap();
+        runtime
+            .register_handler(
+                definition("demo.read", PrivilegeTier::Tier1, &["demo_read"]),
+                |_arguments, _context| {
+                    Ok(ToolHandlerOutput::new(JsonValue::String("ok".to_string())))
+                },
+            )
+            .unwrap();
+
+        let active = runtime.activate().unwrap();
+        assert!(active.summary().active);
+        assert_eq!(active.summary().registered_tool_count, 1);
+        assert_eq!(
+            active
+                .invoke_with_events(&request("demo.read"))
+                .result
+                .output,
+            Some(JsonValue::String("ok".to_string()))
+        );
+    }
+
+    #[test]
+    fn profile_rejects_unlisted_tools_privilege_escalation_and_capability_drift() {
+        let mut runtime = HostProfileRuntime::from_json(PROFILE).unwrap();
+        assert!(matches!(
+            runtime.register_handler(
+                definition("demo.write", PrivilegeTier::Tier1, &["demo_read"]),
+                |_arguments, _context| Ok(ToolHandlerOutput::new(JsonValue::Null)),
+            ),
+            Err(HostRuntimeError::ToolNotAllowed(_))
+        ));
+        assert!(matches!(
+            runtime.register_handler(
+                definition("demo.read", PrivilegeTier::Tier2, &["demo_read"]),
+                |_arguments, _context| Ok(ToolHandlerOutput::new(JsonValue::Null)),
+            ),
+            Err(HostRuntimeError::PrivilegeCeilingExceeded { .. })
+        ));
+        assert!(matches!(
+            runtime.register_handler(
+                definition("demo.read", PrivilegeTier::Tier1, &["undeclared"]),
+                |_arguments, _context| Ok(ToolHandlerOutput::new(JsonValue::Null)),
+            ),
+            Err(HostRuntimeError::MissingCapability { .. })
+        ));
+    }
+
+    #[test]
+    fn profile_cannot_activate_with_missing_catalog_entries() {
+        let runtime = HostProfileRuntime::from_json(PROFILE).unwrap();
+        assert!(matches!(
+            runtime.activate(),
+            Err(HostRuntimeError::CatalogIncomplete(tool_ids))
+                if tool_ids == vec!["demo.read".to_string()]
+        ));
+    }
+
+    #[test]
+    fn orchestrator_profile_routes_tools_to_isolated_owners() {
+        let mut runtime = OrchestratorProfileRuntime::from_json(ORCHESTRATOR_PROFILE).unwrap();
+        runtime
+            .register_handler(
+                definition("demo.read", PrivilegeTier::Tier1, &["demo_read"]),
+                |_arguments, _context| {
+                    Ok(ToolHandlerOutput::new(JsonValue::String(
+                        "read".to_string(),
+                    )))
+                },
+            )
+            .unwrap();
+        runtime
+            .register_handler(
+                definition("demo.write", PrivilegeTier::Tier1, &["demo_write"]),
+                |_arguments, _context| {
+                    Ok(ToolHandlerOutput::new(JsonValue::String(
+                        "write".to_string(),
+                    )))
+                },
+            )
+            .unwrap();
+
+        let active = runtime.activate().unwrap();
+        assert_eq!(active.summary().host_count, 2);
+        assert_eq!(active.host_for_tool("demo.read"), Some("reader_host"));
+        assert_eq!(active.host_for_tool("demo.write"), Some("writer_host"));
+        assert_eq!(
+            active
+                .invoke_with_events(&request("demo.read"))
+                .unwrap()
+                .result
+                .output,
+            Some(JsonValue::String("read".to_string()))
+        );
+    }
+
+    #[test]
+    fn orchestrator_profile_rejects_cross_host_tool_ownership() {
+        let profile = ORCHESTRATOR_PROFILE.replace("demo.write", "demo.read");
+        assert!(matches!(
+            OrchestratorProfile::from_json(&profile),
+            Err(HostRuntimeError::DuplicateToolOwner { .. })
+        ));
+    }
+}

--- a/code/packages/rust/weather-agent-e2e/CHANGELOG.md
+++ b/code/packages/rust/weather-agent-e2e/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Loaded the Weather Agent D18D catalog from a reviewed orchestrator profile
+  with isolated fetcher, classifier, and writer hosts through
+  `chief-of-staff-host-runtime`.
+
 - Initial umbrella-today end-to-end harness that exercises the Chief of Staff
   actor, D18A store, D18C job, D18D tool, read/write separation, and
   capability-caged file-write path with a deterministic Seattle weather fixture.

--- a/code/packages/rust/weather-agent-e2e/Cargo.toml
+++ b/code/packages/rust/weather-agent-e2e/Cargo.toml
@@ -10,6 +10,7 @@ actor = { path = "../actor" }
 artifact-store = { path = "../artifact-store" }
 capability-os-sandbox = { path = "../capability-os-sandbox" }
 capability-cage = { path = "../capability-cage" }
+chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding-adventures-json-value = { path = "../json-value" }
 context-store = { path = "../context-store" }

--- a/code/packages/rust/weather-agent-e2e/README.md
+++ b/code/packages/rust/weather-agent-e2e/README.md
@@ -11,6 +11,11 @@ client refuses undeclared domains before opening TLS sockets. The fixture keeps
 CI stable while still forcing the fetch, classify, supervise, write, journal,
 store, and capability boundaries to run as one pipeline.
 
+The D18D tools are loaded from `orchestrator_profile.json` through
+`chief-of-staff-host-runtime`. Fetch, classification, and file writing belong to
+three isolated host profiles with independent capability sets. The profile must
+be complete and active before the first tool invocation.
+
 The primary tests write a real `umbrella-today.txt` file through the capability
 cage, assert that the supervised agent says to bring an umbrella for the rainy
 fixture, prove the supervisor recreates a killed child before the next tick, and

--- a/code/packages/rust/weather-agent-e2e/orchestrator_profile.json
+++ b/code/packages/rust/weather-agent-e2e/orchestrator_profile.json
@@ -1,0 +1,23 @@
+{
+  "profile_id": "umbrella_today_v1",
+  "hosts": [
+    {
+      "host_id": "weather_fetcher",
+      "max_tier": "tier1",
+      "allowed_tools": ["weather.fetch_current"],
+      "capabilities": ["weather_api_read"]
+    },
+    {
+      "host_id": "weather_classifier",
+      "max_tier": "tier1",
+      "allowed_tools": ["weather.classify_umbrella"],
+      "capabilities": ["internal_reasoning"]
+    },
+    {
+      "host_id": "file_writer",
+      "max_tier": "tier1",
+      "allowed_tools": ["file.write_text"],
+      "capabilities": ["filesystem_write"]
+    }
+  ]
+}

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -22,11 +22,15 @@ use capability_os_sandbox::{
     current_kernel_sandbox_support, plan_all_supported, plan_for_current_os,
     run_with_kernel_sandbox, OsFamily, SandboxPlan, SandboxPlanSummary,
 };
+use chief_of_staff_host_runtime::{
+    ActiveOrchestratorRuntime, HostRuntimeError, OrchestratorProfileRuntime,
+    OrchestratorProfileSummary,
+};
 use chief_of_staff_tool_api::{
-    InMemoryToolRuntime, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError,
-    ToolCallError, ToolConcurrency, ToolDefinition, ToolErrorKind, ToolEventKind,
-    ToolExecutionJournal, ToolExecutionJournalHealthSummary, ToolHandlerOutput, ToolIdempotency,
-    ToolInvocationRequest, ToolSideEffects, ToolStability, ToolStreaming,
+    JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError, ToolCallError,
+    ToolConcurrency, ToolDefinition, ToolErrorKind, ToolEventKind, ToolExecutionJournal,
+    ToolExecutionJournalHealthSummary, ToolHandlerOutput, ToolIdempotency, ToolInvocationRequest,
+    ToolSideEffects, ToolStability, ToolStreaming,
 };
 use coding_adventures_json_value::{JsonNumber, JsonValue};
 use context_store::{
@@ -72,6 +76,7 @@ const FETCH_TOOL_ID: &str = "weather.fetch_current";
 const CLASSIFY_TOOL_ID: &str = "weather.classify_umbrella";
 const WRITE_TOOL_ID: &str = "file.write_text";
 const WEATHER_API_DOMAIN: &str = "api.weather.gov";
+const WEATHER_ORCHESTRATOR_PROFILE: &str = include_str!("../orchestrator_profile.json");
 
 pub type UmbrellaResult<T> = Result<T, UmbrellaAgentError>;
 
@@ -116,6 +121,12 @@ impl From<StorageError> for UmbrellaAgentError {
 
 impl From<ToolApiError> for UmbrellaAgentError {
     fn from(value: ToolApiError) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<HostRuntimeError> for UmbrellaAgentError {
+    fn from(value: HostRuntimeError) -> Self {
         Self::new(value.to_string())
     }
 }
@@ -486,6 +497,7 @@ pub struct UmbrellaAgentRun {
     pub sandbox_plan: UmbrellaSandboxPlanSummary,
     pub kernel_sandbox: UmbrellaKernelSandboxSummary,
     pub supervisor: UmbrellaSupervisorSummary,
+    pub orchestrator_profile: OrchestratorProfileSummary,
     pub tool_journal_health: ToolExecutionJournalHealthSummary,
     pub context_inventory: ContextStoreInventorySummary,
     pub artifact_inventory: ArtifactInventorySummary,
@@ -645,6 +657,7 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         sandbox_plan,
         kernel_sandbox,
         supervisor: supervisor_summary(&system, &actor_stats, supervisor_events),
+        orchestrator_profile: pipeline.tool_runtime.summary(),
         tool_journal_health,
         context_inventory,
         artifact_inventory,
@@ -660,7 +673,7 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
 
 struct UmbrellaPipeline {
     config: UmbrellaAgentConfig,
-    tool_runtime: InMemoryToolRuntime,
+    tool_runtime: ActiveOrchestratorRuntime,
     journal: Mutex<ToolExecutionJournal>,
     channel: Mutex<Channel>,
     context_store: ContextStore<InMemoryStorageBackend>,
@@ -675,7 +688,7 @@ struct UmbrellaPipeline {
 
 impl UmbrellaPipeline {
     fn new(config: UmbrellaAgentConfig) -> UmbrellaResult<Self> {
-        let mut tool_runtime = InMemoryToolRuntime::new();
+        let mut tool_runtime = OrchestratorProfileRuntime::from_json(WEATHER_ORCHESTRATOR_PROFILE)?;
         let http_client = generated_operations::generated_http_client()?;
         register_weather_fetch_tool(
             &mut tool_runtime,
@@ -687,6 +700,7 @@ impl UmbrellaPipeline {
         .map_err(UmbrellaAgentError::from)?;
         register_weather_classifier_tool(&mut tool_runtime)?;
         register_file_writer_tool(&mut tool_runtime, writer_manifest(&config.output_path)?)?;
+        let tool_runtime = tool_runtime.activate()?;
 
         Ok(Self {
             config,
@@ -968,7 +982,7 @@ impl UmbrellaPipeline {
             deadline_at: Some(self.config.fetched_at_ms.saturating_add(30_000)),
             idempotency_key: Some(format!("{}-{}", self.config.tick_id, call_id)),
         };
-        let trace = self.tool_runtime.invoke_with_events(&request);
+        let trace = self.tool_runtime.invoke_with_events(&request)?;
         let result = trace.result.clone();
         self.journal
             .lock()
@@ -1178,12 +1192,12 @@ fn unwrap_pipeline_state(state: Box<dyn std::any::Any>) -> Arc<UmbrellaPipeline>
 }
 
 fn register_weather_fetch_tool(
-    runtime: &mut InMemoryToolRuntime,
+    runtime: &mut OrchestratorProfileRuntime,
     source: WeatherSource,
     fetched_at_ms: u64,
     fetched_at_iso: String,
     http_client: GeneratedOperationHttpClient,
-) -> Result<(), ToolApiError> {
+) -> Result<(), HostRuntimeError> {
     runtime.register_handler(
         tool_definition(
             FETCH_TOOL_ID,
@@ -1468,7 +1482,9 @@ fn snapshot_from_nws_forecast(
     })
 }
 
-fn register_weather_classifier_tool(runtime: &mut InMemoryToolRuntime) -> Result<(), ToolApiError> {
+fn register_weather_classifier_tool(
+    runtime: &mut OrchestratorProfileRuntime,
+) -> Result<(), HostRuntimeError> {
     runtime.register_handler(
         tool_definition(
             CLASSIFY_TOOL_ID,
@@ -1510,9 +1526,9 @@ fn register_weather_classifier_tool(runtime: &mut InMemoryToolRuntime) -> Result
 }
 
 fn register_file_writer_tool(
-    runtime: &mut InMemoryToolRuntime,
+    runtime: &mut OrchestratorProfileRuntime,
     manifest: Manifest,
-) -> Result<(), ToolApiError> {
+) -> Result<(), HostRuntimeError> {
     runtime.register_handler(
         tool_definition(
             WRITE_TOOL_ID,

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -82,6 +82,11 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
     }
 
     assert_eq!(run.supervisor.child_count, 3);
+    assert!(run.orchestrator_profile.active);
+    assert_eq!(run.orchestrator_profile.profile_id, "umbrella_today_v1");
+    assert_eq!(run.orchestrator_profile.host_count, 3);
+    assert_eq!(run.orchestrator_profile.allowed_tool_count, 3);
+    assert_eq!(run.orchestrator_profile.registered_tool_count, 3);
     assert_eq!(run.supervisor.stopped_children, 3);
     assert_eq!(run.supervisor.failed_children, 0);
     assert_eq!(run.supervisor.dead_letters, 0);

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -235,10 +235,16 @@ network I/O into the Chief bridge:
 
 ## Chief Of Staff Remaining Work
 
+The Chief host-profile slice now provides JSON orchestrator profiles, isolated
+host tool ownership, privilege ceilings, capability coverage checks, catalog
+completeness gates, and executable routing. The Weather Agent uses three host
+profiles for fetch, classify, and write instead of wiring an unrestricted tool
+runtime directly.
+
 These items are Chief of Staff architecture, not smart-home platform work:
 
-- Load D18D tool catalogs into a host/orchestrator profile instead of only
-  using in-memory tests.
+- Connect active host/orchestrator profiles to supervised process lifecycle,
+  signed package verification, host RPC, and deny-all Deno workers.
 - Run a Chief job end to end through scheduler or job framework, tool runtime,
   approval checks, result journal, and final user-visible report.
 - Add approval UX and policy wiring for Tier2 or stronger actions such as


### PR DESCRIPTION
## Summary

- add a reusable Chief host/orchestrator profile runtime for D18D catalogs
- fail closed on unlisted tools, incomplete catalogs, privilege escalation, missing capabilities, and cross-host tool ownership
- route the Weather Agent through isolated fetcher, classifier, and writer host profiles before executing its scheduled pipeline
- update the D18-D23 completion inventory with the next honest runtime boundary

## Validation

- cargo test -p chief-of-staff-host-runtime -- --nocapture
- cargo test -p weather-agent-e2e -- --nocapture
- sh BUILD in chief-of-staff-host-runtime
- sh BUILD in weather-agent-e2e
- cargo clippy -p chief-of-staff-host-runtime -p weather-agent-e2e --all-targets -- -D warnings
- cargo test -p smart-home-platform-http -- --nocapture
- cargo fmt --check -p chief-of-staff-host-runtime -p weather-agent-e2e
- git diff --check