### PR TITLE
feat(spice): add BJT forward emission coefficient

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT forward emission coefficient** — BJT model cards now accept `NF` and
+  apply it to DC, transient charge, AC, transfer-function, and noise paths,
+  matching Rust and TypeScript. The supported-parameter catalog now contains
+  80 canonical rows.
+
 - **BJT forward Early voltage** — BJT model cards now accept `VAF`/`VA` and
   apply collector-voltage modulation in DC, transient, AC, transfer-function,
   and noise paths, matching Rust and TypeScript. The supported-parameter

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -211,8 +211,9 @@ transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
-model-specific saturation-current temperature scaling, plus `VAF`/`VA`
-(default `0`, meaning infinite) for forward Early-effect modulation.
+model-specific saturation-current temperature scaling, `VAF`/`VA` (default
+`0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
+`1`) for forward-junction emission shaping.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -596,6 +596,8 @@ class BJT:
     Vaf:
         Forward Early voltage in Volts. Zero disables collector-voltage
         modulation, matching an infinite Early voltage (default 0.0).
+    Nf:
+        Forward emission coefficient (default 1.0).
     """
 
     name: str
@@ -613,6 +615,7 @@ class BJT:
     Xti: float = 3.0        # saturation-current temperature exponent
     Eg: float = 1.11        # semiconductor energy gap (eV)
     Vaf: float = 0.0        # forward Early voltage (V); 0 means infinite
+    Nf: float = 1.0         # forward emission coefficient
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8728,15 +8728,17 @@ def _bjt_base_collector_charge_state_name(el: BJT) -> str:
     return f"_Q_{el.name}_bc_charge"
 
 
-def _bjt_junction_transconductance(el: BJT, voltage: float) -> float:
-    exponent = max(-40.0, min(40.0, voltage / el.Vt))
-    return (el.Is / el.Vt) * math.exp(exponent)
+def _bjt_junction_transconductance(el: BJT, voltage: float, emission_coefficient: float) -> float:
+    effective_thermal_voltage = el.Vt * emission_coefficient
+    exponent = max(-40.0, min(40.0, voltage / effective_thermal_voltage))
+    return (el.Is / effective_thermal_voltage) * math.exp(exponent)
 
 
 def _bjt_charge_dynamic_capacitance(el: BJT, state_kind: str, voltage: float) -> float:
-    conductance = _bjt_junction_transconductance(el, voltage)
     if state_kind == "be":
+        conductance = _bjt_junction_transconductance(el, voltage, el.Nf)
         return el.Cje + el.Tf * conductance
+    conductance = _bjt_junction_transconductance(el, voltage, 1.0)
     return el.Cjc + el.Tr * conductance
 
 
@@ -9052,9 +9054,10 @@ def _stamp_bjt(
     # --- Controlling junction voltage (clamped to avoid exp overflow) --------
     Vjunc = min(Vb - Ve, 0.7) if el.polarity == "NPN" else min(Ve - Vb, 0.7)
 
-    exp_term = math.exp(Vjunc / el.Vt)
+    forward_thermal_voltage = el.Vt * el.Nf
+    exp_term = math.exp(Vjunc / forward_thermal_voltage)
     base_collector_current = el.Is * (exp_term - 1.0)
-    base_gm = (el.Is / el.Vt) * exp_term
+    base_gm = (el.Is / forward_thermal_voltage) * exp_term
     output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
     early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
     output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
@@ -9149,6 +9152,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT energy gap must be finite and positive")
     if not math.isfinite(el.Vaf) or el.Vaf < 0.0:
         raise ValueError(f"{el.name}: BJT forward Early voltage must be finite and non-negative")
+    if not math.isfinite(el.Nf) or el.Nf <= 0.0:
+        raise ValueError(f"{el.name}: BJT forward emission coefficient must be finite and positive")
 
 
 # ---------------------------------------------------------------------------
@@ -12367,10 +12372,11 @@ def _stamp_ac(
             min(Vb_dc - Vc_dc, 0.7) if el.polarity == "NPN"
             else min(Vc_dc - Vb_dc, 0.7)
         )
-        exp_t = math.exp(Vjunc / el.Vt)
+        forward_thermal_voltage = el.Vt * el.Nf
+        exp_t = math.exp(Vjunc / forward_thermal_voltage)
         exp_reverse = math.exp(Vreverse / el.Vt)
         base_collector_current = el.Is * (exp_t - 1.0)
-        base_gm = (el.Is / el.Vt) * exp_t
+        base_gm = (el.Is / forward_thermal_voltage) * exp_t
         output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
         early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
         output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
@@ -12979,9 +12985,10 @@ def _build_ss_matrix(
                 min(Vb_dc - Ve_dc, 0.7) if el.polarity == "NPN"
                 else min(Ve_dc - Vb_dc, 0.7)
             )
-            exp_t = math.exp(Vjunc / el.Vt)
+            forward_thermal_voltage = el.Vt * el.Nf
+            exp_t = math.exp(Vjunc / forward_thermal_voltage)
             base_collector_current = el.Is * (exp_t - 1.0)
-            base_gm = (el.Is / el.Vt) * exp_t
+            base_gm = (el.Is / forward_thermal_voltage) * exp_t
             output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
             early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
             output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
@@ -13865,6 +13872,7 @@ def sens_dc(
                     Xti=el.Xti,
                     Eg=el.Eg,
                     Vaf=el.Vaf,
+                    Nf=el.Nf,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -13884,6 +13892,7 @@ def sens_dc(
                     Xti=el.Xti,
                     Eg=el.Eg,
                     Vaf=el.Vaf,
+                    Nf=el.Nf,
                 ),
             )
 
@@ -14113,6 +14122,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Xti=el.Xti,
             Eg=el.Eg,
             Vaf=el.Vaf,
+            Nf=el.Nf,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.
@@ -14555,7 +14565,7 @@ def _collect_noise_sources(
             )
             output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
             early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
-            I_C = el.Is * math.exp(Vjunc / el.Vt) * early_factor
+            I_C = el.Is * math.exp(Vjunc / (el.Vt * el.Nf)) * early_factor
             psd = q2 * abs(I_C)
             n_b = None if _is_ground(el.base) else node_to_idx[el.base]
             n_e = None if _is_ground(el.emitter) else node_to_idx[el.emitter]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (10, 19, 5, 4),
-    "PNP": (10, 19, 5, 4),
+    "NPN": (11, 20, 5, 4),
+    "PNP": (11, 20, 5, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -374,6 +374,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "EG": "EG",
     "VAF": "VAF",
     "VA": "VAF",
+    "NF": "NF",
 }
 
 _JFET_PARAMETER_ALIASES: dict[str, str] = {
@@ -901,6 +902,7 @@ def bjt_from_model_card(
         Xti=p.get("XTI", 3.0),
         Eg=p.get("EG", 1.11),
         Vaf=p.get("VAF", 0.0),
+        Nf=p.get("NF", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 78
+    assert len(coverage) == 80
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 78
+    assert len(records) == 80
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 78
-    assert report.expected_canonical_parameter_count == 78
-    assert report.accepted_name_count == 128
+    assert report.canonical_parameter_count == 80
+    assert report.expected_canonical_parameter_count == 80
+    assert report.accepted_name_count == 130
     assert report.aliased_parameter_count == 37
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t78\t78\t128\t37\t4\t0"
+        "true\t7\t7\t80\t80\t130\t37\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 77
-    assert report.accepted_name_count == 125
+    assert report.canonical_parameter_count == 79
+    assert report.accepted_name_count == 127
     assert report.aliased_parameter_count == 36
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t77\t78\t125\t36\t4\t4\n"
+        "false\t7\t7\t79\t80\t127\t36\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,16 +647,17 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
     assert bjt_model.Xti == pytest.approx(2.4)
     assert bjt_model.Eg == pytest.approx(1.05)
     assert bjt_model.Vaf == pytest.approx(80.0)
+    assert bjt_model.Nf == pytest.approx(1.2)
 
     jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -2226,7 +2227,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2236,6 +2237,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Xti == pytest.approx(2.4)
     assert expanded.Eg == pytest.approx(1.05)
     assert expanded.Vaf == pytest.approx(80.0)
+    assert expanded.Nf == pytest.approx(1.2)
 
 
 def test_branch_current_in_voltage_source():
@@ -2490,6 +2492,25 @@ def test_dc_rejects_invalid_bjt_forward_early_voltage():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Vaf=-1.0))
     with pytest.raises(ValueError, match="BJT forward Early voltage must be finite and non-negative"):
+        dc_op(circuit)
+
+
+def test_bjt_forward_emission_coefficient_reduces_collector_current():
+    def collector_voltage(nf: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "vcc", "out", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Nf=nf))
+        return dc_op(circuit).node_voltages["out"]
+
+    assert collector_voltage(2.0) > collector_voltage(1.0)
+
+
+def test_dc_rejects_invalid_bjt_forward_emission_coefficient():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Nf=0.0))
+    with pytest.raises(ValueError, match="BJT forward emission coefficient must be finite and positive"):
         dc_op(circuit)
 
 
@@ -4526,6 +4547,20 @@ def test_tf_bjt_forward_early_voltage_reduces_output_impedance():
         return tf(circuit, output_node="out", input_source="Vin").output_impedance
 
     assert output_impedance(10.0) < output_impedance(0.0)
+
+
+def test_tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance():
+    def transfer(nf: float) -> TfResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Nf=nf))
+        return tf(circuit, output_node="out", input_source="Vin")
+
+    ideal = transfer(1.0)
+    shaped = transfer(2.0)
+    assert abs(shaped.gain) < abs(ideal.gain)
+    assert shaped.input_impedance > ideal.input_impedance
 
 
 # ============================================================================

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `NF` forward emission-coefficient support across DC,
+  transient charge, AC, transfer-function, and noise paths, matching Python and
+  TypeScript. The supported-parameter catalog now contains 80 canonical rows.
 - Add BJT model-card `VAF`/`VA` forward Early-voltage support with
   collector-voltage modulation in DC, transient, AC, transfer-function, and
   noise paths, matching Python and TypeScript. The supported-parameter catalog

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -128,8 +128,9 @@ transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
-model-specific saturation-current temperature scaling, plus `VAF`/`VA`
-(default `0`, meaning infinite) for forward Early-effect modulation.
+model-specific saturation-current temperature scaling, `VAF`/`VA` (default
+`0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
+`1`) for forward-junction emission shaping.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -434,6 +434,7 @@ fn clone_subckt_element(
             element.saturation_current_temperature_exponent,
             element.energy_gap_electron_volts,
             element.forward_early_voltage,
+            element.forward_emission_coefficient,
         )),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -2839,6 +2840,7 @@ pub struct Bjt {
     pub saturation_current_temperature_exponent: f64,
     pub energy_gap_electron_volts: f64,
     pub forward_early_voltage: f64,
+    pub forward_emission_coefficient: f64,
 }
 
 impl Bjt {
@@ -2894,6 +2896,7 @@ impl Bjt {
             3.0,
             1.11,
             0.0,
+            1.0,
         )
     }
 
@@ -2914,6 +2917,7 @@ impl Bjt {
         saturation_current_temperature_exponent: f64,
         energy_gap_electron_volts: f64,
         forward_early_voltage: f64,
+        forward_emission_coefficient: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -2931,6 +2935,7 @@ impl Bjt {
             saturation_current_temperature_exponent,
             energy_gap_electron_volts,
             forward_early_voltage,
+            forward_emission_coefficient,
         }
     }
 }
@@ -3321,8 +3326,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 10, 19, 5, 4),
-    (ModelCardKind::Pnp, 10, 19, 5, 4),
+    (ModelCardKind::Npn, 11, 20, 5, 4),
+    (ModelCardKind::Pnp, 11, 20, 5, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3368,6 +3373,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("EG", "EG"),
     ("VAF", "VAF"),
     ("VA", "VAF"),
+    ("NF", "NF"),
 ];
 const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("BETA", "BETA"),
@@ -4023,6 +4029,7 @@ pub fn bjt_from_model_card(
         model_card_value(model, "XTI", 3.0),
         model_card_value(model, "EG", 1.11),
         model_card_value(model, "VAF", 0.0),
+        model_card_value(model, "NF", 1.0),
     ))
 }
 
@@ -21671,7 +21678,9 @@ fn collect_noise_sources(
                     BjtPolarity::Npn => base_voltage - emitter_voltage,
                     BjtPolarity::Pnp => emitter_voltage - base_voltage,
                 };
-                let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
+                let forward_thermal_voltage =
+                    bjt.thermal_voltage * bjt.forward_emission_coefficient;
+                let exponent = (junction_voltage / forward_thermal_voltage).clamp(-40.0, 40.0);
                 let output_voltage = match bjt.polarity {
                     BjtPolarity::Npn => collector_voltage - emitter_voltage,
                     BjtPolarity::Pnp => emitter_voltage - collector_voltage,
@@ -22142,10 +22151,11 @@ fn stamp_bjt(
         BjtPolarity::Npn => base_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - base_voltage,
     };
-    let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
+    let forward_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
+    let exponent = (junction_voltage / forward_thermal_voltage).clamp(-40.0, 40.0);
     let exp_value = exponent.exp();
     let base_collector_current = bjt.saturation_current * (exp_value - 1.0);
-    let base_gm = bjt.saturation_current / bjt.thermal_voltage * exp_value;
+    let base_gm = bjt.saturation_current / forward_thermal_voltage * exp_value;
     let output_voltage = match bjt.polarity {
         BjtPolarity::Npn => collector_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
@@ -22263,10 +22273,11 @@ fn stamp_bjt_small_signal(
         BjtPolarity::Npn => base_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - base_voltage,
     };
-    let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
+    let forward_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
+    let exponent = (junction_voltage / forward_thermal_voltage).clamp(-40.0, 40.0);
     let exp_value = exponent.exp();
     let base_collector_current = bjt.saturation_current * (exp_value - 1.0);
-    let base_gm = bjt.saturation_current / bjt.thermal_voltage * exp_value;
+    let base_gm = bjt.saturation_current / forward_thermal_voltage * exp_value;
     let output_voltage = match bjt.polarity {
         BjtPolarity::Npn => collector_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
@@ -22319,11 +22330,12 @@ fn stamp_ac_bjt_small_signal(
         BjtPolarity::Npn => base_voltage - collector_voltage,
         BjtPolarity::Pnp => collector_voltage - base_voltage,
     };
-    let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
+    let forward_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
+    let exponent = (junction_voltage / forward_thermal_voltage).clamp(-40.0, 40.0);
     let reverse_exponent = (reverse_junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
     let exp_value = exponent.exp();
     let base_collector_current = bjt.saturation_current * (exp_value - 1.0);
-    let base_gm = bjt.saturation_current / bjt.thermal_voltage * exp_value;
+    let base_gm = bjt.saturation_current / forward_thermal_voltage * exp_value;
     let output_voltage = match bjt.polarity {
         BjtPolarity::Npn => collector_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
@@ -22343,7 +22355,7 @@ fn stamp_ac_bjt_small_signal(
     let diffusion_capacitance = bjt.forward_transit_time * gm.real;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let gpi = Complex::new(
-        gm.real / bjt.forward_beta,
+        base_gm / bjt.forward_beta,
         omega * (bjt.base_emitter_capacitance + diffusion_capacitance),
     );
     let ybc = Complex::new(
@@ -22939,18 +22951,23 @@ fn bjt_base_collector_charge_state_name(bjt: &Bjt) -> String {
     format!("_Q_{}_bc_charge", bjt.name)
 }
 
-fn bjt_junction_transconductance(bjt: &Bjt, voltage: f64) -> f64 {
-    bjt.saturation_current / bjt.thermal_voltage
-        * (voltage / bjt.thermal_voltage).clamp(-40.0, 40.0).exp()
+fn bjt_junction_transconductance(bjt: &Bjt, voltage: f64, emission_coefficient: f64) -> f64 {
+    let effective_thermal_voltage = bjt.thermal_voltage * emission_coefficient;
+    bjt.saturation_current / effective_thermal_voltage
+        * (voltage / effective_thermal_voltage)
+            .clamp(-40.0, 40.0)
+            .exp()
 }
 
 fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: f64) -> f64 {
-    let conductance = bjt_junction_transconductance(bjt, voltage);
     match kind {
         BjtChargeStateKind::BaseEmitter => {
+            let conductance =
+                bjt_junction_transconductance(bjt, voltage, bjt.forward_emission_coefficient);
             bjt.base_emitter_capacitance + bjt.forward_transit_time * conductance
         }
         BjtChargeStateKind::BaseCollector => {
+            let conductance = bjt_junction_transconductance(bjt, voltage, 1.0);
             bjt.base_collector_capacitance + bjt.reverse_transit_time * conductance
         }
     }
@@ -23296,6 +23313,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward Early voltage must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.forward_emission_coefficient.is_finite() || bjt.forward_emission_coefficient <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward emission coefficient must be finite and positive".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 78);
+    assert_eq!(coverage.len(), 80);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 78);
+    assert_eq!(records.len(), 80);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 78);
-    assert_eq!(report.expected_canonical_parameter_count, 78);
-    assert_eq!(report.accepted_name_count, 128);
+    assert_eq!(report.canonical_parameter_count, 80);
+    assert_eq!(report.expected_canonical_parameter_count, 80);
+    assert_eq!(report.accepted_name_count, 130);
     assert_eq!(report.aliased_parameter_count, 37);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t78\t78\t128\t37\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t80\t80\t130\t37\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 77);
-    assert_eq!(report.accepted_name_count, 125);
+    assert_eq!(report.canonical_parameter_count, 79);
+    assert_eq!(report.accepted_name_count, 127);
     assert_eq!(report.aliased_parameter_count, 36);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t77\t78\t125\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t79\t80\t127\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -431,6 +431,7 @@ fn model_card_aliases_build_device_instances() {
             ("XTI", 2.4),
             ("EG", 1.05),
             ("VA", 80.0),
+            ("NF", 1.2),
         ],
     )
     .unwrap();
@@ -440,12 +441,14 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("XTI").unwrap(), 2.4);
     assert_close(*bjt_card.parameters.get("EG").unwrap(), 1.05);
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
+    assert_close(*bjt_card.parameters.get("NF").unwrap(), 1.2);
     assert_eq!(bjt_model.polarity, BjtPolarity::Npn);
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
     assert_close(bjt_model.saturation_current_temperature_exponent, 2.4);
     assert_close(bjt_model.energy_gap_electron_volts, 1.05);
     assert_close(bjt_model.forward_early_voltage, 80.0);
+    assert_close(bjt_model.forward_emission_coefficient, 1.2);
 
     let jfet_card = normalize_model_card(
         "Jn",
@@ -1358,6 +1361,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         2.4,
         1.05,
         80.0,
+        1.2,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1386,6 +1390,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.saturation_current_temperature_exponent, 2.4);
     assert_close(expanded.energy_gap_electron_volts, 1.05);
     assert_close(expanded.forward_early_voltage, 80.0);
+    assert_close(expanded.forward_emission_coefficient, 1.2);
 }
 
 #[test]
@@ -1846,6 +1851,7 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
         0.0,
         1.11,
         0.0,
+        1.0,
     );
     let high_exponent = Bjt::with_model_and_temperature_parameters(
         "Qhigh",
@@ -1863,6 +1869,7 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
         4.0,
         1.11,
         0.0,
+        1.0,
     );
     let low = bjt_at_temperature(&low_exponent, 350.0, 300.15, 1.11).unwrap();
     let high = bjt_at_temperature(&high_exponent, 350.0, 300.15, 1.11).unwrap();
@@ -1888,6 +1895,7 @@ fn bjt_temperature_scaling_uses_model_energy_gap() {
         3.0,
         1.11,
         0.0,
+        1.0,
     )));
     let mut lower_gap = Circuit::new();
     lower_gap.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
@@ -1906,6 +1914,7 @@ fn bjt_temperature_scaling_uses_model_energy_gap() {
         3.0,
         0.8,
         0.0,
+        1.0,
     )));
     let silicon_hot = circuit_at_temperature(&silicon, 350.0, 300.15, 1.11).unwrap();
     let lower_gap_hot = circuit_at_temperature(&lower_gap, 350.0, 300.15, 1.11).unwrap();
@@ -1935,6 +1944,7 @@ fn dc_rejects_invalid_bjt_energy_gap() {
         3.0,
         0.0,
         0.0,
+        1.0,
     )));
     let error = dc_op(&circuit).unwrap_err();
     assert!(error
@@ -1971,6 +1981,7 @@ fn bjt_forward_early_voltage_modulates_collector_current() {
             3.0,
             1.11,
             forward_early_voltage,
+            1.0,
         )));
         dc_op(&circuit).unwrap().voltage("out").unwrap()
     };
@@ -1997,11 +2008,76 @@ fn dc_rejects_invalid_bjt_forward_early_voltage() {
         3.0,
         1.11,
         -1.0,
+        1.0,
     )));
     let error = dc_op(&circuit).unwrap_err();
     assert!(error
         .to_string()
         .contains("forward Early voltage must be finite and non-negative"));
+}
+
+#[test]
+fn bjt_forward_emission_coefficient_reduces_collector_current() {
+    let collector_voltage = |forward_emission_coefficient: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc", "vcc", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "vcc", "out", 1_000.0,
+        )));
+        circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+            "Q1",
+            "out",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            1.0e-14,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            3.0,
+            1.11,
+            0.0,
+            forward_emission_coefficient,
+        )));
+        dc_op(&circuit).unwrap().voltage("out").unwrap()
+    };
+
+    assert!(collector_voltage(2.0) > collector_voltage(1.0));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_emission_coefficient() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+        "Qbad",
+        "c",
+        "b",
+        "0",
+        BjtPolarity::Npn,
+        1.0e-14,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        3.0,
+        1.11,
+        0.0,
+        0.0,
+    )));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forward emission coefficient must be finite and positive"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -354,11 +354,50 @@ fn tf_bjt_forward_early_voltage_reduces_output_impedance() {
             3.0,
             1.11,
             forward_early_voltage,
+            1.0,
         )));
         tf(&circuit, "out", "Vin").unwrap().output_impedance_ohms
     };
 
     assert!(output_impedance(10.0) < output_impedance(0.0));
+}
+
+#[test]
+fn tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance() {
+    let transfer = |forward_emission_coefficient: f64| {
+        let mut circuit = Circuit::new();
+        let thermal_voltage = 0.02585;
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vin", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+            "Q1",
+            "out",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            1.0e-14,
+            100.0,
+            thermal_voltage,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            3.0,
+            1.11,
+            0.0,
+            forward_emission_coefficient,
+        )));
+        tf(&circuit, "out", "Vin").unwrap()
+    };
+
+    let ideal = transfer(1.0);
+    let shaped = transfer(2.0);
+    assert!(shaped.gain().abs() < ideal.gain().abs());
+    assert!(shaped.input_impedance_ohms > ideal.input_impedance_ohms);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `NF` forward emission-coefficient support across DC,
+  transient charge, AC, transfer-function, and noise paths, matching Python and
+  Rust. The supported-parameter catalog now contains 80 canonical rows.
 - Add BJT model-card `VAF`/`VA` forward Early-voltage support with
   collector-voltage modulation in DC, transient, AC, transfer-function, and
   noise paths, matching Python and Rust. The supported-parameter catalog now

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -198,8 +198,9 @@ transition.
 Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
-model-specific saturation-current temperature scaling, plus `VAF`/`VA`
-(default `0`, meaning infinite) for forward Early-effect modulation.
+model-specific saturation-current temperature scaling, `VAF`/`VA` (default
+`0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
+`1`) for forward-junction emission shaping.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1713,6 +1713,7 @@ export interface Bjt {
   readonly saturationCurrentTemperatureExponent: number;
   readonly energyGapElectronVolts: number;
   readonly forwardEarlyVoltage: number;
+  readonly forwardEmissionCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1990,8 +1991,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [10, 19, 5, 4],
-  PNP: [10, 19, 5, 4],
+  NPN: [11, 20, 5, 4],
+  PNP: [11, 20, 5, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3581,7 +3582,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7737,6 +7738,7 @@ export function bjt(
   saturationCurrentTemperatureExponent = 3.0,
   energyGapElectronVolts = 1.11,
   forwardEarlyVoltage = 0.0,
+  forwardEmissionCoefficient = 1.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7755,6 +7757,7 @@ export function bjt(
     saturationCurrentTemperatureExponent,
     energyGapElectronVolts,
     forwardEarlyVoltage,
+    forwardEmissionCoefficient,
   };
 }
 
@@ -7860,6 +7863,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   EG: "EG",
   VAF: "VAF",
   VA: "VAF",
+  NF: "NF",
 };
 
 const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8359,6 +8363,7 @@ export function bjtFromModelCard(
     p.XTI ?? 3.0,
     p.EG ?? 1.11,
     p.VAF ?? 0.0,
+    p.NF ?? 1.0,
   );
 }
 
@@ -18287,7 +18292,8 @@ function collectNoiseSources(
         element.polarity === "NPN"
           ? baseVoltage - emitterVoltage
           : emitterVoltage - baseVoltage;
-      const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / element.thermalVoltage));
+      const forwardThermalVoltage = element.thermalVoltage * element.forwardEmissionCoefficient;
+      const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / forwardThermalVoltage));
       const outputVoltage = element.polarity === "NPN"
         ? collectorVoltage - emitterVoltage
         : emitterVoltage - collectorVoltage;
@@ -18764,10 +18770,11 @@ function stampBjt(
     element.polarity === "NPN"
       ? baseVoltage - emitterVoltage
       : emitterVoltage - baseVoltage;
-  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / element.thermalVoltage));
+  const forwardThermalVoltage = element.thermalVoltage * element.forwardEmissionCoefficient;
+  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / forwardThermalVoltage));
   const expValue = Math.exp(exponent);
   const baseCollectorCurrent = element.saturationCurrent * (expValue - 1.0);
-  const baseTransconductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const baseTransconductance = element.saturationCurrent / forwardThermalVoltage * expValue;
   const outputVoltage = element.polarity === "NPN"
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;
@@ -19328,9 +19335,14 @@ function bjtBaseCollectorChargeStateName(element: Bjt): string {
   return `_Q_${element.name}_bc_charge`;
 }
 
-function bjtJunctionTransconductance(element: Bjt, voltage: number): number {
-  const exponent = Math.max(-40.0, Math.min(40.0, voltage / element.thermalVoltage));
-  return (element.saturationCurrent / element.thermalVoltage) * Math.exp(exponent);
+function bjtJunctionTransconductance(
+  element: Bjt,
+  voltage: number,
+  emissionCoefficient: number,
+): number {
+  const effectiveThermalVoltage = element.thermalVoltage * emissionCoefficient;
+  const exponent = Math.max(-40.0, Math.min(40.0, voltage / effectiveThermalVoltage));
+  return (element.saturationCurrent / effectiveThermalVoltage) * Math.exp(exponent);
 }
 
 function bjtChargeDynamicCapacitance(
@@ -19338,10 +19350,15 @@ function bjtChargeDynamicCapacitance(
   kind: BjtChargeStateKind,
   voltage: number,
 ): number {
-  const conductance = bjtJunctionTransconductance(element, voltage);
   if (kind === "base-emitter") {
+    const conductance = bjtJunctionTransconductance(
+      element,
+      voltage,
+      element.forwardEmissionCoefficient,
+    );
     return element.baseEmitterCapacitance + element.forwardTransitTime * conductance;
   }
+  const conductance = bjtJunctionTransconductance(element, voltage, 1.0);
   return element.baseCollectorCapacitance + element.reverseTransitTime * conductance;
 }
 
@@ -19564,6 +19581,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardEarlyVoltage) || element.forwardEarlyVoltage < 0.0) {
     throw invalidElement(element.name, "forward Early voltage must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.forwardEmissionCoefficient) || element.forwardEmissionCoefficient <= 0.0) {
+    throw invalidElement(element.name, "forward emission coefficient must be finite and positive");
   }
 }
 
@@ -20874,10 +20894,11 @@ function stampBjtSmallSignal(
     element.polarity === "NPN"
       ? baseVoltage - emitterVoltage
       : emitterVoltage - baseVoltage;
-  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / element.thermalVoltage));
+  const forwardThermalVoltage = element.thermalVoltage * element.forwardEmissionCoefficient;
+  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / forwardThermalVoltage));
   const expValue = Math.exp(exponent);
   const baseCollectorCurrent = element.saturationCurrent * (expValue - 1.0);
-  const baseTransconductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const baseTransconductance = element.saturationCurrent / forwardThermalVoltage * expValue;
   const outputVoltage = element.polarity === "NPN"
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;
@@ -21455,14 +21476,15 @@ function stampAcBjtSmallSignal(
     element.polarity === "NPN"
       ? baseVoltage - collectorVoltage
       : collectorVoltage - baseVoltage;
-  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / element.thermalVoltage));
+  const forwardThermalVoltage = element.thermalVoltage * element.forwardEmissionCoefficient;
+  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / forwardThermalVoltage));
   const reverseExponent = Math.max(
     -40.0,
     Math.min(40.0, reverseJunctionVoltage / element.thermalVoltage),
   );
   const expValue = Math.exp(exponent);
   const baseCollectorCurrent = element.saturationCurrent * (expValue - 1.0);
-  const baseTransconductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const baseTransconductance = element.saturationCurrent / forwardThermalVoltage * expValue;
   const outputVoltage = element.polarity === "NPN"
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(78);
+    expect(coverage).toHaveLength(80);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(78);
+    expect(records).toHaveLength(80);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 78,
-      expectedCanonicalParameterCount: 78,
-      acceptedNameCount: 128,
+      canonicalParameterCount: 80,
+      expectedCanonicalParameterCount: 80,
+      acceptedNameCount: 130,
       aliasedParameterCount: 37,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t78\t78\t128\t37\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t80\t80\t130\t37\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(77);
-    expect(report.acceptedNameCount).toBe(125);
+    expect(report.canonicalParameterCount).toBe(79);
+    expect(report.acceptedNameCount).toBe(127);
     expect(report.aliasedParameterCount).toBe(36);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t77\t78\t125\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t79\t80\t127\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -337,15 +337,17 @@ describe("dcOp", () => {
       XTI: 2.4,
       EG: 1.05,
       VA: 80.0,
+      NF: 1.2,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
     expectClose(bjtModel.saturationCurrentTemperatureExponent, 2.4);
     expectClose(bjtModel.energyGapElectronVolts, 1.05);
     expectClose(bjtModel.forwardEarlyVoltage, 80.0);
+    expectClose(bjtModel.forwardEmissionCoefficient, 1.2);
 
     const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
@@ -978,7 +980,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -989,6 +991,7 @@ describe("dcOp", () => {
       expectClose(expanded.saturationCurrentTemperatureExponent, 2.4);
       expectClose(expanded.energyGapElectronVolts, 1.05);
       expectClose(expanded.forwardEarlyVoltage, 80.0);
+      expectClose(expanded.forwardEmissionCoefficient, 1.2);
     }
   });
 
@@ -1349,6 +1352,25 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, -1.0));
     expect(() => dcOp(circuit)).toThrowError("forward Early voltage must be finite and non-negative");
+  });
+
+  it("uses BJT forward emission coefficient to reduce collector current", () => {
+    const collectorVoltage = (forwardEmissionCoefficient: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "vcc", "out", 1_000.0));
+      circuit.add(bjt("Q1", "out", "base", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, forwardEmissionCoefficient));
+      return dcOp(circuit).voltage("out");
+    };
+
+    expect(collectorVoltage(2.0)).toBeGreaterThan(collectorVoltage(1.0));
+  });
+
+  it("rejects an invalid BJT forward emission coefficient", () => {
+    const circuit = new Circuit();
+    circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 0.0));
+    expect(() => dcOp(circuit)).toThrowError("forward emission coefficient must be finite and positive");
   });
 
   it("uses MOSFET temperature scaling in common-source drain voltage", () => {

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -59,6 +59,21 @@ describe("tf", () => {
     expect(outputImpedance(10.0)).toBeLessThan(outputImpedance(0.0));
   });
 
+  it("uses BJT forward emission coefficient to reduce gain and raise input impedance", () => {
+    function transfer(forwardEmissionCoefficient: number) {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vin", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add(bjt("Q1", "out", "base", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0, forwardEmissionCoefficient));
+      return tf(circuit, "out", "Vin");
+    }
+
+    const ideal = transfer(1.0);
+    const shaped = transfer(2.0);
+    expect(Math.abs(shaped.gain())).toBeLessThan(Math.abs(ideal.gain()));
+    expect(shaped.inputImpedanceOhms).toBeGreaterThan(ideal.inputImpedanceOhms);
+  });
+
   it("formats stable text output tables for transfer-function results", () => {
     const result = {
       transferRatio: 0.5,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward Early voltage.
+1. Cross-language BJT forward emission coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `VAF` / `VA` forward Early-voltage model-card support in
+   - Add Berkeley BJT `NF` forward emission-coefficient model-card support in
      Rust, Python, and TypeScript.
-   - Apply collector-voltage modulation in DC, transient, AC,
-     transfer-function, and noise paths while preserving the full BJT model
-     through hierarchical subcircuit expansion.
-   - Extend the supported-parameter coverage gate from 76 to 78 canonical rows
-     and lock model-specific output-conductance behavior across all three engines.
+   - Apply `NF` to the forward junction current, transconductance, charge, and
+     noise paths while preserving the full BJT model through hierarchical
+     subcircuit expansion.
+   - Extend the supported-parameter coverage gate from 78 to 80 canonical rows
+     and lock forward-junction behavior across all three engines.
 
 ## Completed Slices
 
@@ -3007,6 +3007,14 @@ the Rust, Python, and TypeScript surfaces together.
      model's energy gap to saturation-current temperature scaling.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 76 canonical rows.
+
+220. Cross-language BJT forward Early voltage.
+   - Status: completed in PR 8734.
+   - Rust, Python, and TypeScript BJT model cards now accept `VAF` / `VA` and
+     apply collector-voltage modulation in DC, transient, AC,
+     transfer-function, and noise paths.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 78 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley SPICE BJT forward emission coefficient `NF` model-card support in Rust, Python, and TypeScript
- apply `NF` consistently to forward-junction DC, AC/TF, transient diffusion-charge, and noise behavior while preserving hierarchy, sensitivity, and Monte Carlo copies
- extend model-depth coverage gates, documentation, changelogs, and the SPICE completion plan

## Verification
- `cargo test -p spice-engine`
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python full package suite: 512 passed, 88.48% coverage
- TypeScript `npm test`: 272 passed
- TypeScript `npm run build`
- Python Ruff on touched source and tests
- `git diff --check`