### PR TITLE
feat(spice): add BJT temperature exponent

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT saturation-current temperature exponent** — BJT model cards now accept
+  `XTI`, apply it to saturation-current temperature scaling, and preserve it
+  through subcircuit expansion, matching Rust and TypeScript. The supported-
+  parameter catalog now contains 74 canonical rows.
+
 - **Diode energy gap** — diode model cards now accept `EG`, apply it to
   saturation-current temperature scaling, and preserve it through subcircuit
   expansion, matching Rust and TypeScript.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -210,6 +210,8 @@ to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
+BJT cards accept `XTI` (default `3`) for the same saturation-current
+temperature exponent behavior.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -235,7 +237,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 72-row supported-parameter catalog and expose stable issue
+expected seven-kind, 74-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -589,6 +589,8 @@ class BJT:
     Tr:
         Reverse transit time in seconds; contributes base-collector diffusion
         capacitance in small-signal AC analysis.
+    Xti:
+        Saturation-current temperature exponent (default 3.0).
     """
 
     name: str
@@ -603,6 +605,7 @@ class BJT:
     Cjc: float = 0.0        # base-collector junction capacitance (F)
     Tf: float = 0.0         # forward transit time (s)
     Tr: float = 0.0         # reverse transit time (s)
+    Xti: float = 3.0        # saturation-current temperature exponent
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -349,7 +349,11 @@ def bjt_at_temperature(
         / _BOLTZMANN
         * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin)
     )
-    saturation_scale = ratio**3 * math.exp(max(-100.0, min(100.0, exponent)))
+    if not math.isfinite(bjt.Xti):
+        raise ValueError(
+            f"{bjt.name}: BJT saturation-current temperature exponent must be finite"
+        )
+    saturation_scale = ratio**bjt.Xti * math.exp(max(-100.0, min(100.0, exponent)))
     return replace(
         bjt,
         Is=bjt.Is * saturation_scale,
@@ -592,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9129,6 +9133,10 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT forward transit time must be finite and non-negative")
     if not math.isfinite(el.Tr) or el.Tr < 0.0:
         raise ValueError(f"{el.name}: BJT reverse transit time must be finite and non-negative")
+    if not math.isfinite(el.Xti):
+        raise ValueError(
+            f"{el.name}: BJT saturation-current temperature exponent must be finite"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -13829,6 +13837,7 @@ def sens_dc(
                     Cjc=el.Cjc,
                     Tf=el.Tf,
                     Tr=el.Tr,
+                    Xti=el.Xti,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -13845,6 +13854,7 @@ def sens_dc(
                     Cjc=el.Cjc,
                     Tf=el.Tf,
                     Tr=el.Tr,
+                    Xti=el.Xti,
                 ),
             )
 
@@ -14071,6 +14081,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Cjc=el.Cjc,
             Tf=el.Tf,
             Tr=el.Tr,
+            Xti=el.Xti,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (7, 15, 4, 4),
-    "PNP": (7, 15, 4, 4),
+    "NPN": (8, 16, 4, 4),
+    "PNP": (8, 16, 4, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -370,6 +370,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "CBC": "CJC",
     "TF": "TF",
     "TR": "TR",
+    "XTI": "XTI",
 }
 
 _JFET_PARAMETER_ALIASES: dict[str, str] = {
@@ -894,6 +895,7 @@ def bjt_from_model_card(
         Cjc=p.get("CJC", 0.0),
         Tf=p.get("TF", 0.0),
         Tr=p.get("TR", 0.0),
+        Xti=p.get("XTI", 3.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -91,6 +91,7 @@ from spice_engine import (
     AcResult,
     AcSource,
     BSource,
+    bjt_at_temperature,
     Capacitor,
     Circuit,
     CornerAcSweepResult,
@@ -411,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 72
+    assert len(coverage) == 74
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -426,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 72
+    assert len(records) == 74
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -500,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 72
-    assert report.expected_canonical_parameter_count == 72
-    assert report.accepted_name_count == 120
+    assert report.canonical_parameter_count == 74
+    assert report.expected_canonical_parameter_count == 74
+    assert report.accepted_name_count == 122
     assert report.aliased_parameter_count == 35
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -510,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t72\t72\t120\t35\t4\t0"
+        "true\t7\t7\t74\t74\t122\t35\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -538,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 71
-    assert report.accepted_name_count == 117
+    assert report.canonical_parameter_count == 73
+    assert report.accepted_name_count == 119
     assert report.aliased_parameter_count == 34
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -554,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t71\t72\t117\t34\t4\t4\n"
+        "false\t7\t7\t73\t74\t119\t34\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -645,12 +646,15 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(2.2) == diode_model.Xti
     assert pytest.approx(1.05) == diode_model.Eg
 
-    bjt_card = normalize_model_card("Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12})
+    bjt_card = normalize_model_card(
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4}
+    )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
+    assert bjt_model.Xti == pytest.approx(2.4)
 
     jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -2216,6 +2220,20 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert expanded.Eg == pytest.approx(1.05)
 
 
+def test_subcircuit_expansion_preserves_bjt_temperature_exponent():
+    cell = SubcircuitDefinition(
+        "bjt-cell",
+        ("c", "b", "e"),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4),),
+    )
+    circuit = Circuit()
+    circuit.define_subcircuit(cell)
+    circuit.add(XInstance("X1", ("c1", "b1", "0"), "bjt-cell"))
+
+    expanded = next(element for element in circuit.elements if isinstance(element, BJT))
+    assert expanded.Xti == pytest.approx(2.4)
+
+
 def test_branch_current_in_voltage_source():
     """V=10V, R=1k -> I=10mA flowing from + to - inside the source."""
     c = Circuit()
@@ -2425,6 +2443,12 @@ def test_bjt_temperature_scaling_reduces_emitter_follower_forward_drop():
     assert hot_result.converged
     assert cold_result.node_voltages["out"] < nominal_result.node_voltages["out"]
     assert hot_result.node_voltages["out"] > nominal_result.node_voltages["out"]
+
+
+def test_bjt_temperature_scaling_uses_model_temperature_exponent():
+    low = bjt_at_temperature(BJT("Qlow", "c", "b", "e", Xti=0.0), 350.0)
+    high = bjt_at_temperature(BJT("Qhigh", "c", "b", "e", Xti=4.0), 350.0)
+    assert high.Is > low.Is
 
 
 def test_mosfet_temperature_scaling_changes_common_source_bias():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `XTI` saturation-current temperature-exponent support,
+  preserving it through subcircuit expansion and matching Python and
+  TypeScript. The supported-parameter catalog now contains 74 canonical rows.
 - Add diode model-card `EG` energy-gap support to temperature scaling,
   preserving it through subcircuit expansion and matching Python and
   TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -127,6 +127,8 @@ to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
+BJT cards accept `XTI` (default `3`) for the same saturation-current
+temperature exponent behavior.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -152,7 +154,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 72-row supported-parameter catalog and expose stable issue
+expected seven-kind, 74-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -418,7 +418,7 @@ fn clone_subckt_element(
             element.gate_source_capacitance,
             element.gate_drain_capacitance,
         )),
-        Element::Bjt(element) => Element::Bjt(Bjt::with_model(
+        Element::Bjt(element) => Element::Bjt(Bjt::with_model_and_temperature_parameters(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.collector, instance_name, node_map),
             map_subckt_node(&element.base, instance_name, node_map),
@@ -431,6 +431,7 @@ fn clone_subckt_element(
             element.base_collector_capacitance,
             element.forward_transit_time,
             element.reverse_transit_time,
+            element.saturation_current_temperature_exponent,
         )),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -2648,7 +2649,14 @@ pub fn bjt_at_temperature(
     let ratio = temperature_kelvin / nominal_temperature_kelvin;
     let exponent = energy_gap_electron_volts * ELECTRON_CHARGE / BOLTZMANN
         * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin);
-    let saturation_scale = ratio.powi(3) * exponent.clamp(-100.0, 100.0).exp();
+    if !bjt.saturation_current_temperature_exponent.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "saturation-current temperature exponent must be finite".to_string(),
+        });
+    }
+    let saturation_scale = ratio.powf(bjt.saturation_current_temperature_exponent)
+        * exponent.clamp(-100.0, 100.0).exp();
     let mut adjusted = bjt.clone();
     adjusted.saturation_current *= saturation_scale;
     adjusted.thermal_voltage *= ratio;
@@ -2826,6 +2834,7 @@ pub struct Bjt {
     pub base_collector_capacitance: f64,
     pub forward_transit_time: f64,
     pub reverse_transit_time: f64,
+    pub saturation_current_temperature_exponent: f64,
 }
 
 impl Bjt {
@@ -2865,6 +2874,39 @@ impl Bjt {
         forward_transit_time: f64,
         reverse_transit_time: f64,
     ) -> Self {
+        Self::with_model_and_temperature_parameters(
+            name,
+            collector,
+            base,
+            emitter,
+            polarity,
+            saturation_current,
+            forward_beta,
+            thermal_voltage,
+            base_emitter_capacitance,
+            base_collector_capacitance,
+            forward_transit_time,
+            reverse_transit_time,
+            3.0,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_and_temperature_parameters(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+        polarity: BjtPolarity,
+        saturation_current: f64,
+        forward_beta: f64,
+        thermal_voltage: f64,
+        base_emitter_capacitance: f64,
+        base_collector_capacitance: f64,
+        forward_transit_time: f64,
+        reverse_transit_time: f64,
+        saturation_current_temperature_exponent: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             collector: collector.into(),
@@ -2878,6 +2920,7 @@ impl Bjt {
             base_collector_capacitance,
             forward_transit_time,
             reverse_transit_time,
+            saturation_current_temperature_exponent,
         }
     }
 }
@@ -3268,8 +3311,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 7, 15, 4, 4),
-    (ModelCardKind::Pnp, 7, 15, 4, 4),
+    (ModelCardKind::Npn, 8, 16, 4, 4),
+    (ModelCardKind::Pnp, 8, 16, 4, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3311,6 +3354,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CBC", "CJC"),
     ("TF", "TF"),
     ("TR", "TR"),
+    ("XTI", "XTI"),
 ];
 const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("BETA", "BETA"),
@@ -3950,7 +3994,7 @@ pub fn bjt_from_model_card(
         ModelCardKind::Pnp => BjtPolarity::Pnp,
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
-    Ok(Bjt::with_model(
+    Ok(Bjt::with_model_and_temperature_parameters(
         name,
         collector,
         base,
@@ -3963,6 +4007,7 @@ pub fn bjt_from_model_card(
         model_card_value(model, "CJC", 0.0),
         model_card_value(model, "TF", 0.0),
         model_card_value(model, "TR", 0.0),
+        model_card_value(model, "XTI", 3.0),
     ))
 }
 
@@ -23145,6 +23190,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "reverse transit time must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.saturation_current_temperature_exponent.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "saturation-current temperature exponent must be finite".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,9 +1,10 @@
 use spice_engine::{
-    analyze_custom_model_source, bjt_from_model_card, circuit_at_temperature, dc_corners,
-    dc_corners_parallel, dc_initial_vector_from_conditions, dc_op, dc_op_with_initial_conditions,
-    dc_op_with_options, dc_sweep, dc_sweep_corners, dc_sweep_corners_parallel,
-    dc_temperature_sweep, dc_temperature_sweep_corners, device_model_audit_fixtures,
-    device_model_behavior_audit_fixtures, device_model_reference_deck_audit_analysis_summary,
+    analyze_custom_model_source, bjt_at_temperature, bjt_from_model_card, circuit_at_temperature,
+    dc_corners, dc_corners_parallel, dc_initial_vector_from_conditions, dc_op,
+    dc_op_with_initial_conditions, dc_op_with_options, dc_sweep, dc_sweep_corners,
+    dc_sweep_corners_parallel, dc_temperature_sweep, dc_temperature_sweep_corners,
+    device_model_audit_fixtures, device_model_behavior_audit_fixtures,
+    device_model_reference_deck_audit_analysis_summary,
     device_model_reference_deck_audit_analysis_summary_records,
     device_model_reference_deck_audit_fixtures, device_model_reference_deck_audit_gate,
     device_model_reference_deck_audit_gate_coverage_digest,
@@ -15,8 +16,7 @@ use spice_engine::{
     device_model_reference_deck_audit_records, device_model_reference_deck_audit_summary,
     device_model_reference_deck_audit_summary_records, device_model_temperature_audit_fixtures,
     diode_at_temperature, diode_from_model_card, format_corner_dc_sweep_table,
-    format_corner_dc_table,
-    format_corner_temperature_dc_table, format_dc_sweep_table,
+    format_corner_dc_table, format_corner_temperature_dc_table, format_dc_sweep_table,
     format_device_model_reference_deck_audit_analysis_summary_csv,
     format_device_model_reference_deck_audit_analysis_summary_json,
     format_device_model_reference_deck_audit_analysis_summary_table,
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 72);
+    assert_eq!(coverage.len(), 74);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 72);
+    assert_eq!(records.len(), 74);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 72);
-    assert_eq!(report.expected_canonical_parameter_count, 72);
-    assert_eq!(report.accepted_name_count, 120);
+    assert_eq!(report.canonical_parameter_count, 74);
+    assert_eq!(report.expected_canonical_parameter_count, 74);
+    assert_eq!(report.accepted_name_count, 122);
     assert_eq!(report.aliased_parameter_count, 35);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t72\t72\t120\t35\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t74\t74\t122\t35\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 71);
-    assert_eq!(report.accepted_name_count, 117);
+    assert_eq!(report.canonical_parameter_count, 73);
+    assert_eq!(report.accepted_name_count, 119);
     assert_eq!(report.aliased_parameter_count, 34);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t71\t72\t117\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t73\t74\t119\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -422,14 +422,20 @@ fn model_card_aliases_build_device_instances() {
     assert_close(diode_model.saturation_current_temperature_exponent, 2.2);
     assert_close(diode_model.energy_gap_electron_volts, 1.05);
 
-    let bjt_card =
-        normalize_model_card("Qsmall", "npn", &[("BETA", 125.0), ("CBE", 2.0e-12)]).unwrap();
+    let bjt_card = normalize_model_card(
+        "Qsmall",
+        "npn",
+        &[("BETA", 125.0), ("CBE", 2.0e-12), ("XTI", 2.4)],
+    )
+    .unwrap();
     let bjt_model = bjt_from_model_card("Q1", "c", "b", "e", &bjt_card).unwrap();
     assert_close(*bjt_card.parameters.get("BF").unwrap(), 125.0);
     assert_close(*bjt_card.parameters.get("CJE").unwrap(), 2.0e-12);
+    assert_close(*bjt_card.parameters.get("XTI").unwrap(), 2.4);
     assert_eq!(bjt_model.polarity, BjtPolarity::Npn);
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
+    assert_close(bjt_model.saturation_current_temperature_exponent, 2.4);
 
     let jfet_card = normalize_model_card(
         "Jn",
@@ -1316,6 +1322,50 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 }
 
 #[test]
+fn subcircuit_expansion_preserves_bjt_temperature_exponent() {
+    let bjt = Bjt::with_model_and_temperature_parameters(
+        "Qcell",
+        "c",
+        "b",
+        "e",
+        BjtPolarity::Npn,
+        2.0e-14,
+        125.0,
+        0.026,
+        1.0e-12,
+        2.0e-12,
+        3.0e-9,
+        4.0e-9,
+        2.4,
+    );
+    let mut circuit = Circuit::new();
+    circuit
+        .define_subcircuit(SubcircuitDefinition::new(
+            "bjt-cell",
+            vec!["c".to_string(), "b".to_string(), "e".to_string()],
+            vec![SubcircuitElement::from(Element::Bjt(bjt))],
+        ))
+        .unwrap();
+    circuit
+        .instantiate(XInstance::new(
+            "X1",
+            vec!["c1".to_string(), "b1".to_string(), "0".to_string()],
+            "bjt-cell",
+        ))
+        .unwrap();
+
+    let expanded = circuit
+        .elements()
+        .iter()
+        .find_map(|element| match element {
+            Element::Bjt(bjt) => Some(bjt),
+            _ => None,
+        })
+        .unwrap();
+    assert_close(expanded.saturation_current_temperature_exponent, 2.4);
+}
+
+#[test]
 fn dc_current_source_into_resistor_uses_positive_to_negative_orientation() {
     let mut circuit = Circuit::new();
     circuit.add(Element::CurrentSource(CurrentSource::new(
@@ -1753,6 +1803,43 @@ fn dc_bjt_temperature_scaling_reduces_emitter_follower_forward_drop() {
 
     assert!(cold_result.voltage("out").unwrap() < nominal_result.voltage("out").unwrap());
     assert!(hot_result.voltage("out").unwrap() > nominal_result.voltage("out").unwrap());
+}
+
+#[test]
+fn bjt_temperature_scaling_uses_model_temperature_exponent() {
+    let low_exponent = Bjt::with_model_and_temperature_parameters(
+        "Qlow",
+        "c",
+        "b",
+        "e",
+        BjtPolarity::Npn,
+        1.0e-14,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    );
+    let high_exponent = Bjt::with_model_and_temperature_parameters(
+        "Qhigh",
+        "c",
+        "b",
+        "e",
+        BjtPolarity::Npn,
+        1.0e-14,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        4.0,
+    );
+    let low = bjt_at_temperature(&low_exponent, 350.0, 300.15, 1.11).unwrap();
+    let high = bjt_at_temperature(&high_exponent, 350.0, 300.15, 1.11).unwrap();
+    assert!(high.saturation_current > low.saturation_current);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `XTI` saturation-current temperature-exponent support,
+  preserving it through subcircuit expansion and matching Python and Rust. The
+  supported-parameter catalog now contains 74 canonical rows.
 - Add diode model-card `EG` energy-gap support to temperature scaling,
   preserving it through subcircuit expansion and matching Python and Rust.
 - Add diode model-card `XTI` saturation-current temperature-exponent support,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -197,6 +197,8 @@ to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
+BJT cards accept `XTI` (default `3`) for the same saturation-current
+temperature exponent behavior.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -222,7 +224,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 72-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 74-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1710,6 +1710,7 @@ export interface Bjt {
   readonly baseCollectorCapacitance: number;
   readonly forwardTransitTime: number;
   readonly reverseTransitTime: number;
+  readonly saturationCurrentTemperatureExponent: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1987,8 +1988,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [7, 15, 4, 4],
-  PNP: [7, 15, 4, 4],
+  NPN: [8, 16, 4, 4],
+  PNP: [8, 16, 4, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3578,7 +3579,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7616,8 +7617,12 @@ export function bjtAtTemperature(
     (energyGapElectronVolts * ELECTRON_CHARGE) /
     BOLTZMANN *
     (1.0 / nominalTemperatureKelvin - 1.0 / temperatureKelvin);
+  if (!Number.isFinite(element.saturationCurrentTemperatureExponent)) {
+    throw invalidElement(element.name, "saturation-current temperature exponent must be finite");
+  }
   const saturationScale =
-    ratio ** 3 * Math.exp(Math.max(-100.0, Math.min(100.0, exponent)));
+    ratio ** element.saturationCurrentTemperatureExponent *
+    Math.exp(Math.max(-100.0, Math.min(100.0, exponent)));
   return {
     ...element,
     saturationCurrent: element.saturationCurrent * saturationScale,
@@ -7727,6 +7732,7 @@ export function bjt(
   baseCollectorCapacitance = 0.0,
   forwardTransitTime = 0.0,
   reverseTransitTime = 0.0,
+  saturationCurrentTemperatureExponent = 3.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7742,6 +7748,7 @@ export function bjt(
     baseCollectorCapacitance,
     forwardTransitTime,
     reverseTransitTime,
+    saturationCurrentTemperatureExponent,
   };
 }
 
@@ -7843,6 +7850,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CBC: "CJC",
   TF: "TF",
   TR: "TR",
+  XTI: "XTI",
 };
 
 const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8339,6 +8347,7 @@ export function bjtFromModelCard(
     p.CJC ?? 0.0,
     p.TF ?? 0.0,
     p.TR ?? 0.0,
+    p.XTI ?? 3.0,
   );
 }
 
@@ -19514,6 +19523,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.reverseTransitTime) || element.reverseTransitTime < 0.0) {
     throw invalidElement(element.name, "reverse transit time must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.saturationCurrentTemperatureExponent)) {
+    throw invalidElement(element.name, "saturation-current temperature exponent must be finite");
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -7,6 +7,7 @@ import {
   bSourceCurrent,
   bSourceVoltage,
   bjt,
+  bjtAtTemperature,
   bjtFromModelCard,
   circuitAtTemperature,
   cccs,
@@ -124,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(72);
+    expect(coverage).toHaveLength(74);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -144,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(72);
+    expect(records).toHaveLength(74);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -209,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 72,
-      expectedCanonicalParameterCount: 72,
-      acceptedNameCount: 120,
+      canonicalParameterCount: 74,
+      expectedCanonicalParameterCount: 74,
+      acceptedNameCount: 122,
       aliasedParameterCount: 35,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t72\t72\t120\t35\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t74\t74\t122\t35\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -240,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(71);
-    expect(report.acceptedNameCount).toBe(117);
+    expect(report.canonicalParameterCount).toBe(73);
+    expect(report.acceptedNameCount).toBe(119);
     expect(report.aliasedParameterCount).toBe(34);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -256,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t71\t72\t117\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t73\t74\t119\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -330,12 +331,17 @@ describe("dcOp", () => {
     expectClose(diodeModel.saturationCurrentTemperatureExponent, 2.2);
     expectClose(diodeModel.energyGapElectronVolts, 1.05);
 
-    const bjtCard = normalizeModelCard("Qsmall", "npn", { BETA: 125.0, CBE: 2.0e-12 });
+    const bjtCard = normalizeModelCard("Qsmall", "npn", {
+      BETA: 125.0,
+      CBE: 2.0e-12,
+      XTI: 2.4,
+    });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
+    expectClose(bjtModel.saturationCurrentTemperatureExponent, 2.4);
 
     const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
@@ -964,6 +970,22 @@ describe("dcOp", () => {
     expectClose(expanded.energyGapElectronVolts, 1.05);
   });
 
+  it("preserves the BJT temperature exponent through subcircuit expansion", () => {
+    const circuit = new Circuit();
+    circuit.defineSubcircuit(
+      subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4),
+      ]),
+    );
+    circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
+
+    const expanded = circuit.elements().find((element) => element.kind === "bjt");
+    expect(expanded?.kind).toBe("bjt");
+    if (expanded?.kind === "bjt") {
+      expectClose(expanded.saturationCurrentTemperatureExponent, 2.4);
+    }
+  });
+
   it("uses positive-to-negative orientation for current sources", () => {
     const circuit = new Circuit();
     circuit.add(currentSource("I1", "0", "n1", 1.0e-3));
@@ -1275,6 +1297,12 @@ describe("dcOp", () => {
 
     expect(coldResult.voltage("out")).toBeLessThan(nominalResult.voltage("out")!);
     expect(hotResult.voltage("out")).toBeGreaterThan(nominalResult.voltage("out")!);
+  });
+
+  it("uses the BJT model temperature exponent", () => {
+    const low = bjtAtTemperature(bjt("Qlow", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 0), 350);
+    const high = bjtAtTemperature(bjt("Qhigh", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 4), 350);
+    expect(high.saturationCurrent).toBeGreaterThan(low.saturationCurrent);
   });
 
   it("uses MOSFET temperature scaling in common-source drain voltage", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,13 +33,13 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language diode energy gap.
+1. Cross-language BJT saturation-current temperature exponent.
    - Status: current PR completion candidate.
-   - Add Berkeley diode `EG` energy-gap model-card support in Rust, Python, and
-     TypeScript.
-   - Apply each diode model's `EG` value to saturation-current temperature
-     scaling and preserve it through hierarchical subcircuit expansion.
-   - Extend the supported-parameter coverage gate from 71 to 72 canonical rows
+   - Add Berkeley BJT `XTI` saturation-current temperature-exponent model-card
+     support in Rust, Python, and TypeScript.
+   - Apply `XTI` to BJT saturation-current temperature scaling and preserve the
+     full BJT model through hierarchical subcircuit expansion.
+   - Extend the supported-parameter coverage gate from 72 to 74 canonical rows
      and lock model-specific temperature scaling across all three engines.
 
 ## Completed Slices
@@ -2985,6 +2985,13 @@ the Rust, Python, and TypeScript surfaces together.
      it to saturation-current temperature scaling.
    - Hierarchical subcircuit expansion now preserves the complete diode model,
      and the supported-parameter release gate now covers 71 canonical rows.
+
+217. Cross-language diode energy gap.
+   - Status: completed in PR 8718.
+   - Rust, Python, and TypeScript diode model cards now accept `EG` and apply
+     each model's energy gap to saturation-current temperature scaling.
+   - Hierarchical subcircuit expansion preserves `EG`, and the supported-
+     parameter release gate now covers 72 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- add Berkeley BJT `XTI` model-card support in Rust, Python, and TypeScript
- use the per-model exponent for BJT saturation-current temperature scaling and preserve it through subcircuits, sensitivity, and Monte Carlo copies
- extend the supported-parameter release gate from 72 to 74 canonical rows and reconcile the SPICE completion plan after #8718

## Verification

- `cargo test -q -p spice-engine -- --test-threads=1`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python: `504 passed`, `88.24%` coverage
- TypeScript: `264 passed`
- TypeScript: `tsc --noEmit`
- Ruff on touched Python source/tests
- `git diff --check`
