### PR TITLE
Add Haskell barcode-1d port

### DIFF
--- a/code/packages/haskell/barcode-1d/BUILD
+++ b/code/packages/haskell/barcode-1d/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/barcode-1d/BUILD_windows
+++ b/code/packages/haskell/barcode-1d/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/barcode-1d/CHANGELOG.md
+++ b/code/packages/haskell/barcode-1d/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure Haskell coordinator for Code 39, Codabar, Code 128, EAN-13,
+  ITF, and UPC-A.
+- Preserve typed encoder and layout failures across the shared pipeline.
+- Render backend-neutral paint scenes through the pure ASCII Paint VM.

--- a/code/packages/haskell/barcode-1d/README.md
+++ b/code/packages/haskell/barcode-1d/README.md
@@ -1,0 +1,44 @@
+# barcode-1d (Haskell)
+
+Pure Haskell coordinator for the repository's one-dimensional barcode
+packages.
+
+The pipeline is:
+
+`symbology package -> barcode-layout-1d -> PaintScene -> paint-vm-ascii`
+
+## Supported symbologies
+
+- Code 39 (the default)
+- Codabar, with configurable start and stop guards
+- Code 128 Code Set B
+- EAN-13
+- Interleaved 2 of 5 (ITF)
+- UPC-A
+
+Names are case-insensitive and ignore hyphens and underscores, so `ean-13`,
+`EAN_13`, and `ean13` select the same encoder. An empty name selects Code 39.
+
+## API
+
+- `normalizeSymbology` validates a user-facing symbology name.
+- `buildScene` routes typed options to the selected native Haskell encoder.
+- `buildSceneForSymbology` combines string normalization and scene building.
+- `renderAscii`, `renderAsciiForSymbology`, and `renderAsciiWithOptions` feed
+  the scene through the pure ASCII Paint VM.
+- `currentBackend` reports `"ascii"`.
+
+Every failure remains explicit in `Either Barcode1DPipelineError`; the
+coordinator does not throw or erase the originating package error.
+
+There is not yet a native Haskell raster Paint VM in this repository, so this
+package intentionally does not claim pixel or PNG output. The returned
+`PaintScene` remains backend-neutral and can be consumed by future renderers.
+
+## Development
+
+```sh
+cabal test all
+cabal test all --enable-coverage
+cabal check
+```

--- a/code/packages/haskell/barcode-1d/barcode-1d.cabal
+++ b/code/packages/haskell/barcode-1d/barcode-1d.cabal
@@ -1,0 +1,43 @@
+cabal-version: 3.0
+name:          barcode-1d
+version:       0.1.0
+synopsis:      Pure Haskell coordinator for one-dimensional barcodes
+description:   Routes six native barcode encoders through shared paint scenes and the pure ASCII Paint VM.
+category:      Graphics
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.Barcode1D
+    build-depends:    base >=4.14 && <5
+                    , barcode-layout-1d >=0.1 && <0.2
+                    , codabar >=0.1 && <0.2
+                    , code128 >=0.1 && <0.2
+                    , code39 >=0.1 && <0.2
+                    , ean13 >=0.1 && <0.2
+                    , itf >=0.1 && <0.2
+                    , paint-instructions >=0.1 && <0.2
+                    , paint-vm-ascii >=0.1 && <0.2
+                    , upc-a >=0.1 && <0.2
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    Barcode1DSpec
+    hs-source-dirs:   test
+    build-depends:    aeson >=2.0 && <3
+                    , barcode-1d
+                    , base >=4.14 && <5
+                    , containers >=0.6 && <0.8
+                    , hspec ==2.*
+                    , paint-instructions >=0.1 && <0.2
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/barcode-1d/cabal.project
+++ b/code/packages/haskell/barcode-1d/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../barcode-layout-1d ../paint-instructions ../paint-vm-ascii ../code39 ../codabar ../code128 ../ean-13 ../itf ../upc-a

--- a/code/packages/haskell/barcode-1d/src/CodingAdventures/Barcode1D.hs
+++ b/code/packages/haskell/barcode-1d/src/CodingAdventures/Barcode1D.hs
@@ -1,0 +1,192 @@
+-- | Pure coordinator for the repository's one-dimensional barcode packages.
+module CodingAdventures.Barcode1D
+  ( Symbology (..)
+  , Barcode1DOptions (..)
+  , Barcode1DPipelineError (..)
+  , Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , CodabarGuards (..)
+  , AsciiOptions (..)
+  , PaintScene (..)
+  , PaintVmAsciiError (..)
+  , Code39Error (..)
+  , CodabarError (..)
+  , Code128Error (..)
+  , Ean13Error (..)
+  , ItfError (..)
+  , UpcAError (..)
+  , defaultBarcode1DOptions
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  , defaultCodabarGuards
+  , defaultAsciiOptions
+  , defaultRenderConfig
+  , currentBackend
+  , normalizeSymbology
+  , buildScene
+  , buildSceneForSymbology
+  , renderAscii
+  , renderAsciiForSymbology
+  , renderAsciiWithOptions
+  , version
+  ) where
+
+import CodingAdventures.BarcodeLayout1D
+  ( Barcode1DRenderConfig (..)
+  , PaintBarcode1DOptions (..)
+  , defaultBarcode1DRenderConfig
+  , defaultPaintBarcode1DOptions
+  )
+import CodingAdventures.Codabar
+  ( CodabarError (..)
+  , CodabarGuards (..)
+  , defaultCodabarGuards
+  )
+import qualified CodingAdventures.Codabar as Codabar
+import CodingAdventures.Code128 (Code128Error (..))
+import qualified CodingAdventures.Code128 as Code128
+import CodingAdventures.Code39 (Code39Error (..))
+import qualified CodingAdventures.Code39 as Code39
+import CodingAdventures.Ean13 (Ean13Error (..))
+import qualified CodingAdventures.Ean13 as Ean13
+import CodingAdventures.Itf (ItfError (..))
+import qualified CodingAdventures.Itf as Itf
+import CodingAdventures.PaintInstructions (PaintScene (..))
+import CodingAdventures.PaintVmAscii
+  ( AsciiOptions (..)
+  , PaintVmAsciiError (..)
+  , defaultAsciiOptions
+  )
+import qualified CodingAdventures.PaintVmAscii as PaintVmAscii
+import CodingAdventures.UpcA (UpcAError (..))
+import qualified CodingAdventures.UpcA as UpcA
+import Data.Bifunctor (first)
+import Data.Char (isSpace, toLower)
+import Data.List (dropWhileEnd)
+
+-- | Package version shared with the other language implementations.
+version :: String
+version = "0.1.0"
+
+-- | The native encoders available through the coordinator.
+data Symbology
+  = Codabar
+  | Code128
+  | Code39
+  | Ean13
+  | Itf
+  | UpcA
+  deriving (Eq, Show)
+
+-- | Encoder selection, shared paint options, and Codabar-specific guards.
+data Barcode1DOptions = Barcode1DOptions
+  { barcodeSymbology :: Symbology
+  , barcodePaintOptions :: PaintBarcode1DOptions
+  , barcodeCodabarGuards :: CodabarGuards
+  } deriving (Eq, Show)
+
+-- | Checked failures retain the originating package and error value.
+data Barcode1DPipelineError
+  = UnsupportedSymbology String
+  | Code39Failure Code39Error
+  | CodabarFailure CodabarError
+  | Code128Failure Code128Error
+  | Ean13Failure Ean13Error
+  | ItfFailure ItfError
+  | UpcAFailure UpcAError
+  | AsciiBackendFailure PaintVmAsciiError
+  deriving (Eq, Show)
+
+-- | Code 39 with the shared paint defaults and standard Codabar guards.
+defaultBarcode1DOptions :: Barcode1DOptions
+defaultBarcode1DOptions = Barcode1DOptions
+  { barcodeSymbology = Code39
+  , barcodePaintOptions = defaultPaintBarcode1DOptions
+  , barcodeCodabarGuards = defaultCodabarGuards
+  }
+
+-- | The cross-language geometry and color defaults.
+defaultRenderConfig :: Barcode1DRenderConfig
+defaultRenderConfig = defaultBarcode1DRenderConfig
+
+-- | The only pure Haskell Paint VM currently wired into this package.
+currentBackend :: String
+currentBackend = "ascii"
+
+-- | Normalize a case-insensitive name while ignoring hyphens and underscores.
+-- An empty name selects Code 39, matching the other coordinator packages.
+normalizeSymbology :: String -> Either Barcode1DPipelineError Symbology
+normalizeSymbology input = case normalized of
+  "codabar" -> Right Codabar
+  "code128" -> Right Code128
+  "code39" -> Right Code39
+  "ean13" -> Right Ean13
+  "itf" -> Right Itf
+  "upca" -> Right UpcA
+  _ -> Left (UnsupportedSymbology input)
+  where
+    compact = filter (`notElem` "-_") (map toLower (trim input))
+    normalized = if null compact then "code39" else compact
+
+-- | Build a backend-neutral scene with the selected native encoder.
+buildScene
+  :: String
+  -> Barcode1DOptions
+  -> Either Barcode1DPipelineError PaintScene
+buildScene input options = case barcodeSymbology options of
+  Codabar -> first CodabarFailure
+    (Codabar.layoutCodabar input
+      (barcodeCodabarGuards options)
+      (barcodePaintOptions options))
+  Code128 -> first Code128Failure
+    (Code128.layoutCode128 input (barcodePaintOptions options))
+  Code39 -> first Code39Failure
+    (Code39.layoutCode39 input (barcodePaintOptions options))
+  Ean13 -> first Ean13Failure
+    (Ean13.layoutEan13 input (barcodePaintOptions options))
+  Itf -> first ItfFailure
+    (Itf.layoutItf input (barcodePaintOptions options))
+  UpcA -> first UpcAFailure
+    (UpcA.layoutUpcA input (barcodePaintOptions options))
+
+-- | Normalize a user-facing name, then build a scene with that encoder.
+buildSceneForSymbology
+  :: String
+  -> String
+  -> Barcode1DOptions
+  -> Either Barcode1DPipelineError PaintScene
+buildSceneForSymbology symbology input options = do
+  selected <- normalizeSymbology symbology
+  buildScene input options { barcodeSymbology = selected }
+
+-- | Build and render with the pure ASCII backend and its default scaling.
+renderAscii
+  :: String
+  -> Barcode1DOptions
+  -> Either Barcode1DPipelineError String
+renderAscii input options = do
+  scene <- buildScene input options
+  first AsciiBackendFailure (PaintVmAscii.renderDefault scene)
+
+-- | Normalize a user-facing name, then render with the ASCII backend.
+renderAsciiForSymbology
+  :: String
+  -> String
+  -> Barcode1DOptions
+  -> Either Barcode1DPipelineError String
+renderAsciiForSymbology symbology input options = do
+  scene <- buildSceneForSymbology symbology input options
+  first AsciiBackendFailure (PaintVmAscii.renderDefault scene)
+
+-- | Build and render with caller-selected ASCII scaling.
+renderAsciiWithOptions
+  :: String
+  -> Barcode1DOptions
+  -> AsciiOptions
+  -> Either Barcode1DPipelineError String
+renderAsciiWithOptions input options asciiOptions = do
+  scene <- buildScene input options
+  first AsciiBackendFailure (PaintVmAscii.render scene asciiOptions)
+
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace

--- a/code/packages/haskell/barcode-1d/test/Barcode1DSpec.hs
+++ b/code/packages/haskell/barcode-1d/test/Barcode1DSpec.hs
@@ -1,0 +1,114 @@
+module Barcode1DSpec (spec) where
+
+import CodingAdventures.Barcode1D
+import CodingAdventures.PaintInstructions (PaintInstruction (..))
+import Data.Aeson (toJSON)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "package metadata and defaults" $ do
+    it "reports the package version and pure backend" $ do
+      version `shouldBe` "0.1.0"
+      currentBackend `shouldBe` "ascii"
+
+    it "defaults to Code 39 and shared paint settings" $ do
+      barcodeSymbology defaultBarcode1DOptions `shouldBe` Code39
+      barcodePaintOptions defaultBarcode1DOptions
+        `shouldBe` defaultPaintBarcode1DOptions
+      barcodeCodabarGuards defaultBarcode1DOptions
+        `shouldBe` defaultCodabarGuards
+      defaultRenderConfig `shouldBe` defaultBarcode1DRenderConfig
+
+  describe "normalizeSymbology" $ do
+    it "accepts every supported spelling" $ do
+      normalizeSymbology " codabar " `shouldBe` Right Codabar
+      normalizeSymbology "CODE_128" `shouldBe` Right Code128
+      normalizeSymbology "code-39" `shouldBe` Right Code39
+      normalizeSymbology "EAN-13" `shouldBe` Right Ean13
+      normalizeSymbology "itf" `shouldBe` Right Itf
+      normalizeSymbology "UPC_A" `shouldBe` Right UpcA
+
+    it "uses Code 39 for an empty normalized name" $ do
+      normalizeSymbology "" `shouldBe` Right Code39
+      normalizeSymbology "  " `shouldBe` Right Code39
+
+    it "rejects unsupported names without losing the input" $
+      normalizeSymbology "qr-code" `shouldBe`
+        Left (UnsupportedSymbology "qr-code")
+
+  describe "buildScene" $ do
+    it "routes all six native encoders" $ do
+      assertRoute Code39 "A" "code39"
+      assertRoute Codabar "123" "codabar"
+      assertRoute Code128 "AB" "code128"
+      assertRoute Ean13 "400638133393" "ean-13"
+      assertRoute Itf "1234" "itf"
+      assertRoute UpcA "03600029145" "upc-a"
+
+    it "supports normalized string routing" $ do
+      scene <- expectRight
+        (buildSceneForSymbology "EAN_13" "400638133393"
+          defaultBarcode1DOptions)
+      Map.lookup "symbology" (psMeta scene) `shouldBe`
+        Just (toJSON ("ean-13" :: String))
+
+    it "forwards custom Codabar guards" $ do
+      let options = defaultBarcode1DOptions
+            { barcodeSymbology = Codabar
+            , barcodeCodabarGuards = CodabarGuards 'B' 'D'
+            }
+      scene <- expectRight (buildScene "123" options)
+      Map.lookup "start" (psMeta scene) `shouldBe`
+        Just (toJSON ("B" :: String))
+      Map.lookup "stop" (psMeta scene) `shouldBe`
+        Just (toJSON ("D" :: String))
+
+    it "forwards shared geometry and paint options" $ do
+      let renderConfig = defaultRenderConfig
+            { configBarHeight = 48
+            , configForeground = "navy"
+            , configBackground = "transparent"
+            }
+          paintOptions = defaultPaintBarcode1DOptions
+            { optionsRenderConfig = renderConfig }
+          options = defaultBarcode1DOptions
+            { barcodePaintOptions = paintOptions }
+      scene <- expectRight (buildScene "A" options)
+      psHeight scene `shouldBe` 48
+      psBg scene `shouldBe` "transparent"
+      map prFill (psInstructions scene) `shouldSatisfy`
+        all (== "navy")
+
+    it "preserves the originating encoder error" $
+      buildScene "@" defaultBarcode1DOptions `shouldBe`
+        Left (Code39Failure (InvalidCode39Character '@'))
+
+  describe "ASCII rendering" $ do
+    it "renders the default pipeline" $ do
+      output <- expectRight (renderAscii "A" defaultBarcode1DOptions)
+      output `shouldSatisfy` elem '\x2588'
+
+    it "renders through normalized string routing" $ do
+      output <- expectRight
+        (renderAsciiForSymbology "itf" "1234" defaultBarcode1DOptions)
+      output `shouldSatisfy` elem '\x2588'
+
+    it "wraps ASCII backend failures" $ do
+      let invalidOptions = defaultAsciiOptions { scaleX = 0 }
+      renderAsciiWithOptions "A" defaultBarcode1DOptions invalidOptions
+        `shouldBe` Left (AsciiBackendFailure (InvalidScaleX 0))
+
+assertRoute :: Symbology -> String -> String -> Expectation
+assertRoute symbology input expected = do
+  let options = defaultBarcode1DOptions { barcodeSymbology = symbology }
+  scene <- expectRight (buildScene input options)
+  Map.lookup "symbology" (psMeta scene) `shouldBe`
+    Just (toJSON expected)
+
+expectRight :: (Show error) => Either error value -> IO value
+expectRight result = case result of
+  Right value -> pure value
+  Left err -> expectationFailure ("expected Right, got Left " ++ show err)
+    >> fail "unreachable"

--- a/code/packages/haskell/barcode-1d/test/Spec.hs
+++ b/code/packages/haskell/barcode-1d/test/Spec.hs
@@ -1,0 +1,5 @@
+import Barcode1DSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -183,7 +183,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 5 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 4 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -703,6 +703,19 @@ block families, multi-block RLE, dictionary-id and content-size header forms,
 checksums, deterministic binary data, compression ratios, and malformed
 frames. The package now spans 13 implementation lanes, reduces the
 high-consensus backlog to 280 slots, and leaves 5 gaps in the Haskell lane.
+
+The thirtieth Haskell high-consensus slice is complete: `barcode-1d` now
+coordinates the six existing native Haskell symbology packages for Code 39,
+Codabar, Code 128, EAN-13, ITF, and UPC-A. It normalizes user-facing
+symbology names, preserves typed encoder and layout failures, forwards shared
+paint options and Codabar guards, emits backend-neutral `PaintScene` values,
+and renders them through the pure ASCII Paint VM without claiming an absent
+native raster backend. Its package-native suite exercises 13 examples with
+93% expression and 100% alternative coverage, including every route, default
+selection, normalized spellings, unsupported names, custom geometry, custom
+guards, typed failures, and ASCII backend errors. The package now spans 12
+implementation lanes, reduces the high-consensus backlog to 279 slots, and
+leaves 4 gaps in the Haskell lane.
 
 Recommended family order:
 


### PR DESCRIPTION
## What changed

- add a pure Haskell `barcode-1d` coordinator for Code 39, Codabar, Code 128, EAN-13, ITF, and UPC-A
- normalize string symbology names while preserving typed encoder, layout, and ASCII backend failures
- forward shared paint options and Codabar guards into backend-neutral `PaintScene` values
- expose the existing pure ASCII Paint VM honestly instead of claiming unavailable Haskell pixel or PNG output
- update the package-parity roadmap for the thirtieth Haskell high-consensus slice

## Impact

`barcode-1d` now spans 12 implementation languages. The high-consensus backlog falls from 280 to 279 missing slots, and the Haskell lane falls from five remaining gaps to four.

## Validation

- `cabal test all` — 201 examples across the coordinator and its nine local dependencies, 0 failures
- `cabal test barcode-1d:spec --enable-coverage` — 13 examples, 93% expression coverage, 100% alternative coverage
- `cabal check`
- `cabal sdist`
- `python code/scripts/tests/test_package_parity_report.py` — 6 tests passed
- parity reporter in Markdown, JSON, and CSV modes with `--fail-on-collisions`
- `git diff origin/main --check`
