### PR TITLE
feat(spice): add diode energy gap

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Diode energy gap** — diode model cards now accept `EG`, apply it to
+  saturation-current temperature scaling, and preserve it through subcircuit
+  expansion, matching Rust and TypeScript.
+
 - **Diode saturation-current temperature exponent** — diode model cards now
   accept `XTI`, apply it to saturation-current temperature scaling, and
   preserve it through subcircuit expansion, matching Rust and TypeScript.
@@ -33,7 +37,7 @@
   `model_card_supported_parameter_coverage_gate_issue_records()`,
   `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
   `format_model_card_supported_parameter_coverage_gate_issue_json()` now
-  validate the expected seven-kind, 71-row supported-parameter catalog and
+  validate the expected seven-kind, 72-row supported-parameter catalog and
   expose stable issue rows for release automation, matching Rust and
   TypeScript.
 

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -208,8 +208,8 @@ Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
 and `FC` forward-bias depletion coefficient. AC and transient analyses use them
 to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
-Diode cards also accept `XTI` (default `3`) to control the saturation-current
-temperature exponent used by temperature sweeps.
+Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
+control saturation-current temperature scaling.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -235,7 +235,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 71-row supported-parameter catalog and expose stable issue
+expected seven-kind, 72-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -492,6 +492,7 @@ class Diode:
     M: float = 0.5  # junction grading coefficient
     Fc: float = 0.5  # forward-bias depletion coefficient
     Xti: float = 3.0  # saturation-current temperature exponent
+    Eg: float = 1.11  # energy gap in electron volts
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -404,7 +404,7 @@ def circuit_at_temperature(
                 element,
                 temperature_kelvin,
                 nominal_temperature_kelvin=nominal_temperature_kelvin,
-                energy_gap_ev=energy_gap_ev,
+                energy_gap_ev=element.Eg,
             )
         if isinstance(element, BJT):
             return bjt_at_temperature(
@@ -585,6 +585,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.M,
             element.Fc,
             element.Xti,
+            element.Eg,
         )
     if isinstance(element, JFET):
         return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd)
@@ -8667,6 +8668,8 @@ def _diode_effective_vt(el: Diode) -> float:
         raise ValueError(
             f"{el.name}: diode saturation-current temperature exponent must be finite"
         )
+    if not math.isfinite(el.Eg) or el.Eg <= 0.0:
+        raise ValueError(f"{el.name}: diode energy gap must be finite and positive")
     if not math.isfinite(el.Tt) or el.Tt < 0.0:
         raise ValueError(f"{el.name}: diode transit time must be finite and non-negative")
     return el.Vt * el.N
@@ -13804,6 +13807,7 @@ def sens_dc(
                     el.M,
                     el.Fc,
                     el.Xti,
+                    el.Eg,
                 ),
             )
 
@@ -14053,6 +14057,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             el.M,
             el.Fc,
             el.Xti,
+            el.Eg,
         )
 
     if isinstance(el, BJT):

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -306,7 +306,7 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
     "PMOS",
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
-    "D": (11, 17, 5, 3),
+    "D": (12, 18, 5, 3),
     "NPN": (7, 15, 4, 4),
     "PNP": (7, 15, 4, 4),
     "NJF": (5, 11, 5, 3),
@@ -351,6 +351,7 @@ _DIODE_PARAMETER_ALIASES: dict[str, str] = {
     "MJ": "M",
     "FC": "FC",
     "XTI": "XTI",
+    "EG": "EG",
 }
 
 _BJT_PARAMETER_ALIASES: dict[str, str] = {
@@ -864,6 +865,7 @@ def diode_from_model_card(
         M=p.get("M", 0.5),
         Fc=p.get("FC", 0.5),
         Xti=p.get("XTI", 3.0),
+        Eg=p.get("EG", 1.11),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -411,7 +411,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 71
+    assert len(coverage) == 72
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -426,7 +426,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 71
+    assert len(records) == 72
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -443,8 +443,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     summary = model_card_supported_parameter_coverage_summary()
     assert len(summary) == 7
     assert summary[0].kind == "D"
-    assert summary[0].canonical_parameter_count == 11
-    assert summary[0].accepted_name_count == 17
+    assert summary[0].canonical_parameter_count == 12
+    assert summary[0].accepted_name_count == 18
     assert summary[0].aliased_parameter_count == 5
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
         == "kind\tcanonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\taliased_parameters"
     )
-    assert table.splitlines()[1] == "D\t11\t17\t5\t3\tIS|VT|CJO|VJ|M"
+    assert table.splitlines()[1] == "D\t12\t18\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
         == "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -478,8 +478,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert len(records) == 7
     assert records[0] == {
         "kind": "D",
-        "canonical_parameter_count": "11",
-        "accepted_name_count": "17",
+        "canonical_parameter_count": "12",
+        "accepted_name_count": "18",
         "aliased_parameter_count": "5",
         "max_alias_count": "3",
         "aliased_parameters": "IS|VT|CJO|VJ|M",
@@ -487,7 +487,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert format_model_card_supported_parameter_coverage_summary_csv().startswith(
         "kind,canonical_parameter_count,accepted_name_count,"
         "aliased_parameter_count,max_alias_count,aliased_parameters\n"
-        "D,11,17,5,3,IS|VT|CJO|VJ|M\n"
+        "D,12,18,5,3,IS|VT|CJO|VJ|M\n"
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_summary_json())
@@ -500,9 +500,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 71
-    assert report.expected_canonical_parameter_count == 71
-    assert report.accepted_name_count == 119
+    assert report.canonical_parameter_count == 72
+    assert report.expected_canonical_parameter_count == 72
+    assert report.accepted_name_count == 120
     assert report.aliased_parameter_count == 35
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -510,7 +510,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t71\t71\t119\t35\t4\t0"
+        "true\t7\t7\t72\t72\t120\t35\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -538,8 +538,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 70
-    assert report.accepted_name_count == 116
+    assert report.canonical_parameter_count == 71
+    assert report.accepted_name_count == 117
     assert report.aliased_parameter_count == 34
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -554,7 +554,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t70\t71\t116\t34\t4\t4\n"
+        "false\t7\t7\t71\t72\t117\t34\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -593,6 +593,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "MJ": 0.4,
             "FC": 0.35,
             "XTI": 2.2,
+            "EG": 1.05,
             "RS": 10.0,
         },
     )
@@ -605,6 +606,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "M": 0.4,
         "FC": 0.35,
         "XTI": 2.2,
+        "EG": 1.05,
     }
     assert diode_card.unsupported_parameters == ("RS",)
     diode_issues = model_card_unsupported_parameter_issues(diode_card)
@@ -641,6 +643,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(0.4) == diode_model.M
     assert pytest.approx(0.35) == diode_model.Fc
     assert pytest.approx(2.2) == diode_model.Xti
+    assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card("Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12})
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
@@ -2199,7 +2202,7 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     cell = SubcircuitDefinition(
         "diode-cell",
         ("in",),
-        (Diode("Dcell", "in", "0", Vj=0.8, M=0.4, Fc=0.35, Xti=2.2),),
+        (Diode("Dcell", "in", "0", Vj=0.8, M=0.4, Fc=0.35, Xti=2.2, Eg=1.05),),
     )
     c = Circuit()
     c.define_subcircuit(cell)
@@ -2210,6 +2213,7 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert pytest.approx(0.4) == expanded.M
     assert expanded.Fc == pytest.approx(0.35)
     assert expanded.Xti == pytest.approx(2.2)
+    assert expanded.Eg == pytest.approx(1.05)
 
 
 def test_branch_current_in_voltage_source():
@@ -2331,6 +2335,18 @@ def test_diode_temperature_scaling_uses_model_saturation_current_exponent():
     assert default_hot.Is / flat_hot.Is == pytest.approx(
         (temperature_kelvin / nominal_temperature_kelvin) ** 3
     )
+
+
+def test_circuit_temperature_scaling_uses_model_energy_gap():
+    silicon = Circuit(elements=[Diode("D1", "a", "0", Eg=1.11)])
+    lower_gap = Circuit(elements=[Diode("D1", "a", "0", Eg=0.8)])
+
+    silicon_hot = circuit_at_temperature(silicon, 350.0)
+    lower_gap_hot = circuit_at_temperature(lower_gap, 350.0)
+
+    assert isinstance(silicon_hot.elements[0], Diode)
+    assert isinstance(lower_gap_hot.elements[0], Diode)
+    assert silicon_hot.elements[0].Is > lower_gap_hot.elements[0].Is
 
 
 def test_dc_temperature_sweep_runs_operating_points_and_formats_table():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add diode model-card `EG` energy-gap support to temperature scaling,
+  preserving it through subcircuit expansion and matching Python and
+  TypeScript.
 - Add diode model-card `XTI` saturation-current temperature-exponent support,
   preserving it through subcircuit expansion and matching Python and
   TypeScript.
@@ -24,7 +27,7 @@
   `model_card_supported_parameter_coverage_gate_issue_records`,
   `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
   `format_model_card_supported_parameter_coverage_gate_issue_json`, stable
-  release-gate checks and issue exports for the seven-kind, 71-row supported
+  release-gate checks and issue exports for the seven-kind, 72-row supported
   model-card parameter catalog, matching Python and TypeScript.
 - Add `model_card_supported_parameter_coverage_summary`,
   `format_model_card_supported_parameter_coverage_summary_table`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -125,8 +125,8 @@ Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
 and `FC` forward-bias depletion coefficient. AC and transient analyses use them
 to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
-Diode cards also accept `XTI` (default `3`) to control the saturation-current
-temperature exponent used by temperature sweeps.
+Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
+control saturation-current temperature scaling.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -152,7 +152,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 71-row supported-parameter catalog and expose stable issue
+expected seven-kind, 72-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -389,7 +389,7 @@ fn clone_subckt_element(
             cloned.negative = map_subckt_node(&element.negative, instance_name, node_map);
             Element::CustomModel(cloned)
         }
-        Element::Diode(element) => Element::Diode(Diode::with_model_and_temperature_exponent(
+        Element::Diode(element) => Element::Diode(Diode::with_model_and_temperature_parameters(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.anode, instance_name, node_map),
             map_subckt_node(&element.cathode, instance_name, node_map),
@@ -404,6 +404,7 @@ fn clone_subckt_element(
             element.grading_coefficient,
             element.forward_bias_depletion_coefficient,
             element.saturation_current_temperature_exponent,
+            element.energy_gap_electron_volts,
         )),
         Element::Jfet(element) => Element::Jfet(Jfet::with_model_and_capacitance(
             format!("{instance_name}.{}", element.name),
@@ -2353,6 +2354,7 @@ pub struct Diode {
     pub grading_coefficient: f64,
     pub forward_bias_depletion_coefficient: f64,
     pub saturation_current_temperature_exponent: f64,
+    pub energy_gap_electron_volts: f64,
 }
 
 impl Diode {
@@ -2514,6 +2516,43 @@ impl Diode {
         forward_bias_depletion_coefficient: f64,
         saturation_current_temperature_exponent: f64,
     ) -> Self {
+        Self::with_model_and_temperature_parameters(
+            name,
+            anode,
+            cathode,
+            saturation_current,
+            thermal_voltage,
+            emission_coefficient,
+            breakdown_voltage,
+            breakdown_current,
+            junction_capacitance,
+            transit_time,
+            junction_potential,
+            grading_coefficient,
+            forward_bias_depletion_coefficient,
+            saturation_current_temperature_exponent,
+            1.11,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_and_temperature_parameters(
+        name: impl Into<String>,
+        anode: impl Into<String>,
+        cathode: impl Into<String>,
+        saturation_current: f64,
+        thermal_voltage: f64,
+        emission_coefficient: f64,
+        breakdown_voltage: Option<f64>,
+        breakdown_current: f64,
+        junction_capacitance: f64,
+        transit_time: f64,
+        junction_potential: f64,
+        grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
+        saturation_current_temperature_exponent: f64,
+        energy_gap_electron_volts: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             anode: anode.into(),
@@ -2529,6 +2568,7 @@ impl Diode {
             grading_coefficient,
             forward_bias_depletion_coefficient,
             saturation_current_temperature_exponent,
+            energy_gap_electron_volts,
         }
     }
 }
@@ -2657,7 +2697,7 @@ pub fn circuit_at_temperature(
                 diode,
                 temperature_kelvin,
                 nominal_temperature_kelvin,
-                energy_gap_electron_volts,
+                diode.energy_gap_electron_volts,
             )?),
             Element::Bjt(bjt) => Element::Bjt(bjt_at_temperature(
                 bjt,
@@ -3227,7 +3267,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
     usize,
 )] = &[
-    (ModelCardKind::Diode, 11, 17, 5, 3),
+    (ModelCardKind::Diode, 12, 18, 5, 3),
     (ModelCardKind::Npn, 7, 15, 4, 4),
     (ModelCardKind::Pnp, 7, 15, 4, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
@@ -3253,6 +3293,7 @@ const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("MJ", "M"),
     ("FC", "FC"),
     ("XTI", "XTI"),
+    ("EG", "EG"),
 ];
 const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -3877,7 +3918,7 @@ pub fn diode_from_model_card(
     if model.kind != ModelCardKind::Diode {
         return Err(model_card_kind_error(&name, "diode", model.kind));
     }
-    Ok(Diode::with_model_and_temperature_exponent(
+    Ok(Diode::with_model_and_temperature_parameters(
         name,
         anode,
         cathode,
@@ -3892,6 +3933,7 @@ pub fn diode_from_model_card(
         model_card_value(model, "M", 0.5),
         model_card_value(model, "FC", 0.5),
         model_card_value(model, "XTI", 3.0),
+        model_card_value(model, "EG", 1.11),
     ))
 }
 
@@ -23045,6 +23087,12 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
             reason: "saturation-current temperature exponent must be finite".to_string(),
+        });
+    }
+    if !diode.energy_gap_electron_volts.is_finite() || diode.energy_gap_electron_volts <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "energy gap must be finite and positive".to_string(),
         });
     }
     if !diode.transit_time.is_finite() || diode.transit_time < 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 71);
+    assert_eq!(coverage.len(), 72);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 71);
+    assert_eq!(records.len(), 72);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -143,8 +143,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let summary = model_card_supported_parameter_coverage_summary();
     assert_eq!(summary.len(), 7);
     assert_eq!(summary[0].kind, ModelCardKind::Diode);
-    assert_eq!(summary[0].canonical_parameter_count, 11);
-    assert_eq!(summary[0].accepted_name_count, 17);
+    assert_eq!(summary[0].canonical_parameter_count, 12);
+    assert_eq!(summary[0].accepted_name_count, 18);
     assert_eq!(summary[0].aliased_parameter_count, 5);
     assert_eq!(summary[0].max_alias_count, 3);
     assert_eq!(
@@ -168,7 +168,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         lines[0],
         "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters"
     );
-    assert_eq!(lines[1], "D\t11\t17\t5\t3\tIS|VT|CJO|VJ|M");
+    assert_eq!(lines[1], "D\t12\t18\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -176,17 +176,17 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
-    assert_eq!(records[0]["canonical_parameter_count"], "11");
-    assert_eq!(records[0]["accepted_name_count"], "17");
+    assert_eq!(records[0]["canonical_parameter_count"], "12");
+    assert_eq!(records[0]["accepted_name_count"], "18");
     assert_eq!(records[0]["aliased_parameter_count"], "5");
     assert_eq!(records[0]["max_alias_count"], "3");
     assert_eq!(records[0]["aliased_parameters"], "IS|VT|CJO|VJ|M");
     assert!(format_model_card_supported_parameter_coverage_summary_csv().starts_with(
-        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,11,17,5,3,IS|VT|CJO|VJ|M\n"
+        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,12,18,5,3,IS|VT|CJO|VJ|M\n"
     ));
     let json = format_model_card_supported_parameter_coverage_summary_json();
     assert!(json.starts_with(
-        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"11\",\"accepted_name_count\":\"17\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
+        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"12\",\"accepted_name_count\":\"18\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
         "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"18\",\"accepted_name_count\":\"25\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 71);
-    assert_eq!(report.expected_canonical_parameter_count, 71);
-    assert_eq!(report.accepted_name_count, 119);
+    assert_eq!(report.canonical_parameter_count, 72);
+    assert_eq!(report.expected_canonical_parameter_count, 72);
+    assert_eq!(report.accepted_name_count, 120);
     assert_eq!(report.aliased_parameter_count, 35);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t71\t71\t119\t35\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t72\t72\t120\t35\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 70);
-    assert_eq!(report.accepted_name_count, 116);
+    assert_eq!(report.canonical_parameter_count, 71);
+    assert_eq!(report.accepted_name_count, 117);
     assert_eq!(report.aliased_parameter_count, 34);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t70\t71\t116\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t71\t72\t117\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -277,10 +277,10 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard.len(), 7);
     assert_eq!(dashboard[0].kind, ModelCardKind::Diode);
     assert!(dashboard[0].passed);
-    assert_eq!(dashboard[0].canonical_parameter_count, 11);
-    assert_eq!(dashboard[0].expected_canonical_parameter_count, 11);
-    assert_eq!(dashboard[0].accepted_name_count, 17);
-    assert_eq!(dashboard[0].expected_accepted_name_count, 17);
+    assert_eq!(dashboard[0].canonical_parameter_count, 12);
+    assert_eq!(dashboard[0].expected_canonical_parameter_count, 12);
+    assert_eq!(dashboard[0].accepted_name_count, 18);
+    assert_eq!(dashboard[0].expected_accepted_name_count, 18);
     assert_eq!(dashboard[0].aliased_parameter_count, 5);
     assert_eq!(dashboard[0].expected_aliased_parameter_count, 5);
     assert_eq!(dashboard[0].max_alias_count, 3);
@@ -298,7 +298,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
         lines[0],
         "kind\tpassed\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\texpected_accepted_name_count\taliased_parameter_count\texpected_aliased_parameter_count\tmax_alias_count\texpected_max_alias_count\tissue_count\tissue_fields"
     );
-    assert_eq!(lines[1], "D\ttrue\t11\t11\t17\t17\t5\t5\t3\t3\t0\t");
+    assert_eq!(lines[1], "D\ttrue\t12\t12\t18\t18\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\ttrue\t18\t18\t25\t25\t6\t6\t3\t3\t0\t"
@@ -307,15 +307,15 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["passed"], "true");
-    assert_eq!(records[0]["canonical_parameter_count"], "11");
-    assert_eq!(records[0]["expected_canonical_parameter_count"], "11");
+    assert_eq!(records[0]["canonical_parameter_count"], "12");
+    assert_eq!(records[0]["expected_canonical_parameter_count"], "12");
     assert_eq!(records[0]["issue_count"], "0");
     assert_eq!(records[0]["issue_fields"], "");
     assert!(format_model_card_supported_parameter_coverage_dashboard_csv(&coverage).starts_with(
-        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,11,11,17,17,5,5,3,3,0,\n"
+        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,12,12,18,18,5,5,3,3,0,\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_dashboard_json(&coverage).starts_with(
-        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"11\",\"expected_canonical_parameter_count\":\"11\""
+        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"12\",\"expected_canonical_parameter_count\":\"12\""
     ));
 }
 
@@ -369,6 +369,7 @@ fn model_card_aliases_build_device_instances() {
             ("MJ", 0.4),
             ("FC", 0.35),
             ("XTI", 2.2),
+            ("EG", 1.05),
             ("RS", 10.0),
         ],
     )
@@ -380,6 +381,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*diode_card.parameters.get("M").unwrap(), 0.4);
     assert_close(*diode_card.parameters.get("FC").unwrap(), 0.35);
     assert_close(*diode_card.parameters.get("XTI").unwrap(), 2.2);
+    assert_close(*diode_card.parameters.get("EG").unwrap(), 1.05);
     assert_eq!(diode_card.unsupported_parameters, vec!["RS".to_string()]);
     let diode_issues = model_card_unsupported_parameter_issues(&diode_card);
     assert_eq!(diode_issues.len(), 1);
@@ -418,6 +420,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(diode_model.grading_coefficient, 0.4);
     assert_close(diode_model.forward_bias_depletion_coefficient, 0.35);
     assert_close(diode_model.saturation_current_temperature_exponent, 2.2);
+    assert_close(diode_model.energy_gap_electron_volts, 1.05);
 
     let bjt_card =
         normalize_model_card("Qsmall", "npn", &[("BETA", 125.0), ("CBE", 2.0e-12)]).unwrap();
@@ -1277,9 +1280,9 @@ fn dc_subcircuit_instance_expands_resistor_divider() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_diode_model() {
-    let diode = Diode::with_model_and_temperature_exponent(
+    let diode = Diode::with_model_and_temperature_parameters(
         "Dcell", "in", "0", 2.0e-14, 0.026, 1.2, Some(6.0), 2.0e-6, 1.5e-12,
-        4.0e-9, 0.8, 0.4, 0.35, 2.2,
+        4.0e-9, 0.8, 0.4, 0.35, 2.2, 1.05,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1309,6 +1312,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
     assert_close(expanded.grading_coefficient, 0.4);
     assert_close(expanded.forward_bias_depletion_coefficient, 0.35);
     assert_close(expanded.saturation_current_temperature_exponent, 2.2);
+    assert_close(expanded.energy_gap_electron_volts, 1.05);
 }
 
 #[test]
@@ -1609,6 +1613,29 @@ fn diode_temperature_scaling_uses_model_saturation_current_exponent() {
         default_hot.saturation_current / flat_hot.saturation_current,
         (temperature_kelvin / nominal_temperature_kelvin).powi(3),
     );
+}
+
+#[test]
+fn circuit_temperature_scaling_uses_model_energy_gap() {
+    let mut silicon = Circuit::new();
+    silicon.add(Element::Diode(Diode::with_model_and_temperature_parameters(
+        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5,
+        0.5, 3.0, 1.11,
+    )));
+    let mut lower_gap = Circuit::new();
+    lower_gap.add(Element::Diode(Diode::with_model_and_temperature_parameters(
+        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5,
+        0.5, 3.0, 0.8,
+    )));
+
+    let silicon_hot = circuit_at_temperature(&silicon, 350.0, 300.15, 1.11).unwrap();
+    let lower_gap_hot = circuit_at_temperature(&lower_gap, 350.0, 300.15, 1.11).unwrap();
+    let saturation_current = |circuit: &Circuit| match &circuit.elements()[0] {
+        Element::Diode(diode) => diode.saturation_current,
+        _ => unreachable!(),
+    };
+
+    assert!(saturation_current(&silicon_hot) > saturation_current(&lower_gap_hot));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add diode model-card `EG` energy-gap support to temperature scaling,
+  preserving it through subcircuit expansion and matching Python and Rust.
 - Add diode model-card `XTI` saturation-current temperature-exponent support,
   preserving it through subcircuit expansion and matching Python and Rust.
 - Add diode model-card `FC` forward-bias depletion coefficient support and a
@@ -22,7 +24,7 @@
   `modelCardSupportedParameterCoverageGateIssueRecords`,
   `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
   `formatModelCardSupportedParameterCoverageGateIssueJson`, stable release-gate
-  checks and issue exports for the seven-kind, 71-row supported model-card
+  checks and issue exports for the seven-kind, 72-row supported model-card
   parameter catalog, matching Python and Rust.
 - Add `modelCardSupportedParameterCoverageSummary`,
   `formatModelCardSupportedParameterCoverageSummaryTable`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -195,8 +195,8 @@ Diode cards accept `VJ`/`PB` junction potential, `M`/`MJ` grading coefficient,
 and `FC` forward-bias depletion coefficient. AC and transient analyses use them
 to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
-Diode cards also accept `XTI` (default `3`) to control the saturation-current
-temperature exponent used by temperature sweeps.
+Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
+control saturation-current temperature scaling.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -222,7 +222,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 71-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 72-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1675,6 +1675,7 @@ export interface Diode {
   readonly gradingCoefficient: number;
   readonly forwardBiasDepletionCoefficient: number;
   readonly saturationCurrentTemperatureExponent: number;
+  readonly energyGapElectronVolts: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -1985,7 +1986,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_KINDS: readonly ModelCardKind[] = 
 const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
-  D: [11, 17, 5, 3],
+  D: [12, 18, 5, 3],
   NPN: [7, 15, 4, 4],
   PNP: [7, 15, 4, 4],
   NJF: [5, 11, 5, 3],
@@ -3573,7 +3574,7 @@ function cloneSubcktElement(
     case "custom-model":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap) };
     case "diode":
-      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent);
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts);
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
@@ -7534,6 +7535,7 @@ export function diode(
   gradingCoefficient = 0.5,
   forwardBiasDepletionCoefficient = 0.5,
   saturationCurrentTemperatureExponent = 3.0,
+  energyGapElectronVolts = 1.11,
 ): Diode {
   return {
     kind: "diode",
@@ -7551,6 +7553,7 @@ export function diode(
     gradingCoefficient,
     forwardBiasDepletionCoefficient,
     saturationCurrentTemperatureExponent,
+    energyGapElectronVolts,
   };
 }
 
@@ -7663,7 +7666,7 @@ export function circuitAtTemperature(
           element,
           temperatureKelvin,
           nominalTemperatureKelvin,
-          energyGapElectronVolts,
+          element.energyGapElectronVolts,
         ),
       );
     } else if (element.kind === "bjt") {
@@ -7821,6 +7824,7 @@ const DIODE_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   MJ: "M",
   FC: "FC",
   XTI: "XTI",
+  EG: "EG",
 };
 
 const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8307,6 +8311,7 @@ export function diodeFromModelCard(
     p.M ?? 0.5,
     p.FC ?? 0.5,
     p.XTI ?? 3.0,
+    p.EG ?? 1.11,
   );
 }
 
@@ -19200,6 +19205,9 @@ function validateDiode(element: Diode): void {
       element.name,
       "saturation-current temperature exponent must be finite",
     );
+  }
+  if (!Number.isFinite(element.energyGapElectronVolts) || element.energyGapElectronVolts <= 0.0) {
+    throw invalidElement(element.name, "energy gap must be finite and positive");
   }
   if (!Number.isFinite(element.transitTime) || element.transitTime < 0.0) {
     throw invalidElement(element.name, "transit time must be finite and non-negative");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -124,7 +124,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(71);
+    expect(coverage).toHaveLength(72);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -144,7 +144,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(71);
+    expect(records).toHaveLength(72);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -162,8 +162,8 @@ describe("dcOp", () => {
     expect(summary).toHaveLength(7);
     expect(summary[0]).toStrictEqual({
       kind: "D",
-      canonicalParameterCount: 11,
-      acceptedNameCount: 17,
+      canonicalParameterCount: 12,
+      acceptedNameCount: 18,
       aliasedParameterCount: 5,
       maxAliasCount: 3,
       aliasedParameters: ["IS", "VT", "CJO", "VJ", "M"],
@@ -182,7 +182,7 @@ describe("dcOp", () => {
     expect(table.split("\n")[0]).toBe(
       "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters",
     );
-    expect(table.split("\n")[1]).toBe("D\t11\t17\t5\t3\tIS|VT|CJO|VJ|M");
+    expect(table.split("\n")[1]).toBe("D\t12\t18\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
       "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
@@ -190,14 +190,14 @@ describe("dcOp", () => {
     expect(records).toHaveLength(7);
     expect(records[0]).toStrictEqual({
       kind: "D",
-      canonical_parameter_count: "11",
-      accepted_name_count: "17",
+      canonical_parameter_count: "12",
+      accepted_name_count: "18",
       aliased_parameter_count: "5",
       max_alias_count: "3",
       aliased_parameters: "IS|VT|CJO|VJ|M",
     });
     expect(formatModelCardSupportedParameterCoverageSummaryCsv()).toMatch(
-      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,11,17,5,3,IS\|VT\|CJO\|VJ\|M\n/,
+      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,12,18,5,3,IS\|VT\|CJO\|VJ\|M\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageSummaryJson())).toStrictEqual(records);
   });
@@ -209,15 +209,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 71,
-      expectedCanonicalParameterCount: 71,
-      acceptedNameCount: 119,
+      canonicalParameterCount: 72,
+      expectedCanonicalParameterCount: 72,
+      acceptedNameCount: 120,
       aliasedParameterCount: 35,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t71\t71\t119\t35\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t72\t72\t120\t35\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -240,8 +240,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(70);
-    expect(report.acceptedNameCount).toBe(116);
+    expect(report.canonicalParameterCount).toBe(71);
+    expect(report.acceptedNameCount).toBe(117);
     expect(report.aliasedParameterCount).toBe(34);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -256,7 +256,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t70\t71\t116\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t71\t72\t117\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -281,6 +281,7 @@ describe("dcOp", () => {
       MJ: 0.4,
       FC: 0.35,
       XTI: 2.2,
+      EG: 1.05,
       RS: 10.0,
     });
     const diodeModel = diodeFromModelCard("D1", "a", "k", diodeCard);
@@ -292,6 +293,7 @@ describe("dcOp", () => {
       M: 0.4,
       FC: 0.35,
       XTI: 2.2,
+      EG: 1.05,
     });
     expect(diodeCard.unsupportedParameters).toStrictEqual(["RS"]);
     const diodeIssues = modelCardUnsupportedParameterIssues(diodeCard);
@@ -326,6 +328,7 @@ describe("dcOp", () => {
     expectClose(diodeModel.gradingCoefficient, 0.4);
     expectClose(diodeModel.forwardBiasDepletionCoefficient, 0.35);
     expectClose(diodeModel.saturationCurrentTemperatureExponent, 2.2);
+    expectClose(diodeModel.energyGapElectronVolts, 1.05);
 
     const bjtCard = normalizeModelCard("Qsmall", "npn", { BETA: 125.0, CBE: 2.0e-12 });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
@@ -944,7 +947,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("diode-cell", ["in"], [
-        diode("Dcell", "in", "0", 2.0e-14, 0.026, 1.2, 6.0, 2.0e-6, 1.5e-12, 4.0e-9, 0.8, 0.4, 0.35, 2.2),
+        diode("Dcell", "in", "0", 2.0e-14, 0.026, 1.2, 6.0, 2.0e-6, 1.5e-12, 4.0e-9, 0.8, 0.4, 0.35, 2.2, 1.05),
       ]),
     );
     circuit.add(xInstance("X1", ["a"], "diode-cell"));
@@ -958,6 +961,7 @@ describe("dcOp", () => {
     expectClose(expanded.gradingCoefficient, 0.4);
     expectClose(expanded.forwardBiasDepletionCoefficient, 0.35);
     expectClose(expanded.saturationCurrentTemperatureExponent, 2.2);
+    expectClose(expanded.energyGapElectronVolts, 1.05);
   });
 
   it("uses positive-to-negative orientation for current sources", () => {
@@ -1180,6 +1184,23 @@ describe("dcOp", () => {
       (temperatureKelvin / nominalTemperatureKelvin) ** 3,
       12,
     );
+  });
+
+  it("uses the diode model energy gap for circuit temperature scaling", () => {
+    const silicon = new Circuit();
+    silicon.add(diode("D1", "a", "0", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, 0.0, 0.0, 1.0, 0.5, 0.5, 3.0, 1.11));
+    const lowerGap = new Circuit();
+    lowerGap.add(diode("D1", "a", "0", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, 0.0, 0.0, 1.0, 0.5, 0.5, 3.0, 0.8));
+
+    const siliconHot = circuitAtTemperature(silicon, 350.0).elements()[0];
+    const lowerGapHot = circuitAtTemperature(lowerGap, 350.0).elements()[0];
+
+    expect(siliconHot.kind).toBe("diode");
+    expect(lowerGapHot.kind).toBe("diode");
+    if (siliconHot.kind !== "diode" || lowerGapHot.kind !== "diode") {
+      throw new Error("expected diode temperature fixtures");
+    }
+    expect(siliconHot.saturationCurrent).toBeGreaterThan(lowerGapHot.saturationCurrent);
   });
 
   it("runs DC temperature sweeps and formats stable table output", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language diode saturation-current temperature exponent.
+1. Cross-language diode energy gap.
    - Status: current PR completion candidate.
-   - Add Berkeley diode `XTI` saturation-current temperature-exponent
-     model-card support in Rust, Python, and TypeScript.
-   - Apply `XTI` to diode saturation-current temperature scaling and preserve
-     the full diode model through hierarchical subcircuit expansion.
-   - Extend the supported-parameter coverage gate from 70 to 71 canonical rows
-     and lock temperature scaling across all three engines.
+   - Add Berkeley diode `EG` energy-gap model-card support in Rust, Python, and
+     TypeScript.
+   - Apply each diode model's `EG` value to saturation-current temperature
+     scaling and preserve it through hierarchical subcircuit expansion.
+   - Extend the supported-parameter coverage gate from 71 to 72 canonical rows
+     and lock model-specific temperature scaling across all three engines.
 
 ## Completed Slices
 
@@ -2978,6 +2978,13 @@ the Rust, Python, and TypeScript surfaces together.
      the continuous Berkeley piecewise depletion-capacitance law around the
      `FC * VJ` transition in AC and transient analysis.
    - The supported-parameter release gate now covers 70 canonical rows.
+
+216. Cross-language diode saturation-current temperature exponent.
+   - Status: completed in PR 8716.
+   - Rust, Python, and TypeScript diode model cards now accept `XTI` and apply
+     it to saturation-current temperature scaling.
+   - Hierarchical subcircuit expansion now preserves the complete diode model,
+     and the supported-parameter release gate now covers 71 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley diode `EG` model-card support with a `1.11 eV` default in Rust, Python, and TypeScript
- use each diode model's energy gap during circuit temperature scaling and preserve it across subcircuits, sensitivity, and Monte Carlo copies
- extend the supported-parameter release gate to 72 canonical rows and reconcile the SPICE completion plan

## Verification
- `cargo test -p spice-engine -- --test-threads=1`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `PYTHONPATH=src:../mosfet-models/src:../device-physics/src python3.12 -m pytest tests/test_engine.py -q` (476 passed, 81.03% coverage)
- `python3.12 -m ruff check --ignore I001 ...`
- `npx vitest run --pool=forks --maxWorkers=1 --reporter=dot` (262 passed)
- `npx tsc --noEmit`
- `git diff --check`
