### PR TITLE
feat(spice): shape diode depletion capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Bias-shaped diode depletion capacitance** — diode model cards now accept
+  `VJ`/`PB` junction potential and `M`/`MJ` grading coefficient parameters and
+  apply them to depletion capacitance in AC and transient analysis, matching
+  Rust and TypeScript.
+
 - **Model-card supported-parameter coverage dashboard** —
   `model_card_supported_parameter_coverage_dashboard()`,
   `format_model_card_supported_parameter_coverage_dashboard_table()`,
@@ -20,7 +25,7 @@
   `model_card_supported_parameter_coverage_gate_issue_records()`,
   `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
   `format_model_card_supported_parameter_coverage_gate_issue_json()` now
-  validate the expected seven-kind, 67-row supported-parameter catalog and
+  validate the expected seven-kind, 69-row supported-parameter catalog and
   expose stable issue rows for release automation, matching Rust and
   TypeScript.
 

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -204,6 +204,9 @@ disable the limiter.
 `bjt_from_model_card()`, `jfet_from_model_card()`, and
 `mosfet_from_model_card()` provide the shared `.model` alias surface for diode,
 BJT, JFET, and Level-1 MOS cards.
+Diode cards accept `VJ`/`PB` junction potential and `M`/`MJ` grading coefficient;
+AC and transient analyses use them to shape `CJO` depletion capacitance from the
+operating-point bias.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -229,7 +232,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 67-row supported-parameter catalog and expose stable issue
+expected seven-kind, 69-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -488,6 +488,8 @@ class Diode:
     IBV: float = 1e-3  # reverse current at breakdown voltage
     Cjo: float = 0.0  # zero-bias junction capacitance
     Tt: float = 0.0  # transit time / diffusion capacitance coefficient
+    Vj: float = 1.0  # junction potential
+    M: float = 0.5  # junction grading coefficient
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -8647,6 +8647,10 @@ def _diode_effective_vt(el: Diode) -> float:
         raise ValueError(f"{el.name}: diode breakdown current must be finite and positive")
     if not math.isfinite(el.Cjo) or el.Cjo < 0.0:
         raise ValueError(f"{el.name}: diode junction capacitance must be finite and non-negative")
+    if not math.isfinite(el.Vj) or el.Vj <= 0.0:
+        raise ValueError(f"{el.name}: diode junction potential must be finite and positive")
+    if not math.isfinite(el.M) or el.M < 0.0:
+        raise ValueError(f"{el.name}: diode grading coefficient must be finite and non-negative")
     if not math.isfinite(el.Tt) or el.Tt < 0.0:
         raise ValueError(f"{el.name}: diode transit time must be finite and non-negative")
     return el.Vt * el.N
@@ -8675,7 +8679,7 @@ def _diode_has_charge_storage(el: Diode) -> bool:
 
 def _diode_dynamic_capacitance(el: Diode, vd: float) -> float:
     _, gd = _diode_current_conductance(el, vd)
-    return el.Cjo + el.Tt * gd
+    return bulk_junction_capacitance(el.Cjo, vd, el.Vj, el.M) + el.Tt * gd
 
 
 def _diode_charge_voltage(el: Diode, node_voltages: dict[str, float]) -> float:
@@ -12236,7 +12240,14 @@ def _stamp_ac(
         Vd = Va - Vk
         _, gd = _diode_current_conductance(el, Vd)
         diffusion_capacitance = el.Tt * gd
-        _stamp_g_c(G, node_to_idx, el.anode, el.cathode, gd + 1j * omega * (el.Cjo + diffusion_capacitance))
+        depletion_capacitance = bulk_junction_capacitance(el.Cjo, Vd, el.Vj, el.M)
+        _stamp_g_c(
+            G,
+            node_to_idx,
+            el.anode,
+            el.cathode,
+            gd + 1j * omega * (depletion_capacitance + diffusion_capacitance),
+        )
 
     elif isinstance(el, JFET):
         Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
@@ -13751,7 +13762,20 @@ def sens_dc(
             _make_entry(
                 "Is",
                 el.Is,
-                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt, el.N, el.BV, el.IBV, el.Cjo, el.Tt),
+                Diode(
+                    el.name,
+                    el.anode,
+                    el.cathode,
+                    el.Is + delta_is,
+                    el.Vt,
+                    el.N,
+                    el.BV,
+                    el.IBV,
+                    el.Cjo,
+                    el.Tt,
+                    el.Vj,
+                    el.M,
+                ),
             )
 
         elif isinstance(el, BJT):
@@ -13985,7 +14009,20 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
         )
 
     if isinstance(el, Diode):
-        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt, el.N, el.BV, el.IBV, el.Cjo, el.Tt)
+        return Diode(
+            el.name,
+            el.anode,
+            el.cathode,
+            _draw(el.Is),
+            el.Vt,
+            el.N,
+            el.BV,
+            el.IBV,
+            el.Cjo,
+            el.Tt,
+            el.Vj,
+            el.M,
+        )
 
     if isinstance(el, BJT):
         return BJT(

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -306,7 +306,7 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
     "PMOS",
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
-    "D": (7, 11, 3, 3),
+    "D": (9, 15, 5, 3),
     "NPN": (7, 15, 4, 4),
     "PNP": (7, 15, 4, 4),
     "NJF": (5, 11, 5, 3),
@@ -345,6 +345,10 @@ _DIODE_PARAMETER_ALIASES: dict[str, str] = {
     "CJ": "CJO",
     "CJ0": "CJO",
     "TT": "TT",
+    "VJ": "VJ",
+    "PB": "VJ",
+    "M": "M",
+    "MJ": "M",
 }
 
 _BJT_PARAMETER_ALIASES: dict[str, str] = {
@@ -854,6 +858,8 @@ def diode_from_model_card(
         IBV=p.get("IBV", 1.0e-3),
         Cjo=p.get("CJO", 0.0),
         Tt=p.get("TT", 0.0),
+        Vj=p.get("VJ", 1.0),
+        M=p.get("M", 0.5),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -410,7 +410,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 67
+    assert len(coverage) == 69
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -425,7 +425,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 67
+    assert len(records) == 69
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -442,11 +442,11 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     summary = model_card_supported_parameter_coverage_summary()
     assert len(summary) == 7
     assert summary[0].kind == "D"
-    assert summary[0].canonical_parameter_count == 7
-    assert summary[0].accepted_name_count == 11
-    assert summary[0].aliased_parameter_count == 3
+    assert summary[0].canonical_parameter_count == 9
+    assert summary[0].accepted_name_count == 15
+    assert summary[0].aliased_parameter_count == 5
     assert summary[0].max_alias_count == 3
-    assert summary[0].aliased_parameters == ("IS", "VT", "CJO")
+    assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
     assert summary[5].canonical_parameter_count == 18
     assert summary[5].accepted_name_count == 25
@@ -468,7 +468,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
         == "kind\tcanonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\taliased_parameters"
     )
-    assert table.splitlines()[1] == "D\t7\t11\t3\t3\tIS|VT|CJO"
+    assert table.splitlines()[1] == "D\t9\t15\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
         == "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -477,16 +477,16 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert len(records) == 7
     assert records[0] == {
         "kind": "D",
-        "canonical_parameter_count": "7",
-        "accepted_name_count": "11",
-        "aliased_parameter_count": "3",
+        "canonical_parameter_count": "9",
+        "accepted_name_count": "15",
+        "aliased_parameter_count": "5",
         "max_alias_count": "3",
-        "aliased_parameters": "IS|VT|CJO",
+        "aliased_parameters": "IS|VT|CJO|VJ|M",
     }
     assert format_model_card_supported_parameter_coverage_summary_csv().startswith(
         "kind,canonical_parameter_count,accepted_name_count,"
         "aliased_parameter_count,max_alias_count,aliased_parameters\n"
-        "D,7,11,3,3,IS|VT|CJO\n"
+        "D,9,15,5,3,IS|VT|CJO|VJ|M\n"
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_summary_json())
@@ -499,17 +499,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 67
-    assert report.expected_canonical_parameter_count == 67
-    assert report.accepted_name_count == 113
-    assert report.aliased_parameter_count == 33
+    assert report.canonical_parameter_count == 69
+    assert report.expected_canonical_parameter_count == 69
+    assert report.accepted_name_count == 117
+    assert report.aliased_parameter_count == 35
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t67\t67\t113\t33\t4\t0"
+        "true\t7\t7\t69\t69\t117\t35\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -537,9 +537,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 66
-    assert report.accepted_name_count == 110
-    assert report.aliased_parameter_count == 32
+    assert report.canonical_parameter_count == 68
+    assert report.accepted_name_count == 114
+    assert report.aliased_parameter_count == 34
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -553,7 +553,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t66\t67\t110\t32\t4\t4\n"
+        "false\t7\t7\t68\t69\t114\t34\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -584,10 +584,23 @@ def test_model_card_aliases_build_device_instances() -> None:
     diode_card = normalize_model_card(
         "Dfast",
         "diode",
-        {"JS": 2.0e-14, "CJ": 1.5e-12, "TT": 4.0e-9, "RS": 10.0},
+        {
+            "JS": 2.0e-14,
+            "CJ": 1.5e-12,
+            "TT": 4.0e-9,
+            "PB": 0.8,
+            "MJ": 0.4,
+            "RS": 10.0,
+        },
     )
     diode_model = diode_from_model_card("D1", "a", "k", diode_card)
-    assert diode_card.parameters == {"IS": 2.0e-14, "CJO": 1.5e-12, "TT": 4.0e-9}
+    assert diode_card.parameters == {
+        "IS": 2.0e-14,
+        "CJO": 1.5e-12,
+        "TT": 4.0e-9,
+        "VJ": 0.8,
+        "M": 0.4,
+    }
     assert diode_card.unsupported_parameters == ("RS",)
     diode_issues = model_card_unsupported_parameter_issues(diode_card)
     assert len(diode_issues) == 1
@@ -619,6 +632,8 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert diode_model.Is == pytest.approx(2.0e-14)
     assert diode_model.Cjo == pytest.approx(1.5e-12)
     assert diode_model.Tt == pytest.approx(4.0e-9)
+    assert diode_model.Vj == pytest.approx(0.8)
+    assert pytest.approx(0.4) == diode_model.M
 
     bjt_card = normalize_model_card("Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12})
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
@@ -3813,6 +3828,23 @@ def test_ac_diode_junction_capacitance_shunts_high_frequency():
 
     assert low > 0.9
     assert high < low / 100.0
+
+
+def test_ac_diode_depletion_capacitance_falls_with_reverse_bias():
+    """VJ/M reduce junction capacitance as reverse bias widens depletion."""
+
+    def high_frequency_voltage(dc_bias: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", dc_bias, ac=AcSource(1.0)))
+        c.add(Resistor("R1", "in", "node", 1000.0))
+        c.add(Diode("D1", anode="0", cathode="node", Cjo=1.0e-6, Vj=1.0, M=0.5))
+        result = ac_sweep(c, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["node"])
+
+    zero_bias = high_frequency_voltage(0.0)
+    reverse_biased = high_frequency_voltage(4.0)
+
+    assert reverse_biased > zero_bias * 1.8
 
 
 def test_ac_diode_transit_time_shunts_forward_bias_at_high_frequency():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Shape diode depletion capacitance from the operating-point bias with model-card
+  `VJ`/`PB` junction-potential and `M`/`MJ` grading-coefficient parameters in AC
+  and transient analysis, matching Python and TypeScript.
 - Add `model_card_supported_parameter_coverage_dashboard`,
   `format_model_card_supported_parameter_coverage_dashboard_table`,
   `model_card_supported_parameter_coverage_dashboard_records`,
@@ -15,7 +18,7 @@
   `model_card_supported_parameter_coverage_gate_issue_records`,
   `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
   `format_model_card_supported_parameter_coverage_gate_issue_json`, stable
-  release-gate checks and issue exports for the seven-kind, 67-row supported
+  release-gate checks and issue exports for the seven-kind, 69-row supported
   model-card parameter catalog, matching Python and TypeScript.
 - Add `model_card_supported_parameter_coverage_summary`,
   `format_model_card_supported_parameter_coverage_summary_table`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -121,6 +121,9 @@ BJT, and Level-1 MOSFET models before running an analysis.
 `normalize_model_card`, `diode_from_model_card`, `bjt_from_model_card`,
 `jfet_from_model_card`, and `mosfet_from_model_card` provide the shared
 `.model` alias surface for diode, BJT, JFET, and Level-1 MOS cards.
+Diode cards accept `VJ`/`PB` junction potential and `M`/`MJ` grading coefficient;
+AC and transient analyses use them to shape `CJO` depletion capacitance from the
+operating-point bias.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -146,7 +149,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 67-row supported-parameter catalog and expose stable issue
+expected seven-kind, 69-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2345,6 +2345,8 @@ pub struct Diode {
     pub breakdown_current: f64,
     pub junction_capacitance: f64,
     pub transit_time: f64,
+    pub junction_potential: f64,
+    pub grading_coefficient: f64,
 }
 
 impl Diode {
@@ -2407,6 +2409,37 @@ impl Diode {
         junction_capacitance: f64,
         transit_time: f64,
     ) -> Self {
+        Self::with_model_and_depletion(
+            name,
+            anode,
+            cathode,
+            saturation_current,
+            thermal_voltage,
+            emission_coefficient,
+            breakdown_voltage,
+            breakdown_current,
+            junction_capacitance,
+            transit_time,
+            1.0,
+            0.5,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_and_depletion(
+        name: impl Into<String>,
+        anode: impl Into<String>,
+        cathode: impl Into<String>,
+        saturation_current: f64,
+        thermal_voltage: f64,
+        emission_coefficient: f64,
+        breakdown_voltage: Option<f64>,
+        breakdown_current: f64,
+        junction_capacitance: f64,
+        transit_time: f64,
+        junction_potential: f64,
+        grading_coefficient: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             anode: anode.into(),
@@ -2418,6 +2451,8 @@ impl Diode {
             breakdown_current,
             junction_capacitance,
             transit_time,
+            junction_potential,
+            grading_coefficient,
         }
     }
 }
@@ -3109,7 +3144,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
     usize,
 )] = &[
-    (ModelCardKind::Diode, 7, 11, 3, 3),
+    (ModelCardKind::Diode, 9, 15, 5, 3),
     (ModelCardKind::Npn, 7, 15, 4, 4),
     (ModelCardKind::Pnp, 7, 15, 4, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
@@ -3129,6 +3164,10 @@ const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CJ", "CJO"),
     ("CJ0", "CJO"),
     ("TT", "TT"),
+    ("VJ", "VJ"),
+    ("PB", "VJ"),
+    ("M", "M"),
+    ("MJ", "M"),
 ];
 const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -3753,7 +3792,7 @@ pub fn diode_from_model_card(
     if model.kind != ModelCardKind::Diode {
         return Err(model_card_kind_error(&name, "diode", model.kind));
     }
-    Ok(Diode::with_model_and_breakdown(
+    Ok(Diode::with_model_and_depletion(
         name,
         anode,
         cathode,
@@ -3764,6 +3803,8 @@ pub fn diode_from_model_card(
         model_card_value(model, "IBV", 1.0e-3),
         model_card_value(model, "CJO", 0.0),
         model_card_value(model, "TT", 0.0),
+        model_card_value(model, "VJ", 1.0),
+        model_card_value(model, "M", 0.5),
     ))
 }
 
@@ -20985,15 +21026,12 @@ fn build_ac_matrix(
                 let voltage = vector_voltage(operating_point, anode)
                     - vector_voltage(operating_point, cathode);
                 let (_, conductance) = diode_current_conductance(diode, voltage);
-                let diffusion_capacitance = diode.transit_time * conductance;
+                let capacitance = diode_dynamic_capacitance(diode, voltage);
                 stamp_complex_conductance(
                     &mut matrix,
                     anode,
                     cathode,
-                    Complex::new(
-                        conductance,
-                        omega * (diode.junction_capacitance + diffusion_capacitance),
-                    ),
+                    Complex::new(conductance, omega * capacitance),
                 );
             }
             Element::Jfet(jfet) => {
@@ -22595,7 +22633,12 @@ fn diode_has_charge_storage(diode: &Diode) -> bool {
 
 fn diode_dynamic_capacitance(diode: &Diode, voltage: f64) -> f64 {
     let (_, conductance) = diode_current_conductance(diode, voltage);
-    diode.junction_capacitance + diode.transit_time * conductance
+    mosfet_bulk_junction_capacitance(
+        diode.junction_capacitance,
+        voltage,
+        diode.junction_potential,
+        diode.grading_coefficient,
+    ) + diode.transit_time * conductance
 }
 
 fn diode_charge_voltage(diode: &Diode, node_voltages: &BTreeMap<String, f64>) -> f64 {
@@ -22877,6 +22920,18 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
             reason: "junction capacitance must be finite and non-negative".to_string(),
+        });
+    }
+    if !diode.junction_potential.is_finite() || diode.junction_potential <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "junction potential must be finite and positive".to_string(),
+        });
+    }
+    if !diode.grading_coefficient.is_finite() || diode.grading_coefficient < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "grading coefficient must be finite and non-negative".to_string(),
         });
     }
     if !diode.transit_time.is_finite() || diode.transit_time < 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -295,6 +295,34 @@ fn ac_diode_junction_capacitance_shunts_high_frequency() {
 }
 
 #[test]
+fn ac_diode_depletion_capacitance_falls_with_reverse_bias() {
+    fn high_frequency_voltage(dc_bias: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", dc_bias, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "R1", "in", "node", 1_000.0,
+        )));
+        circuit.add(Element::Diode(Diode::with_model_and_depletion(
+            "D1", "0", "node", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 1.0e-6, 0.0, 1.0, 0.5,
+        )));
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("node")
+            .unwrap()
+            .abs()
+    }
+
+    let zero_bias = high_frequency_voltage(0.0);
+    let reverse_biased = high_frequency_voltage(4.0);
+
+    assert!(
+        reverse_biased > zero_bias * 1.8,
+        "expected reverse bias to reduce depletion capacitance, got zero={zero_bias} reverse={reverse_biased}"
+    );
+}
+
+#[test]
 fn ac_diode_transit_time_shunts_forward_bias_at_high_frequency() {
     fn high_frequency_anode(transit_time: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -99,7 +99,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 67);
+    assert_eq!(coverage.len(), 69);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -118,7 +118,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 67);
+    assert_eq!(records.len(), 69);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -142,11 +142,14 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let summary = model_card_supported_parameter_coverage_summary();
     assert_eq!(summary.len(), 7);
     assert_eq!(summary[0].kind, ModelCardKind::Diode);
-    assert_eq!(summary[0].canonical_parameter_count, 7);
-    assert_eq!(summary[0].accepted_name_count, 11);
-    assert_eq!(summary[0].aliased_parameter_count, 3);
+    assert_eq!(summary[0].canonical_parameter_count, 9);
+    assert_eq!(summary[0].accepted_name_count, 15);
+    assert_eq!(summary[0].aliased_parameter_count, 5);
     assert_eq!(summary[0].max_alias_count, 3);
-    assert_eq!(summary[0].aliased_parameters, vec!["IS", "VT", "CJO"]);
+    assert_eq!(
+        summary[0].aliased_parameters,
+        vec!["IS", "VT", "CJO", "VJ", "M"]
+    );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
     assert_eq!(summary[5].canonical_parameter_count, 18);
     assert_eq!(summary[5].accepted_name_count, 25);
@@ -164,7 +167,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         lines[0],
         "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters"
     );
-    assert_eq!(lines[1], "D\t7\t11\t3\t3\tIS|VT|CJO");
+    assert_eq!(lines[1], "D\t9\t15\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -172,17 +175,17 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
-    assert_eq!(records[0]["canonical_parameter_count"], "7");
-    assert_eq!(records[0]["accepted_name_count"], "11");
-    assert_eq!(records[0]["aliased_parameter_count"], "3");
+    assert_eq!(records[0]["canonical_parameter_count"], "9");
+    assert_eq!(records[0]["accepted_name_count"], "15");
+    assert_eq!(records[0]["aliased_parameter_count"], "5");
     assert_eq!(records[0]["max_alias_count"], "3");
-    assert_eq!(records[0]["aliased_parameters"], "IS|VT|CJO");
+    assert_eq!(records[0]["aliased_parameters"], "IS|VT|CJO|VJ|M");
     assert!(format_model_card_supported_parameter_coverage_summary_csv().starts_with(
-        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,7,11,3,3,IS|VT|CJO\n"
+        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,9,15,5,3,IS|VT|CJO|VJ|M\n"
     ));
     let json = format_model_card_supported_parameter_coverage_summary_json();
     assert!(json.starts_with(
-        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"7\",\"accepted_name_count\":\"11\",\"aliased_parameter_count\":\"3\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO\"}"
+        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"9\",\"accepted_name_count\":\"15\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
         "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"18\",\"accepted_name_count\":\"25\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
@@ -196,15 +199,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 67);
-    assert_eq!(report.expected_canonical_parameter_count, 67);
-    assert_eq!(report.accepted_name_count, 113);
-    assert_eq!(report.aliased_parameter_count, 33);
+    assert_eq!(report.canonical_parameter_count, 69);
+    assert_eq!(report.expected_canonical_parameter_count, 69);
+    assert_eq!(report.accepted_name_count, 117);
+    assert_eq!(report.aliased_parameter_count, 35);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t67\t67\t113\t33\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t69\t69\t117\t35\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -231,9 +234,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 66);
-    assert_eq!(report.accepted_name_count, 110);
-    assert_eq!(report.aliased_parameter_count, 32);
+    assert_eq!(report.canonical_parameter_count, 68);
+    assert_eq!(report.accepted_name_count, 114);
+    assert_eq!(report.aliased_parameter_count, 34);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -249,7 +252,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t66\t67\t110\t32\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t68\t69\t114\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -273,12 +276,12 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard.len(), 7);
     assert_eq!(dashboard[0].kind, ModelCardKind::Diode);
     assert!(dashboard[0].passed);
-    assert_eq!(dashboard[0].canonical_parameter_count, 7);
-    assert_eq!(dashboard[0].expected_canonical_parameter_count, 7);
-    assert_eq!(dashboard[0].accepted_name_count, 11);
-    assert_eq!(dashboard[0].expected_accepted_name_count, 11);
-    assert_eq!(dashboard[0].aliased_parameter_count, 3);
-    assert_eq!(dashboard[0].expected_aliased_parameter_count, 3);
+    assert_eq!(dashboard[0].canonical_parameter_count, 9);
+    assert_eq!(dashboard[0].expected_canonical_parameter_count, 9);
+    assert_eq!(dashboard[0].accepted_name_count, 15);
+    assert_eq!(dashboard[0].expected_accepted_name_count, 15);
+    assert_eq!(dashboard[0].aliased_parameter_count, 5);
+    assert_eq!(dashboard[0].expected_aliased_parameter_count, 5);
     assert_eq!(dashboard[0].max_alias_count, 3);
     assert_eq!(dashboard[0].expected_max_alias_count, 3);
     assert_eq!(dashboard[0].issue_count, 0);
@@ -294,7 +297,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
         lines[0],
         "kind\tpassed\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\texpected_accepted_name_count\taliased_parameter_count\texpected_aliased_parameter_count\tmax_alias_count\texpected_max_alias_count\tissue_count\tissue_fields"
     );
-    assert_eq!(lines[1], "D\ttrue\t7\t7\t11\t11\t3\t3\t3\t3\t0\t");
+    assert_eq!(lines[1], "D\ttrue\t9\t9\t15\t15\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\ttrue\t18\t18\t25\t25\t6\t6\t3\t3\t0\t"
@@ -303,15 +306,15 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["passed"], "true");
-    assert_eq!(records[0]["canonical_parameter_count"], "7");
-    assert_eq!(records[0]["expected_canonical_parameter_count"], "7");
+    assert_eq!(records[0]["canonical_parameter_count"], "9");
+    assert_eq!(records[0]["expected_canonical_parameter_count"], "9");
     assert_eq!(records[0]["issue_count"], "0");
     assert_eq!(records[0]["issue_fields"], "");
     assert!(format_model_card_supported_parameter_coverage_dashboard_csv(&coverage).starts_with(
-        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,7,7,11,11,3,3,3,3,0,\n"
+        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,9,9,15,15,5,5,3,3,0,\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_dashboard_json(&coverage).starts_with(
-        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"7\",\"expected_canonical_parameter_count\":\"7\""
+        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"9\",\"expected_canonical_parameter_count\":\"9\""
     ));
 }
 
@@ -361,6 +364,8 @@ fn model_card_aliases_build_device_instances() {
             ("JS", 2.0e-14),
             ("CJ", 1.5e-12),
             ("TT", 4.0e-9),
+            ("PB", 0.8),
+            ("MJ", 0.4),
             ("RS", 10.0),
         ],
     )
@@ -368,6 +373,8 @@ fn model_card_aliases_build_device_instances() {
     let diode_model = diode_from_model_card("D1", "a", "k", &diode_card).unwrap();
     assert_close(*diode_card.parameters.get("IS").unwrap(), 2.0e-14);
     assert_close(*diode_card.parameters.get("CJO").unwrap(), 1.5e-12);
+    assert_close(*diode_card.parameters.get("VJ").unwrap(), 0.8);
+    assert_close(*diode_card.parameters.get("M").unwrap(), 0.4);
     assert_eq!(diode_card.unsupported_parameters, vec!["RS".to_string()]);
     let diode_issues = model_card_unsupported_parameter_issues(&diode_card);
     assert_eq!(diode_issues.len(), 1);
@@ -402,6 +409,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(diode_model.saturation_current, 2.0e-14);
     assert_close(diode_model.junction_capacitance, 1.5e-12);
     assert_close(diode_model.transit_time, 4.0e-9);
+    assert_close(diode_model.junction_potential, 0.8);
+    assert_close(diode_model.grading_coefficient, 0.4);
 
     let bjt_card =
         normalize_model_card("Qsmall", "npn", &[("BETA", 125.0), ("CBE", 2.0e-12)]).unwrap();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Shape diode depletion capacitance from the operating-point bias with model-card
+  `VJ`/`PB` junction-potential and `M`/`MJ` grading-coefficient parameters in AC
+  and transient analysis, matching Python and Rust.
 - Add `modelCardSupportedParameterCoverageDashboard`,
   `formatModelCardSupportedParameterCoverageDashboardTable`,
   `modelCardSupportedParameterCoverageDashboardRecords`,
@@ -15,7 +18,7 @@
   `modelCardSupportedParameterCoverageGateIssueRecords`,
   `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
   `formatModelCardSupportedParameterCoverageGateIssueJson`, stable release-gate
-  checks and issue exports for the seven-kind, 67-row supported model-card
+  checks and issue exports for the seven-kind, 69-row supported model-card
   parameter catalog, matching Python and Rust.
 - Add `modelCardSupportedParameterCoverageSummary`,
   `formatModelCardSupportedParameterCoverageSummaryTable`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -191,6 +191,9 @@ with optional `HARMONICS=` and `FROM=` controls.
 `normalizeModelCard`, `diodeFromModelCard`, `bjtFromModelCard`,
 `jfetFromModelCard`, and `mosfetFromModelCard` provide the shared `.model`
 alias surface for diode, BJT, JFET, and Level-1 MOS cards.
+Diode cards accept `VJ`/`PB` junction potential and `M`/`MJ` grading coefficient;
+AC and transient analyses use them to shape `CJO` depletion capacitance from the
+operating-point bias.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -216,7 +219,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 67-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 69-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1671,6 +1671,8 @@ export interface Diode {
   readonly breakdownCurrent: number;
   readonly junctionCapacitance: number;
   readonly transitTime: number;
+  readonly junctionPotential: number;
+  readonly gradingCoefficient: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -1981,7 +1983,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_KINDS: readonly ModelCardKind[] = 
 const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
-  D: [7, 11, 3, 3],
+  D: [9, 15, 5, 3],
   NPN: [7, 15, 4, 4],
   PNP: [7, 15, 4, 4],
   NJF: [5, 11, 5, 3],
@@ -7526,6 +7528,8 @@ export function diode(
   breakdownCurrent = 1.0e-3,
   junctionCapacitance = 0.0,
   transitTime = 0.0,
+  junctionPotential = 1.0,
+  gradingCoefficient = 0.5,
 ): Diode {
   return {
     kind: "diode",
@@ -7539,6 +7543,8 @@ export function diode(
     breakdownCurrent,
     junctionCapacitance,
     transitTime,
+    junctionPotential,
+    gradingCoefficient,
   };
 }
 
@@ -7796,6 +7802,10 @@ const DIODE_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CJ: "CJO",
   CJ0: "CJO",
   TT: "TT",
+  VJ: "VJ",
+  PB: "VJ",
+  M: "M",
+  MJ: "M",
 };
 
 const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8278,6 +8288,8 @@ export function diodeFromModelCard(
     p.IBV ?? 1.0e-3,
     p.CJO ?? 0.0,
     p.TT ?? 0.0,
+    p.VJ ?? 1.0,
+    p.M ?? 0.5,
   );
 }
 
@@ -17809,12 +17821,12 @@ function buildAcMatrix(
         const diodeVoltage = vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.anode)) -
           vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.cathode));
         const [, diodeConductance] = diodeCurrentConductance(element, diodeVoltage);
-        const diffusionCapacitance = element.transitTime * diodeConductance;
+        const diodeCapacitance = diodeDynamicCapacitance(element, diodeVoltage);
         stampComplexConductance(
           matrix,
           nodeIndex(nodeIndices, element.anode),
           nodeIndex(nodeIndices, element.cathode),
-          complex(diodeConductance, omega * (element.junctionCapacitance + diffusionCapacitance)),
+          complex(diodeConductance, omega * diodeCapacitance),
         );
         break;
       case "jfet":
@@ -19150,6 +19162,12 @@ function validateDiode(element: Diode): void {
   if (!Number.isFinite(element.junctionCapacitance) || element.junctionCapacitance < 0.0) {
     throw invalidElement(element.name, "junction capacitance must be finite and non-negative");
   }
+  if (!Number.isFinite(element.junctionPotential) || element.junctionPotential <= 0.0) {
+    throw invalidElement(element.name, "junction potential must be finite and positive");
+  }
+  if (!Number.isFinite(element.gradingCoefficient) || element.gradingCoefficient < 0.0) {
+    throw invalidElement(element.name, "grading coefficient must be finite and non-negative");
+  }
   if (!Number.isFinite(element.transitTime) || element.transitTime < 0.0) {
     throw invalidElement(element.name, "transit time must be finite and non-negative");
   }
@@ -19188,7 +19206,14 @@ function diodeHasChargeStorage(element: Diode): boolean {
 
 function diodeDynamicCapacitance(element: Diode, voltage: number): number {
   const [, conductance] = diodeCurrentConductance(element, voltage);
-  return element.junctionCapacitance + element.transitTime * conductance;
+  return (
+    mosfetBulkJunctionCapacitance(
+      element.junctionCapacitance,
+      voltage,
+      element.junctionPotential,
+      element.gradingCoefficient,
+    ) + element.transitTime * conductance
+  );
 }
 
 function diodeChargeVoltage(element: Diode, nodeVoltages: ReadonlyMap<string, number>): number {

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -211,6 +211,36 @@ describe("acSweep", () => {
     expect(high).toBeLessThan(low / 100.0);
   });
 
+  it("reduces diode depletion capacitance with reverse bias", () => {
+    const highFrequencyVoltage = (dcBias: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", dcBias, 1.0));
+      circuit.add(resistor("R1", "in", "node", 1_000.0));
+      circuit.add(
+        diode(
+          "D1",
+          "0",
+          "node",
+          1.0e-15,
+          0.02585,
+          1.0,
+          undefined,
+          1.0e-3,
+          1.0e-6,
+          0.0,
+          1.0,
+          0.5,
+        ),
+      );
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("node")!);
+    };
+
+    const zeroBias = highFrequencyVoltage(0.0);
+    const reverseBiased = highFrequencyVoltage(4.0);
+
+    expect(reverseBiased).toBeGreaterThan(zeroBias * 1.8);
+  });
+
   it("stamps forward-biased diode transit-time diffusion capacitance", () => {
     const highFrequencyAnode = (transitTime: number): number => {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -123,7 +123,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(67);
+    expect(coverage).toHaveLength(69);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -143,7 +143,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(67);
+    expect(records).toHaveLength(69);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -161,11 +161,11 @@ describe("dcOp", () => {
     expect(summary).toHaveLength(7);
     expect(summary[0]).toStrictEqual({
       kind: "D",
-      canonicalParameterCount: 7,
-      acceptedNameCount: 11,
-      aliasedParameterCount: 3,
+      canonicalParameterCount: 9,
+      acceptedNameCount: 15,
+      aliasedParameterCount: 5,
       maxAliasCount: 3,
-      aliasedParameters: ["IS", "VT", "CJO"],
+      aliasedParameters: ["IS", "VT", "CJO", "VJ", "M"],
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     expect(table.split("\n")[0]).toBe(
       "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters",
     );
-    expect(table.split("\n")[1]).toBe("D\t7\t11\t3\t3\tIS|VT|CJO");
+    expect(table.split("\n")[1]).toBe("D\t9\t15\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
       "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
@@ -189,14 +189,14 @@ describe("dcOp", () => {
     expect(records).toHaveLength(7);
     expect(records[0]).toStrictEqual({
       kind: "D",
-      canonical_parameter_count: "7",
-      accepted_name_count: "11",
-      aliased_parameter_count: "3",
+      canonical_parameter_count: "9",
+      accepted_name_count: "15",
+      aliased_parameter_count: "5",
       max_alias_count: "3",
-      aliased_parameters: "IS|VT|CJO",
+      aliased_parameters: "IS|VT|CJO|VJ|M",
     });
     expect(formatModelCardSupportedParameterCoverageSummaryCsv()).toMatch(
-      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,7,11,3,3,IS\|VT\|CJO\n/,
+      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,9,15,5,3,IS\|VT\|CJO\|VJ\|M\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageSummaryJson())).toStrictEqual(records);
   });
@@ -208,15 +208,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 67,
-      expectedCanonicalParameterCount: 67,
-      acceptedNameCount: 113,
-      aliasedParameterCount: 33,
+      canonicalParameterCount: 69,
+      expectedCanonicalParameterCount: 69,
+      acceptedNameCount: 117,
+      aliasedParameterCount: 35,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t67\t67\t113\t33\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t69\t69\t117\t35\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -239,9 +239,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(66);
-    expect(report.acceptedNameCount).toBe(110);
-    expect(report.aliasedParameterCount).toBe(32);
+    expect(report.canonicalParameterCount).toBe(68);
+    expect(report.acceptedNameCount).toBe(114);
+    expect(report.aliasedParameterCount).toBe(34);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -255,7 +255,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t66\t67\t110\t32\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t68\t69\t114\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -276,10 +276,18 @@ describe("dcOp", () => {
       JS: 2.0e-14,
       CJ: 1.5e-12,
       TT: 4.0e-9,
+      PB: 0.8,
+      MJ: 0.4,
       RS: 10.0,
     });
     const diodeModel = diodeFromModelCard("D1", "a", "k", diodeCard);
-    expect(diodeCard.parameters).toStrictEqual({ IS: 2.0e-14, CJO: 1.5e-12, TT: 4.0e-9 });
+    expect(diodeCard.parameters).toStrictEqual({
+      IS: 2.0e-14,
+      CJO: 1.5e-12,
+      TT: 4.0e-9,
+      VJ: 0.8,
+      M: 0.4,
+    });
     expect(diodeCard.unsupportedParameters).toStrictEqual(["RS"]);
     const diodeIssues = modelCardUnsupportedParameterIssues(diodeCard);
     expect(diodeIssues).toStrictEqual([
@@ -309,6 +317,8 @@ describe("dcOp", () => {
     expectClose(diodeModel.saturationCurrent, 2.0e-14);
     expectClose(diodeModel.junctionCapacitance, 1.5e-12);
     expectClose(diodeModel.transitTime, 4.0e-9);
+    expectClose(diodeModel.junctionPotential, 0.8);
+    expectClose(diodeModel.gradingCoefficient, 0.4);
 
     const bjtCard = normalizeModelCard("Qsmall", "npn", { BETA: 125.0, CBE: 2.0e-12 });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,18 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic acknowledgement-record summary digest.
+1. Cross-language diode depletion-capacitance shaping.
    - Status: current PR completion candidate.
-   - Add a Rust-only Berkeley app-deck shell dashboard surface that wraps
-     runtime activation receipt journal summary handoff receipt acknowledgement
-     record receipt acknowledgement record summaries into compact digest/routing
-     payloads for Mosaic and WebAssembly product shells.
-   - Expose native and JSON helpers with stable schema version, digest ID,
-     route/hold disposition, digest action, badge label/tone, routing targets,
-     compact notification/count metadata, and capability metadata.
-   - Preserve the public Berkeley parser contract and Python/TypeScript parser
-     parity while extending the Rust app facade as an app-substrate acceleration
-     layer.
+   - Add Berkeley diode `VJ`/`PB` junction-potential and `M`/`MJ`
+     grading-coefficient model-card parameters in Rust, Python, and TypeScript.
+   - Shape `CJO` depletion capacitance from the operating-point bias in AC and
+     transient analysis while preserving transit-time diffusion capacitance.
+   - Extend the supported-parameter coverage gate from 67 to 69 canonical rows
+     and lock reverse-bias capacitance behavior across all three engines.
 
 ## Completed Slices
 
@@ -2959,6 +2955,14 @@ the Rust, Python, and TypeScript surfaces together.
      deferred counts, nested acknowledgement-record payload, and capability
      metadata while leaving the public Berkeley parser contract and
      Python/TypeScript parser parity unchanged.
+
+213. Rust Berkeley Mosaic acknowledgement-record summary digest.
+   - Status: completed in PR 7718.
+   - Rust `spice-netlist-parser` now exposes native and JSON acknowledgement-
+     record summary digest helpers for Mosaic and WebAssembly product shells.
+   - The digest preserves stable schema, routing disposition, action, badge,
+     target, compact count, nested summary, and capability metadata while
+     leaving parser and cross-language solver behavior unchanged.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add diode `VJ`/`PB` junction-potential and `M`/`MJ` grading-coefficient model-card support in Rust, Python, and TypeScript
- shape `CJO` depletion capacitance from the DC operating-point bias in AC and transient analyses while preserving transit-time diffusion capacitance
- expand the supported-parameter coverage gate from 67 to 69 canonical rows and reconcile the SPICE implementation plan through merged PR #7718

## Why
A diode model could store zero-bias junction capacitance, but AC and transient analyses treated it as constant regardless of reverse bias. Berkeley-style junction potential and grading coefficient parameters now make that capacitance bias-dependent across all three engines.

## Validation
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python 3.12: `pytest code/packages/python/spice-engine/tests/test_engine.py` (472 passed, 80.91% coverage)
- Python 3.12: `ruff check --ignore I001` on the touched source and test files
- `npm test` (258 passed)
- `npm run build`
- `git diff --check`

## Formatting note
`cargo fmt -p spice-engine -- --check` still reports pre-existing formatting drift in unrelated portions of the large Rust engine source; the new Rust lines were manually aligned with the formatter without sweeping that baseline drift into this PR.