### PR TITLE
feat(app): zero-dependency TrueType reader — and a correction to the Tamil ண/ன claim

### DIFF
--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -69,10 +69,10 @@
       "sound": "ṇa",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a straight top bar", "a loop on the left", "an arch in the middle", "a right stroke that CURVES inward as it drops to the baseline"],
-      "strokeOrder": ["top bar", "left loop", "middle arch", "curving right stroke"],
+      "components": ["a straight top bar", "a loop on the left", "TWO arches", "a straight vertical on the right, down to the baseline"],
+      "strokeOrder": ["top bar", "left loop", "first arch", "second arch", "right vertical"],
       "strokeOrderNote": "conventional",
-      "notes": "The RETROFLEX n — tongue curled back to the roof of the mouth. Learn it beside ன: the two letters are IDENTICAL except for the final stroke — ண's curves inward to the baseline, ன's is a straight vertical. Tamil writes three n-sounds with three letters (ந, ன, ண)."
+      "notes": "The RETROFLEX n — tongue curled back to the roof of the mouth. Learn it beside ன: ண is ன WITH ONE EXTRA ARCH. Both letters end in the same straight vertical; the extra arch is inserted before it. Tamil writes three n-sounds with three letters (ந, ன, ண)."
     },
     {
       "glyph": "ந",
@@ -89,10 +89,10 @@
       "sound": "ṉa",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a straight top bar", "a loop on the left", "an arch in the middle", "a STRAIGHT VERTICAL on the right down to the baseline"],
-      "strokeOrder": ["top bar", "left loop", "middle arch", "straight right vertical"],
+      "components": ["a straight top bar", "a loop on the left", "ONE arch", "a straight vertical on the right, down to the baseline"],
+      "strokeOrder": ["top bar", "left loop", "arch", "right vertical"],
       "strokeOrderNote": "conventional",
-      "notes": "The alveolar n. Identical to ண but for the last stroke: ன ends in a STRAIGHT VERTICAL, ண in a curve. That final stroke is the only difference — everything to its left is the same shape."
+      "notes": "The alveolar n — and visibly ண MINUS ONE ARCH. ண has two arches between the loop and the final vertical; ன has one. Both end in the same straight vertical."
     },
     {
       "glyph": "ல",

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -79,8 +79,8 @@
       "sound": "na",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a straight top bar", "a vertical on the left", "a right stroke curling below the baseline"],
-      "strokeOrder": ["top bar", "left vertical", "right stroke and curl"],
+      "components": ["a straight top bar", "a vertical on the left", "a second vertical in the middle", "a right stroke that curls below the baseline and sweeps left into a descender"],
+      "strokeOrder": ["top bar", "left vertical", "middle vertical", "right stroke, curl and sweep"],
       "strokeOrderNote": "conventional",
       "notes": "The dental n, tongue against the teeth. Contrast ன (alveolar) and ண (retroflex)."
     },

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -77,13 +77,22 @@ scripts while six had data. It now renders seven.
   glyph's true outline and scan-converted it to a text bitmap, which is what the
   `components` and `strokeOrder` descriptions were written against. This caught
   three descriptions that were confidently wrong:
-  - **ண vs ன** were described as differing by an arch count. They do not. The
-    two glyphs are **pixel-identical for their left 53%** — same top bar, same
-    loop, same middle arch — and differ *only* in the final stroke: **ன ends in
-    a straight vertical, ண in a curve inward to the baseline.**
   - **ற** was described as "a single arch, like a Latin n". It has **two**
     arches and three legs, with the right leg continuing below the baseline,
     sweeping left and dropping into a long descender.
+  - **ண vs ன**: ண is **ன with one extra arch** — both open with the same top
+    bar and loop and close with the same straight vertical, and ண carries two
+    arches between them where ன carries one.
+
+    This one is worth recording as a caution, because an intermediate revision
+    of these lessons **replaced that correct statement with a false one** —
+    claiming the two letters differed only in a final curving stroke. The cause
+    was a rasteriser windowed to x≤1030 when **ண's outline runs to x=1631**:
+    it amputated 37% of the letter, including the final vertical, and the
+    description was then written from the truncated picture. A measurement
+    instrument can be as confidently wrong as a memory. The window is now
+    derived from the glyph's own bounding box, and the test asserting this
+    fails if the window ever clips again.
 - Verified in the browser: Tamil renders with 11 letters and "inventory in
   progress"; console clean.
 

--- a/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
@@ -35,8 +35,8 @@ reverse of the Devanagari habit of hanging a shape off a right-hand spine.
 
 1. **a straight top bar**
 2. **a loop on the left**
-3. **an arch in the middle**
-4. **a right stroke that curves inward as it drops to the baseline**
+3. **two arches**
+4. **a straight vertical on the right, down to the baseline**
 
 The dot under the romanization — **ṇ**, not plain *n* — is doing real work.
 
@@ -72,24 +72,23 @@ Three letters, three positions, moving backwards through the mouth. English
 spells all three with one letter and hears them as the same sound.
 
 You'll draw ந and ன in Lesson 4, where the word for "thank you" needs them. Keep
-one thing in view until then: **ண and ன are the same shape except for the very
-last stroke.** Everything to the left — the top bar, the loop, the middle arch —
-is identical. Only the final stroke differs: **ண's curves inward to the
-baseline; ன's is a straight vertical.** Learn the pair together and neither is
-hard.
+one thing in view until then: **ண is ன with one extra arch.** Both letters open
+the same way — top bar, loop — and both finish with the same straight vertical.
+The difference sits in the middle: **ன has one arch, ண has two.** Learn the pair
+together and neither is hard.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU WRITE: ம — "left upright, bottom, **right** arch"]
-- [YOU WRITE: ண — "top bar, left loop, middle arch, **curving** right stroke"]
+- [YOU WRITE: ண — "top bar, left loop, **two** arches, straight vertical"]
 - [YOU SAY: plain *n*, then curl the tongue back — **ṇ**]
 - [YOU SAY: the three positions — "teeth … ridge … **curled back**"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] Draw **ம** — which side is the upright on? (**The left**; the
-arch closes it on the right.) Draw **ண** — what makes it *not* ன? (Only the **last stroke**: ண's **curves** in to the baseline, ன's is a **straight vertical**.) What does the dot in **ṇ** mean? (**Retroflex** — the tongue curls
+arch closes it on the right.) Draw **ண** — what makes it *not* ன? (**One extra arch**: ண has **two** arches where ன has one. Both end in the same straight vertical.) What does the dot in **ṇ** mean? (**Retroflex** — the tongue curls
 **back** to the roof of the mouth.) Why can't you hear it yet? (**English has no
 such sound**; the ear learns it after the hand.) How many n-letters does Tamil
 have, and what separates them? (**Three** — ந dental, ன alveolar, ண retroflex,

--- a/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
@@ -27,7 +27,9 @@ both.
 
 1. **a straight top bar**
 2. **a vertical on the left**
-3. **a right stroke curling below the baseline**
+3. **a second vertical in the middle**
+4. **a right stroke that curls below the baseline** and sweeps left into a
+   descender
 
 **ன** — *ṉa*, the **alveolar** n, tongue on the ridge behind the teeth:
 
@@ -104,7 +106,7 @@ up in the sound that appears nowhere in the spelling.
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU WRITE: ந — "top bar, left vertical, curling right stroke"]
+- [YOU WRITE: ந — "top bar, **two** verticals, then the curl that sweeps left"]
 - [YOU WRITE: ன — "top bar, left loop, **one** arch, straight vertical"]
 - [YOU WRITE: ற — "two arches, then the leg that sweeps left and drops"]
 - [YOU WRITE: றி — "ற, then the hook above right"]

--- a/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
@@ -33,13 +33,13 @@ both.
 
 1. **a straight top bar**
 2. **a loop on the left**
-3. **an arch in the middle**
+3. **one arch**
 4. **a straight vertical on the right, down to the baseline**
 
-Compare it with Lesson 2's **ண** and you'll see they are **the same letter up to
-the final stroke**. Top bar, loop, arch — identical. The *only* difference is how
-the letter ends: **ன finishes with a straight vertical; ண's last stroke curves
-inward.** That one stroke is the whole contrast.
+Compare it with Lesson 2's **ண**: same top bar, same loop, same closing
+vertical. **ண simply has a second arch inserted before that vertical.** So
+**ன is ண minus one arch** — one arch for ன, two for ண. That is the whole
+contrast, and it is the cheapest way to keep them apart.
 
 With Lesson 2's **ண** (retroflex), that completes the set. Same consonant to an
 English ear; three letters, three tongue positions, in Tamil.
@@ -105,7 +105,7 @@ up in the sound that appears nowhere in the spelling.
 
 [PAUSE 1s]
 - [YOU WRITE: ந — "top bar, left vertical, curling right stroke"]
-- [YOU WRITE: ன — "top bar, left loop, middle arch, **straight** vertical"]
+- [YOU WRITE: ன — "top bar, left loop, **one** arch, straight vertical"]
 - [YOU WRITE: ற — "two arches, then the leg that sweeps left and drops"]
 - [YOU WRITE: றி — "ற, then the hook above right"]
 - [YOU WRITE: **நன்றி** — three pieces]

--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -25,7 +25,13 @@
   non-zero winding rule — so shape assertions are checked against what the
   glyph actually looks like. **The raster window is derived from the glyphs'
   own bounding boxes and the rasteriser throws if a glyph would be clipped.**
-  That guard exists because a hard-coded window (x ≤ 1030, against ண's true
+  A second guard checks the metric's INPUT: the final-stroke measure reports
+  its sample count, and the assertion requires samples before believing the
+  answer. Without it the measure anchored on the top bar — which overhangs the
+  final vertical — collected nothing, and `Math.max([]) - Math.min([])` is
+  `-Infinity`, which satisfies any upper bound. It measured nothing and
+  reported agreement.
+  The window guard exists because a hard-coded window (x ≤ 1030, against ண's true
   extent of 1631) silently amputated 37% of the letter and produced a
   confident, wrong description of its final stroke. A clipped raster does not
   look like an error; it looks like a letter.

--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.7.0 — read the letter's TRUE shape out of the font
+
+- **`src/truetype.ts`** — a zero-dependency TrueType reader: table directory,
+  `cmap` (formats 4 and 12), `loca`, `glyf`, simple and composite glyphs, the
+  delta-encoded coordinate flags, and the on-curve midpoint TrueType implies
+  between consecutive off-curve points. Outlines come back in font units
+  (y-up, baseline 0); the renderer applies one `scale(1,-1)`.
+- **Why not hand-drawn SVG paths.** A subtly wrong ண looks fine to anyone who
+  cannot already read Tamil — the entire audience — so the error would ship as
+  the lesson. Extracting from the vendored font makes shapes correct by
+  construction and keeps them identical to what the app renders text with.
+- **Hostile input is bounded.** Every count and offset in a font file is
+  attacker-controlled if this is ever pointed at an untrusted font, and it runs
+  in the browser. `cmap` ranges clamp to U+10FFFF; a single decrementing budget
+  bounds total mapping ITERATIONS across both cmap readers (capping the map's
+  size alone is not enough — re-mapping groups and format 4's BMP-bounded keys
+  both cost work without growing it); a component budget bounds composite
+  FAN-OUT, which the depth cap does not (N components at each of 6 levels is
+  N⁶ visits — minutes of frozen main thread from a 632-byte file);
+  non-ascending contour end points and scaled components are refused rather
+  than drawn wrong.
+- **Tests rasterise the font** — flatten the quadratics, scan-convert with the
+  non-zero winding rule — so shape assertions are checked against what the
+  glyph actually looks like. **The raster window is derived from the glyphs'
+  own bounding boxes and the rasteriser throws if a glyph would be clipped.**
+  That guard exists because a hard-coded window (x ≤ 1030, against ண's true
+  extent of 1631) silently amputated 37% of the letter and produced a
+  confident, wrong description of its final stroke. A clipped raster does not
+  look like an error; it looks like a letter.
+
 ## 0.6.1 — Tamil and Gujarati join the script list
 
 - **Tamil** is new: `data/scripts/tamil.json` ships with the first handwriting

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/truetype.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/truetype.ts
@@ -131,6 +131,26 @@ const REQUIRED_TABLES = ["head", "maxp", "cmap", "loca", "glyf"] as const;
 // characters, and Unicode itself only defines ~150k assigned codepoints.
 const MAX_CMAP_GROUPS = 100_000;
 const MAX_MAPPED_CHARACTERS = 200_000;
+// Total character-mapping ITERATIONS allowed, shared by both cmap readers.
+// Capping the map's SIZE is not enough: groups that re-map an already-mapped
+// range grow the map by nothing while still costing a full loop, and format 4
+// has no size pressure at all since its keys can only span the BMP. This
+// bounds the work rather than the result.
+const MAX_CMAP_ITERATIONS = 500_000;
+// Total glyph components visited when expanding composites. The depth cap
+// alone bounds depth but NOT work: a glyph with N components each pointing at
+// the same subglyph costs N^depth visits, so ~70 components is minutes of
+// frozen main thread from a 632-byte file.
+const MAX_COMPONENT_VISITS = 10_000;
+
+/** A decrementing budget shared across one parse, so total work is bounded. */
+class Budget {
+  constructor(private left: number) {}
+  spend(n = 1): boolean {
+    this.left -= n;
+    return this.left > 0;
+  }
+}
 
 /**
  * Read a TrueType font from raw bytes.
@@ -211,18 +231,25 @@ export function parseFont(bytes: ArrayBuffer): Font {
   if (!chosen) throw new Error("font has no Unicode cmap subtable in format 4 or 12");
 
   const charToGlyph = new Map<number, number>();
+  const cmapBudget = new Budget(MAX_CMAP_ITERATIONS);
   if (chosen.format === 4) {
-    readCmapFormat4(view, chosen.offset, charToGlyph);
+    readCmapFormat4(view, chosen.offset, charToGlyph, cmapBudget);
   } else {
-    readCmapFormat12(view, chosen.offset, charToGlyph);
+    readCmapFormat12(view, chosen.offset, charToGlyph, cmapBudget);
   }
 
   // ---- glyf: the outlines ---------------------------------------------------
   const glyfOffset = tableAt("glyf").offset;
 
+  const componentBudget = new Budget(MAX_COMPONENT_VISITS);
+
   function contoursOf(glyphId: number, depth = 0): Contour[] {
-    // Composite glyphs point at other glyphs; a malformed font could loop.
+    // Composite glyphs point at other glyphs. The depth cap stops infinite
+    // recursion; the budget stops FAN-OUT, which the depth cap does not — a
+    // glyph with N components each pointing at the same subglyph costs N^depth
+    // visits, so a few hundred bytes could otherwise freeze the tab for hours.
     if (depth > 5) return [];
+    if (!componentBudget.spend()) return [];
     if (glyphId < 0 || glyphId + 1 >= loca.length) return [];
     if (loca[glyphId] === loca[glyphId + 1]) return []; // empty glyph, e.g. space
 
@@ -258,9 +285,9 @@ export function parseFont(bytes: ArrayBuffer): Font {
 // cmap format 4: parallel arrays of segments. The `idRangeOffset` trick reads
 // into a glyph-id array that *follows* the offsets, addressed relative to the
 // position of the offset entry itself — which is why we remember that position.
-function readCmapFormat4(view: DataView, offset: number, out: Map<number, number>): void {
+function readCmapFormat4(view: DataView, offset: number, out: Map<number, number>, budget: Budget): void {
   const c = new Cursor(view, offset + 6);
-  const segCount = c.u16() / 2;
+  const segCount = Math.floor(c.u16() / 2); // segCountX2; floor guards an odd value
   c.position = offset + 14;
   const ends: number[] = [];
   const starts: number[] = [];
@@ -277,6 +304,7 @@ function readCmapFormat4(view: DataView, offset: number, out: Map<number, number
   }
   for (let i = 0; i < segCount; i++) {
     for (let ch = starts[i]; ch <= ends[i] && ch !== 0xffff; ch++) {
+      if (out.size >= MAX_MAPPED_CHARACTERS || !budget.spend()) return;
       let g: number;
       if (rangeOffsets[i] === 0) {
         g = (ch + deltas[i]) & 0xffff;
@@ -298,7 +326,7 @@ function readCmapFormat4(view: DataView, offset: number, out: Map<number, number
 // from 0 to 0xFFFFFFFF would otherwise ask us to build a four-billion-entry
 // Map and hang the tab. Unicode stops at U+10FFFF; anything beyond that is
 // malformed, and we drop the excess rather than trust it.
-function readCmapFormat12(view: DataView, offset: number, out: Map<number, number>): void {
+function readCmapFormat12(view: DataView, offset: number, out: Map<number, number>, budget: Budget): void {
   const MAX_CODEPOINT = 0x10ffff;
   const groupCount = Math.min(view.getUint32(offset + 12), MAX_CMAP_GROUPS);
   const c = new Cursor(view, offset + 16);
@@ -309,7 +337,7 @@ function readCmapFormat12(view: DataView, offset: number, out: Map<number, numbe
     const startGlyph = c.u32();
     if (startChar > endChar || startChar > MAX_CODEPOINT) continue;
     for (let ch = startChar; ch <= endChar; ch++) {
-      if (out.size >= MAX_MAPPED_CHARACTERS) return;
+      if (out.size >= MAX_MAPPED_CHARACTERS || !budget.spend()) return;
       out.set(ch, startGlyph + (ch - startChar));
     }
   }
@@ -319,8 +347,16 @@ function readCmapFormat12(view: DataView, offset: number, out: Map<number, numbe
 // coordinate stored as a DELTA from the previous one, in one of three widths
 // depending on two flag bits. Repeated flags are run-length encoded.
 function simpleContours(c: Cursor, contourCount: number): Contour[] {
+  // Contour end-indices must ascend: pointCount is taken from the LAST entry,
+  // so a descending set (e.g. [60000, 5]) would let the first contour read past
+  // the coordinate arrays and emit NaN into the path. A wrong shape that still
+  // renders is the failure mode this module exists to prevent, so refuse it.
   const endPoints: number[] = [];
-  for (let i = 0; i < contourCount; i++) endPoints.push(c.u16());
+  for (let i = 0; i < contourCount; i++) {
+    const e = c.u16();
+    if (i > 0 && e <= endPoints[i - 1]) throw new Error("glyph has non-ascending contour end points");
+    endPoints.push(e);
+  }
   const pointCount = contourCount > 0 ? endPoints[contourCount - 1] + 1 : 0;
   c.skip(c.u16()); // hinting instructions — irrelevant to the outline
 
@@ -399,9 +435,13 @@ function compositeContours(
       dx = c.i8();
       dy = c.i8();
     }
-    if (flags & HAS_SCALE) c.skip(2);
-    else if (flags & HAS_XY_SCALE) c.skip(4);
-    else if (flags & HAS_2X2) c.skip(8);
+    // A scaled component would need its transform applied; drawing it
+    // unscaled is a WRONG SHAPE, and a wrong shape that renders is exactly
+    // what this module refuses to produce. None of the vendored fonts use
+    // one, so refuse rather than quietly mis-draw.
+    if (flags & (HAS_SCALE | HAS_XY_SCALE | HAS_2X2)) {
+      throw new Error("composite glyph uses a scaled component, which is not supported");
+    }
 
     // When ARGS_ARE_XY is clear the arguments are point indices to align,
     // not offsets. That is rare; we place the component unshifted rather

--- a/code/programs/typescript/script-writing-visualizer/src/truetype.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/truetype.ts
@@ -1,0 +1,494 @@
+// ---------------------------------------------------------------------------
+// truetype.ts — pulling the REAL shape of a letter out of a font file
+// ---------------------------------------------------------------------------
+//
+// Why this file exists
+// --------------------
+// This app teaches handwriting. That means it has to show the learner the
+// shape of a letter — and every shape it shows had better be the shape the
+// letter actually has.
+//
+// The tempting shortcut is to hand-draw the letters as SVG paths. Do not. A
+// hand-drawn Tamil ண that is subtly wrong looks completely fine to anyone who
+// cannot already read Tamil, which is precisely the audience. The error would
+// ship, and it would ship *as the lesson*.
+//
+// So instead we read the outline out of the font we already ship. The font is
+// authoritative: it is what the rest of the app renders text with, it was made
+// by typographers, and it cannot drift from what the learner sees. Extracting
+// from it means the shapes are correct *by construction* rather than correct
+// *if we were careful*.
+//
+// This module is a small, zero-dependency TrueType reader. It is not a general
+// font library — it does exactly enough to answer one question:
+//
+//     "given a character, what is its outline?"
+//
+// A one-page tour of a TrueType file
+// ----------------------------------
+// A font is a bag of tables, each named by a 4-character tag, found through a
+// directory at the front of the file:
+//
+//     [ header ][ directory: 'cmap' -> offset, 'glyf' -> offset, ... ][ tables... ]
+//
+// The four tables we need, and what each one is for:
+//
+//     head  — the design grid size (`unitsPerEm`) and which width `loca` uses
+//     maxp  — how many glyphs the font has
+//     cmap  — character -> glyph id      ("which drawing is 'க'?")
+//     loca  — glyph id -> byte offset    ("where is that drawing?")
+//     glyf  — the drawings themselves
+//
+// So looking up a letter is a three-hop chase: cmap gives an id, loca turns
+// the id into an offset, glyf holds the contours at that offset.
+//
+// The coordinate system is worth stating up front because it bites: font units
+// are **y-up** with the baseline at y=0, while SVG is **y-down**. Descenders
+// are therefore *negative*. We do not flip here — we hand back honest font
+// units and let the renderer apply one `scale(1,-1)`, so that everything in
+// this file can be checked against the font spec without mental arithmetic.
+// ---------------------------------------------------------------------------
+
+/** A point on a glyph contour. `on` = on-curve; off-curve points are controls. */
+export interface GlyphPoint {
+  x: number;
+  y: number;
+  on: boolean;
+}
+
+/** One closed contour. A letter is one or more of these. */
+export type Contour = GlyphPoint[];
+
+export interface Glyph {
+  /** Glyph id this came from — useful when debugging a bad mapping. */
+  id: number;
+  contours: Contour[];
+  /** SVG path data in FONT units (y-up). Apply scale(1,-1) to draw it. */
+  path: string;
+}
+
+export interface Font {
+  unitsPerEm: number;
+  numGlyphs: number;
+  /** Which cmap subtable format we ended up using (4 or 12) — for diagnostics. */
+  cmapFormat: number;
+  /** How many characters the chosen subtable maps. */
+  mappedCharacters: number;
+  glyphIdFor(character: string): number | undefined;
+  glyphFor(character: string): Glyph | undefined;
+}
+
+// A cursor over a byte buffer. Font files are big-endian throughout.
+class Cursor {
+  private p: number;
+  constructor(private readonly b: DataView, offset = 0) {
+    this.p = offset;
+  }
+  get position(): number {
+    return this.p;
+  }
+  set position(v: number) {
+    this.p = v;
+  }
+  skip(n: number): void {
+    this.p += n;
+  }
+  u8(): number {
+    return this.b.getUint8(this.p++);
+  }
+  i8(): number {
+    return this.b.getInt8(this.p++);
+  }
+  u16(): number {
+    const v = this.b.getUint16(this.p);
+    this.p += 2;
+    return v;
+  }
+  i16(): number {
+    const v = this.b.getInt16(this.p);
+    this.p += 2;
+    return v;
+  }
+  u32(): number {
+    const v = this.b.getUint32(this.p);
+    this.p += 4;
+    return v;
+  }
+  tag(): string {
+    let s = "";
+    for (let i = 0; i < 4; i++) s += String.fromCharCode(this.b.getUint8(this.p + i));
+    this.p += 4;
+    return s;
+  }
+}
+
+const REQUIRED_TABLES = ["head", "maxp", "cmap", "loca", "glyf"] as const;
+
+// Guard rails for hostile or corrupt input. The fonts we ship are trusted, but
+// this parser runs in the browser and takes byte offsets and loop counts
+// straight from the file, so every file-controlled bound is clamped. These are
+// far above what a real font needs: the largest font here maps a few thousand
+// characters, and Unicode itself only defines ~150k assigned codepoints.
+const MAX_CMAP_GROUPS = 100_000;
+const MAX_MAPPED_CHARACTERS = 200_000;
+
+/**
+ * Read a TrueType font from raw bytes.
+ *
+ * Throws on anything it does not understand rather than guessing — a wrong
+ * glyph is worse than a missing one, because a wrong one still renders.
+ */
+export function parseFont(bytes: ArrayBuffer): Font {
+  const view = new DataView(bytes);
+  const r = new Cursor(view);
+
+  const version = r.u32();
+  // 0x74746366 = 'ttcf', a collection of fonts in one file. We ship plain
+  // .ttf files, so rather than support collections we say so loudly.
+  if (version === 0x74746366) throw new Error("TrueType collections (.ttc) are not supported");
+  // OpenType fonts with CFF (PostScript) outlines use 'OTTO' and store curves
+  // as cubics in a 'CFF ' table — a completely different format from glyf.
+  if (version === 0x4f54544f) throw new Error("CFF/OpenType ('OTTO') outlines are not supported; need glyf");
+
+  const numTables = r.u16();
+  r.skip(6); // searchRange, entrySelector, rangeShift — accelerators we don't need
+  const tables = new Map<string, { offset: number; length: number }>();
+  for (let i = 0; i < numTables; i++) {
+    const tag = r.tag();
+    r.skip(4); // checksum
+    tables.set(tag, { offset: r.u32(), length: r.u32() });
+  }
+  for (const t of REQUIRED_TABLES) {
+    if (!tables.has(t)) throw new Error(`font is missing the '${t}' table`);
+  }
+  const tableAt = (name: string) => tables.get(name)!;
+
+  // ---- head: grid size, and the width of loca's entries ---------------------
+  const headOffset = tableAt("head").offset;
+  const head = new Cursor(view, headOffset + 18);
+  const unitsPerEm = head.u16();
+  head.position = headOffset + 50;
+  // 0 => loca stores 16-bit values meaning offset/2; 1 => plain 32-bit offsets.
+  const indexToLocFormat = head.i16();
+
+  // ---- maxp: glyph count ----------------------------------------------------
+  const maxp = new Cursor(view, tableAt("maxp").offset + 4);
+  const numGlyphs = maxp.u16();
+
+  // ---- loca: glyph id -> offset into glyf -----------------------------------
+  // There are numGlyphs+1 entries: a glyph's data runs from its own entry to
+  // the next one. Equal neighbours mean an EMPTY glyph (a space), not an error.
+  const loca: number[] = [];
+  {
+    const c = new Cursor(view, tableAt("loca").offset);
+    for (let i = 0; i <= numGlyphs; i++) loca.push(indexToLocFormat ? c.u32() : c.u16() * 2);
+  }
+
+  // ---- cmap: character -> glyph id ------------------------------------------
+  // A font carries several encodings. We want a Unicode one, and we prefer
+  // format 12 (full 32-bit range, so it can reach beyond the BMP) over the
+  // older format 4 (16-bit segments).
+  const cmapOffset = tableAt("cmap").offset;
+  const cmapHeader = new Cursor(view, cmapOffset);
+  cmapHeader.skip(2); // version
+  const subtableCount = cmapHeader.u16();
+  let chosen: { offset: number; format: number } | undefined;
+  let chosenScore = -1;
+  for (let i = 0; i < subtableCount; i++) {
+    const platformId = cmapHeader.u16();
+    const encodingId = cmapHeader.u16();
+    const offset = cmapOffset + cmapHeader.u32();
+    const isUnicode =
+      platformId === 0 || (platformId === 3 && (encodingId === 1 || encodingId === 10));
+    if (!isUnicode) continue;
+    const format = view.getUint16(offset);
+    const score = format === 12 ? 20 : format === 4 ? 10 : -1;
+    if (score > chosenScore) {
+      chosenScore = score;
+      chosen = { offset, format };
+    }
+  }
+  if (!chosen) throw new Error("font has no Unicode cmap subtable in format 4 or 12");
+
+  const charToGlyph = new Map<number, number>();
+  if (chosen.format === 4) {
+    readCmapFormat4(view, chosen.offset, charToGlyph);
+  } else {
+    readCmapFormat12(view, chosen.offset, charToGlyph);
+  }
+
+  // ---- glyf: the outlines ---------------------------------------------------
+  const glyfOffset = tableAt("glyf").offset;
+
+  function contoursOf(glyphId: number, depth = 0): Contour[] {
+    // Composite glyphs point at other glyphs; a malformed font could loop.
+    if (depth > 5) return [];
+    if (glyphId < 0 || glyphId + 1 >= loca.length) return [];
+    if (loca[glyphId] === loca[glyphId + 1]) return []; // empty glyph, e.g. space
+
+    const start = glyfOffset + loca[glyphId];
+    const c = new Cursor(view, start);
+    const contourCount = c.i16();
+    c.skip(8); // xMin, yMin, xMax, yMax
+
+    if (contourCount < 0) return compositeContours(c, contoursOf, depth);
+    return simpleContours(c, contourCount);
+  }
+
+  return {
+    unitsPerEm,
+    numGlyphs,
+    cmapFormat: chosen.format,
+    mappedCharacters: charToGlyph.size,
+    glyphIdFor(character: string) {
+      const cp = character.codePointAt(0);
+      return cp === undefined ? undefined : charToGlyph.get(cp);
+    },
+    glyphFor(character: string) {
+      const cp = character.codePointAt(0);
+      if (cp === undefined) return undefined;
+      const id = charToGlyph.get(cp);
+      if (id === undefined) return undefined;
+      const contours = contoursOf(id);
+      return { id, contours, path: contoursToPath(contours) };
+    },
+  };
+}
+
+// cmap format 4: parallel arrays of segments. The `idRangeOffset` trick reads
+// into a glyph-id array that *follows* the offsets, addressed relative to the
+// position of the offset entry itself — which is why we remember that position.
+function readCmapFormat4(view: DataView, offset: number, out: Map<number, number>): void {
+  const c = new Cursor(view, offset + 6);
+  const segCount = c.u16() / 2;
+  c.position = offset + 14;
+  const ends: number[] = [];
+  const starts: number[] = [];
+  const deltas: number[] = [];
+  const rangeOffsetPositions: number[] = [];
+  const rangeOffsets: number[] = [];
+  for (let i = 0; i < segCount; i++) ends.push(c.u16());
+  c.skip(2); // reservedPad
+  for (let i = 0; i < segCount; i++) starts.push(c.u16());
+  for (let i = 0; i < segCount; i++) deltas.push(c.i16());
+  for (let i = 0; i < segCount; i++) {
+    rangeOffsetPositions.push(c.position);
+    rangeOffsets.push(c.u16());
+  }
+  for (let i = 0; i < segCount; i++) {
+    for (let ch = starts[i]; ch <= ends[i] && ch !== 0xffff; ch++) {
+      let g: number;
+      if (rangeOffsets[i] === 0) {
+        g = (ch + deltas[i]) & 0xffff;
+      } else {
+        const p = rangeOffsetPositions[i] + rangeOffsets[i] + (ch - starts[i]) * 2;
+        if (p + 1 >= view.byteLength) continue;
+        g = view.getUint16(p);
+        if (g !== 0) g = (g + deltas[i]) & 0xffff;
+      }
+      if (g !== 0) out.set(ch, g);
+    }
+  }
+}
+
+// cmap format 12: a flat list of (startChar, endChar, startGlyph) groups.
+//
+// Every number here comes from the file, including the group count and the
+// range bounds — so all three are clamped. A font claiming a group running
+// from 0 to 0xFFFFFFFF would otherwise ask us to build a four-billion-entry
+// Map and hang the tab. Unicode stops at U+10FFFF; anything beyond that is
+// malformed, and we drop the excess rather than trust it.
+function readCmapFormat12(view: DataView, offset: number, out: Map<number, number>): void {
+  const MAX_CODEPOINT = 0x10ffff;
+  const groupCount = Math.min(view.getUint32(offset + 12), MAX_CMAP_GROUPS);
+  const c = new Cursor(view, offset + 16);
+  for (let i = 0; i < groupCount; i++) {
+    if (c.position + 12 > view.byteLength) break; // truncated table
+    const startChar = c.u32();
+    const endChar = Math.min(c.u32(), MAX_CODEPOINT);
+    const startGlyph = c.u32();
+    if (startChar > endChar || startChar > MAX_CODEPOINT) continue;
+    for (let ch = startChar; ch <= endChar; ch++) {
+      if (out.size >= MAX_MAPPED_CHARACTERS) return;
+      out.set(ch, startGlyph + (ch - startChar));
+    }
+  }
+}
+
+// A simple glyph: contour end-indices, then flags, then x's, then y's — each
+// coordinate stored as a DELTA from the previous one, in one of three widths
+// depending on two flag bits. Repeated flags are run-length encoded.
+function simpleContours(c: Cursor, contourCount: number): Contour[] {
+  const endPoints: number[] = [];
+  for (let i = 0; i < contourCount; i++) endPoints.push(c.u16());
+  const pointCount = contourCount > 0 ? endPoints[contourCount - 1] + 1 : 0;
+  c.skip(c.u16()); // hinting instructions — irrelevant to the outline
+
+  const ON_CURVE = 0x01;
+  const X_SHORT = 0x02;
+  const Y_SHORT = 0x04;
+  const REPEAT = 0x08;
+  const X_SAME_OR_POSITIVE = 0x10;
+  const Y_SAME_OR_POSITIVE = 0x20;
+
+  const flags: number[] = [];
+  while (flags.length < pointCount) {
+    const f = c.u8();
+    flags.push(f);
+    if (f & REPEAT) {
+      let n = c.u8();
+      while (n-- > 0 && flags.length < pointCount) flags.push(f);
+    }
+  }
+
+  const readCoords = (shortBit: number, sameBit: number): number[] => {
+    const values: number[] = [];
+    let v = 0;
+    for (let i = 0; i < pointCount; i++) {
+      const f = flags[i];
+      if (f & shortBit) {
+        const d = c.u8();
+        v += f & sameBit ? d : -d;
+      } else if (!(f & sameBit)) {
+        v += c.i16();
+      } // else: same as previous, delta 0
+      values.push(v);
+    }
+    return values;
+  };
+  const xs = readCoords(X_SHORT, X_SAME_OR_POSITIVE);
+  const ys = readCoords(Y_SHORT, Y_SAME_OR_POSITIVE);
+
+  const contours: Contour[] = [];
+  let start = 0;
+  for (let i = 0; i < contourCount; i++) {
+    const end = endPoints[i];
+    const pts: Contour = [];
+    for (let p = start; p <= end; p++) pts.push({ x: xs[p], y: ys[p], on: !!(flags[p] & ON_CURVE) });
+    contours.push(pts);
+    start = end + 1;
+  }
+  return contours;
+}
+
+// A composite glyph is built from other glyphs — used for accented letters and
+// for Indic glyphs assembled from parts. We honour translation, which is what
+// the overwhelming majority use; a scaled component keeps its own shape.
+function compositeContours(
+  c: Cursor,
+  contoursOf: (id: number, depth: number) => Contour[],
+  depth: number,
+): Contour[] {
+  const ARGS_ARE_WORDS = 0x0001;
+  const ARGS_ARE_XY = 0x0002;
+  const HAS_SCALE = 0x0008;
+  const MORE_COMPONENTS = 0x0020;
+  const HAS_XY_SCALE = 0x0040;
+  const HAS_2X2 = 0x0080;
+
+  const out: Contour[] = [];
+  for (;;) {
+    const flags = c.u16();
+    const componentId = c.u16();
+    let dx = 0;
+    let dy = 0;
+    if (flags & ARGS_ARE_WORDS) {
+      dx = c.i16();
+      dy = c.i16();
+    } else {
+      dx = c.i8();
+      dy = c.i8();
+    }
+    if (flags & HAS_SCALE) c.skip(2);
+    else if (flags & HAS_XY_SCALE) c.skip(4);
+    else if (flags & HAS_2X2) c.skip(8);
+
+    // When ARGS_ARE_XY is clear the arguments are point indices to align,
+    // not offsets. That is rare; we place the component unshifted rather
+    // than pretend the numbers are coordinates.
+    const ox = flags & ARGS_ARE_XY ? dx : 0;
+    const oy = flags & ARGS_ARE_XY ? dy : 0;
+    for (const contour of contoursOf(componentId, depth + 1)) {
+      out.push(contour.map((p) => ({ x: p.x + ox, y: p.y + oy, on: p.on })));
+    }
+    if (!(flags & MORE_COMPONENTS)) break;
+  }
+  return out;
+}
+
+/**
+ * Turn contours into SVG path data.
+ *
+ * TrueType curves are QUADRATIC (one control point), which maps onto SVG's
+ * `Q` command. The one wrinkle: the format lets two off-curve points sit next
+ * to each other, with an on-curve point implied exactly halfway between them.
+ * We have to insert those midpoints or the outline collapses.
+ *
+ * A contour may also begin on an off-curve point, in which case we synthesise
+ * a start point the same way.
+ */
+export function contoursToPath(contours: Contour[]): string {
+  const round = (n: number) => Math.round(n * 100) / 100;
+  const out: string[] = [];
+
+  for (const points of contours) {
+    if (points.length === 0) continue;
+
+    let startIndex = points.findIndex((p) => p.on);
+    let startPoint: { x: number; y: number };
+    if (startIndex === -1) {
+      const last = points[points.length - 1];
+      const first = points[0];
+      startPoint = { x: (last.x + first.x) / 2, y: (last.y + first.y) / 2 };
+      startIndex = 0;
+    } else {
+      startPoint = points[startIndex];
+      startIndex += 1;
+    }
+    out.push(`M${round(startPoint.x)} ${round(startPoint.y)}`);
+
+    let control: GlyphPoint | null = null;
+    for (let k = 0; k < points.length; k++) {
+      const p = points[(startIndex + k) % points.length];
+      if (p.on) {
+        if (control) {
+          out.push(`Q${round(control.x)} ${round(control.y)} ${round(p.x)} ${round(p.y)}`);
+          control = null;
+        } else {
+          out.push(`L${round(p.x)} ${round(p.y)}`);
+        }
+      } else {
+        if (control) {
+          const midX = (control.x + p.x) / 2;
+          const midY = (control.y + p.y) / 2;
+          out.push(`Q${round(control.x)} ${round(control.y)} ${round(midX)} ${round(midY)}`);
+        }
+        control = p;
+      }
+    }
+    if (control) {
+      out.push(`Q${round(control.x)} ${round(control.y)} ${round(startPoint.x)} ${round(startPoint.y)}`);
+    }
+    out.push("Z");
+  }
+
+  return out.join("");
+}
+
+/** Bounding box of a set of contours, in font units. */
+export function boundsOf(contours: Contour[]): { x0: number; y0: number; x1: number; y1: number } {
+  let x0 = Infinity;
+  let y0 = Infinity;
+  let x1 = -Infinity;
+  let y1 = -Infinity;
+  for (const contour of contours) {
+    for (const p of contour) {
+      if (p.x < x0) x0 = p.x;
+      if (p.x > x1) x1 = p.x;
+      if (p.y < y0) y0 = p.y;
+      if (p.y > y1) y1 = p.y;
+    }
+  }
+  if (x0 === Infinity) return { x0: 0, y0: 0, x1: 0, y1: 0 };
+  return { x0, y0, x1, y1 };
+}

--- a/code/programs/typescript/script-writing-visualizer/src/truetype.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/truetype.ts
@@ -147,8 +147,9 @@ const MAX_COMPONENT_VISITS = 10_000;
 class Budget {
   constructor(private left: number) {}
   spend(n = 1): boolean {
+    if (this.left < n) return false;
     this.left -= n;
-    return this.left > 0;
+    return true;
   }
 }
 
@@ -241,15 +242,19 @@ export function parseFont(bytes: ArrayBuffer): Font {
   // ---- glyf: the outlines ---------------------------------------------------
   const glyfOffset = tableAt("glyf").offset;
 
-  const componentBudget = new Budget(MAX_COMPONENT_VISITS);
-
-  function contoursOf(glyphId: number, depth = 0): Contour[] {
+  function contoursOf(glyphId: number, depth = 0, budget = new Budget(MAX_COMPONENT_VISITS)): Contour[] {
     // Composite glyphs point at other glyphs. The depth cap stops infinite
     // recursion; the budget stops FAN-OUT, which the depth cap does not — a
     // glyph with N components each pointing at the same subglyph costs N^depth
     // visits, so a few hundred bytes could otherwise freeze the tab for hours.
+    // Charged only for COMPONENT expansion (depth > 0), and the budget is
+    // created fresh per top-level lookup — see glyphFor. A budget shared across
+    // a Font's lifetime would decrement forever and start returning EMPTY
+    // outlines for ordinary letters after enough renders: silent blank glyphs
+    // that read as a font bug, which is the very failure this module exists to
+    // prevent.
     if (depth > 5) return [];
-    if (!componentBudget.spend()) return [];
+    if (depth > 0 && !budget.spend()) return [];
     if (glyphId < 0 || glyphId + 1 >= loca.length) return [];
     if (loca[glyphId] === loca[glyphId + 1]) return []; // empty glyph, e.g. space
 
@@ -258,7 +263,7 @@ export function parseFont(bytes: ArrayBuffer): Font {
     const contourCount = c.i16();
     c.skip(8); // xMin, yMin, xMax, yMax
 
-    if (contourCount < 0) return compositeContours(c, contoursOf, depth);
+    if (contourCount < 0) return compositeContours(c, contoursOf, depth, budget);
     return simpleContours(c, contourCount);
   }
 
@@ -412,8 +417,9 @@ function simpleContours(c: Cursor, contourCount: number): Contour[] {
 // the overwhelming majority use; a scaled component keeps its own shape.
 function compositeContours(
   c: Cursor,
-  contoursOf: (id: number, depth: number) => Contour[],
+  contoursOf: (id: number, depth: number, budget: Budget) => Contour[],
   depth: number,
+  budget: Budget,
 ): Contour[] {
   const ARGS_ARE_WORDS = 0x0001;
   const ARGS_ARE_XY = 0x0002;
@@ -448,7 +454,7 @@ function compositeContours(
     // than pretend the numbers are coordinates.
     const ox = flags & ARGS_ARE_XY ? dx : 0;
     const oy = flags & ARGS_ARE_XY ? dy : 0;
-    for (const contour of contoursOf(componentId, depth + 1)) {
+    for (const contour of contoursOf(componentId, depth + 1, budget)) {
       out.push(contour.map((p) => ({ x: p.x + ox, y: p.y + oy, on: p.on })));
     }
     if (!(flags & MORE_COMPONENTS)) break;

--- a/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
@@ -380,14 +380,18 @@ describe("Tamil letter shapes the lessons make claims about", () => {
     // Control: the measure must be able to report a non-vertical final stroke,
     // otherwise "<= 1" is satisfied by a metric that always returns 0. Across
     // the letters this track teaches it returns a range of values.
-    const spreads = ["ண", "ன", "ம", "வ", "அ", "இ", "ல", "ற", "க"]
+    // Built from letters NOT under test, so the control is independent of the
+    // subjects. Deliberately wider than it needs to be: with a bare handful the
+    // survivor count sits right on the guard, and a raster-resolution change
+    // would flip it.
+    const spreads = ["ம", "வ", "அ", "இ", "ல", "ற", "க", "ய", "ப", "ள", "எ"]
       .map((ch) => {
         const cs = f.glyphFor(ch)!.contours;
         return finalStrokeSpread(raster(cs, windowFor(cs)));
       })
       .filter((r) => r.samples > 8)
       .map((r) => r.spread);
-    expect(spreads.length).toBeGreaterThan(3);
+    expect(spreads.length).toBeGreaterThan(5);
     expect(Math.max(...spreads)).toBeGreaterThan(1);
   });
 

--- a/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
@@ -268,6 +268,153 @@ describe("hostile input", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Composite glyphs, built synthetically.
+//
+// Every vendored font tops out at composite DEPTH 1, so five of the six
+// recursion levels had never executed — and composite expansion is where both
+// parser defects found in review lived (the fan-out bomb and the shared
+// budget). These fixtures exercise nesting directly.
+// ---------------------------------------------------------------------------
+type SimpleGlyph = { kind: "simple"; points: Array<[number, number]> };
+type CompositeGlyph = { kind: "composite"; parts: Array<{ glyph: number; dx: number; dy: number }> };
+
+function buildFont(glyphs: Array<SimpleGlyph | CompositeGlyph>, mapFrom = 0x41): ArrayBuffer {
+  const glyphBlobs = glyphs.map((g) => {
+    const bytes: number[] = [];
+    const i16 = (v: number) => bytes.push((v >> 8) & 0xff, v & 0xff);
+    if (g.kind === "simple") {
+      i16(1); // one contour
+      i16(0); i16(0); i16(0); i16(0); // bbox (unused by the reader)
+      i16(g.points.length - 1); // end point index
+      i16(0); // no instructions
+      for (let i = 0; i < g.points.length; i++) bytes.push(0x01); // all on-curve, long deltas
+      let prev = 0;
+      for (const [x] of g.points) { i16(x - prev); prev = x; }
+      prev = 0;
+      for (const [, y] of g.points) { i16(y - prev); prev = y; }
+    } else {
+      i16(-1); // composite
+      i16(0); i16(0); i16(0); i16(0);
+      g.parts.forEach((part, idx) => {
+        const last = idx === g.parts.length - 1;
+        i16(0x0003 | (last ? 0 : 0x0020)); // ARGS_ARE_WORDS | ARGS_ARE_XY [| MORE_COMPONENTS]
+        i16(part.glyph);
+        i16(part.dx);
+        i16(part.dy);
+      });
+    }
+    while (bytes.length % 4) bytes.push(0);
+    return Uint8Array.from(bytes);
+  });
+
+  const n = glyphs.length;
+  const tables = ["cmap", "glyf", "head", "loca", "maxp"];
+  const dir = 12 + tables.length * 16;
+  // 12 bytes of cmap header + encoding record, then the format-12 subtable.
+  const cmapSize = 12 + 16 + 12 * Math.max(1, n);
+  const glyfSize = glyphBlobs.reduce((a, b) => a + b.length, 0);
+  const locaSize = (n + 1) * 4;
+  const off = { cmap: dir, glyf: dir + cmapSize, loca: dir + cmapSize + glyfSize, head: 0, maxp: 0 };
+  off.head = off.loca + locaSize;
+  off.maxp = off.head + 54;
+  const total = off.maxp + 6;
+  const buf = new ArrayBuffer(total);
+  const v = new DataView(buf);
+  v.setUint32(0, 0x00010000);
+  v.setUint16(4, tables.length);
+  const sizes: Record<string, number> = { cmap: cmapSize, glyf: glyfSize, loca: locaSize, head: 54, maxp: 6 };
+  tables.forEach((tag, i) => {
+    const at = 12 + i * 16;
+    for (let k = 0; k < 4; k++) v.setUint8(at + k, tag.charCodeAt(k));
+    v.setUint32(at + 8, (off as Record<string, number>)[tag]);
+    v.setUint32(at + 12, sizes[tag]);
+  });
+  // cmap format 12: one group per glyph
+  v.setUint16(off.cmap + 2, 1);
+  v.setUint16(off.cmap + 4, 3);
+  v.setUint16(off.cmap + 6, 10);
+  v.setUint32(off.cmap + 8, 12);
+  const sub = off.cmap + 12;
+  v.setUint16(sub, 12);
+  v.setUint32(sub + 12, n);
+  for (let i = 0; i < n; i++) {
+    v.setUint32(sub + 16 + i * 12, mapFrom + i);
+    v.setUint32(sub + 20 + i * 12, mapFrom + i);
+    v.setUint32(sub + 24 + i * 12, i);
+  }
+  let p = off.glyf;
+  const starts: number[] = [];
+  for (const blob of glyphBlobs) {
+    starts.push(p - off.glyf);
+    new Uint8Array(buf).set(blob, p);
+    p += blob.length;
+  }
+  starts.push(glyfSize);
+  for (let i = 0; i <= n; i++) v.setUint32(off.loca + i * 4, starts[i]);
+  v.setUint16(off.head + 18, 1000);
+  v.setInt16(off.head + 50, 1); // long loca
+  v.setUint16(off.maxp + 4, n);
+  return buf;
+}
+
+describe("composite glyphs", () => {
+  const triangle: SimpleGlyph = { kind: "simple", points: [[0, 0], [100, 0], [50, 80]] };
+
+  it("accumulates offsets through TWO levels of nesting", () => {
+    const f = parseFont(
+      buildFont([
+        triangle,
+        { kind: "composite", parts: [{ glyph: 0, dx: 100, dy: 0 }] },
+        { kind: "composite", parts: [{ glyph: 1, dx: 0, dy: 200 }] },
+      ]),
+    );
+    const depth2 = f.glyphFor("C")!; // third mapped char
+    expect(depth2.contours.length).toBe(1);
+    // The base triangle, shifted right by the inner component and up by the outer.
+    expect(depth2.contours[0].map((pt) => [pt.x, pt.y])).toEqual([
+      [100, 200],
+      [200, 200],
+      [150, 280],
+    ]);
+  });
+
+  it("stops at the depth cap instead of recursing forever", () => {
+    // A chain 8 deep: each composite wraps the previous one.
+    const glyphs: Array<SimpleGlyph | CompositeGlyph> = [triangle];
+    for (let i = 1; i <= 8; i++) glyphs.push({ kind: "composite", parts: [{ glyph: i - 1, dx: 1, dy: 0 }] });
+    const f = parseFont(buildFont(glyphs));
+    // Within the cap the shape survives; beyond it the reader yields nothing
+    // rather than looping.
+    expect(f.glyphFor("F")!.contours.length).toBe(1); // depth 5
+    expect(f.glyphFor("I")!.contours.length).toBe(0); // depth 8, past the cap
+  });
+
+  it("bounds fan-out that the depth cap alone would not", () => {
+    // 200 components at each of several levels is 200^depth visits unbudgeted.
+    const wide: CompositeGlyph = {
+      kind: "composite",
+      parts: Array.from({ length: 200 }, () => ({ glyph: 0, dx: 1, dy: 1 })),
+    };
+    const f = parseFont(buildFont([triangle, wide, { kind: "composite", parts: Array.from({ length: 200 }, () => ({ glyph: 1, dx: 1, dy: 1 })) }]));
+    const started = Date.now();
+    const g = f.glyphFor("C")!;
+    expect(Date.now() - started).toBeLessThan(5_000);
+    expect(g.contours.length).toBeLessThanOrEqual(10_000);
+  });
+
+  it("gives every lookup its own budget", () => {
+    const wide: CompositeGlyph = {
+      kind: "composite",
+      parts: Array.from({ length: 300 }, () => ({ glyph: 0, dx: 1, dy: 1 })),
+    };
+    const f = parseFont(buildFont([triangle, wide]));
+    const first = f.glyphFor("B")!.contours.length;
+    expect(first).toBe(300);
+    for (let i = 0; i < 200; i++) expect(f.glyphFor("B")!.contours.length).toBe(first);
+  });
+});
+
 describe("contoursToPath", () => {
   it("inserts the implied on-curve midpoint between consecutive off-curve points", () => {
     // Two off-curve points in a row: TrueType implies an on-curve point halfway

--- a/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
@@ -233,6 +233,31 @@ describe("hostile input", () => {
     expect(Date.now() - started).toBeLessThan(10_000);
   });
 
+  it("does not degrade to blank outlines over many lookups", () => {
+    // The component budget must be per-LOOKUP. An earlier version created it
+    // once per Font and decremented it forever, so ordinary letters started
+    // coming back with empty contours after a few thousand renders — silent
+    // blank glyphs that read as a font bug. A browse session does exactly this.
+    const f = tamil();
+    const first = f.glyphFor("ண")!.path;
+    for (let i = 0; i < 12_000; i++) {
+      const g = f.glyphFor("ண")!;
+      if (g.contours.length === 0 || g.path !== first) {
+        throw new Error(`glyph degraded on lookup ${i}`);
+      }
+    }
+    expect(f.glyphFor("ண")!.path).toBe(first);
+  });
+
+  it("keeps composite glyphs intact across repeated lookups too", () => {
+    const dev = parseFont(load("NotoSansDevanagari-Static.ttf"));
+    const first = dev.glyphFor("आ")!;
+    expect(first.contours.length).toBeGreaterThan(0);
+    for (let i = 0; i < 5_000; i++) {
+      expect(dev.glyphFor("आ")!.contours.length).toBe(first.contours.length);
+    }
+  });
+
   it("rejects formats it cannot read rather than guessing", () => {
     const otto = new ArrayBuffer(12);
     new DataView(otto).setUint32(0, 0x4f54544f);
@@ -315,30 +340,54 @@ describe("Tamil letter shapes the lessons make claims about", () => {
     // position, a curve wanders. Tolerance of one cell, because real typefaces
     // taper a stem slightly and the raster is coarse.
     const finalStrokeSpread = (g: boolean[][]) => {
-      const cols = g[0].map((_, c) => g.some((row) => row[c]));
-      const right = cols.lastIndexOf(true);
       const inked = g.map((row) => row.some(Boolean));
       const top = inked.indexOf(true);
       const bottom = inked.lastIndexOf(true);
+      const startRow = top + Math.ceil((bottom - top) * 0.35);
+      // Anchor on the rightmost column inked WITHIN THE BODY ROWS. Anchoring on
+      // the whole-glyph profile picks the top bar, which overhangs the final
+      // vertical in both letters — so no body row has ink in that column, no
+      // samples are collected, and Math.max([]) - Math.min([]) is -Infinity,
+      // which satisfies any upper bound. The metric then silently measures
+      // nothing while reporting agreement: the same failure as a clipped
+      // window, one level down.
+      let right = -1;
+      for (let r = startRow; r <= bottom; r++)
+        for (let c = g[r].length - 1; c > right; c--)
+          if (g[r][c]) { right = c; break; }
       const lefts: number[] = [];
-      for (let r = top + Math.ceil((bottom - top) * 0.35); r <= bottom; r++) {
-        if (!g[r][right]) continue;
+      for (let r = startRow; r <= bottom; r++) {
+        if (right < 0 || !g[r][right]) continue;
         let c = right;
         while (c > 0 && g[r][c - 1]) c--;
         lefts.push(c);
       }
-      return Math.max(...lefts) - Math.min(...lefts);
+      // Report the sample count alongside the answer so callers can guard the
+      // metric's INPUT, the same way raster() guards its window.
+      return {
+        samples: lefts.length,
+        spread: lefts.length ? Math.max(...lefts) - Math.min(...lefts) : NaN,
+      };
     };
-    expect(finalStrokeSpread(a)).toBeLessThanOrEqual(1);
-    expect(finalStrokeSpread(b)).toBeLessThanOrEqual(1);
+    const sa = finalStrokeSpread(a);
+    const sb = finalStrokeSpread(b);
+    // The claim is only meaningful if the metric actually looked at the stroke.
+    expect(sa.samples).toBeGreaterThan(8);
+    expect(sb.samples).toBeGreaterThan(8);
+    expect(sa.spread).toBeLessThanOrEqual(1);
+    expect(sb.spread).toBeLessThanOrEqual(1);
 
     // Control: the measure must be able to report a non-vertical final stroke,
     // otherwise "<= 1" is satisfied by a metric that always returns 0. Across
     // the letters this track teaches it returns a range of values.
-    const spreads = ["ண", "ன", "ம", "வ", "அ", "இ", "ல", "ற", "க"].map((ch) => {
-      const cs = f.glyphFor(ch)!.contours;
-      return finalStrokeSpread(raster(cs, windowFor(cs)));
-    });
+    const spreads = ["ண", "ன", "ம", "வ", "அ", "இ", "ல", "ற", "க"]
+      .map((ch) => {
+        const cs = f.glyphFor(ch)!.contours;
+        return finalStrokeSpread(raster(cs, windowFor(cs)));
+      })
+      .filter((r) => r.samples > 8)
+      .map((r) => r.spread);
+    expect(spreads.length).toBeGreaterThan(3);
     expect(Math.max(...spreads)).toBeGreaterThan(1);
   });
 

--- a/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
@@ -73,10 +73,42 @@ function flatten(contours: Contour[], perCurve = 8): Array<Array<[number, number
   return polys;
 }
 
-/** Render contours to a boolean ink grid on a FIXED em box, so two glyphs are directly comparable. */
-function raster(contours: Contour[], W = 100, H = 34): boolean[][] {
+/**
+ * Render contours to a boolean ink grid on a SHARED window, so two glyphs are
+ * directly comparable.
+ *
+ * The window must be passed in and must enclose every glyph being compared.
+ * An earlier version hard-coded x <= 1030 — but ண's outline runs to x=1631, so
+ * it silently amputated 37% of the letter INCLUDING its final stroke, and a
+ * shape description written from that picture claimed the letter ended in a
+ * curve. Clipping does not look like an error; it looks like a letter.
+ * `windowFor()` below derives the box from the glyphs themselves.
+ */
+interface Window { X0: number; X1: number; Y0: number; Y1: number }
+
+function windowFor(...contourSets: Contour[][]): Window {
+  let X0 = Infinity, X1 = -Infinity, Y0 = Infinity, Y1 = -Infinity;
+  for (const cs of contourSets) {
+    const b = boundsOf(cs);
+    X0 = Math.min(X0, b.x0); X1 = Math.max(X1, b.x1);
+    Y0 = Math.min(Y0, b.y0); Y1 = Math.max(Y1, b.y1);
+  }
+  const padX = (X1 - X0) * 0.04, padY = (Y1 - Y0) * 0.08;
+  return { X0: X0 - padX, X1: X1 + padX, Y0: Y0 - padY, Y1: Y1 + padY };
+}
+
+function raster(contours: Contour[], win: Window, W = 110, H = 26): boolean[][] {
   const polys = flatten(contours);
-  const X0 = -30, X1 = 1030, Y0 = -320, Y1 = 880;
+  const { X0, X1, Y0, Y1 } = win;
+  // Guard: the caller's window must actually contain this glyph. Without this
+  // the whole harness silently measures the clip boundary instead of the letter.
+  const b = boundsOf(contours);
+  if (b.x0 < X0 - 1 || b.x1 > X1 + 1 || b.y0 < Y0 - 1 || b.y1 > Y1 + 1) {
+    throw new Error(
+      `raster window [${X0.toFixed(0)},${X1.toFixed(0)}]x[${Y0.toFixed(0)},${Y1.toFixed(0)}] ` +
+        `clips a glyph with bounds [${b.x0},${b.x1}]x[${b.y0},${b.y1}]`,
+    );
+  }
   const grid: boolean[][] = [];
   for (let r = 0; r < H; r++) {
     const y = Y1 - ((r + 0.5) * (Y1 - Y0)) / H;
@@ -254,84 +286,106 @@ describe("contoursToPath", () => {
 // wrong distinguishing feature. Only a mechanical comparison catches that.
 // ---------------------------------------------------------------------------
 describe("Tamil letter shapes the lessons make claims about", () => {
-  it("ண and ன are the same shape except for their final stroke", () => {
+  // These pin, against the rasterised font, what TA-W02 / TA-W04 / tamil.json
+  // say in prose. They exist because BOTH previous attempts at this claim were
+  // wrong: first "ண is ன with one extra arch" was replaced by a false
+  // "they differ only in the final stroke", the replacement having been written
+  // from a raster window that clipped ண at 63% of its width. The lesson is that
+  // the instrument needs checking as much as the memory does.
+
+  /** Count separate ink runs along a row — how many strokes it crosses. */
+  const runs = (row: boolean[]) => row.reduce((n, v, i) => n + (v && !row[i - 1] ? 1 : 0), 0);
+
+  it("ண is ன with exactly one extra arch, and both end in a straight vertical", () => {
     const f = tamil();
-    const na = raster(f.glyphFor("ண")!.contours);
-    const alveolar = raster(f.glyphFor("ன")!.contours);
+    const retroflex = f.glyphFor("ண")!.contours;
+    const alveolar = f.glyphFor("ன")!.contours;
+    const win = windowFor(retroflex, alveolar);
+    const a = raster(retroflex, win);
+    const b = raster(alveolar, win);
 
-    let firstDiff = na[0].length;
-    outer: for (let r = 0; r < na.length; r++) {
-      for (let c = 0; c < na[r].length; c++) {
-        if (na[r][c] !== alveolar[r][c]) {
-          firstDiff = Math.min(firstDiff, c);
-          break outer;
-        }
-      }
-    }
-    // Identical through the left half: same top bar, same loop, same arch.
-    // If this ever drops sharply, the "only the last stroke differs" claim in
-    // TA-W02/TA-W04 has stopped being true and the lessons need revisiting.
-    expect(firstDiff).toBeGreaterThan(45);
+    // Mid-body, each arch shows up as two legs. ண crosses exactly two more
+    // strokes than ன: one extra arch = two extra legs.
+    const midA = runs(a[Math.floor(a.length * 0.55)]);
+    const midB = runs(b[Math.floor(b.length * 0.55)]);
+    expect(midA - midB).toBe(2);
 
-    // ...and they DO differ — otherwise the claim is vacuous.
-    expect(firstDiff).toBeLessThan(na[0].length);
-
-    // Control: the metric must be capable of reporting "these are different
-    // letters". Two unrelated glyphs diverge almost immediately, so a passing
-    // assertion above is a real property of ண/ன and not a quirk of the measure.
-    const unrelated = raster(f.glyphFor("ம")!.contours);
-    let controlDiff = na[0].length;
-    outerControl: for (let r = 0; r < na.length; r++) {
-      for (let c = 0; c < na[r].length; c++) {
-        if (na[r][c] !== unrelated[r][c]) {
-          controlDiff = Math.min(controlDiff, c);
-          break outerControl;
-        }
-      }
-    }
-    expect(controlDiff).toBeLessThan(20);
-  });
-
-  it("ன's final stroke is a straight vertical; ண's is not", () => {
-    const f = tamil();
-    const straightness = (ch: string) => {
-      const g = raster(f.glyphFor(ch)!.contours);
-      const cols = inkColumns(g);
+    // Both finish with a straight vertical. Measured as the SPREAD of the final
+    // stroke's left edge down the rows it spans: a vertical holds its x
+    // position, a curve wanders. Tolerance of one cell, because real typefaces
+    // taper a stem slightly and the raster is coarse.
+    const finalStrokeSpread = (g: boolean[][]) => {
+      const cols = g[0].map((_, c) => g.some((row) => row[c]));
       const right = cols.lastIndexOf(true);
-      // Walk up the rightmost stroke: for a straight vertical, the leftmost
-      // inked column of the final stroke is the same on every row it occupies.
-      // Look only BELOW the top bar. The bar spans the whole letter, so it
-      // touches the rightmost column too and would swamp the measurement.
       const inked = g.map((row) => row.some(Boolean));
       const top = inked.indexOf(true);
       const bottom = inked.lastIndexOf(true);
-      const firstBodyRow = top + Math.ceil((bottom - top) * 0.3);
       const lefts: number[] = [];
-      for (let r = firstBodyRow; r <= bottom; r++) {
+      for (let r = top + Math.ceil((bottom - top) * 0.35); r <= bottom; r++) {
         if (!g[r][right]) continue;
         let c = right;
         while (c > 0 && g[r][c - 1]) c--;
         lefts.push(c);
       }
-      return new Set(lefts).size; // 1 => perfectly straight
+      return Math.max(...lefts) - Math.min(...lefts);
     };
-    expect(straightness("ன")).toBe(1);
-    expect(straightness("ண")).toBeGreaterThan(1);
+    expect(finalStrokeSpread(a)).toBeLessThanOrEqual(1);
+    expect(finalStrokeSpread(b)).toBeLessThanOrEqual(1);
+
+    // Control: the measure must be able to report a non-vertical final stroke,
+    // otherwise "<= 1" is satisfied by a metric that always returns 0. Across
+    // the letters this track teaches it returns a range of values.
+    const spreads = ["ண", "ன", "ம", "வ", "அ", "இ", "ல", "ற", "க"].map((ch) => {
+      const cs = f.glyphFor(ch)!.contours;
+      return finalStrokeSpread(raster(cs, windowFor(cs)));
+    });
+    expect(Math.max(...spreads)).toBeGreaterThan(1);
   });
 
-  it("ற has two arches (three legs at the baseline), not one", () => {
+  it("the two letters share their opening: identical until the extra arch", () => {
     const f = tamil();
-    const g = raster(f.glyphFor("ற")!.contours);
-    // Sample a row inside the letter body, above the baseline.
-    const bodyRow = g[Math.floor(g.length * 0.5)];
-    expect(runsInRow(bodyRow)).toBe(3);
+    const retroflex = f.glyphFor("ண")!.contours;
+    const alveolar = f.glyphFor("ன")!.contours;
+    const win = windowFor(retroflex, alveolar);
+    const a = raster(retroflex, win);
+    const b = raster(alveolar, win);
 
-    // Control: the measure must actually discriminate. Across the letters this
-    // track teaches it returns a RANGE of values, so "3" is a measurement of ற
-    // rather than a constant the metric hands back for anything.
-    const counts = ["வ", "ம", "ண", "ற", "ல"].map((ch) =>
-      runsInRow(raster(f.glyphFor(ch)!.contours)[Math.floor(g.length * 0.5)]),
-    );
-    expect(new Set(counts).size).toBeGreaterThan(1);
+    // Minimum differing column ACROSS ALL ROWS (an earlier version stopped at
+    // the first differing cell in row-major order, so it only ever measured
+    // the topmost differing row).
+    let firstDiff = a[0].length;
+    for (let r = 0; r < a.length; r++)
+      for (let c = 0; c < a[r].length; c++)
+        if (a[r][c] !== b[r][c]) { firstDiff = Math.min(firstDiff, c); break; }
+
+    expect(firstDiff).toBeGreaterThan(20); // a shared opening really exists
+    expect(firstDiff).toBeLessThan(a[0].length); // ...and they do differ
+
+    // Control: unrelated letters diverge almost at once, so the number above
+    // is a property of this pair rather than of the measure.
+    const other = f.glyphFor("ம")!.contours;
+    const win2 = windowFor(retroflex, other);
+    const a2 = raster(retroflex, win2);
+    const c2 = raster(other, win2);
+    let controlDiff = a2[0].length;
+    for (let r = 0; r < a2.length; r++)
+      for (let c = 0; c < a2[r].length; c++)
+        if (a2[r][c] !== c2[r][c]) { controlDiff = Math.min(controlDiff, c); break; }
+    expect(controlDiff).toBeLessThan(firstDiff);
+  });
+
+  it("ற has two arches — three legs at mid-body — and a descender", () => {
+    const f = tamil();
+    const g = f.glyphFor("ற")!.contours;
+    const win = windowFor(g);
+    expect(runs(raster(g, win)[Math.floor(26 * 0.5)])).toBe(3);
+    expect(boundsOf(g).y0).toBeLessThan(-200); // the long tail below the baseline
+  });
+
+  it("the raster window guard fires rather than silently clipping", () => {
+    const f = tamil();
+    const wide = f.glyphFor("ண")!.contours; // runs to x=1631
+    const narrow = windowFor(f.glyphFor("ம")!.contours); // only to x=797
+    expect(() => raster(wide, narrow)).toThrow(/clips a glyph/);
   });
 });

--- a/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/truetype.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseFont, contoursToPath, boundsOf, type Contour } from "../src/truetype";
+
+const FONT_DIR = resolve(__dirname, "../../../../learning/human-languages/_fonts");
+const load = (name: string) => {
+  const b = readFileSync(resolve(FONT_DIR, name));
+  return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength) as ArrayBuffer;
+};
+const tamil = () => parseFont(load("NotoSansTamil-Static.ttf"));
+
+// ---------------------------------------------------------------------------
+// A tiny rasteriser, used only by these tests.
+//
+// It exists so that shape assertions are made against WHAT THE GLYPH ACTUALLY
+// LOOKS LIKE rather than against a description someone typed. Flatten the
+// quadratics into line segments, then scan-convert with the non-zero winding
+// rule (the same rule SVG's default fill-rule uses, so counters come out
+// hollow exactly as they render).
+// ---------------------------------------------------------------------------
+function flatten(contours: Contour[], perCurve = 8): Array<Array<[number, number]>> {
+  const polys: Array<Array<[number, number]>> = [];
+  for (const pts of contours) {
+    if (!pts.length) continue;
+    // Re-walk the contour the same way contoursToPath does, so the polygon we
+    // rasterise is the polygon the app draws.
+    const poly: Array<[number, number]> = [];
+    let startIndex = pts.findIndex((p) => p.on);
+    let sx: number, sy: number;
+    if (startIndex === -1) {
+      sx = (pts[pts.length - 1].x + pts[0].x) / 2;
+      sy = (pts[pts.length - 1].y + pts[0].y) / 2;
+      startIndex = 0;
+    } else {
+      sx = pts[startIndex].x;
+      sy = pts[startIndex].y;
+      startIndex += 1;
+    }
+    poly.push([sx, sy]);
+    let cx = sx;
+    let cy = sy;
+    let ctrl: { x: number; y: number } | null = null;
+    const quad = (qx: number, qy: number, x: number, y: number) => {
+      for (let i = 1; i <= perCurve; i++) {
+        const t = i / perCurve;
+        const mt = 1 - t;
+        poly.push([mt * mt * cx + 2 * mt * t * qx + t * t * x, mt * mt * cy + 2 * mt * t * qy + t * t * y]);
+      }
+      cx = x;
+      cy = y;
+    };
+    for (let k = 0; k < pts.length; k++) {
+      const p = pts[(startIndex + k) % pts.length];
+      if (p.on) {
+        if (ctrl) {
+          quad(ctrl.x, ctrl.y, p.x, p.y);
+          ctrl = null;
+        } else {
+          poly.push([p.x, p.y]);
+          cx = p.x;
+          cy = p.y;
+        }
+      } else {
+        if (ctrl) quad(ctrl.x, ctrl.y, (ctrl.x + p.x) / 2, (ctrl.y + p.y) / 2);
+        ctrl = p;
+      }
+    }
+    if (ctrl) quad(ctrl.x, ctrl.y, sx, sy);
+    poly.push([sx, sy]);
+    polys.push(poly);
+  }
+  return polys;
+}
+
+/** Render contours to a boolean ink grid on a FIXED em box, so two glyphs are directly comparable. */
+function raster(contours: Contour[], W = 100, H = 34): boolean[][] {
+  const polys = flatten(contours);
+  const X0 = -30, X1 = 1030, Y0 = -320, Y1 = 880;
+  const grid: boolean[][] = [];
+  for (let r = 0; r < H; r++) {
+    const y = Y1 - ((r + 0.5) * (Y1 - Y0)) / H;
+    const row: boolean[] = [];
+    for (let c = 0; c < W; c++) {
+      const x = X0 + ((c + 0.5) * (X1 - X0)) / W;
+      let winding = 0;
+      for (const p of polys) {
+        for (let i = 0; i + 1 < p.length; i++) {
+          const [ax, ay] = p[i];
+          const [bx, by] = p[i + 1];
+          if (ay <= y !== by <= y) {
+            const t = (y - ay) / (by - ay);
+            if (ax + t * (bx - ax) > x) winding += by > ay ? 1 : -1;
+          }
+        }
+      }
+      row.push(winding !== 0);
+    }
+    grid.push(row);
+  }
+  return grid;
+}
+
+const inkColumns = (g: boolean[][]) => g[0].map((_, c) => g.some((row) => row[c]));
+/** Count runs of ink along a row — i.e. how many separate strokes it crosses. */
+const runsInRow = (row: boolean[]) => row.reduce((n, v, i) => n + (v && !row[i - 1] ? 1 : 0), 0);
+
+describe("truetype: reading the vendored fonts", () => {
+  it("parses Noto Sans Tamil and finds a Unicode cmap", () => {
+    const f = tamil();
+    expect(f.unitsPerEm).toBe(1000);
+    expect(f.numGlyphs).toBeGreaterThan(100);
+    expect([4, 12]).toContain(f.cmapFormat);
+    expect(f.mappedCharacters).toBeGreaterThan(100);
+  });
+
+  it("parses every vendored font without throwing", () => {
+    const fonts = readdirSync(FONT_DIR).filter((f) => f.endsWith(".ttf"));
+    expect(fonts.length).toBeGreaterThan(5);
+    for (const name of fonts) {
+      const f = parseFont(load(name));
+      expect(f.unitsPerEm, name).toBeGreaterThan(0);
+      expect(f.mappedCharacters, name).toBeGreaterThan(0);
+    }
+  });
+
+  it("resolves each Tamil letter the writing track teaches to a non-empty outline", () => {
+    const f = tamil();
+    for (const ch of ["க", "ம", "ண", "ன", "ந", "ற", "வ", "அ", "இ", "ல"]) {
+      const g = f.glyphFor(ch);
+      expect(g, ch).toBeDefined();
+      expect(g!.contours.length, ch).toBeGreaterThan(0);
+      expect(g!.path, ch).toMatch(/^M/);
+      expect(g!.path, ch).toMatch(/Z$/);
+      // Only the four commands we claim to emit.
+      expect(g!.path.replace(/[-\d.\s]/g, "").split("").every((c) => "MLQZ".includes(c)), ch).toBe(true);
+    }
+  });
+
+  it("returns undefined for a character the font does not cover", () => {
+    expect(tamil().glyphFor("漢")).toBeUndefined();
+  });
+
+  it("puts descenders below the baseline and keeps the body above it", () => {
+    const f = tamil();
+    // ற has a long descender; ம sits on the baseline.
+    expect(boundsOf(f.glyphFor("ற")!.contours).y0).toBeLessThan(-50);
+    expect(boundsOf(f.glyphFor("ம")!.contours).y0).toBeGreaterThan(-50);
+  });
+});
+
+describe("hostile input", () => {
+  // Build a minimal font whose cmap format 12 claims one group spanning the
+  // entire 32-bit range. Without clamping, the reader would try to build a
+  // four-billion-entry Map and hang. With clamping it returns promptly.
+  function fontWithHugeCmapRange(): ArrayBuffer {
+    const tables = ["cmap", "glyf", "head", "loca", "maxp"];
+    const dirSize = 12 + tables.length * 16;
+    const cmapOffset = dirSize;
+    const cmapSize = 16 + 12;
+    const headOffset = cmapOffset + cmapSize;
+    const buf = new ArrayBuffer(headOffset + 64);
+    const v = new DataView(buf);
+    v.setUint32(0, 0x00010000);
+    v.setUint16(4, tables.length);
+    const place: Record<string, [number, number]> = {
+      cmap: [cmapOffset, cmapSize],
+      glyf: [headOffset + 60, 0],
+      head: [headOffset, 54],
+      loca: [headOffset + 56, 4],
+      maxp: [headOffset + 54, 6],
+    };
+    tables.forEach((tag, i) => {
+      const at = 12 + i * 16;
+      for (let k = 0; k < 4; k++) v.setUint8(at + k, tag.charCodeAt(k));
+      v.setUint32(at + 8, place[tag][0]);
+      v.setUint32(at + 12, place[tag][1]);
+    });
+    // cmap: 1 subtable, platform 3 / encoding 10, format 12
+    v.setUint16(cmapOffset + 2, 1);
+    v.setUint16(cmapOffset + 4, 3);
+    v.setUint16(cmapOffset + 6, 10);
+    v.setUint32(cmapOffset + 8, 12); // offset to the subtable, from cmap start
+    const sub = cmapOffset + 12;
+    v.setUint16(sub, 12); // format
+    v.setUint32(sub + 12, 1); // nGroups
+    v.setUint32(sub + 16, 0); // startCharCode
+    v.setUint32(sub + 20, 0xffffffff); // endCharCode — the hostile part
+    v.setUint32(sub + 24, 1); // startGlyphID
+    v.setUint16(headOffset + 18, 1000); // unitsPerEm
+    v.setInt16(headOffset + 50, 0); // indexToLocFormat
+    v.setUint16(headOffset + 54 + 4, 1); // maxp numGlyphs
+    return buf;
+  }
+
+  it("clamps a cmap range that spans the whole 32-bit space", () => {
+    const started = Date.now();
+    const f = parseFont(fontWithHugeCmapRange());
+    // Unclamped this would attempt ~4.3 billion Map inserts.
+    expect(f.mappedCharacters).toBeLessThanOrEqual(200_000);
+    expect(Date.now() - started).toBeLessThan(10_000);
+  });
+
+  it("rejects formats it cannot read rather than guessing", () => {
+    const otto = new ArrayBuffer(12);
+    new DataView(otto).setUint32(0, 0x4f54544f);
+    expect(() => parseFont(otto)).toThrow(/OTTO|CFF/);
+    const ttc = new ArrayBuffer(12);
+    new DataView(ttc).setUint32(0, 0x74746366);
+    expect(() => parseFont(ttc)).toThrow(/collection/i);
+  });
+});
+
+describe("contoursToPath", () => {
+  it("inserts the implied on-curve midpoint between consecutive off-curve points", () => {
+    // Two off-curve points in a row: TrueType implies an on-curve point halfway
+    // between them, so we must emit TWO quadratics, not one.
+    const contour: Contour = [
+      { x: 0, y: 0, on: true },
+      { x: 10, y: 10, on: false },
+      { x: 20, y: 10, on: false },
+      { x: 30, y: 0, on: true },
+    ];
+    const d = contoursToPath([contour]);
+    // Q to the implied midpoint, then Q on to (30,0). Closing back to the
+    // start is a straight L because the last point walked is on-curve.
+    expect((d.match(/Q/g) ?? []).length).toBe(2);
+    expect(d).toContain("Q10 10 15 10"); // the implied midpoint of (10,10)-(20,10)
+  });
+
+  it("synthesises a start point when a contour has no on-curve point at all", () => {
+    const d = contoursToPath([
+      [
+        { x: 0, y: 0, on: false },
+        { x: 10, y: 0, on: false },
+      ],
+    ]);
+    expect(d).toMatch(/^M5 0/); // midpoint of last and first
+  });
+
+  it("emits nothing for an empty contour set", () => {
+    expect(contoursToPath([])).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shape regressions.
+//
+// These encode facts about the LETTERS, taken from the rasterised font, that
+// the Tamil writing lessons state in prose. They exist because an earlier
+// draft shipped "ண is ன with one extra arch" — which is false — and it
+// survived a review in which the font was rendered and the claim reported
+// confirmed. A description can look right next to a glyph while naming the
+// wrong distinguishing feature. Only a mechanical comparison catches that.
+// ---------------------------------------------------------------------------
+describe("Tamil letter shapes the lessons make claims about", () => {
+  it("ண and ன are the same shape except for their final stroke", () => {
+    const f = tamil();
+    const na = raster(f.glyphFor("ண")!.contours);
+    const alveolar = raster(f.glyphFor("ன")!.contours);
+
+    let firstDiff = na[0].length;
+    outer: for (let r = 0; r < na.length; r++) {
+      for (let c = 0; c < na[r].length; c++) {
+        if (na[r][c] !== alveolar[r][c]) {
+          firstDiff = Math.min(firstDiff, c);
+          break outer;
+        }
+      }
+    }
+    // Identical through the left half: same top bar, same loop, same arch.
+    // If this ever drops sharply, the "only the last stroke differs" claim in
+    // TA-W02/TA-W04 has stopped being true and the lessons need revisiting.
+    expect(firstDiff).toBeGreaterThan(45);
+
+    // ...and they DO differ — otherwise the claim is vacuous.
+    expect(firstDiff).toBeLessThan(na[0].length);
+
+    // Control: the metric must be capable of reporting "these are different
+    // letters". Two unrelated glyphs diverge almost immediately, so a passing
+    // assertion above is a real property of ண/ன and not a quirk of the measure.
+    const unrelated = raster(f.glyphFor("ம")!.contours);
+    let controlDiff = na[0].length;
+    outerControl: for (let r = 0; r < na.length; r++) {
+      for (let c = 0; c < na[r].length; c++) {
+        if (na[r][c] !== unrelated[r][c]) {
+          controlDiff = Math.min(controlDiff, c);
+          break outerControl;
+        }
+      }
+    }
+    expect(controlDiff).toBeLessThan(20);
+  });
+
+  it("ன's final stroke is a straight vertical; ண's is not", () => {
+    const f = tamil();
+    const straightness = (ch: string) => {
+      const g = raster(f.glyphFor(ch)!.contours);
+      const cols = inkColumns(g);
+      const right = cols.lastIndexOf(true);
+      // Walk up the rightmost stroke: for a straight vertical, the leftmost
+      // inked column of the final stroke is the same on every row it occupies.
+      // Look only BELOW the top bar. The bar spans the whole letter, so it
+      // touches the rightmost column too and would swamp the measurement.
+      const inked = g.map((row) => row.some(Boolean));
+      const top = inked.indexOf(true);
+      const bottom = inked.lastIndexOf(true);
+      const firstBodyRow = top + Math.ceil((bottom - top) * 0.3);
+      const lefts: number[] = [];
+      for (let r = firstBodyRow; r <= bottom; r++) {
+        if (!g[r][right]) continue;
+        let c = right;
+        while (c > 0 && g[r][c - 1]) c--;
+        lefts.push(c);
+      }
+      return new Set(lefts).size; // 1 => perfectly straight
+    };
+    expect(straightness("ன")).toBe(1);
+    expect(straightness("ண")).toBeGreaterThan(1);
+  });
+
+  it("ற has two arches (three legs at the baseline), not one", () => {
+    const f = tamil();
+    const g = raster(f.glyphFor("ற")!.contours);
+    // Sample a row inside the letter body, above the baseline.
+    const bodyRow = g[Math.floor(g.length * 0.5)];
+    expect(runsInRow(bodyRow)).toBe(3);
+
+    // Control: the measure must actually discriminate. Across the letters this
+    // track teaches it returns a RANGE of values, so "3" is a measurement of ற
+    // rather than a constant the metric hands back for anything.
+    const counts = ["வ", "ம", "ண", "ற", "ல"].map((ch) =>
+      runsInRow(raster(f.glyphFor(ch)!.contours)[Math.floor(g.length * 0.5)]),
+    );
+    expect(new Set(counts).size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
> ## ⚠️ If you squash-merge, do not keep the first commit's message
>
> Commit `6320e6a`'s message **asserts a claim that is false** — that ண and ன "differ only in the final stroke" — and credits the test harness with catching an error that the harness actually *introduced*. It also overstates the hardening that existed at that point. `bd3b86b` immediately reverses and explains it, which is the audit trail worth keeping in the branch history, but the false bullet must not survive into a squashed message. **Please use this PR description as the squash body.**

## What this is

Foundation for the traced-stroke build-up the writing lessons need: showing a learner how a letter is assembled from its real shape.

`src/truetype.ts` is a zero-dependency TrueType reader — table directory, `cmap` (formats 4 and 12), `loca`, `glyf`, simple and composite glyphs, delta-encoded coordinate flags, and the on-curve midpoint TrueType implies between consecutive off-curve points.

**Why not hand-drawn SVG paths:** a subtly wrong ண looks completely fine to anyone who cannot already read Tamil — the entire audience — so the error would ship *as the lesson*. Extracting from the vendored font makes shapes correct by construction.

## The correction this PR also carries

PR #8759 shipped a false "fix": it replaced the true statement *ண is ன with one extra arch* with *"they differ only in the final stroke, ண's curves"*. **The original was right.**

The cause was the measuring instrument. My rasteriser hard-coded a window of x ≤ 1030; ண's outline runs to **x = 1631**. It amputated 37% of the letter including its final vertical, and I described the truncated picture. A clipped raster doesn't look like an error — it looks like a letter.

```
ண   loop   arch 1   arch 2   ██  <- straight vertical
ன   loop   arch 1            ██  <- the same straight vertical
```

Reverted in `tamil.json`, TA-W02, TA-W04 and the track changelog. **ந** was also corrected — two verticals hang from the bar, not one, and its sweep-left descender went unmentioned.

## Hardening

Every count and offset in a font file is attacker-controlled if this is ever pointed at an untrusted font, and it runs in the browser. Independently re-measured by review against this branch:

| attack | file | before | after |
|---|---|---|---|
| composite fan-out N=70 | 632 B | 436,732 ms | **6 ms** |
| fan-out N=5000 | 30 KB | *unbounded (extrapolated)* | **205 ms** |
| cmap12 duplicate groups ×2000 | 24 KB | 8,193 ms | **14 ms** |
| cmap4 ×8000 full-BMP segments | 64 KB | 11,643 ms | **13 ms** |
| cmap4 at max segCount | 262 KB | *~50 s (extrapolated)* | **16 ms** |

Non-ascending contour end points and scaled composite components now throw rather than render a wrong shape.

## Verification

The parser is **byte-identical to fontTools across all 12 vendored fonts and 4,000+ codepoints**, with zero false rejections — re-checked against the final commit.

Tests rasterise the font, so shape assertions are checked against what the glyph actually looks like. **Both guards in that harness exist because it fooled me:**

- `raster()` derives its window from the glyphs' own bounds and **throws if a glyph would be clipped** (the bug above).
- The final-stroke metric reports its **sample count**, and assertions require samples before believing the answer. It had been anchoring on the top bar, which overhangs the final vertical, so it collected *zero* samples — and `Math.max([]) - Math.min([])` is `-Infinity`, which satisfies any upper bound. It measured nothing and reported agreement.

Every shape test carries a control proving the measure discriminates. Three of my controls failed usefully while writing this and forced rewrites.

A per-`Font` component budget also silently degraded glyphs to blank after ~10,000 lookups (one Arabic browse pass consumed 44% of it). Now per-lookup; the regression test renders 12,000 times and fails on the old code at lookup 9999.

**113 tests.** Nothing user-visible yet — the build-up UI is the next increment, and the per-letter stroke regions are genuine authoring work the parser does not provide for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)