### PR TITLE
feat(chief): wire opaque VaultRef host leases

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -714,6 +714,7 @@ members = [
     "vault-auth",
     "vault-policy",
     "vault-leases",
+    "chief-of-staff-vault-runtime",
     "vault-engine-core",
     "vault-engine-kv2",
     "vault-audit",

--- a/code/packages/rust/chief-of-staff-vault-runtime/BUILD
+++ b/code/packages/rust/chief-of-staff-vault-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-vault-runtime -- --nocapture

--- a/code/packages/rust/chief-of-staff-vault-runtime/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-vault-runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "chief-of-staff-vault-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Opaque VaultRef lease broker for Chief of Staff host tools"
+license = "MIT"
+
+[dependencies]
+coding_adventures_vault_leases = { path = "../vault-leases" }
+smart-home-core = { path = "../smart-home-core" }

--- a/code/packages/rust/chief-of-staff-vault-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-vault-runtime/src/lib.rs
@@ -1,0 +1,171 @@
+//! Host-side broker for issuing opaque Chief of Staff secret leases.
+//!
+//! Model-facing tools receive only a [`VaultRef`]. Raw payload bytes remain in
+//! the zeroizing lease manager and can only be consumed by a trusted host
+//! handler.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Mutex;
+
+use coding_adventures_vault_leases::{
+    InMemoryLeaseManager, LeaseError, LeaseId, LeaseManager, LeasePayload,
+};
+use smart_home_core::VaultRef;
+
+const VAULT_REF_PREFIX: &str = "vault-lease:";
+
+/// A newly issued lease receipt safe to return across the tool boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VaultLeaseReceipt {
+    /// Opaque handle understood only by the trusted host broker.
+    pub vault_ref: VaultRef,
+    /// Authoritative lease expiry in milliseconds since Unix epoch.
+    pub expires_at_ms: u64,
+}
+
+/// Errors produced by the Chief vault lease boundary.
+#[derive(Debug)]
+pub enum VaultRuntimeError {
+    /// The requested secret name is not registered with this broker.
+    SecretNotFound,
+    /// The supplied reference was not minted by this broker format.
+    InvalidVaultRef,
+    /// The underlying lease manager rejected the operation.
+    Lease(LeaseError),
+}
+
+impl fmt::Display for VaultRuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SecretNotFound => f.write_str("secret not found"),
+            Self::InvalidVaultRef => f.write_str("invalid VaultRef"),
+            Self::Lease(error) => write!(f, "lease operation failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for VaultRuntimeError {}
+
+impl From<LeaseError> for VaultRuntimeError {
+    fn from(value: LeaseError) -> Self {
+        Self::Lease(value)
+    }
+}
+
+/// In-process vault actor boundary used by Chief host runtimes.
+pub struct ChiefVaultRuntime {
+    secrets: Mutex<HashMap<String, LeasePayload>>,
+    leases: InMemoryLeaseManager,
+}
+
+impl Default for ChiefVaultRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChiefVaultRuntime {
+    /// Construct an empty vault runtime.
+    pub fn new() -> Self {
+        Self {
+            secrets: Mutex::new(HashMap::new()),
+            leases: InMemoryLeaseManager::new(),
+        }
+    }
+
+    /// Register or rotate a named secret while retaining it in zeroizing memory.
+    pub fn register_secret(&self, name: impl Into<String>, payload: LeasePayload) {
+        self.secrets
+            .lock()
+            .expect("vault secret mutex poisoned")
+            .insert(name.into(), payload);
+    }
+
+    /// Issue a short-lived opaque reference for a named secret.
+    pub fn request_lease(
+        &self,
+        secret_name: &str,
+        ttl_ms: u64,
+    ) -> Result<VaultLeaseReceipt, VaultRuntimeError> {
+        let payload = self
+            .secrets
+            .lock()
+            .expect("vault secret mutex poisoned")
+            .get(secret_name)
+            .cloned()
+            .ok_or(VaultRuntimeError::SecretNotFound)?;
+        let lease_id = self.leases.issue(payload, ttl_ms)?;
+        let info = self.leases.lookup(&lease_id)?;
+        Ok(VaultLeaseReceipt {
+            vault_ref: VaultRef::trusted(format!("{VAULT_REF_PREFIX}{}", lease_id.as_hex())),
+            expires_at_ms: info.expires_at_ms,
+        })
+    }
+
+    /// Atomically resolve and revoke a lease inside a trusted host handler.
+    pub fn consume(&self, vault_ref: &VaultRef) -> Result<LeasePayload, VaultRuntimeError> {
+        let lease_id = lease_id(vault_ref)?;
+        self.leases.consume(&lease_id).map_err(Into::into)
+    }
+
+    /// Revoke an outstanding lease before its TTL elapses.
+    pub fn revoke(&self, vault_ref: &VaultRef) -> Result<(), VaultRuntimeError> {
+        let lease_id = lease_id(vault_ref)?;
+        self.leases.revoke(&lease_id).map_err(Into::into)
+    }
+}
+
+fn lease_id(vault_ref: &VaultRef) -> Result<LeaseId, VaultRuntimeError> {
+    vault_ref
+        .as_str()
+        .strip_prefix(VAULT_REF_PREFIX)
+        .and_then(LeaseId::from_hex)
+        .ok_or(VaultRuntimeError::InvalidVaultRef)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"chief-vault-runtime-secret";
+
+    #[test]
+    fn opaque_reference_resolves_once_inside_host_boundary() {
+        let vault = ChiefVaultRuntime::new();
+        vault.register_secret("weather-api-key", LeasePayload::new(SECRET.to_vec()));
+
+        let receipt = vault
+            .request_lease("weather-api-key", 30_000)
+            .expect("lease should be issued");
+        assert!(receipt.vault_ref.as_str().starts_with(VAULT_REF_PREFIX));
+        assert!(!receipt.vault_ref.as_str().contains("runtime-secret"));
+
+        let payload = vault
+            .consume(&receipt.vault_ref)
+            .expect("trusted host should consume lease");
+        assert_eq!(payload.as_bytes(), SECRET);
+        assert!(vault.consume(&receipt.vault_ref).is_err());
+    }
+
+    #[test]
+    fn revoked_and_unknown_references_fail_closed() {
+        let vault = ChiefVaultRuntime::new();
+        vault.register_secret("weather-api-key", LeasePayload::new(SECRET.to_vec()));
+        let receipt = vault
+            .request_lease("weather-api-key", 30_000)
+            .expect("lease should be issued");
+        vault
+            .revoke(&receipt.vault_ref)
+            .expect("revoke should work");
+
+        assert!(vault.consume(&receipt.vault_ref).is_err());
+        assert!(vault
+            .consume(&VaultRef::trusted("raw-secret-or-random-handle"))
+            .is_err());
+        assert!(vault.request_lease("missing", 30_000).is_err());
+    }
+}

--- a/code/packages/rust/weather-agent-e2e/Cargo.toml
+++ b/code/packages/rust/weather-agent-e2e/Cargo.toml
@@ -13,7 +13,9 @@ capability-cage = { path = "../capability-cage" }
 chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 chief-of-staff-tool-audit-store = { path = "../chief-of-staff-tool-audit-store" }
+chief-of-staff-vault-runtime = { path = "../chief-of-staff-vault-runtime" }
 coding-adventures-json-value = { path = "../json-value" }
+coding_adventures_vault_leases = { path = "../vault-leases" }
 context-store = { path = "../context-store" }
 generic-job-protocol = { path = "../generic-job-protocol" }
 generic-job-runtime = { path = "../generic-job-runtime" }
@@ -25,6 +27,7 @@ os-job-core = { path = "../os-job-core" }
 os-job-runtime = { path = "../os-job-runtime" }
 read-write-separation = { path = "../read-write-separation" }
 skill-store = { path = "../skill-store" }
+smart-home-core = { path = "../smart-home-core" }
 storage-core = { path = "../storage-core" }
 storage-local-folder = { path = "../storage-local-folder" }
 tls-platform = { path = "../tls-platform" }

--- a/code/packages/rust/weather-agent-e2e/orchestrator_profile.json
+++ b/code/packages/rust/weather-agent-e2e/orchestrator_profile.json
@@ -2,6 +2,12 @@
   "profile_id": "umbrella_today_v1",
   "hosts": [
     {
+      "host_id": "vault",
+      "max_tier": "tier2",
+      "allowed_tools": ["vault.request_lease"],
+      "capabilities": ["vault_lease"]
+    },
+    {
       "host_id": "weather_fetcher",
       "max_tier": "tier1",
       "allowed_tools": ["weather.fetch_current"],

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -34,7 +34,9 @@ use chief_of_staff_tool_api::{
     ToolPolicyProfile, ToolSideEffects, ToolStability, ToolStreaming,
 };
 use chief_of_staff_tool_audit_store::{ToolAuditStore, ToolAuditStoreInventorySummary};
+use chief_of_staff_vault_runtime::ChiefVaultRuntime;
 use coding_adventures_json_value::{JsonNumber, JsonValue};
+use coding_adventures_vault_leases::LeasePayload;
 use context_store::{
     AppendEntryInput, ContextEntryKind, ContextStore, ContextStoreInventorySummary,
     CreateSessionInput, CreateSnapshotInput, SessionListOptions,
@@ -63,6 +65,7 @@ use read_write_separation::{
 use skill_store::{
     InstallSkillAssetInput, SkillInventorySummary, SkillListOptions, SkillManifest, SkillStore,
 };
+use smart_home_core::VaultRef;
 use storage_core::{InMemoryStorageBackend, StorageError};
 use storage_local_folder::LocalFolderStorageBackend;
 use tls_platform::TlsConfig;
@@ -76,6 +79,10 @@ const SESSION_ID: &str = "umbrella_today_session";
 const JOB_ID: &str = "umbrella_today_job";
 const DEFAULT_TICK_ID: &str = "8a7b0000000000000000000000000001";
 const USER_ID: &str = "seattle_user";
+const VAULT_TOOL_ID: &str = "vault.request_lease";
+const WEATHER_SECRET_NAME: &str = "weather-api-key";
+const WEATHER_SECRET_FIXTURE: &[u8] = b"weather-api-key-host-only-fixture";
+const WEATHER_LEASE_TTL_MS: u64 = 30_000;
 const FETCH_TOOL_ID: &str = "weather.fetch_current";
 const CLASSIFY_TOOL_ID: &str = "weather.classify_umbrella";
 const WRITE_TOOL_ID: &str = "file.write_text";
@@ -193,6 +200,7 @@ pub struct UmbrellaAgentConfig {
     pub weather_source: WeatherSource,
     pub supervisor_probe: UmbrellaSupervisorProbe,
     pub write_approval: Option<ToolApprovalGrant>,
+    pub vault_approval: Option<ToolApprovalGrant>,
     pub write_required_tier: PrivilegeTier,
     pub audit_root: PathBuf,
 }
@@ -210,6 +218,7 @@ impl UmbrellaAgentConfig {
             weather_source: WeatherSource::Fixture(WeatherSnapshot::rainy_seattle_fixture()),
             supervisor_probe: UmbrellaSupervisorProbe::default(),
             write_approval: Some(default_write_approval(DEFAULT_TICK_ID, 1_778_624_400_000)),
+            vault_approval: Some(default_vault_approval(DEFAULT_TICK_ID, 1_778_624_400_000)),
             write_required_tier: PrivilegeTier::Tier1,
         }
     }
@@ -232,6 +241,7 @@ impl UmbrellaAgentConfig {
             },
             supervisor_probe: UmbrellaSupervisorProbe::default(),
             write_approval: Some(default_write_approval(DEFAULT_TICK_ID, fetched_at_ms)),
+            vault_approval: Some(default_vault_approval(DEFAULT_TICK_ID, fetched_at_ms)),
             write_required_tier: PrivilegeTier::Tier1,
         }
     }
@@ -243,6 +253,11 @@ impl UmbrellaAgentConfig {
 
     pub fn without_write_approval(mut self) -> Self {
         self.write_approval = None;
+        self
+    }
+
+    pub fn without_vault_approval(mut self) -> Self {
+        self.vault_approval = None;
         self
     }
 
@@ -278,6 +293,14 @@ impl UmbrellaAgentConfig {
                 ));
             }
         }
+        if let Some(grant) = self.vault_approval.as_mut() {
+            grant.call_id = scoped_call_id(&self.tick_id, "request_weather_lease");
+            grant.challenge_id = Some(ToolApprovalChallenge::id_for(
+                &grant.call_id,
+                VAULT_TOOL_ID,
+                self.fetched_at_ms,
+            ));
+        }
         self
     }
 }
@@ -294,6 +317,18 @@ fn default_write_approval(tick_id: &str, granted_at: u64) -> ToolApprovalGrant {
         granted_at,
     )
     .with_expires_at(granted_at.saturating_add(300_000))
+}
+
+fn default_vault_approval(tick_id: &str, granted_at: u64) -> ToolApprovalGrant {
+    let call_id = scoped_call_id(tick_id, "request_weather_lease");
+    ToolApprovalGrant::new(&call_id, VAULT_TOOL_ID, USER_ID, granted_at)
+        .with_expires_at(granted_at.saturating_add(300_000))
+        .with_assurance(ApprovalAssurance::Biometric)
+        .with_challenge_id(ToolApprovalChallenge::id_for(
+            call_id,
+            VAULT_TOOL_ID,
+            granted_at,
+        ))
 }
 
 fn scoped_call_id(tick_id: &str, call_id: &str) -> String {
@@ -567,6 +602,7 @@ pub struct UmbrellaAgentRun {
     pub output_path: PathBuf,
     pub output_text: String,
     pub weather_fetch: WeatherFetchSummary,
+    pub vault_lease: VaultLeaseRunSummary,
     pub sandbox_plan: UmbrellaSandboxPlanSummary,
     pub kernel_sandbox: UmbrellaKernelSandboxSummary,
     pub supervisor: UmbrellaSupervisorSummary,
@@ -584,6 +620,13 @@ pub struct UmbrellaAgentRun {
     pub job_receipt: JobRunReceipt,
     pub user_report: UmbrellaUserReport,
     pub durable_audit: UmbrellaDurableAuditSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VaultLeaseRunSummary {
+    pub vault_ref: VaultRef,
+    pub ttl_ms: u64,
+    pub consumed_by_host: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -746,6 +789,7 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
     let recommendation = pipeline.recommendation()?;
     let output_text = fs::read_to_string(&config.output_path)?;
     let weather_fetch = pipeline.weather_fetch_summary()?;
+    let vault_lease = pipeline.vault_lease_summary()?;
     let tool_journal_health = pipeline
         .journal
         .lock()
@@ -801,6 +845,7 @@ pub fn run_umbrella_today_agent(config: UmbrellaAgentConfig) -> UmbrellaResult<U
         output_path: config.output_path,
         output_text,
         weather_fetch,
+        vault_lease,
         sandbox_plan,
         kernel_sandbox,
         supervisor: supervisor_summary(&system, &actor_stats, supervisor_events),
@@ -882,6 +927,7 @@ struct UmbrellaPipeline {
     skill_store: SkillStore<InMemoryStorageBackend>,
     snapshot: Mutex<Option<WeatherSnapshot>>,
     weather_fetch_summary: Mutex<Option<WeatherFetchSummary>>,
+    vault_lease_summary: Mutex<Option<VaultLeaseRunSummary>>,
     recommendation: Mutex<Option<UmbrellaRecommendation>>,
     actor_errors: Mutex<Vec<String>>,
 }
@@ -889,6 +935,12 @@ struct UmbrellaPipeline {
 impl UmbrellaPipeline {
     fn new(config: UmbrellaAgentConfig) -> UmbrellaResult<Self> {
         let mut tool_runtime = OrchestratorProfileRuntime::from_json(WEATHER_ORCHESTRATOR_PROFILE)?;
+        let vault = Arc::new(ChiefVaultRuntime::new());
+        vault.register_secret(
+            WEATHER_SECRET_NAME,
+            LeasePayload::new(WEATHER_SECRET_FIXTURE.to_vec()),
+        );
+        register_vault_lease_tool(&mut tool_runtime, vault.clone())?;
         let http_client = generated_operations::generated_http_client()?;
         register_weather_fetch_tool(
             &mut tool_runtime,
@@ -896,6 +948,7 @@ impl UmbrellaPipeline {
             config.fetched_at_ms,
             config.fetched_at_iso.clone(),
             http_client,
+            vault,
         )
         .map_err(UmbrellaAgentError::from)?;
         register_weather_classifier_tool(&mut tool_runtime)?;
@@ -903,6 +956,10 @@ impl UmbrellaPipeline {
             &mut tool_runtime,
             writer_manifest(&config.output_path)?,
             config.write_required_tier,
+        )?;
+        tool_runtime.set_host_policy(
+            "vault",
+            ToolPolicyProfile::allow_all().with_approval_required_at_or_above(PrivilegeTier::Tier2),
         )?;
         tool_runtime.set_host_policy(
             "file_writer",
@@ -926,6 +983,7 @@ impl UmbrellaPipeline {
             skill_store: SkillStore::new(InMemoryStorageBackend::new()),
             snapshot: Mutex::new(None),
             weather_fetch_summary: Mutex::new(None),
+            vault_lease_summary: Mutex::new(None),
             recommendation: Mutex::new(None),
             actor_errors: Mutex::new(Vec::new()),
         })
@@ -991,11 +1049,13 @@ impl UmbrellaPipeline {
                         .to_string(),
                 entrypoints: vec!["run_once".to_string()],
                 required_tools: vec![
+                    VAULT_TOOL_ID.to_string(),
                     FETCH_TOOL_ID.to_string(),
                     CLASSIFY_TOOL_ID.to_string(),
                     WRITE_TOOL_ID.to_string(),
                 ],
                 required_capabilities: vec![
+                    "vault_lease".to_string(),
                     "weather_api_read".to_string(),
                     "filesystem_write".to_string(),
                 ],
@@ -1014,17 +1074,46 @@ impl UmbrellaPipeline {
 
     fn fetch_step(&self) -> UmbrellaResult<()> {
         self.append_context(
+            "vault_lease_tool_call",
+            ContextEntryKind::ToolCall,
+            object(vec![
+                ("tool_id", string(VAULT_TOOL_ID)),
+                ("secret_name", string(WEATHER_SECRET_NAME)),
+                ("ttl_ms", int(WEATHER_LEASE_TTL_MS as i64)),
+            ]),
+        )?;
+        let lease_output = self.invoke_tool(
+            "request_weather_lease",
+            VAULT_TOOL_ID,
+            object(vec![
+                ("secret_name", string(WEATHER_SECRET_NAME)),
+                ("ttl_ms", int(WEATHER_LEASE_TTL_MS as i64)),
+            ]),
+        )?;
+        let vault_ref =
+            VaultRef::new(field_string(&lease_output, "vault_ref").map_err(tool_error_to_agent)?)
+                .map_err(|error| UmbrellaAgentError::new(error.to_string()))?;
+        self.append_context(
+            "vault_lease_tool_result",
+            ContextEntryKind::ToolResult,
+            lease_output,
+        )?;
+        self.append_context(
             "fetch_tool_call",
             ContextEntryKind::ToolCall,
             object(vec![
                 ("tool_id", string(FETCH_TOOL_ID)),
                 ("location", string(&self.config.location)),
+                ("vault_ref", string(vault_ref.as_str())),
             ]),
         )?;
         let output = self.invoke_tool(
             "fetch_current_weather",
             FETCH_TOOL_ID,
-            object(vec![("location", string(&self.config.location))]),
+            object(vec![
+                ("location", string(&self.config.location)),
+                ("vault_ref", string(vault_ref.as_str())),
+            ]),
         )?;
         let snapshot = WeatherSnapshot::from_json(&output).map_err(tool_error_to_agent)?;
         let fetch_summary = match &self.config.weather_source {
@@ -1039,6 +1128,14 @@ impl UmbrellaPipeline {
             .weather_fetch_summary
             .lock()
             .expect("weather fetch summary mutex poisoned") = Some(fetch_summary);
+        *self
+            .vault_lease_summary
+            .lock()
+            .expect("vault lease summary mutex poisoned") = Some(VaultLeaseRunSummary {
+            vault_ref,
+            ttl_ms: WEATHER_LEASE_TTL_MS,
+            consumed_by_host: true,
+        });
         self.append_context("fetch_tool_result", ContextEntryKind::ToolResult, output)?;
         self.append_channel(
             "weather-fetcher",
@@ -1150,6 +1247,8 @@ impl UmbrellaPipeline {
                 token_estimate: 256,
                 included_entry_ids: vec![
                     "user_request".to_string(),
+                    "vault_lease_tool_call".to_string(),
+                    "vault_lease_tool_result".to_string(),
                     "fetch_tool_call".to_string(),
                     "fetch_tool_result".to_string(),
                     "classify_tool_call".to_string(),
@@ -1195,6 +1294,13 @@ impl UmbrellaPipeline {
         };
         let trace = if tool_id == WRITE_TOOL_ID {
             match self.config.write_approval.as_ref() {
+                Some(grant) => self
+                    .tool_runtime
+                    .invoke_with_events_with_approval(&request, grant)?,
+                None => self.tool_runtime.invoke_with_events(&request)?,
+            }
+        } else if tool_id == VAULT_TOOL_ID {
+            match self.config.vault_approval.as_ref() {
                 Some(grant) => self
                     .tool_runtime
                     .invoke_with_events_with_approval(&request, grant)?,
@@ -1290,6 +1396,14 @@ impl UmbrellaPipeline {
             .expect("weather fetch summary mutex poisoned")
             .clone()
             .ok_or_else(|| UmbrellaAgentError::new("weather fetch summary was not produced"))
+    }
+
+    fn vault_lease_summary(&self) -> UmbrellaResult<VaultLeaseRunSummary> {
+        self.vault_lease_summary
+            .lock()
+            .expect("vault lease summary mutex poisoned")
+            .clone()
+            .ok_or_else(|| UmbrellaAgentError::new("weather VaultRef lease was not consumed"))
     }
 }
 
@@ -1417,6 +1531,7 @@ fn register_weather_fetch_tool(
     fetched_at_ms: u64,
     fetched_at_iso: String,
     http_client: GeneratedOperationHttpClient,
+    vault: Arc<ChiefVaultRuntime>,
 ) -> Result<(), HostRuntimeError> {
     runtime.register_handler(
         tool_definition(
@@ -1424,8 +1539,11 @@ fn register_weather_fetch_tool(
             "Fetch current weather",
             "Fetch the current Seattle weather snapshot through the host weather boundary.",
             JsonSchema::Object {
-                properties: vec![SchemaProperty::new("location", JsonSchema::String)],
-                required: vec!["location".to_string()],
+                properties: vec![
+                    SchemaProperty::new("location", JsonSchema::String),
+                    SchemaProperty::new("vault_ref", JsonSchema::String),
+                ],
+                required: vec!["location".to_string(), "vault_ref".to_string()],
                 allow_unknown_fields: false,
             },
             Some(snapshot_schema()),
@@ -1438,6 +1556,22 @@ fn register_weather_fetch_tool(
         ),
         move |arguments, _context| {
             let location = field_string(&arguments, "location")?;
+            let vault_ref =
+                VaultRef::new(field_string(&arguments, "vault_ref")?).map_err(|error| {
+                    ToolCallError::new(ToolErrorKind::ToolValidationError, error.to_string())
+                })?;
+            let credential = vault.consume(&vault_ref).map_err(|error| {
+                ToolCallError::new(
+                    ToolErrorKind::ToolPermissionDenied,
+                    format!("weather credential lease rejected: {error}"),
+                )
+            })?;
+            if credential.as_bytes().is_empty() {
+                return Err(ToolCallError::new(
+                    ToolErrorKind::ToolPermissionDenied,
+                    "weather credential lease resolved to an empty secret",
+                ));
+            }
             let payload = fetch_weather_from_source(
                 &source,
                 location,
@@ -1471,6 +1605,60 @@ fn register_weather_fetch_tool(
             ))
         },
     )
+}
+
+fn register_vault_lease_tool(
+    runtime: &mut OrchestratorProfileRuntime,
+    vault: Arc<ChiefVaultRuntime>,
+) -> Result<(), HostRuntimeError> {
+    let mut definition = tool_definition(
+        VAULT_TOOL_ID,
+        "Request vault lease",
+        "Issue a short-lived opaque VaultRef for use by a trusted host tool.",
+        JsonSchema::Object {
+            properties: vec![
+                SchemaProperty::new("secret_name", JsonSchema::String),
+                SchemaProperty::new("ttl_ms", JsonSchema::Integer),
+            ],
+            required: vec!["secret_name".to_string(), "ttl_ms".to_string()],
+            allow_unknown_fields: false,
+        },
+        Some(JsonSchema::Object {
+            properties: vec![
+                SchemaProperty::new("vault_ref", JsonSchema::String),
+                SchemaProperty::new("expires_at_ms", JsonSchema::Integer),
+            ],
+            required: vec!["vault_ref".to_string(), "expires_at_ms".to_string()],
+            allow_unknown_fields: false,
+        }),
+        ToolSideEffects::External,
+        ToolIdempotency::Never,
+        ToolConcurrency::Serialized,
+        ToolStreaming::Events,
+        vec!["vault_lease"],
+        vec!["vault", "lease", "secret"],
+    );
+    definition.required_tier = PrivilegeTier::Tier2;
+    runtime.register_handler(definition, move |arguments, _context| {
+        let secret_name = field_string(&arguments, "secret_name")?;
+        let ttl_ms = field_i64(&arguments, "ttl_ms")?;
+        let ttl_ms = u64::try_from(ttl_ms).map_err(|_| {
+            ToolCallError::new(
+                ToolErrorKind::ToolValidationError,
+                "ttl_ms must be a positive integer",
+            )
+        })?;
+        let receipt = vault.request_lease(&secret_name, ttl_ms).map_err(|error| {
+            ToolCallError::new(
+                ToolErrorKind::ToolPermissionDenied,
+                format!("vault lease request rejected: {error}"),
+            )
+        })?;
+        Ok(ToolHandlerOutput::new(object(vec![
+            ("vault_ref", string(receipt.vault_ref.as_str())),
+            ("expires_at_ms", int(receipt.expires_at_ms as i64)),
+        ])))
+    })
 }
 
 fn fetch_weather_from_source(

--- a/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
+++ b/code/packages/rust/weather-agent-e2e/tests/umbrella_today.rs
@@ -84,9 +84,9 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
     assert_eq!(run.supervisor.child_count, 3);
     assert!(run.orchestrator_profile.active);
     assert_eq!(run.orchestrator_profile.profile_id, "umbrella_today_v1");
-    assert_eq!(run.orchestrator_profile.host_count, 3);
-    assert_eq!(run.orchestrator_profile.allowed_tool_count, 3);
-    assert_eq!(run.orchestrator_profile.registered_tool_count, 3);
+    assert_eq!(run.orchestrator_profile.host_count, 4);
+    assert_eq!(run.orchestrator_profile.allowed_tool_count, 4);
+    assert_eq!(run.orchestrator_profile.registered_tool_count, 4);
     assert_eq!(run.supervisor.stopped_children, 3);
     assert_eq!(run.supervisor.failed_children, 0);
     assert_eq!(run.supervisor.dead_letters, 0);
@@ -94,18 +94,18 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
     assert_eq!(run.supervisor.restart_count, 0);
     assert_eq!(run.actor_channel_messages, 3);
 
-    assert_eq!(run.tool_journal_health.invocation_count, 3);
-    assert_eq!(run.tool_journal_health.completed_count, 3);
+    assert_eq!(run.tool_journal_health.invocation_count, 4);
+    assert_eq!(run.tool_journal_health.completed_count, 4);
     assert_eq!(run.tool_journal_health.failed_count, 0);
-    assert_eq!(run.tool_journal_health.approval_granted_count, 1);
+    assert_eq!(run.tool_journal_health.approval_granted_count, 2);
     assert_eq!(run.tool_journal_health.approval_pending_count, 0);
-    assert!(run.tool_journal_health.results_with_output_count >= 3);
+    assert!(run.tool_journal_health.results_with_output_count >= 4);
     assert!(run.tool_journal_health.results_with_artifact_refs_count >= 1);
 
     assert_eq!(run.context_inventory.sessions.total_sessions, 1);
     assert_eq!(run.context_inventory.transcripts.user_entries, 1);
-    assert_eq!(run.context_inventory.transcripts.tool_call_entries, 3);
-    assert_eq!(run.context_inventory.transcripts.tool_result_entries, 3);
+    assert_eq!(run.context_inventory.transcripts.tool_call_entries, 4);
+    assert_eq!(run.context_inventory.transcripts.tool_result_entries, 4);
     assert_eq!(run.context_inventory.transcripts.assistant_entries, 1);
     assert_eq!(run.context_inventory.snapshots.total_snapshots, 1);
     assert!(run.context_inventory.sessions_with_tool_activity >= 1);
@@ -135,19 +135,34 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
         run.user_report.approval_assurance,
         Some(ApprovalAssurance::ExplicitConsent)
     );
-    assert_eq!(run.user_report.journal_invocation_count, 3);
+    assert_eq!(run.user_report.journal_invocation_count, 4);
+    assert!(run
+        .vault_lease
+        .vault_ref
+        .as_str()
+        .starts_with("vault-lease:"));
+    assert_eq!(run.vault_lease.ttl_ms, 30_000);
+    assert!(run.vault_lease.consumed_by_host);
+    assert!(!run
+        .vault_lease
+        .vault_ref
+        .as_str()
+        .contains("host-only-fixture"));
+    assert!(!run
+        .output_text
+        .contains("weather-api-key-host-only-fixture"));
     assert!(run.user_report.render().contains("Bring an umbrella today"));
     assert_eq!(run.durable_audit.job_id, "umbrella_today_job");
     assert_eq!(run.durable_audit.run_id, run.job_receipt.run_id);
     assert_eq!(run.durable_audit.session_id, "umbrella_today_session");
     assert_eq!(run.durable_audit.user_id, "seattle_user");
     assert_eq!(run.durable_audit.profile_id, "umbrella_today_v1");
-    assert_eq!(run.durable_audit.host_count, 3);
-    assert_eq!(run.durable_audit.tool_count, 3);
-    assert_eq!(run.durable_audit.persisted_records, 3);
-    assert_eq!(run.durable_audit.reloaded_records, 3);
-    assert_eq!(run.durable_audit.completed_records, 3);
-    assert_eq!(run.durable_audit.approval_granted_records, 1);
+    assert_eq!(run.durable_audit.host_count, 4);
+    assert_eq!(run.durable_audit.tool_count, 4);
+    assert_eq!(run.durable_audit.persisted_records, 4);
+    assert_eq!(run.durable_audit.reloaded_records, 4);
+    assert_eq!(run.durable_audit.completed_records, 4);
+    assert_eq!(run.durable_audit.approval_granted_records, 2);
     assert!(run.durable_audit.records_with_references >= 1);
     assert_eq!(run.durable_audit.follow_up_records, 0);
     assert!(run.durable_audit.is_complete());
@@ -158,7 +173,11 @@ fn umbrella_today_agent_exercises_architecture_and_writes_text_file() {
     let restarted_rows = restarted_audit
         .query_audits(&ToolAuditRecordQuery::new())
         .expect("durable audit should reopen after the job runtime is dropped");
-    assert_eq!(restarted_rows.len(), 3);
+    assert_eq!(restarted_rows.len(), 4);
+    assert!(restarted_rows
+        .iter()
+        .any(|row| row.tool_id == "vault.request_lease"));
+    assert!(!format!("{restarted_rows:?}").contains("weather-api-key-host-only-fixture"));
 
     assert_eq!(run.rws.fetcher.untrusted_inputs, 1);
     assert_eq!(run.rws.writer.external_actuations, 1);
@@ -190,6 +209,32 @@ fn umbrella_today_job_blocks_write_without_explicit_approval() {
         .expect("denied write row should be persisted");
     assert_eq!(denied_write.approval_state, ApprovalState::Pending);
     assert!(!denied_write.result_summary.ok);
+}
+
+#[test]
+fn umbrella_today_job_blocks_vault_lease_without_tier2_approval() {
+    let root = temp_root("weather-agent-vault-approval-e2e");
+    fs::create_dir_all(&root).expect("temp dir should be created");
+    let output_path = root.join("umbrella-today.txt");
+    let config = UmbrellaAgentConfig::deterministic_seattle(&output_path).without_vault_approval();
+
+    let error = run_umbrella_today_agent(config)
+        .expect_err("vault lease should stop at the centralized Tier 2 approval gate");
+    assert!(error.to_string().contains("requires approval"));
+    assert!(!fs::read_to_string(&output_path)
+        .unwrap_or_default()
+        .contains("Bring an umbrella today"));
+
+    let restarted_audit = ToolAuditStore::new(LocalFolderStorageBackend::new(
+        output_path.with_extension("audit"),
+    ));
+    let denied_lease = restarted_audit
+        .fetch_audit("8a7b0000000000000000000000000001_request_weather_lease")
+        .expect("durable audit should be readable after vault denial")
+        .expect("denied vault lease row should be persisted");
+    assert_eq!(denied_lease.tool_id, "vault.request_lease");
+    assert_eq!(denied_lease.approval_state, ApprovalState::Pending);
+    assert!(!denied_lease.result_summary.ok);
 }
 
 #[test]
@@ -233,9 +278,9 @@ fn tier2_write_accepts_challenge_bound_biometric_approval() {
         run.user_report.approval_assurance,
         Some(ApprovalAssurance::Biometric)
     );
-    assert_eq!(run.tool_journal_health.approval_biometric_count, 1);
+    assert_eq!(run.tool_journal_health.approval_biometric_count, 2);
     assert_eq!(run.tool_journal_health.approval_explicit_consent_count, 0);
-    assert_eq!(run.durable_audit.approval_granted_records, 1);
+    assert_eq!(run.durable_audit.approval_granted_records, 2);
     assert!(run.durable_audit.is_complete());
     assert!(run.output_text.contains("Bring an umbrella today"));
 }
@@ -266,7 +311,7 @@ fn successive_ticks_append_to_one_durable_audit_root() {
             .query_audits(&ToolAuditRecordQuery::new())
             .expect("both ticks should survive restart")
             .len(),
-        6
+        8
     );
     assert!(restarted_audit
         .fetch_audit("8a7b0000000000000000000000000002_write_umbrella_report")

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -296,10 +296,17 @@ a hardware key. The scheduled Weather Agent job proves pending, weak-denied,
 and biometric-approved paths through the real host runtime, execution journal,
 user report, and restarted durable audit reader.
 
+The vault-leasing slice adds a reusable Chief host runtime over the zeroizing
+`vault-leases` manager. `vault.request_lease` now requires a challenge-bound
+Tier2 approval and returns only a random `VaultRef`; the scheduled Weather Agent
+passes that handle to its fetch host, which atomically consumes the lease and
+keeps the raw credential out of model-visible values, reports, and durable
+audit rows. Executable tests cover approved and approval-denied jobs plus
+one-shot, revoked, malformed, and unknown lease behavior.
+
 These items are Chief of Staff architecture, not smart-home platform work:
 
-- Wire vault leasing so tools receive opaque `VaultRef` handles and never raw
-  smart-home secrets.
+- No remaining items within the D18 Chief architecture completion boundary.
 
 ## Smart Home Remaining Work
 


### PR DESCRIPTION
## Summary
- add a reusable Chief vault runtime that issues opaque `VaultRef` handles over zeroized, TTL-bound one-shot leases
- gate `vault.request_lease` at Tier2 and thread its handle through the scheduled Weather Agent fetch host without exposing raw credential bytes
- persist approved and denied lease calls through the existing execution journal/audit path and mark the D18 Chief completion inventory boundary complete

## Validation
- `cargo test -p chief-of-staff-vault-runtime -p weather-agent-e2e -- --nocapture`
- `cargo clippy -p chief-of-staff-vault-runtime -p weather-agent-e2e --all-targets -- -D warnings`
- `sh BUILD` in `code/packages/rust/chief-of-staff-vault-runtime`
- `sh BUILD` in `code/packages/rust/weather-agent-e2e`
- `cargo fmt --manifest-path code/packages/rust/Cargo.toml -p chief-of-staff-vault-runtime -p weather-agent-e2e -- --check`
- `git diff --check`