### PR TITLE
feat(spice): add BJT forward Early voltage

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT forward Early voltage** — BJT model cards now accept `VAF`/`VA` and
+  apply collector-voltage modulation in DC, transient, AC, transfer-function,
+  and noise paths, matching Rust and TypeScript. The supported-parameter
+  catalog now contains 78 canonical rows.
+
 - **BJT energy gap** — BJT model cards now accept `EG`, apply each model's
   energy gap to saturation-current temperature scaling, and preserve it through
   subcircuit expansion, matching Rust and TypeScript. The supported-parameter

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -211,7 +211,8 @@ transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
-model-specific saturation-current temperature scaling.
+model-specific saturation-current temperature scaling, plus `VAF`/`VA`
+(default `0`, meaning infinite) for forward Early-effect modulation.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -593,6 +593,9 @@ class BJT:
         Saturation-current temperature exponent (default 3.0).
     Eg:
         Semiconductor energy gap in electron-volts (default 1.11 eV).
+    Vaf:
+        Forward Early voltage in Volts. Zero disables collector-voltage
+        modulation, matching an infinite Early voltage (default 0.0).
     """
 
     name: str
@@ -609,6 +612,7 @@ class BJT:
     Tr: float = 0.0         # reverse transit time (s)
     Xti: float = 3.0        # saturation-current temperature exponent
     Eg: float = 1.11        # semiconductor energy gap (eV)
+    Vaf: float = 0.0        # forward Early voltage (V); 0 means infinite
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9047,18 +9047,26 @@ def _stamp_bjt(
     # --- Resolve node voltages at the current Newton iterate -----------------
     Vb = 0.0 if _is_ground(el.base) else x[node_to_idx[el.base]]
     Ve = 0.0 if _is_ground(el.emitter) else x[node_to_idx[el.emitter]]
+    Vc = 0.0 if _is_ground(el.collector) else x[node_to_idx[el.collector]]
 
     # --- Controlling junction voltage (clamped to avoid exp overflow) --------
     Vjunc = min(Vb - Ve, 0.7) if el.polarity == "NPN" else min(Ve - Vb, 0.7)
 
     exp_term = math.exp(Vjunc / el.Vt)
-    Ic0 = el.Is * (exp_term - 1.0)
-    gm = (el.Is / el.Vt) * exp_term
-    g_pi = gm / el.beta_f
-    Ib0 = Ic0 / el.beta_f
+    base_collector_current = el.Is * (exp_term - 1.0)
+    base_gm = (el.Is / el.Vt) * exp_term
+    output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
+    early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
+    output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
+    Ic0 = base_collector_current * early_factor
+    gm = base_gm * early_factor
+    g_pi = base_gm / el.beta_f
+    Ib0 = base_collector_current / el.beta_f
 
     Ieq_junc = Ib0 - g_pi * Vjunc      # junction Norton offset
-    Ieq_coll = Ic0 - gm * Vjunc        # VCCS Norton offset
+    Ieq_coll = Ic0 - gm * Vjunc - output_conductance * output_voltage
+
+    _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
 
     if el.polarity == "NPN":
         # --- Junction stamp: gπ between B and E ------------------------------
@@ -9139,6 +9147,8 @@ def _validate_bjt(el: BJT) -> None:
         )
     if not math.isfinite(el.Eg) or el.Eg <= 0.0:
         raise ValueError(f"{el.name}: BJT energy gap must be finite and positive")
+    if not math.isfinite(el.Vaf) or el.Vaf < 0.0:
+        raise ValueError(f"{el.name}: BJT forward Early voltage must be finite and non-negative")
 
 
 # ---------------------------------------------------------------------------
@@ -12359,13 +12369,19 @@ def _stamp_ac(
         )
         exp_t = math.exp(Vjunc / el.Vt)
         exp_reverse = math.exp(Vreverse / el.Vt)
-        gm_b: float = (el.Is / el.Vt) * exp_t
+        base_collector_current = el.Is * (exp_t - 1.0)
+        base_gm = (el.Is / el.Vt) * exp_t
+        output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
+        early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
+        output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
+        gm_b: float = base_gm * early_factor
         gm_reverse: float = (el.Is / el.Vt) * exp_reverse
-        g_pi: float = gm_b / el.beta_f
+        g_pi: float = base_gm / el.beta_f
         diffusion_capacitance = el.Tf * gm_b
         reverse_diffusion_capacitance = el.Tr * gm_reverse
         y_be = g_pi + 1j * omega * (el.Cje + diffusion_capacitance)
         y_bc = 1j * omega * (el.Cjc + reverse_diffusion_capacitance)
+        _stamp_g_c(G, node_to_idx, el.collector, el.emitter, output_conductance + 0j)
 
         if el.polarity == "NPN":
             _stamp_g_c(G, node_to_idx, el.base, el.emitter, y_be)
@@ -12956,6 +12972,7 @@ def _build_ss_matrix(
         elif isinstance(el, BJT):
             # Small-signal model: g_π (junction conductance) + gm VCCS.
             # Mirrors the AC _stamp_ac BJT block in the real domain.
+            Vc_dc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
             Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
             Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
             Vjunc = (
@@ -12963,8 +12980,14 @@ def _build_ss_matrix(
                 else min(Ve_dc - Vb_dc, 0.7)
             )
             exp_t = math.exp(Vjunc / el.Vt)
-            gm_b: float = (el.Is / el.Vt) * exp_t
-            g_pi: float = gm_b / el.beta_f
+            base_collector_current = el.Is * (exp_t - 1.0)
+            base_gm = (el.Is / el.Vt) * exp_t
+            output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
+            early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
+            output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
+            gm_b: float = base_gm * early_factor
+            g_pi: float = base_gm / el.beta_f
+            _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
 
             if el.polarity == "NPN":
                 _stamp_g(G, node_to_idx, el.base, el.emitter, g_pi)
@@ -13841,6 +13864,7 @@ def sens_dc(
                     Tr=el.Tr,
                     Xti=el.Xti,
                     Eg=el.Eg,
+                    Vaf=el.Vaf,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -13859,6 +13883,7 @@ def sens_dc(
                     Tr=el.Tr,
                     Xti=el.Xti,
                     Eg=el.Eg,
+                    Vaf=el.Vaf,
                 ),
             )
 
@@ -14087,6 +14112,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Tr=el.Tr,
             Xti=el.Xti,
             Eg=el.Eg,
+            Vaf=el.Vaf,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.
@@ -14522,11 +14548,14 @@ def _collect_noise_sources(
             # Use actual converged dc_x voltages — no clamp — same reasoning as Diode.
             Vb = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
             Ve = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
+            Vc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
             Vjunc = (
                 Vb - Ve if el.polarity == "NPN"
                 else Ve - Vb
             )
-            I_C = el.Is * math.exp(Vjunc / el.Vt)
+            output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
+            early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
+            I_C = el.Is * math.exp(Vjunc / el.Vt) * early_factor
             psd = q2 * abs(I_C)
             n_b = None if _is_ground(el.base) else node_to_idx[el.base]
             n_e = None if _is_ground(el.emitter) else node_to_idx[el.emitter]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (9, 17, 4, 4),
-    "PNP": (9, 17, 4, 4),
+    "NPN": (10, 19, 5, 4),
+    "PNP": (10, 19, 5, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -372,6 +372,8 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "TR": "TR",
     "XTI": "XTI",
     "EG": "EG",
+    "VAF": "VAF",
+    "VA": "VAF",
 }
 
 _JFET_PARAMETER_ALIASES: dict[str, str] = {
@@ -898,6 +900,7 @@ def bjt_from_model_card(
         Tr=p.get("TR", 0.0),
         Xti=p.get("XTI", 3.0),
         Eg=p.get("EG", 1.11),
+        Vaf=p.get("VAF", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -91,7 +91,6 @@ from spice_engine import (
     AcResult,
     AcSource,
     BSource,
-    bjt_at_temperature,
     Capacitor,
     Circuit,
     CornerAcSweepResult,
@@ -168,6 +167,7 @@ from spice_engine import (
     ac_sweep_corners,
     analyze_custom_model_source,
     analyze_deck_controls,
+    bjt_at_temperature,
     bjt_from_model_card,
     circuit_at_temperature,
     custom_linear_conductance_model,
@@ -280,6 +280,14 @@ from spice_engine import (
     format_device_model_reference_deck_audit_summary_json,
     format_device_model_reference_deck_audit_summary_table,
     format_device_model_reference_deck_audit_table,
+    format_digital_bridge_schedule_table,
+    format_digital_event_stream_table,
+    format_digital_event_stream_vcd,
+    format_digital_event_table,
+    format_distortion_table,
+    format_fourier_table,
+    format_mc_table,
+    format_measurement_table,
     format_model_card_supported_parameter_coverage_csv,
     format_model_card_supported_parameter_coverage_gate_issue_csv,
     format_model_card_supported_parameter_coverage_gate_issue_json,
@@ -293,14 +301,6 @@ from spice_engine import (
     format_model_card_unsupported_parameter_issue_csv,
     format_model_card_unsupported_parameter_issue_json,
     format_model_card_unsupported_parameter_issue_table,
-    format_digital_bridge_schedule_table,
-    format_digital_event_stream_table,
-    format_digital_event_stream_vcd,
-    format_digital_event_table,
-    format_distortion_table,
-    format_fourier_table,
-    format_mc_table,
-    format_measurement_table,
     format_noise_table,
     format_pole_zero_table,
     format_pss_table,
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 76
+    assert len(coverage) == 78
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 76
+    assert len(records) == 78
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,17 +501,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 76
-    assert report.expected_canonical_parameter_count == 76
-    assert report.accepted_name_count == 124
-    assert report.aliased_parameter_count == 35
+    assert report.canonical_parameter_count == 78
+    assert report.expected_canonical_parameter_count == 78
+    assert report.accepted_name_count == 128
+    assert report.aliased_parameter_count == 37
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t76\t76\t124\t35\t4\t0"
+        "true\t7\t7\t78\t78\t128\t37\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,9 +539,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 75
-    assert report.accepted_name_count == 121
-    assert report.aliased_parameter_count == 34
+    assert report.canonical_parameter_count == 77
+    assert report.accepted_name_count == 125
+    assert report.aliased_parameter_count == 36
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t75\t76\t121\t34\t4\t4\n"
+        "false\t7\t7\t77\t78\t125\t36\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,15 +647,16 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
     assert bjt_model.Xti == pytest.approx(2.4)
     assert bjt_model.Eg == pytest.approx(1.05)
+    assert bjt_model.Vaf == pytest.approx(80.0)
 
     jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -2221,11 +2222,11 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert expanded.Eg == pytest.approx(1.05)
 
 
-def test_subcircuit_expansion_preserves_bjt_temperature_parameters():
+def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2234,6 +2235,7 @@ def test_subcircuit_expansion_preserves_bjt_temperature_parameters():
     expanded = next(element for element in circuit.elements if isinstance(element, BJT))
     assert expanded.Xti == pytest.approx(2.4)
     assert expanded.Eg == pytest.approx(1.05)
+    assert expanded.Vaf == pytest.approx(80.0)
 
 
 def test_branch_current_in_voltage_source():
@@ -2467,6 +2469,27 @@ def test_dc_rejects_invalid_bjt_energy_gap():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Eg=0.0))
     with pytest.raises(ValueError, match="BJT energy gap must be finite and positive"):
+        dc_op(circuit)
+
+
+def test_bjt_forward_early_voltage_modulates_collector_current():
+    def collector_voltage(vaf: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "vcc", "out", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Vaf=vaf))
+        result = dc_op(circuit)
+        assert result.converged
+        return result.node_voltages["out"]
+
+    assert collector_voltage(20.0) < collector_voltage(0.0)
+
+
+def test_dc_rejects_invalid_bjt_forward_early_voltage():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Vaf=-1.0))
+    with pytest.raises(ValueError, match="BJT forward Early voltage must be finite and non-negative"):
         dc_op(circuit)
 
 
@@ -4490,6 +4513,19 @@ def test_tf_diode_circuit_linearised():
 
     assert result.converged
     assert 0.0 < result.transfer_ratio < 1.0
+
+
+def test_tf_bjt_forward_early_voltage_reduces_output_impedance():
+    def output_impedance(vaf: float) -> float:
+        thermal_voltage = 0.02585
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+        circuit.add(VoltageSource("Vin", "base", "0", thermal_voltage * math.log(2.0)))
+        circuit.add(Resistor("Rload", "vcc", "out", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Is=25.85e-6, Vt=thermal_voltage, Vaf=vaf))
+        return tf(circuit, output_node="out", input_source="Vin").output_impedance
+
+    assert output_impedance(10.0) < output_impedance(0.0)
 
 
 # ============================================================================

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `VAF`/`VA` forward Early-voltage support with
+  collector-voltage modulation in DC, transient, AC, transfer-function, and
+  noise paths, matching Python and TypeScript. The supported-parameter catalog
+  now contains 78 canonical rows.
 - Add BJT model-card `EG` energy-gap support to model-specific temperature
   scaling, preserving it through subcircuit expansion and matching Python and
   TypeScript. The supported-parameter catalog now contains 76 canonical rows.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -128,7 +128,8 @@ transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
-model-specific saturation-current temperature scaling.
+model-specific saturation-current temperature scaling, plus `VAF`/`VA`
+(default `0`, meaning infinite) for forward Early-effect modulation.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -433,6 +433,7 @@ fn clone_subckt_element(
             element.reverse_transit_time,
             element.saturation_current_temperature_exponent,
             element.energy_gap_electron_volts,
+            element.forward_early_voltage,
         )),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -2837,6 +2838,7 @@ pub struct Bjt {
     pub reverse_transit_time: f64,
     pub saturation_current_temperature_exponent: f64,
     pub energy_gap_electron_volts: f64,
+    pub forward_early_voltage: f64,
 }
 
 impl Bjt {
@@ -2891,6 +2893,7 @@ impl Bjt {
             reverse_transit_time,
             3.0,
             1.11,
+            0.0,
         )
     }
 
@@ -2910,6 +2913,7 @@ impl Bjt {
         reverse_transit_time: f64,
         saturation_current_temperature_exponent: f64,
         energy_gap_electron_volts: f64,
+        forward_early_voltage: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -2926,6 +2930,7 @@ impl Bjt {
             reverse_transit_time,
             saturation_current_temperature_exponent,
             energy_gap_electron_volts,
+            forward_early_voltage,
         }
     }
 }
@@ -3316,8 +3321,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 9, 17, 4, 4),
-    (ModelCardKind::Pnp, 9, 17, 4, 4),
+    (ModelCardKind::Npn, 10, 19, 5, 4),
+    (ModelCardKind::Pnp, 10, 19, 5, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3361,6 +3366,8 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("TR", "TR"),
     ("XTI", "XTI"),
     ("EG", "EG"),
+    ("VAF", "VAF"),
+    ("VA", "VAF"),
 ];
 const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("BETA", "BETA"),
@@ -4015,6 +4022,7 @@ pub fn bjt_from_model_card(
         model_card_value(model, "TR", 0.0),
         model_card_value(model, "XTI", 3.0),
         model_card_value(model, "EG", 1.11),
+        model_card_value(model, "VAF", 0.0),
     ))
 }
 
@@ -4232,11 +4240,7 @@ pub fn device_model_behavior_audit_fixtures() -> Result<Vec<DeviceModelBehaviorF
         "Rs", "source", "0", 1_000.0,
     )));
     jfet_circuit.add(Element::Jfet(jfet_from_model_card(
-        "J1",
-        "drain",
-        "gate",
-        "source",
-        jfet_model,
+        "J1", "drain", "gate", "source", jfet_model,
     )?));
 
     let mos_model = models.get("Mn").ok_or_else(|| SpiceError::InvalidElement {
@@ -4700,11 +4704,7 @@ pub fn device_model_noise_audit_fixtures(
         "Rs", "source", "0", 1_000.0,
     )));
     jfet_circuit.add(Element::Jfet(jfet_from_model_card(
-        "J1",
-        "drain",
-        "gate",
-        "source",
-        jfet_model,
+        "J1", "drain", "gate", "source", jfet_model,
     )?));
 
     let mos_model = models.get("Mn").ok_or_else(|| SpiceError::InvalidElement {
@@ -6953,9 +6953,11 @@ pub fn select_deck_output_probes(netlist: &str, analysis: &str) -> Result<Vec<St
     let mut selected = Vec::new();
     let mut seen = HashSet::new();
     for selection in summary.selections {
-        if !selection.analysis.as_deref().is_none_or(|requested| {
-            deck_output_analysis_matches(requested, analysis)
-        }) {
+        if !selection
+            .analysis
+            .as_deref()
+            .is_none_or(|requested| deck_output_analysis_matches(requested, analysis))
+        {
             continue;
         }
         for probe in selection.probes {
@@ -6982,9 +6984,11 @@ pub fn select_deck_output_probe_lines(
     let mut selected = Vec::new();
     let mut seen = HashSet::new();
     for selection in summary.selections {
-        if !selection.analysis.as_deref().is_none_or(|requested| {
-            deck_output_analysis_matches(requested, analysis)
-        }) {
+        if !selection
+            .analysis
+            .as_deref()
+            .is_none_or(|requested| deck_output_analysis_matches(requested, analysis))
+        {
             continue;
         }
         for probe in selection.probes {
@@ -7011,9 +7015,11 @@ pub fn select_deck_output_directives(
     let mut selected = Vec::new();
     let mut seen = HashSet::new();
     for selection in summary.selections {
-        if !selection.analysis.as_deref().is_none_or(|requested| {
-            deck_output_analysis_matches(requested, analysis)
-        }) {
+        if !selection
+            .analysis
+            .as_deref()
+            .is_none_or(|requested| deck_output_analysis_matches(requested, analysis))
+        {
             continue;
         }
         if seen.insert(selection.directive.clone()) {
@@ -7037,9 +7043,11 @@ pub fn select_deck_output_directive_analysis_kinds(
     let mut selected = Vec::new();
     let mut seen = HashSet::new();
     for selection in summary.selections {
-        if !selection.analysis.as_deref().is_none_or(|requested| {
-            deck_output_analysis_matches(requested, analysis)
-        }) {
+        if !selection
+            .analysis
+            .as_deref()
+            .is_none_or(|requested| deck_output_analysis_matches(requested, analysis))
+        {
             continue;
         }
         let analysis_kind = selection.analysis.unwrap_or_else(|| "global".to_string());
@@ -7064,9 +7072,11 @@ pub fn select_deck_output_directive_lines(
     let mut selected = Vec::new();
     let mut seen = HashSet::new();
     for selection in summary.selections {
-        if !selection.analysis.as_deref().is_none_or(|requested| {
-            deck_output_analysis_matches(requested, analysis)
-        }) {
+        if !selection
+            .analysis
+            .as_deref()
+            .is_none_or(|requested| deck_output_analysis_matches(requested, analysis))
+        {
             continue;
         }
         if seen.insert(selection.line_number) {
@@ -21653,14 +21663,26 @@ fn collect_noise_sources(
                 validate_bjt(bjt)?;
                 let base = node_index(node_indices, &bjt.base);
                 let emitter = node_index(node_indices, &bjt.emitter);
+                let collector = node_index(node_indices, &bjt.collector);
                 let base_voltage = vector_voltage(operating_point, base);
                 let emitter_voltage = vector_voltage(operating_point, emitter);
+                let collector_voltage = vector_voltage(operating_point, collector);
                 let junction_voltage = match bjt.polarity {
                     BjtPolarity::Npn => base_voltage - emitter_voltage,
                     BjtPolarity::Pnp => emitter_voltage - base_voltage,
                 };
                 let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
-                let collector_current = bjt.saturation_current * (exponent.exp() - 1.0);
+                let output_voltage = match bjt.polarity {
+                    BjtPolarity::Npn => collector_voltage - emitter_voltage,
+                    BjtPolarity::Pnp => emitter_voltage - collector_voltage,
+                };
+                let early_factor = if bjt.forward_early_voltage == 0.0 {
+                    1.0
+                } else {
+                    1.0 + output_voltage / bjt.forward_early_voltage
+                };
+                let collector_current =
+                    bjt.saturation_current * (exponent.exp() - 1.0) * early_factor;
                 let (positive, negative) = match bjt.polarity {
                     BjtPolarity::Npn => (base, emitter),
                     BjtPolarity::Pnp => (emitter, base),
@@ -22115,18 +22137,38 @@ fn stamp_bjt(
     let emitter = node_index(node_indices, &bjt.emitter);
     let base_voltage = base.map_or(0.0, |index| operating_point[index]);
     let emitter_voltage = emitter.map_or(0.0, |index| operating_point[index]);
+    let collector_voltage = collector.map_or(0.0, |index| operating_point[index]);
     let junction_voltage = match bjt.polarity {
         BjtPolarity::Npn => base_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - base_voltage,
     };
     let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
     let exp_value = exponent.exp();
-    let collector_current = bjt.saturation_current * (exp_value - 1.0);
-    let gm = bjt.saturation_current / bjt.thermal_voltage * exp_value;
-    let gpi = gm / bjt.forward_beta;
-    let base_current = collector_current / bjt.forward_beta;
-    let equivalent_collector_current = collector_current - gm * junction_voltage;
+    let base_collector_current = bjt.saturation_current * (exp_value - 1.0);
+    let base_gm = bjt.saturation_current / bjt.thermal_voltage * exp_value;
+    let output_voltage = match bjt.polarity {
+        BjtPolarity::Npn => collector_voltage - emitter_voltage,
+        BjtPolarity::Pnp => emitter_voltage - collector_voltage,
+    };
+    let early_factor = if bjt.forward_early_voltage == 0.0 {
+        1.0
+    } else {
+        1.0 + output_voltage / bjt.forward_early_voltage
+    };
+    let output_conductance = if bjt.forward_early_voltage == 0.0 {
+        0.0
+    } else {
+        base_collector_current / bjt.forward_early_voltage
+    };
+    let collector_current = base_collector_current * early_factor;
+    let gm = base_gm * early_factor;
+    let gpi = base_gm / bjt.forward_beta;
+    let base_current = base_collector_current / bjt.forward_beta;
+    let equivalent_collector_current =
+        collector_current - gm * junction_voltage - output_conductance * output_voltage;
     let equivalent_base_current = base_current - gpi * junction_voltage;
+
+    stamp_conductance(matrix, collector, emitter, output_conductance);
 
     match bjt.polarity {
         BjtPolarity::Npn => {
@@ -22216,13 +22258,32 @@ fn stamp_bjt_small_signal(
     let emitter = node_index(node_indices, &bjt.emitter);
     let base_voltage = vector_voltage(operating_point, base);
     let emitter_voltage = vector_voltage(operating_point, emitter);
+    let collector_voltage = vector_voltage(operating_point, collector);
     let junction_voltage = match bjt.polarity {
         BjtPolarity::Npn => base_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - base_voltage,
     };
     let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
-    let gm = bjt.saturation_current / bjt.thermal_voltage * exponent.exp();
-    let gpi = gm / bjt.forward_beta;
+    let exp_value = exponent.exp();
+    let base_collector_current = bjt.saturation_current * (exp_value - 1.0);
+    let base_gm = bjt.saturation_current / bjt.thermal_voltage * exp_value;
+    let output_voltage = match bjt.polarity {
+        BjtPolarity::Npn => collector_voltage - emitter_voltage,
+        BjtPolarity::Pnp => emitter_voltage - collector_voltage,
+    };
+    let early_factor = if bjt.forward_early_voltage == 0.0 {
+        1.0
+    } else {
+        1.0 + output_voltage / bjt.forward_early_voltage
+    };
+    let output_conductance = if bjt.forward_early_voltage == 0.0 {
+        0.0
+    } else {
+        base_collector_current / bjt.forward_early_voltage
+    };
+    let gm = base_gm * early_factor;
+    let gpi = base_gm / bjt.forward_beta;
+    stamp_conductance(matrix, collector, emitter, output_conductance);
     match bjt.polarity {
         BjtPolarity::Npn => {
             stamp_conductance(matrix, base, emitter, gpi);
@@ -22260,10 +22321,24 @@ fn stamp_ac_bjt_small_signal(
     };
     let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
     let reverse_exponent = (reverse_junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
-    let gm = Complex::new(
-        bjt.saturation_current / bjt.thermal_voltage * exponent.exp(),
-        0.0,
-    );
+    let exp_value = exponent.exp();
+    let base_collector_current = bjt.saturation_current * (exp_value - 1.0);
+    let base_gm = bjt.saturation_current / bjt.thermal_voltage * exp_value;
+    let output_voltage = match bjt.polarity {
+        BjtPolarity::Npn => collector_voltage - emitter_voltage,
+        BjtPolarity::Pnp => emitter_voltage - collector_voltage,
+    };
+    let early_factor = if bjt.forward_early_voltage == 0.0 {
+        1.0
+    } else {
+        1.0 + output_voltage / bjt.forward_early_voltage
+    };
+    let output_conductance = if bjt.forward_early_voltage == 0.0 {
+        0.0
+    } else {
+        base_collector_current / bjt.forward_early_voltage
+    };
+    let gm = Complex::new(base_gm * early_factor, 0.0);
     let reverse_gm = bjt.saturation_current / bjt.thermal_voltage * reverse_exponent.exp();
     let diffusion_capacitance = bjt.forward_transit_time * gm.real;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
@@ -22274,6 +22349,12 @@ fn stamp_ac_bjt_small_signal(
     let ybc = Complex::new(
         0.0,
         omega * (bjt.base_collector_capacitance + reverse_diffusion_capacitance),
+    );
+    stamp_complex_conductance(
+        matrix,
+        collector,
+        emitter,
+        Complex::new(output_conductance, 0.0),
     );
     match bjt.polarity {
         BjtPolarity::Npn => {
@@ -23209,6 +23290,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "energy gap must be finite and positive".to_string(),
+        });
+    }
+    if !bjt.forward_early_voltage.is_finite() || bjt.forward_early_voltage < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward Early voltage must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 76);
+    assert_eq!(coverage.len(), 78);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 76);
+    assert_eq!(records.len(), 78);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 76);
-    assert_eq!(report.expected_canonical_parameter_count, 76);
-    assert_eq!(report.accepted_name_count, 124);
-    assert_eq!(report.aliased_parameter_count, 35);
+    assert_eq!(report.canonical_parameter_count, 78);
+    assert_eq!(report.expected_canonical_parameter_count, 78);
+    assert_eq!(report.accepted_name_count, 128);
+    assert_eq!(report.aliased_parameter_count, 37);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t76\t76\t124\t35\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t78\t78\t128\t37\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,9 +235,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 75);
-    assert_eq!(report.accepted_name_count, 121);
-    assert_eq!(report.aliased_parameter_count, 34);
+    assert_eq!(report.canonical_parameter_count, 77);
+    assert_eq!(report.accepted_name_count, 125);
+    assert_eq!(report.aliased_parameter_count, 36);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t75\t76\t121\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t77\t78\t125\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -430,6 +430,7 @@ fn model_card_aliases_build_device_instances() {
             ("CBE", 2.0e-12),
             ("XTI", 2.4),
             ("EG", 1.05),
+            ("VA", 80.0),
         ],
     )
     .unwrap();
@@ -438,11 +439,13 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("CJE").unwrap(), 2.0e-12);
     assert_close(*bjt_card.parameters.get("XTI").unwrap(), 2.4);
     assert_close(*bjt_card.parameters.get("EG").unwrap(), 1.05);
+    assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
     assert_eq!(bjt_model.polarity, BjtPolarity::Npn);
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
     assert_close(bjt_model.saturation_current_temperature_exponent, 2.4);
     assert_close(bjt_model.energy_gap_electron_volts, 1.05);
+    assert_close(bjt_model.forward_early_voltage, 80.0);
 
     let jfet_card = normalize_model_card(
         "Jn",
@@ -1294,8 +1297,21 @@ fn dc_subcircuit_instance_expands_resistor_divider() {
 #[test]
 fn subcircuit_expansion_preserves_complete_diode_model() {
     let diode = Diode::with_model_and_temperature_parameters(
-        "Dcell", "in", "0", 2.0e-14, 0.026, 1.2, Some(6.0), 2.0e-6, 1.5e-12,
-        4.0e-9, 0.8, 0.4, 0.35, 2.2, 1.05,
+        "Dcell",
+        "in",
+        "0",
+        2.0e-14,
+        0.026,
+        1.2,
+        Some(6.0),
+        2.0e-6,
+        1.5e-12,
+        4.0e-9,
+        0.8,
+        0.4,
+        0.35,
+        2.2,
+        1.05,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1306,11 +1322,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
         ))
         .unwrap();
     circuit
-        .instantiate(XInstance::new(
-            "X1",
-            vec!["a".to_string()],
-            "diode-cell",
-        ))
+        .instantiate(XInstance::new("X1", vec!["a".to_string()], "diode-cell"))
         .unwrap();
 
     let expanded = circuit
@@ -1329,7 +1341,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 }
 
 #[test]
-fn subcircuit_expansion_preserves_bjt_temperature_parameters() {
+fn subcircuit_expansion_preserves_complete_bjt_model() {
     let bjt = Bjt::with_model_and_temperature_parameters(
         "Qcell",
         "c",
@@ -1345,6 +1357,7 @@ fn subcircuit_expansion_preserves_bjt_temperature_parameters() {
         4.0e-9,
         2.4,
         1.05,
+        80.0,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1372,6 +1385,7 @@ fn subcircuit_expansion_preserves_bjt_temperature_parameters() {
         .unwrap();
     assert_close(expanded.saturation_current_temperature_exponent, 2.4);
     assert_close(expanded.energy_gap_electron_volts, 1.05);
+    assert_close(expanded.forward_early_voltage, 80.0);
 }
 
 #[test]
@@ -1643,12 +1657,10 @@ fn dc_diode_temperature_scaling_reduces_fixed_current_forward_drop() {
 #[test]
 fn diode_temperature_scaling_uses_model_saturation_current_exponent() {
     let default_xti = Diode::with_model_and_temperature_exponent(
-        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5,
-        0.5, 3.0,
+        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5, 0.5, 3.0,
     );
     let flat_xti = Diode::with_model_and_temperature_exponent(
-        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5,
-        0.5, 0.0,
+        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5, 0.5, 0.0,
     );
 
     let temperature_kelvin = 350.0;
@@ -1677,15 +1689,17 @@ fn diode_temperature_scaling_uses_model_saturation_current_exponent() {
 #[test]
 fn circuit_temperature_scaling_uses_model_energy_gap() {
     let mut silicon = Circuit::new();
-    silicon.add(Element::Diode(Diode::with_model_and_temperature_parameters(
-        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5,
-        0.5, 3.0, 1.11,
-    )));
+    silicon.add(Element::Diode(
+        Diode::with_model_and_temperature_parameters(
+            "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5, 0.5, 3.0, 1.11,
+        ),
+    ));
     let mut lower_gap = Circuit::new();
-    lower_gap.add(Element::Diode(Diode::with_model_and_temperature_parameters(
-        "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5,
-        0.5, 3.0, 0.8,
-    )));
+    lower_gap.add(Element::Diode(
+        Diode::with_model_and_temperature_parameters(
+            "D1", "a", "0", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 0.0, 0.0, 1.0, 0.5, 0.5, 3.0, 0.8,
+        ),
+    ));
 
     let silicon_hot = circuit_at_temperature(&silicon, 350.0, 300.15, 1.11).unwrap();
     let lower_gap_hot = circuit_at_temperature(&lower_gap, 350.0, 300.15, 1.11).unwrap();
@@ -1831,6 +1845,7 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
         0.0,
         0.0,
         1.11,
+        0.0,
     );
     let high_exponent = Bjt::with_model_and_temperature_parameters(
         "Qhigh",
@@ -1847,6 +1862,7 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
         0.0,
         4.0,
         1.11,
+        0.0,
     );
     let low = bjt_at_temperature(&low_exponent, 350.0, 300.15, 1.11).unwrap();
     let high = bjt_at_temperature(&high_exponent, 350.0, 300.15, 1.11).unwrap();
@@ -1871,6 +1887,7 @@ fn bjt_temperature_scaling_uses_model_energy_gap() {
         0.0,
         3.0,
         1.11,
+        0.0,
     )));
     let mut lower_gap = Circuit::new();
     lower_gap.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
@@ -1888,6 +1905,7 @@ fn bjt_temperature_scaling_uses_model_energy_gap() {
         0.0,
         3.0,
         0.8,
+        0.0,
     )));
     let silicon_hot = circuit_at_temperature(&silicon, 350.0, 300.15, 1.11).unwrap();
     let lower_gap_hot = circuit_at_temperature(&lower_gap, 350.0, 300.15, 1.11).unwrap();
@@ -1916,13 +1934,74 @@ fn dc_rejects_invalid_bjt_energy_gap() {
         0.0,
         3.0,
         0.0,
+        0.0,
     )));
     let error = dc_op(&circuit).unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("energy gap must be finite and positive")
-    );
+    assert!(error
+        .to_string()
+        .contains("energy gap must be finite and positive"));
+}
+
+#[test]
+fn bjt_forward_early_voltage_modulates_collector_current() {
+    let collector_voltage = |forward_early_voltage: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc", "vcc", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "vcc", "out", 1_000.0,
+        )));
+        circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+            "Q1",
+            "out",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            1.0e-14,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            3.0,
+            1.11,
+            forward_early_voltage,
+        )));
+        dc_op(&circuit).unwrap().voltage("out").unwrap()
+    };
+
+    assert!(collector_voltage(20.0) < collector_voltage(0.0));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_early_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+        "Qbad",
+        "c",
+        "b",
+        "0",
+        BjtPolarity::Npn,
+        1.0e-14,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        3.0,
+        1.11,
+        -1.0,
+    )));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forward Early voltage must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -322,6 +322,46 @@ fn tf_bjt_common_emitter_reports_small_signal_gain() {
 }
 
 #[test]
+fn tf_bjt_forward_early_voltage_reduces_output_impedance() {
+    let output_impedance = |forward_early_voltage: f64| {
+        let mut circuit = Circuit::new();
+        let thermal_voltage = 0.02585;
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc", "vcc", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vin",
+            "base",
+            "0",
+            thermal_voltage * 2.0_f64.ln(),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "vcc", "out", 1_000.0,
+        )));
+        circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+            "Q1",
+            "out",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            25.85e-6,
+            100.0,
+            thermal_voltage,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            3.0,
+            1.11,
+            forward_early_voltage,
+        )));
+        tf(&circuit, "out", "Vin").unwrap().output_impedance_ohms
+    };
+
+    assert!(output_impedance(10.0) < output_impedance(0.0));
+}
+
+#[test]
 fn tf_mosfet_common_source_uses_gate_bias_for_small_signal_gain() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `VAF`/`VA` forward Early-voltage support with
+  collector-voltage modulation in DC, transient, AC, transfer-function, and
+  noise paths, matching Python and Rust. The supported-parameter catalog now
+  contains 78 canonical rows.
 - Add BJT model-card `EG` energy-gap support to model-specific temperature
   scaling, preserving it through subcircuit expansion and matching Python and
   Rust. The supported-parameter catalog now contains 76 canonical rows.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -198,7 +198,8 @@ transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
-model-specific saturation-current temperature scaling.
+model-specific saturation-current temperature scaling, plus `VAF`/`VA`
+(default `0`, meaning infinite) for forward Early-effect modulation.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1712,6 +1712,7 @@ export interface Bjt {
   readonly reverseTransitTime: number;
   readonly saturationCurrentTemperatureExponent: number;
   readonly energyGapElectronVolts: number;
+  readonly forwardEarlyVoltage: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1989,8 +1990,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [9, 17, 4, 4],
-  PNP: [9, 17, 4, 4],
+  NPN: [10, 19, 5, 4],
+  PNP: [10, 19, 5, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3580,7 +3581,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7735,6 +7736,7 @@ export function bjt(
   reverseTransitTime = 0.0,
   saturationCurrentTemperatureExponent = 3.0,
   energyGapElectronVolts = 1.11,
+  forwardEarlyVoltage = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7752,6 +7754,7 @@ export function bjt(
     reverseTransitTime,
     saturationCurrentTemperatureExponent,
     energyGapElectronVolts,
+    forwardEarlyVoltage,
   };
 }
 
@@ -7855,6 +7858,8 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   TR: "TR",
   XTI: "XTI",
   EG: "EG",
+  VAF: "VAF",
+  VA: "VAF",
 };
 
 const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8353,6 +8358,7 @@ export function bjtFromModelCard(
     p.TR ?? 0.0,
     p.XTI ?? 3.0,
     p.EG ?? 1.11,
+    p.VAF ?? 0.0,
   );
 }
 
@@ -18273,14 +18279,22 @@ function collectNoiseSources(
       validateBjt(element);
       const base = nodeIndex(nodeIndices, element.base);
       const emitter = nodeIndex(nodeIndices, element.emitter);
+      const collector = nodeIndex(nodeIndices, element.collector);
       const baseVoltage = vectorVoltage(operatingPoint, base);
       const emitterVoltage = vectorVoltage(operatingPoint, emitter);
+      const collectorVoltage = vectorVoltage(operatingPoint, collector);
       const junctionVoltage =
         element.polarity === "NPN"
           ? baseVoltage - emitterVoltage
           : emitterVoltage - baseVoltage;
       const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / element.thermalVoltage));
-      const collectorCurrent = element.saturationCurrent * (Math.exp(exponent) - 1.0);
+      const outputVoltage = element.polarity === "NPN"
+        ? collectorVoltage - emitterVoltage
+        : emitterVoltage - collectorVoltage;
+      const earlyFactor = element.forwardEarlyVoltage === 0.0
+        ? 1.0
+        : 1.0 + outputVoltage / element.forwardEarlyVoltage;
+      const collectorCurrent = element.saturationCurrent * (Math.exp(exponent) - 1.0) * earlyFactor;
       sources.push({
         elementName: element.name,
         noiseType: "shot",
@@ -18744,6 +18758,7 @@ function stampBjt(
   const emitter = nodeIndex(nodeIndices, element.emitter);
   const baseVoltage = base === undefined ? 0.0 : operatingPoint[base];
   const emitterVoltage = emitter === undefined ? 0.0 : operatingPoint[emitter];
+  const collectorVoltage = collector === undefined ? 0.0 : operatingPoint[collector];
 
   const junctionVoltage =
     element.polarity === "NPN"
@@ -18751,15 +18766,27 @@ function stampBjt(
       : emitterVoltage - baseVoltage;
   const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / element.thermalVoltage));
   const expValue = Math.exp(exponent);
-  const collectorCurrent = element.saturationCurrent * (expValue - 1.0);
-  const transconductance = element.saturationCurrent / element.thermalVoltage * expValue;
-  const junctionConductance = transconductance / element.forwardBeta;
-  const baseCurrent = collectorCurrent / element.forwardBeta;
+  const baseCollectorCurrent = element.saturationCurrent * (expValue - 1.0);
+  const baseTransconductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const outputVoltage = element.polarity === "NPN"
+    ? collectorVoltage - emitterVoltage
+    : emitterVoltage - collectorVoltage;
+  const earlyFactor = element.forwardEarlyVoltage === 0.0
+    ? 1.0
+    : 1.0 + outputVoltage / element.forwardEarlyVoltage;
+  const outputConductance = element.forwardEarlyVoltage === 0.0
+    ? 0.0
+    : baseCollectorCurrent / element.forwardEarlyVoltage;
+  const collectorCurrent = baseCollectorCurrent * earlyFactor;
+  const transconductance = baseTransconductance * earlyFactor;
+  const junctionConductance = baseTransconductance / element.forwardBeta;
+  const baseCurrent = baseCollectorCurrent / element.forwardBeta;
   const equivalentCollectorCurrent =
-    collectorCurrent - transconductance * junctionVoltage;
+    collectorCurrent - transconductance * junctionVoltage - outputConductance * outputVoltage;
   const equivalentBaseCurrent =
     baseCurrent - junctionConductance * junctionVoltage;
 
+  stampConductance(matrix, collector, emitter, outputConductance);
   if (element.polarity === "NPN") {
     stampConductance(matrix, base, emitter, junctionConductance);
     stampTransconductance(matrix, collector, emitter, base, emitter, transconductance);
@@ -19534,6 +19561,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.energyGapElectronVolts) || element.energyGapElectronVolts <= 0.0) {
     throw invalidElement(element.name, "energy gap must be finite and positive");
+  }
+  if (!Number.isFinite(element.forwardEarlyVoltage) || element.forwardEarlyVoltage < 0.0) {
+    throw invalidElement(element.name, "forward Early voltage must be finite and non-negative");
   }
 }
 
@@ -20839,13 +20869,27 @@ function stampBjtSmallSignal(
   const emitter = nodeIndex(nodeIndices, element.emitter);
   const baseVoltage = vectorVoltage(operatingPoint, base);
   const emitterVoltage = vectorVoltage(operatingPoint, emitter);
+  const collectorVoltage = vectorVoltage(operatingPoint, collector);
   const junctionVoltage =
     element.polarity === "NPN"
       ? baseVoltage - emitterVoltage
       : emitterVoltage - baseVoltage;
   const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / element.thermalVoltage));
-  const transconductance = element.saturationCurrent / element.thermalVoltage * Math.exp(exponent);
-  const junctionConductance = transconductance / element.forwardBeta;
+  const expValue = Math.exp(exponent);
+  const baseCollectorCurrent = element.saturationCurrent * (expValue - 1.0);
+  const baseTransconductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const outputVoltage = element.polarity === "NPN"
+    ? collectorVoltage - emitterVoltage
+    : emitterVoltage - collectorVoltage;
+  const earlyFactor = element.forwardEarlyVoltage === 0.0
+    ? 1.0
+    : 1.0 + outputVoltage / element.forwardEarlyVoltage;
+  const outputConductance = element.forwardEarlyVoltage === 0.0
+    ? 0.0
+    : baseCollectorCurrent / element.forwardEarlyVoltage;
+  const transconductance = baseTransconductance * earlyFactor;
+  const junctionConductance = baseTransconductance / element.forwardBeta;
+  stampConductance(matrix, collector, emitter, outputConductance);
   if (element.polarity === "NPN") {
     stampConductance(matrix, base, emitter, junctionConductance);
     stampTransconductance(matrix, collector, emitter, base, emitter, transconductance);
@@ -21416,8 +21460,20 @@ function stampAcBjtSmallSignal(
     -40.0,
     Math.min(40.0, reverseJunctionVoltage / element.thermalVoltage),
   );
-  const transconductance = element.saturationCurrent / element.thermalVoltage * Math.exp(exponent);
-  const junctionConductance = transconductance / element.forwardBeta;
+  const expValue = Math.exp(exponent);
+  const baseCollectorCurrent = element.saturationCurrent * (expValue - 1.0);
+  const baseTransconductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const outputVoltage = element.polarity === "NPN"
+    ? collectorVoltage - emitterVoltage
+    : emitterVoltage - collectorVoltage;
+  const earlyFactor = element.forwardEarlyVoltage === 0.0
+    ? 1.0
+    : 1.0 + outputVoltage / element.forwardEarlyVoltage;
+  const outputConductance = element.forwardEarlyVoltage === 0.0
+    ? 0.0
+    : baseCollectorCurrent / element.forwardEarlyVoltage;
+  const transconductance = baseTransconductance * earlyFactor;
+  const junctionConductance = baseTransconductance / element.forwardBeta;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
   const reverseTransconductance =
     element.saturationCurrent / element.thermalVoltage * Math.exp(reverseExponent);
@@ -21430,6 +21486,7 @@ function stampAcBjtSmallSignal(
     0.0,
     omega * (element.baseCollectorCapacitance + reverseDiffusionCapacitance),
   );
+  stampComplexConductance(matrix, collector, emitter, complex(outputConductance, 0.0));
   if (element.polarity === "NPN") {
     stampComplexConductance(
       matrix,

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(76);
+    expect(coverage).toHaveLength(78);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(76);
+    expect(records).toHaveLength(78);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 76,
-      expectedCanonicalParameterCount: 76,
-      acceptedNameCount: 124,
-      aliasedParameterCount: 35,
+      canonicalParameterCount: 78,
+      expectedCanonicalParameterCount: 78,
+      acceptedNameCount: 128,
+      aliasedParameterCount: 37,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t76\t76\t124\t35\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t78\t78\t128\t37\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,9 +241,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(75);
-    expect(report.acceptedNameCount).toBe(121);
-    expect(report.aliasedParameterCount).toBe(34);
+    expect(report.canonicalParameterCount).toBe(77);
+    expect(report.acceptedNameCount).toBe(125);
+    expect(report.aliasedParameterCount).toBe(36);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t75\t76\t121\t34\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t77\t78\t125\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -336,14 +336,16 @@ describe("dcOp", () => {
       CBE: 2.0e-12,
       XTI: 2.4,
       EG: 1.05,
+      VA: 80.0,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
     expectClose(bjtModel.saturationCurrentTemperatureExponent, 2.4);
     expectClose(bjtModel.energyGapElectronVolts, 1.05);
+    expectClose(bjtModel.forwardEarlyVoltage, 80.0);
 
     const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
@@ -972,11 +974,11 @@ describe("dcOp", () => {
     expectClose(expanded.energyGapElectronVolts, 1.05);
   });
 
-  it("preserves BJT temperature parameters through subcircuit expansion", () => {
+  it("preserves the complete BJT model through subcircuit expansion", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -986,6 +988,7 @@ describe("dcOp", () => {
     if (expanded?.kind === "bjt") {
       expectClose(expanded.saturationCurrentTemperatureExponent, 2.4);
       expectClose(expanded.energyGapElectronVolts, 1.05);
+      expectClose(expanded.forwardEarlyVoltage, 80.0);
     }
   });
 
@@ -1327,6 +1330,25 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 0));
     expect(() => dcOp(circuit)).toThrowError("energy gap must be finite and positive");
+  });
+
+  it("uses BJT forward Early voltage to modulate collector current", () => {
+    const collectorVoltage = (forwardEarlyVoltage: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "vcc", "out", 1_000.0));
+      circuit.add(bjt("Q1", "out", "base", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, forwardEarlyVoltage));
+      return dcOp(circuit).voltage("out");
+    };
+
+    expect(collectorVoltage(20.0)).toBeLessThan(collectorVoltage(0.0));
+  });
+
+  it("rejects an invalid BJT forward Early voltage", () => {
+    const circuit = new Circuit();
+    circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, -1.0));
+    expect(() => dcOp(circuit)).toThrowError("forward Early voltage must be finite and non-negative");
   });
 
   it("uses MOSFET temperature scaling in common-source drain voltage", () => {

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  bjt,
   Circuit,
   capacitor,
   cccs,
@@ -42,6 +43,20 @@ describe("tf", () => {
     expectClose(result.transferRatio, 0.5);
     expectClose(result.inputImpedanceOhms, 2_000.0);
     expectClose(result.outputImpedanceOhms, 500.0);
+  });
+
+  it("uses BJT forward Early voltage to reduce output impedance", () => {
+    function outputImpedance(forwardEarlyVoltage: number): number {
+      const thermalVoltage = 0.02585;
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+      circuit.add(voltageSource("Vin", "base", "0", thermalVoltage * Math.log(2.0)));
+      circuit.add(resistor("Rload", "vcc", "out", 1_000.0));
+      circuit.add(bjt("Q1", "out", "base", "0", "NPN", 25.85e-6, 100.0, thermalVoltage, 0.0, 0.0, 0.0, 0.0, 3.0, 1.11, forwardEarlyVoltage));
+      return tf(circuit, "out", "Vin").outputImpedanceOhms;
+    }
+
+    expect(outputImpedance(10.0)).toBeLessThan(outputImpedance(0.0));
   });
 
   it("formats stable text output tables for transfer-function results", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT energy gap.
+1. Cross-language BJT forward Early voltage.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `EG` semiconductor energy-gap model-card
-     support in Rust, Python, and TypeScript.
-   - Apply each model's `EG` to BJT saturation-current temperature scaling and preserve the
-     full BJT model through hierarchical subcircuit expansion.
-   - Extend the supported-parameter coverage gate from 74 to 76 canonical rows
-     and lock model-specific temperature scaling across all three engines.
+   - Add Berkeley BJT `VAF` / `VA` forward Early-voltage model-card support in
+     Rust, Python, and TypeScript.
+   - Apply collector-voltage modulation in DC, transient, AC,
+     transfer-function, and noise paths while preserving the full BJT model
+     through hierarchical subcircuit expansion.
+   - Extend the supported-parameter coverage gate from 76 to 78 canonical rows
+     and lock model-specific output-conductance behavior across all three engines.
 
 ## Completed Slices
 
@@ -2998,7 +2999,14 @@ the Rust, Python, and TypeScript surfaces together.
    - Rust, Python, and TypeScript BJT model cards now accept `XTI` and apply it
      to saturation-current temperature scaling.
    - Hierarchical subcircuit expansion preserves `XTI`, and the supported-
-     parameter release gate now covers 74 canonical rows.
+   parameter release gate now covers 74 canonical rows.
+
+219. Cross-language BJT energy gap.
+   - Status: completed in PR 8730.
+   - Rust, Python, and TypeScript BJT model cards now accept `EG` and apply each
+     model's energy gap to saturation-current temperature scaling.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 76 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `VAF` / `VA` model-card support across Rust, Python, and TypeScript
- apply forward Early-effect current modulation and output conductance in DC, transient, AC, transfer-function, and noise paths
- preserve `VAF` through hierarchy and auxiliary model copies, validate it, and advance the supported-parameter gate from 76 to 78 canonical rows
- reconcile the SPICE completion plan after PR #8730

## Verification
- `cargo test -p spice-engine`
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python package: 508 tests passed, 88.19% coverage
- focused Python BJT TF regression passed after addition
- `ruff check` on touched Python sources and tests
- TypeScript: 268 tests passed
- focused TypeScript BJT TF regression passed after addition
- `npm run build`
- `git diff --check`