### PR TITLE
feat(spice): add BJT reverse emission coefficient

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT reverse emission coefficient** — BJT model cards now accept `NR` and
+  apply it to reverse base-collector diffusion charge in AC and transient
+  analysis, matching Rust and TypeScript. The supported-parameter catalog now
+  contains 82 canonical rows.
+
 - **BJT forward emission coefficient** — BJT model cards now accept `NF` and
   apply it to DC, transient charge, AC, transfer-function, and noise paths,
   matching Rust and TypeScript. The supported-parameter catalog now contains

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -213,7 +213,8 @@ control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
-`1`) for forward-junction emission shaping.
+`1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
+base-collector diffusion capacitance in AC and transient analysis.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -598,6 +598,8 @@ class BJT:
         modulation, matching an infinite Early voltage (default 0.0).
     Nf:
         Forward emission coefficient (default 1.0).
+    Nr:
+        Reverse emission coefficient (default 1.0).
     """
 
     name: str
@@ -616,6 +618,7 @@ class BJT:
     Eg: float = 1.11        # semiconductor energy gap (eV)
     Vaf: float = 0.0        # forward Early voltage (V); 0 means infinite
     Nf: float = 1.0         # forward emission coefficient
+    Nr: float = 1.0         # reverse emission coefficient
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8738,7 +8738,7 @@ def _bjt_charge_dynamic_capacitance(el: BJT, state_kind: str, voltage: float) ->
     if state_kind == "be":
         conductance = _bjt_junction_transconductance(el, voltage, el.Nf)
         return el.Cje + el.Tf * conductance
-    conductance = _bjt_junction_transconductance(el, voltage, 1.0)
+    conductance = _bjt_junction_transconductance(el, voltage, el.Nr)
     return el.Cjc + el.Tr * conductance
 
 
@@ -9154,6 +9154,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT forward Early voltage must be finite and non-negative")
     if not math.isfinite(el.Nf) or el.Nf <= 0.0:
         raise ValueError(f"{el.name}: BJT forward emission coefficient must be finite and positive")
+    if not math.isfinite(el.Nr) or el.Nr <= 0.0:
+        raise ValueError(f"{el.name}: BJT reverse emission coefficient must be finite and positive")
 
 
 # ---------------------------------------------------------------------------
@@ -12373,15 +12375,16 @@ def _stamp_ac(
             else min(Vc_dc - Vb_dc, 0.7)
         )
         forward_thermal_voltage = el.Vt * el.Nf
+        reverse_thermal_voltage = el.Vt * el.Nr
         exp_t = math.exp(Vjunc / forward_thermal_voltage)
-        exp_reverse = math.exp(Vreverse / el.Vt)
+        exp_reverse = math.exp(Vreverse / reverse_thermal_voltage)
         base_collector_current = el.Is * (exp_t - 1.0)
         base_gm = (el.Is / forward_thermal_voltage) * exp_t
         output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
         early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
         output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
         gm_b: float = base_gm * early_factor
-        gm_reverse: float = (el.Is / el.Vt) * exp_reverse
+        gm_reverse: float = (el.Is / reverse_thermal_voltage) * exp_reverse
         g_pi: float = base_gm / el.beta_f
         diffusion_capacitance = el.Tf * gm_b
         reverse_diffusion_capacitance = el.Tr * gm_reverse

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (11, 20, 5, 4),
-    "PNP": (11, 20, 5, 4),
+    "NPN": (12, 21, 5, 4),
+    "PNP": (12, 21, 5, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -375,6 +375,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "VAF": "VAF",
     "VA": "VAF",
     "NF": "NF",
+    "NR": "NR",
 }
 
 _JFET_PARAMETER_ALIASES: dict[str, str] = {
@@ -903,6 +904,7 @@ def bjt_from_model_card(
         Eg=p.get("EG", 1.11),
         Vaf=p.get("VAF", 0.0),
         Nf=p.get("NF", 1.0),
+        Nr=p.get("NR", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 80
+    assert len(coverage) == 82
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 80
+    assert len(records) == 82
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 80
-    assert report.expected_canonical_parameter_count == 80
-    assert report.accepted_name_count == 130
+    assert report.canonical_parameter_count == 82
+    assert report.expected_canonical_parameter_count == 82
+    assert report.accepted_name_count == 132
     assert report.aliased_parameter_count == 37
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t80\t80\t130\t37\t4\t0"
+        "true\t7\t7\t82\t82\t132\t37\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 79
-    assert report.accepted_name_count == 127
+    assert report.canonical_parameter_count == 81
+    assert report.accepted_name_count == 129
     assert report.aliased_parameter_count == 36
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t79\t80\t127\t36\t4\t4\n"
+        "false\t7\t7\t81\t82\t129\t36\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2, "NR": 1.3}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2, "NR": 1.3}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
@@ -658,6 +658,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Eg == pytest.approx(1.05)
     assert bjt_model.Vaf == pytest.approx(80.0)
     assert bjt_model.Nf == pytest.approx(1.2)
+    assert bjt_model.Nr == pytest.approx(1.3)
 
     jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -2227,7 +2228,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2238,6 +2239,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Eg == pytest.approx(1.05)
     assert expanded.Vaf == pytest.approx(80.0)
     assert expanded.Nf == pytest.approx(1.2)
+    assert expanded.Nr == pytest.approx(1.3)
 
 
 def test_branch_current_in_voltage_source():
@@ -2511,6 +2513,13 @@ def test_dc_rejects_invalid_bjt_forward_emission_coefficient():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Nf=0.0))
     with pytest.raises(ValueError, match="BJT forward emission coefficient must be finite and positive"):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_reverse_emission_coefficient():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Nr=0.0))
+    with pytest.raises(ValueError, match="BJT reverse emission coefficient must be finite and positive"):
         dc_op(circuit)
 
 
@@ -4124,6 +4133,20 @@ def test_ac_bjt_reverse_transit_time_adds_collector_diffusion_capacitance():
 
     assert without_transit_time > 0.9
     assert with_transit_time < without_transit_time / 100.0
+
+
+def test_ac_bjt_reverse_emission_coefficient_reduces_collector_diffusion_capacitance():
+    """BJT Nr scales the reverse base-collector diffusion charge."""
+    def base_amplitude(nr: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        c.add(Resistor("Rin", "in", "base", 1000.0))
+        c.add(Resistor("Rc", "col", "0", 1.0))
+        c.add(BJT("Q1", collector="col", base="base", emitter="0", Is=25.85e-6, Tr=1.0e-2, Nr=nr))
+        result = ac_sweep(c, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["base"])
+
+    assert base_amplitude(2.0) > base_amplitude(1.0)
 
 
 def test_ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `NR` reverse emission-coefficient support to reverse
+  base-collector diffusion charge in AC and transient analysis, matching Python
+  and TypeScript. The supported-parameter catalog now contains 82 canonical rows.
 - Add BJT model-card `NF` forward emission-coefficient support across DC,
   transient charge, AC, transfer-function, and noise paths, matching Python and
   TypeScript. The supported-parameter catalog now contains 80 canonical rows.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -130,7 +130,8 @@ control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
-`1`) for forward-junction emission shaping.
+`1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
+base-collector diffusion capacitance in AC and transient analysis.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -435,6 +435,7 @@ fn clone_subckt_element(
             element.energy_gap_electron_volts,
             element.forward_early_voltage,
             element.forward_emission_coefficient,
+            element.reverse_emission_coefficient,
         )),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -2841,6 +2842,7 @@ pub struct Bjt {
     pub energy_gap_electron_volts: f64,
     pub forward_early_voltage: f64,
     pub forward_emission_coefficient: f64,
+    pub reverse_emission_coefficient: f64,
 }
 
 impl Bjt {
@@ -2897,6 +2899,7 @@ impl Bjt {
             1.11,
             0.0,
             1.0,
+            1.0,
         )
     }
 
@@ -2918,6 +2921,7 @@ impl Bjt {
         energy_gap_electron_volts: f64,
         forward_early_voltage: f64,
         forward_emission_coefficient: f64,
+        reverse_emission_coefficient: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -2936,6 +2940,7 @@ impl Bjt {
             energy_gap_electron_volts,
             forward_early_voltage,
             forward_emission_coefficient,
+            reverse_emission_coefficient,
         }
     }
 }
@@ -3326,8 +3331,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 11, 20, 5, 4),
-    (ModelCardKind::Pnp, 11, 20, 5, 4),
+    (ModelCardKind::Npn, 12, 21, 5, 4),
+    (ModelCardKind::Pnp, 12, 21, 5, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3374,6 +3379,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("VAF", "VAF"),
     ("VA", "VAF"),
     ("NF", "NF"),
+    ("NR", "NR"),
 ];
 const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("BETA", "BETA"),
@@ -4030,6 +4036,7 @@ pub fn bjt_from_model_card(
         model_card_value(model, "EG", 1.11),
         model_card_value(model, "VAF", 0.0),
         model_card_value(model, "NF", 1.0),
+        model_card_value(model, "NR", 1.0),
     ))
 }
 
@@ -22332,7 +22339,8 @@ fn stamp_ac_bjt_small_signal(
     };
     let forward_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
     let exponent = (junction_voltage / forward_thermal_voltage).clamp(-40.0, 40.0);
-    let reverse_exponent = (reverse_junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
+    let reverse_thermal_voltage = bjt.thermal_voltage * bjt.reverse_emission_coefficient;
+    let reverse_exponent = (reverse_junction_voltage / reverse_thermal_voltage).clamp(-40.0, 40.0);
     let exp_value = exponent.exp();
     let base_collector_current = bjt.saturation_current * (exp_value - 1.0);
     let base_gm = bjt.saturation_current / forward_thermal_voltage * exp_value;
@@ -22351,7 +22359,7 @@ fn stamp_ac_bjt_small_signal(
         base_collector_current / bjt.forward_early_voltage
     };
     let gm = Complex::new(base_gm * early_factor, 0.0);
-    let reverse_gm = bjt.saturation_current / bjt.thermal_voltage * reverse_exponent.exp();
+    let reverse_gm = bjt.saturation_current / reverse_thermal_voltage * reverse_exponent.exp();
     let diffusion_capacitance = bjt.forward_transit_time * gm.real;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let gpi = Complex::new(
@@ -22967,7 +22975,8 @@ fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: 
             bjt.base_emitter_capacitance + bjt.forward_transit_time * conductance
         }
         BjtChargeStateKind::BaseCollector => {
-            let conductance = bjt_junction_transconductance(bjt, voltage, 1.0);
+            let conductance =
+                bjt_junction_transconductance(bjt, voltage, bjt.reverse_emission_coefficient);
             bjt.base_collector_capacitance + bjt.reverse_transit_time * conductance
         }
     }
@@ -23319,6 +23328,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward emission coefficient must be finite and positive".to_string(),
+        });
+    }
+    if !bjt.reverse_emission_coefficient.is_finite() || bjt.reverse_emission_coefficient <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "reverse emission coefficient must be finite and positive".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -867,6 +867,46 @@ fn ac_bjt_uses_reverse_transit_time_as_base_collector_diffusion_capacitance() {
 }
 
 #[test]
+fn ac_bjt_reverse_emission_coefficient_reduces_base_collector_diffusion_capacitance() {
+    fn base_amplitude(reverse_emission_coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new("Rc", "col", "0", 1.0)));
+        circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+            "Q1",
+            "col",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            25.85e-6,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            0.0,
+            1.0e-2,
+            3.0,
+            1.11,
+            0.0,
+            1.0,
+            reverse_emission_coefficient,
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("base")
+            .unwrap()
+            .abs()
+    }
+
+    assert!(base_amplitude(2.0) > base_amplitude(1.0));
+}
+
+#[test]
 fn ac_mosfet_common_source_suppresses_dc_supplies_without_ac_spec() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 80);
+    assert_eq!(coverage.len(), 82);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 80);
+    assert_eq!(records.len(), 82);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 80);
-    assert_eq!(report.expected_canonical_parameter_count, 80);
-    assert_eq!(report.accepted_name_count, 130);
+    assert_eq!(report.canonical_parameter_count, 82);
+    assert_eq!(report.expected_canonical_parameter_count, 82);
+    assert_eq!(report.accepted_name_count, 132);
     assert_eq!(report.aliased_parameter_count, 37);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t80\t80\t130\t37\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t82\t82\t132\t37\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 79);
-    assert_eq!(report.accepted_name_count, 127);
+    assert_eq!(report.canonical_parameter_count, 81);
+    assert_eq!(report.accepted_name_count, 129);
     assert_eq!(report.aliased_parameter_count, 36);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t79\t80\t127\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t81\t82\t129\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -432,6 +432,7 @@ fn model_card_aliases_build_device_instances() {
             ("EG", 1.05),
             ("VA", 80.0),
             ("NF", 1.2),
+            ("NR", 1.3),
         ],
     )
     .unwrap();
@@ -442,6 +443,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("EG").unwrap(), 1.05);
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
     assert_close(*bjt_card.parameters.get("NF").unwrap(), 1.2);
+    assert_close(*bjt_card.parameters.get("NR").unwrap(), 1.3);
     assert_eq!(bjt_model.polarity, BjtPolarity::Npn);
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
@@ -449,6 +451,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.energy_gap_electron_volts, 1.05);
     assert_close(bjt_model.forward_early_voltage, 80.0);
     assert_close(bjt_model.forward_emission_coefficient, 1.2);
+    assert_close(bjt_model.reverse_emission_coefficient, 1.3);
 
     let jfet_card = normalize_model_card(
         "Jn",
@@ -1362,6 +1365,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         1.05,
         80.0,
         1.2,
+        1.3,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1391,6 +1395,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.energy_gap_electron_volts, 1.05);
     assert_close(expanded.forward_early_voltage, 80.0);
     assert_close(expanded.forward_emission_coefficient, 1.2);
+    assert_close(expanded.reverse_emission_coefficient, 1.3);
 }
 
 #[test]
@@ -1852,6 +1857,7 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
         1.11,
         0.0,
         1.0,
+        1.0,
     );
     let high_exponent = Bjt::with_model_and_temperature_parameters(
         "Qhigh",
@@ -1869,6 +1875,7 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
         4.0,
         1.11,
         0.0,
+        1.0,
         1.0,
     );
     let low = bjt_at_temperature(&low_exponent, 350.0, 300.15, 1.11).unwrap();
@@ -1896,6 +1903,7 @@ fn bjt_temperature_scaling_uses_model_energy_gap() {
         1.11,
         0.0,
         1.0,
+        1.0,
     )));
     let mut lower_gap = Circuit::new();
     lower_gap.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
@@ -1914,6 +1922,7 @@ fn bjt_temperature_scaling_uses_model_energy_gap() {
         3.0,
         0.8,
         0.0,
+        1.0,
         1.0,
     )));
     let silicon_hot = circuit_at_temperature(&silicon, 350.0, 300.15, 1.11).unwrap();
@@ -1944,6 +1953,7 @@ fn dc_rejects_invalid_bjt_energy_gap() {
         3.0,
         0.0,
         0.0,
+        1.0,
         1.0,
     )));
     let error = dc_op(&circuit).unwrap_err();
@@ -1982,6 +1992,7 @@ fn bjt_forward_early_voltage_modulates_collector_current() {
             1.11,
             forward_early_voltage,
             1.0,
+            1.0,
         )));
         dc_op(&circuit).unwrap().voltage("out").unwrap()
     };
@@ -2008,6 +2019,7 @@ fn dc_rejects_invalid_bjt_forward_early_voltage() {
         3.0,
         1.11,
         -1.0,
+        1.0,
         1.0,
     )));
     let error = dc_op(&circuit).unwrap_err();
@@ -2046,6 +2058,7 @@ fn bjt_forward_emission_coefficient_reduces_collector_current() {
             1.11,
             0.0,
             forward_emission_coefficient,
+            1.0,
         )));
         dc_op(&circuit).unwrap().voltage("out").unwrap()
     };
@@ -2073,11 +2086,40 @@ fn dc_rejects_invalid_bjt_forward_emission_coefficient() {
         1.11,
         0.0,
         0.0,
+        1.0,
     )));
     let error = dc_op(&circuit).unwrap_err();
     assert!(error
         .to_string()
         .contains("forward emission coefficient must be finite and positive"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_reverse_emission_coefficient() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
+        "Qbad",
+        "c",
+        "b",
+        "0",
+        BjtPolarity::Npn,
+        1.0e-14,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        3.0,
+        1.11,
+        0.0,
+        1.0,
+        0.0,
+    )));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("reverse emission coefficient must be finite and positive"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -355,6 +355,7 @@ fn tf_bjt_forward_early_voltage_reduces_output_impedance() {
             1.11,
             forward_early_voltage,
             1.0,
+            1.0,
         )));
         tf(&circuit, "out", "Vin").unwrap().output_impedance_ohms
     };
@@ -390,6 +391,7 @@ fn tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance()
             1.11,
             0.0,
             forward_emission_coefficient,
+            1.0,
         )));
         tf(&circuit, "out", "Vin").unwrap()
     };

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `NR` reverse emission-coefficient support to reverse
+  base-collector diffusion charge in AC and transient analysis, matching Python
+  and Rust. The supported-parameter catalog now contains 82 canonical rows.
 - Add BJT model-card `NF` forward emission-coefficient support across DC,
   transient charge, AC, transfer-function, and noise paths, matching Python and
   Rust. The supported-parameter catalog now contains 80 canonical rows.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -200,7 +200,8 @@ control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
-`1`) for forward-junction emission shaping.
+`1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
+base-collector diffusion capacitance in AC and transient analysis.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1714,6 +1714,7 @@ export interface Bjt {
   readonly energyGapElectronVolts: number;
   readonly forwardEarlyVoltage: number;
   readonly forwardEmissionCoefficient: number;
+  readonly reverseEmissionCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1991,8 +1992,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [11, 20, 5, 4],
-  PNP: [11, 20, 5, 4],
+  NPN: [12, 21, 5, 4],
+  PNP: [12, 21, 5, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3582,7 +3583,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7739,6 +7740,7 @@ export function bjt(
   energyGapElectronVolts = 1.11,
   forwardEarlyVoltage = 0.0,
   forwardEmissionCoefficient = 1.0,
+  reverseEmissionCoefficient = 1.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7758,6 +7760,7 @@ export function bjt(
     energyGapElectronVolts,
     forwardEarlyVoltage,
     forwardEmissionCoefficient,
+    reverseEmissionCoefficient,
   };
 }
 
@@ -7864,6 +7867,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   VAF: "VAF",
   VA: "VAF",
   NF: "NF",
+  NR: "NR",
 };
 
 const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8364,6 +8368,7 @@ export function bjtFromModelCard(
     p.EG ?? 1.11,
     p.VAF ?? 0.0,
     p.NF ?? 1.0,
+    p.NR ?? 1.0,
   );
 }
 
@@ -19358,7 +19363,11 @@ function bjtChargeDynamicCapacitance(
     );
     return element.baseEmitterCapacitance + element.forwardTransitTime * conductance;
   }
-  const conductance = bjtJunctionTransconductance(element, voltage, 1.0);
+  const conductance = bjtJunctionTransconductance(
+    element,
+    voltage,
+    element.reverseEmissionCoefficient,
+  );
   return element.baseCollectorCapacitance + element.reverseTransitTime * conductance;
 }
 
@@ -19584,6 +19593,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardEmissionCoefficient) || element.forwardEmissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "forward emission coefficient must be finite and positive");
+  }
+  if (!Number.isFinite(element.reverseEmissionCoefficient) || element.reverseEmissionCoefficient <= 0.0) {
+    throw invalidElement(element.name, "reverse emission coefficient must be finite and positive");
   }
 }
 
@@ -21478,9 +21490,10 @@ function stampAcBjtSmallSignal(
       : collectorVoltage - baseVoltage;
   const forwardThermalVoltage = element.thermalVoltage * element.forwardEmissionCoefficient;
   const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / forwardThermalVoltage));
+  const reverseThermalVoltage = element.thermalVoltage * element.reverseEmissionCoefficient;
   const reverseExponent = Math.max(
     -40.0,
-    Math.min(40.0, reverseJunctionVoltage / element.thermalVoltage),
+    Math.min(40.0, reverseJunctionVoltage / reverseThermalVoltage),
   );
   const expValue = Math.exp(exponent);
   const baseCollectorCurrent = element.saturationCurrent * (expValue - 1.0);
@@ -21498,7 +21511,7 @@ function stampAcBjtSmallSignal(
   const junctionConductance = baseTransconductance / element.forwardBeta;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
   const reverseTransconductance =
-    element.saturationCurrent / element.thermalVoltage * Math.exp(reverseExponent);
+    element.saturationCurrent / reverseThermalVoltage * Math.exp(reverseExponent);
   const reverseDiffusionCapacitance = element.reverseTransitTime * reverseTransconductance;
   const baseEmitterAdmittance = complex(
     junctionConductance,

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -592,6 +592,19 @@ describe("acSweep", () => {
     expect(withTransitTime).toBeLessThan(withoutTransitTime / 100.0);
   });
 
+  it("uses BJT reverse emission coefficient to reduce base-collector diffusion capacitance", () => {
+    function baseAmplitude(reverseEmissionCoefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(resistor("Rc", "col", "0", 1.0));
+      circuit.add(bjt("Q1", "col", "base", "0", "NPN", 25.85e-6, 100.0, 0.02585, 0.0, 0.0, 0.0, 1.0e-2, 3.0, 1.11, 0.0, 1.0, reverseEmissionCoefficient));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("base")!);
+    }
+
+    expect(baseAmplitude(2.0)).toBeGreaterThan(baseAmplitude(1.0));
+  });
+
   it("applies VCVS gain in AC analysis", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vin", "in", "0", 1.0));

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(80);
+    expect(coverage).toHaveLength(82);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(80);
+    expect(records).toHaveLength(82);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 80,
-      expectedCanonicalParameterCount: 80,
-      acceptedNameCount: 130,
+      canonicalParameterCount: 82,
+      expectedCanonicalParameterCount: 82,
+      acceptedNameCount: 132,
       aliasedParameterCount: 37,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t80\t80\t130\t37\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t82\t82\t132\t37\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(79);
-    expect(report.acceptedNameCount).toBe(127);
+    expect(report.canonicalParameterCount).toBe(81);
+    expect(report.acceptedNameCount).toBe(129);
     expect(report.aliasedParameterCount).toBe(36);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t79\t80\t127\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t81\t82\t129\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -338,9 +338,10 @@ describe("dcOp", () => {
       EG: 1.05,
       VA: 80.0,
       NF: 1.2,
+      NR: 1.3,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2, NR: 1.3 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
@@ -348,6 +349,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.energyGapElectronVolts, 1.05);
     expectClose(bjtModel.forwardEarlyVoltage, 80.0);
     expectClose(bjtModel.forwardEmissionCoefficient, 1.2);
+    expectClose(bjtModel.reverseEmissionCoefficient, 1.3);
 
     const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
@@ -980,7 +982,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -992,6 +994,7 @@ describe("dcOp", () => {
       expectClose(expanded.energyGapElectronVolts, 1.05);
       expectClose(expanded.forwardEarlyVoltage, 80.0);
       expectClose(expanded.forwardEmissionCoefficient, 1.2);
+      expectClose(expanded.reverseEmissionCoefficient, 1.3);
     }
   });
 
@@ -1371,6 +1374,12 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 0.0));
     expect(() => dcOp(circuit)).toThrowError("forward emission coefficient must be finite and positive");
+  });
+
+  it("rejects an invalid BJT reverse emission coefficient", () => {
+    const circuit = new Circuit();
+    circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 0.0));
+    expect(() => dcOp(circuit)).toThrowError("reverse emission coefficient must be finite and positive");
   });
 
   it("uses MOSFET temperature scaling in common-source drain voltage", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward emission coefficient.
+1. Cross-language BJT reverse emission coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `NF` forward emission-coefficient model-card support in
+   - Add Berkeley BJT `NR` reverse emission-coefficient model-card support in
      Rust, Python, and TypeScript.
-   - Apply `NF` to the forward junction current, transconductance, charge, and
-     noise paths while preserving the full BJT model through hierarchical
-     subcircuit expansion.
-   - Extend the supported-parameter coverage gate from 78 to 80 canonical rows
-     and lock forward-junction behavior across all three engines.
+   - Apply `NR` to the existing reverse base-collector diffusion-charge path in
+     AC and transient analysis while preserving the full BJT model through
+     hierarchical subcircuit expansion.
+   - Extend the supported-parameter coverage gate from 80 to 82 canonical rows
+     and lock reverse-junction capacitance behavior across all three engines.
 
 ## Completed Slices
 
@@ -3015,6 +3015,13 @@ the Rust, Python, and TypeScript surfaces together.
      transfer-function, and noise paths.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 78 canonical rows.
+
+221. Cross-language BJT forward emission coefficient.
+   - Status: completed in PR 8740.
+   - Rust, Python, and TypeScript BJT model cards now accept `NF` and apply it
+     to forward junction current, transconductance, charge, and noise paths.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 80 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `NR` model-card support in Rust, Python, and TypeScript
- apply `NR` to reverse base-collector diffusion charge in AC and transient analysis
- preserve `NR` through subcircuit expansion and extend the coverage gate to 82 canonical rows
- reconcile the SPICE implementation plan with merged `NF` work and this current slice

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python: `514 passed`, 88.49% coverage
- focused Ruff checks on all touched Python source/test files
- TypeScript: `274 passed`
- `npm run build`