### PR TITLE
feat(spice): add BJT reverse Early voltage

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT reverse Early voltage** — BJT model cards now accept `VAR`/`VB` and
+  apply reverse Early-effect base-charge modulation in DC, transient, AC,
+  transfer-function, and noise paths, matching Rust and TypeScript. The
+  supported-parameter catalog now contains 94 canonical rows.
+
 - **BJT forward-bias depletion coefficient** — BJT model cards now accept `FC`
   and apply it to the shared `CJE` and `CJC` Berkeley continuation law in AC and
   transient analysis, matching Rust and TypeScript. The supported-parameter

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -212,7 +212,9 @@ Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
-`0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
+`0`, meaning infinite) for forward Early-effect modulation, `VAR`/`VB`
+(default `0`, meaning infinite) for reverse Early-effect base-charge
+modulation, and `NF` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -596,6 +596,9 @@ class BJT:
     Vaf:
         Forward Early voltage in Volts. Zero disables collector-voltage
         modulation, matching an infinite Early voltage (default 0.0).
+    Var:
+        Reverse Early voltage in Volts. Zero matches an infinite reverse Early
+        voltage (default 0.0).
     Nf:
         Forward emission coefficient (default 1.0).
     Nr:
@@ -624,6 +627,7 @@ class BJT:
     Vjc: float = 0.75       # base-collector junction potential (V)
     Mjc: float = 0.33       # base-collector grading coefficient
     Fc: float = 0.5         # forward-bias depletion coefficient
+    Var: float = 0.0        # reverse Early voltage (V); 0 means infinite
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9003,6 +9003,22 @@ def _stamp_jfet(
         b[node_to_idx[el.source]] += Ieq
 
 
+def _bjt_early_factor(el: BJT, junction_voltage: float, output_voltage: float) -> float:
+    forward_term = 0.0 if el.Vaf == 0.0 else output_voltage / el.Vaf
+    reverse_term = 0.0 if el.Var == 0.0 else junction_voltage / el.Var
+    return 1.0 + forward_term - reverse_term
+
+
+def _bjt_forward_transconductance(
+    el: BJT,
+    base_collector_current: float,
+    base_gm: float,
+    early_factor: float,
+) -> float:
+    reverse_early_conductance = 0.0 if el.Var == 0.0 else base_collector_current / el.Var
+    return base_gm * early_factor - reverse_early_conductance
+
+
 def _stamp_bjt(
     G: list[list[float]],
     b: list[float],
@@ -9083,10 +9099,10 @@ def _stamp_bjt(
     base_collector_current = el.Is * (exp_term - 1.0)
     base_gm = (el.Is / forward_thermal_voltage) * exp_term
     output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
-    early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
+    early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
     output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
     Ic0 = base_collector_current * early_factor
-    gm = base_gm * early_factor
+    gm = _bjt_forward_transconductance(el, base_collector_current, base_gm, early_factor)
     g_pi = base_gm / el.beta_f
     Ib0 = base_collector_current / el.beta_f
 
@@ -9176,6 +9192,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT energy gap must be finite and positive")
     if not math.isfinite(el.Vaf) or el.Vaf < 0.0:
         raise ValueError(f"{el.name}: BJT forward Early voltage must be finite and non-negative")
+    if not math.isfinite(el.Var) or el.Var < 0.0:
+        raise ValueError(f"{el.name}: BJT reverse Early voltage must be finite and non-negative")
     if not math.isfinite(el.Nf) or el.Nf <= 0.0:
         raise ValueError(f"{el.name}: BJT forward emission coefficient must be finite and positive")
     if not math.isfinite(el.Nr) or el.Nr <= 0.0:
@@ -12415,9 +12433,11 @@ def _stamp_ac(
         base_collector_current = el.Is * (exp_t - 1.0)
         base_gm = (el.Is / forward_thermal_voltage) * exp_t
         output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
-        early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
+        early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
         output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
-        gm_b: float = base_gm * early_factor
+        gm_b: float = _bjt_forward_transconductance(
+            el, base_collector_current, base_gm, early_factor
+        )
         gm_reverse: float = (el.Is / reverse_thermal_voltage) * exp_reverse
         g_pi: float = base_gm / el.beta_f
         diffusion_capacitance = el.Tf * gm_b
@@ -13032,9 +13052,11 @@ def _build_ss_matrix(
             base_collector_current = el.Is * (exp_t - 1.0)
             base_gm = (el.Is / forward_thermal_voltage) * exp_t
             output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
-            early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
+            early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
             output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
-            gm_b: float = base_gm * early_factor
+            gm_b: float = _bjt_forward_transconductance(
+                el, base_collector_current, base_gm, early_factor
+            )
             g_pi: float = base_gm / el.beta_f
             _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
 
@@ -13914,6 +13936,7 @@ def sens_dc(
                     Xti=el.Xti,
                     Eg=el.Eg,
                     Vaf=el.Vaf,
+                    Var=el.Var,
                     Nf=el.Nf,
                     Nr=el.Nr,
                     Vje=el.Vje,
@@ -13940,6 +13963,7 @@ def sens_dc(
                     Xti=el.Xti,
                     Eg=el.Eg,
                     Vaf=el.Vaf,
+                    Var=el.Var,
                     Nf=el.Nf,
                     Nr=el.Nr,
                     Vje=el.Vje,
@@ -14176,6 +14200,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Xti=el.Xti,
             Eg=el.Eg,
             Vaf=el.Vaf,
+            Var=el.Var,
             Nf=el.Nf,
             Nr=el.Nr,
             Vje=el.Vje,
@@ -14624,7 +14649,7 @@ def _collect_noise_sources(
                 else Ve - Vb
             )
             output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
-            early_factor = 1.0 if el.Vaf == 0.0 else 1.0 + output_voltage / el.Vaf
+            early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
             I_C = el.Is * math.exp(Vjunc / (el.Vt * el.Nf)) * early_factor
             psd = q2 * abs(I_C)
             n_b = None if _is_ground(el.base) else node_to_idx[el.base]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (17, 30, 9, 4),
-    "PNP": (17, 30, 9, 4),
+    "NPN": (18, 32, 10, 4),
+    "PNP": (18, 32, 10, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -374,6 +374,8 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "EG": "EG",
     "VAF": "VAF",
     "VA": "VAF",
+    "VAR": "VAR",
+    "VB": "VAR",
     "NF": "NF",
     "NR": "NR",
     "VJE": "VJE",
@@ -919,6 +921,7 @@ def bjt_from_model_card(
         Vjc=p.get("VJC", 0.75),
         Mjc=p.get("MJC", 0.33),
         Fc=p.get("FC", 0.5),
+        Var=p.get("VAR", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 92
+    assert len(coverage) == 94
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 92
+    assert len(records) == 94
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,17 +501,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 92
-    assert report.expected_canonical_parameter_count == 92
-    assert report.accepted_name_count == 150
-    assert report.aliased_parameter_count == 45
+    assert report.canonical_parameter_count == 94
+    assert report.expected_canonical_parameter_count == 94
+    assert report.accepted_name_count == 154
+    assert report.aliased_parameter_count == 47
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t92\t92\t150\t45\t4\t0"
+        "true\t7\t7\t94\t94\t154\t47\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,9 +539,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 91
-    assert report.accepted_name_count == 147
-    assert report.aliased_parameter_count == 44
+    assert report.canonical_parameter_count == 93
+    assert report.accepted_name_count == 151
+    assert report.aliased_parameter_count == 46
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t91\t92\t147\t44\t4\t4\n"
+        "false\t7\t7\t93\t94\t151\t46\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,16 +647,17 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "VB": 120.0, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
     assert bjt_model.Xti == pytest.approx(2.4)
     assert bjt_model.Eg == pytest.approx(1.05)
     assert bjt_model.Vaf == pytest.approx(80.0)
+    assert bjt_model.Var == pytest.approx(120.0)
     assert bjt_model.Nf == pytest.approx(1.2)
     assert bjt_model.Nr == pytest.approx(1.3)
     assert bjt_model.Vje == pytest.approx(0.8)
@@ -2294,7 +2295,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2304,6 +2305,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Xti == pytest.approx(2.4)
     assert expanded.Eg == pytest.approx(1.05)
     assert expanded.Vaf == pytest.approx(80.0)
+    assert expanded.Var == pytest.approx(120.0)
     assert expanded.Nf == pytest.approx(1.2)
     assert expanded.Nr == pytest.approx(1.3)
     assert expanded.Vje == pytest.approx(0.8)
@@ -2565,6 +2567,27 @@ def test_dc_rejects_invalid_bjt_forward_early_voltage():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Vaf=-1.0))
     with pytest.raises(ValueError, match="BJT forward Early voltage must be finite and non-negative"):
+        dc_op(circuit)
+
+
+def test_bjt_reverse_early_voltage_modulates_collector_current():
+    def collector_voltage(var: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "vcc", "out", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Var=var))
+        return dc_op(circuit).node_voltages["out"]
+
+    assert collector_voltage(20.0) > collector_voltage(0.0)
+
+
+def test_dc_rejects_invalid_bjt_reverse_early_voltage():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Var=-1.0))
+    with pytest.raises(
+        ValueError, match="BJT reverse Early voltage must be finite and non-negative"
+    ):
         dc_op(circuit)
 
 
@@ -4237,6 +4260,18 @@ def test_ac_bjt_reverse_emission_coefficient_reduces_collector_diffusion_capacit
     assert base_amplitude(2.0) > base_amplitude(1.0)
 
 
+def test_ac_bjt_reverse_early_voltage_reduces_gain():
+    def gain(var: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "base", "0", 0.65, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Var=var))
+        point = ac_sweep(circuit, f_start=1_000.0, f_stop=1_000.0, n_points=1, sweep="lin").points[0]
+        return abs(point.node_voltages["out"])
+
+    assert gain(1.0) < gain(0.0)
+
+
 def test_ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias():
     """BJT Vje/Mje shape Cje under reverse base-emitter bias."""
     def base_amplitude(mje: float) -> float:
@@ -4708,6 +4743,17 @@ def test_tf_bjt_forward_early_voltage_reduces_output_impedance():
         return tf(circuit, output_node="out", input_source="Vin").output_impedance
 
     assert output_impedance(10.0) < output_impedance(0.0)
+
+
+def test_tf_bjt_reverse_early_voltage_reduces_gain():
+    def gain(var: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Var=var))
+        return abs(tf(circuit, output_node="out", input_source="Vin").gain)
+
+    assert gain(1.0) < gain(0.0)
 
 
 def test_tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `VAR`/`VB` reverse Early-voltage support with base-charge
+  modulation in DC, transient, AC, transfer-function, and noise paths, matching
+  Python and TypeScript. The supported-parameter catalog now contains 94
+  canonical rows.
 - Add BJT model-card `FC` forward-bias depletion-coefficient support for the
   shared `CJE` and `CJC` Berkeley continuation law in AC and transient analysis,
   matching Python and TypeScript. The supported-parameter catalog now contains

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -129,7 +129,9 @@ Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
-`0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
+`0`, meaning infinite) for forward Early-effect modulation, `VAR`/`VB`
+(default `0`, meaning infinite) for reverse Early-effect base-charge
+modulation, and `NF` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -419,7 +419,7 @@ fn clone_subckt_element(
             element.gate_drain_capacitance,
         )),
         Element::Bjt(element) => {
-            Element::Bjt(Bjt::with_model_temperature_and_depletion_parameters(
+            Element::Bjt(Bjt::with_model_temperature_depletion_and_early_parameters(
                 format!("{instance_name}.{}", element.name),
                 map_subckt_node(&element.collector, instance_name, node_map),
                 map_subckt_node(&element.base, instance_name, node_map),
@@ -442,6 +442,7 @@ fn clone_subckt_element(
                 element.base_collector_junction_potential,
                 element.base_collector_grading_coefficient,
                 element.forward_bias_depletion_coefficient,
+                element.reverse_early_voltage,
             ))
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2848,6 +2849,7 @@ pub struct Bjt {
     pub saturation_current_temperature_exponent: f64,
     pub energy_gap_electron_volts: f64,
     pub forward_early_voltage: f64,
+    pub reverse_early_voltage: f64,
     pub forward_emission_coefficient: f64,
     pub reverse_emission_coefficient: f64,
     pub base_emitter_junction_potential: f64,
@@ -2986,6 +2988,59 @@ impl Bjt {
         base_collector_grading_coefficient: f64,
         forward_bias_depletion_coefficient: f64,
     ) -> Self {
+        Self::with_model_temperature_depletion_and_early_parameters(
+            name,
+            collector,
+            base,
+            emitter,
+            polarity,
+            saturation_current,
+            forward_beta,
+            thermal_voltage,
+            base_emitter_capacitance,
+            base_collector_capacitance,
+            forward_transit_time,
+            reverse_transit_time,
+            saturation_current_temperature_exponent,
+            energy_gap_electron_volts,
+            forward_early_voltage,
+            forward_emission_coefficient,
+            reverse_emission_coefficient,
+            base_emitter_junction_potential,
+            base_emitter_grading_coefficient,
+            base_collector_junction_potential,
+            base_collector_grading_coefficient,
+            forward_bias_depletion_coefficient,
+            0.0,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_temperature_depletion_and_early_parameters(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+        polarity: BjtPolarity,
+        saturation_current: f64,
+        forward_beta: f64,
+        thermal_voltage: f64,
+        base_emitter_capacitance: f64,
+        base_collector_capacitance: f64,
+        forward_transit_time: f64,
+        reverse_transit_time: f64,
+        saturation_current_temperature_exponent: f64,
+        energy_gap_electron_volts: f64,
+        forward_early_voltage: f64,
+        forward_emission_coefficient: f64,
+        reverse_emission_coefficient: f64,
+        base_emitter_junction_potential: f64,
+        base_emitter_grading_coefficient: f64,
+        base_collector_junction_potential: f64,
+        base_collector_grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
+        reverse_early_voltage: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             collector: collector.into(),
@@ -3009,6 +3064,7 @@ impl Bjt {
             base_collector_junction_potential,
             base_collector_grading_coefficient,
             forward_bias_depletion_coefficient,
+            reverse_early_voltage,
         }
     }
 }
@@ -3399,8 +3455,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 17, 30, 9, 4),
-    (ModelCardKind::Pnp, 17, 30, 9, 4),
+    (ModelCardKind::Npn, 18, 32, 10, 4),
+    (ModelCardKind::Pnp, 18, 32, 10, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3446,6 +3502,8 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("EG", "EG"),
     ("VAF", "VAF"),
     ("VA", "VAF"),
+    ("VAR", "VAR"),
+    ("VB", "VAR"),
     ("NF", "NF"),
     ("NR", "NR"),
     ("VJE", "VJE"),
@@ -4096,7 +4154,7 @@ pub fn bjt_from_model_card(
         ModelCardKind::Pnp => BjtPolarity::Pnp,
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
-    Ok(Bjt::with_model_temperature_and_depletion_parameters(
+    Ok(Bjt::with_model_temperature_depletion_and_early_parameters(
         name,
         collector,
         base,
@@ -4119,6 +4177,7 @@ pub fn bjt_from_model_card(
         model_card_value(model, "VJC", 0.75),
         model_card_value(model, "MJC", 0.33),
         model_card_value(model, "FC", 0.5),
+        model_card_value(model, "VAR", 0.0),
     ))
 }
 
@@ -21774,11 +21833,7 @@ fn collect_noise_sources(
                     BjtPolarity::Npn => collector_voltage - emitter_voltage,
                     BjtPolarity::Pnp => emitter_voltage - collector_voltage,
                 };
-                let early_factor = if bjt.forward_early_voltage == 0.0 {
-                    1.0
-                } else {
-                    1.0 + output_voltage / bjt.forward_early_voltage
-                };
+                let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
                 let collector_current =
                     bjt.saturation_current * (exponent.exp() - 1.0) * early_factor;
                 let (positive, negative) = match bjt.polarity {
@@ -22221,6 +22276,34 @@ fn stamp_diode_charge(
     Ok(())
 }
 
+fn bjt_early_factor(bjt: &Bjt, junction_voltage: f64, output_voltage: f64) -> f64 {
+    let forward_term = if bjt.forward_early_voltage == 0.0 {
+        0.0
+    } else {
+        output_voltage / bjt.forward_early_voltage
+    };
+    let reverse_term = if bjt.reverse_early_voltage == 0.0 {
+        0.0
+    } else {
+        junction_voltage / bjt.reverse_early_voltage
+    };
+    1.0 + forward_term - reverse_term
+}
+
+fn bjt_forward_transconductance(
+    bjt: &Bjt,
+    base_collector_current: f64,
+    base_gm: f64,
+    early_factor: f64,
+) -> f64 {
+    let reverse_early_conductance = if bjt.reverse_early_voltage == 0.0 {
+        0.0
+    } else {
+        base_collector_current / bjt.reverse_early_voltage
+    };
+    base_gm * early_factor - reverse_early_conductance
+}
+
 fn stamp_bjt(
     bjt: &Bjt,
     capacitor_states: &[CapacitorState],
@@ -22249,18 +22332,14 @@ fn stamp_bjt(
         BjtPolarity::Npn => collector_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
     };
-    let early_factor = if bjt.forward_early_voltage == 0.0 {
-        1.0
-    } else {
-        1.0 + output_voltage / bjt.forward_early_voltage
-    };
+    let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
     let output_conductance = if bjt.forward_early_voltage == 0.0 {
         0.0
     } else {
         base_collector_current / bjt.forward_early_voltage
     };
     let collector_current = base_collector_current * early_factor;
-    let gm = base_gm * early_factor;
+    let gm = bjt_forward_transconductance(bjt, base_collector_current, base_gm, early_factor);
     let gpi = base_gm / bjt.forward_beta;
     let base_current = base_collector_current / bjt.forward_beta;
     let equivalent_collector_current =
@@ -22371,17 +22450,13 @@ fn stamp_bjt_small_signal(
         BjtPolarity::Npn => collector_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
     };
-    let early_factor = if bjt.forward_early_voltage == 0.0 {
-        1.0
-    } else {
-        1.0 + output_voltage / bjt.forward_early_voltage
-    };
+    let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
     let output_conductance = if bjt.forward_early_voltage == 0.0 {
         0.0
     } else {
         base_collector_current / bjt.forward_early_voltage
     };
-    let gm = base_gm * early_factor;
+    let gm = bjt_forward_transconductance(bjt, base_collector_current, base_gm, early_factor);
     let gpi = base_gm / bjt.forward_beta;
     stamp_conductance(matrix, collector, emitter, output_conductance);
     match bjt.polarity {
@@ -22430,17 +22505,16 @@ fn stamp_ac_bjt_small_signal(
         BjtPolarity::Npn => collector_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
     };
-    let early_factor = if bjt.forward_early_voltage == 0.0 {
-        1.0
-    } else {
-        1.0 + output_voltage / bjt.forward_early_voltage
-    };
+    let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
     let output_conductance = if bjt.forward_early_voltage == 0.0 {
         0.0
     } else {
         base_collector_current / bjt.forward_early_voltage
     };
-    let gm = Complex::new(base_gm * early_factor, 0.0);
+    let gm = Complex::new(
+        bjt_forward_transconductance(bjt, base_collector_current, base_gm, early_factor),
+        0.0,
+    );
     let reverse_gm = bjt.saturation_current / reverse_thermal_voltage * reverse_exponent.exp();
     let diffusion_capacitance = bjt.forward_transit_time * gm.real;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
@@ -23443,6 +23517,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward Early voltage must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.reverse_early_voltage.is_finite() || bjt.reverse_early_voltage < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "reverse Early voltage must be finite and non-negative".to_string(),
         });
     }
     if !bjt.forward_emission_coefficient.is_finite() || bjt.forward_emission_coefficient <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -867,6 +867,28 @@ fn ac_bjt_uses_reverse_transit_time_as_base_collector_diffusion_capacitance() {
 }
 
 #[test]
+fn ac_bjt_reverse_early_voltage_reduces_gain() {
+    let gain = |reverse_early_voltage: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vin", "base", "0", 0.65, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.reverse_early_voltage = reverse_early_voltage;
+        circuit.add(Element::Bjt(transistor));
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 1).unwrap()[0]
+            .voltage("out")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(gain(1.0) < gain(0.0));
+}
+
+#[test]
 fn ac_bjt_reverse_emission_coefficient_reduces_base_collector_diffusion_capacitance() {
     fn base_amplitude(reverse_emission_coefficient: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 92);
+    assert_eq!(coverage.len(), 94);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 92);
+    assert_eq!(records.len(), 94);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 92);
-    assert_eq!(report.expected_canonical_parameter_count, 92);
-    assert_eq!(report.accepted_name_count, 150);
-    assert_eq!(report.aliased_parameter_count, 45);
+    assert_eq!(report.canonical_parameter_count, 94);
+    assert_eq!(report.expected_canonical_parameter_count, 94);
+    assert_eq!(report.accepted_name_count, 154);
+    assert_eq!(report.aliased_parameter_count, 47);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t92\t92\t150\t45\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t94\t94\t154\t47\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,9 +235,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 91);
-    assert_eq!(report.accepted_name_count, 147);
-    assert_eq!(report.aliased_parameter_count, 44);
+    assert_eq!(report.canonical_parameter_count, 93);
+    assert_eq!(report.accepted_name_count, 151);
+    assert_eq!(report.aliased_parameter_count, 46);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t91\t92\t147\t44\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t93\t94\t151\t46\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -431,6 +431,7 @@ fn model_card_aliases_build_device_instances() {
             ("XTI", 2.4),
             ("EG", 1.05),
             ("VA", 80.0),
+            ("VB", 120.0),
             ("NF", 1.2),
             ("NR", 1.3),
             ("PE", 0.8),
@@ -447,6 +448,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("XTI").unwrap(), 2.4);
     assert_close(*bjt_card.parameters.get("EG").unwrap(), 1.05);
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
+    assert_close(*bjt_card.parameters.get("VAR").unwrap(), 120.0);
     assert_close(*bjt_card.parameters.get("NF").unwrap(), 1.2);
     assert_close(*bjt_card.parameters.get("NR").unwrap(), 1.3);
     assert_close(*bjt_card.parameters.get("VJE").unwrap(), 0.8);
@@ -460,6 +462,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.saturation_current_temperature_exponent, 2.4);
     assert_close(bjt_model.energy_gap_electron_volts, 1.05);
     assert_close(bjt_model.forward_early_voltage, 80.0);
+    assert_close(bjt_model.reverse_early_voltage, 120.0);
     assert_close(bjt_model.forward_emission_coefficient, 1.2);
     assert_close(bjt_model.reverse_emission_coefficient, 1.3);
     assert_close(bjt_model.base_emitter_junction_potential, 0.8);
@@ -1363,7 +1366,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_bjt_model() {
-    let bjt = Bjt::with_model_temperature_and_depletion_parameters(
+    let bjt = Bjt::with_model_temperature_depletion_and_early_parameters(
         "Qcell",
         "c",
         "b",
@@ -1386,6 +1389,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         0.7,
         0.45,
         0.4,
+        120.0,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1414,6 +1418,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.saturation_current_temperature_exponent, 2.4);
     assert_close(expanded.energy_gap_electron_volts, 1.05);
     assert_close(expanded.forward_early_voltage, 80.0);
+    assert_close(expanded.reverse_early_voltage, 120.0);
     assert_close(expanded.forward_emission_coefficient, 1.2);
     assert_close(expanded.reverse_emission_coefficient, 1.3);
     assert_close(expanded.base_emitter_junction_potential, 0.8);
@@ -2051,6 +2056,40 @@ fn dc_rejects_invalid_bjt_forward_early_voltage() {
     assert!(error
         .to_string()
         .contains("forward Early voltage must be finite and non-negative"));
+}
+
+#[test]
+fn bjt_reverse_early_voltage_modulates_collector_current() {
+    let collector_voltage = |reverse_early_voltage: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc", "vcc", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "vcc", "out", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.reverse_early_voltage = reverse_early_voltage;
+        circuit.add(Element::Bjt(transistor));
+        dc_op(&circuit).unwrap().voltage("out").unwrap()
+    };
+
+    assert!(collector_voltage(20.0) > collector_voltage(0.0));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_reverse_early_voltage() {
+    let mut circuit = Circuit::new();
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.reverse_early_voltage = -1.0;
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("reverse Early voltage must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -364,6 +364,25 @@ fn tf_bjt_forward_early_voltage_reduces_output_impedance() {
 }
 
 #[test]
+fn tf_bjt_reverse_early_voltage_reduces_gain() {
+    let gain = |reverse_early_voltage: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vin", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.reverse_early_voltage = reverse_early_voltage;
+        circuit.add(Element::Bjt(transistor));
+        tf(&circuit, "out", "Vin").unwrap().gain().abs()
+    };
+
+    assert!(gain(1.0) < gain(0.0));
+}
+
+#[test]
 fn tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance() {
     let transfer = |forward_emission_coefficient: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `VAR`/`VB` reverse Early-voltage support with base-charge
+  modulation in DC, transient, AC, transfer-function, and noise paths, matching
+  Python and Rust. The supported-parameter catalog now contains 94 canonical
+  rows.
 - Add BJT model-card `FC` forward-bias depletion-coefficient support for the
   shared `CJE` and `CJC` Berkeley continuation law in AC and transient analysis,
   matching Python and Rust. The supported-parameter catalog now contains 92

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -199,7 +199,9 @@ Diode cards also accept `XTI` (default `3`) and `EG` (default `1.11 eV`) to
 control saturation-current temperature scaling.
 BJT cards accept `XTI` (default `3`) and `EG` (default `1.11` eV) for
 model-specific saturation-current temperature scaling, `VAF`/`VA` (default
-`0`, meaning infinite) for forward Early-effect modulation, and `NF` (default
+`0`, meaning infinite) for forward Early-effect modulation, `VAR`/`VB`
+(default `0`, meaning infinite) for reverse Early-effect base-charge
+modulation, and `NF` (default
 `1`) for forward-junction emission shaping. `NR` (default `1`) shapes reverse
 base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 (default `0.75 V`) and `MJE`/`ME` (default `0.33`) shape `CJE` base-emitter

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1713,6 +1713,7 @@ export interface Bjt {
   readonly saturationCurrentTemperatureExponent: number;
   readonly energyGapElectronVolts: number;
   readonly forwardEarlyVoltage: number;
+  readonly reverseEarlyVoltage: number;
   readonly forwardEmissionCoefficient: number;
   readonly reverseEmissionCoefficient: number;
   readonly baseEmitterJunctionPotential: number;
@@ -1997,8 +1998,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [17, 30, 9, 4],
-  PNP: [17, 30, 9, 4],
+  NPN: [18, 32, 10, 4],
+  PNP: [18, 32, 10, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3588,7 +3589,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7751,6 +7752,7 @@ export function bjt(
   baseCollectorJunctionPotential = 0.75,
   baseCollectorGradingCoefficient = 0.33,
   forwardBiasDepletionCoefficient = 0.5,
+  reverseEarlyVoltage = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7769,6 +7771,7 @@ export function bjt(
     saturationCurrentTemperatureExponent,
     energyGapElectronVolts,
     forwardEarlyVoltage,
+    reverseEarlyVoltage,
     forwardEmissionCoefficient,
     reverseEmissionCoefficient,
     baseEmitterJunctionPotential,
@@ -7881,6 +7884,8 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   EG: "EG",
   VAF: "VAF",
   VA: "VAF",
+  VAR: "VAR",
+  VB: "VAR",
   NF: "NF",
   NR: "NR",
   VJE: "VJE",
@@ -8398,6 +8403,7 @@ export function bjtFromModelCard(
     p.VJC ?? 0.75,
     p.MJC ?? 0.33,
     p.FC ?? 0.5,
+    p.VAR ?? 0.0,
   );
 }
 
@@ -18331,9 +18337,7 @@ function collectNoiseSources(
       const outputVoltage = element.polarity === "NPN"
         ? collectorVoltage - emitterVoltage
         : emitterVoltage - collectorVoltage;
-      const earlyFactor = element.forwardEarlyVoltage === 0.0
-        ? 1.0
-        : 1.0 + outputVoltage / element.forwardEarlyVoltage;
+      const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
       const collectorCurrent = element.saturationCurrent * (Math.exp(exponent) - 1.0) * earlyFactor;
       sources.push({
         elementName: element.name,
@@ -18784,6 +18788,32 @@ function stampDiodeCharge(
   }
 }
 
+function bjtEarlyFactor(
+  element: Bjt,
+  junctionVoltage: number,
+  outputVoltage: number,
+): number {
+  const forwardTerm = element.forwardEarlyVoltage === 0.0
+    ? 0.0
+    : outputVoltage / element.forwardEarlyVoltage;
+  const reverseTerm = element.reverseEarlyVoltage === 0.0
+    ? 0.0
+    : junctionVoltage / element.reverseEarlyVoltage;
+  return 1.0 + forwardTerm - reverseTerm;
+}
+
+function bjtForwardTransconductance(
+  element: Bjt,
+  baseCollectorCurrent: number,
+  baseTransconductance: number,
+  earlyFactor: number,
+): number {
+  const reverseEarlyConductance = element.reverseEarlyVoltage === 0.0
+    ? 0.0
+    : baseCollectorCurrent / element.reverseEarlyVoltage;
+  return baseTransconductance * earlyFactor - reverseEarlyConductance;
+}
+
 function stampBjt(
   element: Bjt,
   capacitorStates: readonly CapacitorState[],
@@ -18812,14 +18842,17 @@ function stampBjt(
   const outputVoltage = element.polarity === "NPN"
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;
-  const earlyFactor = element.forwardEarlyVoltage === 0.0
-    ? 1.0
-    : 1.0 + outputVoltage / element.forwardEarlyVoltage;
+  const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
   const outputConductance = element.forwardEarlyVoltage === 0.0
     ? 0.0
     : baseCollectorCurrent / element.forwardEarlyVoltage;
   const collectorCurrent = baseCollectorCurrent * earlyFactor;
-  const transconductance = baseTransconductance * earlyFactor;
+  const transconductance = bjtForwardTransconductance(
+    element,
+    baseCollectorCurrent,
+    baseTransconductance,
+    earlyFactor,
+  );
   const junctionConductance = baseTransconductance / element.forwardBeta;
   const baseCurrent = baseCollectorCurrent / element.forwardBeta;
   const equivalentCollectorCurrent =
@@ -19655,6 +19688,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardEarlyVoltage) || element.forwardEarlyVoltage < 0.0) {
     throw invalidElement(element.name, "forward Early voltage must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.reverseEarlyVoltage) || element.reverseEarlyVoltage < 0.0) {
+    throw invalidElement(element.name, "reverse Early voltage must be finite and non-negative");
   }
   if (!Number.isFinite(element.forwardEmissionCoefficient) || element.forwardEmissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "forward emission coefficient must be finite and positive");
@@ -21000,13 +21036,16 @@ function stampBjtSmallSignal(
   const outputVoltage = element.polarity === "NPN"
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;
-  const earlyFactor = element.forwardEarlyVoltage === 0.0
-    ? 1.0
-    : 1.0 + outputVoltage / element.forwardEarlyVoltage;
+  const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
   const outputConductance = element.forwardEarlyVoltage === 0.0
     ? 0.0
     : baseCollectorCurrent / element.forwardEarlyVoltage;
-  const transconductance = baseTransconductance * earlyFactor;
+  const transconductance = bjtForwardTransconductance(
+    element,
+    baseCollectorCurrent,
+    baseTransconductance,
+    earlyFactor,
+  );
   const junctionConductance = baseTransconductance / element.forwardBeta;
   stampConductance(matrix, collector, emitter, outputConductance);
   if (element.polarity === "NPN") {
@@ -21587,13 +21626,16 @@ function stampAcBjtSmallSignal(
   const outputVoltage = element.polarity === "NPN"
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;
-  const earlyFactor = element.forwardEarlyVoltage === 0.0
-    ? 1.0
-    : 1.0 + outputVoltage / element.forwardEarlyVoltage;
+  const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
   const outputConductance = element.forwardEarlyVoltage === 0.0
     ? 0.0
     : baseCollectorCurrent / element.forwardEarlyVoltage;
-  const transconductance = baseTransconductance * earlyFactor;
+  const transconductance = bjtForwardTransconductance(
+    element,
+    baseCollectorCurrent,
+    baseTransconductance,
+    earlyFactor,
+  );
   const junctionConductance = baseTransconductance / element.forwardBeta;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
   const reverseTransconductance =

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -605,6 +605,18 @@ describe("acSweep", () => {
     expect(baseAmplitude(2.0)).toBeGreaterThan(baseAmplitude(1.0));
   });
 
+  it("uses BJT reverse Early voltage to reduce AC gain", () => {
+    function gain(reverseEarlyVoltage: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vin", "base", "0", 0.65, 1.0));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({ ...bjt("Q1", "out", "base", "0"), reverseEarlyVoltage });
+      return complexAbs(acSweep(circuit, 1_000.0, 1_000.0, 1, "lin")[0].voltage("out")!);
+    }
+
+    expect(gain(1.0)).toBeLessThan(gain(0.0));
+  });
+
   it("shapes BJT base-emitter depletion capacitance under reverse bias", () => {
     function baseAmplitude(baseEmitterGradingCoefficient: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(92);
+    expect(coverage).toHaveLength(94);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(92);
+    expect(records).toHaveLength(94);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 92,
-      expectedCanonicalParameterCount: 92,
-      acceptedNameCount: 150,
-      aliasedParameterCount: 45,
+      canonicalParameterCount: 94,
+      expectedCanonicalParameterCount: 94,
+      acceptedNameCount: 154,
+      aliasedParameterCount: 47,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t92\t92\t150\t45\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t94\t94\t154\t47\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,9 +241,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(91);
-    expect(report.acceptedNameCount).toBe(147);
-    expect(report.aliasedParameterCount).toBe(44);
+    expect(report.canonicalParameterCount).toBe(93);
+    expect(report.acceptedNameCount).toBe(151);
+    expect(report.aliasedParameterCount).toBe(46);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t91\t92\t147\t44\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t93\t94\t151\t46\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -337,6 +337,7 @@ describe("dcOp", () => {
       XTI: 2.4,
       EG: 1.05,
       VA: 80.0,
+      VB: 120.0,
       NF: 1.2,
       NR: 1.3,
       PE: 0.8,
@@ -346,13 +347,14 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, VAR: 120.0, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
     expectClose(bjtModel.saturationCurrentTemperatureExponent, 2.4);
     expectClose(bjtModel.energyGapElectronVolts, 1.05);
     expectClose(bjtModel.forwardEarlyVoltage, 80.0);
+    expectClose(bjtModel.reverseEarlyVoltage, 120.0);
     expectClose(bjtModel.forwardEmissionCoefficient, 1.2);
     expectClose(bjtModel.reverseEmissionCoefficient, 1.3);
     expectClose(bjtModel.baseEmitterJunctionPotential, 0.8);
@@ -992,7 +994,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1003,6 +1005,7 @@ describe("dcOp", () => {
       expectClose(expanded.saturationCurrentTemperatureExponent, 2.4);
       expectClose(expanded.energyGapElectronVolts, 1.05);
       expectClose(expanded.forwardEarlyVoltage, 80.0);
+      expectClose(expanded.reverseEarlyVoltage, 120.0);
       expectClose(expanded.forwardEmissionCoefficient, 1.2);
       expectClose(expanded.reverseEmissionCoefficient, 1.3);
       expectClose(expanded.baseEmitterJunctionPotential, 0.8);
@@ -1370,6 +1373,25 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add(bjt("Qbad", "c", "b", "0", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11, -1.0));
     expect(() => dcOp(circuit)).toThrowError("forward Early voltage must be finite and non-negative");
+  });
+
+  it("uses BJT reverse Early voltage to modulate collector current", () => {
+    const collectorVoltage = (reverseEarlyVoltage: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "vcc", "out", 1_000.0));
+      circuit.add({ ...bjt("Q1", "out", "base", "0"), reverseEarlyVoltage });
+      return dcOp(circuit).voltage("out");
+    };
+
+    expect(collectorVoltage(20.0)).toBeGreaterThan(collectorVoltage(0.0));
+  });
+
+  it("rejects an invalid BJT reverse Early voltage", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...bjt("Qbad", "c", "b", "0"), reverseEarlyVoltage: -1.0 });
+    expect(() => dcOp(circuit)).toThrowError("reverse Early voltage must be finite and non-negative");
   });
 
   it("uses BJT forward emission coefficient to reduce collector current", () => {

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -59,6 +59,18 @@ describe("tf", () => {
     expect(outputImpedance(10.0)).toBeLessThan(outputImpedance(0.0));
   });
 
+  it("uses BJT reverse Early voltage to reduce gain", () => {
+    function gain(reverseEarlyVoltage: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vin", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({ ...bjt("Q1", "out", "base", "0"), reverseEarlyVoltage });
+      return Math.abs(tf(circuit, "out", "Vin").gain());
+    }
+
+    expect(gain(1.0)).toBeLessThan(gain(0.0));
+  });
+
   it("uses BJT forward emission coefficient to reduce gain and raise input impedance", () => {
     function transfer(forwardEmissionCoefficient: number) {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward-bias depletion coefficient.
+1. Cross-language BJT reverse Early voltage.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `FC` forward-bias depletion-coefficient model-card support
-     in Rust, Python, and TypeScript with the standard `0.5` default.
-   - Apply `FC` as the shared continuous piecewise-law transition point for both
-     `CJE` and `CJC` in AC and transient analysis, while preserving the complete
-     BJT model through hierarchical subcircuits.
-   - Extend the supported-parameter coverage gate from 90 to 92 canonical rows
-     and lock both forward-biased junction behaviors in all engines.
+   - Add Berkeley BJT `VAR` / `VB` reverse Early-voltage model-card support in
+     Rust, Python, and TypeScript with infinite behavior represented by the
+     existing zero default.
+   - Apply reverse Early-effect base-charge modulation in DC, transient, AC,
+     transfer-function, and noise paths while preserving the complete BJT model
+     through hierarchical subcircuits.
+   - Extend the supported-parameter coverage gate from 92 to 94 canonical rows
+     and lock model-card aliases, behavior, validation, and hierarchy in all
+     engines.
 
 ## Completed Slices
 
@@ -3045,6 +3047,14 @@ the Rust, Python, and TypeScript surfaces together.
      AC and transient analysis.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 90 canonical rows.
+
+225. Cross-language BJT forward-bias depletion coefficient.
+   - Status: completed in PR 8760.
+   - Rust, Python, and TypeScript BJT model cards now accept `FC` and apply it
+     as the shared continuous Berkeley piecewise-law transition point for both
+     `CJE` and `CJC` in AC and transient analysis.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 92 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- add Berkeley BJT reverse Early-voltage support through `VAR` and `VB` model-card names
- apply reverse Early base-charge modulation consistently in DC, transient, AC, transfer-function, and noise paths
- preserve the parameter through hierarchical expansion and update the cross-language coverage gate from 92 to 94 canonical rows
- reconcile the SPICE implementation plan after PR #8760

## Verification

- `cargo test -p spice-engine -q`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo fmt -p spice-engine -- --check`
- Python SPICE package: 529 tests passed, 88.61% coverage
- `ruff check` on touched Python source and test files
- TypeScript SPICE package: 287 tests passed
- `npm run build`
- `git diff --check`
