### PR TITLE
feat(hl): Russian Ch.2 — introducing yourself

### DIFF
--- a/code/learning/human-languages/russian/CHANGELOG.md
+++ b/code/learning/human-languages/russian/CHANGELOG.md
@@ -1,5 +1,87 @@
 # Changelog — Russian track
 
+## Chapter 2 — Introducing yourself
+
+Russian was one of **two tracks still at Chapter 1** (with Latin); every other
+track had reached Ch. 4 or beyond. This closes that gap, following the
+Ch. 2 plan the roadmap already set out.
+
+- **`RU-C02-ya`** — *я*, one letter and one of the least-changed words in the
+  family: PIE \**eǵh₂(om)* → Proto-Slavic \**azъ* → a single vowel. Cousins
+  *ego*, *ich*, *I*, *egṓ*. **Pronouns are the least borrowable part of a
+  language**, which is why this row survives when everything around it turns over.
+  Warns that **я is not a mirrored Latin R**.
+- **`RU-C02-ty-vy`** — the split English threw away. *Thou* fell out of standard
+  English through the 1600s (hedged — it survives in Quaker usage, northern
+  dialect and liturgy), leaving *you* for everyone.
+  - *вы* is polite the way French *vous* is, and the lesson is careful about
+    **who actually did what**: Russian and French use the **2nd-person plural**,
+    German borrows the **3rd-person plural** (*Sie*, **not** *ihr*), and **Spanish
+    used no plural at all** — *usted* ← *vuestra merced*, "your grace". A draft
+    lumped Spanish in; `ES-C03-tu-usted` and `GE-C02-du-sie` both say otherwise.
+    Russian's *вы*-politeness is also flagged as a likely **18th-century import**
+    rather than an independent invention.
+  - The cognate table is **honest about its third row**: *вы* and *vōs* continue
+    PIE \**wos*, but English *you* and German *ihr* come from the paradigm's
+    **other** stem \**yūs* — so that row is half a set, and says so.
+  - Introduces **ы** properly, since *ты*/*вы* turn on it and it is the hardest
+    Russian vowel for an English speaker — and **adds it to
+    `pronunciation-reference.md`**, where it was missing from every letter group,
+    with a new `yery-vowel` id the lesson cites. The reference previously had no
+    entry for it at all.
+- **`RU-C02-menya-zovut`** — the naming construction, which is the chapter's real
+  content. *Меня зовут Анна* is literally "**[they] call me Anna**": there is
+  **no word for "my"** and **no word for "name"** in it. The "they" is nobody — a
+  bare plural verb meaning "people in general", which English does too in *they
+  say it'll rain*.
+  - This is the course's **first look at case**. *Меня* is not *я* but its object
+    form, and the lesson is careful to set the expectation honestly: English does
+    this with about six **pairs** (*I/me*, *he/him*…), Russian does it with
+    **every noun and pronoun**. The learner isn't asked to learn the system — only to notice
+    that the *shape* carries the meaning.
+- **`RU-C02-kak-vas-zovut`** — asks **how** they call you, not *what*. Russian,
+  French (*comment*) and Spanish (*cómo*) all ask about an **action**; English is
+  the odd one out, asking about a **possession**. Completes the object-form set
+  (*меня / тебя / вас*) so the exchange is a matched pair.
+- **`RU-C02-ochen-priyatno`** — "very pleasant", with no *I am* and no *to meet
+  you*. The etymology is the payoff: *приятно* ← Slavic *prijati* "to favour" ←
+  PIE \**preyH-* "to love, please" — the root behind Russian **приятель**
+  "friend" **and** English **friend**, arriving from opposite ends of Europe.
+  **Free** most likely belongs to the same family ("belonging to the beloved
+  household", i.e. not a slave), hedged as the usual account rather than asserted.
+- **`RU-C02-practice`** — drills the full formal exchange, then the informal one
+  (**greeting and pronoun change; the verb *зовут* never does**), two of the
+  shapes each pronoun takes, and a "what Russian leaves out" table.
+  - The zero-copula point is **scoped to the one sentence that shows it**:
+    ***очень приятно*** has no verb at all. A draft claimed "no sentence in the
+    chapter contains a word for *is*" and that "Russian has none in the present"
+    — both wrong. *Меня зовут* has a verb (*зовут*); it simply isn't a copular
+    sentence. And Russian **does** have a present-tense **есть**, which Ch. 1
+    already met inside **нет** = *не + есть*, and which the roadmap's own Ch. 3
+    section reuses for *у меня есть*.
+
+### Conventions checked, not assumed
+
+- Concept tags are **canonical** (`PRONOUN-I`, `PRONOUN-YOU`, `INTRO-MY-NAME-IS`,
+  `INTRO-WHATS-YOUR-NAME`, `INTRO-NICE-TO-MEET-YOU`) — verified present in
+  `concepts/taxonomy.json`, so no new entries were needed.
+- **я and ты/вы are separate lessons**, which is why. A draft covered all three in
+  one lesson tagged `PRONOUN-I` — leaving Russian with **no `PRONOUN-YOU` node**
+  at all, and dropping the ты/вы split out of a join that **14 other lessons** take part in.
+  **Most** other tracks split them the same way (`FR-C02-je` + `FR-C02-tu-vous`,
+  `GE-C02-ich` + `GE-C02-du-sie`) — though Italian and Portuguese do not, carrying
+  only `PRONOUN-I`.
+- The practice lesson matches **this track's own** shape — `type: practice-mix`
+  with `CH2-PRACTICE` — not the Arabic track's `practice`/`REVIEW`. `CH2-PRACTICE`
+  was already in the taxonomy note's label list.
+- `sounds:` ids come from `russian/pronunciation-reference.md`. A first draft used
+  `cyrillic-new-shapes`, which **is** used by `RU-W03`/`RU-W04` but is **missing
+  from the reference's id list** (as is `cyrillic-honest`) — so the new lessons
+  use `cyrillic-false-friends` and `stress-unmarked`, both canonical.
+- The read-now-draw-later notes (**я**, **ч**, **ы**, **ь**) were written after listing
+  the writing track's actual headwords (в р · с н · б д · п и · е т) — none of
+  those four has been taught.
+
 ## [Unreleased]
 
 ### Added — Chapter 1 (Greetings & courtesy)

--- a/code/learning/human-languages/russian/lessons/RU-C02-kak-vas-zovut.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-kak-vas-zovut.md
@@ -1,0 +1,84 @@
+---
+id: RU-C02-kak-vas-zovut
+chapter: 2
+type: phrase
+headword: как вас зовут?
+gloss: "what's your name? — literally 'HOW do they call you?', not 'what'"
+concept_tag: INTRO-WHATS-YOUR-NAME
+romanization: kak vas zovút
+prerequisites: [RU-C02-menya-zovut, RU-C02-ty-vy]
+sounds: [cyrillic-false-friends, stress-unmarked]
+roots: [slavic-kako, slavic-zvati]
+etymology_hook: "Russian asks HOW they call you, not WHAT — как вас зовут, matching French comment vous appelez-vous and Spanish cómo se llama; English is the odd one out with 'what', because it asks about a possession while the others ask about an action"
+est_minutes: 4
+reviews_of: [RU-C02-menya-zovut, RU-C02-ty-vy]
+---
+
+# как вас зовут? — "what's your name?"
+
+## Warm-up
+
+[PAUSE 2s] You can say your own name. Now ask for someone else's — and notice
+that Russian asks a different question from English.
+
+## The phrase
+
+> **Как вас зовут?** — *Kak vas zovút?* — formal, or to more than one person.
+> **Как тебя зовут?** — *Kak tebyá zovút?* — informal, to one person you know.
+
+Taken apart:
+
+| | | |
+|---|---|---|
+| **как** | *kak* | **how** |
+| **вас** / **тебя** | *vas* / *tebya* | **you** (object form) |
+| **зовут** | *zovut* | they call |
+
+So: **"How do they call you?"**
+
+## Not "what" — "how"
+
+English asks *what* is your name, treating the name as a **thing you have**.
+Russian asks *how* people call you, treating it as **something people do**.
+
+And Russian is not the odd one here — English is:
+
+| | |
+|---|---|
+| Russian | *Как* вас зовут? — **how** |
+| French | *Comment* vous appelez-vous ? — **how** |
+| Spanish | ¿*Cómo* se llama? — **how** |
+| **English** | ***What*** is your name? — **what** |
+
+Three languages ask about an **action**; English asks about a **possession**.
+Once you have heard it in one of them, the others stop feeling strange.
+
+## The object forms again
+
+Last lesson's *меня* has partners, and they follow the same logic — the person
+being called is the **object**, so the word changes shape:
+
+| subject | object | |
+|---|---|---|
+| я | **меня** | me |
+| ты | **тебя** | you (informal) |
+| вы | **вас** | you (formal/plural) |
+
+You now have a matched pair: **Как вас зовут?** — **Меня зовут…**
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Как вас зовут?" — formal]
+- [YOU SAY: "Как тебя зовут?" — informal]
+- [YOU SAY: the whole exchange — "Как вас зовут?" · "Меня зовут…"]
+- [YOU SAY: the odd one out — "**how**, **how**, **how** … *what*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Ask a stranger's name. (*Как вас зовут?*) And a friend's? (*Как тебя
+зовут?*) What does *как* mean, and why does it matter? (**How** — Russian asks
+*how they call you*, about an **action**, where English asks *what*, about a
+**possession**.) Which languages agree with Russian here? (**French** *comment*
+and **Spanish** *cómo* — English is the odd one out.) Give the three object
+forms. (*Меня, тебя, вас*.) Next: "pleased to meet you."

--- a/code/learning/human-languages/russian/lessons/RU-C02-menya-zovut.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-menya-zovut.md
@@ -1,0 +1,88 @@
+---
+id: RU-C02-menya-zovut
+chapter: 2
+type: phrase
+headword: меня зовут…
+gloss: "my name is… — literally 'they call me', with no word for 'my' and no word for 'name'"
+concept_tag: INTRO-MY-NAME-IS
+romanization: menyá zovút
+prerequisites: [RU-C02-ty-vy]
+sounds: [cyrillic-false-friends, stress-unmarked]
+roots: [slavic-zvati]
+etymology_hook: "меня зовут is literally '[they] CALL me' — an unnamed 'they' doing the naming, so the sentence contains no word for 'my' and none for 'name'; and меня is not я plus an ending but a SUPPLETIVE form from a different PIE stem, the first case FORM in the course"
+est_minutes: 5
+reviews_of: [RU-C02-ty-vy, RU-C01-privet]
+---
+
+# меня зовут… — "my name is…"
+
+## Warm-up
+
+[PAUSE 2s] Every other track in this course says "my name is" with a word for
+*my* and a word for *name*. Russian says something quite different, and it is
+worth taking apart slowly.
+
+## The phrase
+
+> **Меня зовут Анна.** — *Menyá zovút Anna.* — "My name is Anna."
+
+Now the literal reading:
+
+| | | |
+|---|---|---|
+| **меня** | *menya* | **me** (object form) |
+| **зовут** | *zovut* | **they call** |
+
+So: **"[they] call me Anna."**
+
+There is **no word for "my"** and **no word for "name"** in the sentence. Russian
+reports what people call you, not what you possess.
+
+## The invisible "they"
+
+*Зовут* is the **they** form of *звать*, "to call." But there is no *они* ("they")
+anywhere — and there isn't meant to be. Russian uses a bare plural verb to mean
+"people in general," the way English says *"they say it'll rain"* without anyone
+in mind.
+
+English has the same trick and doesn't notice it:
+
+> *They call me Anna.* — Who are *they*? Nobody. Everybody.
+
+## меня is not я
+
+This is the important part, and the course's first look at **case**.
+
+You learned **я** for "I" last lesson. But here it is **меня** — because *I* is
+now the **object** of the calling, not the one doing it. Russian changes the
+**shape of the word** to mark that job:
+
+| | |
+|---|---|
+| **я** | I — the one acting |
+| **меня** | me — the one acted on |
+
+English does this with about six **pairs** — *I/me*, *he/him*, *she/her*,
+*we/us*, *they/them*, *who/whom*, plus the archaic *thou/thee*. Russian does it with **every noun and
+pronoun in the language**. That system is called **case**, and it is the main
+thing standing between you and Russian.
+
+You do not need to learn it yet. You need to notice that *меня* is a **different
+shape of я**, and that the shape carries the meaning.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Меня зовут…" and your own name]
+- [YOU SAY: the literal — "**they call me** …"]
+- [YOU SAY: the pair — "**я** … **меня**"]
+- [YOU SAY: the English echo — "*they say it'll rain*"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "my name is Anna." (*Меня зовут Анна*.) What does it literally
+mean? ("**They call me** Anna.") Which two words is it missing? (Any word for
+**my**, and any word for **name**.) Who are "they"? (**Nobody** — a bare plural
+verb meaning "people in general," like English *they say*.) Why *меня* and not
+*я*? (Because it's the **object** — Russian changes a word's **shape** for its
+job. That's **case**.) Next: asking someone else's name.

--- a/code/learning/human-languages/russian/lessons/RU-C02-ochen-priyatno.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-ochen-priyatno.md
@@ -1,0 +1,80 @@
+---
+id: RU-C02-ochen-priyatno
+chapter: 2
+type: phrase
+headword: очень приятно
+gloss: "pleased to meet you — literally 'very pleasant', and a cousin of English FRIEND"
+concept_tag: INTRO-NICE-TO-MEET-YOU
+romanization: óchen priyátno
+prerequisites: [RU-C02-kak-vas-zovut]
+sounds: [cyrillic-false-friends, stress-unmarked]
+roots: [pie-preyh]
+etymology_hook: "приятно 'pleasant' comes from Slavic prijati 'to favour, be well-disposed' ← PIE *preyH- 'to love, please' — the same root that gave Germanic its word for FRIEND (one who is dear) and, most likely, FREE (originally 'belonging to the beloved household, not a slave')"
+est_minutes: 4
+reviews_of: [RU-C02-kak-vas-zovut, RU-C01-spasibo]
+---
+
+# очень приятно — "pleased to meet you"
+
+## Warm-up
+
+[PAUSE 2s] The reply that closes an introduction — and the best etymology in the
+chapter.
+
+## The phrase
+
+> **Очень приятно.** — *Óchen priyátno.* — "Pleased to meet you."
+
+Literally: **"very pleasant."**
+
+| | | |
+|---|---|---|
+| **очень** | *ochen* | very |
+| **приятно** | *priyatno* | pleasant, agreeable |
+
+There is no "to meet you" and no "I am." Russian states the **quality of the
+moment** and leaves the rest understood — the same economy as *меня зовут*, which
+left out "my" and "name."
+
+Both **ч** (*ch*) and **я** are letters the writing track hasn't reached. Read
+them; you'll draw them later.
+
+## приятно is related to "friend"
+
+*Приятно* comes from Slavic ***prijati***, "to favour, to be well-disposed
+toward" — which gives Russian **приятель** (*priyátel'*), a friend.
+
+That root goes back to PIE \**preyH-*, "to love, to please." And it went into
+Germanic too:
+
+| | |
+|---|---|
+| Russian | **приятно** — pleasant · **приятель** — friend |
+| English | **friend** — literally "one who is loving," an old participle of a verb meaning *to love* |
+| German | *Freund* |
+
+So *приятно* and *friend* are the same root, arriving from opposite ends of
+Europe.
+
+**Free** almost certainly belongs to the family too. The usual account: the word
+first meant "belonging to the beloved household" — the members of a family as
+opposed to the slaves in it — and only later meant "not in bondage." *Free* and
+*friend* start in the same place.
+
+Saying *очень приятно* is, at the root, calling the meeting **friendly**.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Очень приятно"]
+- [YOU SAY: the whole exchange — "Как вас зовут?" · "Меня зовут…" · "Очень приятно"]
+- [YOU SAY: the family — "**прия**тно … **прия**тель … **friend**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "pleased to meet you." (*Очень приятно*.) What does it literally
+mean? ("**Very pleasant**" — no "I am," no "to meet you.") What is *приятно*
+related to? (Slavic *prijati* "to favour" → **приятель** "friend" — and, from the
+same PIE root \**preyH-*, English **friend** and German *Freund*.) And *free*?
+(Most likely the **same family** — originally "belonging to the beloved
+household," i.e. not a slave.) Next: putting the chapter together.

--- a/code/learning/human-languages/russian/lessons/RU-C02-practice.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-practice.md
@@ -1,0 +1,98 @@
+---
+id: RU-C02-practice
+chapter: 2
+type: practice-mix
+headword: "Chapter 2 practice"
+gloss: "the whole introduction, and two of the shapes every pronoun takes"
+concept_tag: CH2-PRACTICE
+prerequisites: [RU-C02-ochen-priyatno, RU-C02-kak-vas-zovut]
+sounds: [cyrillic-false-friends, stress-unmarked]
+roots: []
+est_minutes: 5
+reviews_of: [RU-C02-ya, RU-C02-ty-vy, RU-C02-menya-zovut, RU-C02-kak-vas-zovut, RU-C02-ochen-priyatno]
+---
+
+# Chapter 2 practice — a whole introduction
+
+## Warm-up
+
+[PAUSE 2s] Five lessons, and they add up to a real conversation.
+
+## Drill 1 — the exchange
+
+Say both halves aloud, formal first:
+
+| | |
+|---|---|
+| — Здравствуйте! | Hello. *(Ch. 1)* |
+| — **Как вас зовут?** | What's your name? |
+| — **Меня зовут** Анна. **А вас?** | My name is Anna. And you? |
+| — Меня зовут Иван. **Очень приятно.** | My name is Ivan. Pleased to meet you. |
+
+Then the informal version — two swaps and nothing else:
+
+| | |
+|---|---|
+| — Привет! | Hi. *(Ch. 1)* |
+| — **Как тебя зовут?** | What's your name? |
+
+Two things changed, and only two: the **greeting** (Здравствуйте → Привет) and
+the **pronoun** (вас → тебя). The **verb *зовут* never moves**.
+
+## Drill 2 — the two shapes
+
+Each pronoun has more than one shape. Here are **two of them** — the form that
+acts, and the form that is acted on. (Russian has six cases in all; you only need
+these for now.) Cover the right column:
+
+| doing the action | being acted on | |
+|---|---|---|
+| **я** | **меня** | I / me |
+| **ты** | **тебя** | you / you (informal) |
+| **вы** | **вас** | you / you (formal) |
+
+Now use them in the frame. *Зовут* never changes — only the person changes shape:
+
+- **Меня** зовут… — *my* name is…
+- Как **тебя** зовут? — what's *your* name? (informal)
+- Как **вас** зовут? — what's *your* name? (formal)
+
+That's the whole point of case in miniature: **one verb, three people, three
+shapes.**
+
+## Drill 3 — what Russian leaves out
+
+Russian says less than English does. For each phrase, name the missing words:
+
+| Russian | says | leaves out |
+|---|---|---|
+| Меня зовут Анна | "they call me Anna" | *my*, *name* |
+| Очень приятно | "very pleasant" | *I am*, *to meet you* |
+| Как вас зовут? | "how do they call you?" | *what*, *your* |
+
+Look at the middle row especially. ***Очень приятно*** has **no verb at all** —
+Russian normally **drops the linking verb** in the present tense, so "[it is]
+very pleasant" needs no "is". That's the habit to carry into Chapter 3.
+
+(Be careful not to over-read the other two. *Меня зовут* and *Как вас зовут* do
+have a verb — *зовут*. They lack an "is" because they aren't "X is Y" sentences
+in the first place; English just happens to translate them with one. Russian
+*does* have a present-tense **есть**, which Chapter 1 already met inside **нет**
+= *не + есть*, "not-is".)
+
+## Drill 4 — how, not what
+
+One more time, because it's the error English speakers make:
+
+- ~~Что вас зовут?~~ — no.
+- **Как** вас зовут? — **how**, because it's about an *action*.
+
+## Wrap-up Recall
+
+[PAUSE 3s] Run the whole formal exchange. (*Здравствуйте — Как вас зовут? — Меня
+зовут… А вас? — Меня зовут… Очень приятно.*) What changes between formal and
+informal? (The **greeting** and the **pronoun** — *вас* → *тебя*; the verb
+*зовут* stays.) Give
+the three object forms. (*Меня, тебя, вас*.) Which sentence has no verb at all, and why? (***Очень
+приятно*** — Russian **drops the linking verb** in the present.) *Как* or *что*? (***Как*** — "how", because naming is an **action**.)
+Next chapter: being and having.

--- a/code/learning/human-languages/russian/lessons/RU-C02-ty-vy.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-ty-vy.md
@@ -1,0 +1,96 @@
+---
+id: RU-C02-ty-vy
+chapter: 2
+type: word
+headword: ты, вы
+gloss: you (informal) and you (formal) — the split English threw away
+concept_tag: PRONOUN-YOU
+romanization: ty, vy
+prerequisites: [RU-C02-ya, RU-C01-zdravstvuyte]
+sounds: [yery-vowel, stress-unmarked]
+roots: [pie-eg, pie-tu, pie-wos]
+etymology_hook: "я and ты are cousins of Latin ego and tū, English I and thou — pronouns are the least borrowable words a language has; вы continues PIE *wos like Latin vōs, though English you and German ihr come from the paradigm's OTHER stem *yūs, so that row is only half a cognate set; and вы is formal the way French vous is, a plural used as respect"
+est_minutes: 5
+reviews_of: [RU-C02-ya, RU-C01-zdravstvuyte]
+---
+
+# ты, вы — the two words for "you"
+
+## Warm-up
+
+[PAUSE 2s] Chapter 1 gave you two ways to say hello, split by formality. That
+split runs through the whole language — and here is the place it matters most:
+Russian has **two words for "you."**
+
+## The two words
+
+| | | |
+|---|---|---|
+| **ты** | *ty* | you — one person you're familiar with |
+| **вы** | *vy* | you — formal, **or** more than one person |
+
+Both turn on **ы**, which is the hardest vowel in Russian for an English speaker:
+not the *ee* of *ты*'s look-alike, but a tighter, further-back sound made with
+the tongue pulled towards the throat. Say English *ill*, then try to say it with
+your tongue drawn back. The writing track hasn't reached **ы** either.
+
+## The oldest words you will learn
+
+Pronouns are the **least borrowable** part of a language. Nouns come and go;
+*I* and *you* stay. So the first two line up almost too neatly:
+
+| Russian | Latin | English | German |
+|---|---|---|---|
+| **я** (last lesson) | *ego* | **I** | *ich* |
+| **ты** | *tū* | **thou** | *du* |
+| **вы** | *vōs* | — | — |
+
+The first two rows are the same word four times over. **The third row is only
+half a set**: *вы* and *vōs* both continue PIE \**wos*, but English *you* and
+German *ihr* come from the **other** stem in that paradigm, \**yūs*. Cousins,
+not twins — worth marking rather than smoothing over.
+
+**ты** and *tū* and *thou* are the same word, barely touched in four thousand
+years. *Thou* fell out of standard English through the 1600s (it survives in
+Quaker usage, northern dialect and liturgy), leaving *you* for everyone — which
+is why the ты/вы choice feels foreign to English speakers. English **had** it.
+
+## вы is the same politeness French invented
+
+Look at the third row again. *Вы* is a **plural** used for **one person** as a
+mark of respect — and that is exactly what French does with **vous**, and what
+Chapter 1's *здравствуйте* is doing.
+
+The logic is old and slightly strange: addressing someone as though they were
+several people treats them as larger than they are.
+
+Not everyone got there the same way, though. **Russian and French use the
+second-person plural** (*вы*, *vous*). **German borrows the third-person plural**
+(*Sie* — not *ihr*, which is the ordinary "you all"). And **Spanish didn't use a
+plural at all**: *usted* is worn down from *vuestra merced*, "your grace" — a
+title, not a number.
+
+Russian's *вы*-politeness is generally thought to be an **18th-century import**
+from French and German usage, rather than something Russian invented alone.
+
+**When to use which:** *вы* to a stranger, an older person, anyone at work. *ты*
+to a friend, a child, a family member. When in doubt, **вы** — the mistake costs
+nothing, and the reverse is rude.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "я" — *ya*]
+- [YOU SAY: "ты" and "вы" — hear the difference]
+- [YOU SAY: the family — "**ты** … *tū* … **thou**"]
+- [YOU SAY: the rule — "**вы** when in doubt"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "I". (**Я**.) What are the two words for "you", and what splits
+them? (**Ты** informal, **вы** formal — or plural.) Why is *ты* familiar to an
+English speaker's ear? (It's the **same word as *thou***, which left standard
+English through the 1600s.) Why is *вы* polite? (It's a **plural used for one person** — like
+French *vous*. German takes a different route, the **3rd**-person plural *Sie*;
+Spanish a different one again, *usted* ← "your grace".) Which do you use when unsure?
+(**Вы**.) Next: saying your name.

--- a/code/learning/human-languages/russian/lessons/RU-C02-ya.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-ya.md
@@ -1,0 +1,79 @@
+---
+id: RU-C02-ya
+chapter: 2
+type: word
+headword: я
+gloss: I — one letter, and one of the oldest words in Europe
+concept_tag: PRONOUN-I
+romanization: ya
+prerequisites: [RU-C01-privet]
+sounds: [cyrillic-false-friends, stress-unmarked]
+roots: [pie-eg]
+etymology_hook: "я is a cousin of Latin ego, German ich and English I — all from PIE *eǵh₂(om), by way of Proto-Slavic azъ; pronouns are the least borrowable words a language has, so this one is about as close to unchanged Indo-European as Russian gets"
+est_minutes: 3
+reviews_of: [RU-C01-privet]
+---
+
+# я — "I"
+
+## Warm-up
+
+[PAUSE 2s] The shortest word in the chapter: one letter, one sound, and a
+pedigree of about six thousand years.
+
+## The word
+
+> **я** — *ya* — **I**
+
+That is the whole word. A single letter, pronounced *ya*.
+
+It is a **new letter** — the writing track has taught в, р, с, н, б, д, п, и, е
+and т, and hasn't reached **я**. Read it here; you'll draw it when the track
+gets there.
+
+And be careful with its shape. **я looks like a mirrored Latin R and has nothing
+to do with R.** (It descends from ѧ, the "little yus" — not from R at all.)
+
+It is also the **last** letter of the alphabet, 33rd of 33, and Russian has a
+rebuke built on that: «**Я — последняя буква в алфавите**», "*я* is the last
+letter of the alphabet." You say it to someone who talks about themselves too
+much. The letter's position is the joke — don't put yourself first.
+
+## The oldest word you will learn
+
+Pronouns are the **least borrowable** part of a language. Nouns come and go by
+the thousand — *sputnik*, *pizza*, *computer* — but nobody borrows a word for
+*I*. So *я* has simply been inherited, without interruption, for as long as
+there has been an Indo-European family:
+
+| | |
+|---|---|
+| Russian | **я** |
+| Latin | *ego* |
+| German | *ich* |
+| English | **I** |
+| Greek | *egṓ* |
+
+All from PIE \**eǵh₂(om)*. Russian's route ran through Proto-Slavic \**azъ*,
+which East Slavic reshaped — a *j-* was added at the front (\**azъ* → *язъ*) and
+the ending fell away — leaving the **one letter** you now say. It is the most
+extreme change in the table, and the reason *я* looks nothing like *ego* while
+being the same word.
+
+Latin *ego* is the one English borrowed back, whole and untranslated, for the
+part of the mind that says *I*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "я" — *ya*]
+- [YOU SAY: the family — "**я** … *ego* … *ich* … **I**"]
+- [YOU SAY: the erosion — "\**azъ* … **я**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Say "I". (**Я** — one letter, said *ya*.) What must you not mistake it
+for? (A **Latin R** — the shape is a coincidence.) Why has it changed so little
+in meaning? (**Pronouns are the least borrowable words** a language has.) Name
+three relatives. (*Ego*, *ich*, *I* — and Greek *egṓ*.) What did Russian's come from?
+(Proto-Slavic \**azъ*, with a *j-* added at the front and the ending lost.) Next: the two words for "you."

--- a/code/learning/human-languages/russian/pronunciation-reference.md
+++ b/code/learning/human-languages/russian/pronunciation-reference.md
@@ -33,6 +33,11 @@ looks like Latin *x* but says a raspy **"kh."**
 - **Sounds English writes with two letters**: **ж** (zh, as in *measure*),
   **ч** (ch), **ш** (sh), **щ** (shch), **ц** (ts), **ю** (yu), **я** (ya),
   **ё** (yo).
+- **The vowel English hasn't got**: **ы** (`yery-vowel`) — not the *ee* of **и**,
+  but a tighter sound made with the tongue **drawn back**. Say English *ill*, then
+  say it again with your tongue pulled towards your throat. It is the single
+  hardest Russian vowel for an English speaker, and it carries real meaning:
+  **ты** (*you*) and **вы** (*you*, formal) both turn on it.
 - **The two signs** — **ъ** (hard sign) and **ь** (soft sign) — spell *no sound
   of their own*; they only tell you how to pronounce the consonant before them
   (ь softens it).

--- a/code/learning/human-languages/russian/roadmap.md
+++ b/code/learning/human-languages/russian/roadmap.md
@@ -26,20 +26,36 @@ Chapter 1 words introduced — component strokes + stroke order, from the canoni
 - `RU-W04` — **п** (p ← pi) and **и** (ee, the backwards-N quiet false friend).
 - `RU-W05` — **е** (ye, iotated) and **т** (t ← tau), which **completes every
   letter of привет** — the learner can now hand-write the whole word. More letters
-  get a writing lesson as later chapters introduce them (я э ю ч ш ь in Ch.2).
+  get a writing lesson as later chapters introduce them; **я, ч, ы and ь are
+  read-only in Ch. 2**, and э, ю and ш await the chapters that need them.
 
-## Chapter 2 — Introducing yourself *(planned)*
+## Chapter 2 — Introducing yourself *(authored)*
 
-- **меня зовут…** ("I am called…", literally "[they] call me") — the naming
-  construction, and the accusative *меня*.
-- **как вас зовут?** / **как тебя зовут?** — "what's your name?", formal vs
-  informal, cementing вы/ты.
-- **я** (I) · **ты / вы** (you, informal/formal) · **это** ("this is") — the
-  minimal pronouns.
-- **очень приятно** — "very pleasant [to meet you]."
-- **да / нет** revisited as full answers; **меня** and the idea of case previewed.
-- New letters completed: **я** (ya), **э** (e), **ю** (yu), **ч** (ch),
-  **ш** (sh), and the soft sign **ь**.
+**я** — one letter, PIE \**eǵh₂(om)* → Slavic \**azъ*, cousin of *ego / ich / I*;
+pronouns are the least borrowable part of a language → **ты / вы**, the split
+English threw away when *thou* left standard use in the 1600s. *Вы* is polite the
+way French *vous* is, but the routes differ: Russian and French use the
+**2nd-person plural**, German the **3rd-person** (*Sie*), and Spanish **no plural
+at all** (*usted* ← "your grace") — with the *вы*/*vōs* cognate row flagged as
+only half a set, since English *you* and German *ihr* continue \**yūs*
+→ **меня зовут…**, which is literally "**[they] call me**", so the
+sentence contains **no word for "my" and none for "name"**; the "they" is nobody
+(a bare plural verb, like English *they say it'll rain*), and *меня* is not *я*
+but its **object form** — the course's first look at **case** → **как вас
+зовут?**, which asks **how** they call you, not *what*: Russian, French
+(*comment*) and Spanish (*cómo*) all ask about an **action** where English asks
+about a **possession** → **очень приятно**, "very pleasant", whose *приятно* ←
+Slavic *prijati* "to favour" ← PIE \**preyH-* "to love, please" — the root behind
+Russian **приятель** "friend" *and* English **friend**, with **free** most likely
+in the same family ("belonging to the beloved household") → practice, which
+closes on the **zero copula** — scoped to ***очень приятно***, the one sentence
+with no verb at all (Russian *does* have a present-tense *есть*; it just drops
+the linking verb).
+
+Deliberately deferred, so the chapter stays five atoms plus practice: **это**,
+and *да/нет* revisited as full answers. New letters **я**, **ч**, **ы** and the soft sign **ь** are
+flagged read-now-draw-later — the writing track (RU-W01–W05) has taught
+в р с н б д п и е т and not yet reached them.
 
 ## Chapter 3 — Being and having *(planned)*
 

--- a/code/learning/human-languages/russian/session-map.md
+++ b/code/learning/human-languages/russian/session-map.md
@@ -18,9 +18,29 @@ A **session** ≈ one commute leg; each has a ~15–25 min **core block** plus a
 ### Schedule check
 
 Each Chapter-1 word is resurfaced at *N+1* and *N+3* within the chapter; the
-*N+7* and *N+15* resurfacings land in Chapter 2's sessions (tracked there). The
+*N+7* and *N+15* resurfacings land in Chapter 2's sessions, mapped below. The
 four false-friend letters (в р с н) recur in **every** session's read-cold
 drill, so the script is over-learned rather than met once.
 
 The **bonus queue** after each core block re-reads any earlier word for a longer
 drive; on a short leg, stop after the core block.
+
+## Chapter 2 — Introducing yourself
+
+Chapter 1's *N+7* and *N+15* resurfacings land here, as promised above.
+
+| Session | New | Resurfaced | Note |
+|---|---|---|---|
+| **S6** | я | пожалуйста *(N+1)*, спасибо *(N+3)*, да *(N+3)* | **я** is a new letter — read only |
+| **S7** | ты, вы | привет *(N+15)*, я *(N+1)* | **ы**, the hardest vowel; ты/вы against Ch. 1's formality split |
+| **S8** | меня зовут… | здравствуйте *(N+15)*, я *(N+3)*, ты·вы *(N+1)* | the first **case form** (я → меня) |
+| **S9** | как вас зовут? | спасибо *(N+7)*, меня зовут *(N+1)*, ты·вы *(N+3)* | the matched pair; **ч** read only |
+| **S10** | очень приятно | нет *(N+7)*, как вас зовут *(N+1)*, я *(N+7)* | приятно ↔ **friend** |
+| **S11** | — | all five atoms *(N+1 … N+7)* | **RU-C02-practice** (full recap) |
+
+### Schedule check
+
+Chapter 2's own words follow the same *N+1 / N+3* rhythm inside the chapter;
+their *N+7 / N+15* resurfacings will land in Chapter 3. The letters **read but
+not yet written** — я, ы, ч, ь — recur in every session from their introduction
+onward, the same over-learning the four false friends get.


### PR DESCRIPTION
Russian was one of only **two tracks still at Chapter 1** (with Latin); every other track had reached Ch.4 or beyond. Follows the Ch.2 plan the roadmap already set out.

**я** → **ты / вы** → **меня зовут…** → **как вас зовут?** → **очень приятно** → practice.

### The threads

- ***меня зовут*** is literally "**[they] call me**" — no word for *my*, none for *name*, and the "they" is nobody (a bare plural verb, like English *they say it'll rain*). It's the course's **first look at case**.
- Russian asks **how** they call you, not *what* — matching French *comment* and Spanish *cómo*, with **English the odd one out** asking about a possession.
- ***приятно*** ← Slavic *prijati* "to favour" ← PIE \*preyH- — **the same root as English *friend***, and most likely *free*.
- **я** carries the Russian rebuke «Я — последняя буква в алфавите», said to someone who talks about themselves too much.

Also extends **`pronunciation-reference.md`** — **ы** had *no entry* despite being the hardest Russian vowel and the thing *ты*/*вы* turn on — and **`session-map.md`**, which claimed in its own text that Ch.1's N+7/N+15 resurfacings were "tracked" in Ch.2, a promise that was false until this chapter existed.

### Review — 22 findings, then 12 more on the fix pass

**No fabricated cross-reference this round.** Every citation — the RU-C01 lessons, the writing track's exact letter list, the FR/ES "how not what" lessons, the "politeness = plural" claim — was grepped *while writing the sentence*, and all checked out. After five of these across the loop, the discipline finally held.

**What it caught instead was a different failure: claims contradicting other files in the repo.**

- "Russian was the **last** track at Ch.1" — Latin is too
- "**Spanish** arrived at politeness-by-plural" — `ES-C03-tu-usted` and `GE-C02-du-sie` both say *usted* came from a **title** ("your grace"), not a plural
- "Russian has **no word for *is***" — contradicted by `pronunciation-reference.md`, by Ch.1's *нет* = *не + есть*, and by the Ch.3 section of **the very roadmap this PR edits**

I also merged я + ты/вы into **one lesson tagged `PRONOUN-I`**, which would have left Russian with **no `PRONOUN-YOU` node** — dropping the ты/вы split out of a cross-language join 14 other lessons take part in, and which the app feature I shipped in #8739 consumes. Split into two.

**And the fix pass introduced its own errors**, which is why it got reviewed too: I **invented a Russian proverb and inverted its meaning** (« Я — последняя буква » is a *rebuke*, not a compliment about modesty), left "Four lessons" after the split made it five, pointed "the last row" at the wrong row, and left "is" in two table cells the new paragraph directly retracts.

### Checks

- Suite **38/38**; retired-tag sweep **0**
- All concept tags **canonical** — no taxonomy entries needed; `CH2-PRACTICE` already in the note's label list
- `sounds:` ids from the track's own reference (added `yery-vowel`)
- Markdown only, nothing outside `code/learning/human-languages/russian/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)