### PR TITLE
feat(q-lexer): grammar-driven Q tokenizer with whitespace-sensitive lexing (MA11 D-2)

### DIFF
--- a/code/grammars/q/q.tokens
+++ b/code/grammars/q/q.tokens
@@ -1,0 +1,256 @@
+# Q Token Grammar
+# ============================================================================
+#
+# Tokenizes the historical-core subset of Q (kdb+'s scripting language) fixed
+# by MA-11a (code/specs/MA11-q-language.md §4): dense numeric arrays, the
+# primitive verbs `+ - * % ! , # _ & | ~ = < > <= >= <>`, the three adverbs
+# `'` (each) `/` (over/reduce) `\` (scan), `name:expr` assignment,
+# parenthesised grouping and explicit `(a;b;c)` list literals, `{[x;y] ...}`
+# function-literal delimiters, and `/`-to-end-of-line comments.
+#
+# ============================================================================
+# THE ONE MISTAKE TO NOT MAKE (MA11 §4 / §1)
+#
+# Q is APL/J's grandchild, but it is NOT a thin respelling of either one --
+# MA11 §1 spends its whole section establishing this ("a real second
+# frontend", not an "octave-to-semantic-ir thin wrapper"). Concretely, do NOT
+# assume a glyph's APL/J meaning carries over unchanged. Two traps this file
+# specifically guards against:
+#
+#   - Q spells NOT-EQUAL `<>` -- never `~=` (that's MATLAB/Scilab's spelling)
+#     and never `#` (which in Q is COUNT/TAKE, not comparison at all). MA11
+#     §4 says this explicitly because it's the single easiest thing to get
+#     wrong by pattern-matching against a sibling grammar file instead of
+#     reading the spec's own primitive-verb table.
+#   - Q spells a negative NUMBER with an ordinary leading `-`, unlike J's
+#     leading-underscore convention (MA06 §4, `_5`). This is not a free
+#     choice this crate is making the way MA06 did for J -- MA11 §3 bullet 2
+#     documents it as Q's own actual, real disambiguation rule, and it is
+#     the reason this crate cannot be "just another `.tokens` file" (see the
+#     whitespace-sensitivity note below).
+#
+# ============================================================================
+# WHITESPACE IS PART OF THIS GRAMMAR, NOT JUST A SEPARATOR (MA11 §3 bullet 2)
+#
+# Every other `.tokens` file in this family (apl.tokens, j.tokens,
+# scilab.tokens, ...) treats whitespace as pure separator noise: two tokens
+# either touch or they don't, and either way the same characters produce the
+# same token. Q's real lexer breaks that assumption in exactly two places,
+# both driven by *whether whitespace is present at a specific position*
+# rather than by which characters are present:
+#
+#   1. `2 -1` (space before `-`, none after) must tokenize as the two-element
+#      strand NUMBER(2) NUMBER(-1); `2 - 1` (space on both sides) must
+#      tokenize as NUMBER(2) MINUS NUMBER(1); `2-1` (no spaces at all) must
+#      ALSO tokenize as NUMBER(2) MINUS NUMBER(1) (ordinary glued
+#      subtraction, matching real q's own behavior -- this is why the rule
+#      is not simply "no space after the minus").
+#   2. `/` opens a comment-to-end-of-line when it is preceded by whitespace
+#      (or starts a line); it is the REDUCE adverb when it directly follows
+#      a verb/noun character with no preceding space (`+/x`).
+#
+# Rust's `regex` crate (what `GrammarLexer` compiles every pattern below
+# with -- see `code/packages/rust/grammar-tools/src/token_grammar.rs`'s own
+# `validate_token_grammar`, which calls `regex::Regex::new` directly) has NO
+# lookaround support: no `(?<=...)`, no `(?=...)`. So "was there whitespace
+# immediately before this character" is NOT something any pattern in THIS
+# file can express, no matter how the regex is written. This is a structural
+# limit of the shared engine, not a gap this file's author overlooked.
+#
+# There is exactly one place in this repo that already solves a
+# "same character, two token meanings, disambiguated by adjacent context"
+# problem the token-regex layer can't express on its own:
+# `code/packages/rust/scilab-lexer/src/lib.rs`'s `protect_quotes` /
+# `restore_placeholders` pair, which resolves Scilab's `'`
+# transpose-vs-string ambiguity with a **pre-tokenize hook** (rewrites the
+# raw source text before `GrammarLexer` ever sees it) and a
+# **post-tokenize hook** (patches the resulting `Vec<Token>` afterward).
+# `q-lexer/src/lib.rs` reuses that exact strategy, independently
+# reimplemented for these two, different disambiguations:
+#
+#   - The `/`-comment-vs-REDUCE-adverb rule is resolved by a *pre-tokenize*
+#     hook, because comment TEXT is arbitrary and need not lex successfully
+#     as Q code at all -- the hook must run before the regex tokenizer ever
+#     sees it, or an unrelated character inside a comment could make the
+#     whole file fail to tokenize.
+#   - The `-`-vs-negative-literal rule is resolved by a *post-tokenize*
+#     hook, because deciding it requires knowing the TYPE of the previously
+#     emitted token (is it a NUMBER/NAME/closing bracket -- i.e. does it
+#     complete a noun the way `2` does in `2-1`?), which is exactly the kind
+#     of already-classified information only the token stream carries.
+#
+# See `q-lexer/src/lib.rs`'s own doc comments for the exact algorithms
+# (`strip_slash_comments` and `fold_negative_number_literals`). Nothing in
+# THIS file encodes either rule -- by design, per this repo's own
+# declarative-grammar-first philosophy, everything that CAN live here does;
+# these two rules are the one place in this crate where that isn't possible,
+# and that boundary is deliberate and documented, not an oversight.
+#
+# @version 1
+
+# ============================================================================
+# SECTION 1: Two-character comparison digraphs, declared before any
+# single-character token they could be confused with (this repo's
+# longest-match-first lexer convention -- see j.tokens SECTION 1 for the
+# precedent this generalizes). `<=`/`>=`/`<>` must all precede the bare
+# `<`/`>` tokens in SECTION 2, or the bare 1-character pattern would win the
+# first-match race and strand a stray `=`/`>` behind it.
+# ============================================================================
+
+LE = "<="
+GE = ">="
+
+# Q's own not-equal spelling (MA11 §4) -- NOT `~=`, NOT `#`. See the header
+# callout above; this is the single easiest glyph to get wrong in this file.
+NE = "<>"
+
+# ============================================================================
+# SECTION 2: Single-character primitive verb glyphs (MA11 §4), each declared
+# after any two-character digraph sibling from SECTION 1 that shares its
+# first character.
+#
+# One glyph per row, monadic / dyadic meaning, following the monadic-first
+# ordering MA11 §4's own table uses for every other entry: flip / add,
+# negate / subtract (MINUS also participates in the whitespace-sensitive
+# negative-literal rule -- see the header note and `q-lexer/src/lib.rs`),
+# first / multiply, reciprocal / divide (always true/float division, no
+# integer-division special case), til (0-based index generator, monadic
+# only -- dyadic `!` is deferred), enlist / join, count / take, floor /
+# drop, where (monadic) / min (dyadic), reverse (monadic) / max (dyadic),
+# not (monadic) / match (dyadic), then the remaining comparison glyphs.
+#
+# NOTE: MA11 §4's own prose lists `+` as "add / flip" (dyadic-first),
+# breaking the monadic-first pattern every other entry in that same
+# sentence follows (and breaking with real q, where monadic `+` is flip --
+# dictionary/table transpose -- and dyadic `+` is ordinary add). This looks
+# like a word-order slip in the spec text rather than a deliberate
+# deviation; this file documents the monadic-first reading (flip / add) to
+# stay consistent with the rest of the table and with real q. Worth a
+# human double-check against the spec source if that matters later --
+# it has zero effect on this lexer either way, since PLUS is a single
+# token regardless of which reading applies (monadic-vs-dyadic dispatch is
+# a parser concern, not a lexer one, per the header note).
+# ============================================================================
+
+PLUS    = "+"
+MINUS   = "-"
+STAR    = "*"
+PERCENT = "%"
+BANG    = "!"
+COMMA   = ","
+HASH    = "#"
+UNDERSCORE = "_"
+AMP     = "&"
+PIPE    = "|"
+TILDE   = "~"
+
+EQ = "="
+LT = "<"
+GT = ">"
+
+# ============================================================================
+# SECTION 3: Adverbs, assignment, and grouping (MA11 §3 bullet 1 / §4).
+#
+# EACH, REDUCE (over), and SCAN are the three adverbs MA11 §4 puts in scope
+# (each-prior/each-right/each-left are explicitly deferred). REDUCE's other
+# job -- opening a line comment -- is resolved entirely by
+# `q-lexer`'s pre-tokenize hook (see the header note); by the time this
+# pattern is tried, any `/` that should have started a comment has already
+# been blanked out of the source text, so REDUCE below only ever matches a
+# genuine reduce-adverb occurrence.
+#
+# COLON is Q's assignment operator (`name:expr`) -- a colon, not J's
+# `=.`/`=:` pair and not APL's `←` (MA11 §4's "Assignment" bullet).
+# SEMICOLON separates both explicit list-literal
+# elements (`(a;b;c)`) and statements inside a function-literal body
+# (`{[x;y] stmt; stmt}`) -- one token, two grammar-level uses, exactly as
+# MA11 §3 bullets 1 and 3 both describe.
+# ============================================================================
+
+EACH   = "'"
+REDUCE = "/"
+SCAN   = "\"
+
+COLON     = ":"
+SEMICOLON = ";"
+
+LPAREN = "("
+RPAREN = ")"
+
+# ============================================================================
+# SECTION 4: Function-literal delimiters (MA11 §3 bullet 1 / §4).
+#
+# `{` opens a function literal, `}` closes it; `[` and `]` bracket the
+# OPTIONAL parameter list (`{[x;y] x+y}`), defaulting to the implicit
+# `x`/`y`/`z` names when omitted (`{x+y}`). Neither the implicit-parameter
+# convenience nor the "last statement's value is the result" rule is a
+# lexer concern -- `x`/`y`/`z` are ordinary NAME tokens (SECTION 5) with no
+# special lexer treatment, exactly mirroring how `derive-lexer` treats every
+# identifier inside its own bracketed constructs, and how MA06 §3's last
+# bullet already established that monadic-vs-dyadic dispatch is a
+# parser-production concern, not a lexer one. This subset's parser
+# (MA-11c) is what actually recognizes the production; this crate emits the
+# same four punctuation tokens it would emit anywhere else.
+# ============================================================================
+
+LBRACE   = "{"
+RBRACE   = "}"
+LBRACKET = "["
+RBRACKET = "]"
+
+# ============================================================================
+# SECTION 5: Literal value tokens
+#
+# NUMBER has NO leading sign of its own -- Q spells negative numbers with an
+# ordinary leading `-` (unlike J's `_5`), and MA11 §3 bullet 2 is explicit
+# that this is resolved by *context* (the whitespace-sensitive rule in
+# `q-lexer/src/lib.rs`), not by folding an optional sign into this regex.
+# Folding a leading `-` in here directly would make `2-1` lex as a single
+# NUMBER("-1") preceded by nothing, which is simply wrong (real q evaluates
+# `2-1` to `1`, i.e. subtraction, never a bare negative literal) -- the
+# decision to keep the sign OUT of this pattern is not an oversight, it is
+# the whole reason the disambiguation has to live in Rust instead of here.
+#
+# The optional exponent's OWN sign (`1e-5`, `2.5E+3`), by contrast, is
+# written directly into this regex and needs no such treatment: a `-`/`+`
+# immediately after `e`/`E` inside an already-started numeric literal can
+# never be misread as the subtract verb (there is no left operand at that
+# lexical position for it to subtract from), so it carries none of the
+# ambiguity the LEADING sign has. This mirrors how j.tokens' own NUMBER
+# folds its (underscore-spelled) exponent sign directly into its pattern too.
+#
+# NAME deliberately excludes `_` from its continuation characters. `_` is a
+# full primitive-verb glyph in this grammar (UNDERSCORE, floor/drop, SECTION
+# 2) -- if NAME's regex allowed `[0-9a-zA-Z_]*` the way an APL/J-derived gut
+# instinct might suggest, `a_b` would lex as one NAME token instead of
+# NAME("a") UNDERSCORE NAME("b"), silently swallowing a real primitive
+# application. This is the same *shape* of mistake
+# `feedback_check_existing_modules`-style lessons warn about elsewhere in
+# this repo (the S-language `_`-is-assignment lexer note makes the identical
+# point for a different glyph) -- independently rediscovered here for Q's
+# own `_`, not copied from that case. Real q style guides likewise steer
+# users away from underscored identifiers for exactly this reason; a human
+# should double check this specific exclusion against Kx's own reference
+# card if a future subset needs underscored names.
+# ============================================================================
+
+NUMBER = /[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?/
+NAME   = /[a-zA-Z][a-zA-Z0-9]*/
+
+# ============================================================================
+# SECTION 6: Significant newlines + skip patterns
+#
+# A newline separates top-level statements, exactly like APL/J
+# (apl.tokens/j.tokens SECTION 5). Unlike j.tokens, there is no `skip:`
+# entry for comments here -- Q's comment marker (`/`) is the SAME character
+# as a real token (REDUCE), so a static skip regex cannot tell them apart;
+# that job is done entirely by `q-lexer`'s pre-tokenize hook (see the header
+# note), which blanks comment text out of the source before this grammar
+# ever runs. By the time WHITESPACE below is tried, a comment region is
+# already nothing but spaces.
+# ============================================================================
+
+NEWLINE = /\r?\n/
+
+skip:
+  WHITESPACE = /[ \t]+/

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -275,6 +275,7 @@ members = [
     "scilab-runtime",
     "scilab-repl",
     "scilab-to-semantic-ir",
+    "q-lexer",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/q-lexer/BUILD
+++ b/code/packages/rust/q-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-q-lexer -- --nocapture

--- a/code/packages/rust/q-lexer/BUILD_windows
+++ b/code/packages/rust/q-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-q-lexer -- --nocapture

--- a/code/packages/rust/q-lexer/CHANGELOG.md
+++ b/code/packages/rust/q-lexer/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+## [0.1.0] - 2026-07-21
+
+### Added
+
+- Initial grammar-driven Rust Q tokenizer (MA11 §6, task MA-11b).
+- Statically linked compiled token grammar (`code/grammars/q/q.tokens`),
+  covering the historical-core subset fixed by MA-11a: dense numeric
+  arrays, the primitive verb glyphs `+ - * % ! , # _ & | ~`, the six
+  comparison glyphs `= < > <= >= <>`, the three adverbs (each/reduce/scan),
+  `name:expr` assignment, parenthesised grouping, explicit `(a;b;c)` list
+  literals, `{[x;y] ...}` function-literal delimiters, and `/`-to-end-of-line
+  comments.
+- Two whitespace-sensitive lexer disambiguations (MA11 §3 bullet 2), both
+  genuinely novel for this crate family (every other array-language lexer
+  in this repo treats whitespace as pure separator noise):
+  - **Negative-literal vs. subtraction**: `2 -1` folds to the two-element
+    strand `NUMBER(2) NUMBER(-1)`; `2 - 1` and `2-1` both stay
+    `NUMBER(2) MINUS NUMBER(1)`. Implemented as a `GrammarLexer`
+    post-tokenize hook (`fold_negative_number_literals`) that merges a
+    `MINUS` immediately followed by a `NUMBER`, gated on whether the
+    previously emitted token completes a noun glued directly against the
+    `-` — not a hand-written lexer, a documented adjustment pass over the
+    token stream the shared engine already produced.
+  - **`/` comment marker vs. REDUCE adverb**: a `/` preceded by whitespace
+    (or at line-start) opens a comment to end of line; glued directly to a
+    preceding verb/noun with no space, it is REDUCE (`+/x`). Implemented as
+    a `GrammarLexer` pre-tokenize hook (`strip_slash_comments`) that blanks
+    comment text into spaces before the grammar ever runs — necessary
+    because comment content is arbitrary text that need not lex
+    successfully as Q code, so this cannot be a post-tokenize pass.
+  - Both hooks reuse the exact `add_pre_tokenize`/`add_post_tokenize`
+    extension points `scilab-lexer` already established for its own
+    `'`-transpose-vs-string disambiguation — no changes to the shared
+    `lexer`/`grammar-tools` crates were needed.
+- No recursion-depth cap in this crate, by design: `q-lexer` performs no
+  recursive descent at all (that begins with `q-parser`, MA-11c) — the same
+  split every sibling `*-lexer`/`*-parser` pair in this repo already
+  follows (`apl-lexer`/`j-lexer` have none either; `apl-parser`/`j-parser`
+  do).
+- `code/packages/rust/Cargo.toml` workspace registration alongside the
+  other array-language lexer/parser/runtime/repl/to-semantic-ir crate
+  groups.

--- a/code/packages/rust/q-lexer/Cargo.toml
+++ b/code/packages/rust/q-lexer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-q-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "Q (kdb+ scripting language) lexer backed by statically compiled grammar data"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/q-lexer/README.md
+++ b/code/packages/rust/q-lexer/README.md
@@ -1,0 +1,126 @@
+# coding-adventures-q-lexer
+
+Q (kdb+'s scripting language) tokenizer backed by
+`code/grammars/q/q.tokens`, compiled to Rust and statically linked into the
+crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the historical-core subset fixed by
+[MA11 §4](../../../specs/MA11-q-language.md): dense numeric arrays, the
+primitive verb glyphs `+ - * % ! , # _ & | ~`, the six comparison glyphs
+`= < > <= >= <>`, the three adverbs `'` (each) `/` (over/reduce) `\` (scan),
+`name:expr` assignment, parenthesised grouping, explicit `(a;b;c)` list
+literals, `{[x;y] ...}` function-literal delimiters, and `/`-to-end-of-line
+comments.
+
+This crate only tokenizes. There is no `q-parser`/`q.grammar` here (that is
+a separate follow-on task, MA-11c) and no recursion-depth cap (that is a
+parser-level concern for MA-11c, the same split `apl-lexer`/`j-lexer` vs.
+`apl-parser`/`j-parser` already establish in this repo).
+
+## Design decision: two rules are whitespace-sensitive, and live in Rust
+
+Every other lexer in this repo's array-language family (`apl-lexer`,
+`j-lexer`, `scilab-lexer`, ...) treats whitespace as pure separator noise:
+whether two tokens touch or not never changes which token either one is.
+Q's real lexer breaks that assumption in exactly two places
+([MA11 §3 bullet 2](../../../specs/MA11-q-language.md)):
+
+1. **Negative-literal vs. subtraction.** Q spells a negative number with an
+   ordinary leading `-` (unlike J's leading-underscore `_5`), and
+   disambiguates purely by adjacent whitespace: `2 -1` (space before `-`,
+   none after) tokenizes as the two-element strand `NUMBER(2) NUMBER(-1)`;
+   `2 - 1` and `2-1` both tokenize as `NUMBER(2) MINUS NUMBER(1)` (ordinary
+   subtraction).
+2. **`/` comment marker vs. REDUCE adverb.** A `/` preceded by whitespace
+   (or starting a line) opens a comment to end of line; a `/` glued
+   directly to a preceding verb/noun with no space is the REDUCE adverb
+   (`+/x`).
+
+Rust's `regex` crate — what the shared
+[`GrammarLexer`](../lexer/src/grammar_lexer.rs) compiles every `.tokens`
+pattern with — has **no lookaround support** (no `(?<=...)`, no `(?=...)`),
+so "is there whitespace immediately before this character" cannot be
+expressed as a token pattern, full stop. This was confirmed by reading
+`grammar-tools`' own token-grammar validator, which compiles every pattern
+with a plain `regex::Regex::new` call.
+
+Rather than inventing a new mechanism, this crate reuses a strategy already
+established in this repo: `scilab-lexer` resolves an analogous
+same-character-two-meanings problem (`'` is transpose or a string delimiter
+depending on whether a value immediately precedes it) with a
+[**pre-tokenize hook**](../lexer/src/grammar_lexer.rs) (rewrites the raw
+source text before `GrammarLexer` runs) and a **post-tokenize hook**
+(patches the resulting token list afterward). `q-lexer` uses the exact same
+two extension points — `GrammarLexer::add_pre_tokenize` /
+`add_post_tokenize` — for its own two, independently-implemented
+disambiguations:
+
+- **`strip_slash_comments`** (pre-tokenize): blanks `/`-to-end-of-line
+  comment text into spaces before the grammar ever sees it. This has to run
+  *before* tokenization, not after, because comment text is arbitrary and
+  need not lex successfully as Q code — a post-tokenize pass would require
+  the whole file to already lex cleanly, including inside comments, which
+  is not a safe assumption.
+- **`fold_negative_number_literals`** (post-tokenize): merges a `MINUS`
+  token immediately followed by a `NUMBER` token into one signed `NUMBER`
+  token, but only when the previously emitted token does not "complete a
+  noun" glued directly against the `-` with zero gap (see the doc comment
+  on `fold_negative_number_literals` in `src/lib.rs` for the exact rule and
+  a worked table of examples). This needs to run *after* tokenization
+  because the decision depends on the *type* of the previous token
+  (NUMBER/NAME/closing bracket vs. anything else), which only the token
+  stream — not raw characters — carries.
+
+`q.tokens` itself documents this split prominently in its own header
+comment, and states explicitly that no other rule in this crate needs
+special-casing: every other token (every primitive verb, every adverb,
+assignment, grouping, function-literal delimiters) is declarative,
+first-match-wins, exactly like every sibling `.tokens` file in this repo.
+
+While researching this, no genuine bug was found in the shared
+`GrammarLexer` engine — but one real limitation was confirmed and is
+recorded in `src/lib.rs`'s own doc comment: the engine's declarative
+mode-transition table (F10) only fires *after* a token is emitted, keyed on
+that token's type/value, with no way to see "was trivia consumed
+immediately before this token" — so it cannot express either of Q's two
+rules declaratively today. That is a shared-engine gap, not a Q-specific
+one, and is left unfixed here per this repo's "fix what's local, defer what's
+shared" convention.
+
+## The one other thing to get right: `<>` is not-equal, not `~=` or `#`
+
+[MA11 §4](../../../specs/MA11-q-language.md) calls this out explicitly: Q
+spells not-equal `<>` — never MATLAB/Scilab's `~=` spelling, and never `#`
+(which in Q is the unrelated count/take primitive). A frontend built by
+pattern-matching against a sibling array-language grammar file, rather than
+reading MA11 §4's own primitive-verb table directly, is the easiest way to
+get this specific glyph backwards.
+
+## Usage
+
+```rust
+use coding_adventures_q_lexer::tokenize_q;
+
+let tokens = tokenize_q("x:2 -1\nsum:{[a] +/a}\nsum x");
+```
+
+`tokenize_q` panics on a malformed source string; use `create_q_lexer`
+directly (or `try_tokenize_q`) if you need the `Result`-returning form
+instead.
+
+## Where this fits
+
+`q-lexer` is the first of Q's frontend crates
+([MA-11b](../../../specs/MA11-q-language.md#6-crate-layout-and-rollout-one-item--one-pr)),
+following MA-11a's design spec. The sibling `q-parser` crate (MA-11c) will
+consume this crate's token stream against `code/grammars/q/q.grammar` —
+including the one genuinely new grammar production this language needs,
+user-defined function literals (MA11 §2/§3) — to build the `GrammarASTNode`
+CST that a future `q-runtime` (MA-11d) will evaluate, alongside `q-repl`
+and `q-to-semantic-ir` (MA-11e), per
+[HML00](../../../specs/HML00-historical-math-languages-roadmap.md) Wave 6.

--- a/code/packages/rust/q-lexer/required_capabilities.json
+++ b/code/packages/rust/q-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/q-lexer",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/q-lexer/src/_grammar.rs
+++ b/code/packages/rust/q-lexer/src/_grammar.rs
@@ -1,0 +1,258 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: q.tokens
+// Regenerate with: grammar-tools compile-tokens q.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"LE"#.to_string(),
+                pattern: r#"<="#.to_string(),
+                is_regex: false,
+                line_number: 100,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GE"#.to_string(),
+                pattern: r#">="#.to_string(),
+                is_regex: false,
+                line_number: 101,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NE"#.to_string(),
+                pattern: r#"<>"#.to_string(),
+                is_regex: false,
+                line_number: 105,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PLUS"#.to_string(),
+                pattern: r#"+"#.to_string(),
+                is_regex: false,
+                line_number: 135,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"MINUS"#.to_string(),
+                pattern: r#"-"#.to_string(),
+                is_regex: false,
+                line_number: 136,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"STAR"#.to_string(),
+                pattern: r#"*"#.to_string(),
+                is_regex: false,
+                line_number: 137,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PERCENT"#.to_string(),
+                pattern: r#"%"#.to_string(),
+                is_regex: false,
+                line_number: 138,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"BANG"#.to_string(),
+                pattern: r#"!"#.to_string(),
+                is_regex: false,
+                line_number: 139,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMA"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 140,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"HASH"#.to_string(),
+                pattern: r#"#"#.to_string(),
+                is_regex: false,
+                line_number: 141,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"UNDERSCORE"#.to_string(),
+                pattern: r#"_"#.to_string(),
+                is_regex: false,
+                line_number: 142,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"AMP"#.to_string(),
+                pattern: r#"&"#.to_string(),
+                is_regex: false,
+                line_number: 143,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PIPE"#.to_string(),
+                pattern: r#"|"#.to_string(),
+                is_regex: false,
+                line_number: 144,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"TILDE"#.to_string(),
+                pattern: r#"~"#.to_string(),
+                is_regex: false,
+                line_number: 145,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQ"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 147,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LT"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 148,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GT"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 149,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EACH"#.to_string(),
+                pattern: r#"'"#.to_string(),
+                is_regex: false,
+                line_number: 170,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"REDUCE"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 171,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SCAN"#.to_string(),
+                pattern: r#"\"#.to_string(),
+                is_regex: false,
+                line_number: 172,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COLON"#.to_string(),
+                pattern: r#":"#.to_string(),
+                is_regex: false,
+                line_number: 174,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SEMICOLON"#.to_string(),
+                pattern: r#";"#.to_string(),
+                is_regex: false,
+                line_number: 175,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 177,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 178,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACE"#.to_string(),
+                pattern: r#"{"#.to_string(),
+                is_regex: false,
+                line_number: 196,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACE"#.to_string(),
+                pattern: r#"}"#.to_string(),
+                is_regex: false,
+                line_number: 197,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACKET"#.to_string(),
+                pattern: r#"["#.to_string(),
+                is_regex: false,
+                line_number: 198,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACKET"#.to_string(),
+                pattern: r#"]"#.to_string(),
+                is_regex: false,
+                line_number: 199,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 237,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[a-zA-Z][a-zA-Z0-9]*"#.to_string(),
+                is_regex: true,
+                line_number: 238,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NEWLINE"#.to_string(),
+                pattern: r#"\r?\n"#.to_string(),
+                is_regex: true,
+                line_number: 253,
+                alias: None,
+            },
+        ],
+        keywords: vec![],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t]+"#.to_string(),
+                is_regex: true,
+                line_number: 256,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: None,
+        error_definitions: vec![],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
+    }
+}

--- a/code/packages/rust/q-lexer/src/lib.rs
+++ b/code/packages/rust/q-lexer/src/lib.rs
@@ -1,0 +1,371 @@
+//! # Q Lexer — tokenizing kdb+'s scripting language.
+//!
+//! Q (Kx Systems, 2003) is the readable second surface syntax over the
+//! K/kdb+ execution engine (`code/specs/MA11-q-language.md` §1) — the same
+//! noun/verb split and right-to-left, no-precedence evaluation as APL/J
+//! (MA05/MA06), plus keyword-free symbolic primitives, an explicit
+//! function-literal syntax, and (deferred past this cut) a first-class
+//! table type. Like every language frontend in this repo, this crate does
+//! not hand-write the bulk of tokenization — it loads the compiled
+//! `code/grammars/q/q.tokens` grammar and feeds it to the generic
+//! [`GrammarLexer`]. `q-lexer` only tokenizes; there is no `q-parser` or
+//! `q.grammar` here (that is MA-11c, a separate follow-on task) and no
+//! recursion-depth cap (that is a parser-level concern for MA-11c, the
+//! same "cap belongs where recursive descent happens" precedent
+//! `apl-parser`/`j-parser` already set — `apl-lexer`/`j-lexer` have none
+//! either).
+//!
+//! ## Design decision: two whitespace-sensitive rules live in Rust, not in `q.tokens`
+//!
+//! Every other `.tokens` file in this repo's array-language family treats
+//! whitespace as pure separator noise between otherwise unambiguous tokens.
+//! Q's real lexer breaks that assumption in exactly two places
+//! (MA11 §3 bullet 2), both driven by *whether whitespace is adjacent to a
+//! character*, not by which characters are present:
+//!
+//! 1. **Negative-literal vs. subtraction.** `2 -1` (space before `-`, none
+//!    after) tokenizes as the two-element strand `NUMBER(2) NUMBER(-1)`;
+//!    `2 - 1` and `2-1` both tokenize as `NUMBER(2) MINUS NUMBER(1)`
+//!    (ordinary subtraction — with or without surrounding spaces).
+//! 2. **`/` comment marker vs. REDUCE adverb.** A `/` preceded by
+//!    whitespace (or at the start of a line) opens a comment to end of
+//!    line; a `/` glued directly to a preceding verb/noun character with no
+//!    intervening space is the REDUCE adverb (`+/x`).
+//!
+//! Rust's `regex` crate — what [`GrammarLexer`] compiles every `.tokens`
+//! pattern with — has no lookaround support (no `(?<=...)`, no `(?=...)`),
+//! so "was there whitespace immediately before this position" cannot be
+//! written as a token pattern no matter how it's phrased. This is a real
+//! limit of the shared engine, confirmed by reading
+//! `code/packages/rust/grammar-tools/src/token_grammar.rs`'s own
+//! `validate_token_grammar` (it compiles every pattern with
+//! `regex::Regex::new` directly) — not an assumption.
+//!
+//! This is not a new problem in this repo: `scilab-lexer` already solves
+//! the same *shape* of problem (`'` is transpose-or-string depending on
+//! whether a value immediately precedes it) with a **pre-tokenize hook**
+//! (rewrites the raw source text before `GrammarLexer` sees it) and a
+//! **post-tokenize hook** (patches the resulting `Vec<Token>` afterward) —
+//! see `code/packages/rust/scilab-lexer/src/lib.rs`'s `protect_quotes` /
+//! `restore_placeholders`. This crate reuses that exact strategy,
+//! independently implemented for Q's two different disambiguations:
+//!
+//! - [`strip_slash_comments`] is a **pre-tokenize** hook. Comment text is
+//!   arbitrary and need not lex successfully as Q code at all — if this
+//!   ran as a *post*-tokenize pass instead, a single unrecognized character
+//!   inside a comment (anything not in `q.tokens`'s alphabet) would make
+//!   the whole file fail to tokenize before the pass ever got a token list
+//!   to patch. Blanking comment text out of the *source string* first
+//!   sidesteps that entirely: by the time `GrammarLexer` runs, a comment
+//!   region is nothing but spaces, which the grammar's own `WHITESPACE`
+//!   skip pattern consumes exactly like any other run of whitespace.
+//! - [`fold_negative_number_literals`] is a **post-tokenize** hook.
+//!   Deciding whether a `-`/digit pair folds into one signed literal
+//!   requires knowing the *type* of the previously emitted token (is it a
+//!   NUMBER/NAME/closing bracket — does it complete a noun, the way `2`
+//!   does in `2-1`?) — exactly the kind of already-classified information
+//!   only the token stream carries. There is no way to decide this from
+//!   raw characters alone without re-implementing token classification by
+//!   hand, which is precisely the "no hand-written lexer" line this
+//!   design stays on the right side of: the hook consumes tokens
+//!   `GrammarLexer` already produced, it does not re-derive them.
+//!
+//! Neither hook is a general-purpose mechanism bolted onto `GrammarLexer`
+//! itself — the shared engine already exposes `add_pre_tokenize` /
+//! `add_post_tokenize` for exactly this kind of narrow, documented,
+//! per-language adjustment (see `code/packages/rust/lexer/src/grammar_lexer.rs`),
+//! so no changes to the shared crate were needed or made.
+//!
+//! ### A gap noticed in the shared engine (documented, not fixed here)
+//!
+//! While investigating whether `GrammarLexer` already had a *declarative*
+//! way to express "no preceding whitespace" (the F10 pattern-group /
+//! mode-transition system), the transition table only fires *after* a
+//! token is emitted, keyed on the emitted token's type/value — it has no
+//! notion of "was trivia consumed immediately before this token", so it
+//! cannot see the signal this crate needs. That is a real, general gap in
+//! the shared engine (any future language needing the same kind of
+//! whitespace-position signal will hit it too), not something specific to
+//! Q — per this repo's own "fix what's local, defer what's shared"
+//! discipline, it is left unfixed here and simply recorded in this comment
+//! for whoever picks up a language that needs it declaratively.
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+// ===========================================================================
+// Pre-tokenize hook: `/`-comment stripping (MA11 §3 bullet 2, second item)
+// ===========================================================================
+
+/// Blank out `/`-to-end-of-line comments before `GrammarLexer` ever sees the
+/// source text.
+///
+/// A `/` opens a comment when it is preceded by whitespace or starts a line
+/// (including the very start of the file); it is left untouched — becoming
+/// the ordinary `REDUCE` token — when it directly follows a non-whitespace
+/// character.
+///
+/// # Algorithm
+///
+/// A single left-to-right scan over the characters, tracking one boolean:
+/// whether the *immediately preceding* character (in the source as written,
+/// not the rewritten output) was "whitespace-like" — a space, a tab, a
+/// carriage return, a newline, or nothing at all (start of input, which is
+/// trivially the start of line 1).
+///
+/// When a `/` is reached while that flag is set, everything from the `/`
+/// through (but not including) the next `\n` — or end of input, if the
+/// comment is on the last line — is replaced character-for-character with a
+/// single space. Replacing rather than deleting is what keeps this a
+/// *pre*-tokenize hook instead of a hand-rolled lexer: every other
+/// character's line/column position is completely unaffected, because
+/// nothing is removed, only turned into whitespace the grammar's own
+/// `WHITESPACE` skip pattern already knows how to consume. The terminating
+/// newline itself is left alone (not blanked) because `q.tokens` gives it
+/// its own significant `NEWLINE` token, exactly like `NB.` comments do in
+/// `j.tokens` — the comment ends just before it, never swallowing it.
+///
+/// Because Q's in-scope value model has no string or symbol literals yet
+/// (MA11 §4 defers both), there is no quoted region this scan needs to
+/// avoid stepping into — unlike `scilab-lexer`'s `protect_quotes`, which
+/// must dodge `'...'`/`"..."` contents. That asymmetry is exactly why this
+/// hook is a single pass with one boolean instead of a full character-class
+/// state machine.
+fn strip_slash_comments(source: String) -> String {
+    let chars: Vec<char> = source.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(n);
+    let mut i = 0;
+    // Start of input counts as "whitespace-like" — trivially the start of
+    // line 1, per the comment-opening rule.
+    let mut prev_is_whitespace_like = true;
+
+    while i < n {
+        let c = chars[i];
+        if c == '/' && prev_is_whitespace_like {
+            // Comment: blank through to (but not including) the next '\n',
+            // or to end of input if this is the last line.
+            while i < n && chars[i] != '\n' {
+                out.push(' ');
+                i += 1;
+            }
+            // The blanked run is itself whitespace, so the flag stays set —
+            // relevant if a lone '/' were somehow immediately followed by
+            // another '/' at end-of-input with no newline between (it
+            // can't be, since the inner loop above already consumed every
+            // non-newline character up to EOF in that case, but keeping the
+            // flag correct here costs nothing and avoids relying on that).
+            prev_is_whitespace_like = true;
+            continue;
+        }
+        out.push(c);
+        prev_is_whitespace_like = matches!(c, ' ' | '\t' | '\r' | '\n');
+        i += 1;
+    }
+
+    out
+}
+
+// ===========================================================================
+// Post-tokenize hook: negative-literal folding (MA11 §3 bullet 2, first item)
+// ===========================================================================
+
+/// Token type-names that "complete a noun" — a value a following `-`,
+/// glued directly against it with no intervening space, could plausibly be
+/// subtracting from. `NUMBER` and `NAME` are the obvious cases (`2-1`,
+/// `x-1`); `RPAREN` covers a parenthesised expression's result (`(2+3)-1`);
+/// `RBRACE` covers a function-literal value (MA11 §3 bullet 1: a lambda is
+/// itself an ordinary noun); `RBRACKET` is included defensively for the
+/// same "closing delimiter ends a value" principle even though this cut's
+/// grammar has no bracket-terminated noun expression yet (indexing is
+/// deferred, MA11 §4) — future-proofing at zero cost today.
+fn ends_a_noun(effective_type_name: &str) -> bool {
+    matches!(
+        effective_type_name,
+        "NUMBER" | "NAME" | "RPAREN" | "RBRACKET" | "RBRACE"
+    )
+}
+
+/// The column immediately after `tok`, i.e. the column a following
+/// character would occupy if it were glued on with zero gap.
+///
+/// Valid because every token this grammar can produce is single-line: Q's
+/// in-scope literal set (MA11 §4) has no multi-line strings, so `column +
+/// (char count of value)` is always the correct end position. `MINUS`'s own
+/// value is always exactly one character (`"-"`), so this also gives the
+/// position where a following digit would need to start to be "glued".
+fn end_column(tok: &Token) -> usize {
+    tok.column + tok.value.chars().count()
+}
+
+/// Fold a `MINUS` token immediately followed by a `NUMBER` token into a
+/// single signed `NUMBER` token, when doing so is unambiguous per MA11 §3
+/// bullet 2's rule — restated precisely:
+///
+/// > a `-` immediately followed by a digit with no intervening space, at a
+/// > position where a new list-stranding element may start, is folded into
+/// > a signed-numeric-literal token rather than emitted as the standalone
+/// > subtract verb.
+///
+/// "a position where a new list-stranding element may start" is exactly
+/// "NOT immediately continuing an already-completed noun with zero gap" —
+/// i.e. the previous emitted token, if any, is either not present, not a
+/// noun-ending token at all (see [`ends_a_noun`]), or *is* noun-ending but
+/// separated from this `-` by at least one space. Concretely:
+///
+/// | Input       | Prev tok / gap before `-`      | Fold? | Result                 |
+/// |-------------|--------------------------------|-------|------------------------|
+/// | `2 -1`      | `NUMBER(2)`, space before `-`  | yes   | `NUMBER(2) NUMBER(-1)` |
+/// | `2 - 1`     | space before AND after `-`     | no*   | `NUMBER(2) MINUS NUMBER(1)` |
+/// | `2-1`       | `NUMBER(2)`, glued, no gap     | no    | `NUMBER(2) MINUS NUMBER(1)` |
+/// | `x:-1`      | `COLON`, glued, not noun-ending| yes   | `NAME COLON NUMBER(-1)`|
+/// | `(2+3) -1`  | `RPAREN`, space before `-`     | yes   | `... RPAREN NUMBER(-1)`|
+/// | `(2+3)-1`   | `RPAREN`, glued, no gap        | no    | `... RPAREN MINUS NUMBER(1)` |
+///
+/// (*`2 - 1` never even reaches the noun-adjacency check: the space
+/// *after* the `-` alone already disqualifies it, since the rule requires
+/// no gap between `-` and the digit.)
+///
+/// # Algorithm
+///
+/// A single left-to-right pass building a new `Vec<Token>`. At each `MINUS`
+/// token, look at the very next token: if it is a `NUMBER` glued to the
+/// `MINUS` with zero gap (same line, adjacent columns), and the token most
+/// recently pushed to the *output* is either absent, not noun-ending, or
+/// noun-ending but NOT glued to this `MINUS` with zero gap, then splice the
+/// two input tokens into one `NUMBER` token carrying `"-"` + the original
+/// digits, positioned at the `MINUS`'s own line/column. Otherwise the
+/// `MINUS` is pushed through unchanged and the loop continues normally —
+/// crucially, an un-folded `MINUS` still becomes the "previous token" seen
+/// by the next iteration, so a chain like `1 - -1` resolves each `-`
+/// independently and correctly (see the tests).
+fn fold_negative_number_literals(tokens: Vec<Token>) -> Vec<Token> {
+    let mut out: Vec<Token> = Vec::with_capacity(tokens.len());
+    let mut i = 0;
+
+    while i < tokens.len() {
+        let tok = &tokens[i];
+
+        if tok.effective_type_name() == "MINUS" {
+            if let Some(next) = tokens.get(i + 1) {
+                let glued_to_digit = next.effective_type_name() == "NUMBER"
+                    && next.line == tok.line
+                    && next.column == end_column(tok);
+
+                let glued_to_prev_noun = out.last().is_some_and(|prev| {
+                    ends_a_noun(prev.effective_type_name())
+                        && prev.line == tok.line
+                        && end_column(prev) == tok.column
+                });
+
+                if glued_to_digit && !glued_to_prev_noun {
+                    let mut folded = next.clone();
+                    folded.value = format!("-{}", next.value);
+                    folded.line = tok.line;
+                    folded.column = tok.column;
+                    out.push(folded);
+                    i += 2;
+                    continue;
+                }
+            }
+        }
+
+        out.push(tok.clone());
+        i += 1;
+    }
+
+    out
+}
+
+// ===========================================================================
+// Public API
+// ===========================================================================
+
+/// Create a [`GrammarLexer`] configured for Q source, with the
+/// comment-stripping and negative-literal-folding hooks installed.
+pub fn create_q_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    let mut lexer = GrammarLexer::new(source, &grammar);
+    lexer.add_pre_tokenize(Box::new(strip_slash_comments));
+    lexer.add_post_tokenize(Box::new(fold_negative_number_literals));
+    lexer
+}
+
+/// Tokenize Q source text into a vector of tokens (ending in `EOF`).
+///
+/// # Panics
+///
+/// Panics on an unrecognized character. Use [`try_tokenize_q`] for a
+/// `Result`-returning version instead.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_q_lexer::tokenize_q;
+///
+/// let tokens = tokenize_q("x:2 -1\n+/x");
+/// ```
+pub fn tokenize_q(source: &str) -> Vec<Token> {
+    create_q_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|err| panic!("Q tokenization failed: {err}"))
+}
+
+/// Tokenize Q source text, returning a `Result` instead of panicking.
+pub fn try_tokenize_q(source: &str) -> Result<Vec<Token>, String> {
+    create_q_lexer(source).tokenize().map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use lexer::token::TokenType;
+
+    fn types(source: &str) -> Vec<String> {
+        tokenize_q(source)
+            .into_iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.effective_type_name().to_string())
+            .collect()
+    }
+
+    fn values(source: &str) -> Vec<String> {
+        tokenize_q(source)
+            .into_iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.value)
+            .collect()
+    }
+
+    // These are the same disambiguation cases documented above, exercised
+    // directly against the hooks; the crate's `tests/test_tokenizer.rs`
+    // covers the full grammar plus a much larger set of edge cases.
+
+    #[test]
+    fn space_before_minus_only_folds_to_negative_literal() {
+        assert_eq!(types("2 -1"), vec!["NUMBER", "NUMBER"]);
+        assert_eq!(values("2 -1"), vec!["2", "-1"]);
+    }
+
+    #[test]
+    fn space_on_both_sides_of_minus_stays_subtraction() {
+        assert_eq!(types("2 - 1"), vec!["NUMBER", "MINUS", "NUMBER"]);
+    }
+
+    #[test]
+    fn no_space_at_all_stays_subtraction() {
+        assert_eq!(types("2-1"), vec!["NUMBER", "MINUS", "NUMBER"]);
+    }
+
+    #[test]
+    fn comment_preceded_by_space_is_stripped() {
+        assert_eq!(types("1 / a comment"), vec!["NUMBER"]);
+    }
+
+    #[test]
+    fn reduce_glued_to_a_verb_is_not_a_comment() {
+        assert_eq!(types("+/x"), vec!["PLUS", "REDUCE", "NAME"]);
+    }
+}

--- a/code/packages/rust/q-lexer/tests/test_tokenizer.rs
+++ b/code/packages/rust/q-lexer/tests/test_tokenizer.rs
@@ -1,0 +1,476 @@
+use coding_adventures_q_lexer::{create_q_lexer, tokenize_q, try_tokenize_q};
+use lexer::token::TokenType;
+
+fn token_types(source: &str) -> Vec<String> {
+    tokenize_q(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.effective_type_name().to_string())
+        .collect()
+}
+
+fn token_values(source: &str) -> Vec<String> {
+    tokenize_q(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.value)
+        .collect()
+}
+
+// ===========================================================================
+// Primitive verb glyphs -- MA11 §4's table, checked one row at a time.
+// ===========================================================================
+
+#[test]
+fn tokenizes_every_primitive_verb_glyph() {
+    // + - * % ! , # _ & | ~ in MA11 §4's listed order. Space-separated so
+    // none of the whitespace-sensitive rules (MINUS, REDUCE) kick in.
+    assert_eq!(
+        token_types("+ - * % ! , # _ & | ~"),
+        vec![
+            "PLUS", "MINUS", "STAR", "PERCENT", "BANG", "COMMA", "HASH", "UNDERSCORE", "AMP",
+            "PIPE", "TILDE",
+        ]
+    );
+}
+
+#[test]
+fn tokenizes_all_six_comparison_glyphs() {
+    assert_eq!(
+        token_types("= < > <= >= <>"),
+        vec!["EQ", "LT", "GT", "LE", "GE", "NE"]
+    );
+}
+
+#[test]
+fn not_equal_is_spelled_angle_brackets_not_tilde_equals_or_hash() {
+    // MA11 §4's explicit callout: Q spells not-equal `<>`, never `~=` (that's
+    // MATLAB/Scilab's spelling) and never `#` (Q's own count/take glyph).
+    assert_eq!(token_types("<>"), vec!["NE"]);
+    // `~=` lexes as TWO separate tokens in this grammar (TILDE then EQ) --
+    // there is no NE_ALT-style digraph for it, unlike Scilab's own `<>`+`~=`
+    // pair, because Q genuinely only has one spelling.
+    assert_eq!(token_types("~="), vec!["TILDE", "EQ"]);
+    // `#` is its own unrelated primitive (count/take), never comparison.
+    assert_eq!(token_types("#"), vec!["HASH"]);
+}
+
+#[test]
+fn le_ge_digraphs_win_over_bare_lt_gt() {
+    // The core longest-match-first hazard: `<=`/`>=` must win over the bare
+    // `<`/`>` prefix character they start with, at every position.
+    assert_eq!(token_types("<="), vec!["LE"]);
+    assert_eq!(token_types("<"), vec!["LT"]);
+    assert_eq!(token_types(">="), vec!["GE"]);
+    assert_eq!(token_types(">"), vec!["GT"]);
+}
+
+// ===========================================================================
+// Adverbs, assignment, grouping, function-literal delimiters
+// ===========================================================================
+
+#[test]
+fn tokenizes_the_three_adverbs() {
+    // ' (each) / (over/reduce) \ (scan) -- MA11 §4.
+    assert_eq!(token_types("'"), vec!["EACH"]);
+    assert_eq!(token_types("+/"), vec!["PLUS", "REDUCE"]);
+    assert_eq!(token_types("+\\"), vec!["PLUS", "SCAN"]);
+}
+
+#[test]
+fn tokenizes_colon_assignment_not_j_or_apl_spelling() {
+    // Q spells assignment with a colon (`name:expr`) -- not J's `=.`/`=:`
+    // pair and not APL's `←`.
+    assert_eq!(token_types("x:1"), vec!["NAME", "COLON", "NUMBER"]);
+}
+
+#[test]
+fn tokenizes_parenthesised_grouping() {
+    assert_eq!(
+        token_types("(1+2)"),
+        vec!["LPAREN", "NUMBER", "PLUS", "NUMBER", "RPAREN"]
+    );
+}
+
+#[test]
+fn tokenizes_explicit_list_literal_with_semicolons() {
+    // (a;b;c) -- MA11 §3 bullet 3's second list-literal syntax.
+    assert_eq!(
+        token_types("(1;2;3)"),
+        vec![
+            "LPAREN", "NUMBER", "SEMICOLON", "NUMBER", "SEMICOLON", "NUMBER", "RPAREN",
+        ]
+    );
+}
+
+#[test]
+fn tokenizes_function_literal_delimiters_with_explicit_params() {
+    // {[x;y] x+y} -- MA11 §3 bullet 1 / §4.
+    assert_eq!(
+        token_types("{[x;y] x+y}"),
+        vec![
+            "LBRACE", "LBRACKET", "NAME", "SEMICOLON", "NAME", "RBRACKET", "NAME", "PLUS", "NAME",
+            "RBRACE",
+        ]
+    );
+}
+
+#[test]
+fn tokenizes_function_literal_with_implicit_params() {
+    // {x+y} -- the bracket-omitted implicit x/y/z form (MA11 §4). At the
+    // lexer layer x/y/z are ordinary NAME tokens -- the implicit-parameter
+    // convenience is a parser/runtime concern, not a lexer one.
+    assert_eq!(
+        token_types("{x+y}"),
+        vec!["LBRACE", "NAME", "PLUS", "NAME", "RBRACE"]
+    );
+}
+
+#[test]
+fn semicolon_separates_statements_inside_a_function_body_too() {
+    // The SAME token, two grammar-level uses (MA11 §3 bullets 1 and 3):
+    // list-literal separator AND function-body statement separator.
+    assert_eq!(
+        token_types("{a:1;a+1}"),
+        vec![
+            "LBRACE", "NAME", "COLON", "NUMBER", "SEMICOLON", "NAME", "PLUS", "NUMBER", "RBRACE",
+        ]
+    );
+}
+
+// ===========================================================================
+// Numeric literals and stranding
+// ===========================================================================
+
+#[test]
+fn tokenizes_integers_and_decimals() {
+    assert_eq!(token_types("42"), vec!["NUMBER"]);
+    assert_eq!(token_values("3.14"), vec!["3.14"]);
+}
+
+#[test]
+fn tokenizes_numbers_with_exponents() {
+    // The exponent's own sign is written directly into NUMBER's pattern
+    // (unambiguous -- see q.tokens SECTION 5) unlike the leading sign.
+    assert_eq!(token_values("1e10"), vec!["1e10"]);
+    assert_eq!(token_values("1e-5"), vec!["1e-5"]);
+    assert_eq!(token_values("2.5E+3"), vec!["2.5E+3"]);
+}
+
+#[test]
+fn tokenizes_dense_numeric_arrays_via_vector_stranding() {
+    // Adjacent numeric literals separated only by whitespace -- MA11 §3
+    // bullet 3's first list-literal syntax. Grouping into one array value is
+    // the parser's job; the lexer just emits adjacent NUMBER tokens.
+    assert_eq!(token_types("1 2 3"), vec!["NUMBER", "NUMBER", "NUMBER"]);
+    assert_eq!(token_values("1 2 3"), vec!["1", "2", "3"]);
+}
+
+#[test]
+fn name_excludes_underscore_since_underscore_is_its_own_primitive() {
+    // `_` is the floor/drop verb glyph (UNDERSCORE), not a name-continuation
+    // character -- `a_b` must lex as NAME("a") UNDERSCORE NAME("b"), never
+    // as a single identifier, or a real primitive application would be
+    // silently swallowed into a name (q.tokens SECTION 5).
+    assert_eq!(token_types("a_b"), vec!["NAME", "UNDERSCORE", "NAME"]);
+    assert_eq!(token_values("a_b"), vec!["a", "_", "b"]);
+}
+
+// ===========================================================================
+// Whitespace-sensitive rule 1: negative-literal vs. subtraction
+// (MA11 §3 bullet 2, first item)
+// ===========================================================================
+
+#[test]
+fn space_before_minus_none_after_folds_to_negative_literal() {
+    // 2 -1 -- the two-element strand [2, -1].
+    assert_eq!(token_types("2 -1"), vec!["NUMBER", "NUMBER"]);
+    assert_eq!(token_values("2 -1"), vec!["2", "-1"]);
+}
+
+#[test]
+fn space_on_both_sides_of_minus_is_subtraction() {
+    // 2 - 1 -- ordinary subtraction, both operands spaced away from the verb.
+    assert_eq!(token_types("2 - 1"), vec!["NUMBER", "MINUS", "NUMBER"]);
+}
+
+#[test]
+fn no_space_at_all_is_also_subtraction() {
+    // 2-1 -- glued on both sides. This is the case that rules out "no space
+    // after the minus" as the whole story: it must still read as ordinary
+    // subtraction (real q evaluates 2-1 to 1), not as NUMBER(2) NUMBER(-1).
+    assert_eq!(token_types("2-1"), vec!["NUMBER", "MINUS", "NUMBER"]);
+    assert_eq!(token_values("2-1"), vec!["2", "-", "1"]);
+}
+
+#[test]
+fn space_after_minus_only_is_subtraction() {
+    // 2- 1 -- there IS a space between - and the digit, so the "no
+    // intervening space" precondition already fails regardless of what
+    // precedes the minus.
+    assert_eq!(token_types("2- 1"), vec!["NUMBER", "MINUS", "NUMBER"]);
+}
+
+#[test]
+fn negative_literal_at_start_of_line() {
+    // A bare `-1` with nothing before it -- the start of input trivially
+    // counts as "a position where a new list-stranding element may start".
+    assert_eq!(token_types("-1"), vec!["NUMBER"]);
+    assert_eq!(token_values("-1"), vec!["-1"]);
+}
+
+#[test]
+fn negative_literal_after_assignment_colon() {
+    // x:-1 -- COLON is not a noun-ending token, so there is no ambiguity to
+    // resolve via spacing at all; this is an extremely common real-q idiom.
+    assert_eq!(token_types("x:-1"), vec!["NAME", "COLON", "NUMBER"]);
+    assert_eq!(token_values("x:-1"), vec!["x", ":", "-1"]);
+}
+
+#[test]
+fn negative_literal_after_open_paren_and_semicolon() {
+    // (-1;2) -- inside an explicit list literal, `-1` opens a new element
+    // right after `(`, and `2` is an ordinary positive element after `;`.
+    assert_eq!(
+        token_types("(-1;2)"),
+        vec!["LPAREN", "NUMBER", "SEMICOLON", "NUMBER", "RPAREN"]
+    );
+    assert_eq!(token_values("(-1;2)"), vec!["(", "-1", ";", "2", ")"]);
+}
+
+#[test]
+fn subtraction_glued_to_a_closing_paren() {
+    // (2+3)-1 -- RPAREN glued directly to `-` blocks the fold (ordinary
+    // subtraction of 1 from the parenthesised result).
+    assert_eq!(
+        token_types("(2+3)-1"),
+        vec!["LPAREN", "NUMBER", "PLUS", "NUMBER", "RPAREN", "MINUS", "NUMBER"]
+    );
+}
+
+#[test]
+fn negative_literal_stranded_after_a_spaced_closing_paren() {
+    // (2+3) -1 -- a space before `-` means RPAREN is NOT glued to it, so
+    // this strands a second, negative element after the parenthesised value.
+    assert_eq!(
+        token_types("(2+3) -1"),
+        vec!["LPAREN", "NUMBER", "PLUS", "NUMBER", "RPAREN", "NUMBER"]
+    );
+    assert_eq!(token_values("(2+3) -1"), vec!["(", "2", "+", "3", ")", "-1"]);
+}
+
+#[test]
+fn subtraction_glued_to_a_name() {
+    // f-1 -- NAME glued directly to `-` blocks the fold, same as a NUMBER.
+    assert_eq!(token_types("f-1"), vec!["NAME", "MINUS", "NUMBER"]);
+}
+
+#[test]
+fn negative_literal_stranded_after_a_spaced_name() {
+    assert_eq!(token_types("f -1"), vec!["NAME", "NUMBER"]);
+}
+
+#[test]
+fn chained_minus_signs_resolve_independently() {
+    // 1 - -1 -- the FIRST `-` has a space on both sides (stays MINUS); the
+    // SECOND `-` is glued to `1` with a space before it and its "previous
+    // token" is the first (un-folded) MINUS, which is not noun-ending, so it
+    // folds. Net: 1 - (-1).
+    assert_eq!(
+        token_types("1 - -1"),
+        vec!["NUMBER", "MINUS", "NUMBER"]
+    );
+    assert_eq!(token_values("1 - -1"), vec!["1", "-", "-1"]);
+}
+
+#[test]
+fn three_element_negative_strand() {
+    // 2 -1 -2 -- MA11 §3's own worked example, extended to three elements.
+    assert_eq!(
+        token_types("2 -1 -2"),
+        vec!["NUMBER", "NUMBER", "NUMBER"]
+    );
+    assert_eq!(token_values("2 -1 -2"), vec!["2", "-1", "-2"]);
+}
+
+#[test]
+fn negative_literal_after_a_function_literal_value() {
+    // {x+1} -1 -- RBRACE is a noun-ending token (a lambda is itself an
+    // ordinary noun, MA11 §3 bullet 1), so the same spacing rule applies to
+    // it as to RPAREN/NUMBER/NAME.
+    assert_eq!(
+        token_types("{x+1} -1"),
+        vec!["LBRACE", "NAME", "PLUS", "NUMBER", "RBRACE", "NUMBER"]
+    );
+    assert_eq!(
+        token_types("{x+1}-1"),
+        vec!["LBRACE", "NAME", "PLUS", "NUMBER", "RBRACE", "MINUS", "NUMBER"]
+    );
+}
+
+#[test]
+fn negative_decimal_and_exponent_literals_fold_too() {
+    assert_eq!(token_values("x: -3.5"), vec!["x", ":", "-3.5"]);
+    assert_eq!(token_values("2 -1e10"), vec!["2", "-1e10"]);
+}
+
+// ===========================================================================
+// Whitespace-sensitive rule 2: `/` comment marker vs. REDUCE adverb
+// (MA11 §3 bullet 2, second item)
+// ===========================================================================
+
+#[test]
+fn reduce_glued_to_a_preceding_verb_with_no_space() {
+    // +/x -- the canonical sum-reduce idiom.
+    assert_eq!(token_types("+/x"), vec!["PLUS", "REDUCE", "NAME"]);
+}
+
+#[test]
+fn reduce_glued_to_a_preceding_noun_with_no_space() {
+    assert_eq!(token_types("x/"), vec!["NAME", "REDUCE"]);
+}
+
+#[test]
+fn comment_at_start_of_line() {
+    // A `/` at the very start of a line opens a comment to end of line.
+    assert_eq!(token_types("/ comment to end of line"), Vec::<String>::new());
+}
+
+#[test]
+fn comment_preceded_by_a_single_space() {
+    assert_eq!(token_types("x:1 / trailing comment"), vec!["NAME", "COLON", "NUMBER"]);
+}
+
+#[test]
+fn comment_preceded_by_multiple_spaces_behaves_the_same_as_one() {
+    // Presence/absence of whitespace is what matters, not how much of it --
+    // one space and five spaces before `/` must both open a comment.
+    assert_eq!(
+        token_types("x:1     / trailing comment"),
+        vec!["NAME", "COLON", "NUMBER"]
+    );
+    assert_eq!(
+        token_types("x:1 / trailing comment"),
+        token_types("x:1     / trailing comment"),
+    );
+}
+
+#[test]
+fn reduce_immediately_after_a_closing_paren_with_no_space() {
+    // (+/)y or similar -- a `/` glued directly to `)` is still the reduce
+    // adverb, never a comment, because there is no space before it.
+    assert_eq!(
+        token_types("(+/)y"),
+        vec!["LPAREN", "PLUS", "REDUCE", "RPAREN", "NAME"]
+    );
+}
+
+#[test]
+fn comment_after_a_closing_paren_with_a_preceding_space() {
+    // The same `)` followed by `/`, but now with a space before the slash --
+    // this opens a comment instead.
+    assert_eq!(token_types("(1+2) / a comment"), vec!["LPAREN", "NUMBER", "PLUS", "NUMBER", "RPAREN"]);
+}
+
+#[test]
+fn comment_does_not_swallow_the_terminating_newline() {
+    // The comment ends just before the newline -- NEWLINE is still its own
+    // significant token afterward, exactly like j.tokens' NB. comments.
+    assert_eq!(
+        token_types("x:1 / a comment\ny:2"),
+        vec!["NAME", "COLON", "NUMBER", "NEWLINE", "NAME", "COLON", "NUMBER"]
+    );
+}
+
+#[test]
+fn whole_line_comment_between_two_statements() {
+    assert_eq!(
+        token_types("x:1\n/ a whole comment line\ny:2"),
+        vec!["NAME", "COLON", "NUMBER", "NEWLINE", "NEWLINE", "NAME", "COLON", "NUMBER"]
+    );
+}
+
+#[test]
+fn comment_containing_characters_outside_the_grammars_alphabet() {
+    // A comment's content is arbitrary text -- it must never be re-lexed as
+    // code, so characters this grammar has no token for at all (here: `$`
+    // and `@`, both out of scope/deferred per MA11 §4) must not cause a
+    // lexer error when they only ever appear inside a comment.
+    assert!(try_tokenize_q("x:1 / cost is $5 @ 10% off\ny:2").is_ok());
+    assert_eq!(
+        token_types("x:1 / cost is $5 @ 10% off\ny:2"),
+        vec!["NAME", "COLON", "NUMBER", "NEWLINE", "NAME", "COLON", "NUMBER"]
+    );
+}
+
+#[test]
+fn reduce_scan_and_each_all_respect_the_same_comment_rule() {
+    // The comment-vs-adverb distinction is specific to `/` (REDUCE) -- EACH
+    // (') and SCAN (\) have no such ambiguity and are unaffected either way.
+    assert_eq!(token_types("+\\ / a comment"), vec!["PLUS", "SCAN"]);
+    assert_eq!(token_types("+' / a comment"), vec!["PLUS", "EACH"]);
+}
+
+// ===========================================================================
+// Newlines and whitespace
+// ===========================================================================
+
+#[test]
+fn newline_is_its_own_significant_token() {
+    assert_eq!(
+        token_types("x:1\ny:2"),
+        vec!["NAME", "COLON", "NUMBER", "NEWLINE", "NAME", "COLON", "NUMBER"]
+    );
+}
+
+#[test]
+fn skips_ordinary_whitespace() {
+    assert_eq!(token_types("x   :   1"), vec!["NAME", "COLON", "NUMBER"]);
+}
+
+// ===========================================================================
+// Errors
+// ===========================================================================
+
+#[test]
+fn unrecognized_character_is_an_error() {
+    // `@`, `?`, `.`, and `$` are all deferred whole per MA11 §4 -- none of
+    // them has a token in this cut's grammar.
+    assert!(try_tokenize_q("a@b").is_err());
+    assert!(try_tokenize_q("a?b").is_err());
+    assert!(try_tokenize_q("a.b").is_err());
+    assert!(try_tokenize_q("a$b").is_err());
+}
+
+#[test]
+fn tokenize_q_panics_on_malformed_source() {
+    let result = std::panic::catch_unwind(|| tokenize_q("@"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn create_q_lexer_exposes_the_result_returning_api() {
+    assert!(create_q_lexer("x:1").tokenize().is_ok());
+    assert!(create_q_lexer("@").tokenize().is_err());
+}
+
+// ===========================================================================
+// End-to-end: a small, realistic "textbook q session" snippet
+// ===========================================================================
+
+#[test]
+fn tokenizes_a_small_end_to_end_snippet() {
+    // x:2 -1        / a two-element strand, second element negative
+    // sum:{[a] +/a} / a function literal summing its argument
+    // sum x
+    let src = "x:2 -1\nsum:{[a] +/a}\nsum x";
+    assert_eq!(
+        token_types(src),
+        vec![
+            "NAME", "COLON", "NUMBER", "NUMBER", "NEWLINE", "NAME", "COLON", "LBRACE", "LBRACKET",
+            "NAME", "RBRACKET", "PLUS", "REDUCE", "NAME", "RBRACE", "NEWLINE", "NAME", "NAME",
+        ]
+    );
+    assert_eq!(token_values(src)[2], "2");
+    assert_eq!(token_values(src)[3], "-1");
+}


### PR DESCRIPTION
## Summary

First frontend crate for Q (kdb+'s scripting language), per [MA11 §6](code/specs/MA11-q-language.md) task MA-11b.

- `code/grammars/q/q.tokens` — declarative token grammar covering MA11 §4's historical-core subset: primitive verb glyphs, the three adverbs, `name:expr` assignment, parenthesised grouping, explicit `(a;b;c)` list literals, `{[x;y] ...}` function-literal delimiters, and `/`-to-end-of-line comments.
- `code/packages/rust/q-lexer/` — `GrammarLexer`-backed tokenizer crate (no hand-written lexer, per `feedback_no_handwritten_lexers_parsers`), mirroring `j-lexer`'s shape.

### The interesting part: two whitespace-sensitive lexer rules

Every other `.tokens` file in this repo's array-language family treats whitespace as pure separator noise. Q's real lexer doesn't, in exactly two places (spec §3 bullet 2):

1. **Negative-literal vs. subtraction**: `2 -1` → two-element strand `NUMBER(2) NUMBER(-1)`; `2 - 1` and `2-1` → ordinary subtraction.
2. **`/` comment marker vs. REDUCE adverb**: `/` preceded by whitespace (or line-start) opens a comment; glued directly to a preceding verb/noun, it's the reduce adverb (`+/x`).

Rust's `regex` crate has no lookaround, so neither rule can be expressed declaratively in `q.tokens`. Reused the exact `add_pre_tokenize`/`add_post_tokenize` strategy `scilab-lexer` already established for its own `'`-transpose-vs-string disambiguation — no changes to the shared `lexer`/`grammar-tools` crates needed. Full design rationale is in `q-lexer`'s module doc comment and README.

No recursion-depth cap in this crate by design — that's a parser concern (MA-11c, a separate follow-up task), matching every sibling `*-lexer`/`*-parser` split in this repo (`apl-lexer`/`j-lexer` have none either).

### Explicitly out of scope (follow-up tasks)

- `q-parser` / `q.grammar` — MA-11c
- `q-runtime` / `q-repl` / `q` binary — MA-11d
- `q-to-semantic-ir` — MA-11e

## Test plan

- [x] `cargo test -p coding-adventures-q-lexer --all-targets` — 53 tests (5 unit + 47 integration + 1 doctest), all passing
- [x] `cargo clippy -p coding-adventures-q-lexer --all-targets -- -D warnings` — clean
- [x] `cargo metadata --no-deps` resolves cleanly with the new workspace member
- [x] `/security-review` passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)