### PR TITLE
feat(hl): Spanish Ch.17 — the future and the conditional, or one weld twice

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -235,6 +235,8 @@
       "ES-PRETERITE-STRONG": "the strong preterites — tener→tuve, hacer→hice, estar→estuve (stress moves OFF the ending onto the stem, TUve/HIce, hence NO written accent, the reverse of hablé/habló; yo ending -e not -é; hizo c→z; ← Latin strong perfects tenuī/fēcī/stetī, inherited not rebuilt)",
       "ES-IMPERFECT": "the imperfect — hablaba/hablabas/hablaba/hablábamos/hablaban and comía/vivía (the ongoing/habitual past; -er and -ir share ONE set a THIRD time). ← Latin -ābam / -ēbam, the b surviving whole in -aba but wearing away in -ēbam→-ía. Accents do two different jobs: hablábamos = stress 3 syllables back; comía = breaking the diphthong into co-mí-a. yo and él forms are IDENTICAL, so Spanish often un-drops yo here — a pro-drop exception",
       "ES-IMPERFECT-IRREGULARS": "the only THREE irregular imperfects in the language — ser→era (← eram, same es- root as soy/es and English is/are), ir→iba (← ībam), ver→veía (barely irregular: keeps an -e- from older veer). PAYOFF: iba is the ONE tense where ir uses its OWN Latin verb īre — its present came from vādere and its preterite from fuī, so ir is stitched from THREE different Latin verbs",
+      "ES-FUTURE": "the future — hablaré/hablarás/hablará/hablaremos/hablarán, built on the WHOLE INFINITIVE (you don't strip -ar), one ending set for all three conjugations. Latin's own future (amābō) DIED and Romance replaced it with infinitive + habēre ('amāre habeō' = I have to love → I will love), which then FUSED into one word — so the endings -é/-ás/-á/-emos/-án are literally the present of haber (he/has/ha/hemos/han) worn down to a suffix. A compound tense that closed up into a simple one. Portuguese never finished the weld: falá-lo-ei still puts a pronoun INSIDE the join",
+      "ES-CONDITIONAL": "the conditional — hablaría, the SAME infinitive weld as the future but with the IMPERFECT of haber (había) instead of the present, which is exactly why its endings are the -ía/-ías/-íamos/-ían of the Ch.16 -er/-ir imperfect. Uses: hypothetical 'would', politeness (¿podrías?), and future-in-the-past (dijo que hablaría). Accent breaks the diphthong: hablar-í-a",
       "IT-VERB-STARE": "stare — 'to be' (state; ← Latin stare 'to stand', = Spanish estar); drives 'come stai?'",
       "IT-VERB-PARLARE": "parlare — 'to speak' (← parabolāre = French parler; the regular -are present)",
       "IT-VERB-ABITARE": "abitare — 'to live/dwell' (← habitāre → habitat; twin of French habiter)",
@@ -340,6 +342,6 @@
     }
   },
   "practiceTags": {
-    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, CH14-PRACTICE, CH15-PRACTICE, CH16-PRACTICE, REVIEW."
+    "note": "Non-word lessons (type: review | practice-mix | writing) carry a session/orthography label, not a concept, and are exempt from the cross-language join. Existing labels: CH1-PRACTICE, CH2-PRACTICE, CH3-PRACTICE, CH4-PRACTICE, CH9-PRACTICE, CH10-PRACTICE, CH11-PRACTICE, CH12-PRACTICE, CH13-PRACTICE, CH14-PRACTICE, CH15-PRACTICE, CH16-PRACTICE, CH17-PRACTICE, REVIEW."
   }
 }

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## Chapter 17 — The future and the conditional, or one weld twice
+
+- **Chapter 17 authored** (`ES-C17-futuro`, `-condicional`, `-practice`): two
+  tenses that turn out to be **one construction** — reviewing Ch.6/10/11/12/13/16
+  via `reviews_of`.
+- **the future** (`ES-C17-futuro`): *hablaré…hablarán*, built on the **whole
+  infinitive** — the one tense that doesn't strip the ending — with a single set of
+  endings for all three conjugations. The etymology carries the lesson: Latin's own
+  future ***amābō*** **died out**, and Romance replaced it with a phrase,
+  **infinitive + *habēre*** (*amāre habeō*, "I **have to** love"), exactly parallel
+  to English *I have to go* drifting toward futurity. That phrase then **fused**:
+  *hablar he* → *hablar-he* → **hablaré**. So the endings are not endings at all
+  historically — they are the **present of *haber*** (*he/has/ha/hemos/han*) worn
+  down to a suffix, and lining the two lists up shows them identical. Framed as **a
+  compound tense that closed up into a simple one**, the mirror image of the
+  parallel-4 tracks' Ch.15 compound past, which stayed open. Closes with the seam
+  still faintly visible next door: **formal European Portuguese** can lodge a
+  pronoun **inside** the fused future — **falá-*lo*-ei** — a leftover, not the norm
+  (Brazilian Portuguese and ordinary speech don't).
+- **the conditional** (`ES-C17-condicional`): *hablaría* — the **same weld**, with
+  the **imperfect** of *haber* swapped in for the present, which is precisely why
+  its endings are the ***-ía/-ías/-íamos/-ían*** the learner already met as Ch.16's
+  *-er/-ir* imperfect. One trick, two tenses of one auxiliary. Uses covered:
+  hypothetical *would*, politeness (*¿podrías?*, *me gustaría*), and
+  **future-in-the-past** (*dijo que hablaría*) — which makes sense once you know an
+  imperfect is buried inside it.
+- **practice**: the **ten irregular stems** sorted into three families —
+  drop-the-vowel (*podré, querré, sabré, habré*); drop-then-**wedge-a-d**
+  (*tendré, pondré, vendré, saldré*), because dropping alone squeezed ***-n'r-***
+  or ***-l'r-*** together and Old Spanish resolved it rather than leave it (with a
+  note that modern Spanish says *honra*/*alrededor* perfectly well, and that
+  medieval Spanish first tried **metathesis** — *terné, porné, verné* — before the
+  *d*-forms won); and the choppers (**diré, haré**). Two payoffs: the **same bent
+  stem serves both tenses** (ten shapes, twenty conjugations), and **all six**
+  members of Ch.12–13's *-go club* resurface here — four as the *-dr-* group,
+  *hacer* and *decir* as the choppers — the oldest, most-used verbs misbehaving in
+  the same places again. Ends on the
+  **future of probability** (*¿Dónde estará?* "Where can he be?"; *Serán las tres*
+  "It must be three"), with the conditional doing the same for the past — a leap
+  that follows naturally from a tense built out of "I **have to**."
+- Note: *haber* has no lesson of its own yet; it appears here as **etymology**, with
+  its forms shown as evidence, not as a paradigm the learner must produce.
+- Taxonomy: namespaced `ES-FUTURE`, `ES-CONDITIONAL`; practice label
+  `CH17-PRACTICE`.
+
 ## Chapter 16 — The imperfect, and choosing between the two pasts
 
 - **Chapter 16 authored** (`ES-C16-imperfecto`, `-tres-irregulares`,

--- a/code/learning/human-languages/spanish/lessons/ES-C17-condicional.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-condicional.md
@@ -1,0 +1,84 @@
+---
+id: ES-C17-condicional
+chapter: 17
+type: word
+headword: hablaría
+gloss: the conditional — the same weld, using the imperfect of haber instead
+concept_tag: ES-CONDITIONAL
+prerequisites: [ES-C17-futuro, ES-C16-imperfecto]
+sounds: [hiatus-ia, accent-acute]
+roots: [latin-infinitive-habere]
+etymology_hook: "hablaría = hablar + ía (← the old reduced imperfect avía) — the SAME infinitive weld as the future, but with the IMPERFECT of haber instead of the present, which is why its endings are exactly the -ía endings of Ch.16's imperfect; two tenses, one trick, two tenses of haber"
+est_minutes: 5
+reviews_of: [ES-C17-futuro, ES-C16-imperfecto, ES-C11-querer]
+---
+
+# hablaría — the same weld, one tense over
+
+## Warm-up
+
+[PAUSE 2s] If you understood the last lesson, this one is nearly free. Same
+machine, one part swapped.
+
+## The forms
+
+Whole infinitive again, new endings:
+
+| | |
+|---|---|
+| yo | hablar**ía** |
+| tú | hablar**ías** |
+| él/ella/usted | hablar**ía** |
+| nosotros | hablar**íamos** |
+| ellos/ustedes | hablar**ían** |
+
+Look hard at those endings. **You already know them.** They are exactly the
+*-er/-ir* **imperfect** endings from Chapter 16: *com**ía**, com**ías**,
+com**íamos**, com**ían***.
+
+## Why they're the same
+
+Because they **are** the same. The future welded the infinitive to the **present**
+of *haber*; the conditional welds it to the **imperfect** of *haber*:
+
+| tense | infinitive + | result |
+|---|---|---|
+| future | *haber* **present** (*he, has, ha…*) | hablar**é** |
+| conditional | *haber* **imperfect** (*había, habías…*) | hablar**ía** |
+
+(Strictly, what fused was the older, shorter *avía* — which is why you get
+*hablar**ía*** and not *hablarhabía*. The modern *había* is the same word,
+un-worn.)
+
+One trick, two tenses of the same auxiliary. That is the whole chapter.
+
+And the accent does the job Chapter 16 taught: it **breaks the diphthong**, so
+*hablar-í-a* is separate syllables.
+
+## What it's for
+
+| use | example |
+|---|---|
+| **would** — hypothetical | *Hablaría con él.* "I would speak with him." |
+| **politeness** — softening | *¿Podrías ayudarme?* "Could you help me?" |
+| **future-in-the-past** | *Dijo que hablaría.* "He said he would speak." |
+
+That last one is neat: from a point in the past, the conditional is the future.
+Which makes sense if you remember the imperfect is inside it.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hablaría, hablarías, hablaría, hablaríamos, hablarían"]
+- [YOU SAY: the echo — "com**ía** … hablar**ía**" — same endings]
+- [YOU SAY: "Me gustaría…" ("I would like…") — the politest thing in Spanish]
+- [YOU SAY: the pair — "hablar + he … hablar + ía"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do the conditional endings attach to? (**The whole infinitive**,
+as in the future.) Where have you seen *-ía/-ías/-íamos* before? (The **Ch.16
+imperfect** of *-er/-ir* verbs.) Why are they identical? (Because the conditional
+is the infinitive + the **imperfect of *haber***.) So what's the one-line summary
+of this chapter? (**Infinitive + *haber*** — present gives the future, imperfect
+gives the conditional.) Next: the nine verbs that bend the infinitive first.

--- a/code/learning/human-languages/spanish/lessons/ES-C17-futuro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-futuro.md
@@ -1,0 +1,100 @@
+---
+id: ES-C17-futuro
+chapter: 17
+type: word
+headword: hablaré
+gloss: the future — a compound tense that welded itself shut
+concept_tag: ES-FUTURE
+prerequisites: [ES-C16-practice, ES-C10-ir-a-futuro]
+sounds: [accent-acute, stress-final]
+roots: [latin-infinitive-habere]
+etymology_hook: "hablaré is hablar + he — the infinitive plus the present of haber, 'I HAVE to speak' → 'I will speak'; Latin's own future (amābō) died and Romance built a compound to replace it, which then FUSED into a single word, so the endings -é/-ás/-á/-emos/-án are a whole verb worn down to a suffix"
+est_minutes: 5
+reviews_of: [ES-C16-practice, ES-C10-ir-a-futuro, ES-C06-hablar]
+---
+
+# hablaré — the future, welded shut
+
+## Warm-up
+
+[PAUSE 2s] Chapter 10 gave you one future (*voy a hablar*). Here is the other —
+and it has the best origin story of any Spanish tense.
+
+## The forms
+
+Take the **whole infinitive** and add the endings:
+
+| | |
+|---|---|
+| yo | hablar**é** |
+| tú | hablar**ás** |
+| él/ella/usted | hablar**á** |
+| nosotros | hablar**emos** |
+| ellos/ustedes | hablar**án** |
+
+Notice something odd: you don't drop *-ar* first. Every other tense you've
+learned strips the ending off. **The future keeps the infinitive whole** and
+builds on top of it — *comer* → *comeré*, *vivir* → *viviré*. One set of endings
+for all three conjugations.
+
+## Why the infinitive survives
+
+Latin's own future — *amābō*, "I will love" — **died out**. Speakers replaced it
+with a phrase:
+
+> ***amāre habeō*** — "I **have** to love" → "I will love"
+
+Infinitive + the verb *habēre*, "to have." Exactly the English "I **have to**
+go," which also slides toward the future.
+
+Then the phrase **fused**. Say *hablar he* fast enough, often enough, for enough
+centuries, and it becomes one word:
+
+| stage | form |
+|---|---|
+| two words | *hablar* + *he* |
+| squeezed | *hablar-he* |
+| welded | **hablaré** |
+
+So the endings aren't endings at all, historically. They are the present tense of
+*haber* worn down to a suffix:
+
+| *haber* (present) | future ending |
+|---|---|
+| he | -**é** |
+| has | -**ás** |
+| ha | -**á** |
+| hemos | -**emos** |
+| han | -**án** |
+
+Line them up and they're the same list. **A compound tense that closed up into a
+simple one** — the exact reverse of what French and Italian did with their
+compound past, which stayed open as two words.
+
+## The seam is still visible in Portuguese
+
+Portuguese welded its future too (*falarei* is one word). But in **formal European
+Portuguese** a pronoun can still be lodged **inside** it:
+
+> **falá-lo-ei** — "I will speak it"
+
+That *-lo-* is sitting in the join, between *falar* and *ei*. A leftover, not the
+normal pattern — Brazilian Portuguese doesn't do it, and neither does speech. But
+it shows the seam Spanish sealed over completely is still faintly open next door.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hablaré, hablarás, hablará, hablaremos, hablarán"]
+- [YOU SAY: "comeré, viviré" — the infinitive stays whole]
+- [YOU SAY: the weld — "hablar + he → hablaré"]
+- [YOU SAY: the two futures — "voy a hablar … hablaré"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What do you add the future endings to? (**The whole infinitive** — you
+don't strip it.) What happened to Latin's own future? (It **died**; Romance
+replaced it with a phrase.) What was that phrase? (**Infinitive + *habēre***,
+"I have to speak.") So what are the endings really? (**The present of *haber***,
+fused on.) Which language still shows the seam? (**Portuguese** — *falá-lo-ei*.)
+Next: the same trick, with a different tense of *haber*.

--- a/code/learning/human-languages/spanish/lessons/ES-C17-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-practice.md
@@ -1,0 +1,105 @@
+---
+id: ES-C17-practice
+chapter: 17
+type: practice-mix
+headword: (practice)
+gloss: the ten irregular stems that serve both tenses — and the future that isn't about the future
+concept_tag: CH17-PRACTICE
+prerequisites: [ES-C17-futuro, ES-C17-condicional]
+sounds: [epenthetic-d]
+roots: []
+est_minutes: 5
+reviews_of: [ES-C17-futuro, ES-C17-condicional, ES-C13-practice, ES-C12-yo-go]
+---
+
+# Practice — ten stems, two tenses
+
+## Warm-up
+
+[PAUSE 2s] A handful of verbs bend the infinitive before welding. The good news:
+**the same bent stem serves both tenses**, so you learn ten shapes once and get
+twenty conjugations.
+
+## The ten, in three families
+
+**1. Drop the vowel.** The infinitive's last vowel just goes:
+
+| verb | stem | future | conditional |
+|---|---|---|---|
+| poder | pod**r**- | podré | podría |
+| querer | quer**r**- | querré | querría |
+| saber | sab**r**- | sabré | sabría |
+| haber | hab**r**- | habré | habría |
+
+**2. Drop the vowel, then wedge in a d.** Dropping alone would leave *-n'r-* or
+*-l'r-* right here, and Old Spanish refused to leave it that way — so a **d**
+slid in to prop the cluster apart:
+
+| verb | would be | becomes | future |
+|---|---|---|---|
+| tener | *ten-r-* | ten**d**r- | tendré |
+| poner | *pon-r-* | pon**d**r- | pondré |
+| venir | *ven-r-* | ven**d**r- | vendré |
+| salir | *sal-r-* | sal**d**r- | saldré |
+
+(Not that modern Spanish can't say those clusters — *honra*, *sonrisa*,
+*alrededor* are fine. It's that when this particular squeeze happened, the
+language fixed it. It even tried a **second** solution first: medieval Spanish
+also said **terné**, **porné**, **verné**, swapping the consonants around instead.
+The *d*-forms won.)
+
+Recognise those four? Every one is a member of the **-go club** from Chapters
+12–13. The club had six — and the other two, *hacer* and *decir*, are sitting in
+family 3 below. So **all six of the -go verbs are irregular here too**; they just
+split into two shapes. The oldest, most-used verbs misbehave in the same places
+over and over.
+
+**3. Chop hard.** Two verbs shorten drastically:
+
+| verb | future | conditional |
+|---|---|---|
+| decir | **diré** | diría |
+| hacer | **haré** | haría |
+
+## The test
+
+Every irregular here is irregular in the **stem only**. The endings never change:
+
+> **irregular stem + the same -é/-ás/-á… or -ía/-ías…**
+
+## The future that isn't about the future
+
+One more use, and it surprises everyone. Spanish uses the **future** to express
+**present guessing**:
+
+| Spanish | means |
+|---|---|
+| *¿Dónde **estará** Juan?* | "Where **can** Juan be?" (right now) |
+| ***Serán** las tres.* | "It **must be** three o'clock." |
+| *¿Quién **será**?* | "Who **could** that be?" |
+
+And the **conditional** does the same for the **past**:
+
+> ***Serían** las tres cuando llegó.* — "It **must have been** three when he arrived."
+
+If you remember that these tenses were built from "**I have to…**," the leap makes
+sense: *have to* is about **obligation and likelihood**, not only time.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the d-group — "tendré, pondré, vendré, saldré"]
+- [YOU SAY: the choppers — "diré, haré"]
+- [YOU SAY: one verb, both tenses — "tendré … tendría"]
+- [YOU SAY: the guess — "¿Dónde estará?" ("Where can he be?")]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Do the irregulars change the endings or the stem? (**The stem only**.)
+Why does *tener* become *tendr-*? (Dropping the vowel squeezed *-n'r-* together,
+and a **d** wedged in to fix it — medieval Spanish also tried *terné*.) How do the
+**-go club** verbs fare here? (**All six are irregular** — four take the *-dr-*,
+and *hacer/decir* chop instead.) Which two verbs chop hardest? (**Decir → diré**,
+**hacer → haré**.) What does *Serán las tres* mean? ("It **must be** three" — the
+future used for **guessing**.) Next chapter: the subjunctive — the mood for
+things that aren't facts.

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -132,7 +132,30 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   where the choice changes the **meaning** (*sabía* "knew" vs *supe* "found out";
   *conocía* "knew" vs *conocí* "met"). **Authored.**
 
-Next: **Ch. 17** — the **future** and the conditional; then everyday description,
+- **Ch. 17 — The future and the conditional, or one weld twice**: the **future**
+  *hablaré/hablarás/hablará/hablaremos/hablarán*, built on the **whole
+  infinitive** (uniquely, you don't strip the ending) with **one** ending set for
+  all three conjugations. The etymology is the chapter: Latin's own future
+  (*amābō*) **died**, Romance replaced it with **infinitive + *habēre*** (*amāre
+  habeō*, "I **have to** love" → "I will love"), and the phrase then **fused into a
+  single word** — so the endings *-é/-ás/-á/-emos/-án* are literally the present of
+  *haber* (*he/has/ha/hemos/han*) worn down to a suffix. **A compound tense that
+  closed up into a simple one** — the mirror image of the parallel-4 tracks' Ch. 15
+  compound past, which stayed open as two words. And the seam is still visible next
+  door: Portuguese *falá-**lo**-ei* drops a pronoun **inside** the join → the
+  **conditional** *hablaría* — the **same weld** with the **imperfect** of *haber*
+  instead of the present, which is exactly why its endings are the *-ía/-ías/
+  -íamos/-ían* of Ch. 16's imperfect. One trick, two tenses of one auxiliary →
+  practice on the **ten irregular stems**, which fall into three families
+  (drop-the-vowel *podré/sabré*; drop-then-**wedge-a-d** *tendré/pondré/vendré/
+  saldré*, where Old Spanish refused to leave the squeezed *-n'r-* alone and even
+  tried *terné/porné* first; and the choppers *diré/haré*) — with the payoff that
+  the **same bent stem serves both tenses**, and that **all six -go club** verbs of
+  Ch. 12–13 turn up here, split between the *-dr-* group and the choppers. Closes on the **future of
+  probability** (*Serán las tres* = "it **must be** three"), which makes sense once
+  you know the tense was built from "I **have to**." **Authored.**
+
+Next: **Ch. 18** — the **subjunctive**, the mood for what isn't fact; then everyday description,
 building toward real conversation.
 From here the course hands over rules, not phrases. Grammar accumulates piece by
 piece. The theme skeleton below plans the wider road.


### PR DESCRIPTION
Two tenses that turn out to be **one construction**.

**`ES-C17-futuro`** — *hablaré…hablarán*, built on the **whole infinitive** (the one
tense that doesn't strip the ending), with a single ending set for all three
conjugations. The etymology carries the lesson: Latin's own synthetic future
(***amābō***) **died**, and Romance replaced it with a phrase — **infinitive +
*habēre*** (*amāre habeō*, "I **have to** love"), exactly parallel to English *I have
to go* drifting toward futurity. Then the phrase **fused**: *hablar he* → *hablar-he*
→ **hablaré**. So the endings aren't endings historically — they're the **present of
*haber*** (*he/has/ha/hemos/han*) worn down to a suffix, and the two lists line up
exactly. **A compound tense that closed up into a simple one** — the mirror image of
the parallel-4 tracks' Ch.15 compound past, which stayed open as two words.

**`ES-C17-condicional`** — *hablaría*: the **same weld**, with the **imperfect** of
*haber* swapped in for the present, which is precisely why its endings are the
***-ía/-ías/-íamos/-ían*** already met as Ch.16's imperfect. One trick, two tenses of
one auxiliary. Covers hypothetical *would*, politeness (*¿podrías?*, *me gustaría*),
and **future-in-the-past** (*dijo que hablaría*).

**`ES-C17-practice`** — the **ten irregular stems** in three families: drop-the-vowel
(*podré, querré, sabré, habré*), drop-then-**wedge-a-d** (*tendré, pondré, vendré,
saldré*), and the choppers (**diré, haré**). Payoffs: the **same bent stem serves both
tenses**, and **all six** *-go club* verbs of Ch.12–13 resurface here. Ends on the
**future of probability** (*Serán las tres* = "it **must be** three"), which follows
naturally from a tense built out of "I **have to**."

*Note:* `haber` has no lesson of its own yet, so it appears here as **etymology**,
with its forms shown as evidence — not as a paradigm the learner must produce.

### Corrections from the review pass

Asking the review subagent for factual notes alongside security caught real errors again:

- **The stem count was wrong** — ten verbs listed under a "nine" heading, in the
  lesson, roadmap *and* CHANGELOG. Now **ten stems / twenty conjugations**.
- **"The *-dr-* group IS the *-go* club" contradicted our own `ES-C12-yo-go`**, which
  defines the club as **six** verbs. Only four take *-dr-*; *hacer* and *decir* are
  the choppers. Reworded — and the corrected claim is **stronger**: all six *-go*
  verbs are irregular here, split across two families.
- **"*-nr-/-lr-* is a cluster Spanish won't say" is false** (*honra*, *sonrisa*,
  *alrededor*). Narrowed to the actual history: Old Spanish resolved the squeeze in
  *these forms*, and first tried **metathesis** (*terné, porné, verné*) before the
  *d*-forms won — a better story anyway.
- ***haber*'s future cell showed *habrá*** (3sg) among 1sg forms; now *habré*.
- **Mesoclisis** narrowed to **formal European** Portuguese and described as a
  leftover, not evidence the weld "never finished" (*falarei* is one word).
- The conditional's fused element was the older reduced ***avía***, not modern
  *había*.

Taxonomy: namespaced `ES-FUTURE`, `ES-CONDITIONAL`; practice label `CH17-PRACTICE`.
Roadmap (Ch.17 authored, Next Ch.18 = the subjunctive) and CHANGELOG updated.

Suite green at **38/38**; retired-concept-tag sweep clean. Security-reviewed: PASS, no
security findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)