### PR TITLE
feat(hl): Spanish book catches up — Chapters 4–18 typeset (20pp → 114pp)

### DIFF
--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## The book catches up — Chapters 4–18 typeset
+
+The lessons had run ahead of the published artifact: 90 authored lessons through
+Chapter 18, but the LaTeX book still stopped at Chapter 3 ("Introducing
+Yourself"). This closes that gap — **fifteen new book chapters**, written from
+the existing `ES-C04`–`ES-C18` lessons and wired into `book.tex`:
+
+- **Ch4** How Are You · **Ch5** Farewells · **Ch6** The First Verbs ·
+  **Ch7** The *-er* and *-ir* Verbs · **Ch8** Numbers and Age
+- **Ch9** *Ser* and *Estar* · **Ch10** Going, and the Near Future ·
+  **Ch11** Stem-Changing Verbs · **Ch12** The *-go* Verb Club ·
+  **Ch13** Completing the *-go* Club
+- **Ch14** The Preterite · **Ch15** Completing the Preterite ·
+  **Ch16** The Imperfect · **Ch17** The Future and the Conditional ·
+  **Ch18** The Subjunctive
+
+Each chapter follows the established book conventions: one `\section` per
+lesson with a slug `\label`, the `cousinweb` / `grammarlens` / `culture` /
+`sounds` boxes, `booktabs` conjugation tables, and every atom traced to its
+root. Content is faithful to the lessons — no new etymologies introduced.
+
+The book grows from ~20 pages to **114 pages**; compiles clean with XeLaTeX
+(0 errors, 0 missing characters, 0 undefined references, 0 duplicate labels)
+and was rasterized and visually QA'd. Practice-section labels are
+chapter-qualified (`lesson:chN-practice`) to keep them unique.
+
+Also fixed: a corrupted cognate line in `ES-C04-gracias.md` ("French
+**grâce/merci-less** *grâces*") now reads as the intended claim — the Romance
+family kept *grātia* even where everyday thanks went elsewhere.
+
 ## Chapter 18 — The subjunctive, and how much of it you already knew
 
 - **Chapter 18 authored** (`ES-C18-subjuntivo`, `-quiero-que`, `-practice`) — the

--- a/code/learning/human-languages/spanish/README.md
+++ b/code/learning/human-languages/spanish/README.md
@@ -89,12 +89,34 @@ exactly where a word needs it:
 - **Chapter 3 — Introducing Yourself**: me → llamar → me llamo (**reflexive
   verbs**) → **tú / usted** (informal vs formal "you," both roots traced) →
   cómo → se llama → ¿cómo se llama usted? → mucho → mucho gusto → practice.
+- **Chapter 4 — How Are You**: gracias → de nada → estar → ¿cómo está usted? →
+  regular → practice.
+- **Chapter 5 — Farewells**: adiós → hasta → hasta luego / mañana / pronto.
+- **Chapter 6 — The First Verbs**: por favor → hablar (the *-ar* template) →
+  trabajar → estudiar → hablo español.
+- **Chapter 7 — The *-er* and *-ir* Verbs**: comer → vivir → beber → qué → dónde.
+- **Chapter 8 — Numbers and Age**: números 1–5, 6–10 → tener → ¿cuántos años?
+- **Chapter 9 — *Ser* and *Estar***: ser → ser vs estar → soy de → está en.
+- **Chapter 10 — Going, and the Near Future**: ir → ir a + infinitive →
+  mi / tu / su.
+- **Chapter 11 — Stem-Changing Verbs**: querer → poder → the boot pattern →
+  nuestro.
+- **Chapter 12 — The *-go* Verb Club**: hacer → decir → the *yo-go* pattern.
+- **Chapter 13 — Completing the *-go* Club**: poner → salir → venir.
+- **Chapter 14 — The Preterite**: ser/ir preterite → hablar preterite.
+- **Chapter 15 — Completing the Preterite**: comer/vivir → the strong preterites.
+- **Chapter 16 — The Imperfect**: imperfecto → the three irregulars → choosing
+  between the two pasts.
+- **Chapter 17 — The Future and the Conditional**: futuro → condicional (one
+  weld, twice).
+- **Chapter 18 — The Subjunctive**: subjuntivo → quiero que (the mood of the
+  not-yet-real).
 
 Every noun carries its gender (*el*/*la*) and plural; every pronoun is traced
-to its root. Fully authored and in the book (20 pages). Lessons are named by
-**slug** (e.g. `ES-C01-dia`), not numbered — order lives in the book (which
-LaTeX auto-numbers) and in `session-map.md`, so inserting a lesson never
-renumbers anything.
+to its root. **All 18 chapters are authored and in the book (114 pages).**
+Lessons are named by **slug** (e.g. `ES-C01-dia`), not numbered — order lives
+in the book (which LaTeX auto-numbers) and in `session-map.md`, so inserting a
+lesson never renumbers anything.
 - **Pronunciation**: [`pronunciation-reference.md`](./pronunciation-reference.md)
   (look-up reference, not a chapter).
 - **Later chapters**: skeleton in [`roadmap.md`](./roadmap.md).

--- a/code/learning/human-languages/spanish/book/book.tex
+++ b/code/learning/human-languages/spanish/book/book.tex
@@ -82,5 +82,20 @@ adapt, and pass it on.
 \input{chapters/ch01-first-words}
 \input{chapters/ch02-greetings}
 \input{chapters/ch03-introductions}
+\input{chapters/ch04-how-are-you}
+\input{chapters/ch05-farewells}
+\input{chapters/ch06-first-verbs}
+\input{chapters/ch07-er-ir-verbs}
+\input{chapters/ch08-numbers-and-age}
+\input{chapters/ch09-ser-y-estar}
+\input{chapters/ch10-ir-y-futuro}
+\input{chapters/ch11-stem-changes}
+\input{chapters/ch12-yo-go-verbs}
+\input{chapters/ch13-completing-go-club}
+\input{chapters/ch14-preterite}
+\input{chapters/ch15-completing-preterite}
+\input{chapters/ch16-imperfect}
+\input{chapters/ch17-future-conditional}
+\input{chapters/ch18-subjunctive}
 
 \end{document}

--- a/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
@@ -1,0 +1,222 @@
+\chapter{How Are You?}
+\label{ch:how-are-you}
+
+Now the conversation moves: you thank someone, you wave the thanks away, and
+you ask how they are --- a question that turns on one of Spanish's most famous
+features, its \emph{two} verbs for ``to be.''
+\emph{Practice lessons: \texttt{lessons/ES-C04-*.md}.}
+
+\section{\emph{gracias} --- ``thank you,'' a whole English family}
+\label{lesson:gracias}
+
+\begin{sounds}
+\textbf{vowel-a} --- the clean \emph{ah} of \emph{father}, twice.\\[3pt]
+\textbf{r-tap} --- a single flicked \emph{r} (not the English one, and not yet
+the rolled \emph{rr}): the tongue taps once, like the middle of American
+\emph{butter}.\\[3pt]
+\textbf{ci} --- a soft \emph{s} in Latin America (\emph{GRAH-syahs}) and a soft
+\emph{th} in most of Spain (\emph{GRAH-thyahs}). Either is correct --- pick one.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{gracias} is the plural of \emph{gracia} (``grace, favour'')
+$\leftarrow$ Latin \emph{gr\={a}tia}, \emph{favour freely given}. Saying
+\emph{gracias} literally offers someone ``graces,'' good will in return for
+theirs.\\[3pt]
+\textbf{The family:} \textbf{grace}, \textbf{gracious}, \textbf{graceful} (the
+direct borrowings); \textbf{grateful}, \textbf{gratitude} (being \emph{full of}
+\emph{gr\={a}tia}); \textbf{gratis}, \textbf{gratuity} (something given as a
+favour --- for free, or a tip); \textbf{congratulate} (``to wish grace
+\emph{together with} someone'').\\[3pt]
+The whole Romance family keeps \emph{gr\={a}tia}: Italian \emph{grazie},
+French \emph{gr\^{a}ces}, Portuguese \emph{gra\c{c}as}.
+\end{cousinweb}
+
+So \emph{gracias} is not a word to memorize cold: it is \textbf{grace}, made
+plural and handed to another person.
+
+\section{\emph{de nada} --- ``you're welcome,'' or ``it was nothing''}
+\label{lesson:de-nada}
+
+\begin{sounds}
+\textbf{d-soft} --- the \emph{d} in \emph{nada} is soft, almost the \emph{th}
+of \emph{this} (\emph{NAH-thah}), not a hard English \emph{d}. Spanish \emph{d}
+between vowels always softens.\\[3pt]
+\textbf{vowel-a} --- three clean \emph{ah} sounds: \emph{deh NAH-thah}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{de} (``of / from'') $\leftarrow$ Latin \emph{d\={e}} --- the same
+\emph{de-} hiding in English \textbf{de}part, \textbf{de}duct,
+\textbf{de}scend.\\[3pt]
+\textbf{nada} (``nothing'') $\leftarrow$ Latin \emph{(r\={e}s) n\={a}ta},
+``(a thing) \emph{born},'' from \emph{n\={a}sc\={i}} (``to be born'') $\to$
+\textbf{nat}ive, \textbf{nat}ure, \textbf{nat}al, re\textbf{naiss}ance
+(``re-birth''). Latin speakers said \emph{n\={o}n est r\={e}s n\={a}ta},
+``there is not a born thing'' --- not a single thing that ever came into being
+--- and over centuries the emphatic \emph{n\={a}ta} wore down until the word
+for ``born thing'' became the word for ``nothing'' itself.\\[3pt]
+French did the identical trick with \emph{rien} (``nothing''), which is Latin
+\emph{rem}, ``a thing.'' Two languages, same move: the word for \emph{thing}
+collapses into the word for \emph{nothing}.
+\end{cousinweb}
+
+So the reply \emph{de nada} literally says ``of [a] born-thing'' $\to$ ``of
+nothing at all'' --- you are waving the favour off as no trouble, the same move
+English makes with ``it's nothing'' or ``no problem.''
+
+\begin{grammarlens}
+\emph{gracias} $\to$ \emph{de nada} is a fixed \textbf{adjacency pair}: one
+turn expects the other. Learn them as a unit, the way English glues
+``thank you'' $\to$ ``you're welcome.''
+\end{grammarlens}
+
+\section{\emph{estar} --- ``to be,'' the \emph{standing} kind}
+\label{lesson:estar}
+
+\begin{sounds}
+\textbf{st-no-e} --- Spanish never starts a word with a bare \emph{st-}; it
+props it up with an \emph{e}: \emph{es-TAR}. (That reflex is why Spanish
+speakers say \emph{e-Spain}, \emph{e-student} --- the same \emph{e} that Latin
+\emph{stare} grew to become \emph{estar}.)\\[3pt]
+\textbf{r-tap} --- the final \emph{r} is one soft tap: \emph{es-TAR}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{estar} $\leftarrow$ Latin \emph{st\={a}re}, ``to stand'' --- exactly
+the right picture for the \emph{temporary} be-verb: how you are \emph{standing}
+at this moment (well, tired, here, there), not what you permanently
+\emph{are}.\\[3pt]
+\textbf{The st\={a}-/sta- family:} \textbf{stay}, \textbf{stand},
+\textbf{stance}, \textbf{station}, \textbf{stable}, \textbf{stationary} --- to
+stand or stay put; \textbf{state}, \textbf{status}, \textbf{statue},
+\textbf{estate} --- a way of \emph{standing} (your state $=$ how you stand);
+\textbf{constant}, \textbf{circumstance}, \textbf{substance} --- ``standing
+with / around / under.''
+\end{cousinweb}
+
+So \emph{\textquestiondown c\'{o}mo est\'{a}s?} is, at the root, ``how are you
+\emph{standing}?'' --- a snapshot of right now.
+
+\begin{grammarlens}
+Spanish has \textbf{two} verbs for ``to be.'' \textbf{ser} $\leftarrow$ Latin
+\emph{esse} (``to be'') carries permanent identity: \emph{soy David}, ``I am
+David.'' \textbf{estar} $\leftarrow$ Latin \emph{st\={a}re} (``to stand'')
+carries temporary state and location: \emph{estoy bien}, ``I am well (now)'';
+\emph{estoy aqu\'{i}}, ``I am here.''\\[3pt]
+Rule of thumb: how you \emph{feel} and \emph{where} you are $\to$ \emph{estar};
+who you \emph{are} $\to$ \emph{ser}. ``How are you?'' is about your current
+state, so it always takes \emph{estar}.\\[3pt]
+You need only two forms this chapter: \emph{est\'{a}s} (``you are,'' informal
+\emph{t\'{u}}) and \emph{est\'{a}} (``you are,'' formal \emph{usted}; also
+``he/she is'').
+\end{grammarlens}
+
+\section{\textquestiondown\emph{C\'{o}mo est\'{a} usted?} --- ``how are you?''}
+\label{lesson:como-esta}
+
+Everything in this chapter now snaps together. Two pieces come from Chapter
+\ref{ch:introductions}: \textbf{c\'{o}mo} (``how'') $\leftarrow$ Latin
+\emph{qu\={o}modo}, ``in what manner'' --- the \emph{qu-} question family with
+\emph{qu\'{e}}, \emph{qui\'{e}n}, \emph{cu\'{a}ndo}; and the \textbf{usted} /
+\textbf{t\'{u}} choice --- \emph{usted} worn down from \emph{vuestra merced},
+``your grace,'' and \emph{t\'{u}} the old intimate ``thou.'' The third piece is
+the \emph{estar} you just met.
+
+\emph{c\'{o}mo} (``how / in what manner'') $+$ \emph{est\'{a}} (``you are,''
+the \emph{usted}/he-she form of \emph{estar} --- state, not identity) $+$
+\emph{usted} (the formal ``you'') $=$ literally ``in what manner are you
+standing?''
+
+\begin{grammarlens}
+Two registers, and only the verb ending and the pronoun change --- exactly the
+\emph{se llama} / \emph{te llamas} split from the last chapter.\\[3pt]
+\textbf{Formal} (a stranger, an elder, a customer):
+\emph{\textquestiondown C\'{o}mo est\'{a} usted?}\\[3pt]
+\textbf{Informal} (a friend, a peer, a child):
+\emph{\textquestiondown C\'{o}mo est\'{a}s?}
+\end{grammarlens}
+
+\begin{culture}
+Note the opening \textquestiondown. Spanish opens a question with an
+upside-down mark so you know the melody is coming \emph{before} you start
+reading aloud --- the sentence tells you how to say it from its first
+character. (A dedicated writing lesson takes that mark apart.)
+\end{culture}
+
+\section{\emph{regular} and \emph{m\'{a}s o menos} --- the honest ``so-so''}
+\label{lesson:regular}
+
+You asked \emph{\textquestiondown c\'{o}mo est\'{a}s?} Now you can answer three
+ways: great, middling, or a wave of the hand. From Chapter
+\ref{ch:first-words} you have \textbf{bien} (``well'') $\leftarrow$ Latin \emph{bene}, the
+\emph{bene-} of \textbf{bene}fit and \textbf{bene}volent --- so \emph{estoy
+bien} is ``I'm well.'' Here are the answers for when you are not quite
+\emph{bien}, because nobody is \emph{bien} every day.
+
+\begin{cousinweb}
+\textbf{regular} $\leftarrow$ Latin \emph{r\={e}gula}, a \emph{straight rod} a
+builder used to check a line --- the \textbf{ruler}. So \emph{regular} is ``on
+the rule, on the average line'' $\to$ middling.\\[3pt]
+That rod is everywhere in English: \textbf{rule}, \textbf{ruler},
+\textbf{regulate}, \textbf{regular}, \textbf{regiment}, and even \textbf{rail}
+(a straight rod). All the same straight stick.\\[3pt]
+\textbf{m\'{a}s} (``more'') $\leftarrow$ Latin \emph{magis} $\to$
+\textbf{major}, \textbf{master}, \textbf{maximum}. \textbf{menos} (``less'')
+$\leftarrow$ Latin \emph{minus} --- the very word English borrowed for
+\textbf{minus}, \textbf{minor}, \textbf{minimum}, \textbf{minus}cule. So
+\emph{m\'{a}s o menos} is literally ``more or less,'' root for root the exact
+phrase English uses for the same shrug.
+\end{cousinweb}
+
+\begin{culture}
+\emph{regular} as an answer to ``how are you?'' is a famous false-friend trap:
+here it does \emph{not} mean English ``regular / normal / usual.'' It means
+\textbf{so-so, average, not great}.
+\end{culture}
+
+\begin{grammarlens}
+A small, complete answer set for \emph{\textquestiondown c\'{o}mo est\'{a}s?}:
+\emph{(muy) bien} $=$ ``(very) well'' $\cdot$ \emph{regular} $=$ ``so-so''
+$\cdot$ \emph{m\'{a}s o menos} $=$ ``more or less / meh.''
+\end{grammarlens}
+
+\section{Practice --- ``how are you?'', start to finish}
+\label{lesson:ch4-practice}
+
+No new words. This chapter's atoms --- \emph{gracias}, \emph{de nada},
+\emph{estar}, \emph{\textquestiondown c\'{o}mo est\'{a}?}, \emph{regular} ---
+now assemble into a real exchange, picking up right where the Chapter
+\ref{ch:introductions} introduction left off.
+
+\textbf{Formal} (a stranger, an elder, a customer):
+
+\begin{quote}\itshape
+--- Buenos d\'{i}as. \textquestiondown C\'{o}mo est\'{a} usted?\\
+--- Bien, gracias. \textquestiondown Y usted?\\
+--- M\'{a}s o menos.\\
+--- [replying to a thanks, later in the chat] De nada.
+\end{quote}
+
+\textbf{Informal} (a friend, a peer) --- only the verb and the pronoun change:
+
+\begin{quote}\itshape
+--- \textexclamdown Hola! \textquestiondown C\'{o}mo est\'{a}s?\\
+--- Regular. \textquestiondown Y t\'{u}?\\
+--- Bien, gracias.
+\end{quote}
+
+The one new glue word is \emph{\textquestiondown y usted?} /
+\emph{\textquestiondown y t\'{u}?} --- ``and you?'' (\emph{y} $=$ ``and,''
+from Latin \emph{et}). It bounces the question back.
+
+What you built: \emph{gracias}, thank you ($\leftarrow$ \emph{gr\={a}tia},
+``grace'') $\cdot$ \emph{de nada}, you're welcome ($\leftarrow$ ``of a
+born-thing'' $\to$ ``of nothing'') $\cdot$ \emph{estar}, the temporary to-be
+($\leftarrow$ \emph{st\={a}re}, ``to stand''), against \emph{ser} for identity
+$\cdot$ \emph{\textquestiondown c\'{o}mo est\'{a} usted?} /
+\emph{\textquestiondown c\'{o}mo est\'{a}s?}, formal and informal $\cdot$
+\emph{bien / regular / m\'{a}s o menos}, well / so-so / more-or-less. Two words
+swap between the registers: \emph{est\'{a}} $\to$ \emph{est\'{a}s}, and
+\emph{usted} $\to$ \emph{t\'{u}}. Next chapter: farewells --- \emph{hasta
+luego}, \emph{hasta ma\~{n}ana}, \emph{adi\'{o}s}.

--- a/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
@@ -1,0 +1,218 @@
+\chapter{Farewells}
+\label{ch:farewells}
+
+Every conversation needs a door out. Spanish gives you two kinds: a blessing
+worn smooth by centuries, and a small family of ``until\ldots'' phrases built on
+a word Spain took from Arabic. \emph{Practice lessons:
+\texttt{lessons/ES-C05-*.md}.}
+
+\section{\emph{adi\'{o}s} --- ``goodbye,'' or ``to God''}
+\label{lesson:adios}
+
+\begin{cousinweb}
+\textbf{adi\'{o}s} (``goodbye'') is \emph{a} $+$ \emph{Dios} $=$ ``\textbf{to
+God}'' --- the front half of an old blessing, \emph{a Dios te encomiendo}, ``I
+commend you to God,'' said to someone setting off when a journey was
+dangerous and you left them in God's keeping.\\[3pt]
+\textbf{Dios} (``God'') $\leftarrow$ Latin \emph{Deus} $\to$ \textbf{deity},
+\textbf{divine}, \emph{adieu}; and, through Greek \emph{Zeus} from the same
+root, the whole sky-god family.\\[3pt]
+\textbf{Every Romance sister kept the same prayer:} Spanish \emph{adi\'{o}s},
+French \emph{adieu} (\emph{\`{a}~Dieu}), Italian \emph{addio}, Portuguese
+\emph{adeus} --- all four literally ``to God.''\\[3pt]
+\textbf{And English is doing it too, quietly:} \textbf{goodbye} is a
+crushed-down ``God be with ye.'' So \emph{adi\'{o}s} and \emph{goodbye} are, at
+heart, the same sentence --- a blessing for the road.
+\end{cousinweb}
+
+\begin{sounds}
+\emph{adi\'{o}s} $=$ \emph{ah-DYOHS}. The \emph{-i\'{o}s} is one glide, not two
+syllables: \emph{ee} $+$ \emph{ohs} run together into \emph{dyohs}. The written
+accent on the \emph{\'{o}} tells you the stress lands at the end.
+\end{sounds}
+
+\begin{grammarlens}
+\emph{adi\'{o}s} is a \emph{final} goodbye. It leans toward a longer parting ---
+you won't see the person soon, or the day is over. For ``see you later'' or
+``see you tomorrow,'' Spanish reaches instead for \emph{hasta \ldots}, which is
+what the rest of this chapter builds --- and \emph{hasta} has a surprising
+origin.
+\end{grammarlens}
+
+\section{\emph{hasta} --- ``until,'' and Spain's Arabic centuries}
+\label{lesson:hasta}
+
+\begin{cousinweb}
+\textbf{hasta} (``until, up to'') $\leftarrow$ Arabic \emph{\d{h}att\={a}},
+``until, up to.'' Not Latin --- Arabic.\\[3pt]
+\textbf{Why there was Arabic in Spain:} from \textbf{711 CE}, Muslim armies
+ruled much of the Iberian Peninsula --- \emph{al-Andalus} --- and Arabic was the
+language of government, science, and poetry there for centuries, until 1492.
+Spanish absorbed roughly \textbf{four thousand} Arabic words in that time ---
+more of its vocabulary than from any source except Latin itself.\\[3pt]
+\textbf{Spotting the loans:} most are nouns, and a huge number carry the frozen
+Arabic article \emph{al-} (``the'') fused onto the front --- \emph{almohada}
+(pillow), \emph{alc\'{a}zar} (fortress), \emph{alcalde} (mayor),
+\emph{alfombra} (rug), \emph{aduana} (customs), \emph{\'{a}lgebra},
+\emph{alcohol}; also \emph{az\'{u}car} (sugar), \emph{aceite} (oil),
+\emph{naranja} (orange).
+\end{cousinweb}
+
+But \emph{hasta} is rare and special: it is a \textbf{function word} --- a
+preposition, part of the grammatical skeleton. Languages borrow nouns easily and
+grammar words almost never, so an Arabic preposition surviving in everyday
+Spanish shows how deep, how \emph{intimate}, those centuries of contact were.
+(Its Latin rivals \emph{ad} ``to'' and \emph{usque} ``up to'' simply lost.) You
+say a piece of al-Andalus every time you say goodbye.
+
+And \emph{hasta} is not quite alone. \textbf{Ojal\'{a}} (``would that\ldots'')
+is also a function word, from Andalusi Arabic \emph{law sh\={a}\textquoteright\
+All\={a}h}, ``\textbf{if God should will}'' --- the \emph{All\={a}h} is still
+sitting in its second half. It is arguably the stronger case: where \emph{hasta}
+is a preposition, \emph{ojal\'{a}} reaches into the grammar and forces the verb
+after it into a whole different \textbf{mood}. Chapter 18 puts it to work.
+
+\begin{sounds}
+Spanish \textbf{h is always silent}: \emph{hasta} $=$ \emph{AHS-tah}, with no
+breath on the \emph{h} at all. Stress the front.
+\end{sounds}
+
+\begin{grammarlens}
+\emph{hasta} marks the \textbf{end point} of something, in space or in time:
+\emph{hasta aqu\'{i}} (``up to here''), \emph{hasta las tres} (``until three
+o'clock''), and \emph{hasta luego / ma\~{n}ana / pronto} (``until later /
+tomorrow / soon'') --- the farewells that fill the rest of this chapter.
+\end{grammarlens}
+
+\section{\emph{hasta luego} --- the everyday ``see you later''}
+\label{lesson:hasta-luego}
+
+This is the goodbye you will actually use most: friendly, casual, open-ended.
+\emph{hasta} (``until'') $+$ \emph{luego} (``later'') $=$ ``until later'' $\to$
+``see you later.''
+
+\begin{cousinweb}
+\textbf{luego} (``later / then / soon'') $\leftarrow$ Latin \emph{loco}, ``at
+the place, at that point.'' The idea slid from \emph{place} $\to$ \emph{point in
+time} $\to$ ``then, next, soon.''\\[3pt]
+\textbf{Its English cousins all stayed about place:} \textbf{local},
+\textbf{locus}, \textbf{loc}ation, \textbf{loc}ate, al\textbf{loc}ate. Spanish
+moved \emph{loco} from \emph{where} to \emph{when}.\\[3pt]
+\textbf{Two histories in three syllables:} \emph{hasta luego} fuses an
+\textbf{Arabic} word and a \textbf{Latin} word --- the two great layers of
+Spanish, shaking hands as you leave.
+\end{cousinweb}
+
+\begin{sounds}
+\emph{luego} $=$ \emph{LWEH-goh}: the \emph{ue} is a \emph{w}-glide, so
+\emph{lu-} becomes \emph{lweh-}. The whole phrase: \emph{AHS-tah LWEH-goh}.
+\end{sounds}
+
+\begin{grammarlens}
+\emph{hasta} $+$ a time word is Spanish's whole toolkit of soft goodbyes:
+\emph{hasta luego} (``until later'') is the default ``see you'';
+\emph{hasta ma\~{n}ana} (``until tomorrow'') is for leaving for the day;
+\emph{hasta pronto} (``until soon'') is for when you expect to meet again
+shortly. You build the other two in the next two sections.
+\end{grammarlens}
+
+\section{\emph{hasta ma\~{n}ana} --- ``see you tomorrow''}
+\label{lesson:hasta-manana}
+
+Leaving for the day? \emph{hasta} (``until'') $+$ \emph{ma\~{n}ana}
+(``tomorrow'') $=$ ``until tomorrow.'' And it brings back a letter of its own:
+the \textbf{\~{n}}.
+
+\begin{cousinweb}
+\textbf{ma\~{n}ana} means ``tomorrow'' \emph{and} ``morning'' --- one word for
+both --- from Latin \emph{(h\={o}ra) maneana}, ``the \textbf{early} hour'' (from
+\emph{m\={a}ne}, ``in the morning''). The logic: the next early hour you will
+see is \emph{tomorrow morning}, so \emph{ma\~{n}ana} came to mean both
+\textbf{morning} and \textbf{tomorrow}. \emph{por la ma\~{n}ana} $=$ ``in the
+morning''; \emph{hasta ma\~{n}ana} $=$ ``until tomorrow.''\\[3pt]
+\textbf{The \~{n}, in the wild.} The \emph{\~{n}} is a frozen \emph{nn} --- a
+scribe's shorthand for a doubled \emph{n}, the tilde being a tiny second
+\emph{n} written on top. \emph{ma\~{n}ana} comes from Latin \emph{maneana},
+whose \emph{n} $+$ \emph{ea} palatalized (softened) into that single \emph{\~{n}}
+sound. The tilde is a little historical fossil sitting in the middle of
+``tomorrow.''
+\end{cousinweb}
+
+\begin{sounds}
+\emph{ma\~{n}ana} $=$ \emph{mah-NYAH-nah}. The \emph{\~{n}} is the squished
+\emph{ny} of ``canyon.'' Three soft \emph{ah}'s, with the stress in the middle.
+\end{sounds}
+
+\begin{grammarlens}
+\emph{ma\~{n}ana} means ``morning'' \textbf{or} ``tomorrow,'' and the sentence
+tells you which --- Spanish lets context do the disambiguating where English
+uses two separate words. Paired with \emph{hasta}, it is always
+\textbf{tomorrow}: \emph{hasta ma\~{n}ana}, ``until tomorrow.''
+\end{grammarlens}
+
+\section{\emph{hasta pronto} --- ``see you soon''}
+\label{lesson:hasta-pronto}
+
+The last of the trio: \emph{hasta} (``until'') $+$ \emph{pronto} (``soon'') $=$
+``until soon,'' for when you genuinely expect to meet again shortly.
+
+\begin{cousinweb}
+\textbf{pronto} (``soon / quickly / ready'') $\leftarrow$ Latin
+\emph{promptus}, ``brought forth, ready at hand'' (from \emph{pr\={o}mere}, ``to
+bring out''). Something \emph{prompt} is brought out without delay --- so
+\emph{pronto} slid to ``soon.''\\[3pt]
+\textbf{Its English twin is hiding in plain sight:} \textbf{prompt} (on time; to
+bring out a response), \textbf{prompt}er, \textbf{prompt}ly, and the computer
+\textbf{prompt} --- the cursor sitting ``ready'' for input.\\[3pt]
+Italian borrowed \emph{pronto} too: it is what Italians say when they pick up
+the phone --- \emph{\textquotedblleft Pronto!\textquotedblright} $=$ ``Ready!''
+\end{cousinweb}
+
+\begin{sounds}
+\emph{hasta pronto} $=$ \emph{AHS-tah PRON-toh} --- a clean \emph{pr} cluster
+and a pure \emph{o} (not the English \emph{oh-w} glide).
+\end{sounds}
+
+\begin{grammarlens}
+The \emph{hasta \ldots} trio, sharpest to vaguest in time: \emph{hasta pronto}
+(soon --- you'll meet again shortly) $\to$ \emph{hasta luego} (later --- the
+neutral default ``see you'') $\to$ \emph{hasta ma\~{n}ana} (tomorrow --- you're
+parting for the day). And \emph{adi\'{o}s} sits outside the trio, for the long
+or final goodbye.
+\end{grammarlens}
+
+\section{Practice --- saying goodbye}
+\label{lesson:ch5-practice}
+
+No new words. The choice among these four is really one question: \textbf{when
+will you meet again?} Parting for good or for a long time $\to$
+\emph{Adi\'{o}s.} Expecting to meet again shortly $\to$ \emph{Hasta pronto.}
+Just ``see you,'' the neutral default $\to$ \emph{Hasta luego.} Leaving for the
+day $\to$ \emph{Hasta ma\~{n}ana.}
+
+Everything from Chapters 1--5, in one conversation:
+
+\begin{quote}\itshape
+--- \textexclamdown Hola! Buenos d\'{i}as. Me llamo Ana.
+\textquestiondown C\'{o}mo se llama usted?\\
+--- Me llamo Luis. Mucho gusto.\\
+--- \textquestiondown C\'{o}mo est\'{a} usted?\\
+--- Bien, gracias. \textquestiondown Y usted?\\
+--- Muy bien. Bueno\ldots\ hasta ma\~{n}ana, Luis.\\
+--- Hasta ma\~{n}ana, Ana. \textexclamdown Adi\'{o}s!
+\end{quote}
+
+\begin{culture}
+Spanish closes a conversation by naming \emph{the next meeting}, not the
+parting itself. English says ``bye'' and stops; Spanish says ``until later,''
+``until tomorrow,'' ``until soon'' --- each one a small promise about the
+future. Even \emph{adi\'{o}s}, the one goodbye that does \emph{not} promise a
+next time, still hands the person over to someone: ``to God.''
+\end{culture}
+
+What you built this chapter: \emph{adi\'{o}s}, the plain or final goodbye (``to
+God,'' twin of \emph{goodbye}); \emph{hasta}, ``until,'' Spain's everyday Arabic
+word; and \emph{hasta luego / ma\~{n}ana / pronto}, see you later / tomorrow /
+soon, each an Arabic $+$ Latin handshake. You can now open \emph{and} close a
+conversation in Spanish. Next chapter: \emph{por favor}, and the courtesies that
+partner \emph{gracias}.

--- a/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
@@ -1,0 +1,284 @@
+\chapter{The First Verbs}
+\label{ch:first-verbs}
+
+The chapter where the course stops handing you phrases and starts handing you
+\emph{rules}. One courtesy word completes the politeness set; then three verbs
+snap into a single template --- the regular \emph{-ar} present tense --- and
+you build a sentence nobody gave you pre-assembled.
+\emph{Practice lessons: \texttt{lessons/ES-C06-*.md}.}
+
+\section{\emph{por favor} --- ``please,'' i.e.\ ``for a favour''}
+\label{lesson:por-favor}
+
+\begin{sounds}
+One soft tapped \textbf{r} in \emph{por} and in \emph{favor}: the tongue flicks
+the ridge behind the teeth once, as in the middle of English \emph{butter}.\\[3pt]
+Spanish \textbf{v} and \textbf{b} sound \emph{identical} --- both a soft
+\emph{b}. So \emph{favor} is \emph{fah-BOR}: it looks like English
+\emph{favour} \emph{and} its \emph{v} is pronounced like the \emph{b} you hear
+in \emph{harbour}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{por} (``for / through / by'') $\leftarrow$ Latin \emph{pr\={o}} (``for,
+on behalf of'') --- the same \emph{pro-} in English \textbf{pro}noun,
+\textbf{pro}pose, \textbf{pro}tect.\\[3pt]
+\textbf{favor} (``a favour, goodwill'') $\leftarrow$ Latin \emph{fav\={e}re},
+``to be favourable to, to support.'' English borrowed the very word:
+\textbf{favour}, \textbf{favor}ite, \textbf{favor}able, \textbf{favour}itism.
+\end{cousinweb}
+
+\emph{por} $+$ \emph{favor} $=$ literally ``for a favour'' --- \emph{[do this]
+as a kindness to me}. The neighbours build ``please'' out of very different
+pictures:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+\textbf{Language} & \textbf{``Please''} & \textbf{Literally} \\
+\midrule
+Spanish & \emph{por favor}      & ``for a favour'' \\
+Italian & \emph{per favore}     & ``for a favour'' (the exact twin) \\
+French  & \emph{s'il vous pla\^{i}t} & ``if it pleases you'' \\
+German  & \emph{bitte}          & ``I ask / I pray'' \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{grammarlens}
+The courtesy set is now complete, and it is only three pieces:
+\emph{por favor} for asking, \emph{gracias} for receiving, \emph{de nada} for
+replying. \emph{Un caf\'{e}, por favor} $\to$ \emph{\textexclamdown Gracias!}
+$\to$ \emph{De nada.} That loop covers nearly every small transaction you will
+have.
+\end{grammarlens}
+
+\section{\emph{hablar} --- ``to speak,'' and the engine of Spanish sentences}
+\label{lesson:hablar}
+
+\begin{sounds}
+The \textbf{h} is completely silent: \emph{hablar} is \emph{ah-BLAR}, never
+\emph{hah-BLAR}. Spanish \emph{h} never makes a sound at all.\\[3pt]
+The \textbf{b} is soft, halfway to a \emph{v}: \emph{hablo} is \emph{AH-bloh}.
+The final \textbf{r} of \emph{hablar} is a single tap.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{hablar} (``to speak, to talk'') $\leftarrow$ Latin \emph{f\={a}bul\={a}r\={i}},
+``to chat, to tell tales'' $\leftarrow$ \emph{f\={a}bula}, ``a story.'' To
+\emph{speak}, in Spanish, is at root to \emph{tell stories}. That
+\emph{f\={a}bula} is thoroughly English: \textbf{fable}, \textbf{fabul}ous
+(``story-like''), con\textbf{fabul}ate, in\textbf{eff}able
+(``un-speak-able'').\\[3pt]
+\textbf{The f$\to$h sound-law:} Latin \emph{f-} became Spanish \emph{h-} across
+the whole language. Put the \emph{f} back and the cousin appears.
+\end{cousinweb}
+
+That one law decodes hundreds of words:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+\textbf{Spanish (h-)} & \textbf{Latin (f-)} & \textbf{English cousin} \\
+\midrule
+\emph{hablar} (to speak) & \emph{f\={a}bul\={a}r\={i}} & fable \\
+\emph{harina} (flour)    & \emph{far\={i}na}   & farina, farinaceous \\
+\emph{hacer} (to do)     & \emph{facere}       & fact, factory \\
+\emph{hijo} (son)        & \emph{f\={i}lius}   & filial, affiliate \\
+\emph{hierro} (iron)     & \emph{ferrum}       & ferrous, ferric \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{grammarlens}
+A \textbf{verb} is the action word of a sentence, and its plain dictionary form
+--- ``to speak'' --- is the \textbf{infinitive}. Spanish infinitives come in
+three families named for their last two letters: \emph{-ar}, \emph{-er},
+\emph{-ir}. \emph{hablar} is \emph{-ar}, the largest family by far.\\[3pt]
+To \textbf{conjugate} it --- to reshape it for who is doing the action --- you
+drop the \emph{-ar} and add an ending. English barely does this (\emph{I
+speak}, but \emph{he speak\textbf{s}}); Spanish does it for every person, and
+the ending carries so much information that the word for ``I'' becomes
+unnecessary. \emph{Hablo espa\~{n}ol} $=$ ``I speak Spanish'': no \emph{yo}
+needed, because the \emph{-o} already says ``I.''
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+\textbf{Person} & \textbf{Ending} & \emph{hablar} $\to$ & \textbf{Meaning} \\
+\midrule
+\emph{yo} (I)                  & \emph{-o}    & \emph{hablo}    & I speak \\
+\emph{t\'{u}} (you, informal)  & \emph{-as}   & \emph{hablas}   & you speak \\
+\emph{\'{e}l / ella / usted}   & \emph{-a}    & \emph{habla}    & he/she speaks; you (formal) speak \\
+\emph{nosotros} (we)           & \emph{-amos} & \emph{hablamos} & we speak \\
+\emph{ellos / ustedes}         & \emph{-an}   & \emph{hablan}   & they / you-all speak \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+This same template fits \emph{every} regular \emph{-ar} verb. The next two
+sections add no new grammar at all --- they just snap into it.
+
+\section{\emph{trabajar} --- ``to work,'' which once meant \emph{torture}}
+\label{lesson:trabajar}
+
+\begin{sounds}
+The \textbf{j} (the \emph{jota}) is a raspy \emph{h} scraped from the back of
+the throat: \emph{trabajar} is \emph{tra-ba-HAR}. It is the same sound as the
+\emph{j} of \emph{jam\'{o}n}.\\[3pt]
+The \textbf{r}s are single taps and the \textbf{b} is soft.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{trabajar} (``to work'') $\leftarrow$ Vulgar Latin
+\emph{tripali\={a}re}, ``to torture'' $\leftarrow$ \emph{tripalium}, a Roman
+instrument of torture made of \emph{three stakes}: \emph{tri-} (``three'')
+$+$ \emph{p\={a}lus} (``stake''), the root of English \textbf{pale} (a fence
+stake) and im\textbf{pale}.\\[3pt]
+English took the same word down a parallel road: \textbf{travail} (painful,
+laborious effort --- and the pains of childbirth) and, astonishingly,
+\textbf{travel}. Journeying was once such an ordeal that the word for
+\emph{toil} became the word for \emph{taking a trip}.
+\end{cousinweb}
+
+\begin{culture}
+The chain of meaning is grimly logical: \emph{torture} $\to$ \emph{torment,
+suffering} $\to$ \emph{hard toil} $\to$ plain \emph{work}. So \emph{Trabajo
+mucho} (``I work a lot'') is, at the root, ``I am tortured a lot'' --- and
+every time you \emph{travel}, you are etymologically being tortured too.
+\end{culture}
+
+Drop the \emph{-ar}, add the ending --- identical to \emph{hablar}:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+\textbf{Person} & \emph{trabajar} $\to$ & \textbf{Meaning} \\
+\midrule
+\emph{yo}                    & \emph{trabajo}  & I work \\
+\emph{t\'{u}}                & \emph{trabajas} & you work \\
+\emph{\'{e}l / ella / usted} & \emph{trabaja}  & he/she works; you (formal) work \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Notice that you learned nothing new --- that is exactly the point. One
+template, every \emph{-ar} verb.
+
+\section{\emph{estudiar} --- ``to study,'' and the eagerness inside it}
+\label{lesson:estudiar}
+
+\begin{sounds}
+Spanish props up an initial \emph{st-} with an \emph{e}: it is
+\emph{es-tudiar}, never \emph{stu-}. The same reflex gives \emph{estar},
+\emph{Espa\~{n}a}, \emph{escuela}.\\[3pt]
+The \emph{-iar} ending glides into one syllable: \emph{es-too-DYAR}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{estudiar} (``to study'') $\leftarrow$ Latin \emph{stud\={e}re}, ``to be
+eager, to apply oneself zealously.'' A \emph{studium} was \emph{zeal,
+enthusiasm, devotion} --- only later ``study.''\\[3pt]
+That root is everywhere in English: a \textbf{student} is literally ``one who
+is eager''; \textbf{studio}, \textbf{studi}ous, and \textbf{study} are the
+place, the trait, and the act. Italian \emph{studio} and the musical
+\emph{studio} keep the ``devoted practice'' sense.
+\end{cousinweb}
+
+So \emph{Estudio espa\~{n}ol} is, at heart, ``I throw myself eagerly at
+Spanish'' --- a nicer picture than mere schoolwork.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+\textbf{Person} & \emph{estudiar} $\to$ & \textbf{Meaning} \\
+\midrule
+\emph{yo}                    & \emph{estudio}  & I study \\
+\emph{t\'{u}}                & \emph{estudias} & you study \\
+\emph{\'{e}l / ella / usted} & \emph{estudia}  & he/she studies; you (formal) study \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Three verbs, one pattern: \emph{hablo}, \emph{trabajo}, \emph{estudio}. You now
+hold the whole regular \emph{-ar} present tense.
+
+\section{\emph{Hablo espa\~{n}ol} --- your first real sentence}
+\label{lesson:espanol}
+
+\begin{sounds}
+\textbf{\~{n}} is the \emph{ny} of \emph{canyon} --- a doubled \emph{n} that
+Spanish scribes squeezed under a tilde. \emph{espa\~{n}ol} is
+\emph{es-pa-NYOL}, and the \emph{h} of \emph{hablo} stays silent:
+\emph{AH-bloh es-pa-NYOL}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{espa\~{n}ol} (``Spanish''; also ``a Spaniard'') $\leftarrow$
+\emph{Hispania}, the Roman name for the Iberian peninsula. The path
+\emph{Hispania} $\to$ \emph{hispaniolus} $\to$ \emph{espa\~{n}ol} wore the word
+down --- and the \emph{-ni-} of \emph{hispaniolus} is precisely where the
+\textbf{\~{n}} comes from. English \textbf{Spanish}, \textbf{Hispan}ic, and
+\textbf{Hispan}iola are all the same root; \emph{Hispania} itself may go back
+through Latin to a \textbf{Phoenician} name for the coast, ``land of hyraxes
+(rabbits).''
+\end{cousinweb}
+
+Snap two things you already own together: \emph{hablo} (``I speak,'' from
+\emph{hablar}) $+$ \emph{espa\~{n}ol} (``Spanish'') $=$ \emph{Hablo
+espa\~{n}ol.} A complete, grammatical Spanish sentence, assembled by you.
+
+\begin{grammarlens}
+Notice what is \emph{not} there.\\[3pt]
+\textbf{No \emph{yo}.} The \emph{-o} of \emph{hablo} already means ``I,'' so
+the subject pronoun is dropped. \emph{Yo hablo espa\~{n}ol} is correct too, but
+it adds emphasis --- ``\emph{I} speak Spanish (whatever the others do).''\\[3pt]
+\textbf{No ``the'' and no ``a.''} Names of languages stand bare in this
+position: \emph{hablo espa\~{n}ol}, not \emph{hablo el espa\~{n}ol}.
+\end{grammarlens}
+
+Now swap the pieces and watch the template generate:
+\emph{Estudio espa\~{n}ol} (``I study Spanish'') $\cdot$ \emph{Trabajo mucho}
+(``I work a lot'') $\cdot$ \emph{\textquestiondown Hablas espa\~{n}ol?} (``Do
+you speak Spanish?'' --- just raise the pitch, and open with the
+\textquestiondown\ from the writing chapter).
+
+\section{Practice --- making sentences with \emph{-ar} verbs}
+\label{lesson:ch6-practice}
+
+Run each verb through \emph{yo} $\to$ \emph{t\'{u}} $\to$ \emph{\'{e}l/ella}
+until it is automatic:
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+\textbf{Infinitive} & \emph{yo} ($-$o) & \emph{t\'{u}} ($-$as) & \emph{\'{e}l/ella/usted} ($-$a) \\
+\midrule
+\emph{hablar}   & \emph{hablo}   & \emph{hablas}   & \emph{habla} \\
+\emph{trabajar} & \emph{trabajo} & \emph{trabajas} & \emph{trabaja} \\
+\emph{estudiar} & \emph{estudio} & \emph{estudias} & \emph{estudia} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Say something real:
+
+\begin{quote}\itshape
+--- \textquestiondown Hablas espa\~{n}ol? --- S\'{i}, hablo un poco.\\
+--- \textquestiondown Trabajas o estudias? --- Estudio espa\~{n}ol.\\
+--- Un caf\'{e}, por favor. --- \textexclamdown Gracias! --- De nada.
+\end{quote}
+
+What you built this chapter: \emph{por favor} (``for a favour''), completing
+\emph{gracias} / \emph{de nada} / \emph{por favor}; the regular \emph{-ar}
+present tense --- drop \emph{-ar}, add \emph{-o} / \emph{-as} / \emph{-a}
+(then \emph{-amos} / \emph{-an}); the three verbs \emph{hablar} ($\leftarrow$
+\emph{f\={a}bula}, fable, by the f$\to$h law), \emph{trabajar} ($\leftarrow$
+\emph{tripalium}, torture $\to$ travail, travel), \emph{estudiar} ($\leftarrow$
+\emph{stud\={e}re}, eagerness $\to$ student); and \emph{Hablo espa\~{n}ol},
+your first self-assembled sentence, with no \emph{yo} and no article.
+
+You can now generate sentences rather than recite them. Next chapter: the
+\emph{-er} and \emph{-ir} verbs, and questions with \emph{qu\'{e}} and
+\emph{d\'{o}nde}.

--- a/code/learning/human-languages/spanish/book/chapters/ch07-er-ir-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch07-er-ir-verbs.tex
@@ -1,0 +1,262 @@
+\chapter{Eating, Drinking, Living --- the \emph{-er} and \emph{-ir} Verbs}
+\label{ch:er-ir-verbs}
+
+Spanish has exactly three verb families, and you have already met one of them.
+This chapter hands you the other two --- \emph{-er} and \emph{-ir} --- which
+turn out to be almost the same as each other. Then it gives you two question
+words, so that for the first time you can \emph{ask} something and understand
+the answer. \emph{Practice lessons: \texttt{lessons/ES-C07-*.md}.}
+
+\section{\emph{comer} --- ``to eat,'' and the second verb family}
+\label{lesson:comer}
+
+\begin{sounds}
+The \emph{c} before \emph{o} is a hard \emph{k}, and the final \emph{r} is one
+soft tap of the tongue: \emph{comer} $=$ \emph{ko-MER}, with the stress on the
+second syllable.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{comer} (``to eat'') $\leftarrow$ Latin \emph{comedere}, ``to eat up''
+--- \emph{com-} (an intensifier, ``completely'') $+$ \emph{edere}, ``to
+eat.''\\[3pt]
+That \emph{edere} is the twin of English \textbf{eat}: both descend from the
+same ancient root, the Latin and Germanic branches of one family.\\[3pt]
+The English relatives: \textbf{edible} (``fit to be eaten''),
+\textbf{comestible} (a fancy word for food, straight from \emph{comedere}),
+and \textbf{eat} itself.
+\end{cousinweb}
+
+\begin{grammarlens}
+A \textbf{verb} is the action word of a sentence, and Spanish changes its
+ending to show \emph{who} is doing the action. The \emph{-er} family works
+exactly like the \emph{-ar} family with the \emph{a}'s swapped for \emph{e}'s.
+Chop the \emph{-er} off \emph{comer} to get the stem \emph{com-}, then add:
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+person & \emph{-ar} was & \emph{-er} is & \emph{comer} $\to$\\
+\midrule
+\emph{yo} (I) & \emph{-o} & \emph{-o} & \emph{como} (I eat)\\
+\emph{t\'{u}} (you, informal) & \emph{-as} & \emph{-es} & \emph{comes} (you eat)\\
+\emph{\'{e}l / ella / usted} & \emph{-a} & \emph{-e} & \emph{come} (he/she eats)\\
+(\emph{nosotros}, we) & \emph{-amos} & \emph{-emos} & \emph{comemos}\\
+(\emph{ellos / ustedes}, they/you all) & \emph{-an} & \emph{-en} & \emph{comen}\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+So the \emph{yo} form is identical (\emph{-o}), and \emph{t\'{u}}/\emph{\'{e}l}
+simply trade \emph{a} for \emph{e}: \emph{hablas / habla} $\to$
+\emph{comes / come}. If you know \emph{-ar}, you already know ninety percent of
+\emph{-er}.
+\end{grammarlens}
+
+\begin{culture}
+Watch this small trap: \emph{como} means ``I eat'' \emph{and} ``like / as''
+(\emph{como t\'{u}}, ``like you'') \emph{and}, once it puts on an accent,
+\emph{c\'{o}mo} $=$ ``how?'' Same four letters, three jobs --- the accent and
+the surrounding words sort them out.
+\end{culture}
+
+\section{\emph{vivir} --- ``to live,'' and the third family}
+\label{lesson:vivir}
+
+\begin{sounds}
+The Spanish \emph{v} is pronounced as a soft \emph{b}, so \emph{vivir} sounds
+roughly like \emph{bee-BEER}. The final \emph{r} is again a single tap.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{vivir} (``to live'') $\leftarrow$ Latin \emph{v\={i}vere}, ``to live''
+--- one of the most alive roots in English.\\[3pt]
+\textbf{vivid} (``full of life''), \textbf{surv}ive ($\leftarrow$
+\emph{super-v\={i}vere}, ``to live beyond''), re\textbf{vive} (``live
+again''), \textbf{vivac}ious, con\textbf{viv}ial (``living together,'' so
+sociable), \textbf{viva!}, \textbf{vivar}ium.\\[3pt]
+And the noun beside it, Latin \emph{v\={i}ta} (``life''), gives English
+\textbf{vital} and \textbf{vitam}in.
+\end{cousinweb}
+
+\begin{grammarlens}
+Here is the punchline of the whole system: in the present tense, \emph{-ir} is
+almost identical to \emph{-er}. Set the three families side by side in the
+singular:
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+person & \emph{-ar} (\emph{hablar}) & \emph{-er} (\emph{comer}) & \emph{-ir} (\emph{vivir})\\
+\midrule
+\emph{yo} & \emph{hablo} & \emph{como} & \emph{vivo}\\
+\emph{t\'{u}} & \emph{hablas} & \emph{comes} & \emph{vives}\\
+\emph{\'{e}l / ella} & \emph{habla} & \emph{come} & \emph{vive}\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Look closely: \emph{-er} and \emph{-ir} are \emph{identical} in the singular
+(\emph{-o} / \emph{-es} / \emph{-e}). They part company only in the ``we'' and
+``you all'' forms --- \emph{comemos / com\'{e}is} against \emph{vivimos /
+viv\'{i}s}. So learning \emph{-ir} costs you almost nothing.\\[3pt]
+Three families, three vowels, one idea. You can now conjugate the present
+tense of virtually any regular Spanish verb.
+\end{grammarlens}
+
+\section{\emph{beber} --- ``to drink,'' and the pattern is yours}
+\label{lesson:beber}
+
+\begin{sounds}
+Both \emph{b}'s are the soft Spanish \emph{b}, the same sound as the Spanish
+\emph{v}: \emph{be-BER}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{beber} (``to drink'') $\leftarrow$ Latin \emph{bibere}, ``to drink''
+--- a thirsty little root that soaked into English.\\[3pt]
+\textbf{bever}age (a drink, by way of Old French \emph{bevrage}, from
+\emph{bibere}), im\textbf{bibe} (``to drink in'': \emph{in-} $+$
+\emph{bibere}), \textbf{bibul}ous (fond of drinking), and \textbf{bib}, the
+cloth that catches the drips. Even \textbf{beer}'s cousins hover nearby.
+\end{cousinweb}
+
+\begin{grammarlens}
+There is no new grammar here, and that is exactly the point. \emph{beber} is a
+regular \emph{-er} verb, so it takes the endings you already own:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+person & form & meaning\\
+\midrule
+\emph{yo} & \emph{bebo} & I drink\\
+\emph{t\'{u}} & \emph{bebes} & you drink\\
+\emph{\'{e}l / ella / usted} & \emph{bebe} & he/she drinks; you (formal) drink\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Nothing new to learn --- you are simply reusing the machine. Which means you
+can now say: \emph{Como pan y bebo agua.} (``I eat bread and drink water.'')
+Two verbs, two nouns, one sentence you built yourself.
+\end{grammarlens}
+
+\section{\emph{qu\'{e}} --- ``what?'', your first question word}
+\label{lesson:que}
+
+\begin{sounds}
+\emph{qu} is a plain hard \emph{k} and the \emph{u} is silent, so \emph{qu\'{e}}
+$=$ \emph{keh}. The accent on the \emph{\'{e}} marks this as the \emph{question}
+word: \emph{qu\'{e}} $=$ ``what?'', while \emph{que} without the accent $=$
+``that.'' Question words wear the accent.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{qu\'{e}} (``what?'') $\leftarrow$ Latin \emph{quid}, ``what'' --- the
+neuter form of \emph{quis}, ``who.'' It is a small function word with a few
+learned English descendants:\\[3pt]
+\textbf{quidd}ity --- the ``what-ness,'' the essence of a thing;
+\textbf{quid} pro \textbf{quo} --- ``\emph{what} for \emph{what},'' this for
+that.\\[3pt]
+\textbf{The family it heads in Spanish:} \emph{qu\'{e}} (what),
+\emph{qui\'{e}n} (who), \emph{cu\'{a}l} (which) --- Latin's \emph{qu-}
+question words. Latin \emph{qu-} and English \emph{wh-} are ancient cousins,
+which is why the two languages share the same questioning instinct.
+\end{cousinweb}
+
+\begin{grammarlens}
+Put \emph{qu\'{e}} in front of a verb, wrap the whole thing in the pair of
+Spanish question marks, and you have a real question:\\[3pt]
+\emph{\textquestiondown Qu\'{e} comes?} --- ``What are you eating? / What do
+you eat?''\\[3pt]
+\emph{\textquestiondown Qu\'{e} bebes?} --- ``What are you drinking?''\\[3pt]
+The opening \textquestiondown\ warns the reader that a question is coming, and
+the accent on \emph{qu\'{e}} marks which word is doing the asking. Answer with
+the verb you already conjugate: \emph{Como pan.} (``I eat bread.'')
+\end{grammarlens}
+
+\section{\emph{d\'{o}nde} --- ``where?''}
+\label{lesson:donde}
+
+\begin{sounds}
+The middle \emph{d} is soft, close to the \emph{th} of English ``this'':
+\emph{DON-deh}. As with \emph{qu\'{e}}, the accent on the \emph{\'{o}} marks
+the question word --- \emph{d\'{o}nde} $=$ ``where?'', while \emph{donde}
+without the accent means ``where'' as a connector, as in ``the place
+\emph{where} I live.''
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{d\'{o}nde} (``where?'') $\leftarrow$ Latin \emph{de unde}, literally
+``from whence.'' \emph{unde} meant ``from where''; Spanish glued \emph{de}
+onto the front and wore the pair down to \emph{d\'{o}nde}.\\[3pt]
+English once had the matching set \textbf{whence} / \textbf{where} /
+\textbf{whither} --- ``from where / at where / to where.'' Spanish keeps that
+flavour alive: \emph{de d\'{o}nde} (``from where''), \emph{d\'{o}nde}
+(``where''), \emph{ad\'{o}nde} (``to where'').
+\end{cousinweb}
+
+\begin{grammarlens}
+Two question words plus the verbs you own $=$ real conversation:\\[3pt]
+\emph{\textquestiondown D\'{o}nde vives?} --- ``Where do you live?'' $\to$
+\emph{Vivo en Madrid.}\\[3pt]
+\emph{\textquestiondown D\'{o}nde trabajas?} --- ``Where do you work?''\\[3pt]
+\emph{\textquestiondown Qu\'{e} estudias?} --- ``What do you study?''\\[3pt]
+Notice the little \emph{en} (``in'') in the answer, from Latin \emph{in} --- your
+first preposition, slipping in exactly where you need it. You are now trading
+real questions and answers, not reciting fixed phrases.
+\end{grammarlens}
+
+\begin{culture}
+\emph{\textquestiondown D\'{o}nde vives?} is the single most common
+getting-to-know-you question in Spanish, and the answer opens a door: the city
+you name tells your listener which Spanish you speak, which food you eat, and
+often how to place you. Pair it with \emph{\textquestiondown Y t\'{u}?} (``and
+you?'') and the conversation runs itself.
+\end{culture}
+
+\section{Practice --- asking real questions}
+\label{lesson:ch7-practice}
+
+You now have all three verb families \emph{and} two question words. This is
+where it becomes a conversation: you can ask and answer, not just recite.
+Conjugate \emph{yo} $\to$ \emph{t\'{u}} $\to$ \emph{\'{e}l/ella} and feel how
+little differs:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+family & verb & \emph{yo} $\cdot$ \emph{t\'{u}} $\cdot$ \emph{\'{e}l/ella}\\
+\midrule
+\emph{-ar} & \emph{hablar} & \emph{hablo} $\cdot$ \emph{hablas} $\cdot$ \emph{habla}\\
+\emph{-er} & \emph{comer} & \emph{como} $\cdot$ \emph{comes} $\cdot$ \emph{come}\\
+\emph{-ir} & \emph{vivir} & \emph{vivo} $\cdot$ \emph{vives} $\cdot$ \emph{vive}\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The endings: \emph{-ar} takes \emph{-o} / \emph{-as} / \emph{-a}; \emph{-er}
+and \emph{-ir} both take \emph{-o} / \emph{-es} / \emph{-e}, identical in the
+singular. Master these and you conjugate almost any regular verb.
+
+\begin{quote}\itshape
+--- \textquestiondown D\'{o}nde vives? --- Vivo en Sevilla.
+\textquestiondown Y t\'{u}?\\
+--- Vivo en M\'{e}xico. \textquestiondown Qu\'{e} estudias?\\
+--- Estudio espa\~{n}ol. \textquestiondown Qu\'{e} comes?\\
+--- Como una tapa y bebo un caf\'{e}. \textquestiondown Algo m\'{a}s?\\
+--- Un agua, por favor.
+\end{quote}
+
+What you built this chapter: \emph{comer} and \emph{beber} (the \emph{-er}
+family) and \emph{vivir} (the \emph{-ir} family), with the singular endings
+\emph{-o} / \emph{-es} / \emph{-e}; \emph{qu\'{e}} (from \emph{quid}) and
+\emph{d\'{o}nde} (from \emph{de unde}), each wearing its accent and opening
+with \textquestiondown; and real questions ---
+\emph{\textquestiondown Qu\'{e} comes?}, \emph{\textquestiondown D\'{o}nde
+vives?}, \emph{\textquestiondown D\'{o}nde trabajas?} --- answered with the
+first preposition, \emph{en}. Try chaining a whole caf\'{e} moment: greet,
+order with \emph{por favor}, ask and answer, then \emph{gracias} and
+\emph{adi\'{o}s}. Next chapter: numbers --- \emph{uno, dos, tres} --- and
+telling someone your age.

--- a/code/learning/human-languages/spanish/book/chapters/ch08-numbers-and-age.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch08-numbers-and-age.tex
@@ -1,0 +1,229 @@
+\chapter{Numbers, and How Old You Are}
+\label{ch:numbers-and-age}
+
+Numbers are the most reused words in any language, and Spanish counts almost
+exactly the way Latin did --- which means each one planted an English word you
+can lean on. Then one irregular verb, \emph{tener} (``to have''), turns those
+numbers into your age: in Spanish you don't \emph{be} twenty, you \emph{have}
+twenty years. \emph{Practice lessons: \texttt{lessons/ES-C08-*.md}.}
+
+\section{\emph{uno, dos, tres, cuatro, cinco} --- counting to five}
+\label{lesson:numeros-1-5}
+
+\begin{sounds}
+\textbf{cuatro} $=$ \emph{KWA-tro} --- the \emph{cu-} is a \emph{kw} glide, not
+two separate vowels.\\[3pt]
+The \emph{r} in \emph{tres} and \emph{cuatro} is a soft tap of the tongue
+against the ridge behind the upper teeth --- close to the \emph{tt} in the
+American pronunciation of ``butter,'' not an English \emph{r}.
+\end{sounds}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Spanish & $\leftarrow$ Latin & English cousins \\
+\midrule
+\textbf{uno} (1) & \emph{\={u}nus} & \textbf{unit}, \textbf{union}, \textbf{unique}, \textbf{unanimous}, \textbf{universe} \\
+\textbf{dos} (2) & \emph{duo} & \textbf{duo}, \textbf{dual}, \textbf{duet}, \textbf{double}, \textbf{duplex} \\
+\textbf{tres} (3) & \emph{tr\={e}s} & \textbf{trio}, \textbf{triple}, \textbf{trinity}, \textbf{trident}, \textbf{triangle} \\
+\textbf{cuatro} (4) & \emph{quattuor} & \textbf{quart}, \textbf{quarter}, \textbf{quadrant}, \textbf{square} \\
+\textbf{cinco} (5) & \emph{qu\={\i}nque} & \textbf{quintet}, \textbf{quintessence}, \textbf{quintuplet} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{cousinweb}
+\textbf{Pattern:} Latin \emph{qu-} softens on its way into Spanish ---
+\emph{quattuor} $\to$ \emph{cuatro} (\emph{qu-} $\to$ \emph{cu-}),
+\emph{qu\={\i}nque} $\to$ \emph{cinco} (\emph{qu-} $\to$ \emph{c-}).\\[3pt]
+So \emph{cinco} and \textbf{quintet} are the same number wearing different
+clothes. \emph{uno} also stands behind English \textbf{one} and \textbf{a}/%
+\textbf{an}. Count the family on your fingers: \textbf{unit, duo, trio, quart,
+quint}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\emph{uno} shrinks when it stands in front of a noun: \emph{\textbf{un}}
+(masculine) / \emph{\textbf{una}} (feminine). A \textbf{noun} is a word for a
+thing or a person; Spanish sorts every noun into one of two classes,
+\emph{masculine} or \emph{feminine}, and the words in front of it must match.\\[3pt]
+These shrunken forms do double duty: Spanish makes no distinction between
+``one'' and ``a/an.'' \emph{un caf\'{e}} is both ``a coffee'' and ``one
+coffee''; \emph{una cerveza}, ``a beer / one beer.'' The other numbers
+(\emph{dos, tres, cuatro, cinco}) never change shape.
+\end{grammarlens}
+
+\section{\emph{seis, siete, ocho, nueve, diez} --- and the calendar's secret}
+\label{lesson:numeros-6-10}
+
+\begin{sounds}
+\textbf{siete} $=$ \emph{SYE-teh} and \textbf{nueve} $=$ \emph{NWE-veh}. Those
+\emph{ie} and \emph{ue} glides --- two vowels said in one smooth motion --- are
+a Spanish signature; you will meet them again in almost every irregular verb.
+\end{sounds}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Spanish & $\leftarrow$ Latin & English cousins \\
+\midrule
+\textbf{seis} (6) & \emph{sex} & \textbf{sextet}, \textbf{sextant}, \textbf{semester} (six months) \\
+\textbf{siete} (7) & \emph{septem} & \textbf{September} (the 7th month), \textbf{septet}, \textbf{septuagenarian} \\
+\textbf{ocho} (8) & \emph{oct\={o}} & \textbf{October} (8th), \textbf{octopus}, \textbf{octave}, \textbf{octagon} \\
+\textbf{nueve} (9) & \emph{novem} & \textbf{November} (9th), \textbf{novena} \\
+\textbf{diez} (10) & \emph{decem} & \textbf{December} (10th), \textbf{decimal}, \textbf{decade}, \textbf{dime}, \textbf{decimate} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{culture}
+Why are the ``7th--10th'' months numbered 7--10 when they sit at positions
+9--12 on the calendar? Because the old \textbf{Roman year began in March} ---
+so \emph{September} really was the seventh month.\\[3pt]
+Julius Caesar and Augustus later inserted \textbf{July} and \textbf{August},
+named for themselves, shoving the counting-months out of place. The Latin
+numbers stayed put anyway. Every time you say \emph{December}, you are saying
+Roman ``\textbf{ten}.''
+\end{culture}
+
+\begin{grammarlens}
+Past ten, Spanish \textbf{fuses} ``ten and X'' into a single word:\\[3pt]
+\emph{diez y seis} (``ten and six'') $\to$ \emph{diecis\'{e}is} (16);
+\emph{diez y siete} $\to$ \emph{diecisiete} (17), and onward to 19.\\[3pt]
+English built its own teens the identical way: \emph{six} $+$ \emph{ten} $=$
+\textbf{sixteen}. \emph{Diecis\'{e}is} and \textbf{sixteen} are the same two
+numbers glued together in the same order.
+\end{grammarlens}
+
+\section{\emph{tener} --- ``to have,'' your first irregular verb}
+\label{lesson:tener}
+
+A \textbf{verb} is an action or state word (``speak,'' ``eat,'' ``have''), and
+a \textbf{regular} verb changes its ending by a fixed, predictable recipe.
+\emph{hablo} (``I speak''), \emph{como} (``I eat''), \emph{vivo} (``I live'')
+are all tidy that way. \emph{tener} is your first \textbf{irregular} verb, and
+it breaks the rules in the two ways Spanish verbs most often do.
+
+\begin{sounds}
+\textbf{tener} $=$ \emph{te-NER}, with the stress on the second syllable. When
+the stem cracks open you get the \emph{ie} glide again: \textbf{tienes} $=$
+\emph{TYE-nes}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{tener} (``to have'') $\leftarrow$ Latin \emph{ten\={e}re}, ``to hold,
+to keep, to grasp.'' Having is, at root, \emph{holding}.\\[3pt]
+The bare root: \textbf{tenant} (one who \emph{holds} land), \textbf{tenure},
+\textbf{tenacious} (\emph{holding} on), \textbf{tenable}, \textbf{tenet} (a
+\emph{held} belief).\\[3pt]
+With prefixes: con\textbf{tain} (``hold together''), re\textbf{tain} (``hold
+back''), main\textbf{tain} (``hold in hand''), sus\textbf{tain} (``hold up''),
+de\textbf{tain}, ob\textbf{tain}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\emph{tener} misbehaves in exactly the two classic Spanish ways. First, the
+\emph{yo} (``I'') form is odd: not \emph{teno} but \emph{\textbf{tengo}}, with
+a \emph{-g-} appearing from nowhere. A handful of very common verbs do this
+(\emph{hago}, \emph{pongo}, \emph{salgo}, \emph{vengo}).\\[3pt]
+Second, the stem vowel breaks \emph{e} $\to$ \emph{ie} in the stressed forms
+--- a \textbf{stem-changer}.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Note \\
+\midrule
+\emph{yo} (I) & \textbf{tengo} & the \emph{-go} form \\
+\emph{t\'{u}} (you, informal) & \textbf{tienes} & \emph{e} $\to$ \emph{ie} \\
+\emph{\'{e}l / ella / usted} (he, she, you-formal) & \textbf{tiene} & \emph{e} $\to$ \emph{ie} \\
+\emph{nosotros} (we) & \textbf{tenemos} & back to plain \emph{e} --- unstressed \\
+\emph{ellos / ustedes} (they, you-plural) & \textbf{tienen} & \emph{e} $\to$ \emph{ie} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Notice that \emph{tenemos} keeps the plain \emph{e}: the vowel only cracks to
+\emph{ie} when the stress falls on it. Sketch the changed forms on the table
+and they trace a boot shape around the untouched \emph{nosotros} --- which is
+why this is called the \textbf{boot} pattern. It is the single most common
+irregularity in Spanish, and \emph{tener} is your model for it.
+
+\section{\textquestiondown\emph{Cu\'{a}ntos a\~{n}os tienes?} --- ``how old are you?''}
+\label{lesson:cuantos-anos}
+
+With \emph{tener} and your numbers you can now ask and give an \textbf{age} ---
+and Spanish does it in a way English does not.
+
+\begin{center}
+\emph{\textquestiondown Cu\'{a}ntos a\~{n}os tienes?} $=$ ``How old are you?''\\
+literally: ``How many years do you have?''
+\end{center}
+
+\begin{cousinweb}
+\textbf{cu\'{a}ntos} (``how many'') $\leftarrow$ Latin \emph{quantus}, ``how
+much, how great'' $\to$ \textbf{quant}ity, \textbf{quant}um,
+\textbf{quant}ify. It belongs to the \emph{qu-} question family:
+\emph{qu\'{e}}, \emph{c\'{o}mo}, \emph{d\'{o}nde}, \emph{cu\'{a}ntos}.\\[3pt]
+\textbf{a\~{n}os} (``years'') $\leftarrow$ Latin \emph{annus} --- and there is
+the \emph{\~{n}} again, born from the doubled \emph{nn} of \emph{annus}.
+\emph{annus} also gives English \textbf{annual}, \textbf{anniversary},
+\textbf{biennial}.\\[3pt]
+\textbf{tienes} (``you have'') --- the \emph{tener} you just learned.
+\end{cousinweb}
+
+\begin{grammarlens}
+\emph{cu\'{a}ntos} \textbf{agrees} with the noun it counts: because
+\emph{a\~{n}os} is masculine and plural, the question word takes the matching
+masculine plural ending, \emph{cu\'{a}nt\textbf{os} a\~{n}os}. Spanish makes
+the words around a noun echo its gender and number; English leaves them alone.
+\end{grammarlens}
+
+\begin{culture}
+\textbf{Age is had, not been.} Spanish counts age with \emph{tener}
+(``have''), never with \emph{ser}/\emph{estar} (``be'').\\[3pt]
+--- \emph{\textquestiondown Cu\'{a}ntos a\~{n}os tienes?} ---
+\emph{Tengo veinte a\~{n}os.} (``I \emph{have} twenty years.'')\\[3pt]
+Saying \emph{soy veinte} (``I am twenty'') is simply wrong. You possess your
+years; you do not equal them. French and Italian agree --- \emph{j'ai vingt
+ans}, \emph{ho vent'anni}, both ``I \emph{have}.''
+\end{culture}
+
+Say it as \emph{KWAN-tos AN-yos TYE-nes}, and answer \emph{Tengo \ldots\
+a\~{n}os} with your own number.
+
+\section{Practice --- numbers, having, and age}
+\label{lesson:ch8-practice}
+
+Two new powers this chapter: you can \textbf{count}, and you can talk about
+what you \textbf{have} --- including your years. Drill both until they are
+automatic.
+
+\begin{quote}\itshape
+Count up: uno, dos, tres, cuatro, cinco, seis, siete, ocho, nueve, diez.\\
+\emph{tener}, all forms: tengo $\cdot$ tienes $\cdot$ tiene $\cdot$ tenemos
+$\cdot$ tienen.
+\end{quote}
+
+\begin{quote}\itshape
+--- Hola. \textquestiondown C\'{o}mo te llamas? --- Me llamo Ana.
+\textquestiondown Y cu\'{a}ntos a\~{n}os tienes?\\
+--- Tengo veintiuno. \textquestiondown Y t\'{u}?\\
+--- Tengo diecinueve.\\
+--- Un caf\'{e}, por favor. \textquestiondown Cu\'{a}nto es? --- Dos euros.
+\end{quote}
+
+What you have built: the \textbf{numbers 1--10} ($\leftarrow$ \emph{\={u}nus
+\ldots\ decem}; \emph{cinco}/\textbf{quintet}, \emph{diez}/\textbf{December})
+and the \textbf{teen fusion} \emph{diez y seis} $\to$ \emph{diecis\'{e}is}
+($=$ \textbf{sixteen}); \textbf{tener}, ``to have'' ($\leftarrow$
+\emph{ten\={e}re} ``hold''; \textbf{tenant}, \textbf{retain}, \textbf{contain}),
+your first irregular, stem-changing verb, with its \emph{-go} form
+\emph{tengo} and its \emph{e} $\to$ \emph{ie} crack; and
+\emph{\textquestiondown Cu\'{a}ntos a\~{n}os tienes?}, age given with
+\emph{tener} rather than ``be,'' where \emph{a\~{n}os} $\leftarrow$
+\emph{annus} brings back the \emph{\~{n}}.
+
+Next chapter: \emph{ser} versus \emph{estar} head-on --- the two ``to be''
+verbs, sorted for good.

--- a/code/learning/human-languages/spanish/book/chapters/ch09-ser-y-estar.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch09-ser-y-estar.tex
@@ -1,0 +1,316 @@
+\chapter{\emph{Ser} and \emph{Estar} --- Two Ways to Be}
+\label{ch:ser-y-estar}
+
+Spanish has \emph{two} verbs where English has one. This chapter finally meets
+the second one, \emph{ser}, and settles the famous question of when to use
+which --- a choice that is not arbitrary at all, but written into the two Latin
+roots. \emph{Practice lessons: \texttt{lessons/ES-C09-*.md}.}
+
+\section{\emph{ser} --- ``to be,'' the \emph{essential} kind}
+\label{lesson:ser}
+
+Back in Chapter \ref{ch:how-are-you} you met \textbf{estar} --- the
+\emph{temporary} to-be ($\leftarrow$ \emph{st\={a}re}, ``to stand''): how you
+\emph{are right now}, and \emph{where}. It always came with a promise: Spanish
+has \textbf{two} be-verbs, and here is the other. \textbf{ser} is the
+\emph{permanent} one --- what a thing essentially \textbf{is}. It is also your
+second irregular verb, and its irregularity is spectacular.
+
+\begin{sounds}
+\textbf{r-tap} --- \emph{ser} ends in one soft tap of the tongue:
+\emph{SER}.\\[3pt]
+\textbf{no propping \emph{e} here} --- unlike \emph{es-tar}, \emph{ser} already
+starts with its own vowel, so nothing has to be propped up in front of it.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{ser} $\leftarrow$ Latin \emph{esse}, ``to be'' --- the plainest, oldest
+verb there is. (Vulgar Latin actually rebuilt the infinitive as
+\emph{*essere}, and even folded in a second verb, \emph{sed\={e}re} ``to sit,''
+which is why a few forms look like they wandered in from elsewhere.)\\[3pt]
+\textbf{The es- family runs deep into English:} \textbf{essence},
+\textbf{essential}, \textbf{entity}, and --- all the way down --- \textbf{is},
+\textbf{am}, \textbf{are}. This is the ancient PIE root \emph{*h$_1$es-}, ``to
+be.'' When you say \emph{es}, you are saying a cousin of English
+\textbf{is}.\\[3pt]
+\textbf{With prefixes:} \textbf{present} ($\leftarrow$ \emph{prae-esse}, ``to
+be before / at hand''), \textbf{absent} ($\leftarrow$ \emph{ab-esse}, ``to be
+away''), \textbf{interest} ($\leftarrow$ \emph{inter-esse}, ``to be
+between'').
+\end{cousinweb}
+
+So \emph{ser} is not just a word to memorize --- it is the same ancient ``be''
+that English carries in \emph{is / am / are}.
+
+\begin{grammarlens}
+\emph{ser} is \textbf{suppletive}: its forms come from \emph{different} Latin
+words fused into one verb, so you cannot derive them from the infinitive. You
+simply learn them as a set.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+person & form & Latin source \\
+\midrule
+yo & \textbf{soy} & \emph{sum} (``I am''); the \emph{-y} is the same odd tail
+as in \emph{estoy / voy / doy} \\
+t\'{u} & \textbf{eres} & \emph{eris} (``you will be'') --- a future form
+drafted into the present \\
+\'{e}l / ella / usted & \textbf{es} & \emph{est} --- literally cognate with
+English \emph{is} \\
+nosotros & \textbf{somos} & \emph{sumus} \\
+ellos / ustedes & \textbf{son} & \emph{sunt} --- cognate with the plural
+English \emph{are} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Say them as a set: \emph{soy $\cdot$ eres $\cdot$ es $\cdot$ somos $\cdot$
+son.} Notice how \emph{es} and \emph{son} sit right next to English \emph{is}
+and Latin \emph{sunt} --- you half-knew this verb before you started.
+
+\section{\emph{ser} vs \emph{estar} --- essence vs state}
+\label{lesson:ser-vs-estar}
+
+This is the lesson every Spanish learner waits for and dreads. Two verbs, one
+English word (``to be''). But the choice is not arbitrary --- it is written
+into the \textbf{etymology} of each verb. Get the roots, and the rule follows.
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+verb & root & picture & used for \\
+\midrule
+\textbf{ser} & \emph{esse} $\to$ \textbf{essence} & what a thing \emph{is} &
+identity, origin, profession, \\
+ & & & nationality, material, the time \\
+\textbf{estar} & \emph{st\={a}re} $\to$ \textbf{stand}, \textbf{state} & how a
+thing \emph{stands} now & mood, condition, location, \\
+ & & & the temporary \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The mnemonic writes itself: \textbf{\emph{ser} $=$ essence, \emph{estar} $=$
+estado} --- \emph{estado} being the Spanish for ``state,'' the very word
+\emph{estar} built. Permanent, defining truth $\to$ \emph{ser}. Passing state
+or where-you-are $\to$ \emph{estar}.
+
+\begin{quote}\itshape
+Soy alto. --- ``I am tall.'' (a defining trait $\to$ ser)\\
+Estoy cansado. --- ``I am tired.'' (a passing state $\to$ estar)\\
+Es m\'{e}dico. --- ``She is a doctor.'' (identity $\to$ ser)\\
+Est\'{a} en casa. --- ``She is at home.'' (location $\to$ estar, always)
+\end{quote}
+
+\begin{grammarlens}
+Here is the proof that the split is \emph{real}, not decoration. Swap
+\emph{ser} for \emph{estar} on the \textbf{same adjective} and the meaning
+changes --- because \emph{essence} and \emph{state} are genuinely different
+claims.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+with \textbf{ser} (essence) & with \textbf{estar} (state) \\
+\midrule
+\emph{es aburrido} --- ``he \emph{is} boring'' (his nature) & \emph{est\'{a}
+aburrido} --- ``he \emph{is} bored'' (right now) \\
+\emph{es listo} --- ``she \emph{is} clever'' (a trait) & \emph{est\'{a} lista}
+--- ``she \emph{is} ready'' (this moment) \\
+\emph{es rico} --- ``he \emph{is} rich'' (wealth) & \emph{est\'{a} rico} ---
+``it \emph{tastes} delicious'' (this dish) \\
+\emph{es verde} --- ``it \emph{is} green'' (its colour) & \emph{est\'{a}
+verde} --- ``it is \emph{unripe}'' (its state) \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{culture}
+Same adjective, two verbs, two worlds. A boring person \emph{is} (\emph{ser})
+boring; a bored person merely \emph{stands} (\emph{estar}) bored today. This is
+why Spanish keeps two verbs where English merged them into one --- it can say
+in one word things English needs extra words for. Say it twice and let it
+stick: ``\emph{ser} $=$ who/what it \textsc{is}; \emph{estar} $=$ how/where it
+is \emph{right now}.''
+\end{culture}
+
+\section{\emph{soy de\ldots} --- saying where you're from}
+\label{lesson:soy-de}
+
+You have \emph{ser}. Now aim it. \textbf{Where you are from} and \textbf{what
+you do} are treated as \emph{essence} in Spanish --- they define you --- so
+both take \emph{ser}, not \emph{estar}. This is where the split starts paying
+rent.
+
+\begin{cousinweb}
+\textbf{de} (``from / of'') $\leftarrow$ Latin \emph{d\={e}} (``down from,
+about''). It is one of the most common words in Spanish, and its English
+children are everywhere as the prefix \textbf{de-}: \textbf{de}duct,
+\textbf{de}part, \textbf{de}scend, \textbf{de}scribe --- all carrying the
+``from / down-from'' of \emph{d\={e}}.
+\end{cousinweb}
+
+Origin is a permanent fact about you, so the pattern is \emph{ser} $+$
+\emph{de} $+$ place:
+
+\begin{quote}\itshape
+Soy de M\'{e}xico. --- ``I'm from Mexico.''\\
+Eres de Espa\~{n}a. --- ``You're from Spain.''\\
+Es de Colombia. --- ``She's from Colombia.''
+\end{quote}
+
+And to ask it, Spanish fronts the \emph{de}:
+\emph{\textquestiondown De d\'{o}nde eres?} --- literally ``From where
+are-you?'' (\emph{d\'{o}nde}, ``where,'' you met in Chapter 7; here it rides
+with \emph{de} to mean \emph{from where}.)
+
+\begin{grammarlens}
+Note that it is \emph{eres}, not \emph{est\'{a}s} --- even though
+\emph{d\'{o}nde} usually pairs with \emph{estar} for location. Origin is not
+\emph{where you are standing}; it is \emph{what you are}. Essence $\to$
+\emph{ser}.
+\end{grammarlens}
+
+Because profession and nationality also define you, they are \emph{ser} too ---
+and they take \textbf{no article}:
+
+\begin{quote}\itshape
+Soy profesor. --- ``I'm a teacher.''\\
+Soy espa\~{n}ol. --- ``I'm Spanish.''\\
+Somos estudiantes. --- ``We're students.''
+\end{quote}
+
+\begin{culture}
+Spanish drops the ``a'' with a bare profession: \emph{soy profesor}, never
+\emph{soy un profesor}, unless you add something to it. The naked noun is
+enough --- you are not \emph{a} teacher among many, you simply \emph{are}
+teacher. (And there is \emph{espa\~{n}ol} again, from Chapter 6, back through
+Latin \emph{Hispania}.)
+\end{culture}
+
+\section{\emph{est\'{a} en\ldots} --- saying where something is}
+\label{lesson:esta-en}
+
+The mirror image of the last lesson. Origin was \emph{ser} (essence). But
+\textbf{location} --- where a thing physically \emph{stands} right now --- is
+the home turf of \emph{estar} ($\leftarrow$ \emph{st\={a}re}, ``to stand'').
+The root tells you: to be \emph{located} is to \emph{stand} somewhere.
+
+\begin{cousinweb}
+\textbf{en} (``in / on / at'') $\leftarrow$ Latin \emph{in} --- and it
+\emph{is} English \textbf{in}, barely changed in two thousand years. Latin
+\emph{in} $\to$ Spanish \emph{en}, English \emph{in}; the same word runs
+through \textbf{in}terior, \textbf{in}clude, \textbf{in}vade.
+\end{cousinweb}
+
+One Spanish word covers three English prepositions: \emph{en casa} $=$ ``at
+home,'' \emph{en la mesa} $=$ ``on the table,'' \emph{en Madrid} $=$ ``in
+Madrid.'' And location is always \emph{estar} --- never \emph{ser}, with no
+exceptions for physical place:
+
+\begin{quote}\itshape
+Estoy en casa. --- ``I'm at home.''\\
+Est\'{a}s en Madrid. --- ``You're in Madrid.''\\
+Est\'{a} en la mesa. --- ``It's on the table.''
+\end{quote}
+
+To ask it, pair \emph{d\'{o}nde} with \emph{estar}:
+\emph{\textquestiondown D\'{o}nde est\'{a}s?} --- ``Where are you?'' Answer:
+\emph{Estoy en casa.}
+
+\begin{grammarlens}
+Put the two questions side by side and the whole chapter snaps into focus.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+question & verb & why \\
+\midrule
+\emph{\textquestiondown De d\'{o}nde eres?} --- ``Where are you \emph{from}?''
+& \emph{ser} (\emph{eres}) & origin $=$ essence \\
+\emph{\textquestiondown D\'{o}nde est\'{a}s?} --- ``Where are you \emph{at}?''
+& \emph{estar} (\emph{est\'{a}s}) & location $=$ state \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Same word \emph{d\'{o}nde}, two different be-verbs --- and each is locked in by
+meaning. \emph{From} where $\to$ what you \emph{are} (\emph{ser}). \emph{At}
+where $\to$ where you \emph{stand} (\emph{estar}). Even a permanent-seeming
+place stays \emph{estar}: \emph{Madrid est\'{a} en Espa\~{n}a} --- cities do
+not move, but \emph{being located} is still \emph{estar}.
+
+\section{Practice --- \emph{ser} or \emph{estar}?}
+\label{lesson:ch9-practice}
+
+The whole chapter comes down to one reflex: \textbf{essence $\to$ ser, state
+$\to$ estar.} Drill it until you do not have to think. Say each form aloud,
+and for every sentence name \emph{why} the verb is the one it is.
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+\textbf{ser} (essence) & \textbf{estar} (state) \\
+\midrule
+soy & estoy \\
+eres & est\'{a}s \\
+es & est\'{a} \\
+somos & estamos \\
+son & est\'{a}n \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\emph{ser} is suppletive (\emph{sum, eris, est, sumus, sunt}); \emph{estar}
+carries the \emph{-oy} tail in \emph{estoy}, the same tail as \emph{soy},
+\emph{voy}, \emph{doy}.
+
+Sort these --- say ``ser'' or ``estar,'' then the reason:
+
+\begin{quote}\itshape
+``I'm a doctor.'' $\to$ ser (\emph{soy m\'{e}dico} --- identity)\\
+``I'm tired.'' $\to$ estar (\emph{estoy cansado} --- passing state)\\
+``She's from Peru.'' $\to$ ser (\emph{es de Per\'{u}} --- origin)\\
+``The keys are on the table.'' $\to$ estar (\emph{est\'{a}n en la mesa} ---
+location)\\
+``We're students.'' $\to$ ser (\emph{somos estudiantes} --- identity)\\
+``You're at home.'' $\to$ estar (\emph{est\'{a}s en casa} --- location)
+\end{quote}
+
+Then the minimal pairs, where the meaning flips with the verb: \emph{es
+aburrido} (``is boring'') vs \emph{est\'{a} aburrido} (``is bored'')
+$\cdot$ \emph{es listo} (``is clever'') vs \emph{est\'{a} listo} (``is
+ready'') $\cdot$ \emph{es rico} (``is rich'') vs \emph{est\'{a} rico}
+(``tastes delicious'') $\cdot$ \emph{es verde} (``is green'') vs \emph{est\'{a}
+verde} (``is unripe'').
+
+Now say something real:
+
+\begin{quote}\itshape
+--- Hola. \textquestiondown De d\'{o}nde eres? --- Soy de M\'{e}xico.
+\textquestiondown Y t\'{u}?\\
+--- Soy de Espa\~{n}a. Soy profesor. \textquestiondown D\'{o}nde est\'{a}s
+ahora?\\
+--- Estoy en casa. Estoy un poco cansado, pero bien.
+\end{quote}
+
+Two verbs, one conversation: \emph{soy de} / \emph{soy profesor} (essence $\to$
+\emph{ser}), \emph{estoy en casa} / \emph{estoy cansado} (state $\to$
+\emph{estar}).
+
+What you built this chapter: \emph{ser}, the essence to-be ($\leftarrow$
+\emph{esse} $\to$ essence / present; suppletive \emph{soy $\cdot$ eres $\cdot$
+es $\cdot$ somos $\cdot$ son}, cousins of English \emph{is / am / are}),
+completing the pair begun with \emph{estar} in Chapter \ref{ch:how-are-you}
+$\cdot$ the \emph{ser}/\emph{estar} split read straight off the roots ---
+\emph{essence} (ser) vs \emph{estado}/standing (estar) --- with minimal pairs
+that flip meaning $\cdot$ \emph{soy de\ldots} (origin $\to$ ser; \emph{de}
+$\leftarrow$ \emph{d\={e}}) and \emph{est\'{a} en\ldots} (location $\to$ estar;
+\emph{en} $\leftarrow$ \emph{in}), plus the twin questions
+\emph{\textquestiondown De d\'{o}nde eres?} and
+\emph{\textquestiondown D\'{o}nde est\'{a}s?} Next chapter: the near future ---
+\emph{ir a} $+$ infinitive, ``going to\ldots'' --- and possessives.

--- a/code/learning/human-languages/spanish/book/chapters/ch10-ir-y-futuro.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch10-ir-y-futuro.tex
@@ -1,0 +1,215 @@
+\chapter{Going, and the Future You Can Already Say}
+\label{ch:ir-y-futuro}
+
+Three new powers: you can \emph{go} somewhere, you can talk about the
+\emph{future}, and you can say \emph{whose} something is. The future comes
+almost free --- Spanish builds tomorrow out of the verb ``to go,'' exactly as
+English does. \emph{Practice lessons: \texttt{lessons/ES-C10-*.md}.}
+
+\section{\emph{ir} --- ``to go,'' stitched from three verbs}
+\label{lesson:ir}
+
+\begin{sounds}
+\textbf{vowel-i} --- the infinitive \emph{ir} is just \emph{eer}: two letters,
+one of the shortest verbs in Spanish.\\[3pt]
+\textbf{diphthong-oy} --- \emph{voy} sounds like \emph{boy} (a \emph{b}/\emph{v}
+sound $+$ ``oy''), sharing the \emph{-oy} tail of \emph{soy}, \emph{estoy},
+\emph{doy}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{ir} (``to go'') is not one verb but \emph{three} Latin verbs collapsed
+into a single Spanish one.\\[3pt]
+\textbf{The infinitive \emph{ir}} $\leftarrow$ Latin \emph{\={i}re}, ``to go''
+$\to$ English \textbf{exit} (\emph{ex-\={i}re}, ``to go out''),
+\textbf{transit}, \textbf{ambition}.\\[3pt]
+\textbf{The present \emph{voy, vas, va, vamos, van}} $\leftarrow$ a different
+Latin verb, \emph{v\={a}dere}, ``to advance, to rush'' $\to$ English
+\textbf{invade}, \textbf{evade}, \textbf{wade}.\\[3pt]
+\textbf{The past \emph{fui}} (which comes later) $\leftarrow$ Latin
+\emph{esse}/\emph{fu\={i}}, ``to be'' --- the same \emph{fu-} that supplies the
+past of \emph{ser}.
+\end{cousinweb}
+
+So the present tense of ``to go'' does not come from the word \emph{ir} at all.
+It comes from \emph{v\={a}dere}:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Note \\
+\midrule
+yo & \emph{voy} & the \emph{-oy}, like \emph{soy}, \emph{estoy}, \emph{doy} \\
+t\'{u} & \emph{vas} & \\
+\'{e}l / ella / usted & \emph{va} & \\
+nosotros & \emph{vamos} & this is also ``let's go!'' \\
+ellos / ustedes & \emph{van} & \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{grammarlens}
+When a single verb draws its forms from more than one original verb, linguists
+call it \textbf{suppletion}. English does exactly this: \emph{go} in the
+present, but \emph{went} in the past --- and \emph{went} was borrowed from a
+completely different old verb, \emph{wend}. Spanish plays the same trick, only
+it does it \emph{inside} one tense: the infinitive from one Latin verb, the
+present from another, the past from a third.
+\end{grammarlens}
+
+\begin{grammarlens}
+\textbf{Pointing \emph{ir} at a destination.} Add \emph{a} (``to''
+$\leftarrow$ Latin \emph{ad}) and then the place:\\[3pt]
+\emph{\textbf{Voy a} Madrid.} --- ``I'm going to Madrid.''\\[3pt]
+\emph{\textbf{Vamos a} casa.} --- ``We're going home / Let's go home.''\\[3pt]
+When \emph{a} meets the masculine article \emph{el}, the two contract into
+\textbf{al}: \emph{voy al caf\'{e}}, ``I'm going to the caf\'{e}.''
+\end{grammarlens}
+
+\section{\emph{voy a} $+$ infinitive --- the ``going-to'' future}
+\label{lesson:ir-a-futuro}
+
+Here is a gift. Spanish builds its everyday future \emph{exactly} the way
+English does. English says ``I'm \textbf{going to} speak''; Spanish says
+\emph{\textbf{voy a} hablar}. Same verb, same metaphor --- so you get a whole
+tense for almost nothing.
+
+An \textbf{infinitive} is the dictionary form of a verb, the naming form: in
+English ``to speak,'' in Spanish \emph{hablar} (``to speak''), \emph{comer}
+(``to eat''), \emph{vivir} (``to live''). Take the present of \emph{ir}, add
+\emph{a}, then add any infinitive at all:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Spanish & English \\
+\midrule
+yo & \emph{voy a hablar} & ``I'm going to speak'' \\
+t\'{u} & \emph{vas a comer} & ``you're going to eat'' \\
+\'{e}l / ella / usted & \emph{va a estudiar} & ``she's going to study'' \\
+nosotros & \emph{vamos a vivir} & ``we're going to live'' \\
+ellos / ustedes & \emph{van a trabajar} & ``they're going to work'' \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Only \emph{ir} changes. The second verb stays a bare infinitive and is never
+conjugated --- just as English keeps ``to speak'' unchanged after ``going to.''
+
+\begin{grammarlens}
+\textbf{Why ``go'' becomes ``future.''} It is one of the most natural
+metaphors in human language: \emph{movement toward} something becomes
+\emph{time approaching} it. If you are \emph{going to} a place, you have not
+arrived --- the place is ahead of you --- so ``going to (do something)'' comes
+to mean ``about to, soon.'' French makes the same move (\emph{je vais parler},
+``I'm going to speak''), English makes it, Spanish makes it: three languages,
+one picture. Spanish even keeps the little \emph{a} (``to'' $\leftarrow$ Latin
+\emph{ad}) that English swallows in speech, where ``going to'' becomes
+``gonna.''
+\end{grammarlens}
+
+\section{\emph{mi}, \emph{tu}, \emph{su} --- my, your, his/her}
+\label{lesson:mi-tu-su}
+
+To say \emph{whose} something is, Spanish puts a small word in front of the
+noun: \emph{mi casa} (``my house''), \emph{tu caf\'{e}} (``your coffee'').
+These are called \textbf{possessives}, and they come straight from Latin.
+
+\begin{cousinweb}
+\textbf{mi} (``my'') $\leftarrow$ Latin \emph{meus} --- a genuine cousin of
+English \textbf{my} and \textbf{mine} (and \textbf{me}).\\[3pt]
+\textbf{tu} (``your,'' informal --- what belongs to a \emph{t\'{u}})
+$\leftarrow$ Latin \emph{tuus} --- the cousin of English \textbf{thy} and
+\textbf{thine}, the old intimate ``your'' that English retired.\\[3pt]
+\textbf{su} (``his / her / its / your-formal / their'') $\leftarrow$ Latin
+\emph{suus} --- the \emph{su-} that survives in the borrowed phrase
+\emph{sui generis}, ``of its own kind.''
+\end{cousinweb}
+
+Two things to notice.
+
+\begin{grammarlens}
+\textbf{\emph{tu} versus \emph{t\'{u}}.} The possessive \textbf{tu}
+(``your'') has \emph{no} accent; the pronoun \textbf{t\'{u}} (``you'') does.
+This is the same device you have seen elsewhere in the writing system ---
+\emph{el} versus \emph{\'{e}l}, \emph{si} versus \emph{s\'{i}}. The accent
+here is called the \emph{tilde diacr\'{i}tica}: it does no work for
+pronunciation, it only separates two look-alike words on the page.
+\end{grammarlens}
+
+\begin{culture}
+\textbf{\emph{su} does a great deal of work.} One little word covers
+\emph{his}, \emph{her}, \emph{its}, \emph{your-formal} and \emph{their} all at
+once, and context is normally enough to tell you which is meant. \emph{Su
+casa} can be ``his house,'' ``her house,'' ``your house'' (to an
+\emph{usted}), or ``their house.'' When it is genuinely unclear, Spanish spells
+it out afterwards: \emph{de \'{e}l} (``of him''), \emph{de ella} (``of her''),
+and so on.
+\end{culture}
+
+\begin{grammarlens}
+\textbf{They agree in number, not gender.} Unlike most Spanish modifiers,
+\emph{mi} / \emph{tu} / \emph{su} do \emph{not} change for masculine or
+feminine: \emph{mi casa} (feminine) and \emph{mi caf\'{e}} (masculine) both
+take plain \emph{mi}. They change only for \textbf{number} --- add \emph{-s}
+when the noun is plural.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Singular & Plural & English \\
+\midrule
+\emph{mi libro} & \emph{mis libros} & ``my book $\to$ my books'' \\
+\emph{tu casa} & \emph{tus casas} & ``your house $\to$ your houses'' \\
+\emph{su amigo} & \emph{sus amigos} & ``his friend $\to$ his friends'' \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+(\emph{nuestro} / \emph{nuestra}, ``our'' $\leftarrow$ Latin \emph{noster}, is
+the one possessive that \emph{does} flex for gender. You will meet it in full
+later.)
+
+\section{Practice --- going, planning, and possessing}
+\label{lesson:ch10-practice}
+
+No new words. Drill the irregular \emph{ir} until \emph{voy, vas, va, vamos,
+van} is automatic, because the whole future rides on it.
+
+\begin{itemize}
+\item \textbf{\emph{ir}, present:} \emph{voy} $\cdot$ \emph{vas} $\cdot$
+\emph{va} $\cdot$ \emph{vamos} $\cdot$ \emph{van} (from \emph{v\={a}dere} ---
+the \emph{-oy} of \emph{voy}, like \emph{soy}, \emph{estoy}, \emph{doy}).
+\item \textbf{The near future:} \emph{ir} $+$ \emph{a} $+$ infinitive ---
+\emph{voy a hablar}, \emph{vas a comer}, \emph{va a estudiar} (``I'm / you're /
+she's going to \ldots'').
+\item \textbf{Possessives:} \emph{mi} $\cdot$ \emph{tu} $\cdot$ \emph{su}, and
+their plurals \emph{mis} $\cdot$ \emph{tus} $\cdot$ \emph{sus} --- agreeing in
+number, not gender.
+\end{itemize}
+
+\begin{quote}\itshape
+--- \textquestiondown Qu\'{e} vas a hacer hoy?\\
+--- Voy a estudiar en mi casa, y luego voy a trabajar.
+\textquestiondown Y t\'{u}?\\
+--- Voy a comer con mis amigos. Vamos a un caf\'{e}.
+\end{quote}
+
+Three threads run through those four lines: \emph{voy a estudiar} and
+\emph{voy a comer} are the near future (\emph{ir} $+$ \emph{a} $+$ infinitive);
+\emph{mi casa} and \emph{mis amigos} are the possessives, one singular and one
+plural; \emph{vamos a un caf\'{e}} is plain \emph{ir a} $+$ a place.
+
+What you built: \emph{ir}, ``to go,'' the most suppletive verb in Spanish
+(infinitive $\leftarrow$ \emph{\={i}re}; present \emph{voy}/\emph{vas}/\emph{va}/%
+\emph{vamos}/\emph{van} $\leftarrow$ \emph{v\={a}dere} $\to$ invade, evade),
+the same \emph{go}/\emph{went} trick English plays $\cdot$ the near future,
+\emph{ir a} $+$ infinitive (\emph{voy a hablar} $=$ ``I'm going to speak''),
+Spanish making tomorrow out of the verb ``to go'' exactly as English and French
+do $\cdot$ \emph{mi} / \emph{tu} / \emph{su} ($\leftarrow$ \emph{meus} /
+\emph{tuus} / \emph{suus} $\to$ my / thy), possessives that agree in number
+(\emph{mis} / \emph{tus} / \emph{sus}) and not gender, plus \emph{tu}
+(``your'') against \emph{t\'{u}} (``you''), the accent doing its quiet work
+again. Next chapter takes these rules further --- from here on the course runs
+on grammar, not phrases.

--- a/code/learning/human-languages/spanish/book/chapters/ch11-stem-changes.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch11-stem-changes.tex
@@ -1,0 +1,278 @@
+\chapter{Verbs That Break in the Middle --- the Stem Changers}
+\label{ch:stem-changes}
+
+Two power-verbs --- \emph{querer} (``to want'') and \emph{poder} (``can'') ---
+crack their own vowels when you conjugate them. This chapter shows why: one
+ancient sound-law, two vowels, and a boot-shaped pattern you can predict. It
+closes with \emph{nuestro}, ``our,'' which carries the very same crack.
+\emph{Practice lessons: \texttt{lessons/ES-C11-*.md}.}
+
+\section{\emph{querer} --- ``to want,'' and the \emph{e}$\to$\emph{ie} crack}
+\label{lesson:querer}
+
+\begin{sounds}
+\textbf{diphthong-ie} --- under stress the stem breaks open into \emph{-ie-}:
+\emph{quiero} is said \emph{KYE-ro}, one gliding syllable, not \emph{kee-EH-ro}.\\[3pt]
+\textbf{r-tap} --- the \emph{r} of \emph{querer} is a single flicked tap of the
+tongue, like the middle of American \emph{butter}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{querer} (``to want''; of a person, ``to love'') $\leftarrow$ Latin
+\emph{quaerere}, ``to seek, to ask, to want.'' Seeking and wanting are the same
+impulse at the root --- and that root is a treasure-house of English.\\[3pt]
+\textbf{The plain seeking words:} \textbf{quer}y, \textbf{quest},
+\textbf{quest}ion --- each one a seeking.\\[3pt]
+\textbf{With prefixes:} in\textbf{quire} (\emph{in-}, ``into''),
+re\textbf{quire} (\emph{re-}, ``back''), ac\textbf{quire} (\emph{ad-},
+``toward''), con\textbf{quer} (\emph{con-}, ``thoroughly seek/win''),
+ex\textbf{quis}ite (``sought out''), \textbf{quor}um (``of whom'' the seeking
+needs enough).
+\end{cousinweb}
+
+So when you say \emph{quiero}, you are using the same ``seek'' root as
+\textbf{question} and \textbf{conquer}.
+
+\begin{grammarlens}
+A \textbf{stem} is the part of a verb left when you strip the ending: in
+\emph{querer}, the stem is \emph{quer-} and the ending is \emph{-er}. A
+\textbf{stem-changing verb} is one whose stem vowel changes when the stress
+lands on it. In \emph{querer} that stressed \emph{e} breaks into \emph{ie}.\\[3pt]
+Only \emph{queremos} keeps the plain \emph{e}, because there the stress falls on
+the ending, not on the stem. Shade in the forms that do change --- \emph{yo},
+\emph{t\'{u}}, \emph{\'{e}l/ella/usted}, \emph{ellos/ustedes} --- and they draw
+a \textbf{boot} shape around the \emph{nosotros}/\emph{vosotros} gap. That boot
+is the signature of every stem-changer.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Vowel \\
+\midrule
+yo & \emph{quiero} & \emph{e} $\to$ \emph{ie} \\
+t\'{u} & \emph{quieres} & \emph{e} $\to$ \emph{ie} \\
+\'{e}l / ella / usted & \emph{quiere} & \emph{e} $\to$ \emph{ie} \\
+nosotros & \emph{queremos} & plain \emph{e} --- unstressed \\
+ellos / ustedes & \emph{quieren} & \emph{e} $\to$ \emph{ie} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Say it out loud until the crack is automatic: \emph{quiero} $\cdot$
+\emph{quieres} $\cdot$ \emph{quiere} $\cdot$ \emph{queremos} $\cdot$
+\emph{quieren}. Then put it to work: \emph{Quiero un caf\'{e}} (``I want a
+coffee''), \emph{Quiero caf\'{e}, por favor}.
+
+\section{\emph{poder} --- ``to be able,'' and the \emph{o}$\to$\emph{ue} crack}
+\label{lesson:poder}
+
+\begin{sounds}
+\textbf{diphthong-ue} --- under stress the stem breaks to \emph{-ue-}, with a
+\emph{w}-glide: \emph{puedo} is said \emph{PWE-do}.\\[3pt]
+\textbf{r-tap} --- again one flicked tap for the \emph{r} of \emph{poder}.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{poder} (``to be able / can'') $\leftarrow$ Latin \emph{pot\={e}re}
+(from \emph{posse}), ``to be able, to have power.'' It is literally the verb
+\emph{power}.\\[3pt]
+\textbf{power} itself --- English took it through Old French \emph{poeir}
+$\leftarrow$ \emph{pot\={e}re}.\\[3pt]
+\textbf{pot}ent, \textbf{pot}ential, omni\textbf{pot}ent (``all-powerful''),
+\textbf{poss}ible (``able to be''), \textbf{poss}e (``[those] able'' to be
+summoned).
+\end{cousinweb}
+
+So \emph{puedo} and \textbf{power} are the same word --- one a Spanish verb, the
+other its English noun.
+
+\begin{grammarlens}
+\emph{poder} is a stem-changer of the \emph{o}$\to$\emph{ue} kind: the stressed
+stem \emph{o} breaks to \emph{ue}, in exactly the same \textbf{boot} shape ---
+every form but \emph{nosotros}/\emph{vosotros}. Just as with \emph{querer}, only
+the \emph{nosotros} form keeps the plain vowel. Other \emph{o}$\to$\emph{ue}
+verbs you will meet: \emph{dormir} (``sleep'') $\to$ \emph{duermo},
+\emph{volver} (``return'') $\to$ \emph{vuelvo}.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Vowel \\
+\midrule
+yo & \emph{puedo} & \emph{o} $\to$ \emph{ue} \\
+t\'{u} & \emph{puedes} & \emph{o} $\to$ \emph{ue} \\
+\'{e}l / ella / usted & \emph{puede} & \emph{o} $\to$ \emph{ue} \\
+nosotros & \emph{podemos} & plain \emph{o} --- unstressed \\
+ellos / ustedes & \emph{pueden} & \emph{o} $\to$ \emph{ue} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{grammarlens}
+\textbf{\emph{poder} $+$ infinitive.} An \textbf{infinitive} is the naming form
+of a verb --- the one that ends in \emph{-ar}, \emph{-er}, or \emph{-ir}
+(\emph{hablar}, ``to speak''). Point \emph{poder} at an infinitive and you say
+what you are \emph{able} to do:\\[3pt]
+\emph{\textbf{Puedo hablar} espa\~{n}ol.} --- ``I can speak Spanish.''\\[3pt]
+\emph{\textquestiondown \textbf{Puedes} venir?} --- ``Can you come?''\\[3pt]
+\emph{\textbf{No puedo.}} --- ``I can't.''
+\end{grammarlens}
+
+\section{\emph{e}$\to$\emph{ie} and \emph{o}$\to$\emph{ue} --- one rule, two vowels}
+\label{lesson:stem-changes}
+
+You have now seen both cracks: \emph{querer} $\to$ \emph{quiero}
+(\emph{e}$\to$\emph{ie}) and \emph{poder} $\to$ \emph{puedo}
+(\emph{o}$\to$\emph{ue}). They are not two random quirks. They are \emph{one
+sound-law}, and knowing it turns a ``memorize each verb'' chore into a pattern
+you can predict.
+
+\begin{cousinweb}
+\textbf{The law:} in the leap from Latin to Spanish, a \textbf{short, stressed
+\emph{e}} broke into \textbf{ie}, and a \textbf{short, stressed \emph{o}} broke
+into \textbf{ue}. It happened in ordinary nouns, not just verbs.\\[3pt]
+\emph{terra} $\to$ \emph{tierra} (``earth'') --- \emph{e} $\to$ \emph{ie}\\[3pt]
+\emph{septem} $\to$ \emph{siete} (``seven'') --- \emph{e} $\to$ \emph{ie}\\[3pt]
+\emph{porta} $\to$ \emph{puerta} (``door'') --- \emph{o} $\to$ \emph{ue}\\[3pt]
+\emph{novem} $\to$ \emph{nueve} (``nine'') --- \emph{o} $\to$ \emph{ue}\\[3pt]
+The numbers \emph{siete} and \emph{nueve} carry that glide for exactly this
+reason.
+\end{cousinweb}
+
+\begin{grammarlens}
+In verbs, the stem vowel is stressed in the ``boot'' forms and unstressed in
+\emph{nosotros}/\emph{vosotros} --- so it breaks inside the boot and stays plain
+outside it. That single fact explains both patterns at once.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & \emph{e}$\to$\emph{ie} (\emph{querer}) & \emph{o}$\to$\emph{ue} (\emph{poder}) \\
+\midrule
+yo & \emph{quiero} & \emph{puedo} \\
+t\'{u} & \emph{quieres} & \emph{puedes} \\
+\'{e}l / ella / usted & \emph{quiere} & \emph{puede} \\
+\textbf{nosotros} & \emph{queremos} & \emph{podemos} \\
+ellos / ustedes & \emph{quieren} & \emph{pueden} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Same shape both times: the four ``corner'' forms crack, the \emph{nosotros} form
+stays plain --- the boot. The verb \emph{tener} ($\to$ \emph{tienes}), met
+earlier, was your first taste of it; now you own the whole rule.
+
+\section{\emph{nuestro} --- ``our,'' the possessive that agrees fully}
+\label{lesson:nuestro}
+
+\begin{cousinweb}
+\textbf{nuestro} (``our'') $\leftarrow$ Latin \emph{noster}, ``our.'' You have
+heard it without knowing: the \textbf{Paternoster} is the ``\emph{Our} Father,''
+and a \textbf{nostrum} is literally ``\emph{our} thing'' --- a quack's secret
+remedy.\\[3pt]
+Its partner \textbf{vuestro} (``your,'' said to a group) $\leftarrow$ Latin
+\emph{voster}/\emph{vester}.\\[3pt]
+\textbf{The stem-change fossil:} \emph{noster} $\to$ \emph{nuestro} shows the
+very \emph{o}$\to$\emph{ue} break you just learned --- short stressed \emph{o}
+$\to$ \emph{ue}. The possessive cracks exactly like \emph{puerta} and
+\emph{puedo}.
+\end{cousinweb}
+
+\begin{grammarlens}
+A \textbf{possessive} marks who owns the thing. The possessives \emph{mi}
+(``my''), \emph{tu} (``your''), \emph{su} (``his/her/your-formal'') change only
+for \textbf{number}: \emph{mis}, \emph{tus}, \emph{sus}. \emph{nuestro} is
+different --- it agrees in \textbf{both gender and number}, like an ordinary
+\emph{-o}/\emph{-a} adjective, so it has \textbf{four} forms instead of two. It
+is the fullest-flexing of the possessives, and \emph{vuestro} does the same
+(\emph{vuestro}, \emph{vuestra}, \emph{vuestros}, \emph{vuestras}).
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+ & singular & plural \\
+\midrule
+masculine & \emph{nuestro libro} & \emph{nuestros libros} \\
+feminine & \emph{nuestra casa} & \emph{nuestras casas} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+So it is \emph{nuestro coche} (``our car,'' masculine) but \emph{nuestra casa}
+(``our house,'' feminine) --- you match the noun in both gender and number, just
+as with \emph{bueno}/\emph{buena}/\emph{buenos}/\emph{buenas}. Say the full set
+aloud: \emph{nuestro} $\cdot$ \emph{nuestra} $\cdot$ \emph{nuestros} $\cdot$
+\emph{nuestras}, then attach nouns --- \emph{nuestro coche}, \emph{nuestra
+casa}, \emph{nuestros amigos}.
+
+\section{Practice --- wanting, being able, and the boot}
+\label{lesson:ch11-practice}
+
+Two power-verbs and a rule: \emph{querer} (want, \emph{e}$\to$\emph{ie}),
+\emph{poder} (can, \emph{o}$\to$\emph{ue}), and the stem-change boot that shapes
+them both --- plus \emph{nuestro}, the fully-agreeing ``our.'' Drill the cracks
+until \emph{quiero} and \emph{puedo} come without thinking.
+
+\medskip
+\noindent\textbf{Conjugate both boots, out loud.}
+\emph{querer} (\emph{e}$\to$\emph{ie}): \emph{quiero} $\cdot$ \emph{quieres}
+$\cdot$ \emph{quiere} $\cdot$ \emph{queremos} $\cdot$ \emph{quieren} --- only
+\emph{queremos} stays plain. \emph{poder} (\emph{o}$\to$\emph{ue}):
+\emph{puedo} $\cdot$ \emph{puedes} $\cdot$ \emph{puede} $\cdot$ \emph{podemos}
+$\cdot$ \emph{pueden} --- only \emph{podemos} stays plain.
+
+\medskip
+\noindent\textbf{Chain the verbs} (want to / can $+$ infinitive):
+
+\begin{quote}\itshape
+Quiero hablar espa\~{n}ol. --- ``I want to speak Spanish.''\\
+Puedo hablar un poco. --- ``I can speak a little.''\\
+\textquestiondown Quieres comer? --- ``Do you want to eat?''\\
+\textquestiondown Puedes venir? --- ``Can you come?''\\
+Vamos a poder. --- ``We're going to be able to.''
+\end{quote}
+
+\medskip
+\noindent\textbf{\emph{nuestro}, agreeing:} \emph{nuestra casa} (feminine),
+\emph{nuestro coche} (masculine), \emph{nuestros amigos} (masculine plural) ---
+match gender \emph{and} number, unlike \emph{mi}/\emph{tu}/\emph{su}.
+
+\medskip
+\noindent\textbf{Say something real:}
+
+\begin{quote}\itshape
+--- \textquestiondown Qu\'{e} quieres hacer?\\
+--- Quiero ir a un caf\'{e} con nuestros amigos. \textquestiondown Puedes
+venir?\\
+--- S\'{i}, puedo. Podemos ir ahora.
+\end{quote}
+
+Every tool of the chapter is in there: \emph{quiero} (want,
+\emph{e}$\to$\emph{ie}), \emph{puedes}/\emph{puedo}/\emph{podemos} (can,
+\emph{o}$\to$\emph{ue}), \emph{nuestros} (our, agreeing), and the near future
+\emph{ir a}.
+
+\begin{culture}
+\emph{querer} does double duty: aimed at a thing it means ``to want,'' but aimed
+at a person it means ``to love.'' \emph{Te quiero} is one of the warmest things
+one Spanish speaker can say to another --- the same verb that orders a coffee.
+The seeking root never left: to want someone and to seek someone are one word.
+\end{culture}
+
+\medskip
+\noindent\textbf{What you have built this chapter:} \emph{querer} (want,
+$\leftarrow$ \emph{quaerere} ``seek'' $\to$ \textbf{quer}y / \textbf{quest} /
+con\textbf{quer}), the \emph{e}$\to$\emph{ie} stem-changer; \emph{poder} (can,
+$\leftarrow$ \emph{pot\={e}re} $\to$ \textbf{power} / \textbf{pot}ent /
+\textbf{poss}ible), the \emph{o}$\to$\emph{ue} stem-changer, plus \emph{poder}
+$+$ infinitive for ability; \textbf{the boot} --- one sound-law (short stressed
+\emph{e}$\to$\emph{ie}, \emph{o}$\to$\emph{ue}; \emph{tierra}, \emph{puerta})
+cracking all forms but \emph{nosotros}/\emph{vosotros}; and
+\emph{nuestro}/\emph{vuestro} ($\leftarrow$ \emph{noster}/\emph{voster} $\to$
+\textbf{Paternoster}), the possessive that agrees in gender \emph{and} number,
+four forms. The next chapter carries the grammar forward --- the course now runs
+on rules.

--- a/code/learning/human-languages/spanish/book/chapters/ch12-yo-go-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch12-yo-go-verbs.tex
@@ -1,0 +1,239 @@
+\chapter{\emph{Hacer}, \emph{Decir}, and the \emph{-go} Verb Club}
+\label{ch:yo-go-verbs}
+
+Two workhorse verbs --- one for \emph{doing} and \emph{making}, one for
+\emph{saying} --- and the strange little club they belong to, where the ``I''
+form grows a hard \emph{g} out of nowhere. Learn the club once and six of the
+language's most-used verbs stop being surprises.
+\emph{Practice lessons: \texttt{lessons/ES-C12-*.md}.}
+
+\section{\emph{hacer} --- ``to do / to make,'' and the \emph{yo}-form that grows a \emph{g}}
+\label{lesson:hacer}
+
+English splits the work between two verbs: you \emph{do} homework but you
+\emph{make} coffee. Spanish uses one verb for both --- \textbf{hacer}. It is one
+of the language's workhorses, and it hides two patterns worth naming.
+
+\begin{cousinweb}
+\textbf{hacer} (``to do, to make'') $\leftarrow$ Latin \emph{facere} (``to do,
+to make''). Spanish softened the Latin \emph{f-} into an \emph{h-} that is now
+completely silent --- the same change that turned \emph{fabul\={a}r\={\i}} into
+\emph{hablar} (``to speak'') and \emph{filium} into \emph{hijo}
+(``son'').\\[3pt]
+\textbf{The English family from \emph{facere} is enormous:} \textbf{fact} (``a
+thing done''), \textbf{factory} (``a place of making''), \textbf{manufacture}
+(``made by hand''), \textbf{feat}, \textbf{feature}.\\[3pt]
+\textbf{With prefixes:} \textbf{affect} and \textbf{effect} (\emph{ad-} and
+\emph{ex-} $+$ \emph{fac-}), \textbf{perfect} (``thoroughly done''),
+\textbf{satisfy} (``make enough''), \textbf{difficult} (``not easy to do''),
+\textbf{benefit} (``do well'').\\[3pt]
+So \emph{hacer} and \textbf{factory} are the same ``make'' root --- one worn
+down inside Spanish, one kept crisp on its way into English through Latin.
+\end{cousinweb}
+
+\begin{sounds}
+The \emph{h} in \emph{hacer} is \textbf{silent}. Say it \emph{a-THER} (Spain) or
+\emph{a-SER} (Latin America) --- never with an English \emph{h} sound. That
+silent \emph{h} is the ghost of the Latin \emph{f}: the letter stayed on the
+page long after the sound left the mouth.
+\end{sounds}
+
+\begin{grammarlens}
+\emph{hacer} behaves normally through most of the present tense --- but the
+\emph{yo} (``I'') form is irregular: it grows a \textbf{g}, giving
+\textbf{hago}. This is not a one-off. It is the same move you saw in
+\emph{tener} $\to$ \emph{tengo}: a small, very high-frequency club of
+``\emph{-go}'' verbs.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Note \\
+\midrule
+yo (I) & \textbf{hago} & irregular --- grows a \emph{g} \\
+t\'{u} (you, informal) & haces & regular \\
+\'{e}l / ella / usted (he, she, you-formal) & hace & regular \\
+nosotros (we) & hacemos & regular \\
+ellos / ustedes (they, you-plural) & hacen & regular \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The \emph{g} appears in \emph{hago} and nowhere else.
+\end{grammarlens}
+
+\begin{culture}
+\textbf{The weather is something Spanish \emph{makes}.} Where English says ``it
+is hot,'' Spanish says \emph{hace calor} --- literally ``it makes heat.'' So
+too \emph{hace fr\'{i}o} (``it's cold,'' ``it makes cold'') and \emph{hace sol}
+(``it's sunny,'' ``it makes sun''). And the all-purpose everyday question:
+\emph{\textquestiondown Qu\'{e} haces?} --- ``What are you doing?''
+\end{culture}
+
+\section{\emph{decir} --- ``to say,'' the verb with two irregularities at once}
+\label{lesson:decir}
+
+\textbf{decir} (``to say / to tell'') is the trickiest verb so far --- and the
+most instructive, because it stacks \emph{two} separate patterns onto one word:
+the \emph{-go} ending you just met in \emph{hago}, and a change inside the stem
+(the part of the verb before the ending). Learn \emph{decir} and the whole
+system clicks together.
+
+\begin{cousinweb}
+\textbf{decir} (``to say, to tell'') $\leftarrow$ Latin \emph{d\={\i}cere} (``to
+say, to tell, to point out''). Its root \emph{dic-} / \emph{dict-} (``say'')
+runs straight through English.\\[3pt]
+\textbf{Plain:} \textbf{dictate}, \textbf{diction}, \textbf{dictionary},
+\textbf{dictaphone} --- every one of them about \emph{saying}.\\[3pt]
+\textbf{With prefixes:} \textbf{predict} (``say beforehand''),
+\textbf{contradict} (``say against''), \textbf{verdict} (``a true saying''),
+\textbf{indicate} (``point out''), \textbf{dedicate}, \textbf{edict},
+\textbf{index}.\\[3pt]
+So \emph{decir} is the ``say'' root sitting inside \textbf{dictionary} itself
+--- the book of what words \emph{say}.
+\end{cousinweb}
+
+\begin{sounds}
+In \emph{decir} the stressed stem vowel \emph{e} does \emph{not} break into two
+vowels. Instead it \textbf{closes to \emph{i}}: \emph{digo}, \emph{dices},
+\emph{dice}. Keep it a single tight \emph{ee} sound --- no glide, no second
+vowel.
+\end{sounds}
+
+\begin{grammarlens}
+\textbf{Irregularity one: the \emph{-go} \emph{yo}-form.} Exactly like
+\emph{hago} and \emph{tengo}, the ``I'' form grows a \emph{g}: \textbf{digo}.
+
+\textbf{Irregularity two: the stem change \emph{e} $\to$ \emph{i}.} In the
+forms where the stress lands on the stem, that \emph{e} closes to \emph{i} ---
+a tighter shift than the \emph{e} $\to$ \emph{ie} of \emph{querer}.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Note \\
+\midrule
+yo (I) & \textbf{digo} & \emph{-go} form; stem also $\to$ \emph{i} \\
+t\'{u} (you, informal) & \textbf{dices} & \emph{e} $\to$ \emph{i} \\
+\'{e}l / ella / usted (he, she, you-formal) & \textbf{dice} & \emph{e} $\to$ \emph{i} \\
+nosotros (we) & decimos & plain \emph{e} --- unstressed \\
+ellos / ustedes (they, you-plural) & \textbf{dicen} & \emph{e} $\to$ \emph{i} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The \textbf{boot} shape returns: draw a line around the changed forms on the
+table and they make a boot, with \emph{decimos} standing outside it. Only
+\emph{decimos} keeps the plain \emph{e}, because there the stress falls on the
+ending rather than the stem. Everything inside the boot shifts to \emph{i} ---
+and the \emph{yo} corner carries the \emph{-go} on top of that.
+\end{grammarlens}
+
+\begin{culture}
+\textbf{The single most useful question a learner owns:}
+\emph{\textquestiondown C\'{o}mo se dice \ldots ?} --- ``How do you say
+\ldots ?'' It lets you build your own vocabulary out loud, from anyone, forever.
+Its close companion is \emph{dime} --- ``tell me.''
+\end{culture}
+
+\section{The \emph{-go} club --- one irregular corner, many verbs}
+\label{lesson:yo-go}
+
+You have now met three verbs whose \emph{yo}-form ends in a surprising
+\emph{-go}: \emph{tener} $\to$ \textbf{tengo}, \emph{hacer} $\to$
+\textbf{hago}, \emph{decir} $\to$ \textbf{digo}. That is not three
+coincidences --- it is a \textbf{club}. Learn the membership once and you never
+have to re-learn the shape.
+
+\begin{grammarlens}
+Most Spanish verbs build a tidy \emph{yo}-form: \emph{hablo} (``I speak''),
+\emph{como} (``I eat''), \emph{vivo} (``I live''). But a small set of very
+common verbs \textbf{grow a hard \emph{g}} in the \emph{yo}-form only. The rest
+of the present tense behaves normally.
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+Verb & Meaning & \emph{yo}-form & Met it? \\
+\midrule
+\textbf{tener} & to have & \textbf{tengo} & yes --- Chapter 8 \\
+\textbf{hacer} & to do / to make & \textbf{hago} & yes --- this chapter \\
+\textbf{decir} & to say & \textbf{digo} & yes --- this chapter \\
+\textbf{poner} & to put & \textbf{pongo} & coming \\
+\textbf{salir} & to leave / go out & \textbf{salgo} & coming \\
+\textbf{venir} & to come & \textbf{vengo} & coming \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Three you know, three still to come --- and every one follows the same rule:
+\textbf{\emph{-go} in the \emph{yo}-form, regular elsewhere}, with any
+stem-change stacked on top, as in \emph{digo}.
+\end{grammarlens}
+
+\begin{culture}
+\textbf{Why the \emph{g}? A Latin fossil.} The \emph{g} is an inheritance.
+Latin's first-person forms and old sound-laws left a \textbf{velar} sound --- a
+\emph{g} or \emph{k} made at the back of the mouth --- clinging to these
+particular verbs, and Spanish tidied it into a clean \emph{-go}. You do not need
+the history to use them, but it explains why the club is old and closed: these
+are among the \emph{most-used verbs in the language}, and the oldest,
+most-used words are exactly the ones that keep their irregularities. English
+does the same thing --- \textbf{am} / \textbf{was}, \textbf{go} / \textbf{went}.
+\end{culture}
+
+\section{Practice --- doing, making, saying}
+\label{lesson:ch12-practice}
+
+This chapter added two workhorse verbs --- \emph{hacer} (``do / make'') and
+\emph{decir} (``say'') --- and the \emph{-go} club that unites their
+\emph{yo}-forms with \emph{tengo}. Time to make them automatic.
+
+\textbf{Drill 1 --- the \emph{-go} \emph{yo}-forms.} Say the \emph{yo}-form for
+each, then the \emph{t\'{u}}-form, which drops the \emph{g}:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Verb & \emph{yo} & \emph{t\'{u}} \\
+\midrule
+\emph{hacer} & \textbf{hago} & \textbf{haces} \\
+\emph{decir} & \textbf{digo} & \textbf{dices} (mind the \emph{e} $\to$ \emph{i}) \\
+\emph{tener} & \textbf{tengo} & \textbf{tienes} (mind the \emph{e} $\to$ \emph{ie}) \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+What do all three \emph{yo}-forms share? The \emph{-go}. And what happens to it
+in the \emph{t\'{u}}-form? It \emph{drops} --- the \emph{-go} is
+\emph{yo}-only.
+
+\textbf{Drill 2 --- say the full present.} Run each verb top to bottom:
+\emph{hacer}: hago $\cdot$ haces $\cdot$ hace $\cdot$ hacemos $\cdot$ hacen.
+\emph{decir}: digo $\cdot$ dices $\cdot$ dice $\cdot$ decimos $\cdot$ dicen ---
+the boot again, with only \emph{decimos} keeping the plain \emph{e}.
+
+\textbf{Drill 3 --- put it to use.} Say each one out loud:
+
+\begin{quote}\itshape
+\textquestiondown Qu\'{e} haces? --- ``What are you doing?''\\
+Hago la tarea. --- ``I'm doing the homework.''\\
+\textquestiondown C\'{o}mo se dice ``window''? --- ``How do you say
+`window'?''\\
+Hace fr\'{i}o hoy. --- ``It's cold today'' (weather with \emph{hacer} --- ``it
+makes cold'').
+\end{quote}
+
+\textbf{Drill 4 --- the root families.} Name an English cousin from the same
+Latin root: \emph{hacer} $\leftarrow$ \emph{facere} $\to$ \textbf{fact},
+\textbf{factory}, \textbf{perfect}, \textbf{manufacture} --- any of them.
+\emph{decir} $\leftarrow$ \emph{d\={\i}cere} $\to$ \textbf{dictate},
+\textbf{diction}, \textbf{predict}, \textbf{verdict} --- any of them.
+
+\textbf{Recall.} Give the \emph{yo}-forms of \emph{hacer}, \emph{decir}, and
+\emph{tener} (\emph{hago}, \emph{digo}, \emph{tengo} --- the \emph{-go} club).
+In \emph{decir}, which form escapes the \emph{e} $\to$ \emph{i} boot, and why?
+(\emph{decimos} --- the stress falls on the ending.) How does Spanish say ``it's
+hot''? (\emph{Hace calor}.) You can now \emph{do}, \emph{make}, and \emph{say}
+in Spanish --- and you have seen that the language's most irregular verbs are
+its most-used, oldest words.

--- a/code/learning/human-languages/spanish/book/chapters/ch13-completing-go-club.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch13-completing-go-club.tex
@@ -1,0 +1,222 @@
+\chapter{\emph{Poner}, \emph{Salir}, \emph{Venir} --- Completing the \emph{-go} Club}
+\label{ch:completing-go-club}
+
+Three verbs remain in the small club of Spanish verbs whose \emph{I} form grows
+an extra \textbf{g}: \emph{pongo}, \emph{salgo}, \emph{vengo}. They hide a
+Latin ``place'' root, a Latin ``leap'' root, and a Latin ``come'' root --- and
+the last of them stacks \emph{two} irregularities at once.
+\emph{Practice lessons: \texttt{lessons/ES-C13-*.md}.}
+
+\section{\emph{poner} --- ``to put,'' and the club gains a member}
+\label{lesson:poner}
+
+\begin{cousinweb}
+\textbf{poner} (``to put / to place'') $\leftarrow$ Latin \emph{p\={o}nere},
+``to put, to place, to set down.'' Its stem \emph{pon-}/\emph{pos-}
+(``place'') is one of the busiest roots in English.\\[3pt]
+\textbf{Bare:} \textbf{pos}ition, \textbf{pose}, \textbf{pos}it --- each one a
+\emph{placing}.\\[3pt]
+\textbf{With prefixes:} com\textbf{pose} (``place together''),
+de\textbf{posit} (``place down''), ex\textbf{pose} (``place out''),
+op\textbf{pose} / op\textbf{ponent} (``place against''), pro\textbf{pose}
+(``place forward''), post\textbf{pone} (``place after''),
+com\textbf{ponent}.\\[3pt]
+So \emph{poner} and \textbf{position} share the same ``place'' root --- when
+you \emph{poner} something, you are putting it in its \emph{p\={o}nere}.
+\end{cousinweb}
+
+\begin{grammarlens}
+A verb's \textbf{infinitive} is its plain naming form (``to put''), and Spanish
+infinitives end in \emph{-ar}, \emph{-er}, or \emph{-ir}. \emph{poner} is an
+\emph{-er} verb, and it behaves like a perfectly regular one \emph{everywhere
+except} the \emph{yo} (``I'') form, which grows a \textbf{g}: \textbf{pongo}.
+That single odd corner is what marks a verb as a member of the \emph{-go}
+club, alongside \emph{tengo} (``I have''), \emph{hago} (``I do/make''), and
+\emph{digo} (``I say'').
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Note \\
+\midrule
+yo (I) & \textbf{pongo} & \emph{-go}, like \emph{tengo} \\
+t\'{u} (you, informal) & pones & regular \\
+\'{e}l / ella / usted & pone & regular \\
+nosotros (we) & ponemos & regular \\
+ellos / ustedes & ponen & regular \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{sounds}
+The \emph{g} in \textbf{pongo} is a \emph{hard} \emph{g}, as in English
+\emph{go} --- never the soft \emph{g} of English \emph{gem}. The same hard
+\emph{-go} you hear in \emph{tengo}.
+\end{sounds}
+
+\begin{culture}
+The everyday payoff: \emph{poner la mesa} (``to set the table''), \emph{poner
+m\'{u}sica} (``to put on music''), and the reflexive \emph{ponerse} --- ``to
+put on (clothes)'' or ``to become'': \emph{me pongo nervioso}, ``I get
+nervous.'' One verb covers setting, playing, dressing, and becoming.
+\end{culture}
+
+\section{\emph{salir} --- ``to go out,'' from a verb that meant ``to leap''}
+\label{lesson:salir}
+
+\begin{cousinweb}
+\textbf{salir} (``to leave, to go out'') $\leftarrow$ Latin \emph{sal\={\i}re},
+``to leap, to jump, to spring.'' Over time ``leaping out'' softened into
+simply ``going out'' --- but the leap survives all across English.\\[3pt]
+\textbf{Bare:} \textbf{sali}ent (``leaping out,'' so: prominent, sticking
+out), \textbf{sally} (``a sudden rush out''), \textbf{somersault}
+(\emph{sopra} $+$ \emph{saltus}, ``a leap over'').\\[3pt]
+\textbf{With prefixes:} as\textbf{sail} / as\textbf{sault} (``leap at''),
+re\textbf{sili}ent (``leap back''), re\textbf{sult} (``leap back out''),
+in\textbf{sult} (``leap upon'').\\[3pt]
+\textbf{And a fish:} \emph{sal\={\i}re} gave Latin \emph{salm\={o}}, ``the
+\emph{leaper},'' for the \textbf{salmon} that leaps upstream.\\[3pt]
+So every time you say \emph{salgo} (``I go out''), you are using the old
+\emph{leap} verb behind \textbf{salient} and \textbf{salmon}.
+\end{cousinweb}
+
+\begin{grammarlens}
+\emph{salir} is an \emph{-ir} verb, and the story is exactly \emph{poner}'s:
+regular everywhere but the \emph{yo} form, which grows the \textbf{g} ---
+\textbf{salgo}.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Note \\
+\midrule
+yo (I) & \textbf{salgo} & \emph{-go}, like \emph{pongo} / \emph{tengo} \\
+t\'{u} (you, informal) & sales & regular \\
+\'{e}l / ella / usted & sale & regular \\
+nosotros (we) & salimos & regular \\
+ellos / ustedes & salen & regular \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{culture}
+\emph{salir de casa} is ``to leave the house''; \emph{salir con alguien} is
+``to go out with someone'' --- that is, to date. And \emph{la salida} is
+``the \textbf{exit}'' --- the sign you will read at every station. Note that
+English \emph{exit} comes from a \emph{different} Latin verb, \emph{ex\={\i}re}
+(``go out''); Spanish chose the \emph{leaping} one instead.
+\end{culture}
+
+\section{\emph{venir} --- ``to come,'' cracked \emph{and} g-grown}
+\label{lesson:venir}
+
+\begin{cousinweb}
+\textbf{venir} (``to come'') $\leftarrow$ Latin \emph{ven\={\i}re}, ``to
+come.'' Its root \emph{ven-}/\emph{vent-} comes \emph{toward} English from
+every direction:\\[3pt]
+\textbf{ad}\textbf{vent}ure (\emph{ad-ven\={\i}re}, ``what \emph{comes to}
+you''), e\textbf{vent} (``what comes out''), con\textbf{vene} /
+con\textbf{vent}ion (``come together''), in\textbf{vent} (``come upon''),
+pre\textbf{vent} (``come before''), inter\textbf{vene}, re\textbf{venue}
+(``what \emph{comes back}''), a\textbf{venue} (``a coming-toward''), and
+\textbf{souvenir} (from French, ``a thing that \emph{comes to mind}'').
+\end{cousinweb}
+
+\begin{grammarlens}
+\emph{venir} is \textbf{doubly irregular} --- it stacks two changes at
+once.\\[3pt]
+\textbf{(1) The \emph{-go} \emph{yo} form}, like \emph{pongo} / \emph{salgo} /
+\emph{tengo}: \textbf{vengo}.\\[3pt]
+\textbf{(2) The \emph{e} $\to$ \emph{ie} stem-change.} The \textbf{stem} is
+the part of the verb before the ending --- here \emph{ven-}. When the stress
+of the word falls on that stem, its \emph{e} breaks apart into \emph{ie}:
+\emph{vienes}, \emph{viene}, \emph{vienen}. When the stress falls on the
+ending instead, the \emph{e} stays plain: \emph{venimos}.\\[3pt]
+Write the five forms in a column and the changed ones outline the shape of a
+\textbf{boot}: everything cracks to \emph{ie} except \emph{venimos}, which
+sits outside it, and the \emph{yo} corner carries the \emph{-go}.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & Form & Note \\
+\midrule
+yo (I) & \textbf{vengo} & the \emph{-go} form \\
+t\'{u} (you, informal) & \textbf{vienes} & \emph{e} $\to$ \emph{ie} \\
+\'{e}l / ella / usted & \textbf{viene} & \emph{e} $\to$ \emph{ie} \\
+nosotros (we) & venimos & plain \emph{e} --- unstressed \\
+ellos / ustedes & \textbf{vienen} & \emph{e} $\to$ \emph{ie} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{sounds}
+Two things to hear. The \emph{g} of \textbf{vengo} is the hard \emph{-go}
+again. And \emph{ie} is a \textbf{diphthong} --- two vowel sounds glided
+together in one syllable: \emph{vienes} is \emph{vee-EH-nes}.
+\end{sounds}
+
+This is the exact shape of \emph{tener} (\emph{tengo} / \emph{tienes}) ---
+\emph{venir} is its mirror twin: \emph{Vengo de Espa\~{n}a} (``I come from
+Spain''), \emph{\textquestiondown Vienes?} (``Are you coming?'').
+
+\section{The club is complete}
+\label{lesson:ch13-practice}
+
+All six members, in one place: \emph{tengo} $\cdot$ \emph{hago} $\cdot$
+\emph{digo} $\cdot$ \emph{pongo} $\cdot$ \emph{salgo} $\cdot$ \emph{vengo}.
+Every one of them is irregular in the \emph{yo} form only --- the rest of each
+verb is regular, plus whatever stem-change it carries.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Infinitive & \emph{yo} form & Kind \\
+\midrule
+hacer (to do/make) & hago & plain \emph{-go} \\
+poner (to put) & pongo & plain \emph{-go} \\
+salir (to go out) & salgo & plain \emph{-go} \\
+decir (to say) & digo & \emph{-go} $+$ \emph{e} $\to$ \emph{i} (dices/dice) \\
+tener (to have) & tengo & \emph{-go} $+$ \emph{e} $\to$ \emph{ie} (tienes) \\
+venir (to come) & vengo & \emph{-go} $+$ \emph{e} $\to$ \emph{ie} (vienes) \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The two \emph{e} $\to$ \emph{ie} twins run side by side, and only the
+\emph{we} forms keep the plain \emph{e} --- the boot again:
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+\emph{tener} & \emph{venir} \\
+\midrule
+tengo & vengo \\
+tienes & vienes \\
+tiene & viene \\
+tenemos & venimos \\
+tienen & vienen \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Now put them to work. Say each aloud:
+
+\begin{quote}\itshape
+Vengo de casa y pongo la mesa. --- ``I come from home and set the table.''\\
+Salgo a las ocho. --- ``I leave at eight.''\\
+\textquestiondown Qu\'{e} haces? --- Hago la cena. --- ``What are you doing?
+--- I'm making dinner.''\\
+Digo que s\'{i}. --- ``I say yes.''
+\end{quote}
+
+And one English cousin for each new root: \emph{poner} $\leftarrow$
+\emph{p\={o}nere} $\to$ \textbf{position} / \textbf{compose} /
+\textbf{deposit}; \emph{salir} $\leftarrow$ \emph{sal\={\i}re} $\to$
+\textbf{salient} / \textbf{salmon} / \textbf{somersault}; \emph{venir}
+$\leftarrow$ \emph{ven\={\i}re} $\to$ \textbf{adventure} / \textbf{event} /
+\textbf{convene}. You now hold the whole irregular \emph{-go} corner of
+Spanish --- its oldest, most-used verbs, mastered as one pattern.

--- a/code/learning/human-languages/spanish/book/chapters/ch14-preterite.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch14-preterite.tex
@@ -1,0 +1,189 @@
+\chapter{The Preterite --- Your First Past Tense}
+\label{ch:preterite}
+
+Until now everything you have said lived in the present. This chapter crosses
+into ``what happened'': the \textbf{preterite}, Spanish's everyday past. It
+opens with the strangest fact in the language --- ``I was'' and ``I went'' are
+the same word --- and closes with a pattern that covers thousands of verbs and
+hangs on a single accent mark.
+\emph{Practice lessons: \texttt{lessons/ES-C14-*.md}.}
+
+\section{\emph{fui} --- the past arrives, and two verbs become one}
+\label{lesson:ser-ir-preterite}
+
+Spanish's everyday past tense is called the \textbf{preterite}: ``I spoke, I
+went, I was'' --- an action finished, sealed off, done. And it opens with the
+most memorable oddity in the whole language: the verbs \emph{ser} (``to be'')
+and \emph{ir} (``to go'') have the \emph{exact same} preterite. \emph{Fui}
+means both ``\textbf{I was}'' \emph{and} ``\textbf{I went}.''
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+ & \emph{ser} / \emph{ir} (the same!) \\
+\midrule
+yo & \textbf{fui} \\
+t\'{u} & \textbf{fuiste} \\
+\'{e}l / ella / usted & \textbf{fue} \\
+nosotros & \textbf{fuimos} \\
+ellos / ustedes & \textbf{fueron} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+One set of forms, \emph{two} verbs. There is no separate past for ``to go'' ---
+Spanish simply reuses ``to be.''
+
+\begin{cousinweb}
+\textbf{fui} $\leftarrow$ Latin \emph{fu\={i}}, ``I have been.'' Here is the
+twist: Latin had \emph{two} different roots for ``to be.'' The present
+\emph{sum / es / est} (which became \emph{soy / eres / es}) came from the
+ancient root PIE \emph{*es-}. The perfect \emph{fu\={i}} came from a
+\emph{different} root, PIE \emph{*b\textsuperscript{h}uH-}, ``to grow, to
+become'' --- and that is the very root of English \textbf{be} and
+\textbf{been}, and (by way of Greek and Latin) \textbf{future} and
+\textbf{physics}.\\[3pt]
+Spanish stitched the two roots into a single verb. That patchwork is called
+\textbf{suppletion} --- the same thing English does with \emph{go} /
+\emph{went}, two unrelated words serving one verb.
+\end{cousinweb}
+
+\begin{grammarlens}
+Then \emph{ir} (``to go'') borrowed \emph{fu\={i}} as well, because Latin's own
+past of \emph{\={i}re} (``to go'') had worn away to almost nothing. So ``to
+be'' and ``to go'' \emph{merged} in the past tense, and only \textbf{context}
+tells them apart:\\[3pt]
+\emph{\textbf{Fui} a Madrid.} --- ``I \textbf{went} to Madrid.'' (movement
+$\to$ \emph{ir})\\[3pt]
+\emph{\textbf{Fui} profesor.} --- ``I \textbf{was} a teacher.'' (a state $\to$
+\emph{ser})\\[3pt]
+The giveaway is usually what follows: \emph{a} $+$ a place means going; a
+description or a role means being.
+\end{grammarlens}
+
+\begin{sounds}
+\textbf{stress-final} --- the preterite loves the \emph{final} syllable.
+\emph{fui} and \emph{fue} are single syllables; then \emph{fuiste},
+\emph{fuimos}, \emph{fueron}. Say the set aloud pushing the weight to the end:
+\emph{fui $\cdot$ fuiste $\cdot$ fue $\cdot$ fuimos $\cdot$ fueron}.\\[3pt]
+\textbf{diphthong -ui-} --- \emph{ui} is one glide, not two beats:
+``fwee,'' not ``foo-ee.''
+\end{sounds}
+
+\section{\emph{habl\'{e}} --- the regular past, built on an accent}
+\label{lesson:hablar-preterite}
+
+\emph{Fui} was irregular --- a one-off you memorize. Now the \textbf{pattern}
+that covers thousands of verbs. Take any regular \emph{-ar} verb, drop the
+\emph{-ar}, and add the preterite endings. The whole tense hangs on one small
+mark: the \textbf{accent}.
+
+Drop \emph{-ar} from \textbf{hablar} (``to speak'') and add:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+ & preterite & \\
+\midrule
+yo & \textbf{habl\'{e}} & (accent on \'{e}) \\
+t\'{u} & \textbf{hablaste} & \\
+\'{e}l / ella / usted & \textbf{habl\'{o}} & (accent on \'{o}) \\
+nosotros & \textbf{hablamos} & (no accent) \\
+ellos / ustedes & \textbf{hablaron} & \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{grammarlens}
+Set this beside the \textbf{present} tense of the same verb ---
+\emph{hablo, hablas, habla} --- and the difference is almost entirely
+\emph{where the stress lands}: \emph{HA-blo} (``I speak,'' now) versus
+\emph{ha-BL\'{E}} (``I spoke,'' done). The written accent is not decoration;
+it \textbf{carries the tense}. Move the stress to the end and the past tense
+announces itself.
+\end{grammarlens}
+
+\begin{cousinweb}
+These endings are worn-down Latin \textbf{perfect} forms. Latin
+\emph{am\={a}v\={i}} (``I loved'') $\to$ \emph{am\'{e}};
+\emph{am\={a}vist\={i}} $\to$ \emph{amaste}; \emph{am\={a}vit} $\to$
+\emph{am\'{o}}. The \emph{-\={a}v-} in the middle dissolved away and left
+behind the \emph{stressed final vowel} that Spanish now crowns with an
+accent.\\[3pt]
+So \emph{habl\'{e}} is Latin \emph{(fabul\={a}v\={i})} with the middle chewed
+away --- the same erosion you have watched all along, this time applied to an
+entire tense.
+\end{cousinweb}
+
+\begin{culture}
+\textbf{One trap --- \emph{hablamos}.} The \emph{nosotros} form is
+\emph{identical} in present and preterite: \emph{hablamos} is both ``we
+speak'' and ``we spoke.'' Nothing in the word itself decides. Only
+\textbf{context} --- or a time-word such as \emph{ayer} (``yesterday'') ---
+tells them apart: \emph{hablamos ayer} $=$ ``we spoke yesterday.'' Spanish
+speakers lean on \emph{ayer}, \emph{anoche}, \emph{el a\~{n}o pasado} to do the
+work the verb ending leaves undone.
+\end{culture}
+
+\begin{sounds}
+\textbf{accent-acute} --- the written \emph{\'{}} marks the \emph{stressed}
+vowel: \emph{habl-\'{E}}, \emph{habl-\'{O}}. Practise the flip:
+\emph{hablo} $\to$ \emph{habl\'{e}}, \emph{habla} $\to$ \emph{habl\'{o}}. Then
+a full sentence: \emph{Ayer habl\'{e} con Mar\'{i}a} (``Yesterday I spoke with
+Mar\'{i}a'').
+\end{sounds}
+
+\section{Practice --- past against present}
+\label{lesson:ch14-practice}
+
+This chapter gave you the past: the shared \emph{ser}/\emph{ir} preterite
+(\emph{fui}) and the regular \emph{-ar} pattern (\emph{habl\'{e}}). The skill
+now is switching between \emph{now} and \emph{then} without stumbling.
+
+\textbf{Drill 1 --- say the two paradigms.}
+\emph{fui} $\cdot$ \emph{fuiste} $\cdot$ \emph{fue} $\cdot$ \emph{fuimos}
+$\cdot$ \emph{fueron}. Then:
+\emph{habl\'{e}} $\cdot$ \emph{hablaste} $\cdot$ \emph{habl\'{o}} $\cdot$
+\emph{hablamos} $\cdot$ \emph{hablaron}.
+
+\textbf{Drill 2 --- the accent flips the tense.} Say each present form, then
+its preterite twin; the stress jumps to the end.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+present & & preterite \\
+\midrule
+\emph{hablo} (I speak) & $\to$ & \emph{habl\'{e}} (I spoke) \\
+\emph{habla} (s/he speaks) & $\to$ & \emph{habl\'{o}} (s/he spoke) \\
+\emph{trabajo} (I work) & $\to$ & \emph{trabaj\'{e}} (I worked) \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+What one thing changed? The \textbf{accent} --- the stressed syllable moved to
+the end.
+
+\textbf{Drill 3 --- \emph{ser} or \emph{ir}? Context decides.}
+
+\begin{quote}\itshape
+Fui a la escuela. $\to$ \emph{ir} --- ``I went.''\\
+Fui estudiante. $\to$ \emph{ser} --- ``I was a student.''\\
+Ella fue muy amable. $\to$ \emph{ser} --- ``She was very kind.''\\
+Ellos fueron a Espa\~{n}a. $\to$ \emph{ir} --- ``They went.''
+\end{quote}
+
+\textbf{Drill 4 --- put it to use.} Say each aloud:
+
+\begin{quote}\itshape
+Ayer habl\'{e} con mi madre. --- ``Yesterday I spoke with my mother.''\\
+Fui al mercado y compr\'{e} pan. --- ``I went to the market and bought
+bread.''\\
+Fuimos amigos. --- ``We were friends.''
+\end{quote}
+
+Which two verbs share \emph{fui} / \emph{fue}? \emph{Ser} and \emph{ir}. How
+does the accent turn \emph{hablo} into \emph{habl\'{o}}? It moves the stress to
+the end --- present becomes preterite. And in \emph{Fui a casa}, be or go? Go
+--- \emph{ir}. You can now speak in the past: the course has crossed from
+``what is'' to ``what happened.''

--- a/code/learning/human-languages/spanish/book/chapters/ch15-completing-preterite.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch15-completing-preterite.tex
@@ -1,0 +1,194 @@
+\chapter{Completing the Preterite --- Three Families, One Question}
+\label{ch:completing-preterite}
+
+The past tense finishes here. The \emph{-er} and \emph{-ir} verbs hand you a gift
+--- one set of endings for two conjugations --- and then a handful of very old
+verbs pull the stress backwards and drop their accents entirely. One question
+sorts all of them: where does the stress land?
+\emph{Practice lessons: \texttt{lessons/ES-C15-*.md}.}
+
+\section{\emph{com\'{i}}, \emph{viv\'{i}} --- two conjugations become one}
+\label{lesson:comer-vivir-preterite}
+
+You have the \emph{-ar} past (\emph{habl\'{e}}, ``I spoke''). Now the other two
+families. Here Spanish does you a favour it never does in the present tense:
+\emph{-er} and \emph{-ir} verbs take the \emph{exact same} preterite endings.
+Learn one set, get both.
+
+Drop the \emph{-er} or \emph{-ir} from the infinitive, and add
+\emph{-\'{i}, -iste, -i\'{o}, -imos, -ieron}.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+person & \emph{comer} (``to eat'') & \emph{vivir} (``to live'')\\
+\midrule
+\emph{yo} (I) & \textbf{com\'{i}} & \textbf{viv\'{i}}\\
+\emph{t\'{u}} (you, informal) & \textbf{comiste} & \textbf{viviste}\\
+\emph{\'{e}l / ella / usted} & \textbf{comi\'{o}} & \textbf{vivi\'{o}}\\
+\emph{nosotros} (we) & \textbf{comimos} & \textbf{vivimos}\\
+\emph{ellos / ustedes} (they / you all) & \textbf{comieron} & \textbf{vivieron}\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Look down the two columns: the endings are \emph{identical}. That is not true in
+the present, where \emph{-er} and \emph{-ir} pull apart
+(\emph{comemos} versus \emph{vivimos}). In the past, the two conjugations
+\textbf{merge}.
+
+\begin{cousinweb}
+These endings are worn-down Latin \textbf{perfect} forms --- \emph{-\={i},
+-ist\={i}, -it}. The middle one barely changed at all: Latin \emph{-ist\={i}}
+$\to$ Spanish \emph{-iste} (\emph{comiste}, \emph{viviste}). Two thousand years,
+one dropped vowel.
+\end{cousinweb}
+
+\begin{sounds}
+The written accent marks the \textbf{stressed final vowel}: com\textbf{\'{i}},
+comi\textbf{\'{o}}. Say them with the loudness at the very end of the word.
+Stress at the end $=$ the past.
+\end{sounds}
+
+\begin{grammarlens}
+One trap. For \emph{-ir} verbs, the \emph{nosotros} form is the \emph{same} in
+present and preterite: \emph{vivimos} means both ``we live'' and ``we lived''
+(just like \emph{hablamos} in the previous chapter). But for \emph{-er} verbs it
+differs: \emph{comemos} (``we eat'') versus \emph{comimos} (``we ate''). One
+vowel does the whole job.
+\end{grammarlens}
+
+Try it aloud: \emph{com\'{i}, comiste, comi\'{o}, comimos, comieron}; then
+\emph{viv\'{i}, viviste, vivi\'{o}, vivimos, vivieron} --- hear the same endings.
+Then a whole sentence: \emph{Ayer com\'{i} paella} (``Yesterday I ate paella'').
+
+\section{\emph{tuve}, \emph{hice}, \emph{estuve} --- the strong preterites}
+\label{lesson:preterite-fuertes}
+
+Everything so far pushed the stress \emph{to the end}: habl\textbf{\'{e}},
+com\textbf{\'{i}}, com\textbf{i\'{o}}. Now meet the verbs that do the opposite.
+They pull the stress \emph{back into the stem} --- and so they lose their accent
+marks entirely. Spanish calls them \emph{pret\'{e}ritos fuertes}, ``\textbf{strong}''
+preterites: strong because the \emph{stem} carries the weight.
+
+The stem changes, and then one shared set of endings follows:
+\emph{-e, -iste, -o, -imos, -ieron}.
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+person & \emph{tener} $\to$ \emph{tuv-} & \emph{hacer} $\to$ \emph{hic-} & \emph{estar} $\to$ \emph{estuv-}\\
+\midrule
+\emph{yo} & \textbf{tuve} & \textbf{hice} & \textbf{estuve}\\
+\emph{t\'{u}} & \textbf{tuviste} & \textbf{hiciste} & \textbf{estuviste}\\
+\emph{\'{e}l / ella / usted} & \textbf{tuvo} & \textbf{hizo} & \textbf{estuvo}\\
+\emph{nosotros} & \textbf{tuvimos} & \textbf{hicimos} & \textbf{estuvimos}\\
+\emph{ellos / ustedes} & \textbf{tuvieron} & \textbf{hicieron} & \textbf{estuvieron}\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{grammarlens}
+\textbf{The accent rule, inverted.} Compare the \emph{yo} and \emph{\'{e}l} forms
+across the three families.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lllll}
+\toprule
+family & \emph{yo} & \emph{\'{e}l / ella} & stressed syllable & accent?\\
+\midrule
+\emph{-ar} (\emph{hablar}) & habl\textbf{\'{e}} & habl\textbf{\'{o}} & the \textbf{ending} & \textbf{yes}\\
+\emph{-er} / \emph{-ir} (\emph{comer}) & com\textbf{\'{i}} & com\textbf{i\'{o}} & the \textbf{ending} & \textbf{yes}\\
+\textbf{strong} (\emph{tener}) & \textbf{TU}ve & \textbf{TU}vo & the \textbf{stem} & \textbf{no}\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{sounds}
+Say them out loud back to back: \emph{habl\'{O}} \ldots\ \emph{TUvo}. The written
+accent isn't decoration --- it is telling you \emph{where the stress went}. There
+is no accent on a strong preterite because the stress never left the stem.\\[3pt]
+Note the \emph{yo} ending too: \emph{-e}, not \emph{-\'{e}} --- \emph{tuve}, not
+\emph{tuv\'{e}}.
+\end{sounds}
+
+\begin{grammarlens}
+\textbf{One spelling swerve.} \emph{Hacer} gives \textbf{hizo}, not
+\emph{hico} --- Spanish swaps \emph{c} $\to$ \emph{z} before \emph{o} to keep the
+sound the same. The letter changes so the pronunciation won't.
+\end{grammarlens}
+
+\begin{cousinweb}
+Why are these irregular? Because they are \textbf{old}. Latin had two ways to
+build a perfect, and these verbs kept the ``strong'' one, inherited whole rather
+than rebuilt: \emph{tenu\={i}} $\to$ \textbf{tuve}, \emph{f\={e}c\={i}} $\to$
+\textbf{hice}, \emph{stet\={i}} / \emph{st\={a}re} $\to$ \textbf{estuve}.\\[3pt]
+The regular \emph{-ar} / \emph{-er} / \emph{-ir} patterns are the tidy
+replacements that spread later; the strong verbs are the most-used ones, worn
+smooth by frequency and never re-made. Notice that \emph{tuv-} and \emph{estuv-}
+even share the same \emph{-uv-} shape.
+\end{cousinweb}
+
+Say them aloud: \emph{tuve, tuviste, tuvo, tuvimos, tuvieron}; then
+\emph{hice, hiciste, hizo} --- hear the \emph{z}. Then the contrast pair,
+\emph{habl\'{O}} \ldots\ \emph{TUvo}. And a sentence: \emph{Ayer estuve en casa}
+(``Yesterday I was at home'').
+
+\section{Practice --- three families, one question}
+\label{lesson:ch15-practice}
+
+You now have the \emph{entire} everyday past tense. Three families --- and one
+question sorts them: \textbf{where does the stress land?}
+
+\begin{center}
+\begin{tabular}{llllll}
+\toprule
+ & \emph{yo} & \emph{t\'{u}} & \emph{\'{e}l / ella} & \emph{nosotros} & \emph{ellos}\\
+\midrule
+\emph{-ar} (\emph{hablar}) & habl\textbf{\'{e}} & habl\textbf{aste} & habl\textbf{\'{o}} & habl\textbf{amos} & habl\textbf{aron}\\
+\emph{-er} (\emph{comer}) & com\textbf{\'{i}} & com\textbf{iste} & com\textbf{i\'{o}} & com\textbf{imos} & com\textbf{ieron}\\
+\emph{-ir} (\emph{vivir}) & viv\textbf{\'{i}} & viv\textbf{iste} & viv\textbf{i\'{o}} & viv\textbf{imos} & viv\textbf{ieron}\\
+strong (\emph{tener}) & \textbf{tuve} & \textbf{tuviste} & \textbf{tuvo} & \textbf{tuvimos} & \textbf{tuvieron}\\
+\emph{ser} / \emph{ir} & \textbf{fui} & \textbf{fuiste} & \textbf{fue} & \textbf{fuimos} & \textbf{fueron}\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Two things to notice. First, rows two and three are the \emph{same} ---
+\emph{-er} and \emph{-ir} merged. Second, only the first three rows carry
+accents, and only on \emph{yo} and \emph{\'{e}l}. Those are exactly the forms
+where the stress is on the ending.
+
+\begin{grammarlens}
+\textbf{The stress test.} Read any preterite and ask: is the loud syllable the
+\emph{last} one?\\[3pt]
+\textbf{Yes} $\to$ regular. Accent on \emph{yo} and \emph{\'{e}l / ella}
+(\emph{habl\'{e}}, \emph{habl\'{o}}, \emph{com\'{i}}, \emph{comi\'{o}}).\\[3pt]
+\textbf{No, it's the stem} $\to$ \textbf{strong}. No accent (\emph{TUve},
+\emph{HIce}, \emph{ESTUvo}).
+\end{grammarlens}
+
+Some forms live in both tenses, and only context decides.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+form & could be & which?\\
+\midrule
+\emph{hablamos} & we speak / we spoke & either --- context decides\\
+\emph{vivimos} & we live / we lived & either --- context decides\\
+\emph{comemos} / \emph{comimos} & we eat / we ate & \textbf{distinct} --- the vowel tells you\\
+\emph{fui} & I was / I went & either --- \emph{ser} and \emph{ir} share it\\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Practise aloud: the \emph{yo} forms straight down all five rows ---
+\emph{habl\'{e}, com\'{i}, viv\'{i}, tuve, fui}. Then whole sentences:
+\emph{Ayer habl\'{e} con mi madre y com\'{i} en casa} (``Yesterday I spoke with
+my mother and ate at home''); \emph{Hice la comida} (``I made the food'') ---
+stem stress, no accent; \emph{Fui al mercado} (``I went to the market''). Finally
+say the diagnostic itself: last syllable loud $\to$ accent; stem loud $\to$ none.
+
+Next chapter: talking about the past that \emph{kept going} --- the imperfect.

--- a/code/learning/human-languages/spanish/book/chapters/ch16-imperfect.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch16-imperfect.tex
@@ -1,0 +1,222 @@
+\chapter{The Imperfect --- the Past That Kept Going}
+\label{ch:imperfect}
+
+One past tense says a thing finished; this one says a thing was
+\emph{going on}. It is also the most regular tense in the language, with exactly
+three irregular verbs in the whole of Spanish --- and then one genuinely new
+distinction to learn to think in.
+\emph{Practice lessons: \texttt{lessons/ES-C16-*.md}.}
+
+\section{\emph{hablaba}, \emph{com\'{i}a} --- the past that kept going}
+\label{lesson:imperfecto}
+
+A \textbf{tense} is the shape a verb takes to place an action in time. Spanish
+has two ordinary past tenses. The \textbf{preterite} reports that a past thing
+\textbf{finished}: \emph{habl\'{e}}, ``I spoke.'' The \textbf{imperfect} reports
+that a past thing was \textbf{going on}, or happened over and over: ``I
+\textbf{was speaking},'' ``I \textbf{used to speak}.'' That is what this whole
+chapter is about.
+
+And here is the good news: the imperfect is the \textbf{most regular tense in
+the language}. Drop the infinitive ending (\emph{-ar}, \emph{-er}, \emph{-ir})
+and add one of two sets of endings.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Person & \emph{-ar} (\emph{hablar}) & \emph{-er} / \emph{-ir} (\emph{comer}, \emph{vivir}) \\
+\midrule
+yo & habl\textbf{aba} & com\textbf{\'{i}a} / viv\textbf{\'{i}a} \\
+t\'{u} & habl\textbf{abas} & com\textbf{\'{i}as} \\
+\'{e}l / ella / usted & habl\textbf{aba} & com\textbf{\'{i}a} \\
+nosotros & habl\textbf{\'{a}bamos} & com\textbf{\'{i}amos} \\
+ellos / ustedes & habl\textbf{aban} & com\textbf{\'{i}an} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The \textbf{\emph{-er} and \emph{-ir} verbs share one set again} --- the third
+time now (they also shared in the preterite). Two conjugations, one pattern.
+
+\begin{cousinweb}
+\textbf{-aba} $\leftarrow$ Latin \emph{-\={a}bam} $\cdot$ \textbf{-\'{i}a}
+$\leftarrow$ Latin \emph{-\={e}bam}.\\[3pt]
+\textbf{Same Latin ending, two fates.} The \emph{b} survived whole in
+\emph{-aba} (\emph{-\={a}bam} $\to$ \emph{-aba}), but wore away in the other set
+(\emph{-\={e}bam} $\to$ \emph{-ea} $\to$ \emph{-\'{i}a}). One sound, two
+outcomes, inside the same language.
+\end{cousinweb}
+
+\begin{sounds}
+\textbf{accent-acute} --- \emph{habl\'{a}bamos}: the stress falls
+\textbf{three syllables back} (\emph{ha-BL\'{A}-ba-mos}), and Spanish writes an
+accent whenever it does. This is the \emph{only} form in the \emph{-ar} set that
+takes one.\\[3pt]
+\textbf{hiatus-ia} --- \emph{com\'{i}a}: here the accent \textbf{splits the
+vowels}. Without it, \emph{ia} would be a single syllable (as in \emph{piano});
+with it, \emph{co-m\'{i}-a} is three. \textbf{Every} form in the
+\emph{-er}/\emph{-ir} set needs it.
+\end{sounds}
+
+\begin{grammarlens}
+\textbf{One trap, and a broken rule.} \emph{Yo hablaba} and \emph{\'{e}l
+hablaba} are \textbf{identical} --- the ending no longer tells you who is
+speaking. Spanish normally \emph{drops} its subject pronouns, because the ending
+carries the person; in the imperfect the ending stopped doing that job, so the
+pronoun steps back in. You will hear \emph{yo} said out loud here far more often
+than in the present tense.
+\end{grammarlens}
+
+Say them straight through: \emph{hablaba, hablabas, hablaba, habl\'{a}bamos,
+hablaban} $\cdot$ \emph{com\'{i}a, com\'{i}as, com\'{i}a, com\'{i}amos,
+com\'{i}an}. And in a sentence: \emph{Cuando era ni\~{n}o, hablaba espa\~{n}ol
+en casa} (``When I was a child, I used to speak Spanish at home'').
+
+\section{\emph{era}, \emph{iba}, \emph{ve\'{i}a} --- all three of them}
+\label{lesson:tres-irregulares}
+
+The preterite hands you a pile of strong, irregular forms to memorise. Here is
+the compensation: the imperfect has \textbf{three} irregular verbs. Not three
+families --- \textbf{three verbs}, in the entire language.
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+Person & \emph{ser} $\to$ \textbf{era} & \emph{ir} $\to$ \textbf{iba} & \emph{ver} $\to$ \textbf{ve\'{i}a} \\
+\midrule
+yo & era & iba & ve\'{i}a \\
+t\'{u} & eras & ibas & ve\'{i}as \\
+\'{e}l / ella / usted & era & iba & ve\'{i}a \\
+nosotros & \'{e}ramos & \'{i}bamos & ve\'{i}amos \\
+ellos / ustedes & eran & iban & ve\'{i}an \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+That is the entire irregular inventory. Every other verb in Spanish ---
+thousands of them --- takes the regular endings from the last section.
+
+And \emph{ver} barely counts: it simply keeps an extra \emph{-e-} from its older
+form \emph{veer}, then conjugates normally (\emph{ve-} $+$ \emph{-\'{i}a}).
+
+\begin{cousinweb}
+\textbf{era} $\leftarrow$ Latin \emph{eram}, from the same \emph{es-} root that
+gives \emph{ser}, \emph{soy}, \emph{es} --- and English \textbf{is} and
+\textbf{are}. So \emph{ser} uses that ancient root in the present \emph{and} the
+imperfect, but jumps to a different verb entirely, Latin \emph{fu\={\i}}, in the
+preterite: \emph{era} versus \emph{fue}.
+\end{cousinweb}
+
+\begin{cousinweb}
+\textbf{\emph{ir}'s third Latin verb.} Spanish \emph{ir} (``to go'') is
+stitched together out of \textbf{three different Latin verbs}, one per
+tense:\\[3pt]
+present \emph{voy, vas, va} $\leftarrow$ Latin \emph{v\={a}dere}, ``to
+advance''\\[3pt]
+preterite \emph{fui, fuiste, fue} $\leftarrow$ Latin \emph{fu\={\i}}, from
+\emph{esse}\\[3pt]
+imperfect \textbf{\emph{iba, ibas, iba}} $\leftarrow$ Latin \emph{\={\i}re} ---
+\emph{ir}'s \textbf{own infinitive}\\[3pt]
+The imperfect is the \textbf{one place} the original \emph{\={\i}re} survives
+conjugated. The infinitive \emph{ir} and the imperfect \emph{iba} are the last
+two pieces of the real verb; everything else was borrowed from elsewhere.
+\end{cousinweb}
+
+\begin{sounds}
+\textbf{stress-antepenultimate} --- \textbf{\'{e}ramos} and
+\textbf{\'{i}bamos} take a written accent for exactly the reason
+\emph{habl\'{a}bamos} does: the stress lands three syllables back
+(\emph{\'{E}-ra-mos}, \emph{\'{I}-ba-mos}). Those two are the only accented
+forms in the irregular set apart from \emph{ver}, whose accent is the
+vowel-splitting kind (\emph{ve-\'{i}-a}).
+\end{sounds}
+
+Say them: \emph{era, eras, era, \'{e}ramos, eran} $\cdot$ \emph{iba, ibas, iba,
+\'{i}bamos, iban}. In a sentence: \emph{Cuando era ni\~{n}o, iba a la escuela}
+(``When I was a child, I used to go to school''). And say the three sources out
+loud: \emph{voy} $\leftarrow$ \emph{v\={a}dere} $\cdot$ \emph{fui} $\leftarrow$
+\emph{fu\={\i}} $\cdot$ \emph{iba} $\leftarrow$ \emph{\={\i}re}.
+
+\section{Practice --- two pasts, one choice}
+\label{lesson:ch16-practice}
+
+You now have \textbf{both} past tenses. English marks this difference only
+sometimes, and never with an ending --- so this is a genuinely \textbf{new
+distinction} to think in, not merely new forms to learn.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+ & preterite & imperfect \\
+\midrule
+what it does & a \textbf{completed} event & an \textbf{ongoing} or \textbf{habitual} state \\
+shape of time & a \textbf{point} & a \textbf{line} \\
+English & ``I ate'' & ``I \textbf{was} eating'' / ``I \textbf{used to} eat'' \\
+typical clues & \emph{ayer, una vez, de repente} & \emph{siempre, todos los d\'{i}as, mientras} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\textbf{Com\'{i}} $=$ the meal happened and ended. \textbf{Com\'{i}a} $=$ I was
+in the middle of it, or I did it regularly.
+
+\begin{grammarlens}
+\textbf{Background and interruption.} The classic pairing: the imperfect sets
+the scene, the preterite breaks it.\\[3pt]
+\emph{\textbf{Hablaba} con Mar\'{i}a cuando \textbf{lleg\'{o}} Juan.} (``I was
+talking to Mar\'{i}a when Juan arrived.'')\\[3pt]
+The talking is the \textbf{line}; the arriving is the \textbf{point} that lands
+on it. Swap the two tenses and the sentence stops making sense.
+\end{grammarlens}
+
+\begin{culture}
+\textbf{Verbs that change meaning.} With a few verbs the choice does not just
+shift the shape of time --- it changes \textbf{what the word means}. The logic
+is consistent: the imperfect gives you the \emph{state}, the preterite gives you
+the \emph{instant the state began}. Knowing $\to$ the moment of finding out.
+\end{culture}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+verb & imperfect (state) & preterite (the moment it started) \\
+\midrule
+\emph{saber} & \emph{sab\'{i}a} --- I \textbf{knew} & \emph{supe} --- I \textbf{found out} \\
+\emph{conocer} & \emph{conoc\'{i}a} --- I \textbf{knew} (a person) & \emph{conoc\'{i}} --- I \textbf{met} \\
+\emph{tener} & \emph{ten\'{i}a} --- I \textbf{had} & \emph{tuve} --- I \textbf{got, received} \\
+\emph{querer} & \emph{quer\'{i}a} --- I \textbf{wanted} & \emph{quise} --- I \textbf{tried} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+(And the negative sharpens it further: \emph{no quise} $=$ ``I
+\textbf{refused}.'')
+
+\textbf{Drill --- which tense?} Decide before you read the answer.
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+sentence & tense \\
+\midrule
+``Every summer we \textbf{went} to Spain.'' & imperfect (\emph{\'{i}bamos}) --- habitual \\
+``Yesterday we \textbf{went} to Spain.'' & preterite (\emph{fuimos}) --- one event \\
+``She \textbf{was} tall.'' & imperfect (\emph{era}) --- a lasting state \\
+``The concert \textbf{was} yesterday.'' & preterite (\emph{fue}) --- a bounded event \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Say these aloud: \emph{Com\'{i}a cuando llamaste} (``I was eating when you
+called'') $\cdot$ the pair \emph{sab\'{i}a} ``I knew'' \ldots\ \emph{supe} ``I
+found out'' $\cdot$ \emph{Cuando era ni\~{n}o, iba a la playa todos los
+veranos}.
+
+Recall it all: preterite or imperfect for a \textbf{habit}?
+(\textbf{Imperfect}.) Which tense sets the background, and which interrupts it?
+(Imperfect \textbf{sets}, preterite \textbf{interrupts}.) What is the difference
+between \emph{conoc\'{i}a} and \emph{conoc\'{i}}? (``I \textbf{knew} someone''
+versus ``I \textbf{met} them.'') How many irregular imperfects are there?
+(\textbf{Three}.) And the one-word test, the thing to keep:
+\textbf{line} $\to$ imperfect; \textbf{point} $\to$ preterite. Next chapter:
+talking about what \textbf{will} happen.

--- a/code/learning/human-languages/spanish/book/chapters/ch17-future-conditional.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch17-future-conditional.tex
@@ -1,0 +1,317 @@
+\chapter{The Future and the Conditional --- One Weld, Twice}
+\label{ch:future-conditional}
+
+Two whole tenses built from a single trick: glue an infinitive to the verb
+``to have.'' Use the present of ``have'' and you get the future; use its past
+and you get ``would.'' One machine, one part swapped, and a seam you can still
+see. \emph{Practice lessons: \texttt{lessons/ES-C17-*.md}.}
+
+\section{\emph{hablar\'{e}} --- the future, welded shut}
+\label{lesson:futuro}
+
+A \textbf{tense} is the shape a verb takes to say \emph{when} something happens.
+Spanish has two ways to talk about what is coming. One you can already build out
+of small parts --- \emph{voy a hablar}, ``I am going to speak.'' The other is a
+single word, and it has the best origin story of any Spanish tense.
+
+\begin{grammarlens}
+The \textbf{infinitive} is a verb's plain dictionary form --- \emph{hablar}
+(``to speak''), \emph{comer} (``to eat''), \emph{vivir} (``to live''). Every
+other Spanish tense begins by \emph{stripping} that ending off: you cut
+\emph{-ar} from \emph{hablar} and build on \emph{habl-}.\\[3pt]
+\textbf{The future does not.} It keeps the infinitive whole and stacks endings
+on top of it. And because the infinitive stays intact, \emph{one} set of endings
+serves all three verb families: \emph{hablar} $\to$ \emph{hablar\'{e}},
+\emph{comer} $\to$ \emph{comer\'{e}}, \emph{vivir} $\to$ \emph{vivir\'{e}}.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+\textbf{Person} & \textbf{Future of \emph{hablar}} \\
+\midrule
+\emph{yo} (I)                          & \emph{hablar\'{e}} \\
+\emph{t\'{u}} (you, informal)          & \emph{hablar\'{a}s} \\
+\emph{\'{e}l / ella / usted}           & \emph{hablar\'{a}} \\
+\emph{nosotros} (we)                   & \emph{hablaremos} \\
+\emph{ellos / ustedes}                 & \emph{hablar\'{a}n} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{cousinweb}
+\textbf{hablar\'{e}} is not one piece but two, fused: \emph{hablar} $+$
+\emph{he}. That \emph{he} is ``I have,'' the present tense of \emph{haber}
+(``to have'') $\leftarrow$ Latin \emph{hab\={e}re} --- the root English borrowed
+in \textbf{habit} (``what one has''), \textbf{hab}itat, in\textbf{habit},
+\textbf{able} and \textbf{abil}ity (from \emph{hab\={e}re}'s compound
+\emph{hab\={e}lis}, ``handy to have''), pro\textbf{hibit}, ex\textbf{hibit}.
+\end{cousinweb}
+
+Latin had its own future --- \emph{am\={a}b\={o}}, ``I will love'' --- and it
+\textbf{died out}. Speakers replaced it with a phrase:
+
+\begin{quote}\itshape
+am\={a}re habe\={o} --- ``I \textbf{have} to love'' $\to$ ``I will love.''
+\end{quote}
+
+Infinitive $+$ the verb \emph{hab\={e}re}, ``to have.'' This is exactly the
+English ``I \textbf{have to} go,'' which also slides from obligation toward the
+future. Then the Spanish phrase \textbf{fused}. Say \emph{hablar he} fast
+enough, often enough, for enough centuries, and it closes into one word.
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+\textbf{Stage} & \textbf{Form} \\
+\midrule
+two words & \emph{hablar} $+$ \emph{he} \\
+squeezed  & \emph{hablar-he} \\
+welded    & \emph{hablar\'{e}} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+So the endings are not really endings. They are the present tense of
+\emph{haber}, worn down to a suffix. Line the two lists up side by side:
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+\textbf{\emph{haber} (present)} & \textbf{Future ending} \\
+\midrule
+\emph{he}    & \emph{-\'{e}} \\
+\emph{has}   & \emph{-\'{a}s} \\
+\emph{ha}    & \emph{-\'{a}} \\
+\emph{hemos} & \emph{-emos} \\
+\emph{han}   & \emph{-\'{a}n} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+They are the same list. A \textbf{compound} tense --- two words --- that closed
+up into a \textbf{simple} one, a single word. That is the exact reverse of what
+French and Italian did with their compound past, which stayed open as two words.
+
+\begin{culture}
+The seam Spanish sealed over is still faintly open next door. Portuguese welded
+its future too (\emph{falarei} is one word), but in \textbf{formal European
+Portuguese} a pronoun can still be lodged \emph{inside} it:\\[3pt]
+\emph{fal\'{a}-lo-ei} --- ``I will speak it.''\\[3pt]
+That \emph{-lo-} is sitting in the join, between \emph{falar} and \emph{ei}. It
+is a leftover, not the normal pattern --- Brazilian Portuguese does not do it,
+and neither does ordinary speech. But it shows you the weld from the outside.
+\end{culture}
+
+\begin{sounds}
+Every future form except \emph{nosotros} carries a written accent, and the
+accent falls on the very last syllable: \emph{ha-bla-R\'{E}},
+\emph{ha-bla-R\'{A}S}, \emph{ha-bla-R\'{A}N}. That final stress is the ghost of
+the second word --- \emph{he}, \emph{has}, \emph{han} --- that used to stand
+there on its own.\\[3pt]
+\emph{hablaremos} needs no accent: its stress already lands where Spanish
+expects it by default.
+\end{sounds}
+
+\section{\emph{hablar\'{i}a} --- the same weld, one tense over}
+\label{lesson:condicional}
+
+Same machine, one part swapped. Whole infinitive again, new endings.
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+\textbf{Person} & \textbf{Conditional of \emph{hablar}} \\
+\midrule
+\emph{yo}                     & \emph{hablar\'{i}a} \\
+\emph{t\'{u}}                 & \emph{hablar\'{i}as} \\
+\emph{\'{e}l / ella / usted}  & \emph{hablar\'{i}a} \\
+\emph{nosotros}               & \emph{hablar\'{i}amos} \\
+\emph{ellos / ustedes}        & \emph{hablar\'{i}an} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Look hard at those endings: \emph{-\'{i}a}, \emph{-\'{i}as},
+\emph{-\'{i}amos}, \emph{-\'{i}an}. They are exactly the \emph{-er}/\emph{-ir}
+\textbf{imperfect} endings --- \emph{com\'{i}a}, \emph{com\'{i}as},
+\emph{com\'{i}amos}, \emph{com\'{i}an} (``I used to eat,'' and so on).
+
+\begin{grammarlens}
+They are identical because they \emph{are} the same. The future welds the
+infinitive to the \textbf{present} of \emph{haber}; the conditional welds the
+same infinitive to the \textbf{imperfect} of \emph{haber} --- its ``used to''
+past.
+\end{grammarlens}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+\textbf{Tense} & \textbf{Infinitive $+$} & \textbf{Result} \\
+\midrule
+future      & \emph{haber} present (\emph{he, has, ha\ldots})       & \emph{hablar\'{e}} \\
+conditional & \emph{haber} imperfect (\emph{hab\'{i}a, hab\'{i}as\ldots}) & \emph{hablar\'{i}a} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Strictly, what fused was the older, shorter form \emph{av\'{i}a} --- which is
+why you get \emph{hablar\'{i}a} and not \emph{hablarhab\'{i}a}. The modern
+\emph{hab\'{i}a} is the same word, un-worn. One trick, two tenses of the same
+auxiliary: that is the whole chapter.
+
+\begin{sounds}
+The accent on \emph{-\'{i}a} does real work. Left alone, \emph{i} and \emph{a}
+would glide together into one syllable. The accent \textbf{breaks} them apart,
+so \emph{hablar\'{i}a} is three-and-a-bit syllables --- \emph{ha-bla-R\'{I}-a}
+--- with the stressed \emph{\'{i}} standing on its own.
+\end{sounds}
+
+Now, what the conditional is \emph{for}. Three jobs:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+\textbf{Use} & \textbf{Example} & \textbf{English} \\
+\midrule
+\textbf{would} --- hypothetical & \emph{Hablar\'{i}a con \'{e}l.} & ``I would speak with him.'' \\
+\textbf{politeness} --- softening & \emph{\textquestiondown Podr\'{i}as ayudarme?} & ``Could you help me?'' \\
+\textbf{future-in-the-past} & \emph{Dijo que hablar\'{i}a.} & ``He said he would speak.'' \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{culture}
+That third use is the neat one: measured from a point in the \emph{past}, the
+conditional \emph{is} the future --- which makes sense once you remember that a
+past tense of \emph{haber} is sitting inside it.\\[3pt]
+The second use is the one you will reach for daily. \emph{Me gustar\'{i}a\ldots}
+(``I would like\ldots'') is about the politest opening in Spanish: the
+conditional turns a demand into a wish, in every language that has one.
+\end{culture}
+
+\section{Practice --- ten stems, two tenses}
+\label{lesson:ch17-practice}
+
+A handful of verbs bend the infinitive before welding it. The good news:
+\textbf{the same bent stem serves both tenses}, so you learn ten shapes once and
+get twenty conjugations. They fall into three families.
+
+\textbf{1. Drop the vowel.} The infinitive's last vowel simply goes.
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+\textbf{Verb} & \textbf{Stem} & \textbf{Future} & \textbf{Conditional} \\
+\midrule
+\emph{poder} (to be able) & \emph{pod\textbf{r}-}  & \emph{podr\'{e}}  & \emph{podr\'{i}a} \\
+\emph{querer} (to want)   & \emph{quer\textbf{r}-} & \emph{querr\'{e}} & \emph{querr\'{i}a} \\
+\emph{saber} (to know)    & \emph{sab\textbf{r}-}  & \emph{sabr\'{e}}  & \emph{sabr\'{i}a} \\
+\emph{haber} (to have)    & \emph{hab\textbf{r}-}  & \emph{habr\'{e}}  & \emph{habr\'{i}a} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\textbf{2. Drop the vowel, then wedge in a \emph{d}.} Dropping alone would leave
+\emph{-n'r-} or \emph{-l'r-} jammed together, and Old Spanish refused to leave it
+that way --- so a \textbf{d} slid in to prop the cluster apart.
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+\textbf{Verb} & \textbf{Would be} & \textbf{Becomes} & \textbf{Future} \\
+\midrule
+\emph{tener} (to have) & \emph{ten-r-} & \emph{ten\textbf{d}r-} & \emph{tendr\'{e}} \\
+\emph{poner} (to put)  & \emph{pon-r-} & \emph{pon\textbf{d}r-} & \emph{pondr\'{e}} \\
+\emph{venir} (to come) & \emph{ven-r-} & \emph{ven\textbf{d}r-} & \emph{vendr\'{e}} \\
+\emph{salir} (to leave)& \emph{sal-r-} & \emph{sal\textbf{d}r-} & \emph{saldr\'{e}} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{sounds}
+It is not that modern Spanish cannot say those clusters --- \emph{honra},
+\emph{sonrisa}, \emph{alrededor} are perfectly ordinary. It is that when this
+particular squeeze happened, the language fixed it.\\[3pt]
+It even tried a \textbf{second} solution first: medieval Spanish also said
+\emph{tern\'{e}}, \emph{porn\'{e}}, \emph{vern\'{e}}, swapping the two
+consonants around instead of inserting anything. The \emph{d}-forms won.
+\end{sounds}
+
+Those four verbs --- \emph{tener}, \emph{poner}, \emph{venir}, \emph{salir} ---
+are all members of the \textbf{-go club} from Chapters 12--13, the verbs whose
+``I'' form ends in \emph{-go} (\emph{tengo}, \emph{pongo}, \emph{vengo},
+\emph{salgo}). The club has six members, and the other two, \emph{hacer} and
+\emph{decir}, are sitting in family 3 below. So \textbf{all six of the -go verbs
+are irregular here too}; they just split into two shapes. The oldest,
+most-used verbs misbehave in the same places over and over.
+
+\textbf{3. Chop hard.} Two verbs shorten drastically.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+\textbf{Verb} & \textbf{Future} & \textbf{Conditional} \\
+\midrule
+\emph{decir} (to say) & \emph{dir\'{e}} & \emph{dir\'{i}a} \\
+\emph{hacer} (to do)  & \emph{har\'{e}} & \emph{har\'{i}a} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{grammarlens}
+Here is the test that covers every irregular in this chapter: they are irregular
+in the \textbf{stem only}. The endings never change.\\[3pt]
+\textbf{irregular stem} $+$ the same \emph{-\'{e} / -\'{a}s / -\'{a}
+/ -emos / -\'{a}n} (future) or \emph{-\'{i}a / -\'{i}as / -\'{i}amos /
+-\'{i}an} (conditional).
+\end{grammarlens}
+
+One more use, and it surprises everyone: Spanish uses the \textbf{future} to
+express \textbf{present guessing}.
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+\textbf{Spanish} & \textbf{Means} \\
+\midrule
+\emph{\textquestiondown D\'{o}nde estar\'{a} Juan?} & ``Where \textbf{can} Juan be?'' (right now) \\
+\emph{Ser\'{a}n las tres.}                          & ``It \textbf{must be} three o'clock.'' \\
+\emph{\textquestiondown Qui\'{e}n ser\'{a}?}        & ``Who \textbf{could} that be?'' \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+And the \textbf{conditional} does the same job for the \textbf{past}:
+\emph{Ser\'{i}an las tres cuando lleg\'{o}} --- ``It must have been three when
+he arrived.''
+
+\begin{culture}
+This looks arbitrary until you remember where these tenses came from. Both were
+built out of ``\textbf{I have to\ldots}'' --- and \emph{have to} is about
+\textbf{obligation and likelihood}, not only about time. English does the very
+same slide: ``it \emph{must} be three'' is a word of obligation used for a
+guess. Spanish just made the whole tense carry that double duty.
+\end{culture}
+
+\begin{quote}\itshape
+--- \textquestiondown Qu\'{e} har\'{a}s ma\~{n}ana?\\
+--- Hablar\'{e} con Susana. \textquestiondown Podr\'{i}as venir?\\
+--- Me gustar\'{i}a, pero tendr\'{e} que trabajar. \textquestiondown Qu\'{e}
+hora es?\\
+--- Ser\'{a}n las tres.
+\end{quote}
+
+Run the recall. What do the future \emph{and} conditional endings attach to?
+The \textbf{whole infinitive} --- you never strip it. What happened to Latin's
+own future? It \textbf{died}, and Romance replaced it with the phrase
+\textbf{infinitive $+$ \emph{hab\={e}re}}, ``I have to speak.'' So what are the
+endings really? The \textbf{present of \emph{haber}} for the future, the
+\textbf{imperfect of \emph{haber}} for the conditional. Which language still
+shows the seam? \textbf{Portuguese}, in \emph{fal\'{a}-lo-ei}. Do the irregulars
+change the endings or the stem? \textbf{The stem only.} Why does \emph{tener}
+become \emph{tendr-}? Dropping the vowel squeezed \emph{-n'r-} together and a
+\textbf{d} wedged in to fix it. Which two verbs chop hardest? \emph{decir}
+$\to$ \emph{dir\'{e}} and \emph{hacer} $\to$ \emph{har\'{e}}. And what does
+\emph{Ser\'{a}n las tres} mean? ``It must be three'' --- the future used for
+guessing. Next chapter: the subjunctive, the mood for things that are not facts.

--- a/code/learning/human-languages/spanish/book/chapters/ch18-subjunctive.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch18-subjunctive.tex
@@ -1,0 +1,399 @@
+\chapter{The Subjunctive --- the Mood of the Not-Yet-Real}
+\label{ch:subjunctive}
+
+Every verb form so far has \emph{asserted} something. This chapter opens the
+other door: a whole second set of endings reserved for what is wanted, doubted,
+hoped for --- for what has not happened and may never happen. It is built by one
+small trick, triggered by one simple test, and its name means ``joined
+underneath.'' \emph{Practice lessons: \texttt{lessons/ES-C18-*.md}.}
+
+\section{\emph{hable}, \emph{coma}, \emph{viva} --- building the present subjunctive}
+\label{lesson:subjuntivo}
+
+\begin{grammarlens}
+\textbf{What a \emph{mood} is.} A \textbf{tense} tells you \emph{when}: I speak,
+I spoke, I will speak. A \textbf{mood} tells you what the speaker is \emph{doing}
+with the sentence --- reporting it, or reaching for it.\\[3pt]
+Everything in this book up to now has been the \textbf{indicative}: the mood of
+assertion. It states how things are, and it keeps on stating even when it is
+guessing --- \emph{Ser\'{a}n las tres} (``it must be three o'clock'') is still an
+assertion, just a confident one about something unknown.\\[3pt]
+Spanish has a second mood for what is not asserted at all: things wanted,
+doubted, feared, hoped for. That is the \textbf{subjunctive}. English has a
+shrunken one left over in fixed phrases --- ``if I \textbf{were} you'' (not
+\emph{was}), ``I insist that he \textbf{be} here'' (not \emph{is}), ``God
+\textbf{save} the Queen'' (not \emph{saves}). Those odd forms are English's last
+subjunctives. Spanish never let its own wear away.
+\end{grammarlens}
+
+\textbf{The recipe --- and it does not start from the infinitive.} It starts from
+the \emph{yo} (``I'') form of the present tense.
+
+\begin{enumerate}
+\item Take the \emph{yo} form: \emph{hablo} (``I speak''), \emph{como} (``I
+eat''), \emph{vivo} (``I live'').
+\item Drop the \emph{-o}: \emph{habl-}, \emph{com-}, \emph{viv-}.
+\item Add the \textbf{opposite} vowel.
+\end{enumerate}
+
+``Opposite'' is the whole trick. The two verb families swap costumes.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Verb type & Present takes\ldots & Subjunctive takes\ldots \\
+\midrule
+\emph{-ar} & \emph{-a-} (habl\textbf{a}s) & \textbf{-e-} (habl\textbf{e}s) \\
+\emph{-er} / \emph{-ir} & \emph{-e-} / \emph{-i-} (com\textbf{e}s) & \textbf{-a-} (com\textbf{a}s) \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+ & \emph{hablar} (to speak) & \emph{comer} (to eat) & \emph{vivir} (to live) \\
+\midrule
+yo & habl\textbf{e} & com\textbf{a} & viv\textbf{a} \\
+t\'{u} & habl\textbf{es} & com\textbf{as} & viv\textbf{as} \\
+\'{e}l / ella / usted & habl\textbf{e} & com\textbf{a} & viv\textbf{a} \\
+nosotros & habl\textbf{emos} & com\textbf{amos} & viv\textbf{amos} \\
+ellos / ustedes & habl\textbf{en} & com\textbf{an} & viv\textbf{an} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Notice that \emph{-er} and \emph{-ir} verbs are \textbf{identical} here ---
+\emph{coma} and \emph{viva} take exactly the same endings. Outside the present
+tense, those two conjugations keep merging.
+
+\begin{grammarlens}
+\textbf{Why building from \emph{yo} is a gift.} Because the subjunctive is built
+from the \emph{yo} form, \emph{any} irregularity already sitting in that form is
+inherited automatically. The \textbf{\emph{-go} club} --- six very common verbs
+whose ``I'' form grows a hard \emph{g} --- transfers whole, with nothing new to
+memorise.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Verb & \emph{yo} form & Subjunctive \\
+\midrule
+\emph{tener} (to have) & ten\textbf{go} & \textbf{tenga} \\
+\emph{decir} (to say) & di\textbf{go} & \textbf{diga} \\
+\emph{hacer} (to do / make) & ha\textbf{go} & \textbf{haga} \\
+\emph{poner} (to put) & pon\textbf{go} & \textbf{ponga} \\
+\emph{salir} (to leave) & sal\textbf{go} & \textbf{salga} \\
+\emph{venir} (to come) & ven\textbf{go} & \textbf{venga} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The \textbf{stem-changers} --- verbs whose stressed vowel breaks into two ---
+come along on the same free ride:
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Verb & \emph{yo} form & Subjunctive \\
+\midrule
+\emph{querer} (to want) & qu\textbf{ie}ro & qu\textbf{ie}ra \\
+\emph{poder} (to be able) & p\textbf{ue}do & p\textbf{ue}da \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+One caution: for these, the \emph{nosotros} form keeps the \textbf{plain} stem
+--- \emph{queramos}, \emph{podamos}, never \emph{quieramos}. That is the same
+rule as the present tense: the stress falls elsewhere, so the broken vowel never
+appears.
+\end{grammarlens}
+
+\textbf{Where the recipe runs out.} Step two says ``drop the \emph{-o},'' so the
+recipe needs a \emph{yo} form with a strippable \emph{-o} on the end. Five very
+common verbs do not have one.
+
+\begin{center}
+\begin{tabular}{llll}
+\toprule
+Verb & \emph{yo} form & Subjunctive & \\
+\midrule
+\emph{ser} (to be) & s\textbf{oy} & \textbf{sea} & unpredictable \\
+\emph{ir} (to go) & v\textbf{oy} & \textbf{vaya} & unpredictable \\
+\emph{saber} (to know) & s\textbf{\'{e}} & \textbf{sepa} & unpredictable \\
+\emph{haber} (to have, auxiliary) & h\textbf{e} & \textbf{haya} & unpredictable \\
+\emph{estar} (to be) & est\textbf{oy} & \textbf{est\'{e}} & \textbf{predictable} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The first four are simply learned outright --- and \emph{sea} carries a footnote.
+
+\begin{cousinweb}
+\textbf{sea} (``that it be'') $\leftarrow$ Latin \emph{sedeam}, the subjunctive of
+\emph{sed\={e}re}, ``\textbf{to sit}'' --- the second Latin verb that got folded
+into Spanish \emph{ser}. \emph{Sea} comes from that sitting verb's own
+subjunctive. The wanderer turns up again here, at the far end of the grammar.
+\end{cousinweb}
+
+But \emph{estar} behaves differently. Strip off the \emph{whole} \emph{-oy} and a
+perfectly ordinary stem is left --- \textbf{est-} --- which then takes the
+normal \emph{-ar} endings: \emph{est\'{e}, est\'{e}s, est\'{e}, estemos,
+est\'{e}n}.
+
+\begin{sounds}
+\emph{estar}'s one real oddity is \textbf{stress}, not spelling. Spanish's
+default: a word ending in a \textbf{vowel}, \textbf{-n} or \textbf{-s} is
+stressed on the \textbf{second-to-last} syllable. \emph{hablar} obeys that all
+the way through --- \textbf{HA}-ble, ha-\textbf{BLE}-mos, \textbf{HA}-blen --- so
+it never needs a written mark.\\[3pt]
+\emph{estar} breaks it. The stress lands on the \textbf{last} syllable:
+es-\textbf{T\'{E}}, es-\textbf{T\'{E}S}, es-\textbf{T\'{E}N} --- so each of those
+carries a written accent. Only es-\textbf{TE}-mos falls where Spanish expects,
+and it takes none.\\[3pt]
+The written accents are not decoration and not arbitrary: they are the
+\emph{receipt} for a stress that does not sit where the language expects it.
+\end{sounds}
+
+So the honest count is \textbf{four irregular, plus one} whose stem is perfectly
+regular but whose stress is not.
+
+(\emph{dar}, ``to give,'' has the same \emph{-oy} tail --- \emph{doy} --- and its
+stem shrinks the same way, down to \emph{d-}: \textbf{d\'{e}, des, d\'{e},
+demos, den}. Careful, though: that single accent is \emph{not} a stress mark.
+\emph{D\'{e}} is one syllable; the mark is there only to keep the verb apart in
+writing from the little preposition \emph{de}, ``of.'')
+
+\begin{grammarlens}
+\textbf{A caution about \emph{why}.} ``No \emph{-o} to strip'' is a
+\textbf{memory aid for the modern language}, not the history. \emph{sea},
+\emph{vaya}, \emph{sepa} and \emph{haya} come down from Latin \emph{sedeam},
+\emph{v\={a}dam}, \emph{sapiam} and \emph{habeam}; and \emph{saber} and
+\emph{haber} plainly do have usable stems elsewhere, \emph{sab-} and
+\emph{hab-}. The \emph{yo}-form recipe is a superb shortcut, and these five are
+exactly where it stops describing the language.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{subjunctive} $\leftarrow$ Latin \emph{subi\={u}nct\={i}vus},
+``\textbf{joined underneath}'' --- \emph{sub-} (``under'') $+$ \emph{iungere}
+(``to join''). English \textbf{join}, \textbf{junct}ion and \textbf{conjunct}ion
+all descend from that verb.\\[3pt]
+Two more words belong to the family without descending from Latin:
+\textbf{yoke} (a native English word, Old English \emph{geoc}) and
+\textbf{yoga} (Sanskrit \emph{yuj-}, literally ``a yoking''). Those are
+\emph{iungere}'s \textbf{cousins}, not its children --- all three go back to the
+same Proto-Indo-European root \emph{*yewg-}, ``to join.'' A yoke is what joins
+two oxen; yoga is what joins the self to something larger; a conjunction is what
+joins two clauses.\\[3pt]
+Latin coined the term to translate Greek \emph{hypotaktik\'{\={e}}},
+``\textbf{subordinated}.'' So the name describes where the mood \emph{lives},
+not what it means: in a clause hanging \textbf{underneath} another one. The next
+section shows exactly that structure.
+\end{cousinweb}
+
+\section{\emph{quiero que\ldots} --- making the subjunctive appear}
+\label{lesson:quiero-que}
+
+You can now \emph{build} the subjunctive. This section is about what makes it
+\emph{show up} --- and the core case is beautifully simple: \textbf{one person
+wanting a different person to do something.}
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+Spanish & English \\
+\midrule
+\textbf{Quiero hablar} espa\~{n}ol. & I want \textbf{to speak} Spanish. \\
+\textbf{Quiero que hables} espa\~{n}ol. & I want \textbf{you to speak} Spanish. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{grammarlens}
+The first sentence has \textbf{one} subject --- I want, I speak --- so Spanish
+uses a plain infinitive, exactly like English.\\[3pt]
+The second has \textbf{two}. \emph{I} am the wanter; \emph{you} are the speaker.
+The moment the two subjects differ, Spanish must do two things: (1) join the
+halves with \textbf{que} (``that''), and (2) put the second verb in the
+\textbf{subjunctive}. \emph{\textbf{Quiero} que \textbf{hables}.}\\[3pt]
+That is \emph{subi\={u}nct\={i}vus} doing precisely what its name says: living in
+a clause joined \emph{underneath} the main one.
+\end{grammarlens}
+
+\textbf{Why it is not a fact.} \emph{Hables} is not a report that you speak. It
+is what I \emph{want} --- which may never happen. The main clause reaches out and
+bends the second one into something unreal, and the mood marks the bend.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Spanish & English & Mood \\
+\midrule
+S\'{e} que \textbf{hablas} espa\~{n}ol. & I know that you speak Spanish. & indicative (a fact) \\
+Quiero que \textbf{hables} espa\~{n}ol. & I want you to speak Spanish. & subjunctive (not yet real) \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Same \emph{que}, same person, different mood --- because knowing \emph{reports}
+the world and wanting tries to \emph{change} it.
+
+\begin{grammarlens}
+\textbf{The English trap.} English says ``I want \emph{you to speak}'' --- an
+object followed by an infinitive. \textbf{After verbs of wanting, Spanish will
+not do this.} There is no \emph{Quiero te hablar} meaning ``I want you to
+speak.'' You must build the full clause: \textbf{Quiero que hables.} This is the
+single most common English-speaker error with the Spanish subjunctive, and it
+comes from translating the \emph{shape} instead of the \emph{meaning}.\\[3pt]
+Two things keep the rule honest. First, it is about \textbf{wanting}, not about
+Spanish in general: object $+$ infinitive is perfectly good after verbs of
+\emph{perceiving} and \emph{causing} --- \emph{Te vi salir} (``I saw you
+leave''), \emph{Me hizo hablar} (``he made me speak''), \emph{D\'{e}jame hablar}
+(``let me speak''). Volition is the family that demands a clause. Second,
+\emph{Quiero hablarte} is perfectly fine --- it just means ``I want to
+\emph{speak to you}'': one subject, with the pronoun attached to the infinitive.
+What is impossible is using a pronoun to smuggle in a \emph{second} subject.
+\end{grammarlens}
+
+\textbf{\emph{ojal\'{a}} --- a wish, borrowed whole.} Spanish has another
+trigger, and it is a wonderful word: \emph{\textbf{Ojal\'{a} hable}
+espa\~{n}ol} --- ``I hope he speaks Spanish / may he speak Spanish.''
+\emph{Ojal\'{a}} takes the subjunctive \textbf{always}; there is no indicative
+version, because the word \emph{is} a wish.
+
+\begin{cousinweb}
+\textbf{ojal\'{a}} (``would that\ldots'') $\leftarrow$ Andalusi Arabic
+\emph{law sh\={a}\textquoteright\ All\={a}h}, ``\textbf{if God should will}.''
+The \emph{All\={a}h} is still sitting in the second half of the word every time
+a Spanish speaker says it. The nearest English is ``\textbf{God willing}'' ---
+and nearer still, the Arabic \emph{inshallah} that English has now borrowed in
+its own right.
+\end{cousinweb}
+
+\begin{culture}
+Languages borrow \emph{nouns} constantly: Spanish took \emph{az\'{u}car}
+(``sugar''), \emph{aceite} (``oil'') and \emph{\'{a}lgebra} from Arabic without
+blinking. Borrowing a \textbf{function word} --- a piece of the machinery rather
+than a piece of the furniture --- is far rarer, and this course teaches you the
+two that matter: \textbf{hasta} (``until''), from Arabic \emph{\d{h}att\={a}},
+and \textbf{ojal\'{a}}. One is a preposition; the other is a word that
+\emph{forces a grammatical mood}. Eight centuries of contact left Spanish not
+just Arabic words, but Arabic grammar.
+\end{culture}
+
+\section{Practice --- fact or wish?}
+\label{lesson:ch18-practice}
+
+Two skills to drill, in order: \textbf{build the form}, then \textbf{decide
+whether you need it}.
+
+\textbf{Drill 1 --- the vowel flip.} Recipe: \emph{yo} form $\to$ drop the
+\emph{-o} $\to$ flip the vowel.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Verb & \emph{yo} form & Subjunctive \\
+\midrule
+\emph{hablar} & hablo & \textbf{hable} \\
+\emph{estudiar} & estudio & \textbf{estudie} \\
+\emph{comer} & como & \textbf{coma} \\
+\emph{beber} & bebo & \textbf{beba} \\
+\emph{vivir} & vivo & \textbf{viva} \\
+\emph{tener} & tengo & \textbf{tenga} \\
+\emph{hacer} & hago & \textbf{haga} \\
+\emph{venir} & vengo & \textbf{venga} \\
+\emph{querer} & quiero & \textbf{quiera} \\
+\emph{poder} & puedo & \textbf{pueda} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The last four are the point: \textbf{you never learned a new stem.} The
+\emph{-g-} and the broken vowel were already sitting in the \emph{yo} form.
+
+Then the four with no \emph{-o} to strip, learned outright: \emph{ser} $\to$
+\textbf{sea}, \emph{ir} $\to$ \textbf{vaya}, \emph{saber} $\to$ \textbf{sepa},
+\emph{haber} $\to$ \textbf{haya}. And \emph{estar}, which looks as though it
+belongs with them and does not: take off the whole \emph{-oy} and the stem
+\textbf{est-} is completely ordinary --- \emph{est\'{e}, est\'{e}s, est\'{e},
+estemos, est\'{e}n} --- with the irregularity living in the \textbf{stress}
+alone.
+
+\textbf{Drill 2 --- one subject or two?} The test: \emph{does the second verb
+have a different subject?}
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+English & Spanish \\
+\midrule
+I want to eat. & Quiero \textbf{comer}. (same subject $\to$ infinitive) \\
+I want you to eat. & Quiero \textbf{que comas}. (two $\to$ \emph{que} $+$ subjunctive) \\
+We want to live here. & Queremos \textbf{vivir} aqu\'{i}. \\
+We want them to live here. & Queremos \textbf{que vivan} aqu\'{i}. \\
+She wants to work. & Quiere \textbf{trabajar}. \\
+She wants me to work. & Quiere \textbf{que yo trabaje}. \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Say each pair aloud back to back. English switches quietly, from ``to eat'' to
+``you to eat''; Spanish switches loudly --- and the loudness is the help.
+
+\textbf{Drill 3 --- fact or not?} Same \emph{que}, different mood. Report the
+world $\to$ \textbf{indicative}. Reach for it $\to$ \textbf{subjunctive}.
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Spanish & English & \\
+\midrule
+S\'{e} que \textbf{comes} aqu\'{i}. & I know you eat here. & fact \\
+Quiero que \textbf{comas} aqu\'{i}. & I want you to eat here. & wish \\
+S\'{e} que \textbf{est\'{a}} aqu\'{i}. & I know he's here. & fact \\
+Ojal\'{a} \textbf{est\'{e}} aqu\'{i}. & I hope he's here. & wish \\
+Dice que \textbf{viene}. & She says she's coming. & report \\
+Quiero que \textbf{venga}. & I want her to come. & wish \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+Notice that \emph{ojal\'{a}} needs no \emph{que} and no main verb. The word
+\emph{is} the wish, so it triggers the mood all by itself.
+
+\textbf{Drill 4 --- hear the flip.} The vowel swap is small on paper and clear in
+the mouth.
+
+\begin{center}
+\begin{tabular}{ll}
+\toprule
+Indicative & Subjunctive \\
+\midrule
+habl\textbf{a} & habl\textbf{e} \\
+com\textbf{e} & com\textbf{a} \\
+trabaj\textbf{a} & trabaj\textbf{e} \\
+viv\textbf{e} & viv\textbf{a} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\begin{sounds}
+The two \emph{-ar} rows carry a warning. \emph{Hable} and \emph{habl\'{e}} are
+different words --- and so are \emph{trabaje} and \emph{trabaj\'{e}}. The
+written accent is the only thing separating ``\textbf{(that) he speak}'' from
+``\textbf{I spoke}.'' In Spanish the accent does not merely mark a syllable: it
+\emph{carries the tense}.
+\end{sounds}
+
+What you built this chapter: a second \textbf{mood}, made from the \emph{yo}
+form with the vowel flipped --- \emph{hable, coma, viva}; the free ride that
+hands you \emph{tenga, diga, haga, ponga, salga, venga, quiera, pueda}; the four
+you learn outright, \emph{sea, vaya, sepa, haya}, and \emph{est\'{e}}, whose only
+secret is its stress; the two-subject test that summons the mood, \emph{quiero
+que hables}; and \emph{ojal\'{a}}, a wish that Spanish carried over whole from
+Arabic. You now have both halves of the Spanish verb: the mood that reports the
+world, and the mood that reaches for it. Everything still ahead --- describing
+what surrounds you, telling longer stories, arguing, hoping out loud --- is
+built on the pair.

--- a/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
@@ -42,8 +42,9 @@ get a fistful of words for free:
 - **grateful**, **gratitude** — being *full of* grātia.
 - **gratis**, **gratuity** — something given as a *favour* (for free, or a tip).
 - **congratulate** — literally "to wish grace *together with* someone."
-- Italian **grazie**, French **grâce/merci-less** *grâces*, Portuguese
-  **obrigado**'s cousin *graças* — the whole Romance family keeps grātia.
+- Italian **grazie**, French *grâces*, Portuguese *graças* — the whole Romance
+  family kept grātia, even where everyday thanks went elsewhere (French says
+  *merci*, Portuguese *obrigado*).
 
 So *gracias* is not a word to memorize cold: it is **grace**, made plural and
 handed to another person.


### PR DESCRIPTION
## The gap this closes

The **lessons had run far ahead of the published artifact**. Spanish has 90 authored lessons through Chapter 18 — but the LaTeX book still stopped at Chapter 3 ("Introducing Yourself"). Because the CI book build only compiles what's wired into `book.tex`, the missing chapters were invisible to CI, so this drifted silently.

This PR is the first of a series bringing every book back in sync with its lessons.

## What's here

**Fifteen new book chapters**, written from the existing `ES-C04`–`ES-C18` lessons and wired into `book.tex`:

| | | |
|---|---|---|
| Ch4 How Are You | Ch9 *Ser* and *Estar* | Ch14 The Preterite |
| Ch5 Farewells | Ch10 Going, and the Near Future | Ch15 Completing the Preterite |
| Ch6 The First Verbs | Ch11 Stem-Changing Verbs | Ch16 The Imperfect |
| Ch7 The *-er*/*-ir* Verbs | Ch12 The *-go* Verb Club | Ch17 The Future and the Conditional |
| Ch8 Numbers and Age | Ch13 Completing the *-go* Club | Ch18 The Subjunctive |

Each follows the established book conventions: one `\section` per lesson with a slug `\label`, the `cousinweb`/`grammarlens`/`culture`/`sounds` boxes, `booktabs` conjugation tables, every atom traced to its root, and the true-beginner audience rule (no "you already know this from X" — every form supplied in full). **Content is faithful to the lessons; no new etymologies were introduced.**

## Verification

- Book grows **20 → 114 pages**.
- Compiles clean with XeLaTeX: **0 errors, 0 missing characters, 0 undefined references, 0 duplicate labels**.
- Rasterized and visually QA'd — the accent-heavy preterite drills (*hablé/habló/trabajé/compré/España*) and the subjunctive chapter render correctly.
- Practice-section labels are chapter-qualified (`lesson:chN-practice`) so they stay unique across 18 chapters.

## Drive-by fix

`ES-C04-gracias.md` had a corrupted cognate line — "French **grâce/merci-less** *grâces*, Portuguese **obrigado**'s cousin *graças*". Now reads as the intended claim: the Romance family kept *grātia* even where everyday thanks went elsewhere (French *merci*, Portuguese *obrigado*).

## Still behind (follow-up PRs)

Italian & Portuguese (+15 each), French & German (+14 each), Arabic (+2), the Dravidian four (+1 each), and Russian — which has 12 lessons and **no book at all**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)