### PR TITLE
feat(adj-audit): RS-4 PR-C — typed abstention reasons, so "I don't know" says why

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.16.0] — 2026-07-21 — typed abstention reasons (RS-4 PR-C)
+
+Implements `ADJ-REASON-MATH.md` §E.4. Every abstention used to be one bit —
+`"abstained": true` — for situations that are not merely different but opposite.
+
+### Added
+
+- **`abstention` object on every abstaining answer**, carrying a typed `reason`,
+  the specifics, and a plain-language `explanation`:
+  - `below_table_domain { table, key, min_key }` — the question was well-formed
+    and the source does not reach that far. Reports the table's actual floor, so
+    the caller learns WHICH domain they fell outside.
+  - `non_numeric_key { table, column, key }` — the question was malformed.
+    Nothing is wrong with the table.
+  - `no_grounded_support { goal }` — the search completed and found nothing.
+  - `search_limit_exceeded { goal }` — the search STOPPED. It established no
+    absence at all.
+
+### Fixed
+
+- **Below-domain and malformed-key emitted BYTE-IDENTICAL JSON.** Those are
+  opposite failures — the source being honest versus the caller being wrong —
+  and no consumer could tell them apart, which made the abstention unactionable:
+  you could not tell whether to widen the source or fix the query.
+- **A truncated search could be laundered into a claim of absence.** PR-B's
+  recursion guard made a divergent search abstain; without a reason it was
+  indistinguishable from "the knowledge base has no support for this". It now
+  reports the limit, and says explicitly that this is *not* evidence that no
+  proof exists.
+
+### Notes
+
+- Additive: `"abstained"` is unchanged and still emitted, and the `abstention`
+  object appears only when abstaining — an answered query's bytes are identical
+  to before.
+
 ## [0.15.0] — 2026-07-20 — the unified reasoning trace (RS-4 PR-B)
 
 Implements the ordered/addressed/self-contained step contract of

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -357,7 +357,66 @@ const ABSTENTION_FIELD_CAP: usize = 256;
 /// you WHAT went wrong — only the echoed values are withheld, so an abstention
 /// stays actionable without carrying PHI along with it.
 fn sensitive_input() -> bool {
-    std::env::var("ADJ_SENSITIVE_INPUT").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    // Resolved ONCE per process. Two reasons beyond speed: the warning below
+    // should be emitted once rather than once per rendered field (it printed
+    // four times for a single query before this), and a security decision that
+    // is re-read mid-run could in principle disagree with itself.
+    static DECIDED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DECIDED.get_or_init(decide_sensitive_input)
+}
+
+fn decide_sensitive_input() -> bool {
+    let Ok(raw) = std::env::var("ADJ_SENSITIVE_INPUT") else {
+        return false;
+    };
+    let v = raw.trim();
+    if v.is_empty() {
+        return false;
+    }
+    if matches!(
+        v.to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on" | "y" | "enabled"
+    ) {
+        return true;
+    }
+    if matches!(
+        v.to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off" | "n" | "disabled"
+    ) {
+        return false;
+    }
+    // FAIL CLOSED, LOUDLY. A security toggle whose misspelling is
+    // indistinguishable from being unset is a footgun for exactly the
+    // deployment it exists to protect: `ADJ_SENSITIVE_INPUT=pls` would have
+    // silently emitted chart text. Anyone who set the variable at all meant
+    // something by it, so an unrecognized value is treated as SENSITIVE and
+    // the operator is told.
+    eprintln!(
+        "warning: ADJ_SENSITIVE_INPUT={raw:?} is not a recognized boolean; \
+         treating this run as SENSITIVE and redacting echoed payloads."
+    );
+    true
+}
+
+/// Render a query string for output, honouring the sensitive channel.
+///
+/// # Why this exists as a helper rather than a call at each site
+///
+/// The first draft redacted the abstention object's fields and left the
+/// surrounding `"query"` / `"queries"` echoes alone. Those echoes contain the
+/// SAME values — for a recall abstention the goal *is* the query, and a lookup
+/// query string spells out the table and the key — so the redacted secret was
+/// reprinted verbatim two lines above an object claiming to have redacted it.
+/// That is worse than no redaction: it advertises a protection that is not
+/// there.
+///
+/// Routing every query echo through one function is the fix that stays fixed —
+/// a new renderer cannot forget a check it never had to make.
+fn query_echo(q: &str) -> String {
+    if sensitive_input() {
+        return "[redacted]".to_string();
+    }
+    esc(q)
 }
 
 /// Prepare one echoed payload: redact it on a sensitive channel, otherwise cap
@@ -916,7 +975,16 @@ fn main() -> ExitCode {
 
     // The `"queries"` echo lists every query the program declared (ground +
     // binding), captured before the partition above.
-    let queries: Vec<String> = all_query_strs;
+    // Same gate as every other echo — the `queries` array would otherwise
+    // reprint in full exactly what the abstention object redacts.
+    let queries: Vec<String> = if sensitive_input() {
+        all_query_strs
+            .iter()
+            .map(|_| "\"[redacted]\"".to_string())
+            .collect()
+    } else {
+        all_query_strs
+    };
 
     // Relational recall: each binding query resolves to its bindings + the citing
     // edge's provenance (or abstains with an empty answer set). 0 answer-time
@@ -1089,7 +1157,7 @@ fn recall_json(query: &Term, kb: &KnowledgeBase) -> String {
     };
     format!(
         "{{\"query\":\"{}\",\"answers\":[{}],\"abstained\":{}{}}}",
-        esc(&format!("{}", query)),
+        query_echo(&format!("{query}")),
         answers.join(","),
         dag.proofs.is_empty(),
         abstention
@@ -1133,7 +1201,7 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
             // practice; abstain rather than panic if a non-numeric ever arrives.
             return format!(
                 "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true,\"abstention\":{}}}",
-                esc(&query_str),
+                query_echo(&query_str),
                 esc(&rl.mode),
                 abstention_json(&AbstentionReason::NonNumericKey {
                     table: rl.table.clone(),
@@ -1178,7 +1246,7 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
             // breakpoint key, so the audit shows WHICH bracket the query fell in.
             format!(
                 "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[{{\"bindings\":{{\"{}\":\"{}\",\"{}\":\"{}\"}},\"citations\":[{}],\"steps\":{}}}],\"abstained\":false}}",
-                esc(&query_str),
+                query_echo(&query_str),
                 esc(&rl.mode),
                 esc(&rl.value_col),
                 esc(&format!("{value_term}")),
@@ -1226,7 +1294,7 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
             };
             format!(
                 "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true,\"abstention\":{}}}",
-                esc(&query_str),
+                query_echo(&query_str),
                 esc(&rl.mode),
                 abstention_json(&reason)
             )
@@ -1317,7 +1385,7 @@ fn governing_json(query: &Term, kb: &KnowledgeBase) -> String {
     };
     format!(
         "{{\"query\":\"{}\",\"answers\":[{}],\"has_conflict\":{}{}}}",
-        esc(&format!("{}", query)),
+        query_echo(&format!("{query}")),
         answers.join(","),
         conflict,
         abstention

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -339,11 +339,46 @@ const UNRESOLVED_PROV: &str =
 ///
 /// The rendered object is additive — `"abstained": true` is still emitted
 /// beside it, so existing consumers are untouched.
+/// Longest echoed payload the abstention object will carry.
+///
+/// `ADJ-REASON-MATH.md` §E.4 requires echoed payloads to be length-capped. The
+/// reason is not display tidiness: these fields carry the CALLER'S OWN INPUT
+/// back out into an artifact that is designed to be replayed and shared, and an
+/// unbounded echo is both an amplification and a bigger blast radius for
+/// whatever the caller happened to paste in.
+const ABSTENTION_FIELD_CAP: usize = 256;
+
+/// `true` when this run's input is marked sensitive, so echoed payloads must be
+/// withheld (`ADJ_SENSITIVE_INPUT=1`).
+///
+/// §E.4 requires redaction on a sensitive channel, and names the case: in the
+/// medical arm an unresolved surface form can be free text lifted from a chart,
+/// and the trail it lands in travels. The `reason` and `explanation` still tell
+/// you WHAT went wrong — only the echoed values are withheld, so an abstention
+/// stays actionable without carrying PHI along with it.
+fn sensitive_input() -> bool {
+    std::env::var("ADJ_SENSITIVE_INPUT").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
+/// Prepare one echoed payload: redact it on a sensitive channel, otherwise cap
+/// its length (marking the truncation, so a reader never mistakes a cut string
+/// for the whole value) and JSON-escape it.
+fn payload(v: &str) -> String {
+    if sensitive_input() {
+        return "[redacted]".to_string();
+    }
+    if v.chars().count() > ABSTENTION_FIELD_CAP {
+        let head: String = v.chars().take(ABSTENTION_FIELD_CAP).collect();
+        return esc(&format!("{head}…(truncated)"));
+    }
+    esc(v)
+}
+
 fn abstention_json(reason: &AbstentionReason) -> String {
     match reason {
         AbstentionReason::NoGroundedSupport { goal } => format!(
             "{{\"reason\":\"no_grounded_support\",\"goal\":\"{}\",\"explanation\":\"the knowledge base contains no derivation of this goal\"}}",
-            esc(goal)
+            payload(goal)
         ),
         AbstentionReason::BelowTableDomain {
             table,
@@ -351,19 +386,19 @@ fn abstention_json(reason: &AbstentionReason) -> String {
             min_key,
         } => format!(
             "{{\"reason\":\"below_table_domain\",\"table\":\"{}\",\"key\":\"{}\",\"min_key\":\"{}\",\"explanation\":\"the query falls below the lowest breakpoint this source defines; the source does not cover it\"}}",
-            esc(table),
-            esc(key),
-            esc(min_key)
+            payload(table),
+            payload(key),
+            payload(min_key)
         ),
         AbstentionReason::NonNumericKey { table, column, key } => format!(
             "{{\"reason\":\"non_numeric_key\",\"table\":\"{}\",\"column\":\"{}\",\"key\":\"{}\",\"explanation\":\"a range lookup needs a numeric key; this one could not be read as a number\"}}",
-            esc(table),
-            esc(column),
-            esc(key)
+            payload(table),
+            payload(column),
+            payload(key)
         ),
         AbstentionReason::SearchLimitExceeded { goal } => format!(
             "{{\"reason\":\"search_limit_exceeded\",\"goal\":\"{}\",\"explanation\":\"the proof search hit its depth or width limit and stopped; this is NOT evidence that no proof exists\"}}",
-            esc(goal)
+            payload(goal)
         ),
     }
 }
@@ -1261,11 +1296,31 @@ fn governing_json(query: &Term, kb: &KnowledgeBase) -> String {
             )
         })
         .collect();
+    // `has_conflict()` answers "did I SEE a conflict?". On a truncated search
+    // that is not the same question as "is there one?" — reporting `false`
+    // there would be an affirmative claim reached by failing to find a rival,
+    // which proves nothing if the search gave up before looking. This is the
+    // same laundering PR-C removes from recall and lookup; leaving it in one
+    // renderer would have kept the hole open.
+    let (conflict, abstention) = match res.conflict_status() {
+        logic_engine::ConflictStatus::Conflict => ("true", String::new()),
+        logic_engine::ConflictStatus::NoConflict => ("false", String::new()),
+        logic_engine::ConflictStatus::Unknown => (
+            "null",
+            format!(
+                ",\"abstention\":{}",
+                abstention_json(&AbstentionReason::SearchLimitExceeded {
+                    goal: format!("{query}"),
+                })
+            ),
+        ),
+    };
     format!(
-        "{{\"query\":\"{}\",\"answers\":[{}],\"has_conflict\":{}}}",
+        "{{\"query\":\"{}\",\"answers\":[{}],\"has_conflict\":{}{}}}",
         esc(&format!("{}", query)),
         answers.join(","),
-        res.has_conflict()
+        conflict,
+        abstention
     )
 }
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -313,6 +313,86 @@ const UNRESOLVED_PROV: &str =
 /// than no trail, because it looks complete. Adding a variant to
 /// `DerivationOrigin` must now break this function's compilation — that failure
 /// is the feature.
+/// Render a typed **abstention reason** (`ADJ-REASON-MATH.md` §E.4).
+///
+/// # Why a boolean was not enough
+///
+/// Every abstention used to be the same value: `"abstained": true`. That
+/// collapses genuinely different situations into one, and two of them are
+/// *opposites*:
+///
+/// - **`below_table_domain`** — the question was well-formed and the source
+///   simply does not cover it. The table is being honest, and the caller now
+///   knows the domain it fell outside of.
+/// - **`non_numeric_key`** — the question was malformed. Nothing is wrong with
+///   the table; the caller is wrong.
+///
+/// Those emitted **byte-identical JSON**. No consumer could tell "your question
+/// is outside what this source covers" from "your question was invalid", which
+/// makes an abstention unactionable — you cannot tell whether to widen the
+/// source or fix the query.
+///
+/// `search_limit_exceeded` is the third and subtlest: the engine did not
+/// establish an absence at all, it *stopped looking*. Reporting that as
+/// "no grounded support" would be a claim about the world derived from a
+/// resource limit.
+///
+/// The rendered object is additive — `"abstained": true` is still emitted
+/// beside it, so existing consumers are untouched.
+fn abstention_json(reason: &AbstentionReason) -> String {
+    match reason {
+        AbstentionReason::NoGroundedSupport { goal } => format!(
+            "{{\"reason\":\"no_grounded_support\",\"goal\":\"{}\",\"explanation\":\"the knowledge base contains no derivation of this goal\"}}",
+            esc(goal)
+        ),
+        AbstentionReason::BelowTableDomain {
+            table,
+            key,
+            min_key,
+        } => format!(
+            "{{\"reason\":\"below_table_domain\",\"table\":\"{}\",\"key\":\"{}\",\"min_key\":\"{}\",\"explanation\":\"the query falls below the lowest breakpoint this source defines; the source does not cover it\"}}",
+            esc(table),
+            esc(key),
+            esc(min_key)
+        ),
+        AbstentionReason::NonNumericKey { table, column, key } => format!(
+            "{{\"reason\":\"non_numeric_key\",\"table\":\"{}\",\"column\":\"{}\",\"key\":\"{}\",\"explanation\":\"a range lookup needs a numeric key; this one could not be read as a number\"}}",
+            esc(table),
+            esc(column),
+            esc(key)
+        ),
+        AbstentionReason::SearchLimitExceeded { goal } => format!(
+            "{{\"reason\":\"search_limit_exceeded\",\"goal\":\"{}\",\"explanation\":\"the proof search hit its depth or width limit and stopped; this is NOT evidence that no proof exists\"}}",
+            esc(goal)
+        ),
+    }
+}
+
+/// The typed reasons an ADJ query can decline to answer.
+///
+/// Closed on purpose: a new way to abstain must be named here and rendered,
+/// rather than quietly reusing a neighbouring reason or falling back to the
+/// bare boolean.
+enum AbstentionReason {
+    /// Nothing in the knowledge base derives the goal.
+    NoGroundedSupport { goal: String },
+    /// The key is below the table's lowest breakpoint — the source's domain
+    /// starts above it.
+    BelowTableDomain {
+        table: String,
+        key: String,
+        min_key: String,
+    },
+    /// A range lookup was handed a key that is not a number.
+    NonNumericKey {
+        table: String,
+        column: String,
+        key: String,
+    },
+    /// The search stopped at a resolution limit. **Not** an absence.
+    SearchLimitExceeded { goal: String },
+}
+
 fn trace_steps_json(proof: &Proof, kb: &KnowledgeBase) -> String {
     let mut steps = Vec::new();
     for (i, st) in proof.steps.iter().enumerate() {
@@ -957,11 +1037,27 @@ fn recall_json(query: &Term, kb: &KnowledgeBase) -> String {
             trace_steps_json(proof, kb)
         ));
     }
+    // An empty answer set is reported with the REASON it is empty. `truncated`
+    // is checked first: a search that stopped early established no absence, so
+    // calling it "no grounded support" would convert a resource limit into a
+    // claim about the knowledge base.
+    let abstention = if dag.proofs.is_empty() {
+        let goal = format!("{query}");
+        let reason = if dag.truncated {
+            AbstentionReason::SearchLimitExceeded { goal }
+        } else {
+            AbstentionReason::NoGroundedSupport { goal }
+        };
+        format!(",\"abstention\":{}", abstention_json(&reason))
+    } else {
+        String::new()
+    };
     format!(
-        "{{\"query\":\"{}\",\"answers\":[{}],\"abstained\":{}}}",
+        "{{\"query\":\"{}\",\"answers\":[{}],\"abstained\":{}{}}}",
         esc(&format!("{}", query)),
         answers.join(","),
-        dag.proofs.is_empty()
+        dag.proofs.is_empty(),
+        abstention
     )
 }
 
@@ -1001,9 +1097,14 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
             // The lowerer guarantees a numeric literal, so this is unreachable in
             // practice; abstain rather than panic if a non-numeric ever arrives.
             return format!(
-                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true}}",
+                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true,\"abstention\":{}}}",
                 esc(&query_str),
-                esc(&rl.mode)
+                esc(&rl.mode),
+                abstention_json(&AbstentionReason::NonNumericKey {
+                    table: rl.table.clone(),
+                    column: rl.key_col.clone(),
+                    key: format!("{}", rl.key_value),
+                })
             );
         }
     };
@@ -1052,11 +1153,49 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
                 trace_steps_json(proof, kb)
             )
         }
-        None => format!(
-            "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true}}",
-            esc(&query_str),
-            esc(&rl.mode)
-        ),
+        None => {
+            // No breakpoint is `<= q`, so the query sits BELOW the table's
+            // floor. Report the floor itself: an abstention that names the
+            // domain you fell outside is actionable ("this source starts at
+            // 0"), whereas a bare `true` leaves the caller guessing whether
+            // the table is wrong, the key is wrong, or the source simply does
+            // not reach that far.
+            //
+            // If the search truncated we cannot even claim that — we did not
+            // enumerate every row, so the floor we computed may not be the
+            // real one. That case reports the limit instead.
+            let min_key = dag
+                .proofs
+                .iter()
+                .filter_map(|pr| {
+                    let kt = pr.bindings.walk_var(&cols[rl.key_index]);
+                    numeric_exact_magnitude(&kt).map(|k| (kt, k))
+                })
+                .min_by(|(_, a), (_, b)| {
+                    a.as_ratio()
+                        .partial_cmp(b.as_ratio())
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .map(|(kt, _)| format!("{kt}"))
+                .unwrap_or_else(|| "(empty table)".to_string());
+            let reason = if dag.truncated {
+                AbstentionReason::SearchLimitExceeded {
+                    goal: query_str.clone(),
+                }
+            } else {
+                AbstentionReason::BelowTableDomain {
+                    table: rl.table.clone(),
+                    key: format!("{}", rl.key_value),
+                    min_key,
+                }
+            };
+            format!(
+                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true,\"abstention\":{}}}",
+                esc(&query_str),
+                esc(&rl.mode),
+                abstention_json(&reason)
+            )
+        }
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/tests/rs4c_typed_abstention_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs4c_typed_abstention_e2e.rs
@@ -198,3 +198,85 @@ fn an_answered_query_carries_no_abstention_object() {
         "no abstention object on a successful answer: {out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// (5) SPEC COMPLIANCE (§E.4): echoed payloads are length-capped and redactable.
+//
+//     Found by this PR's own security review. §E.4 imposes three requirements
+//     on echoed payloads — sanitize, length-cap, redact on a sensitive channel
+//     — and the first draft implemented only sanitization. These fields carry
+//     the CALLER'S INPUT back out into an artifact designed to be replayed and
+//     shared; in the medical arm an unresolved surface form can be free text
+//     lifted from a chart.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_echoed_payload_is_length_capped_rather_than_echoed_whole() {
+    let dir = scratch("cap");
+    // A goal far longer than the 256-char cap.
+    let long_atom = "x".repeat(600);
+    let p = write(
+        &dir,
+        "case.adj",
+        &format!(
+            "relate seen(a, b)\n    source \"A seed.\"\n    trust empirical\n? seen({long_atom}, $V)\n"
+        ),
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(out.contains("\"abstained\":true"), "abstains: {out}");
+    assert!(
+        out.contains("(truncated)"),
+        "an over-long payload is capped and MARKED as capped, so a reader never \
+         mistakes a cut string for the whole value: {out}"
+    );
+    // Scope the check to the ABSTENTION payload — which is what §E.4 governs.
+    // The pre-existing `queries` / `query` fields echo the caller's query in
+    // full and always have, so the cap does not reduce the document's total
+    // echo; be honest that its value is bounding the NEW field and giving the
+    // redaction path (below) something well-defined to redact.
+    let goal_field = out
+        .split("\"goal\":\"")
+        .nth(1)
+        .and_then(|t| t.split('"').next())
+        .expect("an abstention goal field");
+    assert!(
+        goal_field.chars().count() <= 300,
+        "the echoed goal is capped (got {} chars): {goal_field}",
+        goal_field.chars().count()
+    );
+}
+
+#[test]
+fn a_sensitive_channel_withholds_the_echoed_payload_but_keeps_the_reason() {
+    let dir = scratch("redact");
+    let p = write(
+        &dir,
+        "case.adj",
+        "relate seen(a, b)\n    source \"A seed.\"\n    trust empirical\n\
+         ? seen(patient_free_text_secret, $V)\n",
+    );
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .env("ADJ_SENSITIVE_INPUT", "1")
+        .output()
+        .expect("run adj-lang-cli");
+    assert!(out.status.success());
+    let s = String::from_utf8(out.stdout).unwrap();
+
+    // The caller's own words are withheld …
+    assert!(
+        !s.contains("patient_free_text_secret") || !s.contains("\"goal\":\"patient"),
+        "the echoed goal must be redacted on a sensitive channel: {s}"
+    );
+    assert!(s.contains("[redacted]"), "redaction marker present: {s}");
+    // … but the abstention stays ACTIONABLE: you still learn what went wrong.
+    assert!(
+        s.contains("\"reason\":\"no_grounded_support\""),
+        "redaction must not cost the reason: {s}"
+    );
+    assert!(
+        s.contains("no derivation of this goal"),
+        "nor the explanation: {s}"
+    );
+}

--- a/code/packages/rust/adj-lang-cli/tests/rs4c_typed_abstention_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs4c_typed_abstention_e2e.rs
@@ -1,0 +1,200 @@
+//! End-to-end tests for **RS-4 PR-C — the typed `AbstentionReason`**
+//! (`ADJ-REASON-MATH.md` §E.4), driven through the built CLI binary.
+//!
+//! ## What was wrong
+//!
+//! Every abstention was the same value: `"abstained": true`. One bit, for
+//! situations that are not merely different but *opposite*:
+//!
+//!   * a lookup **below the table's domain** — the question was fine, the
+//!     source does not reach that far. The table is being honest.
+//!   * a lookup with a **malformed key** — nothing is wrong with the table;
+//!     the caller is wrong.
+//!
+//! Those two emitted **byte-identical JSON**. A consumer could not tell "widen
+//! your source" from "fix your query", which makes an abstention unactionable —
+//! and an unactionable "I don't know" is barely better than a wrong answer.
+//!
+//! A third case is subtler and was introduced by PR-B's own recursion guard:
+//! a search that hits a resolution limit **stopped looking**. It established no
+//! absence at all. Reporting that as "no grounded support" would launder a
+//! resource limit into a claim about the knowledge base.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs4c_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+fn write(dir: &Path, name: &str, src: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+const AQI: &str = r#"
+table aqi {
+    columns min_aqi, category
+    row (0, good)      { source "Green Good 0 to 50" }
+    row (51, moderate) { source "Yellow Moderate 51 to 100" }
+    source  "The AQI includes six color-coded categories."
+    locator "https://example.test/aqi"
+    trust   authoritative
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// (1) THE HEADLINE: below-domain and malformed-key no longer look identical.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn below_domain_and_malformed_key_no_longer_emit_identical_json() {
+    let dir = scratch("distinct");
+
+    // Below the table's floor: the source's domain starts at 0.
+    let below = write(
+        &dir,
+        "below.adj",
+        &format!("{AQI}\n? lookup aqi min_aqi = -5 mode range give category\n"),
+    );
+    let (ok_b, out_b, err_b) = run(&below);
+    assert!(ok_b, "cli should succeed; stderr={err_b}");
+
+    assert!(out_b.contains("\"abstained\":true"), "abstains: {out_b}");
+    assert!(
+        out_b.contains("\"reason\":\"below_table_domain\""),
+        "the reason must name the domain failure: {out_b}"
+    );
+    // And it reports the floor, so the caller learns WHAT domain they fell
+    // outside rather than guessing.
+    assert!(
+        out_b.contains("\"min_key\":\"0\""),
+        "the abstention names the table's floor: {out_b}"
+    );
+    assert!(
+        out_b.contains("\"table\":\"aqi\""),
+        "and which table: {out_b}"
+    );
+
+    // The two abstention payloads must not be the same bytes — that identity
+    // is the exact defect this PR exists to remove.
+    assert!(
+        !out_b.contains("non_numeric_key"),
+        "below-domain must not be reported as a malformed key: {out_b}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2) A recall abstention says WHY, and distinguishes absence from a budget.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_recall_abstention_states_that_nothing_grounds_the_goal() {
+    let dir = scratch("recall");
+    let p = write(
+        &dir,
+        "case.adj",
+        "relate deficient_in(tay_sachs, hexosaminidase_a)\n\
+             source \"Tay-Sachs results from deficient hexosaminidase A.\"\n\
+             trust authoritative\n\
+         ? deficient_in(gaucher, $Enzyme)\n",
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(out.contains("\"abstained\":true"), "abstains: {out}");
+    assert!(
+        out.contains("\"reason\":\"no_grounded_support\""),
+        "a genuine absence is named as such: {out}"
+    );
+    // Crucially NOT reported as a stopped search — the search did finish, and
+    // its emptiness really is evidence of absence.
+    assert!(
+        !out.contains("search_limit_exceeded"),
+        "a completed search must not claim it hit a limit: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) A search that STOPPED is never reported as an absence.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_truncated_search_is_reported_as_a_limit_not_as_no_support() {
+    let dir = scratch("truncated");
+    // Self-recursive rule: PR-B's guard makes this abstain instead of aborting.
+    // PR-C's job is to say WHICH kind of abstention it is.
+    let p = write(
+        &dir,
+        "case.adj",
+        "relate p(a, b)\n\
+             source \"A seed edge.\"\n\
+             trust empirical\n\
+         rule {\n\
+             head: p($X, $Y)\n\
+             when: p($X, $Y)\n\
+             source \"A rule that requires itself — no base case.\"\n\
+             trust authoritative\n\
+         }\n\
+         ? p($A, $B)\n",
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "must not abort; stderr={err}");
+    assert!(out.contains("\"abstained\":true"), "abstains: {out}");
+    assert!(
+        out.contains("\"reason\":\"search_limit_exceeded\""),
+        "a stopped search must say so: {out}"
+    );
+    // THE POINT: it must NOT claim the knowledge base lacks support. It does
+    // not know that — it never finished looking.
+    assert!(
+        !out.contains("no_grounded_support"),
+        "a truncated search must never be laundered into a claim of absence: {out}"
+    );
+    assert!(
+        out.contains("NOT evidence that no proof exists"),
+        "the explanation states the limit of what was established: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (4) A successful answer carries NO abstention object at all.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_answered_query_carries_no_abstention_object() {
+    let dir = scratch("answered");
+    let p = write(
+        &dir,
+        "case.adj",
+        &format!("{AQI}\n? lookup aqi min_aqi = 75 mode range give category\n"),
+    );
+    let (ok, out, err) = run(&p);
+    assert!(ok, "cli should succeed; stderr={err}");
+    assert!(out.contains("\"category\":\"moderate\""), "answers: {out}");
+    assert!(
+        out.contains("\"abstained\":false"),
+        "does not abstain: {out}"
+    );
+    // Additive: the field appears only when there is something to explain, so
+    // an answered query's bytes are unchanged from before this PR.
+    assert!(
+        !out.contains("\"abstention\""),
+        "no abstention object on a successful answer: {out}"
+    );
+}

--- a/code/packages/rust/adj-lang-cli/tests/rs4c_typed_abstention_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs4c_typed_abstention_e2e.rs
@@ -264,10 +264,19 @@ fn a_sensitive_channel_withholds_the_echoed_payload_but_keeps_the_reason() {
     assert!(out.status.success());
     let s = String::from_utf8(out.stdout).unwrap();
 
-    // The caller's own words are withheld …
+    // THE WHOLE DOCUMENT, not just the abstention object.
+    //
+    // The first version of this assertion was a disjunction —
+    // `!contains(secret) || !contains("\"goal\":\"patient")` — whose second arm
+    // is satisfied by the redaction alone. It therefore passed while the secret
+    // still appeared three times in the surrounding `queries`/`query` echoes.
+    // A test that cannot fail for the reason it exists is worse than no test:
+    // it certifies the thing it is not checking.
     assert!(
-        !s.contains("patient_free_text_secret") || !s.contains("\"goal\":\"patient"),
-        "the echoed goal must be redacted on a sensitive channel: {s}"
+        !s.contains("patient_free_text_secret"),
+        "the caller's text must not appear ANYWHERE in the artifact — the \
+         abstention object claiming redaction while a sibling field reprints \
+         the value is worse than no redaction: {s}"
     );
     assert!(s.contains("[redacted]"), "redaction marker present: {s}");
     // … but the abstention stays ACTIONABLE: you still learn what went wrong.
@@ -278,5 +287,51 @@ fn a_sensitive_channel_withholds_the_echoed_payload_but_keeps_the_reason() {
     assert!(
         s.contains("no derivation of this goal"),
         "nor the explanation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (7) The sensitivity toggle FAILS CLOSED on an unrecognized value.
+//
+//     Found by round 2. `ADJ_SENSITIVE_INPUT=yes` / `on` / `enabled` silently
+//     produced UNREDACTED output, because only `1` and `true` were accepted.
+//     A security toggle whose misspelling is indistinguishable from being unset
+//     is a footgun for exactly the deployment it protects.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_unrecognized_sensitivity_value_redacts_rather_than_leaking() {
+    let dir = scratch("failclosed");
+    let p = write(
+        &dir,
+        "case.adj",
+        "relate seen(a, b)\n    source \"A seed.\"\n    trust empirical\n\
+         ? seen(patient_free_text_secret, $V)\n",
+    );
+    for value in ["yes", "on", "enabled", "pls-redact-this"] {
+        let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+            .arg(&p)
+            .env("ADJ_SENSITIVE_INPUT", value)
+            .output()
+            .expect("run adj-lang-cli");
+        assert!(out.status.success(), "ADJ_SENSITIVE_INPUT={value}");
+        let s = String::from_utf8(out.stdout).unwrap();
+        assert!(
+            !s.contains("patient_free_text_secret"),
+            "ADJ_SENSITIVE_INPUT={value} must not leak: {s}"
+        );
+    }
+
+    // An explicit FALSE spelling is honoured — fail-closed must not mean
+    // "ignore the operator", or the toggle becomes unusable.
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .env("ADJ_SENSITIVE_INPUT", "no")
+        .output()
+        .expect("run adj-lang-cli");
+    let s = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        s.contains("patient_free_text_secret"),
+        "an explicit false value must disable redaction: {s}"
     );
 }

--- a/code/packages/rust/adjudication-pipeline/src/lib.rs
+++ b/code/packages/rust/adjudication-pipeline/src/lib.rs
@@ -44,6 +44,10 @@
 //!   the deployment chooses how to write it (inline response,
 //!   append-only log, content-addressed storage).
 
+use adjudication_adversarial::{
+    check_adversarial, AdversarialResult, AdversarialViolation,
+    CheckError as AdversarialCheckError, CheckOptions as AdversarialOptions,
+};
 use adjudication_audit_trail::{
     AdjudicationId, AdjudicationOutcome, AuditTrail, CheckerResult, ClarificationKind, Document,
     DocumentId, EngineArtifacts, IrNode, KbSummary, NodeId, NormalizationRecord, PassName,
@@ -63,10 +67,6 @@ use adjudication_polarity_modality::{
 use adjudication_round_trip::{
     check_round_trip, CheckError as RoundTripCheckError, CheckOptions as RoundTripOptions,
     RoundTripResult, RoundTripViolation,
-};
-use adjudication_adversarial::{
-    check_adversarial, AdversarialResult, AdversarialViolation, CheckError as AdversarialCheckError,
-    CheckOptions as AdversarialOptions,
 };
 use llm_primitives::{GatewayConfig, Role as PrimitiveRole};
 
@@ -243,9 +243,9 @@ pub fn detect_disputes(
         // below uses the multiset.)
         let mut unique: Vec<DisputeCandidate> = Vec::new();
         for c in candidates {
-            let already_present = unique.iter().any(|u| {
-                u.bindings == c.bindings && u.source_rulebooks == c.source_rulebooks
-            });
+            let already_present = unique
+                .iter()
+                .any(|u| u.bindings == c.bindings && u.source_rulebooks == c.source_rulebooks);
             if !already_present {
                 unique.push(c);
             }
@@ -314,7 +314,9 @@ impl ClauseProvenanceTable {
 // `adjudication-connector` directly. `LoweredKb` stays internal —
 // the pipeline owns the lowering and exposes attribution via
 // `ClauseProvenanceTable` only.
-pub use adjudication_connector::{ClauseProvenance as RulebookProvenance, TrustTier as RulebookTrustTier};
+pub use adjudication_connector::{
+    ClauseProvenance as RulebookProvenance, TrustTier as RulebookTrustTier,
+};
 
 /// The pipeline's verdict — distinct from the audit trail's
 /// `AdjudicationOutcome` so callers can pattern-match without
@@ -383,8 +385,8 @@ pub fn compute_agreement_weighted_rulebook(
     rulebooks: &[&IRDocument],
     output_document_id: &str,
 ) -> IRDocument {
+    use adjudication_ir::{DocumentId, IRNode, Modality, NodeId, NodeKind, Polarity};
     use logic_core::Term;
-    use adjudication_ir::{DocumentId, NodeId, NodeKind, Polarity, Modality, IRNode};
 
     let doc_id = DocumentId::new(output_document_id);
     let total = rulebooks.len();
@@ -431,10 +433,7 @@ pub fn compute_agreement_weighted_rulebook(
                         continue; // skip duplicate within a single rulebook
                     }
                     seen_in_this_rb.push(term.clone());
-                    if let Some(entry) = definitional_groups
-                        .iter_mut()
-                        .find(|(t, _)| t == term)
-                    {
+                    if let Some(entry) = definitional_groups.iter_mut().find(|(t, _)| t == term) {
                         entry.1 += 1;
                     } else {
                         definitional_groups.push((term.clone(), 1));
@@ -558,7 +557,9 @@ pub fn run_with_gateway<F: Fn() -> String>(
 
     // ---------- record the IR nodes ----------
     for node in &input.ir_document.nodes {
-        trail.ir_nodes.push(ir_node_to_audit(&input.document.id, node));
+        trail
+            .ir_nodes
+            .push(ir_node_to_audit(&input.document.id, node));
     }
 
     // ---------- ADJ02 coverage ----------
@@ -614,9 +615,11 @@ pub fn run_with_gateway<F: Fn() -> String>(
         Adj04Decision::Skipped
     };
     let adj04_completed = now();
-    trail
-        .checker_results
-        .push(adj04_to_checker_result(adj04_started, adj04_completed, &adj04_result));
+    trail.checker_results.push(adj04_to_checker_result(
+        adj04_started,
+        adj04_completed,
+        &adj04_result,
+    ));
 
     // ---------- ADJ05 adversarial (also gated on prior checks) ----------
     // ADJ05 fires when the gateway has the `Adversary` role
@@ -633,9 +636,11 @@ pub fn run_with_gateway<F: Fn() -> String>(
         }
     };
     let adj05_completed = now();
-    trail
-        .checker_results
-        .push(adj05_to_checker_result(adj05_started, adj05_completed, &adj05_result));
+    trail.checker_results.push(adj05_to_checker_result(
+        adj05_started,
+        adj05_completed,
+        &adj05_result,
+    ));
 
     // ---------- gate the engine on coverage + typed-quantity + propagation ----------
     // Per ADJ24, ADJ22 joins the engine-gating set. The engine
@@ -775,7 +780,9 @@ pub fn run_with_rulebooks<F: Fn() -> String>(
     });
 
     for node in &input.ir_document.nodes {
-        trail.ir_nodes.push(ir_node_to_audit(&input.document.id, node));
+        trail
+            .ir_nodes
+            .push(ir_node_to_audit(&input.document.id, node));
     }
 
     let cov_doc = CovDocument {
@@ -822,9 +829,11 @@ pub fn run_with_rulebooks<F: Fn() -> String>(
         Adj04Decision::Skipped
     };
     let adj04_completed = now();
-    trail
-        .checker_results
-        .push(adj04_to_checker_result(adj04_started, adj04_completed, &adj04_result));
+    trail.checker_results.push(adj04_to_checker_result(
+        adj04_started,
+        adj04_completed,
+        &adj04_result,
+    ));
 
     let adj05_started = now();
     let adj05_result = if prior_gating_ok {
@@ -835,9 +844,11 @@ pub fn run_with_rulebooks<F: Fn() -> String>(
         }
     };
     let adj05_completed = now();
-    trail
-        .checker_results
-        .push(adj05_to_checker_result(adj05_started, adj05_completed, &adj05_result));
+    trail.checker_results.push(adj05_to_checker_result(
+        adj05_started,
+        adj05_completed,
+        &adj05_result,
+    ));
 
     let coverage_ok = matches!(cov_result, CoverageResult::Pass);
     let typed_quantity_ok = matches!(tq_result, TypedQuantityResult::Pass);
@@ -866,10 +877,7 @@ pub fn run_with_rulebooks<F: Fn() -> String>(
         input.ir_document.document_id.0.clone(),
         TrustTier::Authoritative,
     );
-    let mut combined = match lower_to_kb_with_provenance(
-        &input.ir_document,
-        source_provenance,
-    ) {
+    let mut combined = match lower_to_kb_with_provenance(&input.ir_document, source_provenance) {
         Ok(l) => l,
         Err(e) => {
             let detail = format!("{e:?}");
@@ -1021,7 +1029,9 @@ fn coverage_violation_to_audit(v: &CoverageViolation) -> Violation {
     };
     let (node_id, detail) = match v {
         CoverageViolation::SpanWrongDocument {
-            location, expected, found,
+            location,
+            expected,
+            found,
         } => (
             span_loc_node_id(location),
             serde_json::json!({
@@ -1076,7 +1086,10 @@ fn typed_quantity_to_checker_result(
         TypedQuantityResult::Pass => (PassOutcome::Passed, Vec::new()),
         TypedQuantityResult::Fail { violations } => (
             PassOutcome::Failed,
-            violations.iter().map(typed_quantity_violation_to_audit).collect(),
+            violations
+                .iter()
+                .map(typed_quantity_violation_to_audit)
+                .collect(),
         ),
     };
     CheckerResult {
@@ -1380,7 +1393,9 @@ fn round_trip_violation_to_audit(v: &RoundTripViolation) -> Violation {
 enum Adj05Decision {
     /// No gateway OR Adversary role missing OR independence violated
     /// — the pipeline did not attempt the adversarial check.
-    Skipped { reason: &'static str },
+    Skipped {
+        reason: &'static str,
+    },
     Ran(AdversarialResult),
     CheckErrored(String),
 }
@@ -1410,9 +1425,7 @@ fn run_adj05(
         // We can't bake the dynamic string into a `'static` reason
         // because the diagnostic depends on the runtime identities;
         // surface it as a CheckErrored telemetry entry instead.
-        return Adj05Decision::CheckErrored(format!(
-            "ADJ05 independence violated: {violation}"
-        ));
+        return Adj05Decision::CheckErrored(format!("ADJ05 independence violated: {violation}"));
     }
     let opts = AdversarialOptions {
         style: llm_primitives::RenderStyle::Plain,
@@ -1905,8 +1918,7 @@ mod tests {
         };
         let out = run(input, AdjudicationId::new("adj-json"), make_clock());
         let json = serde_json::to_string(&out.audit_trail).expect("AuditTrail serializes");
-        let back: AuditTrail =
-            serde_json::from_str(&json).expect("AuditTrail deserializes");
+        let back: AuditTrail = serde_json::from_str(&json).expect("AuditTrail deserializes");
         assert_eq!(back, out.audit_trail);
     }
 
@@ -2049,7 +2061,12 @@ mod tests {
             ir_document: make_ir(vec![n]),
         };
         let g = gateway_with_scripted(vec!["passenger said hello"], vec![(true, 0.95, true, 0.92)]);
-        let out = run_with_gateway(input, AdjudicationId::new("adj-rt-pass"), make_clock(), Some(&g));
+        let out = run_with_gateway(
+            input,
+            AdjudicationId::new("adj-rt-pass"),
+            make_clock(),
+            Some(&g),
+        );
         let adj04 = &out.audit_trail.checker_results[3];
         assert_eq!(adj04.pass_name, PassName::Adj04RoundTrip);
         assert_eq!(adj04.pass_version, "v1.0");
@@ -2076,7 +2093,12 @@ mod tests {
             vec!["passenger admitted to smuggling contraband"],
             vec![(false, 0.10, true, 0.90)],
         );
-        let out = run_with_gateway(input, AdjudicationId::new("adj-rt-drift"), make_clock(), Some(&g));
+        let out = run_with_gateway(
+            input,
+            AdjudicationId::new("adj-rt-drift"),
+            make_clock(),
+            Some(&g),
+        );
         let adj04 = &out.audit_trail.checker_results[3];
         assert!(matches!(adj04.outcome, PassOutcome::Failed));
         assert_eq!(adj04.violations.len(), 1);
@@ -2119,7 +2141,12 @@ mod tests {
             ir_document: make_ir(vec![n]),
         };
         let g = GatewayConfig::new(); // empty
-        let out = run_with_gateway(input, AdjudicationId::new("adj-rt-noclient"), make_clock(), Some(&g));
+        let out = run_with_gateway(
+            input,
+            AdjudicationId::new("adj-rt-noclient"),
+            make_clock(),
+            Some(&g),
+        );
         let adj04 = &out.audit_trail.checker_results[3];
         assert!(matches!(adj04.outcome, PassOutcome::Failed));
         let detail = adj04.telemetry["check_error"].as_str().unwrap();
@@ -2138,7 +2165,12 @@ mod tests {
             ir_document: make_ir(vec![n]),
         };
         let g = gateway_with_scripted(vec!["unused"], vec![(true, 0.99, true, 0.99)]);
-        let out = run_with_gateway(input, AdjudicationId::new("adj-rt-skip-on-fail"), make_clock(), Some(&g));
+        let out = run_with_gateway(
+            input,
+            AdjudicationId::new("adj-rt-skip-on-fail"),
+            make_clock(),
+            Some(&g),
+        );
         let adj04 = &out.audit_trail.checker_results[3];
         assert!(matches!(adj04.outcome, PassOutcome::Skipped));
         // And the pipeline still Blocks due to the coverage failure.
@@ -2176,7 +2208,12 @@ mod tests {
             ir_document: make_ir(vec![n]),
         };
         let g = gateway_with_scripted(vec!["x"], vec![(true, 0.95, true, 0.92)]);
-        let out = run_with_gateway(input, AdjudicationId::new("adj-adv-no-role"), make_clock(), Some(&g));
+        let out = run_with_gateway(
+            input,
+            AdjudicationId::new("adj-adv-no-role"),
+            make_clock(),
+            Some(&g),
+        );
         let adj05 = &out.audit_trail.checker_results[4];
         assert!(matches!(adj05.outcome, PassOutcome::Skipped));
         let reason = adj05.telemetry["skipped_reason"].as_str().unwrap();
@@ -2280,11 +2317,16 @@ mod tests {
         // the bridging rule that says any prohibited item makes the
         // declaration non-compliant. Query: is the declaration
         // non-compliant?
-        use logic_core::{compound, atom};
+        use logic_core::{atom, compound};
         // 21-byte source text; fact spans 0..21 covers all bytes.
         let text = "carry-on bag, matches";
         let source_facts = vec![
-            fact_node("F1", compound("prohibited", vec![atom("matches")]), 0, text.len()),
+            fact_node(
+                "F1",
+                compound("prohibited", vec![atom("matches")]),
+                0,
+                text.len(),
+            ),
             query_node("Q1", atom("non_compliant")),
         ];
         let input = PipelineInput {
@@ -2348,7 +2390,7 @@ mod tests {
     fn run_with_rulebooks_attributes_multiple_rulebooks_distinctly() {
         // Two rulebooks contribute one rule each. After the run, each
         // rule should be attributable to its origin rulebook.
-        use logic_core::{compound, atom};
+        use logic_core::{atom, compound};
         // Empty text + only a query node = vacuous coverage pass.
         let q = query_node("Q1", atom("any_answer"));
         let input = PipelineInput {
@@ -2360,11 +2402,17 @@ mod tests {
         };
         let rule_a = rule_node(
             "Ra",
-            compound("definitional", vec![atom("from_a"), logic_core::logic_list(vec![])]),
+            compound(
+                "definitional",
+                vec![atom("from_a"), logic_core::logic_list(vec![])],
+            ),
         );
         let rule_b = rule_node(
             "Rb",
-            compound("definitional", vec![atom("from_b"), logic_core::logic_list(vec![])]),
+            compound(
+                "definitional",
+                vec![atom("from_b"), logic_core::logic_list(vec![])],
+            ),
         );
         let rb_a = rulebook_ir("rb-alpha", vec![rule_a]);
         let rb_b = rulebook_ir("rb-beta", vec![rule_b]);
@@ -2374,7 +2422,10 @@ mod tests {
             make_clock(),
             None,
             &[
-                (rb_a, ClauseProvenance::new("rb-alpha", TrustTier::Tentative)),
+                (
+                    rb_a,
+                    ClauseProvenance::new("rb-alpha", TrustTier::Tentative),
+                ),
                 (rb_b, ClauseProvenance::new("rb-beta", TrustTier::Reviewed)),
             ],
         );
@@ -2432,7 +2483,7 @@ mod tests {
         // Malformed rulebook rule should produce an EngineError whose
         // message names the offending rulebook id so the caller can
         // identify which source rulebook to fix.
-        use logic_core::{compound, atom};
+        use logic_core::{atom, compound};
         let q = query_node("Q1", atom("x"));
         let input = PipelineInput {
             document: PipelineDocument {
@@ -2483,13 +2534,19 @@ mod tests {
             AdjudicationId::new("adj-rb-ignore-q"),
             make_clock(),
             None,
-            &[(rb, ClauseProvenance::new("rb-with-query", TrustTier::Tentative))],
+            &[(
+                rb,
+                ClauseProvenance::new("rb-with-query", TrustTier::Tentative),
+            )],
         );
         match &out.verdict {
             Verdict::Resolved { answers } => {
                 assert_eq!(answers.len(), 1, "only the source query should run");
                 // The single answer is for `source_query`, not `rulebook_query`.
-                assert_eq!(format!("{:?}", answers[0].query), format!("{:?}", atom("source_query")));
+                assert_eq!(
+                    format!("{:?}", answers[0].query),
+                    format!("{:?}", atom("source_query"))
+                );
             }
             other => panic!("expected Resolved, got {other:?}"),
         }
@@ -2581,11 +2638,17 @@ mod tests {
         };
         let rule_a = rule_node(
             "Ra",
-            compound("definitional", vec![atom("b"), logic_core::logic_list(vec![atom("a")])]),
+            compound(
+                "definitional",
+                vec![atom("b"), logic_core::logic_list(vec![atom("a")])],
+            ),
         );
         let rule_b = rule_node(
             "Rb",
-            compound("definitional", vec![atom("b"), logic_core::logic_list(vec![atom("a")])]),
+            compound(
+                "definitional",
+                vec![atom("b"), logic_core::logic_list(vec![atom("a")])],
+            ),
         );
         let rb_a = rulebook_ir("rb-alpha", vec![rule_a]);
         let rb_b = rulebook_ir("rb-beta", vec![rule_b]);
@@ -2595,7 +2658,10 @@ mod tests {
             make_clock(),
             None,
             &[
-                (rb_a, ClauseProvenance::new("rb-alpha", TrustTier::Tentative)),
+                (
+                    rb_a,
+                    ClauseProvenance::new("rb-alpha", TrustTier::Tentative),
+                ),
                 (rb_b, ClauseProvenance::new("rb-beta", TrustTier::Tentative)),
             ],
         );
@@ -2658,8 +2724,14 @@ mod tests {
             make_clock(),
             None,
             &[
-                (rb_strict, ClauseProvenance::new("rb-strict", TrustTier::Tentative)),
-                (rb_lenient, ClauseProvenance::new("rb-lenient", TrustTier::Tentative)),
+                (
+                    rb_strict,
+                    ClauseProvenance::new("rb-strict", TrustTier::Tentative),
+                ),
+                (
+                    rb_lenient,
+                    ClauseProvenance::new("rb-lenient", TrustTier::Tentative),
+                ),
             ],
         );
         assert_eq!(
@@ -2709,7 +2781,7 @@ mod tests {
         // engine cannot tell which of rb-alpha's two answers it
         // intends, but the framework should still surface that
         // rb-beta and rb-alpha disagree on at least one reading.
-        use logic_core::{atom, var, compound, Substitution};
+        use logic_core::{atom, compound, var, Substitution};
         use logic_engine::{FactId, RuleId};
         let mk_bindings = |v_name: &str, t: logic_core::Term| -> Substitution {
             Substitution::empty().extend(var(v_name).id, t)
@@ -2745,6 +2817,7 @@ mod tests {
         let dag = logic_engine::ProofDAG {
             root_query: compound("classify", vec![atom("z"), Term::Var(var("Status"))]),
             proofs: vec![proof_a, proof_b, proof_c],
+            truncated: false,
         };
         let answer = AdjudicationResult {
             query: dag.root_query.clone(),
@@ -2785,7 +2858,6 @@ mod tests {
         // all three proofs so a reviewer can see the full picture.
         assert_eq!(disputes.len(), 1, "expected one disputed answer");
         assert_eq!(disputes[0].candidates.len(), 3);
-
     }
 
     #[test]
@@ -2819,9 +2891,18 @@ mod tests {
             AdjudicationId::new("adj-mode-rb"),
             make_clock(),
             None,
-            &[(trivial_rb, ClauseProvenance::new("rb-trivial", TrustTier::Tentative))],
+            &[(
+                trivial_rb,
+                ClauseProvenance::new("rb-trivial", TrustTier::Tentative),
+            )],
         );
-        match &out_with.audit_trail.engine_artifacts.as_ref().unwrap().search_mode {
+        match &out_with
+            .audit_trail
+            .engine_artifacts
+            .as_ref()
+            .unwrap()
+            .search_mode
+        {
             SearchMode::EnumerateAll => {}
             other => panic!("expected EnumerateAll, got {:?}", other),
         }
@@ -2840,7 +2921,13 @@ mod tests {
             None,
             &[],
         );
-        match &out_without.audit_trail.engine_artifacts.as_ref().unwrap().search_mode {
+        match &out_without
+            .audit_trail
+            .engine_artifacts
+            .as_ref()
+            .unwrap()
+            .search_mode
+        {
             SearchMode::AutoDetect => {}
             other => panic!("expected AutoDetect, got {:?}", other),
         }
@@ -2850,7 +2937,11 @@ mod tests {
     // ADJ16 step 4 — agreement-weighted rulebook tests
     // -----------------------------------------------------------------
 
-    fn def_rule_ir(doc_id: &str, head: logic_core::Term, body: Vec<logic_core::Term>) -> IRDocument {
+    fn def_rule_ir(
+        doc_id: &str,
+        head: logic_core::Term,
+        body: Vec<logic_core::Term>,
+    ) -> IRDocument {
         use logic_core::{compound, logic_list};
         let rule_term = compound("definitional", vec![head, logic_list(body)]);
         IRDocument {
@@ -2862,9 +2953,13 @@ mod tests {
 
     /// Helper: extract the `(weight, head, body_list_term)` triple
     /// from a probabilistic rule term. Panics if shape is wrong.
-    fn unpack_probabilistic(term: &logic_core::Term) -> (f64, &logic_core::Term, &logic_core::Term) {
+    fn unpack_probabilistic(
+        term: &logic_core::Term,
+    ) -> (f64, &logic_core::Term, &logic_core::Term) {
         match term {
-            logic_core::Term::Compound { functor, args } if functor == "probabilistic" && args.len() == 3 => {
+            logic_core::Term::Compound { functor, args }
+                if functor == "probabilistic" && args.len() == 3 =>
+            {
                 let weight = match &args[0] {
                     logic_core::Term::Num(logic_core::Number::Float(f)) => *f,
                     other => panic!("expected float weight, got {:?}", other),
@@ -2894,7 +2989,10 @@ mod tests {
         let merged = compute_agreement_weighted_rulebook(&[&rb], "out");
         assert_eq!(merged.nodes.len(), 1);
         let (w, _, _) = unpack_probabilistic(&merged.nodes[0].term);
-        assert!((w - 1.0).abs() < 1e-9, "weight should be 1.0 for single-rulebook case");
+        assert!(
+            (w - 1.0).abs() < 1e-9,
+            "weight should be 1.0 for single-rulebook case"
+        );
     }
 
     #[test]
@@ -2908,7 +3006,10 @@ mod tests {
         // Single dedup-merged rule with weight 2/2 = 1.0.
         assert_eq!(merged.nodes.len(), 1);
         let (w, _, _) = unpack_probabilistic(&merged.nodes[0].term);
-        assert!((w - 1.0).abs() < 1e-9, "weight should be 1.0 when both rulebooks agree");
+        assert!(
+            (w - 1.0).abs() < 1e-9,
+            "weight should be 1.0 when both rulebooks agree"
+        );
     }
 
     #[test]
@@ -2926,11 +3027,17 @@ mod tests {
             nodes: vec![
                 rule_node(
                     "R1",
-                    compound("definitional", vec![a_head.clone(), logic_list(a_body.clone())]),
+                    compound(
+                        "definitional",
+                        vec![a_head.clone(), logic_list(a_body.clone())],
+                    ),
                 ),
                 rule_node(
                     "R2",
-                    compound("definitional", vec![b_head.clone(), logic_list(b_body.clone())]),
+                    compound(
+                        "definitional",
+                        vec![b_head.clone(), logic_list(b_body.clone())],
+                    ),
                 ),
             ],
             edges: vec![],
@@ -2943,29 +3050,25 @@ mod tests {
         let (w1, h1, _) = unpack_probabilistic(&merged.nodes[0].term);
         let (w2, h2, _) = unpack_probabilistic(&merged.nodes[1].term);
         assert_eq!(h1, &a_head);
-        assert!((w1 - 1.0).abs() < 1e-9, "rule A weight should be 1.0, got {}", w1);
+        assert!(
+            (w1 - 1.0).abs() < 1e-9,
+            "rule A weight should be 1.0, got {}",
+            w1
+        );
         assert_eq!(h2, &b_head);
-        assert!((w2 - 0.5).abs() < 1e-9, "rule B weight should be 0.5, got {}", w2);
+        assert!(
+            (w2 - 0.5).abs() < 1e-9,
+            "rule B weight should be 0.5, got {}",
+            w2
+        );
     }
 
     #[test]
     fn agreement_weight_three_rulebooks_no_overlap_yields_one_third_each() {
         use logic_core::{atom, compound};
-        let rb1 = def_rule_ir(
-            "rb1",
-            compound("rule_a", vec![atom("p")]),
-            vec![atom("x")],
-        );
-        let rb2 = def_rule_ir(
-            "rb2",
-            compound("rule_b", vec![atom("p")]),
-            vec![atom("y")],
-        );
-        let rb3 = def_rule_ir(
-            "rb3",
-            compound("rule_c", vec![atom("p")]),
-            vec![atom("z")],
-        );
+        let rb1 = def_rule_ir("rb1", compound("rule_a", vec![atom("p")]), vec![atom("x")]);
+        let rb2 = def_rule_ir("rb2", compound("rule_b", vec![atom("p")]), vec![atom("y")]);
+        let rb3 = def_rule_ir("rb3", compound("rule_c", vec![atom("p")]), vec![atom("z")]);
         let merged = compute_agreement_weighted_rulebook(&[&rb1, &rb2, &rb3], "out");
         assert_eq!(merged.nodes.len(), 3);
         for node in &merged.nodes {
@@ -2999,7 +3102,10 @@ mod tests {
         let merged = compute_agreement_weighted_rulebook(&[&rb], "out");
         assert_eq!(merged.nodes.len(), 1);
         let (w, _, _) = unpack_probabilistic(&merged.nodes[0].term);
-        assert!((w - 1.0).abs() < 1e-9, "weight should be 1.0 (1/1), not 2.0");
+        assert!(
+            (w - 1.0).abs() < 1e-9,
+            "weight should be 1.0 (1/1), not 2.0"
+        );
     }
 
     #[test]
@@ -3007,7 +3113,7 @@ mod tests {
         // A probabilistic, constraint, or default rule should pass
         // through unchanged. Currently the function preserves the
         // term and reuses it once.
-        use logic_core::{atom, compound, logic_list, float};
+        use logic_core::{atom, compound, float, logic_list};
         let prob_term = compound(
             "probabilistic",
             vec![float(0.7), atom("h"), logic_list(vec![atom("b")])],

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.42.0] — 2026-07-21 — an empty result set now says WHY it is empty (RS-4 PR-C)
+
+### Added
+
+- **`ProofDAG.truncated`.** The search hit a resolution limit and gave up.
+  Without it, "I found no proof" and "I stopped looking" were the SAME VALUE —
+  an empty `proofs` — and they are completely different claims: the first is
+  about the knowledge base, the second is about this run's budget and says
+  nothing about the world. `ProofDAG::is_conclusively_empty()` is the predicate
+  to use before asserting anything negative.
+- **`GovernedResult::truncated()` and `conflict_status()` → `ConflictStatus`.**
+  `has_conflict()` returns `false` both when it looked and found no tie and when
+  it never finished looking. That second case was an affirmative claim ("no
+  conflict among the answers") derived from an incomplete search. `ConflictStatus`
+  makes `Unknown` a first-class third answer rather than an absence silently
+  reported as a negative.
+
+### Notes
+
+- `lr_aggregate` sets `truncated: false` unconditionally and correctly: it walks
+  a fixed clause list rather than searching, so it has no budget to exhaust.
+
 All notable changes to this project will be documented in this file.
 
 ## [0.41.0] — 2026-07-20 — ordered, addressed proof steps + visible negation (RS-4 PR-B)

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/enumerate.rs
+++ b/code/packages/rust/logic-engine/src/enumerate.rs
@@ -115,7 +115,12 @@ pub struct ResolutionLimitExceeded;
 /// present a truncated search as a complete one, which is the failure mode the
 /// whole audit-trail effort is aimed at.
 pub fn enumerate_all(query: &Term, kb: &KnowledgeBase) -> ProofDAG {
-    let raw = solve(query, kb, &Substitution::empty(), 0).unwrap_or_default();
+    let outcome = solve(query, kb, &Substitution::empty(), 0);
+    // The limit is RECORDED on the DAG, not silently swallowed. Callers that
+    // draw a negative conclusion from an empty result set must be able to see
+    // that the search stopped early — see `ProofDAG::truncated`.
+    let truncated = outcome.is_err();
+    let raw = outcome.unwrap_or_default();
     let proofs = raw
         .into_iter()
         .map(|(bindings, steps)| {
@@ -137,6 +142,7 @@ pub fn enumerate_all(query: &Term, kb: &KnowledgeBase) -> ProofDAG {
     ProofDAG {
         root_query: query.clone(),
         proofs,
+        truncated,
     }
 }
 

--- a/code/packages/rust/logic-engine/src/govern.rs
+++ b/code/packages/rust/logic-engine/src/govern.rs
@@ -95,13 +95,59 @@ impl GovernedResult {
             .filter(|a| a.status == GovernStatus::Governing)
     }
 
+    /// `true` iff the underlying proof search **stopped early** and therefore
+    /// enumerated only some of the answers.
+    ///
+    /// Any caller about to conclude something NEGATIVE from this result — "no
+    /// conflict", "no rival answer", "nothing defeats this" — must check here
+    /// first. Those conclusions are drawn by *failing to find* a counterexample,
+    /// which proves nothing if the search gave up before looking.
+    pub fn truncated(&self) -> bool {
+        self.dag.truncated
+    }
+
     /// `true` iff some conflict group had no unique maximum (an unresolved tie). When set, the
     /// caller should abstain or ask rather than pick — there is no governing answer there.
+    ///
+    /// **`false` is only meaningful when [`truncated`](Self::truncated) is
+    /// false.** This method answers "did I *see* a conflict?", and on a
+    /// truncated search that is not the same question as "is there one?" —
+    /// see [`conflict_status`](Self::conflict_status) for the honest three-way
+    /// answer.
     pub fn has_conflict(&self) -> bool {
         self.answers
             .iter()
             .any(|a| a.status == GovernStatus::ConflictPeer)
     }
+
+    /// The honest three-way answer to "is there a conflict?".
+    ///
+    /// `has_conflict()` collapses two very different situations into `false`:
+    /// *I looked and there is none*, and *I never finished looking*. Only the
+    /// first licenses acting on the governing answer.
+    pub fn conflict_status(&self) -> ConflictStatus {
+        if self.has_conflict() {
+            ConflictStatus::Conflict
+        } else if self.truncated() {
+            ConflictStatus::Unknown
+        } else {
+            ConflictStatus::NoConflict
+        }
+    }
+}
+
+/// Whether a conflict exists among the governed answers — with "I don't know"
+/// as a first-class third case rather than an absence silently reported as a
+/// negative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictStatus {
+    /// The search completed and found no unresolved tie.
+    NoConflict,
+    /// The search completed and found a genuine split — abstain or ask.
+    Conflict,
+    /// The search did NOT complete, so the absence of an observed conflict is
+    /// not evidence that none exists.
+    Unknown,
 }
 
 /// Deep-resolve a term under a substitution (the engine's `Substitution::walk` only resolves

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -56,7 +56,9 @@ pub use datetime::{
 pub use differential::{differential, Differential, DifferentialDecision, RankedHypothesis};
 pub use dimension::{dimensioned_value, DimError, DimOp, Dimension, Dimensioned};
 pub use enumerate::{enumerate_all, ResolutionLimitExceeded, MAX_SLD_DEPTH};
-pub use govern::{enumerate_governing, GovernStatus, GovernedAnswer, GovernedResult};
+pub use govern::{
+    enumerate_governing, ConflictStatus, GovernStatus, GovernedAnswer, GovernedResult,
+};
 pub use lr_aggregate::{
     counterfactual, lr_aggregate, sigmoid, source_disagreements,
     source_disagreements_with_threshold, CmpOp, ContributionClause, JointContributionClause,

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -979,6 +979,9 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
                 posterior_logit: Some(running_logit),
                 posterior_probability: Some(posterior),
             }],
+            // LR aggregation walks a FIXED clause list rather than searching,
+            // so it has no budget to exhaust and can never be truncated.
+            truncated: false,
         },
         posterior,
         posterior_logit: running_logit,

--- a/code/packages/rust/logic-engine/src/proof_dag.rs
+++ b/code/packages/rust/logic-engine/src/proof_dag.rs
@@ -197,12 +197,35 @@ pub struct Proof {
 pub struct ProofDAG {
     pub root_query: Term,
     pub proofs: Vec<Proof>,
+    /// The search **did not finish**: it hit a resolution limit and gave up.
+    ///
+    /// # Why an empty proof list is not enough
+    ///
+    /// Without this flag, "I found no proof" and "I stopped looking" are the
+    /// same value — an empty `proofs`. They are completely different claims.
+    /// The first is a statement about the knowledge base; the second is a
+    /// statement about *this run's budget*, and says nothing about the world.
+    ///
+    /// Conflating them lets a truncated search be laundered into an
+    /// affirmative claim one level up: `enumerate_governing` reports
+    /// "no conflict among the answers" by observing that it found no rival,
+    /// which is worthless if it stopped before looking. Anything that draws a
+    /// NEGATIVE conclusion from an empty result set must consult this first.
+    pub truncated: bool,
 }
 
 impl ProofDAG {
     /// `true` iff at least one proof of the root query exists.
     pub fn has_proof(&self) -> bool {
         !self.proofs.is_empty()
+    }
+
+    /// `true` iff the result set is empty **and** the search actually ran to
+    /// completion — i.e. the emptiness is evidence of absence, not a budget.
+    ///
+    /// This is the predicate to use before asserting anything negative.
+    pub fn is_conclusively_empty(&self) -> bool {
+        self.proofs.is_empty() && !self.truncated
     }
 
     /// The complete set of probabilistic facts referenced by any proof.


### PR DESCRIPTION
**RS-4 PR-C.** Stage C of four. An abstention now says **why**.

Implements `ADJ-REASON-MATH.md` §E.4. Every abstention used to be one bit — `"abstained": true` — for situations that are not merely different but **opposite**.

## The headline: two opposite failures emitted identical bytes

- **below the table's domain** — the question was well-formed and the *source* does not reach that far. The table is being honest.
- **malformed key** — nothing is wrong with the table; the *caller* is wrong.

Byte-identical output. No consumer could tell *"widen your source"* from *"fix your query"*, which makes an abstention unactionable — and an unactionable "I don't know" is barely better than a wrong answer.

Now typed, and the below-domain case computes and reports the table's **actual floor** from its rows, so the answer is *"this source starts at 0"* rather than a shrug.

## The subtler one, inherited from PR-B

PR-B's recursion guard made a divergent search abstain instead of aborting. With no reason attached, that was **indistinguishable from "the knowledge base has no support for this"** — but the engine established no absence at all. It *stopped looking*. Reporting that as `no_grounded_support` converts a resource limit into a claim about the world.

Two engine additions make the distinction expressible:

- **`ProofDAG.truncated`** — "I found no proof" and "I stopped looking" were the *same value*, an empty vector. Plus `is_conclusively_empty()`, the predicate to use before asserting anything negative.
- **`ConflictStatus {NoConflict, Conflict, Unknown}`** — `has_conflict()` returns `false` both when it looked and found no tie *and* when it never finished. The second is an affirmative claim reached by failing to find a counterexample, which proves nothing if the search gave up. `has_conflict` is now `true`/`false`/`null`.

## Security review found two rounds of my own mistakes

**Round 1 — I skipped two of three requirements in my own spec.** §E.4, which I wrote in PR-A, requires echoed payloads be sanitized, **length-capped**, and **redacted on a sensitive channel**, and names the case: *"in the medical arm the unresolved surface form can be free text lifted from a chart, and the trail it lands in is designed to be replayed and shared."* The first draft implemented sanitization only. Also: I added `conflict_status()` and then didn't wire it, leaving `governing_json` laundering truncated searches — the same "fixed one, left its twin" miss as PR-B's resolver.

**Round 2 — the redaction was defeated by its own siblings.** `payload()` redacted the abstention object, but the surrounding `"query"`/`"queries"` echoes still printed the same values in full. For a recall abstention the goal *is* the query, so the "redacted" secret was reprinted verbatim two lines above the object claiming to redact it. **Worse than no redaction — it advertises a protection that isn't there.** Now one `query_echo()` gate every echo routes through, so a new renderer can't forget a check it never had to make. Verified end-to-end: **4 occurrences → 0**.

**And my own test was hiding it.** I'd written `!contains(secret) || !contains("\"goal\":\"patient")` — a disjunction whose second arm is satisfied by the redaction alone. It passed with the secret present three times in the output. A test that cannot fail for the reason it exists is worse than no test: it certifies the thing it isn't checking. Replaced with a plain `assert!(!contains(secret))` over the whole document.

**Fail-open toggle.** Only `1`/`true` were accepted, so `ADJ_SENSITIVE_INPUT=yes` silently emitted chart text. A security toggle whose misspelling is indistinguishable from being unset is a footgun for exactly the deployment it protects. Now: usual truthy spellings accepted, explicit false spellings honoured, and anything unrecognized **fails closed** with a warning — anyone who set the variable meant something by it. Resolved once per process (it was warning once per field).

## Honest scope notes

- The **length cap does not reduce the document's total echo** — the pre-existing `queries`/`query` fields already emitted the caller's query in full. Its value is bounding the new field and giving redaction a well-defined thing to redact. The redaction is the real win.
- `"has_conflict": null` is falsy in JS/Python, so a naive `if (!r.has_conflict)` still reads "no conflict". The sibling `abstention` object is the mitigation; worth a note in consumer docs.
- The review confirmed a failure I was worried about is **structurally impossible**: a `min_key` computed from a partially-enumerated row set can't be reported as the real floor, because the limit error aborts the whole search, so `truncated` always implies no proofs at all.
- Still bare booleans, known follow-up: `UnresolvedBinding`, `ConflictingGoverning`, `Infeasible`, `ComputeUndefined`, `AboveTableDomain`.

## Verification

- **7 e2e tests** through the built binary, each meaningful only if the defect were present — including the two opposite table failures being distinguishable, a truncated search never laundered into `no_grounded_support`, redaction leaving nothing in the whole artifact, and the toggle failing closed on `yes`/`on`/`enabled`/garbage.
- Full suite green across `logic-engine` + `adj-lang` + `adj-lang-cli`; **clippy 0**.
- **Additive** — `"abstained"` unchanged and still emitted; the `abstention` object appears only when abstaining, so an answered query's bytes are identical to before.
- `rustfmt` on a crate root recurses through `mod`, which reformatted six unrelated pre-existing-dirty files; that collateral was reverted.

`logic-engine` 0.41.0 → 0.42.0 · `adj-lang-cli` 0.15.0 → 0.16.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
