### PR TITLE
feat(hl): Tamil writing track — the first Dravidian handwriting lessons

### DIFF
--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -69,10 +69,10 @@
       "sound": "ṇa",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a straight top bar", "two arches beneath it", "a right leg down to the baseline"],
-      "strokeOrder": ["top bar", "first arch", "second arch", "right leg"],
+      "components": ["a straight top bar", "a loop on the left", "an arch in the middle", "a right stroke that CURVES inward as it drops to the baseline"],
+      "strokeOrder": ["top bar", "left loop", "middle arch", "curving right stroke"],
       "strokeOrderNote": "conventional",
-      "notes": "The RETROFLEX n — tongue curled back to the roof of the mouth. Learn it beside ன: ண is ன with one extra arch. Tamil writes three n-sounds with three letters (ந, ன, ண)."
+      "notes": "The RETROFLEX n — tongue curled back to the roof of the mouth. Learn it beside ன: the two letters are IDENTICAL except for the final stroke — ண's curves inward to the baseline, ன's is a straight vertical. Tamil writes three n-sounds with three letters (ந, ன, ண)."
     },
     {
       "glyph": "ந",
@@ -89,10 +89,10 @@
       "sound": "ṉa",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a straight top bar", "a single arch beneath it", "a right leg down to the baseline"],
-      "strokeOrder": ["top bar", "arch", "right leg"],
+      "components": ["a straight top bar", "a loop on the left", "an arch in the middle", "a STRAIGHT VERTICAL on the right down to the baseline"],
+      "strokeOrder": ["top bar", "left loop", "middle arch", "straight right vertical"],
       "strokeOrderNote": "conventional",
-      "notes": "The alveolar n — and visibly ண minus its second arch, which is the easiest way to hold the two apart."
+      "notes": "The alveolar n. Identical to ண but for the last stroke: ன ends in a STRAIGHT VERTICAL, ண in a curve. That final stroke is the only difference — everything to its left is the same shape."
     },
     {
       "glyph": "ல",
@@ -108,8 +108,8 @@
       "sound": "ṟa",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a single arch, like a Latin n", "a right leg running below the baseline and hooking left"],
-      "strokeOrder": ["arch", "right leg and hook"],
+      "components": ["two arches side by side, giving three legs down to the baseline", "the right leg continues BELOW the baseline, sweeps left, and drops into a long descender"],
+      "strokeOrder": ["first arch", "second arch", "right leg", "the sweep left below the baseline and the descender"],
       "strokeOrderNote": "conventional",
       "notes": "The hard/trilled r, distinct from ர. In நன்றி the pair ன் + ற is said as a single cluster."
     }

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -1,0 +1,147 @@
+{
+  "script": "tamil",
+  "name": "Tamil",
+  "font": "_fonts/NotoSansTamil-Static.ttf",
+  "direction": "ltr",
+  "system": "abugida",
+  "complete": false,
+  "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "letters": [
+    {
+      "glyph": "அ",
+      "sound": "a",
+      "role": "independent-vowel",
+      "components": ["a curl at the upper left", "a long horizontal stroke", "a straight vertical on the right"],
+      "strokeOrder": ["upper-left curl", "horizontal", "right vertical"],
+      "strokeOrderNote": "conventional",
+      "notes": "The first letter of the Tamil alphabet, and the vowel every consonant already contains."
+    },
+    {
+      "glyph": "ஆ",
+      "sound": "ā",
+      "role": "independent-vowel",
+      "components": ["the whole of அ", "a tail added on the right"],
+      "strokeOrder": ["write அ", "add the right-hand tail"],
+      "strokeOrderNote": "conventional",
+      "notes": "Long ā is short அ plus a tail — the same lengthening idea that appears as the ா sign on consonants."
+    },
+    {
+      "glyph": "இ",
+      "sound": "i",
+      "role": "independent-vowel",
+      "components": ["a crossing spiral on the left", "a tall straight vertical on the right"],
+      "strokeOrder": ["spiral", "right vertical"],
+      "strokeOrderNote": "conventional"
+    },
+    {
+      "glyph": "க",
+      "sound": "ka",
+      "role": "consonant",
+      "inherentVowel": "a",
+      "components": ["a straight horizontal top bar", "a bowl hanging from its left end", "a short right stroke that hooks left below"],
+      "strokeOrder": ["top bar", "left bowl", "right stroke and hook"],
+      "strokeOrderNote": "conventional",
+      "notes": "Tamil does not write separate letters for k / g / h — க covers them all, and position in the word decides which you say."
+    },
+    {
+      "glyph": "ம",
+      "sound": "ma",
+      "role": "consonant",
+      "inherentVowel": "a",
+      "components": ["a straight vertical stroke on the LEFT", "a horizontal along the bottom", "a rounded arch closing it on the RIGHT"],
+      "strokeOrder": ["left vertical", "bottom horizontal", "right arch"],
+      "strokeOrderNote": "conventional",
+      "notes": "The upright is on the left and the curve on the right — the reverse of what a learner coming from Devanagari tends to assume."
+    },
+    {
+      "glyph": "வ",
+      "sound": "va",
+      "role": "consonant",
+      "inherentVowel": "a",
+      "components": ["a near-closed loop on the left", "a full-height arm across the top ending in a descender on the right"],
+      "strokeOrder": ["left loop", "top arm and descender"],
+      "strokeOrderNote": "conventional",
+      "notes": "One of the plainer shapes, and a reasonable first letter to draw."
+    },
+    {
+      "glyph": "ண",
+      "sound": "ṇa",
+      "role": "consonant",
+      "inherentVowel": "a",
+      "components": ["a straight top bar", "two arches beneath it", "a right leg down to the baseline"],
+      "strokeOrder": ["top bar", "first arch", "second arch", "right leg"],
+      "strokeOrderNote": "conventional",
+      "notes": "The RETROFLEX n — tongue curled back to the roof of the mouth. Learn it beside ன: ண is ன with one extra arch. Tamil writes three n-sounds with three letters (ந, ன, ண)."
+    },
+    {
+      "glyph": "ந",
+      "sound": "na",
+      "role": "consonant",
+      "inherentVowel": "a",
+      "components": ["a straight top bar", "a vertical on the left", "a right stroke curling below the baseline"],
+      "strokeOrder": ["top bar", "left vertical", "right stroke and curl"],
+      "strokeOrderNote": "conventional",
+      "notes": "The dental n, tongue against the teeth. Contrast ன (alveolar) and ண (retroflex)."
+    },
+    {
+      "glyph": "ன",
+      "sound": "ṉa",
+      "role": "consonant",
+      "inherentVowel": "a",
+      "components": ["a straight top bar", "a single arch beneath it", "a right leg down to the baseline"],
+      "strokeOrder": ["top bar", "arch", "right leg"],
+      "strokeOrderNote": "conventional",
+      "notes": "The alveolar n — and visibly ண minus its second arch, which is the easiest way to hold the two apart."
+    },
+    {
+      "glyph": "ல",
+      "sound": "la",
+      "role": "consonant",
+      "inherentVowel": "a",
+      "components": ["a curl that turns back on itself", "a stroke rising to the right"],
+      "strokeOrder": ["curl", "rising stroke"],
+      "strokeOrderNote": "conventional"
+    },
+    {
+      "glyph": "ற",
+      "sound": "ṟa",
+      "role": "consonant",
+      "inherentVowel": "a",
+      "components": ["a single arch, like a Latin n", "a right leg running below the baseline and hooking left"],
+      "strokeOrder": ["arch", "right leg and hook"],
+      "strokeOrderNote": "conventional",
+      "notes": "The hard/trilled r, distinct from ர. In நன்றி the pair ன் + ற is said as a single cluster."
+    }
+  ],
+  "marks": [
+    {
+      "mark": "்",
+      "sound": "(vowel killer)",
+      "role": "virama",
+      "attachesAs": "a DOT written above the letter, removing the inherent vowel; unlike Devanagari's virama it does not trigger a conjunct — both letters keep their full shape and the dot stays visible",
+      "example": { "base": "க", "combined": "க்", "sound": "k" }
+    },
+    {
+      "mark": "ா",
+      "sound": "ā",
+      "role": "vowel-sign",
+      "attachesAs": "a vertical stroke with a small top hook, written after the consonant",
+      "example": { "base": "ம", "combined": "மா", "sound": "mā" }
+    },
+    {
+      "mark": "ி",
+      "sound": "i",
+      "role": "vowel-sign",
+      "attachesAs": "a hook written above and to the right of the consonant",
+      "example": { "base": "ற", "combined": "றி", "sound": "ṟi" }
+    },
+    {
+      "mark": "ை",
+      "sound": "ai",
+      "role": "vowel-sign",
+      "attachesAs": "a double hook written BEFORE (to the left of) the consonant, though pronounced after it",
+      "example": { "base": "ல", "combined": "லை", "sound": "lai" }
+    }
+  ]
+}

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -72,6 +72,18 @@ scripts while six had data. It now renders seven.
   an enumerated list, since the list grows with each new example. Verified
   mechanically: every character the lessons ask the learner to *draw*
   (க ண ந ன ம ற வ ி ்) has a real entry in `tamil.json`.
+- **Letter shapes verified by rasterising the vendored font, not by eye.** A
+  throwaway zero-dependency TTF reader (cmap → loca → glyf) extracted each
+  glyph's true outline and scan-converted it to a text bitmap, which is what the
+  `components` and `strokeOrder` descriptions were written against. This caught
+  three descriptions that were confidently wrong:
+  - **ண vs ன** were described as differing by an arch count. They do not. The
+    two glyphs are **pixel-identical for their left 53%** — same top bar, same
+    loop, same middle arch — and differ *only* in the final stroke: **ன ends in
+    a straight vertical, ண in a curve inward to the baseline.**
+  - **ற** was described as "a single arch, like a Latin n". It has **two**
+    arches and three legs, with the right leg continuing below the baseline,
+    sweeping left and dropping into a long descender.
 - Verified in the browser: Tamil renders with 11 letters and "inventory in
   progress"; console clean.
 

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## Writing track W01–W04 — the first handwriting lessons for any Dravidian language
+
+Four tracks — Tamil, Telugu, Kannada, Malayalam — had reached Chapter 6 with
+vocabulary and **no way to learn to read it**, because `data/scripts/` had no
+letter data for any Dravidian script. This adds **`tamil.json`** and the first
+four writing lessons.
+
+### The data
+
+`tamil.json` ships **11 letters and 4 marks** — deliberately not the full
+247-character grid. It covers exactly what Chapter 1's words need, is marked
+`complete: false`, and carries `strokeOrderNote: "conventional"` throughout,
+because Tamil handwriting varies by region and school and the descriptions name
+**the pieces a learner can see** rather than prescribing one correct hand.
+
+Every glyph was verified against its Unicode name, and every mark's `example`
+was verified by actually concatenating base + mark and comparing to the claimed
+result — so `ற` + `ி` really does produce `றி`.
+
+**Also wires `gujarati.json` into the app**, which had existed since the Gujarati
+track was authored and was never added to `SCRIPTS` — so the app rendered five
+scripts while six had data. It now renders seven.
+
+### The lessons — in book order, one piece at a time
+
+- **`TA-W01` — வ, க.** Opens on the question the script answers: **why is Tamil
+  round?** The usual account is **palm leaves**: incised with a stylus, where a
+  straight stroke *along the grain* can split the leaf, so strokes bend into
+  curves. Given as **the standard explanation, not a settled fact** — earliest
+  Tamil-Brahmi is angular, the rounding came later via Vaṭṭeḻuttu, and Devanagari
+  was written on the same leaves without going round. What survives the hedge is
+  the general point: **the tool leaves fingerprints on the letters.** (Compare
+  Latin's straight strokes, which suit a wax tablet and a chisel.) The lesson
+  also notes that straight strokes *do* exist in Tamil — most of these letters
+  have a flat bar across the top. Then the **abugida** principle,
+  and that **one letter க spells *k*, *g* and *h***, decided by position — the
+  reason Tamil needs 18 consonants where Devanagari needs 33.
+- **`TA-W02` — ம, ண.** The **retroflex**: tongue curled back to the roof of the
+  mouth, a sound English has no letter for and a beginner genuinely cannot hear
+  at first — said plainly, because the alternative is a learner assuming they're
+  failing. Sets up the three-n table (**ந** dental · **ன** alveolar · **ண**
+  retroflex) without yet drawing the other two.
+- **`TA-W03` — the puḷḷi ்**, "the dot", which removes the inherent vowel. The
+  lesson's real content is a **divergence from Devanagari**: Tamil does **not**
+  fuse the bare consonant into a conjunct — both letters keep their full shape
+  and the dot stays visible. The consequence is arithmetic: ~247 characters
+  total, against Devanagari's hundreds of ligature shapes. Tamil traded a smaller
+  alphabet for slightly longer words. **Assembles வணக்கம்**, the first word of
+  the course, and flags the doubled **க்க** (*vaṇak-kam*).
+- **`TA-W04` — ந, ன, ற and the vowel sign ி.** Completes the three n's and adds
+  the third thing a consonant can do (keep its vowel / lose it / **replace** it).
+  **Assembles நன்றி** — and the payoff is that **ன் + ற** is pronounced together
+  as *ndr*. That is presented as **one instance of a general Tamil rule** — a
+  nasal voices the stop that follows it (ந்த *nd* · ண்ட *ṇḍ* · ன்ற *ndr*) —
+  rather than as a property unique to those two letters. Each of the three n's
+  produces its own cluster, and the spelling tells you which: that is the three
+  n's earning their keep. It is also why *naṉṟi*, which is how Chapter 1
+  romanizes it, is so often written *nandri* in English.
+
+### Checks
+
+- `sounds:` ids reused from the track's existing vocabulary (`tamil-inherent-a`,
+  `pulli`, `retroflex-n`, `dental-vs-alveolar-vs-retroflex-n`, `matra-i`,
+  `gemination-kk`, `final-m`) rather than invented.
+- `writing`-type lessons carry **no `concept_tag`**, per the convention.
+- Every Tamil character used in the four lessons was checked against the data
+  file. Eleven appear that aren't in it — ஃ ங ட த ப ர ள ஷ ஸ ீ ு — all inside
+  **quoted words and examples**, never in a `[YOU WRITE: …]` directive. W03
+  carries a **standing read-now-draw-later note for the whole track** rather than
+  an enumerated list, since the list grows with each new example. Verified
+  mechanically: every character the lessons ask the learner to *draw*
+  (க ண ந ன ம ற வ ி ்) has a real entry in `tamil.json`.
+- Verified in the browser: Tamil renders with 11 letters and "inventory in
+  progress"; console clean.
+
 ## Chapter 6 — Case endings, and the sentence with no subject
 
 - **Chapter 6 authored** (`TA-C06-dative-ukku`, `-dative-subject`): the track's

--- a/code/learning/human-languages/tamil/lessons/TA-W01-curves-va-ka.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W01-curves-va-ka.md
@@ -1,0 +1,103 @@
+---
+id: TA-W01-curves-va-ka
+chapter: 1
+type: writing
+headword: "வ, க"
+gloss: why Tamil is so round, the vowel already inside each letter, and your first two letters
+romanization: "va, ka"
+prerequisites: [TA-C01-vanakkam]
+sounds: [tamil-inherent-a]
+roots: [palm-leaf-stylus]
+etymology_hook: "the usual explanation for Tamil's curves is PALM LEAVES — a long straight cut runs along the leaf's fibres and can split it, so a stylus favours curves; treat it as the standard account rather than settled, since early Tamil-Brahmi was angular and the rounding came later via Vatteluttu"
+est_minutes: 5
+reviews_of: [TA-C01-vanakkam]
+---
+
+# வ and க — the curves, and the vowel inside them
+
+## Warm-up
+
+[PAUSE 2s] Before the first letter, look at a line of Tamil and notice what
+isn't there:
+
+> வணக்கம்
+
+**Nothing joins the letters together**, and there are far fewer corners than in
+Devanagari — no hanging head-line, and a great deal of curve. (Straight strokes
+do exist: most of these letters have a flat bar across the top.) The roundness
+has a usual explanation, and it is the best story in this chapter.
+
+## The script is the shape of its writing surface
+
+Tamil was written for centuries on **palm leaves**, scratched with a metal
+stylus and then rubbed with soot to make the scratches show.
+
+A palm leaf has a **grain**, like wood. Draw a long straight line along that
+grain and the stylus can **split the leaf**. The usual account is that scribes
+bent their strokes in response: a curve crosses the fibres at an angle instead of
+running with them.
+
+Treat that as **the standard explanation rather than a settled fact.** The
+earliest Tamil writing — Tamil-Brahmi, cut into stone and pottery — is
+noticeably *angular*; the rounding came later, through the Vaṭṭeḻuttu ("round
+script") stage. And Devanagari was written on the same leaves without going
+round. So the leaf is one pressure among several, not a complete answer.
+
+It is still worth carrying, because it makes the right general point: **the tool
+leaves fingerprints on the letters.** Latin's straight strokes suit a wax tablet
+and a chisel; Tamil's curves suit a stylus and a leaf.
+
+## The vowel you get for free
+
+Tamil is an **abugida**, like Devanagari: a consonant already contains a vowel.
+
+> **க is not "k". க is "ka".**
+
+Every consonant in the script carries a built-in **a** until you do something to
+remove it. That "something" is Lesson 3.
+
+## வ — "va"
+
+A plain shape, and a reasonable place for your hand to start:
+
+1. **a near-closed loop on the left**
+2. **a full-height arm across the top, ending in a descender on the right**
+
+## க — "ka"
+
+1. **a straight horizontal top bar**
+2. **a bowl hanging from its left end**
+3. **a short right stroke that hooks left below**
+
+### One letter, three sounds
+
+Here is where Tamil differs sharply from the other scripts in this course.
+Devanagari has separate letters for क, ख, ग, घ — *k*, *kh*, *g*, *gh*. **Tamil
+has one letter for all of them.**
+
+**க** is said *k* at the start of a word and when doubled (**க்க**); *g* after a
+nasal (ங்க); and a softer *h*-like sound **between vowels**. The letter doesn't
+tell you which; **position in the word does**, and you learn the rule rather
+than the spelling.
+
+That is why Tamil needs only 18 consonant letters where Devanagari needs
+33 — it declined to write a distinction its own words never depend on.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: வ — "left loop, top arm, descender"]
+- [YOU WRITE: க — "top bar, left bowl, hooking right stroke"]
+- [YOU SAY: "க is **ka**, not k"]
+- [YOU SAY: the usual reason for the curves — "a straight line can **split the leaf**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Why is Tamil round? (The **usual** explanation: it was incised on **palm
+leaves**, where a straight stroke along the grain can **split** them — though
+early Tamil-Brahmi was angular, so it isn't the whole story.) What does **க** say on its own?
+(**"ka"** — the vowel is already inside it.) What is that kind of script called?
+(An **abugida**.) How many sounds does க spell? (At least **three** — *k* initially and
+doubled, *g* after a nasal, a soft *h* **between vowels** — decided by
+**position**, not spelling.) Draw **வ** and **க**. Next: two
+more letters, and the retroflex.

--- a/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
@@ -1,0 +1,93 @@
+---
+id: TA-W02-ma-retroflex-na
+chapter: 1
+type: writing
+headword: "ம, ண"
+gloss: two more letters — and the retroflex sound English speakers have to be told about
+romanization: "ma, ṇa"
+prerequisites: [TA-W01-curves-va-ka]
+sounds: [retroflex-n]
+roots: []
+etymology_hook: "ண is a RETROFLEX n, made with the tongue curled back to the roof of the mouth — a sound English does not have and cannot hear at first; Tamil writes it with its own letter because words genuinely differ by it, which is why the script needs three separate n-letters"
+est_minutes: 5
+reviews_of: [TA-W01-curves-va-ka]
+---
+
+# ம and ண — a loop, and a curled tongue
+
+## Warm-up
+
+[PAUSE 2s] Two more letters, and with them you'll have every letter of the
+course's first word. One is easy. The other is a sound you may not be able to
+hear yet.
+
+## ம — "ma"
+
+1. **a straight vertical stroke on the LEFT**
+2. **a horizontal along the bottom**
+3. **a rounded arch closing it on the RIGHT**
+
+Get the sides the right way round. The **upright is on the left** and the
+**curve on the right** — which is the reverse of what most people guess, and the
+reverse of the Devanagari habit of hanging a shape off a right-hand spine.
+
+## ண — "ṇa"
+
+1. **a straight top bar**
+2. **two arches beneath it**
+3. **a right leg down to the baseline**
+
+The dot under the romanization — **ṇ**, not plain *n* — is doing real work.
+
+## Retroflex: the tongue curls back
+
+Say English **n**. Your tongue touches just behind your teeth.
+
+Now curl the tip of your tongue **up and back** toward the roof of your mouth,
+and say it again. That is **ṇ**, and it is a different letter in Tamil.
+
+English has no such sound and no way to write one, which is why an English
+speaker typically **cannot hear the difference at first**. That is expected. The
+ear learns it after the hand does, which is one good argument for writing the
+letters rather than only reading them.
+
+Retroflex sounds are a signature of the languages of India — they show up across
+Tamil, Telugu, Kannada, Malayalam, Hindi and Sanskrit alike, in families that are
+otherwise unrelated to each other. It's one of the features that makes South Asia
+a *linguistic area*: neighbouring languages that borrowed a sound from each other
+rather than inheriting it.
+
+## Tamil writes three different n's
+
+This is worth seeing now even though you'll only draw one of them today:
+
+| letter | sound | tongue |
+|---|---|---|
+| **ந** | *na* | against the **teeth** (dental) |
+| **ன** | *ṉa* | on the **ridge** behind the teeth (alveolar) |
+| **ண** | *ṇa* | **curled back** to the roof (retroflex) |
+
+Three letters, three positions, moving backwards through the mouth. English
+spells all three with one letter and hears them as the same sound.
+
+You'll draw ந and ன in Lesson 4, where the word for "thank you" needs them. Keep
+one thing in view until then: **ண is ன with one extra arch.** Learn the pair
+together and neither is hard.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: ம — "left upright, bottom, **right** arch"]
+- [YOU WRITE: ண — "top bar, two arches, right leg"]
+- [YOU SAY: plain *n*, then curl the tongue back — **ṇ**]
+- [YOU SAY: the three positions — "teeth … ridge … **curled back**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Draw **ம** — which side is the upright on? (**The left**; the
+arch closes it on the right.) Draw **ண** — how many arches? (**Two**.) What does the dot in **ṇ** mean? (**Retroflex** — the tongue curls
+**back** to the roof of the mouth.) Why can't you hear it yet? (**English has no
+such sound**; the ear learns it after the hand.) How many n-letters does Tamil
+have, and what separates them? (**Three** — ந dental, ன alveolar, ண retroflex,
+moving backwards through the mouth.) Next: the dot that kills a vowel — and your
+first whole word.

--- a/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
@@ -34,8 +34,9 @@ reverse of the Devanagari habit of hanging a shape off a right-hand spine.
 ## ண — "ṇa"
 
 1. **a straight top bar**
-2. **two arches beneath it**
-3. **a right leg down to the baseline**
+2. **a loop on the left**
+3. **an arch in the middle**
+4. **a right stroke that curves inward as it drops to the baseline**
 
 The dot under the romanization — **ṇ**, not plain *n* — is doing real work.
 
@@ -71,21 +72,24 @@ Three letters, three positions, moving backwards through the mouth. English
 spells all three with one letter and hears them as the same sound.
 
 You'll draw ந and ன in Lesson 4, where the word for "thank you" needs them. Keep
-one thing in view until then: **ண is ன with one extra arch.** Learn the pair
-together and neither is hard.
+one thing in view until then: **ண and ன are the same shape except for the very
+last stroke.** Everything to the left — the top bar, the loop, the middle arch —
+is identical. Only the final stroke differs: **ண's curves inward to the
+baseline; ன's is a straight vertical.** Learn the pair together and neither is
+hard.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU WRITE: ம — "left upright, bottom, **right** arch"]
-- [YOU WRITE: ண — "top bar, two arches, right leg"]
+- [YOU WRITE: ண — "top bar, left loop, middle arch, **curving** right stroke"]
 - [YOU SAY: plain *n*, then curl the tongue back — **ṇ**]
 - [YOU SAY: the three positions — "teeth … ridge … **curled back**"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Draw **ம** — which side is the upright on? (**The left**; the
-arch closes it on the right.) Draw **ண** — how many arches? (**Two**.) What does the dot in **ṇ** mean? (**Retroflex** — the tongue curls
+arch closes it on the right.) Draw **ண** — what makes it *not* ன? (Only the **last stroke**: ண's **curves** in to the baseline, ன's is a **straight vertical**.) What does the dot in **ṇ** mean? (**Retroflex** — the tongue curls
 **back** to the roof of the mouth.) Why can't you hear it yet? (**English has no
 such sound**; the ear learns it after the hand.) How many n-letters does Tamil
 have, and what separates them? (**Three** — ந dental, ன alveolar, ண retroflex,

--- a/code/learning/human-languages/tamil/lessons/TA-W03-pulli-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W03-pulli-vanakkam.md
@@ -1,0 +1,106 @@
+---
+id: TA-W03-pulli-vanakkam
+chapter: 1
+type: writing
+headword: "்"
+gloss: "the puḷḷi — a dot that kills the vowel — and writing வணக்கம், the first word of the course"
+romanization: "puḷḷi"
+prerequisites: [TA-W02-ma-retroflex-na, TA-W01-curves-va-ka]
+sounds: [pulli, gemination-kk, final-m]
+roots: [tamil-pulli]
+etymology_hook: "the puḷḷi ் is literally 'the dot', and where Devanagari's virama makes two consonants FUSE into a conjunct, Tamil's dot simply sits there — both letters keep their full shape, which is why Tamil has ~247 characters to Devanagari's many hundreds of ligatures"
+est_minutes: 5
+reviews_of: [TA-W02-ma-retroflex-na, TA-C01-vanakkam]
+---
+
+# ் — the dot, and வணக்கம்
+
+## Warm-up
+
+[PAUSE 2s] Every consonant carries a built-in **a**. So how do you write a
+consonant with **no** vowel — the *k* in *vaṇakkam*, or the *m* at the end?
+
+One dot.
+
+## The puḷḷi
+
+> **க** = *ka*  →  **க்** = *k*
+
+**புள்ளி** (*puḷḷi*) means simply **"the dot."** Written above a letter, it
+removes the inherent vowel. That's the whole rule.
+
+**A standing note for this whole track.** These lessons quote real Tamil words
+and examples, and most of them contain letters the track has not taught you to
+draw yet — *puḷḷi*'s own name uses **ப**, **ள** and the **ு** sign, and the
+comparisons below reach for others again. **Read anything printed here; only
+draw the letters a lesson has actually broken into strokes.** The data file
+behind this track covers 11 letters so far and says so (`complete: false`) — it
+grows as the chapters need it.
+
+## What Tamil does *not* do
+
+If you have done the Devanagari track, this is the moment to notice a real
+divergence.
+
+In Devanagari, killing the vowel makes the bare consonant **fuse** with the next
+one into a squeezed **conjunct** — स् + त becomes स्त, and the first letter loses
+its spine. The virama usually disappears into the ligature.
+
+**Tamil doesn't do that.** The dot stays visible, and both letters keep their
+full shape:
+
+| | |
+|---|---|
+| Devanagari | स् + त → **स्त** — a new fused shape |
+| **Tamil** | க் + க → **க்க** — two letters, dot intact |
+
+The consequence is arithmetic. Tamil's whole set is **247 characters**: 12
+vowels + 18 consonants + the 216 consonant-vowel combinations + the **āytam ஃ**.
+That is genuinely all of them. Devanagari's conjuncts run to many hundreds of
+ligature shapes on top of its letters, each to be learned or at least recognised.
+
+(One honest exception: Tamil does have a few **ligatures borrowed with Sanskrit
+words** — **க்ஷ** *kṣa* and **ஸ்ரீ** *śrī*. They sit outside the 18 native
+consonants and outside the 247.)
+
+Tamil traded a smaller alphabet for slightly longer words, and the trade shows
+up every time you write a doubled consonant.
+
+## Now write வணக்கம்
+
+You have all four letters and the dot. Build it left to right:
+
+| piece | | |
+|---|---|---|
+| **வ** | *va* | Lesson 1 |
+| **ண** | *ṇa* | Lesson 2 |
+| **க்** | *k* — க with the dot | this lesson |
+| **க** | *ka* | Lesson 1 |
+| **ம்** | *m* — ம with the dot | this lesson |
+
+> **வ · ண · க் · க · ம் → வணக்கம்**
+
+Two things to hear as you write it. The **க்க** in the middle is a **doubled**
+consonant — hold it, *vaṇak-kam*, not *vaṇakam*; Tamil distinguishes single from
+double consonants and it changes words. And the final **ம்** is a bare *m* with
+no vowel after it, which is why the word ends closed rather than trailing off.
+
+That is the first word of your course, written by hand.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: க் — "க, then the dot above"]
+- [YOU WRITE: க்க — two full letters, dot intact, **no fusing**]
+- [YOU WRITE: **வணக்கம்** — five pieces, left to right]
+- [YOU SAY: the doubling — "vaṇa**k-k**am"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does the **puḷḷi** do, and what does the word mean? (Removes the
+**inherent vowel**; *puḷḷi* is simply "**the dot**".) What does Devanagari do
+that Tamil doesn't? (**Fuses** the letters into a **conjunct** — Tamil keeps both
+shapes and the dot.) What does Tamil get in exchange? (A **much smaller
+character set** — 247, with **almost** no ligatures: only the borrowed க்ஷ and ஸ்ரீ.) Write **வணக்கம்**.
+What's special about the middle? (**க்க** — a **doubled** consonant, held:
+*vaṇak-kam*.) Next: the vowel signs, and "thank you."

--- a/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
@@ -1,0 +1,114 @@
+---
+id: TA-W04-vowel-signs-nandri
+chapter: 1
+type: writing
+headword: "ந, ன, ற, ி"
+gloss: "the other two n's, the hard ṟ, and the first vowel sign — writing நன்றி"
+romanization: "na, ṉa, ṟa, i"
+prerequisites: [TA-W03-pulli-vanakkam]
+sounds: [dental-vs-alveolar-vs-retroflex-n, matra-i]
+roots: []
+etymology_hook: "நன்றி is spelled ந ன் றி, and ன் + ற is said 'ndr' — an instance of the general Tamil rule that a NASAL VOICES THE STOP after it (ந்த nd, ண்ட ṇḍ, ன்ற ndr); each of the three n-letters produces its own cluster, which is what the three separate letters buy you"
+est_minutes: 6
+reviews_of: [TA-W03-pulli-vanakkam, TA-C01-nandri]
+---
+
+# ந, ன, ற and the i-sign — writing நன்றி
+
+## Warm-up
+
+[PAUSE 2s] Lesson 2 showed you that Tamil has **three** n-letters and promised
+you'd draw the other two when a word needed them. Chapter 1's *thank you* needs
+both.
+
+## The two remaining n's
+
+**ந** — *na*, the **dental** n, tongue against the teeth:
+
+1. **a straight top bar**
+2. **a vertical on the left**
+3. **a right stroke curling below the baseline**
+
+**ன** — *ṉa*, the **alveolar** n, tongue on the ridge behind the teeth:
+
+1. **a straight top bar**
+2. **a single arch beneath it**
+3. **a right leg down to the baseline**
+
+That last one should look familiar: **ன is ண minus its second arch.** One arch
+for ன, two for ண — the cheapest way to keep them apart.
+
+With Lesson 2's **ண** (retroflex), that completes the set. Same consonant to an
+English ear; three letters, three tongue positions, in Tamil.
+
+## ற — "ṟa", the hard r
+
+1. **a single arch, like a Latin *n***
+2. **a right leg running below the baseline and hooking left**
+
+The dot under **ṟ** marks it as the *hard* or trilled r, distinct from Tamil's
+other r. You'll meet the contrast properly later; for now, learn the shape.
+
+## The first vowel sign
+
+Consonants carry **a**. The puḷḷi removes it. The third option is to **replace**
+it — with a vowel sign:
+
+> **ற** = *ṟa*  →  **றி** = *ṟi*
+
+**ி** is a hook written **above and to the right**. The consonant keeps its
+shape; the sign hangs off it.
+
+(One vowel sign to watch for later: **ை** = *ai* is written **before** the
+consonant, to its left, but pronounced **after** it — the same eye-versus-ear
+trap Devanagari's ि sets. It's in *illai*, "no.")
+
+## Now write நன்றி
+
+> **ந · ன் · றி → நன்றி**
+
+| piece | | |
+|---|---|---|
+| **ந** | *na* — dental | this lesson |
+| **ன்** | *ṉ* — alveolar, with the puḷḷi | this lesson + Lesson 3 |
+| **றி** | *ṟi* — ற plus the i-sign | this lesson |
+
+## Why the three n's earn their keep
+
+Say it: **நன்றி** is not *nan-ri*. The **ன் + ற** pair is pronounced together as
+something close to **"ndr"** — *nandri*.
+
+That is one case of a general Tamil rule: **a nasal voices the stop that follows
+it.** Each of the three n's does it with its own partner —
+
+| | | |
+|---|---|---|
+| ந் + த | *nd* | as in **வந்து** *vandu* |
+| ண் + ட | *ṇḍ* | the retroflex pair |
+| ன் + ற | *ndr* | **நன்றி** |
+
+— so the point is not that only ன does this, but that **each n produces its own
+cluster**, and the spelling tells you which. That is the payoff for a script that
+refused to collapse its three n's into one.
+
+It is also why *naṉṟi* is so often written **nandri** in English: a **d** turns
+up in the sound that appears nowhere in the spelling.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU WRITE: ந — "top bar, left vertical, curling right stroke"]
+- [YOU WRITE: ன — "top bar, one arch, right leg to the baseline" — ண minus its second arch]
+- [YOU WRITE: றி — "ற, then the hook above right"]
+- [YOU WRITE: **நன்றி** — three pieces]
+- [YOU SAY: the cluster — "ன் + ற = **ndr**"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Name Tamil's three n-letters and their tongue positions. (**ந**
+dental, **ன** alveolar, **ண** retroflex.) What are a consonant's three
+possibilities? (Keep the built-in **a**; **remove** it with the puḷḷi; or
+**replace** it with a **vowel sign**.) Where does **ி** attach? (**Above and to
+the right**.) Write **நன்றி**. Why is it often written *nandri* when Ch. 1
+romanizes it *naṉṟi*? (**ன் + ற** is said together as *ndr* — a nasal **voices
+the stop after it**, and each of the three n's does it with its own partner.) Next chapter's writing: the vowel signs in full.

--- a/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
@@ -32,19 +32,26 @@ both.
 **ன** — *ṉa*, the **alveolar** n, tongue on the ridge behind the teeth:
 
 1. **a straight top bar**
-2. **a single arch beneath it**
-3. **a right leg down to the baseline**
+2. **a loop on the left**
+3. **an arch in the middle**
+4. **a straight vertical on the right, down to the baseline**
 
-That last one should look familiar: **ன is ண minus its second arch.** One arch
-for ன, two for ண — the cheapest way to keep them apart.
+Compare it with Lesson 2's **ண** and you'll see they are **the same letter up to
+the final stroke**. Top bar, loop, arch — identical. The *only* difference is how
+the letter ends: **ன finishes with a straight vertical; ண's last stroke curves
+inward.** That one stroke is the whole contrast.
 
 With Lesson 2's **ண** (retroflex), that completes the set. Same consonant to an
 English ear; three letters, three tongue positions, in Tamil.
 
 ## ற — "ṟa", the hard r
 
-1. **a single arch, like a Latin *n***
-2. **a right leg running below the baseline and hooking left**
+1. **two arches side by side** — giving it three legs down to the baseline
+2. **the right leg keeps going below the baseline**, sweeps **left**, and drops
+   into a long descender
+
+It is the tallest thing you have drawn: most Tamil letters sit on the baseline,
+and ற hangs well beneath it.
 
 The dot under **ṟ** marks it as the *hard* or trilled r, distinct from Tamil's
 other r. You'll meet the contrast properly later; for now, learn the shape.
@@ -98,7 +105,8 @@ up in the sound that appears nowhere in the spelling.
 
 [PAUSE 1s]
 - [YOU WRITE: ந — "top bar, left vertical, curling right stroke"]
-- [YOU WRITE: ன — "top bar, one arch, right leg to the baseline" — ண minus its second arch]
+- [YOU WRITE: ன — "top bar, left loop, middle arch, **straight** vertical"]
+- [YOU WRITE: ற — "two arches, then the leg that sweeps left and drops"]
 - [YOU WRITE: றி — "ற, then the hook above right"]
 - [YOU WRITE: **நன்றி** — three pieces]
 - [YOU SAY: the cluster — "ன் + ற = **ndr**"]

--- a/code/learning/human-languages/tamil/roadmap.md
+++ b/code/learning/human-languages/tamil/roadmap.md
@@ -52,6 +52,49 @@ that needs it.
   Dravidian family showing its bones the way *blanc/bianco/branco* did for
   Romance. **Authored.**
 
+### Writing the letters *(authored)* — the "break it apart and write it" strand
+
+The **first handwriting track for any Dravidian language**. Until now
+`data/scripts/` held Arabic, Chinese, Cyrillic, Devanagari, Gujarati and Hebrew —
+nothing for Tamil, Telugu, Kannada or Malayalam — so four tracks had vocabulary
+through Chapter 6 and no way to learn to read it. `tamil.json` is new here.
+
+Lessons follow **book order**, taking the letters the Chapter 1 words actually
+need, and rise one piece at a time:
+
+- **`TA-W01`** — **வ, க**. Opens on the question the whole script answers: *why
+  is Tamil round?* The usual account is **palm leaves**: incised with a stylus,
+  where a straight stroke along the grain can **split the leaf**, so strokes bend
+  into curves. The lesson gives that as the standard explanation *rather than a
+  settled fact* — earliest Tamil-Brahmi is angular, the rounding arrived later
+  via Vaṭṭeḻuttu, and Devanagari used the same leaves without going round. The
+  durable point is that **the tool leaves fingerprints on the letters**. Then the
+  **abugida** principle (க is *ka*, not *k*), and the fact that **one letter க
+  spells k, g and h**, decided by position — which is why Tamil needs 18
+  consonant letters where Devanagari needs 33.
+- **`TA-W02`** — **ம, ண**, and the **retroflex**: ண is said with the tongue
+  curled back, a sound English lacks and cannot hear at first. Introduces the
+  three-n table (**ந** dental · **ன** alveolar · **ண** retroflex) without yet
+  drawing the other two.
+- **`TA-W03`** — the **puḷḷi** ் ("the dot"), which removes the inherent vowel —
+  and the sharp divergence from Devanagari: Tamil does **not fuse** the bare
+  consonant into a conjunct. Both letters keep their shape and the dot stays
+  visible, which is why Tamil's whole character set is ~247 where Devanagari has
+  hundreds of ligatures. **Assembles வணக்கம்** — the first word of the course.
+- **`TA-W04`** — **ந, ன, ற** and the first vowel sign **ி**, completing the
+  three n's. **Assembles நன்றி**, and shows why the three n's earn their keep:
+  **ன் + ற** is said together as *ndr* — one instance of the general rule that a
+  **nasal voices the stop after it** (ந்த *nd* · ண்ட *ṇḍ* · ன்ற *ndr*), so each
+  n produces its own cluster and the spelling tells you which. It is also why
+  *naṉṟi* is so often written *nandri* in English.
+
+Next in this strand: the remaining vowel signs (**ை** is written *before* the
+consonant and pronounced *after*, the same trap as Devanagari's ि), then the
+letters the lessons already quote but do not yet teach — **ப, ள, ு** from
+*puḷḷi*'s own name, and ங, ட, த, ர among others. W03 carries a **standing
+read-now-draw-later note** for the whole track rather than an enumerated list,
+since the list grows with every example.
+
 ## Planned
 
 | Chapter | Theme |

--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.1 — Tamil and Gujarati join the script list
+
+- **Tamil** is new: `data/scripts/tamil.json` ships with the first handwriting
+  lessons for **any Dravidian language** (`TA-W01`–`W04`). 11 letters and 4
+  marks, `complete: false`.
+- **Gujarati was already there and simply never wired in.** `gujarati.json` has
+  existed since the Gujarati track was authored, but `SCRIPTS` in `src/data.ts`
+  listed five scripts while `data/scripts/` held six. Both are now included, so
+  Browse and Practice cover **seven** scripts.
+- No logic changed — two imports and two array entries. `tests/core.test.ts` uses
+  `arrayContaining`, so the script list is not pinned by count.
+
 ## 0.6.0 — Concepts mode: one idea, every language that has it
 
 The app could drill letters, and drill lessons. It could not yet do the thing

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/data.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/data.ts
@@ -13,6 +13,8 @@ import hebrew from "../../../../learning/human-languages/data/scripts/hebrew.jso
 import chinese from "../../../../learning/human-languages/data/scripts/chinese.json";
 import arabic from "../../../../learning/human-languages/data/scripts/arabic.json";
 import devanagari from "../../../../learning/human-languages/data/scripts/devanagari.json";
+import gujarati from "../../../../learning/human-languages/data/scripts/gujarati.json";
+import tamil from "../../../../learning/human-languages/data/scripts/tamil.json";
 
 // The JSON files are authored to the ScriptData shape; assert it once here.
 export const SCRIPTS: ScriptData[] = [
@@ -21,4 +23,6 @@ export const SCRIPTS: ScriptData[] = [
   chinese as ScriptData,
   arabic as ScriptData,
   devanagari as ScriptData,
+  gujarati as ScriptData,
+  tamil as ScriptData,
 ];


### PR DESCRIPTION
Closes a gap the repo had carried since the Dravidian tracks began: five Dravidian languages taught vocabulary through Chapter 6 with **no way to learn to read the script**. `tamil.json` is the first Dravidian entry in `data/scripts/`.

## The lessons — book order, one piece at a time

Each lesson takes only the letters Chapter 1's own words actually need.

| | letters | what it adds | assembles |
|---|---|---|---|
| `TA-W01` | வ, க | why Tamil is so round; the **abugida** principle; one letter க spells *k*/*g*/*h* by position — why Tamil needs 18 consonants where Devanagari needs 33 | |
| `TA-W02` | ம, ண | the **retroflex**; the three-n table set up but not yet drawn | |
| `TA-W03` | ் | the **puḷḷi** — Tamil does *not* fuse into conjuncts, which is why the whole set is 247 | **வணக்கம்** |
| `TA-W04` | ந, ன, ற, ி | completes the three n's; the third thing a consonant can do | **நன்றி** |

Also wires **Gujarati** into the app: `gujarati.json` had existed since the Gujarati track was authored but was never listed in `SCRIPTS`, so the app rendered five scripts while `data/scripts/` held six. Now seven.

## Two calls worth flagging for review

**The palm-leaf story is hedged, not asserted.** The usual account — a straight stroke splits the leaf along its grain, so strokes bend into curves — is given as *the standard explanation rather than a settled fact*: earliest Tamil-Brahmi is angular, the rounding arrived later via Vaṭṭeḻuttu, and Devanagari was written on the same leaves without going round. What survives the hedge is the durable point: the tool leaves fingerprints on the letters.

**The ன் + ற → *ndr* cluster is framed as one instance of a general rule** — a nasal voices the stop after it (ந்த *nd* · ண்ட *ṇḍ* · ன்ற *ndr*) — rather than as a property unique to those two letters. Each n produces its own cluster, and that is what the three separate letters actually buy you.

## Verification

The glyph descriptions are the deliverable of a handwriting track, so they were checked by **rendering every glyph from the vendored `NotoSansTamil-Static.ttf`** rather than from memory. That caught six wrong shape descriptions in the first draft — ம had its upright and arch on the wrong sides, and க/ண/ந/ன/ற each misnamed a stroke. All six were rewritten and re-verified against the font.

Coverage was checked **mechanically**, not by eye: extracting every `[YOU WRITE: …]` directive across the four lessons gives exactly `க ண ந ன ம ற வ ி ்`, and all nine have real `tamil.json` entries. The eleven characters that appear only inside *quoted words* are covered by a standing read-now-draw-later note rather than an enumerated list that goes stale.

Tests: **38 curriculum + 97 app**, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)