### PR TITLE
feat(spice): add diode temperature exponent

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Diode saturation-current temperature exponent** — diode model cards now
+  accept `XTI`, apply it to saturation-current temperature scaling, and
+  preserve it through subcircuit expansion, matching Rust and TypeScript.
+
 - **Diode forward-bias depletion coefficient** — diode model cards now accept
   `FC` and apply the continuous Berkeley piecewise depletion-capacitance law in
   AC and transient analysis, matching Rust and TypeScript.
@@ -29,7 +33,7 @@
   `model_card_supported_parameter_coverage_gate_issue_records()`,
   `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
   `format_model_card_supported_parameter_coverage_gate_issue_json()` now
-  validate the expected seven-kind, 70-row supported-parameter catalog and
+  validate the expected seven-kind, 71-row supported-parameter catalog and
   expose stable issue rows for release automation, matching Rust and
   TypeScript.
 

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -208,6 +208,8 @@ Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
 and `FC` forward-bias depletion coefficient. AC and transient analyses use them
 to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
+Diode cards also accept `XTI` (default `3`) to control the saturation-current
+temperature exponent used by temperature sweeps.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -233,7 +235,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 70-row supported-parameter catalog and expose stable issue
+expected seven-kind, 71-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -491,6 +491,7 @@ class Diode:
     Vj: float = 1.0  # junction potential
     M: float = 0.5  # junction grading coefficient
     Fc: float = 0.5  # forward-bias depletion coefficient
+    Xti: float = 3.0  # saturation-current temperature exponent
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -308,6 +308,10 @@ def diode_at_temperature(
     effective_n = diode.N
     if not math.isfinite(effective_n) or effective_n <= 0.0:
         raise ValueError(f"{diode.name}: diode emission coefficient must be finite and positive")
+    if not math.isfinite(diode.Xti):
+        raise ValueError(
+            f"{diode.name}: diode saturation-current temperature exponent must be finite"
+        )
     ratio = temperature_kelvin / nominal_temperature_kelvin
     exponent = (
         energy_gap_ev
@@ -315,7 +319,7 @@ def diode_at_temperature(
         / (effective_n * _BOLTZMANN)
         * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin)
     )
-    saturation_scale = ratio**3 * math.exp(max(-100.0, min(100.0, exponent)))
+    saturation_scale = ratio**diode.Xti * math.exp(max(-100.0, min(100.0, exponent)))
     return replace(
         diode,
         Is=diode.Is * saturation_scale,
@@ -577,6 +581,10 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.IBV,
             element.Cjo,
             element.Tt,
+            element.Vj,
+            element.M,
+            element.Fc,
+            element.Xti,
         )
     if isinstance(element, JFET):
         return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd)
@@ -8655,6 +8663,10 @@ def _diode_effective_vt(el: Diode) -> float:
         raise ValueError(
             f"{el.name}: diode forward-bias depletion coefficient must be finite and in [0, 1)"
         )
+    if not math.isfinite(el.Xti):
+        raise ValueError(
+            f"{el.name}: diode saturation-current temperature exponent must be finite"
+        )
     if not math.isfinite(el.Tt) or el.Tt < 0.0:
         raise ValueError(f"{el.name}: diode transit time must be finite and non-negative")
     return el.Vt * el.N
@@ -13791,6 +13803,7 @@ def sens_dc(
                     el.Vj,
                     el.M,
                     el.Fc,
+                    el.Xti,
                 ),
             )
 
@@ -14039,6 +14052,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             el.Vj,
             el.M,
             el.Fc,
+            el.Xti,
         )
 
     if isinstance(el, BJT):

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -306,7 +306,7 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
     "PMOS",
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
-    "D": (10, 16, 5, 3),
+    "D": (11, 17, 5, 3),
     "NPN": (7, 15, 4, 4),
     "PNP": (7, 15, 4, 4),
     "NJF": (5, 11, 5, 3),
@@ -350,6 +350,7 @@ _DIODE_PARAMETER_ALIASES: dict[str, str] = {
     "M": "M",
     "MJ": "M",
     "FC": "FC",
+    "XTI": "XTI",
 }
 
 _BJT_PARAMETER_ALIASES: dict[str, str] = {
@@ -862,6 +863,7 @@ def diode_from_model_card(
         Vj=p.get("VJ", 1.0),
         M=p.get("M", 0.5),
         Fc=p.get("FC", 0.5),
+        Xti=p.get("XTI", 3.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -204,6 +204,7 @@ from spice_engine import (
     digital_event_streams_to_voltage_sources,
     digital_events_to_pwl_waveform,
     digital_events_to_voltage_source,
+    diode_at_temperature,
     diode_from_model_card,
     distortion_from_fourier,
     distortion_from_transient,
@@ -410,7 +411,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 70
+    assert len(coverage) == 71
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -425,7 +426,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 70
+    assert len(records) == 71
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -442,8 +443,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     summary = model_card_supported_parameter_coverage_summary()
     assert len(summary) == 7
     assert summary[0].kind == "D"
-    assert summary[0].canonical_parameter_count == 10
-    assert summary[0].accepted_name_count == 16
+    assert summary[0].canonical_parameter_count == 11
+    assert summary[0].accepted_name_count == 17
     assert summary[0].aliased_parameter_count == 5
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
@@ -468,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
         == "kind\tcanonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\taliased_parameters"
     )
-    assert table.splitlines()[1] == "D\t10\t16\t5\t3\tIS|VT|CJO|VJ|M"
+    assert table.splitlines()[1] == "D\t11\t17\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
         == "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -477,8 +478,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert len(records) == 7
     assert records[0] == {
         "kind": "D",
-        "canonical_parameter_count": "10",
-        "accepted_name_count": "16",
+        "canonical_parameter_count": "11",
+        "accepted_name_count": "17",
         "aliased_parameter_count": "5",
         "max_alias_count": "3",
         "aliased_parameters": "IS|VT|CJO|VJ|M",
@@ -486,7 +487,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert format_model_card_supported_parameter_coverage_summary_csv().startswith(
         "kind,canonical_parameter_count,accepted_name_count,"
         "aliased_parameter_count,max_alias_count,aliased_parameters\n"
-        "D,10,16,5,3,IS|VT|CJO|VJ|M\n"
+        "D,11,17,5,3,IS|VT|CJO|VJ|M\n"
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_summary_json())
@@ -499,9 +500,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 70
-    assert report.expected_canonical_parameter_count == 70
-    assert report.accepted_name_count == 118
+    assert report.canonical_parameter_count == 71
+    assert report.expected_canonical_parameter_count == 71
+    assert report.accepted_name_count == 119
     assert report.aliased_parameter_count == 35
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -509,7 +510,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t70\t70\t118\t35\t4\t0"
+        "true\t7\t7\t71\t71\t119\t35\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -537,8 +538,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 69
-    assert report.accepted_name_count == 115
+    assert report.canonical_parameter_count == 70
+    assert report.accepted_name_count == 116
     assert report.aliased_parameter_count == 34
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -553,7 +554,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t69\t70\t115\t34\t4\t4\n"
+        "false\t7\t7\t70\t71\t116\t34\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -591,6 +592,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "PB": 0.8,
             "MJ": 0.4,
             "FC": 0.35,
+            "XTI": 2.2,
             "RS": 10.0,
         },
     )
@@ -602,6 +604,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "VJ": 0.8,
         "M": 0.4,
         "FC": 0.35,
+        "XTI": 2.2,
     }
     assert diode_card.unsupported_parameters == ("RS",)
     diode_issues = model_card_unsupported_parameter_issues(diode_card)
@@ -637,6 +640,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert diode_model.Vj == pytest.approx(0.8)
     assert pytest.approx(0.4) == diode_model.M
     assert pytest.approx(0.35) == diode_model.Fc
+    assert pytest.approx(2.2) == diode_model.Xti
 
     bjt_card = normalize_model_card("Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12})
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
@@ -2191,6 +2195,23 @@ def test_subcircuit_instance_expands_resistor_divider_at_build_time():
     ]
 
 
+def test_subcircuit_expansion_preserves_complete_diode_model():
+    cell = SubcircuitDefinition(
+        "diode-cell",
+        ("in",),
+        (Diode("Dcell", "in", "0", Vj=0.8, M=0.4, Fc=0.35, Xti=2.2),),
+    )
+    c = Circuit()
+    c.define_subcircuit(cell)
+    c.add(XInstance("X1", ("a",), "diode-cell"))
+
+    expanded = next(element for element in c.elements if isinstance(element, Diode))
+    assert expanded.Vj == pytest.approx(0.8)
+    assert pytest.approx(0.4) == expanded.M
+    assert expanded.Fc == pytest.approx(0.35)
+    assert expanded.Xti == pytest.approx(2.2)
+
+
 def test_branch_current_in_voltage_source():
     """V=10V, R=1k -> I=10mA flowing from + to - inside the source."""
     c = Circuit()
@@ -2291,6 +2312,25 @@ def test_diode_temperature_scaling_reduces_fixed_current_forward_drop():
     assert hot_result.converged
     assert cold_result.node_voltages["a"] > nominal_result.node_voltages["a"]
     assert hot_result.node_voltages["a"] < nominal_result.node_voltages["a"]
+
+
+def test_diode_temperature_scaling_uses_model_saturation_current_exponent():
+    temperature_kelvin = 350.0
+    nominal_temperature_kelvin = 300.15
+    default_hot = diode_at_temperature(
+        Diode("D1", "a", "0", Xti=3.0),
+        temperature_kelvin,
+        nominal_temperature_kelvin=nominal_temperature_kelvin,
+    )
+    flat_hot = diode_at_temperature(
+        Diode("D1", "a", "0", Xti=0.0),
+        temperature_kelvin,
+        nominal_temperature_kelvin=nominal_temperature_kelvin,
+    )
+
+    assert default_hot.Is / flat_hot.Is == pytest.approx(
+        (temperature_kelvin / nominal_temperature_kelvin) ** 3
+    )
 
 
 def test_dc_temperature_sweep_runs_operating_points_and_formats_table():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add diode model-card `XTI` saturation-current temperature-exponent support,
+  preserving it through subcircuit expansion and matching Python and
+  TypeScript.
 - Add diode model-card `FC` forward-bias depletion coefficient support and a
   continuous piecewise depletion-capacitance law, matching Python and
   TypeScript.
@@ -21,7 +24,7 @@
   `model_card_supported_parameter_coverage_gate_issue_records`,
   `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
   `format_model_card_supported_parameter_coverage_gate_issue_json`, stable
-  release-gate checks and issue exports for the seven-kind, 70-row supported
+  release-gate checks and issue exports for the seven-kind, 71-row supported
   model-card parameter catalog, matching Python and TypeScript.
 - Add `model_card_supported_parameter_coverage_summary`,
   `format_model_card_supported_parameter_coverage_summary_table`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -125,6 +125,8 @@ Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
 and `FC` forward-bias depletion coefficient. AC and transient analyses use them
 to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
+Diode cards also accept `XTI` (default `3`) to control the saturation-current
+temperature exponent used by temperature sweeps.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -150,7 +152,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 70-row supported-parameter catalog and expose stable issue
+expected seven-kind, 71-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -389,7 +389,7 @@ fn clone_subckt_element(
             cloned.negative = map_subckt_node(&element.negative, instance_name, node_map);
             Element::CustomModel(cloned)
         }
-        Element::Diode(element) => Element::Diode(Diode::with_model_and_breakdown(
+        Element::Diode(element) => Element::Diode(Diode::with_model_and_temperature_exponent(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.anode, instance_name, node_map),
             map_subckt_node(&element.cathode, instance_name, node_map),
@@ -400,6 +400,10 @@ fn clone_subckt_element(
             element.breakdown_current,
             element.junction_capacitance,
             element.transit_time,
+            element.junction_potential,
+            element.grading_coefficient,
+            element.forward_bias_depletion_coefficient,
+            element.saturation_current_temperature_exponent,
         )),
         Element::Jfet(element) => Element::Jfet(Jfet::with_model_and_capacitance(
             format!("{instance_name}.{}", element.name),
@@ -2348,6 +2352,7 @@ pub struct Diode {
     pub junction_potential: f64,
     pub grading_coefficient: f64,
     pub forward_bias_depletion_coefficient: f64,
+    pub saturation_current_temperature_exponent: f64,
 }
 
 impl Diode {
@@ -2474,6 +2479,41 @@ impl Diode {
         grading_coefficient: f64,
         forward_bias_depletion_coefficient: f64,
     ) -> Self {
+        Self::with_model_and_temperature_exponent(
+            name,
+            anode,
+            cathode,
+            saturation_current,
+            thermal_voltage,
+            emission_coefficient,
+            breakdown_voltage,
+            breakdown_current,
+            junction_capacitance,
+            transit_time,
+            junction_potential,
+            grading_coefficient,
+            forward_bias_depletion_coefficient,
+            3.0,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_and_temperature_exponent(
+        name: impl Into<String>,
+        anode: impl Into<String>,
+        cathode: impl Into<String>,
+        saturation_current: f64,
+        thermal_voltage: f64,
+        emission_coefficient: f64,
+        breakdown_voltage: Option<f64>,
+        breakdown_current: f64,
+        junction_capacitance: f64,
+        transit_time: f64,
+        junction_potential: f64,
+        grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
+        saturation_current_temperature_exponent: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             anode: anode.into(),
@@ -2488,6 +2528,7 @@ impl Diode {
             junction_potential,
             grading_coefficient,
             forward_bias_depletion_coefficient,
+            saturation_current_temperature_exponent,
         }
     }
 }
@@ -2522,11 +2563,18 @@ pub fn diode_at_temperature(
             reason: "emission coefficient must be finite and positive".to_string(),
         });
     }
+    if !diode.saturation_current_temperature_exponent.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "saturation-current temperature exponent must be finite".to_string(),
+        });
+    }
     let ratio = temperature_kelvin / nominal_temperature_kelvin;
     let exponent = energy_gap_electron_volts * ELECTRON_CHARGE
         / (diode.emission_coefficient * BOLTZMANN)
         * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin);
-    let saturation_scale = ratio.powi(3) * exponent.clamp(-100.0, 100.0).exp();
+    let saturation_scale = ratio.powf(diode.saturation_current_temperature_exponent)
+        * exponent.clamp(-100.0, 100.0).exp();
     let mut adjusted = diode.clone();
     adjusted.saturation_current *= saturation_scale;
     adjusted.thermal_voltage *= ratio;
@@ -3179,7 +3227,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
     usize,
 )] = &[
-    (ModelCardKind::Diode, 10, 16, 5, 3),
+    (ModelCardKind::Diode, 11, 17, 5, 3),
     (ModelCardKind::Npn, 7, 15, 4, 4),
     (ModelCardKind::Pnp, 7, 15, 4, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
@@ -3204,6 +3252,7 @@ const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("M", "M"),
     ("MJ", "M"),
     ("FC", "FC"),
+    ("XTI", "XTI"),
 ];
 const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -3828,7 +3877,7 @@ pub fn diode_from_model_card(
     if model.kind != ModelCardKind::Diode {
         return Err(model_card_kind_error(&name, "diode", model.kind));
     }
-    Ok(Diode::with_model_and_forward_depletion(
+    Ok(Diode::with_model_and_temperature_exponent(
         name,
         anode,
         cathode,
@@ -3842,6 +3891,7 @@ pub fn diode_from_model_card(
         model_card_value(model, "VJ", 1.0),
         model_card_value(model, "M", 0.5),
         model_card_value(model, "FC", 0.5),
+        model_card_value(model, "XTI", 3.0),
     ))
 }
 
@@ -22989,6 +23039,12 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
             reason: "forward-bias depletion coefficient must be finite and in [0, 1)".to_string(),
+        });
+    }
+    if !diode.saturation_current_temperature_exponent.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "saturation-current temperature exponent must be finite".to_string(),
         });
     }
     if !diode.transit_time.is_finite() || diode.transit_time < 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -14,7 +14,8 @@ use spice_engine::{
     device_model_reference_deck_audit_matrix, device_model_reference_deck_audit_matrix_records,
     device_model_reference_deck_audit_records, device_model_reference_deck_audit_summary,
     device_model_reference_deck_audit_summary_records, device_model_temperature_audit_fixtures,
-    diode_from_model_card, format_corner_dc_sweep_table, format_corner_dc_table,
+    diode_at_temperature, diode_from_model_card, format_corner_dc_sweep_table,
+    format_corner_dc_table,
     format_corner_temperature_dc_table, format_dc_sweep_table,
     format_device_model_reference_deck_audit_analysis_summary_csv,
     format_device_model_reference_deck_audit_analysis_summary_json,
@@ -99,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 70);
+    assert_eq!(coverage.len(), 71);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -118,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 70);
+    assert_eq!(records.len(), 71);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -142,8 +143,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let summary = model_card_supported_parameter_coverage_summary();
     assert_eq!(summary.len(), 7);
     assert_eq!(summary[0].kind, ModelCardKind::Diode);
-    assert_eq!(summary[0].canonical_parameter_count, 10);
-    assert_eq!(summary[0].accepted_name_count, 16);
+    assert_eq!(summary[0].canonical_parameter_count, 11);
+    assert_eq!(summary[0].accepted_name_count, 17);
     assert_eq!(summary[0].aliased_parameter_count, 5);
     assert_eq!(summary[0].max_alias_count, 3);
     assert_eq!(
@@ -167,7 +168,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         lines[0],
         "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters"
     );
-    assert_eq!(lines[1], "D\t10\t16\t5\t3\tIS|VT|CJO|VJ|M");
+    assert_eq!(lines[1], "D\t11\t17\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -175,17 +176,17 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
-    assert_eq!(records[0]["canonical_parameter_count"], "10");
-    assert_eq!(records[0]["accepted_name_count"], "16");
+    assert_eq!(records[0]["canonical_parameter_count"], "11");
+    assert_eq!(records[0]["accepted_name_count"], "17");
     assert_eq!(records[0]["aliased_parameter_count"], "5");
     assert_eq!(records[0]["max_alias_count"], "3");
     assert_eq!(records[0]["aliased_parameters"], "IS|VT|CJO|VJ|M");
     assert!(format_model_card_supported_parameter_coverage_summary_csv().starts_with(
-        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,10,16,5,3,IS|VT|CJO|VJ|M\n"
+        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,11,17,5,3,IS|VT|CJO|VJ|M\n"
     ));
     let json = format_model_card_supported_parameter_coverage_summary_json();
     assert!(json.starts_with(
-        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"10\",\"accepted_name_count\":\"16\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
+        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"11\",\"accepted_name_count\":\"17\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
         "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"18\",\"accepted_name_count\":\"25\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
@@ -199,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 70);
-    assert_eq!(report.expected_canonical_parameter_count, 70);
-    assert_eq!(report.accepted_name_count, 118);
+    assert_eq!(report.canonical_parameter_count, 71);
+    assert_eq!(report.expected_canonical_parameter_count, 71);
+    assert_eq!(report.accepted_name_count, 119);
     assert_eq!(report.aliased_parameter_count, 35);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t70\t70\t118\t35\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t71\t71\t119\t35\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -234,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 69);
-    assert_eq!(report.accepted_name_count, 115);
+    assert_eq!(report.canonical_parameter_count, 70);
+    assert_eq!(report.accepted_name_count, 116);
     assert_eq!(report.aliased_parameter_count, 34);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -252,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t69\t70\t115\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t70\t71\t116\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -276,10 +277,10 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard.len(), 7);
     assert_eq!(dashboard[0].kind, ModelCardKind::Diode);
     assert!(dashboard[0].passed);
-    assert_eq!(dashboard[0].canonical_parameter_count, 10);
-    assert_eq!(dashboard[0].expected_canonical_parameter_count, 10);
-    assert_eq!(dashboard[0].accepted_name_count, 16);
-    assert_eq!(dashboard[0].expected_accepted_name_count, 16);
+    assert_eq!(dashboard[0].canonical_parameter_count, 11);
+    assert_eq!(dashboard[0].expected_canonical_parameter_count, 11);
+    assert_eq!(dashboard[0].accepted_name_count, 17);
+    assert_eq!(dashboard[0].expected_accepted_name_count, 17);
     assert_eq!(dashboard[0].aliased_parameter_count, 5);
     assert_eq!(dashboard[0].expected_aliased_parameter_count, 5);
     assert_eq!(dashboard[0].max_alias_count, 3);
@@ -297,7 +298,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
         lines[0],
         "kind\tpassed\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\texpected_accepted_name_count\taliased_parameter_count\texpected_aliased_parameter_count\tmax_alias_count\texpected_max_alias_count\tissue_count\tissue_fields"
     );
-    assert_eq!(lines[1], "D\ttrue\t10\t10\t16\t16\t5\t5\t3\t3\t0\t");
+    assert_eq!(lines[1], "D\ttrue\t11\t11\t17\t17\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\ttrue\t18\t18\t25\t25\t6\t6\t3\t3\t0\t"
@@ -306,15 +307,15 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["passed"], "true");
-    assert_eq!(records[0]["canonical_parameter_count"], "10");
-    assert_eq!(records[0]["expected_canonical_parameter_count"], "10");
+    assert_eq!(records[0]["canonical_parameter_count"], "11");
+    assert_eq!(records[0]["expected_canonical_parameter_count"], "11");
     assert_eq!(records[0]["issue_count"], "0");
     assert_eq!(records[0]["issue_fields"], "");
     assert!(format_model_card_supported_parameter_coverage_dashboard_csv(&coverage).starts_with(
-        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,10,10,16,16,5,5,3,3,0,\n"
+        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,11,11,17,17,5,5,3,3,0,\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_dashboard_json(&coverage).starts_with(
-        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"10\",\"expected_canonical_parameter_count\":\"10\""
+        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"11\",\"expected_canonical_parameter_count\":\"11\""
     ));
 }
 
@@ -367,6 +368,7 @@ fn model_card_aliases_build_device_instances() {
             ("PB", 0.8),
             ("MJ", 0.4),
             ("FC", 0.35),
+            ("XTI", 2.2),
             ("RS", 10.0),
         ],
     )
@@ -377,6 +379,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*diode_card.parameters.get("VJ").unwrap(), 0.8);
     assert_close(*diode_card.parameters.get("M").unwrap(), 0.4);
     assert_close(*diode_card.parameters.get("FC").unwrap(), 0.35);
+    assert_close(*diode_card.parameters.get("XTI").unwrap(), 2.2);
     assert_eq!(diode_card.unsupported_parameters, vec!["RS".to_string()]);
     let diode_issues = model_card_unsupported_parameter_issues(&diode_card);
     assert_eq!(diode_issues.len(), 1);
@@ -414,6 +417,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(diode_model.junction_potential, 0.8);
     assert_close(diode_model.grading_coefficient, 0.4);
     assert_close(diode_model.forward_bias_depletion_coefficient, 0.35);
+    assert_close(diode_model.saturation_current_temperature_exponent, 2.2);
 
     let bjt_card =
         normalize_model_card("Qsmall", "npn", &[("BETA", 125.0), ("CBE", 2.0e-12)]).unwrap();
@@ -1272,6 +1276,42 @@ fn dc_subcircuit_instance_expands_resistor_divider() {
 }
 
 #[test]
+fn subcircuit_expansion_preserves_complete_diode_model() {
+    let diode = Diode::with_model_and_temperature_exponent(
+        "Dcell", "in", "0", 2.0e-14, 0.026, 1.2, Some(6.0), 2.0e-6, 1.5e-12,
+        4.0e-9, 0.8, 0.4, 0.35, 2.2,
+    );
+    let mut circuit = Circuit::new();
+    circuit
+        .define_subcircuit(SubcircuitDefinition::new(
+            "diode-cell",
+            vec!["in".to_string()],
+            vec![SubcircuitElement::from(Element::Diode(diode))],
+        ))
+        .unwrap();
+    circuit
+        .instantiate(XInstance::new(
+            "X1",
+            vec!["a".to_string()],
+            "diode-cell",
+        ))
+        .unwrap();
+
+    let expanded = circuit
+        .elements()
+        .iter()
+        .find_map(|element| match element {
+            Element::Diode(diode) => Some(diode),
+            _ => None,
+        })
+        .unwrap();
+    assert_close(expanded.junction_potential, 0.8);
+    assert_close(expanded.grading_coefficient, 0.4);
+    assert_close(expanded.forward_bias_depletion_coefficient, 0.35);
+    assert_close(expanded.saturation_current_temperature_exponent, 2.2);
+}
+
+#[test]
 fn dc_current_source_into_resistor_uses_positive_to_negative_orientation() {
     let mut circuit = Circuit::new();
     circuit.add(Element::CurrentSource(CurrentSource::new(
@@ -1535,6 +1575,40 @@ fn dc_diode_temperature_scaling_reduces_fixed_current_forward_drop() {
 
     assert!(cold_result.voltage("a").unwrap() > nominal_result.voltage("a").unwrap());
     assert!(hot_result.voltage("a").unwrap() < nominal_result.voltage("a").unwrap());
+}
+
+#[test]
+fn diode_temperature_scaling_uses_model_saturation_current_exponent() {
+    let default_xti = Diode::with_model_and_temperature_exponent(
+        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5,
+        0.5, 3.0,
+    );
+    let flat_xti = Diode::with_model_and_temperature_exponent(
+        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5,
+        0.5, 0.0,
+    );
+
+    let temperature_kelvin = 350.0;
+    let nominal_temperature_kelvin = 300.15;
+    let default_hot = diode_at_temperature(
+        &default_xti,
+        temperature_kelvin,
+        nominal_temperature_kelvin,
+        1.11,
+    )
+    .unwrap();
+    let flat_hot = diode_at_temperature(
+        &flat_xti,
+        temperature_kelvin,
+        nominal_temperature_kelvin,
+        1.11,
+    )
+    .unwrap();
+
+    assert_close(
+        default_hot.saturation_current / flat_hot.saturation_current,
+        (temperature_kelvin / nominal_temperature_kelvin).powi(3),
+    );
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add diode model-card `XTI` saturation-current temperature-exponent support,
+  preserving it through subcircuit expansion and matching Python and Rust.
 - Add diode model-card `FC` forward-bias depletion coefficient support and a
   continuous piecewise depletion-capacitance law, matching Python and Rust.
 - Shape diode depletion capacitance from the operating-point bias with model-card
@@ -20,7 +22,7 @@
   `modelCardSupportedParameterCoverageGateIssueRecords`,
   `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
   `formatModelCardSupportedParameterCoverageGateIssueJson`, stable release-gate
-  checks and issue exports for the seven-kind, 70-row supported model-card
+  checks and issue exports for the seven-kind, 71-row supported model-card
   parameter catalog, matching Python and Rust.
 - Add `modelCardSupportedParameterCoverageSummary`,
   `formatModelCardSupportedParameterCoverageSummaryTable`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -195,6 +195,8 @@ Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
 and `FC` forward-bias depletion coefficient. AC and transient analyses use them
 to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
+Diode cards also accept `XTI` (default `3`) to control the saturation-current
+temperature exponent used by temperature sweeps.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -220,7 +222,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 70-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 71-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1674,6 +1674,7 @@ export interface Diode {
   readonly junctionPotential: number;
   readonly gradingCoefficient: number;
   readonly forwardBiasDepletionCoefficient: number;
+  readonly saturationCurrentTemperatureExponent: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -1984,7 +1985,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_KINDS: readonly ModelCardKind[] = 
 const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
-  D: [10, 16, 5, 3],
+  D: [11, 17, 5, 3],
   NPN: [7, 15, 4, 4],
   PNP: [7, 15, 4, 4],
   NJF: [5, 11, 5, 3],
@@ -3572,7 +3573,7 @@ function cloneSubcktElement(
     case "custom-model":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap) };
     case "diode":
-      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime);
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent);
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
@@ -7532,6 +7533,7 @@ export function diode(
   junctionPotential = 1.0,
   gradingCoefficient = 0.5,
   forwardBiasDepletionCoefficient = 0.5,
+  saturationCurrentTemperatureExponent = 3.0,
 ): Diode {
   return {
     kind: "diode",
@@ -7548,6 +7550,7 @@ export function diode(
     junctionPotential,
     gradingCoefficient,
     forwardBiasDepletionCoefficient,
+    saturationCurrentTemperatureExponent,
   };
 }
 
@@ -7569,13 +7572,20 @@ export function diodeAtTemperature(
   if (!Number.isFinite(element.emissionCoefficient) || element.emissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "emission coefficient must be finite and positive");
   }
+  if (!Number.isFinite(element.saturationCurrentTemperatureExponent)) {
+    throw invalidElement(
+      element.name,
+      "saturation-current temperature exponent must be finite",
+    );
+  }
   const ratio = temperatureKelvin / nominalTemperatureKelvin;
   const exponent =
     (energyGapElectronVolts * ELECTRON_CHARGE) /
     (element.emissionCoefficient * BOLTZMANN) *
     (1.0 / nominalTemperatureKelvin - 1.0 / temperatureKelvin);
   const saturationScale =
-    ratio ** 3 * Math.exp(Math.max(-100.0, Math.min(100.0, exponent)));
+    ratio ** element.saturationCurrentTemperatureExponent *
+    Math.exp(Math.max(-100.0, Math.min(100.0, exponent)));
   return {
     ...element,
     saturationCurrent: element.saturationCurrent * saturationScale,
@@ -7810,6 +7820,7 @@ const DIODE_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   M: "M",
   MJ: "M",
   FC: "FC",
+  XTI: "XTI",
 };
 
 const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8295,6 +8306,7 @@ export function diodeFromModelCard(
     p.VJ ?? 1.0,
     p.M ?? 0.5,
     p.FC ?? 0.5,
+    p.XTI ?? 3.0,
   );
 }
 
@@ -19181,6 +19193,12 @@ function validateDiode(element: Diode): void {
     throw invalidElement(
       element.name,
       "forward-bias depletion coefficient must be finite and in [0, 1)",
+    );
+  }
+  if (!Number.isFinite(element.saturationCurrentTemperatureExponent)) {
+    throw invalidElement(
+      element.name,
+      "saturation-current temperature exponent must be finite",
     );
   }
   if (!Number.isFinite(element.transitTime) || element.transitTime < 0.0) {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -39,6 +39,7 @@ import {
   deviceModelReferenceDeckAuditSummaryRecords,
   deviceModelTemperatureAuditFixtures,
   diode,
+  diodeAtTemperature,
   diodeFromModelCard,
   formatCornerDcSweepTable,
   formatCornerDcTable,
@@ -123,7 +124,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(70);
+    expect(coverage).toHaveLength(71);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -143,7 +144,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(70);
+    expect(records).toHaveLength(71);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -161,8 +162,8 @@ describe("dcOp", () => {
     expect(summary).toHaveLength(7);
     expect(summary[0]).toStrictEqual({
       kind: "D",
-      canonicalParameterCount: 10,
-      acceptedNameCount: 16,
+      canonicalParameterCount: 11,
+      acceptedNameCount: 17,
       aliasedParameterCount: 5,
       maxAliasCount: 3,
       aliasedParameters: ["IS", "VT", "CJO", "VJ", "M"],
@@ -181,7 +182,7 @@ describe("dcOp", () => {
     expect(table.split("\n")[0]).toBe(
       "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters",
     );
-    expect(table.split("\n")[1]).toBe("D\t10\t16\t5\t3\tIS|VT|CJO|VJ|M");
+    expect(table.split("\n")[1]).toBe("D\t11\t17\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
       "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
@@ -189,14 +190,14 @@ describe("dcOp", () => {
     expect(records).toHaveLength(7);
     expect(records[0]).toStrictEqual({
       kind: "D",
-      canonical_parameter_count: "10",
-      accepted_name_count: "16",
+      canonical_parameter_count: "11",
+      accepted_name_count: "17",
       aliased_parameter_count: "5",
       max_alias_count: "3",
       aliased_parameters: "IS|VT|CJO|VJ|M",
     });
     expect(formatModelCardSupportedParameterCoverageSummaryCsv()).toMatch(
-      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,10,16,5,3,IS\|VT\|CJO\|VJ\|M\n/,
+      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,11,17,5,3,IS\|VT\|CJO\|VJ\|M\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageSummaryJson())).toStrictEqual(records);
   });
@@ -208,15 +209,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 70,
-      expectedCanonicalParameterCount: 70,
-      acceptedNameCount: 118,
+      canonicalParameterCount: 71,
+      expectedCanonicalParameterCount: 71,
+      acceptedNameCount: 119,
       aliasedParameterCount: 35,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t70\t70\t118\t35\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t71\t71\t119\t35\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -239,8 +240,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(69);
-    expect(report.acceptedNameCount).toBe(115);
+    expect(report.canonicalParameterCount).toBe(70);
+    expect(report.acceptedNameCount).toBe(116);
     expect(report.aliasedParameterCount).toBe(34);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -255,7 +256,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t69\t70\t115\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t70\t71\t116\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -279,6 +280,7 @@ describe("dcOp", () => {
       PB: 0.8,
       MJ: 0.4,
       FC: 0.35,
+      XTI: 2.2,
       RS: 10.0,
     });
     const diodeModel = diodeFromModelCard("D1", "a", "k", diodeCard);
@@ -289,6 +291,7 @@ describe("dcOp", () => {
       VJ: 0.8,
       M: 0.4,
       FC: 0.35,
+      XTI: 2.2,
     });
     expect(diodeCard.unsupportedParameters).toStrictEqual(["RS"]);
     const diodeIssues = modelCardUnsupportedParameterIssues(diodeCard);
@@ -322,6 +325,7 @@ describe("dcOp", () => {
     expectClose(diodeModel.junctionPotential, 0.8);
     expectClose(diodeModel.gradingCoefficient, 0.4);
     expectClose(diodeModel.forwardBiasDepletionCoefficient, 0.35);
+    expectClose(diodeModel.saturationCurrentTemperatureExponent, 2.2);
 
     const bjtCard = normalizeModelCard("Qsmall", "npn", { BETA: 125.0, CBE: 2.0e-12 });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
@@ -936,6 +940,26 @@ describe("dcOp", () => {
     ).toEqual(["X1.Rtop", "X1.Rbot"]);
   });
 
+  it("preserves the complete diode model through subcircuit expansion", () => {
+    const circuit = new Circuit();
+    circuit.defineSubcircuit(
+      subcircuitDefinition("diode-cell", ["in"], [
+        diode("Dcell", "in", "0", 2.0e-14, 0.026, 1.2, 6.0, 2.0e-6, 1.5e-12, 4.0e-9, 0.8, 0.4, 0.35, 2.2),
+      ]),
+    );
+    circuit.add(xInstance("X1", ["a"], "diode-cell"));
+
+    const expanded = circuit.elements().find((element) => element.kind === "diode");
+    expect(expanded?.kind).toBe("diode");
+    if (expanded?.kind !== "diode") {
+      throw new Error("expected expanded diode");
+    }
+    expectClose(expanded.junctionPotential, 0.8);
+    expectClose(expanded.gradingCoefficient, 0.4);
+    expectClose(expanded.forwardBiasDepletionCoefficient, 0.35);
+    expectClose(expanded.saturationCurrentTemperatureExponent, 2.2);
+  });
+
   it("uses positive-to-negative orientation for current sources", () => {
     const circuit = new Circuit();
     circuit.add(currentSource("I1", "0", "n1", 1.0e-3));
@@ -1136,6 +1160,26 @@ describe("dcOp", () => {
 
     expect(coldResult.voltage("a")).toBeGreaterThan(nominalResult.voltage("a")!);
     expect(hotResult.voltage("a")).toBeLessThan(nominalResult.voltage("a")!);
+  });
+
+  it("uses the diode model saturation-current temperature exponent", () => {
+    const temperatureKelvin = 350.0;
+    const nominalTemperatureKelvin = 300.15;
+    const defaultHot = diodeAtTemperature(
+      diode("D1", "a", "0", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, 0.0, 0.0, 1.0, 0.5, 0.5, 3.0),
+      temperatureKelvin,
+      nominalTemperatureKelvin,
+    );
+    const flatHot = diodeAtTemperature(
+      diode("D1", "a", "0", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, 0.0, 0.0, 1.0, 0.5, 0.5, 0.0),
+      temperatureKelvin,
+      nominalTemperatureKelvin,
+    );
+
+    expect(defaultHot.saturationCurrent / flatHot.saturationCurrent).toBeCloseTo(
+      (temperatureKelvin / nominalTemperatureKelvin) ** 3,
+      12,
+    );
   });
 
   it("runs DC temperature sweeps and formats stable table output", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language diode forward-bias depletion coefficient.
+1. Cross-language diode saturation-current temperature exponent.
    - Status: current PR completion candidate.
-   - Add Berkeley diode `FC` forward-bias depletion-coefficient model-card
-     support in Rust, Python, and TypeScript.
-   - Apply the continuous piecewise depletion-capacitance law around the
-     `FC * VJ` transition in AC and transient analysis.
-   - Extend the supported-parameter coverage gate from 69 to 70 canonical rows
-     and lock forward-bias shaping across all three engines.
+   - Add Berkeley diode `XTI` saturation-current temperature-exponent
+     model-card support in Rust, Python, and TypeScript.
+   - Apply `XTI` to diode saturation-current temperature scaling and preserve
+     the full diode model through hierarchical subcircuit expansion.
+   - Extend the supported-parameter coverage gate from 70 to 71 canonical rows
+     and lock temperature scaling across all three engines.
 
 ## Completed Slices
 
@@ -2971,6 +2971,13 @@ the Rust, Python, and TypeScript surfaces together.
    - AC and transient analyses shape `CJO` from reverse bias while preserving
      transit-time diffusion capacitance, and the supported-parameter release
      gate now covers 69 canonical rows.
+
+215. Cross-language diode forward-bias depletion coefficient.
+   - Status: completed in PR 8708.
+   - Rust, Python, and TypeScript diode model cards now accept `FC` and apply
+     the continuous Berkeley piecewise depletion-capacitance law around the
+     `FC * VJ` transition in AC and transient analysis.
+   - The supported-parameter release gate now covers 70 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley diode `XTI` saturation-current temperature exponent support across Rust, Python, and TypeScript
- preserve complete diode model parameters through subcircuit expansion
- grow the supported model-card gate to 71 canonical rows and reconcile the SPICE completion plan

## Verification
- `cargo test -p spice-engine`
- `cargo test -p spice-engine --test dc_tests`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python `tests/test_engine.py`: 475 passed, 81.04% coverage
- Python ruff on touched files (existing import-order baseline ignored)
- TypeScript: 261 tests passed
- TypeScript build passed
- `git diff --check`