### PR TITLE
feat(chief): enforce Tier 2 approval assurance

### DIFF
--- a/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
@@ -9,6 +9,8 @@
   session, returning typed Rust handler results and policy rejections.
 - Allow reviewed host profiles to install centralized D18D policy engines and
   route scoped approval grants through active host ownership boundaries.
+- Enforce challenge binding and biometric-strength assurance for Tier 2 host
+  calls before dispatching their profile-owned handlers.
 
 ## Unreleased
 

--- a/code/packages/rust/chief-of-staff-host-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/README.md
@@ -64,7 +64,10 @@ Host profiles can install a centralized D18D policy before activation with
 the matching approval-aware invocation path, so a scoped `ToolApprovalGrant`
 travels through the same owner routing and policy engine as an ordinary call.
 Approval tokens cannot bypass an unknown host, unowned tool, profile ceiling,
-or capability check.
+or capability check. Profiles may also require approval at a privilege
+threshold. The host emits a canonical challenge for pending calls, rejects weak
+or unbound assertions, requires biometric assurance for Tier 2 and a hardware
+key for Tier 3, and records the accepted assurance in the execution journal.
 
 An orchestrator profile has this shape:
 
@@ -80,7 +83,7 @@ An orchestrator profile has this shape:
     },
     {
       "host_id": "file_writer",
-      "max_tier": "tier1",
+      "max_tier": "tier2",
       "allowed_tools": ["file.write_text"],
       "capabilities": ["filesystem_write"]
     }

--- a/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
@@ -1153,9 +1153,9 @@ fn validate_label(field: &str, value: &str) -> Result<(), HostRuntimeError> {
 mod tests {
     use super::*;
     use chief_of_staff_tool_api::{
-        ApprovalState, JsonSchema, RequestedBy, ToolConcurrency, ToolHandlerOutput,
-        ToolIdempotency, ToolInvocationRequest, ToolPolicyProfile, ToolSideEffects, ToolStability,
-        ToolStreaming,
+        ApprovalAssurance, ApprovalState, JsonSchema, RequestedBy, ToolApprovalChallenge,
+        ToolConcurrency, ToolHandlerOutput, ToolIdempotency, ToolInvocationRequest,
+        ToolPolicyProfile, ToolSideEffects, ToolStability, ToolStreaming,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
     use generic_job_protocol::JobResult;
@@ -1184,7 +1184,7 @@ mod tests {
         },
         {
           "host_id": "writer_host",
-          "max_tier": "tier1",
+          "max_tier": "tier2",
           "allowed_tools": ["demo.write"],
           "capabilities": ["demo_write"]
         }
@@ -1558,8 +1558,9 @@ while (true) {
                 },
             )
             .unwrap();
-        let mut write_definition = definition("demo.write", PrivilegeTier::Tier1, &["demo_write"]);
+        let mut write_definition = definition("demo.write", PrivilegeTier::Tier2, &["demo_write"]);
         write_definition.side_effects = ToolSideEffects::Write;
+        let challenge_definition = write_definition.clone();
         runtime
             .register_handler(write_definition, |_arguments, _context| {
                 Ok(ToolHandlerOutput::new(JsonValue::String(
@@ -1571,7 +1572,8 @@ while (true) {
             .set_host_policy(
                 "writer_host",
                 ToolPolicyProfile::allow_all()
-                    .with_approval_required_for(vec![ToolSideEffects::Write]),
+                    .with_approval_required_for(vec![ToolSideEffects::Write])
+                    .with_approval_required_at_or_above(PrivilegeTier::Tier2),
             )
             .unwrap();
         let active = runtime.activate().unwrap();
@@ -1581,12 +1583,23 @@ while (true) {
         assert_eq!(pending.record.approval_state, ApprovalState::Pending);
         assert!(!pending.result.ok);
 
-        let grant =
-            ToolApprovalGrant::new("call_1", "demo.write", "user_1", 100).with_expires_at(200);
+        let challenge =
+            ToolApprovalChallenge::for_invocation(&challenge_definition, &write_request);
+        let weak = challenge.grant("user_1", 100, ApprovalAssurance::ExplicitConsent);
+        let denied = active
+            .invoke_with_events_with_approval(&write_request, &weak)
+            .unwrap();
+        assert_eq!(denied.record.approval_state, ApprovalState::Denied);
+
+        let grant = challenge.grant("user_1", 100, ApprovalAssurance::Biometric);
         let approved = active
             .invoke_with_events_with_approval(&write_request, &grant)
             .unwrap();
         assert_eq!(approved.record.approval_state, ApprovalState::Granted);
+        assert_eq!(
+            approved.record.approval_assurance,
+            Some(ApprovalAssurance::Biometric)
+        );
         assert_eq!(
             approved.result.output,
             Some(JsonValue::String("written".to_string()))

--- a/code/packages/rust/chief-of-staff-tool-api/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-api/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Added canonical approval challenges and explicit-consent, biometric, and
+  hardware-key assurance levels. Tier-aware policy can now require approval at
+  a privilege threshold, and Tier 2+ grants must match the active challenge
+  before a handler can run.
+
 ## [0.1.0] - 2026-05-08
 
 ### Added

--- a/code/packages/rust/chief-of-staff-tool-api/README.md
+++ b/code/packages/rust/chief-of-staff-tool-api/README.md
@@ -24,8 +24,9 @@ The crate intentionally stops at the contract layer:
   runtime parity definitions
 - a deterministic in-memory registry for runtimes and tests
 - explicit policy decisions for permission, tier, and approval gates
-- explicit approval grants that let a previously gated invocation proceed
-  without weakening permission or tier denials
+- user-visible approval challenges plus assurance-bearing, challenge-bound
+  grants; Tier 2 requires biometric assurance and Tier 3 requires a hardware
+  key without weakening permission or tier denials
 - a deterministic in-memory runtime that validates, invokes handlers, emits
   ordered events, applies policy before handler execution, and returns canonical
   `ToolResult` records

--- a/code/packages/rust/chief-of-staff-tool-api/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-api/src/lib.rs
@@ -2423,8 +2423,7 @@ impl ToolResult {
 // ============================================================================
 
 /// Sort order for tool invocation request queries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ToolInvocationSort {
     #[default]
     RequestedAtAsc,
@@ -2432,7 +2431,6 @@ pub enum ToolInvocationSort {
     ToolIdThenRequestedAt,
     CallId,
 }
-
 
 /// Query options for selecting pending or persisted invocation requests.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -2533,8 +2531,7 @@ where
 }
 
 /// Sort order for durable tool call record queries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ToolCallRecordSort {
     #[default]
     StartedAtAsc,
@@ -2543,7 +2540,6 @@ pub enum ToolCallRecordSort {
     StatusThenToolId,
     CallId,
 }
-
 
 /// Query options for selecting durable tool call lifecycle records.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -2644,8 +2640,7 @@ where
 }
 
 /// Sort order for tool event stream queries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ToolEventSort {
     #[default]
     TimeAsc,
@@ -2653,7 +2648,6 @@ pub enum ToolEventSort {
     SequenceAsc,
     SequenceDesc,
 }
-
 
 /// Query options for selecting events from a tool execution stream.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -2739,15 +2733,13 @@ where
 }
 
 /// Sort order for terminal tool result queries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ToolResultSort {
     #[default]
     CallId,
     RunMsAsc,
     RunMsDesc,
 }
-
 
 /// Query options for selecting terminal tool results.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -3281,6 +3273,43 @@ pub enum ApprovalState {
     Expired,
 }
 
+/// Strength of the user authentication attached to an approval grant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ApprovalAssurance {
+    /// An explicit user confirmation without strong re-authentication.
+    ExplicitConsent,
+    /// A biometric assertion produced by a trusted device boundary.
+    Biometric,
+    /// A hardware-backed assertion suitable for the highest privilege tier.
+    HardwareKey,
+}
+
+impl ApprovalAssurance {
+    /// Stable wire label for audit and user-facing summaries.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ExplicitConsent => "explicit_consent",
+            Self::Biometric => "biometric",
+            Self::HardwareKey => "hardware_key",
+        }
+    }
+
+    /// Minimum assurance required by one Chief privilege tier.
+    pub fn required_for(tier: PrivilegeTier) -> Self {
+        match tier {
+            PrivilegeTier::Tier0 | PrivilegeTier::Tier1 => Self::ExplicitConsent,
+            PrivilegeTier::Tier2 => Self::Biometric,
+            PrivilegeTier::Tier3 => Self::HardwareKey,
+        }
+    }
+}
+
+impl Display for ApprovalAssurance {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl ApprovalState {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -3312,6 +3341,10 @@ pub struct ToolApprovalGrant {
     pub granted_by: String,
     pub granted_at: TimestampMs,
     pub expires_at: Option<TimestampMs>,
+    /// Challenge this grant answers. Tier 2+ grants must be challenge-bound.
+    pub challenge_id: Option<String>,
+    /// Authentication strength asserted by the trusted approval surface.
+    pub assurance: ApprovalAssurance,
 }
 
 impl ToolApprovalGrant {
@@ -3327,6 +3360,8 @@ impl ToolApprovalGrant {
             granted_by: granted_by.into(),
             granted_at,
             expires_at: None,
+            challenge_id: None,
+            assurance: ApprovalAssurance::ExplicitConsent,
         }
     }
 
@@ -3334,6 +3369,113 @@ impl ToolApprovalGrant {
         self.expires_at = Some(expires_at);
         self
     }
+
+    /// Bind this grant to a specific approval challenge.
+    pub fn with_challenge_id(mut self, challenge_id: impl Into<String>) -> Self {
+        self.challenge_id = Some(challenge_id.into());
+        self
+    }
+
+    /// Attach the authentication assurance supplied by the trusted UI.
+    pub fn with_assurance(mut self, assurance: ApprovalAssurance) -> Self {
+        self.assurance = assurance;
+        self
+    }
+}
+
+/// User-visible approval challenge derived from a validated invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolApprovalChallenge {
+    pub challenge_id: String,
+    pub call_id: String,
+    pub tool_id: ToolId,
+    pub display_name: String,
+    pub required_tier: PrivilegeTier,
+    pub required_assurance: ApprovalAssurance,
+    pub requested_at: TimestampMs,
+    pub expires_at: Option<TimestampMs>,
+}
+
+impl ToolApprovalChallenge {
+    /// Derive the challenge id expected for one call without exposing payloads.
+    pub fn id_for(
+        call_id: impl AsRef<str>,
+        tool_id: impl AsRef<str>,
+        requested_at: TimestampMs,
+    ) -> String {
+        format!(
+            "approval:{}:{}:{}",
+            call_id.as_ref(),
+            tool_id.as_ref(),
+            requested_at
+        )
+    }
+
+    /// Derive the stable challenge shown by the trusted approval surface.
+    pub fn for_invocation(definition: &ToolDefinition, request: &ToolInvocationRequest) -> Self {
+        Self {
+            challenge_id: approval_challenge_id(request),
+            call_id: request.call_id.clone(),
+            tool_id: request.tool_id.clone(),
+            display_name: definition.display_name.clone(),
+            required_tier: definition.required_tier,
+            required_assurance: ApprovalAssurance::required_for(definition.required_tier),
+            requested_at: request.requested_at,
+            expires_at: request.deadline_at,
+        }
+    }
+
+    /// Create a challenge-bound grant after the trusted UI authenticates a user.
+    pub fn grant(
+        &self,
+        granted_by: impl Into<String>,
+        granted_at: TimestampMs,
+        assurance: ApprovalAssurance,
+    ) -> ToolApprovalGrant {
+        let mut grant = ToolApprovalGrant::new(
+            self.call_id.clone(),
+            self.tool_id.clone(),
+            granted_by,
+            granted_at,
+        )
+        .with_challenge_id(self.challenge_id.clone())
+        .with_assurance(assurance);
+        grant.expires_at = self.expires_at;
+        grant
+    }
+
+    fn details(&self) -> JsonValue {
+        JsonValue::Object(vec![
+            (
+                "challenge_id".to_string(),
+                JsonValue::String(self.challenge_id.clone()),
+            ),
+            (
+                "call_id".to_string(),
+                JsonValue::String(self.call_id.clone()),
+            ),
+            (
+                "tool_id".to_string(),
+                JsonValue::String(self.tool_id.clone()),
+            ),
+            (
+                "display_name".to_string(),
+                JsonValue::String(self.display_name.clone()),
+            ),
+            (
+                "required_tier".to_string(),
+                JsonValue::String(self.required_tier.as_str().to_string()),
+            ),
+            (
+                "required_assurance".to_string(),
+                JsonValue::String(self.required_assurance.as_str().to_string()),
+            ),
+        ])
+    }
+}
+
+fn approval_challenge_id(request: &ToolInvocationRequest) -> String {
+    ToolApprovalChallenge::id_for(&request.call_id, &request.tool_id, request.requested_at)
 }
 
 /// Durable summary of one tool call lifecycle.
@@ -3346,6 +3488,7 @@ pub struct ToolCallRecord {
     pub completed_at: Option<TimestampMs>,
     pub lock_scope: Option<String>,
     pub approval_state: ApprovalState,
+    pub approval_assurance: Option<ApprovalAssurance>,
     pub metrics: ToolMetrics,
 }
 
@@ -3359,6 +3502,7 @@ impl ToolCallRecord {
             completed_at: None,
             lock_scope: definition.and_then(|definition| definition.preferred_lock_scope.clone()),
             approval_state: ApprovalState::NotRequired,
+            approval_assurance: None,
             metrics: ToolMetrics::default(),
         }
     }
@@ -3496,8 +3640,7 @@ impl ToolAuditSink for InMemoryToolAuditSink {
 }
 
 /// Sort order for audit read-side queries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ToolAuditRecordSort {
     #[default]
     OriginalOrder,
@@ -3507,7 +3650,6 @@ pub enum ToolAuditRecordSort {
     CompletedAtAsc,
     CompletedAtDesc,
 }
-
 
 /// Storage-neutral query for payload-free audit records.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3769,6 +3911,8 @@ pub struct ToolPolicyProfile {
     pub allowed_capabilities: Vec<String>,
     pub allowed_side_effects: Vec<ToolSideEffects>,
     pub approval_required_side_effects: Vec<ToolSideEffects>,
+    /// Require approval for tools at or above this privilege tier.
+    pub approval_required_at_or_above: Option<PrivilegeTier>,
 }
 
 impl ToolPolicyProfile {
@@ -3783,6 +3927,7 @@ impl ToolPolicyProfile {
                 ToolSideEffects::External,
             ],
             approval_required_side_effects: Vec::new(),
+            approval_required_at_or_above: None,
         }
     }
 
@@ -3792,6 +3937,7 @@ impl ToolPolicyProfile {
             allowed_capabilities: vec!["*".to_string()],
             allowed_side_effects: vec![ToolSideEffects::None, ToolSideEffects::Read],
             approval_required_side_effects: Vec::new(),
+            approval_required_at_or_above: None,
         }
     }
 
@@ -3802,6 +3948,12 @@ impl ToolPolicyProfile {
 
     pub fn with_approval_required_for(mut self, side_effects: Vec<ToolSideEffects>) -> Self {
         self.approval_required_side_effects = side_effects;
+        self
+    }
+
+    /// Require challenge-bound approval for tools at or above `minimum_tier`.
+    pub fn with_approval_required_at_or_above(mut self, minimum_tier: PrivilegeTier) -> Self {
+        self.approval_required_at_or_above = Some(minimum_tier);
         self
     }
 
@@ -3852,10 +4004,15 @@ impl ToolPolicyEngine for ToolPolicyProfile {
         if self
             .approval_required_side_effects
             .contains(&definition.side_effects)
+            || self
+                .approval_required_at_or_above
+                .is_some_and(|minimum_tier| definition.required_tier >= minimum_tier)
         {
             return ToolPolicyDecision::require_approval(format!(
-                "tool side effect '{}' requires approval",
-                definition.side_effects
+                "tool '{}' at {} requires approval with '{}' assurance",
+                definition.tool_id,
+                definition.required_tier,
+                ApprovalAssurance::required_for(definition.required_tier)
             ));
         }
 
@@ -4207,6 +4364,9 @@ pub struct ToolExecutionJournalHealthSummary {
     pub approval_granted_count: usize,
     pub approval_denied_count: usize,
     pub approval_expired_count: usize,
+    pub approval_explicit_consent_count: usize,
+    pub approval_biometric_count: usize,
+    pub approval_hardware_key_count: usize,
     pub terminal_event_count: usize,
     pub terminal_event_mismatch_count: usize,
     pub results_without_terminal_event_count: usize,
@@ -4247,6 +4407,14 @@ impl ToolExecutionJournalHealthSummary {
                 ApprovalState::Granted => summary.approval_granted_count += 1,
                 ApprovalState::Denied => summary.approval_denied_count += 1,
                 ApprovalState::Expired => summary.approval_expired_count += 1,
+            }
+            match record.approval_assurance {
+                Some(ApprovalAssurance::ExplicitConsent) => {
+                    summary.approval_explicit_consent_count += 1
+                }
+                Some(ApprovalAssurance::Biometric) => summary.approval_biometric_count += 1,
+                Some(ApprovalAssurance::HardwareKey) => summary.approval_hardware_key_count += 1,
+                None => {}
             }
         }
 
@@ -4485,10 +4653,12 @@ impl InMemoryToolRuntime {
                 return trace_with_terminal(record, request, Vec::new(), result);
             }
             ToolPolicyOutcome::RequiresApproval => {
+                let challenge = ToolApprovalChallenge::for_invocation(definition, request);
                 if let Some(approval_grant) = approval_grant {
-                    match validate_approval_grant(approval_grant, request) {
+                    match validate_approval_grant(approval_grant, request, definition, &challenge) {
                         Ok(()) => {
                             record.approval_state = ApprovalState::Granted;
+                            record.approval_assurance = Some(approval_grant.assurance);
                         }
                         Err((approval_state, error)) => {
                             let result = ToolResult::failed(request.call_id.clone(), error);
@@ -4504,7 +4674,7 @@ impl InMemoryToolRuntime {
                         ToolCallError {
                             kind: ToolErrorKind::ToolApprovalRequired,
                             message: policy_decision.message,
-                            details: policy_decision.details,
+                            details: challenge.details(),
                         },
                     );
                     record.status = ToolCallStatus::AwaitingApproval;
@@ -4600,6 +4770,8 @@ impl InMemoryToolRuntime {
 fn validate_approval_grant(
     grant: &ToolApprovalGrant,
     request: &ToolInvocationRequest,
+    definition: &ToolDefinition,
+    challenge: &ToolApprovalChallenge,
 ) -> Result<(), (ApprovalState, ToolCallError)> {
     if grant.call_id != request.call_id {
         return Err((
@@ -4623,6 +4795,43 @@ fn validate_approval_grant(
         return Err((
             ApprovalState::Denied,
             approval_error("approval grant is missing granted_by", grant_details(grant)),
+        ));
+    }
+    let required_assurance = ApprovalAssurance::required_for(definition.required_tier);
+    if grant.assurance < required_assurance {
+        return Err((
+            ApprovalState::Denied,
+            approval_error(
+                format!(
+                    "approval assurance '{}' is weaker than required '{}'",
+                    grant.assurance, required_assurance
+                ),
+                challenge.details(),
+            ),
+        ));
+    }
+    if definition.required_tier >= PrivilegeTier::Tier2
+        && grant.challenge_id.as_deref() != Some(challenge.challenge_id.as_str())
+    {
+        return Err((
+            ApprovalState::Denied,
+            approval_error(
+                "Tier 2+ approval grant is not bound to the active challenge",
+                challenge.details(),
+            ),
+        ));
+    }
+    if grant
+        .challenge_id
+        .as_deref()
+        .is_some_and(|challenge_id| challenge_id != challenge.challenge_id)
+    {
+        return Err((
+            ApprovalState::Denied,
+            approval_error(
+                "approval grant challenge_id does not match invocation",
+                challenge.details(),
+            ),
         ));
     }
     if grant
@@ -4664,7 +4873,17 @@ fn grant_details(grant: &ToolApprovalGrant) -> JsonValue {
             "granted_at".to_string(),
             JsonValue::Number(JsonNumber::Integer(grant.granted_at as i64)),
         ),
+        (
+            "assurance".to_string(),
+            JsonValue::String(grant.assurance.as_str().to_string()),
+        ),
     ];
+    if let Some(challenge_id) = &grant.challenge_id {
+        fields.push((
+            "challenge_id".to_string(),
+            JsonValue::String(challenge_id.clone()),
+        ));
+    }
     if let Some(expires_at) = grant.expires_at {
         fields.push((
             "expires_at".to_string(),
@@ -5786,6 +6005,7 @@ mod tests {
             completed_at: None,
             lock_scope: Some("artifact".to_string()),
             approval_state: ApprovalState::NotRequired,
+            approval_assurance: None,
             metrics: ToolMetrics::default(),
         };
         let awaiting_approval = ToolCallRecord {
@@ -5829,7 +6049,8 @@ mod tests {
 
     #[test]
     fn event_queries_filter_terminal_events_and_sequences() {
-        let events = [ToolEvent {
+        let events = [
+            ToolEvent {
                 call_id: "call_1".to_string(),
                 sequence: 0,
                 at: 100,
@@ -5856,7 +6077,8 @@ mod tests {
                 at: 115,
                 kind: ToolEventKind::Completed,
                 payload: JsonValue::Null,
-            }];
+            },
+        ];
 
         let terminal = query_tool_events(
             events.iter(),
@@ -6094,6 +6316,9 @@ mod tests {
                 approval_granted_count: 0,
                 approval_denied_count: 0,
                 approval_expired_count: 0,
+                approval_explicit_consent_count: 0,
+                approval_biometric_count: 0,
+                approval_hardware_key_count: 0,
                 terminal_event_count: 1,
                 terminal_event_mismatch_count: 0,
                 results_without_terminal_event_count: 0,
@@ -6422,6 +6647,79 @@ mod tests {
             ToolErrorKind::ToolApprovalDenied
         );
         assert!(!*called.lock().unwrap());
+    }
+
+    #[test]
+    fn tier2_calls_require_challenge_bound_biometric_assurance() {
+        use std::sync::{Arc, Mutex};
+
+        let called = Arc::new(Mutex::new(false));
+        let called_by_handler = Arc::clone(&called);
+        let policy =
+            ToolPolicyProfile::allow_all().with_approval_required_at_or_above(PrivilegeTier::Tier2);
+        let mut runtime = InMemoryToolRuntime::with_policy(policy);
+        let mut definition = artifact_create_definition();
+        definition.required_tier = PrivilegeTier::Tier2;
+        let challenge_definition = definition.clone();
+        runtime
+            .register_handler(definition, move |_, _| {
+                *called_by_handler.lock().unwrap() = true;
+                Ok(ToolHandlerOutput::new(JsonValue::Object(vec![(
+                    "artifact_ref".to_string(),
+                    JsonValue::String("artifact_1".to_string()),
+                )])))
+            })
+            .unwrap();
+        let request = artifact_create_request();
+
+        let pending = runtime.invoke_with_events(&request);
+        assert_eq!(pending.record.approval_state, ApprovalState::Pending);
+        let challenge = ToolApprovalChallenge::for_invocation(&challenge_definition, &request);
+        assert!(format!("{:?}", pending.result.error.unwrap().details)
+            .contains(&challenge.challenge_id));
+
+        let weak = challenge.grant(
+            "user_1",
+            request.requested_at,
+            ApprovalAssurance::ExplicitConsent,
+        );
+        let denied = runtime.invoke_with_events_with_approval(&request, &weak);
+        assert_eq!(denied.record.approval_state, ApprovalState::Denied);
+        assert!(denied
+            .result
+            .error
+            .unwrap()
+            .message
+            .contains("weaker than required"));
+        assert!(!*called.lock().unwrap());
+
+        let unbound = ToolApprovalGrant::new(
+            request.call_id.clone(),
+            request.tool_id.clone(),
+            "user_1",
+            request.requested_at,
+        )
+        .with_assurance(ApprovalAssurance::Biometric);
+        let unbound_denied = runtime.invoke_with_events_with_approval(&request, &unbound);
+        assert_eq!(unbound_denied.record.approval_state, ApprovalState::Denied);
+        assert!(unbound_denied
+            .result
+            .error
+            .unwrap()
+            .message
+            .contains("not bound"));
+        assert!(!*called.lock().unwrap());
+
+        let biometric =
+            challenge.grant("user_1", request.requested_at, ApprovalAssurance::Biometric);
+        let approved = runtime.invoke_with_events_with_approval(&request, &biometric);
+        assert!(approved.result.ok);
+        assert_eq!(approved.record.approval_state, ApprovalState::Granted);
+        assert_eq!(
+            approved.record.approval_assurance,
+            Some(ApprovalAssurance::Biometric)
+        );
+        assert!(*called.lock().unwrap());
     }
 
     #[test]

--- a/code/packages/rust/weather-agent-e2e/CHANGELOG.md
+++ b/code/packages/rust/weather-agent-e2e/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this package will be documented in this file.
   backend and reopen them into a compact job, host, session, and user summary.
 - Persist approval-blocked calls before returning the job error so denied work
   remains available to a restarted audit reader.
+- Added a Tier 2 scheduled-write mode that rejects weak consent, accepts only a
+  challenge-bound biometric assertion, records the accepted assurance in the
+  journal and user report, and persists denied or granted audit outcomes.
 
 - Initial umbrella-today end-to-end harness that exercises the Chief of Staff
   actor, D18A store, D18C job, D18D tool, read/write separation, and

--- a/code/packages/rust/weather-agent-e2e/README.md
+++ b/code/packages/rust/weather-agent-e2e/README.md
@@ -17,11 +17,15 @@ three isolated host profiles with independent capability sets. The profile must
 be complete and active before the first tool invocation. The writer host applies
 a centralized policy that requires a call-scoped user approval before filesystem
 output; an absent grant leaves the call pending and the report unwritten.
+The same scheduled job can raise the writer to Tier 2: the pending result
+contains the trusted UI challenge, explicit consent is rejected before the file
+handler, and only a challenge-bound biometric assertion completes the run.
 
 A successful run now emits a validated D18C `JobRunReceipt` plus a compact
 `UmbrellaUserReport`. The receipt points at the stored report artifact, while the
 user report carries the recommendation, completion time, approval state, and
-journal invocation count. This makes umbrella-today a reusable Chief job with a
+journal invocation count. It also reports the required tier and accepted
+approval assurance. This makes umbrella-today a reusable Chief job with a
 terminal product rather than only an architecture harness.
 
 Every run also copies the canonical payload-free D18D audit rows into

--- a/code/packages/rust/weather-agent-e2e/orchestrator_profile.json
+++ b/code/packages/rust/weather-agent-e2e/orchestrator_profile.json
@@ -15,7 +15,7 @@
     },
     {
       "host_id": "file_writer",
-      "max_tier": "tier1",
+      "max_tier": "tier2",
       "allowed_tools": ["file.write_text"],
       "capabilities": ["filesystem_write"]
     }

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -27,11 +27,11 @@ use chief_of_staff_host_runtime::{
     OrchestratorProfileSummary,
 };
 use chief_of_staff_tool_api::{
-    ApprovalState, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty, ToolApiError,
-    ToolApprovalGrant, ToolAuditRecordQuery, ToolCallError, ToolConcurrency, ToolDefinition,
-    ToolErrorKind, ToolEventKind, ToolExecutionJournal, ToolExecutionJournalHealthSummary,
-    ToolHandlerOutput, ToolIdempotency, ToolInvocationRequest, ToolPolicyProfile, ToolSideEffects,
-    ToolStability, ToolStreaming,
+    ApprovalAssurance, ApprovalState, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty,
+    ToolApiError, ToolApprovalChallenge, ToolApprovalGrant, ToolAuditRecordQuery, ToolCallError,
+    ToolConcurrency, ToolDefinition, ToolErrorKind, ToolEventKind, ToolExecutionJournal,
+    ToolExecutionJournalHealthSummary, ToolHandlerOutput, ToolIdempotency, ToolInvocationRequest,
+    ToolPolicyProfile, ToolSideEffects, ToolStability, ToolStreaming,
 };
 use chief_of_staff_tool_audit_store::{ToolAuditStore, ToolAuditStoreInventorySummary};
 use coding_adventures_json_value::{JsonNumber, JsonValue};
@@ -193,6 +193,7 @@ pub struct UmbrellaAgentConfig {
     pub weather_source: WeatherSource,
     pub supervisor_probe: UmbrellaSupervisorProbe,
     pub write_approval: Option<ToolApprovalGrant>,
+    pub write_required_tier: PrivilegeTier,
     pub audit_root: PathBuf,
 }
 
@@ -209,6 +210,7 @@ impl UmbrellaAgentConfig {
             weather_source: WeatherSource::Fixture(WeatherSnapshot::rainy_seattle_fixture()),
             supervisor_probe: UmbrellaSupervisorProbe::default(),
             write_approval: Some(default_write_approval(DEFAULT_TICK_ID, 1_778_624_400_000)),
+            write_required_tier: PrivilegeTier::Tier1,
         }
     }
 
@@ -230,6 +232,7 @@ impl UmbrellaAgentConfig {
             },
             supervisor_probe: UmbrellaSupervisorProbe::default(),
             write_approval: Some(default_write_approval(DEFAULT_TICK_ID, fetched_at_ms)),
+            write_required_tier: PrivilegeTier::Tier1,
         }
     }
 
@@ -243,6 +246,21 @@ impl UmbrellaAgentConfig {
         self
     }
 
+    pub fn with_tier2_write_approval(mut self, assurance: ApprovalAssurance) -> Self {
+        self.write_required_tier = PrivilegeTier::Tier2;
+        let call_id = scoped_call_id(&self.tick_id, "write_umbrella_report");
+        self.write_approval = Some(
+            default_write_approval(&self.tick_id, self.fetched_at_ms)
+                .with_assurance(assurance)
+                .with_challenge_id(ToolApprovalChallenge::id_for(
+                    call_id,
+                    WRITE_TOOL_ID,
+                    self.fetched_at_ms,
+                )),
+        );
+        self
+    }
+
     pub fn with_audit_root(mut self, audit_root: impl Into<PathBuf>) -> Self {
         self.audit_root = audit_root.into();
         self
@@ -252,6 +270,13 @@ impl UmbrellaAgentConfig {
         self.tick_id = tick_id.into();
         if let Some(grant) = self.write_approval.as_mut() {
             grant.call_id = scoped_call_id(&self.tick_id, "write_umbrella_report");
+            if self.write_required_tier >= PrivilegeTier::Tier2 {
+                grant.challenge_id = Some(ToolApprovalChallenge::id_for(
+                    &grant.call_id,
+                    WRITE_TOOL_ID,
+                    self.fetched_at_ms,
+                ));
+            }
         }
         self
     }
@@ -593,6 +618,8 @@ pub struct UmbrellaUserReport {
     pub completed_at_iso: String,
     pub output_ref: String,
     pub write_approval: ApprovalState,
+    pub write_required_tier: PrivilegeTier,
+    pub approval_assurance: Option<ApprovalAssurance>,
     pub journal_invocation_count: usize,
 }
 
@@ -764,6 +791,8 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         completed_at_iso: config.fetched_at_iso.clone(),
         output_ref: "artifact:umbrella_today_report".to_string(),
         write_approval: ApprovalState::Granted,
+        write_required_tier: config.write_required_tier,
+        approval_assurance: config.write_approval.as_ref().map(|grant| grant.assurance),
         journal_invocation_count: tool_journal_health.invocation_count,
     };
 
@@ -870,10 +899,16 @@ impl UmbrellaPipeline {
         )
         .map_err(UmbrellaAgentError::from)?;
         register_weather_classifier_tool(&mut tool_runtime)?;
-        register_file_writer_tool(&mut tool_runtime, writer_manifest(&config.output_path)?)?;
+        register_file_writer_tool(
+            &mut tool_runtime,
+            writer_manifest(&config.output_path)?,
+            config.write_required_tier,
+        )?;
         tool_runtime.set_host_policy(
             "file_writer",
-            ToolPolicyProfile::allow_all().with_approval_required_for(vec![ToolSideEffects::Write]),
+            ToolPolicyProfile::allow_all()
+                .with_approval_required_for(vec![ToolSideEffects::Write])
+                .with_approval_required_at_or_above(PrivilegeTier::Tier2),
         )?;
         let tool_runtime = tool_runtime.activate()?;
 
@@ -1713,57 +1748,57 @@ fn register_weather_classifier_tool(
 fn register_file_writer_tool(
     runtime: &mut OrchestratorProfileRuntime,
     manifest: Manifest,
+    required_tier: PrivilegeTier,
 ) -> Result<(), HostRuntimeError> {
-    runtime.register_handler(
-        tool_definition(
-            WRITE_TOOL_ID,
-            "Write text file",
-            "Write the umbrella recommendation to a text file through capability-caged fs access.",
-            JsonSchema::Object {
-                properties: vec![
-                    SchemaProperty::new("output_path", JsonSchema::String),
-                    SchemaProperty::new("line", JsonSchema::String),
-                ],
-                required: vec!["output_path".to_string(), "line".to_string()],
-                allow_unknown_fields: false,
-            },
-            Some(JsonSchema::Object {
-                properties: vec![
-                    SchemaProperty::new("output_path", JsonSchema::String),
-                    SchemaProperty::new("bytes_written", JsonSchema::Integer),
-                ],
-                required: vec!["output_path".to_string(), "bytes_written".to_string()],
-                allow_unknown_fields: false,
-            }),
-            ToolSideEffects::Write,
-            ToolIdempotency::Conditional,
-            ToolConcurrency::Serialized,
-            ToolStreaming::Events,
-            vec!["filesystem_write"],
-            vec!["file", "write", "e2e"],
-        ),
-        move |arguments, _context| {
-            let output_path = field_string(&arguments, "output_path")?;
-            let line = field_string(&arguments, "line")?;
-            let mut bytes = line.into_bytes();
-            bytes.push(b'\n');
-            secure_file::write_file(&manifest, Path::new(&output_path), &bytes).map_err(|err| {
-                ToolCallError::new(
-                    ToolErrorKind::ToolExecutionError,
-                    format!("failed to write umbrella report: {err}"),
-                )
-            })?;
-            Ok(ToolHandlerOutput::new(object(vec![
-                ("output_path", string(&output_path)),
-                ("bytes_written", int(bytes.len() as i64)),
-            ]))
-            .with_artifact_ref("umbrella_today_report")
-            .with_event(
-                ToolEventKind::Artifact,
-                object(vec![("path", string(&output_path))]),
-            ))
+    let mut definition = tool_definition(
+        WRITE_TOOL_ID,
+        "Write text file",
+        "Write the umbrella recommendation to a text file through capability-caged fs access.",
+        JsonSchema::Object {
+            properties: vec![
+                SchemaProperty::new("output_path", JsonSchema::String),
+                SchemaProperty::new("line", JsonSchema::String),
+            ],
+            required: vec!["output_path".to_string(), "line".to_string()],
+            allow_unknown_fields: false,
         },
-    )
+        Some(JsonSchema::Object {
+            properties: vec![
+                SchemaProperty::new("output_path", JsonSchema::String),
+                SchemaProperty::new("bytes_written", JsonSchema::Integer),
+            ],
+            required: vec!["output_path".to_string(), "bytes_written".to_string()],
+            allow_unknown_fields: false,
+        }),
+        ToolSideEffects::Write,
+        ToolIdempotency::Conditional,
+        ToolConcurrency::Serialized,
+        ToolStreaming::Events,
+        vec!["filesystem_write"],
+        vec!["file", "write", "e2e"],
+    );
+    definition.required_tier = required_tier;
+    runtime.register_handler(definition, move |arguments, _context| {
+        let output_path = field_string(&arguments, "output_path")?;
+        let line = field_string(&arguments, "line")?;
+        let mut bytes = line.into_bytes();
+        bytes.push(b'\n');
+        secure_file::write_file(&manifest, Path::new(&output_path), &bytes).map_err(|err| {
+            ToolCallError::new(
+                ToolErrorKind::ToolExecutionError,
+                format!("failed to write umbrella report: {err}"),
+            )
+        })?;
+        Ok(ToolHandlerOutput::new(object(vec![
+            ("output_path", string(&output_path)),
+            ("bytes_written", int(bytes.len() as i64)),
+        ]))
+        .with_artifact_ref("umbrella_today_report")
+        .with_event(
+            ToolEventKind::Artifact,
+            object(vec![("path", string(&output_path))]),
+        ))
+    })
 }
 
 #[allow(clippy::too_many_arguments)] // builder-style constructor; signature kept as-is

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use capability_os_sandbox::{current_kernel_sandbox_support, OsFamily};
-use chief_of_staff_tool_api::{ApprovalState, ToolAuditRecordQuery};
+use chief_of_staff_tool_api::{
+    ApprovalAssurance, ApprovalState, PrivilegeTier, ToolAuditRecordQuery,
+};
 use chief_of_staff_tool_audit_store::ToolAuditStore;
 use os_job_core::BackendKind;
 use storage_local_folder::LocalFolderStorageBackend;
@@ -128,6 +130,11 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
         .detail
         .contains("precipitation chance is 72%"));
     assert_eq!(run.user_report.write_approval, ApprovalState::Granted);
+    assert_eq!(run.user_report.write_required_tier, PrivilegeTier::Tier1);
+    assert_eq!(
+        run.user_report.approval_assurance,
+        Some(ApprovalAssurance::ExplicitConsent)
+    );
     assert_eq!(run.user_report.journal_invocation_count, 3);
     assert!(run.user_report.render().contains("Bring an umbrella today"));
     assert_eq!(run.durable_audit.job_id, "umbrella_today_job");
@@ -183,6 +190,54 @@ fn umbrella_today_job_blocks_write_without_explicit_approval() {
         .expect("denied write row should be persisted");
     assert_eq!(denied_write.approval_state, ApprovalState::Pending);
     assert!(!denied_write.result_summary.ok);
+}
+
+#[test]
+fn tier2_write_rejects_weak_consent_and_persists_denial() {
+    let root = temp_root("weather-agent-tier2-weak-approval-e2e");
+    fs::create_dir_all(&root).expect("temp dir should be created");
+    let output_path = root.join("umbrella-today.txt");
+    let config = UmbrellaAgentConfig::deterministic_seattle(&output_path)
+        .with_tier2_write_approval(ApprovalAssurance::ExplicitConsent);
+
+    let error = run_umbrella_today_agent(config)
+        .expect_err("Tier 2 write should reject weak explicit consent");
+    assert!(error.to_string().contains("weaker than required"));
+    assert!(!fs::read_to_string(&output_path)
+        .unwrap_or_default()
+        .contains("Bring an umbrella today"));
+
+    let restarted_audit = ToolAuditStore::new(LocalFolderStorageBackend::new(
+        output_path.with_extension("audit"),
+    ));
+    let denied_write = restarted_audit
+        .fetch_audit("8a7b0000000000000000000000000001_write_umbrella_report")
+        .expect("durable audit should be readable after weak approval denial")
+        .expect("denied Tier 2 write row should be persisted");
+    assert_eq!(denied_write.approval_state, ApprovalState::Denied);
+    assert!(!denied_write.result_summary.ok);
+}
+
+#[test]
+fn tier2_write_accepts_challenge_bound_biometric_approval() {
+    let root = temp_root("weather-agent-tier2-biometric-approval-e2e");
+    fs::create_dir_all(&root).expect("temp dir should be created");
+    let output_path = root.join("umbrella-today.txt");
+    let config = UmbrellaAgentConfig::deterministic_seattle(&output_path)
+        .with_tier2_write_approval(ApprovalAssurance::Biometric);
+
+    let run = run_umbrella_today_agent(config)
+        .expect("challenge-bound biometric approval should complete the Tier 2 job");
+    assert_eq!(run.user_report.write_required_tier, PrivilegeTier::Tier2);
+    assert_eq!(
+        run.user_report.approval_assurance,
+        Some(ApprovalAssurance::Biometric)
+    );
+    assert_eq!(run.tool_journal_health.approval_biometric_count, 1);
+    assert_eq!(run.tool_journal_health.approval_explicit_consent_count, 0);
+    assert_eq!(run.durable_audit.approval_granted_records, 1);
+    assert!(run.durable_audit.is_complete());
+    assert!(run.output_text.contains("Bring an umbrella today"));
 }
 
 #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -288,10 +288,16 @@ compact summary keyed to job, run, host profile, session, and user. Executable
 tests prove both the successful three-call run and the approval-blocked write
 survive a runtime restart without storing arguments, outputs, or credentials.
 
+The Tier2 approval slice now gives D18D a canonical user-visible challenge and
+explicit-consent, biometric, and hardware-key assurance levels. Host policy can
+require approval at a privilege threshold; Tier2 grants must be biometric and
+bound to the active call challenge before a handler runs, while Tier3 requires
+a hardware key. The scheduled Weather Agent job proves pending, weak-denied,
+and biometric-approved paths through the real host runtime, execution journal,
+user report, and restarted durable audit reader.
+
 These items are Chief of Staff architecture, not smart-home platform work:
 
-- Add approval UX and policy wiring for Tier2 or stronger actions such as
-  bridge pairing, locks, cameras, alarms, and safety devices.
 - Wire vault leasing so tools receive opaque `VaultRef` handles and never raw
   smart-home secrets.
 


### PR DESCRIPTION
## Summary

- add canonical D18D approval challenges and explicit-consent, biometric, and hardware-key assurance levels
- let Chief host policy require approval at a privilege threshold and reject weak, stale, mismatched, or unbound Tier 2 grants before handler execution
- prove pending, weak-denied, unbound-denied, and biometric-approved behavior through the real host runtime and scheduled Weather Agent job
- expose accepted assurance in journal health and the user-visible report while persisting denied and granted outcomes through the existing durable audit store
- update the D18-D23 inventory so VaultRef leasing is the remaining Chief architecture item

## Validation

- `cargo test -p chief-of-staff-tool-api -p chief-of-staff-host-runtime -p weather-agent-e2e -- --nocapture`
- `cargo clippy -p chief-of-staff-tool-api -p chief-of-staff-host-runtime -p weather-agent-e2e --all-targets -- -D warnings`
- `cargo fmt --package chief-of-staff-tool-api --package chief-of-staff-host-runtime --package weather-agent-e2e -- --check`
- `sh chief-of-staff-tool-api/BUILD`
- `sh chief-of-staff-host-runtime/BUILD`
- `sh weather-agent-e2e/BUILD`
- `git diff --check`

Generated `code/packages/rust/Cargo.lock` was removed before commit.