### PR TITLE
Add Haskell SQL CSV source port

### DIFF
--- a/code/packages/haskell/sql-csv-source/BUILD
+++ b/code/packages/haskell/sql-csv-source/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/sql-csv-source/BUILD_windows
+++ b/code/packages/haskell/sql-csv-source/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/sql-csv-source/CHANGELOG.md
+++ b/code/packages/haskell/sql-csv-source/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Load every CSV file in a selected directory into an immutable SQL data source.
+- Parse quoted RFC 4180-style fields and validate header and row widths.
+- Coerce null, boolean, integer, real, and text values into the shared SQL types.
+- Execute queries through the existing Haskell `sql-execution-engine` package.

--- a/code/packages/haskell/sql-csv-source/README.md
+++ b/code/packages/haskell/sql-csv-source/README.md
@@ -1,0 +1,31 @@
+# sql-csv-source (Haskell)
+
+A filesystem adapter for the Haskell `sql-execution-engine`. Each `name.csv`
+file in a selected directory becomes a queryable SQL table named `name`.
+
+```haskell
+import SqlCsvSource
+
+main = do
+  result <- executeCsv
+    "SELECT name FROM employees WHERE active = true"
+    "data"
+  print result
+```
+
+`loadCsvDataSource` is the explicit IO boundary: it lists and reads the CSV
+files once, validates their records, coerces values into `SqlValue`, and
+returns an immutable snapshot. `csvDataSource` then exposes that snapshot
+through the execution engine's pure `DataSource` callbacks.
+
+The package handles quoted commas, escaped quotes, embedded newlines, CRLF,
+header ordering, and row-width validation. Coercion follows the shared lane
+contract: empty fields become SQL `NULL`, booleans are case-insensitive,
+integers and finite real numbers become numeric values, and all remaining
+fields stay text.
+
+## Development
+
+```sh
+cabal test all --enable-coverage
+```

--- a/code/packages/haskell/sql-csv-source/cabal.project
+++ b/code/packages/haskell/sql-csv-source/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../sql-execution-engine

--- a/code/packages/haskell/sql-csv-source/required_capabilities.json
+++ b/code/packages/haskell/sql-csv-source/required_capabilities.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "haskell/sql-csv-source",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads CSV data files from a user-supplied directory to serve as SQL tables."
+    },
+    {
+      "category": "fs",
+      "action": "list",
+      "target": "*",
+      "justification": "Lists a user-supplied directory to discover queryable CSV tables."
+    }
+  ],
+  "justification": "Reads and lists CSV files under a caller-selected directory. It does not write files, access the network, or spawn processes."
+}

--- a/code/packages/haskell/sql-csv-source/sql-csv-source.cabal
+++ b/code/packages/haskell/sql-csv-source/sql-csv-source.cabal
@@ -1,0 +1,43 @@
+cabal-version: 3.0
+name:          sql-csv-source
+version:       0.1.0
+synopsis:      CSV-backed data source for the educational SQL engine
+description:   Loads CSV files into typed rows and exposes them through the existing Haskell SQL execution engine.
+category:      Database
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+extra-source-files:
+    required_capabilities.json
+
+library
+    exposed-modules:  SqlCsvSource
+    build-depends:    base >=4.14 && <5
+                    , containers >=0.6 && <0.9
+                    , directory >=1.3 && <2
+                    , filepath >=1.4 && <2
+                    , sql-execution-engine >=0.1 && <0.2
+                    , text >=1.2 && <3
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    SqlCsvSourceSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , containers >=0.6 && <0.9
+                    , directory >=1.3 && <2
+                    , filepath >=1.4 && <2
+                    , hspec ==2.*
+                    , sql-csv-source
+                    , sql-execution-engine >=0.1 && <0.2
+                    , text >=1.2 && <3
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/sql-csv-source/src/SqlCsvSource.hs
+++ b/code/packages/haskell/sql-csv-source/src/SqlCsvSource.hs
@@ -1,0 +1,271 @@
+-- | CSV-backed tables for the educational Haskell SQL execution engine.
+module SqlCsvSource
+    ( CsvDataSource
+    , csvDirectory
+    , loadCsvDataSource
+    , csvDataSource
+    , csvSchema
+    , csvScan
+    , executeCsv
+    , tryExecuteCsv
+    , coerceCsvValue
+    , parseCsv
+    , version
+    ) where
+
+import Control.Exception (IOException, displayException, try)
+import Control.Monad (filterM)
+import Data.Char (isSpace, toLower)
+import Data.List (nub, sort)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
+import SqlExecutionEngine
+    ( DataSource(..)
+    , ExecutionResult(..)
+    , QueryResult
+    , Row
+    , SqlExecutionError(..)
+    , SqlValue(..)
+    , execute
+    )
+import System.Directory (doesFileExist, listDirectory)
+import System.FilePath ((</>), dropExtension, takeExtension)
+import Text.Read (readMaybe)
+
+-- | Package version shared with the established implementations.
+version :: String
+version = "0.1.0"
+
+-- | An immutable snapshot of every CSV table found in one directory.
+data CsvDataSource = CsvDataSource
+    { csvDirectory :: FilePath
+    , sourceSchemas :: Map.Map String [String]
+    , sourceTables :: Map.Map String [Row]
+    } deriving (Eq, Show)
+
+-- | List and load every @*.csv@ file in a directory.
+--
+-- File IO is completed here so the resulting 'DataSource' callbacks remain
+-- pure, matching the existing SQL execution engine contract.
+loadCsvDataSource :: FilePath -> IO (Either SqlExecutionError CsvDataSource)
+loadCsvDataSource directory = do
+    listing <- listDirectoryChecked directory
+    case listing of
+        Left failure -> pure (Left (ioErrorMessage "reading CSV directory" directory failure))
+        Right entries -> do
+            let csvEntries = sort
+                    [ entry
+                    | entry <- entries
+                    , map toLower (takeExtension entry) == ".csv"
+                    ]
+            files <- filterM (doesFileExist . (directory </>)) csvEntries
+            loaded <- mapM (loadTable directory) files
+            pure (buildSource directory =<< sequence loaded)
+
+-- | Convert a loaded snapshot to the engine's pure data-source record.
+csvDataSource :: CsvDataSource -> DataSource
+csvDataSource source = DataSource
+    { dataSourceSchema = csvSchema source
+    , dataSourceScan = csvScan source
+    }
+
+-- | Look up a table's columns in header order.
+csvSchema :: CsvDataSource -> String -> Either SqlExecutionError [String]
+csvSchema source tableName =
+    maybe (Left (tableNotFound tableName)) Right
+        (Map.lookup tableName (sourceSchemas source))
+
+-- | Look up all typed rows for a table.
+csvScan :: CsvDataSource -> String -> Either SqlExecutionError [Row]
+csvScan source tableName =
+    maybe (Left (tableNotFound tableName)) Right
+        (Map.lookup tableName (sourceTables source))
+
+-- | Load a directory snapshot and execute one SQL query against it.
+executeCsv
+    :: String
+    -> FilePath
+    -> IO (Either SqlExecutionError QueryResult)
+executeCsv sql directory = do
+    loaded <- loadCsvDataSource directory
+    pure (loaded >>= execute sql . csvDataSource)
+
+-- | Total convenience wrapper matching the execution engine's result shape.
+tryExecuteCsv :: String -> FilePath -> IO ExecutionResult
+tryExecuteCsv sql directory = do
+    result <- executeCsv sql directory
+    pure $ case result of
+        Left failure -> ExecutionResult
+            { executionOk = False
+            , executionResult = Nothing
+            , executionError = Just (sqlExecutionMessage failure)
+            }
+        Right queryResult -> ExecutionResult
+            { executionOk = True
+            , executionResult = Just queryResult
+            , executionError = Nothing
+            }
+
+-- | Parse one CSV document into a header and typed rows.
+parseCsv :: String -> Either SqlExecutionError ([String], [Row])
+parseCsv source = do
+    records <- parseCsvRecords source
+    case records of
+        [] -> Right ([], [])
+        rawHeader : rawRows -> do
+            let header = case map trim rawHeader of
+                    [""] -> []
+                    columns -> columns
+            validateHeader header
+            rows <- traverse (uncurry (recordToRow header))
+                (zip [2 :: Int ..] rawRows)
+            Right (header, rows)
+
+-- | Coerce one untyped CSV field into the engine's SQL value family.
+coerceCsvValue :: String -> SqlValue
+coerceCsvValue value
+    | null value = SqlNull
+    | lowered == "true" = SqlBool True
+    | lowered == "false" = SqlBool False
+    | Just integer <- readMaybe value = SqlInteger integer
+    | Just real <- readMaybe value
+    , not (isNaN real || isInfinite real) = SqlReal real
+    | otherwise = SqlText value
+  where
+    lowered = map toLower value
+
+loadTable
+    :: FilePath
+    -> FilePath
+    -> IO (Either SqlExecutionError (String, [String], [Row]))
+loadTable directory entry = do
+    let path = directory </> entry
+        tableName = dropExtension entry
+    content <- readUtf8 path
+    pure $ case content of
+        Left failure -> Left (ioErrorMessage "reading CSV table" path failure)
+        Right text -> do
+            (columns, rows) <- firstContext tableName (parseCsv (Text.unpack text))
+            Right (tableName, columns, rows)
+
+buildSource
+    :: FilePath
+    -> [(String, [String], [Row])]
+    -> Either SqlExecutionError CsvDataSource
+buildSource directory tables
+    | length normalizedNames /= length (nub normalizedNames) =
+        Left (csvError "CSV table names collide when compared case-insensitively")
+    | otherwise = Right CsvDataSource
+        { csvDirectory = directory
+        , sourceSchemas = Map.fromList
+            [(name, columns) | (name, columns, _) <- tables]
+        , sourceTables = Map.fromList
+            [(name, rows) | (name, _, rows) <- tables]
+        }
+  where
+    normalizedNames = map (map toLower . firstOf3) tables
+    firstOf3 (name, _, _) = name
+
+validateHeader :: [String] -> Either SqlExecutionError ()
+validateHeader [] = Right ()
+validateHeader header
+    | any null header = Left (csvError "CSV header contains an empty column name")
+    | length header /= length (nub header) =
+        Left (csvError "CSV header contains duplicate column names")
+    | otherwise = Right ()
+
+recordToRow
+    :: [String]
+    -> Int
+    -> [String]
+    -> Either SqlExecutionError Row
+recordToRow header rowNumber fields
+    | length fields /= length header = Left (csvError
+        ("CSV row " ++ show rowNumber ++ " has " ++ show (length fields)
+            ++ " fields; expected " ++ show (length header)))
+    | otherwise = Right (Map.fromList
+        (zip header (map coerceCsvValue fields)))
+
+-- A small strict record parser keeps this adapter useful even though the
+-- current Haskell csv-parser package is still a token-level starter wrapper.
+data CsvMode = FieldStart | UnquotedField | QuotedField | AfterQuote
+    deriving (Eq, Show)
+
+parseCsvRecords :: String -> Either SqlExecutionError [[String]]
+parseCsvRecords = go FieldStart [] [] [] False . stripBom
+  where
+    go mode field fields records touched remaining = case remaining of
+        [] -> finishInput mode field fields records touched
+        '\r' : '\n' : rest -> lineBreak mode field fields records rest
+        '\r' : rest -> lineBreak mode field fields records rest
+        '\n' : rest -> lineBreak mode field fields records rest
+        '"' : '"' : rest
+            | mode == QuotedField ->
+                go QuotedField ('"' : field) fields records True rest
+        '"' : rest -> case mode of
+            FieldStart -> go QuotedField field fields records True rest
+            QuotedField -> go AfterQuote field fields records True rest
+            UnquotedField -> Left (csvError "unexpected quote in unquoted CSV field")
+            AfterQuote -> Left (csvError "unexpected quote after closing CSV quote")
+        ',' : rest -> case mode of
+            QuotedField -> go QuotedField (',' : field) fields records True rest
+            _ -> go FieldStart [] (reverse field : fields) records True rest
+        character : rest -> case mode of
+            FieldStart -> go UnquotedField [character] fields records True rest
+            UnquotedField -> go UnquotedField (character : field) fields records True rest
+            QuotedField -> go QuotedField (character : field) fields records True rest
+            AfterQuote
+                | character == ' ' || character == '\t' ->
+                    go AfterQuote field fields records True rest
+                | otherwise -> Left (csvError
+                    ("unexpected character " ++ show character
+                        ++ " after closing CSV quote"))
+
+    lineBreak QuotedField field fields records rest =
+        go QuotedField ('\n' : field) fields records True rest
+    lineBreak _ field fields records rest =
+        go FieldStart [] []
+            (finishRecord field fields : records) False rest
+
+    finishInput QuotedField _ _ _ _ =
+        Left (csvError "unclosed quoted CSV field")
+    finishInput _ field fields records touched
+        | touched || not (null field) || not (null fields) =
+            Right (reverse (finishRecord field fields : records))
+        | otherwise = Right (reverse records)
+
+    finishRecord field fields = reverse (reverse field : fields)
+
+stripBom :: String -> String
+stripBom ('\xfeff' : rest) = rest
+stripBom text = text
+
+trim :: String -> String
+trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+
+tableNotFound :: String -> SqlExecutionError
+tableNotFound name = csvError ("table not found: " ++ name)
+
+csvError :: String -> SqlExecutionError
+csvError = SqlExecutionError
+
+firstContext
+    :: String
+    -> Either SqlExecutionError value
+    -> Either SqlExecutionError value
+firstContext tableName result = case result of
+    Left failure -> Left (csvError
+        ("parsing CSV table " ++ tableName ++ ": "
+            ++ sqlExecutionMessage failure))
+    Right value -> Right value
+
+ioErrorMessage :: String -> FilePath -> IOException -> SqlExecutionError
+ioErrorMessage action path failure = csvError
+    (action ++ " " ++ show path ++ ": " ++ displayException failure)
+
+listDirectoryChecked :: FilePath -> IO (Either IOException [FilePath])
+listDirectoryChecked = try . listDirectory
+
+readUtf8 :: FilePath -> IO (Either IOException Text.Text)
+readUtf8 = try . TextIO.readFile

--- a/code/packages/haskell/sql-csv-source/test/Spec.hs
+++ b/code/packages/haskell/sql-csv-source/test/Spec.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import qualified SqlCsvSourceSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec SqlCsvSourceSpec.spec

--- a/code/packages/haskell/sql-csv-source/test/SqlCsvSourceSpec.hs
+++ b/code/packages/haskell/sql-csv-source/test/SqlCsvSourceSpec.hs
@@ -1,0 +1,242 @@
+module SqlCsvSourceSpec (spec) where
+
+import Control.Exception (bracket)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
+import SqlCsvSource
+import SqlExecutionEngine
+import System.Directory
+    ( createDirectory
+    , getTemporaryDirectory
+    , removeFile
+    , removePathForcibly
+    )
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "metadata" $
+        it "reports the shared package version" $
+            version `shouldBe` "0.1.0"
+
+    describe "coerceCsvValue" $ do
+        it "coerces empty and case-insensitive boolean fields" $ do
+            coerceCsvValue "" `shouldBe` SqlNull
+            coerceCsvValue "true" `shouldBe` SqlBool True
+            coerceCsvValue "TRUE" `shouldBe` SqlBool True
+            coerceCsvValue "False" `shouldBe` SqlBool False
+
+        it "coerces integer and finite real fields" $ do
+            coerceCsvValue "42" `shouldBe` SqlInteger 42
+            coerceCsvValue "-7" `shouldBe` SqlInteger (-7)
+            coerceCsvValue "0" `shouldBe` SqlInteger 0
+            coerceCsvValue "3.14" `shouldBe` SqlReal 3.14
+
+        it "preserves non-numeric and non-finite text" $ do
+            coerceCsvValue "hello" `shouldBe` SqlText "hello"
+            coerceCsvValue "Alice Smith" `shouldBe` SqlText "Alice Smith"
+            coerceCsvValue "NaN" `shouldBe` SqlText "NaN"
+            coerceCsvValue "Infinity" `shouldBe` SqlText "Infinity"
+
+    describe "parseCsv" $ do
+        it "parses headers and typed rows" $ do
+            (columns, rows) <- expectRight (parseCsv
+                "id,name,active,score\n1,Alice,true,9.5\n2,Bob,false,8")
+            columns `shouldBe` ["id", "name", "active", "score"]
+            rows `shouldBe`
+                [ row
+                    [ "id" .= SqlInteger 1
+                    , "name" .= SqlText "Alice"
+                    , "active" .= SqlBool True
+                    , "score" .= SqlReal 9.5
+                    ]
+                , row
+                    [ "id" .= SqlInteger 2
+                    , "name" .= SqlText "Bob"
+                    , "active" .= SqlBool False
+                    , "score" .= SqlInteger 8
+                    ]
+                ]
+
+        it "supports quoted commas, escaped quotes, embedded newlines, and CRLF" $ do
+            (columns, rows) <- expectRight (parseCsv
+                "id,display_name,note\r\n1,\"Ada, Jr.\",\"hello \"\"world\"\"\"\r\n2,Bob,\"two\nlines\"\r\n")
+            columns `shouldBe` ["id", "display_name", "note"]
+            Map.lookup "display_name" (head rows) `shouldBe`
+                Just (SqlText "Ada, Jr.")
+            Map.lookup "note" (head rows) `shouldBe`
+                Just (SqlText "hello \"world\"")
+            Map.lookup "note" (last rows) `shouldBe`
+                Just (SqlText "two\nlines")
+
+        it "accepts empty and header-only documents" $ do
+            parseCsv "" `shouldBe` Right ([], [])
+            parseCsv "\n" `shouldBe` Right ([], [])
+            parseCsv "id,name\n" `shouldBe` Right (["id", "name"], [])
+
+        it "rejects malformed quotes and row widths" $ do
+            parseCsv "id,name\n1,\"Alice" `shouldSatisfy` isLeftContaining "unclosed quoted"
+            parseCsv "id,name\n1" `shouldSatisfy` isLeftContaining "has 1 fields; expected 2"
+            parseCsv "id,\"na\"me\n" `shouldSatisfy` isLeftContaining "after closing CSV quote"
+
+        it "rejects empty and duplicate header names" $ do
+            parseCsv "id,,name\n1,2,Alice" `shouldSatisfy`
+                isLeftContaining "empty column name"
+            parseCsv "id,name,id\n1,Alice,2" `shouldSatisfy`
+                isLeftContaining "duplicate column names"
+
+    describe "filesystem snapshot" $
+        around withFixtureDirectory $ do
+            it "loads CSV files and ignores other extensions" $ \directory -> do
+                source <- loadSource directory
+                csvDirectory source `shouldBe` directory
+                csvSchema source "employees" `shouldBe`
+                    Right ["id", "name", "dept_id", "salary", "active"]
+                fmap length (csvScan source "employees") `shouldBe` Right 4
+                csvSchema source "notes" `shouldSatisfy`
+                    isLeftContaining "table not found: notes"
+
+            it "scans rows with typed values and SQL NULL" $ \directory -> do
+                source <- loadSource directory
+                rows <- expectRight (csvScan source "employees")
+                Map.lookup "id" (head rows) `shouldBe` Just (SqlInteger 1)
+                Map.lookup "name" (head rows) `shouldBe` Just (SqlText "Alice")
+                Map.lookup "salary" (head rows) `shouldBe` Just (SqlInteger 90000)
+                Map.lookup "active" (head rows) `shouldBe` Just (SqlBool True)
+                Map.lookup "dept_id" (last rows) `shouldBe` Just SqlNull
+
+            it "reports missing tables through both source callbacks" $ \directory -> do
+                source <- loadSource directory
+                csvSchema source "ghosts" `shouldSatisfy`
+                    isLeftContaining "table not found: ghosts"
+                csvScan source "ghosts" `shouldSatisfy`
+                    isLeftContaining "table not found: ghosts"
+
+            it "executes filtered and ordered projections" $ \directory -> do
+                result <- executeRight
+                    "SELECT name, salary FROM employees WHERE active = true AND salary > 70000 ORDER BY salary DESC"
+                    directory
+                resultColumns result `shouldBe` ["name", "salary"]
+                resultRows result `shouldBe`
+                    [ [SqlText "Alice", SqlInteger 90000]
+                    , [SqlText "Bob", SqlInteger 75000]
+                    ]
+
+            it "supports null predicates" $ \directory -> do
+                result <- executeRight
+                    "SELECT name FROM employees WHERE dept_id IS NULL"
+                    directory
+                resultRows result `shouldBe` [[SqlText "Dave"]]
+
+            it "supports joins across CSV tables" $ \directory -> do
+                result <- executeRight
+                    ("SELECT e.name AS employee, d.name AS department "
+                        ++ "FROM employees AS e INNER JOIN departments AS d "
+                        ++ "ON e.dept_id = d.id ORDER BY e.id")
+                    directory
+                resultColumns result `shouldBe` ["employee", "department"]
+                resultRows result `shouldBe`
+                    [ [SqlText "Alice", SqlText "Engineering"]
+                    , [SqlText "Bob", SqlText "Marketing"]
+                    , [SqlText "Carol", SqlText "Engineering"]
+                    ]
+
+            it "supports grouping, aggregates, and limits" $ \directory -> do
+                result <- executeRight
+                    ("SELECT dept_id, COUNT(*) AS count FROM employees "
+                        ++ "WHERE dept_id IS NOT NULL GROUP BY dept_id "
+                        ++ "ORDER BY dept_id LIMIT 2")
+                    directory
+                resultColumns result `shouldBe` ["dept_id", "count"]
+                resultRows result `shouldBe`
+                    [ [SqlInteger 1, SqlInteger 2]
+                    , [SqlInteger 2, SqlInteger 1]
+                    ]
+
+            it "returns total execution results for success and failure" $ \directory -> do
+                success <- tryExecuteCsv "SELECT name FROM employees LIMIT 1" directory
+                executionOk success `shouldBe` True
+                executionResult success `shouldSatisfy` maybe False (const True)
+                failure <- tryExecuteCsv "SELECT * FROM ghosts" directory
+                executionOk failure `shouldBe` False
+                executionError failure `shouldSatisfy`
+                    maybe False ("table not found: ghosts" `contains`)
+
+    describe "loading errors" $ do
+        it "reports a missing directory" $ do
+            result <- loadCsvDataSource "this-directory-does-not-exist-for-sql-csv-source"
+            result `shouldSatisfy` isLeftContaining "reading CSV directory"
+
+        it "adds table context to malformed CSV errors" $
+            withFixtureDirectory $ \directory -> do
+                TextIO.writeFile (directory </> "broken.csv")
+                    (Text.pack "id,name\n1,\"unclosed")
+                result <- loadCsvDataSource directory
+                result `shouldSatisfy`
+                    isLeftContaining "parsing CSV table broken"
+
+loadSource :: FilePath -> IO CsvDataSource
+loadSource directory = loadCsvDataSource directory >>= expectRight
+
+executeRight :: String -> FilePath -> IO QueryResult
+executeRight sql directory = executeCsv sql directory >>= expectRight
+
+withFixtureDirectory :: ActionWith FilePath -> IO ()
+withFixtureDirectory = bracket makeFixtureDirectory removePathForcibly
+
+makeFixtureDirectory :: IO FilePath
+makeFixtureDirectory = do
+    temporaryRoot <- getTemporaryDirectory
+    (directory, handle) <- openTempFile temporaryRoot "sql-csv-source-"
+    hClose handle
+    removeFile directory
+    createDirectory directory
+    TextIO.writeFile (directory </> "employees.csv") (Text.pack employeesCsv)
+    TextIO.writeFile (directory </> "departments.csv") (Text.pack departmentsCsv)
+    TextIO.writeFile (directory </> "notes.txt") (Text.pack "not a table")
+    pure directory
+
+employeesCsv :: String
+employeesCsv = unlines
+    [ "id,name,dept_id,salary,active"
+    , "1,Alice,1,90000,true"
+    , "2,Bob,2,75000,true"
+    , "3,Carol,1,95000,false"
+    , "4,Dave,,60000,true"
+    ]
+
+departmentsCsv :: String
+departmentsCsv = unlines
+    [ "id,name,budget"
+    , "1,Engineering,500000"
+    , "2,Marketing,200000"
+    ]
+
+(.=) :: String -> SqlValue -> (String, SqlValue)
+(.=) = (,)
+
+row :: [(String, SqlValue)] -> Row
+row = Map.fromList
+
+expectRight :: Show error => Either error value -> IO value
+expectRight (Right value) = pure value
+expectRight (Left failure) =
+    expectationFailure ("expected Right, got Left: " ++ show failure)
+        >> error "unreachable"
+
+isLeftContaining :: String -> Either SqlExecutionError value -> Bool
+isLeftContaining needle (Left failure) = needle `contains` sqlExecutionMessage failure
+isLeftContaining _ (Right _) = False
+
+contains :: String -> String -> Bool
+contains needle haystack = any (needle `prefixOf`) (tails haystack)
+  where
+    tails [] = [[]]
+    tails text@(_ : rest) = text : tails rest
+    prefixOf [] _ = True
+    prefixOf _ [] = False
+    prefixOf (left : leftRest) (right : rightRest) =
+        left == right && prefixOf leftRest rightRest

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -121,12 +121,12 @@ ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
 `point2d`, `affine2d`, `bezier2d`, and `arc2d`
 ports, followed by the Haskell `gradient-descent`, `perceptron`, and
 `type-checker-protocol` ports, and the Haskell `paint-vm-ascii`,
-`barcode-layout-1d`, `itf`, `code39`, `codabar`, `code128`, `upc-a`, and
-`ean-13` ports:
+`barcode-layout-1d`, `itf`, `code39`, `codabar`, `code128`, `upc-a`, `ean-13`,
+and `sql-csv-source` ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 282 |
+| Present in 10-15 languages | 172 | 281 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 712 | 9,968 |
@@ -172,7 +172,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 282
+The 172 packages present in at least ten implementation languages need 281
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -183,7 +183,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 7 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 6 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -677,6 +677,19 @@ and parity pattern, computed and supplied checks, ASCII and length guards,
 exact module geometry, metadata precedence, aliases, and shared validation
 paths. The package now spans 12 implementation lanes, reduces the
 high-consensus backlog to 282 slots, and leaves 7 gaps in the Haskell lane.
+
+The twenty-eighth Haskell high-consensus slice is complete: `sql-csv-source`
+now provides the filesystem adapter for the existing pure
+`sql-execution-engine`. It loads every CSV table through an explicit IO
+boundary, preserves header order in an immutable data-source snapshot, handles
+quoted commas, escaped quotes, embedded newlines, and CRLF, validates malformed
+records, and coerces null, boolean, integer, finite real, and text values into
+the shared SQL types. Its package-native suite exercises 19 examples with 89%
+expression and 86% alternative coverage, including parsing failures, missing
+directories and tables, typed scans, filters, ordering, null predicates, joins,
+grouping, aggregates, limits, and total result wrappers. The package now spans
+13 implementation lanes, reduces the high-consensus backlog to 281 slots, and
+leaves 6 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `sql-csv-source` package that snapshots CSV files behind the existing SQL engine's immutable `DataSource` interface
- parse quoted commas, escaped quotes, embedded newlines, and CRLF; validate headers and row widths; and coerce null, boolean, integer, finite-real, and text values
- cover typed scans and end-to-end filters, ordering, null predicates, joins, grouping, aggregates, limits, missing tables, and filesystem failures in 19 package-native examples
- declare the package's filesystem read/list capabilities and refresh the live parity roadmap to 281 high-consensus slots and 6 remaining Haskell gaps

The explicit `loadCsvDataSource` IO boundary reads each file once. Query execution after loading remains pure and delegates to the established Haskell `sql-execution-engine` package.

## Validation

- `cabal test all --enable-coverage` (19 adapter examples plus 8 dependency examples)
- HPC: 89% expressions, 86% alternatives
- `cabal check`
- `cabal sdist all`
- required-capabilities JSON parse and package assertion
- `python code/scripts/tests/test_package_parity_report.py` (6 tests)
- package parity reporter in Markdown, JSON, and CSV with `--fail-on-collisions`
- `git diff --check`
- generated artifact scan (0 package-local artifact directories)
