### PR TITLE
feat(chief): persist durable job audit

### DIFF
--- a/code/packages/rust/weather-agent-e2e/CHANGELOG.md
+++ b/code/packages/rust/weather-agent-e2e/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this package will be documented in this file.
   `chief-of-staff-host-runtime`.
 - Added centralized write approval enforcement, a validated D18C run receipt,
   and a compact user-visible report backed by canonical journal health.
+- Persist canonical payload-free D18D audit rows through the D18A local-folder
+  backend and reopen them into a compact job, host, session, and user summary.
+- Persist approval-blocked calls before returning the job error so denied work
+  remains available to a restarted audit reader.
 
 - Initial umbrella-today end-to-end harness that exercises the Chief of Staff
   actor, D18A store, D18C job, D18D tool, read/write separation, and

--- a/code/packages/rust/weather-agent-e2e/Cargo.toml
+++ b/code/packages/rust/weather-agent-e2e/Cargo.toml
@@ -12,6 +12,7 @@ capability-os-sandbox = { path = "../capability-os-sandbox" }
 capability-cage = { path = "../capability-cage" }
 chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+chief-of-staff-tool-audit-store = { path = "../chief-of-staff-tool-audit-store" }
 coding-adventures-json-value = { path = "../json-value" }
 context-store = { path = "../context-store" }
 generic-job-protocol = { path = "../generic-job-protocol" }
@@ -25,6 +26,7 @@ os-job-runtime = { path = "../os-job-runtime" }
 read-write-separation = { path = "../read-write-separation" }
 skill-store = { path = "../skill-store" }
 storage-core = { path = "../storage-core" }
+storage-local-folder = { path = "../storage-local-folder" }
 tls-platform = { path = "../tls-platform" }
 
 [dev-dependencies]

--- a/code/packages/rust/weather-agent-e2e/README.md
+++ b/code/packages/rust/weather-agent-e2e/README.md
@@ -24,6 +24,15 @@ user report carries the recommendation, completion time, approval state, and
 journal invocation count. This makes umbrella-today a reusable Chief job with a
 terminal product rather than only an architecture harness.
 
+Every run also copies the canonical payload-free D18D audit rows into
+`chief-of-staff-tool-audit-store` over the D18A local-folder backend before actor
+errors are returned. The job then reopens that store as a fresh reader and emits
+an `UmbrellaDurableAuditSummary` keyed to the job, run, session, user, and host
+profile. Approved runs and approval-blocked writes are therefore both durable
+without persisting tool arguments, outputs, or credentials. Durable call IDs are
+scoped by scheduler tick, allowing successive runs to share one audit root while
+preserving duplicate-delivery conflicts inside a tick.
+
 The primary tests write a real `umbrella-today.txt` file through the capability
 cage, assert that the supervised agent says to bring an umbrella for the rainy
 fixture, prove the supervisor recreates a killed child before the next tick, and

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -28,11 +28,12 @@ use chief_of_staff_host_runtime::{
 };
 use chief_of_staff_tool_api::{
     ApprovalState, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError,
-    ToolApprovalGrant, ToolCallError, ToolConcurrency, ToolDefinition, ToolErrorKind,
-    ToolEventKind, ToolExecutionJournal, ToolExecutionJournalHealthSummary, ToolHandlerOutput,
-    ToolIdempotency, ToolInvocationRequest, ToolPolicyProfile, ToolSideEffects, ToolStability,
-    ToolStreaming,
+    ToolApprovalGrant, ToolAuditRecordQuery, ToolCallError, ToolConcurrency, ToolDefinition,
+    ToolErrorKind, ToolEventKind, ToolExecutionJournal, ToolExecutionJournalHealthSummary,
+    ToolHandlerOutput, ToolIdempotency, ToolInvocationRequest, ToolPolicyProfile, ToolSideEffects,
+    ToolStability, ToolStreaming,
 };
+use chief_of_staff_tool_audit_store::{ToolAuditStore, ToolAuditStoreInventorySummary};
 use coding_adventures_json_value::{JsonNumber, JsonValue};
 use context_store::{
     AppendEntryInput, ContextEntryKind, ContextStore, ContextStoreInventorySummary,
@@ -63,6 +64,7 @@ use skill_store::{
     InstallSkillAssetInput, SkillInventorySummary, SkillListOptions, SkillManifest, SkillStore,
 };
 use storage_core::{InMemoryStorageBackend, StorageError};
+use storage_local_folder::LocalFolderStorageBackend;
 use tls_platform::TlsConfig;
 
 mod generated_operations;
@@ -72,6 +74,7 @@ use generated_operations::GeneratedOperationHttpClient;
 const AGENT_ID: &str = "umbrella_today_agent";
 const SESSION_ID: &str = "umbrella_today_session";
 const JOB_ID: &str = "umbrella_today_job";
+const DEFAULT_TICK_ID: &str = "8a7b0000000000000000000000000001";
 const USER_ID: &str = "seattle_user";
 const FETCH_TOOL_ID: &str = "weather.fetch_current";
 const CLASSIFY_TOOL_ID: &str = "weather.classify_umbrella";
@@ -190,19 +193,22 @@ pub struct UmbrellaAgentConfig {
     pub weather_source: WeatherSource,
     pub supervisor_probe: UmbrellaSupervisorProbe,
     pub write_approval: Option<ToolApprovalGrant>,
+    pub audit_root: PathBuf,
 }
 
 impl UmbrellaAgentConfig {
     pub fn deterministic_seattle(output_path: impl Into<PathBuf>) -> Self {
+        let output_path = output_path.into();
         Self {
             location: "Seattle".to_string(),
-            output_path: output_path.into(),
-            tick_id: "8a7b0000000000000000000000000001".to_string(),
+            audit_root: default_audit_root(&output_path),
+            output_path,
+            tick_id: DEFAULT_TICK_ID.to_string(),
             fetched_at_ms: 1_778_624_400_000,
             fetched_at_iso: "2026-05-12T12:00:00.000Z".to_string(),
             weather_source: WeatherSource::Fixture(WeatherSnapshot::rainy_seattle_fixture()),
             supervisor_probe: UmbrellaSupervisorProbe::default(),
-            write_approval: Some(default_write_approval(1_778_624_400_000)),
+            write_approval: Some(default_write_approval(DEFAULT_TICK_ID, 1_778_624_400_000)),
         }
     }
 
@@ -211,17 +217,19 @@ impl UmbrellaAgentConfig {
         fetched_at_ms: u64,
         fetched_at_iso: impl Into<String>,
     ) -> Self {
+        let output_path = output_path.into();
         Self {
             location: "Seattle".to_string(),
-            output_path: output_path.into(),
-            tick_id: "8a7b0000000000000000000000000001".to_string(),
+            audit_root: default_audit_root(&output_path),
+            output_path,
+            tick_id: DEFAULT_TICK_ID.to_string(),
             fetched_at_ms,
             fetched_at_iso: fetched_at_iso.into(),
             weather_source: WeatherSource::LiveNws {
                 user_agent: "coding-adventures-weather-agent-e2e/0.1 (adhithyan15)".to_string(),
             },
             supervisor_probe: UmbrellaSupervisorProbe::default(),
-            write_approval: Some(default_write_approval(fetched_at_ms)),
+            write_approval: Some(default_write_approval(DEFAULT_TICK_ID, fetched_at_ms)),
         }
     }
 
@@ -234,11 +242,37 @@ impl UmbrellaAgentConfig {
         self.write_approval = None;
         self
     }
+
+    pub fn with_audit_root(mut self, audit_root: impl Into<PathBuf>) -> Self {
+        self.audit_root = audit_root.into();
+        self
+    }
+
+    pub fn with_tick_id(mut self, tick_id: impl Into<String>) -> Self {
+        self.tick_id = tick_id.into();
+        if let Some(grant) = self.write_approval.as_mut() {
+            grant.call_id = scoped_call_id(&self.tick_id, "write_umbrella_report");
+        }
+        self
+    }
 }
 
-fn default_write_approval(granted_at: u64) -> ToolApprovalGrant {
-    ToolApprovalGrant::new("write_umbrella_report", WRITE_TOOL_ID, USER_ID, granted_at)
-        .with_expires_at(granted_at.saturating_add(300_000))
+fn default_audit_root(output_path: &Path) -> PathBuf {
+    output_path.with_extension("audit")
+}
+
+fn default_write_approval(tick_id: &str, granted_at: u64) -> ToolApprovalGrant {
+    ToolApprovalGrant::new(
+        scoped_call_id(tick_id, "write_umbrella_report"),
+        WRITE_TOOL_ID,
+        USER_ID,
+        granted_at,
+    )
+    .with_expires_at(granted_at.saturating_add(300_000))
+}
+
+fn scoped_call_id(tick_id: &str, call_id: &str) -> String {
+    format!("{tick_id}_{call_id}")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -524,6 +558,32 @@ pub struct UmbrellaAgentRun {
     pub actor_channel_messages: usize,
     pub job_receipt: JobRunReceipt,
     pub user_report: UmbrellaUserReport,
+    pub durable_audit: UmbrellaDurableAuditSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UmbrellaDurableAuditSummary {
+    pub job_id: String,
+    pub run_id: String,
+    pub session_id: String,
+    pub user_id: String,
+    pub profile_id: String,
+    pub host_count: usize,
+    pub tool_count: usize,
+    pub persisted_records: usize,
+    pub reloaded_records: usize,
+    pub completed_records: usize,
+    pub approval_granted_records: usize,
+    pub records_with_references: usize,
+    pub follow_up_records: usize,
+}
+
+impl UmbrellaDurableAuditSummary {
+    pub fn is_complete(&self) -> bool {
+        self.persisted_records == self.reloaded_records
+            && self.reloaded_records == self.completed_records
+            && self.follow_up_records == 0
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -652,6 +712,8 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
     )?;
     let actor_stats = system.run_until_done();
 
+    let run_id = format!("{}_run", config.tick_id);
+    let durable_audit = persist_and_reload_audit(&pipeline, &config, &run_id)?;
     pipeline.raise_actor_errors()?;
 
     let recommendation = pipeline.recommendation()?;
@@ -681,7 +743,7 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         .expect("actor channel mutex poisoned")
         .len();
     let job_receipt = JobRunReceipt::succeeded(
-        format!("{}_run", config.tick_id),
+        run_id,
         JOB_ID,
         config.fetched_at_ms,
         config.fetched_at_ms.saturating_add(1),
@@ -726,6 +788,57 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         actor_channel_messages,
         job_receipt,
         user_report,
+        durable_audit,
+    })
+}
+
+fn persist_and_reload_audit(
+    pipeline: &UmbrellaPipeline,
+    config: &UmbrellaAgentConfig,
+    run_id: &str,
+) -> UmbrellaResult<UmbrellaDurableAuditSummary> {
+    let audit_records = pipeline
+        .journal
+        .lock()
+        .expect("tool journal mutex poisoned")
+        .audit_records()
+        .to_vec();
+    let store = ToolAuditStore::new(LocalFolderStorageBackend::new(&config.audit_root));
+    let write = store.record_audit_batch(audit_records);
+    if !write.completed_without_failures() {
+        return Err(UmbrellaAgentError::new(format!(
+            "failed to persist {} of {} umbrella audit rows",
+            write.failed_records, write.attempted_records
+        )));
+    }
+    drop(store);
+
+    let reopened = ToolAuditStore::new(LocalFolderStorageBackend::new(&config.audit_root));
+    let call_prefix = format!("{}_", config.tick_id);
+    let records = reopened
+        .query_audits(&ToolAuditRecordQuery::new())?
+        .into_iter()
+        .filter(|record| record.call_id.starts_with(&call_prefix))
+        .collect::<Vec<_>>();
+    let inventory = ToolAuditStoreInventorySummary::from_records(&records);
+    let profile = pipeline.tool_runtime.summary();
+    Ok(UmbrellaDurableAuditSummary {
+        job_id: JOB_ID.to_string(),
+        run_id: run_id.to_string(),
+        session_id: SESSION_ID.to_string(),
+        user_id: USER_ID.to_string(),
+        profile_id: profile.profile_id,
+        host_count: profile.host_count,
+        tool_count: profile.registered_tool_count,
+        persisted_records: write.stored_records,
+        reloaded_records: records.len(),
+        completed_records: inventory.completed_records,
+        approval_granted_records: records
+            .iter()
+            .filter(|record| record.approval_state == ApprovalState::Granted)
+            .count(),
+        records_with_references: inventory.records_with_references,
+        follow_up_records: inventory.follow_up_records,
     })
 }
 
@@ -1031,8 +1144,9 @@ impl UmbrellaPipeline {
         tool_id: &str,
         arguments: JsonValue,
     ) -> UmbrellaResult<JsonValue> {
+        let call_id = scoped_call_id(&self.config.tick_id, call_id);
         let request = ToolInvocationRequest {
-            call_id: call_id.to_string(),
+            call_id: call_id.clone(),
             tool_id: tool_id.to_string(),
             arguments,
             requested_by: RequestedBy::Agent,
@@ -1042,7 +1156,7 @@ impl UmbrellaPipeline {
             user_id: Some(USER_ID.to_string()),
             requested_at: self.config.fetched_at_ms,
             deadline_at: Some(self.config.fetched_at_ms.saturating_add(30_000)),
-            idempotency_key: Some(format!("{}-{}", self.config.tick_id, call_id)),
+            idempotency_key: Some(call_id),
         };
         let trace = if tool_id == WRITE_TOOL_ID {
             match self.config.write_approval.as_ref() {

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -1,22 +1,19 @@
 use std::fs;
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use capability_os_sandbox::{current_kernel_sandbox_support, OsFamily};
-use chief_of_staff_tool_api::ApprovalState;
+use chief_of_staff_tool_api::{ApprovalState, ToolAuditRecordQuery};
+use chief_of_staff_tool_audit_store::ToolAuditStore;
 use os_job_core::BackendKind;
+use storage_local_folder::LocalFolderStorageBackend;
 use weather_agent_e2e::{
     run_umbrella_today_agent, RecommendationKind, UmbrellaAgentConfig, WeatherFetchSourceKind,
 };
 
 #[test]
 fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
-    let root = std::env::temp_dir().join(format!(
-        "weather-agent-e2e-{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after unix epoch")
-            .as_nanos()
-    ));
+    let root = temp_root("weather-agent-e2e");
     fs::create_dir_all(&root).expect("temp dir should be created");
     let output_path = root.join("umbrella-today.txt");
 
@@ -133,6 +130,28 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
     assert_eq!(run.user_report.write_approval, ApprovalState::Granted);
     assert_eq!(run.user_report.journal_invocation_count, 3);
     assert!(run.user_report.render().contains("Bring an umbrella today"));
+    assert_eq!(run.durable_audit.job_id, "umbrella_today_job");
+    assert_eq!(run.durable_audit.run_id, run.job_receipt.run_id);
+    assert_eq!(run.durable_audit.session_id, "umbrella_today_session");
+    assert_eq!(run.durable_audit.user_id, "seattle_user");
+    assert_eq!(run.durable_audit.profile_id, "umbrella_today_v1");
+    assert_eq!(run.durable_audit.host_count, 3);
+    assert_eq!(run.durable_audit.tool_count, 3);
+    assert_eq!(run.durable_audit.persisted_records, 3);
+    assert_eq!(run.durable_audit.reloaded_records, 3);
+    assert_eq!(run.durable_audit.completed_records, 3);
+    assert_eq!(run.durable_audit.approval_granted_records, 1);
+    assert!(run.durable_audit.records_with_references >= 1);
+    assert_eq!(run.durable_audit.follow_up_records, 0);
+    assert!(run.durable_audit.is_complete());
+
+    let restarted_audit = ToolAuditStore::new(LocalFolderStorageBackend::new(
+        output_path.with_extension("audit"),
+    ));
+    let restarted_rows = restarted_audit
+        .query_audits(&ToolAuditRecordQuery::new())
+        .expect("durable audit should reopen after the job runtime is dropped");
+    assert_eq!(restarted_rows.len(), 3);
 
     assert_eq!(run.rws.fetcher.untrusted_inputs, 1);
     assert_eq!(run.rws.writer.external_actuations, 1);
@@ -141,13 +160,7 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
 
 #[test]
 fn umbrella_today_job_blocks_write_without_explicit_approval() {
-    let root = std::env::temp_dir().join(format!(
-        "weather-agent-approval-e2e-{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after unix epoch")
-            .as_nanos()
-    ));
+    let root = temp_root("weather-agent-approval-e2e");
     fs::create_dir_all(&root).expect("temp dir should be created");
     let output_path = root.join("umbrella-today.txt");
     let config = UmbrellaAgentConfig::deterministic_seattle(&output_path).without_write_approval();
@@ -160,17 +173,55 @@ fn umbrella_today_job_blocks_write_without_explicit_approval() {
         assert_eq!(persisted_text, "kernel sandbox allowed");
     }
     assert!(!persisted_text.contains("Bring an umbrella today"));
+
+    let restarted_audit = ToolAuditStore::new(LocalFolderStorageBackend::new(
+        output_path.with_extension("audit"),
+    ));
+    let denied_write = restarted_audit
+        .fetch_audit("8a7b0000000000000000000000000001_write_umbrella_report")
+        .expect("durable audit should be readable after denial")
+        .expect("denied write row should be persisted");
+    assert_eq!(denied_write.approval_state, ApprovalState::Pending);
+    assert!(!denied_write.result_summary.ok);
+}
+
+#[test]
+fn successive_ticks_append_to_one_durable_audit_root() {
+    let root = temp_root("weather-agent-durable-audit-e2e");
+    fs::create_dir_all(&root).expect("temp dir should be created");
+    let audit_root = root.join("audit");
+
+    let first = run_umbrella_today_agent(
+        UmbrellaAgentConfig::deterministic_seattle(root.join("first.txt"))
+            .with_audit_root(&audit_root),
+    )
+    .expect("first tick should complete");
+    let second = run_umbrella_today_agent(
+        UmbrellaAgentConfig::deterministic_seattle(root.join("second.txt"))
+            .with_tick_id("8a7b0000000000000000000000000002")
+            .with_audit_root(&audit_root),
+    )
+    .expect("second tick should append");
+
+    assert!(first.durable_audit.is_complete());
+    assert!(second.durable_audit.is_complete());
+    let restarted_audit = ToolAuditStore::new(LocalFolderStorageBackend::new(&audit_root));
+    assert_eq!(
+        restarted_audit
+            .query_audits(&ToolAuditRecordQuery::new())
+            .expect("both ticks should survive restart")
+            .len(),
+        6
+    );
+    assert!(restarted_audit
+        .fetch_audit("8a7b0000000000000000000000000002_write_umbrella_report")
+        .expect("second write lookup should succeed")
+        .is_some());
 }
 
 #[test]
 fn supervisor_recreates_killed_fetcher_before_pipeline_tick() {
-    let root = std::env::temp_dir().join(format!(
-        "weather-agent-supervisor-e2e-{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after unix epoch")
-            .as_nanos()
-    ));
+    let root = temp_root("weather-agent-supervisor-e2e");
     fs::create_dir_all(&root).expect("temp dir should be created");
     let output_path = root.join("umbrella-today.txt");
     let config = UmbrellaAgentConfig::deterministic_seattle(&output_path)
@@ -192,13 +243,7 @@ fn supervisor_recreates_killed_fetcher_before_pipeline_tick() {
 #[test]
 #[ignore = "performs live HTTPS requests to api.weather.gov"]
 fn umbrella_today_agent_fetches_live_weather_over_tls() {
-    let root = std::env::temp_dir().join(format!(
-        "weather-agent-live-e2e-{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after unix epoch")
-            .as_nanos()
-    ));
+    let root = temp_root("weather-agent-live-e2e");
     fs::create_dir_all(&root).expect("temp dir should be created");
     let output_path = root.join("umbrella-today.txt");
     let config = UmbrellaAgentConfig::live_seattle_with_timestamp(
@@ -235,4 +280,15 @@ fn umbrella_today_agent_fetches_live_weather_over_tls() {
         assert!(!run.kernel_sandbox.host_exact_kernel_enforced);
     }
     assert!(output_path.exists());
+}
+
+fn temp_root(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "{label}-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos()
+    ))
 }

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -281,14 +281,19 @@ write-approval policy, D18D execution journal, artifact write, validated
 records one granted write and three completed calls; the unapproved path stops
 at the policy gate and never writes the recommendation.
 
+That job now persists each canonical payload-free D18D audit row through
+`chief-of-staff-tool-audit-store` and the D18A local-folder backend before
+returning actor failures. A fresh store instance reloads the rows and emits a
+compact summary keyed to job, run, host profile, session, and user. Executable
+tests prove both the successful three-call run and the approval-blocked write
+survive a runtime restart without storing arguments, outputs, or credentials.
+
 These items are Chief of Staff architecture, not smart-home platform work:
 
 - Add approval UX and policy wiring for Tier2 or stronger actions such as
   bridge pairing, locks, cameras, alarms, and safety devices.
 - Wire vault leasing so tools receive opaque `VaultRef` handles and never raw
   smart-home secrets.
-- Persist tool execution journals and expose compact audit summaries for jobs,
-  hosts, sessions, and user review.
 
 ## Smart Home Remaining Work
 


### PR DESCRIPTION
## Summary\n- persist the reusable Weather Chief job's canonical payload-free D18D audit rows through the existing audit store and D18A local-folder backend\n- write audit rows before propagating actor failures so approval-blocked calls survive runtime failure\n- reopen the store and emit a compact job, run, host profile, session, and user audit summary\n- scope durable call ids by scheduler tick and prove successive ticks append safely to one audit root\n- update the D18-D23 completion inventory to close the durable job-audit gap\n\n## Validation\n- cargo test -p weather-agent-e2e -- --nocapture\n- cargo clippy -p weather-agent-e2e --all-targets -- -D warnings\n- cargo fmt --package weather-agent-e2e -- --check\n- sh weather-agent-e2e/BUILD\n- git diff --check\n