### PR TITLE
feat(q-parser): grammar-driven Q parser with function literals + dual list-literal syntax (MA-11c)

### DIFF
--- a/code/grammars/q/q.grammar
+++ b/code/grammars/q/q.grammar
@@ -1,0 +1,269 @@
+# @version 1
+
+# =============================================================================
+# q.grammar — Parser grammar for the Q historical core (MA-11c)
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from the Q lexer (code/grammars/q/q.tokens). See
+# code/specs/MA11-q-language.md, especially §3 (the grammar design this file
+# implements) and §4 (the exact primitive/adverb/function-literal scope).
+#
+# Token names (UPPERCASE) come from the Q lexer:
+#   NUMBER NAME                                        literals and variables
+#   COLON                                              assignment (name:expr)
+#   PLUS MINUS STAR PERCENT BANG COMMA HASH UNDERSCORE  primitive verbs
+#   AMP PIPE TILDE
+#   EQ LT GT LE GE NE                                   dyadic comparison verbs
+#   EACH (') REDUCE (/) SCAN (\)                        adverbs
+#   LPAREN RPAREN                                       grouping / list literal
+#   LBRACE RBRACE LBRACKET RBRACKET                     function-literal delims
+#   SEMICOLON                                           list/param/stmt separator
+#   NEWLINE
+#
+# -----------------------------------------------------------------------------
+# What is REUSED unchanged from APL/J (MA11 §3's own framing: "reused
+# UNCHANGED... this is the easy, mechanical part")
+# -----------------------------------------------------------------------------
+# Two nonterminals, exactly like `apl.grammar`/`j.grammar`:
+#
+#   noun_expr  — arrays and scalars (values). Built from `term`s combined by
+#                `verb_expr`s, ONE precedence tier, right-to-left (`a F b G c`
+#                parses as `a F (b G c)`).
+#   verb_expr  — a callable: a primitive glyph (optionally with one adverb
+#                applied — a "derived verb", e.g. `+/`), OR (MA11's own
+#                novelty, see below) something that names a user-defined
+#                callable.
+#
+# Monadic-vs-dyadic dispatch is still a RUNTIME concern, not a grammar
+# concern (MA05 §3 bullet 3, reused unchanged by MA06 §3 and again here):
+# `noun_expr`'s two productions that start with a `verb_expr` (monadic:
+# nothing precedes it) vs. that have a `term` before it (dyadic) are exactly
+# the "which alternative matched" a later pass reads off.
+#
+# Q has NO trains and NO `@` compose in this cut (MA11 §4 explicitly defers
+# `@`; trains/hooks/forks are a J/K-internal device this repo's Q subset
+# never uses at all — Q's own real grammar doesn't have them either), so
+# `verb_expr` is flatter here than `j.grammar`'s own (no `verb_train`, no
+# `AT`-continuation).
+#
+# -----------------------------------------------------------------------------
+# What is GENUINELY NEW here (MA11 §3 bullets 1 and 3)
+# -----------------------------------------------------------------------------
+# 1. FUNCTION LITERALS (§3 bullet 1 / §4) — `function_literal`, a new `term`
+#    alternative: `{[x;y] stmt; stmt; ...}` — an optional bracketed,
+#    semicolon-separated parameter list (`param_list`; defaulting to the
+#    implicit `x`/`y`/`z` names when the brackets are omitted entirely — that
+#    default is a RUNTIME/lowering concern, not something this grammar needs
+#    to encode, since the brackets are simply absent from the parse tree in
+#    that case) followed by a semicolon-separated sequence of statements
+#    (`stmt_seq`), the last one's value being the result.
+#
+# 2. DUAL LIST-LITERAL SYNTAX (§3 bullet 3) — adjacent NUMBER stranding is
+#    reused unchanged from APL/J (`term`'s own `NUMBER { NUMBER }`
+#    alternative, below); the EXPLICIT `(a; b; c)` form is a second, new
+#    `term` alternative (`list_literal`), disambiguated from ordinary
+#    parenthesised grouping purely by the PRESENCE of a top-level `;` inside
+#    the parens (MA11 §3 bullet 3's own last sentence, and §4's
+#    "Parenthesised grouping" bullet says the same thing). See the
+#    `list_literal` rule's own comment below for exactly how the packrat
+#    parser's first-alternative-wins Alternation makes this disambiguation
+#    fall out for free with NO lookahead of its own: `term`'s
+#    `LPAREN noun_expr RPAREN` alternative is tried FIRST and simply FAILS
+#    (the mandatory trailing RPAREN never arrives; a SEMICOLON is in its
+#    place) whenever the parenthesised content contains a top-level `;`,
+#    naturally falling through to `list_literal` on backtrack.
+#
+# -----------------------------------------------------------------------------
+# THE ONE GENUINELY HARD PROBLEM: calling a NAME-bound or inline function
+# value via juxtaposition, without a symbol table (MA11 §2/§3 bullet 1)
+# -----------------------------------------------------------------------------
+# MA11 §3 bullet 1 is explicit: "A function literal is itself an ordinary
+# noun value (assignable, passable), applied with the same juxtaposition/`@`
+# mechanism as a primitive verb — no new *application* production, only a
+# new way to *produce* a callable value." Taken completely literally, this
+# means: do NOT add a brand-new top-level rule like `function_call = ...`;
+# instead, extend the alphabet of things `verb_expr` can BE, so the EXISTING
+# `noun_expr` alternatives (unchanged in SHAPE) already parse a call.
+#
+# Concretely, `verb_expr` gains two new alternatives beyond a bare primitive
+# glyph: a bare `NAME` (a previously-assigned function value, per MA11 §4's
+# "every function body in scope calls only primitives and other
+# already-defined functions") and an inline `function_literal` (so an
+# anonymous lambda can be applied the moment it's written, e.g.
+# `{x+y}[2]`... no — bracket-CALL syntax is out of scope (MA11 §4 reserves
+# `[`/`]` for the function-literal's OWN parameter list only, and indexing
+# is explicitly deferred) — but plain juxtaposition, `{x*2} 5` or
+# `2 {x+y} 3`, works via this same mechanism).
+#
+# The hard part: `NAME` and `function_literal` are ALSO valid `term`
+# (noun-side) alternatives — they have to be, so a bare, un-applied function
+# value can still be assigned (`f:{x+y}`) or passed around. This means
+# `term` and `verb_expr` now OVERLAP on two token shapes, where APL/J's own
+# `term`/`verb_expr` were always completely DISJOINT (NUMBER/NAME/LPAREN vs.
+# a fixed set of primitive-glyph tokens) — the exact reason APL/J never
+# needed to solve this problem at all. Two consequences, both deliberate,
+# both disclosed:
+#
+#   (a) `noun_expr`'s OPTIONAL dyadic continuation is widened from
+#       `[ verb_expr noun_expr ]` (APL/J's own shape, unchanged in the
+#       PRIMITIVE case) to `[ verb_expr noun_expr | noun_expr ]` — an
+#       ADDITIONAL fallback alternative, tried only when no verb_expr is
+#       present at that position. This is what lets `f 5` (nothing before
+#       `f`, calling it monadically with the value that follows) parse at
+#       all: `term` will always win the FIRST alternative's mandatory
+#       leading element when the input starts with a NAME (there is no way
+#       to make an Alternation prefer "treat this NAME as a verb" over
+#       "treat this NAME as a plain term" at that exact position without
+#       unbounded lookahead a packrat parser doesn't have) — but once `f`
+#       is consumed as `term`, checking "does an entire, independent
+#       `noun_expr` immediately follow with nothing in between?" is exactly
+#       the shape that means "apply." This is still `noun_expr`'s OWN
+#       existing optional continuation, just with one more inner
+#       alternative — not a new named production.
+#   (b) A GENUINE, DISCLOSED LIMITATION: real K/Q resolves whether a bare
+#       NAME plays a noun role or a verb (callable) role, in a chain of
+#       three or more juxtaposed names (`f g h`), by tracking each name's
+#       already-defined ARITY during parsing (a symbol table) — something
+#       no context-free grammar can do, and something this repo's shared
+#       `GrammarParser` engine has no mechanism for at all (every other
+#       frontend in this family resolves monadic/dyadic dispatch purely
+#       from grammar SHAPE, never from what a name was previously bound
+#       to). This grammar's own resolution for a 3+-name juxtaposition
+#       chain — inner alternative (a) (`verb_expr noun_expr`, i.e. "the
+#       token right after the first term looks like a verb-shaped thing")
+#       is tried BEFORE inner alternative (b) (a bare `noun_expr`) — means
+#       `x f y` (exactly one middle "verb" name between two operands)
+#       parses as a DYADIC call `f(x, y)`, but a longer chain right of that
+#       point recurses through the SAME rule and does not attempt to look
+#       further ahead to decide any global grouping. This is a best-effort,
+#       NOT a faithful reproduction of true K/Q valence resolution — exactly
+#       the same class of disclosed simplification `j.grammar`'s own header
+#       comment accepts for a bare-noun train tooth outside a fork's leading
+#       position ("this grammar accepts the shape syntactically and leaves
+#       the restriction to a later pass"). A future `q-runtime` (MA-11d)
+#       needs to be aware of this when it walks the tree.
+#
+# See `verb_expr` and `noun_expr`'s own comments below for the exact rules.
+# =============================================================================
+
+program = { line } ;
+
+line = statement NEWLINE
+     | statement
+     | NEWLINE ;
+
+statement = assignment ;
+
+# Assignment (MA11 §4): `name:expr`, right-associative and right-to-left
+# evaluated, mirroring `apl.grammar`/`j.grammar`'s own `assignment`
+# production shape exactly (chained assignment, `a:b:3`, assigns 3 to both).
+# Q spells assignment with a single COLON (no local/global distinction —
+# MA11 §4's own "Assignment" bullet explicitly puts the global-vs-local `::`
+# subtlety out of scope, since this cut has no nested function literals for
+# it to matter to).
+assignment = NAME COLON assignment
+           | noun_expr ;
+
+# The core two-nonterminal, one-precedence-tier, right-to-left application
+# chain (MA11 §3), reused from `apl.grammar`/`j.grammar`'s `value_expr`/
+# `noun_expr` in SHAPE for the primitive-verb case, widened by exactly one
+# inner alternative for the genuinely new "apply a callable term" case (see
+# the header note above). Read as: a `term`, optionally followed EITHER by
+# an explicit `verb_expr` and another `noun_expr` (ordinary dyadic — a
+# primitive glyph, or a NAME/function_literal playing the same role, e.g.
+# `x f y`) OR by a bare `noun_expr` with nothing in between (function
+# application — `f 5`, the first `term` is assumed callable) — OR, with no
+# leading `term` at all, a bare `verb_expr noun_expr` (ordinary monadic
+# primitive application, e.g. `+5`, unchanged from APL/J).
+noun_expr = term [ verb_expr noun_expr | noun_expr ]
+          | verb_expr noun_expr ;
+
+# A noun atom (MA11 §4): a run of one or more juxtaposed NUMBER literals
+# (stranding, reused unchanged from APL/J's own numeric-only restriction:
+# `1 2 3` strands, `a b` does not strand this way — two bare NAMEs
+# juxtaposed instead falls through to `noun_expr`'s new "apply" alternative
+# above), a NAME, a function literal (MA11 §3 bullet 1 — needed here so an
+# UN-applied lambda value can still be assigned/passed, e.g. `f:{x+y}`), a
+# fully parenthesised noun_expr (ordinary grouping), or an explicit
+# semicolon-separated list literal (MA11 §3 bullet 3).
+term = NUMBER { NUMBER }
+     | NAME
+     | function_literal
+     | LPAREN noun_expr RPAREN
+     | list_literal ;
+
+# The explicit list-literal form (MA11 §3 bullet 3 / §4): `(a; b; c)`, for
+# lists of arbitrary expressions (including function literals or mixed
+# types) that numeric stranding cannot express. Requires AT LEAST one
+# SEMICOLON (i.e. 2+ elements) — this is exactly what disambiguates it from
+# ordinary parenthesised grouping (`term`'s OTHER, plain
+# `LPAREN noun_expr RPAREN` alternative, which has no SEMICOLON at all).
+#
+# No explicit lookahead is written anywhere for this disambiguation — it
+# falls out entirely from `term`'s alternatives being tried IN ORDER by the
+# underlying packrat Alternation: for `(2+3)` (plain grouping), the earlier
+# `LPAREN noun_expr RPAREN` alternative already succeeds outright (noun_expr
+# greedily consumes `2+3` as one dyadic chain, then RPAREN matches), so
+# `list_literal` is never even attempted. For `(2;3)` (an explicit list),
+# that SAME earlier alternative is tried first and FAILS cleanly: noun_expr
+# can only consume `2` (its own dyadic continuation requires a verb_expr or
+# a bare noun_expr right after `2`, and a bare SEMICOLON is neither), then
+# the mandatory RPAREN check finds a SEMICOLON instead and the whole
+# alternative backtracks (the packrat engine resets `self.pos` on every
+# failed Alternation choice) — falling through cleanly to `list_literal`,
+# which matches.
+list_literal = LPAREN noun_expr SEMICOLON noun_expr { SEMICOLON noun_expr } RPAREN ;
+
+# Function literals — the headline novelty (MA11 §2 / §3 bullet 1 / §4):
+# `{[x;y] stmt; stmt; ...}`. The bracketed parameter list is OPTIONAL in the
+# grammar (defaulting to the implicit `x`/`y`/`z` names when omitted — a
+# RUNTIME/lowering convention this grammar does not need to encode itself,
+# since the parse tree simply has no `param_list` child in that case); the
+# body is a semicolon-separated sequence of statements (`stmt_seq`), the
+# last one's value being the call's result (also a RUNTIME concern, not a
+# grammar one — this rule only builds the flat statement sequence).
+function_literal = LBRACE [ LBRACKET param_list RBRACKET ] stmt_seq RBRACE ;
+
+# One or more parameter NAMEs, semicolon-separated (`{[x;y;z] ...}`). At
+# least one NAME is required whenever the brackets are present at all — an
+# explicitly empty `[]` (a real, rarer Q idiom meaning "no implicit
+# parameters, an explicitly niladic function") is not handled here; this
+# cut only needs the two forms MA11 §3 bullet 1 actually describes
+# (brackets present with 1+ names, or brackets entirely absent).
+param_list = NAME { SEMICOLON NAME } ;
+
+# One or more statements, semicolon-separated, forming a function literal's
+# body (MA11 §3 bullet 1). Reuses `statement` (== `assignment`) directly —
+# assignment inside a function body is syntactically identical to top-level
+# assignment (MA11 §4's "Assignment" bullet: local to that call, no nested-
+# function scoping subtlety to encode here since this cut has no nested
+# function literals inside a parameter list's own scope to worry about
+# distinguishing).
+stmt_seq = statement { SEMICOLON statement } ;
+
+# Verb-valued expressions (MA11 §3/§4). A bare primitive verb, optionally
+# postfixed by ONE adverb (a "derived verb", e.g. `+/`, `+\`, `+'`) — OR,
+# the two genuinely new alternatives this grammar needs for function
+# literals to be "applied with the same juxtaposition mechanism as a
+# primitive verb" (see the header note's full rationale): a bare NAME
+# (assumed, at evaluation time, to be bound to a previously-defined
+# function value) or an inline function_literal (an anonymous lambda,
+# applied the moment it is written). Stacking adverbs (applying one to an
+# already-adverbed verb), and adverbing a NAME/function_literal directly
+# (Q's real `f/x` idiom for a user-defined `f`), are both out of this first
+# cut's scope, matching how `apl.grammar`/`j.grammar` restrict adverb
+# stacking on primitives too.
+verb_expr = verb_primitive [ EACH | REDUCE | SCAN ]
+          | NAME
+          | function_literal ;
+
+# One primitive verb glyph (MA11 §4's full primitive-verb table): flip/add,
+# negate/subtract, first/multiply, reciprocal/divide, til (monadic-only —
+# dyadic `!` is deferred), enlist/join, count/take, floor/drop, where/min,
+# reverse/max, not/match, then the six comparison glyphs (Q's own `<>` for
+# not-equal, never `~=` or `#` — see `q.tokens`' own header callout on this
+# exact trap).
+verb_primitive = PLUS | MINUS | STAR | PERCENT | BANG | COMMA | HASH
+               | UNDERSCORE | AMP | PIPE | TILDE
+               | EQ | LT | GT | LE | GE | NE ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -276,6 +276,7 @@ members = [
     "scilab-repl",
     "scilab-to-semantic-ir",
     "q-lexer",
+    "q-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/q-parser/BUILD
+++ b/code/packages/rust/q-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-q-parser -- --nocapture

--- a/code/packages/rust/q-parser/BUILD_windows
+++ b/code/packages/rust/q-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-q-parser -- --nocapture

--- a/code/packages/rust/q-parser/CHANGELOG.md
+++ b/code/packages/rust/q-parser/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+## [0.1.0] - 2026-07-21
+
+### Added
+
+- Initial grammar-driven Rust Q parser (MA11 §6, task MA-11c): consumes
+  `q-lexer`'s token stream, drives it through the compiled
+  `code/grammars/q/q.grammar`, and produces a `GrammarASTNode` CST rooted at
+  `program`. Exposes `create_q_parser`/`parse_q`/`try_parse_q`, matching
+  every sibling parser crate's established shape.
+- `q.grammar` reuses `apl.grammar`/`j.grammar`'s two-nonterminal
+  `noun_expr`/`verb_expr` design UNCHANGED for primitive-verb application
+  (MA11 §3: "reused UNCHANGED... this is the easy, mechanical part") — one
+  precedence tier, right-to-left, monadic/dyadic dispatch left to a later
+  pass. Q has no trains and no `@` compose in this cut, so `verb_expr` is
+  flatter than `j.grammar`'s own.
+- Two genuinely new productions (MA11 §3 bullets 1 and 3):
+  - **Function literals** (`function_literal`): `{[x;y] stmt; stmt; ...}`,
+    an optional bracketed semicolon-separated parameter list (`param_list`)
+    followed by a semicolon-separated statement sequence (`stmt_seq`).
+    Assignable/passable as an ordinary noun value without being applied
+    (`f:{x+y}`).
+  - **Dual list-literal syntax**: numeric stranding is reused unchanged from
+    APL/J; the explicit `(a;b;c)` form (`list_literal`) is a new `term`
+    alternative, disambiguated from plain parenthesised grouping purely by
+    the presence of a top-level `;` — this falls out of the packrat
+    parser's ordered Alternation with **no explicit lookahead needed**:
+    `term`'s plain `LPAREN noun_expr RPAREN` alternative is tried first and
+    simply fails (backtracking cleanly) whenever a top-level `;` is
+    present, falling through to `list_literal`.
+- **The one genuinely hard grammar problem**: making a function literal
+  "applied with the same juxtaposition/@ mechanism as a primitive verb" (MA11
+  §3 bullet 1) without adding a new named application production. Solved by
+  extending `verb_expr` with two new alternatives (a bare `NAME` and an
+  inline `function_literal`) and widening `noun_expr`'s existing optional
+  dyadic continuation from `[ verb_expr noun_expr ]` (APL/J's shape,
+  unchanged for primitives) to `[ verb_expr noun_expr | noun_expr ]` — one
+  more inner alternative, not a new top-level rule. This correctly parses
+  monadic named-function calls (`f 5`), dyadic named-function calls
+  (`2 f 3`), and both arities of an inline anonymous lambda (`{x*2} 5`,
+  `2 {x+y} 3`), verified directly by dedicated tests. **A disclosed,
+  deliberate limitation**: real K/Q resolves a 3+-name juxtaposition chain's
+  verb/noun roles (`f g h`) via arity tracking during parsing (a symbol
+  table), which this repo's shared context-free `GrammarParser` has no
+  mechanism for; this grammar's best-effort resolution (try
+  `verb_expr noun_expr` before a bare `noun_expr` fallback) correctly
+  handles the required case (`x f y` = dyadic `f(x,y)`) but does not
+  attempt to replicate full K/Q valence resolution for longer chains — see
+  `q.grammar`'s own header comment and this crate's README for the full
+  rationale. `q-runtime` (MA-11d) needs to be aware of this.
+- Ships with a recursion-depth cap (`MAX_RULE_DEPTH = 32`) from day one,
+  following MA11 §6's explicit instruction to measure the *actual*
+  native-stack crash floor for **every** distinct way this grammar can
+  recurse deeply — parenthesised nesting, a flat right-recursive dyadic
+  chain, and (genuinely new to this grammar family, no sibling crate has
+  measured this shape before) nested function-literal bodies — rather than
+  assuming any prior crate's floor or ordering transfers. All three measured
+  independently (binary search, a throwaway subprocess per data point, a
+  `std::thread::spawn` worker on the **default ~2 MiB stack**, an
+  *uncapped* `GrammarParser`, **debug** build to match `cargo test`'s own
+  profile):
+
+  1. **Parenthesised nesting**, `((((…5…))))`. Safe up to 101 levels,
+     crashes the process at 102.
+  2. **A flat, unparenthesised dyadic chain**, `1+1+1+…+1`. Safe up to 115
+     terms, crashes at 116.
+  3. **Nested function-literal bodies**, `{{{…5…}}}` — this grammar's own
+     genuinely new recursion shape, exercising
+     `function_literal -> stmt_seq -> statement -> assignment -> noun_expr
+     -> term -> function_literal` (six named-rule hops per level, versus
+     parenthesised nesting's two). Safe up to only 45 levels, crashes at
+     46 — **by far the lowest of the three floors**, and the shape this
+     cap is actually chosen against.
+
+  `MAX_RULE_DEPTH` is set to `32` — about 29% below the binding
+  nested-function-literal floor of 45 (comparable margin to `apl-parser`'s
+  own ~26.5% and `j-parser`'s own ~30%), safely below the other two floors
+  (101, 115) as well. Measured headroom at `32` (using the *capped* parser,
+  so no crash risk at all): parenthesised nesting to 13 levels (14 trips),
+  flat chain to 26 terms (27 trips), nested function literals to 4 levels
+  (5 trips) — modest for the function-literal shape in absolute terms, but
+  not a practical limitation, since MA11 §4 puts nested function-literal
+  *definitions* out of this cut's semantic scope entirely (no
+  closure/scoping model specified for them); the cap exists to reject a
+  pathologically crafted deep input cleanly, not to bound realistic
+  programs. See `MAX_RULE_DEPTH`'s doc comment in `src/lib.rs` for the full
+  derivation.
+- 38 tests + 1 doctest: one per grammar production (literals/stranding,
+  chained assignment, monadic/dyadic primitive application, the
+  right-to-left dyadic chain, every adverb, every comparison and primitive
+  verb parsed monadically, parenthesised grouping, the list-literal-vs-
+  grouping disambiguation with a structural check, function-literal
+  definition with explicit params, with implicit params, with a
+  multi-statement body, assignability without calling, calling a named
+  function both monadically and dyadically, calling an inline lambda both
+  monadically and dyadically, a function body calling another
+  already-defined function, comment/blank lines, multi-line programs,
+  three distinct malformed-input rejections), plus 9 depth-cap regression
+  tests (3 shapes × {huge-input-on-32MiB-worker, exact-boundary-at-the-cap,
+  cap-trips-before-overflow-on-default-stack}).
+- `code/packages/rust/Cargo.toml` workspace registration alongside
+  `q-lexer` and the other array-language frontend crate groups.
+
+### Notes for `q-runtime` (MA-11d)
+
+- The 3+-name juxtaposition-chain limitation noted above (this grammar
+  builds a best-effort shape for `f g h`-style chains, not a faithful K/Q
+  valence resolution).
+- Per this repo's own "grammar `{ }` repetition width is NOT bounded by the
+  parser depth cap" lesson: `term`'s numeric stranding, `param_list`, and
+  `stmt_seq` are all flat EBNF repetitions (bounded only by source length,
+  not by `MAX_RULE_DEPTH`) — this parser emits them as flat sibling
+  children in the CST (no recursion risk in *this* crate), but if
+  `q-runtime` ever folds any of them into a recursively-walked or
+  recursively-dropped tree shape, it needs its own separate width budget,
+  the same way `MAX_RULE_DEPTH` bounds *nesting* depth here but never
+  bounds repetition *width*.
+- No bug was found in `q-lexer` while building this crate; it is consumed
+  exactly as published.

--- a/code/packages/rust/q-parser/Cargo.toml
+++ b/code/packages/rust/q-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-q-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Q (kdb+ scripting language) parser backed by statically compiled grammar data"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-q-lexer = { path = "../q-lexer" }

--- a/code/packages/rust/q-parser/README.md
+++ b/code/packages/rust/q-parser/README.md
@@ -1,0 +1,186 @@
+# coding-adventures-q-parser
+
+Q (kdb+'s scripting language) parser backed by `code/grammars/q/q.grammar`,
+compiled to Rust and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Where this fits
+
+Consumes the token stream from `q-lexer` (MA-11b) and drives it through
+`q.grammar`'s two-nonterminal design (`noun_expr`/`verb_expr`, see
+[MA11 §3](../../../specs/MA11-q-language.md)) to produce a `GrammarASTNode`
+CST rooted at `program` — the second of Q's frontend crates (MA-11c). A
+future `q-runtime` crate (MA-11d) will walk this tree to evaluate, alongside
+`q-repl` (the `q` binary) and `q-to-semantic-ir` (MA-11e), per
+[HML00](../../../specs/HML00-historical-math-languages-roadmap.md) Wave 6.
+
+This crate only parses — it does not evaluate anything. There is no `QFn`
+representation, no environment/scope model, and no lowering here; those are
+`q-runtime`'s job (MA-11d).
+
+## The two-nonterminal design, reused from APL/J
+
+Q's grammar reuses `apl.grammar`/`j.grammar`'s exact two-nonterminal shape
+for primitive-verb application (MA11 §3: "reused UNCHANGED... this is the
+easy, mechanical part"):
+
+- **`noun_expr`** — arrays and scalars. Built from `term`s combined by
+  `verb_expr`s, one precedence tier, right-to-left (`a F b G c` parses as
+  `a F (b G c)`, unchanged from APL/J).
+- **`verb_expr`** — a primitive glyph, optionally with one adverb applied
+  (a "derived verb", e.g. `+/`).
+
+Q has no trains and no `@` compose in this cut (MA11 §4 defers `@`; trains
+are a J/K-internal device Q's own real grammar never had), so `verb_expr`
+here is flatter than `j.grammar`'s own (no `verb_train`, no
+`AT`-continuation).
+
+## Function literals — the headline novelty (MA11 §2 / §3 bullet 1)
+
+`{[x;y] stmt; stmt; ...}`: an optional bracketed, semicolon-separated
+parameter list (defaulting to the implicit `x`/`y`/`z` names when the
+brackets are omitted entirely — a runtime/lowering convention, not
+something this grammar encodes) followed by a semicolon-separated statement
+sequence, the last statement's value being the result. A function literal
+is itself an ordinary noun value: assignable (`f:{x+y}`) and passable,
+without being applied.
+
+### Calling a function value — the one genuinely hard grammar problem here
+
+MA11 §3 bullet 1 is explicit that a function literal is "applied with the
+same juxtaposition/`@` mechanism as a primitive verb — no new *application*
+production, only a new way to *produce* a callable value." Taken literally,
+this means `verb_expr` gains two new alternatives — a bare `NAME` (a
+previously-assigned function value) and an inline `function_literal` — so
+the *existing* `noun_expr` production already parses a call once something
+callable can occupy the `verb_expr` slot.
+
+The catch: `NAME` and `function_literal` are *also* valid `term` (noun-side)
+alternatives — they have to be, so an un-applied function value can still
+be assigned. APL/J never had this overlap (their `term`/`verb_expr` token
+sets were always completely disjoint — NUMBER/NAME/LPAREN vs. a fixed set
+of primitive-glyph tokens), so they never needed to solve it. Two
+consequences, both deliberate and documented in `q.grammar`'s own header
+comment:
+
+- `noun_expr`'s optional dyadic continuation widens from `[ verb_expr
+  noun_expr ]` (APL/J's shape, unchanged for the primitive case) to
+  `[ verb_expr noun_expr | noun_expr ]` — one more inner alternative, not a
+  new named production — so that `f 5` (nothing before `f`, calling it
+  monadically) parses: `term` always wins the first alternative's leading
+  element when the input starts with a NAME, but once `f` is consumed,
+  checking whether an entire independent `noun_expr` immediately follows
+  with nothing in between is exactly the shape that means "apply."
+- **A disclosed, deliberate limitation:** real K/Q resolves whether a bare
+  NAME plays a noun role or a verb (callable) role in a chain of three or
+  more juxtaposed names (`f g h`) by tracking each name's already-defined
+  arity during parsing — a symbol table this repo's shared,
+  context-free `GrammarParser` has no mechanism for at all (every other
+  frontend in this family resolves monadic/dyadic dispatch purely from
+  grammar shape, never from what a name was previously bound to). This
+  grammar's own resolution — the inner alternative `verb_expr noun_expr` is
+  tried before the bare `noun_expr` fallback — means `x f y` (exactly one
+  middle "verb" name) parses as the dyadic call `f(x, y)`, but a longer
+  chain right of that point recurses through the same rule without any
+  attempt at global lookahead. This is a best-effort, *not* a faithful
+  reproduction of true K/Q valence resolution — the same class of disclosed
+  simplification `j.grammar`'s own header comment accepts for a bare-noun
+  train tooth outside a fork's leading position. `q-runtime` (MA-11d) needs
+  to be aware of this when it walks the tree.
+
+Verified directly (see this crate's own tests): `f 5` (monadic named call),
+`2 f 3` (dyadic named call), `{x*2} 5` and `2 {x+y} 3` (inline-lambda calls,
+both arities), and `f:{x+y}` (assigning a lambda without calling it) all
+parse correctly and distinctly from each other.
+
+## Dual list-literal syntax (MA11 §3 bullet 3)
+
+Two syntaxes lower to the same list value, and this grammar has two
+distinct `term` alternatives for them (mirroring how MA07 §3 gave Derive's
+`[a, b, c]` vector literal its own production alongside ordinary
+arithmetic):
+
+- **Adjacent numeric stranding** (`1 2 3`), reused unchanged from APL/J's
+  own `NUMBER { NUMBER }` — no new production needed.
+- **Explicit `(a; b; c)`** (`list_literal`), for lists of arbitrary
+  expressions — including function literals or mixed types — that
+  stranding cannot express.
+
+The explicit form is disambiguated from ordinary parenthesised grouping
+purely by the presence of a top-level `;` — and needs **no explicit
+lookahead of its own** to make that work. `term`'s plain
+`LPAREN noun_expr RPAREN` alternative is tried first; for `(2;3)` it simply
+**fails** (`noun_expr` can only consume up to the first element, then the
+mandatory `RPAREN` check finds a `SEMICOLON` instead), and the packrat
+parser's Alternation backtracks cleanly to `list_literal`, which matches.
+For plain `(2+3)`, the first alternative already succeeds outright, so
+`list_literal` is never even attempted.
+
+## Usage
+
+```rust
+use coding_adventures_q_parser::{parse_q, try_parse_q};
+
+let tree = try_parse_q("f:{[x;y] x+y}\nf 2 3\n")?;
+assert_eq!(tree.rule_name, "program");
+# Ok::<(), String>(())
+```
+
+`parse_q`/`create_q_parser` panic on a lexical or syntax error; `try_parse_q`
+returns a `Result` instead.
+
+## Recursion-depth guard
+
+`create_q_parser` opts the shared `GrammarParser` into a recursion-depth cap
+(`MAX_RULE_DEPTH = 32`), empirically derived via the same binary-search
+methodology `apl-parser`/`j-parser` used for their own caps — measured fresh
+for **three** distinct recursion shapes this grammar can drive deep, per
+MA11 §6's own instruction (a throwaway subprocess per data point, on a
+`std::thread::spawn` worker with the **default ~2 MiB stack**, an *uncapped*
+`GrammarParser`, in a **debug** build to match how `cargo test` actually
+runs):
+
+| Shape                                       | Safe (default stack) | Crashes at |
+|----------------------------------------------|-----------------------|------------|
+| Parenthesised nesting `((((5))))`             | 101 levels            | 102        |
+| Flat dyadic chain `1+1+1+…+1`                 | 115 terms             | 116        |
+| Nested function-literal bodies `{{{5}}}`      | 45 levels             | 46         |
+
+**Nested function-literal bodies are the binding (lowest) floor** — the
+genuinely new shape MA11 §6 flagged as needing its own fresh measurement
+("no sibling crate has measured this shape before"). It costs the most
+native-stack per level of the three: each additional `{`/`}` layer recurses
+through `function_literal -> stmt_seq -> statement -> assignment ->
+noun_expr -> term -> function_literal`, six named-rule hops, versus
+parenthesised nesting's two (`term -> noun_expr`) — a function literal's
+body is a full statement sequence, not a bare `noun_expr` the way a
+parenthesised group's contents are.
+
+`MAX_RULE_DEPTH` is set to **32** — about 29% below the binding
+nested-function-literal floor of 45 (comparable margin to `apl-parser`'s own
+~26.5% and `j-parser`'s own ~30%), and therefore safely below the other two
+floors (101, 115) as well. Measured real-input headroom at `32` (using the
+*capped* parser, so no crash risk at all): parenthesised nesting parses
+cleanly to 13 levels (14 trips), a flat chain to 26 terms (27 trips), and
+nested function literals to 4 levels (5 trips). The function-literal
+headroom is modest in absolute terms, but not a practical limitation: MA11
+§4 puts nested function-literal *definitions* out of this cut's semantic
+scope entirely (no closure/scoping model is specified for them), so no
+legitimate program in this subset needs more than one level of `{...}`
+nesting — the cap exists to reject a *pathologically crafted* deep input
+cleanly, not to bound realistic programs. See `MAX_RULE_DEPTH`'s doc comment
+in `src/lib.rs` for the full derivation, and `CHANGELOG.md` for the
+measurement methodology.
+
+## Known limitations (disclosed, not fixed here)
+
+- **Three-or-more bare-name juxtaposition chains** (`f g h`) do not
+  replicate real K/Q's arity-tracking valence resolution — see "Calling a
+  function value" above. A future `q-runtime` needs to account for this.
+- **`q-lexer` bug/gap discipline**: this crate consumes `q-lexer`'s token
+  stream as-is and does not modify it. No genuine bug was found in
+  `q-lexer` while building this crate; if one is found later, per this
+  repo's "fix what's local, defer what's shared" convention it belongs in a
+  separate change to `q-lexer` itself, not folded into this crate's own PR.

--- a/code/packages/rust/q-parser/required_capabilities.json
+++ b/code/packages/rust/q-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/q-parser",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/q-parser/src/_grammar.rs
+++ b/code/packages/rust/q-parser/src/_grammar.rs
@@ -1,0 +1,178 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: q.grammar
+// Regenerate with: grammar-tools compile-grammar q.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"line"#.to_string() }) },
+            line_number: 150,
+        },
+        GrammarRule {
+            name: r#"line"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 152,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+            line_number: 156,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+            ] },
+            line_number: 165,
+        },
+        GrammarRule {
+            name: r#"noun_expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::Sequence { elements: vec![
+                                GrammarElement::RuleReference { name: r#"verb_expr"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                            ] },
+                            GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"verb_expr"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                ] },
+            ] },
+            line_number: 179,
+        },
+        GrammarRule {
+            name: r#"term"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() }) },
+                ] },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"function_literal"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"list_literal"#.to_string() },
+            ] },
+            line_number: 190,
+        },
+        GrammarRule {
+            name: r#"list_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"SEMICOLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"SEMICOLON"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 216,
+        },
+        GrammarRule {
+            name: r#"function_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"param_list"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"stmt_seq"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 226,
+        },
+        GrammarRule {
+            name: r#"param_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"SEMICOLON"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 234,
+        },
+        GrammarRule {
+            name: r#"stmt_seq"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"SEMICOLON"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 243,
+        },
+        GrammarRule {
+            name: r#"verb_expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"verb_primitive"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::TokenReference { name: r#"EACH"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"REDUCE"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"SCAN"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"function_literal"#.to_string() },
+            ] },
+            line_number: 257,
+        },
+        GrammarRule {
+            name: r#"verb_primitive"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+                GrammarElement::TokenReference { name: r#"PERCENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"BANG"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                GrammarElement::TokenReference { name: r#"HASH"#.to_string() },
+                GrammarElement::TokenReference { name: r#"UNDERSCORE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"AMP"#.to_string() },
+                GrammarElement::TokenReference { name: r#"PIPE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"TILDE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+            ] },
+            line_number: 267,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/q-parser/src/lib.rs
+++ b/code/packages/rust/q-parser/src/lib.rs
@@ -1,0 +1,676 @@
+//! Grammar-driven Q parser.
+//!
+//! The parser grammar is compiled into this crate at build time, so runtime
+//! callers do not need filesystem access to `code/grammars/q`.
+
+use coding_adventures_q_lexer::create_q_lexer;
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+
+mod _grammar;
+
+/// Recursion-depth cap for the Q [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own `Result`-returning entry points ever get a chance to report
+/// anything).
+///
+/// # Three crash shapes, measured independently — not two, and not copied
+/// from a sibling
+///
+/// `apl-parser`'s own `MAX_RULE_DEPTH` doc comment documents a twice-
+/// corrected history: its first value (`150`) was validated against only
+/// ONE way its grammar recurses deeply (parenthesised nesting) and was
+/// silently unsafe against a SECOND, independently measured way (a flat
+/// unparenthesised dyadic chain) — the corrected value respects the
+/// *lower* of the two floors, not whichever was measured first.
+/// `j.grammar` inherited both of `apl.grammar`'s crash shapes and added a
+/// third of its own (`verb_train`'s flat repetition), and found — contrary
+/// to a naive "the shape that bit `apl-parser` will bite again" guess —
+/// that parenthesised nesting, not the flat chain, ended up binding for
+/// `j.grammar`. `q.grammar` reuses APL/J's `noun_expr`/`term` shape for its
+/// own primitive-verb application (MA11 §3: "reused UNCHANGED... this is
+/// the easy, mechanical part"), so it inherits both of THOSE crash shapes
+/// too — plus a genuinely new THIRD one, unique to this grammar and with NO
+/// precedent in any sibling crate: nested function-literal bodies
+/// (`{{{...}}}`), MA11 §3 bullet 1's headline novelty. All three were
+/// measured independently here, exactly per MA11 §6's own instruction,
+/// rather than assuming any prior crate's floor (or ordering) transfers.
+///
+/// All three measurements below use the identical methodology every prior
+/// crate in this family used: binary search, driving a throwaway
+/// subprocess per data point (a real native stack overflow calls
+/// `process::abort()` and kills the *whole* process, not just the
+/// offending thread, so a single in-process loop cannot survive past the
+/// first crash), each subprocess parsing on a `std::thread::spawn` worker
+/// with the **default ~2 MiB stack** (no `stack_size` override) using an
+/// *uncapped* `GrammarParser` (`max_depth = usize::MAX`, i.e.
+/// `with_max_depth` never called) — this is what finds the real
+/// native-stack crash floor rather than the depth-guard's own configured
+/// trip point. This crate's own `cargo test` runs in a debug (unoptimized)
+/// build by default, and debug frames are meaningfully larger than release
+/// frames, so these floors were measured in a **debug** build (`cargo
+/// build` without `--release`) to match the conditions real callers of
+/// this crate's test suite actually run under.
+///
+/// 1. **Parenthesised nesting**, `((((…5…))))` — `noun_expr -> term ->
+///    LPAREN noun_expr RPAREN -> term -> …`. Measured: parses safely up to
+///    **101 levels**, crashes the process at **102**.
+/// 2. **A flat, unparenthesised dyadic chain**, `1+1+1+…+1` —
+///    `noun_expr`'s own right-recursive continuation. Measured: parses
+///    safely up to **115 terms**, crashes at **116**.
+/// 3. **Nested function-literal bodies**, `{{{…5…}}}` — every additional
+///    layer of `{`/`}` recurses through `function_literal -> stmt_seq ->
+///    statement -> assignment -> noun_expr -> term -> function_literal`,
+///    six named-rule hops per level versus parenthesised nesting's two
+///    (`term -> noun_expr`), since a function literal's body is not a bare
+///    `noun_expr` the way a parenthesised group's contents are — it is a
+///    full statement sequence, reached through the SAME `assignment`/
+///    `statement` machinery a top-level line uses. Measured: parses safely
+///    up to **45 levels**, crashes at **46** — by far the *lowest* of the
+///    three floors, exactly because each level costs more native-stack
+///    frames than either of the other two shapes.
+///
+/// # The binding constraint
+///
+/// **Nested function-literal bodies bind here** (45, vs. 101 for
+/// parenthesised nesting and 115 for the flat chain) — this is the
+/// genuinely new shape MA11 §6 flagged as needing its own fresh
+/// measurement ("no sibling crate has measured this shape before"), and it
+/// turns out to be the most expensive per level of the three, exactly
+/// because it recurses through six named rules per layer instead of two or
+/// three. `MAX_RULE_DEPTH` is set to **32** — about 29% below the binding
+/// nested-function-literal floor of 45 (comparable margin to `apl-parser`'s
+/// own ~26.5% and `j-parser`'s own ~30%), and therefore safely below the
+/// other two floors (101, 115) as well. Measured real-input headroom at
+/// `32` (using the CAPPED parser, i.e. `create_q_parser`/`try_parse_q`, so
+/// no crash risk at all): parenthesised nesting parses cleanly up to 13
+/// levels (14 trips the cap), a flat dyadic chain parses cleanly up to 26
+/// terms (27 trips the cap), and nested function-literal bodies parse
+/// cleanly up to 4 levels (5 trips the cap). The function-literal headroom
+/// is modest in absolute terms, but this is not a practical limitation:
+/// MA11 §4 itself puts nested function-literal definitions out of this
+/// cut's semantic scope entirely (no closure/scoping model for them is
+/// specified), so no legitimate Q program in this subset ever needs more
+/// than one level of `{...}` nesting at all — the cap exists purely to
+/// reject a *pathologically crafted* deep input cleanly, not to bound
+/// realistic programs, exactly as `apl-parser`'s and `j-parser`'s own caps
+/// do for their respective binding shapes.
+const MAX_RULE_DEPTH: usize = 32;
+
+/// Create a [`GrammarParser`] wired to the Q grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+///
+/// # Panics
+///
+/// Panics if tokenization fails. Use [`try_parse_q`] for a `Result`.
+pub fn create_q_parser(source: &str) -> GrammarParser {
+    let tokens = create_q_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|err| panic!("Q tokenization failed: {err}"));
+    let grammar = _grammar::parser_grammar();
+    GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Parse Q source into a syntax tree rooted at the `program` rule.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_q`] for a `Result`.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_q_parser::parse_q;
+///
+/// let tree = parse_q("f:{[x;y] x+y}\nf 2 3\n");
+/// assert_eq!(tree.rule_name, "program");
+/// ```
+pub fn parse_q(source: &str) -> GrammarASTNode {
+    create_q_parser(source)
+        .parse()
+        .unwrap_or_else(|err| panic!("Q parse failed: {err}"))
+}
+
+/// Parse Q source, returning a `Result` instead of panicking on a lexical or
+/// syntax error.
+pub fn try_parse_q(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = create_q_lexer(source)
+        .tokenize()
+        .map_err(|err| err.to_string())?;
+    let grammar = _grammar::parser_grammar();
+    GrammarParser::new(tokens, grammar)
+        .with_max_depth(MAX_RULE_DEPTH)
+        .parse()
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------
+    // Parsing correctness — one example per grammar production (MA11 §3/§4)
+    // -------------------------------------------------------------------
+
+    fn rule_names(node: &GrammarASTNode) -> Vec<String> {
+        use parser::grammar_parser::ASTNodeOrToken;
+        node.children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n.rule_name.clone()),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .collect()
+    }
+
+    /// Recursively collect every token *name* (e.g. `"REDUCE"`) appearing
+    /// anywhere in the tree.
+    fn token_names(node: &GrammarASTNode) -> Vec<String> {
+        use parser::grammar_parser::ASTNodeOrToken;
+        let mut out = Vec::new();
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) => out.push(t.effective_type_name().to_string()),
+                ASTNodeOrToken::Node(n) => out.extend(token_names(n)),
+            }
+        }
+        out
+    }
+
+    /// Recursively check whether any node in the tree has the given
+    /// `rule_name` — used by the list-literal-vs-grouping disambiguation
+    /// test below to make a structural assertion without decoding
+    /// semantics.
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        use parser::grammar_parser::ASTNodeOrToken;
+        if node.rule_name == name {
+            return true;
+        }
+        node.children.iter().any(|c| match c {
+            ASTNodeOrToken::Node(n) => contains_rule(n, name),
+            ASTNodeOrToken::Token(_) => false,
+        })
+    }
+
+    #[test]
+    fn a_bare_number_parses() {
+        let ast = parse_q("5\n");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn stranded_numbers_form_one_term() {
+        // `1 2 3` is a single 3-element vector term, not three statements.
+        let ast = try_parse_q("1 2 3\n").expect("stranding should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn simple_assignment_parses() {
+        let ast = try_parse_q("x:5\n").expect("assignment should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn chained_assignment_is_right_associative() {
+        // x:y:3 assigns 3 to both y and x (MA11 §4's "Assignment" bullet,
+        // mirrors apl.grammar's/j.grammar's own chained-assignment shape).
+        let ast = try_parse_q("x:y:3\n").expect("chained assignment should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn monadic_primitive_application_parses() {
+        // `!` with nothing to its left is monadic (til).
+        let ast = try_parse_q("!5\n").expect("monadic application should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn dyadic_primitive_application_parses() {
+        let ast = try_parse_q("2+3\n").expect("dyadic application should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn right_to_left_dyadic_chain_parses_as_one_noun_expr() {
+        // 2*3+4 is 2*(3+4) -- a single right-recursive noun_expr, not three
+        // separate statements (MA11 §3: reused UNCHANGED from APL/J, one
+        // precedence tier, right-to-left).
+        let ast = try_parse_q("2*3+4\n").expect("chain should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn every_adverb_parses() {
+        // each ('), over/reduce (/), scan (\) -- MA11 §4's three in-scope
+        // adverbs, each postfixed onto a primitive verb.
+        for src in ["+/x\n", "+\\x\n", "+'x\n"] {
+            try_parse_q(src).unwrap_or_else(|e| panic!("`{src}` should parse: {e}"));
+        }
+    }
+
+    #[test]
+    fn reduce_parses_as_reduce_not_something_else() {
+        // `+/x` must lower `/` as the REDUCE adverb (postfix on `+`). Check
+        // this structurally: the tree must contain a REDUCE token. (The
+        // comment-vs-reduce whitespace disambiguation itself is entirely
+        // `q-lexer`'s job -- MA11 §3 bullet 2 -- this is a sanity check
+        // that the parser's own grammar correctly consumes the REDUCE
+        // token the lexer hands it, not a re-test of the lexer's own
+        // disambiguation.)
+        let ast = try_parse_q("+/x\n").expect("reduce should parse");
+        let tokens = token_names(&ast);
+        assert!(
+            tokens.iter().any(|t| t == "REDUCE"),
+            "expected a REDUCE token in the parse tree for `+/x`, got: {tokens:?}"
+        );
+    }
+
+    #[test]
+    fn every_comparison_verb_parses() {
+        for op in ["=", "<", ">", "<=", ">=", "<>"] {
+            let src = format!("a{op}b\n");
+            try_parse_q(&src).unwrap_or_else(|e| panic!("`{src}` should parse: {e}"));
+        }
+    }
+
+    #[test]
+    fn every_primitive_verb_parses_monadically() {
+        for op in [
+            "+", "-", "*", "%", "!", ",", "#", "_", "&", "|", "~", "=", "<", ">", "<=", ">=", "<>",
+        ] {
+            let src = format!("{op}a\n");
+            try_parse_q(&src).unwrap_or_else(|e| panic!("`{src}` should parse: {e}"));
+        }
+    }
+
+    #[test]
+    fn parenthesised_grouping_parses() {
+        let ast = try_parse_q("(2+3)*4\n").expect("grouping should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    // -------------------------------------------------------------------
+    // Dual list-literal syntax (MA11 §3 bullet 3) — the disambiguation
+    // between plain parenthesised grouping and an explicit list literal.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn plain_grouping_does_not_produce_a_list_literal_node() {
+        let ast = parse_q("(2+3)\n");
+        assert!(
+            !contains_rule(&ast, "list_literal"),
+            "`(2+3)` (no top-level `;`) must parse as plain grouping, not a list literal"
+        );
+    }
+
+    #[test]
+    fn explicit_semicolon_list_literal_parses_and_is_distinct_from_grouping() {
+        let ast = try_parse_q("(2;3)\n").expect("explicit list literal should parse");
+        assert!(
+            contains_rule(&ast, "list_literal"),
+            "`(2;3)` (a top-level `;`) must produce a list_literal node"
+        );
+    }
+
+    #[test]
+    fn a_three_element_list_literal_with_mixed_content_parses() {
+        // Mixed types (a function literal alongside plain numbers) --
+        // exactly the case numeric stranding cannot express (MA11 §3
+        // bullet 3).
+        let ast =
+            try_parse_q("(2;{x+1};3)\n").expect("mixed-type list literal should parse");
+        assert!(contains_rule(&ast, "list_literal"));
+        assert!(contains_rule(&ast, "function_literal"));
+    }
+
+    // -------------------------------------------------------------------
+    // Function literals (MA11 §2 / §3 bullet 1) — the headline novelty.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn function_literal_with_explicit_params_parses() {
+        let ast =
+            try_parse_q("{[x;y] x+y}\n").expect("explicit-param function literal should parse");
+        assert!(contains_rule(&ast, "function_literal"));
+        assert!(contains_rule(&ast, "param_list"));
+    }
+
+    #[test]
+    fn function_literal_with_implicit_params_parses() {
+        // No bracketed parameter list at all -- defaults to implicit x/y/z
+        // (MA11 §3 bullet 1), a RUNTIME/lowering convention this grammar
+        // does not need to encode: the parse tree simply has no
+        // `param_list` child.
+        let ast = try_parse_q("{x+y}\n").expect("implicit-param function literal should parse");
+        assert!(contains_rule(&ast, "function_literal"));
+        assert!(!contains_rule(&ast, "param_list"));
+    }
+
+    #[test]
+    fn function_literal_with_multi_statement_body_parses() {
+        // Semicolon-separated statement sequence -- the last statement's
+        // value is the result (a runtime concern; the grammar only needs
+        // to build the flat `stmt_seq`).
+        let ast = try_parse_q("{[x] a:x+1; a*2}\n")
+            .expect("multi-statement function literal should parse");
+        assert!(contains_rule(&ast, "function_literal"));
+        assert!(contains_rule(&ast, "stmt_seq"));
+    }
+
+    #[test]
+    fn function_literal_is_assignable_without_being_called() {
+        // A function literal is itself an ordinary noun value (MA11 §3
+        // bullet 1): assigning it must not require applying it.
+        let ast = try_parse_q("f:{x+y}\n").expect("assigning a bare lambda should parse");
+        assert!(contains_rule(&ast, "function_literal"));
+    }
+
+    // -------------------------------------------------------------------
+    // Calling a function value via juxtaposition (MA11 §3 bullet 1: "the
+    // same juxtaposition/@ mechanism as a primitive verb") -- see
+    // `q.grammar`'s own header comment for the full design rationale
+    // (`verb_expr` gains NAME/function_literal alternatives; `noun_expr`'s
+    // existing optional continuation gains a bare `noun_expr` fallback).
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn calling_a_named_function_monadically_parses() {
+        // f 5 -- f previously bound to a one-parameter lambda, applied via
+        // plain juxtaposition, exactly like a primitive (`!5`).
+        let ast =
+            try_parse_q("f:{x+1}\nf 5\n").expect("monadic named-function call should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn calling_a_named_function_dyadically_parses() {
+        // 2 f 3 -- f used infix, exactly like a primitive (`2+3`).
+        let ast =
+            try_parse_q("f:{x+y}\n2 f 3\n").expect("dyadic named-function call should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn calling_an_inline_function_literal_monadically_parses() {
+        // {x*2} 5 -- an anonymous lambda applied the moment it is written.
+        let ast = try_parse_q("{x*2} 5\n").expect("monadic inline-lambda call should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn calling_an_inline_function_literal_dyadically_parses() {
+        let ast = try_parse_q("2 {x+y} 3\n").expect("dyadic inline-lambda call should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn a_function_body_calling_another_already_defined_function_parses() {
+        // MA11 §4: "every function body in scope calls only primitives and
+        // other already-defined functions" -- exercised here at top level
+        // (calling one already-defined function from another already-
+        // defined function's own later invocation).
+        let ast = try_parse_q("double:{x*2}\nadd1:{x+1}\ndouble add1 5\n")
+            .expect("chained already-defined-function calls should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    // -------------------------------------------------------------------
+    // Structure / multi-line programs
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn a_multi_line_program_parses_into_multiple_lines() {
+        let ast =
+            try_parse_q("x:1\ny:2\nx+y\n").expect("multi-line program should parse");
+        let lines = rule_names(&ast);
+        assert_eq!(lines.iter().filter(|n| *n == "line").count(), 3);
+    }
+
+    #[test]
+    fn a_comment_line_and_a_blank_line_both_parse() {
+        // `/`-to-end-of-line comments are stripped by q-lexer's pre-
+        // tokenize hook (MA11 §3 bullet 2); a bare NEWLINE is its own
+        // `line` alternative.
+        let ast =
+            try_parse_q("/ just a comment\n\nx:1\n").expect("comment/blank line should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    // -------------------------------------------------------------------
+    // Malformed-input rejection
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn a_bare_each_adverb_with_nothing_to_modify_is_rejected() {
+        // `'` (EACH) can only ever appear as a postfix on a verb_primitive
+        // (MA11 §4) -- unlike REDUCE (`/`), EACH has no comment-marker
+        // dual meaning, so a bare leading `'` is unambiguously a syntax
+        // error, not silently swallowed by any lexer hook.
+        assert!(try_parse_q("'a\n").is_err());
+    }
+
+    #[test]
+    fn unbalanced_parentheses_are_rejected() {
+        assert!(try_parse_q("(2+3\n").is_err());
+    }
+
+    #[test]
+    fn a_bare_colon_with_no_name_before_it_is_rejected() {
+        assert!(try_parse_q(":5\n").is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- mirrors the exact
+    // methodology `apl-parser`/`j-parser` used for their own `MAX_RULE_DEPTH`
+    // (see those crates' `CHANGELOG.md`s), applied fresh to Q's own THREE
+    // recursion shapes (MA11 §6): parenthesised nesting, a flat
+    // right-recursive dyadic chain, and nested function-literal bodies --
+    // the last one genuinely new to this grammar family, with no sibling
+    // precedent (see `MAX_RULE_DEPTH`'s own doc comment for the full
+    // derivation and measured numbers).
+    // -------------------------------------------------------------------
+
+    /// Build `n` nested parens around a `5`, e.g. `((5))` for `n == 2`.
+    fn nested_paren_source(n: usize) -> String {
+        format!("{}5{}\n", "(".repeat(n), ")".repeat(n))
+    }
+
+    /// Build a flat, unparenthesised dyadic chain `1+1+1+…+1` with `n` `+`s.
+    fn flat_chain_source(n: usize) -> String {
+        let mut s = String::from("1");
+        for _ in 0..n {
+            s.push_str("+1");
+        }
+        s.push('\n');
+        s
+    }
+
+    /// Build `n` nested function-literal bodies around a `5`, e.g. `{{5}}`
+    /// for `n == 2` -- Q's own third, genuinely new recursion shape (MA11
+    /// §6), with no `apl-parser`/`j-parser` precedent.
+    fn nested_funclit_source(n: usize) -> String {
+        format!("{}5{}\n", "{".repeat(n), "}".repeat(n))
+    }
+
+    /// Deeply-nested parenthesised input must produce a recoverable error,
+    /// not overflow the native stack (an uncatchable process abort). We
+    /// parse 5000 levels -- far past `MAX_RULE_DEPTH` -- on a worker thread
+    /// with a generous 32 MiB stack, so the *guard* is what stops the
+    /// recursion, not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow() {
+        let handle = std::thread::Builder::new()
+            .name("q-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let source = nested_paren_source(5000);
+                let result = try_parse_q(&source);
+                assert!(
+                    result.is_err(),
+                    "deeply-nested input must fail with an error, not parse or crash"
+                );
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// The flat-chain analogue of the parenthesised-nesting test above.
+    #[test]
+    fn test_huge_flat_chain_returns_error_not_overflow() {
+        let handle = std::thread::Builder::new()
+            .name("q-chain-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let source = flat_chain_source(5000);
+                let result = try_parse_q(&source);
+                assert!(
+                    result.is_err(),
+                    "a huge flat dyadic chain must fail with an error, not parse or crash"
+                );
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// The nested-function-literal analogue of the two tests above -- this
+    /// grammar's own third, genuinely new recursion shape (MA11 §6), and
+    /// the one that turned out to be BINDING (see `MAX_RULE_DEPTH`'s doc
+    /// comment).
+    #[test]
+    fn test_huge_nested_function_literal_returns_error_not_overflow() {
+        let handle = std::thread::Builder::new()
+            .name("q-funclit-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let source = nested_funclit_source(5000);
+                let result = try_parse_q(&source);
+                assert!(
+                    result.is_err(),
+                    "deeply-nested function literals must fail with an error, not parse or crash"
+                );
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// Input that nests *exactly up to* `MAX_RULE_DEPTH`'s measured boundary
+    /// still parses cleanly, and one layer deeper cleanly trips the guard.
+    /// These exact boundary counts (13 legitimate levels at
+    /// `MAX_RULE_DEPTH = 32`) were found empirically by binary-searching
+    /// `create_q_parser` against increasing nesting counts -- see
+    /// `MAX_RULE_DEPTH`'s doc comment. Without this test, a future change to
+    /// the constant could silently change this boundary while the other
+    /// shapes' boundary tests kept passing.
+    #[test]
+    fn test_nesting_up_to_cap_still_parses() {
+        let ok_source = nested_paren_source(13);
+        let ast = try_parse_q(&ok_source).expect("13 levels must stay under the cap");
+        assert_eq!(ast.rule_name, "program");
+
+        let tripped_source = nested_paren_source(14);
+        assert!(
+            try_parse_q(&tripped_source).is_err(),
+            "one nesting level past the cap's measured limit must fail"
+        );
+    }
+
+    /// The flat-chain analogue of the boundary test above -- 26 terms is
+    /// the measured safe limit at `MAX_RULE_DEPTH = 32`, one more (27)
+    /// trips it.
+    #[test]
+    fn test_flat_chain_up_to_cap_still_parses() {
+        let ok_source = flat_chain_source(26);
+        let ast = try_parse_q(&ok_source).expect("26 chain terms must stay under the cap");
+        assert_eq!(ast.rule_name, "program");
+
+        let tripped_source = flat_chain_source(27);
+        assert!(
+            try_parse_q(&tripped_source).is_err(),
+            "one chain term past the cap's measured limit must fail"
+        );
+    }
+
+    /// The nested-function-literal analogue of the boundary tests above --
+    /// 4 levels is the measured safe limit at `MAX_RULE_DEPTH = 32`, one
+    /// more (5) trips it. This is this grammar's own third, genuinely new
+    /// recursion shape (MA11 §6) that has no sibling-crate precedent at
+    /// all, and the one this cap was actually chosen against (see
+    /// `MAX_RULE_DEPTH`'s doc comment).
+    #[test]
+    fn test_nested_function_literal_up_to_cap_still_parses() {
+        let ok_source = nested_funclit_source(4);
+        let ast = try_parse_q(&ok_source).expect("4 nested function literals must stay under the cap");
+        assert_eq!(ast.rule_name, "program");
+
+        let tripped_source = nested_funclit_source(5);
+        assert!(
+            try_parse_q(&tripped_source).is_err(),
+            "one function-literal nesting level past the cap's measured limit must fail"
+        );
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (e.g. a future `q-runtime`, or `cargo
+    /// test`'s own per-test thread) would still crash. We parse far-too-deep
+    /// input on a worker thread with **no** `stack_size` override (the same
+    /// ~2 MiB a default thread gets). A clean `Err` (not a `join()` failure
+    /// from a crashed thread) proves `MAX_RULE_DEPTH` sits safely below the
+    /// native overflow point on the default stack, for all three crash
+    /// shapes.
+    #[test]
+    fn test_opt_in_cap_trips_before_overflow_on_default_stack() {
+        let handle = std::thread::spawn(|| {
+            let source = nested_paren_source(5000);
+            let result = try_parse_q(&source);
+            assert!(result.is_err(), "deeply-nested input must error, not crash");
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// The flat-chain analogue of the default-stack test above.
+    #[test]
+    fn test_flat_chain_cap_trips_before_overflow_on_default_stack() {
+        let handle = std::thread::spawn(|| {
+            let source = flat_chain_source(5000);
+            let result = try_parse_q(&source);
+            assert!(result.is_err(), "a huge flat chain must error, not crash");
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// The nested-function-literal analogue of the default-stack test
+    /// above -- the test that would catch a future `MAX_RULE_DEPTH` change
+    /// that is unsafe for this grammar's own third (and binding) crash
+    /// shape.
+    #[test]
+    fn test_nested_function_literal_cap_trips_before_overflow_on_default_stack() {
+        let handle = std::thread::spawn(|| {
+            let source = nested_funclit_source(5000);
+            let result = try_parse_q(&source);
+            assert!(
+                result.is_err(),
+                "deeply-nested function literals must error, not crash"
+            );
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+}


### PR DESCRIPTION
## Summary

Second frontend crate for Q, per [MA11 §6](code/specs/MA11-q-language.md) task MA-11c. Consumes `q-lexer`'s token stream, drives it through `code/grammars/q/q.grammar`, and produces a `GrammarASTNode` CST.

- Reuses `apl.grammar`/`j.grammar`'s two-nonterminal `noun_expr`/`verb_expr` design unchanged for primitive-verb application (one precedence tier, right-to-left).
- Two genuinely new productions (spec §3): **function literals** (`{[x;y] stmt; stmt; ...}`, optional bracketed param list) and the **explicit list-literal form** `(a;b;c)`, disambiguated from plain parenthesised grouping purely by the presence of a top-level `;` — falls out of the packrat parser's ordered alternation with no explicit lookahead.
- **The hard problem**: making a function literal "applied with the same juxtaposition mechanism as a primitive verb" without a new application production, since `NAME`/`function_literal` need to occupy both noun and verb roles — something APL/J never needed since their verb tokens were always lexically disjoint from noun tokens. Solved by widening `verb_expr` with `NAME`/`function_literal` alternatives and `noun_expr`'s optional continuation with a bare fallback. A disclosed, deliberate limitation: 3+-name juxtaposition chains (`f g h`) don't replicate real K/Q's arity-tracking valence resolution, since the shared `GrammarParser` has no symbol table — flagged for `q-runtime` (MA-11d).

### Recursion-depth cap — measured fresh, not copied

Per spec §6's explicit instruction, empirically measured the native-stack crash floor for all three ways this grammar recurses deeply (binary search, throwaway subprocess per data point, default ~2 MiB stack, uncapped parser, debug build):

| Shape | Safe | Crashes at |
|---|---|---|
| Parenthesised nesting `((((5))))` | 101 | 102 |
| Flat dyadic chain `1+1+1+…` | 115 | 116 |
| Nested function-literal bodies `{{{5}}}` (genuinely new, no sibling precedent) | 45 | 46 |

`MAX_RULE_DEPTH = 32` — ~29% below the binding nested-function-literal floor (comparable margin to `apl-parser`'s ~26.5%/`j-parser`'s ~30%).

## Test plan

- [x] `cargo test -p coding-adventures-q-parser --all-targets` — 38 tests + 1 doctest, all passing (includes 9 depth-cap regression tests: 3 shapes × {huge-input, exact-boundary, cap-trips-before-default-stack-overflow})
- [x] `cargo clippy -p coding-adventures-q-parser --all-targets -- -D warnings` — clean
- [x] `/security-review` passed — reviewer additionally verified a 4th recursion shape (chained assignment) not explicitly covered by the PR's own measurement, confirming consistent behavior

## Explicitly out of scope (follow-up tasks)

- `q-runtime` / `q-repl` / `q` binary — MA-11d
- `q-to-semantic-ir` — MA-11e

🤖 Generated with [Claude Code](https://claude.com/claude-code)