### PR TITLE
feat(adj-formula-stdlib): FL-4 fraction library (composes cited primitives)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_fraction_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_fraction_e2e.rs
@@ -1,0 +1,194 @@
+//! End-to-end tests for ADJ-FORMULA-LIBRARIES FL-4 — the `fraction.adj`
+//! elementary library — driven through the built CLI binary against the SHIPPED
+//! stdlib. Each proves the FL-4 invariant: the library COMPOSES the cited
+//! `arithmetic.adj` primitives (it re-derives no arithmetic), computes the exact
+//! value on the CPU, and carries BOTH its own citation and the primitives' as
+//! corroborations — write-once-use-many all the way down.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fl4frac_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy a shipped `.adj` file (by relative path under the stdlib) into `dir`
+/// under its basename, so a consumer's relative `import` resolves.
+fn place(dir: &Path, rel: &str) {
+    let src = stdlib().join(rel);
+    let name = Path::new(rel).file_name().unwrap();
+    std::fs::copy(&src, dir.join(name)).unwrap_or_else(|e| panic!("copy {rel}: {e}"));
+}
+
+fn with_lib(dir: &Path) {
+    place(dir, "arithmetic/arithmetic.adj");
+    place(dir, "arithmetic/fraction.adj");
+}
+
+// ---------------------------------------------------------------------------
+// fraction_of — a fractional part of a whole, composing product.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fraction_of_composes_product_and_carries_both_citations() {
+    let dir = scratch("fraction_of");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fraction.adj\"\n\
+         observe fraction(0.25)\n\
+         observe whole(12)\n\
+         ? fraction_of(fraction, whole)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.25 * 12 = 3, via the product primitive on the CPU.
+    assert!(
+        s.contains("\"name\":\"fraction_of\"") && s.contains("\"value\":3"),
+        "fraction_of(0.25, 12) = 3: {s}"
+    );
+    // BOTH citations: fraction's own definition (primary) AND the product
+    // primitive it composed (corroboration).
+    assert!(
+        s.contains("mathworld.wolfram.com/Fraction.html"),
+        "primary cites the fraction definition: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Product.html"),
+        "corroboration cites the product primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// reciprocal — the fraction flipped, composing quotient with swapped args.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reciprocal_flips_the_fraction_via_quotient() {
+    let dir = scratch("reciprocal");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fraction.adj\"\n\
+         observe numerator(4)\n\
+         observe denominator(5)\n\
+         ? reciprocal(numerator, denominator)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // reciprocal of 4/5 is 5/4 = 1.25, via quotient(denominator, numerator).
+    assert!(
+        s.contains("\"name\":\"reciprocal\"") && s.contains("\"value\":1.25"),
+        "reciprocal(4, 5) = 1.25: {s}"
+    );
+    // The exact rational is preserved as 5/4 — no f64 round-trip.
+    assert!(
+        s.contains("\"num\":\"5\"") && s.contains("\"den\":\"4\""),
+        "the exact value is 5/4, not a lossy decimal: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Reciprocal.html"),
+        "primary cites the reciprocal definition: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Quotient.html"),
+        "corroboration cites the quotient primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// mixed_number — a whole plus a proper fraction, composing sum and quotient.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mixed_number_composes_sum_and_quotient() {
+    let dir = scratch("mixed");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fraction.adj\"\n\
+         observe whole_number(2)\n\
+         observe numerator(1)\n\
+         observe denominator(2)\n\
+         ? mixed_number(whole_number, numerator, denominator)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // two and a half = 2 + 1/2 = 2.5, composing sum and quotient.
+    assert!(
+        s.contains("\"name\":\"mixed_number\"") && s.contains("\"value\":2.5"),
+        "mixed_number(2, 1, 2) = 2.5: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/MixedFraction.html"),
+        "primary cites the mixed-number definition: {s}"
+    );
+    // Both composed primitives appear as corroborations.
+    assert!(
+        s.contains("mathworld.wolfram.com/Sum.html"),
+        "corroboration cites the sum primitive: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Quotient.html"),
+        "corroboration cites the quotient primitive: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The compute trace bottoms out at the observed slots — no model arithmetic.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_derivation_tree_names_the_composed_op_and_its_leaves() {
+    let dir = scratch("tree");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fraction.adj\"\n\
+         observe fraction(0.5)\n\
+         observe whole(10)\n\
+         ? fraction_of(fraction, whole)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    // 0.5 * 10 = 5, and the trace shows the multiplication over the two observed
+    // leaves — the answer is reconstructable operand by operand, not asserted.
+    assert!(s.contains("\"value\":5"), "fraction_of(0.5, 10) = 5: {s}");
+    assert!(
+        s.contains("\"node\":\"op\"") && s.contains("\"op\":\"*\""),
+        "the derivation names the product op: {s}"
+    );
+    assert!(
+        s.contains("\"slot\":\"fraction\"") && s.contains("\"slot\":\"whole\""),
+        "the leaves name the observed slots the value was built from: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/fraction.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/fraction.adj
@@ -1,0 +1,87 @@
+% ============================================================================
+% fraction.adj — the fraction formula library (ADJ-FORMULA-LIBRARIES FL-4).
+% ============================================================================
+% The "part of a whole" track of the compute standard library, built ENTIRELY by
+% composing the cited primitives of `arithmetic.adj` — it re-derives no
+% arithmetic. Where `ratio.adj` ships the bare value of a fraction (a/b as a
+% quotient), this ships the operations a fraction actually PARTICIPATES in:
+% taking a fraction OF a quantity, flipping it (its reciprocal), and reading a
+% mixed number as a value. Each is a single application of a cited primitive, so
+% the answer names every formula that took part.
+%
+%     import "fraction.adj"                        % transitively imports arithmetic.adj
+%     observe fraction(0.25)                       % "…a quarter…"   (span cited by the model)
+%     observe whole(12)                            % "…of 12…"       (span cited by the model)
+%     ? fraction_of(fraction, whole)               % engine → 3, carrying every citation
+%
+% The engine expands `fraction_of` → `product` (from arithmetic.adj) on the CPU
+% and composes the provenance chain, so the answer cites BOTH the fraction
+% definition (primary) and the `product` primitive it builds on (corroboration).
+% The model performs zero arithmetic, and the audit trail names every formula
+% that participated.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% This library depends on the elementary primitives — `product`, `quotient`, and
+% `sum` in particular. The import is RELATIVE to this file, so a consumer that
+% imports `fraction.adj` gets those primitives transitively and the bodies below
+% resolve.
+% ----------------------------------------------------------------------------
+import "arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `fraction_of` scales a whole by a fractional part; `reciprocal`
+% flips a fraction's numerator and denominator; `mixed_number` reads a
+% whole-plus-fraction quantity as a single value. Rung-0 types an observable slot
+% as `finding`; the `surface` synonyms let a decomposer map everyday phrasing
+% ("a quarter of", "flip", "and a half") onto the canonical terms.
+% ----------------------------------------------------------------------------
+dictionary fraction_vocab {
+    define fraction     : finding  surface "fraction", "fractional part", "the fraction"
+    define whole        : finding  surface "whole", "quantity", "total", "of the"
+
+    define numerator    : finding  surface "numerator", "top", "part", "first number"
+    define denominator  : finding  surface "denominator", "bottom", "whole", "second number"
+
+    define whole_number : finding  surface "whole number", "integer part", "whole part"
+
+    define fraction_of  : finding  surface "fraction of", "part of", "a fraction of a quantity"
+    define reciprocal   : finding  surface "reciprocal", "multiplicative inverse", "flipped fraction"
+    define mixed_number : finding  surface "mixed number", "mixed fraction", "whole and a fraction"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formulas. None writes a bare operator: each APPLIES the cited
+% primitive from `arithmetic.adj`, so the operation is what it is BECAUSE of the
+% primitive it composes, cited as such.
+%
+%   fraction_of(fraction, whole)               = fraction * whole
+%   reciprocal(numerator, denominator)         = denominator / numerator
+%   mixed_number(whole_number, numerator, denominator)
+%                                              = whole_number + (numerator / denominator)
+% ----------------------------------------------------------------------------
+formulabook fractions {
+    use fraction_vocab
+
+    % A fraction OF a quantity — the fractional part scaling the whole. Composes
+    % `product` from arithmetic.adj: a quarter of 12 is 0.25 × 12 = 3.
+    formula fraction_of(fraction, whole) = product(fraction, whole)
+        source "A fraction represents a part of a whole; a fraction of a quantity is that quantity multiplied by the fraction."
+        locator "https://mathworld.wolfram.com/Fraction.html"
+        trust authoritative
+
+    % The reciprocal — the fraction flipped, numerator and denominator swapped.
+    % Composes `quotient` with its arguments exchanged: the reciprocal of a/b is
+    % b/a.
+    formula reciprocal(numerator, denominator) = quotient(denominator, numerator)
+        source "The reciprocal of a number x is the number which, when multiplied by x, yields 1; the reciprocal of a fraction a/b is b/a."
+        locator "https://mathworld.wolfram.com/Reciprocal.html"
+        trust authoritative
+
+    % A mixed number — a whole number plus a proper fraction, read as a single
+    % value. Composes `sum` and `quotient`: two and a half is 2 + 1/2 = 2.5.
+    formula mixed_number(whole_number, numerator, denominator) = sum(whole_number, quotient(numerator, denominator))
+        source "A mixed number is the sum of an integer and a proper fraction."
+        locator "https://mathworld.wolfram.com/MixedFraction.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/fraction.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/fraction.query.adj
@@ -1,0 +1,18 @@
+% ============================================================================
+% fraction.query.adj — a worked example of the fraction formula library.
+% ============================================================================
+% Run against the shipped stdlib:
+%
+%   adj-lang-cli fraction.query.adj
+%
+% "A quarter of a 12-metre length" → 0.25 × 12 = 3, computed on the CPU by
+% composing the cited `product` primitive from arithmetic.adj. The answer carries
+% BOTH the fraction definition (primary) and the product primitive it built on
+% (corroboration) — the model performs zero arithmetic.
+% ============================================================================
+import "fraction.adj"
+
+observe fraction(0.25)
+observe whole(12)
+
+? fraction_of(fraction, whole)


### PR DESCRIPTION
## What

Completes the **FL-4 elementary set** (`ratio`/`percent`/`average` already ship) with the **`fraction`** library — the "part of a whole" track of the compute standard library. Every formula COMPOSES a cited `arithmetic.adj` primitive and re-derives no arithmetic:

| Formula | Composes | Example |
|---|---|---|
| `fraction_of(fraction, whole)` | `product` | a quarter of 12 → **3** |
| `reciprocal(numerator, denominator)` | `quotient` (swapped) | 4/5 flips to 5/4 → **1.25** |
| `mixed_number(whole, num, denom)` | `sum` + `quotient` | two and a half → **2.5** |

Each carries its own authoritative MathWorld citation as **primary** and the composed primitive's as **corroboration**, so the answer names every formula that participated and the model performs zero arithmetic. Exact rationals are preserved (5/4, 5/2 — no f64 round-trip).

## Ships
- `arithmetic/fraction.adj` — the library (composes `product`/`quotient`/`sum` from `arithmetic.adj`).
- `arithmetic/fraction.query.adj` — a worked example.
- `adj-lang-cli/tests/fl4_fraction_e2e.rs` — 4 e2e cases driving the built CLI against the **shipped** stdlib, each asserting the exact value AND both citations, plus one that walks the compute tree down to the observed leaves.

`fraction` was already listed in `ADJ-FORMULA-LIBRARIES.md`'s Elementary ladder, so the spec is in sync.

## Notes
Data + test only — **no source changes**, so this is conflict-free with the RS-4 PR-D2 branch in flight. Gate: clippy clean, fraction e2e 4/4, no regressions in the sibling percent/average/primitives suites. Security review passed (no injection surface, no network, no untrusted-input execution).

Follows FL-4a (#8189, percent + average).

🤖 Generated with [Claude Code](https://claude.com/claude-code)