### PR TITLE
feat(spice): add BJT forward-bias depletion coefficient

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT forward-bias depletion coefficient** — BJT model cards now accept `FC`
+  and apply it to the shared `CJE` and `CJC` Berkeley continuation law in AC and
+  transient analysis, matching Rust and TypeScript. The supported-parameter
+  catalog now contains 92 canonical rows.
+
 - **BJT base-collector depletion shaping** — BJT model cards now accept
   `VJC`/`PC` junction potential and `MJC`/`MC` grading coefficient parameters
   and apply them to `CJC` in AC and transient analysis, matching Rust and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -217,8 +217,9 @@ model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
 depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
-`0.33`) likewise shape `CJC` base-collector depletion capacitance. Both use the
-Berkeley default `FC=0.5` continuation.
+`0.33`) likewise shape `CJC` base-collector depletion capacitance. `FC`
+(default `0.5`) selects the shared Berkeley forward-bias continuation point for
+both junctions.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -623,6 +623,7 @@ class BJT:
     Mje: float = 0.33       # base-emitter grading coefficient
     Vjc: float = 0.75       # base-collector junction potential (V)
     Mjc: float = 0.33       # base-collector grading coefficient
+    Fc: float = 0.5         # forward-bias depletion coefficient
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8746,7 +8746,7 @@ def _bjt_base_emitter_depletion_capacitance(el: BJT, voltage: float) -> float:
     if el.Cje <= 0.0 or el.Mje == 0.0:
         return el.Cje
     normalized_voltage = voltage / el.Vje
-    coefficient = 0.5
+    coefficient = el.Fc
     if normalized_voltage < coefficient:
         return el.Cje / ((1.0 - normalized_voltage) ** el.Mje)
     transition_scale = (1.0 - coefficient) ** (1.0 + el.Mje)
@@ -8758,7 +8758,7 @@ def _bjt_base_collector_depletion_capacitance(el: BJT, voltage: float) -> float:
     if el.Cjc <= 0.0 or el.Mjc == 0.0:
         return el.Cjc
     normalized_voltage = voltage / el.Vjc
-    coefficient = 0.5
+    coefficient = el.Fc
     if normalized_voltage < coefficient:
         return el.Cjc / ((1.0 - normalized_voltage) ** el.Mjc)
     transition_scale = (1.0 - coefficient) ** (1.0 + el.Mjc)
@@ -9188,6 +9188,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT base-collector junction potential must be finite and positive")
     if not math.isfinite(el.Mjc) or not 0.0 <= el.Mjc < 1.0:
         raise ValueError(f"{el.name}: BJT base-collector grading coefficient must be finite and in [0, 1)")
+    if not math.isfinite(el.Fc) or not 0.0 <= el.Fc < 1.0:
+        raise ValueError(f"{el.name}: BJT forward-bias depletion coefficient must be finite and in [0, 1)")
 
 
 # ---------------------------------------------------------------------------
@@ -13918,6 +13920,7 @@ def sens_dc(
                     Mje=el.Mje,
                     Vjc=el.Vjc,
                     Mjc=el.Mjc,
+                    Fc=el.Fc,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -13943,6 +13946,7 @@ def sens_dc(
                     Mje=el.Mje,
                     Vjc=el.Vjc,
                     Mjc=el.Mjc,
+                    Fc=el.Fc,
                 ),
             )
 
@@ -14178,6 +14182,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Mje=el.Mje,
             Vjc=el.Vjc,
             Mjc=el.Mjc,
+            Fc=el.Fc,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (16, 29, 9, 4),
-    "PNP": (16, 29, 9, 4),
+    "NPN": (17, 30, 9, 4),
+    "PNP": (17, 30, 9, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -384,6 +384,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "PC": "VJC",
     "MJC": "MJC",
     "MC": "MJC",
+    "FC": "FC",
 }
 
 _JFET_PARAMETER_ALIASES: dict[str, str] = {
@@ -917,6 +918,7 @@ def bjt_from_model_card(
         Mje=p.get("MJE", 0.33),
         Vjc=p.get("VJC", 0.75),
         Mjc=p.get("MJC", 0.33),
+        Fc=p.get("FC", 0.5),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 90
+    assert len(coverage) == 92
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 90
+    assert len(records) == 92
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 90
-    assert report.expected_canonical_parameter_count == 90
-    assert report.accepted_name_count == 148
+    assert report.canonical_parameter_count == 92
+    assert report.expected_canonical_parameter_count == 92
+    assert report.accepted_name_count == 150
     assert report.aliased_parameter_count == 45
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t90\t90\t148\t45\t4\t0"
+        "true\t7\t7\t92\t92\t150\t45\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 89
-    assert report.accepted_name_count == 145
+    assert report.canonical_parameter_count == 91
+    assert report.accepted_name_count == 147
     assert report.aliased_parameter_count == 44
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t89\t90\t145\t44\t4\t4\n"
+        "false\t7\t7\t91\t92\t147\t44\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
@@ -663,6 +663,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Mje == pytest.approx(0.4)
     assert bjt_model.Vjc == pytest.approx(0.7)
     assert bjt_model.Mjc == pytest.approx(0.45)
+    assert bjt_model.Fc == pytest.approx(0.4)
 
     jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -1554,6 +1555,33 @@ def test_transient_bjt_base_collector_depletion_capacitance_falls_with_reverse_b
     assert stepped_collector_voltage(0.5) < stepped_collector_voltage(0.0)
 
 
+def test_transient_bjt_forward_bias_depletion_coefficient_shapes_both_junctions() -> None:
+    def held_voltage(coefficient: float, base_emitter: bool) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vdrive",
+            "in",
+            "0",
+            0.6,
+            waveform=PwlWaveform(((0.0, 0.6), (1.0e-9, 0.6), (2.0e-9, 0.0), (5.0e-9, 0.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "base", 1000.0))
+        circuit.add(BJT(
+            "Q1",
+            collector="0",
+            base="base",
+            emitter="0",
+            Is=1.0e-30,
+            Cje=1.0e-12 if base_emitter else 0.0,
+            Cjc=0.0 if base_emitter else 1.0e-12,
+            Fc=coefficient,
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler").points[2].node_voltages["base"]
+
+    for base_emitter in (True, False):
+        assert held_voltage(0.8, base_emitter) > held_voltage(0.2, base_emitter)
+
+
 def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> None:
     def run(forward_transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -2266,7 +2294,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2282,6 +2310,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Mje == pytest.approx(0.4)
     assert expanded.Vjc == pytest.approx(0.7)
     assert expanded.Mjc == pytest.approx(0.45)
+    assert expanded.Fc == pytest.approx(0.4)
 
 
 def test_branch_current_in_voltage_source():
@@ -2572,6 +2601,7 @@ def test_dc_rejects_invalid_bjt_reverse_emission_coefficient():
         ({"Mje": 1.0}, "BJT base-emitter grading coefficient must be finite and in \\[0, 1\\)"),
         ({"Vjc": 0.0}, "BJT base-collector junction potential must be finite and positive"),
         ({"Mjc": 1.0}, "BJT base-collector grading coefficient must be finite and in \\[0, 1\\)"),
+        ({"Fc": 1.0}, "BJT forward-bias depletion coefficient must be finite and in \\[0, 1\\)"),
     ],
 )
 def test_dc_rejects_invalid_bjt_depletion_parameters(kwargs, message):
@@ -4231,6 +4261,30 @@ def test_ac_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias():
         return abs(result.points[0].node_voltages["collector"])
 
     assert collector_amplitude(0.5) > collector_amplitude(0.0)
+
+
+def test_ac_bjt_forward_bias_depletion_coefficient_shapes_both_junctions():
+    def junction_amplitude(coefficient: float, base_emitter: bool) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.6, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "base", 1000.0))
+        circuit.add(BJT(
+            "Q1",
+            collector="0",
+            base="base",
+            emitter="0",
+            Is=1.0e-30,
+            Cje=1.0e-6 if base_emitter else 0.0,
+            Cjc=0.0 if base_emitter else 1.0e-6,
+            Fc=coefficient,
+        ))
+        result = ac_sweep(circuit, f_start=1000.0, f_stop=1000.0, n_points=1)
+        return abs(result.points[0].node_voltages["base"])
+
+    for base_emitter in (True, False):
+        early_transition = junction_amplitude(0.2, base_emitter)
+        late_transition = junction_amplitude(0.8, base_emitter)
+        assert late_transition < early_transition * 0.9
 
 
 def test_ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `FC` forward-bias depletion-coefficient support for the
+  shared `CJE` and `CJC` Berkeley continuation law in AC and transient analysis,
+  matching Python and TypeScript. The supported-parameter catalog now contains
+  92 canonical rows.
 - Add BJT model-card `VJC`/`PC` base-collector junction-potential and `MJC`/`MC`
   grading-coefficient support with bias-shaped `CJC` depletion capacitance in
   AC and transient analysis, matching Python and TypeScript. The supported-

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -134,8 +134,9 @@ model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
 depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
-`0.33`) likewise shape `CJC` base-collector depletion capacitance. Both use the
-Berkeley default `FC=0.5` continuation.
+`0.33`) likewise shape `CJC` base-collector depletion capacitance. `FC`
+(default `0.5`) selects the shared Berkeley forward-bias continuation point for
+both junctions.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -441,6 +441,7 @@ fn clone_subckt_element(
                 element.base_emitter_grading_coefficient,
                 element.base_collector_junction_potential,
                 element.base_collector_grading_coefficient,
+                element.forward_bias_depletion_coefficient,
             ))
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2853,6 +2854,7 @@ pub struct Bjt {
     pub base_emitter_grading_coefficient: f64,
     pub base_collector_junction_potential: f64,
     pub base_collector_grading_coefficient: f64,
+    pub forward_bias_depletion_coefficient: f64,
 }
 
 impl Bjt {
@@ -2955,6 +2957,7 @@ impl Bjt {
             0.33,
             0.75,
             0.33,
+            0.5,
         )
     }
 
@@ -2981,6 +2984,7 @@ impl Bjt {
         base_emitter_grading_coefficient: f64,
         base_collector_junction_potential: f64,
         base_collector_grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -3004,6 +3008,7 @@ impl Bjt {
             base_emitter_grading_coefficient,
             base_collector_junction_potential,
             base_collector_grading_coefficient,
+            forward_bias_depletion_coefficient,
         }
     }
 }
@@ -3394,8 +3399,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 16, 29, 9, 4),
-    (ModelCardKind::Pnp, 16, 29, 9, 4),
+    (ModelCardKind::Npn, 17, 30, 9, 4),
+    (ModelCardKind::Pnp, 17, 30, 9, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3451,6 +3456,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("PC", "VJC"),
     ("MJC", "MJC"),
     ("MC", "MJC"),
+    ("FC", "FC"),
 ];
 const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("BETA", "BETA"),
@@ -4112,6 +4118,7 @@ pub fn bjt_from_model_card(
         model_card_value(model, "MJE", 0.33),
         model_card_value(model, "VJC", 0.75),
         model_card_value(model, "MJC", 0.33),
+        model_card_value(model, "FC", 0.5),
     ))
 }
 
@@ -23068,7 +23075,7 @@ fn bjt_base_emitter_depletion_capacitance(bjt: &Bjt, voltage: f64) -> f64 {
         return bjt.base_emitter_capacitance;
     }
     let normalized_voltage = voltage / bjt.base_emitter_junction_potential;
-    let coefficient = 0.5;
+    let coefficient = bjt.forward_bias_depletion_coefficient;
     if normalized_voltage < coefficient {
         return bjt.base_emitter_capacitance
             / (1.0 - normalized_voltage).powf(bjt.base_emitter_grading_coefficient);
@@ -23084,7 +23091,7 @@ fn bjt_base_collector_depletion_capacitance(bjt: &Bjt, voltage: f64) -> f64 {
         return bjt.base_collector_capacitance;
     }
     let normalized_voltage = voltage / bjt.base_collector_junction_potential;
-    let coefficient = 0.5;
+    let coefficient = bjt.forward_bias_depletion_coefficient;
     if normalized_voltage < coefficient {
         return bjt.base_collector_capacitance
             / (1.0 - normalized_voltage).powf(bjt.base_collector_grading_coefficient);
@@ -23480,6 +23487,14 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "base-collector grading coefficient must be finite and in [0, 1)".to_string(),
+        });
+    }
+    if !bjt.forward_bias_depletion_coefficient.is_finite()
+        || !(0.0..1.0).contains(&bjt.forward_bias_depletion_coefficient)
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward-bias depletion coefficient must be finite and in [0, 1)".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -939,6 +939,7 @@ fn ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() {
                 grading_coefficient,
                 0.75,
                 0.33,
+                0.5,
             ),
         ));
 
@@ -987,6 +988,7 @@ fn ac_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() {
                 0.33,
                 0.75,
                 grading_coefficient,
+                0.5,
             ),
         ));
 
@@ -997,6 +999,58 @@ fn ac_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() {
     }
 
     assert!(collector_amplitude(0.5) > collector_amplitude(0.0));
+}
+
+#[test]
+fn ac_bjt_forward_bias_depletion_coefficient_shapes_both_junctions() {
+    fn junction_amplitude(coefficient: f64, base_emitter: bool) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.6, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "junction", 1_000.0,
+        )));
+        circuit.add(Element::Bjt(
+            Bjt::with_model_temperature_and_depletion_parameters(
+                "Q1",
+                "0",
+                "junction",
+                "0",
+                BjtPolarity::Npn,
+                1.0e-30,
+                100.0,
+                0.02585,
+                if base_emitter { 1.0e-6 } else { 0.0 },
+                if base_emitter { 0.0 } else { 1.0e-6 },
+                0.0,
+                0.0,
+                3.0,
+                1.11,
+                0.0,
+                1.0,
+                1.0,
+                0.75,
+                0.33,
+                0.75,
+                0.33,
+                coefficient,
+            ),
+        ));
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 1).unwrap()[0]
+            .voltage("junction")
+            .unwrap()
+            .abs()
+    }
+
+    for base_emitter in [true, false] {
+        let early_transition = junction_amplitude(0.2, base_emitter);
+        let late_transition = junction_amplitude(0.8, base_emitter);
+        assert!(
+            late_transition < early_transition * 0.9,
+            "base_emitter={base_emitter} early={early_transition} late={late_transition}"
+        );
+    }
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 90);
+    assert_eq!(coverage.len(), 92);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 90);
+    assert_eq!(records.len(), 92);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 90);
-    assert_eq!(report.expected_canonical_parameter_count, 90);
-    assert_eq!(report.accepted_name_count, 148);
+    assert_eq!(report.canonical_parameter_count, 92);
+    assert_eq!(report.expected_canonical_parameter_count, 92);
+    assert_eq!(report.accepted_name_count, 150);
     assert_eq!(report.aliased_parameter_count, 45);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t90\t90\t148\t45\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t92\t92\t150\t45\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 89);
-    assert_eq!(report.accepted_name_count, 145);
+    assert_eq!(report.canonical_parameter_count, 91);
+    assert_eq!(report.accepted_name_count, 147);
     assert_eq!(report.aliased_parameter_count, 44);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t89\t90\t145\t44\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t91\t92\t147\t44\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -437,6 +437,7 @@ fn model_card_aliases_build_device_instances() {
             ("ME", 0.4),
             ("PC", 0.7),
             ("MC", 0.45),
+            ("FC", 0.4),
         ],
     )
     .unwrap();
@@ -452,6 +453,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("MJE").unwrap(), 0.4);
     assert_close(*bjt_card.parameters.get("VJC").unwrap(), 0.7);
     assert_close(*bjt_card.parameters.get("MJC").unwrap(), 0.45);
+    assert_close(*bjt_card.parameters.get("FC").unwrap(), 0.4);
     assert_eq!(bjt_model.polarity, BjtPolarity::Npn);
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
@@ -464,6 +466,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.base_emitter_grading_coefficient, 0.4);
     assert_close(bjt_model.base_collector_junction_potential, 0.7);
     assert_close(bjt_model.base_collector_grading_coefficient, 0.45);
+    assert_close(bjt_model.forward_bias_depletion_coefficient, 0.4);
 
     let jfet_card = normalize_model_card(
         "Jn",
@@ -1382,6 +1385,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         0.4,
         0.7,
         0.45,
+        0.4,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1416,6 +1420,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.base_emitter_grading_coefficient, 0.4);
     assert_close(expanded.base_collector_junction_potential, 0.7);
     assert_close(expanded.base_collector_grading_coefficient, 0.45);
+    assert_close(expanded.forward_bias_depletion_coefficient, 0.4);
 }
 
 #[test]
@@ -2180,6 +2185,7 @@ fn dc_rejects_invalid_bjt_base_emitter_depletion_parameters() {
                 grading_coefficient,
                 0.75,
                 0.33,
+                0.5,
             ),
         ));
         assert!(dc_op(&circuit).unwrap_err().to_string().contains(message));
@@ -2224,9 +2230,24 @@ fn dc_rejects_invalid_bjt_base_collector_depletion_parameters() {
                 0.33,
                 junction_potential,
                 grading_coefficient,
+                0.5,
             ),
         ));
         assert!(dc_op(&circuit).unwrap_err().to_string().contains(message));
+    }
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_bias_depletion_coefficient() {
+    for coefficient in [-0.1, 1.0, f64::NAN] {
+        let mut bjt = Bjt::new("Qbad", "c", "b", "0");
+        bjt.forward_bias_depletion_coefficient = coefficient;
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Bjt(bjt));
+        assert!(dc_op(&circuit)
+            .unwrap_err()
+            .to_string()
+            .contains("forward-bias depletion coefficient must be finite and in [0, 1)"));
     }
 }
 

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -565,6 +565,7 @@ fn transient_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias() {
                 grading_coefficient,
                 0.75,
                 0.33,
+                0.5,
             ),
         ));
         transient(&circuit, 1.0e-9, 5.0e-9).unwrap()[1]
@@ -620,6 +621,7 @@ fn transient_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() 
                 0.33,
                 0.75,
                 grading_coefficient,
+                0.5,
             ),
         ));
         transient(&circuit, 1.0e-9, 5.0e-9).unwrap()[1]
@@ -628,6 +630,61 @@ fn transient_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() 
     }
 
     assert!(stepped_collector_voltage(0.5) < stepped_collector_voltage(0.0));
+}
+
+#[test]
+fn transient_bjt_forward_bias_depletion_coefficient_shapes_both_junctions() {
+    fn held_voltage(coefficient: f64, base_emitter: bool) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vdrive",
+            "in",
+            "0",
+            0.6,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.6),
+                (1.0e-9, 0.6),
+                (2.0e-9, 0.0),
+                (5.0e-9, 0.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Bjt(
+            Bjt::with_model_temperature_and_depletion_parameters(
+                "Q1",
+                "0",
+                "base",
+                "0",
+                BjtPolarity::Npn,
+                1.0e-30,
+                100.0,
+                0.02585,
+                if base_emitter { 1.0e-12 } else { 0.0 },
+                if base_emitter { 0.0 } else { 1.0e-12 },
+                0.0,
+                0.0,
+                3.0,
+                1.11,
+                0.0,
+                1.0,
+                1.0,
+                0.75,
+                0.33,
+                0.75,
+                0.33,
+                coefficient,
+            ),
+        ));
+        transient(&circuit, 1.0e-9, 5.0e-9).unwrap()[1]
+            .voltage("base")
+            .unwrap()
+    }
+
+    for base_emitter in [true, false] {
+        assert!(held_voltage(0.8, base_emitter) > held_voltage(0.2, base_emitter));
+    }
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `FC` forward-bias depletion-coefficient support for the
+  shared `CJE` and `CJC` Berkeley continuation law in AC and transient analysis,
+  matching Python and Rust. The supported-parameter catalog now contains 92
+  canonical rows.
 - Add BJT model-card `VJC`/`PC` base-collector junction-potential and `MJC`/`MC`
   grading-coefficient support with bias-shaped `CJC` depletion capacitance in
   AC and transient analysis, matching Python and Rust. The supported-parameter

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -204,8 +204,9 @@ model-specific saturation-current temperature scaling, `VAF`/`VA` (default
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter
 depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
-`0.33`) likewise shape `CJC` base-collector depletion capacitance. Both use the
-Berkeley default `FC=0.5` continuation.
+`0.33`) likewise shape `CJC` base-collector depletion capacitance. `FC`
+(default `0.5`) selects the shared Berkeley forward-bias continuation point for
+both junctions.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1719,6 +1719,7 @@ export interface Bjt {
   readonly baseEmitterGradingCoefficient: number;
   readonly baseCollectorJunctionPotential: number;
   readonly baseCollectorGradingCoefficient: number;
+  readonly forwardBiasDepletionCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1996,8 +1997,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [16, 29, 9, 4],
-  PNP: [16, 29, 9, 4],
+  NPN: [17, 30, 9, 4],
+  PNP: [17, 30, 9, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3587,7 +3588,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7749,6 +7750,7 @@ export function bjt(
   baseEmitterGradingCoefficient = 0.33,
   baseCollectorJunctionPotential = 0.75,
   baseCollectorGradingCoefficient = 0.33,
+  forwardBiasDepletionCoefficient = 0.5,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7773,6 +7775,7 @@ export function bjt(
     baseEmitterGradingCoefficient,
     baseCollectorJunctionPotential,
     baseCollectorGradingCoefficient,
+    forwardBiasDepletionCoefficient,
   };
 }
 
@@ -7888,6 +7891,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   PC: "VJC",
   MJC: "MJC",
   MC: "MJC",
+  FC: "FC",
 };
 
 const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8393,6 +8397,7 @@ export function bjtFromModelCard(
     p.MJE ?? 0.33,
     p.VJC ?? 0.75,
     p.MJC ?? 0.33,
+    p.FC ?? 0.5,
   );
 }
 
@@ -19402,7 +19407,7 @@ function bjtBaseEmitterDepletionCapacitance(element: Bjt, voltage: number): numb
     return element.baseEmitterCapacitance;
   }
   const normalizedVoltage = voltage / element.baseEmitterJunctionPotential;
-  const coefficient = 0.5;
+  const coefficient = element.forwardBiasDepletionCoefficient;
   if (normalizedVoltage < coefficient) {
     return element.baseEmitterCapacitance /
       ((1.0 - normalizedVoltage) ** element.baseEmitterGradingCoefficient);
@@ -19419,7 +19424,7 @@ function bjtBaseCollectorDepletionCapacitance(element: Bjt, voltage: number): nu
     return element.baseCollectorCapacitance;
   }
   const normalizedVoltage = voltage / element.baseCollectorJunctionPotential;
-  const coefficient = 0.5;
+  const coefficient = element.forwardBiasDepletionCoefficient;
   if (normalizedVoltage < coefficient) {
     return element.baseCollectorCapacitance /
       ((1.0 - normalizedVoltage) ** element.baseCollectorGradingCoefficient);
@@ -19672,6 +19677,11 @@ function validateBjt(element: Bjt): void {
       element.baseCollectorGradingCoefficient < 0.0 ||
       element.baseCollectorGradingCoefficient >= 1.0) {
     throw invalidElement(element.name, "base-collector grading coefficient must be finite and in [0, 1)");
+  }
+  if (!Number.isFinite(element.forwardBiasDepletionCoefficient) ||
+      element.forwardBiasDepletionCoefficient < 0.0 ||
+      element.forwardBiasDepletionCoefficient >= 1.0) {
+    throw invalidElement(element.name, "forward-bias depletion coefficient must be finite and in [0, 1)");
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -629,6 +629,22 @@ describe("acSweep", () => {
     expect(collectorAmplitude(0.5)).toBeGreaterThan(collectorAmplitude(0.0));
   });
 
+  it("uses BJT FC to shape both forward-biased depletion junctions", () => {
+    function junctionAmplitude(coefficient: number, baseEmitter: boolean): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.6, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(bjt("Q1", "0", "base", "0", "NPN", 1.0e-30, 100.0, 0.02585, baseEmitter ? 1.0e-6 : 0.0, baseEmitter ? 0.0 : 1.0e-6, 0.0, 0.0, 3.0, 1.11, 0.0, 1.0, 1.0, 0.75, 0.33, 0.75, 0.33, coefficient));
+      return complexAbs(acSweep(circuit, 1_000.0, 1_000.0, 1)[0].voltage("base")!);
+    }
+
+    for (const baseEmitter of [true, false]) {
+      expect(junctionAmplitude(0.8, baseEmitter)).toBeLessThan(
+        junctionAmplitude(0.2, baseEmitter) * 0.9,
+      );
+    }
+  });
+
   it("applies VCVS gain in AC analysis", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vin", "in", "0", 1.0));

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(90);
+    expect(coverage).toHaveLength(92);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(90);
+    expect(records).toHaveLength(92);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 90,
-      expectedCanonicalParameterCount: 90,
-      acceptedNameCount: 148,
+      canonicalParameterCount: 92,
+      expectedCanonicalParameterCount: 92,
+      acceptedNameCount: 150,
       aliasedParameterCount: 45,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t90\t90\t148\t45\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t92\t92\t150\t45\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(89);
-    expect(report.acceptedNameCount).toBe(145);
+    expect(report.canonicalParameterCount).toBe(91);
+    expect(report.acceptedNameCount).toBe(147);
     expect(report.aliasedParameterCount).toBe(44);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t89\t90\t145\t44\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t91\t92\t147\t44\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -343,9 +343,10 @@ describe("dcOp", () => {
       ME: 0.4,
       PC: 0.7,
       MC: 0.45,
+      FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
@@ -358,6 +359,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseEmitterGradingCoefficient, 0.4);
     expectClose(bjtModel.baseCollectorJunctionPotential, 0.7);
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
+    expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
     const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
@@ -990,7 +992,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1007,6 +1009,7 @@ describe("dcOp", () => {
       expectClose(expanded.baseEmitterGradingCoefficient, 0.4);
       expectClose(expanded.baseCollectorJunctionPotential, 0.7);
       expectClose(expanded.baseCollectorGradingCoefficient, 0.45);
+      expectClose(expanded.forwardBiasDepletionCoefficient, 0.4);
     }
   });
 
@@ -1412,6 +1415,14 @@ describe("dcOp", () => {
     const invalidGrading = new Circuit();
     invalidGrading.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 1.0, 0.75, 0.33, 0.75, 1.0));
     expect(() => dcOp(invalidGrading)).toThrowError("base-collector grading coefficient must be finite and in [0, 1)");
+  });
+
+  it("rejects invalid BJT forward-bias depletion coefficients", () => {
+    for (const coefficient of [-0.1, 1.0, Number.NaN]) {
+      const circuit = new Circuit();
+      circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, 0.0, 1.0, 1.0, 0.75, 0.33, 0.75, 0.33, coefficient));
+      expect(() => dcOp(circuit)).toThrowError("forward-bias depletion coefficient must be finite and in [0, 1)");
+    }
   });
 
   it("uses MOSFET temperature scaling in common-source drain voltage", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -493,6 +493,26 @@ describe("transient", () => {
     expect(steppedCollectorVoltage(0.5)).toBeLessThan(steppedCollectorVoltage(0.0));
   });
 
+  it("uses BJT FC to shape both forward-biased transient charge companions", () => {
+    function heldVoltage(coefficient: number, baseEmitter: boolean): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vdrive",
+        "in",
+        "0",
+        0.6,
+        new PwlWaveform([[0.0, 0.6], [1.0e-9, 0.6], [2.0e-9, 0.0], [5.0e-9, 0.0]]),
+      ));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(bjt("Q1", "0", "base", "0", "NPN", 1.0e-30, 100.0, 0.02585, baseEmitter ? 1.0e-12 : 0.0, baseEmitter ? 0.0 : 1.0e-12, 0.0, 0.0, 3.0, 1.11, 0.0, 1.0, 1.0, 0.75, 0.33, 0.75, 0.33, coefficient));
+      return transient(circuit, 1.0e-9, 5.0e-9)[1].voltage("base")!;
+    }
+
+    for (const baseEmitter of [true, false]) {
+      expect(heldVoltage(0.8, baseEmitter)).toBeGreaterThan(heldVoltage(0.2, baseEmitter));
+    }
+  });
+
   it("uses BJT forward transit time to hold base charge on turnoff", () => {
     function run(forwardTransitTime: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT base-collector depletion-capacitance shaping.
+1. Cross-language BJT forward-bias depletion coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `VJC` / `PC` base-collector junction-potential and `MJC` /
-     `MC` grading-coefficient model-card support in Rust, Python, and TypeScript.
-   - Shape `CJC` base-collector depletion capacitance in AC and transient
-     analysis with the continuous Berkeley piecewise law and default `FC=0.5`,
-     while preserving the full BJT model through hierarchical subcircuits.
-   - Extend the supported-parameter coverage gate from 86 to 90 canonical rows
-     and lock reverse-biased base-collector capacitance behavior in all engines.
+   - Add Berkeley BJT `FC` forward-bias depletion-coefficient model-card support
+     in Rust, Python, and TypeScript with the standard `0.5` default.
+   - Apply `FC` as the shared continuous piecewise-law transition point for both
+     `CJE` and `CJC` in AC and transient analysis, while preserving the complete
+     BJT model through hierarchical subcircuits.
+   - Extend the supported-parameter coverage gate from 90 to 92 canonical rows
+     and lock both forward-biased junction behaviors in all engines.
 
 ## Completed Slices
 
@@ -3037,6 +3037,14 @@ the Rust, Python, and TypeScript surfaces together.
      AC and transient analysis.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 86 canonical rows.
+
+224. Cross-language BJT base-collector depletion-capacitance shaping.
+   - Status: completed in PR 8755.
+   - Rust, Python, and TypeScript BJT model cards now accept `VJC` / `PC` and
+     `MJC` / `MC` and apply continuous Berkeley depletion shaping to `CJC` in
+     AC and transient analysis.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 90 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `FC` forward-bias depletion-coefficient support across Rust, Python, and TypeScript
- apply the model parameter to the shared continuous `CJE` and `CJC` forward-bias continuation law in AC and transient analysis
- preserve and validate the parameter through model-card construction, hierarchy expansion, and Python reconstruction paths
- advance the supported-parameter coverage gate from 90 to 92 canonical rows and reconcile the SPICE implementation plan

## Verification
- `cargo test -p spice-engine` (333 passed)
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python spice-engine: 525 passed, 88.60% coverage
- `ruff check` on touched Python sources/tests
- TypeScript spice-engine: 283 passed
- `npm run build`
- `git diff --check`