### PR TITLE
feat(app): Concepts mode — one idea across every language, plus prerequisite gating

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,95 @@
 # Changelog
 
+## 0.6.0 — Concepts mode: one idea, every language that has it
+
+The app could drill letters, and drill lessons. It could not yet do the thing
+the curriculum's shared `concept_tag`s exist for: **compare**.
+
+- **New "Concepts" mode.** Canonical concept tags are deliberately identical
+  across tracks, which makes them a join key — *gracias / merci / danke /
+  धन्यवाद / നന്ദി* are one concept realized eighteen ways. The mode lists every
+  concept **two or more languages** share (**39** of them, from **701** lessons)
+  and expands each into a side-by-side table.
+- **It calls the package's own `languagesForConcept`.** That function has
+  shipped since HL01, tested and documented as "what the companion app calls,"
+  with **no caller**. This is the caller — and `buildDataset` beside it, so the
+  join is the package's tested logic rather than a second implementation that
+  could drift from it.
+- Each row carries **headword**, **romanization** (only when it differs from the
+  headword — for Latin-script tracks the package sets them equal, and repeating
+  it is noise), and gloss. The **etymology hooks** follow the comparison, which
+  is where they earn their keep: *gracias* ← *gratia* "favour", *merci* ←
+  *mercēs* "wages, price", *danke* ← *denken* "to think", *спасибо* ← *спаси
+  Бог* "God save you". One courtesy, four unrelated ideas.
+- **Concepts only one language realizes are dropped.** Not a special case for
+  namespaced tags — a language floor removes them naturally, because a card with
+  nothing to compare against isn't a card.
+
+### Prerequisite gating (the other half)
+
+`scheduler.ts` is generic over a numeric index and has no idea that "the
+preterite of *comer*" presupposes *comer*. New `concepts.ts` supplies that
+knowledge before the scheduler ever sees the pool:
+
+- A lesson unlocks when every id in its `prerequisites` has been **seen**.
+- **Unknown prerequisite ids count as satisfied.** A curriculum typo, or a
+  prerequisite pointing at an unwritten lesson, should degrade to "shown
+  slightly early" — never to "silently unreachable forever," which is the
+  failure nobody notices.
+- **The gate fails open.** `unlockedOrAll` falls back to every lesson if the
+  gated pool is empty (a prerequisite cycle would do it), because practice
+  stalling completely is worse than practising something early. Tested with an
+  actual cycle.
+- "Seen" is computed from **review history** (`reps`/`lapses`/`box`), never from
+  `dueAtSession` — the 0.5.0 bug that reported the whole curriculum as started
+  after one reload.
+- `reviewTargets` maps `reviews_of` onto scheduler indices and is tested, but
+  **nothing calls it yet** — it is groundwork for having the app follow the
+  syllabus's own "answering this should refresh those" instead of waiting on a
+  Leitner interval. Said plainly because an earlier draft of this entry claimed
+  the app already did that, which was false. (`ConceptCard.namespaced` is
+  likewise computed and not yet rendered.)
+
+### The bug this shipped with, and how it was caught
+
+The first cut gated the **pick**: choose from the rotation, and if the chosen
+lesson is locked, substitute the first unlocked one. That is wrong in a way that
+is invisible by inspection — the same pick is rejected every turn, so the
+substitute is served over and over. A review simulation of the real curriculum
+measured it serving **one Arabic lesson 34 times in 40**, wiping out both the
+0.5.0 rotating cursor and cross-language interleaving.
+
+The fix gates the **pool**: `nextDue` now takes an `accept` predicate and skips
+locked indices *during* the scan, so the cursor keeps advancing; the
+nothing-due fallback runs `pickNext` over the unlocked states rather than
+grabbing `open[0]`.
+
+The regression test took three attempts to make honest, which is worth
+recording. Versions 1 and 2 **passed against the broken implementation** — the
+fixture's chain order happened to match its pool order, so the rotation landed
+on unlocked lessons anyway. Only a fixture whose dependency order runs
+*counter* to pool order (as the real curriculum's does) reproduces it. The test
+now fails on the broken version and passes on the fixed one, and both were
+verified by actually injecting the old code.
+
+### Notes
+
+- Tests: **97**, up from 75 — `tests/concepts.test.ts`, including checks against
+  the **real curriculum** (every card genuinely spans ≥2 languages; gating opens
+  a non-empty but non-total pool on a fresh profile; everything is reachable
+  once everything is seen).
+- `Lesson` gained `romanization`, `script` and `etymologyHook`, which the cards
+  need. `tests/lessons.test.ts` now builds fixtures through a defaulting helper
+  so adding a field doesn't touch every test.
+- **Verified in a browser**, not just built: the 0.5.0 `process is not defined`
+  bug was a successful build that died on load, and only a real page load
+  catches that class of error. Both new deep imports (`parse.ts`, `queries.ts`)
+  are pure modules; console is clean.
+- **Known cost, unchanged:** the eager `import.meta.glob` still inlines every
+  lesson, so the bundle is ~1.72 MB (542 kB gzipped). Concepts mode makes the
+  parsed corpus more valuable, not less, but a lazy glob or a build-time index
+  remains the right fix. Deferred, not hidden.
+
 ## 0.5.0 — Lessons mode: the whole curriculum, and a memory that survives reloads
 
 The app could already schedule you. It could not **remember** you, and it had

--- a/code/programs/typescript/script-writing-visualizer/README.md
+++ b/code/programs/typescript/script-writing-visualizer/README.md
@@ -1,12 +1,33 @@
 # Script Writing Visualizer
 
-**The HL02 companion app.** Three modes: **Browse** and **Practice** work on
+**The HL02 companion app.** Four modes: **Browse** and **Practice** work on
 *script letters*; **Lessons** drills the *written curriculum* — every lesson in
-every track — on a spaced-repetition schedule that persists between visits.
+every track — on a spaced-repetition schedule that persists between visits; and
+**Concepts** shows one idea in every language that has it, side by side.
+
+## Concepts mode
+
+The curriculum tags lessons with a shared `concept_tag`, and canonical tags are
+deliberately the same across tracks. That makes them a **join key**: *gracias /
+merci / danke / धन्यवाद / നന്ദി* are one concept realized eighteen ways.
+
+This mode is that join, and it is the data package's own
+`languagesForConcept` — a function shipped from the start, documented as "what
+the companion app calls," which until now had **no caller**.
+
+- **39 concepts are shared by two or more tracks**, from 701 lessons. A concept
+  only one language tags is filtered out: there is nothing to compare it with,
+  which also removes almost every namespaced (`ES-…`) tag without a special case.
+- Each row shows the **headword**, a **romanization** where it differs, and the
+  gloss — so a non-Latin script is legible next to a Latin one.
+- The **etymology hooks** sit underneath the comparison, where they do the most
+  work: *gracias* ← *gratia* "favour", *merci* ← *mercēs* "wages", *danke* ←
+  *denken* "to think", *спасибо* ← *спаси Бог* "God save you". Four languages'
+  words for the same courtesy, from four unrelated ideas.
 
 ## Lessons mode
 
-Reads all **679 lessons across 18 languages** straight from the curriculum via
+Reads all **701 lessons across 18 languages** straight from the curriculum via
 `@coding-adventures/human-language-data`, and schedules them with the same
 Leitner machinery the letter drills use (`scheduler.ts` is generic over an
 index; it never needed to know what an item is).

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/concepts.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/concepts.ts
@@ -1,0 +1,213 @@
+// ---------------------------------------------------------------------------
+// concepts.ts — cross-language study, and the gate that keeps it teachable.
+//
+// The curriculum tags almost every lesson with a `concept_tag`. Canonical tags
+// (GREETING-HELLO, TIME-DAY) are shared across tracks *on purpose*: they are the
+// join key that lets you ask "how does every language I'm learning say this?"
+// The data package has shipped `languagesForConcept` for exactly that since the
+// beginning, documented as "what the companion app calls" — with no caller.
+// This module is the caller.
+//
+// It does two jobs:
+//
+//   1. CROSS-LANGUAGE GROUPS. Build a real `Dataset` and pull out the concepts
+//      that more than one track realizes. Those are the study cards: one idea,
+//      several languages, side by side.
+//
+//   2. PREREQUISITE GATING. Lessons declare `prerequisites`. Serving a learner
+//      "the preterite of *comer*" before they have met *comer* is worse than
+//      useless, and the scheduler — which is deliberately generic over a numeric
+//      index — has no way to know that. So gating happens here, before the
+//      scheduler ever sees the pool.
+//
+// Everything here is pure: data in, data out, no DOM and no storage. The impure
+// edges stay in `main.ts`.
+// ---------------------------------------------------------------------------
+
+// Deep imports, for the reason spelled out at the top of `lessons.ts`: the
+// package barrel drags `loader.ts` (node:fs) and `cli.ts` (process) into the
+// browser bundle, and the build *succeeds* before the app dies on load. Both
+// modules reached for here are pure — `parse.ts` does frontmatter → dataset,
+// `queries.ts` imports nothing but types.
+import {
+  buildDataset,
+  type ParsedLesson,
+} from "@coding-adventures/human-language-data/src/parse.ts";
+import { languagesForConcept } from "@coding-adventures/human-language-data/src/queries.ts";
+import type {
+  Dataset,
+  Realization,
+  Script,
+  Taxonomy,
+} from "@coding-adventures/human-language-data/src/types.ts";
+import type { Lesson } from "./lessons.js";
+
+/**
+ * One study card: a concept, and every language's way of saying it.
+ *
+ * `realizations` is whatever `languagesForConcept` returned, so the shape is
+ * the package's, not ours — headword, gloss, romanization and etymology hook
+ * all come along for free.
+ */
+export interface ConceptCard {
+  id: string;
+  /** Human-readable gloss from the taxonomy, or the first realization's. */
+  gloss: string;
+  /** True when the tag is language-specific (ES-…) rather than canonical. */
+  namespaced: boolean;
+  realizations: Realization[];
+}
+
+/**
+ * Concepts realized by at least `minLanguages` tracks, id-sorted.
+ *
+ * The floor matters. A concept only one track has ever tagged is a perfectly
+ * good lesson but a *useless* cross-language card — there is nothing to compare
+ * it with. Namespaced tags (ES-SUBJUNCTIVE-PRESENT) are almost always in that
+ * position by construction, so this filter removes most of them without needing
+ * a special case for them.
+ */
+export function crossLanguageConcepts(
+  dataset: Dataset,
+  minLanguages = 2,
+): ConceptCard[] {
+  const out: ConceptCard[] = [];
+  for (const concept of dataset.concepts) {
+    const realizations = languagesForConcept(dataset, concept.id);
+    const languages = new Set(realizations.map((r) => r.language));
+    if (languages.size < minLanguages) continue;
+    out.push({
+      id: concept.id,
+      gloss: concept.gloss,
+      namespaced: concept.namespaced,
+      realizations,
+    });
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Build the dataset the cross-language mode reads.
+ *
+ * `buildDataset` wants `ParsedLesson[]`, but this app has already mapped those
+ * down to its own leaner `Lesson`. Re-parsing would mean holding every lesson
+ * twice, so instead we hand `buildDataset` the realizations it actually reads.
+ * Keeping that adaptation in one named function means the shape mismatch is
+ * documented rather than scattered.
+ */
+export function datasetFromLessons(
+  taxonomy: Taxonomy,
+  lessons: Lesson[],
+): Dataset {
+  const parsed: ParsedLesson[] = lessons.map((l) => ({
+    language: l.language,
+    script: l.script as Script,
+    // `buildDataset` reads only `.realization`; frontmatter is inert here, and
+    // an empty object is honest about that rather than reconstructing a fake.
+    frontmatter: {},
+    realization: {
+      concept: l.concept,
+      language: l.language,
+      lessonId: l.id,
+      chapter: l.chapter,
+      type: l.type,
+      headword: l.headword,
+      gloss: l.gloss,
+      romanization: l.romanization,
+      script: l.script as Script,
+      // The app's leaner Lesson doesn't carry gender, and `buildDataset`
+      // doesn't read it. `null` is the type's own "unknown", so this is
+      // truthful rather than a placeholder.
+      gender: null,
+      sounds: [],
+      roots: [],
+      etymologyHook: l.etymologyHook,
+    },
+  }));
+  return buildDataset(taxonomy, parsed);
+}
+
+// ---------------------------------------------------------------------------
+// Prerequisite gating
+// ---------------------------------------------------------------------------
+
+/**
+ * Is this lesson teachable yet?
+ *
+ * A lesson unlocks when every id in its `prerequisites` has been seen. Unknown
+ * ids — a typo, or a prerequisite pointing at a lesson not yet written — are
+ * treated as ALREADY SATISFIED rather than as a permanent lock. A curriculum
+ * bug should degrade to "shown slightly early", never to "silently unreachable
+ * forever," which is the failure mode nobody notices.
+ */
+export function isUnlocked(
+  lesson: Lesson,
+  seen: ReadonlySet<string>,
+  known: ReadonlySet<string>,
+): boolean {
+  return lesson.prerequisites.every((id) => !known.has(id) || seen.has(id));
+}
+
+/**
+ * The indices of every lesson that is teachable right now.
+ *
+ * Returned as indices because that is the currency the scheduler speaks.
+ *
+ * NEVER-EMPTY GUARANTEE: on a fresh profile nothing has been seen, so any
+ * lesson with prerequisites is locked — but chapter-1 lessons have none, so the
+ * pool opens with those and widens as they are learned. If a curriculum change
+ * ever did lock everything, the caller gets an empty array and must fall back;
+ * `unlockedOrAll` below is that fallback, made explicit.
+ */
+export function unlockedIndices(
+  lessons: Lesson[],
+  seen: ReadonlySet<string>,
+): number[] {
+  const known = new Set(lessons.map((l) => l.id));
+  const out: number[] = [];
+  for (let i = 0; i < lessons.length; i += 1) {
+    if (isUnlocked(lessons[i], seen, known)) out.push(i);
+  }
+  return out;
+}
+
+/**
+ * `unlockedIndices`, but never empty — falls back to every index.
+ *
+ * Practice stalling completely is the one outcome worse than practising
+ * something slightly too early, so the gate is allowed to fail open.
+ */
+export function unlockedOrAll(
+  lessons: Lesson[],
+  seen: ReadonlySet<string>,
+): number[] {
+  const gated = unlockedIndices(lessons, seen);
+  return gated.length > 0 ? gated : lessons.map((_, i) => i);
+}
+
+/**
+ * Ids a lesson explicitly revisits, restricted to ones that exist.
+ *
+ * `reviews_of` is the curriculum's own statement of "answering this should
+ * refresh those." Surfacing it lets the app bring the named lessons forward
+ * instead of waiting for their Leitner interval — the difference between a
+ * scheduler that merely repeats and one that follows the syllabus.
+ */
+export function reviewTargets(
+  lesson: Lesson,
+  byId: ReadonlyMap<string, number>,
+): number[] {
+  const out: number[] = [];
+  for (const id of lesson.reviewsOf) {
+    const index = byId.get(id);
+    if (index !== undefined) out.push(index);
+  }
+  return out;
+}
+
+/** id → index, for `reviewTargets`. */
+export function indexById(lessons: Lesson[]): Map<string, number> {
+  const map = new Map<string, number>();
+  lessons.forEach((l, i) => map.set(l.id, i));
+  return map;
+}

--- a/code/programs/typescript/script-writing-visualizer/src/lessons.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/lessons.ts
@@ -51,6 +51,12 @@ export interface Lesson {
   concept: string;
   prerequisites: string[];
   reviewsOf: string[];
+  /** Latin-script reading; equals `headword` for Latin-script tracks. */
+  romanization: string;
+  /** Script slug the package assigned from the track name. */
+  script: string;
+  /** ≤120-char memory anchor; "" when not yet authored. */
+  etymologyHook: string;
 }
 
 /**
@@ -94,6 +100,9 @@ export function toLesson(parsed: ParsedLesson): Lesson | null {
     concept: r.concept,
     prerequisites: arr(fm.prerequisites),
     reviewsOf: arr(fm.reviews_of),
+    romanization: r.romanization,
+    script: r.script,
+    etymologyHook: r.etymologyHook,
   };
 }
 
@@ -157,6 +166,16 @@ export function nextDue(
   schedule: DueLike[],
   session: number,
   cursor: number,
+  /**
+   * Optional filter, applied DURING the scan.
+   *
+   * This is how prerequisite gating enters the rotation. Filtering afterwards
+   * — picking, then rejecting, then substituting a fallback — collapses to
+   * serving that one fallback over and over, because the same pick is rejected
+   * every time. Skipping unacceptable indices *inside* the scan keeps the
+   * cursor advancing and the rotation intact.
+   */
+  accept: (index: number) => boolean = () => true,
 ): NextDue {
   if (pool.length === 0) return { index: null, cursor };
   let at = cursor;
@@ -165,6 +184,7 @@ export function nextDue(
     const entry = pool[at]!;
     const index = groups[entry.scriptIndex]?.[entry.letterIndex];
     if (index === undefined) continue;
+    if (!accept(index)) continue;
     const state = schedule[index];
     if (state && state.dueAtSession <= session) return { index, cursor: at };
   }

--- a/code/programs/typescript/script-writing-visualizer/src/main.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/main.ts
@@ -33,6 +33,14 @@ import {
 import { buildPool, type PoolEntry } from "./interleave.ts";
 import { loadLessons, indicesByLanguage, nextDue } from "./lessons.ts";
 import {
+  crossLanguageConcepts,
+  datasetFromLessons,
+  unlockedOrAll,
+  type ConceptCard,
+} from "./concepts.ts";
+import taxonomyJson from "../../../../learning/human-languages/concepts/taxonomy.json";
+import type { Taxonomy } from "@coding-adventures/human-language-data/src/types.ts";
+import {
   browserStorage,
   fromSaved,
   loadProgress,
@@ -45,7 +53,7 @@ import "./styles.css";
 const app = document.getElementById("app");
 if (!app) throw new Error("missing #app root");
 
-type Mode = "browse" | "practice" | "lessons";
+type Mode = "browse" | "practice" | "lessons" | "concepts";
 let mode: Mode = "browse";
 
 // --- lesson review state ----------------------------------------------------
@@ -62,6 +70,15 @@ const LESSON_IDS = LESSONS.map((l) => l.id);
 // reviews can walk across languages cheaply.
 const LESSON_GROUPS = indicesByLanguage(LESSONS);
 const LESSON_POOL = buildPool(LESSON_GROUPS.map((g) => g.length));
+
+// Cross-language cards: one concept, several languages. Built once — the join
+// walks every lesson, and neither the curriculum nor the taxonomy changes while
+// the page is open.
+const CONCEPT_CARDS: ConceptCard[] = crossLanguageConcepts(
+  datasetFromLessons(taxonomyJson as unknown as Taxonomy, LESSONS),
+);
+/** Which concept card is expanded; null = none. */
+let openConcept: string | null = null;
 let savedProgress = loadProgress(browserStorage());
 let lessonSchedule: ItemState[] = fromSaved(LESSON_IDS, savedProgress);
 let lessonSession = savedProgress.session;
@@ -127,8 +144,9 @@ function renderModeToggle(): HTMLElement {
     browse: "Browse",
     practice: "Practice",
     lessons: "Lessons",
+    concepts: "Concepts",
   };
-  (["browse", "practice", "lessons"] as Mode[]).forEach((m) => {
+  (["browse", "practice", "lessons", "concepts"] as Mode[]).forEach((m) => {
     const b = el("button", "mode" + (m === mode ? " mode--active" : ""));
     b.textContent = LABELS[m];
     b.setAttribute("aria-pressed", String(m === mode));
@@ -387,6 +405,19 @@ function pickLesson(): void {
     lessonIndex = null;
     return;
   }
+  // PREREQUISITE GATE, applied to the POOL rather than to the pick.
+  //
+  // The scheduler is generic over a numeric index and has no idea that "the
+  // preterite of comer" presupposes "comer". But gating must happen *inside*
+  // the rotation, not after it: picking and then rejecting collapses to serving
+  // the one fallback lesson forever, because the same pick is rejected on every
+  // turn. That is the 0.5.0 bug in a new costume — a review simulation caught
+  // it serving one Arabic lesson 34 times in 40.
+  //
+  // Recomputed per pick because `seen` grows as you study; it is a single pass
+  // over ~700 lessons, dwarfed by the render that follows.
+  const open = new Set(unlockedOrAll(LESSONS, seenLessonIds()));
+
   // The scan itself is a pure function in lessons.ts (and tested there); this
   // only threads the cursor. LESSON_GROUPS / LESSON_POOL are computed once —
   // they are constant for the page's lifetime.
@@ -396,11 +427,36 @@ function pickLesson(): void {
     lessonSchedule,
     lessonSession,
     lessonCursor,
+    (i) => open.has(i),
   );
   lessonCursor = cursor;
-  // Nothing due: fall back to the scheduler's most-overdue pick so the mode is
-  // never a dead end.
-  lessonIndex = index ?? pickNext(lessonSchedule, lessonSession);
+  if (index !== null) {
+    lessonIndex = index;
+    return;
+  }
+
+  // Nothing due among the unlocked lessons: fall back to the most-overdue pick,
+  // but only over the unlocked ones, so the mode is never a dead end AND never
+  // a loop. `pickNext` reads `letterIndex`, which carries the real lesson index
+  // through the filter.
+  const openStates = lessonSchedule.filter((s) => open.has(s.letterIndex));
+  lessonIndex =
+    openStates.length > 0 ? pickNext(openStates, lessonSession) : null;
+}
+
+/**
+ * Lesson ids the learner has actually reviewed.
+ *
+ * Keyed on REVIEW HISTORY, never on `dueAtSession` — fresh items are seeded
+ * with the current session, so a due-based test reports the whole curriculum as
+ * "seen" on any reload after the first. That bug shipped once; see progress.ts.
+ */
+function seenLessonIds(): ReadonlySet<string> {
+  const out = new Set<string>();
+  lessonSchedule.forEach((s, i) => {
+    if (s.reps > 0 || s.lapses > 0 || s.box > 0) out.add(LESSON_IDS[i]!);
+  });
+  return out;
 }
 
 /** Grade the current lesson, advance the clock, and save. */
@@ -411,6 +467,107 @@ function gradeLesson(wasCorrect: boolean): void {
   persistLessons();
   pickLesson();
   render();
+}
+
+/**
+ * Concepts mode — the same idea, side by side, in every language that has it.
+ *
+ * This is the cross-learning the curriculum's shared `concept_tag`s were always
+ * for: *hola / bonjour / नमस्ते* are one concept realized four ways, and seeing
+ * them together is a different act from meeting them four chapters apart.
+ *
+ * Rendered as a collapsed list because there are hundreds of concepts and only
+ * one is ever being studied. Everything goes in via `textContent` — the corpus
+ * is repo-authored, but it is still data, and it is never worth building an
+ * innerHTML habit.
+ */
+function renderConcepts(): HTMLElement {
+  const wrap = el("div", "practice");
+
+  const stats = el("p", "score");
+  stats.textContent =
+    `${CONCEPT_CARDS.length} concepts shared by two or more languages` +
+    ` · from ${LESSONS.length} lessons`;
+  wrap.appendChild(stats);
+
+  if (CONCEPT_CARDS.length === 0) {
+    const empty = el("p", "muted");
+    empty.textContent = "No concept is taught in more than one language yet.";
+    wrap.appendChild(empty);
+    return wrap;
+  }
+
+  const list = el("div", "concept-list");
+  for (const card of CONCEPT_CARDS) {
+    const item = el("div", "concept");
+
+    const langs = new Set(card.realizations.map((r) => r.language));
+    const head = el("button", "concept__head");
+    head.setAttribute("aria-expanded", String(openConcept === card.id));
+    head.textContent = `${card.id} — ${langs.size} languages`;
+    head.onclick = () => {
+      openConcept = openConcept === card.id ? null : card.id;
+      render();
+    };
+    item.appendChild(head);
+
+    if (card.gloss) {
+      const gloss = el("p", "muted concept__gloss");
+      gloss.textContent = card.gloss;
+      item.appendChild(gloss);
+    }
+
+    if (openConcept === card.id) {
+      const rows = el("div", "concept__rows");
+      // One row per language, in track order so the list is stable between
+      // openings rather than reordering under the reader.
+      for (const r of [...card.realizations].sort((a, b) =>
+        a.language.localeCompare(b.language),
+      )) {
+        const row = el("div", "concept__row");
+
+        const lang = el("span", "concept__lang");
+        lang.textContent = r.language;
+        row.appendChild(lang);
+
+        const word = el("span", "concept__word");
+        word.textContent = r.headword;
+        row.appendChild(word);
+
+        // Only useful when it differs from the headword — for Latin-script
+        // tracks the package sets them equal, and repeating it is noise.
+        if (r.romanization && r.romanization !== r.headword) {
+          const rom = el("span", "concept__rom");
+          rom.textContent = r.romanization;
+          row.appendChild(rom);
+        }
+
+        const gloss = el("span", "concept__gloss-inline");
+        gloss.textContent = r.gloss;
+        row.appendChild(gloss);
+
+        rows.appendChild(row);
+      }
+      item.appendChild(rows);
+
+      // The etymology hooks are the reason this curriculum exists; surface them
+      // where the comparison is happening, not three clicks away.
+      const hooks = card.realizations.filter((r) => r.etymologyHook);
+      if (hooks.length > 0) {
+        const why = el("div", "concept__hooks");
+        for (const r of hooks) {
+          const p = el("p", "muted");
+          p.textContent = `${r.language}: ${r.etymologyHook}`;
+          why.appendChild(p);
+        }
+        item.appendChild(why);
+      }
+    }
+
+    list.appendChild(item);
+  }
+  wrap.appendChild(list);
+  return wrap;
 }
 
 function renderLessons(): HTMLElement {
@@ -482,12 +639,16 @@ function render(): void {
   app!.replaceChildren();
   app!.append(renderHeader());
   // The script tabs steer per-script work; hide them during a mixed session,
-  // and in Lessons mode, which spans every language rather than one script.
-  if (mode !== "lessons" && !(mode === "practice" && scope === "mixed")) {
+  // and in Lessons/Concepts modes, which span every language rather than one
+  // script.
+  const spansAllLanguages = mode === "lessons" || mode === "concepts";
+  if (!spansAllLanguages && !(mode === "practice" && scope === "mixed")) {
     app!.appendChild(renderTabs());
   }
 
-  if (mode === "lessons") {
+  if (mode === "concepts") {
+    app!.appendChild(renderConcepts());
+  } else if (mode === "lessons") {
     app!.appendChild(renderLessons());
   } else if (mode === "browse") {
     const views = buildScriptView(data);

--- a/code/programs/typescript/script-writing-visualizer/src/styles.css
+++ b/code/programs/typescript/script-writing-visualizer/src/styles.css
@@ -188,3 +188,48 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
+
+/* --- concepts mode (one idea, several languages) ------------------------- */
+.concept-list { display: flex; flex-direction: column; gap: 8px; }
+.concept {
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.concept__head {
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: none;
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0;
+}
+.concept__gloss { margin: 4px 0 0; font-size: 0.85rem; }
+.concept__rows { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; }
+.concept__row {
+  display: grid;
+  grid-template-columns: 7rem minmax(6rem, auto) auto 1fr;
+  gap: 10px;
+  align-items: baseline;
+  padding-top: 6px;
+  border-top: 1px solid var(--line);
+}
+.concept__lang {
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.concept__word { font-size: 1.15rem; }
+.concept__rom { color: var(--muted); font-size: 0.85rem; font-style: italic; }
+.concept__gloss-inline { color: var(--muted); font-size: 0.85rem; }
+.concept__hooks { margin-top: 10px; border-top: 1px solid var(--line); padding-top: 8px; }
+.concept__hooks p { margin: 0 0 6px; font-size: 0.82rem; line-height: 1.45; }
+
+@media (max-width: 560px) {
+  .concept__row { grid-template-columns: 1fr; gap: 2px; }
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/concepts.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/concepts.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest";
+import {
+  crossLanguageConcepts,
+  datasetFromLessons,
+  indexById,
+  isUnlocked,
+  reviewTargets,
+  unlockedIndices,
+  unlockedOrAll,
+} from "../src/concepts.js";
+import {
+  indicesByLanguage,
+  loadLessons,
+  nextDue,
+  type Lesson,
+} from "../src/lessons.js";
+import { buildPool } from "../src/interleave.js";
+import { initStates, pickNext, reviewIn } from "../src/scheduler.js";
+import taxonomy from "../../../../learning/human-languages/concepts/taxonomy.json";
+import type { Taxonomy } from "@coding-adventures/human-language-data/src/types.ts";
+
+const TAXONOMY = taxonomy as unknown as Taxonomy;
+
+/** A Lesson with everything defaulted, so a test states only what it cares about. */
+function lesson(over: Partial<Lesson> & { id: string }): Lesson {
+  return {
+    language: "spanish",
+    headword: "",
+    gloss: "",
+    type: "word",
+    chapter: 1,
+    concept: "",
+    prerequisites: [],
+    reviewsOf: [],
+    romanization: "",
+    script: "latin",
+    etymologyHook: "",
+    ...over,
+  };
+}
+
+describe("prerequisite gating", () => {
+  const known = (ids: string[]) => new Set(ids);
+
+  it("unlocks a lesson with no prerequisites", () => {
+    expect(isUnlocked(lesson({ id: "A" }), new Set(), known(["A"]))).toBe(true);
+  });
+
+  it("locks a lesson whose prerequisite has not been seen", () => {
+    const l = lesson({ id: "B", prerequisites: ["A"] });
+    expect(isUnlocked(l, new Set(), known(["A", "B"]))).toBe(false);
+  });
+
+  it("unlocks once every prerequisite has been seen", () => {
+    const l = lesson({ id: "C", prerequisites: ["A", "B"] });
+    expect(isUnlocked(l, new Set(["A"]), known(["A", "B", "C"]))).toBe(false);
+    expect(isUnlocked(l, new Set(["A", "B"]), known(["A", "B", "C"]))).toBe(true);
+  });
+
+  // The important one: a curriculum typo must not make a lesson unreachable.
+  it("treats an UNKNOWN prerequisite as satisfied, not as a permanent lock", () => {
+    const l = lesson({ id: "D", prerequisites: ["ES-C99-typo"] });
+    expect(isUnlocked(l, new Set(), known(["D"]))).toBe(true);
+  });
+
+  it("returns the indices of teachable lessons only", () => {
+    const lessons = [
+      lesson({ id: "A" }),
+      lesson({ id: "B", prerequisites: ["A"] }),
+      lesson({ id: "C", prerequisites: ["B"] }),
+    ];
+    expect(unlockedIndices(lessons, new Set())).toEqual([0]);
+    expect(unlockedIndices(lessons, new Set(["A"]))).toEqual([0, 1]);
+    expect(unlockedIndices(lessons, new Set(["A", "B"]))).toEqual([0, 1, 2]);
+  });
+
+  it("opens with chapter-1 lessons on a fresh profile", () => {
+    const lessons = [
+      lesson({ id: "ES-C01-hola" }),
+      lesson({ id: "ES-C17-futuro", prerequisites: ["ES-C01-hola"] }),
+    ];
+    expect(unlockedIndices(lessons, new Set())).toEqual([0]);
+  });
+
+  it("fails OPEN rather than stalling when everything is locked", () => {
+    // A cycle locks both lessons; practice must not simply stop.
+    const lessons = [
+      lesson({ id: "A", prerequisites: ["B"] }),
+      lesson({ id: "B", prerequisites: ["A"] }),
+    ];
+    expect(unlockedIndices(lessons, new Set())).toEqual([]);
+    expect(unlockedOrAll(lessons, new Set())).toEqual([0, 1]);
+  });
+
+  it("prefers the gated pool when one exists", () => {
+    const lessons = [lesson({ id: "A" }), lesson({ id: "B", prerequisites: ["A"] })];
+    expect(unlockedOrAll(lessons, new Set())).toEqual([0]);
+  });
+});
+
+describe("reviews_of targets", () => {
+  const lessons = [
+    lesson({ id: "A" }),
+    lesson({ id: "B" }),
+    lesson({ id: "C", reviewsOf: ["A", "GONE", "B"] }),
+  ];
+  const byId = indexById(lessons);
+
+  it("maps ids to indices", () => {
+    expect(reviewTargets(lessons[2], byId)).toEqual([0, 1]);
+  });
+
+  // Asserting the exact array, not `.not.toContain(undefined)`: that weaker
+  // form passes for [] and for a wholly broken implementation.
+  it("drops dangling ids while preserving the order of the survivors", () => {
+    expect(reviewTargets(lessons[2], byId)).toEqual([0, 1]);
+    expect(reviewTargets(lesson({ id: "D", reviewsOf: ["B", "A"] }), byId)).toEqual([
+      1, 0,
+    ]);
+  });
+
+  it("is empty when a lesson reviews nothing", () => {
+    expect(reviewTargets(lessons[0], byId)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The regression this module exists to prevent.
+//
+// v0.5.0 shipped a picker that scanned from the front, and because boxes 0/1
+// fall due again after a single session it served item 0 forever. The rotating
+// cursor fixed that. Adding prerequisite gating then RE-BROKE it in a new way:
+// gating the *pick* (choose, reject, substitute a fallback) rejects the same
+// index every turn and so serves the one fallback repeatedly.
+//
+// This test drives the real loop shape — scan, grade, advance — and asserts
+// variety, so neither costume of the bug can come back unnoticed.
+// ---------------------------------------------------------------------------
+describe("gated rotation actually rotates", () => {
+  it("serves many distinct lessons when most are locked behind chapter 1", () => {
+    // The fixture has to reproduce the real failure, and the first attempt did
+    // NOT: a chain whose pool order happens to match its unlock order lets the
+    // broken picker look fine, because the rotation lands on an unlocked lesson
+    // anyway. (Verified — the buggy implementation passed it.)
+    //
+    // What makes the bug bite is pool order being OUT OF SYNC with dependency
+    // order, which is the real curriculum's situation: lessons rotate in id
+    // order while prerequisites point wherever they like. So here the chain runs
+    // BACKWARDS relative to the pool — the only initially-unlocked lesson in
+    // each track sits last, and everything the rotation reaches first is locked.
+    const lessons: Lesson[] = [];
+    for (const lang of ["spanish", "french", "hindi"]) {
+      // c1 needs c2 needs c3 … needs the root, which is pushed last.
+      for (let c = 1; c <= 9; c += 1) {
+        lessons.push(
+          lesson({
+            id: `${lang}-c${c}`,
+            language: lang,
+            prerequisites: [c === 9 ? `${lang}-root` : `${lang}-c${c + 1}`],
+          }),
+        );
+      }
+      lessons.push(lesson({ id: `${lang}-root`, language: lang }));
+    }
+
+    const groups = indicesByLanguage(lessons);
+    const pool = buildPool(groups.map((g) => g.length));
+    let schedule = initStates(lessons.length);
+    let session = 0;
+    let cursor = -1;
+    const served: number[] = [];
+
+    for (let turn = 0; turn < 30; turn += 1) {
+      const seen = new Set(
+        schedule.filter((s) => s.reps > 0 || s.lapses > 0 || s.box > 0)
+          .map((s) => lessons[s.letterIndex]!.id),
+      );
+      const open = new Set(unlockedOrAll(lessons, seen));
+      const { index, cursor: next } = nextDue(
+        groups, pool, schedule, session, cursor, (i) => open.has(i),
+      );
+      cursor = next;
+      const pick =
+        index ??
+        (() => {
+          const states = schedule.filter((s) => open.has(s.letterIndex));
+          return states.length > 0 ? pickNext(states, session) : null;
+        })();
+      if (pick === null) break;
+      served.push(pick);
+      schedule = reviewIn(schedule, pick, true, session);
+      session += 1;
+    }
+
+    expect(served.length).toBe(30);
+
+    // THE DISCRIMINATOR. Gating must not cost us the interleaving, so the very
+    // first few picks have to cross tracks. Measured against the actual broken
+    // implementation: it opens with ELEVEN consecutive Spanish lessons (it keeps
+    // substituting the same fallback, which walks one track), where gating the
+    // pool opens french / hindi / spanish / french / hindi / spanish.
+    const firstSix = served.slice(0, 6).map((i) => lessons[i]!.language);
+    expect(new Set(firstSix).size).toBeGreaterThan(1);
+
+    // And no single lesson may dominate the session: 4 for the fixed version
+    // against 11 for the broken one.
+    const counts = new Map<number, number>();
+    for (const i of served) counts.set(i, (counts.get(i) ?? 0) + 1);
+    expect(Math.max(...counts.values())).toBeLessThan(served.length / 4);
+  });
+
+  it("unlocks the gated lessons once their prerequisite is studied", () => {
+    const lessons = [
+      lesson({ id: "A" }),
+      lesson({ id: "B", prerequisites: ["A"] }),
+    ];
+    expect(unlockedOrAll(lessons, new Set())).toEqual([0]);
+    expect(unlockedOrAll(lessons, new Set(["A"]))).toEqual([0, 1]);
+  });
+});
+
+describe("cross-language concepts", () => {
+  const lessons = [
+    lesson({ id: "ES-1", language: "spanish", concept: "GREETING-HELLO", headword: "hola" }),
+    lesson({ id: "FR-1", language: "french", concept: "GREETING-HELLO", headword: "bonjour" }),
+    lesson({ id: "ES-2", language: "spanish", concept: "ES-ONLY", headword: "solo" }),
+  ];
+
+  it("keeps a concept realized by two or more languages", () => {
+    const cards = crossLanguageConcepts(datasetFromLessons(TAXONOMY, lessons));
+    expect(cards.map((c) => c.id)).toEqual(["GREETING-HELLO"]);
+    expect(cards[0].realizations.map((r) => r.headword).sort()).toEqual([
+      "bonjour",
+      "hola",
+    ]);
+  });
+
+  it("drops a concept only one language realizes — nothing to compare it with", () => {
+    const cards = crossLanguageConcepts(datasetFromLessons(TAXONOMY, lessons));
+    expect(cards.map((c) => c.id)).not.toContain("ES-ONLY");
+  });
+
+  it("honours a higher language floor", () => {
+    const cards = crossLanguageConcepts(datasetFromLessons(TAXONOMY, lessons), 3);
+    expect(cards).toEqual([]);
+  });
+
+  it("counts LANGUAGES, not lessons — two lessons in one track is not a card", () => {
+    const sameTrack = [
+      lesson({ id: "ES-1", language: "spanish", concept: "X" }),
+      lesson({ id: "ES-2", language: "spanish", concept: "X" }),
+    ];
+    expect(crossLanguageConcepts(datasetFromLessons(TAXONOMY, sameTrack))).toEqual([]);
+  });
+});
+
+describe("against the real curriculum", () => {
+  const lessons = loadLessons();
+  const dataset = datasetFromLessons(TAXONOMY, lessons);
+  const cards = crossLanguageConcepts(dataset);
+
+  it("finds real cross-language concepts", () => {
+    expect(cards.length).toBeGreaterThan(10);
+  });
+
+  it("every card genuinely spans two or more languages", () => {
+    for (const card of cards) {
+      expect(new Set(card.realizations.map((r) => r.language)).size).toBeGreaterThan(1);
+    }
+  });
+
+  it("GREETING-HELLO spans several tracks", () => {
+    const hello = cards.find((c) => c.id === "GREETING-HELLO");
+    expect(hello).toBeDefined();
+    expect(new Set(hello!.realizations.map((r) => r.language)).size).toBeGreaterThan(2);
+  });
+
+  it("gating opens a non-empty pool on a fresh profile", () => {
+    const open = unlockedIndices(lessons, new Set());
+    expect(open.length).toBeGreaterThan(0);
+    expect(open.length).toBeLessThan(lessons.length);
+  });
+
+  it("every lesson becomes reachable once everything is seen", () => {
+    const all = new Set(lessons.map((l) => l.id));
+    expect(unlockedIndices(lessons, all).length).toBe(lessons.length);
+  });
+});

--- a/code/programs/typescript/script-writing-visualizer/tests/lessons.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/lessons.test.ts
@@ -104,11 +104,29 @@ describe("loadLessons", () => {
   });
 });
 
+/** A Lesson with everything defaulted, so a test only states what it cares about. */
+export function lesson(over: Partial<Lesson> & { id: string }): Lesson {
+  return {
+    language: "spanish",
+    headword: "",
+    gloss: "",
+    type: "word",
+    chapter: 1,
+    concept: "",
+    prerequisites: [],
+    reviewsOf: [],
+    romanization: "",
+    script: "latin",
+    etymologyHook: "",
+    ...over,
+  };
+}
+
 describe("grouping for interleaving", () => {
   const lessons: Lesson[] = [
-    { id: "A1", language: "spanish", headword: "", gloss: "", type: "word", chapter: 1, concept: "", prerequisites: [], reviewsOf: [] },
-    { id: "B1", language: "tamil", headword: "", gloss: "", type: "word", chapter: 1, concept: "", prerequisites: [], reviewsOf: [] },
-    { id: "A2", language: "spanish", headword: "", gloss: "", type: "word", chapter: 2, concept: "", prerequisites: [], reviewsOf: [] },
+    lesson({ id: "A1", language: "spanish", chapter: 1 }),
+    lesson({ id: "B1", language: "tamil", chapter: 1 }),
+    lesson({ id: "A2", language: "spanish", chapter: 2 }),
   ];
 
   it("lists the distinct languages, sorted", () => {

--- a/code/programs/typescript/script-writing-visualizer/vitest.config.ts
+++ b/code/programs/typescript/script-writing-visualizer/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         "src/drill.ts",
         "src/scheduler.ts",
         "src/interleave.ts",
+        "src/concepts.ts",
         "src/lessons.ts",
         "src/progress.ts",
       ],


### PR DESCRIPTION
The study app could drill letters and drill lessons. It could not do the thing the curriculum's shared `concept_tag`s exist for: **compare**.

### Concepts mode

Canonical concept tags are deliberately identical across tracks, which makes them a **join key**: *gracias / merci / danke / धन्यवाद / നന്ദി* are **one concept realized eighteen ways**.

- **39 concepts** are shared by two or more tracks, from **701 lessons**
- Each row: headword, romanization (only where it differs from the headword), gloss
- The **etymology hooks sit under the comparison**, where they earn their keep — *gracias* ← *gratia* "favour", *merci* ← *mercēs* "wages", *danke* ← *denken* "to think", *спасибо* ← *спаси Бог* "God save you". One courtesy, four unrelated ideas.

**It calls the package's own `languagesForConcept` and `buildDataset`.** Those have shipped since HL01, tested and documented as *"what the companion app calls"* — with no caller. This is the caller, and using them means the join is the package's tested logic rather than a second implementation free to drift.

### Prerequisite gating

`scheduler.ts` is generic over a numeric index and cannot know that "the preterite of *comer*" presupposes *comer*. New pure module `concepts.ts` supplies that:

- A lesson unlocks when its prerequisites are **seen** (keyed on review history, never `dueAtSession` — the 0.5.0 bug)
- **Unknown prerequisite ids count as satisfied.** A curriculum typo must degrade to "shown early", never to "silently unreachable forever"
- **The gate fails open** — practice stalling is worse than practising early

### ⚠️ The bug this shipped with

The first cut gated the **pick**: choose from the rotation; if locked, substitute the first unlocked lesson. That's wrong in a way invisible to inspection — the same pick is rejected every turn, so the substitute is served over and over. **A review simulation of the real curriculum measured it serving one Arabic lesson 34 times in 40**, destroying both the 0.5.0 rotating cursor and cross-language interleaving.

The fix gates the **pool**: `nextDue` takes an `accept` predicate and skips locked indices *during* the scan, so the cursor keeps advancing; the nothing-due fallback runs `pickNext` over unlocked states instead of grabbing `open[0]`.

### ⚠️ The regression test took three attempts to make honest

Versions 1 and 2 **passed against the broken implementation**. The fixture's chain order happened to match its pool order, so the rotation landed on unlocked lessons anyway. Only a fixture whose dependency order runs *counter* to pool order — as the real curriculum's does — reproduces it.

The final test **fails on the broken version and passes on the fixed one**, and both were verified by actually injecting the old code back in.

### Verification

**In a browser, not just built** — the 0.5.0 `process is not defined` bug was a *successful build* that died on load, and only a real page load catches that class of error.

- 12 consecutive picks → **12 distinct lessons across 9 languages**, all chapter-1 (the gate holding)
- Console clean; both new deep imports (`parse.ts`, `queries.ts`) are pure modules

### Also

- `Lesson` gained `romanization` / `script` / `etymologyHook`; `tests/lessons.test.ts` now uses a defaulting fixture helper
- `src/concepts.ts` added to the coverage include list (it was invisible to the >80% rule)
- A **vacuous test** replaced: `.not.toContain(undefined)` on a `number[]` passes for any array, including a broken one
- Tests **75 → 97**; CHANGELOG corrected, since a draft claimed the app follows `reviews_of` — it doesn't yet, and now says so

🤖 Generated with [Claude Code](https://claude.com/claude-code)