### PR TITLE
feat(task-core): labels + priority — two new first-class view dimensions

### DIFF
--- a/code/packages/rust/task-core/CHANGELOG.md
+++ b/code/packages/rust/task-core/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to `task-core` are documented here.
 
 ### Added
 
+- **Labels and priority — two new first-class view dimensions** (Phase 3 PR-5 of
+  `code/specs/task-app-view-layer.md`).
+  - `Label { id, name, color }` + `LabelId`, registered per project
+    (`ProjectState::labels`) and referenced from `Task::labels`, so renaming or
+    recolouring a label updates every task at once. `Priority { Low, Normal, High,
+    Urgent }` on `Task::priority`, with `rank()`/`label()`/`from_rank()`.
+  - Ops: `upsert_label`, `delete_label` (removes the label from every task, so no task is
+    left pointing at a deleted label), `set_task_labels` (rejects unknown label/task ids
+    and de-duplicates), and `set_priority`.
+  - View built-ins: **`priority` resolves to its numeric *rank*, not its name**, so a
+    sort orders by urgency (Low→Urgent) instead of alphabetically (High→Low→Normal→
+    Urgent); `format_cell` turns the rank back into the display name. **`labels` resolves
+    to the label *names*** (comma-joined via the project registry) so filtering and
+    searching see what the user sees rather than opaque ids.
+  - Both fields are serde-defaulted and skipped when empty, so **pre-label snapshots
+    still deserialize** unchanged.
+
+### Fixed
+
+- **Blank values now sort last in *both* directions.** A descending sort previously
+  reversed the whole ordering, floating every empty cell to the top — not what "sort by
+  priority, highest first" means. Emptiness is now decided before direction is applied,
+  so only real values reverse (matching spreadsheets and every board tool). Caught by the
+  new priority sort test; covered by a dedicated descending-with-blanks case.
+
 - **The `calendar()` projection — dated events over the same selection** (`view` module —
   Phase 3 PR-4 of `code/specs/task-app-view-layer.md`).
   - `calendar(project, view, range, schedule) -> CalendarView` (and

--- a/code/packages/rust/task-core/src/ids.rs
+++ b/code/packages/rust/task-core/src/ids.rs
@@ -84,6 +84,10 @@ id_type!(
     FieldId
 );
 id_type!(
+    /// Identifies a label (a colour-coded tag applied to tasks).
+    LabelId
+);
+id_type!(
     /// Identifies a captured baseline (a schedule snapshot).
     BaselineId
 );

--- a/code/packages/rust/task-core/src/model.rs
+++ b/code/packages/rust/task-core/src/model.rs
@@ -44,6 +44,20 @@ pub struct Task {
     /// UI: is this summary's subtree collapsed.
     pub collapsed: bool,
 
+    /// Colour-coded tags. A first-class filter/group dimension, like every board tool.
+    /// Serialized only when non-empty, so pre-label snapshots still deserialize.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty")
+    )]
+    pub labels: Vec<LabelId>,
+    /// Triage priority. `None` means unprioritized (sorts after every set priority).
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub priority: Option<Priority>,
+
     /// Workflow status (kanban/agile). `None` uses the board's default status.
     pub status: Option<StatusId>,
     /// The checklist "done" flag — kept distinct from `status` so a board and a
@@ -75,12 +89,84 @@ impl Task {
             order: 0,
             kind: TaskKind::Leaf,
             collapsed: false,
+            labels: Vec::new(),
+            priority: None,
             status: None,
             completed: false,
             percent_complete: 0,
             schedule: None,
             fields: BTreeMap::new(),
             decision: None,
+        }
+    }
+}
+
+/// A colour-coded tag. Labels are defined once per project and referenced by id, so
+/// renaming or recolouring one updates every task at once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Label {
+    /// Label identity.
+    pub id: LabelId,
+    /// Display name.
+    pub name: String,
+    /// A host-interpreted colour token (e.g. `"red"` or `"#c0392b"`); the engine never
+    /// parses it, it just round-trips it verbatim.
+    ///
+    /// **Host note:** because this is stored as free text and echoed back unchanged, a
+    /// host that interpolates it into a `style` attribute or a stylesheet must escape or
+    /// validate it there — the engine deliberately takes no view on colour syntax.
+    pub color: String,
+}
+
+/// Triage priority, ordered from least to most urgent.
+///
+/// The discriminants are meaningful: [`Priority::rank`] exposes them so views sort by
+/// *urgency* rather than alphabetically (which would put "High" before "Low").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum Priority {
+    /// Nice to have.
+    Low,
+    /// The default working priority.
+    Normal,
+    /// Should be done soon.
+    High,
+    /// Drop everything.
+    Urgent,
+}
+
+impl Priority {
+    /// The sort rank: `Low` = 0 … `Urgent` = 3.
+    pub fn rank(self) -> u8 {
+        match self {
+            Priority::Low => 0,
+            Priority::Normal => 1,
+            Priority::High => 2,
+            Priority::Urgent => 3,
+        }
+    }
+
+    /// The display name, and the inverse of [`Priority::rank`]'s ordering.
+    pub fn label(self) -> &'static str {
+        match self {
+            Priority::Low => "Low",
+            Priority::Normal => "Normal",
+            Priority::High => "High",
+            Priority::Urgent => "Urgent",
+        }
+    }
+
+    /// The priority for a rank produced by [`Priority::rank`], if it is in range.
+    pub fn from_rank(rank: u8) -> Option<Priority> {
+        match rank {
+            0 => Some(Priority::Low),
+            1 => Some(Priority::Normal),
+            2 => Some(Priority::High),
+            3 => Some(Priority::Urgent),
+            _ => None,
         }
     }
 }
@@ -847,6 +933,9 @@ pub struct ProjectState {
     pub project_calendar: CalendarId,
     /// User-defined custom fields, by id.
     pub fields: BTreeMap<FieldId, FieldDef>,
+    /// Label definitions, by id. Defaulted so pre-label snapshots still deserialize.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub labels: BTreeMap<LabelId, Label>,
     /// Status workflows, by id.
     pub workflows: BTreeMap<WorkflowId, Workflow>,
     /// Captured baselines, by id.
@@ -878,6 +967,7 @@ impl ProjectState {
             calendars,
             project_calendar: cal_id,
             fields: BTreeMap::new(),
+            labels: BTreeMap::new(),
             workflows: BTreeMap::new(),
             baselines: BTreeMap::new(),
             views: BTreeMap::new(),

--- a/code/packages/rust/task-core/src/ops.rs
+++ b/code/packages/rust/task-core/src/ops.rs
@@ -162,6 +162,47 @@ impl ProjectState {
         Ok(())
     }
 
+    /// Set (or clear) a task's triage priority.
+    pub fn set_priority(&mut self, id: &TaskId, priority: Option<Priority>) -> Result<(), OpError> {
+        self.task_mut(id)?.priority = priority;
+        Ok(())
+    }
+
+    // ── labels ───────────────────────────────────────────────────────────────────
+
+    /// Create or replace a label definition.
+    pub fn upsert_label(&mut self, label: Label) {
+        self.labels.insert(label.id.clone(), label);
+    }
+
+    /// Delete a label and remove it from every task that carried it, so no task is left
+    /// referencing a label that no longer exists.
+    pub fn delete_label(&mut self, id: &LabelId) {
+        self.labels.remove(id);
+        for t in self.tasks.values_mut() {
+            t.labels.retain(|l| l != id);
+        }
+    }
+
+    /// Replace a task's labels. Rejects an unknown label id, and de-duplicates so a
+    /// label can't be applied twice to the same task.
+    pub fn set_task_labels(&mut self, id: &TaskId, labels: Vec<LabelId>) -> Result<(), OpError> {
+        if !self.tasks.contains_key(id) {
+            return Err(OpError::NotFound);
+        }
+        if labels.iter().any(|l| !self.labels.contains_key(l)) {
+            return Err(OpError::NotFound);
+        }
+        let mut deduped: Vec<LabelId> = Vec::with_capacity(labels.len());
+        for l in labels {
+            if !deduped.contains(&l) {
+                deduped.push(l);
+            }
+        }
+        self.task_mut(id)?.labels = deduped;
+        Ok(())
+    }
+
     // ── scheduling ───────────────────────────────────────────────────────────────
 
     /// Set or clear a task's whole scheduling block.

--- a/code/packages/rust/task-core/src/view.rs
+++ b/code/packages/rust/task-core/src/view.rs
@@ -26,6 +26,8 @@
 //! | `kind`                            | `Text` (`leaf`/`summary`/`milestone`)   |
 //! | `completed`, `critical`           | `Bool`                                  |
 //! | `percentComplete`                 | `Number` (0..=100)                      |
+//! | `priority`                        | `Number` (**rank**, so it sorts by urgency; formats as the name) |
+//! | `labels`                          | `Text` (label *names*, comma-joined) or `Empty` |
 //! | `duration`, `totalSlack`, `freeSlack` | `Number` (working minutes)          |
 //! | `deadline`                        | `Date`                                  |
 //! | `start`/`scheduledStart`, `finish`/`scheduledFinish` | `Date`               |
@@ -37,8 +39,8 @@
 
 use crate::ids::TaskId;
 use crate::model::{
-    DurationUnit, FieldKind, FieldRef, FieldValue, Filter, ProjectSettings, ProjectState, SortKey,
-    Task, TaskKind, View,
+    DurationUnit, FieldKind, FieldRef, FieldValue, Filter, Priority, ProjectSettings, ProjectState,
+    SortKey, Task, TaskKind, View,
 };
 use crate::primitives::Date;
 use crate::scheduler::ScheduleResult;
@@ -70,24 +72,28 @@ pub enum CellValue {
 /// Resolve `field` on `task` to a [`CellValue`].
 ///
 /// `schedule` supplies the computed dates/slack/critical built-ins (a task absent from
-/// the schedule yields `Empty` for those). `project` is threaded through for the computed
-/// custom-field resolution added in a later PR; today custom fields read their stored
-/// value.
+/// the schedule yields `Empty` for those). `project` resolves label names; it is also
+/// where computed formula/rollup custom fields will resolve in a later PR — today custom
+/// fields read their stored value.
 pub fn cell(
     project: &ProjectState,
     task: &Task,
     field: &FieldRef,
     schedule: &ScheduleResult,
 ) -> CellValue {
-    let _ = project; // reserved for formula/rollup resolution (see module docs)
     match field {
-        FieldRef::Builtin(name) => builtin_cell(task, name, schedule),
+        FieldRef::Builtin(name) => builtin_cell(project, task, name, schedule),
         FieldRef::Custom(id) => task.fields.get(id).map_or(CellValue::Empty, value_cell),
     }
 }
 
 /// Resolve a built-in column. Unknown names are `Empty` (graceful, never an error).
-fn builtin_cell(task: &Task, name: &str, schedule: &ScheduleResult) -> CellValue {
+fn builtin_cell(
+    project: &ProjectState,
+    task: &Task,
+    name: &str,
+    schedule: &ScheduleResult,
+) -> CellValue {
     let dates = schedule.dates.get(&task.id);
     match name {
         "name" => CellValue::Text(task.name.clone()),
@@ -106,6 +112,27 @@ fn builtin_cell(task: &Task, name: &str, schedule: &ScheduleResult) -> CellValue
         ),
         "completed" => CellValue::Bool(task.completed),
         "percentComplete" => CellValue::Number(task.percent_complete as f64),
+        // Priority resolves to its RANK, not its name, so a sort orders by urgency
+        // (Low→Urgent) instead of alphabetically (High→Low→Normal→Urgent).
+        // `format_cell` turns the rank back into the display name.
+        "priority" => task
+            .priority
+            .map_or(CellValue::Empty, |p| CellValue::Number(p.rank() as f64)),
+        // Labels join their *names* (resolved through the project's registry), so a
+        // filter/search sees what the user sees rather than opaque ids.
+        "labels" if !task.labels.is_empty() => CellValue::Text(
+            task.labels
+                .iter()
+                .map(|l| {
+                    project
+                        .labels
+                        .get(l)
+                        .map_or_else(|| l.0.clone(), |lab| lab.name.clone())
+                })
+                .collect::<Vec<_>>()
+                .join(", "),
+        ),
+        "labels" => CellValue::Empty,
         "duration" => task.schedule.as_ref().map_or(CellValue::Empty, |s| {
             CellValue::Number(s.duration.working_minutes as f64)
         }),
@@ -166,6 +193,11 @@ pub fn format_cell(value: &CellValue, field: &FieldRef, settings: &ProjectSettin
 fn format_number(n: f64, field: &FieldRef, settings: &ProjectSettings) -> String {
     if let FieldRef::Builtin(name) = field {
         match name.as_str() {
+            // Priority is stored as a rank so it sorts by urgency; show its name.
+            "priority" => {
+                return Priority::from_rank(n as u8)
+                    .map_or_else(String::new, |p| p.label().to_string())
+            }
             "percentComplete" => return format!("{}%", trim_number(n)),
             "duration" | "totalSlack" | "freeSlack" => return format_working_minutes(n, settings),
             _ => {}
@@ -283,6 +315,11 @@ fn passes_filter(task: &Task, filter: &Filter) -> bool {
 
 /// Compare two tasks by a list of sort keys, first non-equal key wins. A descending key
 /// reverses that key's order; ties fall through to the next key.
+///
+/// **Missing values always sort last**, in *both* directions — reversing a descending
+/// sort would otherwise float every blank to the top, which is not what anyone means by
+/// "sort by priority, highest first". So emptiness is decided before direction is applied,
+/// and only real values are reversed. (Spreadsheets and every board tool behave this way.)
 fn compare_by_keys(
     project: &ProjectState,
     a: &Task,
@@ -293,8 +330,19 @@ fn compare_by_keys(
     for key in keys {
         let va = cell(project, a, &key.field, schedule);
         let vb = cell(project, b, &key.field, schedule);
-        let ord = cmp_cell(&va, &vb);
-        let ord = if key.ascending { ord } else { ord.reverse() };
+        let ord = match (&va, &vb) {
+            (CellValue::Empty, CellValue::Empty) => Ordering::Equal,
+            (CellValue::Empty, _) => Ordering::Greater, // blanks last, either direction
+            (_, CellValue::Empty) => Ordering::Less,
+            _ => {
+                let o = cmp_cell(&va, &vb);
+                if key.ascending {
+                    o
+                } else {
+                    o.reverse()
+                }
+            }
+        };
         if ord != Ordering::Equal {
             return ord;
         }
@@ -511,6 +559,8 @@ fn builtin_label(name: &str) -> &str {
         "status" => "Status",
         "kind" => "Type",
         "completed" => "Done",
+        "priority" => "Priority",
+        "labels" => "Labels",
         "percentComplete" => "% Complete",
         "duration" => "Duration",
         "deadline" => "Deadline",
@@ -533,7 +583,9 @@ fn column_kind(project: &ProjectState, field: &FieldRef) -> ColumnKind {
     match field {
         FieldRef::Builtin(name) => match name.as_str() {
             "completed" | "critical" => ColumnKind::Bool,
-            "percentComplete" | "duration" | "totalSlack" | "freeSlack" => ColumnKind::Number,
+            "percentComplete" | "duration" | "totalSlack" | "freeSlack" | "priority" => {
+                ColumnKind::Number
+            }
             "deadline" | "start" | "scheduledStart" | "finish" | "scheduledFinish"
             | "earlyStart" | "earlyFinish" | "lateStart" | "lateFinish" => ColumnKind::Date,
             _ => ColumnKind::Text,
@@ -982,6 +1034,21 @@ mod tests {
         let p = sample();
         let sched = no_schedule();
 
+        // Blanks stay last even when the sort is DESCENDING: d has no status, so it must
+        // not float to the top just because the direction flipped.
+        let desc_status = SortKey {
+            field: builtin("status"),
+            ascending: false,
+        };
+        assert_eq!(
+            ids(&select(
+                &p,
+                &view(Filter::default(), vec![desc_status, asc("name")], None),
+                &sched
+            )),
+            ["b", "a", "c", "d"] // done > doing, blank (d) still last
+        );
+
         // Descending percentComplete: 100, 60, 10, 0 → b, c, a, d.
         let desc = SortKey {
             field: builtin("percentComplete"),
@@ -1135,6 +1202,126 @@ mod tests {
         assert_eq!(a.cells[1].display, "○"); // completed=false → glyph
         assert_eq!(a.cells[1].value, CellValue::Bool(false)); // typed value still available
         assert_eq!(a.cells[2].display, "10%"); // percentComplete formatted
+    }
+
+    // ── labels & priority ────────────────────────────────────────────────────────
+
+    #[test]
+    fn priority_sorts_by_urgency_and_displays_its_name() {
+        use crate::model::Priority;
+        let mut p = project();
+        for (id, name, pr) in [
+            ("hi", "High one", Some(Priority::High)),
+            ("lo", "Low one", Some(Priority::Low)),
+            ("ur", "Urgent one", Some(Priority::Urgent)),
+            ("no", "Unset one", None),
+        ] {
+            let mut t = Task::new(TaskId::from_raw(id), name);
+            t.priority = pr;
+            p.tasks.insert(t.id.clone(), t);
+        }
+        let sched = no_schedule();
+
+        // Descending priority: Urgent, High, Low, then the unset one (Empty sorts last).
+        let desc = SortKey {
+            field: builtin("priority"),
+            ascending: false,
+        };
+        let got = select(&p, &view(Filter::default(), vec![desc], None), &sched);
+        assert_eq!(ids(&got), ["ur", "hi", "lo", "no"]);
+
+        // The cell is a rank (so it sorts) but displays as the name.
+        let hi = &p.tasks[&TaskId::from_raw("hi")];
+        let v = cell(&p, hi, &builtin("priority"), &sched);
+        assert_eq!(v, CellValue::Number(2.0));
+        assert_eq!(format_cell(&v, &builtin("priority"), &p.settings), "High");
+        // An unset priority renders blank.
+        let none = &p.tasks[&TaskId::from_raw("no")];
+        let v = cell(&p, none, &builtin("priority"), &sched);
+        assert_eq!(format_cell(&v, &builtin("priority"), &p.settings), "");
+    }
+
+    #[test]
+    fn labels_resolve_to_names_and_group() {
+        use crate::ids::LabelId;
+        use crate::model::Label;
+        let mut p = project();
+        p.upsert_label(Label {
+            id: LabelId::from_raw("l1"),
+            name: "Bug".into(),
+            color: "red".into(),
+        });
+        p.upsert_label(Label {
+            id: LabelId::from_raw("l2"),
+            name: "Chore".into(),
+            color: "grey".into(),
+        });
+        for (id, name) in [("a", "Alpha"), ("b", "Bravo"), ("c", "Charlie")] {
+            p.create_task(TaskId::from_raw(id), name, None).unwrap();
+        }
+        p.set_task_labels(&TaskId::from_raw("a"), vec![LabelId::from_raw("l1")])
+            .unwrap();
+        p.set_task_labels(
+            &TaskId::from_raw("b"),
+            vec![LabelId::from_raw("l1"), LabelId::from_raw("l2")],
+        )
+        .unwrap();
+        let sched = no_schedule();
+
+        // The cell shows label NAMES, joined — not opaque ids.
+        let b = &p.tasks[&TaskId::from_raw("b")];
+        assert_eq!(
+            cell(&p, b, &builtin("labels"), &sched),
+            CellValue::Text("Bug, Chore".into())
+        );
+        // A task with no labels is Empty (and groups last).
+        let groups = select(
+            &p,
+            &view(
+                Filter::default(),
+                vec![asc("name")],
+                Some(builtin("labels")),
+            ),
+            &sched,
+        );
+        let labels: Vec<_> = groups.iter().map(|g| g.key_label.clone()).collect();
+        assert_eq!(labels, ["Bug", "Bug, Chore", ""]);
+    }
+
+    #[test]
+    fn label_ops_validate_and_clean_up() {
+        use crate::ids::LabelId;
+        use crate::model::Label;
+        let mut p = project();
+        p.upsert_label(Label {
+            id: LabelId::from_raw("l1"),
+            name: "Bug".into(),
+            color: "red".into(),
+        });
+        p.create_task(TaskId::from_raw("a"), "Alpha", None).unwrap();
+
+        // Unknown label id is rejected.
+        assert_eq!(
+            p.set_task_labels(&TaskId::from_raw("a"), vec![LabelId::from_raw("ghost")]),
+            Err(crate::ops::OpError::NotFound)
+        );
+        // Unknown task is rejected.
+        assert_eq!(
+            p.set_task_labels(&TaskId::from_raw("ghost"), vec![]),
+            Err(crate::ops::OpError::NotFound)
+        );
+        // Duplicates are collapsed.
+        p.set_task_labels(
+            &TaskId::from_raw("a"),
+            vec![LabelId::from_raw("l1"), LabelId::from_raw("l1")],
+        )
+        .unwrap();
+        assert_eq!(p.tasks[&TaskId::from_raw("a")].labels.len(), 1);
+
+        // Deleting the label removes it from the task — no dangling reference.
+        p.delete_label(&LabelId::from_raw("l1"));
+        assert!(p.labels.is_empty());
+        assert!(p.tasks[&TaskId::from_raw("a")].labels.is_empty());
     }
 
     // ── calendar projection ──────────────────────────────────────────────────────


### PR DESCRIPTION
**Phase 3, PR-5 of 6** from `code/specs/task-app-view-layer.md`. **Stacked on #8726** (base = `feat/task-app-view-calendar`).

## What's added
- **`Label { id, name, color }`** + `LabelId`, registered per project (`ProjectState::labels`) and referenced from `Task::labels` — so renaming or recolouring a label updates every task at once. **`Priority { Low, Normal, High, Urgent }`** on `Task::priority`, with `rank()`/`label()`/`from_rank()`.
- **Ops**: `upsert_label`, `delete_label` (prunes the label from every task, so none is left pointing at a deleted one), `set_task_labels` (rejects unknown label/task ids, de-duplicates, validates *before* mutating), `set_priority`.
- **View built-ins**:
  - **`priority` resolves to its numeric *rank*, not its name** — so sorting orders by urgency (Low→Urgent) rather than alphabetically (High→Low→Normal→Urgent). `format_cell` maps the rank back to the display name.
  - **`labels` resolves to label *names*** (comma-joined via the project registry), so filtering and searching see what the user sees rather than opaque ids.
- Both `Task` fields are serde-defaulted and skipped when empty, so **pre-label snapshots still deserialize** unchanged.

## Fixed (caught by the new priority sort test)
**Blanks now sort last in *both* directions.** A descending sort previously reversed the whole ordering, floating every empty cell to the top — not what "sort by priority, highest first" means. Emptiness is now decided *before* direction is applied, so only real values reverse (matching spreadsheets and every board tool). The comparator remains a total order, so `sort_by` still can't panic. Covered by a dedicated descending-with-blanks case.

## Verification
3 new tests + the descending-with-blanks case (**89 total**). Clippy clean **with and without** `--all-features`; fmt clean. **Security-reviewed clean** — `f64 as u8` is saturating and `from_rank` returns `Option` (and that branch is unreachable for custom fields anyway); label ops are bounded and validate-before-mutate; serde back-compat confirmed; the blanks-last comparator re-verified total. Also documented that `Label::color` is round-tripped verbatim, so a host interpolating it into CSS must escape it there.

## Next
PR-6 (last of Phase 3): `task-wasm` view exports + move the web host's row-formatting into the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)