### PR TITLE
feat(scilab-to-semantic-ir): Scilab CST -> SIR22 lowering (MA-10e, closes Scilab frontend rollout)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -274,6 +274,7 @@ members = [
     "scilab-parser",
     "scilab-runtime",
     "scilab-repl",
+    "scilab-to-semantic-ir",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/scilab-to-semantic-ir/BUILD
+++ b/code/packages/rust/scilab-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p scilab-to-semantic-ir -- --nocapture

--- a/code/packages/rust/scilab-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/scilab-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p scilab-to-semantic-ir -- --nocapture

--- a/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
@@ -87,7 +87,7 @@
   scope) — mirroring `scilab-runtime::eval::Interpreter::register_function`'s
   own more complete three-way reading of this grammar shape, whose doc
   comment confirms its own handling is "exactly correct."
-- 87 tests: 66 unit tests over lowering shapes, every documented scope
+- 93 tests: 71 unit tests over lowering shapes, every documented scope
   limit's rejection, and the DoS-guard regression pair
   (`a_pathologically_long_flat_{additive,multiplicative}_chain_is_
   cleanly_rejected`, reproducing the identical flat-operand-chain hazard
@@ -99,6 +99,57 @@
 - Marks `scilab-to-semantic-ir` (MA-10e) done in
   `MA10-scilab-language.md` §6 — the last item in the Scilab frontend
   rollout.
+
+### Security
+
+Two rounds of pre-merge security review found and fixed four issues, all
+before this crate ever shipped:
+
+- **CRITICAL/HIGH** (round 1): `lower_if`/`lower_select` folded
+  `elseif_clause*`/`case_clause*` — flat `{ x }`-repetition CST nodes,
+  costing the *parser* zero native stack — into an `Expr::If` chain N
+  levels deep via `Box`, with no cap. A source file with 300,000 `elseif`
+  clauses compiled successfully, but merely dropping the returned
+  `Module` overflowed the native stack and aborted the process
+  (uncatchable by `catch_unwind`). Fixed by capping `clauses.len()`
+  against the existing `MAX_EXPR_DEPTH` (256) in both functions, before
+  any per-clause lowering.
+- **CRITICAL/HIGH** (round 2): the identical hazard, found independently
+  in `lower_postfix`'s `{ transpose_suffix | call_suffix | ... }` suffix
+  fold — the same flat-repetition shape, also unguarded. 300,000 chained
+  transpose/call suffixes reproduced the identical uncatchable
+  stack-overflow abort. Fixed the same way: a `suffixes.len() >
+  MAX_EXPR_DEPTH` cap before the fold.
+- **MEDIUM** (round 1): the `select`/`case` hoisted selector temp was
+  named `__select_N` — an ordinary, fully legal Scilab identifier a
+  program could itself declare, silently colliding with (and producing
+  invalid, duplicate-declaration JavaScript from) a same-named user
+  variable. Fixed by renaming to `$select_N`: `$` is never part of a
+  Scilab `NAME` token, so collision is now structurally impossible.
+- **MEDIUM** (round 1): `if`/`else` and `select`/`case`/`else` bodies
+  (mutually exclusive) were lowered against a single, still-mutating
+  `ctx.locals`, so a name first-assigned in one branch was misclassified
+  as a re-assignment by a sibling branch lowered afterward — breaking the
+  ordinary idiom of a function assigning its own output variable in
+  every branch of an `if`/`select`. Fixed by lowering every branch
+  against the same pre-statement `ctx.locals` snapshot (the existing
+  `for`-loop scope_mark/scope_rewind mechanism), folding the union of
+  every branch's newly-introduced names back in once at the end.
+- **MEDIUM** (round 2): the round-1 fix above, and `lower_assignment`'s
+  pre-existing first-occurrence check, both tested local-name membership
+  via `Vec::contains` — an O(n) scan per check, making a flat sequence of
+  n distinct-name assignments (or an if/select's branches collectively
+  introducing n names) O(n²) overall. Fixed by adding a `HashSet`-backed
+  `FunctionCtx::has_local`/`push_local` pair (kept in sync with the
+  existing `Vec` `scope_mark`/`scope_rewind` needs for ordered
+  truncation), and backing the branch-fix's own `newly_introduced`
+  accumulator with a `HashSet` instead of a `Vec`.
+
+Also separately discovered (not fixed here, tracked as its own follow-up
+task): `scilab-parser`'s own `elseif_clause*` parsing appears to scale
+worse than linearly at very large clause counts (17s to parse 100,000
+`elseif` clauses in `--release`) — a pre-existing, already-merged,
+separate crate, out of scope for this PR.
 
 ### Notes on divergence from the spec
 

--- a/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
@@ -87,7 +87,7 @@
   scope) — mirroring `scilab-runtime::eval::Interpreter::register_function`'s
   own more complete three-way reading of this grammar shape, whose doc
   comment confirms its own handling is "exactly correct."
-- 100 tests: 72 unit tests over lowering shapes, every documented scope
+- 99 tests: 72 unit tests over lowering shapes, every documented scope
   limit's rejection, and the DoS-guard regression set
   (`a_pathologically_long_flat_{additive,multiplicative}_chain_is_
   cleanly_rejected` plus the `elseif`/`case`/transpose-suffix chain
@@ -103,8 +103,8 @@
 
 ### Security
 
-Four rounds of pre-merge security review found and fixed nine issues, all
-before this crate ever shipped:
+Five rounds of pre-merge security review found and fixed eleven issues,
+all before this crate ever shipped:
 
 - **CRITICAL/HIGH** (round 1): `lower_if`/`lower_select` folded
   `elseif_clause*`/`case_clause*` — flat `{ x }`-repetition CST nodes,
@@ -201,6 +201,45 @@ before this crate ever shipped:
   candidates) rather than shipping; fixed by reusing `peel_to_named`
   (the same helper `bare_name`/`indexed_target` already use) instead of a
   direct `rule_name` comparison.
+- **HIGH** (round 5, a genuine data-correctness bug the round-4 fix made
+  reachable in a new, inconsistent way): reusing an already-known
+  variable as a `for`-loop's own counter (round 3's own "fixed and
+  supported" idiom) reads back the STALE pre-loop value, not the loop's
+  true final value, if read after the loop without first reassigning it
+  -- confirmed via `node`: `y=1; for y=1:3; disp(y); end; disp(y);`
+  prints `1 2 3 1`, not `1 2 3 3`. Root cause: this crate's own `ctx`
+  bookkeeping treats a reused counter as "the same variable, surviving
+  the loop" (matching `scilab-runtime`'s real semantics), but the shared
+  `semantic-ir-to-javascript` backend's `ForRange` codegen JS-block-scopes
+  the loop variable regardless, so the outer binding is left untouched by
+  the loop entirely. Round 3's own regression test never caught this
+  because it always reassigned the reused name before reading it again.
+  Compounding it: `collect_assigned_names_stmt`'s `for_stmt` arm
+  unconditionally reported a NESTED for-loop's own counter name as a
+  candidate to any ENCLOSING construct's hoist scan -- so the identical
+  program rejected the counter as correctly loop-scoped at the top level,
+  but silently accepted it (with the wrong value) when the same loop was
+  nested one level inside an `if`. Fixed by (1) no longer reporting a
+  `for`-loop's own counter name from `collect_assigned_names_stmt` at all
+  (only the body's own genuinely-new names should ever bubble up to an
+  enclosing scope), and (2) rejecting reuse of an already-known variable
+  as a `for`-loop counter outright, with a clean `ScilabLowerError` --
+  since this frontend has no control over the JS backend's own codegen
+  choice, a disclosed rejection replaces a "supported but sometimes
+  silently wrong" feature. Round 3's regression tests for this idiom were
+  replaced with tests asserting the (now correct) rejection.
+- **MEDIUM/documentation** (round 5): the round-4 module-doc-comment's own
+  description of its disclosed residual limitation (reading a hoisted
+  name before it's genuinely written, e.g. an uninitialised accumulator)
+  understated the actual failure mode as "silently computing a wrong
+  value." Verified directly: it's actually an uncaught `TypeError`
+  exception at the JS layer (`Expr::NilLit` lowers to JS `null`, and the
+  arithmetic reading it dereferences a field on `null`), not a silent
+  wrong numeric result. Fixed by correcting both doc-comment copies
+  (`hoist_assigned_names`'s own, and the module-level section) to
+  accurately describe this as a fail-loud crash, not a fail-silent one --
+  anyone relying on the prior description to accept this residual risk
+  was working from an inaccurate characterization of it.
 
 Also separately discovered (not fixed here, tracked as its own follow-up
 task): `scilab-parser`'s own `elseif_clause*` parsing appears to scale

--- a/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
@@ -87,21 +87,23 @@
   scope) — mirroring `scilab-runtime::eval::Interpreter::register_function`'s
   own more complete three-way reading of this grammar shape, whose doc
   comment confirms its own handling is "exactly correct."
-- 96 tests: 72 unit tests over lowering shapes, every documented scope
+- 100 tests: 72 unit tests over lowering shapes, every documented scope
   limit's rejection, and the DoS-guard regression set
   (`a_pathologically_long_flat_{additive,multiplicative}_chain_is_
   cleanly_rejected` plus the `elseif`/`case`/transpose-suffix chain
   variants added during security review, see below); 11
-  validator/capability-acceptance tests; 12 end-to-end tests that
+  validator/capability-acceptance tests; 15 end-to-end tests that
   actually execute lowered Scilab through `semantic-ir-to-javascript` and
-  `node` (gated on `node` availability).
+  `node` (gated on `node` availability), including the round-4
+  scope-hoisting fix's own headline case (a function computing its output
+  variable inside `if`/`elseif`/`else`).
 - Marks `scilab-to-semantic-ir` (MA-10e) done in
   `MA10-scilab-language.md` §6 — the last item in the Scilab frontend
   rollout.
 
 ### Security
 
-Three rounds of pre-merge security review found and fixed six issues, all
+Four rounds of pre-merge security review found and fixed nine issues, all
 before this crate ever shipped:
 
 - **CRITICAL/HIGH** (round 1): `lower_if`/`lower_select` folded
@@ -165,6 +167,40 @@ before this crate ever shipped:
   `scilab-parser`, but `compile()`/`GrammarASTNode` is a public API) with
   exactly one child panicked on the slice instead of erroring cleanly.
   Fixed by checking `kids.len() < 2` instead.
+- **HIGH/architectural** (round 4, the most significant finding of the
+  four rounds): `lower_if`/`lower_select`'s round-1 fix, and
+  `lower_while`, only tracked a branch/loop-introduced name in this
+  crate's OWN lowering-time bookkeeping (`ctx.locals`/`ctx.locals_set`) --
+  they never emitted an actual DECLARATION for it anywhere other than the
+  `Stmt::LetStarBinding` nested inside the introducing construct's own
+  `Block`. `semantic_ir::validate` scopes each `Block` independently, so
+  that nested declaration never made the name visible OUTSIDE its own
+  block -- meaning a function computing its own output variable inside
+  `if`/`else` (the single most ordinary Scilab/MATLAB function shape
+  there is) produced a module that `semantic_ir::validate` *always*
+  rejected. `lower_for`'s body had the identical gap for any
+  non-loop-counter name it introduced. Fixed by adding
+  `Lowerer::collect_assigned_names` (a purely syntactic, non-lowering CST
+  pre-scan) and `Lowerer::hoist_assigned_names` (which uses it to
+  pre-declare every name a branch/loop body might introduce, at the
+  ENCLOSING scope, with a placeholder `Expr::NilLit`, before lowering the
+  body for real) -- see `src/lower.rs`'s new "Hoisting a branch/loop
+  body's introduced names" module-doc section for the full design,
+  including the exponential-blowup DoS vector an alternative
+  lower-twice-to-discover design would have introduced (rejected in
+  favour of the static pre-scan) and the one disclosed residual
+  limitation (no data-flow/definite-assignment analysis).
+- **LOW** (round 4, found while implementing the fix above): the new
+  `collect_assigned_names`'s own "is this statement an assignment"
+  detection assumed `inner.rule_name == "assignment"` directly, but the
+  CST reaches `assignment` through a chain of single-child precedence-
+  cascade wrapper rules the grammar does not flatten away -- exactly the
+  shape `lower_statement_expr` itself must peel through via its own
+  `peel_to_named`-style logic. The bug was caught immediately by this
+  round's own new regression tests (the hoist silently found zero
+  candidates) rather than shipping; fixed by reusing `peel_to_named`
+  (the same helper `bare_name`/`indexed_target` already use) instead of a
+  direct `rule_name` comparison.
 
 Also separately discovered (not fixed here, tracked as its own follow-up
 task): `scilab-parser`'s own `elseif_clause*` parsing appears to scale

--- a/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
@@ -87,22 +87,21 @@
   scope) — mirroring `scilab-runtime::eval::Interpreter::register_function`'s
   own more complete three-way reading of this grammar shape, whose doc
   comment confirms its own handling is "exactly correct."
-- 93 tests: 71 unit tests over lowering shapes, every documented scope
-  limit's rejection, and the DoS-guard regression pair
+- 96 tests: 72 unit tests over lowering shapes, every documented scope
+  limit's rejection, and the DoS-guard regression set
   (`a_pathologically_long_flat_{additive,multiplicative}_chain_is_
-  cleanly_rejected`, reproducing the identical flat-operand-chain hazard
-  `matlab-to-semantic-ir`'s own security review found and fixed, since
-  Scilab's grammar collapses a flat operator run into one many-child CST
-  node the same way); 10 validator/capability-acceptance tests; 11
-  end-to-end tests that actually execute lowered Scilab through
-  `semantic-ir-to-javascript` and `node` (gated on `node` availability).
+  cleanly_rejected` plus the `elseif`/`case`/transpose-suffix chain
+  variants added during security review, see below); 11
+  validator/capability-acceptance tests; 12 end-to-end tests that
+  actually execute lowered Scilab through `semantic-ir-to-javascript` and
+  `node` (gated on `node` availability).
 - Marks `scilab-to-semantic-ir` (MA-10e) done in
   `MA10-scilab-language.md` §6 — the last item in the Scilab frontend
   rollout.
 
 ### Security
 
-Two rounds of pre-merge security review found and fixed four issues, all
+Three rounds of pre-merge security review found and fixed six issues, all
 before this crate ever shipped:
 
 - **CRITICAL/HIGH** (round 1): `lower_if`/`lower_select` folded
@@ -144,6 +143,28 @@ before this crate ever shipped:
   existing `Vec` `scope_mark`/`scope_rewind` needs for ordered
   truncation), and backing the branch-fix's own `newly_introduced`
   accumulator with a `HashSet` instead of a `Vec`.
+- **HIGH** (round 3, a regression introduced by round 2's own fix): the
+  new `push_local` unconditionally appended to `locals`/`locals_set` even
+  when the name was ALREADY a known local — the case hit by `lower_for`
+  reusing an already-assigned variable as the loop counter (`y = 1; for
+  y = 1:3 ... end`, an ordinary Scilab idiom). `scope_rewind` at the
+  loop's own scope boundary then drained that duplicate `locals` entry
+  and removed the name from `locals_set` entirely — since a `HashSet` has
+  no duplicate-count tracking, this erased the variable's pre-existing
+  membership too, not just the loop-local copy. Confirmed via `node`:
+  the resulting JS had two top-level `let y` declarations in the same
+  scope, rejected with "Identifier 'y' has already been declared". Fixed
+  by making `push_local` a no-op when the name is already known — it
+  needs no scope tracking at all in that case, since it was in scope
+  before the push and stays in scope after, regardless of what happens in
+  the interim scope.
+- **LOW** (round 3): `lower_select` checked only `kids.is_empty()` before
+  indexing `kids[0]`/slicing `&kids[2..]`, unlike every sibling function's
+  length-based guard (e.g. `lower_if`'s `kids.len() < 3`). A
+  directly-constructed malformed `select_stmt` (unreachable via the real
+  `scilab-parser`, but `compile()`/`GrammarASTNode` is a public API) with
+  exactly one child panicked on the slice instead of erroring cleanly.
+  Fixed by checking `kids.len() < 2` instead.
 
 Also separately discovered (not fixed here, tracked as its own follow-up
 task): `scilab-parser`'s own `elseif_clause*` parsing appears to scale

--- a/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,118 @@
+# Changelog
+
+## [0.1.0] - 2026-07-20
+
+### Added
+
+- Initial `scilab-to-semantic-ir` frontend crate (MA10 §6, task MA-10e —
+  the last item in the Scilab frontend rollout, built alongside
+  `scilab-runtime`/`scilab-repl` per `HML01` §2's "every math language
+  gets a `-to-semantic-ir` frontend built alongside the runtime"
+  convention): `compile`/`compile_source` lowering
+  `coding-adventures-scilab-parser`'s `GrammarASTNode` CST into a
+  `semantic_ir::Module` over the shared SIR22 array/matrix domain.
+- Built as a close structural mirror of `matlab-to-semantic-ir` (per MA10
+  §5's finding that the grammar *shape* is a legitimate MATLAB-family
+  inheritance even though the *language* is not): the same
+  `compile`/`compile_source` shape, the same `LowerError { message, line,
+  column }` error shape (renamed `ScilabLowerError`), and the same
+  scalar/array disambiguation heuristic for `+ - * / \` and the same
+  "clean error over silent mis-lowering" philosophy for anything outside
+  a well-defined first-cut scope.
+- Supported: literals (int/float/string — both `'...'` and `"..."`
+  spellings lower to the same `Expr::StrLit`, MA10 §3), assignment
+  (`LetStarBinding` on first occurrence, `Assign` on re-assignment),
+  arithmetic (`+ - * / \ ^` and their dotted elementwise forms),
+  comparisons (`== ~= <> < > <= >=` — both not-equal spellings),
+  logical `&& || & |`, unary `+ - ~`, ranges (`a:b`, `a:step:b`),
+  transpose (`'` and `.'`), matrix literals (`ArrayLit`), indexing (read
+  → `IndexGet`, write → `Stmt::IndexSet`) with 1-based → 0-based
+  translation at lowering time, `if`/`elseif`/`else` and `while`/
+  `for i = a:b` (both accepting the optional `then`/`do` linker keyword
+  or a bare comma/newline, MA10 §3's `stmt_sep`), `select`/`case`/`else`
+  (desugared into a nested `if`-chain over a hoisted selector
+  temporary), the eight `%`-prefixed special constants (constant-folded
+  to `IntLit`/`FloatLit`), single- and zero-output function definitions
+  (including the explicit `[] = f(...)` and single-name-in-brackets
+  `[y] = f(...)` spellings) and calls to them, and `disp` (mapped onto
+  the shared SIR `print` builtin).
+- Explicit, disclosed scope limits (each rejected with a clear
+  `ScilabLowerError`, never silently mis-lowered): `$` (last-index,
+  mirrors the MATLAB template's `end`-relative-indexing exclusion — no
+  `size`/`shape` builtin is wired up yet to resolve it at lowering time),
+  `%i` (complex numbers — `array-runtime` has no representation, mirrors
+  `scilab-runtime::builtins::percent_const`'s identical choice),
+  multi-output functions (`[a, b] = f(...)`, mirrors the MATLAB
+  template's identical exclusion), `break`/`continue` (semantic-ir has no
+  early-exit control-flow node at all yet — a whole-IR gap, not specific
+  to this frontend), stepped/non-range `for` loops, matrix power and
+  right division (`/` mrdivide) between non-scalars, nested function
+  definitions, cell arrays/`list`/`tlist`/`mlist`, field access, chained
+  assignment, auto-vivification on indexed assignment, and any
+  arithmetic/ordering operator over a directly-written string literal
+  operand (equality remains in scope).
+- One deliberate divergence from the `matlab-to-semantic-ir` template:
+  `\`/`.\ ` (left division) are lowered *uniformly* as a broadcast
+  reciprocal division regardless of operand scalar-ness, rather than
+  mirroring the MATLAB template's asymmetric treatment (which rejects
+  bare `\` between non-scalars as an unimplemented matrix solve).
+  `scilab-runtime::eval::apply_binop`'s own doc comment confirms this
+  repo's ground-truth Scilab interpreter already makes this exact
+  simplification for both spellings uniformly, so lowering bare `\` more
+  strictly than the language's own shipped interpreter would be a
+  regression relative to the actual authority on what Scilab's `\`
+  computes, not a safety improvement. See `src/lower.rs`'s module doc
+  comment for the full rationale.
+- One deliberate addition beyond the `matlab-to-semantic-ir` template:
+  every additive/multiplicative/power/ordering-comparison operator
+  construction site rejects a directly-written `Expr::StrLit` operand
+  with a clean error. MA10 §1 finding 1 — the decisive finding motivating
+  this whole language's existence as its own frontend rather than a thin
+  MATLAB wrapper — is that Scilab's `+` means concatenation on strings
+  where MATLAB's means ASCII-numeric addition; the MATLAB template's own
+  `expr_is_known_scalar` heuristic does not special-case a string operand
+  at all, so a literal string reaching `+`/`-`/`*`/... there would
+  silently take the ordinary array-domain path — precisely the silent
+  mis-lowering MA10 §1 finding 1 warns against. This is a syntactic,
+  non-evaluating check (a variable merely known to hold a string is not
+  caught, since this frontend has no type inference), disclosed plainly
+  in `src/lower.rs`'s module doc comment.
+- One deliberate improvement beyond the `matlab-to-semantic-ir` template:
+  `func_returns` parsing distinguishes `NAME EQ` (single output), the
+  explicit-bracket single-name spelling `[y] = f(...)` (also single
+  output — the MATLAB template's coarser handling treats any non-empty
+  bracket name list as unconditionally multi-output and would incorrectly
+  reject this), the explicit empty-bracket zero-output spelling
+  `[] = f(...)`, and a genuine multi-name bracket list (rejected, out of
+  scope) — mirroring `scilab-runtime::eval::Interpreter::register_function`'s
+  own more complete three-way reading of this grammar shape, whose doc
+  comment confirms its own handling is "exactly correct."
+- 87 tests: 66 unit tests over lowering shapes, every documented scope
+  limit's rejection, and the DoS-guard regression pair
+  (`a_pathologically_long_flat_{additive,multiplicative}_chain_is_
+  cleanly_rejected`, reproducing the identical flat-operand-chain hazard
+  `matlab-to-semantic-ir`'s own security review found and fixed, since
+  Scilab's grammar collapses a flat operator run into one many-child CST
+  node the same way); 10 validator/capability-acceptance tests; 11
+  end-to-end tests that actually execute lowered Scilab through
+  `semantic-ir-to-javascript` and `node` (gated on `node` availability).
+- Marks `scilab-to-semantic-ir` (MA-10e) done in
+  `MA10-scilab-language.md` §6 — the last item in the Scilab frontend
+  rollout.
+
+### Notes on divergence from the spec
+
+`MA10-scilab-language.md` §5/§6 anticipated that the `stmt_sep` linker
+keyword and `select`/`case` would need no new SIR node, and that the
+`%`-prefixed constants could be constant-folded rather than needing a
+dedicated node — this implementation confirms all three predictions
+exactly as stated; no new `semantic-ir` core `Expr`/`SirType`/`Feature`
+variant was added. The spec did not anticipate the `\`/`.\ ` uniform-
+broadcast divergence from the MATLAB template, nor the string-operand
+guard, nor the more complete `func_returns` three-way reading — these are
+implementation-level refinements below the spec's own level of detail,
+each traceable to a concrete finding (respectively:
+`scilab-runtime::eval::apply_binop`'s own documented simplification, MA10
+§1 finding 1's own stated concern, and
+`scilab-runtime::eval::Interpreter::register_function`'s own doc comment)
+rather than a change to the spec's architectural decisions.

--- a/code/packages/rust/scilab-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/scilab-to-semantic-ir/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "scilab-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "Scilab CST → narrow-waist Semantic IR (SIR22 array/matrix domain). MA-10e, the last item in the Scilab frontend rollout per MA10 §6."
+
+[dependencies]
+semantic-ir = { path = "../semantic-ir" }
+coding-adventures-scilab-parser = { path = "../scilab-parser" }
+# The parser emits a generic `parser::grammar_parser::GrammarASTNode` whose
+# leaf tokens are `lexer::token::Token`; we walk both directly. Note this
+# crate deliberately does NOT depend on `coding-adventures-scilab-runtime` --
+# lowering only needs the parse tree shape (`scilab-parser`), not the
+# tree-walking evaluator, mirroring `apl-to-semantic-ir`/`j-to-semantic-ir`'s
+# identical choice (and MA10 §6's own framing: this is a separate,
+# ahead-of-time lowering pass over the same CST shape the runtime walks, not
+# a consumer of the runtime itself).
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+
+[dev-dependencies]
+# The scalar-only (non-array) subset of a lowered module can round-trip
+# through the JS backend and actually execute with the system `node`
+# (gated on availability), mirroring `matlab-to-semantic-ir`'s own identical
+# dev-dependency. Array/matrix (SIR22) codegen is exercised too where the JS
+# backend already implements it (see `tests/e2e_node.rs`); anything it
+# doesn't yet accept is instead verified via the capability-rejection path
+# in `tests/test_validator.rs`.
+semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/scilab-to-semantic-ir/README.md
+++ b/code/packages/rust/scilab-to-semantic-ir/README.md
@@ -1,0 +1,124 @@
+# scilab-to-semantic-ir
+
+Scilab CST → narrow-waist Semantic IR. Targets
+[SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md), the array/matrix
+domain extension of the SIR10 narrow-waist IR (see
+[HML01](../../../specs/HML01-math-to-semantic-ir.md)) — the same domain
+`matlab-to-semantic-ir`/`apl-to-semantic-ir`/`j-to-semantic-ir` already
+target. This is **MA-10e**, the last item in the Scilab frontend rollout
+(see [MA10](../../../specs/MA10-scilab-language.md) §6), built alongside
+`scilab-runtime`/`scilab-repl` per `HML01` §2's "every math language gets a
+`-to-semantic-ir` frontend built alongside the runtime" convention.
+
+## Where this fits
+
+```
+Scilab source
+   │
+   ▼  coding_adventures_scilab_parser::try_parse_scilab(src)
+parser::grammar_parser::GrammarASTNode   (generic CST)
+   │
+   ▼  scilab_to_semantic_ir::compile
+semantic_ir::Module                      (per SIR10 + SIR16 + SIR22)
+```
+
+The lowered `Module` can then be validated (`semantic_ir::validate`) and
+handed to any SIR backend (e.g. `semantic-ir-to-javascript`) — "write the
+Scilab frontend once, target every SIR backend" is the whole point of this
+narrow-waist design.
+
+This crate is a wholly separate, ahead-of-time lowering pass over the same
+CST shape `scilab-parser` produces — it does **not** depend on
+`coding-adventures-scilab-runtime` (the tree-walking evaluator) at all,
+mirroring `apl-to-semantic-ir`/`j-to-semantic-ir`'s identical choice.
+
+## Usage
+
+```rust
+use scilab_to_semantic_ir::compile_source;
+
+let module = compile_source("x = 1 + 2;\n", "demo")?;
+```
+
+## Scope (v0.1.0)
+
+Scilab is close to MATLAB in *grammar shape* but not in *language* (MA10
+§1); this first cut covers MA10 §4's own in-scope surface and returns a
+clean `ScilabLowerError` for anything outside it, rather than silently
+mis-lowering. See `src/lower.rs`'s module doc comment for the exact
+supported-construct list and every deliberate, disclosed scope limit.
+
+### What's genuinely new relative to `matlab-to-semantic-ir` (this crate's
+primary template)
+
+- **The `stmt_sep` linker** (`then`/`do`/comma/newline before a
+  control-flow body) needs no SIR representation at all — by lowering
+  time it has already collapsed to "which statements are in this
+  branch/body." It does, however, shift every control-flow lowering
+  function's child-node indexing by one slot relative to the MATLAB
+  template, since `stmt_sep` is a real child node in this grammar.
+- **`select`/`case`/`else`** (Scilab's own multi-way conditional, no
+  MATLAB `switch`/`otherwise` analogue) desugars into a nested `if`-chain
+  at lowering time — no new SIR node — mirroring how
+  `scilab-runtime::eval::eval_select` evaluates it at runtime. The
+  selector is hoisted into a fresh, uniquely-numbered temporary
+  (`__select_N`) and evaluated exactly once, since re-lowering it once per
+  `case` would re-evaluate a possibly side-effecting expression multiple
+  times.
+- **The eight `%`-prefixed special constants** (`%pi %e %i %inf %nan %eps
+  %t %f`) are constant-folded directly into a plain `Expr::IntLit`/
+  `Expr::FloatLit` at lowering time — their values are fixed and already
+  known, so no dedicated SIR node is needed. `%i` (complex numbers) is a
+  clean, honest `ScilabLowerError`, mirroring
+  `scilab-runtime::builtins::percent_const`'s own identical choice.
+- **`$` (last-index)** mirrors `matlab-to-semantic-ir`'s own
+  `end`-relative-indexing exclusion: a disclosed v0.1.0 scope limit, not
+  a silently-wrong lowering.
+- **Multi-output functions** (`[a, b] = f(...)`) are out of scope,
+  mirroring the MATLAB template's identical exclusion — no sibling
+  frontend in this repo has since solved multi-output lowering either.
+  Single- and zero-output functions (including the explicit `[] = f(...)`
+  bracket spelling) are supported, following
+  `scilab-runtime::eval::Interpreter::register_function`'s own more
+  complete reading of `func_returns` (a strict superset of the MATLAB
+  template's coarser handling, which cannot distinguish `[y] = f(x)` from
+  a genuine multi-name bracket list).
+- **`\`/`.\ ` (left division)** are handled *uniformly* as a broadcast
+  reciprocal division, regardless of operand scalar-ness — a deliberate
+  divergence from the MATLAB template's asymmetric treatment (which
+  rejects bare `\` between non-scalars), because `scilab-runtime`'s own
+  ground-truth interpreter already makes this exact simplification for
+  both spellings. See `src/lower.rs`'s module doc comment for the full
+  rationale.
+- **No arithmetic or ordering over a directly-written string literal.**
+  MA10 §1 finding 1 — the decisive finding motivating Scilab's existence
+  as its own frontend — is that `+` means concatenation on Scilab strings
+  where it means ASCII-numeric addition on MATLAB ones. This frontend
+  proactively guards every additive/multiplicative/power/ordering-
+  comparison operator against a bare `Expr::StrLit` operand, closing a gap
+  the MATLAB template's own `expr_is_known_scalar` heuristic does not
+  address. String *equality* (`==`/`~=`/`<>`) remains in scope, per MA10
+  §4.
+
+### Testing
+
+- `tests/test_lower.rs` — unit tests over every supported construct
+  (literals, assignment, arithmetic scalar/array disambiguation, matrix
+  literals, ranges, 1-D/2-D indexing, `if`/`elseif`/`else` including both
+  linker spellings, `while`/`for` including both linker spellings,
+  `select`/`case` desugaring, the eight `%`-constants, and every
+  documented scope-limit rejection), plus the same DoS-guard regression
+  pair (`a_pathologically_long_flat_{additive,multiplicative}_chain_is_
+  cleanly_rejected`) `matlab-to-semantic-ir` carries for the identical
+  flat-chain hazard (Scilab's grammar collapses a flat operator run into
+  one many-child CST node the same way MATLAB's does).
+- `tests/test_validator.rs` — every lowered module passes
+  `semantic_ir::validate`, and modules using SIR22 array/matrix features,
+  strings, `%`-constants, and desugared `select`/`case` are all correctly
+  *accepted* by `semantic-ir-to-javascript`'s capability check.
+- `tests/e2e_node.rs` — lowers Scilab source, emits JavaScript, and
+  **actually executes it with `node`** (gated on availability), covering
+  scalar arithmetic, forward-referenced function calls, matrix
+  multiplication, elementwise scalar broadcast, indexed assignment,
+  range+transpose, `%pi`, a `for`-loop accumulator, and both branches of a
+  desugared `select`/`case`.

--- a/code/packages/rust/scilab-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/src/lib.rs
@@ -1,0 +1,71 @@
+//! # scilab-to-semantic-ir
+//!
+//! Scilab CST → narrow-waist Semantic IR, **v0.1.0**.
+//!
+//! Targets [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md), the
+//! array/matrix domain extension of the SIR10 narrow-waist IR (see
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)) — the same
+//! domain `matlab-to-semantic-ir`/`apl-to-semantic-ir`/`j-to-semantic-ir`
+//! already target. It consumes the generic `GrammarASTNode` CST produced by
+//! the `coding-adventures-scilab-parser` crate and emits a
+//! [`semantic_ir::Module`].
+//!
+//! Per [`MA10`](../../../specs/MA10-scilab-language.md) §5/§6, this crate is
+//! built *alongside* `scilab-runtime`/`scilab-repl` in the same rollout wave
+//! (MA-10e, the last item), not bolted on afterward — but it is a wholly
+//! separate, ahead-of-time lowering pass over the same CST shape
+//! `scilab-runtime`'s tree-walking evaluator walks, not a consumer of that
+//! evaluator (this crate has no dependency on `coding-adventures-scilab-runtime`
+//! at all, mirroring `apl-to-semantic-ir`/`j-to-semantic-ir`'s identical
+//! choice).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Scilab source
+//!    │
+//!    ▼  coding_adventures_scilab_parser::try_parse_scilab(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  scilab_to_semantic_ir::compile
+//! semantic_ir::Module                      (per SIR10 + SIR16 + SIR22)
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use scilab_to_semantic_ir::compile_source;
+//! let module = compile_source("x = 1 + 2;\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+//!
+//! ## Scope (v0.1.0)
+//!
+//! Scilab is close to MATLAB in grammar shape but not in language (MA10
+//! §1); this first cut covers MA10 §4's own in-scope surface and returns a
+//! clean [`ScilabLowerError`] — rather than silently mis-lowering — for
+//! anything outside it. See `lower.rs`'s module doc comment for the exact
+//! supported-construct list and the documented, deliberate scope limits
+//! (`$`-relative indexing, `%i`, multi-output functions, `break`/`continue`,
+//! stepped/non-range `for`, matrix division, cell arrays/`list`/`tlist`/
+//! `mlist`, and any operator over string literals).
+
+mod lower;
+pub use lower::{compile, ScilabLowerError};
+
+/// Parse `source` as Scilab and lower it into a [`semantic_ir::Module`] in
+/// one step, mirroring every other `-to-semantic-ir` frontend's
+/// `compile_source` convenience wrapper.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, ScilabLowerError> {
+    let tree = coding_adventures_scilab_parser::try_parse_scilab(source).map_err(|msg| {
+        ScilabLowerError {
+            message: format!("parse error: {msg}"),
+            line: 1,
+            column: 1,
+        }
+    })?;
+    compile(&tree, module_name)
+}

--- a/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
@@ -1,0 +1,2550 @@
+//! The lowering pass from `coding_adventures_scilab_parser`'s generic
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **v0.1.0**.
+//!
+//! This crate's structure mirrors `matlab-to-semantic-ir` closely (per
+//! [`MA10`](../../../specs/MA10-scilab-language.md) §5's "grammar shape is a
+//! legitimate MATLAB-family inheritance" finding): `scilab.grammar`'s own
+//! precedence-cascade rule names (`logical_or`, `bit_and`, `comparison`,
+//! `colon_expr`, `additive`, `multiplicative`, `unary`, `power`, `postfix`,
+//! `primary`, ...) are *identical* to `matlab.grammar`'s, since it was
+//! forked from that grammar at the source level (MA10 §3). Where the two
+//! languages' CSTs genuinely diverge, this file diverges too — see each
+//! section below.
+//!
+//! # Scope
+//!
+//! **Supported** (MA10 §4's in-scope surface):
+//! - Literals: `NUMBER` (int- or float-shaped by lexeme), `STRING` (single-
+//!   or double-quoted — the same underlying type in Scilab, MA10 §3),
+//!   matrix literals `[1 2; 3 4]` → [`Expr::ArrayLit`].
+//! - The eight `%`-prefixed special constants (MA10 §3/§4) — see
+//!   "`%`-constants: constant-folded, not a new SIR node" below.
+//! - Variables (`NAME`), assignment (`x = expr`; first occurrence →
+//!   `LetStarBinding`, later re-assignment → `Assign`).
+//! - Arithmetic: `+`/`-` always lower to [`Expr::ElementwiseOp`] *unless
+//!   both operands are provably scalar* (see "Scalar/array
+//!   disambiguation" below), in which case a plain `BuiltinCall` is
+//!   emitted instead. `.* ./ .^` likewise take the same scalar fast path;
+//!   bare `*` disambiguates to [`Expr::MatMul`] vs. elementwise per the
+//!   same rule. `\`/`.\ ` (left division) are handled **uniformly** as a
+//!   broadcast reciprocal division — see "`\`/`.\ `: one divergence from
+//!   the MATLAB template" below. Bare `/` (mrdivide) between two
+//!   non-scalars is **unsupported**, mirroring `matlab-to-semantic-ir`
+//!   exactly (no linear-solve kernel exists in `array-runtime`).
+//! - Comparisons `== ~= <> < > <= >=` (both not-equal spellings, MA10 §1
+//!   finding 6) — `==`/`~=`/`<>` lower to `BuiltinCall("=" | "!=", ...)`
+//!   same as every ordering comparison; see "No arithmetic or ordering
+//!   over string literals" below for the one extra guard this frontend
+//!   adds beyond the MATLAB template.
+//! - Logical `&& || & |` (short-circuit and elementwise forms are **not**
+//!   distinguished — both lower to `LogicalAnd`/`LogicalOr`, the same
+//!   disclosed simplification `matlab-to-semantic-ir` already makes), and
+//!   unary `+ - ~`.
+//! - Ranges `a:b` (as a value, and specialised for `for i = a:b`) →
+//!   [`Expr::Range`].
+//! - Transpose `'`/`.'` → [`Expr::Transpose`].
+//! - Indexing `A(i, j, ...)` (read → [`Expr::IndexGet`], write →
+//!   [`Stmt::IndexSet`]) with 1-based → 0-based translation at lowering
+//!   time; `:` → [`IndexArg::Whole`].
+//! - Control flow `if`/`elseif`/`else`, `while`, `for i = a:b` — the
+//!   `then`/`do`/comma/newline linker keyword (MA10 §3's `stmt_sep`)
+//!   needs no SIR representation at all; see "The `stmt_sep` linker"
+//!   below.
+//! - `select`/`case`/`else` — Scilab's own multi-way conditional,
+//!   desugared into a nested `if`-chain; see "`select`/`case`: desugared,
+//!   no new SIR node" below.
+//! - Single- or zero-output function definitions
+//!   (`function [out =] name(params) ... endfunction`) and calls to them
+//!   ([`Expr::DirectCall`]).
+//! - `disp(x)` — the one recognised builtin, mapped onto the shared SIR
+//!   `print` builtin, mirroring `matlab-to-semantic-ir`'s identical
+//!   choice for MATLAB's own `disp`.
+//!
+//! **Deliberately out of scope for v0.1.0** (each rejected with an explicit
+//! [`ScilabLowerError`], not silently mis-lowered):
+//! - **`$` (last-index)** — mirrors `matlab-to-semantic-ir`'s own
+//!   `end`-relative-indexing exclusion: no `size`/`shape` builtin is wired
+//!   up yet to resolve "the current indexing dimension's size" at
+//!   lowering time (this is an ahead-of-time pass; `scilab-runtime`'s own
+//!   `$` resolution is a *runtime* mechanism, per its `eval_call_args` doc
+//!   comment, that this frontend has no equivalent of). Neither
+//!   `apl-to-semantic-ir` nor `j-to-semantic-ir` has an analogous "current
+//!   dimension size inside an index" construct to borrow a solved pattern
+//!   from, so this mirrors MATLAB's own scope decision rather than
+//!   inventing one.
+//! - **`%i`** — complex numbers are not representable (`array-runtime` is
+//!   real-`f64`-only), mirroring `scilab-runtime::builtins::percent_const`'s
+//!   own clean `Err` for the identical reason.
+//! - **Multi-output functions** (`[a, b] = f(...)`) — mirrors
+//!   `matlab-to-semantic-ir`'s own explicit v0.1.0 scope exclusion; no
+//!   sibling frontend (`apl-to-semantic-ir`, `j-to-semantic-ir`, or any
+//!   other `-to-semantic-ir` crate in this repo) has since solved
+//!   multi-output/multi-return lowering either, so there is no more
+//!   mature pattern to mirror instead.
+//! - **`break`/`continue`** — `semantic-ir` has no early-exit
+//!   control-flow node at all yet (confirmed: no `Break`/`Continue`
+//!   variant anywhere in `semantic-ir/src/nodes.rs`) — a whole-IR gap,
+//!   not specific to this frontend, exactly as `matlab-to-semantic-ir`'s
+//!   own doc comment states for MATLAB's identical `break`/`continue`.
+//! - Stepped (`a:step:b`) or non-range (`for i = A`) `for` loops — only
+//!   `for i = a:b` (unit step) is supported, mirroring
+//!   `matlab-to-semantic-ir`'s identical `for`-loop scope limit.
+//! - Matrix power (`A^2`/`A.^2` with a non-scalar base — `array-runtime`
+//!   has no eigendecomposition kernel), matrix right division `/`
+//!   (mrdivide) between two non-scalars.
+//! - Nested function definitions, cell arrays / `list`/`tlist`/`mlist`
+//!   (MA10 §4's own deferred aggregate-type system), field access
+//!   (`.NAME`), auto-vivification on indexed assignment to an undeclared
+//!   variable, and chained assignment (`a = b = c`).
+//! - **Any operator over a directly-written string literal** beyond
+//!   assignment/display/`==`/`~=`/`<>` — see the dedicated section below.
+//!
+//! # The `stmt_sep` linker: no SIR representation needed
+//!
+//! MA10 §3's `stmt_sep` production (`"then" | "do" | COMMA | NEWLINE`) is a
+//! genuine new grammar rule with no MATLAB equivalent — but by the time
+//! source reaches *this* lowering pass, it has already served its only
+//! purpose (telling the parser where a header ends and a body begins) and
+//! carries no information this frontend needs to preserve. Concretely,
+//! `if_stmt`'s children are `[cond, stmt_sep, block_body, elseif_clause*,
+//! else_clause?]` — one slot wider than `matlab-to-semantic-ir`'s own
+//! `if_stmt` shape (`[cond, block_body, ...]`), so every control-flow
+//! lowering function below indexes one position further in to skip over
+//! the `stmt_sep` node, exactly mirroring how `scilab-runtime::eval::eval_if`
+//! (MA-10d) already had to adjust its own child-indexing for the identical
+//! reason — confirmed directly against that crate's own doc comment on
+//! `eval_if`, which documents the exact same off-by-one-node correction.
+//! This is precisely the outcome MA10 §5 predicted: "by lowering time,
+//! `then`/`do`/comma/newline have already collapsed to 'which statements
+//! are in this branch/body,' the identical shape an ordinary `if`/`while`
+//! lowering already produces."
+//!
+//! # `select`/`case`: desugared, no new SIR node
+//!
+//! Mirroring how `scilab-runtime::eval::eval_select` evaluates `select` at
+//! *runtime* (evaluate the selector once, then compare it against each
+//! `case`'s value in turn, running the first match's body or `else`'s if
+//! none match), this frontend desugars `select`/`case`/`else` into a nested
+//! `if`-chain at *lowering* time — no new `Expr`/`Stmt` variant, per MA10
+//! §5's own prediction for this construct. The one wrinkle a pure `if`-chain
+//! doesn't handle for free: the selector must be evaluated **once**, not
+//! once per `case` (re-evaluating a side-effecting selector expression,
+//! e.g. a function call, once per case would be observably wrong — it
+//! would call the function N times instead of once). So [`Lowerer::lower_select`]
+//! first binds the selector to a fresh, compiler-generated local
+//! (`__select_N`, uniquely numbered per `select` statement in the module)
+//! via an ordinary `LetStarBinding`, then folds the `case`/`else` clauses
+//! into an `if`-chain of `BuiltinCall("=", [VarRef(temp), case_value])`
+//! conditions — the same equality [`crate::lower::values_equal`]-shaped
+//! comparison `eval_select` itself uses, just built as IR instead of
+//! executed directly. This is why `lower_select` returns `Vec<Lowered>`
+//! (the temp binding *and* the if-chain) rather than the single `Expr`
+//! `lower_if` returns — mirroring `apl-to-semantic-ir::lower_assignment_chain`'s
+//! identical "one syntactic construct unrolls into several IR statements"
+//! shape, the nearest existing precedent in this repo for a construct that
+//! needs its own hoisted temporary.
+//!
+//! # `%`-constants: constant-folded, not a new SIR node
+//!
+//! MA10 §5 asks whether the eight `PERCENT_CONST` spellings need a
+//! dedicated SIR node. They do not: every one of `%pi %e %inf %nan %eps
+//! %t %f` has a value fixed at compile time (`std::f64::consts::PI`, etc.
+//! — `%t`/`%f` are plain `1`/`0`, this repo's established "logicals are
+//! ordinary 0/1 numeric values" convention, matching
+//! `scilab-runtime::builtins::percent_const`'s identical choice), so this
+//! frontend simply constant-folds each spelling directly into a plain
+//! [`Expr::IntLit`]/[`Expr::FloatLit`] at the point it is lexed as a
+//! `primary` — see [`Lowerer::percent_const_expr`]. `%i` is the one
+//! exception: it has no representable value at all (no complex-number
+//! type exists anywhere in this repo's array-family stack), so it is a
+//! clean, honest [`ScilabLowerError`] instead of a guessed substitute,
+//! mirroring `scilab-runtime::builtins::percent_const`'s own identical
+//! choice for the identical reason.
+//!
+//! # `\`/`.\ `: one divergence from the MATLAB template
+//!
+//! `matlab-to-semantic-ir`'s own `build_multiplicative` treats bare `\`
+//! (mldivide, a real matrix left-division/solve problem for non-scalar
+//! operands) as **unsupported** outside the scalar case, while treating
+//! `.\ ` (the explicitly-elementwise spelling) as an unconditional
+//! broadcast reciprocal division. Scilab's own ground-truth interpreter,
+//! `scilab-runtime::eval::apply_binop`, does **not** draw that distinction:
+//! its own doc comment states plainly that "bare `\` and `.\ ` are both
+//! treated as the elementwise reference operation (`y / x`, broadcasting
+//! scalars) ... an honest, disclosed simplification for the general matrix
+//! case" — i.e. the crate that is this repo's actual authority on what
+//! Scilab's `\` computes has *already* made the "treat both spellings the
+//! same, always" call, for both spellings uniformly. Lowering bare `\` the
+//! way MATLAB's frontend does (rejecting it between two non-scalars) would
+//! therefore make this frontend **stricter than the language's own
+//! shipped, ground-truth interpreter** for no reason — the interpreter
+//! already computes an answer for that shape. So this frontend mirrors
+//! `scilab-runtime`'s own choice instead: both `\` and `.\ ` uniformly
+//! lower to `BuiltinCall("/", [rhs, lhs])` when both operands are provably
+//! scalar, or `Expr::ElementwiseOp { op: Div, lhs: rhs, rhs: lhs, .. }`
+//! (broadcast, operands swapped) otherwise — see
+//! [`Lowerer::build_multiplicative`]'s `"\\" | ".\\"` arm. This is the one
+//! place this crate's lowering deliberately does **not** copy
+//! `matlab-to-semantic-ir` verbatim, and the reason is traceable to a
+//! specific, already-shipped decision in this language's own runtime
+//! rather than an invented simplification of this crate's own.
+//!
+//! # No arithmetic or ordering over string literals
+//!
+//! MA10 §1 finding 1 — the decisive finding motivating this whole
+//! language's existence as its own frontend — is that Scilab's `+` means
+//! *concatenation* on strings where MATLAB's means ASCII-numeric addition.
+//! MA10 §4 accordingly scopes strings down to assignment/display/equality
+//! only, explicitly refusing to implement `+` (or any other operator) over
+//! them this cut: "implementing `+` at all here, without the typed-dispatch
+//! layer §2 defers, would risk landing on MATLAB's numeric-addition answer
+//! by accident, which would be *worse* than simply not having the operator
+//! yet." `matlab-to-semantic-ir`'s own scalar/array disambiguation
+//! (`expr_is_known_scalar`) does not special-case a string operand at all —
+//! a bare `Expr::StrLit` simply falls through to `_ => false` (not scalar),
+//! so a literal string reaching `+`/`-`/`*`/... would silently take the
+//! ordinary array-domain `ElementwiseOp` path there, exactly the silent
+//! mis-lowering MA10 §1 finding 1 warns against. This frontend closes that
+//! gap for the *directly-written-literal* case (see
+//! [`Lowerer::reject_string_operand`]): every additive, multiplicative,
+//! power, and ordering-comparison (`< <= > >=`) operator construction
+//! site checks each already-lowered operand and rejects with a clean
+//! [`ScilabLowerError`] if it is a bare `Expr::StrLit`. Equality (`==`/
+//! `~=`/`<>`) is deliberately **not** guarded — MA10 §4 explicitly keeps
+//! string equality in scope. This is a syntactic, non-evaluating check
+//! (identical in spirit to `expr_is_known_scalar`'s own syntactic-only
+//! reach): a *variable* merely known by the programmer to hold a string
+//! (`s = "hi"; y = s + 1;`) is invisible to it, since this frontend has no
+//! type inference at all — a real, disclosed limitation, not a full fix,
+//! but one that catches the direct, obvious case MA10 §1 finding 1 is
+//! actually about.
+//!
+//! # Scalar/array disambiguation
+//!
+//! Identical heuristic to `matlab-to-semantic-ir`'s own (see that crate's
+//! module doc comment for the full rationale): an operand is "known
+//! scalar" iff it is a bare `IntLit`/`FloatLit`, or a `BuiltinCall` of
+//! `+ - * / neg` whose own arguments are (transitively) known-scalar.
+//! Falling through to the array-domain node in an ambiguous case is
+//! always semantically safe, just occasionally more conservative than a
+//! full type-inference pass would be.
+
+use std::collections::HashSet;
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, IndexArg,
+    Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
+};
+
+/// Maximum expression-nesting depth. Mirrors every other SIR frontend's
+/// identically-named, identically-justified guard: turns pathologically
+/// deep (but parseable) input into a clean [`ScilabLowerError`] instead of
+/// a native (uncatchable) stack overflow.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// Maximum statement-block nesting depth (each `if`/`while`/`for`/`select`
+/// body, or a `function` body, re-enters the block lowerer one level
+/// deeper).
+const MAX_BLOCK_DEPTH: usize = 256;
+
+/// Synthetic file name used for all spans (the CST does not carry the
+/// original path).
+const FILE: &str = "<scilab>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during Scilab → SIR lowering.
+///
+/// Mirrors `MatlabLowerError`/`AplLowerError`'s shape exactly (`message` +
+/// 1-based `line`/`column`) so tooling can treat every SIR frontend
+/// uniformly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScilabLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for ScilabLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ScilabLowerError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for ScilabLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Scilab CST (rooted at the `program` rule) into a SIR
+/// module.
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, ScilabLowerError> {
+    Lowerer::new(module_name).lower_file(tree)
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// One lowered top-level / body statement: either a `Stmt` or a bare
+/// expression (an expression statement).
+enum Lowered {
+    Stmt(Box<Stmt>),
+    Expr(Expr),
+}
+
+/// Per-function name-resolution context. Like MATLAB, Scilab scopes a
+/// variable to its *whole enclosing function* (no block scoping) — a
+/// function call gets a wholly fresh workspace (`scilab-runtime::eval::
+/// Interpreter::call_user_function`'s own doc comment confirms this: "no
+/// closures, no access to the caller's variables"). So, mirroring
+/// `matlab-to-semantic-ir::FunctionCtx` exactly, `locals` simply
+/// accumulates for the function's lifetime and is never rewound when
+/// leaving an `if`/`while`/`for`/`select` body. The one place `locals` is
+/// temporarily extended and then rewound is a `for`-loop variable, whose
+/// scope genuinely is the loop.
+struct FunctionCtx {
+    params: HashSet<String>,
+    locals: Vec<String>,
+}
+
+impl FunctionCtx {
+    fn new(params: HashSet<String>) -> Self {
+        Self {
+            params,
+            locals: Vec::new(),
+        }
+    }
+
+    fn top_level() -> Self {
+        Self::new(HashSet::new())
+    }
+}
+
+struct Lowerer {
+    module_name: String,
+    /// Features observed while lowering, used to build the manifest so it
+    /// declares *exactly* what the module emits.
+    observed: FeatureManifest,
+    /// Every top-level `function` name, collected in a first pass so a call
+    /// to a function defined later in the file resolves as
+    /// [`Expr::DirectCall`] regardless of textual order.
+    function_names: HashSet<String>,
+    /// The lowered top-level functions, in definition order. `main` is
+    /// appended last by [`Self::lower_file`].
+    functions: Vec<Function>,
+    /// Counter for the compiler-generated `__select_N` temporaries
+    /// [`Self::lower_select`] hoists the selector into — see this file's
+    /// module doc comment, "`select`/`case`: desugared, no new SIR node".
+    /// A single module-wide counter (not per-function) is simplest and
+    /// still guarantees uniqueness: every `select` statement anywhere in
+    /// the module gets its own number, so nested or sibling `select`s
+    /// never collide.
+    select_counter: usize,
+}
+
+impl Lowerer {
+    fn new(module_name: &str) -> Self {
+        Self {
+            module_name: module_name.to_string(),
+            observed: FeatureManifest::new(),
+            function_names: HashSet::new(),
+            functions: Vec::new(),
+            select_counter: 0,
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // for-loop variable scope: mark/rewind (the ONE place Scilab truly
+    // does introduce a scope narrower than the whole function).
+    // -------------------------------------------------------------------
+
+    fn scope_mark(ctx: &FunctionCtx) -> usize {
+        ctx.locals.len()
+    }
+
+    fn scope_rewind(ctx: &mut FunctionCtx, mark: usize) {
+        ctx.locals.truncate(mark);
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program` → collect function names, then lower
+    // -------------------------------------------------------------------
+
+    fn lower_file(&mut self, program: &GrammarASTNode) -> Result<Module, ScilabLowerError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        // Every value this frontend lowers has `sir_type: None` -- Scilab
+        // has no static type declarations anywhere -- mirroring
+        // `matlab-to-semantic-ir`'s identical observation.
+        self.observed.add(Feature::DynamicTyping);
+
+        self.collect_function_names(program)?;
+
+        let mut ctx = FunctionCtx::top_level();
+        let mut items: Vec<Lowered> = Vec::new();
+        for stmt_line in child_nodes(program) {
+            if stmt_line.rule_name != "statement_line" {
+                continue;
+            }
+            let stmt = match self.first_child_named(stmt_line, "statement") {
+                Some(s) => s,
+                None => continue, // a bare terminator (blank line) -- nothing to lower
+            };
+            let inner = only_node(stmt, self)?;
+            if inner.rule_name == "func_def" {
+                let f = self.lower_func_def(inner)?;
+                self.functions.push(f);
+                continue;
+            }
+            items.extend(self.lower_statement_body_item(inner, &mut ctx, 0)?);
+        }
+
+        let span = Span::point(FILE, 1, 1);
+        let main_body =
+            assemble_stmts_only(items, Expr::NilLit { span: span.clone() }, span.clone());
+        let main = Function {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: main_body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: span.clone(),
+        };
+
+        let mut functions = std::mem::take(&mut self.functions);
+        functions.push(main);
+
+        let metadata = Metadata::new()
+            .with_source_language("scilab")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION);
+
+        Ok(Module {
+            name: self.module_name.clone(),
+            manifest: self.observed.clone(),
+            imports: vec![],
+            exports: vec![],
+            functions,
+            globals: vec![],
+            metadata,
+            span,
+        })
+    }
+
+    /// Pass 1: collect every top-level `function`'s name, so a call
+    /// anywhere in the file — regardless of textual order — resolves as
+    /// [`Expr::DirectCall`]. Nested function definitions are rejected (as
+    /// an explicit error) when actually lowered, not here.
+    fn collect_function_names(&mut self, program: &GrammarASTNode) -> Result<(), ScilabLowerError> {
+        for stmt_line in child_nodes(program) {
+            if stmt_line.rule_name != "statement_line" {
+                continue;
+            }
+            let stmt = match self.first_child_named(stmt_line, "statement") {
+                Some(s) => s,
+                None => continue,
+            };
+            let inner = match only_node(stmt, self) {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            if inner.rule_name == "func_def" {
+                let name = self.func_def_name(inner)?;
+                self.function_names.insert(name);
+            }
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // function definitions
+    // -------------------------------------------------------------------
+
+    /// The function's own name: a bare `NAME` token directly under
+    /// `func_def` (distinct from the *output variable*'s name, which lives
+    /// one level deeper inside `func_returns` and is therefore invisible to
+    /// this direct scan) — mirrors
+    /// `matlab_to_semantic_ir::Lowerer::func_def_name` exactly.
+    fn func_def_name(&self, def: &GrammarASTNode) -> Result<String, ScilabLowerError> {
+        def.children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                    Some(t.value.clone())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| self.err_at(def, "malformed function definition: no name".to_string()))
+    }
+
+    /// Extract the declared output name, if any, from a `func_returns`
+    /// node: `NAME EQ` (single output), `LBRACKET NAME RBRACKET EQ` (single
+    /// output, explicit-bracket spelling), `LBRACKET RBRACKET EQ` (explicit
+    /// zero-output bracket form), or a multi-name bracket list
+    /// (unsupported — multi-output functions are out of scope, MA10 §4/this
+    /// file's module doc comment).
+    ///
+    /// This is a strictly more complete reading of `func_returns` than
+    /// `matlab-to-semantic-ir::lower_func_def`'s own inline handling (which
+    /// treats a non-empty `name_list` as unconditionally multi-output and
+    /// therefore cannot distinguish `[y] = f(x)` — a single name in
+    /// brackets — from a genuine `[a, b] = f(x)`): mirrors
+    /// `scilab-runtime::eval::Interpreter::register_function`'s own
+    /// three-way handling instead, whose doc comment confirms "neither
+    /// branch matching (`[] = f(...)`, an explicitly zero-output bracket
+    /// form) leaves `returns` empty, which is exactly correct" — the
+    /// ground-truth interpreter already solved this distinction correctly,
+    /// so this frontend reuses that reading rather than the (slightly
+    /// coarser) MATLAB-template one.
+    fn lower_func_returns(&self, returns: &GrammarASTNode) -> Result<Option<String>, ScilabLowerError> {
+        if let Some(name_list) = self.first_child_named(returns, "name_list") {
+            let names: Vec<String> = name_list
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                        Some(t.value.clone())
+                    }
+                    _ => None,
+                })
+                .collect();
+            return match names.len() {
+                // `name_list = NAME { COMMA NAME }` requires at least one
+                // NAME by construction; an empty vec here would mean the
+                // grammar matched a `name_list` node with no NAME children
+                // at all, which the parser cannot produce.
+                0 => Err(self.err_at(name_list, "malformed output name list".to_string())),
+                1 => Ok(Some(names.into_iter().next().expect("len checked above"))),
+                _ => Err(self.err_at(
+                    returns,
+                    "unsupported: multiple output arguments (`[a, b] = f(...)`) are out of \
+                     scope for v0.1.0"
+                        .to_string(),
+                )),
+            };
+        }
+        // No `name_list` child: either the bare `NAME EQ` single-output
+        // spelling, or the explicit, empty `[] = ` zero-output bracket
+        // form -- a direct scan for a bare NAME token directly under
+        // `func_returns` tells them apart.
+        let bare = returns.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => Some(t.value.clone()),
+            _ => None,
+        });
+        Ok(bare)
+    }
+
+    /// Lower a `func_def` into a top-level [`Function`]. Scilab functions
+    /// have no `return`-expression; the designated output variable's final
+    /// value *is* the return value, so the body's trailing [`Block::value`]
+    /// is synthesised as a `VarRef` to it (or `NilLit` for a function with
+    /// no output) — identical to `matlab-to-semantic-ir::lower_func_def`.
+    fn lower_func_def(&mut self, def: &GrammarASTNode) -> Result<Function, ScilabLowerError> {
+        let span = self.span_of(def);
+        let name = self.func_def_name(def)?;
+
+        let mut output: Option<String> = None;
+        if let Some(returns) = self.first_child_named(def, "func_returns") {
+            output = self.lower_func_returns(returns)?;
+        }
+
+        let mut param_names: Vec<String> = Vec::new();
+        if let Some(name_list) = self.first_child_named(def, "name_list") {
+            param_names.extend(name_list.children.iter().filter_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                    Some(t.value.clone())
+                }
+                _ => None,
+            }));
+        }
+
+        let body_node = self
+            .first_child_named(def, "block_body")
+            .ok_or_else(|| self.err_at(def, "malformed function: no body".to_string()))?;
+
+        let mut ctx = FunctionCtx::new(param_names.iter().cloned().collect());
+        let items = self.lower_body_items(body_node, &mut ctx, 0)?;
+
+        let value = match &output {
+            Some(out_name) => Expr::VarRef {
+                name: out_name.clone(),
+                scope: Scope::Local,
+                span: span.clone(),
+            },
+            None => Expr::NilLit { span: span.clone() },
+        };
+        let body = assemble_stmts_only(items, value, span.clone());
+
+        Ok(Function {
+            name,
+            params: param_names
+                .into_iter()
+                .map(|p| Param {
+                    name: p,
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: span.clone(),
+                })
+                .collect(),
+            return_type: None,
+            captures: vec![],
+            body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // statement bodies (shared by `if`/`while`/`for`/`select`/`function`
+    // bodies)
+    // -------------------------------------------------------------------
+
+    fn lower_body_items(
+        &mut self,
+        body_node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Vec<Lowered>, ScilabLowerError> {
+        let mut items = Vec::new();
+        for stmt_line in child_nodes(body_node) {
+            if stmt_line.rule_name == "statement_line" {
+                items.extend(self.lower_statement_line(stmt_line, ctx, depth)?);
+            }
+        }
+        Ok(items)
+    }
+
+    fn lower_block_body(
+        &mut self,
+        block_body: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Block, ScilabLowerError> {
+        if depth > MAX_BLOCK_DEPTH {
+            return Err(self.err_at(
+                block_body,
+                format!("control-flow nesting too deep (exceeds {MAX_BLOCK_DEPTH} levels)"),
+            ));
+        }
+        let items = self.lower_body_items(block_body, ctx, depth)?;
+        let span = self.span_of(block_body);
+        Ok(assemble_stmts_only(
+            items,
+            Expr::NilLit { span: span.clone() },
+            span,
+        ))
+    }
+
+    fn lower_statement_line(
+        &mut self,
+        stmt_line: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Vec<Lowered>, ScilabLowerError> {
+        let stmt = match self.first_child_named(stmt_line, "statement") {
+            Some(s) => s,
+            None => return Ok(Vec::new()), // a bare terminator (blank line)
+        };
+        let inner = only_node(stmt, self)?;
+        self.lower_statement_body_item(inner, ctx, depth)
+    }
+
+    /// Dispatch one `statement` alternative that is *not* a top-level
+    /// `func_def` (that case is handled directly by [`Self::lower_file`]).
+    /// Reached here, `func_def` can only mean a *nested* definition, which
+    /// this frontend does not support.
+    ///
+    /// Returns a `Vec` rather than an `Option` (unlike
+    /// `matlab-to-semantic-ir::lower_statement_body_item`) because
+    /// `select`/`case` desugars into *two* IR statements per syntactic
+    /// statement (the hoisted selector binding, then the if-chain) — see
+    /// [`Self::lower_select`]'s own doc comment, and
+    /// `apl-to-semantic-ir::lower_top_level_statement`'s identical
+    /// "one construct, several unrolled `Stmt`s" return shape for chained
+    /// assignment.
+    fn lower_statement_body_item(
+        &mut self,
+        inner: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Vec<Lowered>, ScilabLowerError> {
+        if depth > MAX_BLOCK_DEPTH {
+            return Err(self.err_at(
+                inner,
+                format!("control-flow nesting too deep (exceeds {MAX_BLOCK_DEPTH} levels)"),
+            ));
+        }
+        match inner.rule_name.as_str() {
+            "func_def" => Err(self.err_at(
+                inner,
+                "unsupported: nested function definitions are out of scope for v0.1.0".to_string(),
+            )),
+            "if_stmt" => Ok(vec![Lowered::Expr(self.lower_if(inner, ctx, depth)?)]),
+            "select_stmt" => self.lower_select(inner, ctx, depth),
+            "while_stmt" => Ok(vec![Lowered::Stmt(Box::new(
+                self.lower_while(inner, ctx, depth)?,
+            ))]),
+            "for_stmt" => Ok(vec![Lowered::Stmt(Box::new(
+                self.lower_for(inner, ctx, depth)?,
+            ))]),
+            "break_stmt" => Err(self.err_at(
+                inner,
+                "unsupported: `break` has no SIR equivalent yet (semantic-ir has no early-exit \
+                 control-flow node at all -- a whole-IR gap, not specific to this frontend)"
+                    .to_string(),
+            )),
+            "continue_stmt" => Err(self.err_at(
+                inner,
+                "unsupported: `continue` has no SIR equivalent yet (semantic-ir has no early-exit \
+                 control-flow node at all -- a whole-IR gap, not specific to this frontend)"
+                    .to_string(),
+            )),
+            _ => Ok(vec![self.lower_statement_expr(inner, ctx, depth)?]),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // control flow
+    // -------------------------------------------------------------------
+
+    /// Lower `if cond stmt_sep body { elseif_clause } [ else_clause ] end`.
+    /// `node_children(if_stmt)` is `[cond, stmt_sep, body, elseif_clause*,
+    /// else_clause?]` -- one slot wider than the MATLAB template, since
+    /// `stmt_sep` is a real child node here (this file's module doc
+    /// comment, "The `stmt_sep` linker"). `elseif_clause`'s own children
+    /// are `[cond, stmt_sep, body]` for the identical reason; `else_clause`
+    /// has no `stmt_sep` of its own (MA10 §3 never lists `else` among the
+    /// six `stmt_sep` sites), so its shape (`[body]`) is unchanged from
+    /// the MATLAB template.
+    fn lower_if(
+        &mut self,
+        if_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, ScilabLowerError> {
+        struct Clause<'a> {
+            cond: &'a GrammarASTNode,
+            body: &'a GrammarASTNode,
+        }
+        let kids = child_nodes(if_stmt);
+        if kids.len() < 3 {
+            return Err(self.err_at(if_stmt, "malformed if: expected condition and body".to_string()));
+        }
+        let mut clauses: Vec<Clause> = vec![Clause {
+            cond: kids[0],
+            body: kids[2],
+        }];
+        let mut else_body: Option<&GrammarASTNode> = None;
+        for rest in &kids[3..] {
+            match rest.rule_name.as_str() {
+                "elseif_clause" => match child_nodes(rest).as_slice() {
+                    [c, _stmt_sep, b] => clauses.push(Clause { cond: c, body: b }),
+                    _ => return Err(self.err_at(rest, "malformed elseif clause".to_string())),
+                },
+                "else_clause" => match child_nodes(rest).as_slice() {
+                    [b] => else_body = Some(b),
+                    _ => return Err(self.err_at(rest, "malformed else clause".to_string())),
+                },
+                other => {
+                    return Err(self.err_at(
+                        rest,
+                        format!("unexpected `{other}` inside if statement"),
+                    ))
+                }
+            }
+        }
+
+        let if_span = self.span_of(if_stmt);
+        let mut else_branch: Block = match else_body {
+            Some(b) => self.lower_block_body(b, ctx, depth + 1)?,
+            None => empty_block(if_span.clone()),
+        };
+        for clause in clauses.into_iter().rev() {
+            // Scilab truthiness ("nonzero is true", identical to MATLAB's
+            // -- see `to_scilab_condition`'s doc comment).
+            let cond = to_scilab_condition(self.lower_expr(clause.cond, ctx)?);
+            let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
+            let span = cond.span().clone();
+            let folded = Expr::If {
+                cond: Box::new(cond),
+                then_branch: Box::new(then_branch),
+                else_branch: Box::new(else_branch),
+                span,
+            };
+            else_branch = value_block(folded);
+        }
+        match else_branch.value {
+            Expr::If { .. } => Ok(else_branch.value),
+            other => Ok(other),
+        }
+    }
+
+    /// Lower `select selector stmt_sep { case_clause } [ else_clause ] end`
+    /// into a nested `if`-chain — this file's module doc comment,
+    /// "`select`/`case`: desugared, no new SIR node", explains the full
+    /// design (why the selector must be hoisted into a fresh temp rather
+    /// than re-lowered per case, and why this returns `Vec<Lowered>`
+    /// rather than a single `Expr`).
+    ///
+    /// `node_children(select_stmt)` is `[selector, stmt_sep, case_clause*,
+    /// else_clause?]`; each `case_clause`'s own children are `[value,
+    /// stmt_sep, body]` (mirroring `if_stmt`'s `elseif_clause` shape
+    /// exactly, since `case` is one of the six `stmt_sep` sites, MA10 §3).
+    fn lower_select(
+        &mut self,
+        select_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Vec<Lowered>, ScilabLowerError> {
+        struct Clause<'a> {
+            value: &'a GrammarASTNode,
+            body: &'a GrammarASTNode,
+        }
+        let kids = child_nodes(select_stmt);
+        if kids.is_empty() {
+            return Err(self.err_at(select_stmt, "malformed select: no selector".to_string()));
+        }
+        let selector_node = kids[0];
+        let span = self.span_of(select_stmt);
+
+        let selector = self.lower_expr(selector_node, ctx)?;
+        let temp = format!("__select_{}", self.select_counter);
+        self.select_counter += 1;
+        ctx.locals.push(temp.clone());
+        let mut stmts: Vec<Lowered> = vec![Lowered::Stmt(Box::new(Stmt::LetStarBinding {
+            name: temp.clone(),
+            sir_type: None,
+            value: selector,
+            span: span.clone(),
+        }))];
+
+        // `kids[1]` is `select`'s own `stmt_sep` (its header is one of the
+        // six `stmt_sep` sites, MA10 §3) -- the case/else clause scan
+        // starts at `kids[2]`, mirroring `scilab-runtime::eval::eval_select`'s
+        // own `let mut i = 2;` exactly.
+        let mut clauses: Vec<Clause> = Vec::new();
+        let mut else_body: Option<&GrammarASTNode> = None;
+        for rest in &kids[2..] {
+            match rest.rule_name.as_str() {
+                "case_clause" => match child_nodes(rest).as_slice() {
+                    [v, _stmt_sep, b] => clauses.push(Clause { value: v, body: b }),
+                    _ => return Err(self.err_at(rest, "malformed case clause".to_string())),
+                },
+                "else_clause" => match child_nodes(rest).as_slice() {
+                    [b] => else_body = Some(b),
+                    _ => return Err(self.err_at(rest, "malformed else clause".to_string())),
+                },
+                other => {
+                    return Err(self.err_at(
+                        rest,
+                        format!("unexpected `{other}` inside select statement"),
+                    ))
+                }
+            }
+        }
+
+        let mut else_branch: Block = match else_body {
+            Some(b) => self.lower_block_body(b, ctx, depth + 1)?,
+            None => empty_block(span.clone()),
+        };
+        for clause in clauses.into_iter().rev() {
+            let case_value = self.lower_expr(clause.value, ctx)?;
+            let cmp_span = case_value.span().clone();
+            let eq = Expr::BuiltinCall {
+                name: "=".to_string(),
+                args: vec![
+                    Expr::VarRef {
+                        name: temp.clone(),
+                        scope: Scope::Local,
+                        span: cmp_span.clone(),
+                    },
+                    case_value,
+                ],
+                effects: EffectSet::PURE,
+                span: cmp_span,
+            };
+            let cond = to_scilab_condition(eq);
+            let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
+            let if_span = cond.span().clone();
+            let folded = Expr::If {
+                cond: Box::new(cond),
+                then_branch: Box::new(then_branch),
+                else_branch: Box::new(else_branch),
+                span: if_span,
+            };
+            else_branch = value_block(folded);
+        }
+
+        let final_expr = match else_branch.value {
+            Expr::If { .. } => else_branch.value,
+            other => other,
+        };
+        stmts.push(Lowered::Expr(final_expr));
+        Ok(stmts)
+    }
+
+    /// `while cond stmt_sep body end`. `node_children(while_stmt)` is
+    /// `[cond, stmt_sep, body]` -- kids[2], not kids[1], is the loop body
+    /// (this file's module doc comment, "The `stmt_sep` linker").
+    fn lower_while(
+        &mut self,
+        while_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Stmt, ScilabLowerError> {
+        let (cond_node, body_node) = match child_nodes(while_stmt).as_slice() {
+            [c, _stmt_sep, b] => (*c, *b),
+            _ => {
+                return Err(self.err_at(
+                    while_stmt,
+                    "malformed while: expected condition and body".to_string(),
+                ))
+            }
+        };
+        let cond = to_scilab_condition(self.lower_expr(cond_node, ctx)?);
+        let body = self.lower_block_body(body_node, ctx, depth + 1)?;
+        self.observed.add(Feature::Loops);
+        Ok(Stmt::While {
+            cond,
+            body,
+            span: self.span_of(while_stmt),
+        })
+    }
+
+    /// Lower `for NAME = a:b stmt_sep body end` into [`Stmt::ForRange`].
+    /// Only the unit-step, two-operand range form is supported (matches
+    /// `matlab-to-semantic-ir`'s identical `for`-loop scope limit);
+    /// `ForRange` is half-open, but Scilab's `a:b` is inclusive, so the
+    /// exclusive bound is `b + 1` -- exact for any `a`/`b` precisely
+    /// because the step is fixed at 1. `node_children(for_stmt)` is
+    /// `[range, stmt_sep, body]` (the loop variable's `NAME`/`EQ` are bare
+    /// tokens, not child nodes, extracted separately below) -- kids[2],
+    /// not kids[1], is the loop body.
+    fn lower_for(
+        &mut self,
+        for_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Stmt, ScilabLowerError> {
+        let span = self.span_of(for_stmt);
+        let var = for_stmt
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                    Some(t.value.clone())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| self.err_at(for_stmt, "malformed for: no loop variable".to_string()))?;
+
+        let (iter_node, body_node) = match child_nodes(for_stmt).as_slice() {
+            [i, _stmt_sep, b] => (*i, *b),
+            _ => {
+                return Err(self.err_at(
+                    for_stmt,
+                    "malformed for: expected range and body".to_string(),
+                ))
+            }
+        };
+
+        let range_node = self.peel_to_named(iter_node, "colon_expr", 0);
+        let (start_n, stop_n) = match range_node {
+            Some(r) => match child_nodes(r).as_slice() {
+                [s, e] => (*s, *e),
+                _ => {
+                    return Err(self.err_at(
+                        r,
+                        "unsupported: stepped for-loop ranges (`for i = a:step:b`) are out of \
+                         scope for v0.1.0"
+                            .to_string(),
+                    ))
+                }
+            },
+            None => {
+                return Err(self.err_at(
+                    iter_node,
+                    "unsupported: `for` over a non-range expression is out of scope for v0.1.0 \
+                     (only `for NAME = a:b` is supported)"
+                        .to_string(),
+                ))
+            }
+        };
+
+        let start = self.lower_expr(start_n, ctx)?;
+        let stop_val = self.lower_expr(stop_n, ctx)?;
+        let stop_span = stop_val.span().clone();
+        let stop = Expr::BuiltinCall {
+            name: "+".to_string(),
+            args: vec![
+                stop_val,
+                Expr::IntLit {
+                    value: 1,
+                    span: stop_span.clone(),
+                },
+            ],
+            effects: EffectSet::PURE,
+            span: stop_span,
+        };
+        let step = Expr::IntLit {
+            value: 1,
+            span: span.clone(),
+        };
+
+        self.observed.add(Feature::Loops);
+        let mark = Self::scope_mark(ctx);
+        ctx.locals.push(var.clone());
+        let body = self.lower_block_body(body_node, ctx, depth + 1)?;
+        Self::scope_rewind(ctx, mark);
+
+        Ok(Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            span,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // assignment
+    // -------------------------------------------------------------------
+
+    /// Lower a `statement`'s `expr` alternative: either a value expression
+    /// (a bare function call, e.g. `disp(x)`) or an assignment. Scilab's
+    /// own grammar folds assignment *into* the expression precedence chain
+    /// exactly like MATLAB's (`expr = assignment`, `assignment = logical_or
+    /// [ EQ assignment ]`), so this peels down to the `assignment` rule
+    /// specifically wherever it lands in the collapsed tree, mirroring
+    /// `matlab_to_semantic_ir::lower_statement_expr` exactly.
+    fn lower_statement_expr(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Lowered, ScilabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        if node.rule_name != "assignment" {
+            return match child_nodes(node).as_slice() {
+                [only] if node.children.len() == 1 => {
+                    self.lower_statement_expr(only, ctx, depth + 1)
+                }
+                _ => {
+                    let expr = self.lower_expr(node, ctx)?;
+                    Ok(Lowered::Expr(expr))
+                }
+            };
+        }
+        match child_nodes(node).as_slice() {
+            [lhs] if node.children.len() == 1 => {
+                let expr = self.lower_expr(lhs, ctx)?;
+                Ok(Lowered::Expr(expr))
+            }
+            [lhs, rhs] => {
+                if rhs.rule_name == "assignment" && child_nodes(rhs).len() == 2 {
+                    return Err(self.err_at(
+                        rhs,
+                        "unsupported: chained assignment (`a = b = c`) is out of scope for v0.1.0"
+                            .to_string(),
+                    ));
+                }
+                self.lower_assignment(node, lhs, rhs, ctx)
+            }
+            _ => Err(self.err_at(node, "malformed assignment".to_string())),
+        }
+    }
+
+    fn lower_assignment(
+        &mut self,
+        assign_node: &GrammarASTNode,
+        lhs: &GrammarASTNode,
+        rhs: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Lowered, ScilabLowerError> {
+        let span = self.span_of(assign_node);
+
+        if let Some(name) = self.bare_name(lhs) {
+            let value = self.lower_expr(rhs, ctx)?;
+            if ctx.locals.contains(&name) || ctx.params.contains(&name) {
+                self.observed.add(Feature::MutableBindings);
+                return Ok(Lowered::Stmt(Box::new(Stmt::Assign {
+                    name,
+                    scope: Scope::Local,
+                    value,
+                    span,
+                })));
+            }
+            ctx.locals.push(name.clone());
+            return Ok(Lowered::Stmt(Box::new(Stmt::LetStarBinding {
+                name,
+                sir_type: None,
+                value,
+                span,
+            })));
+        }
+
+        if let Some((base_name, call_suffix)) = self.indexed_target(lhs) {
+            if !(ctx.locals.contains(&base_name) || ctx.params.contains(&base_name)) {
+                return Err(self.err_at(
+                    lhs,
+                    format!(
+                        "cannot index-assign into `{base_name}`: not previously assigned \
+                         (auto-vivification is out of scope for v0.1.0)"
+                    ),
+                ));
+            }
+            // A fresh statement's own expression tree gets its own
+            // `MAX_EXPR_DEPTH` budget (depth 0) -- see
+            // `Self::lower_index_args`'s doc comment for why *nested*
+            // index/call positions instead thread the caller's depth.
+            let indices = self.lower_index_args(call_suffix, ctx, 0)?;
+            let value = self.lower_expr(rhs, ctx)?;
+            return Ok(Lowered::Stmt(Box::new(Stmt::IndexSet {
+                target: Box::new(Expr::VarRef {
+                    name: base_name,
+                    scope: Scope::Local,
+                    span: span.clone(),
+                }),
+                indices,
+                value: Box::new(value),
+                span,
+            })));
+        }
+
+        Err(self.err_at(
+            lhs,
+            "unsupported: assignment target is not a bare name or a simple index expression \
+             (a multi-output destructuring target like `[a, b] = f(x)` is also rejected here, \
+             since multi-output functions are out of scope for v0.1.0)"
+                .to_string(),
+        ))
+    }
+
+    // -------------------------------------------------------------------
+    // expressions: precedence dispatch
+    // -------------------------------------------------------------------
+
+    fn lower_expr(&mut self, node: &GrammarASTNode, ctx: &mut FunctionCtx) -> Result<Expr, ScilabLowerError> {
+        self.lower_expr_d(node, ctx, 0)
+    }
+
+    fn lower_expr_d(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, ScilabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        match node.rule_name.as_str() {
+            "logical_or" | "bit_or" => {
+                if let Some(e) = self.try_logical(node, ctx, depth, true)? {
+                    return Ok(e);
+                }
+            }
+            "logical_and" | "bit_and" => {
+                if let Some(e) = self.try_logical(node, ctx, depth, false)? {
+                    return Ok(e);
+                }
+            }
+            "comparison" => {
+                if let Some(e) = self.try_comparison(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "colon_expr" => {
+                if let Some(e) = self.lower_colon(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "additive" => {
+                if let Some(e) = self.try_additive(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "multiplicative" => {
+                if let Some(e) = self.try_multiplicative(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "unary" => {
+                if let Some(e) = self.lower_unary(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "power" => {
+                if let Some(e) = self.try_power(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "postfix" => {
+                if let Some(e) = self.lower_postfix(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "assignment" => {
+                // The RHS of a real assignment is itself grammatically
+                // labelled `assignment` even when it carries no further
+                // `=` -- see `matlab_to_semantic_ir`'s identical comment
+                // for the full rationale.
+                return match child_nodes(node).as_slice() {
+                    [only] if node.children.len() == 1 => {
+                        self.lower_expr_d(only, ctx, depth + 1)
+                    }
+                    _ => Err(self.err_at(
+                        node,
+                        "unsupported: assignment used as a value expression".to_string(),
+                    )),
+                };
+            }
+            _ => {}
+        }
+        match child_nodes(node).as_slice() {
+            [only] if node.children.len() == 1 => self.lower_expr_d(only, ctx, depth + 1),
+            _ => Err(self.err_at(
+                node,
+                format!("unsupported: `{}` (deferred)", node.rule_name),
+            )),
+        }
+    }
+
+    fn try_logical(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+        is_or: bool,
+    ) -> Result<Option<Expr>, ScilabLowerError> {
+        let ops: &[&str] = if is_or { &["||", "|"] } else { &["&&", "&"] };
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if ops.contains(&t.value.as_str())));
+        if !has_op {
+            return Ok(None);
+        }
+        self.check_chain_length(node)?;
+        // `Expr::LogicalAnd`/`Expr::LogicalOr` require `Feature::
+        // ShortCircuit` in the manifest per the validator's own ground
+        // truth -- see `matlab_to_semantic_ir::try_logical`'s identical
+        // comment (and the confirmed bug that crate once shipped by
+        // omitting this).
+        self.observed.add(Feature::ShortCircuit);
+        let mut acc: Option<Expr> = None;
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                // Short-circuit and elementwise `&&`/`&`, `||`/`|` are
+                // deliberately NOT distinguished (this file's module doc
+                // comment) -- every operand is forced to Scilab truthiness
+                // before it can become the "deciding operand" a
+                // short-circuit returns, mirroring the MATLAB template.
+                let operand = to_scilab_condition(self.lower_expr_d(n, ctx, depth + 1)?);
+                acc = Some(match acc.take() {
+                    None => operand,
+                    Some(lhs) => {
+                        let span = lhs.span().clone();
+                        if is_or {
+                            Expr::LogicalOr {
+                                lhs: Box::new(lhs),
+                                rhs: Box::new(operand),
+                                span,
+                            }
+                        } else {
+                            Expr::LogicalAnd {
+                                lhs: Box::new(lhs),
+                                rhs: Box::new(operand),
+                                span,
+                            }
+                        }
+                    }
+                });
+            }
+        }
+        match acc {
+            Some(e) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty logical expression".to_string())),
+        }
+    }
+
+    /// `colon_expr { (EQ_EQ|NE|NE_ALT|LE|GE|LT|GT) colon_expr }`. `<>` (MA10
+    /// §1 finding 6, Scilab's own not-equal digraph) maps to the same
+    /// `"!="` builtin as `~=` -- `scilab-parser`'s own grammar comment
+    /// confirms both spellings collapse onto this one production, so the
+    /// two-spellings-one-meaning collapse happens here, at lowering, not
+    /// earlier.
+    ///
+    /// The four ORDERING operators (`< <= > >=`) reject a directly-written
+    /// string-literal operand (see this file's module doc comment, "No
+    /// arithmetic or ordering over string literals") -- MA10 §7's own
+    /// citation restricts ordering comparisons to numeric/integer types.
+    /// `=`/`!=` (equality) are deliberately NOT guarded: MA10 §4 keeps
+    /// string equality in scope.
+    fn try_comparison(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, ScilabLowerError> {
+        const OPS: &[&str] = &["==", "~=", "<>", "<=", ">=", "<", ">"];
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if OPS.contains(&t.value.as_str())));
+        if !has_op {
+            return Ok(None);
+        }
+        self.check_chain_length(node)?;
+        let mut acc: Option<Expr> = None;
+        let mut pending: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) if OPS.contains(&t.value.as_str()) => {
+                    pending = Some(match t.value.as_str() {
+                        "==" => "=".to_string(),
+                        "~=" | "<>" => "!=".to_string(),
+                        other => other.to_string(),
+                    });
+                }
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                    acc = Some(match (acc.take(), pending.take()) {
+                        (None, _) => operand,
+                        (Some(lhs), Some(op)) => {
+                            if matches!(op.as_str(), "<" | "<=" | ">" | ">=") {
+                                self.reject_string_operand(&lhs, node, "ordering comparisons")?;
+                                self.reject_string_operand(&operand, node, "ordering comparisons")?;
+                            }
+                            let span = lhs.span().clone();
+                            Expr::BuiltinCall {
+                                name: op,
+                                args: vec![lhs, operand],
+                                effects: EffectSet::PURE,
+                                span,
+                            }
+                        }
+                        (Some(_), None) => {
+                            return Err(self.err_at(node, "malformed comparison".to_string()))
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(_) => {}
+            }
+        }
+        match acc {
+            Some(e) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty comparison".to_string())),
+        }
+    }
+
+    fn lower_colon(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, ScilabLowerError> {
+        if node.rule_name != "colon_expr" {
+            return Ok(None);
+        }
+        let kids = child_nodes(node);
+        let span = self.span_of(node);
+        match kids.as_slice() {
+            [only] => self.lower_expr_d(only, ctx, depth + 1).map(Some),
+            [start, stop] => {
+                self.observed.add(Feature::NDArrays);
+                let start_e = self.lower_expr_d(start, ctx, depth + 1)?;
+                let stop_e = self.lower_expr_d(stop, ctx, depth + 1)?;
+                Ok(Some(Expr::Range {
+                    start: Box::new(start_e),
+                    step: None,
+                    stop: Box::new(stop_e),
+                    span,
+                }))
+            }
+            [start, step, stop] => {
+                self.observed.add(Feature::NDArrays);
+                let start_e = self.lower_expr_d(start, ctx, depth + 1)?;
+                let step_e = self.lower_expr_d(step, ctx, depth + 1)?;
+                let stop_e = self.lower_expr_d(stop, ctx, depth + 1)?;
+                Ok(Some(Expr::Range {
+                    start: Box::new(start_e),
+                    step: Some(Box::new(step_e)),
+                    stop: Box::new(stop_e),
+                    span,
+                }))
+            }
+            _ => Err(self.err_at(node, "malformed range expression".to_string())),
+        }
+    }
+
+    fn try_additive(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, ScilabLowerError> {
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "+" || t.value == "-"));
+        if !has_op {
+            return Ok(None);
+        }
+        self.check_chain_length(node)?;
+        // `acc` tracks the accumulated `Expr` *and* whether it is itself
+        // known-scalar, updated incrementally (O(1) per fold step) --
+        // see `matlab_to_semantic_ir::try_additive`'s identical comment for
+        // why this must not be re-derived by re-walking the whole
+        // accumulator on every step.
+        let mut acc: Option<(Expr, bool)> = None;
+        let mut pending: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) if t.value == "+" || t.value == "-" => {
+                    pending = Some(t.value.clone());
+                }
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                    self.reject_string_operand(&operand, node, "arithmetic (`+`/`-`)")?;
+                    let operand_scalar = expr_is_known_scalar(&operand);
+                    acc = Some(match (acc.take(), pending.take()) {
+                        (None, _) => (operand, operand_scalar),
+                        (Some((lhs, lhs_scalar)), Some(op)) => {
+                            self.build_additive(lhs, lhs_scalar, operand, operand_scalar, &op)
+                        }
+                        (Some(_), None) => {
+                            return Err(
+                                self.err_at(node, "malformed additive expression".to_string())
+                            )
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(_) => {}
+            }
+        }
+        match acc {
+            Some((e, _)) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty additive expression".to_string())),
+        }
+    }
+
+    /// Combine one fold step of an additive chain -- mirrors
+    /// `matlab_to_semantic_ir::build_additive` exactly (see that function's
+    /// doc comment for why scalar-ness is threaded incrementally).
+    fn build_additive(
+        &mut self,
+        lhs: Expr,
+        lhs_scalar: bool,
+        rhs: Expr,
+        rhs_scalar: bool,
+        op: &str,
+    ) -> (Expr, bool) {
+        let span = lhs.span().clone();
+        if lhs_scalar && rhs_scalar {
+            (
+                Expr::BuiltinCall {
+                    name: op.to_string(),
+                    args: vec![lhs, rhs],
+                    effects: EffectSet::PURE,
+                    span,
+                },
+                true,
+            )
+        } else {
+            self.observed.add(Feature::MatrixOps);
+            self.observed.add(Feature::ArrayColumnMajor);
+            let kind = if op == "+" {
+                ElementwiseOpKind::Add
+            } else {
+                ElementwiseOpKind::Sub
+            };
+            (
+                Expr::ElementwiseOp {
+                    op: kind,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                    span,
+                },
+                false,
+            )
+        }
+    }
+
+    fn try_multiplicative(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, ScilabLowerError> {
+        const OPS: &[&str] = &["*", "/", "\\", ".*", "./", ".\\"];
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if OPS.contains(&t.value.as_str())));
+        if !has_op {
+            return Ok(None);
+        }
+        self.check_chain_length(node)?;
+        let mut acc: Option<(Expr, bool)> = None;
+        let mut pending: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) if OPS.contains(&t.value.as_str()) => {
+                    pending = Some(t.value.clone());
+                }
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                    self.reject_string_operand(&operand, node, "arithmetic (`* / \\`)")?;
+                    let operand_scalar = expr_is_known_scalar(&operand);
+                    acc = Some(match (acc.take(), pending.take()) {
+                        (None, _) => (operand, operand_scalar),
+                        (Some((lhs, lhs_scalar)), Some(op)) => self.build_multiplicative(
+                            lhs,
+                            lhs_scalar,
+                            operand,
+                            operand_scalar,
+                            &op,
+                            node,
+                        )?,
+                        (Some(_), None) => {
+                            return Err(self.err_at(
+                                node,
+                                "malformed multiplicative expression".to_string(),
+                            ))
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(_) => {}
+            }
+        }
+        match acc {
+            Some((e, _)) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty multiplicative expression".to_string())),
+        }
+    }
+
+    /// `lhs_scalar`/`rhs_scalar` are the caller's already-known scalar-ness
+    /// of each operand -- see `matlab_to_semantic_ir::build_multiplicative`
+    /// for the shared rationale. The `"\\" | ".\\"` arm is this crate's one
+    /// deliberate divergence from that template -- see this file's module
+    /// doc comment, "`\`/`.\ `: one divergence from the MATLAB template".
+    fn build_multiplicative(
+        &mut self,
+        lhs: Expr,
+        lhs_scalar: bool,
+        rhs: Expr,
+        rhs_scalar: bool,
+        op: &str,
+        node: &GrammarASTNode,
+    ) -> Result<(Expr, bool), ScilabLowerError> {
+        let span = lhs.span().clone();
+        match op {
+            ".*" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "*".to_string(),
+                            args: vec![lhs, rhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
+                } else {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Mul,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
+                }
+            }
+            "./" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "/".to_string(),
+                            args: vec![lhs, rhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
+                } else {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Div,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
+                }
+            }
+            // Both spellings treated UNIFORMLY as a broadcast reciprocal
+            // division (`rhs / lhs`) -- see this file's module doc
+            // comment for why this diverges from the MATLAB template's
+            // asymmetric `\`-vs-`.\ ` treatment.
+            "\\" | ".\\" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "/".to_string(),
+                            args: vec![rhs, lhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
+                } else {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Div,
+                            lhs: Box::new(rhs),
+                            rhs: Box::new(lhs),
+                            span,
+                        },
+                        false,
+                    ))
+                }
+            }
+            "*" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "*".to_string(),
+                            args: vec![lhs, rhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
+                } else if lhs_scalar || rhs_scalar {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Mul,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
+                } else {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok((
+                        Expr::MatMul {
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
+                }
+            }
+            "/" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "/".to_string(),
+                            args: vec![lhs, rhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
+                } else if lhs_scalar || rhs_scalar {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Div,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
+                } else {
+                    Err(self.err_at(
+                        node,
+                        "unsupported: matrix right division `/` (mrdivide) has no backend \
+                         kernel yet"
+                            .to_string(),
+                    ))
+                }
+            }
+            other => Err(self.err_at(node, format!("unsupported multiplicative operator `{other}`"))),
+        }
+    }
+
+    fn lower_unary(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, ScilabLowerError> {
+        if node.rule_name != "unary" || node.children.len() != 2 {
+            return Ok(None);
+        }
+        let sign = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) => Some(t.value.clone()),
+                ASTNodeOrToken::Node(_) => None,
+            })
+            .ok_or_else(|| self.err_at(node, "malformed unary expression".to_string()))?;
+        let inner_node = *child_nodes(node)
+            .first()
+            .ok_or_else(|| self.err_at(node, "malformed unary expression: no operand".to_string()))?;
+        let operand = self.lower_expr_d(inner_node, ctx, depth + 1)?;
+        let span = operand.span().clone();
+        let result = match sign.as_str() {
+            "+" => operand,
+            "-" => {
+                self.reject_string_operand(&operand, node, "unary `-`")?;
+                match operand {
+                    Expr::IntLit { value, span } => Expr::IntLit {
+                        value: value.wrapping_neg(),
+                        span,
+                    },
+                    Expr::FloatLit { value, span } => Expr::FloatLit { value: -value, span },
+                    other => Expr::BuiltinCall {
+                        name: "neg".to_string(),
+                        args: vec![other],
+                        effects: EffectSet::PURE,
+                        span,
+                    },
+                }
+            }
+            "~" => Expr::BuiltinCall {
+                name: "not".to_string(),
+                // Scilab truthiness ("nonzero is true"), identical to
+                // MATLAB's -- see `to_scilab_condition`'s doc comment.
+                args: vec![to_scilab_condition(operand)],
+                effects: EffectSet::PURE,
+                span,
+            },
+            other => return Err(self.err_at(node, format!("unsupported unary operator `{other}`"))),
+        };
+        Ok(Some(result))
+    }
+
+    /// `postfix [ (^|.^) unary ]`. Both spellings lower identically
+    /// (elementwise power, scalar broadcasting handled by the runtime) --
+    /// mirrors `matlab_to_semantic_ir::try_power` exactly, including its
+    /// choice not to apply the scalar-fast-path `BuiltinCall` optimisation
+    /// here (unlike `+`/`-`/`*`/`/`/`\`).
+    fn try_power(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, ScilabLowerError> {
+        if node.rule_name != "power" {
+            return Ok(None);
+        }
+        let op = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.value == "^" || t.value == ".^" => Some(t.value.clone()),
+            _ => None,
+        });
+        let op = match op {
+            Some(o) => o,
+            None => return Ok(None),
+        };
+        let (base, exp) = match child_nodes(node).as_slice() {
+            [b, e] => (*b, *e),
+            _ => return Err(self.err_at(node, "malformed power expression".to_string())),
+        };
+        let _ = op; // both `^` and `.^` lower identically (see module scope note)
+        let base_e = self.lower_expr_d(base, ctx, depth + 1)?;
+        let exp_e = self.lower_expr_d(exp, ctx, depth + 1)?;
+        self.reject_string_operand(&base_e, node, "power (`^`/`.^`)")?;
+        self.reject_string_operand(&exp_e, node, "power (`^`/`.^`)")?;
+        let span = base_e.span().clone();
+        self.observed.add(Feature::MatrixOps);
+        self.observed.add(Feature::ArrayColumnMajor);
+        Ok(Some(Expr::ElementwiseOp {
+            op: ElementwiseOpKind::Pow,
+            lhs: Box::new(base_e),
+            rhs: Box::new(exp_e),
+            span,
+        }))
+    }
+
+    // -------------------------------------------------------------------
+    // postfix: transpose / call / index
+    // -------------------------------------------------------------------
+
+    fn lower_postfix(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, ScilabLowerError> {
+        if node.rule_name != "postfix" {
+            return Ok(None);
+        }
+        let kids = child_nodes(node);
+        let (primary, suffixes) = match kids.split_first() {
+            Some((p, rest)) => (*p, rest),
+            None => return Err(self.err_at(node, "malformed postfix expression".to_string())),
+        };
+        if suffixes.is_empty() {
+            return self.lower_primary(primary, ctx, depth + 1).map(Some);
+        }
+
+        let mut acc: Option<Expr> = None;
+        let mut first = true;
+        for suffix in suffixes {
+            match suffix.rule_name.as_str() {
+                "transpose_suffix" => {
+                    let target = match acc.take() {
+                        Some(e) => e,
+                        None => self.lower_primary(primary, ctx, depth + 1)?,
+                    };
+                    let tok = suffix
+                        .token()
+                        .ok_or_else(|| self.err_at(suffix, "malformed transpose suffix".to_string()))?;
+                    let conjugate = tok.value == "'";
+                    let span = target.span().clone();
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    acc = Some(Expr::Transpose {
+                        target: Box::new(target),
+                        conjugate,
+                        span,
+                    });
+                }
+                "call_suffix" => {
+                    if first {
+                        let name = self.primary_bare_name(primary).ok_or_else(|| {
+                            self.err_at(
+                                primary,
+                                "unsupported: call/index target is not a bare name".to_string(),
+                            )
+                        })?;
+                        if ctx.locals.contains(&name) || ctx.params.contains(&name) {
+                            let span = self.span_of(primary);
+                            let indices = self.lower_index_args(suffix, ctx, depth + 1)?;
+                            acc = Some(Expr::IndexGet {
+                                target: Box::new(Expr::VarRef {
+                                    name,
+                                    scope: Scope::Local,
+                                    span: span.clone(),
+                                }),
+                                indices,
+                                span,
+                            });
+                        } else if name == "disp" {
+                            // The one builtin this frontend recognises,
+                            // mirroring `matlab-to-semantic-ir`'s identical
+                            // `disp` -> `"print"` mapping.
+                            let span = self.span_of(primary);
+                            let args = self.lower_call_args(suffix, ctx, depth + 1)?;
+                            if args.len() != 1 {
+                                return Err(self.err_at(
+                                    primary,
+                                    "`disp` takes exactly one argument".to_string(),
+                                ));
+                            }
+                            acc = Some(Expr::BuiltinCall {
+                                name: "print".to_string(),
+                                args,
+                                effects: EffectSet::PURE,
+                                span,
+                            });
+                        } else if self.function_names.contains(&name) {
+                            let span = self.span_of(primary);
+                            let args = self.lower_call_args(suffix, ctx, depth + 1)?;
+                            acc = Some(Expr::DirectCall {
+                                fn_name: name,
+                                args,
+                                effects: EffectSet::PURE,
+                                span,
+                            });
+                        } else {
+                            return Err(self.err_at(
+                                primary,
+                                format!(
+                                    "unsupported: unknown identifier `{name}` (not a known \
+                                     variable or user function -- only `disp` is recognised as \
+                                     a builtin in this cut)"
+                                ),
+                            ));
+                        }
+                    } else {
+                        let base = acc
+                            .take()
+                            .expect("acc is set after the first suffix in the fold");
+                        let span = base.span().clone();
+                        let indices = self.lower_index_args(suffix, ctx, depth + 1)?;
+                        acc = Some(Expr::IndexGet {
+                            target: Box::new(base),
+                            indices,
+                            span,
+                        });
+                    }
+                }
+                "cell_suffix" | "field_suffix" => {
+                    return Err(self.err_at(
+                        suffix,
+                        format!("unsupported: `{}` is out of scope for v0.1.0", suffix.rule_name),
+                    ))
+                }
+                other => return Err(self.err_at(suffix, format!("unsupported postfix suffix `{other}`"))),
+            }
+            first = false;
+        }
+        Ok(acc)
+    }
+
+    fn lower_primary(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, ScilabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        if let Some(tok) = node.token() {
+            let span = self.span_of(node);
+            // Dispatch on `effective_type_name()`, NOT `tok.type_` --
+            // unlike MATLAB's own lexer (where NUMBER/STRING/NAME map
+            // directly onto core `TokenType` variants), Scilab's grammar-
+            // specific token kinds (`PERCENT_CONST`, `DOLLAR`) do NOT map
+            // onto any core `TokenType` variant, so they fall back to
+            // `TokenType::Name` with `type_name` set to the real spelling
+            // (see `lexer::token::Token::effective_type_name`'s own doc
+            // comment). Matching on `tok.type_` alone -- the MATLAB
+            // template's own approach -- would silently misread a `$` or
+            // `%pi` token as an ordinary bare variable named `"$"`/`"%pi"`.
+            // `scilab-runtime::eval::Interpreter::eval_primary` already
+            // established this exact dispatch style for the identical
+            // reason; mirrored here rather than the MATLAB template's.
+            return match tok.effective_type_name() {
+                "NUMBER" => Ok(self.number_literal_expr(tok, &span)),
+                "STRING" => {
+                    self.observed.add(Feature::Strings);
+                    Ok(Expr::StrLit {
+                        value: tok.value.clone(),
+                        span,
+                    })
+                }
+                "PERCENT_CONST" => self.percent_const_expr(tok, &span),
+                "DOLLAR" => Err(self.err_at(
+                    node,
+                    "unsupported: `$` (last-index) is out of scope for v0.1.0 -- mirrors \
+                     matlab-to-semantic-ir's own `end`-relative-indexing exclusion (no \
+                     size/shape builtin is wired up yet to resolve \"the current indexing \
+                     dimension's size\" at lowering time)"
+                        .to_string(),
+                )),
+                "NAME" => {
+                    let name = tok.value.clone();
+                    if ctx.params.contains(&name) {
+                        Ok(Expr::VarRef {
+                            name,
+                            scope: Scope::Param,
+                            span,
+                        })
+                    } else if ctx.locals.contains(&name) {
+                        Ok(Expr::VarRef {
+                            name,
+                            scope: Scope::Local,
+                            span,
+                        })
+                    } else {
+                        Err(self.err_at(
+                            node,
+                            format!("undefined variable `{name}` (not previously assigned)"),
+                        ))
+                    }
+                }
+                other => Err(self.err_at(node, format!("unsupported literal token `{other}`"))),
+            };
+        }
+        let only = match child_nodes(node).as_slice() {
+            [only] => *only,
+            _ => return Err(self.err_at(node, "malformed primary expression".to_string())),
+        };
+        match only.rule_name.as_str() {
+            "matrix_literal" => self.lower_matrix_literal(only, ctx, depth + 1),
+            "cell_literal" => Err(self.err_at(
+                only,
+                "unsupported: cell arrays (`{ ... }`) are out of scope for v0.1.0 (MA10 §4 \
+                 defers `list`/`tlist`/`mlist` entirely)"
+                    .to_string(),
+            )),
+            "group" => match child_nodes(only).as_slice() {
+                [inner] => self.lower_expr_d(inner, ctx, depth + 1),
+                _ => Err(self.err_at(only, "malformed parenthesised expression".to_string())),
+            },
+            other => Err(self.err_at(only, format!("unsupported: `{other}` (deferred)"))),
+        }
+    }
+
+    /// Resolve one of the eight fixed `PERCENT_CONST` spellings to a
+    /// constant-folded `Expr` -- see this file's module doc comment,
+    /// "`%`-constants: constant-folded, not a new SIR node".
+    fn percent_const_expr(&mut self, tok: &Token, span: &Span) -> Result<Expr, ScilabLowerError> {
+        match tok.value.as_str() {
+            "%pi" => {
+                self.observed.add(Feature::Floats);
+                Ok(Expr::FloatLit {
+                    value: std::f64::consts::PI,
+                    span: span.clone(),
+                })
+            }
+            "%e" => {
+                self.observed.add(Feature::Floats);
+                Ok(Expr::FloatLit {
+                    value: std::f64::consts::E,
+                    span: span.clone(),
+                })
+            }
+            "%inf" => {
+                self.observed.add(Feature::Floats);
+                Ok(Expr::FloatLit {
+                    value: f64::INFINITY,
+                    span: span.clone(),
+                })
+            }
+            "%nan" => {
+                self.observed.add(Feature::Floats);
+                Ok(Expr::FloatLit {
+                    value: f64::NAN,
+                    span: span.clone(),
+                })
+            }
+            "%eps" => {
+                self.observed.add(Feature::Floats);
+                Ok(Expr::FloatLit {
+                    value: f64::EPSILON,
+                    span: span.clone(),
+                })
+            }
+            // `%t`/`%f` are ordinary `1`/`0` -- this repo's established
+            // "logicals are ordinary 0/1 numeric values" convention
+            // (matches `scilab-runtime::builtins::percent_const`'s
+            // identical choice); plain `IntLit`s need no extra feature.
+            "%t" => Ok(Expr::IntLit {
+                value: 1,
+                span: span.clone(),
+            }),
+            "%f" => Ok(Expr::IntLit {
+                value: 0,
+                span: span.clone(),
+            }),
+            "%i" => Err(ScilabLowerError {
+                message: "unsupported: `%i` (complex numbers) is out of scope for v0.1.0 -- \
+                          array-runtime has no complex-number representation, mirroring \
+                          scilab-runtime::builtins::percent_const's own clean error for the \
+                          identical reason"
+                    .to_string(),
+                line: span.start_line,
+                column: span.start_col,
+            }),
+            other => Err(ScilabLowerError {
+                message: format!(
+                    "unsupported special constant `{other}` (scilab-lexer's PERCENT_CONST \
+                     pattern should only ever produce one of the eight fixed spellings)"
+                ),
+                line: span.start_line,
+                column: span.start_col,
+            }),
+        }
+    }
+
+    fn lower_matrix_literal(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, ScilabLowerError> {
+        if depth > MAX_BLOCK_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("matrix literal nesting too deep (exceeds {MAX_BLOCK_DEPTH} levels)"),
+            ));
+        }
+        self.observed.add(Feature::NDArrays);
+        self.observed.add(Feature::ArrayColumnMajor);
+        let span = self.span_of(node);
+        let mut rows: Vec<Vec<Expr>> = Vec::new();
+        if let Some(matrix_rows) = self.first_child_named(node, "matrix_rows") {
+            for row in child_nodes(matrix_rows) {
+                if row.rule_name == "matrix_row" {
+                    let mut cells = Vec::new();
+                    for cell in child_nodes(row) {
+                        cells.push(self.lower_expr_d(cell, ctx, depth + 1)?);
+                    }
+                    rows.push(cells);
+                }
+            }
+        }
+        Ok(Expr::ArrayLit { rows, span })
+    }
+
+    // -------------------------------------------------------------------
+    // indexing / call arguments
+    // -------------------------------------------------------------------
+
+    /// `depth` is the *enclosing expression's* depth, not a fresh count --
+    /// see `matlab_to_semantic_ir::lower_index_args`'s identical doc
+    /// comment for why this must be threaded rather than restarted.
+    fn lower_index_args(
+        &mut self,
+        call_suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Vec<IndexArg>, ScilabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                call_suffix,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        self.observed.add(Feature::NDArrays);
+        let arg_list = match self.first_child_named(call_suffix, "arg_list") {
+            Some(a) => a,
+            None => return Ok(vec![]),
+        };
+        let mut out = Vec::new();
+        for arg in child_nodes(arg_list) {
+            if arg.rule_name == "arg" {
+                out.push(self.lower_one_index_arg(arg, ctx, depth + 1)?);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Lower one index-position argument, translating 1-based Scilab
+    /// indexing to the IR's 0-based convention -- mirrors
+    /// `matlab_to_semantic_ir::lower_one_index_arg` exactly. A range-valued
+    /// index argument (`A(1:3)`) is not specially represented as
+    /// [`IndexArg::Range`] here -- like the MATLAB template, this frontend
+    /// always emits [`IndexArg::Scalar`] with a uniform `-1` shift; see
+    /// this file's module doc comment for why that (inherited) gap is left
+    /// as-is rather than fixed in this crate.
+    fn lower_one_index_arg(
+        &mut self,
+        arg: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<IndexArg, ScilabLowerError> {
+        if let Some(tok) = arg.token() {
+            if tok.value == ":" {
+                return Ok(IndexArg::Whole);
+            }
+        }
+        let inner = match child_nodes(arg).as_slice() {
+            [only] => *only,
+            _ => return Err(self.err_at(arg, "malformed index argument".to_string())),
+        };
+        let idx = self.lower_expr_d(inner, ctx, depth)?;
+        let span = idx.span().clone();
+        let shifted = match idx {
+            Expr::IntLit { value, .. } => Expr::IntLit {
+                value: value - 1,
+                span,
+            },
+            other => Expr::BuiltinCall {
+                name: "-".to_string(),
+                args: vec![
+                    other,
+                    Expr::IntLit {
+                        value: 1,
+                        span: span.clone(),
+                    },
+                ],
+                effects: EffectSet::PURE,
+                span,
+            },
+        };
+        Ok(IndexArg::Scalar(Box::new(shifted)))
+    }
+
+    /// See [`Self::lower_index_args`] on why `depth` is threaded rather
+    /// than restarted.
+    fn lower_call_args(
+        &mut self,
+        call_suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Vec<Expr>, ScilabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                call_suffix,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        let arg_list = match self.first_child_named(call_suffix, "arg_list") {
+            Some(a) => a,
+            None => return Ok(vec![]),
+        };
+        let mut out = Vec::new();
+        for arg in child_nodes(arg_list) {
+            if arg.rule_name != "arg" {
+                continue;
+            }
+            if let Some(tok) = arg.token() {
+                if tok.value == ":" {
+                    return Err(self.err_at(
+                        arg,
+                        "unsupported: `:` is not a valid function-call argument".to_string(),
+                    ));
+                }
+            }
+            let inner = match child_nodes(arg).as_slice() {
+                [only] => *only,
+                _ => return Err(self.err_at(arg, "malformed call argument".to_string())),
+            };
+            out.push(self.lower_expr_d(inner, ctx, depth + 1)?);
+        }
+        Ok(out)
+    }
+
+    // -------------------------------------------------------------------
+    // target resolution (assignment LHS)
+    // -------------------------------------------------------------------
+
+    fn bare_name(&self, node: &GrammarASTNode) -> Option<String> {
+        let postfix = self.peel_to_named(node, "postfix", 0)?;
+        match child_nodes(postfix).as_slice() {
+            [primary] => self.primary_bare_name(primary),
+            _ => None,
+        }
+    }
+
+    fn indexed_target<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+    ) -> Option<(String, &'a GrammarASTNode)> {
+        let postfix = self.peel_to_named(node, "postfix", 0)?;
+        match child_nodes(postfix).as_slice() {
+            [primary, suffix] if suffix.rule_name == "call_suffix" => {
+                self.primary_bare_name(primary).map(|name| (name, *suffix))
+            }
+            _ => None,
+        }
+    }
+
+    fn primary_bare_name(&self, primary: &GrammarASTNode) -> Option<String> {
+        let tok = primary.token()?;
+        if tok.effective_type_name() == "NAME" {
+            Some(tok.value.clone())
+        } else {
+            None
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // small tree helpers
+    // -------------------------------------------------------------------
+
+    /// Peel through a chain of single-Node-child wrapper rules until
+    /// reaching a node named `name`, or return `None` if the chain
+    /// branches or runs out of depth first.
+    fn peel_to_named<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+        name: &str,
+        depth: usize,
+    ) -> Option<&'a GrammarASTNode> {
+        if depth > MAX_EXPR_DEPTH {
+            return None;
+        }
+        if node.rule_name == name {
+            return Some(node);
+        }
+        match child_nodes(node).as_slice() {
+            [only] if node.children.len() == 1 => self.peel_to_named(only, name, depth + 1),
+            _ => None,
+        }
+    }
+
+    fn first_child_named<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+        kind: &str,
+    ) -> Option<&'a GrammarASTNode> {
+        child_nodes(node).into_iter().find(|n| n.rule_name == kind)
+    }
+
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        Span::point(
+            FILE,
+            node.start_line.unwrap_or(1),
+            node.start_column.unwrap_or(1),
+        )
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> ScilabLowerError {
+        ScilabLowerError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+
+    /// Err if `e` is a direct string literal -- see this file's module doc
+    /// comment, "No arithmetic or ordering over string literals", for the
+    /// full rationale (MA10 §1 finding 1) and the disclosed variable-blind-
+    /// spot limitation.
+    fn reject_string_operand(
+        &self,
+        e: &Expr,
+        node: &GrammarASTNode,
+        op_desc: &str,
+    ) -> Result<(), ScilabLowerError> {
+        if matches!(e, Expr::StrLit { .. }) {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "unsupported: {op_desc} is not implemented over string operands in this cut \
+                     (MA10 §4) -- Scilab's own `+` means concatenation, not numeric addition, \
+                     and this frontend does not guess at string-operator semantics without a \
+                     typed-dispatch layer"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// A `NUMBER` lexeme is a float if it has a decimal point or exponent,
+    /// otherwise an int; an integer lexeme too large for `i64` falls back
+    /// to a float rather than silently truncating or erroring. Must be an
+    /// instance method (not a free function) so every `FloatLit`-
+    /// constructing branch can call `self.observed.add(Feature::Floats)`
+    /// immediately -- see `matlab_to_semantic_ir::number_literal_expr`'s
+    /// doc comment for the confirmed bug this discipline exists to avoid
+    /// repeating.
+    fn number_literal_expr(&mut self, tok: &Token, span: &Span) -> Expr {
+        let text = &tok.value;
+        if text.contains('.') || text.contains('e') || text.contains('E') {
+            self.observed.add(Feature::Floats);
+            Expr::FloatLit {
+                value: text.parse::<f64>().unwrap_or(0.0),
+                span: span.clone(),
+            }
+        } else {
+            match text.parse::<i64>() {
+                Ok(v) => Expr::IntLit {
+                    value: v,
+                    span: span.clone(),
+                },
+                Err(_) => {
+                    self.observed.add(Feature::Floats);
+                    Expr::FloatLit {
+                        value: text.parse::<f64>().unwrap_or(0.0),
+                        span: span.clone(),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reject a same-precedence operator chain with more than
+    /// `MAX_EXPR_DEPTH` operands -- mirrors
+    /// `matlab_to_semantic_ir::check_chain_length` exactly (see that
+    /// function's own extensive doc comment for the full DoS rationale:
+    /// Scilab's grammar collapses a flat run of `+`/`-`/`*`/... into one
+    /// CST node with many children too, via the identical `{ x }`
+    /// repetition shape, so the same unbounded-fold-depth hazard applies
+    /// here verbatim).
+    fn check_chain_length(&self, node: &GrammarASTNode) -> Result<(), ScilabLowerError> {
+        let operand_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .count();
+        if operand_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "expression chain too long ({operand_count} operands, exceeds \
+                     {MAX_EXPR_DEPTH})"
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// Collect the *node* children of `node` (dropping tokens).
+fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+/// The sole node child of `node`, erroring (via the lowerer's own
+/// `err_at`) if there is not exactly one. Mirrors
+/// `scilab-runtime::eval::only_node`'s "first Node child found" shape but
+/// returns a proper [`ScilabLowerError`] instead of a bare `String`.
+fn only_node<'a>(node: &'a GrammarASTNode, lowerer: &Lowerer) -> Result<&'a GrammarASTNode, ScilabLowerError> {
+    match child_nodes(node).as_slice() {
+        [only] => Ok(*only),
+        _ => Err(lowerer.err_at(node, format!("malformed `{}` node", node.rule_name))),
+    }
+}
+
+/// Is `e` provably a scalar? See this file's module doc comment's
+/// "Scalar/array disambiguation" section -- mirrors
+/// `matlab_to_semantic_ir::expr_is_known_scalar` exactly, including its
+/// own depth-capped core (defense in depth against re-deriving scalar-ness
+/// by re-walking a growing accumulator, which no call site in this file
+/// does -- see `matlab_to_semantic_ir::expr_is_known_scalar_d`'s doc
+/// comment for the full rationale).
+fn expr_is_known_scalar(e: &Expr) -> bool {
+    expr_is_known_scalar_d(e, 0)
+}
+
+fn expr_is_known_scalar_d(e: &Expr, depth: usize) -> bool {
+    if depth > MAX_EXPR_DEPTH {
+        return false;
+    }
+    match e {
+        Expr::IntLit { .. } | Expr::FloatLit { .. } => true,
+        Expr::BuiltinCall { name, args, .. }
+            if matches!(name.as_str(), "+" | "-" | "*" | "/" | "neg") =>
+        {
+            args.iter().all(|a| expr_is_known_scalar_d(a, depth + 1))
+        }
+        _ => false,
+    }
+}
+
+/// Coerce an already-lowered Scilab expression to genuine Scilab
+/// truthiness at the point it reaches a boolean context: an `if`/`while`
+/// condition (including a desugared `select`/`case` comparison), the
+/// operand of unary `~`, or an operand of `&&`/`||`/`&`/`|`.
+///
+/// Scilab's own truthiness rule for numeric values is byte-for-byte
+/// identical to MATLAB's ("nonzero is true" -- confirmed directly against
+/// `scilab-runtime::value::ScilabValue::is_true`'s numeric arm, which is
+/// the same rule `matlab_runtime::MatValue::is_true` uses). This function
+/// therefore reuses the *exact* runtime intrinsic
+/// `matlab_to_semantic_ir::to_matlab_condition` already established --
+/// `BuiltinCall("matlab_truthy", [expr])`, which `semantic-ir-to-javascript`
+/// already implements as `typeof x === "boolean" ? x : (numOf(x) !== 0)` --
+/// rather than inventing a same-shaped `"scilab_truthy"` builtin the shared
+/// JS backend would need a matching, currently-nonexistent implementation
+/// for. Reusing the existing name is deliberate, not an oversight: this
+/// crate's own `Cargo.toml` does not (and should not) depend on
+/// `matlab-to-semantic-ir` -- `"matlab_truthy"` here is just a well-known
+/// SIR *builtin name* string, the same kind of cross-frontend reuse this
+/// repo already does for `"neg"`/`"print"`/etc. (`apl-to-semantic-ir`'s own
+/// `apply_monadic_scalar` doc comment states the identical "a `BuiltinCall`
+/// name is a generic operation any backend implements polymorphically"
+/// convention).
+///
+/// One disclosed gap: Scilab's *string* truthiness ("a non-empty string is
+/// true" -- `ScilabValue::is_true`'s `Str` arm) is **not** represented by
+/// this reuse (`matlabTruthy`'s own runtime implementation only knows how
+/// to coerce a *number* or an already-genuine boolean, never a string).
+/// This is accepted because MA10 §4 never lists "a string used directly as
+/// an `if`/`while`/`select` condition" as in-scope surface at all -- MA10
+/// §4's string surface is explicitly "assignment, display, and equality
+/// only" -- so there is no in-scope construct this gap could silently
+/// mis-lower; it would only matter for a construct already outside this
+/// cut's own stated scope.
+fn to_scilab_condition(expr: Expr) -> Expr {
+    let span = expr.span().clone();
+    Expr::BuiltinCall {
+        name: "matlab_truthy".to_string(),
+        args: vec![expr],
+        effects: EffectSet::PURE,
+        span,
+    }
+}
+
+/// An empty `Block` whose value is `NilLit`.
+fn empty_block(span: Span) -> Block {
+    Block {
+        stmts: vec![],
+        value: Expr::NilLit { span: span.clone() },
+        span,
+    }
+}
+
+/// A `Block` with no statements whose value is `expr`.
+fn value_block(expr: Expr) -> Block {
+    let span = expr.span().clone();
+    Block {
+        stmts: vec![],
+        value: expr,
+        span,
+    }
+}
+
+/// Assemble a list of lowered items into a `Block` whose every item is a
+/// statement (bare expressions wrapped as `ExprStmt`) and whose value is
+/// always `value` -- unlike a script-oriented frontend, Scilab has no
+/// "trailing expression is the result" convention at any body level.
+fn assemble_stmts_only(items: Vec<Lowered>, value: Expr, span: Span) -> Block {
+    let stmts: Vec<Stmt> = items
+        .into_iter()
+        .map(|item| match item {
+            Lowered::Stmt(s) => *s,
+            Lowered::Expr(expr) => {
+                let s = expr.span().clone();
+                Stmt::ExprStmt { expr, span: s }
+            }
+        })
+        .collect();
+    Block { stmts, value, span }
+}

--- a/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
@@ -771,10 +771,44 @@ impl Lowerer {
                 }
             }
         }
+        // Security regression: `elseif_clause*` is a flat `{ x }`-repetition
+        // CST node, so a source file with N `elseif` clauses costs the
+        // *parser* zero native stack (sibling repetition, not nested source
+        // text) but folds into an `Expr::If` chain N levels deep via `Box`
+        // below. Merely dropping the returned `Module` at that depth
+        // overflows the native stack and aborts the process (uncatchable by
+        // `catch_unwind`) -- the identical hazard `check_chain_length`
+        // already guards for flat operator chains, here applied to a flat
+        // clause-list fold instead.
+        if clauses.len() > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                if_stmt,
+                format!(
+                    "too many elseif clauses ({} exceeds {MAX_EXPR_DEPTH})",
+                    clauses.len()
+                ),
+            ));
+        }
 
         let if_span = self.span_of(if_stmt);
+        // `if`/`elseif`/`else` bodies are mutually exclusive -- see the
+        // identical fix (and full rationale) in `lower_select`, which this
+        // mirrors exactly: every branch is lowered against the same
+        // pre-`if` `ctx.locals` snapshot, then the union of every branch's
+        // newly-introduced names is folded back in once, after all branches
+        // are done, so a name first assigned in one branch is never
+        // mistaken for an already-known local by a sibling branch that
+        // happens to lower afterward.
+        let mark = Self::scope_mark(ctx);
+        let mut newly_introduced: Vec<String> = Vec::new();
+
         let mut else_branch: Block = match else_body {
-            Some(b) => self.lower_block_body(b, ctx, depth + 1)?,
+            Some(b) => {
+                let block = self.lower_block_body(b, ctx, depth + 1)?;
+                newly_introduced.extend(ctx.locals[mark..].iter().cloned());
+                Self::scope_rewind(ctx, mark);
+                block
+            }
             None => empty_block(if_span.clone()),
         };
         for clause in clauses.into_iter().rev() {
@@ -782,6 +816,12 @@ impl Lowerer {
             // -- see `to_scilab_condition`'s doc comment).
             let cond = to_scilab_condition(self.lower_expr(clause.cond, ctx)?);
             let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
+            for name in &ctx.locals[mark..] {
+                if !newly_introduced.contains(name) {
+                    newly_introduced.push(name.clone());
+                }
+            }
+            Self::scope_rewind(ctx, mark);
             let span = cond.span().clone();
             let folded = Expr::If {
                 cond: Box::new(cond),
@@ -791,6 +831,7 @@ impl Lowerer {
             };
             else_branch = value_block(folded);
         }
+        ctx.locals.extend(newly_introduced);
         match else_branch.value {
             Expr::If { .. } => Ok(else_branch.value),
             other => Ok(other),
@@ -826,7 +867,18 @@ impl Lowerer {
         let span = self.span_of(select_stmt);
 
         let selector = self.lower_expr(selector_node, ctx)?;
-        let temp = format!("__select_{}", self.select_counter);
+        // `$` is never part of a Scilab `NAME` token (`NAME =
+        // /[A-Za-z_][A-Za-z0-9_]*/`, `code/grammars/scilab/scilab.tokens`)
+        // -- it lexes as its own distinct `DOLLAR` token, used only for
+        // `$`/`$-1` last-index. So a temp name containing `$` can *never*
+        // collide with a user-declared identifier, by construction, no
+        // runtime collision check needed. (A bare `__select_N` prefix does
+        // NOT have this property: `__select_0` etc. are ordinary, fully
+        // legal Scilab identifiers a program could declare itself, which
+        // would silently merge the compiler's hoisted selector with an
+        // unrelated user variable of the same name -- confirmed to produce
+        // invalid/duplicate-declaration JavaScript from the JS backend.)
+        let temp = format!("$select_{}", self.select_counter);
         self.select_counter += 1;
         ctx.locals.push(temp.clone());
         let mut stmts: Vec<Lowered> = vec![Lowered::Stmt(Box::new(Stmt::LetStarBinding {
@@ -860,9 +912,46 @@ impl Lowerer {
                 }
             }
         }
+        // See the identical guard in `lower_if`: `case_clause*` is the same
+        // flat `{ x }`-repetition shape, folding into an equally deep
+        // `Expr::If` chain with the same uncatchable-stack-overflow hazard.
+        if clauses.len() > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                select_stmt,
+                format!(
+                    "too many case clauses ({} exceeds {MAX_EXPR_DEPTH})",
+                    clauses.len()
+                ),
+            ));
+        }
+
+        // `if`/`case` bodies are mutually exclusive -- at most one of them
+        // ever actually executes -- but `FunctionCtx::locals` is a single,
+        // unscoped, append-only accumulator (Scilab has no block scoping,
+        // this file's module doc comment). Lowering the bodies in the wrong
+        // relative order let one sibling's first-occurrence assignment
+        // "leak" into another sibling as an already-known local, silently
+        // misclassifying that sibling's OWN first occurrence of the same
+        // name as a re-assignment (`Stmt::Assign`) instead of a declaration
+        // (`Stmt::LetStarBinding`) -- breaking the ordinary idiom of a
+        // function assigning its own output variable in every branch of a
+        // `select`/`case`. Fixed the same way `for`'s own loop-variable
+        // scope already is (`Self::scope_mark`/`scope_rewind`): every
+        // branch is lowered against the *same* pre-select snapshot, then
+        // the union of every branch's newly-introduced names is folded back
+        // in once, after all branches are done -- so no branch's
+        // first-occurrence classification depends on sibling iteration
+        // order.
+        let mark = Self::scope_mark(ctx);
+        let mut newly_introduced: Vec<String> = Vec::new();
 
         let mut else_branch: Block = match else_body {
-            Some(b) => self.lower_block_body(b, ctx, depth + 1)?,
+            Some(b) => {
+                let block = self.lower_block_body(b, ctx, depth + 1)?;
+                newly_introduced.extend(ctx.locals[mark..].iter().cloned());
+                Self::scope_rewind(ctx, mark);
+                block
+            }
             None => empty_block(span.clone()),
         };
         for clause in clauses.into_iter().rev() {
@@ -883,6 +972,12 @@ impl Lowerer {
             };
             let cond = to_scilab_condition(eq);
             let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
+            for name in &ctx.locals[mark..] {
+                if !newly_introduced.contains(name) {
+                    newly_introduced.push(name.clone());
+                }
+            }
+            Self::scope_rewind(ctx, mark);
             let if_span = cond.span().clone();
             let folded = Expr::If {
                 cond: Box::new(cond),
@@ -892,6 +987,7 @@ impl Lowerer {
             };
             else_branch = value_block(folded);
         }
+        ctx.locals.extend(newly_introduced);
 
         let final_expr = match else_branch.value {
             Expr::If { .. } => else_branch.value,

--- a/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
@@ -355,6 +355,25 @@ impl FunctionCtx {
     /// Record a newly-introduced local, keeping `locals`/`locals_set` in
     /// sync.
     fn push_local(&mut self, name: String) {
+        // Security regression (round 3 review): if `name` is ALREADY a
+        // known local (e.g. `lower_for` reusing an existing variable as
+        // the loop counter -- `y = 1; for y = 1:3 ... end`, an ordinary
+        // Scilab idiom), pushing another copy into `locals` would later
+        // be drained by `scope_rewind` at the loop's own scope boundary --
+        // and since `locals_set` is a genuine set (no duplicate-count
+        // tracking), that removal erases the name's PRE-EXISTING
+        // membership too, even though one logical occurrence should
+        // remain. Confirmed empirically: without this guard, `node`
+        // rejects the resulting JS with "Identifier 'y' has already been
+        // declared" (a duplicate top-level `let y`, since the name
+        // silently "forgot" it was already known after the loop). Since a
+        // name that's already known needs no tracking at all here — it
+        // was in scope before this push and stays in scope after,
+        // regardless of what happens inside the interim scope — this is
+        // simply a no-op.
+        if self.locals_set.contains(&name) {
+            return;
+        }
         self.locals_set.insert(name.clone());
         self.locals.push(name);
     }
@@ -896,7 +915,16 @@ impl Lowerer {
             body: &'a GrammarASTNode,
         }
         let kids = child_nodes(select_stmt);
-        if kids.is_empty() {
+        // A well-formed `select_stmt` always has at least `[selector,
+        // stmt_sep]` (even with zero case/else clauses) -- checking only
+        // `is_empty()` (mirrors an earlier revision of this function, but
+        // unlike `lower_if`'s own `kids.len() < 3` guard) let a
+        // single-child tree slip through to the `&kids[2..]` slice below
+        // and panic instead of erroring cleanly. Unreachable via the real
+        // `scilab-parser` (which never emits a malformed `select_stmt`),
+        // but `compile()`/`GrammarASTNode` is a public API, so a
+        // directly-constructed tree must still fail closed, not panic.
+        if kids.len() < 2 {
             return Err(self.err_at(select_stmt, "malformed select: no selector".to_string()));
         }
         let selector_node = kids[0];

--- a/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
@@ -132,7 +132,10 @@
 //! e.g. a function call, once per case would be observably wrong — it
 //! would call the function N times instead of once). So [`Lowerer::lower_select`]
 //! first binds the selector to a fresh, compiler-generated local
-//! (`__select_N`, uniquely numbered per `select` statement in the module)
+//! (`$select_N`, uniquely numbered per `select` statement in the module --
+//! `$` is never part of a Scilab `NAME` token, so this can never collide
+//! with a user-declared identifier, unlike an earlier `__select_N` scheme
+//! this crate shipped with briefly and fixed after security review)
 //! via an ordinary `LetStarBinding`, then folds the `case`/`else` clauses
 //! into an `if`-chain of `BuiltinCall("=", [VarRef(temp), case_value])`
 //! conditions — the same equality [`crate::lower::values_equal`]-shaped
@@ -307,14 +310,26 @@ enum Lowered {
 /// function call gets a wholly fresh workspace (`scilab-runtime::eval::
 /// Interpreter::call_user_function`'s own doc comment confirms this: "no
 /// closures, no access to the caller's variables"). So, mirroring
-/// `matlab-to-semantic-ir::FunctionCtx` exactly, `locals` simply
-/// accumulates for the function's lifetime and is never rewound when
-/// leaving an `if`/`while`/`for`/`select` body. The one place `locals` is
-/// temporarily extended and then rewound is a `for`-loop variable, whose
-/// scope genuinely is the loop.
+/// `matlab-to-semantic-ir::FunctionCtx`'s own accumulate-for-the-whole-
+/// function model, `locals` simply grows for the function's lifetime by
+/// default. Two places temporarily extend it and then rewind: a
+/// `for`-loop variable, whose scope genuinely is the loop, and each
+/// mutually-exclusive branch of an `if`/`select` (every branch is lowered
+/// against the *same* pre-statement snapshot, then the union of every
+/// branch's newly-introduced names is folded back in once, after all
+/// branches are done — see `lower_if`/`lower_select`'s own doc comments).
+///
+/// `locals_set` mirrors `locals` (same names, same lifetime) purely so
+/// membership testing (`has_local`) is O(1) instead of the O(n) linear
+/// scan `Vec::contains` would need — with every assignment statement
+/// doing at least one such check, a flat run of n distinct-name
+/// assignments would otherwise cost O(n²) overall. `locals` itself stays
+/// a `Vec` (not replaced by the set) because `scope_mark`/`scope_rewind`
+/// need its *insertion order* to truncate back to an exact prior length.
 struct FunctionCtx {
     params: HashSet<String>,
     locals: Vec<String>,
+    locals_set: HashSet<String>,
 }
 
 impl FunctionCtx {
@@ -322,11 +337,26 @@ impl FunctionCtx {
         Self {
             params,
             locals: Vec::new(),
+            locals_set: HashSet::new(),
         }
     }
 
     fn top_level() -> Self {
         Self::new(HashSet::new())
+    }
+
+    /// O(1) "is `name` an already-known local" check — see this struct's
+    /// own doc comment for why a second, set-backed field exists purely
+    /// for this.
+    fn has_local(&self, name: &str) -> bool {
+        self.locals_set.contains(name)
+    }
+
+    /// Record a newly-introduced local, keeping `locals`/`locals_set` in
+    /// sync.
+    fn push_local(&mut self, name: String) {
+        self.locals_set.insert(name.clone());
+        self.locals.push(name);
     }
 }
 
@@ -342,7 +372,7 @@ struct Lowerer {
     /// The lowered top-level functions, in definition order. `main` is
     /// appended last by [`Self::lower_file`].
     functions: Vec<Function>,
-    /// Counter for the compiler-generated `__select_N` temporaries
+    /// Counter for the compiler-generated `$select_N` temporaries
     /// [`Self::lower_select`] hoists the selector into — see this file's
     /// module doc comment, "`select`/`case`: desugared, no new SIR node".
     /// A single module-wide counter (not per-function) is simplest and
@@ -373,7 +403,9 @@ impl Lowerer {
     }
 
     fn scope_rewind(ctx: &mut FunctionCtx, mark: usize) {
-        ctx.locals.truncate(mark);
+        for name in ctx.locals.drain(mark..) {
+            ctx.locals_set.remove(&name);
+        }
     }
 
     // -------------------------------------------------------------------
@@ -800,7 +832,13 @@ impl Lowerer {
         // mistaken for an already-known local by a sibling branch that
         // happens to lower afterward.
         let mark = Self::scope_mark(ctx);
-        let mut newly_introduced: Vec<String> = Vec::new();
+        // A `HashSet`, not a `Vec` -- membership testing every branch's
+        // names against a growing `Vec` (via `.contains`) would be an O(n²)
+        // scan over the total distinct names across all branches, entirely
+        // unbounded by the `clauses.len()` cap above (that cap bounds
+        // branch *count*, not the *names per branch*, which an ordinary
+        // flat statement list has no size limit on at all).
+        let mut newly_introduced: HashSet<String> = HashSet::new();
 
         let mut else_branch: Block = match else_body {
             Some(b) => {
@@ -816,11 +854,7 @@ impl Lowerer {
             // -- see `to_scilab_condition`'s doc comment).
             let cond = to_scilab_condition(self.lower_expr(clause.cond, ctx)?);
             let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
-            for name in &ctx.locals[mark..] {
-                if !newly_introduced.contains(name) {
-                    newly_introduced.push(name.clone());
-                }
-            }
+            newly_introduced.extend(ctx.locals[mark..].iter().cloned());
             Self::scope_rewind(ctx, mark);
             let span = cond.span().clone();
             let folded = Expr::If {
@@ -831,7 +865,9 @@ impl Lowerer {
             };
             else_branch = value_block(folded);
         }
-        ctx.locals.extend(newly_introduced);
+        for name in newly_introduced {
+            ctx.push_local(name);
+        }
         match else_branch.value {
             Expr::If { .. } => Ok(else_branch.value),
             other => Ok(other),
@@ -880,7 +916,7 @@ impl Lowerer {
         // invalid/duplicate-declaration JavaScript from the JS backend.)
         let temp = format!("$select_{}", self.select_counter);
         self.select_counter += 1;
-        ctx.locals.push(temp.clone());
+        ctx.push_local(temp.clone());
         let mut stmts: Vec<Lowered> = vec![Lowered::Stmt(Box::new(Stmt::LetStarBinding {
             name: temp.clone(),
             sir_type: None,
@@ -943,7 +979,11 @@ impl Lowerer {
         // first-occurrence classification depends on sibling iteration
         // order.
         let mark = Self::scope_mark(ctx);
-        let mut newly_introduced: Vec<String> = Vec::new();
+        // See the identical `HashSet` choice (and full rationale) in
+        // `lower_if`: a `Vec`-backed membership check here would be an
+        // O(n²) scan over the total distinct names across all case/else
+        // bodies, unbounded by the `clauses.len()` cap above.
+        let mut newly_introduced: HashSet<String> = HashSet::new();
 
         let mut else_branch: Block = match else_body {
             Some(b) => {
@@ -972,11 +1012,7 @@ impl Lowerer {
             };
             let cond = to_scilab_condition(eq);
             let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
-            for name in &ctx.locals[mark..] {
-                if !newly_introduced.contains(name) {
-                    newly_introduced.push(name.clone());
-                }
-            }
+            newly_introduced.extend(ctx.locals[mark..].iter().cloned());
             Self::scope_rewind(ctx, mark);
             let if_span = cond.span().clone();
             let folded = Expr::If {
@@ -987,7 +1023,9 @@ impl Lowerer {
             };
             else_branch = value_block(folded);
         }
-        ctx.locals.extend(newly_introduced);
+        for name in newly_introduced {
+            ctx.push_local(name);
+        }
 
         let final_expr = match else_branch.value {
             Expr::If { .. } => else_branch.value,
@@ -1107,7 +1145,7 @@ impl Lowerer {
 
         self.observed.add(Feature::Loops);
         let mark = Self::scope_mark(ctx);
-        ctx.locals.push(var.clone());
+        ctx.push_local(var.clone());
         let body = self.lower_block_body(body_node, ctx, depth + 1)?;
         Self::scope_rewind(ctx, mark);
 
@@ -1185,7 +1223,7 @@ impl Lowerer {
 
         if let Some(name) = self.bare_name(lhs) {
             let value = self.lower_expr(rhs, ctx)?;
-            if ctx.locals.contains(&name) || ctx.params.contains(&name) {
+            if ctx.has_local(&name) || ctx.params.contains(&name) {
                 self.observed.add(Feature::MutableBindings);
                 return Ok(Lowered::Stmt(Box::new(Stmt::Assign {
                     name,
@@ -1194,7 +1232,7 @@ impl Lowerer {
                     span,
                 })));
             }
-            ctx.locals.push(name.clone());
+            ctx.push_local(name.clone());
             return Ok(Lowered::Stmt(Box::new(Stmt::LetStarBinding {
                 name,
                 sir_type: None,
@@ -1204,7 +1242,7 @@ impl Lowerer {
         }
 
         if let Some((base_name, call_suffix)) = self.indexed_target(lhs) {
-            if !(ctx.locals.contains(&base_name) || ctx.params.contains(&base_name)) {
+            if !(ctx.has_local(&base_name) || ctx.params.contains(&base_name)) {
                 return Err(self.err_at(
                     lhs,
                     format!(
@@ -1929,6 +1967,28 @@ impl Lowerer {
         if suffixes.is_empty() {
             return self.lower_primary(primary, ctx, depth + 1).map(Some);
         }
+        // Security regression: `postfix = primary { transpose_suffix |
+        // call_suffix | cell_suffix | field_suffix }` is the identical flat
+        // `{ x }`-repetition CST shape as `elseif_clause*`/`case_clause*`
+        // (costs the *parser* zero native stack) but was folded below into
+        // a `Box`-nested `Expr::Transpose`/`Expr::IndexGet` chain with no
+        // cap at all -- unlike every operator-chain fold in this file,
+        // which calls `check_chain_length` first. A source file with N
+        // chained transpose/call suffixes (`y = x' ' ' ...` or
+        // `y = A(1)(1)(1)...`) previously compiled successfully, but
+        // merely dropping the returned `Module` at large N overflowed the
+        // native stack and aborted the process (uncatchable by
+        // `catch_unwind`) -- the same hazard class the elseif/case fix
+        // closed, reachable through this third, previously-unguarded path.
+        if suffixes.len() > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "expression chain too long ({} operands, exceeds {MAX_EXPR_DEPTH})",
+                    suffixes.len()
+                ),
+            ));
+        }
 
         let mut acc: Option<Expr> = None;
         let mut first = true;
@@ -1960,7 +2020,7 @@ impl Lowerer {
                                 "unsupported: call/index target is not a bare name".to_string(),
                             )
                         })?;
-                        if ctx.locals.contains(&name) || ctx.params.contains(&name) {
+                        if ctx.has_local(&name) || ctx.params.contains(&name) {
                             let span = self.span_of(primary);
                             let indices = self.lower_index_args(suffix, ctx, depth + 1)?;
                             acc = Some(Expr::IndexGet {
@@ -2088,7 +2148,7 @@ impl Lowerer {
                             scope: Scope::Param,
                             span,
                         })
-                    } else if ctx.locals.contains(&name) {
+                    } else if ctx.has_local(&name) {
                         Ok(Expr::VarRef {
                             name,
                             scope: Scope::Local,

--- a/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
@@ -231,6 +231,67 @@
 //! Falling through to the array-domain node in an ambiguous case is
 //! always semantically safe, just occasionally more conservative than a
 //! full type-inference pass would be.
+//!
+//! # Hoisting a branch/loop body's introduced names
+//!
+//! Scilab has no block scoping (this file's earlier "select/case" section
+//! already leans on that fact): a variable first assigned inside an
+//! `if`/`elseif`/`else` branch, a `select`/`case`/`else` branch, a
+//! `while` body, or a `for` body is visible for the rest of the
+//! *function*, not just inside the construct that introduced it — most
+//! commonly, a function's own designated output variable, computed
+//! conditionally.
+//!
+//! An earlier revision of this file only got half of this right: it
+//! correctly tracked such a name in `ctx.locals`/`ctx.locals_set` (this
+//! crate's own lowering-time bookkeeping, so a *second* occurrence
+//! anywhere classifies consistently as `Stmt::Assign`), but never
+//! actually emitted a declaration for it anywhere OTHER than the
+//! `Stmt::LetStarBinding` nested inside the introducing construct's own
+//! `Block`. `semantic_ir::validate` scopes each `Block` independently
+//! (`check_block` marks/rewinds its own local environment on entry/exit),
+//! so that nested `LetStarBinding` never made the name visible to
+//! anything outside its own immediate block — meaning any function
+//! computing its own output variable inside `if`/`else` (the single most
+//! ordinary Scilab/MATLAB function shape there is) produced a module that
+//! `semantic_ir::validate` *always* rejected, with a dangling "var-ref
+//! scope=local references unknown name" error on the function's own
+//! trailing-value reference to it.
+//!
+//! The fix: `lower_if`/`lower_select`/`lower_while`/`lower_for` all call
+//! [`Lowerer::hoist_assigned_names`] before lowering their branch/loop
+//! body for real, which:
+//! 1. Statically scans the body/bodies (via [`Lowerer::collect_assigned_names`],
+//!    a purely syntactic CST walk — no lowering, no side effects) for
+//!    every bare-`NAME` this construct might introduce for the first
+//!    time, recursing transitively through further-nested control flow.
+//! 2. Filters out any name that's ALREADY known (re-declaring it with a
+//!    placeholder would silently clobber a real value).
+//! 3. Emits a genuine `Stmt::LetStarBinding` for each remaining name, at
+//!    the ENCLOSING scope, with a placeholder `Expr::NilLit` value —
+//!    *before* the construct itself — and marks it known in `ctx` so
+//!    every occurrence inside the construct (any branch, any iteration)
+//!    lowers as `Stmt::Assign` against this real declaration.
+//!
+//! An earlier design considered instead discovering introduced names by
+//! lowering each branch/body TWICE (once to discover, once for real) —
+//! rejected during security review because it would compound into an
+//! exponential `2^K` blowup for K levels of nested control flow (each
+//! level doubling the work of everything nested inside it), a new and
+//! severe DoS vector the static-scan design avoids entirely by
+//! construction (one linear pass, no re-lowering, ever).
+//!
+//! **Known, disclosed residual limitation** (no data-flow/definite-
+//! assignment analysis): this does not distinguish "every reachable path
+//! genuinely writes this name before it's read" from "some path reads a
+//! hoisted name that nothing before it, in this construct, ever actually
+//! assigned" (e.g. an uninitialised accumulator, `for i=1:5; total =
+//! total+i; end` with no `total = 0;` first). Real Scilab would raise a
+//! clean "undefined variable" runtime error for that exact program; this
+//! frontend instead silently reads the `NilLit` placeholder. Closing this
+//! narrower gap needs real data-flow analysis, out of scope for v0.1.0 —
+//! every genuinely common pattern (a value every reachable branch/every
+//! loop iteration that runs at all actually assigns) is unaffected.
 
 use std::collections::HashSet;
 
@@ -425,6 +486,240 @@ impl Lowerer {
         for name in ctx.locals.drain(mark..) {
             ctx.locals_set.remove(&name);
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Hoisting a branch/loop body's introduced names (security review,
+    // round 4). See this file's module doc comment, "Hoisting a
+    // branch/loop body's introduced names", for the full rationale: a
+    // `LetStarBinding` nested inside a `Block` (an `if`/`while`/`for`/
+    // `select` body) does NOT, on its own, make that name visible to
+    // `semantic_ir::validate` from an ENCLOSING block's perspective, even
+    // though this crate's own lowering-time `ctx.locals` bookkeeping
+    // (correctly, since round 1/2/3) treats it as known from that point
+    // forward. `lower_if`/`lower_select`/`lower_while`/`lower_for` all
+    // call `hoist_assigned_names` before lowering their body/bodies for
+    // real, to pre-declare (with a placeholder `Expr::NilLit`) every name
+    // that body might introduce -- so every branch's own first occurrence
+    // of such a name lowers as `Stmt::Assign` (not `Stmt::LetStarBinding`)
+    // against a REAL, enclosing-scope declaration, and code that follows
+    // the construct can reference it too.
+    // -------------------------------------------------------------------
+
+    /// Statically scan a `block_body` node -- WITHOUT lowering anything --
+    /// for every bare-`NAME` assignment target it introduces, recursing
+    /// transitively through nested `if`/`elseif`/`else`/`while`/`for`/
+    /// `select`/`case` bodies (any nested construct's own introduced name
+    /// still needs promoting all the way up, since Scilab has no block
+    /// scoping at all -- this file's module doc comment). Indexed
+    /// assignment (`A(i) = x`) is deliberately NOT collected: it can never
+    /// introduce a genuinely NEW name (`lower_assignment` itself requires
+    /// the base variable to already be assigned).
+    ///
+    /// This is a purely syntactic pre-pass -- no lowering, no `self`/`ctx`
+    /// mutation -- so calling it before the real lowering never
+    /// double-counts a `Feature` or a `select_counter` increment, and
+    /// (critically) never re-lowers anything: an earlier design considered
+    /// during security review instead discovered introduced names by
+    /// lowering each branch/body TWICE (once to discover, once for real),
+    /// which would have compounded into an exponential `2^K` blowup for K
+    /// levels of nested control flow -- a new, severe DoS vector this
+    /// static scan avoids entirely by construction.
+    fn collect_assigned_names(
+        &self,
+        body: &GrammarASTNode,
+        depth: usize,
+        out: &mut HashSet<String>,
+    ) -> Result<(), ScilabLowerError> {
+        if depth > MAX_BLOCK_DEPTH {
+            return Err(self.err_at(
+                body,
+                format!("control-flow nesting too deep (exceeds {MAX_BLOCK_DEPTH} levels)"),
+            ));
+        }
+        for stmt_line in child_nodes(body) {
+            if stmt_line.rule_name != "statement_line" {
+                continue;
+            }
+            let stmt = match self.first_child_named(stmt_line, "statement") {
+                Some(s) => s,
+                None => continue,
+            };
+            let inner = match only_node(stmt, self) {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            self.collect_assigned_names_stmt(inner, depth, out)?;
+        }
+        Ok(())
+    }
+
+    /// One statement's contribution to [`Self::collect_assigned_names`] --
+    /// split out so each control-flow shape's own child-node layout is
+    /// documented once, matching the equivalent lowering function's own
+    /// indexing exactly (`lower_if`/`lower_select`/`lower_while`/
+    /// `lower_for`).
+    fn collect_assigned_names_stmt(
+        &self,
+        inner: &GrammarASTNode,
+        depth: usize,
+        out: &mut HashSet<String>,
+    ) -> Result<(), ScilabLowerError> {
+        match inner.rule_name.as_str() {
+            "if_stmt" => {
+                // `[cond, stmt_sep, block_body, elseif_clause*, else_clause?]`
+                // -- see `lower_if`'s own doc comment.
+                let kids = child_nodes(inner);
+                if kids.len() >= 3 {
+                    self.collect_assigned_names(kids[2], depth + 1, out)?;
+                    for rest in &kids[3..] {
+                        match rest.rule_name.as_str() {
+                            "elseif_clause" => {
+                                if let [_c, _s, b] = child_nodes(rest).as_slice() {
+                                    self.collect_assigned_names(b, depth + 1, out)?;
+                                }
+                            }
+                            "else_clause" => {
+                                if let [b] = child_nodes(rest).as_slice() {
+                                    self.collect_assigned_names(b, depth + 1, out)?;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            "select_stmt" => {
+                // `[selector, stmt_sep, case_clause*, else_clause?]` --
+                // see `lower_select`'s own doc comment.
+                let kids = child_nodes(inner);
+                if kids.len() >= 2 {
+                    for rest in &kids[2..] {
+                        match rest.rule_name.as_str() {
+                            "case_clause" => {
+                                if let [_v, _s, b] = child_nodes(rest).as_slice() {
+                                    self.collect_assigned_names(b, depth + 1, out)?;
+                                }
+                            }
+                            "else_clause" => {
+                                if let [b] = child_nodes(rest).as_slice() {
+                                    self.collect_assigned_names(b, depth + 1, out)?;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            "while_stmt" => {
+                // `[cond, stmt_sep, block_body]` -- see `lower_while`.
+                if let [_c, _s, b] = child_nodes(inner).as_slice() {
+                    self.collect_assigned_names(b, depth + 1, out)?;
+                }
+            }
+            "for_stmt" => {
+                // The loop variable itself is a bare-name assignment
+                // target too -- `lower_for`'s own callers exclude it
+                // explicitly where that matters (it has its own, separate,
+                // correctly loop-scoped handling).
+                if let Some(name) = inner.children.iter().find_map(|c| match c {
+                    ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                        Some(t.value.clone())
+                    }
+                    _ => None,
+                }) {
+                    out.insert(name);
+                }
+                // `[range, stmt_sep, block_body]` -- see `lower_for`.
+                if let [_r, _s, b] = child_nodes(inner).as_slice() {
+                    self.collect_assigned_names(b, depth + 1, out)?;
+                }
+            }
+            _ => {
+                // `inner`'s own `rule_name` is NOT necessarily literally
+                // `"assignment"` here: `statement`'s `expr` alternative
+                // reaches `assignment` through a chain of single-child
+                // wrapper rules (`logical_or`, etc., per the precedence
+                // cascade) that the CST does not flatten away on its own
+                // -- exactly the same shape `lower_statement_expr` itself
+                // must peel through via its own `if node.rule_name !=
+                // "assignment" { peel... }` logic, which this mirrors via
+                // the same `peel_to_named` helper `bare_name`/
+                // `indexed_target` already use. A peeled node with only
+                // ONE child (`assignment = logical_or [ EQ assignment ]`
+                // with the optional part absent) is a value-only
+                // expression statement, not a real assignment -- no name
+                // to collect.
+                if let Some(assign_node) = self.peel_to_named(inner, "assignment", 0) {
+                    if let [lhs, _rhs] = child_nodes(assign_node).as_slice() {
+                        if let Some(name) = self.bare_name(lhs) {
+                            out.insert(name);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Pre-declare (hoist) every name [`Self::collect_assigned_names`]
+    /// finds across `bodies`, at the CURRENT enclosing scope, with a
+    /// placeholder [`Expr::NilLit`] value -- returning the hoisted
+    /// [`Stmt::LetStarBinding`]s to prepend before the construct itself.
+    /// `exclude` filters out one name unconditionally (a `for`-loop's own
+    /// counter variable, which already has its own separate, correct,
+    /// loop-scoped handling -- see `lower_for`). Any name that's ALREADY
+    /// known (`ctx.has_local`/`ctx.params.contains`) is filtered too:
+    /// re-declaring an already-assigned variable with a `NilLit`
+    /// placeholder would silently clobber its real value, exactly the
+    /// silent mis-lowering this crate's whole design otherwise refuses to
+    /// do.
+    ///
+    /// **Known, disclosed residual limitation**: this makes a
+    /// branch/loop-introduced name usable both inside every sibling
+    /// branch and after the construct, matching real Scilab's
+    /// whole-function scoping for the load-bearing case this fixes (most
+    /// commonly, a function computing its own output variable
+    /// conditionally). It does NOT perform definite-assignment analysis:
+    /// a body that reads a hoisted name before ever genuinely writing it
+    /// in the SAME construct (e.g. an uninitialised accumulator,
+    /// `for i = 1:5; total = total + i; end` with no `total = 0;`
+    /// beforehand) will read the `NilLit` placeholder instead of getting
+    /// the clean "undefined variable" error real Scilab would raise at
+    /// runtime for the identical program -- silently computing a wrong
+    /// value rather than erroring. Closing this residual gap needs real
+    /// data-flow analysis, out of scope for this v0.1.0 cut; every
+    /// genuinely common pattern (conditionally computing a value that
+    /// every reachable branch actually assigns) is unaffected.
+    fn hoist_assigned_names(
+        &mut self,
+        bodies: &[&GrammarASTNode],
+        exclude: Option<&str>,
+        depth: usize,
+        span: &Span,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Vec<Lowered>, ScilabLowerError> {
+        let mut candidates: HashSet<String> = HashSet::new();
+        for body in bodies {
+            self.collect_assigned_names(body, depth, &mut candidates)?;
+        }
+        if let Some(ex) = exclude {
+            candidates.remove(ex);
+        }
+        let mut hoisted = Vec::new();
+        for name in candidates {
+            if ctx.has_local(&name) || ctx.params.contains(&name) {
+                continue;
+            }
+            ctx.push_local(name.clone());
+            hoisted.push(Lowered::Stmt(Box::new(Stmt::LetStarBinding {
+                name,
+                sir_type: None,
+                value: Expr::NilLit { span: span.clone() },
+                span: span.clone(),
+            })));
+        }
+        Ok(hoisted)
     }
 
     // -------------------------------------------------------------------
@@ -748,14 +1043,10 @@ impl Lowerer {
                 inner,
                 "unsupported: nested function definitions are out of scope for v0.1.0".to_string(),
             )),
-            "if_stmt" => Ok(vec![Lowered::Expr(self.lower_if(inner, ctx, depth)?)]),
+            "if_stmt" => self.lower_if(inner, ctx, depth),
             "select_stmt" => self.lower_select(inner, ctx, depth),
-            "while_stmt" => Ok(vec![Lowered::Stmt(Box::new(
-                self.lower_while(inner, ctx, depth)?,
-            ))]),
-            "for_stmt" => Ok(vec![Lowered::Stmt(Box::new(
-                self.lower_for(inner, ctx, depth)?,
-            ))]),
+            "while_stmt" => self.lower_while(inner, ctx, depth),
+            "for_stmt" => self.lower_for(inner, ctx, depth),
             "break_stmt" => Err(self.err_at(
                 inner,
                 "unsupported: `break` has no SIR equivalent yet (semantic-ir has no early-exit \
@@ -790,7 +1081,7 @@ impl Lowerer {
         if_stmt: &GrammarASTNode,
         ctx: &mut FunctionCtx,
         depth: usize,
-    ) -> Result<Expr, ScilabLowerError> {
+    ) -> Result<Vec<Lowered>, ScilabLowerError> {
         struct Clause<'a> {
             cond: &'a GrammarASTNode,
             body: &'a GrammarASTNode,
@@ -842,30 +1133,25 @@ impl Lowerer {
         }
 
         let if_span = self.span_of(if_stmt);
-        // `if`/`elseif`/`else` bodies are mutually exclusive -- see the
-        // identical fix (and full rationale) in `lower_select`, which this
-        // mirrors exactly: every branch is lowered against the same
-        // pre-`if` `ctx.locals` snapshot, then the union of every branch's
-        // newly-introduced names is folded back in once, after all branches
-        // are done, so a name first assigned in one branch is never
-        // mistaken for an already-known local by a sibling branch that
-        // happens to lower afterward.
-        let mark = Self::scope_mark(ctx);
-        // A `HashSet`, not a `Vec` -- membership testing every branch's
-        // names against a growing `Vec` (via `.contains`) would be an O(n²)
-        // scan over the total distinct names across all branches, entirely
-        // unbounded by the `clauses.len()` cap above (that cap bounds
-        // branch *count*, not the *names per branch*, which an ordinary
-        // flat statement list has no size limit on at all).
-        let mut newly_introduced: HashSet<String> = HashSet::new();
+
+        // Hoist every name any branch might introduce, at the ENCLOSING
+        // scope, BEFORE lowering any branch for real -- see
+        // `hoist_assigned_names`'s own doc comment ("Hoisting a
+        // branch/loop body's introduced names"). This is what makes a
+        // branch-introduced name visible to code AFTER the `if` (most
+        // commonly, a function's own designated output variable computed
+        // conditionally) -- `semantic_ir::validate` scopes each `Block` (an
+        // `If`'s own branches included) independently, so a
+        // `LetStarBinding` nested inside a branch's own block does NOT, on
+        // its own, make that name visible outside it.
+        let mut branch_bodies: Vec<&GrammarASTNode> = clauses.iter().map(|c| c.body).collect();
+        if let Some(b) = else_body {
+            branch_bodies.push(b);
+        }
+        let mut stmts = self.hoist_assigned_names(&branch_bodies, None, depth + 1, &if_span, ctx)?;
 
         let mut else_branch: Block = match else_body {
-            Some(b) => {
-                let block = self.lower_block_body(b, ctx, depth + 1)?;
-                newly_introduced.extend(ctx.locals[mark..].iter().cloned());
-                Self::scope_rewind(ctx, mark);
-                block
-            }
+            Some(b) => self.lower_block_body(b, ctx, depth + 1)?,
             None => empty_block(if_span.clone()),
         };
         for clause in clauses.into_iter().rev() {
@@ -873,8 +1159,6 @@ impl Lowerer {
             // -- see `to_scilab_condition`'s doc comment).
             let cond = to_scilab_condition(self.lower_expr(clause.cond, ctx)?);
             let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
-            newly_introduced.extend(ctx.locals[mark..].iter().cloned());
-            Self::scope_rewind(ctx, mark);
             let span = cond.span().clone();
             let folded = Expr::If {
                 cond: Box::new(cond),
@@ -884,13 +1168,12 @@ impl Lowerer {
             };
             else_branch = value_block(folded);
         }
-        for name in newly_introduced {
-            ctx.push_local(name);
-        }
-        match else_branch.value {
-            Expr::If { .. } => Ok(else_branch.value),
-            other => Ok(other),
-        }
+        let final_expr = match else_branch.value {
+            Expr::If { .. } => else_branch.value,
+            other => other,
+        };
+        stmts.push(Lowered::Expr(final_expr));
+        Ok(stmts)
     }
 
     /// Lower `select selector stmt_sep { case_clause } [ else_clause ] end`
@@ -989,37 +1272,20 @@ impl Lowerer {
             ));
         }
 
-        // `if`/`case` bodies are mutually exclusive -- at most one of them
-        // ever actually executes -- but `FunctionCtx::locals` is a single,
-        // unscoped, append-only accumulator (Scilab has no block scoping,
-        // this file's module doc comment). Lowering the bodies in the wrong
-        // relative order let one sibling's first-occurrence assignment
-        // "leak" into another sibling as an already-known local, silently
-        // misclassifying that sibling's OWN first occurrence of the same
-        // name as a re-assignment (`Stmt::Assign`) instead of a declaration
-        // (`Stmt::LetStarBinding`) -- breaking the ordinary idiom of a
-        // function assigning its own output variable in every branch of a
-        // `select`/`case`. Fixed the same way `for`'s own loop-variable
-        // scope already is (`Self::scope_mark`/`scope_rewind`): every
-        // branch is lowered against the *same* pre-select snapshot, then
-        // the union of every branch's newly-introduced names is folded back
-        // in once, after all branches are done -- so no branch's
-        // first-occurrence classification depends on sibling iteration
-        // order.
-        let mark = Self::scope_mark(ctx);
-        // See the identical `HashSet` choice (and full rationale) in
-        // `lower_if`: a `Vec`-backed membership check here would be an
-        // O(n²) scan over the total distinct names across all case/else
-        // bodies, unbounded by the `clauses.len()` cap above.
-        let mut newly_introduced: HashSet<String> = HashSet::new();
+        // Hoist every name any case/else body might introduce, at the
+        // ENCLOSING scope, BEFORE lowering any branch for real -- see
+        // `hoist_assigned_names`'s own doc comment and `lower_if`'s
+        // identical use of it (this mirrors it exactly): makes a
+        // branch-introduced name visible to code AFTER the `select`, not
+        // just to `ctx`'s own lowering-time bookkeeping.
+        let mut branch_bodies: Vec<&GrammarASTNode> = clauses.iter().map(|c| c.body).collect();
+        if let Some(b) = else_body {
+            branch_bodies.push(b);
+        }
+        stmts.extend(self.hoist_assigned_names(&branch_bodies, None, depth + 1, &span, ctx)?);
 
         let mut else_branch: Block = match else_body {
-            Some(b) => {
-                let block = self.lower_block_body(b, ctx, depth + 1)?;
-                newly_introduced.extend(ctx.locals[mark..].iter().cloned());
-                Self::scope_rewind(ctx, mark);
-                block
-            }
+            Some(b) => self.lower_block_body(b, ctx, depth + 1)?,
             None => empty_block(span.clone()),
         };
         for clause in clauses.into_iter().rev() {
@@ -1040,8 +1306,6 @@ impl Lowerer {
             };
             let cond = to_scilab_condition(eq);
             let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
-            newly_introduced.extend(ctx.locals[mark..].iter().cloned());
-            Self::scope_rewind(ctx, mark);
             let if_span = cond.span().clone();
             let folded = Expr::If {
                 cond: Box::new(cond),
@@ -1050,9 +1314,6 @@ impl Lowerer {
                 span: if_span,
             };
             else_branch = value_block(folded);
-        }
-        for name in newly_introduced {
-            ctx.push_local(name);
         }
 
         let final_expr = match else_branch.value {
@@ -1071,7 +1332,7 @@ impl Lowerer {
         while_stmt: &GrammarASTNode,
         ctx: &mut FunctionCtx,
         depth: usize,
-    ) -> Result<Stmt, ScilabLowerError> {
+    ) -> Result<Vec<Lowered>, ScilabLowerError> {
         let (cond_node, body_node) = match child_nodes(while_stmt).as_slice() {
             [c, _stmt_sep, b] => (*c, *b),
             _ => {
@@ -1081,14 +1342,24 @@ impl Lowerer {
                 ))
             }
         };
+        let span = self.span_of(while_stmt);
+        // Hoist every name the loop body might introduce, at the
+        // ENCLOSING scope, BEFORE lowering the body for real -- see
+        // `hoist_assigned_names`'s own doc comment and `lower_if`'s
+        // identical use of it. A `while` loop's body may run zero or many
+        // times, so (unlike `if`/`select`'s mutually-exclusive branches)
+        // there is no guarantee a hoisted name is ever actually assigned
+        // -- but this exactly matches real Scilab's own behaviour for a
+        // loop that never runs (the variable stays undefined), and this
+        // crate has no data-flow analysis to do better (see
+        // `hoist_assigned_names`'s own disclosed residual-limitation
+        // note).
+        let mut stmts = self.hoist_assigned_names(&[body_node], None, depth + 1, &span, ctx)?;
         let cond = to_scilab_condition(self.lower_expr(cond_node, ctx)?);
         let body = self.lower_block_body(body_node, ctx, depth + 1)?;
         self.observed.add(Feature::Loops);
-        Ok(Stmt::While {
-            cond,
-            body,
-            span: self.span_of(while_stmt),
-        })
+        stmts.push(Lowered::Stmt(Box::new(Stmt::While { cond, body, span })));
+        Ok(stmts)
     }
 
     /// Lower `for NAME = a:b stmt_sep body end` into [`Stmt::ForRange`].
@@ -1105,7 +1376,7 @@ impl Lowerer {
         for_stmt: &GrammarASTNode,
         ctx: &mut FunctionCtx,
         depth: usize,
-    ) -> Result<Stmt, ScilabLowerError> {
+    ) -> Result<Vec<Lowered>, ScilabLowerError> {
         let span = self.span_of(for_stmt);
         let var = for_stmt
             .children
@@ -1172,19 +1443,31 @@ impl Lowerer {
         };
 
         self.observed.add(Feature::Loops);
+
+        // Hoist every name the loop body might introduce (EXCLUDING the
+        // loop counter `var` itself, which keeps its own separate,
+        // correct, loop-scoped handling just below), at the ENCLOSING
+        // scope, BEFORE lowering the body for real -- see
+        // `hoist_assigned_names`'s own doc comment and `lower_if`'s
+        // identical use of it. Same "loop may run zero times" caveat as
+        // `lower_while`.
+        let mut stmts =
+            self.hoist_assigned_names(&[body_node], Some(var.as_str()), depth + 1, &span, ctx)?;
+
         let mark = Self::scope_mark(ctx);
         ctx.push_local(var.clone());
         let body = self.lower_block_body(body_node, ctx, depth + 1)?;
         Self::scope_rewind(ctx, mark);
 
-        Ok(Stmt::ForRange {
+        stmts.push(Lowered::Stmt(Box::new(Stmt::ForRange {
             var,
             start,
             stop,
             step,
             body,
             span,
-        })
+        })));
+        Ok(stmts)
     }
 
     // -------------------------------------------------------------------

--- a/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/src/lower.rs
@@ -287,11 +287,20 @@
 //! hoisted name that nothing before it, in this construct, ever actually
 //! assigned" (e.g. an uninitialised accumulator, `for i=1:5; total =
 //! total+i; end` with no `total = 0;` first). Real Scilab would raise a
-//! clean "undefined variable" runtime error for that exact program; this
-//! frontend instead silently reads the `NilLit` placeholder. Closing this
-//! narrower gap needs real data-flow analysis, out of scope for v0.1.0 —
-//! every genuinely common pattern (a value every reachable branch/every
-//! loop iteration that runs at all actually assigns) is unaffected.
+//! clean "undefined variable" runtime error for that exact program.
+//! Verified (round 5 review) what this frontend actually does instead:
+//! NOT a silently-wrong numeric result as first assumed — the shared JS
+//! backend lowers `Expr::NilLit` to JS `null`, and `total + i` lowers to
+//! an `ElementwiseOp` whose runtime helper unconditionally dereferences
+//! `.data` on both operands, so the generated program throws an uncaught
+//! `TypeError: Cannot read properties of null (reading 'data')` and exits
+//! non-zero — a crash, not a silent miscalculation. Still not the clean,
+//! "unsupported: ..." `ScilabLowerError` real definite-assignment
+//! analysis would produce, and still out of scope for v0.1.0 to close
+//! properly, but the failure mode is fail-loud (an exception at the
+//! JS layer), not fail-silent. Every genuinely common pattern (a value
+//! every reachable branch/every loop iteration that runs at all actually
+//! assigns) is unaffected either way.
 
 use std::collections::HashSet;
 
@@ -618,18 +627,25 @@ impl Lowerer {
                 }
             }
             "for_stmt" => {
-                // The loop variable itself is a bare-name assignment
-                // target too -- `lower_for`'s own callers exclude it
-                // explicitly where that matters (it has its own, separate,
-                // correctly loop-scoped handling).
-                if let Some(name) = inner.children.iter().find_map(|c| match c {
-                    ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
-                        Some(t.value.clone())
-                    }
-                    _ => None,
-                }) {
-                    out.insert(name);
-                }
+                // Deliberately do NOT insert the loop variable's own name
+                // into `out` here (security regression, round 5 review):
+                // this scan exists so an ENCLOSING construct (an outer
+                // `if`/`while`/`select`/`for` this `for_stmt` is nested
+                // inside) can hoist names that need to survive past ITS
+                // OWN boundary -- but a `for`-loop's counter has its own,
+                // separate, genuinely loop-scoped lifetime (`lower_for`'s
+                // own `scope_mark`/`scope_rewind`), identical whether or
+                // not this `for_stmt` happens to be nested inside another
+                // construct. Reporting it here previously let an
+                // ENCLOSING construct's hoist pre-declare it at ITS OWN
+                // scope -- making the counter spuriously "survive" the
+                // loop (with a stale, JS-block-scoping-dependent value,
+                // not even the loop's true final value) purely because
+                // the identical `for` happened to be nested one level
+                // deeper, while the same loop at the top level correctly
+                // rejected the identical post-loop reference as
+                // undefined. Only the loop BODY's own newly-introduced
+                // names (excluding the counter) should ever bubble up.
                 // `[range, stmt_sep, block_body]` -- see `lower_for`.
                 if let [_r, _s, b] = child_nodes(inner).as_slice() {
                     self.collect_assigned_names(b, depth + 1, out)?;
@@ -686,11 +702,16 @@ impl Lowerer {
     /// `for i = 1:5; total = total + i; end` with no `total = 0;`
     /// beforehand) will read the `NilLit` placeholder instead of getting
     /// the clean "undefined variable" error real Scilab would raise at
-    /// runtime for the identical program -- silently computing a wrong
-    /// value rather than erroring. Closing this residual gap needs real
-    /// data-flow analysis, out of scope for this v0.1.0 cut; every
-    /// genuinely common pattern (conditionally computing a value that
-    /// every reachable branch actually assigns) is unaffected.
+    /// runtime for the identical program. Verified (round 5 review) this
+    /// fails LOUD, not silent: `NilLit` lowers to JS `null`, and the
+    /// arithmetic reading it throws an uncaught `TypeError` at runtime
+    /// (not a silently-wrong numeric result), since the shared JS
+    /// backend's own runtime helpers unconditionally dereference a field
+    /// on both operands. Still not the clean `ScilabLowerError` real
+    /// definite-assignment analysis would produce; closing this residual
+    /// gap properly needs that analysis, out of scope for this v0.1.0
+    /// cut. Every genuinely common pattern (conditionally computing a
+    /// value that every reachable branch actually assigns) is unaffected.
     fn hoist_assigned_names(
         &mut self,
         bodies: &[&GrammarASTNode],
@@ -1388,6 +1409,39 @@ impl Lowerer {
                 _ => None,
             })
             .ok_or_else(|| self.err_at(for_stmt, "malformed for: no loop variable".to_string()))?;
+
+        // Security regression (round 5 review): reusing an already-known
+        // variable as a `for`-loop's own counter was previously ACCEPTED
+        // -- this crate's own `ctx` bookkeeping (correctly, per round 3's
+        // fix) treats it as "the same variable, surviving the loop with
+        // its final value," matching `scilab-runtime::eval_for`'s own
+        // ground-truth semantics (`self.vars.insert` never removes the
+        // binding). But the shared `semantic-ir-to-javascript` backend's
+        // `ForRange` codegen does NOT honour that: it JS-block-scopes the
+        // loop variable, so the OUTER binding is left untouched by the
+        // loop entirely. Confirmed empirically: `y = 1; for y = 1:3;
+        // disp(y); end; disp(y);` prints `1 2 3 1`, not `1 2 3 3` --
+        // reading the counter after the loop without first reassigning it
+        // silently returns the STALE pre-loop value, not the loop's true
+        // final value. (Round 3's own regression test never caught this
+        // because it always reassigns the reused name before reading it
+        // again, masking the gap.) Since this frontend has no control
+        // over the JS backend's own codegen choice, and this is a genuine
+        // silent-wrong-value hazard reachable through an entirely
+        // ordinary-looking idiom, this cut instead rejects the reuse
+        // outright -- a clean, disclosed `ScilabLowerError`, not a
+        // "supported but sometimes wrong" feature.
+        if ctx.has_local(&var) || ctx.params.contains(&var) {
+            return Err(self.err_at(
+                for_stmt,
+                format!(
+                    "unsupported: reusing an existing variable `{var}` as a for-loop counter is \
+                     out of scope for v0.1.0 (the shared JS backend's ForRange codegen \
+                     block-scopes the loop variable, so its value would not correctly persist \
+                     past the loop if read without first reassigning it)"
+                ),
+            ));
+        }
 
         let (iter_node, body_node) = match child_nodes(for_stmt).as_slice() {
             [i, _stmt_sep, b] => (*i, *b),

--- a/code/packages/rust/scilab-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/e2e_node.rs
@@ -1,0 +1,222 @@
+//! End-to-end round-trip: Scilab → SIR → JavaScript → `node`.
+//!
+//! Mirrors `matlab-to-semantic-ir/tests/e2e_node.rs`'s own harness exactly:
+//! lower a Scilab program to SIR with this crate, validate the module, emit
+//! JavaScript with the merged `semantic-ir-to-javascript` backend (a
+//! dev-dependency), write it to a temp file, and **execute it with
+//! `node`**, asserting the printed output. Every test is gated on `node`
+//! availability, matching every other `-to-semantic-ir` frontend's own
+//! e2e harness in this repo.
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use scilab_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_via_node(name: &str, src: &str) -> String {
+    let module = compile_source(src, "prog").expect("lowering should succeed");
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    let artifact =
+        semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("scilab_sir_e2e_{name}_{}.js", std::process::id()));
+    // `create_new` fails if the path already exists (including as a
+    // symlink) instead of following it -- see
+    // `matlab-to-semantic-ir/tests/e2e_node.rs`'s identical comment (a
+    // confirmed, fixed LOW-severity finding from that crate's own security
+    // review) for why this is `create_new`, not `std::fs::write`.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes())
+        .expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn a_function_over_pure_literals_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_function_over_pure_literals_runs_in_node: `node` not available");
+        return;
+    }
+    let out = run_via_node(
+        "literal_function",
+        "function r = seven()\n  r = 3 + 4;\nendfunction\ndisp(seven());\n",
+    );
+    assert_eq!(out, "7");
+}
+
+#[test]
+fn nested_literal_arithmetic_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping nested_literal_arithmetic_runs_in_node: `node` not available");
+        return;
+    }
+    let out = run_via_node("nested_literal_arithmetic", "disp(2 * 3 + 4 * 5);\n");
+    assert_eq!(out, "26");
+}
+
+#[test]
+fn a_call_before_its_textual_definition_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping a_call_before_its_textual_definition_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node(
+        "forward_reference",
+        "disp(double_seven());\nfunction r = double_seven()\n  r = 3 + 4 + 3 + 4;\nendfunction\n",
+    );
+    assert_eq!(out, "14");
+}
+
+#[test]
+fn matrix_multiplication_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping matrix_multiplication_runs_in_node: `node` not available");
+        return;
+    }
+    // A * A where A = [1 2; 3 4] -> [7 10; 15 22]. A(1, 1) (1-based) = 7.
+    let out = run_via_node("matmul", "A = [1 2; 3 4];\nB = A * A;\ndisp(B(1, 1));\n");
+    assert_eq!(out, "7");
+}
+
+#[test]
+fn elementwise_scale_with_a_bare_scalar_operand_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping elementwise_scale_with_a_bare_scalar_operand_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node(
+        "elementwise_scalar",
+        "A = [1 2; 3 4];\nB = A .* 2;\ndisp(B(2, 2));\n",
+    );
+    assert_eq!(out, "8");
+}
+
+#[test]
+fn indexed_assignment_mutates_in_place_and_reads_back_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping indexed_assignment_mutates_in_place_and_reads_back_in_node: `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node("index_set", "A = [1 2 3];\nA(2) = 9;\ndisp(A(2));\n");
+    assert_eq!(out, "9");
+}
+
+#[test]
+fn range_and_transpose_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping range_and_transpose_run_in_node: `node` not available");
+        return;
+    }
+    let out = run_via_node(
+        "range_and_transpose",
+        "A = [1 2; 3 4];\nv = 1:5;\nB = A';\ndisp(B(2, 1));\n",
+    );
+    assert_eq!(out, "2");
+}
+
+#[test]
+fn select_case_desugaring_produces_the_correct_branch_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping select_case_desugaring_produces_the_correct_branch_in_node: `node` not available"
+        );
+        return;
+    }
+    // `y` is pre-declared before the `select` -- the SIR validator scopes
+    // each branch `Block` lexically (mark/rewind around every block, per
+    // `semantic-ir/src/validator.rs`'s `check_block`), so a name that is
+    // only ever *introduced* inside a branch (`LetStarBinding`) does not
+    // survive past it, even though this frontend's own lowering-time
+    // `FunctionCtx` (matching real Scilab/MATLAB semantics) treats an
+    // `if`/`select`-introduced binding as scoped to the whole function.
+    // Pre-declaring `y` here means each branch re-*assigns* it (`Assign`,
+    // which does not introduce a new name into the validator's scope) --
+    // ordinary, idiomatic Scilab practice matches this shape too.
+    let out = run_via_node(
+        "select_case",
+        "x = 2;\ny = 0;\nselect x\n  case 1\n    y = 10;\n  case 2\n    y = 20;\n  else\n    y = 0;\nend\ndisp(y);\n",
+    );
+    assert_eq!(out, "20");
+}
+
+#[test]
+fn select_case_falls_through_to_else_when_nothing_matches_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping select_case_falls_through_to_else_when_nothing_matches_in_node: `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node(
+        "select_case_else",
+        "x = 99;\ny = 0;\nselect x\n  case 1\n    y = 10;\n  case 2\n    y = 20;\n  else\n    y = -1;\nend\ndisp(y);\n",
+    );
+    assert_eq!(out, "-1");
+}
+
+#[test]
+fn percent_pi_constant_computes_correctly_in_node() {
+    if !node_available() {
+        eprintln!("skipping percent_pi_constant_computes_correctly_in_node: `node` not available");
+        return;
+    }
+    // Observe the branch taken by an `if` rather than `disp`-ing a raw
+    // comparison result directly -- the latter would hit an unrelated,
+    // already-documented representational difference between a bare
+    // comparison's runtime JS shape and Scilab's own "logicals are
+    // doubles" convention (see `matlab-to-semantic-ir`'s own oracle tests,
+    // which take the identical precaution for the identical reason).
+    let out = run_via_node(
+        "percent_pi",
+        "if %pi > 3\n  disp(1);\nelse\n  disp(0);\nend\n",
+    );
+    assert_eq!(out, "1");
+}
+
+#[test]
+fn for_loop_accumulator_converges_in_node() {
+    if !node_available() {
+        eprintln!("skipping for_loop_accumulator_converges_in_node: `node` not available");
+        return;
+    }
+    let out = run_via_node(
+        "for_accumulator",
+        "total = 0;\nfor i = 1:10\n  total = total + i;\nend\ndisp(total);\n",
+    );
+    assert_eq!(out, "55");
+}

--- a/code/packages/rust/scilab-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/e2e_node.rs
@@ -220,3 +220,28 @@ fn for_loop_accumulator_converges_in_node() {
     );
     assert_eq!(out, "55");
 }
+
+#[test]
+fn for_loop_reusing_an_already_assigned_variable_as_the_counter_runs_in_node() {
+    // Security regression (round 3 review, a bug the round-2 `HashSet`
+    // optimization itself introduced): reusing an already-assigned
+    // variable as a `for`-loop counter -- an ordinary Scilab idiom --
+    // previously desynced `FunctionCtx::locals`/`locals_set`, so the name
+    // "forgot" it was already known once the loop's own scope rewound.
+    // The resulting JavaScript had two top-level `let y` declarations in
+    // the same scope, which `node` rejected outright with "Identifier 'y'
+    // has already been declared" -- this test would fail with that exact
+    // error if the bug were still present.
+    if !node_available() {
+        eprintln!(
+            "skipping for_loop_reusing_an_already_assigned_variable_as_the_counter_runs_in_node: \
+             `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node(
+        "for_reuses_existing_var",
+        "y = 1;\nfor y = 1:3\n  disp(y);\nend\ny = 99;\ndisp(y);\n",
+    );
+    assert_eq!(out, "1\n2\n3\n99");
+}

--- a/code/packages/rust/scilab-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/e2e_node.rs
@@ -74,6 +74,78 @@ fn a_function_over_pure_literals_runs_in_node() {
 }
 
 #[test]
+fn a_function_computing_its_output_conditionally_in_if_else_runs_in_node() {
+    // Security regression (round 4 review) -- the actual, end-to-end
+    // headline case: a function computing its own designated output
+    // variable inside `if`/`else` (arguably the single most common
+    // Scilab/MATLAB function shape there is) previously produced a
+    // module that ALWAYS failed `semantic_ir::validate` (a dangling
+    // "var-ref scope=local references unknown name" error), since the
+    // output variable's own `LetStarBinding` lived inside a branch's
+    // nested `Block`, invisible to the function's own trailing
+    // `VarRef` reading it as the return value. This is the true
+    // end-to-end proof the fix (hoisting a real pre-declaration to the
+    // enclosing scope) works: it compiles AND actually runs correctly.
+    if !node_available() {
+        eprintln!(
+            "skipping a_function_computing_its_output_conditionally_in_if_else_runs_in_node: \
+             `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node(
+        "conditional_output",
+        "function y = sign_of(x)\n  if x > 0\n    y = 1;\n  elseif x < 0\n    y = -1;\n  else\n    y = 0;\n  end\nendfunction\ndisp(sign_of(5));\ndisp(sign_of(-5));\ndisp(sign_of(0));\n",
+    );
+    assert_eq!(out, "1\n-1\n0");
+}
+
+#[test]
+fn a_while_loop_introducing_a_fresh_variable_is_visible_afterward_in_node() {
+    // Security regression (round 4 review): `lower_while` did zero scope
+    // tracking around its body at all -- a fresh variable assigned inside
+    // a `while` loop was correctly known to this crate's own lowering-time
+    // bookkeeping (no rewind ever undid it, unlike `if`/`select`'s
+    // mutually-exclusive branches or `for`'s own loop-scoped counter), but
+    // its `LetStarBinding` still lived inside the loop body's own nested
+    // `Block`, invisible to `semantic_ir::validate` from the ENCLOSING
+    // scope -- so reading it after the loop failed identically to the
+    // `if`/`else` case.
+    if !node_available() {
+        eprintln!(
+            "skipping a_while_loop_introducing_a_fresh_variable_is_visible_afterward_in_node: \
+             `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node(
+        "while_fresh_var",
+        "n = 3;\nwhile n > 0\n  doubled = n * 2;\n  n = n - 1;\nend\ndisp(doubled);\n",
+    );
+    assert_eq!(out, "2");
+}
+
+#[test]
+fn a_for_loop_body_introducing_a_fresh_non_counter_variable_is_visible_afterward_in_node() {
+    // Security regression (round 4 review): the identical hazard as the
+    // `while` case above, for a `for` loop's BODY (not its own counter
+    // variable, which already has correct, separate, loop-scoped
+    // handling) introducing a fresh name for the first time.
+    if !node_available() {
+        eprintln!(
+            "skipping a_for_loop_body_introducing_a_fresh_non_counter_variable_is_visible_afterward_in_node: \
+             `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node(
+        "for_body_fresh_var",
+        "for i = 1:3\n  last_seen = i * 10;\nend\ndisp(last_seen);\n",
+    );
+    assert_eq!(out, "30");
+}
+
+#[test]
 fn nested_literal_arithmetic_runs_in_node() {
     if !node_available() {
         eprintln!("skipping nested_literal_arithmetic_runs_in_node: `node` not available");

--- a/code/packages/rust/scilab-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/e2e_node.rs
@@ -294,26 +294,27 @@ fn for_loop_accumulator_converges_in_node() {
 }
 
 #[test]
-fn for_loop_reusing_an_already_assigned_variable_as_the_counter_runs_in_node() {
-    // Security regression (round 3 review, a bug the round-2 `HashSet`
-    // optimization itself introduced): reusing an already-assigned
-    // variable as a `for`-loop counter -- an ordinary Scilab idiom --
-    // previously desynced `FunctionCtx::locals`/`locals_set`, so the name
-    // "forgot" it was already known once the loop's own scope rewound.
-    // The resulting JavaScript had two top-level `let y` declarations in
-    // the same scope, which `node` rejected outright with "Identifier 'y'
-    // has already been declared" -- this test would fail with that exact
-    // error if the bug were still present.
-    if !node_available() {
-        eprintln!(
-            "skipping for_loop_reusing_an_already_assigned_variable_as_the_counter_runs_in_node: \
-             `node` not available"
-        );
-        return;
-    }
-    let out = run_via_node(
-        "for_reuses_existing_var",
-        "y = 1;\nfor y = 1:3\n  disp(y);\nend\ny = 99;\ndisp(y);\n",
-    );
-    assert_eq!(out, "1\n2\n3\n99");
+fn for_loop_reusing_an_already_assigned_variable_as_the_counter_is_rejected() {
+    // History: round 3 review fixed a bug where this idiom (reusing an
+    // already-assigned variable as a `for`-loop counter) produced invalid
+    // duplicate-`let` JavaScript, and added a test asserting it now ran
+    // correctly (always reassigning the reused name before reading it
+    // again). Round 5 review found that "fix" was still unsound for the
+    // more general case: the shared JS backend's `ForRange` codegen
+    // JS-block-scopes the loop variable regardless of this frontend's own
+    // "the same variable, surviving the loop" bookkeeping, so reading the
+    // reused counter after the loop WITHOUT first reassigning it silently
+    // returns the stale pre-loop value, not the loop's true final value.
+    // Confirmed directly: compiling `y = 1;\nfor y = 1:3\n  disp(y);\nend\ndisp(y);\n`
+    // and running it in `node` prints `1\n2\n3\n1`, not `1\n2\n3\n3`. Since
+    // this frontend cannot fix the JS backend's own codegen choice, this
+    // is now a clean, disclosed rejection instead of a "supported but
+    // sometimes silently wrong" feature -- see the non-node-gated
+    // `test_validator.rs` test of the identical rejection.
+    let err = scilab_to_semantic_ir::compile_source(
+        "y = 1;\nfor y = 1:3\n  disp(y);\nend\n",
+        "prog",
+    )
+    .expect_err("reusing an existing variable as a for-loop counter should be rejected");
+    assert!(err.message.contains("for-loop counter"));
 }

--- a/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
@@ -1,0 +1,813 @@
+use scilab_to_semantic_ir::compile_source;
+use semantic_ir::{ElementwiseOpKind, Expr, Function, IndexArg, Module, Stmt};
+
+fn compile_ok(src: &str) -> Module {
+    compile_source(src, "prog").unwrap_or_else(|e| panic!("expected lowering to succeed: {e}"))
+}
+
+fn main_fn(m: &Module) -> &Function {
+    m.functions.iter().find(|f| f.name == "main").expect("main function")
+}
+
+fn user_fn<'a>(m: &'a Module, name: &str) -> &'a Function {
+    m.functions
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("expected a function named `{name}`"))
+}
+
+// ── literals, assignment ────────────────────────────────────────────────
+
+#[test]
+fn integer_literal_assignment_is_a_let_star_binding() {
+    let m = compile_ok("x = 42;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { name, value, .. } => {
+            assert_eq!(name, "x");
+            assert!(matches!(value, Expr::IntLit { value: 42, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn float_literal_is_recognised_by_decimal_point() {
+    let m = compile_ok("x = 2.5;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::FloatLit { value, .. } if (*value - 2.5).abs() < 1e-9));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::Floats));
+}
+
+#[test]
+fn single_quoted_string_literal_lowers_to_str_lit() {
+    let m = compile_ok("s = 'hello';\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::StrLit { value, .. } if value == "hello"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::Strings));
+}
+
+#[test]
+fn double_quoted_string_literal_lowers_to_the_same_str_lit_shape() {
+    // MA10 §3: `'...'`/`"..."` are the SAME underlying type in Scilab,
+    // unlike modern MATLAB's char-array-vs-string-scalar split.
+    let m = compile_ok("s = \"hello\";\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::StrLit { value, .. } if value == "hello"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn reassignment_of_a_known_local_is_assign_not_let() {
+    let m = compile_ok("x = 1;\nx = 2;\n");
+    let main = main_fn(&m);
+    assert!(matches!(main.body.stmts[0], Stmt::LetStarBinding { .. }));
+    assert!(matches!(main.body.stmts[1], Stmt::Assign { .. }));
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::MutableBindings));
+}
+
+// ── arithmetic: scalar fast path vs array-domain ────────────────────────
+
+#[test]
+fn scalar_addition_of_two_literals_is_a_plain_builtin_call() {
+    let m = compile_ok("y = 1 + 2;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected a plain BuiltinCall(\"+\"), got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn addition_involving_a_variable_is_elementwise() {
+    let m = compile_ok("x = 1;\ny = x + 2;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(
+                value,
+                Expr::ElementwiseOp { op: ElementwiseOpKind::Add, .. }
+            ));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::MatrixOps));
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::ArrayColumnMajor));
+}
+
+#[test]
+fn matrix_star_between_two_variables_is_matmul() {
+    let m = compile_ok("A = [1 2; 3 4];\nB = [5 6; 7 8];\nC = A * B;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[2] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::MatMul { .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn scalar_times_matrix_broadcasts_as_elementwise() {
+    let m = compile_ok("A = [1 2; 3 4];\nB = 2 * A;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(
+                value,
+                Expr::ElementwiseOp { op: ElementwiseOpKind::Mul, .. }
+            ));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn dot_star_of_two_literals_still_takes_the_scalar_fast_path() {
+    let m = compile_ok("y = 2 .* 3;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "*"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn power_always_lowers_to_elementwise_pow() {
+    let m = compile_ok("y = 2 ^ 10;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(
+                value,
+                Expr::ElementwiseOp { op: ElementwiseOpKind::Pow, .. }
+            ));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn matrix_right_division_between_variables_is_unsupported() {
+    let err = compile_source("A = [1 2; 3 4];\nB = [1 0; 0 1];\nC = A / B;\n", "prog")
+        .expect_err("mrdivide between non-scalars should be rejected");
+    assert!(err.message.contains("mrdivide"));
+}
+
+#[test]
+fn scalar_backslash_division_is_supported() {
+    // `2 \ 10` -- Scilab's `\` reciprocal-broadcast rule: 10 / 2 = 5.
+    let m = compile_ok("y = 2 \\ 10;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "/"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn bare_backslash_between_two_matrices_is_supported_as_broadcast_division() {
+    // Deliberate divergence from matlab-to-semantic-ir (see lower.rs's
+    // module doc comment): scilab-runtime's own apply_binop treats bare
+    // `\` and `.\ ` identically (broadcast reciprocal), so this frontend
+    // does NOT reject a non-scalar bare `\` the way the MATLAB template
+    // rejects mldivide.
+    let m = compile_ok("A = [1 2; 3 4];\nB = [1 0; 0 1];\nC = A \\ B;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[2] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(
+                value,
+                Expr::ElementwiseOp { op: ElementwiseOpKind::Div, .. }
+            ));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+// ── comparisons, logical, unary ─────────────────────────────────────────
+
+#[test]
+fn equality_comparison_normalises_to_the_shared_builtin_name() {
+    let m = compile_ok("y = (1 == 2);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "="));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn not_equal_normalises_from_tilde_eq_spelling() {
+    let m = compile_ok("y = (1 ~= 2);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "!="));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn not_equal_normalises_from_the_scilab_only_angle_bracket_spelling() {
+    // `<>` -- MA10 §1 finding 6, Scilab's own second not-equal digraph.
+    let m = compile_ok("y = (1 <> 2);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "!="));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn string_equality_is_supported() {
+    let m = compile_ok("y = ('ab' == 'cd');\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "="));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn logical_and_or_lower_to_dedicated_nodes() {
+    let m = compile_ok("y = (1 && 0) || 1;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::LogicalOr { .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::ShortCircuit));
+}
+
+#[test]
+fn unary_minus_on_a_literal_constant_folds() {
+    let m = compile_ok("y = -5;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::IntLit { value: -5, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn unary_minus_on_a_variable_is_a_neg_builtin_call() {
+    let m = compile_ok("x = 5;\ny = -x;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "neg"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn logical_not_lowers_to_a_not_builtin_call_wrapping_matlab_truthy() {
+    let m = compile_ok("x = 1;\ny = ~x;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::BuiltinCall { name, args, .. } if name == "not" => {
+                assert_eq!(args.len(), 1);
+                assert!(matches!(
+                    &args[0],
+                    Expr::BuiltinCall { name, .. } if name == "matlab_truthy"
+                ));
+            }
+            other => panic!("expected a `not` BuiltinCall, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+// ── ranges, transpose, matrix literals ──────────────────────────────────
+
+#[test]
+fn matrix_literal_lowers_to_array_lit_with_correct_shape() {
+    let m = compile_ok("A = [1 2 3; 4 5 6];\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::ArrayLit { rows, .. } => {
+                assert_eq!(rows.len(), 2);
+                assert_eq!(rows[0].len(), 3);
+            }
+            other => panic!("expected ArrayLit, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::NDArrays));
+}
+
+#[test]
+fn two_operand_range_lowers_to_expr_range() {
+    let m = compile_ok("v = 1:5;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::Range { step: None, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn stepped_range_lowers_to_expr_range_with_a_step() {
+    let m = compile_ok("v = 1:2:10;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::Range { step: Some(_), .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn transpose_lowers_to_expr_transpose() {
+    let m = compile_ok("A = [1 2; 3 4];\nB = A';\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::Transpose { conjugate: true, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn dot_transpose_is_non_conjugate() {
+    let m = compile_ok("A = [1 2; 3 4];\nB = A.';\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::Transpose { conjugate: false, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+// ── indexing ─────────────────────────────────────────────────────────────
+
+#[test]
+fn one_d_index_read_shifts_to_zero_based() {
+    let m = compile_ok("A = [1 2 3];\ny = A(2);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::IndexGet { indices, .. } => {
+                assert_eq!(indices.len(), 1);
+                assert!(matches!(indices[0], IndexArg::Scalar(ref e) if matches!(**e, Expr::IntLit { value: 1, .. })));
+            }
+            other => panic!("expected IndexGet, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn two_d_index_read_with_whole_column() {
+    let m = compile_ok("A = [1 2; 3 4];\ny = A(:, 1);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::IndexGet { indices, .. } => {
+                assert_eq!(indices.len(), 2);
+                assert!(matches!(indices[0], IndexArg::Whole));
+                assert!(matches!(indices[1], IndexArg::Scalar(_)));
+            }
+            other => panic!("expected IndexGet, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn indexed_assignment_lowers_to_index_set() {
+    let m = compile_ok("A = [1 2 3];\nA(2) = 9;\n");
+    let main = main_fn(&m);
+    assert!(matches!(main.body.stmts[1], Stmt::IndexSet { .. }));
+}
+
+#[test]
+fn dollar_last_index_is_rejected() {
+    let err = compile_source("A = [1 2 3];\ny = A($);\n", "prog")
+        .expect_err("`$` should be rejected in this cut");
+    assert!(err.message.contains('$'));
+}
+
+// ── control flow: if/elseif/else ────────────────────────────────────────
+
+#[test]
+fn if_condition_wraps_in_matlab_truthy() {
+    let m = compile_ok("x = 0;\nif x\n  y = 1;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::ExprStmt {
+            expr: Expr::If { cond, .. },
+            ..
+        } => {
+            assert!(matches!(**cond, Expr::BuiltinCall { ref name, .. } if name == "matlab_truthy"));
+        }
+        other => panic!("expected ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
+fn if_elseif_else_chain_nests_correctly() {
+    let m = compile_ok(
+        "x = 5;\nif x == 1\n  y = 1;\nelseif x == 2\n  y = 2;\nelse\n  y = 3;\nend\n",
+    );
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::ExprStmt {
+            expr: Expr::If { else_branch, .. },
+            ..
+        } => {
+            // The elseif clause folds into the else branch's own value.
+            assert!(matches!(else_branch.value, Expr::If { .. }));
+        }
+        other => panic!("expected ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
+fn if_with_comma_linker_instead_of_then_lowers_the_same_way() {
+    // MA10 §3: `then`/`do` are ALTERNATIVES to a bare comma/newline, not an
+    // addition on top of it.
+    let m = compile_ok("x = 1;\nif x > 0, y = 1;\nend\n");
+    let main = main_fn(&m);
+    assert!(matches!(
+        main.body.stmts[1],
+        Stmt::ExprStmt { expr: Expr::If { .. }, .. }
+    ));
+}
+
+#[test]
+fn if_with_then_linker_lowers_the_same_way() {
+    let m = compile_ok("x = 1;\nif x > 0 then\n  y = 1;\nend\n");
+    let main = main_fn(&m);
+    assert!(matches!(
+        main.body.stmts[1],
+        Stmt::ExprStmt { expr: Expr::If { .. }, .. }
+    ));
+}
+
+// ── control flow: while / for ────────────────────────────────────────────
+
+#[test]
+fn while_loop_lowers_to_stmt_while() {
+    let m = compile_ok("x = 5;\nwhile x > 0\n  x = x - 1;\nend\n");
+    let main = main_fn(&m);
+    assert!(matches!(main.body.stmts[1], Stmt::While { .. }));
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::Loops));
+}
+
+#[test]
+fn while_with_do_linker_lowers_the_same_way() {
+    let m = compile_ok("x = 5;\nwhile x > 0 do\n  x = x - 1;\nend\n");
+    let main = main_fn(&m);
+    assert!(matches!(main.body.stmts[1], Stmt::While { .. }));
+}
+
+#[test]
+fn for_over_a_unit_step_range_lowers_to_for_range() {
+    let m = compile_ok("total = 0;\nfor i = 1:10\n  total = total + i;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::ForRange { var, .. } => assert_eq!(var, "i"),
+        other => panic!("expected ForRange, got {other:?}"),
+    }
+}
+
+#[test]
+fn stepped_for_loop_is_rejected() {
+    let err = compile_source("for i = 1:2:10\n  y = i;\nend\n", "prog")
+        .expect_err("stepped for-loop ranges should be rejected in v0.1.0");
+    assert!(err.message.contains("stepped"));
+}
+
+#[test]
+fn break_is_rejected() {
+    let err = compile_source("while 1\n  break;\nend\n", "prog")
+        .expect_err("`break` should be rejected (no SIR early-exit node)");
+    assert!(err.message.contains("break"));
+}
+
+#[test]
+fn continue_is_rejected() {
+    let err = compile_source("while 1\n  continue;\nend\n", "prog")
+        .expect_err("`continue` should be rejected (no SIR early-exit node)");
+    assert!(err.message.contains("continue"));
+}
+
+// ── select/case: desugared into a nested if-chain ───────────────────────
+
+#[test]
+fn select_case_desugars_into_a_temp_binding_and_an_if_chain() {
+    let m = compile_ok(
+        "x = 2;\nselect x\n  case 1\n    y = 10;\n  case 2\n    y = 20;\n  else\n    y = 0;\nend\n",
+    );
+    let main = main_fn(&m);
+    // stmts[1] is the hoisted selector temp binding.
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { name, .. } => assert!(name.starts_with("__select_")),
+        other => panic!("expected the hoisted selector LetStarBinding, got {other:?}"),
+    }
+    // stmts[2] is the desugared if-chain.
+    match &main.body.stmts[2] {
+        Stmt::ExprStmt {
+            expr: Expr::If { cond, .. },
+            ..
+        } => {
+            // cond is `matlab_truthy(BuiltinCall("=", [temp, case_value]))`.
+            match &**cond {
+                Expr::BuiltinCall { name, args, .. } if name == "matlab_truthy" => {
+                    assert!(matches!(args[0], Expr::BuiltinCall { ref name, .. } if name == "="));
+                }
+                other => panic!("expected matlab_truthy(...), got {other:?}"),
+            }
+        }
+        other => panic!("expected ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
+fn select_evaluates_the_selector_exactly_once() {
+    // Two `select` statements in the same function must not collide on the
+    // hoisted temp name.
+    let m = compile_ok(
+        "x = 1;\nselect x\n  case 1\n    y = 1;\nend\nselect x\n  case 1\n    z = 1;\nend\n",
+    );
+    let main = main_fn(&m);
+    let mut temp_names = Vec::new();
+    for stmt in &main.body.stmts {
+        if let Stmt::LetStarBinding { name, .. } = stmt {
+            if name.starts_with("__select_") {
+                temp_names.push(name.clone());
+            }
+        }
+    }
+    assert_eq!(temp_names.len(), 2);
+    assert_ne!(temp_names[0], temp_names[1]);
+}
+
+#[test]
+fn select_without_a_matching_case_or_else_still_validates() {
+    let m = compile_ok("x = 5;\nselect x\n  case 1\n    y = 1;\nend\n");
+    let report = semantic_ir::validate(&m);
+    assert!(report.is_ok(), "issues: {:?}", report.issues);
+}
+
+// ── %-constants: constant-folded ─────────────────────────────────────────
+
+#[test]
+fn percent_pi_constant_folds_to_a_float_lit() {
+    let m = compile_ok("y = %pi;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::FloatLit { value, .. } if (*value - std::f64::consts::PI).abs() < 1e-12));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn percent_e_constant_folds_to_a_float_lit() {
+    let m = compile_ok("y = %e;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::FloatLit { value, .. } if (*value - std::f64::consts::E).abs() < 1e-12));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn percent_inf_and_nan_fold_correctly() {
+    let m = compile_ok("a = %inf;\nb = %nan;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::FloatLit { value, .. } if value.is_infinite()));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::FloatLit { value, .. } if value.is_nan()));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn percent_t_and_f_fold_to_int_lits_one_and_zero() {
+    let m = compile_ok("a = %t;\nb = %f;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => assert!(matches!(value, Expr::IntLit { value: 1, .. })),
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => assert!(matches!(value, Expr::IntLit { value: 0, .. })),
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn percent_i_is_rejected_as_an_unsupported_complex_number() {
+    let err = compile_source("y = %i;\n", "prog").expect_err("%i should be rejected");
+    assert!(err.message.contains("%i"));
+    assert!(err.message.to_lowercase().contains("complex"));
+}
+
+// ── functions ─────────────────────────────────────────────────────────────
+
+#[test]
+fn single_output_function_definition_and_call() {
+    let m = compile_ok(
+        "function r = seven()\n  r = 3 + 4;\nendfunction\ndisp(seven());\n",
+    );
+    let f = user_fn(&m, "seven");
+    assert!(matches!(f.body.value, Expr::VarRef { .. }));
+}
+
+#[test]
+fn zero_output_function_bare_form_has_a_nil_body_value() {
+    let m = compile_ok("function greet()\n  disp(1);\nendfunction\ngreet();\n");
+    let f = user_fn(&m, "greet");
+    assert!(matches!(f.body.value, Expr::NilLit { .. }));
+}
+
+#[test]
+fn zero_output_function_explicit_empty_bracket_form_is_also_zero_output() {
+    // `function [] = greet(...) ... endfunction` -- MA10's own
+    // register_function doc comment: "leaves `returns` empty, which is
+    // exactly correct."
+    let m = compile_ok("function [] = greet()\n  disp(1);\nendfunction\ngreet();\n");
+    let f = user_fn(&m, "greet");
+    assert!(matches!(f.body.value, Expr::NilLit { .. }));
+}
+
+#[test]
+fn single_name_in_brackets_is_still_single_output_not_multi() {
+    // `function [y] = f(x)` -- a name_list of length exactly 1 is
+    // single-output, not the multi-output shape.
+    let m = compile_ok("function [y] = f(x)\n  y = x + 1;\nendfunction\ndisp(f(1));\n");
+    let f = user_fn(&m, "f");
+    assert!(matches!(&f.body.value, Expr::VarRef { name, .. } if name == "y"));
+}
+
+#[test]
+fn multi_output_function_is_rejected() {
+    let err = compile_source(
+        "function [a, b] = both(x)\n  a = x;\n  b = x;\nendfunction\n",
+        "prog",
+    )
+    .expect_err("multi-output functions are out of scope for v0.1.0");
+    assert!(err.message.contains("multiple output"));
+}
+
+#[test]
+fn call_before_textual_definition_resolves_via_two_pass_collection() {
+    let m = compile_ok("disp(double_seven());\nfunction r = double_seven()\n  r = 3 + 4 + 3 + 4;\nendfunction\n");
+    let main = main_fn(&m);
+    assert!(matches!(
+        &main.body.stmts[0],
+        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "print"
+    ));
+}
+
+#[test]
+fn disp_maps_onto_the_shared_print_builtin() {
+    let m = compile_ok("disp(5);\n");
+    let main = main_fn(&m);
+    assert!(matches!(
+        &main.body.stmts[0],
+        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, .. }, .. } if name == "print"
+    ));
+}
+
+#[test]
+fn unknown_identifier_call_is_rejected() {
+    let err = compile_source("y = zeros(3);\n", "prog")
+        .expect_err("only `disp` is a recognised builtin in this cut");
+    assert!(err.message.contains("zeros"));
+}
+
+// ── scope limits: string operators, cell arrays, chained assignment, etc ──
+
+#[test]
+fn addition_over_a_direct_string_literal_operand_is_rejected() {
+    let err = compile_source("y = 'ab' + 1;\n", "prog")
+        .expect_err("no arithmetic over string literals in this cut");
+    assert!(err.message.to_lowercase().contains("string"));
+}
+
+#[test]
+fn ordering_comparison_over_a_direct_string_literal_is_rejected() {
+    let err = compile_source("y = ('ab' < 'cd');\n", "prog")
+        .expect_err("no ordering comparison over string literals in this cut");
+    assert!(err.message.to_lowercase().contains("string"));
+}
+
+#[test]
+fn cell_literal_is_rejected() {
+    let err = compile_source("c = {1, 2, 3};\n", "prog")
+        .expect_err("cell arrays are out of scope for v0.1.0");
+    assert!(err.message.to_lowercase().contains("cell"));
+}
+
+#[test]
+fn field_access_is_rejected() {
+    let err = compile_source("A = [1 2 3];\ny = A.field;\n", "prog")
+        .expect_err("field access is out of scope for v0.1.0");
+    assert!(err.message.contains("field_suffix"));
+}
+
+#[test]
+fn chained_assignment_is_rejected() {
+    let err = compile_source("a = b = 3;\n", "prog")
+        .expect_err("chained assignment is out of scope for v0.1.0");
+    assert!(err.message.contains("chained"));
+}
+
+#[test]
+fn nested_function_definition_is_rejected() {
+    let err = compile_source(
+        "function r = outer()\n  function s = inner()\n    s = 1;\n  endfunction\n  r = 1;\nendfunction\n",
+        "prog",
+    )
+    .expect_err("nested function definitions are out of scope for v0.1.0");
+    assert!(err.message.contains("nested"));
+}
+
+#[test]
+fn indexed_assignment_into_an_undeclared_variable_is_rejected() {
+    let err = compile_source("A(1) = 5;\n", "prog")
+        .expect_err("auto-vivification is out of scope for v0.1.0");
+    assert!(err.message.to_lowercase().contains("auto-vivification"));
+}
+
+// ── DoS-guard regressions: long flat operator chains ────────────────────
+
+#[test]
+fn a_pathologically_long_flat_additive_chain_is_cleanly_rejected() {
+    let mut src = String::from("y = 1");
+    for _ in 0..100_000 {
+        src.push_str(" + 1");
+    }
+    src.push_str(";\n");
+    let err = compile_source(&src, "prog").expect_err("an overlong chain should be rejected");
+    assert!(err.message.contains("too long"));
+}
+
+#[test]
+fn a_pathologically_long_flat_multiplicative_chain_is_cleanly_rejected() {
+    let mut src = String::from("y = 1");
+    for _ in 0..100_000 {
+        src.push_str(" * 1");
+    }
+    src.push_str(";\n");
+    let err = compile_source(&src, "prog").expect_err("an overlong chain should be rejected");
+    assert!(err.message.contains("too long"));
+}

--- a/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
@@ -906,3 +906,26 @@ fn a_pathologically_long_case_chain_is_cleanly_rejected() {
     let err = compile_source(&src, "prog").expect_err("an overlong case chain should be rejected");
     assert!(err.message.contains("too many case clauses"));
 }
+
+#[test]
+fn a_pathologically_long_transpose_suffix_chain_is_cleanly_rejected() {
+    // Security regression: `postfix = primary { transpose_suffix |
+    // call_suffix | ... }` is the identical flat CST repetition as
+    // elseif/case above -- found independently in a second security
+    // review round after the elseif/case fix above had already landed.
+    // `lower_postfix` folded the suffix list into a `Box`-nested
+    // `Expr::Transpose`/`Expr::IndexGet` chain with NO cap at all (unlike
+    // every operator-chain fold in this file, which calls
+    // `check_chain_length` first); a source file with enough chained `'`
+    // transpose suffixes compiled successfully, but merely dropping the
+    // returned `Module` overflowed the native stack and aborted the
+    // process (uncatchable).
+    let mut src = String::from("y = x");
+    for _ in 0..100_000 {
+        src.push('\'');
+    }
+    src.push_str(";\n");
+    let err =
+        compile_source(&src, "prog").expect_err("an overlong transpose suffix chain should be rejected");
+    assert!(err.message.contains("too long"));
+}

--- a/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
@@ -438,7 +438,9 @@ fn dollar_last_index_is_rejected() {
 fn if_condition_wraps_in_matlab_truthy() {
     let m = compile_ok("x = 0;\nif x\n  y = 1;\nend\n");
     let main = main_fn(&m);
-    match &main.body.stmts[1] {
+    // stmts[1] is the hoisted pre-declaration of `y` (round 4 review);
+    // the `if` itself is at stmts[2].
+    match &main.body.stmts[2] {
         Stmt::ExprStmt {
             expr: Expr::If { cond, .. },
             ..
@@ -455,7 +457,9 @@ fn if_elseif_else_chain_nests_correctly() {
         "x = 5;\nif x == 1\n  y = 1;\nelseif x == 2\n  y = 2;\nelse\n  y = 3;\nend\n",
     );
     let main = main_fn(&m);
-    match &main.body.stmts[1] {
+    // stmts[1] is the hoisted pre-declaration of `y` (round 4 review);
+    // the `if` itself is at stmts[2].
+    match &main.body.stmts[2] {
         Stmt::ExprStmt {
             expr: Expr::If { else_branch, .. },
             ..
@@ -469,33 +473,53 @@ fn if_elseif_else_chain_nests_correctly() {
 
 #[test]
 fn if_and_else_both_first_assigning_the_same_new_variable_both_declare_it() {
-    // Regression: `if`/`else` are mutually exclusive -- at most one of them
-    // ever actually runs -- but were previously lowered against a SHARED,
-    // still-mutating `ctx.locals`, so whichever branch happened to lower
-    // second saw the name already "known" (added by its sibling) and was
-    // misclassified as a re-assignment (`Stmt::Assign`) instead of a first
-    // declaration (`Stmt::LetStarBinding`) -- even though, on that branch's
-    // own actual runtime path, no `LetStarBinding` for the name ever
-    // executes. This is the single most ordinary Scilab/MATLAB idiom there
-    // is (a function assigning its own output variable in every branch),
-    // and it previously failed `semantic_ir::validate` outright (a
-    // dangling `var-ref scope=local references unknown name` error) for
-    // any such function whose `if` arm lowered second. Both branches must
-    // independently see `y` as new.
-    let m = compile_ok("x = 1;\nif x == 1\n  y = 1;\nelse\n  y = 2;\nend\n");
-    let main = main_fn(&m);
+    // Regression (security review round 4): `if`/`else` are mutually
+    // exclusive -- at most one of them ever actually runs -- and a name
+    // first assigned inside them (a function's own output variable,
+    // computed conditionally, is by far the most common real-world case)
+    // must be visible to code AFTER the `if`, not just inside it.
+    // `semantic_ir::validate` scopes each `Block` (an `If`'s own branches
+    // included) independently, so a `LetStarBinding` NESTED inside a
+    // branch's own block does NOT, on its own, make the name visible
+    // outside it -- an earlier fix (round 1) only corrected this crate's
+    // OWN lowering-time bookkeeping (so each branch's occurrence
+    // classified consistently as `Assign`), without ever emitting an
+    // actual enclosing-scope declaration, so `semantic_ir::validate` still
+    // rejected any code that read the variable after the `if` (or, as
+    // here, the function's own designated-output-variable mechanism
+    // implicitly reading it as the function's return value) with a
+    // dangling "var-ref scope=local references unknown name" error. Fixed
+    // by hoisting a real pre-declaration (`Stmt::LetStarBinding` with a
+    // placeholder `Expr::NilLit`) to the ENCLOSING scope, before the `if`
+    // itself, so every branch's own first occurrence lowers as
+    // `Stmt::Assign` against a genuine declaration, not a fake one -- see
+    // `hoist_assigned_names`'s own doc comment for the full design.
+    let m = compile_ok(
+        "function y = f(x)\n  if x == 1\n    y = 1;\n  else\n    y = 2;\n  end\nendfunction\n",
+    );
     let report = semantic_ir::validate(&m);
     assert!(report.is_ok(), "module should validate cleanly: {:?}", report.issues);
-    match &main.body.stmts[1] {
+    let f = user_fn(&m, "f");
+    // stmts[0] is the hoisted pre-declaration of `y`.
+    assert!(matches!(
+        f.body.stmts[0],
+        Stmt::LetStarBinding { value: Expr::NilLit { .. }, .. }
+    ));
+    // stmts[1] is the desugared if/else; both branches now Assign into
+    // the already-hoisted `y`, not LetStarBinding a second, nested copy.
+    match &f.body.stmts[1] {
         Stmt::ExprStmt {
             expr: Expr::If { then_branch, else_branch, .. },
             ..
         } => {
-            assert!(matches!(then_branch.stmts[0], Stmt::LetStarBinding { .. }));
-            assert!(matches!(else_branch.stmts[0], Stmt::LetStarBinding { .. }));
+            assert!(matches!(then_branch.stmts[0], Stmt::Assign { .. }));
+            assert!(matches!(else_branch.stmts[0], Stmt::Assign { .. }));
         }
         other => panic!("expected ExprStmt(If), got {other:?}"),
     }
+    // The function's own trailing value (a VarRef to `y`) is exactly what
+    // this fix makes resolvable.
+    assert!(matches!(f.body.value, Expr::VarRef { ref name, .. } if name == "y"));
 }
 
 #[test]
@@ -504,8 +528,9 @@ fn if_with_comma_linker_instead_of_then_lowers_the_same_way() {
     // addition on top of it.
     let m = compile_ok("x = 1;\nif x > 0, y = 1;\nend\n");
     let main = main_fn(&m);
+    // stmts[1] is the hoisted pre-declaration of `y` (round 4 review).
     assert!(matches!(
-        main.body.stmts[1],
+        main.body.stmts[2],
         Stmt::ExprStmt { expr: Expr::If { .. }, .. }
     ));
 }
@@ -514,8 +539,9 @@ fn if_with_comma_linker_instead_of_then_lowers_the_same_way() {
 fn if_with_then_linker_lowers_the_same_way() {
     let m = compile_ok("x = 1;\nif x > 0 then\n  y = 1;\nend\n");
     let main = main_fn(&m);
+    // stmts[1] is the hoisted pre-declaration of `y` (round 4 review).
     assert!(matches!(
-        main.body.stmts[1],
+        main.body.stmts[2],
         Stmt::ExprStmt { expr: Expr::If { .. }, .. }
     ));
 }
@@ -581,8 +607,10 @@ fn select_case_desugars_into_a_temp_binding_and_an_if_chain() {
         Stmt::LetStarBinding { name, .. } => assert!(name.starts_with("$select_")),
         other => panic!("expected the hoisted selector LetStarBinding, got {other:?}"),
     }
-    // stmts[2] is the desugared if-chain.
-    match &main.body.stmts[2] {
+    // stmts[2] is the hoisted pre-declaration of `y` (round 4 review,
+    // since every case/else branch assigns it fresh); the desugared
+    // if-chain itself is at stmts[3].
+    match &main.body.stmts[3] {
         Stmt::ExprStmt {
             expr: Expr::If { cond, .. },
             ..

--- a/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/test_lower.rs
@@ -468,6 +468,37 @@ fn if_elseif_else_chain_nests_correctly() {
 }
 
 #[test]
+fn if_and_else_both_first_assigning_the_same_new_variable_both_declare_it() {
+    // Regression: `if`/`else` are mutually exclusive -- at most one of them
+    // ever actually runs -- but were previously lowered against a SHARED,
+    // still-mutating `ctx.locals`, so whichever branch happened to lower
+    // second saw the name already "known" (added by its sibling) and was
+    // misclassified as a re-assignment (`Stmt::Assign`) instead of a first
+    // declaration (`Stmt::LetStarBinding`) -- even though, on that branch's
+    // own actual runtime path, no `LetStarBinding` for the name ever
+    // executes. This is the single most ordinary Scilab/MATLAB idiom there
+    // is (a function assigning its own output variable in every branch),
+    // and it previously failed `semantic_ir::validate` outright (a
+    // dangling `var-ref scope=local references unknown name` error) for
+    // any such function whose `if` arm lowered second. Both branches must
+    // independently see `y` as new.
+    let m = compile_ok("x = 1;\nif x == 1\n  y = 1;\nelse\n  y = 2;\nend\n");
+    let main = main_fn(&m);
+    let report = semantic_ir::validate(&m);
+    assert!(report.is_ok(), "module should validate cleanly: {:?}", report.issues);
+    match &main.body.stmts[1] {
+        Stmt::ExprStmt {
+            expr: Expr::If { then_branch, else_branch, .. },
+            ..
+        } => {
+            assert!(matches!(then_branch.stmts[0], Stmt::LetStarBinding { .. }));
+            assert!(matches!(else_branch.stmts[0], Stmt::LetStarBinding { .. }));
+        }
+        other => panic!("expected ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
 fn if_with_comma_linker_instead_of_then_lowers_the_same_way() {
     // MA10 §3: `then`/`do` are ALTERNATIVES to a bare comma/newline, not an
     // addition on top of it.
@@ -547,7 +578,7 @@ fn select_case_desugars_into_a_temp_binding_and_an_if_chain() {
     let main = main_fn(&m);
     // stmts[1] is the hoisted selector temp binding.
     match &main.body.stmts[1] {
-        Stmt::LetStarBinding { name, .. } => assert!(name.starts_with("__select_")),
+        Stmt::LetStarBinding { name, .. } => assert!(name.starts_with("$select_")),
         other => panic!("expected the hoisted selector LetStarBinding, got {other:?}"),
     }
     // stmts[2] is the desugared if-chain.
@@ -579,7 +610,7 @@ fn select_evaluates_the_selector_exactly_once() {
     let mut temp_names = Vec::new();
     for stmt in &main.body.stmts {
         if let Stmt::LetStarBinding { name, .. } = stmt {
-            if name.starts_with("__select_") {
+            if name.starts_with("$select_") {
                 temp_names.push(name.clone());
             }
         }
@@ -593,6 +624,35 @@ fn select_without_a_matching_case_or_else_still_validates() {
     let m = compile_ok("x = 5;\nselect x\n  case 1\n    y = 1;\nend\n");
     let report = semantic_ir::validate(&m);
     assert!(report.is_ok(), "issues: {:?}", report.issues);
+}
+
+#[test]
+fn select_case_and_else_both_first_assigning_the_same_new_variable_both_declare_it() {
+    // Regression: the identical `if`/`else` branch-locals-ordering bug (see
+    // `if_and_else_both_first_assigning_the_same_new_variable_both_declare_it`),
+    // for `select`/`case`/`else`.
+    let m = compile_ok("x = 1;\nselect x\n  case 1\n    y = 1;\n  else\n    y = 2;\nend\n");
+    let report = semantic_ir::validate(&m);
+    assert!(report.is_ok(), "module should validate cleanly: {:?}", report.issues);
+}
+
+#[test]
+fn a_user_variable_literally_named_dunder_select_0_cannot_collide_with_the_hoisted_temp() {
+    // Security regression: the hoisted selector temp used to be named
+    // `__select_N` -- an ordinary, fully legal Scilab identifier a program
+    // could itself declare, which would silently merge the compiler's
+    // hoisted selector with an unrelated user variable of the same name
+    // (confirmed to produce invalid, duplicate-declaration JavaScript from
+    // the JS backend). The temp is now named `$select_N`; `$` is never
+    // part of a Scilab `NAME` token (it lexes as the unrelated `DOLLAR`
+    // token), so a user variable named `__select_0` -- the exact string
+    // the OLD scheme could have collided on -- must lower and validate
+    // without any interference.
+    let m = compile_ok(
+        "function y = f(x)\n  __select_0 = 99;\n  y = 0;\n  select x\n    case 1\n      y = 1;\n  end\nendfunction\n",
+    );
+    let report = semantic_ir::validate(&m);
+    assert!(report.is_ok(), "module should validate cleanly: {:?}", report.issues);
 }
 
 // ── %-constants: constant-folded ─────────────────────────────────────────
@@ -810,4 +870,39 @@ fn a_pathologically_long_flat_multiplicative_chain_is_cleanly_rejected() {
     src.push_str(";\n");
     let err = compile_source(&src, "prog").expect_err("an overlong chain should be rejected");
     assert!(err.message.contains("too long"));
+}
+
+#[test]
+fn a_pathologically_long_elseif_chain_is_cleanly_rejected() {
+    // Security regression: `elseif_clause*` is a flat CST repetition, so N
+    // `elseif`s cost the parser zero native stack but previously folded
+    // into an `Expr::If` chain N levels deep -- deep enough that merely
+    // dropping the returned `Module` overflowed the native stack and
+    // aborted the process (uncatchable). Must now be a clean error well
+    // before that. (5,000 -- ~20x `MAX_EXPR_DEPTH` -- rather than this
+    // file's usual 100,000: `scilab-parser`'s own `elseif_clause*` parsing
+    // has been separately found to scale worse than linearly at very large
+    // clause counts, tracked as its own follow-up task; 5,000 is still a
+    // generous margin over the cap without that unrelated slowdown making
+    // this single test dominate the suite's runtime.)
+    let mut src = String::from("if x == 0\n  y = 1;\n");
+    for _ in 0..5_000 {
+        src.push_str("elseif x == 0\n  y = 1;\n");
+    }
+    src.push_str("end\n");
+    let err = compile_source(&src, "prog").expect_err("an overlong elseif chain should be rejected");
+    assert!(err.message.contains("too many elseif clauses"));
+}
+
+#[test]
+fn a_pathologically_long_case_chain_is_cleanly_rejected() {
+    // Security regression: the identical hazard as the elseif chain above,
+    // for `case_clause*` inside `select`.
+    let mut src = String::from("x = 0;\nselect x\n");
+    for _ in 0..100_000 {
+        src.push_str("case 0\n  y = 1;\n");
+    }
+    src.push_str("end\n");
+    let err = compile_source(&src, "prog").expect_err("an overlong case chain should be rejected");
+    assert!(err.message.contains("too many case clauses"));
 }

--- a/code/packages/rust/scilab-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/test_validator.rs
@@ -1,0 +1,153 @@
+//! Structural verification of lowered modules: every module this frontend
+//! produces must pass the shared SIR validator, and any module using the
+//! SIR22 array/matrix domain must be correctly *accepted* by the
+//! `semantic-ir-to-javascript` backend -- mirroring
+//! `matlab-to-semantic-ir/tests/test_validator.rs`'s own capability-
+//! acceptance verification pattern exactly (a real `Module`, checked
+//! through the actual `Backend::check_module` path, not an isolated unit
+//! assertion).
+
+use scilab_to_semantic_ir::compile_source;
+use semantic_ir::backend::Backend;
+use semantic_ir_to_javascript::JavaScriptBackend;
+
+fn assert_valid(src: &str) -> semantic_ir::Module {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for `{src}`: {:?}",
+        report.issues
+    );
+    module
+}
+
+#[test]
+fn a_purely_literal_program_validates_and_the_js_backend_accepts_it() {
+    let module = assert_valid("function r = seven()\n  r = 3 + 4;\nendfunction\ndisp(seven());\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a purely-literal module, got: {errors:?}"
+    );
+}
+
+#[test]
+fn a_float_literal_program_validates_and_declares_floats() {
+    let module = assert_valid("y = 1.5;\ndisp(y);\n");
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::Floats));
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a purely-literal float module, got: {errors:?}"
+    );
+}
+
+#[test]
+fn a_string_literal_program_declares_strings_and_the_js_backend_accepts_it() {
+    let module = assert_valid("s = 'hello';\ndisp(s);\n");
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::Strings));
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a module using a string literal, got: {errors:?}"
+    );
+}
+
+#[test]
+fn a_logical_and_program_validates_and_declares_short_circuit() {
+    let module = assert_valid("x = 5;\ny = 10;\nif x > 3 && y > 5\n  disp(1);\nend\n");
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::ShortCircuit));
+}
+
+#[test]
+fn control_flow_with_a_variable_accumulator_validates_but_needs_array_features() {
+    let module = assert_valid(
+        "total = 0;\nfor i = 1:10\n  if i > 5\n    total = total + i;\n  end\nend\ndisp(total);\n",
+    );
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::MatrixOps));
+}
+
+#[test]
+fn a_matrix_program_validates_and_the_js_backend_accepts_it() {
+    let module = assert_valid("A = [1 2; 3 4];\nB = A * A;\ndisp(B);\n");
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::MatrixOps));
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a module using SIR22 array/matrix features, got: {errors:?}"
+    );
+}
+
+#[test]
+fn an_indexing_program_validates_and_the_js_backend_accepts_it() {
+    let module = assert_valid("A = [1 2 3];\nA(2) = 9;\ndisp(A(2));\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a module using IndexGet/IndexSet, got: {errors:?}"
+    );
+}
+
+#[test]
+fn a_range_and_transpose_program_validates_and_the_js_backend_accepts_it() {
+    let module = assert_valid("A = [1 2; 3 4];\nv = 1:5;\nB = A';\ndisp(B);\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a module using Range/Transpose, got: {errors:?}"
+    );
+}
+
+#[test]
+fn a_select_case_program_desugars_to_valid_if_chain_and_validates() {
+    // `y` is pre-declared before the `select` so each branch re-*assigns*
+    // it rather than introducing it -- see `tests/e2e_node.rs`'s identical
+    // comment on why a branch-local `LetStarBinding` does not survive the
+    // SIR validator's own lexical block scoping.
+    let module = assert_valid(
+        "x = 2;\ny = 0;\nselect x\n  case 1\n    y = 10;\n  case 2\n    y = 20;\n  else\n    y = 0;\nend\ndisp(y);\n",
+    );
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a desugared select/case module, got: {errors:?}"
+    );
+}
+
+#[test]
+fn a_percent_constant_program_validates_and_the_js_backend_accepts_it() {
+    let module = assert_valid("y = %pi * 2;\ndisp(y);\n");
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::Floats));
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a module using a %-constant, got: {errors:?}"
+    );
+}

--- a/code/packages/rust/scilab-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/test_validator.rs
@@ -151,3 +151,19 @@ fn a_percent_constant_program_validates_and_the_js_backend_accepts_it() {
         "expected the JS backend to accept a module using a %-constant, got: {errors:?}"
     );
 }
+
+#[test]
+fn for_loop_reusing_an_already_assigned_variable_validates_and_the_js_backend_accepts_it() {
+    // Non-node-gated backstop for the identical e2e regression in
+    // `tests/e2e_node.rs` (round 3 review): reusing an already-assigned
+    // variable as a `for`-loop counter must validate cleanly and the JS
+    // backend must accept it, regardless of whether `node` is available
+    // in the environment running this test.
+    let module = assert_valid("y = 1;\nfor y = 1:3\n  disp(y);\nend\ny = 99;\ndisp(y);\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a for-loop reusing an existing variable, got: {errors:?}"
+    );
+}

--- a/code/packages/rust/scilab-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/test_validator.rs
@@ -153,17 +153,20 @@ fn a_percent_constant_program_validates_and_the_js_backend_accepts_it() {
 }
 
 #[test]
-fn for_loop_reusing_an_already_assigned_variable_validates_and_the_js_backend_accepts_it() {
-    // Non-node-gated backstop for the identical e2e regression in
-    // `tests/e2e_node.rs` (round 3 review): reusing an already-assigned
-    // variable as a `for`-loop counter must validate cleanly and the JS
-    // backend must accept it, regardless of whether `node` is available
-    // in the environment running this test.
-    let module = assert_valid("y = 1;\nfor y = 1:3\n  disp(y);\nend\ny = 99;\ndisp(y);\n");
-    let backend = JavaScriptBackend;
-    let errors = backend.check_module(&module);
-    assert!(
-        errors.is_empty(),
-        "expected the JS backend to accept a for-loop reusing an existing variable, got: {errors:?}"
-    );
+fn for_loop_reusing_an_already_assigned_variable_as_the_counter_is_rejected() {
+    // Round 3 review had this idiom lowering "successfully" (validating
+    // and JS-backend-accepting). Round 5 review found that was actually
+    // UNSOUND: the shared `semantic-ir-to-javascript` backend's
+    // `ForRange` codegen JS-block-scopes the loop variable, so reading a
+    // reused counter after the loop WITHOUT first reassigning it silently
+    // returns the stale pre-loop value, not the loop's true final value
+    // (confirmed via `node`: prints the pre-loop value, not the
+    // post-loop one). Round 3's own test masked this by always
+    // reassigning before reading. Since this frontend has no control over
+    // the JS backend's codegen choice, this is now a clean, disclosed
+    // rejection instead of a "supported but sometimes silently wrong"
+    // feature.
+    let err = compile_source("y = 1;\nfor y = 1:3\n  disp(y);\nend\n", "prog")
+        .expect_err("reusing an existing variable as a for-loop counter should be rejected");
+    assert!(err.message.contains("for-loop counter"));
 }

--- a/code/specs/MA10-scilab-language.md
+++ b/code/specs/MA10-scilab-language.md
@@ -448,7 +448,32 @@ scilab-to-semantic-ir/  src/{lib.rs, lower.rs}       ← MA-10e
 - **MA-10e — `scilab-to-semantic-ir`**, built alongside per `HML01` §2 /
   MA06's own precedent (§5) — `compile`/`compile_source` lowering
   `scilab-parser`'s CST into a `semantic_ir::Module` over the shared
-  SIR22 array/matrix domain.
+  SIR22 array/matrix domain. **Done** — this item's own three predictions
+  (§5) all held exactly as stated: the `stmt_sep` linker keyword needed no
+  SIR representation (it collapses to child-node position by lowering
+  time), `select`/`case` needed no new node (desugared into a nested
+  `if`-chain over a once-evaluated, hoisted selector temporary, mirroring
+  `scilab-runtime::eval::eval_select`), and the eight `%`-prefixed
+  constants were constant-folded directly into `IntLit`/`FloatLit` rather
+  than needing a dedicated node. No new `semantic-ir` core `Expr`/
+  `SirType`/`Feature` variant was added. Three implementation-level
+  refinements below this spec's own level of detail, each traceable to a
+  concrete finding rather than a change to this spec's architectural
+  decisions (full rationale in `scilab-to-semantic-ir/CHANGELOG.md`): (1)
+  `\`/`.\ ` lower *uniformly* as a broadcast reciprocal division,
+  diverging from `matlab-to-semantic-ir`'s own asymmetric `\`-vs-`.\ `
+  template, because `scilab-runtime::eval::apply_binop` — this repo's
+  actual ground-truth Scilab interpreter — already makes exactly that
+  simplification for both spellings; (2) every arithmetic/ordering
+  operator rejects a directly-written string-literal operand, closing a
+  gap the MATLAB template's own scalar/array heuristic leaves open, given
+  §1 finding 1's own concern is precisely about a string reaching such an
+  operator unnoticed; (3) `func_returns` parsing distinguishes single-
+  output, explicit-bracket single-output (`[y] = f(...)`), and explicit
+  zero-output (`[] = f(...)`) from a genuine multi-output name list,
+  mirroring `scilab-runtime::eval::Interpreter::register_function`'s own
+  more complete reading of this grammar shape rather than the MATLAB
+  template's coarser one.
 - **Next**: K/Q or IDL per
   [`HML00`](HML00-historical-math-languages-roadmap.md) Wave 6 — each gets
   its own fresh substrate/grammar-gap analysis, not a rubber stamp, the same


### PR DESCRIPTION
## Summary

Implements **MA-10e**, the last item in the Scilab frontend rollout per `code/specs/MA10-scilab-language.md` §6: `scilab-to-semantic-ir`, an ahead-of-time compiler pass lowering `scilab-parser`'s CST into a `semantic_ir::Module` over the shared SIR22 array/matrix domain — built alongside `scilab-runtime`/`scilab-repl` (merged in #8693) per `HML01` §2's "every math language gets a `-to-semantic-ir` frontend" convention.

Closely mirrors `matlab-to-semantic-ir` (the closest architectural sibling — same array/`Num`-first value model), reusing the existing SIR22 vocabulary (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`) with **no new `semantic-ir` core variant needed** — all three of MA10 §5's own predictions held: the `stmt_sep` linker needs no SIR node, `select`/`case` desugars into a nested `if`-chain with no new node, and the eight `%`-constants constant-fold directly into `IntLit`/`FloatLit`.

## Security review — 5 rounds, converged

This is an unusually deep review chain; documenting all of it since several rounds found real issues in the *previous* round's own fix, not just new independent findings.

- **Round 1**: unbounded `elseif`/`case` clause fold → uncatchable stack-overflow abort (300k clauses) — fixed with a depth cap. `__select_N` temp naming could collide with a user variable → invalid JS — fixed by renaming to `$select_N` (structurally collision-proof, `$` isn't in Scilab's `NAME` token alphabet). `if`/`select` branch-locals ordering bug — fixed via scope snapshot/rewind per branch.
- **Round 2**: identical unbounded-fold hazard found in `lower_postfix`'s suffix chain — fixed the same way. The round-1 fix's own `Vec::contains` membership testing was O(n²) — fixed with a `HashSet`-backed `FunctionCtx`.
- **Round 3**: the round-2 fix itself had a bug (unconditionally appending an already-known name, breaking `for`-loop-reusing-an-existing-variable) — fixed by making the push a no-op when already known. Also fixed an unrelated panic-safety gap in `lower_select`'s bounds checking.
- **Round 4 (the big one)**: found that a name introduced inside `if`/`select`/`while`/`for` bodies was only tracked in the lowerer's own bookkeeping, never actually *declared* in the output IR at the right scope — meaning a function computing its own output variable inside `if`/`else` (the single most common Scilab/MATLAB function pattern) **always failed validation**. Fixed by adding a static CST pre-scan (`collect_assigned_names`) + a hoisting pass (`hoist_assigned_names`) that pre-declares such names at the enclosing scope before lowering the body for real. An alternative "lower twice, once to discover" design was considered and rejected — it would have caused an exponential 2^K blowup for K levels of nested control flow.
- **Round 5**: found the round-4 fix made a *pre-existing* (round 3) bug reachable inconsistently: reusing an existing variable as a `for`-loop counter reads back the **stale pre-loop value** after the loop (confirmed via `node`), because the shared JS backend's `ForRange` codegen block-scopes the loop variable regardless of this crate's own bookkeeping. Round 3's own test never caught this (it always reassigned before reading). Fixed by rejecting the reuse outright with a clean, disclosed error, and by excluding a `for`-loop's own counter from what bubbles up to an enclosing construct's hoist scan (closing the inconsistency). Also corrected a doc comment that understated a disclosed residual limitation (reading a hoisted-but-never-written name is an uncaught JS `TypeError`, not a silent wrong value).

**Round 5 came back clean modulo the two items above**, which are now fixed. Given the progressively narrower scope of each round's findings, and that nothing in this crate has shipped/been exposed to any user yet, this is where the review converges.

## Test plan
- [x] `cargo test -p scilab-to-semantic-ir` — 99 tests (72 unit + 11 validator + 15 e2e-via-`node` + 1 doctest), all pass
- [x] `cargo clippy -p scilab-to-semantic-ir --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` (usual exclusions) — clean
- [x] Security review: 5 rounds, converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)