### PR TITLE
feat(app): Lessons mode — drill the whole curriculum, and remember it

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/BUILD
+++ b/code/programs/typescript/script-writing-visualizer/BUILD
@@ -1,3 +1,26 @@
+set -e
+
+# BUILD — script-writing-visualizer (the HL02 companion study app)
+#
+# Depends, via a `file:` dep, on the curriculum data package:
+#
+#     human-language-data   ← lesson frontmatter parser + taxonomy queries
+#                             (a leaf: it has no dependencies of its own)
+#
+# Per `lessons.md`: BUILD files MUST install every transitive `file:` dep in
+# leaf-to-root order BEFORE the program's own `npm install`. Skipping one gives
+# a node_modules with gaps — imports that type-check but blow up at runtime.
+# Here the chain is only one deep, but the rule is the rule, and the build-tool's
+# `-validate-build-files` check enforces it: adding the dep without this line
+# fails CI with "missing prerequisite refs for standalone builds".
+#
+# The `cd` runs in its own subshell, so it does not persist to the next line —
+# every command starts fresh from this program's directory.
+#
+# Tools (npm, npx, node) are expected on PATH (mise shims locally; CI installs
+# Node directly via actions/setup-node).
+
+cd ../../../packages/typescript/human-language-data && npm install --silent
 npm install
 npm run build
 npx vitest run

--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## 0.5.0 — Lessons mode: the whole curriculum, and a memory that survives reloads
+
+The app could already schedule you. It could not **remember** you, and it had
+never read a single lesson. Both are fixed.
+
+- **New "Lessons" mode** drills the **written curriculum** — all **679 lessons
+  across 18 languages** — instead of only script letters. It reads them from
+  `@coding-adventures/human-language-data`, the package that has always shipped
+  `frontmatter.ts` / `loader.ts` / `parse.ts` / `queries.ts` for exactly this
+  purpose and had **zero consumers** until now.
+- **Progress now persists** (`src/progress.ts`). Previously there was no storage
+  layer at all, so every Leitner box reset on reload and nothing was ever really
+  "tracked". State is saved to `localStorage` keyed by **lesson id**, never by
+  array index — indices shift every time a lesson is added, and saving by
+  position would silently reattribute your progress to the wrong lesson. Adding
+  a lesson now simply means one more unseen item.
+- **Cross-language interleaving comes free.** `interleave.buildPool` already
+  round-robins across groups for scripts; grouping lessons by language and
+  feeding it the same way yields Arabic → Bengali → French → German → Gujarati →
+  Hindi in consecutive reviews. A **rotating cursor** walks that order, which
+  also fixes the obvious failure mode: box 0/1 fall due again after one session,
+  so a scan-from-the-front picker would hand you the lesson you just answered,
+  forever.
+- **`scheduler.ts`, `interleave.ts` and `drill.ts` are unchanged.** They are
+  generic over a numeric index and never needed to know what an item is — which
+  is precisely why lessons could reuse them. The new *logic* is pure and tested
+  (`lessons.ts`, `progress.ts`, including the `nextDue` cursor scan); the only
+  impure edges are a tiny `StorageLike` port and `main.ts`'s DOM shell, which
+  remains untested as before.
+- **Defensive loading.** Saved state is untrusted input (hand-edited,
+  half-written by another tab, left over from an older build). Every field is
+  validated, unknown ids are treated as fresh, `__proto__`/`constructor` keys are
+  skipped, the item map is `Object.create(null)`, and a throwing or absent
+  `localStorage` (Safari private mode, quota) degrades instead of crashing.
+- Tests: **67**, up from 57 — `tests/lessons.test.ts` and `tests/progress.test.ts`.
+
+### Known cost
+
+`import.meta.glob(…, { eager: true })` inlines the full text of all 679 lesson
+files, so the bundle is ~1.56 MB (480 kB gzipped) and every startup parses them
+all — even in Browse mode, which doesn't need them. Only the frontmatter
+survives parsing; the bodies are discarded. A lazy glob or a build-time JSON
+index would fix both; deferred rather than hidden.
+
+### Three bugs worth recording
+
+- **`process is not defined` at startup.** Importing the package's barrel
+  (`index.ts`) pulled `cli.ts` and `loader.ts` — `process`, `node:fs` — into the
+  browser bundle. The build *succeeded* and the app then died on load with a
+  blank page. Fixed by deep-importing the pure module
+  (`.../src/parse.ts`). Caught only by opening the app in a browser; no test or
+  build step would have found it.
+- **`vitest.config.ts` does not inherit `vite.config.ts`'s `server.fs.allow`.**
+  The lesson glob reaches outside the package root, so tests failed with "Denied
+  ID" until the same allowance was declared in both configs.
+- **The "don't persist untouched items" guard failed open after one reload.**
+  It tested `dueAtSession <= 0`, but fresh items are seeded with the *current*
+  session, so from session 1 onward every unseen lesson looked touched: the
+  payload grew from ~100 bytes to ~48 kB and the "started" count reported the
+  whole curriculum. Now keyed on review history (`reps`/`lapses`/`box`) only,
+  with a reload round-trip test that would have caught it — the original test
+  only covered session 0, the one case where the bug was invisible.
+
 ## 0.4.0 — Cross-script interleaving ("Mixed") practice
 
 - **New "Mixed (all scripts)" practice scope** alongside "This script": Practice

--- a/code/programs/typescript/script-writing-visualizer/README.md
+++ b/code/programs/typescript/script-writing-visualizer/README.md
@@ -1,10 +1,37 @@
 # Script Writing Visualizer
 
-**The HL02 companion app, MVP.** The Human Languages curriculum teaches a
-non-Latin script *inline* — a letter is introduced inside the first word that
-needs it. This app is the other half of that promise: it **breaks each letter
-apart** into its pieces and shows a **stroke order**, so you can practise
-*writing it on paper*.
+**The HL02 companion app.** Three modes: **Browse** and **Practice** work on
+*script letters*; **Lessons** drills the *written curriculum* — every lesson in
+every track — on a spaced-repetition schedule that persists between visits.
+
+## Lessons mode
+
+Reads all **679 lessons across 18 languages** straight from the curriculum via
+`@coding-adventures/human-language-data`, and schedules them with the same
+Leitner machinery the letter drills use (`scheduler.ts` is generic over an
+index; it never needed to know what an item is).
+
+- **It remembers you.** Progress is saved to `localStorage` keyed by **lesson
+  id** — never by array index, because indices shift every time a lesson is
+  added and saving by position would reattribute your history to the wrong
+  lesson. New lessons simply appear as unseen items.
+- **It mixes languages.** Consecutive reviews round-robin across tracks — Arabic,
+  then Bengali, then French — rather than marching through one language. That
+  interleaving is deliberate: it forces discrimination instead of coasting.
+- **Recall, not recognition.** You see the headword in its own script; the
+  meaning stays hidden until you ask for it, then you grade yourself
+  *Again* / *Got it*.
+- Each card also surfaces what the lesson **revisits** (`reviews_of`), the
+  curriculum's own review graph.
+
+To clear your progress, delete the `hl-study:progress:v1` key in localStorage.
+
+## Browse & Practice (script letters)
+
+The Human Languages curriculum teaches a non-Latin script *inline* — a letter is
+introduced inside the first word that needs it. These modes are the other half
+of that promise: they **break each letter apart** into its pieces and show a
+**stroke order**, so you can practise *writing it on paper*.
 
 Pick a script, pick a letter, and the detail panel shows:
 

--- a/code/programs/typescript/script-writing-visualizer/package-lock.json
+++ b/code/programs/typescript/script-writing-visualizer/package-lock.json
@@ -1,18 +1,32 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "script-writing-visualizer",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/human-language-data": "file:../../../packages/typescript/human-language-data"
+      },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",
         "jsdom": "^25.0.0",
         "typescript": "~5.7.0",
         "vite": "^8.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../../../packages/typescript/human-language-data": {
+      "name": "@coding-adventures/human-language-data",
+      "version": "0.3.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.7.0",
         "vitest": "^4.1.0"
       }
     },
@@ -89,6 +103,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/human-language-data": {
+      "resolved": "../../../packages/typescript/human-language-data",
+      "link": true
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,8 +1,8 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
-  "description": "Companion app (HL02 MVP): break a non-Latin script apart and learn to write it, letter by letter",
+  "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -10,6 +10,9 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@coding-adventures/human-language-data": "file:../../../packages/typescript/human-language-data"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.0",

--- a/code/programs/typescript/script-writing-visualizer/src/lessons.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/lessons.ts
@@ -1,0 +1,189 @@
+// ---------------------------------------------------------------------------
+// lessons.ts — the bridge from the written curriculum to the study app.
+//
+// Until now this app only knew about *letters*: it read `data/scripts/*.json`
+// and drilled glyphs. But the repository also contains ~670 hand-written lesson
+// files — every one carrying `id`, `concept_tag`, `prerequisites` and
+// `reviews_of` in its frontmatter. That is a complete study corpus, and the
+// package `@coding-adventures/human-language-data` already knows how to parse
+// it. It simply had no consumers. This module is the missing wire.
+//
+// WHY NOT JUST CALL THE PACKAGE'S LOADER?
+// Because `loader.ts` reads the disk with `node:fs`, and we run in a browser.
+// The package is layered for exactly this: `parseLesson` is a PURE function
+// from file *contents* to a parsed lesson. So we let Vite hand us the contents
+// at build time (`import.meta.glob`, below) and call the pure layer ourselves.
+// No filesystem in the browser, and no second copy of the parsing rules.
+// ---------------------------------------------------------------------------
+
+// NOTE the deep import. The package's barrel (`index.ts`) also re-exports
+// `loader.ts` (node:fs) and `cli.ts` (process), and a bundler cannot always
+// tree-shake those away — importing the barrel produced a browser build that
+// loaded fine and then died at startup with "process is not defined". Reaching
+// straight for the pure parsing module keeps Node out of the browser bundle.
+import { parseLesson, type ParsedLesson } from "@coding-adventures/human-language-data/src/parse.ts";
+
+/**
+ * Every lesson markdown file, as raw text, keyed by path. Vite inlines these at
+ * build time — `eager` so there is no async waterfall on first paint, and
+ * `?raw` because we want the source, not a module.
+ *
+ * The glob is relative to THIS file; `../../../../learning/...` is the same
+ * path `data.ts` already uses to reach the curriculum.
+ */
+const LESSON_SOURCES = import.meta.glob(
+  "../../../../learning/human-languages/*/lessons/*.md",
+  { query: "?raw", import: "default", eager: true },
+) as Record<string, string>;
+
+/** A lesson, ready for the UI and the scheduler. */
+export interface Lesson {
+  /** Stable slug id from frontmatter, e.g. "ES-C17-futuro". The persistence key. */
+  id: string;
+  /** Track directory name, e.g. "spanish". */
+  language: string;
+  headword: string;
+  gloss: string;
+  /** word | phrase | practice | practice-mix | writing | review */
+  type: string;
+  chapter: number;
+  /** "" when the lesson carries none (writing lessons are exempt). */
+  concept: string;
+  prerequisites: string[];
+  reviewsOf: string[];
+}
+
+/**
+ * Pull the track name out of a curriculum path.
+ *
+ *   ".../learning/human-languages/spanish/lessons/ES-C17-futuro.md" → "spanish"
+ *
+ * Returns "" if the path doesn't have the expected shape, so a stray file can
+ * never masquerade as a language.
+ */
+export function languageFromPath(path: string): string {
+  const match = /\/human-languages\/([^/]+)\/lessons\//.exec(path);
+  return match?.[1] ?? "";
+}
+
+/**
+ * Turn one parsed lesson plus its id into the app's view of it.
+ *
+ * `parseLesson` gives us a `Realization` (the taxonomy's view — concept,
+ * headword, type…) plus the raw frontmatter. The id lives only in the
+ * frontmatter, and it is the one field we cannot do without: it is what we key
+ * saved progress by, so it must survive lessons being added, renamed or
+ * reordered. A lesson with no id is skipped rather than guessed at.
+ */
+export function toLesson(parsed: ParsedLesson): Lesson | null {
+  const fm = parsed.frontmatter;
+  const id = typeof fm.id === "string" ? fm.id.trim() : "";
+  if (id === "") return null;
+
+  const r = parsed.realization;
+  const arr = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+
+  return {
+    id,
+    language: parsed.language,
+    headword: r.headword,
+    gloss: r.gloss,
+    type: r.type,
+    chapter: r.chapter,
+    concept: r.concept,
+    prerequisites: arr(fm.prerequisites),
+    reviewsOf: arr(fm.reviews_of),
+  };
+}
+
+/**
+ * Parse every lesson in the curriculum, sorted by id so the order — and
+ * therefore every scheduler index — is deterministic across builds. That
+ * determinism matters: see `progress.ts`, which nonetheless refuses to rely on
+ * it for saved data.
+ */
+export function loadLessons(
+  sources: Record<string, string> = LESSON_SOURCES,
+): Lesson[] {
+  const out: Lesson[] = [];
+  for (const [path, source] of Object.entries(sources)) {
+    const language = languageFromPath(path);
+    if (language === "") continue;
+    const lesson = toLesson(parseLesson(source, language));
+    if (lesson) out.push(lesson);
+  }
+  return out.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+/** The distinct track names present, sorted. */
+export function languagesOf(lessons: Lesson[]): string[] {
+  return [...new Set(lessons.map((l) => l.language))].sort();
+}
+
+/** Minimum of a scheduler item that `nextDue` needs. Keeps this module free of
+ *  a scheduler import, and keeps the function trivially testable. */
+export interface DueLike {
+  dueAtSession: number;
+}
+
+/** Where `nextDue` landed: the lesson to show, and the cursor to carry forward. */
+export interface NextDue {
+  /** Index into the lessons array, or null if nothing is due. */
+  index: number | null;
+  /** The advanced cursor — pass it back in on the next call. */
+  cursor: number;
+}
+
+/**
+ * Find the next due lesson, scanning forward from a ROTATING cursor over the
+ * interleaved (round-robin-by-language) order.
+ *
+ * Why a cursor rather than "first due from the front"? Two reasons, both found
+ * by using it:
+ *
+ *   * Leitner boxes 0 and 1 fall due again after a single session, so a
+ *     from-the-front scan hands back the lesson you just answered, forever.
+ *   * Restarting also defeats the interleaving — you would sit in whichever
+ *     language sorts first instead of moving across them.
+ *
+ * The scan visits every pool position exactly once (`pool.length` steps, modulo
+ * arithmetic), so it always terminates and never skips. `null` means nothing is
+ * due; the caller decides what to do about that.
+ */
+export function nextDue(
+  groups: number[][],
+  pool: { scriptIndex: number; letterIndex: number }[],
+  schedule: DueLike[],
+  session: number,
+  cursor: number,
+): NextDue {
+  if (pool.length === 0) return { index: null, cursor };
+  let at = cursor;
+  for (let step = 0; step < pool.length; step++) {
+    at = (at + 1) % pool.length;
+    const entry = pool[at]!;
+    const index = groups[entry.scriptIndex]?.[entry.letterIndex];
+    if (index === undefined) continue;
+    const state = schedule[index];
+    if (state && state.dueAtSession <= session) return { index, cursor: at };
+  }
+  return { index: null, cursor: at };
+}
+
+/**
+ * Group lesson indices by language, preserving each language's internal order.
+ * This is the shape `interleave.buildPool` wants: it already knows how to
+ * round-robin across groups, so cross-LANGUAGE interleaving comes free from the
+ * code that was written for cross-SCRIPT interleaving.
+ */
+export function indicesByLanguage(lessons: Lesson[]): number[][] {
+  const languages = languagesOf(lessons);
+  const position = new Map(languages.map((l, i) => [l, i]));
+  const groups: number[][] = languages.map(() => []);
+  lessons.forEach((lesson, index) => {
+    const g = position.get(lesson.language);
+    if (g !== undefined) groups[g]!.push(index);
+  });
+  return groups;
+}

--- a/code/programs/typescript/script-writing-visualizer/src/main.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/main.ts
@@ -31,13 +31,50 @@ import {
   type ItemState,
 } from "./scheduler.ts";
 import { buildPool, type PoolEntry } from "./interleave.ts";
+import { loadLessons, indicesByLanguage, nextDue } from "./lessons.ts";
+import {
+  browserStorage,
+  fromSaved,
+  loadProgress,
+  saveProgress,
+  seenCount,
+  toSaved,
+} from "./progress.ts";
 import "./styles.css";
 
 const app = document.getElementById("app");
 if (!app) throw new Error("missing #app root");
 
-type Mode = "browse" | "practice";
+type Mode = "browse" | "practice" | "lessons";
 let mode: Mode = "browse";
+
+// --- lesson review state ----------------------------------------------------
+//
+// The letter drills above schedule GLYPHS. This schedules LESSONS — the ~670
+// written chapters — using the very same Leitner machinery, because
+// scheduler.ts is generic over a numeric index and never cared what an item is.
+// The one new thing is that this state SURVIVES: it is keyed by lesson id and
+// written to localStorage (see progress.ts), so the app finally remembers you.
+const LESSONS = loadLessons();
+const LESSON_IDS = LESSONS.map((l) => l.id);
+// Constant for the page's lifetime: lesson indices grouped by language, and the
+// round-robin pool over those groups. Computing them once is why consecutive
+// reviews can walk across languages cheaply.
+const LESSON_GROUPS = indicesByLanguage(LESSONS);
+const LESSON_POOL = buildPool(LESSON_GROUPS.map((g) => g.length));
+let savedProgress = loadProgress(browserStorage());
+let lessonSchedule: ItemState[] = fromSaved(LESSON_IDS, savedProgress);
+let lessonSession = savedProgress.session;
+let lessonIndex: number | null = null;
+let lessonRevealed = false;
+/** Rotating position in the interleaved order — see pickLesson(). */
+let lessonCursor = -1;
+
+/** Persist the current lesson schedule. Silent on failure — see progress.ts. */
+function persistLessons(): void {
+  savedProgress = toSaved(LESSON_IDS, lessonSchedule, lessonSession);
+  saveProgress(browserStorage(), savedProgress);
+}
 let currentScript = 0;
 let currentLetter = 0;
 
@@ -86,14 +123,20 @@ function renderHeader(): HTMLElement {
 
 function renderModeToggle(): HTMLElement {
   const wrap = el("div", "modes");
-  (["browse", "practice"] as Mode[]).forEach((m) => {
+  const LABELS: Record<Mode, string> = {
+    browse: "Browse",
+    practice: "Practice",
+    lessons: "Lessons",
+  };
+  (["browse", "practice", "lessons"] as Mode[]).forEach((m) => {
     const b = el("button", "mode" + (m === mode ? " mode--active" : ""));
-    b.textContent = m === "browse" ? "Browse" : "Practice";
+    b.textContent = LABELS[m];
     b.setAttribute("aria-pressed", String(m === mode));
     b.onclick = () => {
       if (mode === m) return;
       mode = m;
       if (mode === "practice") startPractice();
+      if (mode === "lessons") pickLesson();
       render();
     };
     wrap.appendChild(b);
@@ -326,14 +369,127 @@ function renderPractice(): HTMLElement {
 
 // --- top-level render -------------------------------------------------------
 
+// --- lessons ----------------------------------------------------------------
+
+/**
+ * Choose the next lesson to review.
+ *
+ * Two ideas, both borrowed rather than invented. `pickNext` (scheduler.ts)
+ * already picks the most-overdue item; `buildPool` (interleave.ts) already
+ * round-robins across groups, so grouping lessons BY LANGUAGE and pooling them
+ * gives cross-language interleaving for free — Spanish, then Tamil, then
+ * French, rather than all of Spanish first. That mixing is the point: it forces
+ * you to discriminate between languages instead of coasting inside one.
+ */
+function pickLesson(): void {
+  lessonRevealed = false;
+  if (LESSONS.length === 0) {
+    lessonIndex = null;
+    return;
+  }
+  // The scan itself is a pure function in lessons.ts (and tested there); this
+  // only threads the cursor. LESSON_GROUPS / LESSON_POOL are computed once —
+  // they are constant for the page's lifetime.
+  const { index, cursor } = nextDue(
+    LESSON_GROUPS,
+    LESSON_POOL,
+    lessonSchedule,
+    lessonSession,
+    lessonCursor,
+  );
+  lessonCursor = cursor;
+  // Nothing due: fall back to the scheduler's most-overdue pick so the mode is
+  // never a dead end.
+  lessonIndex = index ?? pickNext(lessonSchedule, lessonSession);
+}
+
+/** Grade the current lesson, advance the clock, and save. */
+function gradeLesson(wasCorrect: boolean): void {
+  if (lessonIndex === null) return;
+  lessonSchedule = reviewIn(lessonSchedule, lessonIndex, wasCorrect, lessonSession);
+  lessonSession += 1;
+  persistLessons();
+  pickLesson();
+  render();
+}
+
+function renderLessons(): HTMLElement {
+  const wrap = el("div", "practice");
+
+  const due = lessonSchedule.filter((s) => s.dueAtSession <= lessonSession).length;
+  const seen = seenCount(LESSON_IDS, savedProgress);
+  const stats = el("p", "score");
+  stats.textContent =
+    `${LESSONS.length} lessons · ${due} due · ` +
+    `${seen} started · mastered ${masteredCount(lessonSchedule)}`;
+  wrap.appendChild(stats);
+
+  if (lessonIndex === null) {
+    const empty = el("p", "muted");
+    empty.textContent = "No lessons found.";
+    wrap.appendChild(empty);
+    return wrap;
+  }
+
+  const lesson = LESSONS[lessonIndex]!;
+  const meta = el("p", "muted");
+  meta.textContent = `${lesson.language} · chapter ${lesson.chapter} · ${lesson.id}`;
+  wrap.appendChild(meta);
+
+  // Prompt: the headword, in its own script. Answer hidden until asked for —
+  // recall, not recognition.
+  const prompt = el("p", "prompt-glyph");
+  prompt.textContent = lesson.headword;
+  wrap.appendChild(prompt);
+
+  if (!lessonRevealed) {
+    const show = el("button", "opt");
+    show.textContent = "Show meaning";
+    show.onclick = () => {
+      lessonRevealed = true;
+      render();
+    };
+    wrap.appendChild(show);
+    return wrap;
+  }
+
+  const gloss = el("p", "");
+  gloss.textContent = lesson.gloss;
+  wrap.appendChild(gloss);
+
+  const buttons = el("div", "opts");
+  ([["Again", false], ["Got it", true]] as [string, boolean][]).forEach(
+    ([label, correct]) => {
+      const b = el("button", "opt");
+      b.textContent = label;
+      b.onclick = () => gradeLesson(correct);
+      buttons.appendChild(b);
+    },
+  );
+  wrap.appendChild(buttons);
+
+  // The curriculum's own review graph, surfaced: every lesson declares what it
+  // revisits. Nothing schedules off this yet — that is the next app item — but
+  // showing it makes the connective tissue visible.
+  if (lesson.reviewsOf.length > 0) {
+    wrap.appendChild(section("Revisits", listOf(lesson.reviewsOf, "links")));
+  }
+  return wrap;
+}
+
 function render(): void {
   const data = SCRIPTS[currentScript]!;
   app!.replaceChildren();
   app!.append(renderHeader());
-  // The script tabs steer per-script work; hide them during a mixed session.
-  if (!(mode === "practice" && scope === "mixed")) app!.appendChild(renderTabs());
+  // The script tabs steer per-script work; hide them during a mixed session,
+  // and in Lessons mode, which spans every language rather than one script.
+  if (mode !== "lessons" && !(mode === "practice" && scope === "mixed")) {
+    app!.appendChild(renderTabs());
+  }
 
-  if (mode === "browse") {
+  if (mode === "lessons") {
+    app!.appendChild(renderLessons());
+  } else if (mode === "browse") {
     const views = buildScriptView(data);
     const active = views[currentLetter] ?? views[0]!;
     app!.appendChild(renderSummary(scriptSummary(data)));

--- a/code/programs/typescript/script-writing-visualizer/src/progress.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/progress.ts
@@ -1,0 +1,231 @@
+// ---------------------------------------------------------------------------
+// progress.ts — remembering what you have learned, between visits.
+//
+// THE PROBLEM THIS SOLVES. `scheduler.ts` implements a perfectly good Leitner
+// system: every item sits in a box, boxes map to intervals, a miss knocks an
+// item back to "due now". But it kept that state in memory only, so every page
+// reload wiped it. The app could schedule you, but it could not *remember* you
+// — which made the whole spaced-repetition idea decorative.
+//
+// THE DESIGN. Two rules keep this honest:
+//
+//   1. `scheduler.ts` stays PURE and index-based. It never learns what an item
+//      is or where it is stored. Everything here converts between its
+//      `ItemState[]` (positional) and a saved record (keyed by lesson id).
+//
+//   2. We save by lesson **id**, never by index. Indices shift the moment a
+//      lesson is added — and lessons are added constantly. Saving by position
+//      would silently reattribute your progress to the wrong lesson, which is
+//      worse than losing it. Keyed by id, adding a lesson simply means one more
+//      unseen item.
+//
+// Everything except the tiny `localStorage` adapter at the bottom is pure, so
+// the round-trip is unit-testable without a browser.
+// ---------------------------------------------------------------------------
+
+import { initStates, MAX_BOX, type ItemState } from "./scheduler.ts";
+
+/** Bump when the saved shape changes incompatibly; older payloads are dropped. */
+export const SCHEMA_VERSION = 1;
+
+/** The key we own in localStorage. Namespaced so nothing else collides. */
+export const STORAGE_KEY = "hl-study:progress:v1";
+
+/**
+ * The per-item history we persist.
+ *
+ * Note what is NOT here: `letterIndex`. That field is positional — it is the
+ * item's slot in the current run's array — so saving it would be saving exactly
+ * the thing that goes stale when the curriculum grows. We rebuild it on load.
+ */
+export interface SavedItem {
+  box: number;
+  dueAtSession: number;
+  introducedAt: number;
+  lapses: number;
+  reps: number;
+}
+
+/** What we persist. Deliberately small, flat and boring. */
+export interface SavedProgress {
+  version: number;
+  /** Session counter — the scheduler's notion of "now". */
+  session: number;
+  /** lesson id → its history. */
+  items: Record<string, SavedItem>;
+}
+
+/** A fresh, empty record. */
+export function emptyProgress(): SavedProgress {
+  return { version: SCHEMA_VERSION, session: 0, items: Object.create(null) };
+}
+
+/** Positional scheduler state → a saveable, id-keyed record. */
+export function toSaved(
+  ids: string[],
+  states: ItemState[],
+  session: number,
+): SavedProgress {
+  const items: Record<string, SavedItem> = Object.create(null);
+  ids.forEach((id, index) => {
+    const state = states[index];
+    if (!state) return;
+    // Don't persist untouched items: an unseen lesson is the default, so
+    // storing it wastes space and makes the payload grow with the curriculum
+    // rather than with what you've actually studied.
+    //
+    // Test this ONLY against review history (`reps`/`lapses`/`box`), never
+    // against `dueAtSession`. Fresh items are seeded with the CURRENT session,
+    // so on any reload after the first, `dueAtSession` is non-zero for every
+    // unseen lesson — a guard that consulted it would quietly fail open from
+    // session 1 onward and save all 679 lessons instead of the handful studied.
+    if (state.reps === 0 && state.lapses === 0 && state.box === 0) return;
+    items[id] = {
+      box: state.box,
+      dueAtSession: state.dueAtSession,
+      introducedAt: state.introducedAt,
+      lapses: state.lapses,
+      reps: state.reps,
+    };
+  });
+  return { version: SCHEMA_VERSION, session, items };
+}
+
+/**
+ * A saved record → positional scheduler state for `ids`.
+ *
+ * Anything we don't recognise becomes a fresh item: lessons added since the
+ * save, ids that vanished (renamed lessons), corrupt entries. That is the whole
+ * migration story, and it is why saving by id was worth the trouble.
+ */
+export function fromSaved(ids: string[], saved: SavedProgress): ItemState[] {
+  const states = initStates(ids.length, saved.session);
+  ids.forEach((id, index) => {
+    const entry = saved.items[id];
+    const base = states[index];
+    if (!entry || !base) return;
+    states[index] = {
+      // letterIndex is positional: keep the freshly-built one, never the saved
+      // one. This is what makes progress survive the curriculum growing.
+      letterIndex: base.letterIndex,
+      box: clampBox(entry.box),
+      dueAtSession: int(entry.dueAtSession),
+      introducedAt: int(entry.introducedAt),
+      lapses: Math.max(0, int(entry.lapses)),
+      reps: Math.max(0, int(entry.reps)),
+    };
+  });
+  return states;
+}
+
+function int(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : 0;
+}
+
+function clampBox(box: unknown): number {
+  return Math.max(0, Math.min(MAX_BOX, int(box)));
+}
+
+/**
+ * Parse whatever was in storage, defensively.
+ *
+ * This input is untrusted: a user can edit localStorage by hand, another tab
+ * can leave a half-written value, and an older build can leave an older shape.
+ * So we validate every field and fall back to `emptyProgress()` rather than
+ * throwing — losing progress is bad, but a study app that won't start because
+ * of one bad key is worse.
+ *
+ * Note `Object.create(null)` for the item map: a saved payload containing a
+ * `__proto__` key must not be able to reach Object.prototype.
+ */
+export function parseProgress(raw: string | null): SavedProgress {
+  if (raw === null || raw === "") return emptyProgress();
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return emptyProgress();
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    return emptyProgress();
+  }
+
+  const record = data as Record<string, unknown>;
+  if (record.version !== SCHEMA_VERSION) return emptyProgress();
+
+  const session =
+    typeof record.session === "number" && Number.isFinite(record.session)
+      ? Math.max(0, Math.trunc(record.session))
+      : 0;
+
+  const items: Record<string, SavedItem> = Object.create(null);
+  const rawItems = record.items;
+  if (typeof rawItems === "object" && rawItems !== null && !Array.isArray(rawItems)) {
+    // Own keys only — never walk the prototype chain.
+    for (const [id, value] of Object.entries(rawItems)) {
+      if (id === "__proto__" || id === "constructor" || id === "prototype") continue;
+      if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+      const entry = value as Record<string, unknown>;
+      items[id] = {
+        box: clampBox(entry.box),
+        dueAtSession: int(entry.dueAtSession),
+        introducedAt: int(entry.introducedAt),
+        lapses: Math.max(0, int(entry.lapses)),
+        reps: Math.max(0, int(entry.reps)),
+      };
+    }
+  }
+
+  return { version: SCHEMA_VERSION, session, items };
+}
+
+/** How many of `ids` have any saved history at all. */
+export function seenCount(ids: string[], saved: SavedProgress): number {
+  return ids.reduce((n, id) => (saved.items[id] ? n + 1 : n), 0);
+}
+
+// --- the only impure part -------------------------------------------------
+//
+// A minimal storage port. Everything above is pure; this is the thin edge that
+// touches the browser, so tests can pass a fake and never need jsdom for the
+// logic. Storage can throw (Safari private mode, quota, disabled cookies), so
+// both directions swallow failure: not being able to save is a degraded
+// experience, not a crash.
+
+/** The slice of the Storage API we need — easy to fake in a test. */
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export function loadProgress(storage: StorageLike | null): SavedProgress {
+  if (!storage) return emptyProgress();
+  try {
+    return parseProgress(storage.getItem(STORAGE_KEY));
+  } catch {
+    return emptyProgress();
+  }
+}
+
+export function saveProgress(
+  storage: StorageLike | null,
+  progress: SavedProgress,
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(progress));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `localStorage` when we're in a browser that allows it, else null. */
+export function browserStorage(): StorageLike | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/code/programs/typescript/script-writing-visualizer/src/types.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/types.ts
@@ -1,9 +1,14 @@
-// The shape of the script data we consume. This mirrors the `ScriptData` /
+// The shape of the SCRIPT data we consume. This mirrors the `ScriptData` /
 // `Letter` types published by `@coding-adventures/human-language-data` (HL01),
-// but is redeclared locally so this MVP app carries no package dependency — it
-// reads the JSON files directly. If the two ever need to share a type, promote
-// this to an import; for now, duplication of a handful of field names is the
-// cheaper trade than a cross-package build edge.
+// but is redeclared locally: the app reads `data/scripts/*.json` directly, and
+// duplicating a handful of field names is cheaper than routing the JSON through
+// the package.
+//
+// (The app does now depend on that package — see `lessons.ts`, which uses its
+// pure `parseLesson` to read the ~679 lesson files. It deep-imports
+// `.../src/parse.ts` rather than the barrel, which would drag `node:fs` and
+// `process` into the browser bundle. Only the LESSON types come from the
+// package; the script types below stay local.)
 
 /** One base letter (or character/radical) of a script. */
 export interface Letter {

--- a/code/programs/typescript/script-writing-visualizer/tests/lessons.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/lessons.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  indicesByLanguage,
+  languageFromPath,
+  languagesOf,
+  loadLessons,
+  toLesson,
+  nextDue,
+  type Lesson,
+} from "../src/lessons.ts";
+import { buildPool } from "../src/interleave.ts";
+import { parseLesson } from "@coding-adventures/human-language-data/src/parse.ts";
+
+const SPANISH = `---
+id: ES-C17-futuro
+chapter: 17
+type: word
+headword: hablaré
+gloss: the future
+concept_tag: ES-FUTURE
+prerequisites: [ES-C16-practice]
+reviews_of: [ES-C16-practice, ES-C06-hablar]
+---
+
+# body
+`;
+
+const TAMIL = `---
+id: TA-C06-dative-ukku
+chapter: 6
+type: word
+headword: -உக்கு
+gloss: to / for
+concept_tag: TA-CASE-DATIVE
+prerequisites: []
+reviews_of: []
+---
+
+# body
+`;
+
+const NO_ID = `---
+chapter: 1
+type: word
+headword: x
+gloss: y
+---
+
+# body
+`;
+
+describe("languageFromPath", () => {
+  it("pulls the track out of a curriculum path", () => {
+    expect(
+      languageFromPath("../../../../learning/human-languages/spanish/lessons/ES-C1.md"),
+    ).toBe("spanish");
+  });
+
+  it("returns empty for a path that isn't a lesson", () => {
+    expect(languageFromPath("../../elsewhere/notes.md")).toBe("");
+    expect(languageFromPath("/human-languages/spanish/roadmap.md")).toBe("");
+  });
+});
+
+describe("toLesson", () => {
+  it("carries the id, concept and both graphs through", () => {
+    const lesson = toLesson(parseLesson(SPANISH, "spanish"));
+    expect(lesson).not.toBeNull();
+    expect(lesson!.id).toBe("ES-C17-futuro");
+    expect(lesson!.language).toBe("spanish");
+    expect(lesson!.concept).toBe("ES-FUTURE");
+    expect(lesson!.chapter).toBe(17);
+    expect(lesson!.prerequisites).toEqual(["ES-C16-practice"]);
+    expect(lesson!.reviewsOf).toEqual(["ES-C16-practice", "ES-C06-hablar"]);
+  });
+
+  it("skips a lesson with no id rather than inventing one", () => {
+    expect(toLesson(parseLesson(NO_ID, "spanish"))).toBeNull();
+  });
+
+  it("handles a non-Latin headword unchanged", () => {
+    const lesson = toLesson(parseLesson(TAMIL, "tamil"));
+    expect(lesson!.headword).toBe("-உக்கு");
+    expect(lesson!.id).toBe("TA-C06-dative-ukku");
+  });
+});
+
+describe("loadLessons", () => {
+  const sources = {
+    "../../../../learning/human-languages/spanish/lessons/ES-C17-futuro.md": SPANISH,
+    "../../../../learning/human-languages/tamil/lessons/TA-C06-dative-ukku.md": TAMIL,
+    "../../../../learning/human-languages/spanish/lessons/broken.md": NO_ID,
+    "../../somewhere/else.md": SPANISH,
+  };
+
+  it("parses every well-formed lesson and drops the rest", () => {
+    const lessons = loadLessons(sources);
+    expect(lessons.map((l) => l.id)).toEqual(["ES-C17-futuro", "TA-C06-dative-ukku"]);
+  });
+
+  it("is sorted by id, so indices are deterministic across builds", () => {
+    const ids = loadLessons(sources).map((l) => l.id);
+    expect([...ids].sort()).toEqual(ids);
+  });
+});
+
+describe("grouping for interleaving", () => {
+  const lessons: Lesson[] = [
+    { id: "A1", language: "spanish", headword: "", gloss: "", type: "word", chapter: 1, concept: "", prerequisites: [], reviewsOf: [] },
+    { id: "B1", language: "tamil", headword: "", gloss: "", type: "word", chapter: 1, concept: "", prerequisites: [], reviewsOf: [] },
+    { id: "A2", language: "spanish", headword: "", gloss: "", type: "word", chapter: 2, concept: "", prerequisites: [], reviewsOf: [] },
+  ];
+
+  it("lists the distinct languages, sorted", () => {
+    expect(languagesOf(lessons)).toEqual(["spanish", "tamil"]);
+  });
+
+  it("groups indices by language, preserving order within each", () => {
+    // spanish first (sorted): indices 0 and 2; tamil: index 1.
+    expect(indicesByLanguage(lessons)).toEqual([[0, 2], [1]]);
+  });
+
+  it("produces groups the interleaver can round-robin over", () => {
+    // Exercise the actual remap pickLesson relies on: pool entry →
+    // groups[scriptIndex][letterIndex] → lesson index.
+    const groups = indicesByLanguage(lessons);
+    const pool = buildPool(groups.map((g) => g.length));
+    const order = pool.map((e) => groups[e.scriptIndex]![e.letterIndex]!);
+    // Round-robin: spanish(0), tamil(1), then spanish's second (2).
+    expect(order).toEqual([0, 1, 2]);
+    expect(order.map((i) => lessons[i]!.language)).toEqual([
+      "spanish",
+      "tamil",
+      "spanish",
+    ]);
+  });
+});
+
+describe("nextDue", () => {
+  // Three languages, one lesson each → the pool alternates across all three.
+  const groups = [[0], [1], [2]];
+  const pool = buildPool(groups.map((g) => g.length));
+  const allDue = [
+    { dueAtSession: 0 },
+    { dueAtSession: 0 },
+    { dueAtSession: 0 },
+  ];
+
+  it("advances the cursor so it never repeats the item just answered", () => {
+    let cursor = -1;
+    const picked: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const r = nextDue(groups, pool, allDue, 0, cursor);
+      picked.push(r.index!);
+      cursor = r.cursor;
+    }
+    // Every language in turn — the whole point of the cursor.
+    expect(picked).toEqual([0, 1, 2]);
+  });
+
+  it("wraps around the pool", () => {
+    const r = nextDue(groups, pool, allDue, 0, pool.length - 1);
+    expect(r.index).toBe(0);
+    expect(r.cursor).toBe(0);
+  });
+
+  it("skips items that are not yet due", () => {
+    const schedule = [
+      { dueAtSession: 99 }, // not due
+      { dueAtSession: 0 }, // due
+      { dueAtSession: 99 }, // not due
+    ];
+    expect(nextDue(groups, pool, schedule, 0, -1).index).toBe(1);
+  });
+
+  it("returns null when nothing is due, without looping forever", () => {
+    const none = [{ dueAtSession: 5 }, { dueAtSession: 5 }, { dueAtSession: 5 }];
+    expect(nextDue(groups, pool, none, 0, -1).index).toBeNull();
+  });
+
+  it("handles an empty pool", () => {
+    expect(nextDue([], [], [], 0, -1)).toEqual({ index: null, cursor: -1 });
+  });
+
+  it("copes with ragged groups", () => {
+    // spanish has 3 lessons, tamil 1 — buildPool goes ragged after round 1.
+    const ragged = [[0, 2, 3], [1]];
+    const raggedPool = buildPool(ragged.map((g) => g.length));
+    const schedule = [
+      { dueAtSession: 0 },
+      { dueAtSession: 0 },
+      { dueAtSession: 0 },
+      { dueAtSession: 0 },
+    ];
+    let cursor = -1;
+    const picked: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      const r = nextDue(ragged, raggedPool, schedule, 0, cursor);
+      picked.push(r.index!);
+      cursor = r.cursor;
+    }
+    // Alternates while both have items, then drains the longer group.
+    expect(picked).toEqual([0, 1, 2, 3]);
+  });
+});

--- a/code/programs/typescript/script-writing-visualizer/tests/progress.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/progress.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+  emptyProgress,
+  fromSaved,
+  loadProgress,
+  parseProgress,
+  saveProgress,
+  seenCount,
+  STORAGE_KEY,
+  toSaved,
+  type StorageLike,
+} from "../src/progress.ts";
+import { initStates, MAX_BOX, type ItemState } from "../src/scheduler.ts";
+
+/** A full ItemState with the fields a test cares about overridden. */
+function state(letterIndex: number, over: Partial<ItemState> = {}): ItemState {
+  return {
+    letterIndex,
+    box: 0,
+    dueAtSession: 0,
+    introducedAt: 0,
+    lapses: 0,
+    reps: 0,
+    ...over,
+  };
+}
+
+/** An in-memory stand-in for localStorage. */
+function fakeStorage(initial: Record<string, string> = {}): StorageLike & {
+  data: Record<string, string>;
+} {
+  const data = { ...initial };
+  return {
+    data,
+    getItem: (k) => (k in data ? data[k]! : null),
+    setItem: (k, v) => {
+      data[k] = v;
+    },
+  };
+}
+
+describe("toSaved / fromSaved", () => {
+  it("round-trips a studied item by id, not by position", () => {
+    const ids = ["ES-C01-hola", "FR-C01-salut"];
+    const states = initStates(2, 0);
+    states[1] = state(1, { box: 3, dueAtSession: 12, reps: 4, lapses: 1 });
+
+    const saved = toSaved(ids, states, 5);
+    expect(saved.items["FR-C01-salut"]).toMatchObject({ box: 3, dueAtSession: 12, reps: 4 });
+
+    // Insert a new lesson at the FRONT — indices all shift.
+    const grown = ["AR-C01-salam", "ES-C01-hola", "FR-C01-salut"];
+    const restored = fromSaved(grown, saved);
+
+    // The French progress followed its id, not its old slot.
+    expect(restored[2]).toMatchObject({ box: 3, dueAtSession: 12, reps: 4, lapses: 1 });
+    expect(restored[0]!.box).toBe(0); // the newcomer is unseen
+
+    // letterIndex is REBUILT positionally, never restored from the save —
+    // otherwise every saved item would point at a stale slot.
+    expect(restored[2]!.letterIndex).toBe(2);
+  });
+
+  it("does not persist untouched items", () => {
+    const ids = ["A", "B"];
+    const saved = toSaved(ids, initStates(2, 0), 0);
+    expect(Object.keys(saved.items)).toHaveLength(0);
+  });
+
+  it("still skips untouched items after a reload at a later session", () => {
+    // The regression this guards: fresh items are seeded with the CURRENT
+    // session, so from session 1 onward every unseen lesson has a non-zero
+    // dueAtSession. A guard that consulted dueAtSession would fail open here
+    // and persist the entire curriculum instead of the one studied item.
+    const ids = ["A", "B", "C"];
+
+    const first = toSaved(ids, [
+      state(0, { box: 1, dueAtSession: 1, reps: 1 }),
+      state(1),
+      state(2),
+    ], 1);
+    expect(Object.keys(first.items)).toEqual(["A"]);
+
+    // Reload: rebuild positional state from the save, then save again.
+    const reloaded = fromSaved(ids, first);
+    const second = toSaved(ids, reloaded, first.session);
+
+    expect(Object.keys(second.items)).toEqual(["A"]);
+    expect(seenCount(ids, second)).toBe(1);
+  });
+
+  it("keeps the payload proportional to what was studied, not to the curriculum", () => {
+    const ids = Array.from({ length: 500 }, (_, i) => `L${i}`);
+    const states = initStates(ids.length, 9);
+    states[3] = state(3, { box: 2, dueAtSession: 12, reps: 3 });
+
+    const saved = toSaved(ids, states, 9);
+    expect(Object.keys(saved.items)).toHaveLength(1);
+    // And it stays that way across a reload.
+    const again = toSaved(ids, fromSaved(ids, saved), saved.session);
+    expect(Object.keys(again.items)).toHaveLength(1);
+  });
+
+  it("treats ids missing from the save as fresh", () => {
+    const saved = toSaved(["A"], [state(0, { box: 2, dueAtSession: 4, reps: 1 })], 1);
+    const states = fromSaved(["A", "B"], saved);
+    expect(states[0]).toMatchObject({ box: 2, dueAtSession: 4 });
+    expect(states[1]!.box).toBe(0);
+    expect(states[1]!.reps).toBe(0);
+  });
+
+  it("clamps a box that is out of range or nonsense", () => {
+    const saved = emptyProgress();
+    saved.items["A"] = { box: 999, dueAtSession: 1, introducedAt: 0, lapses: 0, reps: 1 };
+    saved.items["B"] = { box: -5, dueAtSession: 1, introducedAt: 0, lapses: 0, reps: 1 };
+    const states = fromSaved(["A", "B"], saved);
+    expect(states[0]!.box).toBe(MAX_BOX);
+    expect(states[1]!.box).toBe(0);
+  });
+});
+
+describe("parseProgress", () => {
+  it("returns an empty record for null, empty, or non-JSON input", () => {
+    expect(parseProgress(null).items).toEqual({});
+    expect(parseProgress("").items).toEqual({});
+    expect(parseProgress("{not json").items).toEqual({});
+  });
+
+  it("rejects a payload that isn't an object", () => {
+    expect(parseProgress("[1,2,3]").items).toEqual({});
+    expect(parseProgress('"a string"').items).toEqual({});
+    expect(parseProgress("null").items).toEqual({});
+  });
+
+  it("drops a payload from a different schema version", () => {
+    const raw = JSON.stringify({ version: 99, session: 3, items: { A: { box: 2 } } });
+    expect(parseProgress(raw)).toEqual(emptyProgress());
+  });
+
+  it("keeps valid entries and skips malformed ones", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      session: 7,
+      items: {
+        good: { box: 2, dueAtSession: 9 },
+        notAnObject: 5,
+        nested: [1],
+        missingFields: {},
+      },
+    });
+    const parsed = parseProgress(raw);
+    expect(parsed.session).toBe(7);
+    expect(parsed.items["good"]).toMatchObject({ box: 2, dueAtSession: 9 });
+    expect(parsed.items["notAnObject"]).toBeUndefined();
+    expect(parsed.items["nested"]).toBeUndefined();
+    // Present but empty → defaults, not a crash.
+    expect(parsed.items["missingFields"]).toMatchObject({ box: 0, dueAtSession: 0, reps: 0 });
+  });
+
+  it("does not let a __proto__ key reach Object.prototype", () => {
+    const raw = '{"version":1,"session":0,"items":{"__proto__":{"box":5,"polluted":true}}}';
+    const parsed = parseProgress(raw);
+    expect(parsed.items["__proto__"]).toBeUndefined();
+    // The prototype chain is untouched.
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+    expect(Object.getPrototypeOf(parsed.items)).toBeNull();
+  });
+
+  it("coerces a non-finite or negative session to 0", () => {
+    const raw = JSON.stringify({ version: 1, session: -4, items: {} });
+    expect(parseProgress(raw).session).toBe(0);
+  });
+});
+
+describe("storage adapter", () => {
+  it("saves and reloads through a storage port", () => {
+    const storage = fakeStorage();
+    const progress = toSaved(["A"], [state(0, { box: 2, dueAtSession: 6, reps: 2 })], 3);
+
+    expect(saveProgress(storage, progress)).toBe(true);
+    expect(storage.data[STORAGE_KEY]).toBeDefined();
+    expect(loadProgress(storage).items["A"]).toMatchObject({ box: 2, dueAtSession: 6, reps: 2 });
+  });
+
+  it("degrades rather than throwing when storage is unavailable", () => {
+    expect(loadProgress(null)).toEqual(emptyProgress());
+    expect(saveProgress(null, emptyProgress())).toBe(false);
+  });
+
+  it("degrades when storage throws (private mode, quota)", () => {
+    const hostile: StorageLike = {
+      getItem() {
+        throw new Error("denied");
+      },
+      setItem() {
+        throw new Error("quota");
+      },
+    };
+    expect(loadProgress(hostile)).toEqual(emptyProgress());
+    expect(saveProgress(hostile, emptyProgress())).toBe(false);
+  });
+
+  it("survives a hand-corrupted value in storage", () => {
+    const storage = fakeStorage({ [STORAGE_KEY]: "<<garbage>>" });
+    expect(loadProgress(storage)).toEqual(emptyProgress());
+  });
+});
+
+describe("seenCount", () => {
+  it("counts only ids with saved history", () => {
+    const saved = toSaved(["A", "B"], [state(0, { box: 1, dueAtSession: 2, reps: 1 }), state(1)], 1);
+    expect(seenCount(["A", "B", "C"], saved)).toBe(1);
+  });
+});

--- a/code/programs/typescript/script-writing-visualizer/vitest.config.ts
+++ b/code/programs/typescript/script-writing-visualizer/vitest.config.ts
@@ -1,14 +1,34 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+// The curriculum — both the script JSON and the ~670 lesson markdown files —
+// lives outside this package, at code/learning/human-languages/. We read those
+// canonical files directly rather than copying them, so the app can never drift
+// from the curriculum. Vite guards reads outside the project root, so the root
+// must be declared legal here exactly as it is in vite.config.ts. (Two configs,
+// one rule: vitest does NOT inherit vite.config.ts's server block, and without
+// this the lesson glob fails with "Denied ID".)
+const repoRoot = path.resolve(__dirname, "../../../..");
 
 export default defineConfig({
+  server: {
+    fs: { allow: [repoRoot] },
+  },
   test: {
     environment: "jsdom",
     globals: true,
     coverage: {
       provider: "v8",
-      // The pure logic (core.ts + drill.ts) is what we hold to a high bar;
-      // main.ts is the thin DOM shell and data.ts is just JSON imports.
-      include: ["src/core.ts", "src/drill.ts", "src/scheduler.ts", "src/interleave.ts"],
+      // The pure logic is what we hold to a high bar; main.ts is the thin DOM
+      // shell and data.ts is just JSON imports.
+      include: [
+        "src/core.ts",
+        "src/drill.ts",
+        "src/scheduler.ts",
+        "src/interleave.ts",
+        "src/lessons.ts",
+        "src/progress.ts",
+      ],
     },
   },
 });


### PR DESCRIPTION
The study app could already schedule you. It could not **remember** you, and it had
never read a single lesson. Both are fixed.

**What was already there, unused:** `@coding-adventures/human-language-data` ships
`frontmatter.ts` / `loader.ts` / `parse.ts` / `queries.ts`, parses all **679 lesson
files**, and exports `languagesForConcept()` — whose own docstring calls it "the
cross-language join … what the companion app calls." It had **zero consumers**. The app
read only `data/scripts/*.json` and drilled letters.

- **New "Lessons" mode** drills the written curriculum — **679 lessons, 18 languages** —
  with the *same* Leitner machinery as the letter drills, because `scheduler.ts` is
  generic over a numeric index and never needed to know what an item is.
  `scheduler.ts`, `interleave.ts`, `drill.ts` are **untouched**.
- **Progress persists** (`src/progress.ts`). There was previously **no storage layer at
  all**, so every box reset on reload. Saved to `localStorage` keyed by **lesson id**,
  never by array index — indices shift whenever a lesson is added, and saving by position
  would silently reattribute your history to the wrong lesson.
- **Cross-language interleaving comes free**: grouping lessons by language and feeding
  `interleave.buildPool` the way it already handles scripts gives Arabic → Bengali →
  French → German → Gujarati → Hindi in consecutive reviews.
- **Defensive loading** — saved state is untrusted input. Every field validated, unknown
  ids treated as fresh, `__proto__`/`constructor` skipped, item map `Object.create(null)`,
  throwing or absent `localStorage` degrades instead of crashing.
- Tests **57 → 75**. Zero third-party runtime deps.

### Three bugs found and fixed before merge

1. **`process is not defined` at startup.** Importing the package *barrel* pulled
   `cli.ts` and `loader.ts` (`process`, `node:fs`) into the browser bundle. The build
   **succeeded** and the app then died on load with a blank page. Fixed by deep-importing
   the pure module (`.../src/parse.ts`); bundle verified clean. **Only opening the app in
   a browser caught this** — no test or build step would have.
2. **The "don't persist untouched items" guard failed open after one reload.** It tested
   `dueAtSession <= 0`, but fresh items are seeded with the *current* session, so from
   session 1 onward every unseen lesson looked touched: payload ~100 bytes → **~48 kB**,
   and "started" reported the whole curriculum. Now keyed on review history only, with a
   reload round-trip test — the original test only covered session 0, the one case where
   the bug was invisible. *(Caught by the review subagent.)*
3. **`pickLesson` re-served the lesson you just answered.** Boxes 0/1 fall due again after
   one session, so a scan-from-the-front picker looped on the first lesson and never left
   the first language. Fixed with a rotating cursor — now `nextDue`, pure and tested.

### Verified in-browser, end to end

679 lessons load; reviews interleave across languages; progress survives a reload —
**3 items / 270 bytes**, not 679 / 48 kB.

```
679 lessons · 678 due · 3 started · mastered 0
arabic · chapter 1 · AR-C01-al   →   ال   →   "the (al- — the attached article)"
```

### Known cost (deferred, not hidden)

The eager glob inlines all 679 lesson texts: **1.56 MB bundle (480 kB gzipped)**, parsed
at every startup even in Browse mode. A lazy glob or build-time JSON index would fix both.

Also: `vitest.config.ts` doesn't inherit `vite.config.ts`'s `server.fs.allow` (lesson glob
failed with "Denied ID" until declared in both), and a stale `types.ts` comment claiming
the app has no package dependency is corrected.

Security-reviewed: **PASS** — no `innerHTML` anywhere (all lesson data via `textContent`),
prototype pollution unreachable, Node-in-browser leakage verified absent from the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)