### PR TITLE
feat(spice): shape BJT base-collector depletion capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT base-collector depletion shaping** — BJT model cards now accept
+  `VJC`/`PC` junction potential and `MJC`/`MC` grading coefficient parameters
+  and apply them to `CJC` in AC and transient analysis, matching Rust and
+  TypeScript. The supported-parameter catalog now contains 90 canonical rows.
+
 - **BJT base-emitter depletion shaping** — BJT model cards now accept
   `VJE`/`PE` junction potential and `MJE`/`ME` grading coefficient parameters
   and apply them to `CJE` in AC and transient analysis, matching Rust and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -216,7 +216,9 @@ model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
-depletion capacitance using the Berkeley default `FC=0.5` continuation.
+depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
+`0.33`) likewise shape `CJC` base-collector depletion capacitance. Both use the
+Berkeley default `FC=0.5` continuation.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -621,6 +621,8 @@ class BJT:
     Nr: float = 1.0         # reverse emission coefficient
     Vje: float = 0.75       # base-emitter junction potential (V)
     Mje: float = 0.33       # base-emitter grading coefficient
+    Vjc: float = 0.75       # base-collector junction potential (V)
+    Mjc: float = 0.33       # base-collector grading coefficient
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8739,7 +8739,7 @@ def _bjt_charge_dynamic_capacitance(el: BJT, state_kind: str, voltage: float) ->
         conductance = _bjt_junction_transconductance(el, voltage, el.Nf)
         return _bjt_base_emitter_depletion_capacitance(el, voltage) + el.Tf * conductance
     conductance = _bjt_junction_transconductance(el, voltage, el.Nr)
-    return el.Cjc + el.Tr * conductance
+    return _bjt_base_collector_depletion_capacitance(el, voltage) + el.Tr * conductance
 
 
 def _bjt_base_emitter_depletion_capacitance(el: BJT, voltage: float) -> float:
@@ -8752,6 +8752,18 @@ def _bjt_base_emitter_depletion_capacitance(el: BJT, voltage: float) -> float:
     transition_scale = (1.0 - coefficient) ** (1.0 + el.Mje)
     continuation = 1.0 - coefficient * (1.0 + el.Mje) + el.Mje * normalized_voltage
     return el.Cje * continuation / transition_scale
+
+
+def _bjt_base_collector_depletion_capacitance(el: BJT, voltage: float) -> float:
+    if el.Cjc <= 0.0 or el.Mjc == 0.0:
+        return el.Cjc
+    normalized_voltage = voltage / el.Vjc
+    coefficient = 0.5
+    if normalized_voltage < coefficient:
+        return el.Cjc / ((1.0 - normalized_voltage) ** el.Mjc)
+    transition_scale = (1.0 - coefficient) ** (1.0 + el.Mjc)
+    continuation = 1.0 - coefficient * (1.0 + el.Mjc) + el.Mjc * normalized_voltage
+    return el.Cjc * continuation / transition_scale
 
 
 def _bjt_charge_state_specs(el: BJT) -> list[tuple[str, str, str, str]]:
@@ -9172,6 +9184,10 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT base-emitter junction potential must be finite and positive")
     if not math.isfinite(el.Mje) or not 0.0 <= el.Mje < 1.0:
         raise ValueError(f"{el.name}: BJT base-emitter grading coefficient must be finite and in [0, 1)")
+    if not math.isfinite(el.Vjc) or el.Vjc <= 0.0:
+        raise ValueError(f"{el.name}: BJT base-collector junction potential must be finite and positive")
+    if not math.isfinite(el.Mjc) or not 0.0 <= el.Mjc < 1.0:
+        raise ValueError(f"{el.name}: BJT base-collector grading coefficient must be finite and in [0, 1)")
 
 
 # ---------------------------------------------------------------------------
@@ -12407,7 +12423,10 @@ def _stamp_ac(
         y_be = g_pi + 1j * omega * (
             _bjt_base_emitter_depletion_capacitance(el, Vjunc) + diffusion_capacitance
         )
-        y_bc = 1j * omega * (el.Cjc + reverse_diffusion_capacitance)
+        y_bc = 1j * omega * (
+            _bjt_base_collector_depletion_capacitance(el, Vreverse)
+            + reverse_diffusion_capacitance
+        )
         _stamp_g_c(G, node_to_idx, el.collector, el.emitter, output_conductance + 0j)
 
         if el.polarity == "NPN":
@@ -13897,6 +13916,8 @@ def sens_dc(
                     Nr=el.Nr,
                     Vje=el.Vje,
                     Mje=el.Mje,
+                    Vjc=el.Vjc,
+                    Mjc=el.Mjc,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -13920,6 +13941,8 @@ def sens_dc(
                     Nr=el.Nr,
                     Vje=el.Vje,
                     Mje=el.Mje,
+                    Vjc=el.Vjc,
+                    Mjc=el.Mjc,
                 ),
             )
 
@@ -14153,6 +14176,8 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Nr=el.Nr,
             Vje=el.Vje,
             Mje=el.Mje,
+            Vjc=el.Vjc,
+            Mjc=el.Mjc,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (14, 25, 7, 4),
-    "PNP": (14, 25, 7, 4),
+    "NPN": (16, 29, 9, 4),
+    "PNP": (16, 29, 9, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -380,6 +380,10 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "PE": "VJE",
     "MJE": "MJE",
     "ME": "MJE",
+    "VJC": "VJC",
+    "PC": "VJC",
+    "MJC": "MJC",
+    "MC": "MJC",
 }
 
 _JFET_PARAMETER_ALIASES: dict[str, str] = {
@@ -911,6 +915,8 @@ def bjt_from_model_card(
         Nr=p.get("NR", 1.0),
         Vje=p.get("VJE", 0.75),
         Mje=p.get("MJE", 0.33),
+        Vjc=p.get("VJC", 0.75),
+        Mjc=p.get("MJC", 0.33),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 86
+    assert len(coverage) == 90
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 86
+    assert len(records) == 90
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,17 +501,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 86
-    assert report.expected_canonical_parameter_count == 86
-    assert report.accepted_name_count == 140
-    assert report.aliased_parameter_count == 41
+    assert report.canonical_parameter_count == 90
+    assert report.expected_canonical_parameter_count == 90
+    assert report.accepted_name_count == 148
+    assert report.aliased_parameter_count == 45
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t86\t86\t140\t41\t4\t0"
+        "true\t7\t7\t90\t90\t148\t45\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,9 +539,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 85
-    assert report.accepted_name_count == 137
-    assert report.aliased_parameter_count == 40
+    assert report.canonical_parameter_count == 89
+    assert report.accepted_name_count == 145
+    assert report.aliased_parameter_count == 44
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t85\t86\t137\t40\t4\t4\n"
+        "false\t7\t7\t89\t90\t145\t44\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
@@ -661,6 +661,8 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Nr == pytest.approx(1.3)
     assert bjt_model.Vje == pytest.approx(0.8)
     assert bjt_model.Mje == pytest.approx(0.4)
+    assert bjt_model.Vjc == pytest.approx(0.7)
+    assert bjt_model.Mjc == pytest.approx(0.45)
 
     jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -1535,6 +1537,23 @@ def test_transient_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bia
     assert stepped_base_voltage(0.5) > stepped_base_voltage(0.0)
 
 
+def test_transient_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() -> None:
+    def stepped_collector_voltage(mjc: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vdrive",
+            "in",
+            "0",
+            1.0,
+            waveform=PwlWaveform(((0.0, 1.0), (1.0e-9, 1.0), (2.0e-9, 0.0), (5.0e-9, 0.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "collector", 1000.0))
+        circuit.add(BJT("Q1", collector="collector", base="0", emitter="0", Cjc=1.0e-12, Vjc=0.75, Mjc=mjc))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler").points[2].node_voltages["collector"]
+
+    assert stepped_collector_voltage(0.5) < stepped_collector_voltage(0.0)
+
+
 def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> None:
     def run(forward_transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -2247,7 +2266,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2261,6 +2280,8 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Nr == pytest.approx(1.3)
     assert expanded.Vje == pytest.approx(0.8)
     assert expanded.Mje == pytest.approx(0.4)
+    assert expanded.Vjc == pytest.approx(0.7)
+    assert expanded.Mjc == pytest.approx(0.45)
 
 
 def test_branch_current_in_voltage_source():
@@ -2549,9 +2570,11 @@ def test_dc_rejects_invalid_bjt_reverse_emission_coefficient():
     [
         ({"Vje": 0.0}, "BJT base-emitter junction potential must be finite and positive"),
         ({"Mje": 1.0}, "BJT base-emitter grading coefficient must be finite and in \\[0, 1\\)"),
+        ({"Vjc": 0.0}, "BJT base-collector junction potential must be finite and positive"),
+        ({"Mjc": 1.0}, "BJT base-collector grading coefficient must be finite and in \\[0, 1\\)"),
     ],
 )
-def test_dc_rejects_invalid_bjt_base_emitter_depletion_parameters(kwargs, message):
+def test_dc_rejects_invalid_bjt_depletion_parameters(kwargs, message):
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", **kwargs))
     with pytest.raises(ValueError, match=message):
@@ -4195,6 +4218,19 @@ def test_ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias():
         return abs(result.points[0].node_voltages["base"])
 
     assert base_amplitude(0.5) > base_amplitude(0.0)
+
+
+def test_ac_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias():
+    """BJT Vjc/Mjc shape Cjc under reverse base-collector bias."""
+    def collector_amplitude(mjc: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 1.0, ac=AcSource(1.0)))
+        c.add(Resistor("Rin", "in", "collector", 1000.0))
+        c.add(BJT("Q1", collector="collector", base="0", emitter="0", Cjc=1.0e-6, Vjc=0.75, Mjc=mjc))
+        result = ac_sweep(c, f_start=1000.0, f_stop=1000.0, n_points=1)
+        return abs(result.points[0].node_voltages["collector"])
+
+    assert collector_amplitude(0.5) > collector_amplitude(0.0)
 
 
 def test_ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `VJC`/`PC` base-collector junction-potential and `MJC`/`MC`
+  grading-coefficient support with bias-shaped `CJC` depletion capacitance in
+  AC and transient analysis, matching Python and TypeScript. The supported-
+  parameter catalog now contains 90 canonical rows.
 - Add BJT model-card `VJE`/`PE` base-emitter junction-potential and `MJE`/`ME`
   grading-coefficient support with bias-shaped `CJE` depletion capacitance in
   AC and transient analysis, matching Python and TypeScript. The supported-

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -133,7 +133,9 @@ model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
-depletion capacitance using the Berkeley default `FC=0.5` continuation.
+depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
+`0.33`) likewise shape `CJC` base-collector depletion capacitance. Both use the
+Berkeley default `FC=0.5` continuation.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -439,6 +439,8 @@ fn clone_subckt_element(
                 element.reverse_emission_coefficient,
                 element.base_emitter_junction_potential,
                 element.base_emitter_grading_coefficient,
+                element.base_collector_junction_potential,
+                element.base_collector_grading_coefficient,
             ))
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2849,6 +2851,8 @@ pub struct Bjt {
     pub reverse_emission_coefficient: f64,
     pub base_emitter_junction_potential: f64,
     pub base_emitter_grading_coefficient: f64,
+    pub base_collector_junction_potential: f64,
+    pub base_collector_grading_coefficient: f64,
 }
 
 impl Bjt {
@@ -2949,6 +2953,8 @@ impl Bjt {
             reverse_emission_coefficient,
             0.75,
             0.33,
+            0.75,
+            0.33,
         )
     }
 
@@ -2973,6 +2979,8 @@ impl Bjt {
         reverse_emission_coefficient: f64,
         base_emitter_junction_potential: f64,
         base_emitter_grading_coefficient: f64,
+        base_collector_junction_potential: f64,
+        base_collector_grading_coefficient: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -2994,6 +3002,8 @@ impl Bjt {
             reverse_emission_coefficient,
             base_emitter_junction_potential,
             base_emitter_grading_coefficient,
+            base_collector_junction_potential,
+            base_collector_grading_coefficient,
         }
     }
 }
@@ -3384,8 +3394,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 14, 25, 7, 4),
-    (ModelCardKind::Pnp, 14, 25, 7, 4),
+    (ModelCardKind::Npn, 16, 29, 9, 4),
+    (ModelCardKind::Pnp, 16, 29, 9, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3437,6 +3447,10 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("PE", "VJE"),
     ("MJE", "MJE"),
     ("ME", "MJE"),
+    ("VJC", "VJC"),
+    ("PC", "VJC"),
+    ("MJC", "MJC"),
+    ("MC", "MJC"),
 ];
 const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("BETA", "BETA"),
@@ -4096,6 +4110,8 @@ pub fn bjt_from_model_card(
         model_card_value(model, "NR", 1.0),
         model_card_value(model, "VJE", 0.75),
         model_card_value(model, "MJE", 0.33),
+        model_card_value(model, "VJC", 0.75),
+        model_card_value(model, "MJC", 0.33),
     ))
 }
 
@@ -22429,7 +22445,9 @@ fn stamp_ac_bjt_small_signal(
     );
     let ybc = Complex::new(
         0.0,
-        omega * (bjt.base_collector_capacitance + reverse_diffusion_capacitance),
+        omega
+            * (bjt_base_collector_depletion_capacitance(bjt, reverse_junction_voltage)
+                + reverse_diffusion_capacitance),
     );
     stamp_complex_conductance(
         matrix,
@@ -23039,7 +23057,8 @@ fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: 
         BjtChargeStateKind::BaseCollector => {
             let conductance =
                 bjt_junction_transconductance(bjt, voltage, bjt.reverse_emission_coefficient);
-            bjt.base_collector_capacitance + bjt.reverse_transit_time * conductance
+            bjt_base_collector_depletion_capacitance(bjt, voltage)
+                + bjt.reverse_transit_time * conductance
         }
     }
 }
@@ -23058,6 +23077,23 @@ fn bjt_base_emitter_depletion_capacitance(bjt: &Bjt, voltage: f64) -> f64 {
     let continuation = 1.0 - coefficient * (1.0 + bjt.base_emitter_grading_coefficient)
         + bjt.base_emitter_grading_coefficient * normalized_voltage;
     bjt.base_emitter_capacitance * continuation / transition_scale
+}
+
+fn bjt_base_collector_depletion_capacitance(bjt: &Bjt, voltage: f64) -> f64 {
+    if bjt.base_collector_capacitance <= 0.0 || bjt.base_collector_grading_coefficient == 0.0 {
+        return bjt.base_collector_capacitance;
+    }
+    let normalized_voltage = voltage / bjt.base_collector_junction_potential;
+    let coefficient = 0.5;
+    if normalized_voltage < coefficient {
+        return bjt.base_collector_capacitance
+            / (1.0 - normalized_voltage).powf(bjt.base_collector_grading_coefficient);
+    }
+    let transition_scale =
+        (1.0_f64 - coefficient).powf(1.0 + bjt.base_collector_grading_coefficient);
+    let continuation = 1.0 - coefficient * (1.0 + bjt.base_collector_grading_coefficient)
+        + bjt.base_collector_grading_coefficient * normalized_voltage;
+    bjt.base_collector_capacitance * continuation / transition_scale
 }
 
 fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec<'_>> {
@@ -23428,6 +23464,22 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "base-emitter grading coefficient must be finite and in [0, 1)".to_string(),
+        });
+    }
+    if !bjt.base_collector_junction_potential.is_finite()
+        || bjt.base_collector_junction_potential <= 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-collector junction potential must be finite and positive".to_string(),
+        });
+    }
+    if !bjt.base_collector_grading_coefficient.is_finite()
+        || !(0.0..1.0).contains(&bjt.base_collector_grading_coefficient)
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-collector grading coefficient must be finite and in [0, 1)".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -937,6 +937,8 @@ fn ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() {
                 1.0,
                 0.75,
                 grading_coefficient,
+                0.75,
+                0.33,
             ),
         ));
 
@@ -947,6 +949,54 @@ fn ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() {
     }
 
     assert!(base_amplitude(0.5) > base_amplitude(0.0));
+}
+
+#[test]
+fn ac_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() {
+    fn collector_amplitude(grading_coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 1.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin",
+            "in",
+            "collector",
+            1_000.0,
+        )));
+        circuit.add(Element::Bjt(
+            Bjt::with_model_temperature_and_depletion_parameters(
+                "Q1",
+                "collector",
+                "0",
+                "0",
+                BjtPolarity::Npn,
+                1.0e-14,
+                100.0,
+                0.02585,
+                0.0,
+                1.0e-6,
+                0.0,
+                0.0,
+                3.0,
+                1.11,
+                0.0,
+                1.0,
+                1.0,
+                0.75,
+                0.33,
+                0.75,
+                grading_coefficient,
+            ),
+        ));
+
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 1).unwrap()[0]
+            .voltage("collector")
+            .unwrap()
+            .abs()
+    }
+
+    assert!(collector_amplitude(0.5) > collector_amplitude(0.0));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 86);
+    assert_eq!(coverage.len(), 90);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 86);
+    assert_eq!(records.len(), 90);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 86);
-    assert_eq!(report.expected_canonical_parameter_count, 86);
-    assert_eq!(report.accepted_name_count, 140);
-    assert_eq!(report.aliased_parameter_count, 41);
+    assert_eq!(report.canonical_parameter_count, 90);
+    assert_eq!(report.expected_canonical_parameter_count, 90);
+    assert_eq!(report.accepted_name_count, 148);
+    assert_eq!(report.aliased_parameter_count, 45);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t86\t86\t140\t41\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t90\t90\t148\t45\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,9 +235,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 85);
-    assert_eq!(report.accepted_name_count, 137);
-    assert_eq!(report.aliased_parameter_count, 40);
+    assert_eq!(report.canonical_parameter_count, 89);
+    assert_eq!(report.accepted_name_count, 145);
+    assert_eq!(report.aliased_parameter_count, 44);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t85\t86\t137\t40\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t89\t90\t145\t44\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -435,6 +435,8 @@ fn model_card_aliases_build_device_instances() {
             ("NR", 1.3),
             ("PE", 0.8),
             ("ME", 0.4),
+            ("PC", 0.7),
+            ("MC", 0.45),
         ],
     )
     .unwrap();
@@ -448,6 +450,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("NR").unwrap(), 1.3);
     assert_close(*bjt_card.parameters.get("VJE").unwrap(), 0.8);
     assert_close(*bjt_card.parameters.get("MJE").unwrap(), 0.4);
+    assert_close(*bjt_card.parameters.get("VJC").unwrap(), 0.7);
+    assert_close(*bjt_card.parameters.get("MJC").unwrap(), 0.45);
     assert_eq!(bjt_model.polarity, BjtPolarity::Npn);
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
@@ -458,6 +462,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.reverse_emission_coefficient, 1.3);
     assert_close(bjt_model.base_emitter_junction_potential, 0.8);
     assert_close(bjt_model.base_emitter_grading_coefficient, 0.4);
+    assert_close(bjt_model.base_collector_junction_potential, 0.7);
+    assert_close(bjt_model.base_collector_grading_coefficient, 0.45);
 
     let jfet_card = normalize_model_card(
         "Jn",
@@ -1374,6 +1380,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         1.3,
         0.8,
         0.4,
+        0.7,
+        0.45,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1406,6 +1414,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.reverse_emission_coefficient, 1.3);
     assert_close(expanded.base_emitter_junction_potential, 0.8);
     assert_close(expanded.base_emitter_grading_coefficient, 0.4);
+    assert_close(expanded.base_collector_junction_potential, 0.7);
+    assert_close(expanded.base_collector_grading_coefficient, 0.45);
 }
 
 #[test]
@@ -2166,6 +2176,52 @@ fn dc_rejects_invalid_bjt_base_emitter_depletion_parameters() {
                 0.0,
                 1.0,
                 1.0,
+                junction_potential,
+                grading_coefficient,
+                0.75,
+                0.33,
+            ),
+        ));
+        assert!(dc_op(&circuit).unwrap_err().to_string().contains(message));
+    }
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_base_collector_depletion_parameters() {
+    for (junction_potential, grading_coefficient, message) in [
+        (
+            0.0,
+            0.33,
+            "base-collector junction potential must be finite and positive",
+        ),
+        (
+            0.75,
+            1.0,
+            "base-collector grading coefficient must be finite and in [0, 1)",
+        ),
+    ] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Bjt(
+            Bjt::with_model_temperature_and_depletion_parameters(
+                "Qbad",
+                "c",
+                "b",
+                "0",
+                BjtPolarity::Npn,
+                1.0e-14,
+                100.0,
+                0.02585,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                3.0,
+                1.11,
+                0.0,
+                1.0,
+                1.0,
+                0.75,
+                0.33,
                 junction_potential,
                 grading_coefficient,
             ),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -563,6 +563,8 @@ fn transient_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() {
                 1.0,
                 0.75,
                 grading_coefficient,
+                0.75,
+                0.33,
             ),
         ));
         transient(&circuit, 1.0e-9, 5.0e-9).unwrap()[1]
@@ -571,6 +573,61 @@ fn transient_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() {
     }
 
     assert!(stepped_base_voltage(0.5) > stepped_base_voltage(0.0));
+}
+
+#[test]
+fn transient_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() {
+    fn stepped_collector_voltage(grading_coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vdrive",
+            "in",
+            "0",
+            1.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 1.0),
+                (1.0e-9, 1.0),
+                (2.0e-9, 0.0),
+                (5.0e-9, 0.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin",
+            "in",
+            "collector",
+            1_000.0,
+        )));
+        circuit.add(Element::Bjt(
+            Bjt::with_model_temperature_and_depletion_parameters(
+                "Q1",
+                "collector",
+                "0",
+                "0",
+                BjtPolarity::Npn,
+                1.0e-14,
+                100.0,
+                0.02585,
+                0.0,
+                1.0e-12,
+                0.0,
+                0.0,
+                3.0,
+                1.11,
+                0.0,
+                1.0,
+                1.0,
+                0.75,
+                0.33,
+                0.75,
+                grading_coefficient,
+            ),
+        ));
+        transient(&circuit, 1.0e-9, 5.0e-9).unwrap()[1]
+            .voltage("collector")
+            .unwrap()
+    }
+
+    assert!(stepped_collector_voltage(0.5) < stepped_collector_voltage(0.0));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `VJC`/`PC` base-collector junction-potential and `MJC`/`MC`
+  grading-coefficient support with bias-shaped `CJC` depletion capacitance in
+  AC and transient analysis, matching Python and Rust. The supported-parameter
+  catalog now contains 90 canonical rows.
 - Add BJT model-card `VJE`/`PE` base-emitter junction-potential and `MJE`/`ME`
   grading-coefficient support with bias-shaped `CJE` depletion capacitance in
   AC and transient analysis, matching Python and Rust. The supported-parameter

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -203,7 +203,9 @@ model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
-depletion capacitance using the Berkeley default `FC=0.5` continuation.
+depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
+`0.33`) likewise shape `CJC` base-collector depletion capacitance. Both use the
+Berkeley default `FC=0.5` continuation.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1717,6 +1717,8 @@ export interface Bjt {
   readonly reverseEmissionCoefficient: number;
   readonly baseEmitterJunctionPotential: number;
   readonly baseEmitterGradingCoefficient: number;
+  readonly baseCollectorJunctionPotential: number;
+  readonly baseCollectorGradingCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1994,8 +1996,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [14, 25, 7, 4],
-  PNP: [14, 25, 7, 4],
+  NPN: [16, 29, 9, 4],
+  PNP: [16, 29, 9, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3585,7 +3587,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7745,6 +7747,8 @@ export function bjt(
   reverseEmissionCoefficient = 1.0,
   baseEmitterJunctionPotential = 0.75,
   baseEmitterGradingCoefficient = 0.33,
+  baseCollectorJunctionPotential = 0.75,
+  baseCollectorGradingCoefficient = 0.33,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7767,6 +7771,8 @@ export function bjt(
     reverseEmissionCoefficient,
     baseEmitterJunctionPotential,
     baseEmitterGradingCoefficient,
+    baseCollectorJunctionPotential,
+    baseCollectorGradingCoefficient,
   };
 }
 
@@ -7878,6 +7884,10 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   PE: "VJE",
   MJE: "MJE",
   ME: "MJE",
+  VJC: "VJC",
+  PC: "VJC",
+  MJC: "MJC",
+  MC: "MJC",
 };
 
 const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8381,6 +8391,8 @@ export function bjtFromModelCard(
     p.NR ?? 1.0,
     p.VJE ?? 0.75,
     p.MJE ?? 0.33,
+    p.VJC ?? 0.75,
+    p.MJC ?? 0.33,
   );
 }
 
@@ -19381,7 +19393,8 @@ function bjtChargeDynamicCapacitance(
     voltage,
     element.reverseEmissionCoefficient,
   );
-  return element.baseCollectorCapacitance + element.reverseTransitTime * conductance;
+  return bjtBaseCollectorDepletionCapacitance(element, voltage) +
+    element.reverseTransitTime * conductance;
 }
 
 function bjtBaseEmitterDepletionCapacitance(element: Bjt, voltage: number): number {
@@ -19399,6 +19412,23 @@ function bjtBaseEmitterDepletionCapacitance(element: Bjt, voltage: number): numb
   const continuation = 1.0 - coefficient * (1.0 + element.baseEmitterGradingCoefficient) +
     element.baseEmitterGradingCoefficient * normalizedVoltage;
   return element.baseEmitterCapacitance * continuation / transitionScale;
+}
+
+function bjtBaseCollectorDepletionCapacitance(element: Bjt, voltage: number): number {
+  if (element.baseCollectorCapacitance <= 0.0 || element.baseCollectorGradingCoefficient === 0.0) {
+    return element.baseCollectorCapacitance;
+  }
+  const normalizedVoltage = voltage / element.baseCollectorJunctionPotential;
+  const coefficient = 0.5;
+  if (normalizedVoltage < coefficient) {
+    return element.baseCollectorCapacitance /
+      ((1.0 - normalizedVoltage) ** element.baseCollectorGradingCoefficient);
+  }
+  const transitionScale = (1.0 - coefficient) **
+    (1.0 + element.baseCollectorGradingCoefficient);
+  const continuation = 1.0 - coefficient * (1.0 + element.baseCollectorGradingCoefficient) +
+    element.baseCollectorGradingCoefficient * normalizedVoltage;
+  return element.baseCollectorCapacitance * continuation / transitionScale;
 }
 
 function bjtChargeStateSpecs(element: Bjt): BjtChargeStateSpec[] {
@@ -19634,6 +19664,14 @@ function validateBjt(element: Bjt): void {
       element.baseEmitterGradingCoefficient < 0.0 ||
       element.baseEmitterGradingCoefficient >= 1.0) {
     throw invalidElement(element.name, "base-emitter grading coefficient must be finite and in [0, 1)");
+  }
+  if (!Number.isFinite(element.baseCollectorJunctionPotential) || element.baseCollectorJunctionPotential <= 0.0) {
+    throw invalidElement(element.name, "base-collector junction potential must be finite and positive");
+  }
+  if (!Number.isFinite(element.baseCollectorGradingCoefficient) ||
+      element.baseCollectorGradingCoefficient < 0.0 ||
+      element.baseCollectorGradingCoefficient >= 1.0) {
+    throw invalidElement(element.name, "base-collector grading coefficient must be finite and in [0, 1)");
   }
 }
 
@@ -21559,7 +21597,10 @@ function stampAcBjtSmallSignal(
   );
   const baseCollectorAdmittance = complex(
     0.0,
-    omega * (element.baseCollectorCapacitance + reverseDiffusionCapacitance),
+    omega * (
+      bjtBaseCollectorDepletionCapacitance(element, reverseJunctionVoltage) +
+      reverseDiffusionCapacitance
+    ),
   );
   stampComplexConductance(matrix, collector, emitter, complex(outputConductance, 0.0));
   if (element.polarity === "NPN") {

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -617,6 +617,18 @@ describe("acSweep", () => {
     expect(baseAmplitude(0.5)).toBeGreaterThan(baseAmplitude(0.0));
   });
 
+  it("shapes BJT base-collector depletion capacitance under reverse bias", () => {
+    function collectorAmplitude(baseCollectorGradingCoefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 1.0, 1.0));
+      circuit.add(resistor("Rin", "in", "collector", 1_000.0));
+      circuit.add(bjt("Q1", "collector", "0", "0", "NPN", 1.0e-14, 100.0, 0.02585, 0.0, 1.0e-6, 0.0, 0.0, 3.0, 1.11, 0.0, 1.0, 1.0, 0.75, 0.33, 0.75, baseCollectorGradingCoefficient));
+      return complexAbs(acSweep(circuit, 1_000.0, 1_000.0, 1)[0].voltage("collector")!);
+    }
+
+    expect(collectorAmplitude(0.5)).toBeGreaterThan(collectorAmplitude(0.0));
+  });
+
   it("applies VCVS gain in AC analysis", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vin", "in", "0", 1.0));

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(86);
+    expect(coverage).toHaveLength(90);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(86);
+    expect(records).toHaveLength(90);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 86,
-      expectedCanonicalParameterCount: 86,
-      acceptedNameCount: 140,
-      aliasedParameterCount: 41,
+      canonicalParameterCount: 90,
+      expectedCanonicalParameterCount: 90,
+      acceptedNameCount: 148,
+      aliasedParameterCount: 45,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t86\t86\t140\t41\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t90\t90\t148\t45\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,9 +241,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(85);
-    expect(report.acceptedNameCount).toBe(137);
-    expect(report.aliasedParameterCount).toBe(40);
+    expect(report.canonicalParameterCount).toBe(89);
+    expect(report.acceptedNameCount).toBe(145);
+    expect(report.aliasedParameterCount).toBe(44);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t85\t86\t137\t40\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t89\t90\t145\t44\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -341,9 +341,11 @@ describe("dcOp", () => {
       NR: 1.3,
       PE: 0.8,
       ME: 0.4,
+      PC: 0.7,
+      MC: 0.45,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
@@ -354,6 +356,8 @@ describe("dcOp", () => {
     expectClose(bjtModel.reverseEmissionCoefficient, 1.3);
     expectClose(bjtModel.baseEmitterJunctionPotential, 0.8);
     expectClose(bjtModel.baseEmitterGradingCoefficient, 0.4);
+    expectClose(bjtModel.baseCollectorJunctionPotential, 0.7);
+    expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
 
     const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
@@ -986,7 +990,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1001,6 +1005,8 @@ describe("dcOp", () => {
       expectClose(expanded.reverseEmissionCoefficient, 1.3);
       expectClose(expanded.baseEmitterJunctionPotential, 0.8);
       expectClose(expanded.baseEmitterGradingCoefficient, 0.4);
+      expectClose(expanded.baseCollectorJunctionPotential, 0.7);
+      expectClose(expanded.baseCollectorGradingCoefficient, 0.45);
     }
   });
 
@@ -1396,6 +1402,16 @@ describe("dcOp", () => {
     const invalidGrading = new Circuit();
     invalidGrading.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 1.0, 0.75, 1.0));
     expect(() => dcOp(invalidGrading)).toThrowError("base-emitter grading coefficient must be finite and in [0, 1)");
+  });
+
+  it("rejects invalid BJT base-collector depletion parameters", () => {
+    const invalidPotential = new Circuit();
+    invalidPotential.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 1.0, 0.75, 0.33, 0.0));
+    expect(() => dcOp(invalidPotential)).toThrowError("base-collector junction potential must be finite and positive");
+
+    const invalidGrading = new Circuit();
+    invalidGrading.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 1.0, 0.75, 0.33, 0.75, 1.0));
+    expect(() => dcOp(invalidGrading)).toThrowError("base-collector grading coefficient must be finite and in [0, 1)");
   });
 
   it("uses MOSFET temperature scaling in common-source drain voltage", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -475,6 +475,24 @@ describe("transient", () => {
     expect(steppedBaseVoltage(0.5)).toBeGreaterThan(steppedBaseVoltage(0.0));
   });
 
+  it("shapes BJT base-collector depletion capacitance during reverse-biased transients", () => {
+    function steppedCollectorVoltage(baseCollectorGradingCoefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vdrive",
+        "in",
+        "0",
+        1.0,
+        new PwlWaveform([[0.0, 1.0], [1.0e-9, 1.0], [2.0e-9, 0.0], [5.0e-9, 0.0]]),
+      ));
+      circuit.add(resistor("Rin", "in", "collector", 1_000.0));
+      circuit.add(bjt("Q1", "collector", "0", "0", "NPN", 1.0e-14, 100.0, 0.02585, 0.0, 1.0e-12, 0.0, 0.0, 3.0, 1.11, 0.0, 1.0, 1.0, 0.75, 0.33, 0.75, baseCollectorGradingCoefficient));
+      return transient(circuit, 1.0e-9, 5.0e-9)[1].voltage("collector")!;
+    }
+
+    expect(steppedCollectorVoltage(0.5)).toBeLessThan(steppedCollectorVoltage(0.0));
+  });
+
   it("uses BJT forward transit time to hold base charge on turnoff", () => {
     function run(forwardTransitTime: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT base-emitter depletion-capacitance shaping.
+1. Cross-language BJT base-collector depletion-capacitance shaping.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `VJE` / `PE` base-emitter junction-potential and `MJE` /
-     `ME` grading-coefficient model-card support in Rust, Python, and TypeScript.
-   - Shape `CJE` base-emitter depletion capacitance in AC and transient
+   - Add Berkeley BJT `VJC` / `PC` base-collector junction-potential and `MJC` /
+     `MC` grading-coefficient model-card support in Rust, Python, and TypeScript.
+   - Shape `CJC` base-collector depletion capacitance in AC and transient
      analysis with the continuous Berkeley piecewise law and default `FC=0.5`,
      while preserving the full BJT model through hierarchical subcircuits.
-   - Extend the supported-parameter coverage gate from 82 to 86 canonical rows
-     and lock reverse-biased base-emitter capacitance behavior in all engines.
+   - Extend the supported-parameter coverage gate from 86 to 90 canonical rows
+     and lock reverse-biased base-collector capacitance behavior in all engines.
 
 ## Completed Slices
 
@@ -3029,6 +3029,14 @@ the Rust, Python, and TypeScript surfaces together.
      to reverse base-collector diffusion charge in AC and transient analysis.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 82 canonical rows.
+
+223. Cross-language BJT base-emitter depletion-capacitance shaping.
+   - Status: completed in PR 8752.
+   - Rust, Python, and TypeScript BJT model cards now accept `VJE` / `PE` and
+     `MJE` / `ME` and apply continuous Berkeley depletion shaping to `CJE` in
+     AC and transient analysis.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 86 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add BJT base-collector junction-potential and grading-coefficient model parameters across Rust, Python, and TypeScript
- accept Berkeley SPICE aliases `VJC`/`PC` and `MJC`/`MC`, with validation and hierarchy preservation
- apply continuous piecewise depletion-capacitance shaping to BJT AC and transient behavior
- advance the model-card coverage gate from 86 to 90 canonical parameters and reconcile the SPICE implementation plan

## Verification
- `cargo test -p spice-engine`
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python spice-engine: 496 passed, 81.45% coverage
- `ruff check` on touched Python sources/tests
- TypeScript spice-engine: 280 passed
- `npm run build`
- `git diff --check`