### PR TITLE
feat(adj-facts-stdlib): Platonic-solid vertices + edges (completes V,E,F triple)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_solid_vertices_edges_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_solid_vertices_edges_e2e.rs
@@ -1,0 +1,115 @@
+//! End-to-end test for the geometry FACTS library
+//! (`adj-facts-stdlib/geometry/solid-vertices-edges.adj`) driven through the
+//! built CLI: native `table`s of solid → vertices and solid → edges resolve
+//! binding-query recalls with the source's citation, and abstain on a non-solid
+//! — 0 model calls. Completes the (V, E, F) triple whose faces sibling ships in
+//! `solid-shapes.adj`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsve_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn with_lib(dir: &Path) {
+    let src = facts_stdlib().join("geometry/solid-vertices-edges.adj");
+    std::fs::copy(&src, dir.join("solid-vertices-edges.adj"))
+        .expect("copy shipped solid-vertices-edges.adj");
+}
+
+#[test]
+fn vertices_recall_binds_count_with_citation() {
+    let dir = scratch("vertices");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"solid-vertices-edges.adj\"\n\
+         ? solid_vertices(cube, $V)\n\
+         ? solid_vertices(dodecahedron, $V)\n\
+         ? solid_vertices(sphere, $V)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A cube has eight vertices; a dodecahedron has twenty.
+    assert!(out.contains("\"V\":\"8\""), "cube → 8 vertices: {out}");
+    assert!(out.contains("\"V\":\"20\""), "dodecahedron → 20 vertices: {out}");
+    assert!(
+        out.contains("mathworld.wolfram.com") && out.contains("\"trust\":\"authoritative\""),
+        "carries the MathWorld citation: {out}"
+    );
+    // A sphere is not a Platonic solid — honest abstention, never a fabricated count.
+    assert!(out.contains("\"abstained\":true"), "sphere abstains: {out}");
+}
+
+#[test]
+fn edges_recall_binds_count_with_citation() {
+    let dir = scratch("edges");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"solid-vertices-edges.adj\"\n\
+         ? solid_edges(cube, $E)\n\
+         ? solid_edges(icosahedron, $E)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // A cube has twelve edges; an icosahedron has thirty.
+    assert!(out.contains("\"E\":\"12\""), "cube → 12 edges: {out}");
+    assert!(out.contains("\"E\":\"30\""), "icosahedron → 30 edges: {out}");
+    assert!(
+        out.contains("mathworld.wolfram.com/PlatonicSolid.html"),
+        "carries the MathWorld PlatonicSolid citation: {out}"
+    );
+}
+
+#[test]
+fn the_three_libraries_together_satisfy_eulers_formula() {
+    // The payoff of shipping V and E beside the existing F: recall all three and
+    // Euler's V - E + F = 2 holds for every Platonic solid, checkable on the CPU
+    // from grounded facts alone. Here we assert the recalled counts for the cube
+    // (8 - 12 + 6 = 2); the arithmetic itself is exercised elsewhere.
+    let dir = scratch("euler");
+    with_lib(&dir);
+    let src = facts_stdlib().join("geometry/solid-shapes.adj");
+    std::fs::copy(&src, dir.join("solid-shapes.adj")).expect("copy shipped solid-shapes.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"solid-vertices-edges.adj\"\n\
+         import \"solid-shapes.adj\"\n\
+         ? solid_vertices(cube, $V)\n\
+         ? solid_edges(cube, $E)\n\
+         ? solid_faces(cube, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // 8 vertices, 12 edges, 6 faces — the operands of 8 - 12 + 6 = 2, all grounded.
+    assert!(out.contains("\"V\":\"8\""), "cube V=8: {out}");
+    assert!(out.contains("\"E\":\"12\""), "cube E=12: {out}");
+    assert!(out.contains("\"F\":\"6\""), "cube F=6: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/geometry/solid-vertices-edges.adj
+++ b/code/specs/data/adj-facts-stdlib/geometry/solid-vertices-edges.adj
@@ -1,0 +1,63 @@
+% ============================================================================
+% solid-vertices-edges — how many vertices and edges each Platonic solid has
+% (adj-facts-stdlib, GEOMETRY).
+% ============================================================================
+% The companion of solid-shapes.adj (solid -> FACES): this ships the other two
+% columns of the same MathWorld "Platonic Solid" table — solid -> VERTICES and
+% solid -> EDGES. Together the three libraries carry the full (V, E, F) triple
+% for each of the five Platonic solids, so a consumer can recall all three and
+% CHECK Euler's formula for convex polyhedra, V - E + F = 2, entirely on the CPU:
+%
+%     ? solid_vertices(cube, $V)       % 8
+%     ? solid_edges(cube, $E)          % 12
+%     % with solid_faces(cube, 6) from solid-shapes.adj: 8 - 12 + 6 = 2. ✓
+%
+% Each is a native `table` (ADJ-TABLES RS-5): every `row` lowers to a ground
+% relation carrying the table's citation, so the lookup is the ordinary SLD
+% binding query — the engine returns the count WITH its source, on the CPU, with
+% zero model calls, and abstains on a solid not in the table. Because the values
+% are NUMBERS, a recalled count composes straight into a formula — the same
+% concrete RECALL -> COMPUTE bridge as its faces sibling.
+%
+% Provenance: the vertex and edge counts are read straight off the Wolfram
+% MathWorld "Platonic Solid" table, which lists for each solid its number of
+% vertices, edges, and faces. In the standard order (tetrahedron, cube,
+% octahedron, dodecahedron, icosahedron) the vertices are 4, 8, 6, 20, 12 and the
+% edges are 6, 12, 12, 30, 30. `trust authoritative` — a primary mathematics
+% reference. Nothing here is asserted from memory. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vertices — the corner points where edges meet.
+% ----------------------------------------------------------------------------
+table solid_vertices {
+    columns solid, vertices
+
+    row (tetrahedron, 4)
+    row (cube, 8)
+    row (octahedron, 6)
+    row (dodecahedron, 20)
+    row (icosahedron, 12)
+
+    source "MathWorld's Platonic Solid table gives, for each solid, its number of vertices: tetrahedron 4, cube 8, octahedron 6, dodecahedron 20, icosahedron 12."
+    locator "https://mathworld.wolfram.com/PlatonicSolid.html"
+    trust authoritative
+}
+
+% ----------------------------------------------------------------------------
+% Edges — the line segments where two faces meet.
+% ----------------------------------------------------------------------------
+table solid_edges {
+    columns solid, edges
+
+    row (tetrahedron, 6)
+    row (cube, 12)
+    row (octahedron, 12)
+    row (dodecahedron, 30)
+    row (icosahedron, 30)
+
+    source "MathWorld's Platonic Solid table gives, for each solid, its number of edges: tetrahedron 6, cube 12, octahedron 12, dodecahedron 30, icosahedron 30."
+    locator "https://mathworld.wolfram.com/PlatonicSolid.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/geometry/solid-vertices-edges.query.adj
+++ b/code/specs/data/adj-facts-stdlib/geometry/solid-vertices-edges.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% solid-vertices-edges.query.adj — a worked recall over the geometry
+% vertices/edges libraries.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how many vertices does a
+% cube have?": it states no geometry fact — it only `import`s the grounded
+% tables and asks binding queries. The engine resolves each `?` against the
+% `solid_vertices` / `solid_edges` rows and returns the count + the table's
+% source/locator/trust. A solid not in the table abstains honestly — the engine
+% never invents a count.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli solid-vertices-edges.query.adj
+% ============================================================================
+
+import "solid-vertices-edges.adj"
+
+? solid_vertices(cube, $V)             % expect 8
+? solid_edges(cube, $E)                % expect 12
+? solid_vertices(dodecahedron, $V)     % expect 20
+? solid_edges(icosahedron, $E)         % expect 30
+? solid_vertices(sphere, $V)           % expect abstain — a sphere is not a Platonic solid


### PR DESCRIPTION
## What

Ships the two columns of MathWorld's **Platonic Solid** table that `solid-shapes.adj` (solid → **faces**) doesn't: **solid → vertices** and **solid → edges**, as native `table`s whose rows lower to ground relations carrying the source's citation.

| solid | V | E | F (existing) |
|---|---|---|---|
| tetrahedron | 4 | 6 | 4 |
| cube | 8 | 12 | 6 |
| octahedron | 6 | 12 | 8 |
| dodecahedron | 20 | 30 | 12 |
| icosahedron | 12 | 30 | 20 |

## Why

With faces already grounded, a consumer can now recall all three and **check Euler's formula for convex polyhedra, V − E + F = 2**, entirely on the CPU from grounded facts (cube: 8 − 12 + 6 = 2). The counts are read straight off the MathWorld table; nothing is asserted from memory (`feedback_nothing_human_authored`).

## Ships
- `geometry/solid-vertices-edges.adj` — the two grounded tables.
- `geometry/solid-vertices-edges.query.adj` — a worked recall (incl. an honest abstention on `sphere`, which is not a Platonic solid).
- `adj-lang-cli/tests/facts_solid_vertices_edges_e2e.rs` — 3 e2e cases: binds V/E with the MathWorld citation, abstains on a non-solid, and demonstrates the three libraries composing into the Euler check.

## Notes
Data + test only — **no source changes**. Follows the `facts_solids_e2e.rs` pattern. Gate: clippy clean, new e2e 3/3, sibling solids suite green. Security review passed (inert declarative data, no network, no untrusted-input execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)