### PR TITLE
feat(spice): add BJT model energy gap

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT energy gap** — BJT model cards now accept `EG`, apply each model's
+  energy gap to saturation-current temperature scaling, and preserve it through
+  subcircuit expansion, matching Rust and TypeScript. The supported-parameter
+  catalog now contains 76 canonical rows.
+
 - **BJT saturation-current temperature exponent** — BJT model cards now accept
   `XTI`, apply it to saturation-current temperature scaling, and preserve it
   through subcircuit expansion, matching Rust and TypeScript. The supported-

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -210,8 +210,8 @@ to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
-BJT cards accept `XTI` (default `3`) for the same saturation-current
-temperature exponent behavior.
+BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
+model-specific saturation-current temperature scaling.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -591,6 +591,8 @@ class BJT:
         capacitance in small-signal AC analysis.
     Xti:
         Saturation-current temperature exponent (default 3.0).
+    Eg:
+        Semiconductor energy gap in electron-volts (default 1.11 eV).
     """
 
     name: str
@@ -606,6 +608,7 @@ class BJT:
     Tf: float = 0.0         # forward transit time (s)
     Tr: float = 0.0         # reverse transit time (s)
     Xti: float = 3.0        # saturation-current temperature exponent
+    Eg: float = 1.11        # semiconductor energy gap (eV)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -415,7 +415,7 @@ def circuit_at_temperature(
                 element,
                 temperature_kelvin,
                 nominal_temperature_kelvin=nominal_temperature_kelvin,
-                energy_gap_ev=energy_gap_ev,
+                energy_gap_ev=element.Eg,
             )
         if isinstance(element, Mosfet):
             return mosfet_at_temperature(
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9137,6 +9137,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(
             f"{el.name}: BJT saturation-current temperature exponent must be finite"
         )
+    if not math.isfinite(el.Eg) or el.Eg <= 0.0:
+        raise ValueError(f"{el.name}: BJT energy gap must be finite and positive")
 
 
 # ---------------------------------------------------------------------------
@@ -13838,6 +13840,7 @@ def sens_dc(
                     Tf=el.Tf,
                     Tr=el.Tr,
                     Xti=el.Xti,
+                    Eg=el.Eg,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -13855,6 +13858,7 @@ def sens_dc(
                     Tf=el.Tf,
                     Tr=el.Tr,
                     Xti=el.Xti,
+                    Eg=el.Eg,
                 ),
             )
 
@@ -14082,6 +14086,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Tf=el.Tf,
             Tr=el.Tr,
             Xti=el.Xti,
+            Eg=el.Eg,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (8, 16, 4, 4),
-    "PNP": (8, 16, 4, 4),
+    "NPN": (9, 17, 4, 4),
+    "PNP": (9, 17, 4, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -371,6 +371,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "TF": "TF",
     "TR": "TR",
     "XTI": "XTI",
+    "EG": "EG",
 }
 
 _JFET_PARAMETER_ALIASES: dict[str, str] = {
@@ -896,6 +897,7 @@ def bjt_from_model_card(
         Tf=p.get("TF", 0.0),
         Tr=p.get("TR", 0.0),
         Xti=p.get("XTI", 3.0),
+        Eg=p.get("EG", 1.11),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 74
+    assert len(coverage) == 76
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 74
+    assert len(records) == 76
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 74
-    assert report.expected_canonical_parameter_count == 74
-    assert report.accepted_name_count == 122
+    assert report.canonical_parameter_count == 76
+    assert report.expected_canonical_parameter_count == 76
+    assert report.accepted_name_count == 124
     assert report.aliased_parameter_count == 35
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t74\t74\t122\t35\t4\t0"
+        "true\t7\t7\t76\t76\t124\t35\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 73
-    assert report.accepted_name_count == 119
+    assert report.canonical_parameter_count == 75
+    assert report.accepted_name_count == 121
     assert report.aliased_parameter_count == 34
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t73\t74\t119\t34\t4\t4\n"
+        "false\t7\t7\t75\t76\t121\t34\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,14 +647,15 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
     assert bjt_model.Xti == pytest.approx(2.4)
+    assert bjt_model.Eg == pytest.approx(1.05)
 
     jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -2220,11 +2221,11 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert expanded.Eg == pytest.approx(1.05)
 
 
-def test_subcircuit_expansion_preserves_bjt_temperature_exponent():
+def test_subcircuit_expansion_preserves_bjt_temperature_parameters():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2232,6 +2233,7 @@ def test_subcircuit_expansion_preserves_bjt_temperature_exponent():
 
     expanded = next(element for element in circuit.elements if isinstance(element, BJT))
     assert expanded.Xti == pytest.approx(2.4)
+    assert expanded.Eg == pytest.approx(1.05)
 
 
 def test_branch_current_in_voltage_source():
@@ -2449,6 +2451,23 @@ def test_bjt_temperature_scaling_uses_model_temperature_exponent():
     low = bjt_at_temperature(BJT("Qlow", "c", "b", "e", Xti=0.0), 350.0)
     high = bjt_at_temperature(BJT("Qhigh", "c", "b", "e", Xti=4.0), 350.0)
     assert high.Is > low.Is
+
+
+def test_bjt_temperature_scaling_uses_model_energy_gap():
+    silicon = Circuit()
+    silicon.add(BJT("Qsilicon", "c", "b", "e", Eg=1.11))
+    lower_gap = Circuit()
+    lower_gap.add(BJT("Qlower", "c", "b", "e", Eg=0.8))
+    silicon_hot = circuit_at_temperature(silicon, 350.0)
+    lower_gap_hot = circuit_at_temperature(lower_gap, 350.0)
+    assert silicon_hot.elements[0].Is > lower_gap_hot.elements[0].Is
+
+
+def test_dc_rejects_invalid_bjt_energy_gap():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Eg=0.0))
+    with pytest.raises(ValueError, match="BJT energy gap must be finite and positive"):
+        dc_op(circuit)
 
 
 def test_mosfet_temperature_scaling_changes_common_source_bias():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `EG` energy-gap support to model-specific temperature
+  scaling, preserving it through subcircuit expansion and matching Python and
+  TypeScript. The supported-parameter catalog now contains 76 canonical rows.
 - Add BJT model-card `XTI` saturation-current temperature-exponent support,
   preserving it through subcircuit expansion and matching Python and
   TypeScript. The supported-parameter catalog now contains 74 canonical rows.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -127,8 +127,8 @@ to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
-BJT cards accept `XTI` (default `3`) for the same saturation-current
-temperature exponent behavior.
+BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
+model-specific saturation-current temperature scaling.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -432,6 +432,7 @@ fn clone_subckt_element(
             element.forward_transit_time,
             element.reverse_transit_time,
             element.saturation_current_temperature_exponent,
+            element.energy_gap_electron_volts,
         )),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -2693,7 +2694,7 @@ pub fn circuit_at_temperature(
     circuit: &Circuit,
     temperature_kelvin: f64,
     nominal_temperature_kelvin: f64,
-    energy_gap_electron_volts: f64,
+    _energy_gap_electron_volts: f64,
 ) -> Result<Circuit, SpiceError> {
     let mut adjusted = Circuit {
         elements: Vec::new(),
@@ -2711,7 +2712,7 @@ pub fn circuit_at_temperature(
                 bjt,
                 temperature_kelvin,
                 nominal_temperature_kelvin,
-                energy_gap_electron_volts,
+                bjt.energy_gap_electron_volts,
             )?),
             Element::Mosfet(mosfet) => Element::Mosfet(mosfet_at_temperature(
                 mosfet,
@@ -2835,6 +2836,7 @@ pub struct Bjt {
     pub forward_transit_time: f64,
     pub reverse_transit_time: f64,
     pub saturation_current_temperature_exponent: f64,
+    pub energy_gap_electron_volts: f64,
 }
 
 impl Bjt {
@@ -2888,6 +2890,7 @@ impl Bjt {
             forward_transit_time,
             reverse_transit_time,
             3.0,
+            1.11,
         )
     }
 
@@ -2906,6 +2909,7 @@ impl Bjt {
         forward_transit_time: f64,
         reverse_transit_time: f64,
         saturation_current_temperature_exponent: f64,
+        energy_gap_electron_volts: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -2921,6 +2925,7 @@ impl Bjt {
             forward_transit_time,
             reverse_transit_time,
             saturation_current_temperature_exponent,
+            energy_gap_electron_volts,
         }
     }
 }
@@ -3311,8 +3316,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 8, 16, 4, 4),
-    (ModelCardKind::Pnp, 8, 16, 4, 4),
+    (ModelCardKind::Npn, 9, 17, 4, 4),
+    (ModelCardKind::Pnp, 9, 17, 4, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3355,6 +3360,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("TF", "TF"),
     ("TR", "TR"),
     ("XTI", "XTI"),
+    ("EG", "EG"),
 ];
 const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("BETA", "BETA"),
@@ -4008,6 +4014,7 @@ pub fn bjt_from_model_card(
         model_card_value(model, "TF", 0.0),
         model_card_value(model, "TR", 0.0),
         model_card_value(model, "XTI", 3.0),
+        model_card_value(model, "EG", 1.11),
     ))
 }
 
@@ -23196,6 +23203,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "saturation-current temperature exponent must be finite".to_string(),
+        });
+    }
+    if !bjt.energy_gap_electron_volts.is_finite() || bjt.energy_gap_electron_volts <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "energy gap must be finite and positive".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 74);
+    assert_eq!(coverage.len(), 76);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 74);
+    assert_eq!(records.len(), 76);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 74);
-    assert_eq!(report.expected_canonical_parameter_count, 74);
-    assert_eq!(report.accepted_name_count, 122);
+    assert_eq!(report.canonical_parameter_count, 76);
+    assert_eq!(report.expected_canonical_parameter_count, 76);
+    assert_eq!(report.accepted_name_count, 124);
     assert_eq!(report.aliased_parameter_count, 35);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t74\t74\t122\t35\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t76\t76\t124\t35\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 73);
-    assert_eq!(report.accepted_name_count, 119);
+    assert_eq!(report.canonical_parameter_count, 75);
+    assert_eq!(report.accepted_name_count, 121);
     assert_eq!(report.aliased_parameter_count, 34);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t73\t74\t119\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t75\t76\t121\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -425,17 +425,24 @@ fn model_card_aliases_build_device_instances() {
     let bjt_card = normalize_model_card(
         "Qsmall",
         "npn",
-        &[("BETA", 125.0), ("CBE", 2.0e-12), ("XTI", 2.4)],
+        &[
+            ("BETA", 125.0),
+            ("CBE", 2.0e-12),
+            ("XTI", 2.4),
+            ("EG", 1.05),
+        ],
     )
     .unwrap();
     let bjt_model = bjt_from_model_card("Q1", "c", "b", "e", &bjt_card).unwrap();
     assert_close(*bjt_card.parameters.get("BF").unwrap(), 125.0);
     assert_close(*bjt_card.parameters.get("CJE").unwrap(), 2.0e-12);
     assert_close(*bjt_card.parameters.get("XTI").unwrap(), 2.4);
+    assert_close(*bjt_card.parameters.get("EG").unwrap(), 1.05);
     assert_eq!(bjt_model.polarity, BjtPolarity::Npn);
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
     assert_close(bjt_model.saturation_current_temperature_exponent, 2.4);
+    assert_close(bjt_model.energy_gap_electron_volts, 1.05);
 
     let jfet_card = normalize_model_card(
         "Jn",
@@ -1322,7 +1329,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 }
 
 #[test]
-fn subcircuit_expansion_preserves_bjt_temperature_exponent() {
+fn subcircuit_expansion_preserves_bjt_temperature_parameters() {
     let bjt = Bjt::with_model_and_temperature_parameters(
         "Qcell",
         "c",
@@ -1337,6 +1344,7 @@ fn subcircuit_expansion_preserves_bjt_temperature_exponent() {
         3.0e-9,
         4.0e-9,
         2.4,
+        1.05,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1363,6 +1371,7 @@ fn subcircuit_expansion_preserves_bjt_temperature_exponent() {
         })
         .unwrap();
     assert_close(expanded.saturation_current_temperature_exponent, 2.4);
+    assert_close(expanded.energy_gap_electron_volts, 1.05);
 }
 
 #[test]
@@ -1821,6 +1830,7 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
         0.0,
         0.0,
         0.0,
+        1.11,
     );
     let high_exponent = Bjt::with_model_and_temperature_parameters(
         "Qhigh",
@@ -1836,10 +1846,83 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
         0.0,
         0.0,
         4.0,
+        1.11,
     );
     let low = bjt_at_temperature(&low_exponent, 350.0, 300.15, 1.11).unwrap();
     let high = bjt_at_temperature(&high_exponent, 350.0, 300.15, 1.11).unwrap();
     assert!(high.saturation_current > low.saturation_current);
+}
+
+#[test]
+fn bjt_temperature_scaling_uses_model_energy_gap() {
+    let mut silicon = Circuit::new();
+    silicon.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+        "Qsilicon",
+        "c",
+        "b",
+        "e",
+        BjtPolarity::Npn,
+        1.0e-14,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        3.0,
+        1.11,
+    )));
+    let mut lower_gap = Circuit::new();
+    lower_gap.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+        "Qlower",
+        "c",
+        "b",
+        "e",
+        BjtPolarity::Npn,
+        1.0e-14,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        3.0,
+        0.8,
+    )));
+    let silicon_hot = circuit_at_temperature(&silicon, 350.0, 300.15, 1.11).unwrap();
+    let lower_gap_hot = circuit_at_temperature(&lower_gap, 350.0, 300.15, 1.11).unwrap();
+    let saturation_current = |circuit: &Circuit| match &circuit.elements()[0] {
+        Element::Bjt(bjt) => bjt.saturation_current,
+        _ => unreachable!(),
+    };
+    assert!(saturation_current(&silicon_hot) > saturation_current(&lower_gap_hot));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_energy_gap() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+        "Qbad",
+        "c",
+        "b",
+        "0",
+        BjtPolarity::Npn,
+        1.0e-14,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        3.0,
+        0.0,
+    )));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("energy gap must be finite and positive")
+    );
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `EG` energy-gap support to model-specific temperature
+  scaling, preserving it through subcircuit expansion and matching Python and
+  Rust. The supported-parameter catalog now contains 76 canonical rows.
 - Add BJT model-card `XTI` saturation-current temperature-exponent support,
   preserving it through subcircuit expansion and matching Python and Rust. The
   supported-parameter catalog now contains 74 canonical rows.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -197,8 +197,8 @@ to shape `CJO` depletion capacitance continuously around the `FC * VJ`
 transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
-BJT cards accept `XTI` (default `3`) for the same saturation-current
-temperature exponent behavior.
+BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
+model-specific saturation-current temperature scaling.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1711,6 +1711,7 @@ export interface Bjt {
   readonly forwardTransitTime: number;
   readonly reverseTransitTime: number;
   readonly saturationCurrentTemperatureExponent: number;
+  readonly energyGapElectronVolts: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1988,8 +1989,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [8, 16, 4, 4],
-  PNP: [8, 16, 4, 4],
+  NPN: [9, 17, 4, 4],
+  PNP: [9, 17, 4, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3579,7 +3580,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7680,7 +7681,7 @@ export function circuitAtTemperature(
           element,
           temperatureKelvin,
           nominalTemperatureKelvin,
-          energyGapElectronVolts,
+          element.energyGapElectronVolts,
         ),
       );
     } else if (element.kind === "mosfet") {
@@ -7733,6 +7734,7 @@ export function bjt(
   forwardTransitTime = 0.0,
   reverseTransitTime = 0.0,
   saturationCurrentTemperatureExponent = 3.0,
+  energyGapElectronVolts = 1.11,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7749,6 +7751,7 @@ export function bjt(
     forwardTransitTime,
     reverseTransitTime,
     saturationCurrentTemperatureExponent,
+    energyGapElectronVolts,
   };
 }
 
@@ -7851,6 +7854,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   TF: "TF",
   TR: "TR",
   XTI: "XTI",
+  EG: "EG",
 };
 
 const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8348,6 +8352,7 @@ export function bjtFromModelCard(
     p.TF ?? 0.0,
     p.TR ?? 0.0,
     p.XTI ?? 3.0,
+    p.EG ?? 1.11,
   );
 }
 
@@ -19526,6 +19531,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.saturationCurrentTemperatureExponent)) {
     throw invalidElement(element.name, "saturation-current temperature exponent must be finite");
+  }
+  if (!Number.isFinite(element.energyGapElectronVolts) || element.energyGapElectronVolts <= 0.0) {
+    throw invalidElement(element.name, "energy gap must be finite and positive");
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(74);
+    expect(coverage).toHaveLength(76);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(74);
+    expect(records).toHaveLength(76);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 74,
-      expectedCanonicalParameterCount: 74,
-      acceptedNameCount: 122,
+      canonicalParameterCount: 76,
+      expectedCanonicalParameterCount: 76,
+      acceptedNameCount: 124,
       aliasedParameterCount: 35,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t74\t74\t122\t35\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t76\t76\t124\t35\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(73);
-    expect(report.acceptedNameCount).toBe(119);
+    expect(report.canonicalParameterCount).toBe(75);
+    expect(report.acceptedNameCount).toBe(121);
     expect(report.aliasedParameterCount).toBe(34);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t73\t74\t119\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t75\t76\t121\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -335,13 +335,15 @@ describe("dcOp", () => {
       BETA: 125.0,
       CBE: 2.0e-12,
       XTI: 2.4,
+      EG: 1.05,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
     expectClose(bjtModel.saturationCurrentTemperatureExponent, 2.4);
+    expectClose(bjtModel.energyGapElectronVolts, 1.05);
 
     const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
@@ -970,11 +972,11 @@ describe("dcOp", () => {
     expectClose(expanded.energyGapElectronVolts, 1.05);
   });
 
-  it("preserves the BJT temperature exponent through subcircuit expansion", () => {
+  it("preserves BJT temperature parameters through subcircuit expansion", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -983,6 +985,7 @@ describe("dcOp", () => {
     expect(expanded?.kind).toBe("bjt");
     if (expanded?.kind === "bjt") {
       expectClose(expanded.saturationCurrentTemperatureExponent, 2.4);
+      expectClose(expanded.energyGapElectronVolts, 1.05);
     }
   });
 
@@ -1303,6 +1306,27 @@ describe("dcOp", () => {
     const low = bjtAtTemperature(bjt("Qlow", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 0), 350);
     const high = bjtAtTemperature(bjt("Qhigh", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 4), 350);
     expect(high.saturationCurrent).toBeGreaterThan(low.saturationCurrent);
+  });
+
+  it("uses the BJT model energy gap", () => {
+    const silicon = new Circuit();
+    silicon.add(bjt("Qsilicon", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11));
+    const lowerGap = new Circuit();
+    lowerGap.add(bjt("Qlower", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 0.8));
+    const siliconHot = circuitAtTemperature(silicon, 350);
+    const lowerGapHot = circuitAtTemperature(lowerGap, 350);
+    const siliconBjt = siliconHot.elements()[0];
+    const lowerGapBjt = lowerGapHot.elements()[0];
+    if (siliconBjt?.kind !== "bjt" || lowerGapBjt?.kind !== "bjt") {
+      throw new Error("expected temperature-adjusted BJTs");
+    }
+    expect(siliconBjt.saturationCurrent).toBeGreaterThan(lowerGapBjt.saturationCurrent);
+  });
+
+  it("rejects an invalid BJT energy gap", () => {
+    const circuit = new Circuit();
+    circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 0));
+    expect(() => dcOp(circuit)).toThrowError("energy gap must be finite and positive");
   });
 
   it("uses MOSFET temperature scaling in common-source drain voltage", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,13 +33,13 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT saturation-current temperature exponent.
+1. Cross-language BJT energy gap.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `XTI` saturation-current temperature-exponent model-card
+   - Add Berkeley BJT `EG` semiconductor energy-gap model-card
      support in Rust, Python, and TypeScript.
-   - Apply `XTI` to BJT saturation-current temperature scaling and preserve the
+   - Apply each model's `EG` to BJT saturation-current temperature scaling and preserve the
      full BJT model through hierarchical subcircuit expansion.
-   - Extend the supported-parameter coverage gate from 72 to 74 canonical rows
+   - Extend the supported-parameter coverage gate from 74 to 76 canonical rows
      and lock model-specific temperature scaling across all three engines.
 
 ## Completed Slices
@@ -2992,6 +2992,13 @@ the Rust, Python, and TypeScript surfaces together.
      each model's energy gap to saturation-current temperature scaling.
    - Hierarchical subcircuit expansion preserves `EG`, and the supported-
      parameter release gate now covers 72 canonical rows.
+
+218. Cross-language BJT saturation-current temperature exponent.
+   - Status: completed in PR 8725.
+   - Rust, Python, and TypeScript BJT model cards now accept `XTI` and apply it
+     to saturation-current temperature scaling.
+   - Hierarchical subcircuit expansion preserves `XTI`, and the supported-
+     parameter release gate now covers 74 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `EG` model-card support with a 1.11 eV default in Rust, Python, and TypeScript
- use each BJT model's energy gap for saturation-current temperature scaling and preserve it through hierarchy, sensitivity, and Monte Carlo copies
- extend the supported-parameter coverage gate from 74 to 76 canonical rows and reconcile the SPICE completion plan after PR #8725

## Verification
- `cargo test -p spice-engine -- --test-threads=1` (all 302 Rust integration tests passed; macOS startup delays required running the final transient binary directly after ad-hoc signing)
- `cargo test -q -p spice-engine --test dc_tests -- --test-threads=1` (88 passed after final validation test)
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `PYTHONPATH=$(find ../../python -type d -name src | paste -sd: -) /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest -q` (506 passed, 88.24% coverage)
- Python Ruff check for `src` and `tests`
- `npm test -- --run` (266 passed)
- `npx tsc --noEmit`
- `git diff --check`

`cargo fmt --all -- --check` still reports the repository's existing workspace-wide formatting drift across unrelated Rust crates; no bulk formatter churn is included here.
