### PR TITLE
feat(spice): add diode forward depletion coefficient

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Diode forward-bias depletion coefficient** — diode model cards now accept
+  `FC` and apply the continuous Berkeley piecewise depletion-capacitance law in
+  AC and transient analysis, matching Rust and TypeScript.
+
 - **Bias-shaped diode depletion capacitance** — diode model cards now accept
   `VJ`/`PB` junction potential and `M`/`MJ` grading coefficient parameters and
   apply them to depletion capacitance in AC and transient analysis, matching
@@ -25,7 +29,7 @@
   `model_card_supported_parameter_coverage_gate_issue_records()`,
   `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
   `format_model_card_supported_parameter_coverage_gate_issue_json()` now
-  validate the expected seven-kind, 69-row supported-parameter catalog and
+  validate the expected seven-kind, 70-row supported-parameter catalog and
   expose stable issue rows for release automation, matching Rust and
   TypeScript.
 

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -204,9 +204,10 @@ disable the limiter.
 `bjt_from_model_card()`, `jfet_from_model_card()`, and
 `mosfet_from_model_card()` provide the shared `.model` alias surface for diode,
 BJT, JFET, and Level-1 MOS cards.
-Diode cards accept `VJ`/`PB` junction potential and `M`/`MJ` grading coefficient;
-AC and transient analyses use them to shape `CJO` depletion capacitance from the
-operating-point bias.
+Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
+and `FC` forward-bias depletion coefficient. AC and transient analyses use them
+to shape `CJO` depletion capacitance continuously around the `FC * VJ`
+transition.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -232,7 +233,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 69-row supported-parameter catalog and expose stable issue
+expected seven-kind, 70-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -490,6 +490,7 @@ class Diode:
     Tt: float = 0.0  # transit time / diffusion capacitance coefficient
     Vj: float = 1.0  # junction potential
     M: float = 0.5  # junction grading coefficient
+    Fc: float = 0.5  # forward-bias depletion coefficient
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -8651,6 +8651,10 @@ def _diode_effective_vt(el: Diode) -> float:
         raise ValueError(f"{el.name}: diode junction potential must be finite and positive")
     if not math.isfinite(el.M) or el.M < 0.0:
         raise ValueError(f"{el.name}: diode grading coefficient must be finite and non-negative")
+    if not math.isfinite(el.Fc) or el.Fc < 0.0 or el.Fc >= 1.0:
+        raise ValueError(
+            f"{el.name}: diode forward-bias depletion coefficient must be finite and in [0, 1)"
+        )
     if not math.isfinite(el.Tt) or el.Tt < 0.0:
         raise ValueError(f"{el.name}: diode transit time must be finite and non-negative")
     return el.Vt * el.N
@@ -8679,7 +8683,18 @@ def _diode_has_charge_storage(el: Diode) -> bool:
 
 def _diode_dynamic_capacitance(el: Diode, vd: float) -> float:
     _, gd = _diode_current_conductance(el, vd)
-    return bulk_junction_capacitance(el.Cjo, vd, el.Vj, el.M) + el.Tt * gd
+    return _diode_depletion_capacitance(el, vd) + el.Tt * gd
+
+
+def _diode_depletion_capacitance(el: Diode, vd: float) -> float:
+    if el.Cjo <= 0.0 or el.M == 0.0:
+        return el.Cjo
+    normalized_voltage = vd / el.Vj
+    if normalized_voltage < el.Fc:
+        return el.Cjo / ((1.0 - normalized_voltage) ** el.M)
+    transition_scale = (1.0 - el.Fc) ** (1.0 + el.M)
+    continuation = 1.0 - el.Fc * (1.0 + el.M) + el.M * normalized_voltage
+    return el.Cjo * continuation / transition_scale
 
 
 def _diode_charge_voltage(el: Diode, node_voltages: dict[str, float]) -> float:
@@ -12240,7 +12255,7 @@ def _stamp_ac(
         Vd = Va - Vk
         _, gd = _diode_current_conductance(el, Vd)
         diffusion_capacitance = el.Tt * gd
-        depletion_capacitance = bulk_junction_capacitance(el.Cjo, Vd, el.Vj, el.M)
+        depletion_capacitance = _diode_depletion_capacitance(el, Vd)
         _stamp_g_c(
             G,
             node_to_idx,
@@ -13775,6 +13790,7 @@ def sens_dc(
                     el.Tt,
                     el.Vj,
                     el.M,
+                    el.Fc,
                 ),
             )
 
@@ -14022,6 +14038,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             el.Tt,
             el.Vj,
             el.M,
+            el.Fc,
         )
 
     if isinstance(el, BJT):

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -306,7 +306,7 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
     "PMOS",
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
-    "D": (9, 15, 5, 3),
+    "D": (10, 16, 5, 3),
     "NPN": (7, 15, 4, 4),
     "PNP": (7, 15, 4, 4),
     "NJF": (5, 11, 5, 3),
@@ -349,6 +349,7 @@ _DIODE_PARAMETER_ALIASES: dict[str, str] = {
     "PB": "VJ",
     "M": "M",
     "MJ": "M",
+    "FC": "FC",
 }
 
 _BJT_PARAMETER_ALIASES: dict[str, str] = {
@@ -860,6 +861,7 @@ def diode_from_model_card(
         Tt=p.get("TT", 0.0),
         Vj=p.get("VJ", 1.0),
         M=p.get("M", 0.5),
+        Fc=p.get("FC", 0.5),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -410,7 +410,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 69
+    assert len(coverage) == 70
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -425,7 +425,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 69
+    assert len(records) == 70
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -442,8 +442,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     summary = model_card_supported_parameter_coverage_summary()
     assert len(summary) == 7
     assert summary[0].kind == "D"
-    assert summary[0].canonical_parameter_count == 9
-    assert summary[0].accepted_name_count == 15
+    assert summary[0].canonical_parameter_count == 10
+    assert summary[0].accepted_name_count == 16
     assert summary[0].aliased_parameter_count == 5
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
@@ -468,7 +468,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
         == "kind\tcanonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\taliased_parameters"
     )
-    assert table.splitlines()[1] == "D\t9\t15\t5\t3\tIS|VT|CJO|VJ|M"
+    assert table.splitlines()[1] == "D\t10\t16\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
         == "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -477,8 +477,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert len(records) == 7
     assert records[0] == {
         "kind": "D",
-        "canonical_parameter_count": "9",
-        "accepted_name_count": "15",
+        "canonical_parameter_count": "10",
+        "accepted_name_count": "16",
         "aliased_parameter_count": "5",
         "max_alias_count": "3",
         "aliased_parameters": "IS|VT|CJO|VJ|M",
@@ -486,7 +486,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert format_model_card_supported_parameter_coverage_summary_csv().startswith(
         "kind,canonical_parameter_count,accepted_name_count,"
         "aliased_parameter_count,max_alias_count,aliased_parameters\n"
-        "D,9,15,5,3,IS|VT|CJO|VJ|M\n"
+        "D,10,16,5,3,IS|VT|CJO|VJ|M\n"
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_summary_json())
@@ -499,9 +499,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 69
-    assert report.expected_canonical_parameter_count == 69
-    assert report.accepted_name_count == 117
+    assert report.canonical_parameter_count == 70
+    assert report.expected_canonical_parameter_count == 70
+    assert report.accepted_name_count == 118
     assert report.aliased_parameter_count == 35
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -509,7 +509,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t69\t69\t117\t35\t4\t0"
+        "true\t7\t7\t70\t70\t118\t35\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -537,8 +537,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 68
-    assert report.accepted_name_count == 114
+    assert report.canonical_parameter_count == 69
+    assert report.accepted_name_count == 115
     assert report.aliased_parameter_count == 34
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -553,7 +553,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t68\t69\t114\t34\t4\t4\n"
+        "false\t7\t7\t69\t70\t115\t34\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -590,6 +590,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "TT": 4.0e-9,
             "PB": 0.8,
             "MJ": 0.4,
+            "FC": 0.35,
             "RS": 10.0,
         },
     )
@@ -600,6 +601,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "TT": 4.0e-9,
         "VJ": 0.8,
         "M": 0.4,
+        "FC": 0.35,
     }
     assert diode_card.unsupported_parameters == ("RS",)
     diode_issues = model_card_unsupported_parameter_issues(diode_card)
@@ -634,6 +636,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert diode_model.Tt == pytest.approx(4.0e-9)
     assert diode_model.Vj == pytest.approx(0.8)
     assert pytest.approx(0.4) == diode_model.M
+    assert pytest.approx(0.35) == diode_model.Fc
 
     bjt_card = normalize_model_card("Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12})
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
@@ -3845,6 +3848,34 @@ def test_ac_diode_depletion_capacitance_falls_with_reverse_bias():
     reverse_biased = high_frequency_voltage(4.0)
 
     assert reverse_biased > zero_bias * 1.8
+
+
+def test_ac_diode_forward_depletion_coefficient_shapes_capacitance():
+    """FC controls the continuous forward-bias depletion continuation."""
+
+    def forward_biased_voltage(coefficient: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 0.75, ac=AcSource(1.0)))
+        c.add(Resistor("R1", "in", "node", 1000.0))
+        c.add(
+            Diode(
+                "D1",
+                anode="node",
+                cathode="0",
+                Is=1.0e-30,
+                Cjo=1.0e-6,
+                Vj=1.0,
+                M=0.5,
+                Fc=coefficient,
+            )
+        )
+        result = ac_sweep(c, f_start=1000.0, f_stop=1000.0, n_points=1)
+        return abs(result.points[0].node_voltages["node"])
+
+    early_transition = forward_biased_voltage(0.2)
+    late_transition = forward_biased_voltage(0.8)
+
+    assert late_transition < early_transition * 0.85
 
 
 def test_ac_diode_transit_time_shunts_forward_bias_at_high_frequency():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add diode model-card `FC` forward-bias depletion coefficient support and a
+  continuous piecewise depletion-capacitance law, matching Python and
+  TypeScript.
 - Shape diode depletion capacitance from the operating-point bias with model-card
   `VJ`/`PB` junction-potential and `M`/`MJ` grading-coefficient parameters in AC
   and transient analysis, matching Python and TypeScript.
@@ -18,7 +21,7 @@
   `model_card_supported_parameter_coverage_gate_issue_records`,
   `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
   `format_model_card_supported_parameter_coverage_gate_issue_json`, stable
-  release-gate checks and issue exports for the seven-kind, 69-row supported
+  release-gate checks and issue exports for the seven-kind, 70-row supported
   model-card parameter catalog, matching Python and TypeScript.
 - Add `model_card_supported_parameter_coverage_summary`,
   `format_model_card_supported_parameter_coverage_summary_table`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -121,9 +121,10 @@ BJT, and Level-1 MOSFET models before running an analysis.
 `normalize_model_card`, `diode_from_model_card`, `bjt_from_model_card`,
 `jfet_from_model_card`, and `mosfet_from_model_card` provide the shared
 `.model` alias surface for diode, BJT, JFET, and Level-1 MOS cards.
-Diode cards accept `VJ`/`PB` junction potential and `M`/`MJ` grading coefficient;
-AC and transient analyses use them to shape `CJO` depletion capacitance from the
-operating-point bias.
+Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
+and `FC` forward-bias depletion coefficient. AC and transient analyses use them
+to shape `CJO` depletion capacitance continuously around the `FC * VJ`
+transition.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -149,7 +150,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 69-row supported-parameter catalog and expose stable issue
+expected seven-kind, 70-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2347,6 +2347,7 @@ pub struct Diode {
     pub transit_time: f64,
     pub junction_potential: f64,
     pub grading_coefficient: f64,
+    pub forward_bias_depletion_coefficient: f64,
 }
 
 impl Diode {
@@ -2440,6 +2441,39 @@ impl Diode {
         junction_potential: f64,
         grading_coefficient: f64,
     ) -> Self {
+        Self::with_model_and_forward_depletion(
+            name,
+            anode,
+            cathode,
+            saturation_current,
+            thermal_voltage,
+            emission_coefficient,
+            breakdown_voltage,
+            breakdown_current,
+            junction_capacitance,
+            transit_time,
+            junction_potential,
+            grading_coefficient,
+            0.5,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_and_forward_depletion(
+        name: impl Into<String>,
+        anode: impl Into<String>,
+        cathode: impl Into<String>,
+        saturation_current: f64,
+        thermal_voltage: f64,
+        emission_coefficient: f64,
+        breakdown_voltage: Option<f64>,
+        breakdown_current: f64,
+        junction_capacitance: f64,
+        transit_time: f64,
+        junction_potential: f64,
+        grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             anode: anode.into(),
@@ -2453,6 +2487,7 @@ impl Diode {
             transit_time,
             junction_potential,
             grading_coefficient,
+            forward_bias_depletion_coefficient,
         }
     }
 }
@@ -3144,7 +3179,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
     usize,
 )] = &[
-    (ModelCardKind::Diode, 9, 15, 5, 3),
+    (ModelCardKind::Diode, 10, 16, 5, 3),
     (ModelCardKind::Npn, 7, 15, 4, 4),
     (ModelCardKind::Pnp, 7, 15, 4, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
@@ -3168,6 +3203,7 @@ const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("PB", "VJ"),
     ("M", "M"),
     ("MJ", "M"),
+    ("FC", "FC"),
 ];
 const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -3792,7 +3828,7 @@ pub fn diode_from_model_card(
     if model.kind != ModelCardKind::Diode {
         return Err(model_card_kind_error(&name, "diode", model.kind));
     }
-    Ok(Diode::with_model_and_depletion(
+    Ok(Diode::with_model_and_forward_depletion(
         name,
         anode,
         cathode,
@@ -3805,6 +3841,7 @@ pub fn diode_from_model_card(
         model_card_value(model, "TT", 0.0),
         model_card_value(model, "VJ", 1.0),
         model_card_value(model, "M", 0.5),
+        model_card_value(model, "FC", 0.5),
     ))
 }
 
@@ -22633,12 +22670,23 @@ fn diode_has_charge_storage(diode: &Diode) -> bool {
 
 fn diode_dynamic_capacitance(diode: &Diode, voltage: f64) -> f64 {
     let (_, conductance) = diode_current_conductance(diode, voltage);
-    mosfet_bulk_junction_capacitance(
-        diode.junction_capacitance,
-        voltage,
-        diode.junction_potential,
-        diode.grading_coefficient,
-    ) + diode.transit_time * conductance
+    diode_depletion_capacitance(diode, voltage) + diode.transit_time * conductance
+}
+
+fn diode_depletion_capacitance(diode: &Diode, voltage: f64) -> f64 {
+    if diode.junction_capacitance <= 0.0 || diode.grading_coefficient == 0.0 {
+        return diode.junction_capacitance;
+    }
+    let normalized_voltage = voltage / diode.junction_potential;
+    if normalized_voltage < diode.forward_bias_depletion_coefficient {
+        return diode.junction_capacitance
+            / (1.0 - normalized_voltage).powf(diode.grading_coefficient);
+    }
+    let coefficient = diode.forward_bias_depletion_coefficient;
+    let transition_scale = (1.0 - coefficient).powf(1.0 + diode.grading_coefficient);
+    let continuation = 1.0 - coefficient * (1.0 + diode.grading_coefficient)
+        + diode.grading_coefficient * normalized_voltage;
+    diode.junction_capacitance * continuation / transition_scale
 }
 
 fn diode_charge_voltage(diode: &Diode, node_voltages: &BTreeMap<String, f64>) -> f64 {
@@ -22932,6 +22980,15 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
             reason: "grading coefficient must be finite and non-negative".to_string(),
+        });
+    }
+    if !diode.forward_bias_depletion_coefficient.is_finite()
+        || diode.forward_bias_depletion_coefficient < 0.0
+        || diode.forward_bias_depletion_coefficient >= 1.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "forward-bias depletion coefficient must be finite and in [0, 1)".to_string(),
         });
     }
     if !diode.transit_time.is_finite() || diode.transit_time < 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -323,6 +323,46 @@ fn ac_diode_depletion_capacitance_falls_with_reverse_bias() {
 }
 
 #[test]
+fn ac_diode_forward_depletion_coefficient_shapes_capacitance() {
+    fn forward_biased_voltage(coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.75, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "R1", "in", "node", 1_000.0,
+        )));
+        circuit.add(Element::Diode(Diode::with_model_and_forward_depletion(
+            "D1",
+            "node",
+            "0",
+            1.0e-30,
+            0.02585,
+            1.0,
+            None,
+            1.0e-3,
+            1.0e-6,
+            0.0,
+            1.0,
+            0.5,
+            coefficient,
+        )));
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 1).unwrap()[0]
+            .voltage("node")
+            .unwrap()
+            .abs()
+    }
+
+    let early_transition = forward_biased_voltage(0.2);
+    let late_transition = forward_biased_voltage(0.8);
+
+    assert!(
+        late_transition < early_transition * 0.85,
+        "expected FC to shape forward depletion capacitance, got early={early_transition} late={late_transition}"
+    );
+}
+
+#[test]
 fn ac_diode_transit_time_shunts_forward_bias_at_high_frequency() {
     fn high_frequency_anode(transit_time: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -99,7 +99,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 69);
+    assert_eq!(coverage.len(), 70);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -118,7 +118,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 69);
+    assert_eq!(records.len(), 70);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -142,8 +142,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let summary = model_card_supported_parameter_coverage_summary();
     assert_eq!(summary.len(), 7);
     assert_eq!(summary[0].kind, ModelCardKind::Diode);
-    assert_eq!(summary[0].canonical_parameter_count, 9);
-    assert_eq!(summary[0].accepted_name_count, 15);
+    assert_eq!(summary[0].canonical_parameter_count, 10);
+    assert_eq!(summary[0].accepted_name_count, 16);
     assert_eq!(summary[0].aliased_parameter_count, 5);
     assert_eq!(summary[0].max_alias_count, 3);
     assert_eq!(
@@ -167,7 +167,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         lines[0],
         "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters"
     );
-    assert_eq!(lines[1], "D\t9\t15\t5\t3\tIS|VT|CJO|VJ|M");
+    assert_eq!(lines[1], "D\t10\t16\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -175,17 +175,17 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
-    assert_eq!(records[0]["canonical_parameter_count"], "9");
-    assert_eq!(records[0]["accepted_name_count"], "15");
+    assert_eq!(records[0]["canonical_parameter_count"], "10");
+    assert_eq!(records[0]["accepted_name_count"], "16");
     assert_eq!(records[0]["aliased_parameter_count"], "5");
     assert_eq!(records[0]["max_alias_count"], "3");
     assert_eq!(records[0]["aliased_parameters"], "IS|VT|CJO|VJ|M");
     assert!(format_model_card_supported_parameter_coverage_summary_csv().starts_with(
-        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,9,15,5,3,IS|VT|CJO|VJ|M\n"
+        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,10,16,5,3,IS|VT|CJO|VJ|M\n"
     ));
     let json = format_model_card_supported_parameter_coverage_summary_json();
     assert!(json.starts_with(
-        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"9\",\"accepted_name_count\":\"15\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
+        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"10\",\"accepted_name_count\":\"16\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
         "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"18\",\"accepted_name_count\":\"25\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
@@ -199,15 +199,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 69);
-    assert_eq!(report.expected_canonical_parameter_count, 69);
-    assert_eq!(report.accepted_name_count, 117);
+    assert_eq!(report.canonical_parameter_count, 70);
+    assert_eq!(report.expected_canonical_parameter_count, 70);
+    assert_eq!(report.accepted_name_count, 118);
     assert_eq!(report.aliased_parameter_count, 35);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t69\t69\t117\t35\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t70\t70\t118\t35\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -234,8 +234,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 68);
-    assert_eq!(report.accepted_name_count, 114);
+    assert_eq!(report.canonical_parameter_count, 69);
+    assert_eq!(report.accepted_name_count, 115);
     assert_eq!(report.aliased_parameter_count, 34);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -252,7 +252,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t68\t69\t114\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t69\t70\t115\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -276,10 +276,10 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard.len(), 7);
     assert_eq!(dashboard[0].kind, ModelCardKind::Diode);
     assert!(dashboard[0].passed);
-    assert_eq!(dashboard[0].canonical_parameter_count, 9);
-    assert_eq!(dashboard[0].expected_canonical_parameter_count, 9);
-    assert_eq!(dashboard[0].accepted_name_count, 15);
-    assert_eq!(dashboard[0].expected_accepted_name_count, 15);
+    assert_eq!(dashboard[0].canonical_parameter_count, 10);
+    assert_eq!(dashboard[0].expected_canonical_parameter_count, 10);
+    assert_eq!(dashboard[0].accepted_name_count, 16);
+    assert_eq!(dashboard[0].expected_accepted_name_count, 16);
     assert_eq!(dashboard[0].aliased_parameter_count, 5);
     assert_eq!(dashboard[0].expected_aliased_parameter_count, 5);
     assert_eq!(dashboard[0].max_alias_count, 3);
@@ -297,7 +297,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
         lines[0],
         "kind\tpassed\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\texpected_accepted_name_count\taliased_parameter_count\texpected_aliased_parameter_count\tmax_alias_count\texpected_max_alias_count\tissue_count\tissue_fields"
     );
-    assert_eq!(lines[1], "D\ttrue\t9\t9\t15\t15\t5\t5\t3\t3\t0\t");
+    assert_eq!(lines[1], "D\ttrue\t10\t10\t16\t16\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\ttrue\t18\t18\t25\t25\t6\t6\t3\t3\t0\t"
@@ -306,15 +306,15 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["passed"], "true");
-    assert_eq!(records[0]["canonical_parameter_count"], "9");
-    assert_eq!(records[0]["expected_canonical_parameter_count"], "9");
+    assert_eq!(records[0]["canonical_parameter_count"], "10");
+    assert_eq!(records[0]["expected_canonical_parameter_count"], "10");
     assert_eq!(records[0]["issue_count"], "0");
     assert_eq!(records[0]["issue_fields"], "");
     assert!(format_model_card_supported_parameter_coverage_dashboard_csv(&coverage).starts_with(
-        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,9,9,15,15,5,5,3,3,0,\n"
+        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,10,10,16,16,5,5,3,3,0,\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_dashboard_json(&coverage).starts_with(
-        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"9\",\"expected_canonical_parameter_count\":\"9\""
+        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"10\",\"expected_canonical_parameter_count\":\"10\""
     ));
 }
 
@@ -366,6 +366,7 @@ fn model_card_aliases_build_device_instances() {
             ("TT", 4.0e-9),
             ("PB", 0.8),
             ("MJ", 0.4),
+            ("FC", 0.35),
             ("RS", 10.0),
         ],
     )
@@ -375,6 +376,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*diode_card.parameters.get("CJO").unwrap(), 1.5e-12);
     assert_close(*diode_card.parameters.get("VJ").unwrap(), 0.8);
     assert_close(*diode_card.parameters.get("M").unwrap(), 0.4);
+    assert_close(*diode_card.parameters.get("FC").unwrap(), 0.35);
     assert_eq!(diode_card.unsupported_parameters, vec!["RS".to_string()]);
     let diode_issues = model_card_unsupported_parameter_issues(&diode_card);
     assert_eq!(diode_issues.len(), 1);
@@ -411,6 +413,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(diode_model.transit_time, 4.0e-9);
     assert_close(diode_model.junction_potential, 0.8);
     assert_close(diode_model.grading_coefficient, 0.4);
+    assert_close(diode_model.forward_bias_depletion_coefficient, 0.35);
 
     let bjt_card =
         normalize_model_card("Qsmall", "npn", &[("BETA", 125.0), ("CBE", 2.0e-12)]).unwrap();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add diode model-card `FC` forward-bias depletion coefficient support and a
+  continuous piecewise depletion-capacitance law, matching Python and Rust.
 - Shape diode depletion capacitance from the operating-point bias with model-card
   `VJ`/`PB` junction-potential and `M`/`MJ` grading-coefficient parameters in AC
   and transient analysis, matching Python and Rust.
@@ -18,7 +20,7 @@
   `modelCardSupportedParameterCoverageGateIssueRecords`,
   `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
   `formatModelCardSupportedParameterCoverageGateIssueJson`, stable release-gate
-  checks and issue exports for the seven-kind, 69-row supported model-card
+  checks and issue exports for the seven-kind, 70-row supported model-card
   parameter catalog, matching Python and Rust.
 - Add `modelCardSupportedParameterCoverageSummary`,
   `formatModelCardSupportedParameterCoverageSummaryTable`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -191,9 +191,10 @@ with optional `HARMONICS=` and `FROM=` controls.
 `normalizeModelCard`, `diodeFromModelCard`, `bjtFromModelCard`,
 `jfetFromModelCard`, and `mosfetFromModelCard` provide the shared `.model`
 alias surface for diode, BJT, JFET, and Level-1 MOS cards.
-Diode cards accept `VJ`/`PB` junction potential and `M`/`MJ` grading coefficient;
-AC and transient analyses use them to shape `CJO` depletion capacitance from the
-operating-point bias.
+Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
+and `FC` forward-bias depletion coefficient. AC and transient analyses use them
+to shape `CJO` depletion capacitance continuously around the `FC * VJ`
+transition.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -219,7 +220,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 69-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 70-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1673,6 +1673,7 @@ export interface Diode {
   readonly transitTime: number;
   readonly junctionPotential: number;
   readonly gradingCoefficient: number;
+  readonly forwardBiasDepletionCoefficient: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -1983,7 +1984,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_KINDS: readonly ModelCardKind[] = 
 const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
-  D: [9, 15, 5, 3],
+  D: [10, 16, 5, 3],
   NPN: [7, 15, 4, 4],
   PNP: [7, 15, 4, 4],
   NJF: [5, 11, 5, 3],
@@ -7530,6 +7531,7 @@ export function diode(
   transitTime = 0.0,
   junctionPotential = 1.0,
   gradingCoefficient = 0.5,
+  forwardBiasDepletionCoefficient = 0.5,
 ): Diode {
   return {
     kind: "diode",
@@ -7545,6 +7547,7 @@ export function diode(
     transitTime,
     junctionPotential,
     gradingCoefficient,
+    forwardBiasDepletionCoefficient,
   };
 }
 
@@ -7806,6 +7809,7 @@ const DIODE_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   PB: "VJ",
   M: "M",
   MJ: "M",
+  FC: "FC",
 };
 
 const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8290,6 +8294,7 @@ export function diodeFromModelCard(
     p.TT ?? 0.0,
     p.VJ ?? 1.0,
     p.M ?? 0.5,
+    p.FC ?? 0.5,
   );
 }
 
@@ -19168,6 +19173,16 @@ function validateDiode(element: Diode): void {
   if (!Number.isFinite(element.gradingCoefficient) || element.gradingCoefficient < 0.0) {
     throw invalidElement(element.name, "grading coefficient must be finite and non-negative");
   }
+  if (
+    !Number.isFinite(element.forwardBiasDepletionCoefficient) ||
+    element.forwardBiasDepletionCoefficient < 0.0 ||
+    element.forwardBiasDepletionCoefficient >= 1.0
+  ) {
+    throw invalidElement(
+      element.name,
+      "forward-bias depletion coefficient must be finite and in [0, 1)",
+    );
+  }
   if (!Number.isFinite(element.transitTime) || element.transitTime < 0.0) {
     throw invalidElement(element.name, "transit time must be finite and non-negative");
   }
@@ -19206,14 +19221,23 @@ function diodeHasChargeStorage(element: Diode): boolean {
 
 function diodeDynamicCapacitance(element: Diode, voltage: number): number {
   const [, conductance] = diodeCurrentConductance(element, voltage);
-  return (
-    mosfetBulkJunctionCapacitance(
-      element.junctionCapacitance,
-      voltage,
-      element.junctionPotential,
-      element.gradingCoefficient,
-    ) + element.transitTime * conductance
-  );
+  return diodeDepletionCapacitance(element, voltage) + element.transitTime * conductance;
+}
+
+function diodeDepletionCapacitance(element: Diode, voltage: number): number {
+  if (element.junctionCapacitance <= 0.0 || element.gradingCoefficient === 0.0) {
+    return element.junctionCapacitance;
+  }
+  const normalizedVoltage = voltage / element.junctionPotential;
+  if (normalizedVoltage < element.forwardBiasDepletionCoefficient) {
+    return element.junctionCapacitance /
+      ((1.0 - normalizedVoltage) ** element.gradingCoefficient);
+  }
+  const coefficient = element.forwardBiasDepletionCoefficient;
+  const transitionScale = (1.0 - coefficient) ** (1.0 + element.gradingCoefficient);
+  const continuation = 1.0 - coefficient * (1.0 + element.gradingCoefficient) +
+    element.gradingCoefficient * normalizedVoltage;
+  return element.junctionCapacitance * continuation / transitionScale;
 }
 
 function diodeChargeVoltage(element: Diode, nodeVoltages: ReadonlyMap<string, number>): number {

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -241,6 +241,37 @@ describe("acSweep", () => {
     expect(reverseBiased).toBeGreaterThan(zeroBias * 1.8);
   });
 
+  it("shapes forward-biased diode depletion capacitance with FC", () => {
+    const forwardBiasedVoltage = (coefficient: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.75, 1.0));
+      circuit.add(resistor("R1", "in", "node", 1_000.0));
+      circuit.add(
+        diode(
+          "D1",
+          "node",
+          "0",
+          1.0e-30,
+          0.02585,
+          1.0,
+          undefined,
+          1.0e-3,
+          1.0e-6,
+          0.0,
+          1.0,
+          0.5,
+          coefficient,
+        ),
+      );
+      return complexAbs(acSweep(circuit, 1_000.0, 1_000.0, 1)[0].voltage("node")!);
+    };
+
+    const earlyTransition = forwardBiasedVoltage(0.2);
+    const lateTransition = forwardBiasedVoltage(0.8);
+
+    expect(lateTransition).toBeLessThan(earlyTransition * 0.85);
+  });
+
   it("stamps forward-biased diode transit-time diffusion capacitance", () => {
     const highFrequencyAnode = (transitTime: number): number => {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -123,7 +123,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(69);
+    expect(coverage).toHaveLength(70);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -143,7 +143,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(69);
+    expect(records).toHaveLength(70);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -161,8 +161,8 @@ describe("dcOp", () => {
     expect(summary).toHaveLength(7);
     expect(summary[0]).toStrictEqual({
       kind: "D",
-      canonicalParameterCount: 9,
-      acceptedNameCount: 15,
+      canonicalParameterCount: 10,
+      acceptedNameCount: 16,
       aliasedParameterCount: 5,
       maxAliasCount: 3,
       aliasedParameters: ["IS", "VT", "CJO", "VJ", "M"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     expect(table.split("\n")[0]).toBe(
       "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters",
     );
-    expect(table.split("\n")[1]).toBe("D\t9\t15\t5\t3\tIS|VT|CJO|VJ|M");
+    expect(table.split("\n")[1]).toBe("D\t10\t16\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
       "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
@@ -189,14 +189,14 @@ describe("dcOp", () => {
     expect(records).toHaveLength(7);
     expect(records[0]).toStrictEqual({
       kind: "D",
-      canonical_parameter_count: "9",
-      accepted_name_count: "15",
+      canonical_parameter_count: "10",
+      accepted_name_count: "16",
       aliased_parameter_count: "5",
       max_alias_count: "3",
       aliased_parameters: "IS|VT|CJO|VJ|M",
     });
     expect(formatModelCardSupportedParameterCoverageSummaryCsv()).toMatch(
-      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,9,15,5,3,IS\|VT\|CJO\|VJ\|M\n/,
+      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,10,16,5,3,IS\|VT\|CJO\|VJ\|M\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageSummaryJson())).toStrictEqual(records);
   });
@@ -208,15 +208,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 69,
-      expectedCanonicalParameterCount: 69,
-      acceptedNameCount: 117,
+      canonicalParameterCount: 70,
+      expectedCanonicalParameterCount: 70,
+      acceptedNameCount: 118,
       aliasedParameterCount: 35,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t69\t69\t117\t35\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t70\t70\t118\t35\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -239,8 +239,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(68);
-    expect(report.acceptedNameCount).toBe(114);
+    expect(report.canonicalParameterCount).toBe(69);
+    expect(report.acceptedNameCount).toBe(115);
     expect(report.aliasedParameterCount).toBe(34);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -255,7 +255,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t68\t69\t114\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t69\t70\t115\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -278,6 +278,7 @@ describe("dcOp", () => {
       TT: 4.0e-9,
       PB: 0.8,
       MJ: 0.4,
+      FC: 0.35,
       RS: 10.0,
     });
     const diodeModel = diodeFromModelCard("D1", "a", "k", diodeCard);
@@ -287,6 +288,7 @@ describe("dcOp", () => {
       TT: 4.0e-9,
       VJ: 0.8,
       M: 0.4,
+      FC: 0.35,
     });
     expect(diodeCard.unsupportedParameters).toStrictEqual(["RS"]);
     const diodeIssues = modelCardUnsupportedParameterIssues(diodeCard);
@@ -319,6 +321,7 @@ describe("dcOp", () => {
     expectClose(diodeModel.transitTime, 4.0e-9);
     expectClose(diodeModel.junctionPotential, 0.8);
     expectClose(diodeModel.gradingCoefficient, 0.4);
+    expectClose(diodeModel.forwardBiasDepletionCoefficient, 0.35);
 
     const bjtCard = normalizeModelCard("Qsmall", "npn", { BETA: 125.0, CBE: 2.0e-12 });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language diode depletion-capacitance shaping.
+1. Cross-language diode forward-bias depletion coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley diode `VJ`/`PB` junction-potential and `M`/`MJ`
-     grading-coefficient model-card parameters in Rust, Python, and TypeScript.
-   - Shape `CJO` depletion capacitance from the operating-point bias in AC and
-     transient analysis while preserving transit-time diffusion capacitance.
-   - Extend the supported-parameter coverage gate from 67 to 69 canonical rows
-     and lock reverse-bias capacitance behavior across all three engines.
+   - Add Berkeley diode `FC` forward-bias depletion-coefficient model-card
+     support in Rust, Python, and TypeScript.
+   - Apply the continuous piecewise depletion-capacitance law around the
+     `FC * VJ` transition in AC and transient analysis.
+   - Extend the supported-parameter coverage gate from 69 to 70 canonical rows
+     and lock forward-bias shaping across all three engines.
 
 ## Completed Slices
 
@@ -2963,6 +2963,14 @@ the Rust, Python, and TypeScript surfaces together.
    - The digest preserves stable schema, routing disposition, action, badge,
      target, compact count, nested summary, and capability metadata while
      leaving parser and cross-language solver behavior unchanged.
+
+214. Cross-language diode depletion-capacitance shaping.
+   - Status: completed in PR 8705.
+   - Rust, Python, and TypeScript diode model cards now accept `VJ`/`PB`
+     junction potential and `M`/`MJ` grading coefficient parameters.
+   - AC and transient analyses shape `CJO` from reverse bias while preserving
+     transit-time diffusion capacitance, and the supported-parameter release
+     gate now covers 69 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley diode `FC` forward-bias depletion-coefficient model-card support in Rust, Python, and TypeScript
- apply the continuous piecewise depletion-capacitance law around the `FC * VJ` transition in AC and transient analysis
- expand the supported-parameter release gate to 70 canonical rows and mark merged PR #8705 complete in the SPICE plan

## Why
The previous slice made reverse-bias diode capacitance depend on `VJ` and `M`, but forward bias still clamped depletion capacitance at its zero-bias value. `FC` now selects the continuous Berkeley forward-bias continuation and avoids the singular power law near the junction potential.

## Validation
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python 3.12: `pytest code/packages/python/spice-engine/tests/test_engine.py` (473 passed, 80.92% coverage)
- Python 3.12: `ruff check --ignore I001` on touched source and test files
- `npm test` (259 passed)
- `npm run build`
- `git diff --check`

## Formatting note
`cargo fmt -p spice-engine -- --check` continues to report pre-existing formatting drift in unrelated portions of the large Rust engine source. The new Rust lines were aligned with rustfmt without sweeping that baseline drift into this PR.