### PR TITLE
feat(adj-audit): RS-4 PR-D1 — the verbatim quote and its pinned snapshot

### DIFF
--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [0.43.0] — 2026-07-21 — the verbatim quote and its pinned snapshot (RS-4 PR-D1)
+
+Implements `ADJ-REASON-MATH.md` §E.3 — the two fields that turn the audit trail
+from something ADJ *reports* into something a third party can *check*.
+
+### Added
+
+- **`Provenance.quote: Quote`.** The verbatim span a clause rests on, separate
+  from `source`. Until now the span was *stuffed into* `source` by convention,
+  which conflates the **quotation** (bytes that must appear at the locator) with
+  the **citation label** (how a human names the document). One string cannot be
+  checked as both.
+- **`Provenance.snapshot: Option<ContentHash>`.** A SHA-256 of the source
+  document as captured at ingest. Verification runs against this, not the live
+  web — a verbatim check against a live URL is decided by whoever controls that
+  URL at verification time, so anyone able to publish there could make a
+  fabricated quote verify. Pinning makes later divergence *evidence of drift*
+  rather than a passing grade.
+- `Quote::Verbatim { text, byte_offset }` records WHERE the span sits, so
+  verification is **anchored** rather than an unanchored substring search. A
+  search would confirm the words exist somewhere — in a footnote, a nav menu, or
+  a passage saying the opposite — not that they support this clause.
+
+### Notes on two deliberate choices
+
+- **`Quote` is an enum, not the `String` the spec literally writes.** A plain
+  `String` cannot hold the `Unmigrated` state safely, and the obvious migration —
+  defaulting `quote` to the `source` label — **fails open**: labels are short
+  ("NIST", "AQI basics") and would trivially appear somewhere on the cited page,
+  so the strongest check in the system would pass while checking nothing and
+  report the step verified. A closed sum moves "never fail open" from a
+  convention someone must remember into a fact the compiler enforces.
+- **SHA-256, not the repo's `hash-functions` crate.** This hash is
+  tamper-evidence, so it needs collision resistance; FNV/DJB2/murmur/SipHash have
+  none and would look like a security control while providing nothing.
+  `coding_adventures_sha256` is the repo's own zero-dependency implementation, so
+  this stays inside the no-third-party rule.
+
+### Compatibility
+
+- Every existing `Provenance` constructor yields `Quote::Unmigrated` and
+  `snapshot: None` — the honest record of "no checkable span was captured",
+  never a guess. `adj-verify` (PR-D2) reports these `Unverified`, never
+  `Verified`. No existing call site changed.
+
 ## [0.42.0] — 2026-07-21 — an empty result set now says WHY it is empty (RS-4 PR-C)
 
 ### Added

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -23,6 +23,10 @@ from something ADJ *reports* into something a third party can *check*.
   search would confirm the words exist somewhere — in a footnote, a nav menu, or
   a passage saying the opposite — not that they support this clause.
 
+- `Quote::Verbatim(VerbatimSpan)` — the payload's fields are **private**, with
+  one fallible constructor. The invariant "a span must be able to support a
+  claim" therefore holds on every construction path, not just inside a builder.
+
 ### Notes on two deliberate choices
 
 - **`Quote` is an enum, not the `String` the spec literally writes.** A plain

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "logic-engine"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 
 [dependencies]
+coding_adventures_sha256 = { path = "../sha256" }
 logic-core = { path = "../logic-core" }
 bignum-core = { path = "../bignum-core" }

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -66,7 +66,7 @@ pub use lr_aggregate::{
     PriorClause, SourceDisagreementReport, SourceLogitDelta, UncertaintyMarker, UncertaintyReport,
 };
 pub use proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
-pub use provenance::{Citation, Provenance, TrustTier};
+pub use provenance::{Citation, ContentHash, Provenance, Quote, TrustTier};
 pub use wmc::weighted_model_count;
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -66,7 +66,7 @@ pub use lr_aggregate::{
     PriorClause, SourceDisagreementReport, SourceLogitDelta, UncertaintyMarker, UncertaintyReport,
 };
 pub use proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
-pub use provenance::{Citation, ContentHash, Provenance, Quote, TrustTier};
+pub use provenance::{Citation, ContentHash, Provenance, Quote, TrustTier, VerbatimSpan};
 pub use wmc::weighted_model_count;
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/logic-engine/src/provenance.rs
+++ b/code/packages/rust/logic-engine/src/provenance.rs
@@ -29,6 +29,31 @@
 /// without external grounding" at proof-display time.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Provenance {
+    /// The **verbatim span** this clause rests on — the bytes an auditor
+    /// re-finds at the locator (`ADJ-REASON-MATH.md` §E.3).
+    ///
+    /// # Why this is separate from `source`
+    ///
+    /// Until now the quoted span was *stuffed into* `source` by convention.
+    /// That conflates two different things: the **quotation** (bytes that must
+    /// appear at the locator, unchanged) and the **citation label** (how a
+    /// human names the document). A verifier needs the first; a reader needs
+    /// the second. One string cannot be checked as both.
+    pub quote: Quote,
+    /// A content hash of the source document as captured **at ingest time**.
+    ///
+    /// Verification runs against this snapshot, not against the live web, and
+    /// that is not a performance choice — it is what makes the check mean
+    /// anything. A verbatim check against a live URL is decided by whoever
+    /// controls that URL *at verification time*, so anyone able to publish
+    /// there (a compromised source, a DNS hijack, or just an ordinary content
+    /// edit) could make a fabricated quote verify. Pinning inverts that: the
+    /// snapshot is fixed when the fact enters, and later divergence becomes
+    /// **evidence of drift** rather than a passing grade.
+    ///
+    /// `None` means no snapshot was captured, which is a reason to report the
+    /// step `Unverified` — never `Verified`.
+    pub snapshot: Option<ContentHash>,
     /// Human-readable citation. Typically a journal reference, a
     /// guideline name + year, a statute, a clinical trial id, etc.
     /// Empty string only when `trust_tier == TrustTier::Unattributed`.
@@ -48,6 +73,107 @@ pub struct Provenance {
     /// the same fact would inflate posteriors). Empty for the common
     /// single-citation case; defaults to empty everywhere.
     pub corroborations: Vec<Citation>,
+}
+
+/// The verbatim span a clause rests on, or an explicit admission that it has
+/// not been recorded yet.
+///
+/// # Why this is an enum and not a `String`
+///
+/// `ADJ-REASON-MATH.md` §E.3 writes the field as `quote: String` with an
+/// `Unmigrated` state alongside. A plain `String` cannot express that state
+/// safely — the sentinel would be indistinguishable from a library that
+/// genuinely quoted the word "Unmigrated", and, worse, the obvious migration
+/// (default `quote` to the `source` label) **fails open**.
+///
+/// That failure mode is the reason this type exists. `source` labels are short
+/// — "NIST", "AQI basics" — and would trivially appear *somewhere* on the cited
+/// page. The strongest check in the system would therefore pass while verifying
+/// nothing, and report the step as verified. That manufactures confidence,
+/// which is the precise failure the whole audit-trail effort exists to prevent,
+/// and it would have been the default state of the entire stdlib on day one.
+///
+/// Making it a closed sum moves "never fail open" from a convention someone
+/// must remember into a fact the compiler enforces: you cannot read a quote
+/// without deciding what to do about `Unmigrated`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Quote {
+    /// The recorded span, and where it sits in the pinned snapshot.
+    Verbatim {
+        /// The exact bytes, as captured.
+        text: String,
+        /// Byte offset of `text` within the snapshot document.
+        ///
+        /// Verification is **anchored** to this offset rather than searching
+        /// the document for the text. An unanchored substring search would
+        /// accept a quote that appears anywhere — including in a footnote, a
+        /// navigation menu, or a passage that says the opposite — so it would
+        /// confirm that the words exist somewhere, not that they support this
+        /// clause. `None` means the offset was not recorded, which downgrades
+        /// the step to `Unverified` rather than falling back to searching.
+        byte_offset: Option<usize>,
+    },
+    /// This clause predates the `quote`/`source` split. **Never verifiable.**
+    Unmigrated,
+}
+
+impl Quote {
+    /// The recorded span, if there is one.
+    pub fn text(&self) -> Option<&str> {
+        match self {
+            Quote::Verbatim { text, .. } => Some(text),
+            Quote::Unmigrated => None,
+        }
+    }
+
+    /// `true` when this clause carries no checkable span. A verifier that sees
+    /// this **must** report `Unverified`; it must not report `Verified`, and it
+    /// must not silently skip the step.
+    pub fn is_unmigrated(&self) -> bool {
+        matches!(self, Quote::Unmigrated)
+    }
+}
+
+/// A content-addressed hash of a source document, captured at ingest.
+///
+/// # Why SHA-256 and not the repo's `hash-functions` crate
+///
+/// This hash is **tamper-evidence**, not a hash-table index. The threat is an
+/// adversary who wants a forged snapshot to verify, so the property required is
+/// collision resistance. FNV, DJB2, murmur and SipHash — everything in
+/// `hash-functions` — are fast non-cryptographic hashes with no such guarantee;
+/// using one here would look like a security control while providing none.
+/// `coding_adventures_sha256` is the repo's own zero-dependency implementation,
+/// so this stays within the no-third-party rule.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ContentHash {
+    /// Lowercase hex of the SHA-256 digest.
+    hex: String,
+}
+
+impl ContentHash {
+    /// Hash a source document's bytes.
+    pub fn of(bytes: &[u8]) -> Self {
+        Self {
+            hex: coding_adventures_sha256::sha256_hex(bytes),
+        }
+    }
+
+    /// Reconstruct from a stored hex digest (e.g. read back from a trail).
+    pub fn from_hex(hex: impl Into<String>) -> Self {
+        Self { hex: hex.into() }
+    }
+
+    /// The hex digest.
+    pub fn as_hex(&self) -> &str {
+        &self.hex
+    }
+
+    /// `true` iff `bytes` hash to this digest — i.e. the document on hand is
+    /// byte-for-byte the one that was captured at ingest.
+    pub fn matches(&self, bytes: &[u8]) -> bool {
+        Self::of(bytes).hex == self.hex
+    }
 }
 
 /// One corroborating citation (ADJ-A9). Both fields are required: a
@@ -106,14 +232,43 @@ pub enum TrustTier {
 }
 
 impl Provenance {
-    /// Construct a `Provenance` with all three fields explicit.
+    /// Construct a `Provenance` with the classic three fields explicit.
+    ///
+    /// The quote is [`Quote::Unmigrated`] and the snapshot is `None`: every
+    /// existing caller predates the §E.3 split, and the honest record of that
+    /// is "no checkable span was captured", not a guess. A verifier reports
+    /// these `Unverified` — never `Verified`. Use [`with_quote`](Self::with_quote)
+    /// to record a real span.
     pub fn new(source: impl Into<String>, locator: Option<String>, trust_tier: TrustTier) -> Self {
         Self {
+            quote: Quote::Unmigrated,
+            snapshot: None,
             source: source.into(),
             locator,
             trust_tier,
             corroborations: Vec::new(),
         }
+    }
+
+    /// Record the verbatim span this clause rests on, anchored at `byte_offset`
+    /// within the document whose content hashes to `snapshot`.
+    ///
+    /// Both anchors are optional at the type level because real libraries are
+    /// migrated incrementally — but a verifier treats a missing offset or a
+    /// missing snapshot as `Unverified`, so partial migration never reads as
+    /// success.
+    pub fn with_quote(
+        mut self,
+        text: impl Into<String>,
+        byte_offset: Option<usize>,
+        snapshot: Option<ContentHash>,
+    ) -> Self {
+        self.quote = Quote::Verbatim {
+            text: text.into(),
+            byte_offset,
+        };
+        self.snapshot = snapshot;
+        self
     }
 
     /// The common case: a single-line citation at

--- a/code/packages/rust/logic-engine/src/provenance.rs
+++ b/code/packages/rust/logic-engine/src/provenance.rs
@@ -160,8 +160,23 @@ impl ContentHash {
     }
 
     /// Reconstruct from a stored hex digest (e.g. read back from a trail).
-    pub fn from_hex(hex: impl Into<String>) -> Self {
-        Self { hex: hex.into() }
+    ///
+    /// Returns `None` unless the input really is a 64-character SHA-256 digest.
+    /// Validating here is what makes the type mean something: a `ContentHash`
+    /// value is a well-formed digest **by construction**, so the weaker
+    /// hash-to-hash comparison below cannot be satisfied by two copies of the
+    /// same garbage string read out of the same untrusted trail.
+    ///
+    /// Case and surrounding whitespace are normalized rather than rejected —
+    /// a digest that survived a round trip through a system that upcased it
+    /// should read as the same digest, not as permanent, silent drift.
+    pub fn from_hex(hex: impl AsRef<str>) -> Option<Self> {
+        let h = hex.as_ref().trim().to_ascii_lowercase();
+        if h.len() == 64 && h.bytes().all(|b| b.is_ascii_hexdigit()) {
+            Some(Self { hex: h })
+        } else {
+            None
+        }
     }
 
     /// The hex digest.
@@ -171,6 +186,11 @@ impl ContentHash {
 
     /// `true` iff `bytes` hash to this digest — i.e. the document on hand is
     /// byte-for-byte the one that was captured at ingest.
+    ///
+    /// **This, not `==`, is verification.** Comparing two `ContentHash` values
+    /// compares two hex strings, which says only that a trail agrees with
+    /// itself; it never touches the document. A verifier must re-hash the bytes
+    /// it actually has, which is what this does.
     pub fn matches(&self, bytes: &[u8]) -> bool {
         Self::of(bytes).hex == self.hex
     }
@@ -263,12 +283,48 @@ impl Provenance {
         byte_offset: Option<usize>,
         snapshot: Option<ContentHash>,
     ) -> Self {
-        self.quote = Quote::Verbatim {
-            text: text.into(),
-            byte_offset,
+        let text = text.into();
+        // A BLANK SPAN IS NOT A WEAKER QUOTE — IT IS A UNIVERSAL ONE. The
+        // verifier checks `doc[at..at + text.len()] == text`, which is
+        // trivially true for an empty span at every offset in every document.
+        // So an empty `quote` would report Verified while resting on nothing:
+        // exactly the failure the `Unmigrated` variant exists to prevent,
+        // reached through a different door. Record the absence instead.
+        self.quote = if text.trim().is_empty() {
+            Quote::Unmigrated
+        } else {
+            Quote::Verbatim { text, byte_offset }
         };
         self.snapshot = snapshot;
         self
+    }
+
+    /// Record a span **against the document it came from** — the safer path,
+    /// and the one new grounded libraries should use.
+    ///
+    /// [`with_quote`](Self::with_quote) takes the text, the offset and the
+    /// snapshot as three independent values, so nothing stops them describing
+    /// three different documents: an offset that does not point at the text, or
+    /// a hash of something else entirely. This constructor takes the document
+    /// itself and *derives* the other two, which makes that disagreement
+    /// unrepresentable.
+    ///
+    /// Returns `None` — rather than panicking — when the range does not name a
+    /// real span: past the end, not on a UTF-8 character boundary, arithmetic
+    /// overflow, or blank text. A caller that cannot record a span must find
+    /// that out, not discover it later as a slicing panic inside a verifier.
+    pub fn with_quote_in(mut self, doc: &str, byte_offset: usize, len: usize) -> Option<Self> {
+        let end = byte_offset.checked_add(len)?;
+        let text = doc.get(byte_offset..end)?;
+        if text.trim().is_empty() {
+            return None;
+        }
+        self.quote = Quote::Verbatim {
+            text: text.to_string(),
+            byte_offset: Some(byte_offset),
+        };
+        self.snapshot = Some(ContentHash::of(doc.as_bytes()));
+        Some(self)
     }
 
     /// The common case: a single-line citation at

--- a/code/packages/rust/logic-engine/src/provenance.rs
+++ b/code/packages/rust/logic-engine/src/provenance.rs
@@ -99,20 +99,11 @@ pub struct Provenance {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Quote {
     /// The recorded span, and where it sits in the pinned snapshot.
-    Verbatim {
-        /// The exact bytes, as captured.
-        text: String,
-        /// Byte offset of `text` within the snapshot document.
-        ///
-        /// Verification is **anchored** to this offset rather than searching
-        /// the document for the text. An unanchored substring search would
-        /// accept a quote that appears anywhere — including in a footnote, a
-        /// navigation menu, or a passage that says the opposite — so it would
-        /// confirm that the words exist somewhere, not that they support this
-        /// clause. `None` means the offset was not recorded, which downgrades
-        /// the step to `Unverified` rather than falling back to searching.
-        byte_offset: Option<usize>,
-    },
+    ///
+    /// The payload's fields are **private**, so the only way to obtain one is
+    /// [`VerbatimSpan::new`], which enforces the invariant. See that type for
+    /// why the check cannot live in a builder.
+    Verbatim(VerbatimSpan),
     /// This clause predates the `quote`/`source` split. **Never verifiable.**
     Unmigrated,
 }
@@ -121,7 +112,15 @@ impl Quote {
     /// The recorded span, if there is one.
     pub fn text(&self) -> Option<&str> {
         match self {
-            Quote::Verbatim { text, .. } => Some(text),
+            Quote::Verbatim(v) => Some(v.text()),
+            Quote::Unmigrated => None,
+        }
+    }
+
+    /// Where the span sits in the snapshot, if both are recorded.
+    pub fn byte_offset(&self) -> Option<usize> {
+        match self {
+            Quote::Verbatim(v) => v.byte_offset(),
             Quote::Unmigrated => None,
         }
     }
@@ -132,6 +131,85 @@ impl Quote {
     pub fn is_unmigrated(&self) -> bool {
         matches!(self, Quote::Unmigrated)
     }
+}
+
+/// A span that is guaranteed, by construction, to be capable of supporting a
+/// claim.
+///
+/// # Why the fields are private
+///
+/// The first version of this enforced "a span must not be blank" inside the
+/// `with_quote` builder. A security review disproved that with a downstream
+/// probe crate: `Quote::Verbatim` was a public struct-variant, so a consumer
+/// could write `Quote::Verbatim { text: String::new(), .. }` directly and
+/// bypass the builder entirely — and an empty span satisfies the verifier's
+/// `doc[at..at + text.len()] == text` at **every offset in every document**.
+///
+/// The builder was never going to be the chokepoint, and the reason matters:
+/// **deserialization builds the enum directly**, so a trail read back from disk
+/// would reconstruct exactly the value the builder refused to make. That is
+/// PR-D2's whole job, which means the hole would have reopened precisely where
+/// it does the most damage. Private fields plus one fallible constructor make
+/// the invariant hold on every path, including ones not written yet.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VerbatimSpan {
+    text: String,
+    byte_offset: Option<usize>,
+}
+
+impl VerbatimSpan {
+    /// Build a span, or `None` if it could not support a claim.
+    ///
+    /// Rejects text with no **visible** content. `str::trim` alone is not
+    /// enough: it follows the Unicode `White_Space` property, which covers
+    /// U+00A0 and U+3000 but *not* the zero-width family (U+200B–U+200D,
+    /// U+2060, U+FEFF). A zero-width span is invisible in every rendering of
+    /// the trail, so a human auditor would see what looks like a blank quote
+    /// while the verifier reported a real one — the same manufactured
+    /// confidence, in miniature.
+    pub fn new(text: impl Into<String>, byte_offset: Option<usize>) -> Option<Self> {
+        let text = text.into();
+        if !has_visible_content(&text) {
+            return None;
+        }
+        Some(Self { text, byte_offset })
+    }
+
+    /// The exact bytes, as captured.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Byte offset of the span within the snapshot document.
+    ///
+    /// Verification is **anchored** to this offset rather than searching the
+    /// document for the text. An unanchored substring search would accept a
+    /// quote that appears anywhere — a footnote, a navigation menu, a passage
+    /// saying the opposite — so it would confirm the words exist somewhere, not
+    /// that they support this clause. `None` means no offset was recorded,
+    /// which downgrades the step to `Unverified` rather than falling back to
+    /// searching.
+    ///
+    /// Note what this does **not** promise: a very short span (one or two
+    /// characters) is anchored but weak. Anchoring means it must really occur
+    /// at that offset, so it is not the universal match a blank span would be —
+    /// but it is thin evidence. No arbitrary minimum length is imposed here,
+    /// because any threshold would be false precision; instead `adj-verify`
+    /// (PR-D2) should surface span length so a reader can judge for themselves.
+    pub fn byte_offset(&self) -> Option<usize> {
+        self.byte_offset
+    }
+}
+
+/// `true` if `s` contains at least one character a human would actually see.
+fn has_visible_content(s: &str) -> bool {
+    s.chars().any(|c| !is_invisible(c))
+}
+
+/// Whitespace *plus* the zero-width characters `str::trim` does not treat as
+/// whitespace but which render as nothing.
+fn is_invisible(c: char) -> bool {
+    c.is_whitespace() || matches!(c, '\u{200B}'..='\u{200D}' | '\u{2060}' | '\u{FEFF}')
 }
 
 /// A content-addressed hash of a source document, captured at ingest.
@@ -283,17 +361,13 @@ impl Provenance {
         byte_offset: Option<usize>,
         snapshot: Option<ContentHash>,
     ) -> Self {
-        let text = text.into();
-        // A BLANK SPAN IS NOT A WEAKER QUOTE — IT IS A UNIVERSAL ONE. The
-        // verifier checks `doc[at..at + text.len()] == text`, which is
-        // trivially true for an empty span at every offset in every document.
-        // So an empty `quote` would report Verified while resting on nothing:
-        // exactly the failure the `Unmigrated` variant exists to prevent,
-        // reached through a different door. Record the absence instead.
-        self.quote = if text.trim().is_empty() {
-            Quote::Unmigrated
-        } else {
-            Quote::Verbatim { text, byte_offset }
+        // A BLANK SPAN IS NOT A WEAKER QUOTE — IT IS A UNIVERSAL ONE, matching
+        // at every offset in every document. `VerbatimSpan::new` is the single
+        // place that decides; a span it refuses is recorded as the absence it
+        // is, rather than as a check that would always pass.
+        self.quote = match VerbatimSpan::new(text, byte_offset) {
+            Some(v) => Quote::Verbatim(v),
+            None => Quote::Unmigrated,
         };
         self.snapshot = snapshot;
         self
@@ -316,13 +390,7 @@ impl Provenance {
     pub fn with_quote_in(mut self, doc: &str, byte_offset: usize, len: usize) -> Option<Self> {
         let end = byte_offset.checked_add(len)?;
         let text = doc.get(byte_offset..end)?;
-        if text.trim().is_empty() {
-            return None;
-        }
-        self.quote = Quote::Verbatim {
-            text: text.to_string(),
-            byte_offset: Some(byte_offset),
-        };
+        self.quote = Quote::Verbatim(VerbatimSpan::new(text, Some(byte_offset))?);
         self.snapshot = Some(ContentHash::of(doc.as_bytes()));
         Some(self)
     }

--- a/code/packages/rust/logic-engine/tests/test_quote_and_snapshot.rs
+++ b/code/packages/rust/logic-engine/tests/test_quote_and_snapshot.rs
@@ -93,9 +93,15 @@ fn the_anchor_actually_points_at_the_quote_in_the_document() {
         panic!("expected a verbatim quote");
     };
     let at = byte_offset.expect("anchored");
+    // CHECKED slicing, deliberately — this is the pattern the verifier copies.
+    // `&doc[at..at + text.len()]` panics three ways on stale or hostile input:
+    // an offset past the end, an offset off a UTF-8 character boundary, and
+    // `at + len` overflowing. A verifier must treat all three as Unverified,
+    // never as a crash.
+    let found = doc.get(at..at.checked_add(text.len()).expect("no overflow"));
     assert_eq!(
-        &doc[at..at + text.len()],
-        text,
+        found,
+        Some(text.as_str()),
         "the recorded offset must land exactly on the recorded span"
     );
 }
@@ -127,7 +133,7 @@ fn a_snapshot_round_trips_through_its_hex_form() {
     // A trail is stored and re-read; the hash has to survive that trip, or the
     // pin is only good within one process.
     let snap = ContentHash::of(b"The AQI includes six color-coded categories.");
-    let restored = ContentHash::from_hex(snap.as_hex());
+    let restored = ContentHash::from_hex(snap.as_hex()).expect("a real digest");
     assert_eq!(snap, restored);
     assert!(restored.matches(b"The AQI includes six color-coded categories."));
     assert_eq!(snap.as_hex().len(), 64, "SHA-256 hex is 64 chars");
@@ -164,4 +170,109 @@ fn a_quote_without_an_anchor_or_snapshot_is_still_incomplete() {
         ),
         Quote::Unmigrated => panic!("expected a verbatim quote"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// (5) The blank-span door: an empty quote would verify against EVERYTHING.
+//
+//     Found by this PR's security review. The `Unmigrated` variant closes
+//     "the label silently became the quote"; this closes the other way in.
+//     A verifier checks `doc[at..at + text.len()] == text`, which is trivially
+//     true for an empty span at every offset in every document — so an empty
+//     quote reports Verified while resting on nothing, and does it through the
+//     intended builder where nothing looks wrong.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_blank_span_is_recorded_as_absent_rather_than_as_a_universal_match() {
+    let snap = ContentHash::of(b"any document at all");
+    for blank in ["", " ", "\t\n  "] {
+        let p = Provenance::cited("EPA AirNow").with_quote(blank, Some(0), Some(snap.clone()));
+        assert!(
+            p.quote.is_unmigrated(),
+            "a blank span ({blank:?}) must degrade to Unmigrated — it would \
+             otherwise match every document at every offset"
+        );
+        assert_eq!(p.quote.text(), None);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (6) A digest is a digest by CONSTRUCTION, so `==` cannot be satisfied by
+//     two copies of the same garbage out of the same untrusted trail.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_hex_rejects_anything_that_is_not_a_real_digest() {
+    for junk in [
+        "not-a-hash",
+        "",
+        "deadbeef",                                                         // too short
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8",   // 62 chars
+        "g3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", // non-hex
+    ] {
+        assert!(
+            ContentHash::from_hex(junk).is_none(),
+            "{junk:?} is not a SHA-256 digest and must not become a ContentHash"
+        );
+    }
+}
+
+#[test]
+fn a_digest_survives_case_and_whitespace_without_becoming_silent_drift() {
+    // A trail round-tripped through something that upcases hex, or leaves a
+    // stray newline, must still read as the SAME digest. Otherwise it would
+    // never match, and that permanent failure is indistinguishable at the call
+    // site from the genuine document drift the snapshot exists to detect.
+    let snap = ContentHash::of(b"Yellow   Moderate   51 to 100");
+    let upper = ContentHash::from_hex(snap.as_hex().to_uppercase()).expect("still a digest");
+    let padded = ContentHash::from_hex(format!("  {}\n", snap.as_hex())).expect("still a digest");
+    assert_eq!(snap, upper);
+    assert_eq!(snap, padded);
+    assert!(upper.matches(b"Yellow   Moderate   51 to 100"));
+}
+
+// ---------------------------------------------------------------------------
+// (7) `with_quote_in` makes the three anchors agree by construction.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn recording_a_span_against_its_document_derives_a_consistent_snapshot() {
+    let doc = "Green   Good   0 to 50   Air quality is satisfactory.";
+    let at = doc.find("Good   0 to 50").expect("fixture");
+    let p = Provenance::cited("EPA AirNow")
+        .with_quote_in(doc, at, "Good   0 to 50".len())
+        .expect("a real span");
+
+    assert_eq!(p.quote.text(), Some("Good   0 to 50"));
+    // The snapshot was DERIVED from the same document, so it cannot disagree
+    // with the offset — which is the whole point of this constructor.
+    assert!(p.snapshot.expect("derived").matches(doc.as_bytes()));
+}
+
+#[test]
+fn recording_a_span_refuses_ranges_that_would_panic_a_verifier() {
+    let doc = "Purple   Very Unhealthy   201 to 300";
+
+    // Past the end.
+    assert!(Provenance::cited("x").with_quote_in(doc, 30, 999).is_none());
+    // Arithmetic overflow rather than a wrapped, in-range-looking end.
+    assert!(Provenance::cited("x")
+        .with_quote_in(doc, usize::MAX, 2)
+        .is_none());
+    // Blank.
+    assert!(Provenance::cited("x").with_quote_in(doc, 6, 3).is_none());
+
+    // A multi-byte document, sliced off a character boundary.
+    // 'R' is byte 0; 'é' occupies bytes 1..3, so byte 2 is INSIDE it — the
+    // offset that would panic a naive `&doc[2..4]`.
+    let utf8 = "Résumé — 51 to 100";
+    assert!(
+        !utf8.is_char_boundary(2),
+        "fixture: byte 2 is mid-character"
+    );
+    assert!(
+        Provenance::cited("x").with_quote_in(utf8, 2, 2).is_none(),
+        "an offset off a UTF-8 boundary must be refused, not panicked on"
+    );
 }

--- a/code/packages/rust/logic-engine/tests/test_quote_and_snapshot.rs
+++ b/code/packages/rust/logic-engine/tests/test_quote_and_snapshot.rs
@@ -1,0 +1,167 @@
+//! RS-4 PR-D1 — the verbatim `quote` and its pinned `snapshot`
+//! (`ADJ-REASON-MATH.md` §E.3).
+//!
+//! These two fields are what turn the audit trail from something ADJ *reports*
+//! into something a third party can *check*. The tests below are mostly about
+//! one property, because it is the one that can silently destroy the value of
+//! everything else:
+//!
+//! **A clause with no recorded span must never look verified.**
+//!
+//! The tempting migration — default `quote` to the existing `source` label —
+//! fails open. `source` labels are short ("NIST", "AQI basics") and would
+//! trivially appear *somewhere* on the cited page, so the strongest check in
+//! the system would pass while checking nothing, and would say so in a field
+//! named `verified`. That is worse than having no verifier: it manufactures
+//! confidence at scale, and it would have been the default state of the entire
+//! shipped stdlib on day one.
+
+use logic_engine::{ContentHash, Provenance, Quote};
+
+// ---------------------------------------------------------------------------
+// (1) The fail-open trap: an un-migrated clause is explicitly unverifiable.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_clause_built_the_old_way_is_unmigrated_not_silently_quoted() {
+    // Every pre-existing call site goes through `new`/`cited`/`empirical`.
+    let p = Provenance::cited("Pope 1995");
+
+    assert!(
+        p.quote.is_unmigrated(),
+        "an un-split clause must SAY it has no checkable span"
+    );
+    assert_eq!(
+        p.quote.text(),
+        None,
+        "and must not hand a verifier the citation label as if it were a quote"
+    );
+    // The label is still there for humans — the split loses nothing.
+    assert_eq!(p.source, "Pope 1995");
+}
+
+#[test]
+fn the_citation_label_is_never_reused_as_the_quote() {
+    // The specific fail-open shape, stated as an executable claim: a short
+    // label like "NIST" would appear on almost any NIST page, so if it were
+    // ever promoted to `quote` the verifier would pass without checking.
+    for label in ["NIST", "AQI basics", "WHO", "Pope 1995"] {
+        let p = Provenance::cited(label);
+        assert!(
+            p.quote.text() != Some(label),
+            "the label {label:?} must never become the quote — it would verify \
+             trivially and prove nothing"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (2) A migrated clause carries the span, its anchor, and its snapshot.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_migrated_clause_carries_an_anchored_span_and_a_pinned_snapshot() {
+    let doc = b"Green   Good   0 to 50   Air quality is satisfactory.";
+    let snap = ContentHash::of(doc);
+    let p =
+        Provenance::cited("EPA AirNow").with_quote("Good   0 to 50", Some(8), Some(snap.clone()));
+
+    assert_eq!(p.quote.text(), Some("Good   0 to 50"));
+    assert!(!p.quote.is_unmigrated());
+    match &p.quote {
+        Quote::Verbatim { byte_offset, .. } => assert_eq!(*byte_offset, Some(8)),
+        Quote::Unmigrated => panic!("expected a verbatim quote"),
+    }
+    assert_eq!(p.snapshot.as_ref(), Some(&snap));
+}
+
+#[test]
+fn the_anchor_actually_points_at_the_quote_in_the_document() {
+    // The anchor is the whole reason verification is not a substring search:
+    // it says WHERE the span sits, so a verifier confirms the clause rests on
+    // this passage rather than on the words appearing somewhere in a footnote.
+    let doc = "Green   Good   0 to 50   Air quality is satisfactory.";
+    let quote = "Good   0 to 50";
+    let offset = doc.find(quote).expect("fixture");
+    let p = Provenance::cited("EPA AirNow").with_quote(
+        quote,
+        Some(offset),
+        Some(ContentHash::of(doc.as_bytes())),
+    );
+
+    let Quote::Verbatim { text, byte_offset } = &p.quote else {
+        panic!("expected a verbatim quote");
+    };
+    let at = byte_offset.expect("anchored");
+    assert_eq!(
+        &doc[at..at + text.len()],
+        text,
+        "the recorded offset must land exactly on the recorded span"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) The snapshot is tamper-evident: any edit breaks the match.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_snapshot_detects_that_the_document_changed_under_the_quote() {
+    let original = b"Maroon   Hazardous   301 and higher";
+    let snap = ContentHash::of(original);
+    assert!(
+        snap.matches(original),
+        "the captured document still matches"
+    );
+
+    // One character edited — the sort of quiet revision that would otherwise
+    // let a stale citation keep passing.
+    let edited = b"Maroon   Hazardous   300 and higher";
+    assert!(
+        !snap.matches(edited),
+        "an edited document must NOT match the pinned snapshot"
+    );
+}
+
+#[test]
+fn a_snapshot_round_trips_through_its_hex_form() {
+    // A trail is stored and re-read; the hash has to survive that trip, or the
+    // pin is only good within one process.
+    let snap = ContentHash::of(b"The AQI includes six color-coded categories.");
+    let restored = ContentHash::from_hex(snap.as_hex());
+    assert_eq!(snap, restored);
+    assert!(restored.matches(b"The AQI includes six color-coded categories."));
+    assert_eq!(snap.as_hex().len(), 64, "SHA-256 hex is 64 chars");
+}
+
+#[test]
+fn distinct_documents_get_distinct_hashes() {
+    let a = ContentHash::of(b"Yellow   Moderate   51 to 100");
+    let b = ContentHash::of(b"Orange   Unhealthy for Sensitive Groups   101 to 150");
+    assert_ne!(a, b);
+}
+
+// ---------------------------------------------------------------------------
+// (4) Partial migration never reads as success.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_quote_without_an_anchor_or_snapshot_is_still_incomplete() {
+    // Real libraries migrate incrementally, so the type permits a span with no
+    // offset and no snapshot. What must NOT happen is that state reading as
+    // fully checkable — the verifier (PR-D2) treats either gap as Unverified.
+    let p = Provenance::cited("EPA AirNow").with_quote("Good   0 to 50", None, None);
+
+    assert_eq!(p.quote.text(), Some("Good   0 to 50"));
+    assert!(
+        p.snapshot.is_none(),
+        "no snapshot was captured, and the record says so"
+    );
+    match &p.quote {
+        Quote::Verbatim { byte_offset, .. } => assert_eq!(
+            *byte_offset, None,
+            "no anchor was captured, and the record says so rather than \
+             implying the span can be located"
+        ),
+        Quote::Unmigrated => panic!("expected a verbatim quote"),
+    }
+}

--- a/code/packages/rust/logic-engine/tests/test_quote_and_snapshot.rs
+++ b/code/packages/rust/logic-engine/tests/test_quote_and_snapshot.rs
@@ -16,7 +16,7 @@
 //! confidence at scale, and it would have been the default state of the entire
 //! shipped stdlib on day one.
 
-use logic_engine::{ContentHash, Provenance, Quote};
+use logic_engine::{ContentHash, Provenance, Quote, VerbatimSpan};
 
 // ---------------------------------------------------------------------------
 // (1) The fail-open trap: an un-migrated clause is explicitly unverifiable.
@@ -68,10 +68,7 @@ fn a_migrated_clause_carries_an_anchored_span_and_a_pinned_snapshot() {
 
     assert_eq!(p.quote.text(), Some("Good   0 to 50"));
     assert!(!p.quote.is_unmigrated());
-    match &p.quote {
-        Quote::Verbatim { byte_offset, .. } => assert_eq!(*byte_offset, Some(8)),
-        Quote::Unmigrated => panic!("expected a verbatim quote"),
-    }
+    assert_eq!(p.quote.byte_offset(), Some(8));
     assert_eq!(p.snapshot.as_ref(), Some(&snap));
 }
 
@@ -89,10 +86,11 @@ fn the_anchor_actually_points_at_the_quote_in_the_document() {
         Some(ContentHash::of(doc.as_bytes())),
     );
 
-    let Quote::Verbatim { text, byte_offset } = &p.quote else {
+    let Quote::Verbatim(span) = &p.quote else {
         panic!("expected a verbatim quote");
     };
-    let at = byte_offset.expect("anchored");
+    let text = span.text();
+    let at = span.byte_offset().expect("anchored");
     // CHECKED slicing, deliberately — this is the pattern the verifier copies.
     // `&doc[at..at + text.len()]` panics three ways on stale or hostile input:
     // an offset past the end, an offset off a UTF-8 character boundary, and
@@ -101,7 +99,7 @@ fn the_anchor_actually_points_at_the_quote_in_the_document() {
     let found = doc.get(at..at.checked_add(text.len()).expect("no overflow"));
     assert_eq!(
         found,
-        Some(text.as_str()),
+        Some(text),
         "the recorded offset must land exactly on the recorded span"
     );
 }
@@ -162,14 +160,12 @@ fn a_quote_without_an_anchor_or_snapshot_is_still_incomplete() {
         p.snapshot.is_none(),
         "no snapshot was captured, and the record says so"
     );
-    match &p.quote {
-        Quote::Verbatim { byte_offset, .. } => assert_eq!(
-            *byte_offset, None,
-            "no anchor was captured, and the record says so rather than \
-             implying the span can be located"
-        ),
-        Quote::Unmigrated => panic!("expected a verbatim quote"),
-    }
+    assert_eq!(
+        p.quote.byte_offset(),
+        None,
+        "no anchor was captured, and the record says so rather than implying \
+         the span can be located"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -274,5 +270,60 @@ fn recording_a_span_refuses_ranges_that_would_panic_a_verifier() {
     assert!(
         Provenance::cited("x").with_quote_in(utf8, 2, 2).is_none(),
         "an offset off a UTF-8 boundary must be refused, not panicked on"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (8) The invariant is STRUCTURAL, not merely enforced by the builder.
+//
+//     Round 2 of the security review disproved the builder-only version with a
+//     downstream probe crate: `Quote::Verbatim` was a public struct-variant, so
+//     a consumer could construct an empty span directly and bypass the check.
+//     The reason that mattered more than it looks: DESERIALIZATION builds the
+//     enum directly, so a trail read back from disk — PR-D2's entire job —
+//     would reconstruct exactly the value the builder refused to make.
+//
+//     `VerbatimSpan` now has private fields and one fallible constructor, so
+//     every path is covered, including paths not written yet. This test states
+//     the property through that constructor, which is the only door left.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_span_with_no_visible_content_cannot_be_constructed_at_all() {
+    // Ordinary whitespace …
+    for blank in ["", " ", "\t\n  ", "\u{00A0}", "\u{3000}"] {
+        assert!(
+            VerbatimSpan::new(blank, Some(0)).is_none(),
+            "{blank:?} has no visible content and must not become a span"
+        );
+    }
+    // … and the zero-width family, which `str::trim` does NOT treat as
+    // whitespace. A zero-width span renders as nothing, so an auditor would
+    // see an apparently blank quote while the verifier reported a real one.
+    for invisible in ["\u{200B}", "\u{200C}", "\u{200D}", "\u{2060}", "\u{FEFF}"] {
+        assert!(
+            VerbatimSpan::new(invisible, Some(0)).is_none(),
+            "U+{:04X} is invisible in every rendering and must not become a span",
+            invisible.chars().next().unwrap() as u32
+        );
+    }
+    // A span with any visible character is fine, even alongside invisibles.
+    assert!(VerbatimSpan::new("\u{200B}Good 0 to 50", Some(0)).is_some());
+}
+
+#[test]
+fn both_builders_route_through_the_one_constructor() {
+    let doc = "Green\u{200B}\u{FEFF}   Good   0 to 50";
+    let snap = ContentHash::of(doc.as_bytes());
+
+    // `with_quote` degrades an invisible span to the honest absence …
+    let p = Provenance::cited("x").with_quote("\u{200B}\u{FEFF}", Some(0), Some(snap));
+    assert!(p.quote.is_unmigrated(), "invisible span must not verify");
+
+    // … and `with_quote_in` refuses to build one at all.
+    let zw = doc.find('\u{200B}').expect("fixture");
+    assert!(
+        Provenance::cited("x").with_quote_in(doc, zw, 6).is_none(),
+        "the document-anchored builder must apply the same rule"
     );
 }


### PR DESCRIPTION
**RS-4 PR-D1.** First half of the final stage. Everything merged so far makes ADJ **report** its reasoning; PR-D makes that reasoning **independently checkable** — the difference between testimony and evidence, which is the point of *"hallucination is an accounting failure."*

D1 adds the two fields without which there is nothing to check. **D2 is the `adj-verify` binary itself.**

## The two fields (§E.3)

**`Provenance.quote`** — the verbatim span, *separate from* `source`. Until now the span was stuffed into `source` by convention, conflating two different things: the **quotation** (bytes that must appear at the locator, unchanged) and the **citation label** (how a human names the document). A verifier needs the first, a reader needs the second, and one string cannot be checked as both.

**`Provenance.snapshot`** — SHA-256 of the source document as captured **at ingest**. Verification runs against that, not the live web. Not a performance choice: a verbatim check against a live URL is decided by whoever controls that URL *at verification time*, so a compromised source, a DNS hijack, or an ordinary content edit could make a fabricated quote verify. Pinning inverts it — the snapshot is fixed when the fact enters, and later divergence becomes *evidence of drift* rather than a passing grade.

`Quote::Verbatim` also records `byte_offset`, so verification is **anchored** rather than an unanchored substring search. A search would confirm the words exist *somewhere* — a footnote, a nav menu, a passage saying the opposite — not that they support this clause.

## Two deliberate divergences from the spec

**1. §E.3 writes `quote: String`. This implements an enum, on purpose.** A `String` cannot hold the `Unmigrated` state safely, and the obvious migration — defaulting `quote` to the `source` label — **fails open**. Labels are short ("NIST", "AQI basics") and would trivially appear somewhere on the cited page, so the strongest check in the system would pass while checking nothing and report the step **Verified**. That manufactures confidence, which is the precise failure this rung exists to prevent, and it would have been the default state of the entire stdlib on day one.

**2. SHA-256 via the repo's own zero-dep crate, not `hash-functions`.** Everything in that crate — FNV, DJB2, murmur, SipHash — is a fast *non-cryptographic* hash with no collision resistance. This hash is tamper-evidence; using one of those would look like a security control while providing none.

## Security review: two rounds, and the second one mattered

**Round 1** verified the repo's SHA-256 against four FIPS 180-4 vectors (empty, `"abc"`, the two-block vector, 1,000,000×`'a'`) — all pass, so snapshots are not worthless. It then found the fail-open trap still open through two other doors: an **empty span verifies against every document at every offset**, and `from_hex` accepted arbitrary strings so a verifier writing `snapshot == expected` would pass without ever hashing anything.

**Round 2 disproved my fix with a downstream probe crate.** I had put the blank check in the builder — but `Quote::Verbatim` was a public struct-variant, so a consumer could construct the empty span directly and skip it. The probe showed that value "verifying" against *"totally unrelated document"*, against `""`, against everything.

Why that mattered more than API hygiene: **deserialization constructs the enum directly.** A trail read back from disk — PR-D2's entire job — would rebuild exactly the value the builder refused to make. The hole would have reopened *inside the verifier*, with the comment asserting the property sitting next to it.

Now structural: `Quote::Verbatim(VerbatimSpan)`, private fields, one fallible constructor. The invariant holds on every path, including ones not written yet.

Round 2 also caught that `str::trim()` misses the **zero-width family** (U+200B–U+200D, U+2060, U+FEFF). A zero-width span is invisible in every rendering, so an auditor would see a blank quote while the verifier reported a real one — and it passed through *both* builders, including the "safe" one.

**One suggestion I declined:** a minimum span length. Anchoring already means a short span must genuinely occur at that offset, so it is not the universal match a blank span is — and any specific threshold would be false precision dressed as rigour. Recorded instead as a D2 requirement to *surface* span length so a reader can judge.

## Verification

- **15 tests**, most aimed at the one property that can silently destroy everything else: *a clause with no recorded span must never look verified.* Including an executable statement of the fail-open shape (for `"NIST"`/`"AQI basics"`/`"WHO"`/`"Pope 1995"`, the label must never become the quote) and of the zero-width case.
- **664 tests pass, 0 fail; clippy 0.**
- **No existing call site changed** — every constructor yields `Unmigrated` + `snapshot: None`, the honest record that nothing checkable was captured, never a guess.
- The anchor test uses **checked** slicing deliberately: it is the pattern D2 will copy, and `&doc[at..at+len]` panics three ways on stale or hostile input.

## Carried forward to D2

When D2 renders a quote it must route through the PR-C `payload()` handling — sensitivity redaction and length cap — not the bare `esc()` that `prov()` uses. Quote text is verbatim source material, unbounded, and in the medical arm potentially chart text. No exposure today: nothing in this PR renders `quote`.

`logic-engine` 0.42.0 → 0.43.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
