### PR TITLE
test(j-to-semantic-ir): oracle/golden tests cross-checking j-runtime vs SIR->JS->node (MA-6e follow-on)

### DIFF
--- a/code/packages/rust/j-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/j-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## [0.1.2] - 2026-07-21
+
+### Added
+
+- **`tests/oracle.rs` — HML01 §7 oracle/golden testing, cross-checking
+  `j-runtime` (ground truth) against `j_to_semantic_ir::compile_source` →
+  `semantic_ir::Module` → `semantic_ir_to_javascript::compile` → a real
+  `node` process.** The direct J sibling of `apl-to-semantic-ir/tests/
+  oracle.rs`, completing HML01 §5's "J's own oracle tests remain an open
+  follow-on item" note (that spec line is updated by this PR). 36-case
+  corpus covering: right-to-left/no-precedence evaluation; a true/false
+  comparison pair; a scalar-vector broadcast; assignment read back by a
+  later statement; a printed 2-D matrix; reduce (`+/`)/scan (`+\`); every
+  SIR22/addendum `Expr` variant this crate's own `src/lower.rs` can emit
+  (`ElementwiseOp`, `ArrayLit`+`Ravel`, `Shape`, `Reshape`,
+  `IndexGenerator`, `IndexOf`, `Ravel`, `Catenate`, `Reduce`, `Scan`,
+  `BuiltinCall` for `neg`/`sign`/`recip`/`floor`/`ceil`/`tally`/
+  `replicate`/`exp`/`print`); `@` compose; two hooks, two verb-left forks,
+  and a leading-noun fork (trains — MA06 §3, J's genuinely novel feature
+  with no APL precedent); and J's own leading-underscore negative-literal
+  spelling (`_5`).
+  - Like `apl-to-semantic-ir`'s own oracle file, needs no `setup`/
+    `final_expr` split (J auto-prints a bare top-level expression natively
+    on both sides, confirmed against `j-runtime`'s own module doc) and no
+    `normalize()` (J's comparisons convert to plain `1.0`/`0.0` floats on
+    both sides, same as APL). Unlike either MATLAB/Octave's or APL's own
+    oracle file, `Case` carries one more field, `known_bug: Option<&'static
+    str>`, to record entries where the compiled side is known to disagree
+    with `j-runtime` due to a documented, NOT-fixed-here bug in the shared
+    `semantic-ir-to-javascript` crate (see below) — `ground_truth` is still
+    asserted for those entries (so a wrong corpus value is still caught),
+    only the `compiled`-side assertion is skipped.
+
+### Fixed (in this crate's own `src/lower.rs`)
+
+Both found by this crate's own new oracle harness, and — per this repo's
+established discipline for a bug genuinely local to a frontend's own
+lowering — fixed directly here, not deferred:
+
+1. **Stranded literals of 2+ numbers were never `Ravel`-wrapped**, unlike
+   `apl-to-semantic-ir`'s own identical construct (that crate's 0.1.3 fix,
+   which this crate shipped without). A bare `Expr::ArrayLit { rows:
+   vec![row], .. }` is a genuinely rank-2 `[1, n]` value under SIR's
+   column-major convention, not the rank-1 `[n]` vector a J stranded
+   literal actually is — any op validating its operand is rank ≤ 1
+   (dyadic `$`'s shape argument, dyadic `i.`'s haystack) rejected it
+   outright. Confirmed: `2 2$1 2 3 4` (reshape whose *shape* argument is
+   the stranded literal `2 2`) crashed the compiled path with `reshape:
+   shape argument must be a scalar or vector (got rank 2)`, even though
+   this exact program round-trips correctly through `j-runtime`. Fixed in
+   `Lowerer::lower_term`, mirroring `apl-to-semantic-ir::Lowerer::
+   lower_term`'s `Expr::Ravel`-wrap exactly.
+2. **Monadic/dyadic `i.` silently inherited APL's 1-based `Expr::
+   IndexGenerator`/`Expr::IndexOf` convention and `len + 1`-not-found
+   sentinel**, genuinely wrong for J's 0-based `i.` with a plain-tally
+   not-found sentinel (MA06 §1 bullet 3 — this crate's single most
+   safety-critical distinction from APL). Confirmed: `i.5` compiled to
+   `1 2 3 4 5` (APL's 1-based iota), not `j-runtime`'s own `0 1 2 3 4`.
+   Fixed via a new `Lowerer::zero_base_index` helper that wraps both
+   nodes' output in an elementwise `- 1` — an exact arithmetic identity
+   for both the found and not-found cases (see that function's own doc
+   comment for the proof), needing no shared-crate change at all. Updated
+   `tests/test_lower.rs`'s `idot_index_generator_monadic_and_index_of_
+   dyadic`, `dollar_shape_monadic_and_reshape_dyadic`, `hash_tally_
+   monadic_and_replicate_dyadic`, and renamed/updated `stranded_literal_
+   is_a_single_row_array_lit` → `stranded_literal_is_a_single_row_array_
+   lit_wrapped_in_ravel` to match the new emitted shapes.
+
+### Found, NOT fixed here (shared `semantic-ir-to-javascript` crate — follow-up task)
+
+Recorded here — mirroring how `apl-to-semantic-ir`'s own oracle file
+originally shipped its three bugs excluded-not-fixed before a later,
+separate PR fixed them in `semantic-ir-to-javascript` 0.43.0 — rather than
+patched in this PR, per this task's own scope discipline (`tests/
+oracle.rs`'s module doc has the full write-up):
+
+- **Bug A — no J-specific display convention at all.**
+  `semantic-ir-to-javascript`'s `emit.rs` only ever checks
+  `source_language == "apl"` to decide the negative-number/infinity glyph
+  (`SIR_DISPLAY_APL_HIGH_MINUS`); there is no equivalent flag for `"j"`.
+  Consequence: a bare/boxed scalar negative number or `Infinity` prints
+  plain ASCII (`"-5"`, `"Infinity"`) instead of J's own leading underscore
+  (`"_5"`, `"inf"`); a genuine `NDArray` (rank ≥ 1, or an already-boxed
+  rank-0 value) prints APL's high-minus `¯` *unconditionally* (`ArrayRt.
+  fmtNum` has no flag check at all). Confirmed against `-5`, `_5`,
+  `-1 2 _3`, `-/+\1 2 3`, `(+*-)5`, and `%0`. 8 of this crate's 36 new
+  oracle cases hit this and are marked `known_bug` accordingly.
+- **Bug B — `tally`/`replicate`/`exp` never registered as builtins.** This
+  crate's own `src/lower.rs`/README/CHANGELOG (see 0.1.0 below) document
+  `#`'s monadic/dyadic forms and `^`'s monadic form as `BuiltinCall("tally"
+  | "replicate" | "exp", ..)`, but `semantic-ir-to-javascript`'s builtin
+  dispatch table never gained entries for any of the three — every use
+  crashes with `TypeError: unknown builtin: <name>` for every operand.
+  Same bug *class* as APL's own historical bug #3 (`sign`/`recip`/`ceil`/
+  `floor`, fixed in `semantic-ir-to-javascript` 0.43.0), but these three
+  names are new to J and were never registered at all. 3 of this crate's
+  36 new oracle cases hit this. Dyadic `^` (power) is unaffected — it
+  reuses the already-implemented `ElementwiseOpKind::Pow`.
+
 ## [0.1.1] - 2026-07-18
 
 ### Changed

--- a/code/packages/rust/j-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/j-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "j-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "J CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-6e."
 
@@ -23,3 +23,11 @@ lexer = { path = "../lexer" }
 # exercise real acceptance, not just the capability-rejection path they
 # originally verified.
 semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }
+# `tests/oracle.rs`'s ground truth: the same tree-walking interpreter this
+# frontend's own CST comes from (HML01 §7's oracle/golden testing), mirroring
+# `apl-to-semantic-ir`'s identical use of `coding-adventures-apl-runtime` as
+# its own oracle ground truth. Note the OTHER, non-dev `[dependencies]`
+# section above still deliberately does NOT depend on this crate -- lowering
+# itself only needs the parse-tree shape, never the evaluator; only this test
+# file needs it, for comparison purposes only.
+coding-adventures-j-runtime = { path = "../j-runtime" }

--- a/code/packages/rust/j-to-semantic-ir/README.md
+++ b/code/packages/rust/j-to-semantic-ir/README.md
@@ -100,7 +100,34 @@ section for the full reasoning and all three mechanisms.
 `+` (conjugate) is a pass-through no-op, exactly like APL's. `-`/`*`/`%`/
 `<.`/`>.` map onto `"neg"`/`"sign"`/`"recip"`/`"floor"`/`"ceil"` — the
 *exact* names `apl-to-semantic-ir` already introduced. `#`/`^` introduce
-`"tally"`/`"replicate"`/`"exp"`, new to this crate.
+`"tally"`/`"replicate"`/`"exp"`, new to this crate. **As of 0.1.2**,
+`semantic-ir-to-javascript` has not yet registered any of these three
+names in its builtin dispatch table — every use crashes with `TypeError:
+unknown builtin: <name>` (see `tests/oracle.rs`'s module doc, "Bug B", and
+this crate's own `CHANGELOG.md`). This is a shared-crate gap, not a bug in
+this crate's own lowering.
+
+## Two things this crate's own lowering had to work around, not just reuse
+directly, from `apl-to-semantic-ir` (found by `tests/oracle.rs`, fixed in
+0.1.2)
+
+- **Stranded literals of 2+ numbers are `Ravel`-wrapped**, exactly like
+  `apl-to-semantic-ir`'s own identical fix: a bare `Expr::ArrayLit { rows:
+  vec![row], .. }` is a genuinely rank-2 `[1, n]` value under SIR's
+  column-major convention, not the rank-1 `[n]` vector a stranded literal
+  (`2 2`, `1 2 3`, …) actually is. Any op that validates its operand is
+  rank ≤ 1 (dyadic `$`'s shape argument, dyadic `i.`'s haystack) would
+  otherwise reject a perfectly valid J program.
+- **Monadic/dyadic `i.` no longer emits a bare `Expr::IndexGenerator`/
+  `Expr::IndexOf`.** Those two SIR22-addendum nodes hardcode APL's own
+  1-based convention and `len + 1`-not-found sentinel (their
+  `semantic-ir-to-javascript` codegen is "ported 1:1" from
+  `apl_runtime::builtins`) — genuinely wrong for J's 0-based `i.` with a
+  plain-tally not-found sentinel (MA06 §1 bullet 3). `Lowerer::
+  zero_base_index` wraps both node's output in an elementwise `- 1`, an
+  exact arithmetic identity for both the found and not-found cases (see
+  that function's own doc comment in `src/lower.rs` for the proof) — no
+  shared-crate change needed.
 
 ### Testing
 
@@ -114,14 +141,28 @@ section for the full reasoning and all three mechanisms.
   too-deep *chain* of separately-parenthesised hooks — the security-review
   regression — two accepted within-cap cases, and a long chain of
   non-duplicating verbs confirming the cap tracks actual duplication risk
-  rather than raw chain length), stranded/underscore-negative literals,
-  parenthesised grouping, chained assignment,
-  first-occurrence-vs-reassignment, undefined-variable rejection,
-  parse-error propagation, and a full multi-line program that validates
-  via `semantic_ir::validate`.
+  rather than raw chain length), stranded/underscore-negative literals
+  (now `Ravel`-wrapped, see above), parenthesised grouping, chained
+  assignment, first-occurrence-vs-reassignment, undefined-variable
+  rejection, parse-error propagation, and a full multi-line program that
+  validates via `semantic_ir::validate`.
 - `tests/test_validator.rs` — mirrors `apl-to-semantic-ir`'s own
   capability-rejection pattern: `semantic-ir-to-javascript` accepts
   base-cut modules (including hook/fork-using ones, which are ordinary
   nested base-cut applications) and rejects `Reduce`-using ones via its
   dedicated tree-walk (not the plain feature-flag check, which can no
   longer distinguish the two).
+- `tests/oracle.rs` (HML01 §7, added 0.1.2) — the direct J sibling of
+  `apl-to-semantic-ir/tests/oracle.rs`: the SAME J source run through (a)
+  `j-runtime`'s tree-walking interpreter and (b) this crate's own
+  `compile_source` → `semantic_ir::validate` → `semantic_ir_to_javascript
+  ::compile` → a real `node` process, asserted equal. 36-case corpus
+  covering every SIR22/addendum `Expr` variant this crate can emit, both
+  hooks and forks (including a leading-noun fork), `@` compose, and J's
+  own leading-underscore negative-literal spelling. Skips (does not fail)
+  if `node` is not on `PATH`. See that file's own module doc comment for
+  the two bugs found and fixed directly in this crate's own lowering
+  (above) and the two found in the shared `semantic-ir-to-javascript`
+  crate and deliberately left open for a follow-up PR (a missing
+  J-specific display convention for negative numbers/infinity, and three
+  never-registered builtin names — `tally`/`replicate`/`exp`).

--- a/code/packages/rust/j-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/j-to-semantic-ir/src/lower.rs
@@ -728,14 +728,47 @@ impl Lowerer {
                 if numbers.len() == 1 {
                     self.number_literal(numbers[0])
                 } else {
+                    // BUG FIX (found by this crate's own `tests/oracle.rs`,
+                    // root-caused against `apl-to-semantic-ir`'s identical
+                    // fix, its own 0.1.3 CHANGELOG entry): `semantic-ir`'s
+                    // own `ArrayLit` doc comment (`nodes.rs`) is explicit
+                    // that a 1-row literal (`rows.len() == 1`) is a *row
+                    // vector* -- under this IR's MATLAB-derived column-major
+                    // storage convention (`Feature::ArrayColumnMajor`), that
+                    // means a genuinely rank-2 `[1, n]` value, NOT a rank-1
+                    // `[n]` vector. A bare `ArrayLit { rows: vec![row], .. }`
+                    // is therefore the WRONG shape for J's stranded literal,
+                    // which genuinely is rank 1 -- this crate shipped
+                    // (v0.1.0/0.1.1) without the identical fix
+                    // `apl-to-semantic-ir` already carries, so any stranded
+                    // literal of 2+ numbers used where a rank-1 vector is
+                    // required (dyadic `$`'s shape argument, dyadic `i.`'s
+                    // haystack, monadic `,`/`#` on a matrix built from one)
+                    // silently produced a rank-2 `[1, n]` value instead --
+                    // confirmed empirically: `2 2$1 2 3 4` (dyadic reshape
+                    // whose *shape* argument is the stranded literal `2 2`)
+                    // crashed the compiled path with `reshape: shape
+                    // argument must be a scalar or vector (got rank 2)`,
+                    // even though this exact program round-trips correctly
+                    // through `j-runtime`.
+                    //
+                    // Fix (identical to `apl-to-semantic-ir::lower_term`):
+                    // build the row-vector `ArrayLit` as before, then wrap
+                    // it in `Expr::Ravel` (SIR22 addendum "monadic `,A`"),
+                    // which flattens any input rank down to a genuine
+                    // rank-1 result. Invisible to J source -- nothing about
+                    // the surface syntax changes, only which IR node shape
+                    // represents it.
                     self.observed.add(Feature::NDArrays);
                     self.observed.add(Feature::ArrayColumnMajor);
+                    self.observed.add(Feature::MatrixOps);
                     let span = self.span_of(node);
                     let row: Vec<Expr> = numbers
                         .iter()
                         .map(|tok| self.number_literal(tok))
                         .collect::<Result<Vec<_>, _>>()?;
-                    Ok(Expr::ArrayLit { rows: vec![row], span })
+                    let array_lit = Expr::ArrayLit { rows: vec![row], span: span.clone() };
+                    Ok(Expr::Ravel { target: Box::new(array_lit), span })
                 }
             }
             Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => {
@@ -1035,7 +1068,14 @@ impl Lowerer {
             }
             FnKind::NonScalar(NonScalarAtom::Idot) => {
                 self.observed.add(Feature::NDArrays);
-                Ok(Expr::IndexGenerator { count: Box::new(arg), span })
+                // BUG FIX (found by this crate's own `tests/oracle.rs`):
+                // see `Self::zero_base_index`'s own doc comment for the
+                // full root-cause writeup of why the bare
+                // `Expr::IndexGenerator` node cannot be emitted as-is here.
+                Ok(self.zero_base_index(
+                    Expr::IndexGenerator { count: Box::new(arg), span: span.clone() },
+                    span,
+                ))
             }
             FnKind::NonScalar(NonScalarAtom::Ravel) => {
                 self.observed.add(Feature::MatrixOps);
@@ -1108,7 +1148,11 @@ impl Lowerer {
             }
             FnKind::NonScalar(NonScalarAtom::Idot) => {
                 self.observed.add(Feature::NDArrays);
-                Ok(Expr::IndexOf { haystack: Box::new(lhs), needle: Box::new(rhs), span })
+                // BUG FIX -- see `Self::zero_base_index`'s own doc comment.
+                Ok(self.zero_base_index(
+                    Expr::IndexOf { haystack: Box::new(lhs), needle: Box::new(rhs), span: span.clone() },
+                    span,
+                ))
             }
             FnKind::NonScalar(NonScalarAtom::Ravel) => {
                 self.observed.add(Feature::MatrixOps);
@@ -1217,6 +1261,63 @@ impl Lowerer {
                  \"Two new primitives\" section), so ElementwiseOpKind::Pow only ever reaches \
                  apply_dyadic's own NonScalar(Caret) arm directly, never this scalar-atom table"
             ),
+        }
+    }
+
+    /// Convert an `Expr::IndexGenerator`/`Expr::IndexOf` result (both
+    /// SIR22-addendum nodes this crate shares field-for-field with
+    /// `apl-to-semantic-ir`) from their hardcoded APL convention to J's own
+    /// `i.` convention, by wrapping in an elementwise `- 1`.
+    ///
+    /// **Root cause (found by this crate's own `tests/oracle.rs` diffing
+    /// `j-runtime` against the compiled-then-`node` path):**
+    /// `semantic-ir-to-javascript`'s codegen for these two nodes
+    /// (`runtime.rs`'s `indexGenerator`/`indexOf` functions) hardcodes
+    /// APL's own `⍳` semantics with NO parameterization: monadic `⍳n` is
+    /// the **1-based** `[1, …, n]` (`out[i] = i + 1`, confirmed against
+    /// `apl_runtime::builtins::index_generator`, which it is explicitly
+    /// "ported 1:1" from), and dyadic `⍳` returns a **1-based** position or
+    /// the not-found sentinel `haystack.length + 1`. J's `i.` is
+    /// genuinely different arithmetic, not just a different surface
+    /// spelling of the same thing (MA06 §1 bullet 3, this crate's single
+    /// most safety-critical distinction from APL): `i.n` is the
+    /// **0-based** `[0, …, n-1]` (`j_runtime::builtins::index_generator`),
+    /// and dyadic `i.`'s not-found sentinel is the plain tally
+    /// (`haystack.length`, not `+ 1`, `j_runtime::builtins::index_of`).
+    /// Emitting the bare SIR22-addendum node directly for J's `i.` (as
+    /// this crate did prior to this fix) silently reused APL's 1-based
+    /// values and sentinel, verified to disagree with `j-runtime`'s ground
+    /// truth on every case exercising either primitive.
+    ///
+    /// This is **not** a bug to report against the shared
+    /// `semantic-ir-to-javascript` crate (unlike the display-glyph and
+    /// missing-builtin gaps `tests/oracle.rs`'s own module doc documents):
+    /// the shared node's fixed 1-based-with-`len+1`-sentinel semantics are
+    /// exactly correct for the APL frontend that motivated it, and this
+    /// crate's own choice to reuse that node for a *different* primitive
+    /// with different semantics is what needs correcting, entirely on this
+    /// side. The fix is a pure arithmetic identity, not a hack: for every
+    /// element, `j_value = apl_value - 1` holds in BOTH cases --
+    /// found (`apl_value` is the 1-based position `k+1` for J's 0-based
+    /// `k`, so `apl_value - 1 == k`) and not-found (`apl_value` is
+    /// `len + 1`, so `apl_value - 1 == len`, exactly J's own tally
+    /// sentinel) -- so wrapping the shared node's output in an ordinary
+    /// `Expr::ElementwiseOp { op: Sub, .. }` against the literal `1`
+    /// (broadcasting exactly like `2 * 1 2 3` already does elsewhere in
+    /// this file) produces genuinely correct J values using only
+    /// pre-existing, generic SIR nodes -- no shared-crate change needed.
+    /// Mirrors `Self::lower_term`'s own `Expr::Ravel`-wrapping fix in
+    /// spirit: work around a node whose emitted shape/values don't fit
+    /// this frontend by wrapping it in one more ordinary node, rather than
+    /// changing the node's shared meaning out from under APL.
+    fn zero_base_index(&mut self, apl_convention: Expr, span: Span) -> Expr {
+        self.observed.add(Feature::MatrixOps);
+        self.observed.add(Feature::ArrayColumnMajor);
+        Expr::ElementwiseOp {
+            op: ElementwiseOpKind::Sub,
+            lhs: Box::new(apl_convention),
+            rhs: Box::new(Expr::IntLit { value: 1, span: span.clone() }),
+            span,
         }
     }
 

--- a/code/packages/rust/j-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/j-to-semantic-ir/tests/oracle.rs
@@ -1,0 +1,692 @@
+//! Oracle/golden tests (HML01 §7): the SAME J source, run through **two
+//! independent implementations**, and diffed:
+//!
+//!   (a) `j-runtime` (`coding-adventures-j-runtime`) — this frontend's own
+//!       sibling crate, a tree-walking interpreter over `array-runtime` —
+//!       the ground truth.
+//!   (b) `j_to_semantic_ir::compile_source` → `semantic_ir::Module` →
+//!       `semantic_ir_to_javascript::compile` → **an actual `node`
+//!       process**.
+//!
+//! This is the direct J sibling of
+//! [`apl-to-semantic-ir`'s own `tests/oracle.rs`](../../apl-to-semantic-ir/tests/oracle.rs)
+//! (itself the sibling of `matlab-to-semantic-ir`'s/`octave-to-semantic-ir`'s)
+//! — same overall shape (`node_available` skip-not-fail guard, a
+//! `Case`/`CORPUS`, a `ground_truth`/`compiled` pair, one looping `#[test]`)
+//! — completing HML01 §5's "J's own oracle tests remain an open follow-on
+//! item" note (this PR updates that line — see the spec).
+//!
+//! ## Same simplifications as APL, confirmed empirically for J too
+//!
+//! 1. **No `setup`/`final_expr` split.** `j-runtime`'s own module doc
+//!    (`eval.rs`) states plainly: "Assignment is silent; a bare
+//!    (non-assignment) statement auto-prints its result — mirrors
+//!    `apl-runtime`'s own real-session convention exactly", and
+//!    `j-to-semantic-ir`'s own lowering wraps a bare top-level `noun_expr`
+//!    in the shared `"print"` builtin unconditionally
+//!    (`src/lower.rs::lower_top_level_statement`'s 1-child arm) — exactly
+//!    like APL. So [`Case`] here is just `name` + `source` (one full
+//!    program, identical on both sides) + `expected`, plus one addition
+//!    neither APL's file nor the MATLAB/Octave template needs: `known_bug`
+//!    (see below).
+//! 2. **No `normalize()`.** J's 12 shared scalar atoms map onto the same
+//!    `ElementwiseOpKind` comparisons APL uses, which convert straight back
+//!    to a `1.0`/`0.0` float before reaching `display` on both sides (see
+//!    `apl-to-semantic-ir/tests/oracle.rs`'s own "normalize()" section for
+//!    the full reasoning, which transfers unchanged) — `5>3` prints `"1"`
+//!    on both sides with no spelling gap to paper over.
+//!
+//! ## A THIRD thing this file needs that neither APL's nor MATLAB/Octave's
+//! oracle files needed: `known_bug`
+//!
+//! Building this corpus found real, reproducible disagreements between
+//! `j-runtime` and the compiled-then-`node` path that are **not** bugs in
+//! this crate or in `j-runtime` (verified by root-causing each one — see
+//! below) but in the SHARED `semantic-ir-to-javascript` backend crate,
+//! consumed by many other frontends (MATLAB, Octave, Wolfram, Derive,
+//! Reduce, Maple, Scilab, etc.). Per this task's own explicit discipline
+//! (mirroring how APL's oracle file originally shipped its own three bugs
+//! excluded-not-fixed, before a later, separate PR fixed them in
+//! `semantic-ir-to-javascript` 0.43.0), a shared-crate bug is documented
+//! here and left for a follow-up PR, not patched in this one. [`Case`]
+//! therefore carries one more field, `known_bug: Option<&'static str>`:
+//! `None` for every ordinary entry (both `ground_truth` and `compiled` must
+//! agree with `expected`), or `Some(reason)` for an entry where
+//! `ground_truth` is still asserted against `expected` (so a wrong corpus
+//! value is still caught) but the `compiled`-side assertion is skipped
+//! entirely (matching the task's own "temporarily comment out just that
+//! one assertion" instruction, implemented as a data-driven skip rather
+//! than literal commented-out code, so the reason travels with the case
+//! instead of living only in a comment).
+//!
+//! ### Bug A: no J-specific display convention at all in
+//! `semantic-ir-to-javascript` (glyph for negative numbers AND infinity)
+//!
+//! `emit.rs`'s `display_apl_high_minus` flag is `m.metadata.source_language
+//! .as_deref() == Some("apl")` — there is no equivalent check for `"j"`
+//! anywhere in that crate. Two consequences, both confirmed by hand-running
+//! the generated JavaScript:
+//! - A **bare/boxed scalar** negative number or `Infinity` reaches
+//!   `formatSeen`'s `SIR_DISPLAY_APL_HIGH_MINUS`-gated branch, which is
+//!   `false` for a J-sourced module, so it falls through to plain
+//!   JavaScript stringification: `String(-5)` → `"-5"` (ASCII, not J's own
+//!   leading underscore `_5`; confirmed: `-5` alone), `String(Infinity)` →
+//!   `"Infinity"` (not J's own lowercase `inf`; confirmed: `%0`, monadic
+//!   reciprocal of zero).
+//! - A **genuine `NDArray`** (rank ≥ 1, or a rank-0 value that happens to
+//!   already be boxed as one) reaches `ArrayRt.fmtNum`, which
+//!   *unconditionally* renders APL's own high-minus `¯` for any negative
+//!   value with **no flag check of any kind** — confirmed: `-1 2 _3`
+//!   (monadic negate of a genuine rank-1 vector) prints `¯1 ¯2 3`, and
+//!   `-/+\1 2 3` (reduce-of-scan, a rank-0 `NDArray` by the time it reaches
+//!   `print`) prints `¯8`. Neither ASCII `-`/`Infinity` nor APL's `¯` is J's
+//!   own convention (`j_runtime::value::fmt_num`: leading underscore `_`,
+//!   `inf`/`_inf` for infinities — see that module's own doc comment for
+//!   why J can't reuse APL's `¯` at all: ASCII-only, MA06 §4).
+//!
+//! This is **not** something `j-to-semantic-ir`'s own lowering can route
+//! around the way [`lower_term`](../src/lower.rs)'s `Ravel`-wrap or
+//! [`Lowerer::zero_base_index`](../src/lower.rs)'s `- 1` wrap do (see this
+//! file's "Two genuine bugs, found and fixed HERE" section below for those)
+//! — this is a pure **display**-time decision baked into
+//! `semantic-ir-to-javascript`'s own inlined runtime string, with no SIR
+//! node or value-level workaround available from the frontend side. Fixing
+//! it needs a THIRD per-module display flag in that shared crate (e.g.
+//! `SIR_DISPLAY_J_UNDERSCORE`, mirroring `SIR_DISPLAY_APL_HIGH_MINUS`'s own
+//! existing pattern) plus a matching `ArrayRt.fmtNum`/`formatSeen` branch —
+//! exactly the kind of shared-crate change this task's own instructions say
+//! must NOT be made in this PR. Every `CORPUS` entry below whose `expected`
+//! value contains a negative number or `inf` therefore carries a
+//! `known_bug` note citing this section.
+//!
+//! ### Bug B: `semantic-ir-to-javascript` never registered J's two new
+//! builtins (`tally`, `replicate`, `exp`)
+//!
+//! `j-to-semantic-ir`'s own `src/lower.rs`/`README.md`/`CHANGELOG.md`
+//! document `#`'s monadic form as `BuiltinCall("tally", ..)`, `#`'s dyadic
+//! form as `BuiltinCall("replicate", ..)`, and `^`'s monadic form as
+//! `BuiltinCall("exp", ..)` — but `semantic-ir-to-javascript`'s `builtins`
+//! dispatch table (the generic `__Sir.callBuiltin` fallback every
+//! unrecognised name routes through) never gained entries for any of the
+//! three, so all three crash **unconditionally**, for every operand:
+//! `node` exits with `TypeError: unknown builtin: tally` (or `replicate`,
+//! or `exp`) every time. Confirmed by hand-running the generated
+//! JavaScript for `#1 2 3`, `2 0 3#1 2 3`, and `^0`. This is the exact same
+//! *class* of bug as APL's own historical bug #3 (`sign`/`recip`/`ceil`/
+//! `floor` never registered) — a pure omission in the shared crate, not a
+//! subtler logic error — except unlike that one (fixed in
+//! `semantic-ir-to-javascript` 0.43.0 before this file was written), these
+//! three names are new to J and have never been registered at all. Dyadic
+//! `^` (power) is unaffected — it reuses `ElementwiseOpKind::Pow`, already
+//! implemented for MATLAB's `.^` (`dyadic_pow` below passes cleanly).
+//!
+//! ## Two genuine bugs, found AND FIXED here (in `j-to-semantic-ir`'s own
+//! `src/lower.rs`, not the shared crate)
+//!
+//! Building this corpus also found two bugs genuinely local to this
+//! crate's own lowering — both fixed directly in this PR, per this task's
+//! own instructions ("if the bug is in `j-to-semantic-ir`'s OWN lowering
+//! ... FIX it directly"):
+//!
+//! 1. **Stranded literals of 2+ numbers were never `Ravel`-wrapped**,
+//!    unlike `apl-to-semantic-ir`'s own identical construct (that crate's
+//!    0.1.3 fix). `semantic-ir`'s own `ArrayLit` doc comment is explicit
+//!    that a 1-row literal is a genuinely rank-2 `[1, n]` value under this
+//!    IR's column-major convention, not a rank-1 `[n]` vector — so a bare
+//!    `Expr::ArrayLit { rows: vec![row], .. }` was the WRONG shape for a J
+//!    stranded literal (`2 2`, `1 2 3`, …), and any op that validates its
+//!    operand is rank ≤ 1 (dyadic `$`'s shape argument, dyadic `i.`'s
+//!    haystack) rejected it outright: confirmed empirically,
+//!    `2 2$1 2 3 4` (reshape whose *shape* argument, `2 2`, is a stranded
+//!    literal) crashed the compiled path with `reshape: shape argument
+//!    must be a scalar or vector (got rank 2)`, even though this exact
+//!    program round-trips correctly through `j-runtime`. Fixed in
+//!    `src/lower.rs::Lowerer::lower_term`, mirroring
+//!    `apl-to-semantic-ir::Lowerer::lower_term`'s identical `Expr::Ravel`
+//!    wrap exactly. `printed_matrix_two_by_two`, `shape_of_a_reshaped_
+//!    matrix`, `reshape_cycles_a_shorter_source`, and
+//!    `dyadic_index_of_is_zero_based_with_tally_sentinel` below all
+//!    regression-guard this (each was a hard `node` crash before the fix,
+//!    confirmed by re-running this exact corpus against the pre-fix
+//!    lowering).
+//! 2. **Monadic/dyadic `i.` reused APL's `Expr::IndexGenerator`/
+//!    `Expr::IndexOf` nodes directly, silently inheriting APL's 1-based
+//!    convention and `len + 1`-not-found sentinel** — genuinely wrong
+//!    values for J, whose `i.` is 0-based with a plain-tally not-found
+//!    sentinel (MA06 §1 bullet 3, this crate's single most
+//!    safety-critical distinction from APL — see `j_runtime::builtins`'
+//!    own doc comments for `index_generator`/`index_of`). Confirmed
+//!    empirically: `i.5` compiled to `1 2 3 4 5` (APL's 1-based iota),
+//!    not `j-runtime`'s own `0 1 2 3 4`. Unlike Bug A/B above, this one
+//!    **can** be corrected entirely from this crate's own lowering, with
+//!    no shared-crate change: `apl_value - 1` is an exact identity for
+//!    BOTH J conventions (found: `apl_value` is the 1-based position
+//!    `k + 1` for J's 0-based `k`, so `apl_value - 1 == k`; not found:
+//!    `apl_value` is `len + 1`, so `apl_value - 1 == len`, exactly J's own
+//!    tally sentinel) — see `src/lower.rs::Lowerer::zero_base_index`'s own
+//!    doc comment for the full proof. `index_generator_is_zero_based` and
+//!    `dyadic_index_of_is_zero_based_with_tally_sentinel` below regression-
+//!    guard this.
+//!
+//! ## Corpus
+//!
+//! Mirrors `apl-to-semantic-ir/tests/oracle.rs`'s own breadth target: J's
+//! signature right-to-left/no-precedence evaluation; a true/false
+//! comparison pair; a scalar-vector broadcast; an assignment read back by a
+//! later statement; a printed matrix (2-D display); reduce (`+/`) and scan
+//! (`+\`) via the shared SIR22-addendum kernels; every SIR22/addendum
+//! `Expr` variant this crate's own `src/lower.rs` can emit
+//! (`ElementwiseOp`, `ArrayLit`+`Ravel`, `Shape`, `Reshape`,
+//! `IndexGenerator`, `IndexOf`, `Ravel`, `Catenate`, `Reduce`, `Scan`,
+//! `BuiltinCall` for every one of `neg`/`sign`/`recip`/`floor`/`ceil`/
+//! `tally`/`replicate`/`exp`/`print`); the `@` compose conjunction; **at
+//! least one hook and one fork** (J's genuinely novel trains feature, MA06
+//! §3 — the single most J-specific thing to verify, absent from APL
+//! entirely) — this corpus has two hooks, two verb-left forks, and one
+//! leading-noun fork; and J's own leading-underscore negative-literal
+//! spelling (`_5`, confirmed against `j_runtime::value::fmt_num`, distinct
+//! from APL's high-minus `¯` and from a bare ASCII `-`).
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use coding_adventures_j_runtime::eval as j_eval;
+use j_to_semantic_ir::compile_source;
+
+/// Is a `node` binary on `PATH`? Mirrors `apl-to-semantic-ir/tests/
+/// oracle.rs`'s own `node_available` (and every sibling oracle file's)
+/// exactly: the test below skips (logs, does not fail) when it is not.
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// One oracle corpus entry. Like `apl-to-semantic-ir`'s own `Case`,
+/// `source` is the WHOLE program, byte-for-byte identical on both the
+/// `ground_truth` and `compiled` sides (see this file's module doc
+/// comment, point 1, for why J needs no `setup`/`final_expr` split any
+/// more than APL does). `known_bug` is the one addition beyond that
+/// template — see this file's own "A THIRD thing this file needs" section.
+struct Case {
+    name: &'static str,
+    source: &'static str,
+    expected: &'static str,
+    /// `None`: both `ground_truth` and `compiled` must equal `expected`.
+    /// `Some(reason)`: only `ground_truth` is checked against `expected`;
+    /// the `compiled`-side call is skipped entirely (not even invoked),
+    /// with `reason` naming which documented shared-crate bug (this file's
+    /// module doc, "Bug A"/"Bug B") is responsible.
+    known_bug: Option<&'static str>,
+}
+
+const CORPUS: &[Case] = &[
+    // --- Base-cut breadth (mirrors apl-to-semantic-ir/tests/oracle.rs) ---
+    //
+    // J's signature semantics: no operator precedence, strictly
+    // right-to-left. `2*3+4` is `2*(3+4) = 14`, NOT `(2*3)+4 = 10` --
+    // matching `j-runtime`'s own `right_to_left_evaluation_has_no_
+    // precedence` test.
+    Case {
+        name: "right_to_left_no_operator_precedence",
+        source: "2*3+4\n",
+        expected: "14",
+        known_bug: None,
+    },
+    // A true and a false comparison -- both sides agree on the bare
+    // numeric spelling (`1`/`0`), never a JS-native boolean (see this
+    // file's module doc comment's "No normalize()" point).
+    Case {
+        name: "comparison_true",
+        source: "5>3\n",
+        expected: "1",
+        known_bug: None,
+    },
+    Case {
+        name: "comparison_false",
+        source: "3>5\n",
+        expected: "0",
+        known_bug: None,
+    },
+    // Scalar-vector broadcast: `2*1 2 3` doubles each element. `1 2 3`
+    // lowers to a genuine rank-1 vector via the `Ravel`-wrap fix (this
+    // file's module doc comment, "genuine bugs found AND FIXED here" #1),
+    // so this also incidentally confirms that fix from the ground-truth
+    // side.
+    Case {
+        name: "scalar_vector_broadcast",
+        source: "2*1 2 3\n",
+        expected: "2 4 6",
+        known_bug: None,
+    },
+    // Assignment is silent; a LATER bare statement reads the bound name
+    // back and auto-prints.
+    Case {
+        name: "variable_assignment_and_later_reference",
+        source: "A=.3\nA+4\n",
+        expected: "7",
+        known_bug: None,
+    },
+    // A printed MATRIX (2-D display), not just a vector line. The shape
+    // argument `2 2` is itself a stranded literal -- this is the exact
+    // program that crashed the compiled path with `reshape: shape
+    // argument must be a scalar or vector (got rank 2)` before this PR's
+    // `Ravel`-wrap fix (this file's module doc comment, bug #1).
+    Case {
+        name: "printed_matrix_two_by_two",
+        source: "2 2$1 2 3 4\n",
+        expected: "1 2\n3 4",
+        known_bug: None,
+    },
+
+    // --- Reduce (+/) and scan (+\), the shared SIR22-addendum kernels ---
+    Case {
+        name: "reduce_add",
+        source: "+/1 2 3 4\n",
+        expected: "10",
+        known_bug: None,
+    },
+    Case {
+        name: "scan_running_sum",
+        source: "+\\1 2 3\n",
+        expected: "1 3 6",
+        known_bug: None,
+    },
+    // Reduce-of-scan: `-/+\1 2 3` = `-/[1,3,6]` = `(1-3)-6` = `-8`. By the
+    // time this reaches `print` it is a rank-0 `NDArray`, so it hits
+    // `ArrayRt.fmtNum`'s unconditional high-minus branch -- see this
+    // file's module doc comment, "Bug A".
+    Case {
+        name: "scan_then_reduce",
+        source: "-/+\\1 2 3\n",
+        expected: "_8",
+        known_bug: Some(
+            "Bug A (display convention): the reduce result is a rank-0 NDArray by the time it \
+             reaches print, so semantic-ir-to-javascript's ArrayRt.fmtNum renders APL's \
+             unconditional high-minus glyph (\"\u{af}8\") -- there is no J-specific display flag \
+             in that shared crate at all, so neither this nor ASCII \"-8\" is available; J's own \
+             convention is a leading underscore, \"_8\".",
+        ),
+    },
+
+    // --- `@` compose (atop) -- both cases give a POSITIVE result, so
+    // neither exercises Bug A; these are clean, both-sides-pass regression
+    // cases for the compose formula itself.
+    Case {
+        name: "compose_monadic_double_negate",
+        source: "-@-5\n",
+        expected: "5",
+        known_bug: None,
+    },
+    Case {
+        name: "compose_dyadic_negate_of_difference",
+        source: "3-@-4\n",
+        expected: "1",
+        known_bug: None,
+    },
+
+    // --- Trains: hooks and forks (MA06 §3) -- J's genuinely novel
+    // feature, no APL precedent at all (this file's module doc comment).
+    //
+    // Hook, monadic: `(+ *) y = y + (*y)`. For y=5: 5 + sign(5) = 6.
+    Case {
+        name: "hook_monadic",
+        source: "(+*)5\n",
+        expected: "6",
+        known_bug: None,
+    },
+    // Hook, dyadic: `x (+ *) y = x + (*y)` -- `*` (sign) applies
+    // monadically to y alone. For x=3, y=5: 3 + sign(5) = 4.
+    Case {
+        name: "hook_dyadic",
+        source: "3(+*)5\n",
+        expected: "4",
+        known_bug: None,
+    },
+    // Verb-left fork, monadic: `(+ * -) y = (+y) * (-y)`. For y=5:
+    // 5 * (-5) = -25 -- a genuine negative RESULT (not just an
+    // intermediate), so this hits Bug A on the compiled side.
+    Case {
+        name: "fork_monadic_verb_left",
+        source: "(+*-)5\n",
+        expected: "_25",
+        known_bug: Some(
+            "Bug A (display convention): (+*-)5 = 5 * (-5) = -25, a genuine negative scalar -- \
+             see the corpus-wide note at the top of this file. The train-folding itself is \
+             correct (the VALUE -25 is right); only the printed glyph is wrong (\"\u{af}25\", not \"_25\").",
+        ),
+    },
+    // Verb-left fork, dyadic: `x (+ * -) y = (x+y) * (x-y)`. For x=3, y=5:
+    // 8 * (-2) = -16 -- same Bug A.
+    Case {
+        name: "fork_dyadic_verb_left",
+        source: "3(+*-)5\n",
+        expected: "_16",
+        known_bug: Some(
+            "Bug A (display convention): 3(+*-)5 = (3+5) * (3-5) = 8 * -2 = -16, a genuine \
+             negative scalar -- see the corpus-wide note at the top of this file.",
+        ),
+    },
+    // Leading-noun fork, monadic: `(5 + -) y = 5 + (-y)`. For y=3:
+    // 5 + (-3) = 2 -- POSITIVE, so this one is a clean both-sides-pass
+    // regression case for the leading-noun-fork formula itself, free of
+    // Bug A.
+    Case {
+        name: "leading_noun_fork_monadic",
+        source: "(5 + -)3\n",
+        expected: "2",
+        known_bug: None,
+    },
+
+    // --- J's own leading-underscore negative-literal spelling ---
+    //
+    // `_5` alone is a single NUMBER token (leading underscore in the
+    // mantissa -- j.tokens SECTION 4), not monadic `-` applied to `5` --
+    // confirmed against `j_runtime::builtins`'s own parse convention.
+    // Required breadth item: "negative-literal spelling (_5, J's leading-
+    // underscore convention, unlike APL's high-minus or plain numerics)".
+    Case {
+        name: "negative_literal_spelling",
+        source: "_5\n",
+        expected: "_5",
+        known_bug: Some(
+            "Bug A (display convention): a bare IntLit(-5) reaches formatSeen's bare-number \
+             branch, gated by SIR_DISPLAY_APL_HIGH_MINUS which is false for a J-sourced module \
+             (that flag only ever checks source_language == \"apl\"), so it falls through to \
+             plain JS stringification (\"-5\") instead of J's own leading-underscore \"_5\".",
+        ),
+    },
+
+    // --- Monadic scalar atoms (`- * % <. >.`) -- mirrors
+    // apl-to-semantic-ir/tests/oracle.rs's identical breadth, minus the
+    // "Three genuine bugs" story (those were already fixed in
+    // semantic-ir-to-javascript 0.43.0 before this crate's own lowering
+    // was written, so neg/sign/recip/ceil/floor all compute the correct
+    // VALUE here -- only the display GLYPH is wrong for J, per Bug A,
+    // whenever the value is actually negative).
+    Case {
+        name: "monadic_negate_scalar",
+        source: "-5\n",
+        expected: "_5",
+        known_bug: Some("Bug A (display convention) -- same root cause as negative_literal_spelling above."),
+    },
+    // `1 2 _3` is a genuine rank-1 vector (stranded literal, Ravel-wrapped
+    // per this PR's fix #1) -- negating it now correctly computes
+    // `_1 _2 3` (values right, per apl-to-semantic-ir's own historical
+    // bug #2 fix in semantic-ir-to-javascript 0.43.0), but the compiled
+    // side still renders APL's high-minus glyph unconditionally (Bug A).
+    Case {
+        name: "monadic_negate_array",
+        source: "-1 2 _3\n",
+        expected: "_1 _2 3",
+        known_bug: Some(
+            "Bug A (display convention): the negated array is a genuine rank-1 NDArray, so \
+             ArrayRt.fmtNum renders APL's unconditional high-minus glyph (\"\u{af}1 \u{af}2 3\") \
+             for the negative elements, not J's own leading underscore.",
+        ),
+    },
+    Case {
+        name: "monadic_sign_positive",
+        source: "*5\n",
+        expected: "1",
+        known_bug: None,
+    },
+    Case {
+        name: "monadic_sign_zero",
+        source: "*0\n",
+        expected: "0",
+        known_bug: None,
+    },
+    Case {
+        name: "monadic_sign_negative",
+        source: "*_5\n",
+        expected: "_1",
+        known_bug: Some("Bug A (display convention) -- same root cause as monadic_negate_scalar above."),
+    },
+    Case {
+        name: "monadic_reciprocal",
+        source: "%4\n",
+        expected: "0.25",
+        known_bug: None,
+    },
+    // `j_runtime::builtins`'s own doc comment calls this edge case out
+    // explicitly: `recip(0) == Infinity`, never an error. `j-runtime`
+    // renders it as J's own lowercase `inf`; the compiled side reaches the
+    // SAME Bug A branch as a negative number does (formatSeen's
+    // SIR_DISPLAY_APL_HIGH_MINUS-gated bare-number path also decides the
+    // infinity spelling), so it prints JavaScript's native `"Infinity"`
+    // instead.
+    Case {
+        name: "monadic_reciprocal_zero",
+        source: "%0\n",
+        expected: "inf",
+        known_bug: Some(
+            "Bug A (display convention): reciprocal of 0 is a bare, non-finite JS number; \
+             formatSeen's SIR_DISPLAY_APL_HIGH_MINUS-gated branch (false for J) falls through to \
+             plain JS stringification (\"Infinity\") instead of J's own lowercase \"inf\" -- the \
+             SAME missing-J-flag root cause as the negative-number cases above, just the \
+             infinity-spelling half of it rather than the sign-glyph half.",
+        ),
+    },
+    Case {
+        name: "monadic_ceiling",
+        source: ">.3.2\n",
+        expected: "4",
+        known_bug: None,
+    },
+    Case {
+        name: "monadic_floor",
+        source: "<.3.8\n",
+        expected: "3",
+        known_bug: None,
+    },
+
+    // --- $ / i. / , (shared SIR22-addendum nodes with APL) ---
+    //
+    // Monadic `$` (Shape) of a dyadic `$` (Reshape) result -- exercises
+    // BOTH nodes in one program, and (since the Reshape's own shape
+    // argument, `2 3`, is a stranded literal) regression-guards this PR's
+    // `Ravel`-wrap fix #1 exactly like `printed_matrix_two_by_two` above.
+    Case {
+        name: "shape_of_a_reshaped_matrix",
+        source: "$2 3$1 2 3 4 5 6\n",
+        expected: "2 3",
+        known_bug: None,
+    },
+    // Dyadic `$` (Reshape) CYCLING a shorter source to fill a larger
+    // target -- `1 2` repeats to `1 2 1 / 2 1 2`.
+    Case {
+        name: "reshape_cycles_a_shorter_source",
+        source: "2 3$1 2\n",
+        expected: "1 2 1\n2 1 2",
+        known_bug: None,
+    },
+    // Monadic `i.` (IndexGenerator) -- 0-based, `i.5` is `0 1 2 3 4`, NEVER
+    // APL's 1-based `1 2 3 4 5`. This is the exact regression case for
+    // this PR's fix #2 (`Lowerer::zero_base_index`) -- confirmed to
+    // compile to APL's own 1-based iota before that fix.
+    Case {
+        name: "index_generator_is_zero_based",
+        source: "i.5\n",
+        expected: "0 1 2 3 4",
+        known_bug: None,
+    },
+    // Dyadic `i.` (IndexOf) -- 0-based positions with a plain-tally
+    // not-found sentinel: search `[20, 99, 10]` in `[10, 20, 30]`. `20` is
+    // at 0-based index 1; `99` is not found (tally = 3, NOT APL's
+    // `len + 1` = 4); `10` is at 0-based index 0. The haystack `10 20 30`
+    // is itself a stranded literal, so this ALSO regression-guards fix #1
+    // (it crashed the compiled path with `indexOf: left argument must be
+    // a scalar or vector (got rank 2)` before that fix).
+    Case {
+        name: "dyadic_index_of_is_zero_based_with_tally_sentinel",
+        source: "10 20 30 i.20 99 10\n",
+        expected: "1 3 0",
+        known_bug: None,
+    },
+    // Monadic `,` (Ravel) of a reshaped matrix: flatten `[[1,2,3],[4,5,6]]`
+    // row-major back to `1 2 3 4 5 6`.
+    Case {
+        name: "ravel_of_a_reshaped_matrix",
+        source: ",(2 3$1 2 3 4 5 6)\n",
+        expected: "1 2 3 4 5 6",
+        known_bug: None,
+    },
+    // Dyadic `,` (Catenate): `1 2,3 4` end-to-end catenates two vectors.
+    Case {
+        name: "dyadic_catenate",
+        source: "1 2,3 4\n",
+        expected: "1 2 3 4",
+        known_bug: None,
+    },
+
+    // --- `#` and `^` -- genuinely new primitives, no APL analogue at all
+    // (this crate's own module doc comment's "Two new primitives"
+    // section). All three of `tally`/`replicate`/`exp` hit Bug B (the
+    // shared crate never registered these builtin names at all, so `node`
+    // crashes with `TypeError: unknown builtin: <name>` for every operand
+    // -- not a wrong VALUE, a hard crash).
+    Case {
+        name: "monadic_tally",
+        source: "#1 2 3\n",
+        expected: "3",
+        known_bug: Some(
+            "Bug B (missing builtin): semantic-ir-to-javascript's builtin dispatch table has no \
+             \"tally\" entry at all -- node exits with `TypeError: unknown builtin: tally` for \
+             every operand, not merely a wrong value.",
+        ),
+    },
+    Case {
+        name: "dyadic_replicate",
+        source: "2 0 3#1 2 3\n",
+        expected: "1 1 3 3 3",
+        known_bug: Some(
+            "Bug B (missing builtin): semantic-ir-to-javascript's builtin dispatch table has no \
+             \"replicate\" entry at all -- node exits with `TypeError: unknown builtin: \
+             replicate` for every operand.",
+        ),
+    },
+    Case {
+        name: "monadic_exp",
+        source: "^0\n",
+        expected: "1",
+        known_bug: Some(
+            "Bug B (missing builtin): semantic-ir-to-javascript's builtin dispatch table has no \
+             \"exp\" entry at all -- node exits with `TypeError: unknown builtin: exp` for every \
+             operand.",
+        ),
+    },
+    // Dyadic `^` (Pow) is UNAFFECTED by Bug B -- it reuses
+    // `ElementwiseOpKind::Pow`, already implemented in
+    // semantic-ir-to-javascript for MATLAB's `.^`, so this is a clean,
+    // both-sides-pass case.
+    Case {
+        name: "dyadic_pow",
+        source: "2^3\n",
+        expected: "8",
+        known_bug: None,
+    },
+];
+
+/// Ground truth: run `source` through `j-runtime`'s own [`j_eval`], which
+/// already returns exactly the auto-print output of the program's bare
+/// top-level expression(s) (see this file's module doc comment, point 1)
+/// -- no echo-parsing needed, unlike the MATLAB/Octave oracle files' `name
+/// = value` convention.
+fn ground_truth(source: &str) -> String {
+    j_eval(source)
+        .unwrap_or_else(|e| panic!("j-runtime eval failed for {source:?}: {e}"))
+        .trim()
+        .to_string()
+}
+
+/// Compiled path: run `source` (unchanged) through
+/// `j_to_semantic_ir::compile_source`, `semantic_ir::validate`,
+/// `semantic_ir_to_javascript::compile`, and an actual `node` process.
+/// Mirrors `apl-to-semantic-ir/tests/oracle.rs`'s own `compiled` exactly,
+/// down to the `OpenOptions::create_new(true)` temp-file handling (that
+/// file's own doc comment explains why: `create_new` fails instead of
+/// silently following an existing symlink planted at the shared,
+/// predictable system temp path).
+fn compiled(name: &str, source: &str) -> String {
+    let module = compile_source(source, "prog")
+        .unwrap_or_else(|e| panic!("lowering failed for {name} ({source:?}): {e:?}"));
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    let artifact = semantic_ir_to_javascript::compile(&module)
+        .unwrap_or_else(|e| panic!("backend emit failed for {name}: {e:?}"));
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("j_sir_oracle_{name}_{}.js", std::process::id()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes())
+        .expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node")
+        .arg(&path)
+        .output()
+        .expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn oracle_corpus_matches_native_j_runtime() {
+    if !node_available() {
+        eprintln!("skipping oracle_corpus_matches_native_j_runtime: `node` not available");
+        return;
+    }
+    for case in CORPUS {
+        let gt = ground_truth(case.source);
+        assert_eq!(
+            gt, case.expected,
+            "{}: j-runtime itself disagrees with this corpus entry's own `expected` -- \
+             the program or `expected` is wrong, fix the corpus rather than this assertion",
+            case.name
+        );
+
+        match case.known_bug {
+            None => {
+                let got = compiled(case.name, case.source);
+                assert_eq!(
+                    got, case.expected,
+                    "{}: j-to-semantic-ir -> semantic-ir-to-javascript -> node disagrees with \
+                     the j-runtime ground truth ({gt:?}) -- see this file's module doc for the \
+                     two documented, already-excluded shared-crate bug classes (Bug A: display \
+                     convention; Bug B: missing tally/replicate/exp builtins) before assuming \
+                     this is a new one",
+                    case.name
+                );
+            }
+            Some(reason) => {
+                // KNOWN BUG: the compiled-side assertion is deliberately
+                // skipped (not even invoked) for this entry -- see this
+                // file's module doc comment's "A THIRD thing this file
+                // needs" section for why, and `reason` for exactly which
+                // documented shared-crate bug applies here.
+                eprintln!(
+                    "{}: skipping compiled-side assertion (KNOWN BUG, not fixed in this PR): {reason}",
+                    case.name
+                );
+            }
+        }
+    }
+}

--- a/code/packages/rust/j-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/j-to-semantic-ir/tests/test_lower.rs
@@ -76,21 +76,31 @@ fn underscore_negative_float_literal_with_underscore_exponent() {
 }
 
 #[test]
-fn stranded_literal_is_a_single_row_array_lit() {
+fn stranded_literal_is_a_single_row_array_lit_wrapped_in_ravel() {
+    // BUG FIX regression case (found by `tests/oracle.rs`, root-caused
+    // against `apl-to-semantic-ir`'s identical fix): a bare `ArrayLit {
+    // rows: vec![row], .. }` is a genuinely rank-2 `[1, n]` value under
+    // this IR's column-major convention, not the rank-1 `[n]` vector a
+    // stranded literal actually is -- `Expr::Ravel` wraps it to flatten
+    // down to rank 1 (see `src/lower.rs`'s `lower_term` doc comment).
     let m = compile_ok("1 2 3\n");
     let main = main_fn(&m);
     match printed_value(&main.body.stmts[0]) {
-        Expr::ArrayLit { rows, .. } => {
-            assert_eq!(rows.len(), 1, "stranded literal must be a single row (rank-1 vector)");
-            assert_eq!(rows[0].len(), 3);
-            assert!(matches!(rows[0][0], Expr::IntLit { value: 1, .. }));
-            assert!(matches!(rows[0][1], Expr::IntLit { value: 2, .. }));
-            assert!(matches!(rows[0][2], Expr::IntLit { value: 3, .. }));
-        }
-        other => panic!("expected ArrayLit, got {other:?}"),
+        Expr::Ravel { target, .. } => match target.as_ref() {
+            Expr::ArrayLit { rows, .. } => {
+                assert_eq!(rows.len(), 1, "stranded literal must be a single row (rank-1 vector)");
+                assert_eq!(rows[0].len(), 3);
+                assert!(matches!(rows[0][0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(rows[0][1], Expr::IntLit { value: 2, .. }));
+                assert!(matches!(rows[0][2], Expr::IntLit { value: 3, .. }));
+            }
+            other => panic!("expected Ravel(ArrayLit(..)), got Ravel({other:?})"),
+        },
+        other => panic!("expected Ravel(ArrayLit(..)), got {other:?}"),
     }
     assert!(m.manifest.iter().any(|f| f == Feature::NDArrays));
     assert!(m.manifest.iter().any(|f| f == Feature::ArrayColumnMajor));
+    assert!(m.manifest.iter().any(|f| f == Feature::MatrixOps));
 }
 
 #[test]
@@ -179,7 +189,15 @@ fn dollar_shape_monadic_and_reshape_dyadic() {
     match printed_value(&main_fn(&m).body.stmts[0]) {
         Expr::Reshape { shape, target, .. } => {
             assert!(matches!(**shape, Expr::IntLit { value: 2, .. }));
-            assert!(matches!(**target, Expr::ArrayLit { .. }));
+            // `target` is the stranded literal `1 2 3 4`, so it's wrapped
+            // in `Expr::Ravel` per `lower_term`'s rank-1 fix (see
+            // `stranded_literal_is_a_single_row_array_lit_wrapped_in_ravel`).
+            match target.as_ref() {
+                Expr::Ravel { target: inner, .. } => {
+                    assert!(matches!(**inner, Expr::ArrayLit { .. }));
+                }
+                other => panic!("expected Ravel(ArrayLit(..)), got {other:?}"),
+            }
         }
         other => panic!("expected Reshape, got {other:?}"),
     }
@@ -187,11 +205,32 @@ fn dollar_shape_monadic_and_reshape_dyadic() {
 
 #[test]
 fn idot_index_generator_monadic_and_index_of_dyadic() {
+    // BUG FIX regression case (found by `tests/oracle.rs`): the bare
+    // `Expr::IndexGenerator`/`Expr::IndexOf` nodes hardcode APL's 1-based
+    // convention with a `len + 1` not-found sentinel (see
+    // `semantic-ir-to-javascript`'s `runtime.rs`); J's own `i.` is
+    // genuinely 0-based with a plain-tally not-found sentinel (MA06 §1
+    // bullet 3), so `Self::zero_base_index` wraps both in an elementwise
+    // `- 1` to convert -- see that function's own doc comment for the
+    // arithmetic proof this is correct in both the found and not-found
+    // cases.
     let m = compile_ok("i.5\n");
-    assert!(matches!(printed_value(&main_fn(&m).body.stmts[0]), Expr::IndexGenerator { .. }));
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Sub, lhs, rhs, .. } => {
+            assert!(matches!(**lhs, Expr::IndexGenerator { .. }));
+            assert!(matches!(**rhs, Expr::IntLit { value: 1, .. }));
+        }
+        other => panic!("expected ElementwiseOp(Sub, IndexGenerator(..), 1), got {other:?}"),
+    }
 
     let m = compile_ok("(1 2 3)i.2\n");
-    assert!(matches!(printed_value(&main_fn(&m).body.stmts[0]), Expr::IndexOf { .. }));
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Sub, lhs, rhs, .. } => {
+            assert!(matches!(**lhs, Expr::IndexOf { .. }));
+            assert!(matches!(**rhs, Expr::IntLit { value: 1, .. }));
+        }
+        other => panic!("expected ElementwiseOp(Sub, IndexOf(..), 1), got {other:?}"),
+    }
 }
 
 #[test]
@@ -209,7 +248,12 @@ fn ravel_monadic_and_catenate_dyadic() {
 fn hash_tally_monadic_and_replicate_dyadic() {
     let m = compile_ok("#1 2 3\n");
     let args = builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "tally");
-    assert!(matches!(args[0], Expr::ArrayLit { .. }));
+    // `1 2 3` is a stranded literal, wrapped in `Expr::Ravel` per
+    // `lower_term`'s rank-1 fix.
+    match &args[0] {
+        Expr::Ravel { target, .. } => assert!(matches!(**target, Expr::ArrayLit { .. })),
+        other => panic!("expected Ravel(ArrayLit(..)), got {other:?}"),
+    }
 
     let m = compile_ok("2#3\n");
     let args = builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "replicate");

--- a/code/specs/HML01-math-to-semantic-ir.md
+++ b/code/specs/HML01-math-to-semantic-ir.md
@@ -274,8 +274,8 @@ without any change to the IR or the frontends.
 `SIR22` spec → `semantic-ir` core additions → `matlab-to-semantic-ir` →
 `octave-to-semantic-ir` → `sir-runtime-array` → JS/TS backend codegen →
 `apl-to-semantic-ir` (SIR22 addendum for APL primitives) →
-`j-to-semantic-ir` → golden/oracle tests (MATLAB's, Octave's, and APL's own
-now shipped; J's remains open. MATLAB — see
+`j-to-semantic-ir` → golden/oracle tests (MATLAB's, Octave's, APL's, and
+J's own now shipped. MATLAB — see
 `matlab-to-semantic-ir/tests/oracle.rs`, the first
 true oracle diff anywhere in this track: the same computation run through
 `matlab-runtime` and through this frontend's compiled-JS-via-`node` path,
@@ -305,9 +305,21 @@ comparison instead, and the gap is recorded in that crate's `CHANGELOG.md`
 for a follow-up. APL — see `apl-to-semantic-ir/tests/oracle.rs`, its own
 distinct 17-case corpus (not just MATLAB's reused), which also surfaced 3
 new bugs in monadic `- × ÷ ⌈ ⌊` (a wrong display glyph, a wrong value on
-array operands, and a hard crash on `× ÷ ⌈ ⌊`), all still open — see that
-crate's `CHANGELOG.md`. J's own oracle tests remain an open follow-on item.
-All items through JS/TS backend codegen are shipped.
+array operands, and a hard crash on `× ÷ ⌈ ⌊`) — all three now fixed, in
+`semantic-ir-to-javascript` 0.43.0, see that crate's `CHANGELOG.md`. J —
+see `j-to-semantic-ir/tests/oracle.rs`, its own 36-case corpus, which
+fixed two bugs genuinely local to that frontend's own lowering (stranded
+literals missing the same rank-1 `Ravel`-wrap fix APL's own lowering
+already had, and monadic/dyadic `i.` silently inheriting APL's 1-based
+`IndexGenerator`/`IndexOf` convention instead of J's own 0-based one with
+a plain-tally not-found sentinel) directly in this PR, and found two more
+bugs in the shared `semantic-ir-to-javascript` crate itself, deliberately
+left open for a follow-up PR (no J-specific display convention for
+negative numbers/infinity at all — only APL's high-minus glyph is wired
+up — and three of J's own builtin names, `tally`/`replicate`/`exp`, never
+registered in that crate's dispatch table) — see that crate's
+`CHANGELOG.md` for the full write-up. All items through JS/TS backend
+codegen are shipped.
 
 **Stream B (symbolic/CAS, backs Wolfram/Macsyma/Maxima/Derive/Reduce/
 Maple):** `SIR23` spec → `semantic-ir` core additions →


### PR DESCRIPTION
## Summary

Closes the HML01 "J's own oracle tests remain an open follow-on item" gap (per §7): j-runtime, matlab-to-semantic-ir, octave-to-semantic-ir, and apl-to-semantic-ir all have oracle/golden test harnesses that cross-check a native runtime against the compiled-then-node-executed path; J shipped without one. This adds `j-to-semantic-ir/tests/oracle.rs`, the direct J sibling of `apl-to-semantic-ir`'s own oracle file.

- **36-case corpus** covering right-to-left/no-precedence evaluation, comparisons, scalar-vector broadcast, assignment, a printed 2-D matrix, reduce/scan, every SIR22/addendum `Expr` variant this crate emits, `@` compose, **hooks and forks** (J's genuinely novel trains feature, absent from APL entirely), and J's own leading-underscore negative-literal spelling.
- **Two real bugs found and fixed directly in this crate's own `src/lower.rs`** (verified empirically, not assumed):
  1. Stranded literals of 2+ numbers were never `Ravel`-wrapped, unlike `apl-to-semantic-ir`'s identical fix — any op requiring a rank-≤1 operand (dyadic `$`'s shape argument, dyadic `i.`'s haystack) rejected valid J programs. Fixed by wrapping in `Expr::Ravel`, mirroring APL's fix exactly.
  2. Monadic/dyadic `i.` silently inherited APL's 1-based `IndexGenerator`/`IndexOf` convention and `len+1` not-found sentinel instead of J's own 0-based convention with a plain-tally sentinel (MA06 §1's single most safety-critical J/APL distinction). Fixed via a new `zero_base_index` helper — `apl_value - 1` is an exact arithmetic identity for both the found and not-found cases (proven in that function's doc comment), needing zero shared-crate changes.
- **Two real bugs found in the shared `semantic-ir-to-javascript` backend, deliberately left unfixed here** (documented via a data-driven `known_bug` field on 11 corpus entries, mirroring how APL's own oracle file originally shipped its 3 bugs excluded-not-fixed before a later PR fixed them in `semantic-ir-to-javascript` 0.43.0):
  - **Bug A**: no J-specific display convention at all — `emit.rs`'s `SIR_DISPLAY_APL_HIGH_MINUS` flag only checks `source_language == "apl"`, so a J-sourced module's negative numbers/infinity print plain ASCII or APL's high-minus glyph instead of J's own leading-underscore convention.
  - **Bug B**: `tally`/`replicate`/`exp` (J's two genuinely new builtins) were never registered in the shared builtin dispatch table — hard `TypeError: unknown builtin` crash for every operand. Filed as follow-up tasks for a dedicated front1 PR (same bug class as APL's historical `sign`/`recip`/`ceil`/`floor` omission, already fixed for APL).

Updates `HML01-math-to-semantic-ir.md` §5 to mark J's oracle tests shipped.

## Verification

- `cargo test -p j-to-semantic-ir` — 48 passed (1 oracle + 43 test_lower + 4 test_validator), 0 failed. Re-ran independently myself, not just trusting the build agent.
- `cargo clippy -p j-to-semantic-ir --all-targets -- -D warnings` — clean.
- `cargo build --workspace` (excluding the usual platform-gated crates) — succeeds.
- `/security-review` passed — no vulnerabilities found (reviewed the temp-file `create_new` symlink-safety pattern, subprocess argv-based `node` invocation with no shell, and confirmed the test corpus is fixed/hardcoded, not attacker-controlled).

## Test plan

- [x] `cargo test -p j-to-semantic-ir` passes (verified independently)
- [x] `cargo clippy -p j-to-semantic-ir --all-targets -- -D warnings` clean
- [x] Full workspace build succeeds
- [x] `/security-review` passed
- [ ] User review/merge (async)

🤖 Generated with [Claude Code](https://claude.com/claude-code)