### PR TITLE
feat(spice): shape BJT base-emitter depletion capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT base-emitter depletion shaping** — BJT model cards now accept
+  `VJE`/`PE` junction potential and `MJE`/`ME` grading coefficient parameters
+  and apply them to `CJE` in AC and transient analysis, matching Rust and
+  TypeScript. The supported-parameter catalog now contains 86 canonical rows.
+
 - **BJT reverse emission coefficient** — BJT model cards now accept `NR` and
   apply it to reverse base-collector diffusion charge in AC and transient
   analysis, matching Rust and TypeScript. The supported-parameter catalog now

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -214,7 +214,9 @@ BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
-base-collector diffusion capacitance in AC and transient analysis.
+base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
+(default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
+depletion capacitance using the Berkeley default `FC=0.5` continuation.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -619,6 +619,8 @@ class BJT:
     Vaf: float = 0.0        # forward Early voltage (V); 0 means infinite
     Nf: float = 1.0         # forward emission coefficient
     Nr: float = 1.0         # reverse emission coefficient
+    Vje: float = 0.75       # base-emitter junction potential (V)
+    Mje: float = 0.33       # base-emitter grading coefficient
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8737,9 +8737,21 @@ def _bjt_junction_transconductance(el: BJT, voltage: float, emission_coefficient
 def _bjt_charge_dynamic_capacitance(el: BJT, state_kind: str, voltage: float) -> float:
     if state_kind == "be":
         conductance = _bjt_junction_transconductance(el, voltage, el.Nf)
-        return el.Cje + el.Tf * conductance
+        return _bjt_base_emitter_depletion_capacitance(el, voltage) + el.Tf * conductance
     conductance = _bjt_junction_transconductance(el, voltage, el.Nr)
     return el.Cjc + el.Tr * conductance
+
+
+def _bjt_base_emitter_depletion_capacitance(el: BJT, voltage: float) -> float:
+    if el.Cje <= 0.0 or el.Mje == 0.0:
+        return el.Cje
+    normalized_voltage = voltage / el.Vje
+    coefficient = 0.5
+    if normalized_voltage < coefficient:
+        return el.Cje / ((1.0 - normalized_voltage) ** el.Mje)
+    transition_scale = (1.0 - coefficient) ** (1.0 + el.Mje)
+    continuation = 1.0 - coefficient * (1.0 + el.Mje) + el.Mje * normalized_voltage
+    return el.Cje * continuation / transition_scale
 
 
 def _bjt_charge_state_specs(el: BJT) -> list[tuple[str, str, str, str]]:
@@ -9156,6 +9168,10 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT forward emission coefficient must be finite and positive")
     if not math.isfinite(el.Nr) or el.Nr <= 0.0:
         raise ValueError(f"{el.name}: BJT reverse emission coefficient must be finite and positive")
+    if not math.isfinite(el.Vje) or el.Vje <= 0.0:
+        raise ValueError(f"{el.name}: BJT base-emitter junction potential must be finite and positive")
+    if not math.isfinite(el.Mje) or not 0.0 <= el.Mje < 1.0:
+        raise ValueError(f"{el.name}: BJT base-emitter grading coefficient must be finite and in [0, 1)")
 
 
 # ---------------------------------------------------------------------------
@@ -12388,7 +12404,9 @@ def _stamp_ac(
         g_pi: float = base_gm / el.beta_f
         diffusion_capacitance = el.Tf * gm_b
         reverse_diffusion_capacitance = el.Tr * gm_reverse
-        y_be = g_pi + 1j * omega * (el.Cje + diffusion_capacitance)
+        y_be = g_pi + 1j * omega * (
+            _bjt_base_emitter_depletion_capacitance(el, Vjunc) + diffusion_capacitance
+        )
         y_bc = 1j * omega * (el.Cjc + reverse_diffusion_capacitance)
         _stamp_g_c(G, node_to_idx, el.collector, el.emitter, output_conductance + 0j)
 
@@ -13876,6 +13894,9 @@ def sens_dc(
                     Eg=el.Eg,
                     Vaf=el.Vaf,
                     Nf=el.Nf,
+                    Nr=el.Nr,
+                    Vje=el.Vje,
+                    Mje=el.Mje,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -13896,6 +13917,9 @@ def sens_dc(
                     Eg=el.Eg,
                     Vaf=el.Vaf,
                     Nf=el.Nf,
+                    Nr=el.Nr,
+                    Vje=el.Vje,
+                    Mje=el.Mje,
                 ),
             )
 
@@ -14126,6 +14150,9 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Eg=el.Eg,
             Vaf=el.Vaf,
             Nf=el.Nf,
+            Nr=el.Nr,
+            Vje=el.Vje,
+            Mje=el.Mje,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (12, 21, 5, 4),
-    "PNP": (12, 21, 5, 4),
+    "NPN": (14, 25, 7, 4),
+    "PNP": (14, 25, 7, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -376,6 +376,10 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "VA": "VAF",
     "NF": "NF",
     "NR": "NR",
+    "VJE": "VJE",
+    "PE": "VJE",
+    "MJE": "MJE",
+    "ME": "MJE",
 }
 
 _JFET_PARAMETER_ALIASES: dict[str, str] = {
@@ -905,6 +909,8 @@ def bjt_from_model_card(
         Vaf=p.get("VAF", 0.0),
         Nf=p.get("NF", 1.0),
         Nr=p.get("NR", 1.0),
+        Vje=p.get("VJE", 0.75),
+        Mje=p.get("MJE", 0.33),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 82
+    assert len(coverage) == 86
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 82
+    assert len(records) == 86
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,17 +501,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 82
-    assert report.expected_canonical_parameter_count == 82
-    assert report.accepted_name_count == 132
-    assert report.aliased_parameter_count == 37
+    assert report.canonical_parameter_count == 86
+    assert report.expected_canonical_parameter_count == 86
+    assert report.accepted_name_count == 140
+    assert report.aliased_parameter_count == 41
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t82\t82\t132\t37\t4\t0"
+        "true\t7\t7\t86\t86\t140\t41\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,9 +539,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 81
-    assert report.accepted_name_count == 129
-    assert report.aliased_parameter_count == 36
+    assert report.canonical_parameter_count == 85
+    assert report.accepted_name_count == 137
+    assert report.aliased_parameter_count == 40
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t81\t82\t129\t36\t4\t4\n"
+        "false\t7\t7\t85\t86\t137\t40\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2, "NR": 1.3}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2, "NR": 1.3}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
@@ -659,6 +659,8 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Vaf == pytest.approx(80.0)
     assert bjt_model.Nf == pytest.approx(1.2)
     assert bjt_model.Nr == pytest.approx(1.3)
+    assert bjt_model.Vje == pytest.approx(0.8)
+    assert bjt_model.Mje == pytest.approx(0.4)
 
     jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -1516,6 +1518,23 @@ def test_transient_bjt_base_emitter_capacitance_slows_base_current_step() -> Non
     assert charged_first < uncharged_first
 
 
+def test_transient_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() -> None:
+    def stepped_base_voltage(mje: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vdrive",
+            "in",
+            "0",
+            -1.0,
+            waveform=PwlWaveform(((0.0, -1.0), (1.0e-9, -1.0), (2.0e-9, 0.0), (5.0e-9, 0.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "base", 1000.0))
+        circuit.add(BJT("Q1", collector="0", base="base", emitter="0", Cje=1.0e-12, Vje=0.75, Mje=mje))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler").points[2].node_voltages["base"]
+
+    assert stepped_base_voltage(0.5) > stepped_base_voltage(0.0)
+
+
 def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> None:
     def run(forward_transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -2228,7 +2247,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2240,6 +2259,8 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Vaf == pytest.approx(80.0)
     assert expanded.Nf == pytest.approx(1.2)
     assert expanded.Nr == pytest.approx(1.3)
+    assert expanded.Vje == pytest.approx(0.8)
+    assert expanded.Mje == pytest.approx(0.4)
 
 
 def test_branch_current_in_voltage_source():
@@ -2520,6 +2541,20 @@ def test_dc_rejects_invalid_bjt_reverse_emission_coefficient():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Nr=0.0))
     with pytest.raises(ValueError, match="BJT reverse emission coefficient must be finite and positive"):
+        dc_op(circuit)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"Vje": 0.0}, "BJT base-emitter junction potential must be finite and positive"),
+        ({"Mje": 1.0}, "BJT base-emitter grading coefficient must be finite and in \\[0, 1\\)"),
+    ],
+)
+def test_dc_rejects_invalid_bjt_base_emitter_depletion_parameters(kwargs, message):
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", **kwargs))
+    with pytest.raises(ValueError, match=message):
         dc_op(circuit)
 
 
@@ -4147,6 +4182,19 @@ def test_ac_bjt_reverse_emission_coefficient_reduces_collector_diffusion_capacit
         return abs(result.points[0].node_voltages["base"])
 
     assert base_amplitude(2.0) > base_amplitude(1.0)
+
+
+def test_ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias():
+    """BJT Vje/Mje shape Cje under reverse base-emitter bias."""
+    def base_amplitude(mje: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", -1.0, ac=AcSource(1.0)))
+        c.add(Resistor("Rin", "in", "base", 1000.0))
+        c.add(BJT("Q1", collector="0", base="base", emitter="0", Cje=1.0e-6, Vje=0.75, Mje=mje))
+        result = ac_sweep(c, f_start=1000.0, f_stop=1000.0, n_points=1)
+        return abs(result.points[0].node_voltages["base"])
+
+    assert base_amplitude(0.5) > base_amplitude(0.0)
 
 
 def test_ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `VJE`/`PE` base-emitter junction-potential and `MJE`/`ME`
+  grading-coefficient support with bias-shaped `CJE` depletion capacitance in
+  AC and transient analysis, matching Python and TypeScript. The supported-
+  parameter catalog now contains 86 canonical rows.
 - Add BJT model-card `NR` reverse emission-coefficient support to reverse
   base-collector diffusion charge in AC and transient analysis, matching Python
   and TypeScript. The supported-parameter catalog now contains 82 canonical rows.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -131,7 +131,9 @@ BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
-base-collector diffusion capacitance in AC and transient analysis.
+base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
+(default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
+depletion capacitance using the Berkeley default `FC=0.5` continuation.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -418,25 +418,29 @@ fn clone_subckt_element(
             element.gate_source_capacitance,
             element.gate_drain_capacitance,
         )),
-        Element::Bjt(element) => Element::Bjt(Bjt::with_model_and_temperature_parameters(
-            format!("{instance_name}.{}", element.name),
-            map_subckt_node(&element.collector, instance_name, node_map),
-            map_subckt_node(&element.base, instance_name, node_map),
-            map_subckt_node(&element.emitter, instance_name, node_map),
-            element.polarity,
-            element.saturation_current,
-            element.forward_beta,
-            element.thermal_voltage,
-            element.base_emitter_capacitance,
-            element.base_collector_capacitance,
-            element.forward_transit_time,
-            element.reverse_transit_time,
-            element.saturation_current_temperature_exponent,
-            element.energy_gap_electron_volts,
-            element.forward_early_voltage,
-            element.forward_emission_coefficient,
-            element.reverse_emission_coefficient,
-        )),
+        Element::Bjt(element) => {
+            Element::Bjt(Bjt::with_model_temperature_and_depletion_parameters(
+                format!("{instance_name}.{}", element.name),
+                map_subckt_node(&element.collector, instance_name, node_map),
+                map_subckt_node(&element.base, instance_name, node_map),
+                map_subckt_node(&element.emitter, instance_name, node_map),
+                element.polarity,
+                element.saturation_current,
+                element.forward_beta,
+                element.thermal_voltage,
+                element.base_emitter_capacitance,
+                element.base_collector_capacitance,
+                element.forward_transit_time,
+                element.reverse_transit_time,
+                element.saturation_current_temperature_exponent,
+                element.energy_gap_electron_volts,
+                element.forward_early_voltage,
+                element.forward_emission_coefficient,
+                element.reverse_emission_coefficient,
+                element.base_emitter_junction_potential,
+                element.base_emitter_grading_coefficient,
+            ))
+        }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.drain, instance_name, node_map),
@@ -2843,6 +2847,8 @@ pub struct Bjt {
     pub forward_early_voltage: f64,
     pub forward_emission_coefficient: f64,
     pub reverse_emission_coefficient: f64,
+    pub base_emitter_junction_potential: f64,
+    pub base_emitter_grading_coefficient: f64,
 }
 
 impl Bjt {
@@ -2923,6 +2929,51 @@ impl Bjt {
         forward_emission_coefficient: f64,
         reverse_emission_coefficient: f64,
     ) -> Self {
+        Self::with_model_temperature_and_depletion_parameters(
+            name,
+            collector,
+            base,
+            emitter,
+            polarity,
+            saturation_current,
+            forward_beta,
+            thermal_voltage,
+            base_emitter_capacitance,
+            base_collector_capacitance,
+            forward_transit_time,
+            reverse_transit_time,
+            saturation_current_temperature_exponent,
+            energy_gap_electron_volts,
+            forward_early_voltage,
+            forward_emission_coefficient,
+            reverse_emission_coefficient,
+            0.75,
+            0.33,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_temperature_and_depletion_parameters(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+        polarity: BjtPolarity,
+        saturation_current: f64,
+        forward_beta: f64,
+        thermal_voltage: f64,
+        base_emitter_capacitance: f64,
+        base_collector_capacitance: f64,
+        forward_transit_time: f64,
+        reverse_transit_time: f64,
+        saturation_current_temperature_exponent: f64,
+        energy_gap_electron_volts: f64,
+        forward_early_voltage: f64,
+        forward_emission_coefficient: f64,
+        reverse_emission_coefficient: f64,
+        base_emitter_junction_potential: f64,
+        base_emitter_grading_coefficient: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             collector: collector.into(),
@@ -2941,6 +2992,8 @@ impl Bjt {
             forward_early_voltage,
             forward_emission_coefficient,
             reverse_emission_coefficient,
+            base_emitter_junction_potential,
+            base_emitter_grading_coefficient,
         }
     }
 }
@@ -3331,8 +3384,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 12, 21, 5, 4),
-    (ModelCardKind::Pnp, 12, 21, 5, 4),
+    (ModelCardKind::Npn, 14, 25, 7, 4),
+    (ModelCardKind::Pnp, 14, 25, 7, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3380,6 +3433,10 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("VA", "VAF"),
     ("NF", "NF"),
     ("NR", "NR"),
+    ("VJE", "VJE"),
+    ("PE", "VJE"),
+    ("MJE", "MJE"),
+    ("ME", "MJE"),
 ];
 const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("BETA", "BETA"),
@@ -4019,7 +4076,7 @@ pub fn bjt_from_model_card(
         ModelCardKind::Pnp => BjtPolarity::Pnp,
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
-    Ok(Bjt::with_model_and_temperature_parameters(
+    Ok(Bjt::with_model_temperature_and_depletion_parameters(
         name,
         collector,
         base,
@@ -4037,6 +4094,8 @@ pub fn bjt_from_model_card(
         model_card_value(model, "VAF", 0.0),
         model_card_value(model, "NF", 1.0),
         model_card_value(model, "NR", 1.0),
+        model_card_value(model, "VJE", 0.75),
+        model_card_value(model, "MJE", 0.33),
     ))
 }
 
@@ -22364,7 +22423,9 @@ fn stamp_ac_bjt_small_signal(
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let gpi = Complex::new(
         base_gm / bjt.forward_beta,
-        omega * (bjt.base_emitter_capacitance + diffusion_capacitance),
+        omega
+            * (bjt_base_emitter_depletion_capacitance(bjt, junction_voltage)
+                + diffusion_capacitance),
     );
     let ybc = Complex::new(
         0.0,
@@ -22972,7 +23033,8 @@ fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: 
         BjtChargeStateKind::BaseEmitter => {
             let conductance =
                 bjt_junction_transconductance(bjt, voltage, bjt.forward_emission_coefficient);
-            bjt.base_emitter_capacitance + bjt.forward_transit_time * conductance
+            bjt_base_emitter_depletion_capacitance(bjt, voltage)
+                + bjt.forward_transit_time * conductance
         }
         BjtChargeStateKind::BaseCollector => {
             let conductance =
@@ -22980,6 +23042,22 @@ fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: 
             bjt.base_collector_capacitance + bjt.reverse_transit_time * conductance
         }
     }
+}
+
+fn bjt_base_emitter_depletion_capacitance(bjt: &Bjt, voltage: f64) -> f64 {
+    if bjt.base_emitter_capacitance <= 0.0 || bjt.base_emitter_grading_coefficient == 0.0 {
+        return bjt.base_emitter_capacitance;
+    }
+    let normalized_voltage = voltage / bjt.base_emitter_junction_potential;
+    let coefficient = 0.5;
+    if normalized_voltage < coefficient {
+        return bjt.base_emitter_capacitance
+            / (1.0 - normalized_voltage).powf(bjt.base_emitter_grading_coefficient);
+    }
+    let transition_scale = (1.0_f64 - coefficient).powf(1.0 + bjt.base_emitter_grading_coefficient);
+    let continuation = 1.0 - coefficient * (1.0 + bjt.base_emitter_grading_coefficient)
+        + bjt.base_emitter_grading_coefficient * normalized_voltage;
+    bjt.base_emitter_capacitance * continuation / transition_scale
 }
 
 fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec<'_>> {
@@ -23334,6 +23412,22 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "reverse emission coefficient must be finite and positive".to_string(),
+        });
+    }
+    if !bjt.base_emitter_junction_potential.is_finite()
+        || bjt.base_emitter_junction_potential <= 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-emitter junction potential must be finite and positive".to_string(),
+        });
+    }
+    if !bjt.base_emitter_grading_coefficient.is_finite()
+        || !(0.0..1.0).contains(&bjt.base_emitter_grading_coefficient)
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-emitter grading coefficient must be finite and in [0, 1)".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -907,6 +907,49 @@ fn ac_bjt_reverse_emission_coefficient_reduces_base_collector_diffusion_capacita
 }
 
 #[test]
+fn ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() {
+    fn base_amplitude(grading_coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", -1.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Bjt(
+            Bjt::with_model_temperature_and_depletion_parameters(
+                "Q1",
+                "0",
+                "base",
+                "0",
+                BjtPolarity::Npn,
+                1.0e-14,
+                100.0,
+                0.02585,
+                1.0e-6,
+                0.0,
+                0.0,
+                0.0,
+                3.0,
+                1.11,
+                0.0,
+                1.0,
+                1.0,
+                0.75,
+                grading_coefficient,
+            ),
+        ));
+
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 1).unwrap()[0]
+            .voltage("base")
+            .unwrap()
+            .abs()
+    }
+
+    assert!(base_amplitude(0.5) > base_amplitude(0.0));
+}
+
+#[test]
 fn ac_mosfet_common_source_suppresses_dc_supplies_without_ac_spec() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 82);
+    assert_eq!(coverage.len(), 86);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 82);
+    assert_eq!(records.len(), 86);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 82);
-    assert_eq!(report.expected_canonical_parameter_count, 82);
-    assert_eq!(report.accepted_name_count, 132);
-    assert_eq!(report.aliased_parameter_count, 37);
+    assert_eq!(report.canonical_parameter_count, 86);
+    assert_eq!(report.expected_canonical_parameter_count, 86);
+    assert_eq!(report.accepted_name_count, 140);
+    assert_eq!(report.aliased_parameter_count, 41);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t82\t82\t132\t37\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t86\t86\t140\t41\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,9 +235,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 81);
-    assert_eq!(report.accepted_name_count, 129);
-    assert_eq!(report.aliased_parameter_count, 36);
+    assert_eq!(report.canonical_parameter_count, 85);
+    assert_eq!(report.accepted_name_count, 137);
+    assert_eq!(report.aliased_parameter_count, 40);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t81\t82\t129\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t85\t86\t137\t40\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -433,6 +433,8 @@ fn model_card_aliases_build_device_instances() {
             ("VA", 80.0),
             ("NF", 1.2),
             ("NR", 1.3),
+            ("PE", 0.8),
+            ("ME", 0.4),
         ],
     )
     .unwrap();
@@ -444,6 +446,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
     assert_close(*bjt_card.parameters.get("NF").unwrap(), 1.2);
     assert_close(*bjt_card.parameters.get("NR").unwrap(), 1.3);
+    assert_close(*bjt_card.parameters.get("VJE").unwrap(), 0.8);
+    assert_close(*bjt_card.parameters.get("MJE").unwrap(), 0.4);
     assert_eq!(bjt_model.polarity, BjtPolarity::Npn);
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
@@ -452,6 +456,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_early_voltage, 80.0);
     assert_close(bjt_model.forward_emission_coefficient, 1.2);
     assert_close(bjt_model.reverse_emission_coefficient, 1.3);
+    assert_close(bjt_model.base_emitter_junction_potential, 0.8);
+    assert_close(bjt_model.base_emitter_grading_coefficient, 0.4);
 
     let jfet_card = normalize_model_card(
         "Jn",
@@ -1348,7 +1354,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_bjt_model() {
-    let bjt = Bjt::with_model_and_temperature_parameters(
+    let bjt = Bjt::with_model_temperature_and_depletion_parameters(
         "Qcell",
         "c",
         "b",
@@ -1366,6 +1372,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         80.0,
         1.2,
         1.3,
+        0.8,
+        0.4,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1396,6 +1404,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.forward_early_voltage, 80.0);
     assert_close(expanded.forward_emission_coefficient, 1.2);
     assert_close(expanded.reverse_emission_coefficient, 1.3);
+    assert_close(expanded.base_emitter_junction_potential, 0.8);
+    assert_close(expanded.base_emitter_grading_coefficient, 0.4);
 }
 
 #[test]
@@ -2120,6 +2130,48 @@ fn dc_rejects_invalid_bjt_reverse_emission_coefficient() {
     assert!(error
         .to_string()
         .contains("reverse emission coefficient must be finite and positive"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_base_emitter_depletion_parameters() {
+    for (junction_potential, grading_coefficient, message) in [
+        (
+            0.0,
+            0.33,
+            "base-emitter junction potential must be finite and positive",
+        ),
+        (
+            0.75,
+            1.0,
+            "base-emitter grading coefficient must be finite and in [0, 1)",
+        ),
+    ] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Bjt(
+            Bjt::with_model_temperature_and_depletion_parameters(
+                "Qbad",
+                "c",
+                "b",
+                "0",
+                BjtPolarity::Npn,
+                1.0e-14,
+                100.0,
+                0.02585,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                3.0,
+                1.11,
+                0.0,
+                1.0,
+                1.0,
+                junction_potential,
+                grading_coefficient,
+            ),
+        ));
+        assert!(dc_op(&circuit).unwrap_err().to_string().contains(message));
+    }
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -524,6 +524,56 @@ fn transient_bjt_base_emitter_capacitance_slows_base_current_step() {
 }
 
 #[test]
+fn transient_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() {
+    fn stepped_base_voltage(grading_coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vdrive",
+            "in",
+            "0",
+            -1.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, -1.0),
+                (1.0e-9, -1.0),
+                (2.0e-9, 0.0),
+                (5.0e-9, 0.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Bjt(
+            Bjt::with_model_temperature_and_depletion_parameters(
+                "Q1",
+                "0",
+                "base",
+                "0",
+                BjtPolarity::Npn,
+                1.0e-14,
+                100.0,
+                0.02585,
+                1.0e-12,
+                0.0,
+                0.0,
+                0.0,
+                3.0,
+                1.11,
+                0.0,
+                1.0,
+                1.0,
+                0.75,
+                grading_coefficient,
+            ),
+        ));
+        transient(&circuit, 1.0e-9, 5.0e-9).unwrap()[1]
+            .voltage("base")
+            .unwrap()
+    }
+
+    assert!(stepped_base_voltage(0.5) > stepped_base_voltage(0.0));
+}
+
+#[test]
 fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
     fn run(forward_transit_time: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `VJE`/`PE` base-emitter junction-potential and `MJE`/`ME`
+  grading-coefficient support with bias-shaped `CJE` depletion capacitance in
+  AC and transient analysis, matching Python and Rust. The supported-parameter
+  catalog now contains 86 canonical rows.
 - Add BJT model-card `NR` reverse emission-coefficient support to reverse
   base-collector diffusion charge in AC and transient analysis, matching Python
   and Rust. The supported-parameter catalog now contains 82 canonical rows.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -201,7 +201,9 @@ BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
-base-collector diffusion capacitance in AC and transient analysis.
+base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
+(default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
+depletion capacitance using the Berkeley default `FC=0.5` continuation.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1715,6 +1715,8 @@ export interface Bjt {
   readonly forwardEarlyVoltage: number;
   readonly forwardEmissionCoefficient: number;
   readonly reverseEmissionCoefficient: number;
+  readonly baseEmitterJunctionPotential: number;
+  readonly baseEmitterGradingCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1992,8 +1994,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [12, 21, 5, 4],
-  PNP: [12, 21, 5, 4],
+  NPN: [14, 25, 7, 4],
+  PNP: [14, 25, 7, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3583,7 +3585,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7741,6 +7743,8 @@ export function bjt(
   forwardEarlyVoltage = 0.0,
   forwardEmissionCoefficient = 1.0,
   reverseEmissionCoefficient = 1.0,
+  baseEmitterJunctionPotential = 0.75,
+  baseEmitterGradingCoefficient = 0.33,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7761,6 +7765,8 @@ export function bjt(
     forwardEarlyVoltage,
     forwardEmissionCoefficient,
     reverseEmissionCoefficient,
+    baseEmitterJunctionPotential,
+    baseEmitterGradingCoefficient,
   };
 }
 
@@ -7868,6 +7874,10 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   VA: "VAF",
   NF: "NF",
   NR: "NR",
+  VJE: "VJE",
+  PE: "VJE",
+  MJE: "MJE",
+  ME: "MJE",
 };
 
 const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8369,6 +8379,8 @@ export function bjtFromModelCard(
     p.VAF ?? 0.0,
     p.NF ?? 1.0,
     p.NR ?? 1.0,
+    p.VJE ?? 0.75,
+    p.MJE ?? 0.33,
   );
 }
 
@@ -19361,7 +19373,8 @@ function bjtChargeDynamicCapacitance(
       voltage,
       element.forwardEmissionCoefficient,
     );
-    return element.baseEmitterCapacitance + element.forwardTransitTime * conductance;
+    return bjtBaseEmitterDepletionCapacitance(element, voltage) +
+      element.forwardTransitTime * conductance;
   }
   const conductance = bjtJunctionTransconductance(
     element,
@@ -19369,6 +19382,23 @@ function bjtChargeDynamicCapacitance(
     element.reverseEmissionCoefficient,
   );
   return element.baseCollectorCapacitance + element.reverseTransitTime * conductance;
+}
+
+function bjtBaseEmitterDepletionCapacitance(element: Bjt, voltage: number): number {
+  if (element.baseEmitterCapacitance <= 0.0 || element.baseEmitterGradingCoefficient === 0.0) {
+    return element.baseEmitterCapacitance;
+  }
+  const normalizedVoltage = voltage / element.baseEmitterJunctionPotential;
+  const coefficient = 0.5;
+  if (normalizedVoltage < coefficient) {
+    return element.baseEmitterCapacitance /
+      ((1.0 - normalizedVoltage) ** element.baseEmitterGradingCoefficient);
+  }
+  const transitionScale = (1.0 - coefficient) **
+    (1.0 + element.baseEmitterGradingCoefficient);
+  const continuation = 1.0 - coefficient * (1.0 + element.baseEmitterGradingCoefficient) +
+    element.baseEmitterGradingCoefficient * normalizedVoltage;
+  return element.baseEmitterCapacitance * continuation / transitionScale;
 }
 
 function bjtChargeStateSpecs(element: Bjt): BjtChargeStateSpec[] {
@@ -19596,6 +19626,14 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.reverseEmissionCoefficient) || element.reverseEmissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "reverse emission coefficient must be finite and positive");
+  }
+  if (!Number.isFinite(element.baseEmitterJunctionPotential) || element.baseEmitterJunctionPotential <= 0.0) {
+    throw invalidElement(element.name, "base-emitter junction potential must be finite and positive");
+  }
+  if (!Number.isFinite(element.baseEmitterGradingCoefficient) ||
+      element.baseEmitterGradingCoefficient < 0.0 ||
+      element.baseEmitterGradingCoefficient >= 1.0) {
+    throw invalidElement(element.name, "base-emitter grading coefficient must be finite and in [0, 1)");
   }
 }
 
@@ -21515,7 +21553,9 @@ function stampAcBjtSmallSignal(
   const reverseDiffusionCapacitance = element.reverseTransitTime * reverseTransconductance;
   const baseEmitterAdmittance = complex(
     junctionConductance,
-    omega * (element.baseEmitterCapacitance + diffusionCapacitance),
+    omega * (
+      bjtBaseEmitterDepletionCapacitance(element, junctionVoltage) + diffusionCapacitance
+    ),
   );
   const baseCollectorAdmittance = complex(
     0.0,

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -605,6 +605,18 @@ describe("acSweep", () => {
     expect(baseAmplitude(2.0)).toBeGreaterThan(baseAmplitude(1.0));
   });
 
+  it("shapes BJT base-emitter depletion capacitance under reverse bias", () => {
+    function baseAmplitude(baseEmitterGradingCoefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", -1.0, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(bjt("Q1", "0", "base", "0", "NPN", 1.0e-14, 100.0, 0.02585, 1.0e-6, 0.0, 0.0, 0.0, 3.0, 1.11, 0.0, 1.0, 1.0, 0.75, baseEmitterGradingCoefficient));
+      return complexAbs(acSweep(circuit, 1_000.0, 1_000.0, 1)[0].voltage("base")!);
+    }
+
+    expect(baseAmplitude(0.5)).toBeGreaterThan(baseAmplitude(0.0));
+  });
+
   it("applies VCVS gain in AC analysis", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vin", "in", "0", 1.0));

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(82);
+    expect(coverage).toHaveLength(86);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(82);
+    expect(records).toHaveLength(86);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 82,
-      expectedCanonicalParameterCount: 82,
-      acceptedNameCount: 132,
-      aliasedParameterCount: 37,
+      canonicalParameterCount: 86,
+      expectedCanonicalParameterCount: 86,
+      acceptedNameCount: 140,
+      aliasedParameterCount: 41,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t82\t82\t132\t37\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t86\t86\t140\t41\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,9 +241,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(81);
-    expect(report.acceptedNameCount).toBe(129);
-    expect(report.aliasedParameterCount).toBe(36);
+    expect(report.canonicalParameterCount).toBe(85);
+    expect(report.acceptedNameCount).toBe(137);
+    expect(report.aliasedParameterCount).toBe(40);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t81\t82\t129\t36\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t85\t86\t137\t40\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -339,9 +339,11 @@ describe("dcOp", () => {
       VA: 80.0,
       NF: 1.2,
       NR: 1.3,
+      PE: 0.8,
+      ME: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2, NR: 1.3 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
@@ -350,6 +352,8 @@ describe("dcOp", () => {
     expectClose(bjtModel.forwardEarlyVoltage, 80.0);
     expectClose(bjtModel.forwardEmissionCoefficient, 1.2);
     expectClose(bjtModel.reverseEmissionCoefficient, 1.3);
+    expectClose(bjtModel.baseEmitterJunctionPotential, 0.8);
+    expectClose(bjtModel.baseEmitterGradingCoefficient, 0.4);
 
     const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
@@ -982,7 +986,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -995,6 +999,8 @@ describe("dcOp", () => {
       expectClose(expanded.forwardEarlyVoltage, 80.0);
       expectClose(expanded.forwardEmissionCoefficient, 1.2);
       expectClose(expanded.reverseEmissionCoefficient, 1.3);
+      expectClose(expanded.baseEmitterJunctionPotential, 0.8);
+      expectClose(expanded.baseEmitterGradingCoefficient, 0.4);
     }
   });
 
@@ -1380,6 +1386,16 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 0.0));
     expect(() => dcOp(circuit)).toThrowError("reverse emission coefficient must be finite and positive");
+  });
+
+  it("rejects invalid BJT base-emitter depletion parameters", () => {
+    const invalidPotential = new Circuit();
+    invalidPotential.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 1.0, 0.0));
+    expect(() => dcOp(invalidPotential)).toThrowError("base-emitter junction potential must be finite and positive");
+
+    const invalidGrading = new Circuit();
+    invalidGrading.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 1.0, 0.75, 1.0));
+    expect(() => dcOp(invalidGrading)).toThrowError("base-emitter grading coefficient must be finite and in [0, 1)");
   });
 
   it("uses MOSFET temperature scaling in common-source drain voltage", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -452,6 +452,29 @@ describe("transient", () => {
     expect(chargedFirst!).toBeLessThan(unchargedFirst!);
   });
 
+  it("shapes BJT base-emitter depletion capacitance during reverse-biased transients", () => {
+    function steppedBaseVoltage(baseEmitterGradingCoefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vdrive",
+        "in",
+        "0",
+        -1.0,
+        new PwlWaveform([
+          [0.0, -1.0],
+          [1.0e-9, -1.0],
+          [2.0e-9, 0.0],
+          [5.0e-9, 0.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(bjt("Q1", "0", "base", "0", "NPN", 1.0e-14, 100.0, 0.02585, 1.0e-12, 0.0, 0.0, 0.0, 3.0, 1.11, 0.0, 1.0, 1.0, 0.75, baseEmitterGradingCoefficient));
+      return transient(circuit, 1.0e-9, 5.0e-9)[1].voltage("base")!;
+    }
+
+    expect(steppedBaseVoltage(0.5)).toBeGreaterThan(steppedBaseVoltage(0.0));
+  });
+
   it("uses BJT forward transit time to hold base charge on turnoff", () => {
     function run(forwardTransitTime: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT reverse emission coefficient.
+1. Cross-language BJT base-emitter depletion-capacitance shaping.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `NR` reverse emission-coefficient model-card support in
-     Rust, Python, and TypeScript.
-   - Apply `NR` to the existing reverse base-collector diffusion-charge path in
-     AC and transient analysis while preserving the full BJT model through
-     hierarchical subcircuit expansion.
-   - Extend the supported-parameter coverage gate from 80 to 82 canonical rows
-     and lock reverse-junction capacitance behavior across all three engines.
+   - Add Berkeley BJT `VJE` / `PE` base-emitter junction-potential and `MJE` /
+     `ME` grading-coefficient model-card support in Rust, Python, and TypeScript.
+   - Shape `CJE` base-emitter depletion capacitance in AC and transient
+     analysis with the continuous Berkeley piecewise law and default `FC=0.5`,
+     while preserving the full BJT model through hierarchical subcircuits.
+   - Extend the supported-parameter coverage gate from 82 to 86 canonical rows
+     and lock reverse-biased base-emitter capacitance behavior in all engines.
 
 ## Completed Slices
 
@@ -3022,6 +3022,13 @@ the Rust, Python, and TypeScript surfaces together.
      to forward junction current, transconductance, charge, and noise paths.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 80 canonical rows.
+
+222. Cross-language BJT reverse emission coefficient.
+   - Status: completed in PR 8744.
+   - Rust, Python, and TypeScript BJT model cards now accept `NR` and apply it
+     to reverse base-collector diffusion charge in AC and transient analysis.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 82 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add BJT base-emitter junction-potential and grading-coefficient model parameters across Rust, Python, and TypeScript
- accept Berkeley SPICE aliases `VJE`/`PE` and `MJE`/`ME`, with validation and hierarchy preservation
- apply continuous piecewise depletion-capacitance shaping to BJT AC and transient behavior
- advance the model-card coverage gate from 82 to 86 canonical parameters and reconcile the SPICE implementation plan

## Verification
- `cargo test -p spice-engine`
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python spice-engine: 492 passed, 81.39% coverage
- `ruff check` on touched Python sources/tests
- TypeScript spice-engine: 277 passed
- `npm run build`
- `git diff --check`