### PR TITLE
feat(hl): Devanagari writing track HI-W01–W05 (first Indic writing lessons)

### DIFF
--- a/code/learning/human-languages/hindi/CHANGELOG.md
+++ b/code/learning/human-languages/hindi/CHANGELOG.md
@@ -1,5 +1,108 @@
 # Changelog
 
+## Writing track W01–W05 — hand-writing Devanagari
+
+The first writing lessons for **any Indic track**. Ten Indic/Dravidian tracks had
+reached Chapter 5 with **zero** writing lessons; this opens the first of them,
+modelled on Arabic `AR-W01–12` and Russian `RU-W01–05`.
+
+The arc is built so every lesson assembles vocabulary the learner already has,
+and the last one produces the **first word of the course**:
+
+- **`HI-W01-shirorekha-na-ma`** — the **shirorekhā**, the line Devanagari hangs
+  from. शिरोरेखा is literally "**head-line**" (*śiras* + *rekhā*), and *śiras*
+  descends from PIE \**ḱerh₂-* "head, horn" — the root behind Latin *cornu*,
+  Latin *cerebrum* and English **horn**. Two counter-intuitive habits taken
+  straight from the data: it is drawn **last**, and across a word it is **one
+  bar** — both flagged in the lesson as the **common convention, not a rule**,
+  since plenty of writers cap each letter as they go. Plus न and म and the
+  commonest frame — **spine on the right, character on the left, bar across the
+  top** — stated as *commonest* rather than universal, with the spineless
+  minority (**द**, **र**) named up front.
+- **`HI-W02-abugida-ka-ta`** — the **inherent vowel**, met head-on: **क is "ka",
+  not "k"**. Which retroactively upgrades W01: नम was never "nm", it was *nama*,
+  the first half of *namaste*. Names the script type — an **abugida** — and gets
+  the coinage right, which is more interesting than the version usually told:
+  *ʾä-bu-gi-da* names the first four **consonants of the old Semitic order** *and*
+  the first four **Ge'ez vowel series** simultaneously, so unlike *alphabet*
+  (which merely recites *alpha-beta*) the term **demonstrates the system it
+  names**. Noted too that Ge'ez's own recitation order is *hä-lä-ḥä-mä…*, so this
+  is a scholar's coinage, not the Ethiopian schoolroom sequence. Plus क, त, and
+  the **five stop families** sorted by place of articulation, soft palate forward
+  to the lips (क → च → ट → त → प), analysed by Indian phoneticians — Pāṇini is
+  roughly 4th c. BCE — millennia before Europe attempted the same.
+- **`HI-W03-matras-naam`** — **mātrās**. मात्रा means "a **measure**", from *mā-*
+  "to measure" (PIE \**meh₁-*, whence *meter*, *measure*, *immense*, and *month*
+  — the moon as the original measuring instrument). The load-bearing point is
+  that a mātrā **replaces** the inherent vowel rather than adding to it. Teaches
+  ा and े, builds **नाम** (Ch. 2), and closes on **ि** — *the only Hindi mātrā*
+  written **before** the consonant and pronounced **after**. The lesson declines
+  to explain why: the placement is an inherited Brahmi quirk, and an invented
+  rationalisation would be worse than none.
+- **`HI-W04-ra-sa-mera-naam`** — र, the **first spineless letter the learner
+  writes** (with **द** named so it doesn't read as unique — द has in fact already
+  been *read*, in Ch. 1's *dhanyavād*), and स. Carries a long-range
+  etymology told with its uncertainty intact: *šin* → **Σ** → **S** going west is
+  certain; **Brahmi**'s descent from the same Semitic family via **Aramaic** is
+  the **leading view, not consensus**, so the lesson says "probably cousins," not
+  "cousins." Builds **मेरा नाम**, and gets the word-boundary story the right way
+  round: modern Hindi uses an **ordinary space** like English, and the break in
+  the bar is the **consequence** of that space, not the device that marks it.
+  (Continuous bars across a whole line belong to spaceless Sanskrit manuscripts.)
+- **`HI-W05-virama-namaste`** — the **virama** ्, which kills the inherent vowel.
+  विराम is "a **stopping**" (*vi-* + *ram-*) — and rather than the loose claim
+  that it *is* the Hindi full stop, the lesson shows the word **grading Hindi's
+  punctuation**: *pūrṇ virām* (complete stop) = full stop, *alp virām* (slight
+  stop) = comma, *ardh virām* (half stop) = semicolon. Also names the mark
+  honestly: *virāma* is the Sanskrit/Unicode term, **halant** is what everyday
+  Hindi calls it. Then what actually happens in handwriting: the bare consonant
+  **fuses** with the next into a **conjunct** (स् + त → स्त), a **spine-bearing**
+  first consonant surrendering its spine — scoped that way because र, taught one
+  lesson earlier, has no spine to surrender and uses **repha**/**ra-kāra**
+  instead (र् + क → र्क, क + ्र → क्र), while क्ष/त्र/ज्ञ are simply irregular.
+  Assembles **नमस्ते**, then reveals
+  what the learner has been saying since lesson one: *namas* ("a **bow**", ←
+  *nam-* "to bend") + *te* ("to you"). The greeting **is** the bow. *Namaskār* is
+  the same *namas* + *kāra*, "making".
+
+### Data honesty
+
+Everything the learner is asked to **hand-write** comes from
+`data/scripts/devanagari.json` — 28 letters and 12 marks. Every such letter,
+mātrā and mark has a real entry with real `components` and `strokeOrder`;
+**nothing was invented**.
+
+**Six** letters appear somewhere in the text without entries — **ख ज ञ ट ण ष** —
+and none of them is ever presented as something to draw. Two are cited as letters
+(**ट** in W02's articulation chart, **ख** inside the word *shirorekhā*) and each
+carries an explicit "read it now, draw it when its entry is written" note. The
+other four only occur *inside quoted Hindi words* — ण in *pūrṇ virām*, ष in क्ष,
+ज and ञ in ज्ञ — where the word is the point and the glyph is incidental.
+
+To be precise about the guarantee, since a vaguer version of it was wrong in an
+earlier draft of this entry: **every letter this track asks you to hand-write has
+a real entry with real `components` and `strokeOrder`.** It is not true, and is
+not claimed, that every Devanagari character appearing anywhere in the prose has
+one.
+
+The file is marked `complete: false` (its inventory covers the
+greeting/self-introduction vocabulary), and its stroke orders are flagged as the
+common handwriting convention rather than a standard — so **W01 says the same in
+the lesson text**, since it would otherwise state "draw the bar last, one bar per
+word" as flat rules when many writers cap each letter as they go.
+
+### Scope note
+
+`devanagari.json` serves **three** tracks — Hindi, **Marathi** and **Sanskrit**.
+This PR opens only the Hindi one; the other two can mirror this arc against the
+same data, and **नमस्ते is identical in all three**.
+
+**Still blocked, stated rather than skipped:** among Indic scripts only
+`devanagari.json` and `gujarati.json` exist. **Tamil, Telugu, Kannada, Malayalam,
+Bengali and Gurmukhi have no letter data at all**, so no writing track is
+possible for them until that data is authored — a real piece of work, not an
+oversight.
+
 ## Chapters 3–5 — How-are-you, Farewells, First Verbs
 
 - Three new chapters carry Hindi to Chapter 5, matching the leading tracks'

--- a/code/learning/human-languages/hindi/lessons/HI-W01-shirorekha-na-ma.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W01-shirorekha-na-ma.md
@@ -1,0 +1,101 @@
+---
+id: HI-W01-shirorekha-na-ma
+chapter: 1
+type: writing
+headword: "न, म"
+gloss: the shirorekhā (the line Devanagari hangs from) and your first two letters, न (na) and म (ma)
+romanization: "na, ma"
+prerequisites: [HI-C01-namaste]
+sounds: [devanagari-top-bar, devanagari-spine]
+roots: [sanskrit-shiras, sanskrit-rekha]
+etymology_hook: "shirorekhā = शिरोरेखा, literally 'HEAD-LINE' — śiras 'head' + rekhā 'line'; and śiras comes from PIE *ḱerh₂-, the same root that gave Latin cornu 'horn' and cerebrum 'brain', and English HORN — so the line over Hindi writing is, etymologically, its horn"
+est_minutes: 4
+reviews_of: [HI-C01-namaste, HI-C01-namaskar]
+---
+
+# The line on top — and न, म
+
+## Warm-up
+
+[PAUSE 2s] Look at any line of Hindi:
+
+> नमस्ते
+
+Before any individual letter, notice the thing you cannot miss: **a horizontal
+line running across the top of the whole word.** Latin letters sit *on* a line.
+Devanagari letters **hang from** one.
+
+## The shirorekhā
+
+That line is the **शिरोरेखा** (*shirorekhā*) — literally the **"head-line"**:
+*śiras* "head" + *rekhā* "line."
+
+*Śiras* is worth a moment. It descends from Proto-Indo-European \**ḱerh₂-*,
+"head, horn" — the root behind Latin *cornu* ("horn"), Latin *cerebrum*
+("brain"), Greek *kara* ("head"), and English **horn**. The line across the top
+of Hindi writing is, by ancestry, its **horn**.
+
+Two habits about it, and they are the opposite of what you'd guess:
+
+1. **You draw it last.** Write the letter's body first, then cap it.
+2. **Across a word it is one line.** Rather than capping each letter separately,
+   write the letters and then draw a single bar over the whole word. That is why
+   Hindi words look like they're strung on a wire: they are.
+
+A caveat you should have from the first lesson: this is the **common convention,
+not a rule**. Plenty of writers cap each letter as they go, and some draw the bar
+first. Stroke orders in this track are how it is usually taught, not a standard
+you can be wrong about.
+
+And one note about the word *shirorekhā* itself, written **शिरोरेखा**: it
+contains a letter — **ख** — that this curriculum can't yet give you stroke data
+for. Read the word; don't try to draw it. This track only asks you to hand-write
+letters whose stroke data actually exists, and it will say so every time that gap
+shows up.
+
+## न — "na"
+
+Three pieces:
+
+1. **a left bowl** — a rounded scoop on the left.
+2. **a right spine** — a vertical downstroke on the right.
+3. **the top bar** — capping both. *Last.*
+
+## म — "ma"
+
+Four pieces — the same spine, with two loops instead of a bowl:
+
+1. **a lower loop**
+2. **an upper loop**, sitting above it
+3. **the right spine**
+4. **the top bar** — last, again.
+
+## The pattern you should already be noticing
+
+Both letters end with *the top bar*. And both have a **vertical spine on the
+right**, with the letter's distinguishing shape hanging off to the left of it.
+
+That is the commonest Devanagari skeleton: **spine on the right, character on the
+left, bar across the top.** Learn the frame once and many new letters are only
+the left-hand part.
+
+"Commonest," not "only" — a minority of letters (**द** and **र** among them)
+have **no** right-hand spine at all. You'll meet them as they come.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: न — "bowl, spine, **bar last**"]
+- [YOU WRITE: म — "lower loop, upper loop, spine, **bar last**"]
+- [YOU WRITE: न and म side by side, then **one single bar across both**]
+- [YOU SAY: "शिरोरेखा — the **head-line**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the line across the top called, and what does the word
+literally mean? (**Shirorekhā** — "**head-line**".) When is it usually drawn?
+(**Last** — and as **one** line across the whole word. Usually: it's the common
+convention, not a rule.) Draw **न** — its
+three pieces? (Bowl, spine, bar.) Draw **म** — what makes it different from न?
+(**Two loops** where न has one bowl.) Where does the spine sit in both? (**On the
+right** — though a minority of letters have none at all.) Next: the surprise hiding inside every Devanagari consonant.

--- a/code/learning/human-languages/hindi/lessons/HI-W02-abugida-ka-ta.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W02-abugida-ka-ta.md
@@ -1,0 +1,123 @@
+---
+id: HI-W02-abugida-ka-ta
+chapter: 1
+type: writing
+headword: "क, त"
+gloss: "the inherent vowel — क is not 'k' but 'ka' — plus the letters क and त"
+romanization: "ka, ta"
+prerequisites: [HI-W01-shirorekha-na-ma]
+sounds: [devanagari-inherent-vowel, devanagari-spine]
+roots: [ethiopic-abugida]
+etymology_hook: "a script whose consonants carry a built-in vowel is called an ABUGIDA — a name coined from Ge'ez, and cleverly built: ʾä-bu-gi-da names the first four consonants of the old SEMITIC letter order AND the first four VOWEL series at once, so the word demonstrates the very consonant-plus-vowel system it names"
+est_minutes: 5
+reviews_of: [HI-W01-shirorekha-na-ma, HI-C01-namaste]
+---
+
+# The vowel that's already there — and क, त
+
+## Warm-up
+
+[PAUSE 2s] Here is the thing that trips up every English speaker, and it is
+better to meet it now than to be confused for a month.
+
+**क is not "k". क is "ka".**
+
+## Consonants come with a vowel attached
+
+In the Latin alphabet, *k* is a bare consonant and you must add a vowel to say
+anything. In Devanagari, every consonant **already contains** the vowel **"a"**:
+
+| letter | says | *not* |
+|---|---|---|
+| क | **ka** | ~~k~~ |
+| न | **na** | ~~n~~ |
+| म | **ma** | ~~m~~ |
+| त | **ta** | ~~t~~ |
+
+That built-in "a" is the **inherent vowel**. You get it free, whether you want it
+or not — and the next two lessons are entirely about what to do when you *don't*
+want it.
+
+So the two letters you learned last lesson were never "n" and "m." They were
+**na** and **ma** — and if you write them together you have already written a
+real syllable pair: **नम**, *nama*, the first half of *namaste*.
+
+## What this kind of script is called
+
+A script that works this way — consonants carrying a default vowel — is an
+**abugida**.
+
+The word comes from **Ge'ez**, the old liturgical language of Ethiopia, whose
+script works the same way — and it is built more cleverly than "alphabet" is.
+
+*ʾä — bu — gi — da* names two things at once:
+
+- the **consonants** ʾ, b, g, d — the first four of the old **Semitic** letter
+  order (the same order that gives Greek *alpha, beta, gamma, delta*);
+- the **vowels** ä, u, i, a — the first four of Ge'ez's **vowel series**.
+
+So the word doesn't just recite the start of a list, the way *alphabet* recites
+*alpha-beta*. It **demonstrates the system it names**: consonant plus vowel,
+consonant plus vowel, four times over. A term that performs its own definition.
+
+(Ge'ez's own traditional recitation order is different — *hä-lä-ḥä-mä…* — so
+*abugida* is a scholar's coinage drawing on the inherited Semitic order, not the
+Ethiopian schoolroom one.)
+
+## क — "ka"
+
+1. **a left loop**
+2. **a vertical spine** on the right
+3. **the top bar** — last.
+
+## त — "ta"
+
+1. **a small left curl**
+2. **a tall spine**
+3. **the top bar** — last.
+
+Same frame as before: spine right, shape left, bar on top. Only the left-hand
+part changes.
+
+## Why the letters are in the order they're in
+
+One more thing worth knowing, because it makes the whole script feel less
+arbitrary. The heart of the Devanagari consonant order is not historical accident
+like A-B-C. The stops are grouped into five families (*vargas*), **sorted by
+where in your mouth the closure happens** — starting at the soft palate and
+walking forward to the lips:
+
+**क** (soft palate) → **च** (hard palate) → **ट** (roof, tongue curled back) →
+**त** (teeth) → **प** (lips)
+
+Say those five in order and feel the closure travel forward. Indian phoneticians
+organised the sounds this way well over two thousand years ago — Pāṇini's work is
+roughly 4th century BCE — producing a phonetics chart memorised as an alphabet,
+long before anyone in Europe attempted the same analysis.
+
+Two honest footnotes. The tidy front-to-back walk describes the **five stop
+families**, not the whole letter list — the vowels come first, and ह sits at the
+very end after the labials. And of those five sample letters, **ट is not yet in
+this curriculum's Devanagari data**: read it here, and you'll draw it when its
+entry is written. This track only asks you to hand-write letters whose stroke
+data actually exists.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "क is **ka**, not k"]
+- [YOU WRITE: क — "loop, spine, bar last"]
+- [YOU WRITE: त — "curl, spine, bar last"]
+- [YOU WRITE: नम — two letters, **one bar across both** — "nama"]
+- [YOU SAY: the mouth-walk — "ka … ca … ṭa … ta … pa", back to front]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does क say on its own? (**"ka"** — the vowel is built in.) What
+is that vowel called? (The **inherent vowel**.) What kind of script is this, and
+where does the word come from? (An **abugida** — *ʾä-bu-gi-da*, from Ge'ez,
+naming four **consonants** of the old Semitic order **and** four **vowel series**
+at once, so the word performs its own definition.) Write **नम** — what does it
+say? (*Nama*.) What orders the five stop families? (**Place of articulation** —
+soft palate forward to the lips.) Next: how to get rid of the inherent vowel
+and put a different one in.

--- a/code/learning/human-languages/hindi/lessons/HI-W03-matras-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W03-matras-naam.md
@@ -1,0 +1,95 @@
+---
+id: HI-W03-matras-naam
+chapter: 2
+type: writing
+headword: "ा, े, ि"
+gloss: "mātrās — the vowel signs that replace the inherent 'a', including the one written before the letter it follows; writing नाम"
+romanization: "ā, e, i"
+prerequisites: [HI-W02-abugida-ka-ta, HI-W01-shirorekha-na-ma]
+sounds: [devanagari-matra, devanagari-inherent-vowel]
+roots: [sanskrit-matra, pie-meh1]
+etymology_hook: "mātrā मात्रा means 'a MEASURE' — from mā- 'to measure', PIE *meh₁-, the root behind English METER, MEASURE, and even MONTH (the moon being the old measurer of time); the vowel signs are literally the measures of the syllable"
+est_minutes: 5
+reviews_of: [HI-W02-abugida-ka-ta, HI-C02-naam]
+---
+
+# Mātrās — swapping the built-in vowel
+
+## Warm-up
+
+[PAUSE 2s] Last lesson: every consonant carries a free **"a"**. So how do you
+write *ni*, or *mo*, or *nā*?
+
+You **overwrite** the inherent vowel with a small mark called a **mātrā**.
+
+## The word itself
+
+**मात्रा** (*mātrā*) means **"a measure"** — from the verb *mā-*, "to measure."
+That root is Proto-Indo-European \**meh₁-*, and it is the ancestor of English
+**meter**, **measure**, **immense** ("un-measurable"), and — by the oldest
+measuring instrument of all — **month**, the moon being what humans first counted
+time with.
+
+A vowel sign is a *measure* of the syllable. The name is a description.
+
+## Two to start with
+
+**ा** — the vowel **ā** (a long "aa"). A vertical bar to the **right**:
+
+> न + ा → **ना** (*nā*)
+
+**े** — the vowel **e**. A stroke **above** the top bar:
+
+> म + े → **मे** (*me*)
+
+Notice the mātrā did not *add* a vowel. It **replaced** one. न was already "na";
+now it is "nā". The inherent vowel is gone the moment a mātrā arrives.
+
+## Now write a word you already know
+
+You have न, ा, म. That is enough for the Hindi word for "name" (Chapter 2):
+
+> न + ा + म → **नाम** (*nām*)
+
+Write the three characters, then draw **one bar** across all of them.
+
+## The famous one
+
+Mātrās can attach almost anywhere — right, above, below. And one of them goes
+somewhere that will feel wrong for a while:
+
+**ि** — the vowel **i** — is written **BEFORE** the consonant, to its **left**,
+but pronounced **AFTER** it.
+
+> श + ि → **शि**, and that says ***śi***, not *iś*.
+
+Read it aloud in the order you'd guess and you get the wrong word. The mark
+*leans left* on the page and *lands right* in the mouth.
+
+There is no satisfying reason for it. It is an inherited quirk — the placement
+comes down from the script's Brahmi ancestry, and it simply stuck. Don't look for
+logic; your eye will learn it faster than your intuition will.
+
+The rule to carry away:
+
+> **A mātrā replaces the inherent vowel. And one of them — ि, the only one in
+> Hindi that does this — is written before the consonant it follows.**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: ना — "na, then the bar to the right" — *nā*]
+- [YOU WRITE: मे — "ma, then the stroke above" — *me*]
+- [YOU WRITE: **नाम** — three characters, **one bar**, "nām"]
+- [YOU SAY: "**मात्रा** = a **measure**"]
+- [YOU SAY: the warning — "शि is ***śi***, not *iś*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does a mātrā do to the inherent vowel? (**Replaces** it — never
+adds to it.) What does the word *mātrā* mean, and what English words share its
+root? ("**Measure**" — *meter*, *measure*, *month*.) Where does **ा** attach, and
+where does **े**? (Right; above the bar.) Write **नाम** — what does it mean?
+("**Name**".) And the trap: **शि** — is that *śi* or *iś*? (***Śi*** — the ि is
+written **before** but pronounced **after**.) Next: र and स, and your own name
+sentence.

--- a/code/learning/human-languages/hindi/lessons/HI-W04-ra-sa-mera-naam.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W04-ra-sa-mera-naam.md
@@ -1,0 +1,104 @@
+---
+id: HI-W04-ra-sa-mera-naam
+chapter: 2
+type: writing
+headword: "र, स"
+gloss: "र (ra) and स (sa) — your first spineless letter — and hand-writing मेरा नाम"
+romanization: "ra, sa"
+prerequisites: [HI-W03-matras-naam, HI-W01-shirorekha-na-ma]
+sounds: [devanagari-spine, devanagari-matra]
+roots: [sanskrit-sa, greek-sigma]
+etymology_hook: "Greek SIGMA and Latin S descend from the Phoenician letter šin — and on the leading (though not universally accepted) account, Brahmi, Devanagari's ancestor, came from the same Semitic family by way of Aramaic; if that is right, स and S are very distant cousins that stopped looking alike thousands of years ago"
+est_minutes: 5
+reviews_of: [HI-W03-matras-naam, HI-C02-meraa, HI-C02-mera-naam-hai]
+---
+
+# र and स — and writing "my name"
+
+## Warm-up
+
+[PAUSE 2s] Two more letters, and then you can hand-write a whole phrase from
+Chapter 2.
+
+## र — "ra", your first spineless letter
+
+Every letter you have *written* so far has had a **vertical spine on the right**.
+र doesn't:
+
+1. **a shoulder** — a small hook at the top left.
+2. **a downstroke** — falling away from it.
+3. **the top bar** — last.
+
+That's all. A shoulder and a stroke.
+
+र is the first of these you write, but not the only one in the script — **द** is
+spineless too, and you have already *read* it in *dhanyavād* (Chapter 1). Think
+of "no right-hand post" as a small family to learn, not as र's private signature.
+
+## स — "sa"
+
+Back to the normal frame, with a curl and a body:
+
+1. **a left curl**
+2. **a body**
+3. **the right spine**
+4. **the top bar** — last.
+
+### A possible very distant cousin
+
+**स** and English **S** may be related — and the story is worth telling carefully,
+because half of it is certain and half is not.
+
+The certain half: English **S** comes from Latin, Latin from Greek **Σ** (sigma),
+and Greek from the **Phoenician** letter *šin*. That western line is not in doubt.
+
+The uncertain half: **Brahmi**, the ancestor of Devanagari, is *most likely*
+descended from the same Semitic family, arriving in India by way of **Aramaic**.
+That is the leading scholarly view, but it is not settled — some scholars argue
+Brahmi was an indigenous invention, and even among those who accept a Semitic
+source, which letter became which is disputed.
+
+So: if the mainstream account holds, स and S share a great-great-grandparent some
+three thousand years back, with no family resemblance left at all. Say "probably
+cousins," not "cousins."
+
+## Write the phrase
+
+You now have every piece of *merā nām* — "my name" (Chapter 2):
+
+| | |
+|---|---|
+| **मेरा** | म + े + र + ा — *merā*, "my" |
+| **नाम** | न + ा + म — *nām*, "name" |
+
+> **मेरा नाम**
+
+Two words, so **two bars**. Modern Hindi separates words with an ordinary space,
+exactly like English — and because the shirorekhā is drawn over each word, the
+space shows up as a **break in the line**. The gap in the bar is the *result* of
+the space, not a substitute for it.
+
+(Worth knowing why that needs saying: classical Sanskrit manuscripts often ran
+words together with no spaces at all, so the bar really was continuous across a
+whole line. Modern Hindi doesn't do that.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: र — "shoulder, downstroke, bar" — **no spine**]
+- [YOU WRITE: स — "curl, body, spine, bar"]
+- [YOU WRITE: **मेरा** — four pieces, one bar]
+- [YOU WRITE: **मेरा नाम** — two words, **two separate bars**]
+- [YOU SAY: the probable cousins — "Σ · S from *šin* … and **probably** स too"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What makes **र** unlike the letters you've written so far? (**No
+right-hand spine** — just a shoulder and a downstroke.) Is it the only spineless
+letter? (**No** — **द** is one too, and there are a few others.) Draw **स** — four pieces? (Curl, body,
+spine, bar.) Which English letter might स be related to, and how sure are we?
+(**S** — certainly *šin* → Σ → S going west; the eastern leg through Aramaic to
+**Brahmi** is the **leading view, not settled**.) Write **मेरा नाम** — how many
+bars, and why? (**Two** — Hindi uses an ordinary **space**, and the bar breaks
+because of it.) Next: the mark that
+kills a vowel, and you'll write *namaste*.

--- a/code/learning/human-languages/hindi/lessons/HI-W05-virama-namaste.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W05-virama-namaste.md
@@ -1,0 +1,119 @@
+---
+id: HI-W05-virama-namaste
+chapter: 2
+type: writing
+headword: "्"
+gloss: "the virama — the mark that kills the inherent vowel — conjuncts, and hand-writing नमस्ते"
+romanization: "(vowel killer)"
+prerequisites: [HI-W04-ra-sa-mera-naam, HI-W03-matras-naam, HI-W02-abugida-ka-ta]
+sounds: [devanagari-virama, devanagari-conjunct]
+roots: [sanskrit-virama, sanskrit-namas]
+etymology_hook: "virāma विराम means 'a STOPPING, a cessation' (vi- + ram- 'to rest') — the same word that grades Hindi's punctuation, pūrṇ virām 'complete stop' = full stop, alp virām 'slight stop' = comma; and namaste = namas 'a bow' + te 'to you', so the first word of the course is literally 'a bowing to you', from nam- 'to bend'"
+est_minutes: 5
+reviews_of: [HI-W04-ra-sa-mera-naam, HI-W02-abugida-ka-ta, HI-C01-namaste]
+---
+
+# The vowel killer — and नमस्ते at last
+
+## Warm-up
+
+[PAUSE 2s] One problem remains. Every consonant carries a free "a". Mātrās can
+**replace** that vowel with a different one. But what if you want **no vowel at
+all** — a bare consonant clamped onto the next?
+
+That is the last piece, and then you can write the first word you ever learned.
+
+## The virama ्
+
+**्** is the **virama** — a small stroke **below** the consonant that removes the
+inherent vowel:
+
+> क = *ka* → क् = ***k***
+
+The name says exactly what it does. **विराम** (*virāma*) is "a **stopping**, a
+cessation" — *vi-* + *ram-*, "to rest, to come to a halt." The vowel is told to
+stop.
+
+And the word is still working elsewhere in Hindi punctuation: a full stop is
+**पूर्ण विराम** ("*complete* stop"), a comma is **अल्प विराम** ("*slight* stop"),
+a semicolon **अर्ध विराम** ("*half* stop"). One word, graded by how long you rest.
+
+A naming note: *virāma* is the Sanskrit term, and the one Unicode uses. In
+everyday Hindi the mark is usually called the **हलंत** (*halant*). Same mark,
+two names — you'll meet both.
+
+## What actually happens when you write it
+
+Here is the twist. In careful print you *can* leave the virama sitting there —
+but in ordinary writing, a vowel-less consonant doesn't stand alone. It **fuses
+with the consonant that follows**, and the two are written as one squeezed
+character called a **conjunct**:
+
+> स् + त → **स्त** (*sta*)
+
+Look at what happened to स. It lost its right-hand spine, shrank, and leaned into
+त. For **spine-bearing** letters that is the usual move: **the first consonant
+gives up its spine and hands the syllable over to the second.**
+
+It is not the *only* move, though — and the counterexample is a letter you learned
+last lesson. **र has no spine to give up**, so it forms conjuncts differently: as
+a hook riding above a later letter (र् + क → **र्क**) or as a small stroke
+underneath an earlier one (क + ्र → **क्र**). Other spineless letters, **द**
+among them, stack or take special shapes instead. And a handful of very common
+conjuncts — **क्ष**, **त्र**, **ज्ञ** — are simply irregular and have to be
+learned whole.
+
+This is why Devanagari has so many shapes: it isn't only 40-odd letters, it's
+those letters plus the ligatures they form when they collide. You don't need to
+memorise conjuncts as separate characters. You need to recognise the *squeeze*.
+
+## Assemble नमस्ते
+
+You have every piece:
+
+| piece | | |
+|---|---|---|
+| **न** | *na* | Lesson 1 |
+| **म** | *ma* | Lesson 1 |
+| **स्** | *s* — स with its vowel killed | this lesson |
+| **ते** | *te* — त + the े mātrā | Lessons 2 and 3 |
+
+> **न · म · स् · ते → नमस्ते**
+
+Write it, then draw **one bar** across the whole word.
+
+## What you have been writing all along
+
+**नमस्ते** is two words fused: **namas** + **te**.
+
+- **namas** — "a bow, an obeisance," from the verb *nam-*, "**to bend**."
+- **te** — "to you."
+
+So *namaste* is, literally, **"a bowing to you."** Not "hello" — a described
+physical gesture, which is why the word and the folded hands go together. The
+greeting *is* the bow, said aloud.
+
+And *namaskār* (Lesson 1 of Chapter 1) is the same *namas* with *kāra*, "making":
+"**making** a bow." One root, two greetings.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: क् — "क with the stroke below" — the vowel is dead]
+- [YOU WRITE: स्त — watch स **lose its spine** and lean in]
+- [YOU WRITE: ते — त plus the stroke above]
+- [YOU WRITE: **नमस्ते** — one bar across all of it]
+- [YOU SAY: "*namas* = a **bow**, *te* = **to you**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the virama **्** do, and what does its name mean? (Kills the
+**inherent vowel**; *virāma* = "a **stopping**" — and a full stop in Hindi is
+**पूर्ण विराम**, a "complete stop".) What is the mark usually called in everyday
+Hindi? (The **halant**.) What usually happens instead of leaving it visible? (The
+consonant **fuses** with the next into a **conjunct** — स् + त → स्त.) What does
+a **spine-bearing** first consonant give up? (**Its spine** — but र, having none,
+uses a hook above or a stroke below instead.) Write **नमस्ते** — how many bars? (**One** —
+it's one word.) What does it literally mean? ("**A bowing to you**" — *namas*
+from *nam-*, "to bend," + *te*, "to you.") And *namaskār*? (The same *namas* +
+*kāra*, "**making** a bow.")

--- a/code/learning/human-languages/hindi/roadmap.md
+++ b/code/learning/human-languages/hindi/roadmap.md
@@ -32,6 +32,57 @@ reading course.
   Hindi; *hindī* ← *sindhu*) → rahnā (to live; postposition *meṁ*) → karnā (to
   do; ← √kṛ, the root of *karma/namaskār/Sanskrit*) → practice. The present
   habitual (stem + *-tā/-tī/-te* + *honā*), verb-last, gender agreement.
+- **Writing track W01–W05 — hand-writing Devanagari.** A parallel spine, the
+  Hindi counterpart of Arabic AR-W01–12 and Russian RU-W01–05, ending on the
+  first word of the course. **W01** the **shirorekhā** (शिरोरेखा = "head-line";
+  *śiras* ← PIE \**ḱerh₂-*, the root of Latin *cornu*/*cerebrum* and English
+  **horn**) — drawn **last**, and as **one** bar across a whole word, so Hindi
+  hangs *from* a line where Latin sits *on* one (flagged as the **common
+  convention, not a rule**); plus न and म and the commonest letter frame
+  (**spine right, shape left, bar on top**), with the spineless minority named
+  rather than implied away. **W02** the **inherent vowel** — क is *ka*, not *k* —
+  so the script is an **abugida**, a coinage from Ge'ez that names four
+  **consonants** of the old Semitic order *and* four **vowel series** at once
+  (*ʾä-bu-gi-da*), so the term performs its own definition; plus क, त, and the
+  five **stop families** ordered by **place of articulation** (soft palate →
+  lips), a phonetics chart memorised as an alphabet. **W03**
+  **mātrās** (मात्रा = "a **measure**", ← *mā-* "to measure", PIE \**meh₁-*,
+  whence *meter*/*measure*/*month*), which **replace** the inherent vowel rather
+  than adding to it — ा and े, building **नाम**, with **ि** as the punchline: the
+  one Hindi mātrā written **before** the consonant and pronounced **after** it (an
+  inherited Brahmi quirk, not something to rationalise). **W04** र — the **first
+  spineless letter** the learner writes, with **द** named so it doesn't read as
+  unique — and स, plus the **probable** long-lost cousinhood of **स · Σ · S**:
+  certainly *šin* → Σ → S going west, while Brahmi's Semitic descent via Aramaic
+  is the **leading view, not settled**. Builds **मेरा नाम**, where two words means
+  **two bars** — Hindi uses an ordinary **space**, and the bar breaks *because* of
+  it. **W05** the **virama** ् / **halant** (विराम = "a **stopping**", the word
+  that grades Hindi punctuation: *pūrṇ virām* = full stop, *alp virām* = comma),
+  which kills the inherent vowel and in practice **fuses** the consonant into a
+  **conjunct** (स् + त → स्त, a **spine-bearing** first consonant surrendering
+  its spine — with र's repha/ra-kāra and क्ष/त्र/ज्ञ named as the exceptions) —
+  assembling **नमस्ते**, and
+  revealing that it is *namas* ("a **bow**", ← *nam-* "to bend") + *te* ("to
+  you"): the greeting *is* the bow. **Authored.**
+  - Data source: `data/scripts/devanagari.json` (28 letters, 12 marks), which is
+    marked `complete: false` and covers the greeting/self-introduction vocabulary.
+    **Every letter the learner is asked to WRITE has a real entry** with real
+    `components`/`strokeOrder`; nothing was invented. Six letters appear in the
+    prose without entries (**ख ज ञ ट ण ष**), none of them as something to draw;
+    where one is cited *as a letter* (**ट** in W02's articulation chart, **ख** in
+    the word *shirorekhā*) the lesson says so outright — "read it now, draw it
+    when its entry is written."
+  - **Known data defects found while writing this, not fixed here.**
+    `devanagari.json`'s **ध** entry ("like द with an extra inner loop") omits the
+    vertical spine that ध actually has, and its **ह** entry asserts a right spine
+    although ह is traditionally counted in the *no-pāī* class. Both are
+    load-bearing for conjunct behaviour. The lessons therefore cite only **द** and
+    **र** as spineless — the two the data and the tradition agree on — and a
+    separate data pass should settle ध and ह against a typography source rather
+    than a guess.
+  - **The same file serves Marathi and Sanskrit**, which share the script. Their
+    parallel W-tracks are the obvious follow-on and can mirror this arc directly —
+    नमस्ते is identical in all three.
 
 ## Planned
 


### PR DESCRIPTION
Opens hand-writing instruction for the first **Indic** track. Ten Indic/Dravidian tracks had reached Chapter 5 with **zero** writing lessons — this is the first. Modelled on Arabic `AR-W01–12` and Russian `RU-W01–05`; `writing` type, no `concept_tag`.

Every lesson assembles vocabulary the learner already has, and the last one produces the **first word of the course**.

| | teaches | builds |
|---|---|---|
| **W01** | the **shirorekhā** — the line Devanagari *hangs from* — plus न, म | नम |
| **W02** | the **inherent vowel**: क is *ka*, not *k* → the script is an **abugida**; plus क, त | |
| **W03** | **mātrās** ा े, and ि — written *before*, pronounced *after* | **नाम** |
| **W04** | र (first spineless letter) and स | **मेरा नाम** |
| **W05** | the **virama**/halant and conjuncts | **नमस्ते** |

### The threads

- **शिरोरेखा** is literally "**head-line**" — and *śiras* descends from PIE \*ḱerh₂- "head, horn", the root behind Latin *cornu*, *cerebrum*, and English **horn**.
- **abugida** is better built than *alphabet*: *ʾä-bu-gi-da* names four **consonants** of the old Semitic order **and** four Ge'ez **vowel series** at once — so the term *demonstrates the system it names*, where *alphabet* merely recites *alpha-beta*.
- **मात्रा** means "a **measure**" (← *mā-* "to measure", PIE \*meh₁-, whence *meter*, *measure*, *month*). A mātrā **replaces** the inherent vowel rather than adding to it.
- **नमस्ते** is *namas* ("a bow", ← *nam-* "to bend") + *te* ("to you"). The greeting **is** the bow — which is why it comes with folded hands.

### Data honesty

**Every letter the track asks you to hand-write has a real entry** in `devanagari.json` with real `components`/`strokeOrder`. Nothing was invented. Six letters appear in the prose without entries (**ख ज ञ ट ण ष**); none is ever presented as something to draw, and the two cited *as letters* carry explicit "read it now, draw it when its entry is written" notes.

**Known data defects, deliberately not fixed here:** `devanagari.json`'s **ध** entry omits the vertical spine ध actually has, and its **ह** entry asserts a spine although ह is traditionally in the *no-pāī* class. Both are load-bearing for conjunct behaviour. Rather than guess into shared script data the study app consumes, the lessons cite only **द** and **र** as spineless — where data and tradition agree — and the roadmap records the defect for a proper data pass. Filed separately.

**Still blocked, stated rather than skipped:** among Indic scripts only `devanagari.json` and `gujarati.json` exist. **Tamil, Telugu, Kannada, Malayalam, Bengali and Gurmukhi have no letter data**, so no writing track is possible for them until it's authored. `devanagari.json` also serves **Marathi and Sanskrit** — their tracks can mirror this arc, since नमस्ते is identical in all three.

### Review

Three passes, **20 findings**, four of them introduced by an earlier pass's own repair — the same signature as #8720. The worst was a **fabricated cross-reference**: the CHANGELOG claimed the read-don't-draw note was "the same move the Arabic track made for ف and ق", *inside the Data-honesty section*. No such note exists anywhere in `arabic/`. Deleted, nothing substituted.

Also caught: claimed "two letters" lack entries when it's **six** (four added *by the fixes*); asserted **ध** is spineless (it isn't); asserted **ह** is spineless where the data says otherwise; explained the ि placement with a rationalisation that actually described **ी**; and said Devanagari marks word boundaries "with gaps in the line", which would have taught that the script has no spaces.

### Checks

- Suite **38/38**
- Byte-level bidi/ZWJ/homoglyph scan clean; all **47 Devanagari runs** verified codepoint-by-codepoint
- Markdown only, nothing outside `code/learning/human-languages/hindi/`
- `chapter:` sequence 1,1,2,2,2 — monotonic, matching the Arabic convention
- All `prerequisites`/`reviews_of` ids verified to exist before authoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)