### PR TITLE
feat(chief): complete approved job report path

### DIFF
--- a/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Route subprocess host RPC calls through profile-gated D18D handlers in Rust.
 - Serve agent-originated `host.*` calls over the live deny-all Deno stdio
   session, returning typed Rust handler results and policy rejections.
+- Allow reviewed host profiles to install centralized D18D policy engines and
+  route scoped approval grants through active host ownership boundaries.
 
 ## Unreleased
 

--- a/code/packages/rust/chief-of-staff-host-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/README.md
@@ -59,6 +59,13 @@ back to the child until it exits. The executable Deno test proves an allowed
 call reaches a real Rust handler while a non-allowlisted call receives a terminal
 host rejection and never invokes one.
 
+Host profiles can install a centralized D18D policy before activation with
+`set_policy` or `set_host_policy`. Active host and orchestrator runtimes expose
+the matching approval-aware invocation path, so a scoped `ToolApprovalGrant`
+travels through the same owner routing and policy engine as an ordinary call.
+Approval tokens cannot bypass an unknown host, unowned tool, profile ceiling,
+or capability check.
+
 An orchestrator profile has this shape:
 
 ```json

--- a/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
@@ -11,7 +11,8 @@ pub use package::{
 
 use chief_of_staff_tool_api::{
     validate_tool_id, InMemoryToolRuntime, PrivilegeTier, RequestedBy, ToolApiError,
-    ToolDefinition, ToolExecutionTrace, ToolHandler, ToolInvocationRequest,
+    ToolApprovalGrant, ToolDefinition, ToolExecutionTrace, ToolHandler, ToolInvocationRequest,
+    ToolPolicyEngine,
 };
 use coding_adventures_json_serializer::serialize as serialize_json;
 use coding_adventures_json_value::{parse as parse_json, JsonValue};
@@ -246,6 +247,18 @@ impl OrchestratorProfileRuntime {
             .register_handler(definition, handler)
     }
 
+    pub fn set_host_policy<P>(&mut self, host_id: &str, policy: P) -> Result<(), HostRuntimeError>
+    where
+        P: ToolPolicyEngine + 'static,
+    {
+        let host = self
+            .hosts
+            .get_mut(host_id)
+            .ok_or_else(|| HostRuntimeError::UnknownProcessHost(host_id.to_string()))?;
+        host.set_policy(policy);
+        Ok(())
+    }
+
     pub fn summary(&self) -> OrchestratorProfileSummary {
         let registered_tool_count = self
             .hosts
@@ -290,6 +303,13 @@ impl HostProfileRuntime {
 
     pub fn profile(&self) -> &HostProfile {
         &self.profile
+    }
+
+    pub fn set_policy<P>(&mut self, policy: P)
+    where
+        P: ToolPolicyEngine + 'static,
+    {
+        self.runtime.set_policy(policy);
     }
 
     pub fn register_handler<H>(
@@ -660,6 +680,22 @@ impl ActiveOrchestratorRuntime {
             .invoke_with_events(request))
     }
 
+    pub fn invoke_with_events_with_approval(
+        &self,
+        request: &ToolInvocationRequest,
+        approval_grant: &ToolApprovalGrant,
+    ) -> Result<ToolExecutionTrace, HostRuntimeError> {
+        let host_id = self
+            .tool_owners
+            .get(&request.tool_id)
+            .ok_or_else(|| HostRuntimeError::ToolNotAllowed(request.tool_id.clone()))?;
+        Ok(self
+            .hosts
+            .get(host_id)
+            .expect("active orchestrator must retain each tool owner")
+            .invoke_with_events_with_approval(request, approval_grant))
+    }
+
     /// Dispatch one subprocess-originated call through the canonical D18D
     /// handler runtime owned by the tool's profile host.
     pub fn handle_rpc(&self, request: HostRpcRequest) -> Result<HostRpcResponse, HostRuntimeError> {
@@ -693,6 +729,15 @@ impl ActiveHostToolRuntime {
 
     pub fn invoke_with_events(&self, request: &ToolInvocationRequest) -> ToolExecutionTrace {
         self.runtime.invoke_with_events(request)
+    }
+
+    pub fn invoke_with_events_with_approval(
+        &self,
+        request: &ToolInvocationRequest,
+        approval_grant: &ToolApprovalGrant,
+    ) -> ToolExecutionTrace {
+        self.runtime
+            .invoke_with_events_with_approval(request, approval_grant)
     }
 
     pub fn definitions(&self) -> Vec<&ToolDefinition> {
@@ -1108,8 +1153,9 @@ fn validate_label(field: &str, value: &str) -> Result<(), HostRuntimeError> {
 mod tests {
     use super::*;
     use chief_of_staff_tool_api::{
-        JsonSchema, RequestedBy, ToolConcurrency, ToolHandlerOutput, ToolIdempotency,
-        ToolInvocationRequest, ToolSideEffects, ToolStability, ToolStreaming,
+        ApprovalState, JsonSchema, RequestedBy, ToolConcurrency, ToolHandlerOutput,
+        ToolIdempotency, ToolInvocationRequest, ToolPolicyProfile, ToolSideEffects, ToolStability,
+        ToolStreaming,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
     use generic_job_protocol::JobResult;
@@ -1496,6 +1542,54 @@ while (true) {
                 .result
                 .output,
             Some(JsonValue::String("read".to_string()))
+        );
+    }
+
+    #[test]
+    fn orchestrator_profile_enforces_scoped_approval_before_write_handler() {
+        let mut runtime = OrchestratorProfileRuntime::from_json(ORCHESTRATOR_PROFILE).unwrap();
+        runtime
+            .register_handler(
+                definition("demo.read", PrivilegeTier::Tier1, &["demo_read"]),
+                |_arguments, _context| {
+                    Ok(ToolHandlerOutput::new(JsonValue::String(
+                        "read".to_string(),
+                    )))
+                },
+            )
+            .unwrap();
+        let mut write_definition = definition("demo.write", PrivilegeTier::Tier1, &["demo_write"]);
+        write_definition.side_effects = ToolSideEffects::Write;
+        runtime
+            .register_handler(write_definition, |_arguments, _context| {
+                Ok(ToolHandlerOutput::new(JsonValue::String(
+                    "written".to_string(),
+                )))
+            })
+            .unwrap();
+        runtime
+            .set_host_policy(
+                "writer_host",
+                ToolPolicyProfile::allow_all()
+                    .with_approval_required_for(vec![ToolSideEffects::Write]),
+            )
+            .unwrap();
+        let active = runtime.activate().unwrap();
+        let write_request = request("demo.write");
+
+        let pending = active.invoke_with_events(&write_request).unwrap();
+        assert_eq!(pending.record.approval_state, ApprovalState::Pending);
+        assert!(!pending.result.ok);
+
+        let grant =
+            ToolApprovalGrant::new("call_1", "demo.write", "user_1", 100).with_expires_at(200);
+        let approved = active
+            .invoke_with_events_with_approval(&write_request, &grant)
+            .unwrap();
+        assert_eq!(approved.record.approval_state, ApprovalState::Granted);
+        assert_eq!(
+            approved.result.output,
+            Some(JsonValue::String("written".to_string()))
         );
     }
 

--- a/code/packages/rust/weather-agent-e2e/CHANGELOG.md
+++ b/code/packages/rust/weather-agent-e2e/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this package will be documented in this file.
 - Loaded the Weather Agent D18D catalog from a reviewed orchestrator profile
   with isolated fetcher, classifier, and writer hosts through
   `chief-of-staff-host-runtime`.
+- Added centralized write approval enforcement, a validated D18C run receipt,
+  and a compact user-visible report backed by canonical journal health.
 
 - Initial umbrella-today end-to-end harness that exercises the Chief of Staff
   actor, D18A store, D18C job, D18D tool, read/write separation, and

--- a/code/packages/rust/weather-agent-e2e/README.md
+++ b/code/packages/rust/weather-agent-e2e/README.md
@@ -14,7 +14,15 @@ store, and capability boundaries to run as one pipeline.
 The D18D tools are loaded from `orchestrator_profile.json` through
 `chief-of-staff-host-runtime`. Fetch, classification, and file writing belong to
 three isolated host profiles with independent capability sets. The profile must
-be complete and active before the first tool invocation.
+be complete and active before the first tool invocation. The writer host applies
+a centralized policy that requires a call-scoped user approval before filesystem
+output; an absent grant leaves the call pending and the report unwritten.
+
+A successful run now emits a validated D18C `JobRunReceipt` plus a compact
+`UmbrellaUserReport`. The receipt points at the stored report artifact, while the
+user report carries the recommendation, completion time, approval state, and
+journal invocation count. This makes umbrella-today a reusable Chief job with a
+terminal product rather than only an architecture harness.
 
 The primary tests write a real `umbrella-today.txt` file through the capability
 cage, assert that the supervised agent says to bring an umbrella for the rainy

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -27,10 +27,11 @@ use chief_of_staff_host_runtime::{
     OrchestratorProfileSummary,
 };
 use chief_of_staff_tool_api::{
-    JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError, ToolCallError,
-    ToolConcurrency, ToolDefinition, ToolErrorKind, ToolEventKind, ToolExecutionJournal,
-    ToolExecutionJournalHealthSummary, ToolHandlerOutput, ToolIdempotency, ToolInvocationRequest,
-    ToolSideEffects, ToolStability, ToolStreaming,
+    ApprovalState, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError,
+    ToolApprovalGrant, ToolCallError, ToolConcurrency, ToolDefinition, ToolErrorKind,
+    ToolEventKind, ToolExecutionJournal, ToolExecutionJournalHealthSummary, ToolHandlerOutput,
+    ToolIdempotency, ToolInvocationRequest, ToolPolicyProfile, ToolSideEffects, ToolStability,
+    ToolStreaming,
 };
 use coding_adventures_json_value::{JsonNumber, JsonValue};
 use context_store::{
@@ -50,8 +51,8 @@ use memory_store::{
 };
 use operation_primitives::{OperationError, OperationHttpClientError, OperationHttpRequest};
 use os_job_core::{
-    BackendKind, ConcurrencyPolicy, DateTimeParts, JobAction, JobSpec, JobTrigger, OutputPolicy,
-    RetryPolicy,
+    BackendKind, ConcurrencyPolicy, DateTimeParts, JobAction, JobRunReceipt, JobSpec, JobTrigger,
+    OutputPolicy, RetryPolicy,
 };
 use os_job_runtime::NativeJobRuntime;
 use read_write_separation::{
@@ -188,6 +189,7 @@ pub struct UmbrellaAgentConfig {
     pub fetched_at_iso: String,
     pub weather_source: WeatherSource,
     pub supervisor_probe: UmbrellaSupervisorProbe,
+    pub write_approval: Option<ToolApprovalGrant>,
 }
 
 impl UmbrellaAgentConfig {
@@ -200,6 +202,7 @@ impl UmbrellaAgentConfig {
             fetched_at_iso: "2026-05-12T12:00:00.000Z".to_string(),
             weather_source: WeatherSource::Fixture(WeatherSnapshot::rainy_seattle_fixture()),
             supervisor_probe: UmbrellaSupervisorProbe::default(),
+            write_approval: Some(default_write_approval(1_778_624_400_000)),
         }
     }
 
@@ -218,6 +221,7 @@ impl UmbrellaAgentConfig {
                 user_agent: "coding-adventures-weather-agent-e2e/0.1 (adhithyan15)".to_string(),
             },
             supervisor_probe: UmbrellaSupervisorProbe::default(),
+            write_approval: Some(default_write_approval(fetched_at_ms)),
         }
     }
 
@@ -225,6 +229,16 @@ impl UmbrellaAgentConfig {
         self.supervisor_probe.kill_child_before_tick = Some(actor_id.into());
         self
     }
+
+    pub fn without_write_approval(mut self) -> Self {
+        self.write_approval = None;
+        self
+    }
+}
+
+fn default_write_approval(granted_at: u64) -> ToolApprovalGrant {
+    ToolApprovalGrant::new("write_umbrella_report", WRITE_TOOL_ID, USER_ID, granted_at)
+        .with_expires_at(granted_at.saturating_add(300_000))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -508,6 +522,24 @@ pub struct UmbrellaAgentRun {
     pub job_executor_status: ExecutorFleetStatusSummary,
     pub rws: HostRwsSummary,
     pub actor_channel_messages: usize,
+    pub job_receipt: JobRunReceipt,
+    pub user_report: UmbrellaUserReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UmbrellaUserReport {
+    pub headline: String,
+    pub detail: String,
+    pub completed_at_iso: String,
+    pub output_ref: String,
+    pub write_approval: ApprovalState,
+    pub journal_invocation_count: usize,
+}
+
+impl UmbrellaUserReport {
+    pub fn render(&self) -> String {
+        format!("{}\n{}", self.headline, self.detail)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -648,6 +680,30 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         .lock()
         .expect("actor channel mutex poisoned")
         .len();
+    let job_receipt = JobRunReceipt::succeeded(
+        format!("{}_run", config.tick_id),
+        JOB_ID,
+        config.fetched_at_ms,
+        config.fetched_at_ms.saturating_add(1),
+        vec!["artifact:umbrella_today_report".to_string()],
+    );
+    if !job_receipt.validate().is_valid() {
+        return Err(UmbrellaAgentError::new(
+            "umbrella job produced an invalid D18C run receipt",
+        ));
+    }
+    let user_report = UmbrellaUserReport {
+        headline: if recommendation.kind.needs_umbrella() {
+            "Bring an umbrella today".to_string()
+        } else {
+            "No umbrella needed today".to_string()
+        },
+        detail: recommendation.explanation.clone(),
+        completed_at_iso: config.fetched_at_iso.clone(),
+        output_ref: "artifact:umbrella_today_report".to_string(),
+        write_approval: ApprovalState::Granted,
+        journal_invocation_count: tool_journal_health.invocation_count,
+    };
 
     Ok(UmbrellaAgentRun {
         recommendation,
@@ -668,6 +724,8 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         job_executor_status,
         rws: validate_host_boundaries(&pipeline.config.output_path)?,
         actor_channel_messages,
+        job_receipt,
+        user_report,
     })
 }
 
@@ -700,6 +758,10 @@ impl UmbrellaPipeline {
         .map_err(UmbrellaAgentError::from)?;
         register_weather_classifier_tool(&mut tool_runtime)?;
         register_file_writer_tool(&mut tool_runtime, writer_manifest(&config.output_path)?)?;
+        tool_runtime.set_host_policy(
+            "file_writer",
+            ToolPolicyProfile::allow_all().with_approval_required_for(vec![ToolSideEffects::Write]),
+        )?;
         let tool_runtime = tool_runtime.activate()?;
 
         Ok(Self {
@@ -982,7 +1044,16 @@ impl UmbrellaPipeline {
             deadline_at: Some(self.config.fetched_at_ms.saturating_add(30_000)),
             idempotency_key: Some(format!("{}-{}", self.config.tick_id, call_id)),
         };
-        let trace = self.tool_runtime.invoke_with_events(&request)?;
+        let trace = if tool_id == WRITE_TOOL_ID {
+            match self.config.write_approval.as_ref() {
+                Some(grant) => self
+                    .tool_runtime
+                    .invoke_with_events_with_approval(&request, grant)?,
+                None => self.tool_runtime.invoke_with_events(&request)?,
+            }
+        } else {
+            self.tool_runtime.invoke_with_events(&request)?
+        };
         let result = trace.result.clone();
         self.journal
             .lock()

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -155,9 +155,11 @@ fn umbrella_today_job_blocks_write_without_explicit_approval() {
     let error = run_umbrella_today_agent(config)
         .expect_err("write step should stop at the centralized approval gate");
     assert!(error.to_string().contains("requires approval"));
-    let probe_text = fs::read_to_string(&output_path).expect("sandbox probe output should exist");
-    assert!(probe_text.contains("kernel sandbox allowed"));
-    assert!(!probe_text.contains("Bring an umbrella today"));
+    let persisted_text = fs::read_to_string(&output_path).unwrap_or_default();
+    if current_kernel_sandbox_support().available {
+        assert_eq!(persisted_text, "kernel sandbox allowed");
+    }
+    assert!(!persisted_text.contains("Bring an umbrella today"));
 }
 
 #[test]

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use capability_os_sandbox::{current_kernel_sandbox_support, OsFamily};
+use chief_of_staff_tool_api::ApprovalState;
 use os_job_core::BackendKind;
 use weather_agent_e2e::{
     run_umbrella_today_agent, RecommendationKind, UmbrellaAgentConfig, WeatherFetchSourceKind,
@@ -97,6 +98,8 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
     assert_eq!(run.tool_journal_health.invocation_count, 3);
     assert_eq!(run.tool_journal_health.completed_count, 3);
     assert_eq!(run.tool_journal_health.failed_count, 0);
+    assert_eq!(run.tool_journal_health.approval_granted_count, 1);
+    assert_eq!(run.tool_journal_health.approval_pending_count, 0);
     assert!(run.tool_journal_health.results_with_output_count >= 3);
     assert!(run.tool_journal_health.results_with_artifact_refs_count >= 1);
 
@@ -116,10 +119,45 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
     assert_eq!(run.job_plan_file_count, 0);
     assert!(run.job_executor_status.is_quiescent());
     assert!(run.job_executor_status.has_executors());
+    assert!(run.job_receipt.exit_status.is_success());
+    assert_eq!(run.job_receipt.job_id, "umbrella_today_job");
+    assert_eq!(
+        run.job_receipt.output_refs,
+        vec!["artifact:umbrella_today_report"]
+    );
+    assert_eq!(run.user_report.headline, "Bring an umbrella today");
+    assert!(run
+        .user_report
+        .detail
+        .contains("precipitation chance is 72%"));
+    assert_eq!(run.user_report.write_approval, ApprovalState::Granted);
+    assert_eq!(run.user_report.journal_invocation_count, 3);
+    assert!(run.user_report.render().contains("Bring an umbrella today"));
 
     assert_eq!(run.rws.fetcher.untrusted_inputs, 1);
     assert_eq!(run.rws.writer.external_actuations, 1);
     assert!(run.rws.combined_manifest_rejected);
+}
+
+#[test]
+fn umbrella_today_job_blocks_write_without_explicit_approval() {
+    let root = std::env::temp_dir().join(format!(
+        "weather-agent-approval-e2e-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos()
+    ));
+    fs::create_dir_all(&root).expect("temp dir should be created");
+    let output_path = root.join("umbrella-today.txt");
+    let config = UmbrellaAgentConfig::deterministic_seattle(&output_path).without_write_approval();
+
+    let error = run_umbrella_today_agent(config)
+        .expect_err("write step should stop at the centralized approval gate");
+    assert!(error.to_string().contains("requires approval"));
+    let probe_text = fs::read_to_string(&output_path).expect("sandbox probe output should exist");
+    assert!(probe_text.contains("kernel sandbox allowed"));
+    assert!(!probe_text.contains("Bring an umbrella today"));
 }
 
 #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -274,18 +274,21 @@ D18D handler catalog, and returns typed rejection frames for denied tools. A
 real-Deno test proves one allowed call reaches Rust and one undeclared call does
 not reach a handler.
 
+The first reusable Chief job slice now takes the existing Weather Agent through
+the in-process D18C job plan and executor, isolated host tool runtime, centralized
+write-approval policy, D18D execution journal, artifact write, validated
+`JobRunReceipt`, and compact user-visible umbrella report. The approved path
+records one granted write and three completed calls; the unapproved path stops
+at the policy gate and never writes the recommendation.
+
 These items are Chief of Staff architecture, not smart-home platform work:
 
-- Run a Chief job end to end through scheduler or job framework, tool runtime,
-  approval checks, result journal, and final user-visible report.
 - Add approval UX and policy wiring for Tier2 or stronger actions such as
   bridge pairing, locks, cameras, alarms, and safety devices.
 - Wire vault leasing so tools receive opaque `VaultRef` handles and never raw
   smart-home secrets.
 - Persist tool execution journals and expose compact audit summaries for jobs,
   hosts, sessions, and user review.
-- Package at least one reusable Chief job such as "home status brief",
-  "goodnight check", or "device health triage".
 
 ## Smart Home Remaining Work
 


### PR DESCRIPTION
## Summary\n- install centralized D18D policy engines on reviewed host profiles and route scoped approval grants through active host ownership\n- require explicit approval for the Weather Agent report write, with executable approved and denied paths\n- emit a validated D18C JobRunReceipt and compact user-visible report backed by canonical journal health\n- update the D18-D23 completion inventory to record the reusable end-to-end Chief job slice\n\n## Validation\n- cargo test -p chief-of-staff-host-runtime -p weather-agent-e2e -- --nocapture\n- cargo clippy -p chief-of-staff-host-runtime -p weather-agent-e2e --all-targets -- -D warnings\n- sh chief-of-staff-host-runtime/BUILD\n- sh weather-agent-e2e/BUILD\n- cargo fmt --package chief-of-staff-host-runtime --package weather-agent-e2e -- --check\n- git diff --check\n