### PR TITLE
feat(chief): gate host RPC behind Rust handlers

### DIFF
--- a/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Add a canonical deny-all Deno launch plan shared by package generation,
+  verification, and process activation.
+- Route subprocess host RPC calls through profile-gated D18D handlers in Rust.
+
+## Unreleased
+
 - Added JSON host profiles with exact D18D tool allowlists, privilege ceilings,
   capability coverage checks, catalog completeness validation, and an active
   runtime wrapper for executable Chief jobs.

--- a/code/packages/rust/chief-of-staff-host-runtime/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host-runtime/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding-adventures-json-value = { path = "../json-value" }
+coding-adventures-json-serializer = { path = "../json-serializer" }
 coding_adventures_ed25519 = { path = "../ed25519" }
 coding_adventures_sha256 = { path = "../sha256" }
 generic-job-protocol = { path = "../generic-job-protocol" }

--- a/code/packages/rust/chief-of-staff-host-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/README.md
@@ -38,6 +38,18 @@ receives no differentiated OS permissions; it communicates only through the
 versioned stdio RPC envelope. The executable test proves all five observable OS
 surfaces are denied and that post-signing code tampering prevents launch.
 
+The trusted build and runtime paths now share `DenoLaunchPlan`. It emits the
+literal `launch.sh` stored inside the signed package, verifies that exact script
+before activation, and derives the child process arguments from the same fixed
+flag list. A package cannot sign one command while the runtime executes another.
+
+Subprocess-originated `HostRpcRequest` values can be handled by
+`ActiveHostToolRuntime::handle_rpc` or routed across profile hosts with
+`ActiveOrchestratorRuntime::handle_rpc`. The Rust host parses the untrusted JSON,
+constructs the canonical D18D invocation context, and executes only the
+allowlisted, capability-checked handler catalog. Unknown tools and malformed
+arguments are rejected before any handler can run.
+
 An orchestrator profile has this shape:
 
 ```json

--- a/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
@@ -5,14 +5,15 @@
 mod package;
 
 pub use package::{
-    verify_agent_package, PackageKeyType, PackageKeyring, PackageVerificationError,
+    verify_agent_package, DenoLaunchPlan, PackageKeyType, PackageKeyring, PackageVerificationError,
     TrustedPackageKey, VerifiedAgentPackage,
 };
 
 use chief_of_staff_tool_api::{
-    validate_tool_id, InMemoryToolRuntime, PrivilegeTier, ToolApiError, ToolDefinition,
-    ToolExecutionTrace, ToolHandler, ToolInvocationRequest,
+    validate_tool_id, InMemoryToolRuntime, PrivilegeTier, RequestedBy, ToolApiError,
+    ToolDefinition, ToolExecutionTrace, ToolHandler, ToolInvocationRequest,
 };
+use coding_adventures_json_serializer::serialize as serialize_json;
 use coding_adventures_json_value::{parse as parse_json, JsonValue};
 use generic_job_protocol::{JobRequest, JobResponse};
 use generic_job_runtime::{
@@ -412,30 +413,16 @@ impl HostProcessSpec {
         package: &VerifiedAgentPackage,
         restart_policy: StdioWorkerRestartPolicy,
     ) -> Result<Self, HostRuntimeError> {
-        let entrypoint = package.path().join("code/agent_runtime.ts");
+        let entrypoint = package.path().join(DenoLaunchPlan::entrypoint_relative());
         if !entrypoint.is_file() {
             return Err(HostRuntimeError::MissingDenoEntrypoint(entrypoint));
         }
-        let entrypoint = entrypoint
-            .to_str()
-            .ok_or_else(|| HostRuntimeError::InvalidDenoEntrypoint(entrypoint.clone()))?;
         Ok(Self::new(
             host_id,
             StdioWorkerCommand::new(
                 deno_program,
-                vec![
-                    "run".to_string(),
-                    "--quiet".to_string(),
-                    "--no-prompt".to_string(),
-                    "--deny-net".to_string(),
-                    "--deny-read".to_string(),
-                    "--deny-write".to_string(),
-                    "--deny-env".to_string(),
-                    "--deny-sys".to_string(),
-                    "--deny-run".to_string(),
-                    "--deny-ffi".to_string(),
-                    entrypoint.to_string(),
-                ],
+                DenoLaunchPlan::arguments(&entrypoint)
+                    .map_err(|_| HostRuntimeError::InvalidDenoEntrypoint(entrypoint.clone()))?,
             ),
             restart_policy,
         ))
@@ -659,6 +646,19 @@ impl ActiveOrchestratorRuntime {
             .expect("active orchestrator must retain each tool owner")
             .invoke_with_events(request))
     }
+
+    /// Dispatch one subprocess-originated call through the canonical D18D
+    /// handler runtime owned by the tool's profile host.
+    pub fn handle_rpc(&self, request: HostRpcRequest) -> Result<HostRpcResponse, HostRuntimeError> {
+        let host_id = self
+            .tool_owners
+            .get(&request.tool_id)
+            .ok_or_else(|| HostRuntimeError::ToolNotAllowed(request.tool_id.clone()))?;
+        self.hosts
+            .get(host_id)
+            .expect("active orchestrator must retain each tool owner")
+            .handle_rpc(request)
+    }
 }
 
 impl ActiveHostToolRuntime {
@@ -684,6 +684,43 @@ impl ActiveHostToolRuntime {
 
     pub fn definitions(&self) -> Vec<&ToolDefinition> {
         self.runtime.list()
+    }
+
+    /// Convert an untrusted subprocess RPC frame into the repository-owned
+    /// invocation contract, then execute only through registered handlers.
+    pub fn handle_rpc(&self, request: HostRpcRequest) -> Result<HostRpcResponse, HostRuntimeError> {
+        validate_label("call_id", &request.call_id)?;
+        validate_tool_id(&request.tool_id).map_err(HostRuntimeError::ToolApi)?;
+        if !self.profile.allows_tool(&request.tool_id) {
+            return Err(HostRuntimeError::ToolNotAllowed(request.tool_id));
+        }
+        let arguments = parse_json(&request.arguments_json)
+            .map_err(|error| HostRuntimeError::InvalidRpcArguments(error.message.to_string()))?;
+        let invocation = ToolInvocationRequest {
+            call_id: request.call_id,
+            tool_id: request.tool_id,
+            arguments,
+            requested_by: RequestedBy::Agent,
+            session_id: None,
+            job_id: None,
+            agent_id: Some(self.profile.host_id.clone()),
+            user_id: None,
+            requested_at: 0,
+            deadline_at: None,
+            idempotency_key: None,
+        };
+        let trace = self.runtime.invoke_with_events(&invocation);
+        if let Some(error) = trace.result.error {
+            return Err(HostRuntimeError::ToolExecution {
+                tool_id: invocation.tool_id,
+                kind: error.kind.to_string(),
+                message: error.message,
+            });
+        }
+        let output = trace.result.output.unwrap_or(JsonValue::Null);
+        let output_json = serialize_json(&output)
+            .map_err(|error| HostRuntimeError::InvalidRpcOutput(error.message))?;
+        Ok(HostRpcResponse { output_json })
     }
 }
 
@@ -720,6 +757,12 @@ pub enum HostRuntimeError {
     MissingProcessHosts(Vec<String>),
     UnknownProcessHost(String),
     InvalidRpcArguments(String),
+    InvalidRpcOutput(String),
+    ToolExecution {
+        tool_id: String,
+        kind: String,
+        message: String,
+    },
     ProcessIo {
         host_id: String,
         message: String,
@@ -801,6 +844,14 @@ impl Display for HostRuntimeError {
             Self::InvalidRpcArguments(message) => {
                 write!(f, "invalid host RPC arguments JSON: {message}")
             }
+            Self::InvalidRpcOutput(message) => {
+                write!(f, "host RPC output could not be serialized: {message}")
+            }
+            Self::ToolExecution {
+                tool_id,
+                kind,
+                message,
+            } => write!(f, "host handler '{tool_id}' failed with {kind}: {message}"),
             Self::ProcessIo { host_id, message } => {
                 write!(f, "host '{host_id}' process I/O failed: {message}")
             }
@@ -926,7 +977,10 @@ mod tests {
     use coding_adventures_ed25519::{generate_keypair, sign};
     use generic_job_protocol::JobResult;
     use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static NEXT_PACKAGE_ID: AtomicU64 = AtomicU64::new(0);
 
     const PROFILE: &str = r#"{
       "profile_id": "test_profile",
@@ -1018,16 +1072,17 @@ mod tests {
 
     fn signed_deno_package() -> (std::path::PathBuf, PackageKeyring) {
         let path = std::env::temp_dir().join(format!(
-            "chief-deno-package-{}-{}",
+            "chief-deno-package-{}-{}-{}",
             std::process::id(),
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            NEXT_PACKAGE_ID.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::create_dir_all(path.join("code")).unwrap();
         std::fs::write(path.join("manifest.json"), b"{\"runtime\":\"typescript\"}").unwrap();
-        std::fs::write(path.join("launch.sh"), b"generated by host runtime").unwrap();
+        DenoLaunchPlan::write_launch_script(&path).unwrap();
         std::fs::write(path.join("PUBKEY_ID"), b"dev-deno").unwrap();
         std::fs::write(
             path.join("code/agent_runtime.ts"),
@@ -1110,6 +1165,94 @@ while (true) {
                 .output,
             Some(JsonValue::String("ok".to_string()))
         );
+    }
+
+    #[test]
+    fn active_host_dispatches_rpc_through_profile_gated_handler() {
+        let mut runtime = HostProfileRuntime::from_json(PROFILE).unwrap();
+        runtime
+            .register_handler(
+                definition("demo.read", PrivilegeTier::Tier1, &["demo_read"]),
+                |arguments, context: chief_of_staff_tool_api::ToolExecutionContext| {
+                    assert_eq!(context.requested_by, RequestedBy::Agent);
+                    assert_eq!(context.agent_id.as_deref(), Some("test_host"));
+                    assert_eq!(arguments, JsonValue::Object(vec![]));
+                    Ok(ToolHandlerOutput::new(JsonValue::String(
+                        "rust".to_string(),
+                    )))
+                },
+            )
+            .unwrap();
+        let active = runtime.activate().unwrap();
+
+        let response = active
+            .handle_rpc(HostRpcRequest {
+                call_id: "rpc_1".to_string(),
+                tool_id: "demo.read".to_string(),
+                arguments_json: "{}".to_string(),
+            })
+            .unwrap();
+
+        assert_eq!(
+            parse_json(&response.output_json).unwrap(),
+            JsonValue::String("rust".to_string())
+        );
+    }
+
+    #[test]
+    fn active_host_rejects_rpc_before_unregistered_handler_execution() {
+        let mut runtime = HostProfileRuntime::from_json(PROFILE).unwrap();
+        runtime
+            .register_handler(
+                definition("demo.read", PrivilegeTier::Tier1, &["demo_read"]),
+                |_arguments, _context| {
+                    Ok(ToolHandlerOutput::new(JsonValue::String("ok".to_string())))
+                },
+            )
+            .unwrap();
+        let active = runtime.activate().unwrap();
+
+        assert!(matches!(
+            active.handle_rpc(HostRpcRequest {
+                call_id: "rpc_2".to_string(),
+                tool_id: "demo.write".to_string(),
+                arguments_json: "{}".to_string(),
+            }),
+            Err(HostRuntimeError::ToolNotAllowed(tool_id)) if tool_id == "demo.write"
+        ));
+    }
+
+    #[test]
+    fn deno_process_arguments_match_signed_launch_plan() {
+        let (package_path, keyring) = signed_deno_package();
+        let package = verify_agent_package(&package_path, &keyring).unwrap();
+        let spec = HostProcessSpec::deny_all_deno(
+            "deno_host",
+            "deno",
+            &package,
+            StdioWorkerRestartPolicy::Never,
+        )
+        .unwrap();
+        let expected = DenoLaunchPlan::launch_script()
+            .lines()
+            .nth(1)
+            .unwrap()
+            .strip_prefix("exec deno ")
+            .unwrap()
+            .split_whitespace()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            spec.command.args[..spec.command.args.len() - 1],
+            expected[..expected.len() - 1]
+        );
+        assert!(spec
+            .command
+            .args
+            .last()
+            .unwrap()
+            .ends_with(expected.last().unwrap()));
+        std::fs::remove_dir_all(package_path).unwrap();
     }
 
     #[test]
@@ -1329,7 +1472,11 @@ for line in sys.stdin:
 
     #[test]
     fn signed_package_launches_deny_all_deno_rpc_worker() {
-        if Command::new("deno").arg("--version").output().is_err() {
+        if !Command::new("deno")
+            .arg("--version")
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
             eprintln!("skipping test because Deno is unavailable");
             return;
         }

--- a/code/packages/rust/chief-of-staff-host-runtime/src/package.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/package.rs
@@ -9,6 +9,55 @@ use std::path::{Path, PathBuf};
 const SIGNATURE_FILE: &str = "SIGNATURE";
 const KEY_ID_FILE: &str = "PUBKEY_ID";
 const HASH_DOMAIN: &[u8] = b"chief-agent-package-v1\0";
+const DENO_ENTRYPOINT: &str = "code/agent_runtime.ts";
+const DENO_FLAGS: &[&str] = &[
+    "run",
+    "--quiet",
+    "--no-prompt",
+    "--deny-net",
+    "--deny-read",
+    "--deny-write",
+    "--deny-env",
+    "--deny-sys",
+    "--deny-run",
+    "--deny-ffi",
+];
+
+/// Canonical build-time and runtime launch plan for deny-all Deno agents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DenoLaunchPlan;
+
+impl DenoLaunchPlan {
+    pub fn entrypoint_relative() -> &'static str {
+        DENO_ENTRYPOINT
+    }
+
+    pub fn arguments(entrypoint: &Path) -> Result<Vec<String>, PackageVerificationError> {
+        let entrypoint = entrypoint
+            .to_str()
+            .ok_or_else(|| PackageVerificationError::NonUtf8Path(entrypoint.to_path_buf()))?;
+        Ok(DENO_FLAGS
+            .iter()
+            .map(|flag| (*flag).to_string())
+            .chain(std::iter::once(entrypoint.to_string()))
+            .collect())
+    }
+
+    pub fn launch_script() -> String {
+        let arguments = DENO_FLAGS
+            .iter()
+            .copied()
+            .chain(std::iter::once(DENO_ENTRYPOINT))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("#!/bin/sh\nexec deno {arguments}\n")
+    }
+
+    pub fn write_launch_script(package_path: &Path) -> Result<(), PackageVerificationError> {
+        fs::write(package_path.join("launch.sh"), Self::launch_script())
+            .map_err(PackageVerificationError::Io)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackageKeyType {
@@ -129,6 +178,14 @@ pub fn verify_agent_package(
     if !files.iter().any(|path| path.starts_with("code/")) {
         return Err(PackageVerificationError::MissingCode);
     }
+    if !files.contains(DENO_ENTRYPOINT) {
+        return Err(PackageVerificationError::MissingDenoEntrypoint);
+    }
+    let launch_script =
+        fs::read_to_string(package_path.join("launch.sh")).map_err(PackageVerificationError::Io)?;
+    if launch_script != DenoLaunchPlan::launch_script() {
+        return Err(PackageVerificationError::UntrustedLaunchScript);
+    }
     if !coding_adventures_ed25519::verify(&digest, &signature, &key.public_key) {
         return Err(PackageVerificationError::SignatureMismatch);
     }
@@ -215,6 +272,8 @@ pub enum PackageVerificationError {
     InvalidSignatureLength,
     MissingRequiredFile(&'static str),
     MissingCode,
+    MissingDenoEntrypoint,
+    UntrustedLaunchScript,
     Symlink(PathBuf),
     NonUtf8Path(PathBuf),
     SignatureMismatch,
@@ -234,6 +293,12 @@ impl Display for PackageVerificationError {
             Self::InvalidSignatureLength => f.write_str("package signature must be 64 raw bytes"),
             Self::MissingRequiredFile(path) => write!(f, "agent package is missing '{path}'"),
             Self::MissingCode => f.write_str("agent package must contain at least one code file"),
+            Self::MissingDenoEntrypoint => {
+                f.write_str("agent package is missing 'code/agent_runtime.ts'")
+            }
+            Self::UntrustedLaunchScript => {
+                f.write_str("agent package launch.sh does not match the trusted deny-all plan")
+            }
             Self::Symlink(path) => write!(
                 f,
                 "agent package cannot contain symlink '{}'",
@@ -269,12 +334,12 @@ mod tests {
     fn write_signed_package(path: &Path, key_id: &str, secret_key: &[u8; 64]) {
         fs::create_dir_all(path.join("code")).unwrap();
         fs::write(path.join("manifest.json"), b"{\"runtime\":\"typescript\"}").unwrap();
+        DenoLaunchPlan::write_launch_script(path).unwrap();
         fs::write(
-            path.join("launch.sh"),
-            b"#!/bin/sh\nexec deno run --no-prompt code/agent.ts\n",
+            path.join("code/agent_runtime.ts"),
+            b"console.log('ready');\n",
         )
         .unwrap();
-        fs::write(path.join("code/agent.ts"), b"console.log('ready');\n").unwrap();
         fs::write(path.join(KEY_ID_FILE), key_id).unwrap();
         let (digest, _) = hash_package_contents(path).unwrap();
         fs::write(path.join(SIGNATURE_FILE), sign(&digest, secret_key)).unwrap();
@@ -322,6 +387,43 @@ mod tests {
         );
         fs::remove_dir_all(first).unwrap();
         fs::remove_dir_all(second).unwrap();
+    }
+
+    #[test]
+    fn trusted_launch_plan_is_literal_and_rejects_script_tampering() {
+        let path = package_dir("launch-plan");
+        let (public_key, secret_key) = generate_keypair(&[31; 32]);
+        write_signed_package(&path, "prod-launch", &secret_key);
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    "prod-launch",
+                    PackageKeyType::Production,
+                    public_key,
+                    PrivilegeTier::Tier3,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        let script = DenoLaunchPlan::launch_script();
+        for flag in DENO_FLAGS {
+            assert!(script.contains(flag));
+        }
+        assert!(!script.contains('$'));
+        verify_agent_package(&path, &keyring).unwrap();
+
+        fs::write(
+            path.join("launch.sh"),
+            "#!/bin/sh\nexec deno run --allow-net code/agent_runtime.ts\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            verify_agent_package(&path, &keyring),
+            Err(PackageVerificationError::UntrustedLaunchScript)
+        ));
+        fs::remove_dir_all(path).unwrap();
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -260,11 +260,16 @@ literal no-prompt and deny flags in Rust, launches the signed
 The executable worker proves environment, filesystem read/write, subprocess,
 and network access are denied; post-signing entrypoint tampering prevents launch.
 
+The host-capability slice now makes the signed `launch.sh` and runtime process
+arguments come from one canonical deny-all launch plan. Launch-time verification
+rejects any script drift. Subprocess-originated RPC is parsed into the canonical
+D18D invocation contract and executed only by the Rust host's profile-gated,
+capability-checked handler catalog; unknown tools never reach a handler.
+
 These items are Chief of Staff architecture, not smart-home platform work:
 
-- Move the deny-all Deno proof worker behind production host-side capability
-  handlers and make the package launch script generation part of the trusted
-  build pipeline.
+- Complete the bidirectional Deno agent transport so agent-originated `host.*`
+  calls use the production Rust dispatcher during a supervised process run.
 - Run a Chief job end to end through scheduler or job framework, tool runtime,
   approval checks, result journal, and final user-visible report.
 - Add approval UX and policy wiring for Tier2 or stronger actions such as


### PR DESCRIPTION
## Summary
- route subprocess-originated host RPC through profile-gated D18D handlers in the Rust host
- generate signed `launch.sh` and runtime Deno arguments from one canonical deny-all launch plan
- reject launch-script drift and document the remaining bidirectional agent transport gap

## Validation
- `cargo test -p chief-of-staff-host-runtime -- --nocapture` (18 passed)
- real Deno 2.9.1 deny-all worker test passed
- `cargo clippy -p chief-of-staff-host-runtime --all-targets -- -D warnings`
- `sh chief-of-staff-host-runtime/BUILD`
- `cargo test -p weather-agent-e2e -- --nocapture` (5 unit + 2 integration passed; 1 live HTTPS test ignored)
- `sh weather-agent-e2e/BUILD`
- generated `code/packages/rust/Cargo.lock` removed